### PR TITLE
fix: unblock catalog startup and Codex fork recovery retry

### DIFF
--- a/src/app/api/account-migrations/[intentId]/action.test.ts
+++ b/src/app/api/account-migrations/[intentId]/action.test.ts
@@ -48,3 +48,54 @@ test("stop settles held input as cancelled without a delivery attempt", async ()
     error: expect.stringContaining("migration was stopped"),
   });
 });
+
+test("operator retry authorizes an unknown Codex fork before restarting the migration", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-migration-action-retry-"));
+  roots.push(root);
+  const registry = new AgentRegistry(path.join(root, "registry.json"));
+  const conversation = registry.ensureConversation("codex", "/migration-retry.jsonl", "source");
+  const intent = registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "target",
+    origin: "manual",
+    requestId: "retry-action",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const requested = registry.conversation(conversation.id)!;
+  const failed = registry.transitionConversationMigration(
+    conversation.id,
+    requested.migration!.revision,
+    ["requested"],
+    {
+      phase: "failed-recoverable",
+      error: "Codex fork outcome is awaiting recovery",
+      errorCode: "codex-fork-outcome-unknown",
+    },
+  );
+  const authorized: Array<{ operationId: string; conversationId: string }> = [];
+  let ticks = 0;
+
+  const response = await updateMigrationAction(new NextRequest(
+    `http://127.0.0.1/api/account-migrations/${intent.id}`,
+    {
+      method: "POST",
+      headers: { host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({ action: "retry-failed", expectedRevision: intent.revision }),
+    },
+  ), { params: Promise.resolve({ intentId: intent.id }) }, registry, () => { ticks += 1; }, async (operationId, conversationId) => {
+    authorized.push({ operationId, conversationId });
+    return "reauthorized";
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({ retried: 1 });
+  expect(authorized).toEqual([{
+    operationId: failed.migration!.operationId,
+    conversationId: conversation.id,
+  }]);
+  expect(registry.conversation(conversation.id)?.migration).toMatchObject({
+    phase: "requested",
+    operationId: failed.migration!.operationId,
+  });
+  expect(ticks).toBe(1);
+});

--- a/src/app/api/account-migrations/[intentId]/action.ts
+++ b/src/app/api/account-migrations/[intentId]/action.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
+import { authorizeCodexForkRetry } from "@/lib/accounts/migration/provider";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export async function updateMigrationAction(
@@ -9,6 +10,7 @@ export async function updateMigrationAction(
   { params }: { params: Promise<{ intentId: string }> },
   registry: AgentRegistry = agentRegistry(),
   requestTick: () => void = requestAccountMigrationTick,
+  authorizeForkRetry: typeof authorizeCodexForkRetry = authorizeCodexForkRetry,
 ) {
   const rejected = rejectCrossOrigin(req); if (rejected) return rejected;
   let body: { action?: unknown; expectedRevision?: unknown }; try { body = await req.json() as typeof body; } catch { return NextResponse.json({ error: "invalid JSON" }, { status: 400 }); }
@@ -24,9 +26,16 @@ export async function updateMigrationAction(
     const intent = snapshot.migrationIntents[intentId];
     if (!intent) return NextResponse.json({ error: "migration intent is unknown" }, { status: 404 });
     if (body.expectedRevision !== undefined && intent.revision !== body.expectedRevision) return NextResponse.json({ error: "migration intent revision is stale" }, { status: 409 });
-    const retried = Object.values(snapshot.conversations)
-      .filter((conversation) => conversation.migration?.intentId === intentId && conversation.migration.phase === "failed-recoverable")
-      .map((conversation) => registry.retryConversationMigration(conversation.id, conversation.migration?.revision));
+    const failed = Object.values(snapshot.conversations)
+      .filter((conversation) => conversation.migration?.intentId === intentId && conversation.migration.phase === "failed-recoverable");
+    const retried = [];
+    for (const conversation of failed) {
+      const migration = conversation.migration!;
+      if (conversation.engine === "codex" && migration.errorCode === "codex-fork-outcome-unknown") {
+        await authorizeForkRetry(migration.operationId, conversation.id);
+      }
+      retried.push(registry.retryConversationMigration(conversation.id, migration.revision));
+    }
     if (retried.length > 0) requestTick();
     return NextResponse.json({ intent, retried: retried.length });
   }

--- a/src/app/api/conversations/[conversationId]/migration/route.test.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { NextRequest } from "next/server";
 
 import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import type { SuccessorProviderPort } from "@/lib/accounts/migration/contracts";
+import { applyConversationMigration } from "@/lib/accounts/migration/conversationCommand";
 import { AgentRegistry, setAgentRegistryForTests, type ConversationObservation } from "@/lib/agent/registry";
 
 const { POST } = await import("./route");
@@ -135,4 +137,53 @@ test("retry reaches normal migration handling", async () => {
   const response = await POST(request, { params: Promise.resolve({ conversationId: "conversation_missing" }) });
 
   expect(await response.json()).toEqual({ error: "migration retry failed a recoverable preflight" });
+});
+
+test("the operator-facing conversation retry authorizes an unknown Codex fork before advancing", async () => {
+  const { registry, id } = seededRegistry(false);
+  const requested = registry.requestConversationReseat(id, "default");
+  const failed = registry.transitionConversationMigration(
+    id,
+    requested.migration!.revision,
+    ["requested"],
+    {
+      phase: "failed-recoverable",
+      error: "Codex fork outcome is awaiting recovery",
+      errorCode: "codex-fork-outcome-unknown",
+    },
+  );
+  let authorized = false;
+  const provider: SuccessorProviderPort = {
+    virtualSource: true,
+    async create(input) {
+      expect(authorized).toBeTrue();
+      return {
+        operationId: input.operationId,
+        nativeId: "successor",
+        path: "/sessions/successor.jsonl",
+        continuityPaths: [],
+        historyHash: "hash",
+        host: { kind: "codex-app-server", identity: "successor", epoch: 1, verifiedAt: "now" },
+      };
+    },
+    async verify() {},
+  };
+
+  const result = await applyConversationMigration(
+    { conversationId: id, action: "retry", expectedRevision: failed.migration!.revision },
+    {
+      registry: () => registry,
+      provider: () => provider,
+      authorizeForkRetry: async (operationId, conversationId) => {
+        expect(operationId).toBe(failed.migration!.operationId);
+        expect(conversationId).toBe(id);
+        authorized = true;
+        return "reauthorized";
+      },
+    },
+  );
+
+  expect(result.status).toBe(200);
+  expect(authorized).toBeTrue();
+  expect(registry.conversation(id)!.migration?.phase).toBe("committed");
 });

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -535,7 +535,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   markTiming("files-project-rate-limits");
   const effectiveProjectCatalog = projectedProjectCatalog(projectCatalog, registrySnapshot);
   /* GitHub repository identity for readiness issue links (issue #290): cached
-     per project root with a bounded git probe, nullable on any failure. */
+     per project root from local .git/config, nullable on any failure. */
   for (const entry of effectiveProjectCatalog) {
     entry.repository = entry.projectRoot ? repositoryForProjectRoot(entry.projectRoot) : null;
   }

--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -361,6 +361,51 @@ test("oversized unterminated JSONL fails with a bounded buffer", async () => {
   expect(child.signals).toContain("SIGTERM");
 });
 
+test("the default transport accepts a JSONL response larger than the legacy one-megabyte cap", async () => {
+  const { child, start } = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+  });
+  const client = await start();
+  const pending = client.readAccount();
+  child.output(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 2,
+    result: {
+      account: { type: "chatgpt", padding: "x".repeat(2 * 1024 * 1024) },
+      requiresOpenaiAuth: true,
+    },
+  }) + "\n");
+  await expect(pending).resolves.toEqual({ account: { type: "chatgpt" }, requiresOpenaiAuth: true });
+  client.close();
+});
+
+test("a fragmented 25 MB JSONL response is accumulated without quadratic event-loop work", async () => {
+  const { child, start } = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+  });
+  const client = await start();
+  const pending = client.readAccount();
+  const frame = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 2,
+    result: {
+      account: { type: "chatgpt", padding: "x".repeat(25 * 1024 * 1024) },
+      requiresOpenaiAuth: true,
+    },
+  }) + "\n";
+  const startedAt = performance.now();
+  for (let offset = 0; offset < frame.length; offset += 64 * 1024) {
+    child.output(frame.slice(offset, offset + 64 * 1024));
+  }
+  const synchronousMs = performance.now() - startedAt;
+  await expect(pending).resolves.toEqual({ account: { type: "chatgpt" }, requiresOpenaiAuth: true });
+  /* The former repeated concat + full byteLength scan took about 3 seconds on
+     this payload. The chunk accumulator stays comfortably below this loose CI
+     bound while keeping the regression test insensitive to normal host load. */
+  expect(synchronousMs).toBeLessThan(2_000);
+  client.close();
+});
+
 test("SIGTERM acknowledgement and escalation both end in a reaped child", async () => {
   const acknowledged = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), {});

--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 
 import { expect, test } from "bun:test";
 
-import { CodexAppServerClient } from "./codexAppServer";
+import { CodexAppServerClient, type CodexAppServerOptions } from "./codexAppServer";
 
 class FakeChild extends EventEmitter {
   readonly pid = 4242;
@@ -62,10 +62,16 @@ function requestId(message: Record<string, unknown>): number {
   return message.id as number;
 }
 
-function clientWith(handler: (child: FakeChild, message: Record<string, unknown>) => void): { child: FakeChild; start: () => Promise<CodexAppServerClient> } {
+function clientWith(handler: (child: FakeChild, message: Record<string, unknown>) => void): {
+  child: FakeChild;
+  start: (options?: Partial<CodexAppServerOptions>) => Promise<CodexAppServerClient>;
+} {
   const child = new FakeChild();
   child.onWrite = (message) => handler(child, message);
-  return { child, start: () => CodexAppServerClient.start({ home: "/fake/home", spawn: () => child as never }) };
+  return {
+    child,
+    start: (options = {}) => CodexAppServerClient.start({ ...options, home: "/fake/home", spawn: () => child as never }),
+  };
 }
 
 test("account-management app-server retains zero-MCP process isolation", async () => {
@@ -209,7 +215,7 @@ test("successor thread methods use the structured fork, resume, read, name, and 
     sandbox: "read-only",
     config: {
       mcp_servers: { playwright: { enabled: false }, "telegram-readonly": { enabled: false } },
-      features: { apps: false, plugins: false, multi_agent: false },
+      features: { apps: false, plugins: false, multi_agent: false, realtime_conversation: true },
       include_apps_instructions: false,
       model_reasoning_effort: "high",
     },
@@ -348,9 +354,9 @@ test("oversized unterminated JSONL fails with a bounded buffer", async () => {
   const { child, start } = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), {});
   });
-  const client = await start();
+  const client = await start({ maxStdoutBufferBytes: 128 });
   const pending = client.readAccount();
-  child.output("x".repeat(1024 * 1024 + 1));
+  child.output("x".repeat(129));
   await expect(pending).rejects.toThrow("oversized unterminated JSONL line");
   expect(child.signals).toContain("SIGTERM");
 });

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -36,6 +36,7 @@ export interface CodexAppServerOptions {
   clock?: CodexAppServerClock;
   requestTimeoutMs?: number;
   shutdownGraceMs?: number;
+  maxStdoutBufferBytes?: number;
   signalProcess?: ProcessSignal;
 }
 
@@ -95,7 +96,10 @@ export interface CodexAppServerLifecycleEvent {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
-const MAX_STDOUT_BUFFER_BYTES = 1024 * 1024;
+/* Resume/read responses can contain a whole long-running thread in one JSONL
+   envelope. Keep the transport bounded while allowing realistic coordinator
+   histories to cross the app-server boundary. */
+const DEFAULT_MAX_STDOUT_BUFFER_BYTES = 64 * 1024 * 1024;
 const CODEX_ACCOUNT_APP_SERVER_ARGS = [
   "-c",
   "cli_auth_credentials_store=file",
@@ -195,6 +199,7 @@ export class CodexAppServerClient {
     private readonly clock: CodexAppServerClock,
     private readonly requestTimeoutMs: number,
     private readonly shutdownGraceMs: number,
+    private readonly maxStdoutBufferBytes: number,
     private readonly signalProcess: ProcessSignal,
   ) {
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
@@ -216,6 +221,7 @@ export class CodexAppServerClient {
       options.clock ?? defaultClock,
       options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
       options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS,
+      options.maxStdoutBufferBytes ?? DEFAULT_MAX_STDOUT_BUFFER_BYTES,
       options.signalProcess ?? process.kill,
     );
     try {
@@ -407,7 +413,7 @@ export class CodexAppServerClient {
     while (newline >= 0) {
       const rawLine = this.stdoutBuffer.slice(0, newline);
       this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
-      if (Buffer.byteLength(rawLine, "utf8") > MAX_STDOUT_BUFFER_BYTES) {
+      if (Buffer.byteLength(rawLine, "utf8") > this.maxStdoutBufferBytes) {
         this.fail(protocolError("received an oversized JSONL line"));
         return;
       }
@@ -415,7 +421,7 @@ export class CodexAppServerClient {
       if (line) this.acceptMessage(line);
       newline = this.stdoutBuffer.indexOf("\n");
     }
-    if (Buffer.byteLength(this.stdoutBuffer, "utf8") > MAX_STDOUT_BUFFER_BYTES) {
+    if (Buffer.byteLength(this.stdoutBuffer, "utf8") > this.maxStdoutBufferBytes) {
       this.fail(protocolError("received an oversized unterminated JSONL line"));
     }
   }

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -187,7 +187,8 @@ export class CodexAppServerClient {
   private readonly requestListeners = new Set<(request: AppServerRequest) => unknown | Promise<unknown>>();
   private readonly lifecycleListeners = new Set<(event: CodexAppServerLifecycleEvent) => void>();
   private nextId = 1;
-  private stdoutBuffer = "";
+  private stdoutChunks: string[] = [];
+  private stdoutBufferBytes = 0;
   private stderrTail = "";
   private lastInboundEnvelope: AppServerEnvelope | null = null;
   private closed = false;
@@ -361,6 +362,8 @@ export class CodexAppServerClient {
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.stdoutChunks = [];
+    this.stdoutBufferBytes = 0;
     for (const pending of this.pending.values()) {
       this.clock.clearTimeout(pending.timeout);
       pending.reject(new CodexAppServerError("Codex app-server client closed", "unknown"));
@@ -408,22 +411,35 @@ export class CodexAppServerClient {
 
   private acceptStdout(chunk: string): void {
     if (this.closed) return;
-    this.stdoutBuffer += chunk;
-    let newline = this.stdoutBuffer.indexOf("\n");
+    let offset = 0;
+    let newline = chunk.indexOf("\n", offset);
     while (newline >= 0) {
-      const rawLine = this.stdoutBuffer.slice(0, newline);
-      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
-      if (Buffer.byteLength(rawLine, "utf8") > this.maxStdoutBufferBytes) {
+      const fragment = chunk.slice(offset, newline);
+      const lineBytes = this.stdoutBufferBytes + Buffer.byteLength(fragment, "utf8");
+      if (lineBytes > this.maxStdoutBufferBytes) {
         this.fail(protocolError("received an oversized JSONL line"));
         return;
       }
+      const rawLine = this.stdoutChunks.length > 0
+        ? this.stdoutChunks.join("") + fragment
+        : fragment;
+      this.stdoutChunks = [];
+      this.stdoutBufferBytes = 0;
       const line = rawLine.trim();
       if (line) this.acceptMessage(line);
-      newline = this.stdoutBuffer.indexOf("\n");
+      if (this.closed) return;
+      offset = newline + 1;
+      newline = chunk.indexOf("\n", offset);
     }
-    if (Buffer.byteLength(this.stdoutBuffer, "utf8") > this.maxStdoutBufferBytes) {
+    const remainder = chunk.slice(offset);
+    if (!remainder) return;
+    const remainderBytes = Buffer.byteLength(remainder, "utf8");
+    if (this.stdoutBufferBytes + remainderBytes > this.maxStdoutBufferBytes) {
       this.fail(protocolError("received an oversized unterminated JSONL line"));
+      return;
     }
+    this.stdoutChunks.push(remainder);
+    this.stdoutBufferBytes += remainderBytes;
   }
 
   private acceptMessage(line: string): void {
@@ -483,6 +499,8 @@ export class CodexAppServerClient {
   private fail(error: CodexAppServerError): void {
     if (this.closed) return;
     this.closed = true;
+    this.stdoutChunks = [];
+    this.stdoutBufferBytes = 0;
     for (const pending of this.pending.values()) {
       this.clock.clearTimeout(pending.timeout);
       pending.reject(error);

--- a/src/lib/accounts/migration/conversationCommand.ts
+++ b/src/lib/accounts/migration/conversationCommand.ts
@@ -5,8 +5,8 @@ import { chooseReseatTarget } from "@/lib/accounts/reseat";
 
 import { advanceConversationMigration, drainHeldDeliveries } from "./coordinator";
 import { createMigrationDeliveryPort } from "./deliveryPort";
-import { RegisteredSuccessorProvider } from "./provider";
-import type { ViewerConversationId } from "./contracts";
+import { authorizeCodexForkRetry, RegisteredSuccessorProvider } from "./provider";
+import type { SuccessorProviderPort, ViewerConversationId } from "./contracts";
 
 export type ConversationMigrationCommand = {
   conversationId: string;
@@ -20,12 +20,22 @@ export type ConversationMigrationCommandResult = {
   body: Record<string, unknown>;
 };
 
+export interface ConversationMigrationCommandDependencies {
+  registry?: typeof agentRegistry;
+  provider?: () => SuccessorProviderPort;
+  authorizeForkRetry?: typeof authorizeCodexForkRetry;
+}
+
 const deliveryPort = createMigrationDeliveryPort();
 const IN_FLIGHT_PHASES = new Set(["requested", "waiting-turn", "preparing", "successor-starting", "verifying"]);
 
 export async function applyConversationMigration(
   command: ConversationMigrationCommand,
+  dependencies: ConversationMigrationCommandDependencies = {},
 ): Promise<ConversationMigrationCommandResult> {
+  const registryForCommand = dependencies.registry ?? agentRegistry;
+  const providerForCommand = dependencies.provider ?? (() => new RegisteredSuccessorProvider());
+  const authorizeForkRetry = dependencies.authorizeForkRetry ?? authorizeCodexForkRetry;
   if (!command.conversationId.startsWith("conversation_")) {
     return { status: 400, body: { error: "invalid conversation id" } };
   }
@@ -34,7 +44,7 @@ export async function applyConversationMigration(
     if (command.path !== undefined && typeof command.path !== "string") {
       return { status: 400, body: { error: "path must be a string" } };
     }
-    const registry = agentRegistry();
+    const registry = registryForCommand();
     const conversation = registry.conversation(conversationId);
     if (!conversation) return { status: 404, body: { error: "viewer conversation is unknown" } };
     const source = conversation.generations.at(-1);
@@ -56,7 +66,7 @@ export async function applyConversationMigration(
     let final = requested;
     if (requested.migration) {
       try {
-        final = await advanceConversationMigration(conversationId, registry, new RegisteredSuccessorProvider());
+        final = await advanceConversationMigration(conversationId, registry, providerForCommand());
         if (final.migration?.phase === "committed") await drainHeldDeliveries(final.id, deliveryPort, registry);
       } catch {
         final = registry.conversation(conversationId) ?? requested;
@@ -79,7 +89,7 @@ export async function applyConversationMigration(
   }
   if (command.action === "rollback") {
     try {
-      const registry = agentRegistry();
+      const registry = registryForCommand();
       const conversation = registry.rollbackConversationMigration(conversationId, command.expectedRevision);
       await drainHeldDeliveries(conversation.id, deliveryPort, registry);
       return { status: 200, body: conversation as unknown as Record<string, unknown> };
@@ -93,9 +103,18 @@ export async function applyConversationMigration(
   }
   if (command.action === "retry") {
     try {
-      const registry = agentRegistry();
+      const registry = registryForCommand();
+      const failed = registry.conversation(conversationId);
+      const migration = failed?.migration;
+      if (!failed || !migration) throw new Error("conversation has no migration");
+      if (migration.revision !== command.expectedRevision) throw new Error("migration revision is stale");
+      if (failed.engine === "codex"
+        && migration.phase === "failed-recoverable"
+        && migration.errorCode === "codex-fork-outcome-unknown") {
+        await authorizeForkRetry(migration.operationId, failed.id);
+      }
       registry.retryConversationMigration(conversationId, command.expectedRevision);
-      const conversation = await advanceConversationMigration(conversationId, registry, new RegisteredSuccessorProvider());
+      const conversation = await advanceConversationMigration(conversationId, registry, providerForCommand());
       if (conversation.migration?.phase === "committed") await drainHeldDeliveries(conversation.id, deliveryPort, registry);
       return { status: 200, body: conversation as unknown as Record<string, unknown> };
     } catch {

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -5,7 +5,13 @@ import os from "node:os";
 import path from "node:path";
 
 import { emptyLaunchProfile, sameProviderReceiptOutcome, type NativeGeneration, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
-import { codexForkArtifacts, CodexForkOutcomeUnknownError, RegisteredSuccessorProvider, type ProviderDependencies } from "./provider";
+import {
+  authorizeCodexForkRetry,
+  codexForkArtifacts,
+  CodexForkOutcomeUnknownError,
+  RegisteredSuccessorProvider,
+  type ProviderDependencies,
+} from "./provider";
 import { CodexAppServerError, type CodexAppServerClient } from "@/lib/accounts/codexAppServer";
 import { AgentRegistry, type ConversationObservation, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { ClaudeStreamBrokerHost } from "@/lib/runtime/claudeStreamBrokerHost";
@@ -1607,6 +1613,75 @@ test("two forks inside one operation's own window resolve to the newest", async 
   expect(recorded).toContain(forkPath(forkIds[0]!));
   expect(fs.existsSync(forkPath(forkIds[0]!))).toBeTrue();
   expect(fs.existsSync(forkPath(forkIds[1]!))).toBeTrue();
+});
+
+test("an explicit retry reauthorizes one fork after an unknown outcome produced no artifact", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-empty-unknown-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const journalRoot = path.join(base, "provider-journal");
+  const sourceId = "729f423a-d6e9-\x37903-b597-3e676b6ff3d4";
+  const forkId = "729f423a-d6e9-\x34903-8597-000000000001";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  const forkPath = path.join(source.transcriptRoot, `rollout-${forkId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  const client = () => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      if (forkCalls === 1) throw new CodexAppServerError("fork outcome is unknown", "unknown");
+      fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o600 });
+      return { id: forkId, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client(),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot,
+    now: () => "2026-07-10T12:00:00.000Z",
+  } as ProviderDependencies & { journalRoot: string };
+  const provider = new RegisteredSuccessorProvider(dependencies);
+  const input = {
+    engine: "codex" as const,
+    operationId: "empty-unknown-operation",
+    conversationId: "conversation_empty_unknown" as const,
+    targetAccountId: "target",
+    source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
+  };
+
+  await expect(provider.create(input)).rejects.toBeInstanceOf(CodexForkOutcomeUnknownError);
+  await expect(provider.create(input)).rejects.toBeInstanceOf(CodexForkOutcomeUnknownError);
+  expect(forkCalls).toBe(1);
+
+  expect(await authorizeCodexForkRetry(
+    input.operationId,
+    input.conversationId,
+    journalRoot,
+    () => [],
+  )).toBe("reauthorized");
+
+  const receipt = await provider.create(input);
+  expect(forkCalls).toBe(2);
+  expect(receipt.nativeId).toBe(forkId);
+  expect(fs.existsSync(receipt.path)).toBeTrue();
+  const journalFile = path.join(
+    journalRoot,
+    `${crypto.createHash("sha256").update(input.operationId).digest("hex")}.json`,
+  );
+  const journal = JSON.parse(fs.readFileSync(journalFile, "utf8")) as {
+    forkRecoveryFloorMs: number | null;
+    forkRequestedAtMs: number | null;
+  };
+  expect(journal.forkRecoveryFloorMs).toBeNumber();
+  expect(journal.forkRequestedAtMs).toBeNumber();
 });
 
 test("a retry re-forks when the source gained turns while the migration was parked", async () => {

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -1665,7 +1665,7 @@ test("an explicit retry reauthorizes one fork after an unknown outcome produced 
     input.operationId,
     input.conversationId,
     journalRoot,
-    () => [],
+    () => [{ id: forkId, path: path.join(source.transcriptRoot, "vanished-fork.jsonl") }],
   )).toBe("reauthorized");
 
   const receipt = await provider.create(input);
@@ -1682,6 +1682,93 @@ test("an explicit retry reauthorizes one fork after an unknown outcome produced 
   };
   expect(journal.forkRecoveryFloorMs).toBeNumber();
   expect(journal.forkRequestedAtMs).toBeNumber();
+});
+
+test("a late artifact from the first uncertain attempt is adopted after an operator retry", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-late-fork-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const journalRoot = path.join(base, "provider-journal");
+  const sourceId = "739f423a-d6e9-\x37903-b597-3e676b6ff3d4";
+  const lateForkId = "739f423a-d6e9-\x34903-8597-000000000001";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  const lateForkPath = path.join(source.transcriptRoot, `rollout-${lateForkId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  const client = () => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      throw new CodexAppServerError("fork outcome is unknown", "unknown");
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client(),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot,
+    now: () => "2026-07-10T12:00:00.000Z",
+  } as ProviderDependencies & { journalRoot: string };
+  const provider = new RegisteredSuccessorProvider(dependencies);
+  const input = {
+    engine: "codex" as const,
+    operationId: "late-fork-operation",
+    conversationId: "conversation_late_fork" as const,
+    targetAccountId: "target",
+    source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
+  };
+
+  await expect(provider.create(input)).rejects.toBeInstanceOf(CodexForkOutcomeUnknownError);
+  expect(forkCalls).toBe(1);
+  expect(await authorizeCodexForkRetry(input.operationId, input.conversationId, journalRoot, () => [])).toBe("reauthorized");
+  fs.writeFileSync(lateForkPath, codexSessionMeta(lateForkId, sourceId), { mode: 0o600 });
+
+  const receipt = await provider.create(input);
+  expect(forkCalls).toBe(1);
+  expect(receipt.nativeId).toBe(lateForkId);
+});
+
+test("a legacy journal backfills its first recovery floor before retry authorization clears the request", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-legacy-floor-"));
+  roots.push(base);
+  const journalRoot = path.join(base, "provider-journal");
+  fs.mkdirSync(journalRoot, { recursive: true, mode: 0o700 });
+  const operationId = "legacy-floor-operation";
+  const conversationId = "conversation_legacy_floor";
+  const requestedAt = 1_700_000_000_000;
+  const filename = path.join(
+    journalRoot,
+    `${crypto.createHash("sha256").update(operationId).digest("hex")}.json`,
+  );
+  fs.writeFileSync(filename, JSON.stringify({
+    version: 1,
+    operationId,
+    conversationId,
+    sourceNativeId: "749f423a-d6e9-\x37903-b597-3e676b6ff3d4",
+    sourceRoot: path.join(base, "source"),
+    targetRoot: path.join(base, "target"),
+    createdAtMs: requestedAt - 5_000,
+    forkRequestedAtMs: requestedAt,
+    fork: null,
+    forkSource: null,
+    supersededForks: [],
+  }, null, 2));
+
+  expect(await authorizeCodexForkRetry(operationId, conversationId, journalRoot, () => [])).toBe("reauthorized");
+  const after = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+    forkRecoveryFloorMs: number | null;
+    forkRequestedAtMs: number | null;
+  };
+  expect(after.forkRecoveryFloorMs).toBe(requestedAt);
+  expect(after.forkRequestedAtMs).toBe(null);
+  expect(await authorizeCodexForkRetry(operationId, conversationId, journalRoot, () => [])).toBe("not-needed");
+  expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { forkRecoveryFloorMs: number }).forkRecoveryFloorMs).toBe(requestedAt);
 });
 
 test("a retry re-forks when the source gained turns while the migration was parked", async () => {

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -138,6 +138,10 @@ interface CodexProviderOperationJournal {
   sourceRoot: string;
   targetRoot: string;
   createdAtMs: number;
+  /** Earliest uncertain fork request that still needs recovery scanning. Unlike
+      `forkRequestedAtMs`, this survives an explicit operator retry so a late
+      artifact from any earlier attempt is adopted or retained as continuity. */
+  forkRecoveryFloorMs: number | null;
   forkRequestedAtMs: number | null;
   fork: CodexForkArtifact | null;
   /** The source identity `fork` was taken from, observed just before the fork
@@ -633,6 +637,11 @@ function normalizeCodexOperationJournal(value: unknown): CodexProviderOperationJ
     sourceRoot: journal.sourceRoot,
     targetRoot: journal.targetRoot,
     createdAtMs: journal.createdAtMs,
+    forkRecoveryFloorMs: typeof journal.forkRecoveryFloorMs === "number" && Number.isFinite(journal.forkRecoveryFloorMs)
+      ? journal.forkRecoveryFloorMs
+      : (typeof journal.forkRequestedAtMs === "number" && Number.isFinite(journal.forkRequestedAtMs)
+        ? journal.forkRequestedAtMs
+        : null),
     forkRequestedAtMs: typeof journal.forkRequestedAtMs === "number" && Number.isFinite(journal.forkRequestedAtMs)
       ? journal.forkRequestedAtMs
       : null,
@@ -683,6 +692,7 @@ function prepareCodexOperationJournal(
     sourceRoot,
     targetRoot,
     createdAtMs: Date.now(),
+    forkRecoveryFloorMs: null,
     forkRequestedAtMs: null,
     fork: null,
     forkSource: null,
@@ -827,14 +837,62 @@ function recoverCodexFork(
       superseded: [],
     };
   }
-  if (journal.forkRequestedAtMs === null) return { fork: null, forkSource: null, superseded: [] };
+  const recoveryFloor = journal.forkRecoveryFloorMs ?? journal.forkRequestedAtMs;
+  if (recoveryFloor === null) return { fork: null, forkSource: null, superseded: [] };
   const setAside = new Set(journal.supersededForks.map((artifact) => artifact.id));
-  const candidates = newestForkFirst(scan(journal.sourceRoot, journal.sourceNativeId, journal.forkRequestedAtMs)
+  const candidates = newestForkFirst(scan(journal.sourceRoot, journal.sourceNativeId, recoveryFloor)
     .filter((candidate) => !setAside.has(candidate.id))
     .map((candidate) => validatedCodexFork(candidate, journal.sourceNativeId, journal.sourceRoot)));
   /* This operation requested the fork itself, so the identity it recorded before
      asking describes whichever artifact that request produced. */
   return { fork: candidates[0] ?? null, forkSource: journal.forkSource, superseded: candidates.slice(1) };
+}
+
+export type CodexForkRetryAuthorization = "not-needed" | "recovery-ready" | "reauthorized";
+
+/**
+ * Converts an explicit operator retry into one new fork attempt when recovery
+ * found no artifact for the prior unknown outcome. Automatic controller ticks
+ * never call this seam, so an app-server timeout cannot become a fork loop.
+ *
+ * The recovery floor remains anchored to the first uncertain request. A late
+ * artifact from any attempt is therefore adopted on the next provider pass;
+ * ambiguity keeps the newest and records every other validated fork as
+ * continuity.
+ */
+export async function authorizeCodexForkRetry(
+  operationId: string,
+  conversationId: string,
+  journalRoot = statePath("migration-provider-operations"),
+  scan: NonNullable<ProviderDependencies["scanCodexForkArtifacts"]> = codexForkArtifacts,
+): Promise<CodexForkRetryAuthorization> {
+  const filename = operationJournalPath(journalRoot, operationId);
+  let initial: CodexProviderOperationJournal | null;
+  try {
+    initial = normalizeCodexOperationJournal(JSON.parse(fs.readFileSync(filename, "utf8")));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "not-needed";
+    throw error;
+  }
+  if (!initial || initial.operationId !== operationId
+    || (initial.conversationId && initial.conversationId !== conversationId)) {
+    throw new Error("Codex provider operation journal does not match");
+  }
+  return withCodexOperationLease(journalRoot, `move:${initial.sourceNativeId}`, async (assertLeaseOwned) => {
+    const journal = normalizeCodexOperationJournal(JSON.parse(fs.readFileSync(filename, "utf8")));
+    if (!journal || journal.operationId !== operationId
+      || (journal.conversationId && journal.conversationId !== conversationId)) {
+      throw new Error("Codex provider operation journal does not match");
+    }
+    if (journal.fork || journal.forkRequestedAtMs === null) return "not-needed";
+    const recovered = recoverCodexFork(journal, scan);
+    if (recovered.fork) return "recovery-ready";
+    journal.forkRecoveryFloorMs ??= journal.forkRequestedAtMs;
+    journal.forkRequestedAtMs = null;
+    assertLeaseOwned();
+    writeCodexOperationJournal(journalRoot, journal);
+    return "reauthorized";
+  });
 }
 
 function ensureTargetRoot(account: AccountContext): void {
@@ -1266,6 +1324,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
         const account = await sourceClient.readAccount();
         if (!account.account) throw new Error("source Codex account is not authenticated");
         journal.forkRequestedAtMs = Date.now();
+        journal.forkRecoveryFloorMs ??= journal.forkRequestedAtMs;
         /* Observed before the request, so it names the state the fork copies.
            Reading it afterwards would count a turn that landed in between as
            already forked, which is the loss this whole check exists to stop. */

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -842,7 +842,10 @@ function recoverCodexFork(
   const setAside = new Set(journal.supersededForks.map((artifact) => artifact.id));
   const candidates = newestForkFirst(scan(journal.sourceRoot, journal.sourceNativeId, recoveryFloor)
     .filter((candidate) => !setAside.has(candidate.id))
-    .map((candidate) => validatedCodexFork(candidate, journal.sourceNativeId, journal.sourceRoot)));
+    .flatMap((candidate) => {
+      try { return [validatedCodexFork(candidate, journal.sourceNativeId, journal.sourceRoot)]; }
+      catch { return []; }
+    }));
   /* This operation requested the fork itself, so the identity it recorded before
      asking describes whichever artifact that request produced. */
   return { fork: candidates[0] ?? null, forkSource: journal.forkSource, superseded: candidates.slice(1) };
@@ -856,8 +859,8 @@ export type CodexForkRetryAuthorization = "not-needed" | "recovery-ready" | "rea
  * never call this seam, so an app-server timeout cannot become a fork loop.
  *
  * The recovery floor remains anchored to the first uncertain request. A late
- * artifact from any attempt is therefore adopted on the next provider pass;
- * ambiguity keeps the newest and records every other validated fork as
+ * artifact visible before the operation adopts a fork is therefore recovered;
+ * ambiguity keeps the newest and records every other validated candidate as
  * continuity.
  */
 export async function authorizeCodexForkRetry(
@@ -887,7 +890,6 @@ export async function authorizeCodexForkRetry(
     if (journal.fork || journal.forkRequestedAtMs === null) return "not-needed";
     const recovered = recoverCodexFork(journal, scan);
     if (recovered.fork) return "recovery-ready";
-    journal.forkRecoveryFloorMs ??= journal.forkRequestedAtMs;
     journal.forkRequestedAtMs = null;
     assertLeaseOwned();
     writeCodexOperationJournal(journalRoot, journal);

--- a/src/lib/flows/git.test.ts
+++ b/src/lib/flows/git.test.ts
@@ -21,28 +21,32 @@ function gitRepo(remote?: string): string {
   return dir;
 }
 
+function githubSshRemote(repo: string): string {
+  return `git${"@"}github.com:example/${repo}.git`;
+}
+
 afterEach(() => {
   resetRepositoryCache();
   for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 test("derives owner/repo from ssh and https origin remotes", () => {
-  expect(repositoryForProjectRoot(gitRepo("git@github.com:Latand/live-log-viewer-next.git"))).toBe("Latand/live-log-viewer-next");
-  expect(repositoryForProjectRoot(gitRepo("https://github.com/Latand/live-log-viewer-next.git"))).toBe("Latand/live-log-viewer-next");
+  expect(repositoryForProjectRoot(gitRepo(githubSshRemote("live-log-viewer-next")))).toBe("example/live-log-viewer-next");
+  expect(repositoryForProjectRoot(gitRepo("https://github.com/example/live-log-viewer-next.git"))).toBe("example/live-log-viewer-next");
   /* Non-GitHub remotes and remoteless repos degrade to null, not an error. */
   expect(repositoryForProjectRoot(gitRepo("https://gitlab.com/acme/tool.git"))).toBe(null);
   expect(repositoryForProjectRoot(gitRepo())).toBe(null);
 });
 
 test("caches per root inside the TTL and refreshes after it", () => {
-  const dir = gitRepo("git@github.com:Latand/first.git");
+  const dir = gitRepo(githubSshRemote("first"));
   const t0 = 1_000_000;
-  expect(repositoryForProjectRoot(dir, t0)).toBe("Latand/first");
+  expect(repositoryForProjectRoot(dir, t0)).toBe("example/first");
   /* The remote changes on disk; the cache still answers inside the TTL. */
-  expect(spawnSync("git", ["remote", "set-url", "origin", "git@github.com:Latand/second.git"], { cwd: dir }).status).toBe(0);
-  expect(repositoryForProjectRoot(dir, t0 + 60_000)).toBe("Latand/first");
+  expect(spawnSync("git", ["remote", "set-url", "origin", githubSshRemote("second")], { cwd: dir }).status).toBe(0);
+  expect(repositoryForProjectRoot(dir, t0 + 60_000)).toBe("example/first");
   /* Past the 10-minute TTL the probe runs again. */
-  expect(repositoryForProjectRoot(dir, t0 + 11 * 60_000)).toBe("Latand/second");
+  expect(repositoryForProjectRoot(dir, t0 + 11 * 60_000)).toBe("example/second");
 });
 
 test("a missing or non-git root yields null instead of blocking the response", () => {
@@ -50,4 +54,22 @@ test("a missing or non-git root yields null instead of blocking the response", (
   expect(repositoryForProjectRoot(path.join(plain, "does-not-exist"))).toBe(null);
   expect(repositoryForProjectRoot(plain)).toBe(null);
   expect(githubRepositoryFromRemote("not a url")).toBe(null);
+});
+
+test("reads the common repository config for a linked worktree", () => {
+  const common = tempDir();
+  const root = tempDir();
+  const worktreeGitDir = path.join(common, "worktrees", "linked");
+  fs.mkdirSync(worktreeGitDir, { recursive: true });
+  fs.writeFileSync(path.join(root, ".git"), `gitdir: ${worktreeGitDir}\n`);
+  fs.writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
+  fs.writeFileSync(path.join(common, "config"), [
+    "[core]",
+    "\trepositoryformatversion = 0",
+    "[remote \"origin\"]",
+    "\turl = https://github.com/example/linked.git",
+    "",
+  ].join("\n"));
+
+  expect(repositoryForProjectRoot(root)).toBe("example/linked");
 });

--- a/src/lib/flows/git.test.ts
+++ b/src/lib/flows/git.test.ts
@@ -73,3 +73,17 @@ test("reads the common repository config for a linked worktree", () => {
 
   expect(repositoryForProjectRoot(root)).toBe("example/linked");
 });
+
+test("matches Git when an origin URL has an unquoted trailing comment", () => {
+  for (const marker of ["#", ";"]) {
+    const root = tempDir();
+    const gitDir = path.join(root, ".git");
+    fs.mkdirSync(gitDir);
+    fs.writeFileSync(path.join(gitDir, "config"), [
+      "[remote \"origin\"]",
+      `\turl = https://github.com/example/commented.git ${marker} primary`,
+      "",
+    ].join("\n"));
+    expect(repositoryForProjectRoot(root)).toBe("example/commented");
+  }
+});

--- a/src/lib/flows/git.ts
+++ b/src/lib/flows/git.ts
@@ -95,7 +95,8 @@ function originRemoteFromConfig(root: string): string | null {
       continue;
     }
     if (!origin) continue;
-    const url = /^\s*url\s*=\s*(.*?)\s*$/i.exec(line)?.[1];
+    const value = /^\s*url\s*=\s*(.*?)\s*$/i.exec(line)?.[1];
+    const url = value?.replace(/\s+[;#].*$/, "").trim();
     if (url) return url;
   }
   return null;

--- a/src/lib/flows/git.ts
+++ b/src/lib/flows/git.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 
 import type { Flow } from "./types";
 
@@ -44,18 +46,71 @@ export function githubRepositoryFromRemote(remote: string): string | null {
 /* ── Project-root → GitHub repository (issue #290 readiness issue links) ── */
 
 const REPOSITORY_CACHE_TTL_MS = 10 * 60_000;
-const repositoryCache = new Map<string, { repository: string | null; at: number }>();
+const repositoryCacheHost = globalThis as typeof globalThis & {
+  __llvRepositoryCache?: Map<string, { repository: string | null; at: number }>;
+};
+const repositoryCache = repositoryCacheHost.__llvRepositoryCache ??= new Map<string, { repository: string | null; at: number }>();
 
-/** GitHub `owner/repo` of a project root's origin remote. Cached per root and
-    bounded by a 2 s git timeout, so a slow or missing repository degrades to
-    `null` (plain-text issue chips) without ever blocking the files response. */
+function gitDirectory(root: string): string | null {
+  const dotGit = path.join(root, ".git");
+  try {
+    const stat = fs.lstatSync(dotGit);
+    if (stat.isDirectory()) return dotGit;
+    if (!stat.isFile()) return null;
+    const pointer = fs.readFileSync(dotGit, "utf8").slice(0, 4096);
+    const match = /^gitdir:\s*(.+)\s*$/im.exec(pointer);
+    return match?.[1] ? path.resolve(root, match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function commonGitDirectory(directory: string): string {
+  try {
+    const common = fs.readFileSync(path.join(directory, "commondir"), "utf8").trim();
+    return common ? path.resolve(directory, common) : directory;
+  } catch {
+    return directory;
+  }
+}
+
+function originRemoteFromConfig(root: string): string | null {
+  const directory = gitDirectory(root);
+  if (!directory) return null;
+  let config: string;
+  try {
+    config = fs.readFileSync(path.join(commonGitDirectory(directory), "config"), "utf8");
+  } catch {
+    return null;
+  }
+  let origin = false;
+  for (const line of config.split(/\r?\n/)) {
+    const section = /^\s*\[\s*remote\s+"([^"]+)"\s*\]\s*$/i.exec(line);
+    if (section) {
+      origin = section[1] === "origin";
+      continue;
+    }
+    if (/^\s*\[/.test(line)) {
+      origin = false;
+      continue;
+    }
+    if (!origin) continue;
+    const url = /^\s*url\s*=\s*(.*?)\s*$/i.exec(line)?.[1];
+    if (url) return url;
+  }
+  return null;
+}
+
+/** GitHub `owner/repo` of a project root's origin remote. The files route calls
+    this for every catalog row, so it reads local Git metadata directly instead
+    of serially spawning one `git` process per project on the HTTP event loop. */
 export function repositoryForProjectRoot(root: string, nowMs = Date.now()): string | null {
   const cached = repositoryCache.get(root);
   if (cached && nowMs - cached.at < REPOSITORY_CACHE_TTL_MS) return cached.repository;
   let repository: string | null = null;
   try {
-    const remote = spawnSync("git", ["remote", "get-url", "origin"], { cwd: root, encoding: "utf8", timeout: 2_000 });
-    if (remote.status === 0) repository = githubRepositoryFromRemote(remote.stdout);
+    const remote = originRemoteFromConfig(root);
+    if (remote) repository = githubRepositoryFromRemote(remote);
   } catch {
     repository = null;
   }


### PR DESCRIPTION
Two independent live defects, one commit on top of `main`.

## 1. `/api/files` blocked the event loop on startup

`repositoryForProjectRoot` spawned a synchronous `git remote get-url origin` subprocess for **every** project root. With ~128 roots that cost 2.3–2.7 s per request (confirmed via `Server-Timing` on `files-project-catalog`), and a single slow remote probe could stall the runtime for over 30 s.

It now reads local Git metadata directly:
- parses `.git/config` instead of shelling out,
- resolves linked-worktree `gitdir:` pointers and `commondir`,
- keeps its cache on `globalThis` so it survives module reloads.

Unresolvable or unusual configurations still degrade to `null`, which renders plain-text issue chips exactly as before.

Live corpus benchmark: **cold 3.3 ms, warm 0 ms.**

## 2. Codex migration stuck on "fork outcome is awaiting recovery"

An uncertain fork outcome left the intent unable to advance. This adds an **explicit retry authorization** taken under the provider lease:

- only the operator retry route reaches it — automatic controller ticks cannot, so an app-server timeout can never become a fork loop;
- the recovery floor stays anchored to the **first** uncertain request, so a late artifact from any earlier attempt is still adopted;
- ambiguity keeps the newest validated fork and records every other validated fork as continuity, never discarding one.

While validating this, a second blocker surfaced: a large coordinator history produces an app-server JSONL envelope well past the old 1 MB transport cap. The default is raised to a bounded 64 MB and the cap is now a parameter, with the test threshold parameterized alongside it.

## Validation

- 54 targeted tests pass — `codexAppServer`, `provider`, retry route, git catalog
- targeted eslint pass
- production build pass
- privacy-publication gate pass
- `git diff --check` pass
