### PR TITLE
Unscoped voice directives route by the caller's canonical project, never the last-seated legacy record

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -36,6 +36,7 @@ import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
+import { projectForCwd } from "@/lib/scanner/describe";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
@@ -143,6 +144,29 @@ export interface ViewerMcpDomainDependencies {
       `@/lib/orchestrator/authority`), for project-scoped directive routing.
       Optional so partial harnesses fall back to the production resolver. */
   authorizedSeats?(): ReturnType<typeof authorizedManagerSeats>;
+  /** The calling voice session's CANONICAL PROJECT — production resolves it
+      from the caller's conversation cwd through the worktree-grouping path
+      (`projectInfoFromCwd`), the same attribution every other surface uses.
+      Null means the invariant "a registered session has a canonical project"
+      is violated, and unscoped directive routing fails closed diagnostically. */
+  callerProject?(): string | null;
+}
+
+/**
+ * FIX 2's production resolver: the caller's conversation (pid ancestry merged
+ * with capability lineage — the identity chain everything else trusts), its
+ * newest generation's cwd, and the canonical project that cwd groups under.
+ * No second resolution scheme: `projectForCwd` IS `projectInfoFromCwd`.
+ */
+function productionCallerProject(): string | null {
+  const authority = attentionCallerAuthority(attentionCallerSources());
+  const conversationId = authority.kind === "root" || authority.kind === "worker" ? authority.conversationId : null;
+  if (!conversationId) return null;
+  const conversation = agentRegistry().conversation(conversationId as `conversation_${string}`);
+  if (!conversation) return null;
+  if (conversation.projectOwnership?.project) return conversation.projectOwnership.project;
+  const cwd = conversation.generations.at(-1)?.launchProfile?.cwd?.trim();
+  return cwd ? projectForCwd(cwd) : null;
 }
 
 /** Server-derived origin of the current caller. Shared by the attention record
@@ -625,35 +649,37 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
   /* Both throw on anything that would not round-trip through the parser. */
   const deliveryId = bridgeDirectiveId(text(args.rootTurnId), utterance);
 
-  /* Recipient resolution (MEDIUM 6, #758 review). Per-project seats share one
-     legacy record, so an UN-SCOPED directive keeps the legacy primary — the
-     conversation the newest designation synced — while a directive carrying
-     `project` resolves through the VALIDATED seat authority, never the raw
-     record: seating project B must not redirect project A's directives, and a
-     project whose seat fails the fail-closed checks gets a refusal rather than
-     somebody else's orchestrator. */
-  const project = text(args.project);
-  let manager: { conversationId: string; path: string | null };
-  if (project) {
-    const seats = dependencies.authorizedSeats?.() ?? authorizedManagerSeats(productionManagerAuthoritySources());
-    const seat = seats.find((candidate) => candidate.project === project);
-    if (!seat) {
-      throw new McpToolRefusal(
-        `no validated orchestrator is designated for ${project}; create one first, then relay again`,
-        { code: "manager_not_designated", project },
-      );
-    }
-    manager = { conversationId: seat.conversationId, path: seat.path };
-  } else {
-    const record = readOrchestratorRecord();
-    if (!record) {
-      throw new McpToolRefusal(
-        "no manager conversation is designated, so there is nobody to relay this to; tell the user the manager is not running",
-        { code: "manager_not_designated" },
-      );
-    }
-    manager = { conversationId: record.conversationId, path: record.path };
+  /* Recipient resolution (FIX 2, post-#758 operator decision). Every directive
+     routes through the VALIDATED per-project seat authority — the global
+     last-seated legacy record is NEVER consulted, because that was the defect:
+     seating project B silently redirected project A's directives.
+
+     An explicitly named project overrides. An UN-SCOPED directive follows the
+     CALLING VOICE SESSION'S canonical project, resolved from the conversation's
+     cwd through the same worktree-grouping path (`projectInfoFromCwd`) every
+     other project attribution uses — never a second scheme. */
+  const callerProject = dependencies.callerProject ? dependencies.callerProject() : productionCallerProject();
+  const project = text(args.project) || callerProject;
+  if (!project) {
+    /* Diagnostic, not a menu: a REGISTERED voice session always has a cwd and
+       therefore a canonical project. Reaching this line means the invariant is
+       violated — corrupted or incomplete registry state — and the refusal names
+       that rather than modelling it as an ordinary choice or falling back to
+       whatever project was seated last. */
+    throw new McpToolRefusal(
+      "INVARIANT VIOLATION: the calling voice session resolves to no canonical project — a registered conversation must derive one from its cwd through the worktree-grouping path. Routing fails closed; investigate the session's registry record (an explicit project can be named meanwhile).",
+      { code: "caller_project_unresolved" },
+    );
   }
+  const seats = dependencies.authorizedSeats?.() ?? authorizedManagerSeats(productionManagerAuthoritySources());
+  const seat = seats.find((candidate) => candidate.project === project);
+  if (!seat) {
+    throw new McpToolRefusal(
+      `no validated orchestrator is designated for ${project}; create one first, then relay again`,
+      { code: "manager_not_designated", project },
+    );
+  }
+  const manager: { conversationId: string; path: string | null } = { conversationId: seat.conversationId, path: seat.path };
 
   const ref = args.ref;
   const trailer = typeof ref === "number" && Number.isInteger(ref) && ref > 0

--- a/src/lib/mcp/bridgeDirective.test.ts
+++ b/src/lib/mcp/bridgeDirective.test.ts
@@ -7,6 +7,13 @@ import { mintBridgeConfirmation } from "@/lib/bridge/confirmation";
 import { parseBridgeTrailer } from "@/lib/bridge/directive";
 import { recordManagerReport } from "@/lib/bridge/service";
 import { drainBridgeReports, openBridgeChannel } from "@/lib/bridge/store";
+import { authorizedManagerSeats } from "@/lib/orchestrator/authority";
+import {
+  activeOrchestratorSeats,
+  beginOrchestratorSeatIntent,
+  completeOrchestratorSeatIntent,
+  orchestratorRevocations,
+} from "@/lib/orchestrator/seats";
 import { adoptOrchestratorRecord } from "@/lib/orchestrator/store";
 
 import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
@@ -32,21 +39,43 @@ afterEach(() => {
 
 let posted: { pathname: string; body: Record<string, unknown> }[] = [];
 
+/** REAL seat activation through the durable store — the designation evidence
+    routing actually reads. */
+function seatProject(project: string, conversationId: string): void {
+  beginOrchestratorSeatIntent({ project, mandate: "own the board", clientRequestId: `seed_${project}`, mode: "spawn" });
+  completeOrchestratorSeatIntent({ project, clientRequestId: `seed_${project}`, conversationId, path: null });
+}
+
+/** The validated seat authority over the REAL store, with permissive registry
+    facts — designation evidence is real, only the registry is stubbed. */
+function realSeatAuthority() {
+  return authorizedManagerSeats({
+    activeSeats: activeOrchestratorSeats,
+    revocations: orchestratorRevocations,
+    legacyManagerConversationId: () => null,
+    conversationFacts: () => ({ superseded: false, hasGeneration: true, project: null }),
+    resolveAlias: (id) => id,
+  });
+}
+
 function sandbox(withManager = true): void {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-bridge-directive-"));
   sandboxes.push(dir);
   process.env.LLV_STATE_DIR = path.join(dir, "state");
   openBridgeChannel("root_directive");
   if (withManager) {
+    /* The caller's own project holds the designated orchestrator; a legacy
+       record is ALSO written and must be irrelevant to routing. */
+    seatProject("proj-voice", "conversation_manager");
     adoptOrchestratorRecord({
-      conversationId: "conversation_manager",
+      conversationId: "conversation_legacy_pointer",
       path: null,
       createdAt: new Date().toISOString(),
     });
   }
 }
 
-function bindings() {
+function bindings(callerProject: string | null = "proj-voice") {
   posted = [];
   const control: ViewerControlDependencies = {
     async post(pathname, body) {
@@ -54,7 +83,12 @@ function bindings() {
       return { outcome: "delivered", operationId: "op-1" };
     },
   };
-  return viewerMcpBindings(undefined, control);
+  /* The caller's canonical project as the production resolver would derive it
+     from the voice conversation's cwd through projectInfoFromCwd. */
+  return viewerMcpBindings(undefined, control, {
+    callerProject: () => callerProject,
+    authorizedSeats: realSeatAuthority,
+  } as never);
 }
 
 test("a directive is addressed to the manager the record names, not to whoever the caller says", async () => {
@@ -159,7 +193,7 @@ test("a half-formed confirmation answer is refused rather than relayed as a bare
   expect(posted).toEqual([]);
 });
 
-test("with no manager designated the directive is refused, not delivered somewhere else", async () => {
+test("with no orchestrator designated for the caller's project the directive is refused, not delivered somewhere else", async () => {
   sandbox(false);
   const tools = bindings();
   await expect(tools.bridge_directive({
@@ -167,7 +201,7 @@ test("with no manager designated the directive is refused, not delivered somewhe
     rootTurnId: "turn_0203",
     utterance: 0,
     instruction: "start a reviewer",
-  })).rejects.toThrow(/manager/i);
+  })).rejects.toThrow(/orchestrator|manager/i);
   expect(posted).toEqual([]);
 });
 
@@ -217,11 +251,44 @@ test("a project-scoped directive reaches THAT project's orchestrator even after 
   expect(posted.map((post) => post.body.conversationId)).toEqual(["conversation_a", "conversation_b"]);
 });
 
-test("an un-scoped directive keeps the legacy primary recipient", async () => {
+/* ── FIX 2 (post-#758 operator decision): unscoped routing follows the CALLING
+      VOICE SESSION'S canonical project, never a global last-writer record ──── */
+
+test("FIX 2 ACCEPTANCE: seat A, then seat B — an unscoped directive from a voice session in project A reaches A's orchestrator", async () => {
+  sandbox(false);
+  /* REAL seat activations, in this order: A first, then B, so B is the most
+     recently seated project AND the one the last-writer legacy record names. */
+  seatProject("proj-a", "conversation_a");
+  seatProject("proj-b", "conversation_b");
+  adoptOrchestratorRecord({ conversationId: "conversation_b", path: null, createdAt: new Date().toISOString() });
+
+  /* The caller is a voice session whose canonical project is A. */
+  const tools = bindings("proj-a");
+  const receipt = await tools.bridge_directive({
+    clientRequestId: "d-unscoped",
+    rootTurnId: "turn_unscoped",
+    utterance: 0,
+    instruction: "status?",
+  });
+
+  expect(posted).toHaveLength(1);
+  expect(posted[0]!.body.conversationId).toBe("conversation_a");
+  expect(receipt).toMatchObject({ managerConversationId: "conversation_a" });
+});
+
+test("FIX 2: an unresolvable caller project fails closed DIAGNOSTICALLY — never another project's orchestrator", async () => {
   sandbox();
-  const tools = seatedBindings();
-  await tools.bridge_directive({ clientRequestId: "d-l", rootTurnId: "turn_l", utterance: 0, instruction: "status?" });
-  expect(posted[0]!.body.conversationId).toBe("conversation_manager");
+  /* A registered voice session always has a cwd and therefore a canonical
+     project; this state is invariant-violating, and the refusal says so
+     instead of guessing or falling back to whatever was seated last. */
+  const tools = bindings(null);
+  await expect(tools.bridge_directive({
+    clientRequestId: "d-lost",
+    rootTurnId: "turn_lost",
+    utterance: 0,
+    instruction: "status?",
+  })).rejects.toThrow(/invariant/i);
+  expect(posted).toEqual([]);
 });
 
 test("a project with no VALIDATED seat refuses rather than falling back to another project's orchestrator", async () => {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1211,7 +1211,7 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     rootTurnId: z.string().regex(/^[A-Za-z0-9_.:-]+$/).describe("The realtime turn this instruction came from. The delivery id derives from it, so a retry must reuse the same value."),
     utterance: z.number().int().min(0).describe("Index of this instruction within that turn, from 0."),
     instruction: z.string().min(1).describe("What the user asked for, in plain words. No board state, no tool output."),
-    project: z.string().optional().describe("Route to THIS project's designated orchestrator (validated seat). Absent: the legacy primary recipient."),
+    project: z.string().optional().describe("Route to THIS project's designated orchestrator (validated seat). Absent: routes to the orchestrator of the calling voice session's own canonical project."),
     ref: z.number().int().positive().optional().describe("seq of the report this answers, when it answers one."),
     nonce: z.string().optional().describe("With sha: the deploy authorization the user just gave aloud."),
     sha: z.string().regex(/^[0-9a-f]{40}$/).optional(),


### PR DESCRIPTION
## The fix (operator-required follow-up to #758; FIX 1 was cancelled by operator decision)

`bridge_directive` with no explicit `project` used to resolve its recipient from the global single-instance orchestrator record — rewritten by every seat activation — so seating project B silently redirected project A's voice directives.

Now:
- **Every directive routes through the validated per-project seat authority.** The legacy last-writer record is never consulted for routing.
- **Explicit `project` overrides**, after normal validation (unchanged from #758).
- **Unscoped** resolves the **calling voice session's canonical project**: the caller's conversation via the resolved identity chain (pid ancestry merged with capability lineage), its durable `projectOwnership` when the operator recorded one, otherwise its newest generation's cwd through the existing worktree-grouping path (`projectForCwd` → `projectInfoFromCwd`). No second resolution scheme; the canonical grouping algorithm in AGENTS.md is untouched.
- **Unresolvable caller project fails closed diagnostically**: a registered voice session always has a cwd and therefore a canonical project, so the refusal names the violated invariant (`caller_project_unresolved`) instead of guessing or falling back to another project's orchestrator. It is not modelled as an ordinary operator choice.

## Explicit confirmation on FIX 1

**No worker/role-based denial was added anywhere** — not to `create_orchestrator`, not to `rotate_orchestrator`, not to the seat/rotate routes. A denial had been started under the earlier instruction and was **fully reverted** (`src/lib/mcp/bindings.ts` and `src/lib/mcp/orchestratorTools.test.ts` restored byte-identical to merged main before FIX 2 work began). The operation gate remains exactly as merged: intentionally permissive, workers may explicitly designate/rotate, attribution and idempotency intact, axis 1 universal.

## Red-proven test (no further review round — this is the quality bar)

`src/lib/mcp/bridgeDirective.test.ts`:
- **"FIX 2 ACCEPTANCE: seat A, then seat B — an unscoped directive from a voice session in project A reaches A's orchestrator"** — REAL seat activations through the durable store, in that order, with the legacy record deliberately pointing at B exactly as a last-writer sync leaves it. **Red against merged main** (the directive went to the legacy record's conversation), green with the fix.
- **"FIX 2: an unresolvable caller project fails closed DIAGNOSTICALLY"** — also red before (it delivered via the legacy record), green with the fix; asserts the invariant-naming refusal and zero deliveries.
- The pre-existing suite was reworked onto real seat activations + a caller-project seam, so every assertion observes durable state or recorded control-plane calls (no write-less assertions).

## Gates at 7da2ba5001ab870e1a1e676d9a64424db2b48644
- 236 pass / 0 fail across 22 test files by path in isolated `HOME`/`XDG_CONFIG_HOME`/`TMPDIR`/`LLV_STATE_DIR`
- `tsc --noEmit` clean; eslint clean on changed files; privacy publication gate PASS (base e8e547ff); `bun run build` exit 0
- No runtime/registry sweeps, no process enumeration, no live-Viewer posts (control planes stubbed); PR #759-owned paths untouched

DO NOT MERGE, DO NOT DEPLOY — operator confirms by exact SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)