### PR TITLE
fix(wakatime): preserve operator engagement accounting

### DIFF
--- a/docs/design/wakatime-integration.md
+++ b/docs/design/wakatime-integration.md
@@ -138,6 +138,8 @@ scanner interface:
 ```ts
 interface RecentTurnWindows {
   windows: TurnBoundary[];
+  operatorActionsAtMs: number[];
+  unprovenancedUserActionsAtMs: number[];
   prefixTruncated: boolean;
   complete: boolean;
 }
@@ -150,6 +152,15 @@ every initiator-to-terminal window in the existing 128 KiB transcript tail,
 including the final open window. `lastTurnFromRecords()` returns the final item
 from that shared parser, preserving the UI contract and all issue #268/#406
 semantics.
+
+The parser also preserves direct operator action timestamps. Claude uses the
+shared user/system classification, including explicit human and typed
+provenance. Legacy bare Claude input is retained separately and becomes
+operator engagement only for a root conversation; delegated launch input keeps
+agent-only accounting. Codex accepts Viewer-structured user input and
+deduplicates its `message` plus `user_message` copies by timestamp. SDK, peer,
+coordinator, spawn, command, notification, and harness envelopes keep their
+agent semantics and never create operator engagement intervals.
 
 `prefixTruncated` comes from the tail read offset. A truncated prefix can omit
 old windows after a long outage or an unusually large turn. The sync module
@@ -172,7 +183,10 @@ up an entry after registry adoption or complete derivation.
 
 ## WakaTime field mapping
 
-One scanner turn becomes one stable heartbeat stream.
+Each scanner turn and each direct operator engagement interval becomes a stable
+heartbeat stream. Separate digest namespaces let overlapping agent and operator
+intervals retain independent durable boundaries while WakaTime unions them on
+the account timeline.
 
 | WakaTime field | value | rule |
 |---|---|---|
@@ -213,6 +227,20 @@ For each turn:
 effectiveStart = max(turn.startedAt, enabledAtMs)
 effectiveEnd   = turn.endedAt ?? now
 ```
+
+Each direct operator action contributes a conservative ten-minute engagement
+interval:
+
+```text
+engagementStart = max(action.at, enabledAtMs)
+engagementEnd   = action.at + 10 minutes
+```
+
+The scheduler emits only samples due at the current clock. Agent turn intervals
+and operator engagement intervals are unioned on the WakaTime timeline. Short
+turns retain the operator engagement tail, steering input receives its own
+interval, and agent execution continues through its full observed end,
+including silent tool calls and orchestrated work.
 
 The module materializes heartbeats at:
 
@@ -271,6 +299,13 @@ interface WakatimeStateV1 {
     endedAtMs: number | null;
     lastMaterializedAtMs: number;
     lastObservedAtMs: number;
+    boundaryFinalizedAtMs: number | null;
+  }>;
+  retiredStreams: Record<string, {
+    lastMaterializedAtMs: number;
+    lastObservedAtMs: number;
+    boundaryFinalizedAtMs: number | null;
+    expiresAtMs: number;
   }>;
   pending: Array<{
     key: string;
@@ -319,6 +354,12 @@ Bounds:
 - delivered closed-stream retention: 30 days;
 - bulk request size: 25;
 - bulk requests per tick: one.
+
+When the stream cap evicts a delivered stream, a compact 30-day retired
+watermark preserves its last materialized sample and finalized boundary.
+Rediscovery resumes after that watermark. Boundary finalization is durable, so
+a covering overlap disappearing from a later transcript tail cannot mint a
+stale boundary for an interval already settled.
 
 At the pending limit, compact each stream while preserving its first sample,
 exact final sample, newest sample, and interior samples no farther than ten

--- a/docs/wakatime.md
+++ b/docs/wakatime.md
@@ -36,21 +36,31 @@ restart.
 
 ## Activity mapping
 
-Each observed agent turn becomes a WakaTime `app` heartbeat stream:
+Each observed agent turn and direct operator engagement interval becomes a
+WakaTime `app` heartbeat stream:
 
 | WakaTime field | Value |
 | --- | --- |
 | Project | The Viewer's canonical project attribution, including parent-repository grouping for worktrees. |
-| Entity | An opaque, stable per-turn identifier such as `agent-log-viewer/codex/0123abcd…`. |
+| Entity | An opaque, stable per-interval identifier such as `agent-log-viewer/codex/0123abcd…`. |
 | Category | `ai coding`. |
 | Language | Omitted because transcript activity does not identify a source-file language. |
-| Time | Turn start, 120-second active samples, and an exact interval-boundary marker at the end. |
-| AI session | An opaque SHA-256 turn identifier. |
+| Time | Interval start, 120-second active samples, and an exact interval-boundary marker at the end. |
+| AI session | An opaque SHA-256 interval identifier. |
 
 Project names, engine names, opaque turn identifiers, the category, and
 timestamps leave the machine. Titles, prompts, responses, transcript paths,
 working directories, model names, account ids, source contents, and branch
 names stay local.
+
+A direct operator action contributes a ten-minute engagement interval sampled
+at the same 120-second cadence. Viewer-structured Codex input and Claude input
+classified as human are eligible. Legacy bare Claude input is eligible in root
+conversations; delegated launch input remains agent-only. Harness, spawn,
+command, notification, SDK, peer, and coordinator envelopes do not create
+operator intervals. These intervals union with agent turns on the same
+timeline. Short turns retain the engagement tail, while long and silent agent
+turns continue through their full observed execution.
 
 The first enabled start creates a forward-only boundary. Completed work from
 before that timestamp remains local. A turn that crosses the boundary begins
@@ -93,6 +103,10 @@ The outbox retains at most 10,000 events and 5,000 streams. During a long
 outage, the Viewer compacts interior samples to ten-minute spacing and can
 drop the oldest whole streams to stay within those bounds. Scanner requests,
 agent execution, and browser responses do not wait for WakaTime delivery.
+Compact retired watermarks keep delivered stream cursors for 30 days after a
+stream-cap eviction, preventing a visible transcript from replaying its
+already delivered history. Finalized boundary state also prevents later tail
+changes from creating delayed boundaries for settled overlaps.
 
 Blue-green releases coordinate through a process-shared scheduler lease in the
 common state directory. The live owner retains that fence through promotion,

--- a/src/lib/scanner/turnDuration.test.ts
+++ b/src/lib/scanner/turnDuration.test.ts
@@ -4,7 +4,12 @@ import os from "node:os";
 import path from "node:path";
 
 import type { FileEntry } from "../types";
-import { lastTurnFromRecords, recentTurnWindowsFor, recentTurnWindowsFromRecords } from "./turnDuration";
+import {
+  lastTurnFromRecords,
+  recentTurnActivityFromRecords,
+  recentTurnWindowsFor,
+  recentTurnWindowsFromRecords,
+} from "./turnDuration";
 
 const ms = (iso: string) => Date.parse(iso);
 
@@ -65,6 +70,34 @@ const codexToolOutput = (timestamp: string, id: string) => ({
 const codexTaskComplete = (timestamp: string) => ({ timestamp, payload: { type: "task_complete" } });
 
 describe("lastTurnFromRecords — Claude", () => {
+  test("preserves direct operator action times without treating relayed work as operator input", () => {
+    const result = recentTurnActivityFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000+03:00", "start"),
+        claudeAssistantOpen("2026-07-14T07:00:05.000Z"),
+        {
+          ...claudeUser("2026-07-14T07:03:00.000Z", "steer"),
+          promptSource: "typed",
+          origin: { kind: "human" },
+        },
+        {
+          ...claudeUser("2026-07-14T07:04:00.000Z", "relayed"),
+          isMeta: true,
+          origin: { kind: "coordinator" },
+        },
+        claudeAssistantEnd("2026-07-14T07:05:00.000Z"),
+      ],
+      false,
+    );
+
+    expect(result.operatorActionsAtMs).toEqual([ms("2026-07-14T07:03:00.000Z")]);
+    expect(result.unprovenancedUserActionsAtMs).toEqual([ms("2026-07-14T07:00:00.000Z")]);
+    expect(result.windows).toEqual([{
+      startedAt: ms("2026-07-14T07:00:00.000Z"),
+      endedAt: ms("2026-07-14T07:05:00.000Z"),
+    }]);
+  });
+
   test("enumerates every completed turn in chronological order", () => {
     const result = recentTurnWindowsFromRecords(
       [
@@ -420,6 +453,28 @@ describe("lastTurnFromRecords — Claude", () => {
 });
 
 describe("lastTurnFromRecords — Codex", () => {
+  test("deduplicates Viewer operator input and excludes unstructured harness prompts", () => {
+    const at = "2026-07-14T10:00:00.000Z";
+    const structured = "<!-- llv:structured-user -->\ncontinue";
+    const result = recentTurnActivityFromRecords(
+      [
+        {
+          type: "response_item",
+          timestamp: at,
+          payload: { type: "message", role: "user", content: [{ type: "input_text", text: structured }] },
+        },
+        codexUser(at, structured),
+        codexTaskStarted("2026-07-14T10:00:01.000Z"),
+        codexTaskComplete("2026-07-14T10:01:00.000Z"),
+        codexUser("2026-07-14T10:02:00.000Z", "# AGENTS.md instructions for a worker"),
+      ],
+      true,
+    );
+
+    expect(result.operatorActionsAtMs).toEqual([ms(at)]);
+    expect(result.unprovenancedUserActionsAtMs).toEqual([]);
+  });
+
   test("enumerates completed turns followed by the final open turn", () => {
     expect(recentTurnWindowsFromRecords(
       [
@@ -541,6 +596,8 @@ test("a truncated transcript prefix reports the gap and never fabricates a turn 
     expect(recentTurnWindowsFor(entry)).toEqual({
       prefixTruncated: true,
       complete: true,
+      operatorActionsAtMs: [],
+      unprovenancedUserActionsAtMs: [ms("2026-07-14T10:00:00.000Z")],
       windows: [{
         startedAt: ms("2026-07-14T10:00:00.000Z"),
         endedAt: ms("2026-07-14T10:01:00.000Z"),

--- a/src/lib/scanner/turnDuration.ts
+++ b/src/lib/scanner/turnDuration.ts
@@ -1,5 +1,6 @@
 import type { FileEntry, TurnBoundary } from "../types";
-import { isClaudeTurnWindowMeta } from "@/lib/claudeProtocolUser";
+import { isClaudeProtocolUser, isClaudeTurnWindowMeta } from "@/lib/claudeProtocolUser";
+import { decodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
 import { tailRecordsResult } from "./activity";
 import { globalCache } from "./caches";
 import { recordValue, recordsValue, stringValue } from "./json";
@@ -9,10 +10,12 @@ type RecordLike = Record<string, unknown>;
 // v5: meta/command user records no longer open windows (issue #406) — persisted
 // v4 boundaries could start before the real initiating prompt.
 const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v5");
-const recentTurnWindowsCache = globalCache<[number, number, RecentTurnWindows]>("recent-turn-windows-v1");
+const recentTurnWindowsCache = globalCache<[number, number, RecentTurnWindows]>("recent-turn-windows-v2");
 
 export interface RecentTurnWindows {
   windows: TurnBoundary[];
+  operatorActionsAtMs?: number[];
+  unprovenancedUserActionsAtMs?: number[];
   prefixTruncated: boolean;
   complete: boolean;
 }
@@ -154,6 +157,51 @@ export function recentTurnWindowsFromRecords(records: RecordLike[], codex: boole
   return windows;
 }
 
+/** Direct operator actions are preserved independently from turn windows.
+    A short agent turn can end before the operator's engagement window, and a
+    steering action can occur inside an already-open turn. Codex Viewer input
+    carries the structured-user marker; Claude uses the feed's user/system
+    classification so SDK, peer, coordinator, and automation envelopes remain
+    agent activity without being reclassified as operator input. */
+export function recentTurnActivityFromRecords(
+  records: RecordLike[],
+  codex: boolean,
+): Pick<RecentTurnWindows, "windows" | "operatorActionsAtMs" | "unprovenancedUserActionsAtMs"> {
+  const operatorActions = new Set<number>();
+  const unprovenancedUserActions = new Set<number>();
+  for (const record of records) {
+    const atMs = parseMillis(record.timestamp);
+    if (atMs === null) continue;
+    if (codex) {
+      const payload = recordValue(record.payload) ?? {};
+      let text = "";
+      if (stringValue(payload.type) === "user_message") {
+        text = stringValue(payload.message) ?? "";
+      } else if (stringValue(payload.type) === "message" && payload.role === "user") {
+        text = recordsValue(payload.content)
+          .map((part) => stringValue(part.text) ?? stringValue(part.input_text) ?? "")
+          .join("\n");
+      }
+      if (text && decodeCodexStructuredUserText(text).structured) operatorActions.add(atMs);
+      continue;
+    }
+    if (!isTurnStart(record, false)) continue;
+    const originKind = typeof record.origin === "string"
+      ? record.origin
+      : stringValue(recordValue(record.origin)?.kind);
+    if (originKind === "human" || record.promptSource === "typed") {
+      operatorActions.add(atMs);
+    } else if (!isClaudeProtocolUser(record)) {
+      unprovenancedUserActions.add(atMs);
+    }
+  }
+  return {
+    windows: recentTurnWindowsFromRecords(records, codex),
+    operatorActionsAtMs: [...operatorActions].sort((left, right) => left - right),
+    unprovenancedUserActionsAtMs: [...unprovenancedUserActions].sort((left, right) => left - right),
+  };
+}
+
 export function lastTurnFromRecords(records: RecordLike[], codex: boolean): TurnBoundary | null {
   return recentTurnWindowsFromRecords(records, codex).at(-1) ?? null;
 }
@@ -168,8 +216,9 @@ export function recentTurnWindowsFor(entry: FileEntry): RecentTurnWindows {
   const cached = recentTurnWindowsCache.get(entry.path);
   if (cached?.[0] === entry.size && cached[1] === mtimeMs) return structuredClone(cached[2]);
   const tail = tailRecordsResult(entry.path, entry.size, mtimeMs);
+  const activity = recentTurnActivityFromRecords(tail.records, entry.root === "codex-sessions");
   const result: RecentTurnWindows = {
-    windows: recentTurnWindowsFromRecords(tail.records, entry.root === "codex-sessions"),
+    ...activity,
     prefixTruncated: tail.prefixTruncated,
     complete: tail.complete,
   };

--- a/src/lib/wakatime/sync.test.ts
+++ b/src/lib/wakatime/sync.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import type { RegistryFile } from "@/lib/agent/registry";
+import { recentTurnActivityFromRecords } from "@/lib/scanner/turnDuration";
 import type { FileEntry } from "@/lib/types";
 import {
   createWakatimeSync,
@@ -563,6 +564,44 @@ describe("WakaTime activity sync", () => {
     sync.stop();
   });
 
+  test("legacy root input gets engagement while delegated launch input remains agent-only", async () => {
+    const durationAtDepth = async (delegationDepth: number) => {
+      const snapshot = registrySnapshot();
+      snapshot.conversations.conversation_test!.delegationDepth = delegationDepth;
+      const initialState: WakatimeStateV1 = {
+        version: 1,
+        enabledAtMs: NOW - 1,
+        credentialGeneration: null,
+        streams: {},
+        pending: [],
+        retry: { failures: 0, retryAtMs: 0, reason: null },
+        counters: { accepted: 0, permanentlyRejected: 0, compacted: 0, dropped: 0, historyGaps: 0 },
+      };
+      const fixture = harness({
+        now: () => NOW + 15 * 60_000,
+        readState: async () => initialState,
+        registrySnapshot: () => snapshot,
+        recentTurnWindows: () => ({
+          windows: [{ startedAt: NOW, endedAt: NOW + 30_000 }],
+          operatorActionsAtMs: [],
+          unprovenancedUserActionsAtMs: [NOW],
+          prefixTruncated: false,
+          complete: true,
+        }),
+      });
+      await fixture.sync.tick();
+      const duration = projectDurationSeconds(
+        fixture.state()!.pending.map((event) => event.heartbeat),
+        "-repo",
+      );
+      fixture.sync.stop();
+      return duration;
+    };
+
+    expect(await durationAtDepth(0)).toBe(10 * 60);
+    expect(await durationAtDepth(1)).toBe(30);
+  });
+
   test("overlapping same-project turns contribute their wall-clock union", async () => {
     const { sync, state } = harness({
       recentTurnWindows: () => ({
@@ -581,6 +620,145 @@ describe("WakaTime activity sync", () => {
     expect(projectDurationSeconds(heartbeats, "-repo")).toBe(90);
     expect(heartbeats.filter((heartbeat) => heartbeat.project === "agent-log-viewer-boundary")).toHaveLength(1);
     sync.stop();
+  });
+
+  test("an overlap-finalized stream never mints a stale boundary when the covering tail disappears", async () => {
+    let windows = [
+      { startedAt: NOW, endedAt: NOW + 60_000 },
+      { startedAt: NOW + 30_000, endedAt: NOW + 90_000 },
+    ];
+    const { sync, state } = harness({
+      recentTurnWindows: () => ({ windows, prefixTruncated: false, complete: true }),
+    });
+
+    await sync.tick();
+    windows = [windows[0]!];
+    await sync.tick();
+
+    expect(state()?.pending.filter((event) =>
+      event.kind === "boundary" && event.heartbeat.time === (NOW + 60_000) / 1_000
+    )).toHaveLength(0);
+    sync.stop();
+  });
+
+  test("operator engagement ending on a live tick never cuts off a continuing silent agent", async () => {
+    let clock = NOW;
+    const { sync, state } = harness({
+      now: () => clock,
+      scan: async () => ({
+        complete: true,
+        files: [entry({
+          proc: "running",
+          pid: 42,
+          activity: "recent",
+          activityReason: "jsonl_turn_active",
+          mtime: clock / 1_000,
+        })],
+      }),
+      recentTurnWindows: () => ({
+        windows: [{ startedAt: NOW, endedAt: null }],
+        operatorActionsAtMs: [NOW],
+        prefixTruncated: false,
+        complete: true,
+      }),
+    });
+
+    await sync.tick();
+    clock += 10 * 60_000;
+    await sync.tick();
+
+    expect(state()?.pending.filter((event) =>
+      event.kind === "boundary" && event.heartbeat.time === clock / 1_000
+    )).toHaveLength(0);
+    expect(state()?.pending.some((event) =>
+      event.kind === "activity" && event.heartbeat.time === clock / 1_000
+    )).toBe(true);
+    sync.stop();
+  });
+
+  test("production-shaped replay preserves operator engagement, agent overlap, idle gaps, resume, and retry", async () => {
+    const secondPath = "/sessions/overlap.jsonl";
+    const snapshot = registrySnapshot();
+    snapshot.conversations.conversation_overlap = structuredClone(snapshot.conversations.conversation_test!);
+    snapshot.conversations.conversation_overlap!.id = "conversation_overlap";
+    snapshot.conversations.conversation_overlap!.generations[0]!.path = secondPath;
+    const structuredUser = (timestamp: number, text: string) => ({
+      timestamp: new Date(timestamp).toISOString(),
+      payload: { type: "user_message", message: `<!-- llv:structured-user -->\n${text}` },
+    });
+    const primaryActivity = recentTurnActivityFromRecords(
+      [
+        structuredUser(NOW, "start"),
+        { timestamp: new Date(NOW + 1_000).toISOString(), payload: { type: "task_started" } },
+        { timestamp: new Date(NOW + 60_000).toISOString(), payload: { type: "turn_aborted" } },
+        structuredUser(NOW + 25 * 60_000, "resume"),
+        { timestamp: new Date(NOW + 25 * 60_000 + 1_000).toISOString(), payload: { type: "task_started" } },
+        { timestamp: new Date(NOW + 26 * 60_000).toISOString(), payload: { type: "task_complete" } },
+      ],
+      true,
+    );
+    let clock = NOW + 40 * 60_000;
+    const initialState: WakatimeStateV1 = {
+      version: 1,
+      enabledAtMs: NOW - 1,
+      credentialGeneration: null,
+      streams: {},
+      pending: [],
+      retry: { failures: 0, retryAtMs: 0, reason: null },
+      counters: { accepted: 0, permanentlyRejected: 0, compacted: 0, dropped: 0, historyGaps: 0 },
+    };
+    const attempted: WakatimeStateV1["pending"][number]["heartbeat"][][] = [];
+    const accepted: WakatimeStateV1["pending"][number]["heartbeat"][] = [];
+    const fixture = harness({
+      now: () => clock,
+      readState: async () => initialState,
+      readCredential: async () => ({ value: TEST_CREDENTIAL, sourceStamp: "fixture" }),
+      scan: async () => ({
+        complete: true,
+        files: [
+          entry({ mtime: (NOW + 26 * 60_000) / 1_000 }),
+          entry({ path: secondPath, name: "overlap.jsonl", mtime: (NOW + 15 * 60_000) / 1_000 }),
+        ],
+      }),
+      registrySnapshot: () => snapshot,
+      recentTurnWindows: (candidate) => candidate.path === PATH
+        ? { ...primaryActivity, prefixTruncated: false, complete: true }
+        : {
+            windows: [{ startedAt: NOW + 2 * 60_000, endedAt: NOW + 15 * 60_000 }],
+            operatorActionsAtMs: [],
+            prefixTruncated: false,
+            complete: true,
+          },
+      fetch: async (_url, init) => {
+        const body = JSON.parse(String(init.body)) as WakatimeStateV1["pending"][number]["heartbeat"][];
+        attempted.push(body);
+        if (attempted.length === 1) {
+          return { status: 500, headers: new Headers(), text: async () => "" };
+        }
+        accepted.push(...body);
+        return {
+          status: 201,
+          headers: new Headers(),
+          text: async () => JSON.stringify({
+            responses: body.map((_, index) => [{ data: { id: `accepted-${index}` } }, 201]),
+          }),
+        };
+      },
+    });
+
+    await fixture.sync.tick();
+    clock += 30_000;
+    await fixture.sync.tick();
+    await fixture.sync.tick();
+
+    expect(attempted).toHaveLength(2);
+    expect(attempted[1]).toEqual(attempted[0]);
+    expect(projectDurationSeconds(accepted, "-repo")).toBe(25 * 60);
+    expect(accepted.some((heartbeat) =>
+      heartbeat.project === "-repo" && heartbeat.time === (NOW + 12 * 60_000) / 1_000
+    )).toBe(true);
+    expect(fixture.state()?.pending).toHaveLength(0);
+    fixture.sync.stop();
   });
 
   test("an archived generation cannot create a second heartbeat stream", async () => {
@@ -1026,6 +1204,79 @@ describe("WakaTime activity sync", () => {
     expect(state()?.pending).toHaveLength(4);
     expect(state()?.counters.dropped).toBe(2);
     sync.stop();
+  });
+
+  test("max-stream eviction preserves the delivered watermark when an open stream resumes", async () => {
+    let clock = NOW + 10 * 60_000;
+    let active = true;
+    let windows = [
+      { startedAt: NOW, endedAt: null },
+      { startedAt: NOW + 9 * 60_000, endedAt: NOW + 10 * 60_000 },
+    ];
+    const openWindow = windows[0]!;
+    const scan = async () => ({
+      files: [entry({
+        activity: active ? "recent" : "idle",
+        activityReason: active ? "jsonl_turn_active" : "pane_at_composer",
+        proc: active ? "running" : "done",
+        pid: active ? 42 : null,
+        mtime: (active ? clock : NOW + 10 * 60_000) / 1_000,
+      })],
+      complete: true,
+    });
+    const first = harness({
+      now: () => clock,
+      limits: { maxStreams: 2 },
+      scan,
+      recentTurnWindows: () => ({ windows, prefixTruncated: false, complete: true }),
+      readCredential: async () => ({ value: TEST_CREDENTIAL, sourceStamp: "fixture" }),
+      readState: async () => ({
+        version: 1,
+        enabledAtMs: NOW - 1,
+        credentialGeneration: null,
+        streams: {},
+        pending: [],
+        retry: { failures: 0, retryAtMs: 0, reason: null },
+        counters: { accepted: 0, permanentlyRejected: 0, compacted: 0, dropped: 0, historyGaps: 0 },
+      } satisfies WakatimeStateV1),
+    });
+    await first.sync.tick();
+    const persisted = structuredClone(first.state());
+    first.sync.stop();
+
+    active = false;
+    clock += 60_000;
+    const resumedBodies: WakatimeStateV1["pending"][number]["heartbeat"][][] = [];
+    const resumed = harness({
+      now: () => clock,
+      limits: { maxStreams: 1 },
+      scan,
+      recentTurnWindows: () => ({ windows, prefixTruncated: false, complete: true }),
+      readCredential: async () => ({ value: TEST_CREDENTIAL, sourceStamp: "fixture" }),
+      readState: async () => persisted,
+      fetch: async (_url, init) => {
+        const body = JSON.parse(String(init.body)) as WakatimeStateV1["pending"][number]["heartbeat"][];
+        resumedBodies.push(body);
+        return {
+          status: 201,
+          headers: new Headers(),
+          text: async () => JSON.stringify({
+            responses: body.map((_, index) => [{ data: { id: `accepted-${index}` } }, 201]),
+          }),
+        };
+      },
+    });
+    windows = [windows[1]!];
+    await resumed.sync.tick();
+
+    active = true;
+    windows = [openWindow];
+    clock += 60_000;
+    await resumed.sync.tick();
+
+    expect(resumedBodies).toHaveLength(1);
+    expect(resumedBodies.at(-1)?.map((heartbeat) => heartbeat.time)).toEqual([clock / 1_000]);
+    resumed.sync.stop();
   });
 
   test("a pruned delivered stream cannot be rediscovered from an old transcript tail", async () => {

--- a/src/lib/wakatime/sync.test.ts
+++ b/src/lib/wakatime/sync.test.ts
@@ -602,6 +602,45 @@ describe("WakaTime activity sync", () => {
     expect(await durationAtDepth(1)).toBe(30);
   });
 
+  test("structured engagement requires root provenance while delegated agent seconds stay unchanged", async () => {
+    const durationAtDepth = async (delegationDepth: number, operatorActionsAtMs: number[]) => {
+      const snapshot = registrySnapshot();
+      snapshot.conversations.conversation_test!.delegationDepth = delegationDepth;
+      const fixture = harness({
+        now: () => NOW + 15 * 60_000,
+        readState: async () => ({
+          version: 1,
+          enabledAtMs: NOW - 1,
+          credentialGeneration: null,
+          streams: {},
+          pending: [],
+          retry: { failures: 0, retryAtMs: 0, reason: null },
+          counters: { accepted: 0, permanentlyRejected: 0, compacted: 0, dropped: 0, historyGaps: 0 },
+        }),
+        registrySnapshot: () => snapshot,
+        recentTurnWindows: () => ({
+          windows: [{ startedAt: NOW, endedAt: NOW + 30_000 }],
+          operatorActionsAtMs,
+          unprovenancedUserActionsAtMs: [],
+          prefixTruncated: false,
+          complete: true,
+        }),
+      });
+      await fixture.sync.tick();
+      const duration = projectDurationSeconds(
+        fixture.state()!.pending.map((event) => event.heartbeat),
+        "-repo",
+      );
+      fixture.sync.stop();
+      return duration;
+    };
+
+    const agentOnlySeconds = await durationAtDepth(1, []);
+    expect(agentOnlySeconds).toBe(30);
+    expect(await durationAtDepth(1, [NOW])).toBe(agentOnlySeconds);
+    expect(await durationAtDepth(0, [NOW])).toBe(10 * 60);
+  });
+
   test("overlapping same-project turns contribute their wall-clock union", async () => {
     const { sync, state } = harness({
       recentTurnWindows: () => ({
@@ -643,8 +682,11 @@ describe("WakaTime activity sync", () => {
 
   test("operator engagement ending on a live tick never cuts off a continuing silent agent", async () => {
     let clock = NOW;
+    const snapshot = registrySnapshot();
+    snapshot.conversations.conversation_test!.delegationDepth = 0;
     const { sync, state } = harness({
       now: () => clock,
+      registrySnapshot: () => snapshot,
       scan: async () => ({
         complete: true,
         files: [entry({
@@ -679,6 +721,7 @@ describe("WakaTime activity sync", () => {
   test("production-shaped replay preserves operator engagement, agent overlap, idle gaps, resume, and retry", async () => {
     const secondPath = "/sessions/overlap.jsonl";
     const snapshot = registrySnapshot();
+    snapshot.conversations.conversation_test!.delegationDepth = 0;
     snapshot.conversations.conversation_overlap = structuredClone(snapshot.conversations.conversation_test!);
     snapshot.conversations.conversation_overlap!.id = "conversation_overlap";
     snapshot.conversations.conversation_overlap!.generations[0]!.path = secondPath;

--- a/src/lib/wakatime/sync.ts
+++ b/src/lib/wakatime/sync.ts
@@ -16,6 +16,7 @@ const SAMPLE_INTERVAL_MS = 120_000;
 const TICK_INTERVAL_MS = 60_000;
 const REQUEST_TIMEOUT_MS = 5_000;
 const MAX_BATCH = 25;
+const OPERATOR_ENGAGEMENT_MS = 10 * 60_000;
 const DEFAULT_MAX_PENDING = 10_000;
 const DEFAULT_MAX_STREAMS = 5_000;
 const CLOSED_STREAM_RETENTION_MS = 30 * 24 * 60 * 60_000;
@@ -48,6 +49,13 @@ export interface WakatimeStateV1 {
     endedAtMs: number | null;
     lastMaterializedAtMs: number;
     lastObservedAtMs: number;
+    boundaryFinalizedAtMs?: number | null;
+  }>;
+  retiredStreams?: Record<string, {
+    lastMaterializedAtMs: number;
+    lastObservedAtMs: number;
+    boundaryFinalizedAtMs: number | null;
+    expiresAtMs: number;
   }>;
   pending: Array<{
     key: string;
@@ -116,6 +124,10 @@ function turnDigest(conversationId: string, startedAtMs: number): string {
   return digest("llv-wakatime-v1", conversationId, startedAtMs);
 }
 
+function operatorDigest(conversationId: string, actionAtMs: number): string {
+  return digest("llv-wakatime-operator-v1", conversationId, actionAtMs);
+}
+
 function eventKey(stream: string, sampleTimeMs: number, kind: "activity" | "boundary" = "activity"): string {
   return digest(kind === "activity" ? "llv-wakatime-heartbeat-v1" : "llv-wakatime-boundary-v1", stream, sampleTimeMs);
 }
@@ -126,6 +138,7 @@ function freshState(now: number): WakatimeStateV1 {
     enabledAtMs: now,
     credentialGeneration: null,
     streams: {},
+    retiredStreams: {},
     pending: [],
     retry: { failures: 0, retryAtMs: 0, reason: null },
     counters: { accepted: 0, permanentlyRejected: 0, compacted: 0, dropped: 0, historyGaps: 0 },
@@ -179,6 +192,9 @@ function stateFrom(value: unknown): WakatimeStateV1 | null {
       || !(candidate.endedAtMs === null || finite(candidate.endedAtMs))
       || !finite(candidate.lastMaterializedAtMs)
       || !finite(candidate.lastObservedAtMs)
+      || !(candidate.boundaryFinalizedAtMs === undefined
+        || candidate.boundaryFinalizedAtMs === null
+        || finite(candidate.boundaryFinalizedAtMs))
       || (candidate.endedAtMs !== null && candidate.endedAtMs <= candidate.startedAtMs)
       || candidate.lastMaterializedAtMs < candidate.startedAtMs - 1) return null;
     streams[key] = {
@@ -189,6 +205,23 @@ function stateFrom(value: unknown): WakatimeStateV1 | null {
       endedAtMs: candidate.endedAtMs,
       lastMaterializedAtMs: candidate.lastMaterializedAtMs,
       lastObservedAtMs: candidate.lastObservedAtMs,
+      boundaryFinalizedAtMs: candidate.boundaryFinalizedAtMs ?? null,
+    };
+  }
+  const retiredStreams: NonNullable<WakatimeStateV1["retiredStreams"]> = {};
+  const rawRetiredStreams = value.retiredStreams ?? {};
+  if (!record(rawRetiredStreams)) return null;
+  for (const [key, candidate] of Object.entries(rawRetiredStreams)) {
+    if (!/^[a-f0-9]{64}$/.test(key) || !record(candidate)
+      || !finite(candidate.lastMaterializedAtMs)
+      || !finite(candidate.lastObservedAtMs)
+      || !(candidate.boundaryFinalizedAtMs === null || finite(candidate.boundaryFinalizedAtMs))
+      || !finite(candidate.expiresAtMs)) return null;
+    retiredStreams[key] = {
+      lastMaterializedAtMs: candidate.lastMaterializedAtMs,
+      lastObservedAtMs: candidate.lastObservedAtMs,
+      boundaryFinalizedAtMs: candidate.boundaryFinalizedAtMs,
+      expiresAtMs: candidate.expiresAtMs,
     };
   }
   const pending: WakatimeStateV1["pending"] = [];
@@ -234,6 +267,7 @@ function stateFrom(value: unknown): WakatimeStateV1 | null {
       dropped: counters.dropped,
       historyGaps: counters.historyGaps,
     },
+    retiredStreams,
   };
 }
 
@@ -258,7 +292,7 @@ function sampleTimes(start: number, end: number, closed: boolean, last: number |
 function addWindow(
   state: WakatimeStateV1,
   entry: FileEntry,
-  conversationId: string,
+  streamKey: string,
   project: string,
   window: TurnBoundary,
   now: number,
@@ -270,31 +304,37 @@ function addWindow(
   if (window.endedAt !== null && window.endedAt <= state.enabledAtMs) return;
   if (window.endedAt !== null && window.endedAt < now - CLOSED_STREAM_RETENTION_MS) return;
   const start = Math.max(window.startedAt, state.enabledAtMs);
-  const streamKey = turnDigest(conversationId, window.startedAt);
   const existing = state.streams[streamKey];
-  if (window.endedAt === null && !openWindowActive && !existing && entry.mtime * 1_000 <= state.enabledAtMs) return;
+  const retired = state.retiredStreams?.[streamKey];
+  if (window.endedAt === null && !openWindowActive && !existing && !retired && entry.mtime * 1_000 <= state.enabledAtMs) return;
   const lastProvenActivityAt = Math.min(now, Math.max(
     start,
     entry.mtime * 1_000,
-    existing?.lastObservedAtMs ?? start,
+    existing?.lastObservedAtMs ?? retired?.lastObservedAtMs ?? start,
   ));
   const end = window.endedAt ?? (openWindowActive ? now : lastProvenActivityAt);
   if (end < start) return;
+  if (!existing && retired
+    && end <= retired.lastMaterializedAtMs
+    && retired.boundaryFinalizedAtMs === end) return;
   const stream = existing ?? {
     entity: `agent-log-viewer/${entry.engine}/${streamKey.slice(0, 16)}`,
     engine: entry.engine as "claude" | "codex",
     project,
     startedAtMs: window.startedAt,
     endedAtMs: window.endedAt,
-    lastMaterializedAtMs: start - 1,
-    lastObservedAtMs: now,
+    lastMaterializedAtMs: Math.max(start - 1, retired?.lastMaterializedAtMs ?? start - 1),
+    lastObservedAtMs: retired?.lastObservedAtMs ?? now,
+    boundaryFinalizedAtMs: retired?.boundaryFinalizedAtMs ?? null,
   };
+  if (retired) delete state.retiredStreams?.[streamKey];
   stream.endedAtMs = window.endedAt;
   stream.lastObservedAtMs = window.endedAt ?? (openWindowActive ? now : lastProvenActivityAt);
   state.streams[streamKey] = stream;
   const last = stream.lastMaterializedAtMs < start ? null : stream.lastMaterializedAtMs;
   const closesObservedInterval = window.endedAt !== null || !openWindowActive;
-  for (const sampleTimeMs of sampleTimes(start, end, closesObservedInterval, last)) {
+  const boundaryAlreadyFinalized = stream.boundaryFinalizedAtMs === end;
+  for (const sampleTimeMs of sampleTimes(start, end, closesObservedInterval && !boundaryAlreadyFinalized, last)) {
     const kind = closesObservedInterval && sampleTimeMs === end && emitEndBoundary ? "boundary" : "activity";
     const key = eventKey(streamKey, sampleTimeMs, kind);
     if (existingKeys.has(key)) continue;
@@ -315,6 +355,7 @@ function addWindow(
     existingKeys.add(key);
   }
   stream.lastMaterializedAtMs = Math.max(stream.lastMaterializedAtMs, end);
+  if (closesObservedInterval) stream.boundaryFinalizedAtMs = end;
 }
 
 function openTurnIsActive(entry: FileEntry): boolean {
@@ -364,6 +405,10 @@ function compactPending(state: WakatimeStateV1): number {
 }
 
 function enforceBounds(state: WakatimeStateV1, now: number, maxPending: number, maxStreams: number): void {
+  state.retiredStreams ??= {};
+  for (const [key, retired] of Object.entries(state.retiredStreams)) {
+    if (retired.expiresAtMs < now) delete state.retiredStreams[key];
+  }
   const pendingStreams = new Set(state.pending.map((event) => event.stream));
   for (const [key, stream] of Object.entries(state.streams)) {
     if (stream.endedAtMs !== null && stream.endedAtMs < now - CLOSED_STREAM_RETENTION_MS && !pendingStreams.has(key)) {
@@ -383,12 +428,24 @@ function enforceBounds(state: WakatimeStateV1, now: number, maxPending: number, 
     delete state.streams[oldest];
     state.counters.dropped += before - state.pending.length;
   }
-  const orderedStreams = Object.entries(state.streams).sort((a, b) => a[1].lastObservedAtMs - b[1].lastObservedAtMs);
+  const orderedStreams = Object.entries(state.streams).sort((a, b) => {
+    const pendingDifference = Number(pendingStreams.has(a[0])) - Number(pendingStreams.has(b[0]));
+    return pendingDifference || a[1].lastObservedAtMs - b[1].lastObservedAtMs;
+  });
   while (orderedStreams.length > maxStreams) {
     const [key] = orderedStreams.shift()!;
+    const stream = state.streams[key]!;
     const before = state.pending.length;
     state.pending = state.pending.filter((event) => event.stream !== key);
     state.counters.dropped += before - state.pending.length;
+    if (before === state.pending.length) {
+      state.retiredStreams[key] = {
+        lastMaterializedAtMs: stream.lastMaterializedAtMs,
+        lastObservedAtMs: stream.lastObservedAtMs,
+        boundaryFinalizedAtMs: stream.boundaryFinalizedAtMs ?? null,
+        expiresAtMs: Math.max(now, stream.endedAtMs ?? stream.lastObservedAtMs) + CLOSED_STREAM_RETENTION_MS,
+      };
+    }
     delete state.streams[key];
   }
 }
@@ -501,7 +558,7 @@ export function createWakatimeSync(deps: WakatimeSyncDependencies): WakatimeSync
     const existingKeys = new Set(current.pending.map((event) => event.key));
     const observations: Array<{
       entry: FileEntry;
-      conversationId: string;
+      streamKey: string;
       project: string;
       window: TurnBoundary;
       openWindowActive: boolean;
@@ -528,32 +585,57 @@ export function createWakatimeSync(deps: WakatimeSyncDependencies): WakatimeSync
       }).project;
       if (!project) continue;
       const openWindowActive = openTurnIsActive(entry);
-      for (const window of recent.windows) observations.push({ entry, conversationId: conversation.id, project, window, openWindowActive });
+      for (const window of recent.windows) {
+        observations.push({
+          entry,
+          streamKey: turnDigest(conversation.id, window.startedAt),
+          project,
+          window,
+          openWindowActive,
+        });
+      }
+      const actionTimes = new Set(recent.operatorActionsAtMs ?? []);
+      if ((conversation.delegationDepth ?? 0) === 0) {
+        for (const actionAtMs of recent.unprovenancedUserActionsAtMs ?? []) actionTimes.add(actionAtMs);
+      }
+      for (const actionAtMs of actionTimes) {
+        if (!finite(actionAtMs) || actionAtMs <= 0) continue;
+        const engagementEndMs = actionAtMs + OPERATOR_ENGAGEMENT_MS;
+        const engagementActive = engagementEndMs > now;
+        observations.push({
+          entry,
+          streamKey: operatorDigest(conversation.id, actionAtMs),
+          project,
+          window: { startedAt: actionAtMs, endedAt: engagementActive ? null : engagementEndMs },
+          openWindowActive: engagementActive,
+        });
+      }
     }
     const effectiveEnd = (observation: typeof observations[number]): number => {
       if (observation.window.endedAt !== null) return observation.window.endedAt;
       if (observation.openWindowActive) return now;
-      const key = turnDigest(observation.conversationId, observation.window.startedAt);
       return Math.min(now, Math.max(
         observation.window.startedAt,
         observation.entry.mtime * 1_000,
-        current.streams[key]?.lastObservedAtMs ?? observation.window.startedAt,
+        current.streams[observation.streamKey]?.lastObservedAtMs ?? observation.window.startedAt,
       ));
     };
     for (let index = 0; index < observations.length; index += 1) {
       const observation = observations[index]!;
       const end = effectiveEnd(observation);
       const closesObservedInterval = observation.window.endedAt !== null || !observation.openWindowActive;
-      const coveredBySameProject = closesObservedInterval && observations.some((candidate, candidateIndex) =>
-        candidateIndex !== index
-        && candidate.project === observation.project
-        && candidate.window.startedAt <= end
-        && effectiveEnd(candidate) > end,
-      );
+      const coveredBySameProject = closesObservedInterval && observations.some((candidate, candidateIndex) => {
+        const candidateEnd = effectiveEnd(candidate);
+        return candidateIndex !== index
+          && candidate.project === observation.project
+          && candidate.window.startedAt <= end
+          && (candidateEnd > end
+            || (candidateEnd === end && candidate.window.endedAt === null && candidate.openWindowActive));
+      });
       addWindow(
         current,
         observation.entry,
-        observation.conversationId,
+        observation.streamKey,
         observation.project,
         observation.window,
         now,

--- a/src/lib/wakatime/sync.ts
+++ b/src/lib/wakatime/sync.ts
@@ -594,8 +594,9 @@ export function createWakatimeSync(deps: WakatimeSyncDependencies): WakatimeSync
           openWindowActive,
         });
       }
-      const actionTimes = new Set(recent.operatorActionsAtMs ?? []);
-      if ((conversation.delegationDepth ?? 0) === 0) {
+      const actionTimes = new Set<number>();
+      if (conversation.delegationDepth === 0) {
+        for (const actionAtMs of recent.operatorActionsAtMs ?? []) actionTimes.add(actionAtMs);
         for (const actionAtMs of recent.unprovenancedUserActionsAtMs ?? []) actionTimes.add(actionAtMs);
       }
       for (const actionAtMs of actionTimes) {


### PR DESCRIPTION
## Summary

Refs #763 Phase 0.

The confirmed defect direction is **under-send**. The transcript parser preserved turn start/end windows while discarding direct operator action timestamps. A short turn therefore ended the emitted interval before the conservative operator engagement window, and steering input inside an open turn created no independent engagement interval.

This change:

- preserves deduplicated direct operator timestamps beside turn windows;
- emits a ten-minute engagement interval at the existing 120-second cadence;
- unions engagement with the full agent timeline, including silent tool execution and orchestrated work;
- keeps legacy bare input eligible only in root conversations, while delegated launch and harness envelopes retain agent-only accounting;
- persists finalized boundaries so later tail changes cannot mint stale boundaries;
- preserves delivered watermarks across stream-cap eviction.

Payload shape, field values, endpoint, credential handling, batch size, tick cadence, and the forward-only enable boundary remain unchanged.

## Accounting evidence

- Accepted records are retained only as an aggregate counter; acknowledged rows are removed, so historical per-stream/per-day acceptance cannot be reconstructed from local state.
- Historical permanent rejections are also count-only and remain unclassifiable by event kind after removal.
- The 120-second cadence is complete inside materialized intervals.
- Retry keys remain stable; a failed batch replays the same entity/time set.
- Same-project overlap remains a wall-clock union.
- Timestamp parsing remains UTC milliseconds internally and fractional Unix seconds at the heartbeat boundary.
- historyGaps is diagnostic, while a truncated transcript prefix still represents a recovery risk when an observation was missed.

## Verification

- bun test src/lib/scanner/turnDuration.test.ts src/lib/wakatime/sync.test.ts — 87 pass
- bun x tsc --noEmit — pass
- changed-file ESLint — pass
- privacy publication gate with commit checking — pass
- bun run build — exit 0

The production-shaped replay covers idle gaps, overlapping agents, interrupted and resumed turns, and retry after a failed batch. A mutation archive with operator extraction disabled changes the synthetic replay from the expected 25-minute union to 15 minutes and fails the test. Separate mutations make the stale-boundary and eviction-watermark regressions fail.

No deployment is included. Dashboard validation after an authorized deployment remains the hosted acceptance gate.
