### PR TITLE
fix(orchestrator): default maximum workers to three

### DIFF
--- a/src/components/DraftAgentPane.tsx
+++ b/src/components/DraftAgentPane.tsx
@@ -13,6 +13,7 @@ import { codexModelSupportsImages, defaultModelFor } from "@/lib/agent/models";
 import { useLocale } from "@/lib/i18n";
 import { requestFilesRefresh } from "@/lib/filesEvents";
 import { BUILDER_APPLY_FIXES_CONFIG, BUILDER_FRONTEND_CONFIG } from "@/lib/roles/paramConfig";
+import { defaultRoleParameterValues } from "@/lib/roles/parameters";
 import type { RoleDefinition } from "@/lib/roles/types";
 import type { FileEntry } from "@/lib/types";
 import { conversationIdentity, withoutArchivedPredecessors } from "@/lib/accounts/identity";
@@ -249,7 +250,7 @@ export function RoleSection({
                         ))}
                       </Select>
                     ) : (
-                      <input type={parameter.kind === "integer" ? "number" : "text"} min={parameter.min} max={parameter.max} value={String(roleParams[parameter.key] ?? "")} disabled={disabled} onChange={(event) => onSetParam(parameter.key, parameter.kind === "integer" && event.target.value ? Number(event.target.value) : event.target.value)} aria-label={label} className="h-7 min-w-0 rounded-control border border-border bg-card px-1.5 text-ui text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60" />
+                      <input type={parameter.kind === "integer" ? "number" : "text"} min={parameter.kind === "integer" ? parameter.min : undefined} max={parameter.kind === "integer" ? parameter.max : undefined} value={String(roleParams[parameter.key] ?? "")} disabled={disabled} onChange={(event) => onSetParam(parameter.key, parameter.kind === "integer" && event.target.value ? Number(event.target.value) : event.target.value)} aria-label={label} className="h-7 min-w-0 rounded-control border border-border bg-card px-1.5 text-ui text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60" />
                     )}
                     <span className="leading-3">{roleParamDescription(t, selectedRole.id, parameter)}</span>
                   </label>
@@ -541,10 +542,7 @@ export function DraftAgentPane({
       setDeployConfirm("");
       return;
     }
-    const params = Object.fromEntries(selected.parameters.map((parameter) => [
-      parameter.key,
-      parameter.kind === "integer" ? parameter.min ?? 1 : parameter.options?.[0] ?? "",
-    ]));
+    const params = defaultRoleParameterValues(selected);
     setRoleParams(params);
     setDeployConfirm("");
     setEngine(selected.config.engine);

--- a/src/components/pipelines/StagePlaceholderPane.tsx
+++ b/src/components/pipelines/StagePlaceholderPane.tsx
@@ -15,6 +15,7 @@ import type { FlowEngine } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import type { PatchPipelineRequest, PipelineRoleId } from "@/lib/pipelines/types";
 import { renderStagePrompt } from "@/lib/pipelines/prompts";
+import { defaultRoleParameterValues } from "@/lib/roles/parameters";
 
 import {
   PIPELINE_ROLE_OPTIONS,
@@ -170,12 +171,7 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
   const selectRole = (next: string) => {
     setRoleId(next);
     const selected = roles.find((role) => role.id === next);
-    const params = selected
-      ? Object.fromEntries(selected.parameters.map((parameter) => [
-          parameter.key,
-          parameter.kind === "integer" ? parameter.min ?? 1 : parameter.options?.[0] ?? "",
-        ]))
-      : {};
+    const params = selected ? defaultRoleParameterValues(selected) : {};
     setRoleParams(params);
     /* A role change hands unpinned runtime back to the new role's defaults
        server-side; the echo re-seeds the pickers above. */

--- a/src/lib/pipelines/roles.test.ts
+++ b/src/lib/pipelines/roles.test.ts
@@ -162,6 +162,12 @@ test("operator role params substitute into the resolved prompt scaffold", () => 
   expect(resolved.role?.promptScaffold).toContain("lens scope");
 });
 
+test("pipeline role lookup defaults omitted orchestrator maxWorkers to three", () => {
+  expect(pipelineRoleLookup("orchestrator")?.promptScaffold).toContain("Maximum workers: 3");
+  expect(pipelineRoleLookup("orchestrator", { maxWorkers: 1 })?.promptScaffold).toContain("Maximum workers: 1");
+  expect(pipelineRoleLookup("reviewer")?.promptScaffold).toContain("Run 1 independent pass(es)");
+});
+
 test("blank role params fall back to the registry default token value", () => {
   const resolved = resolvePipelineRole(
     { role: { roleId: "reviewer", params: { diffSource: "", lens: "" } } },

--- a/src/lib/pipelines/roles.ts
+++ b/src/lib/pipelines/roles.ts
@@ -2,6 +2,7 @@ import { configForParams, listRoles, roleFenceBlock, roleScaffoldBody, validateR
 import { MAX_SCAFFOLD_LENGTH } from "@/lib/roles/store";
 import { isEngineEffort } from "@/lib/agent/efforts";
 import { isCodexLaunchModel, normalizeClaudeLaunchModel } from "@/lib/agent/models";
+import { defaultRoleParameterValue } from "@/lib/roles/parameters";
 
 import { PIPELINE_DISALLOWED_ROLE_IDS, type EffectivePipelineRole, type PipelineRoleId, type PipelineStage, type PipelineStageKind } from "./types";
 
@@ -31,11 +32,6 @@ export type PipelineRoleLookup = (roleId: string, params?: Record<string, string
 
 let installedLookup: PipelineRoleLookup | null = null;
 
-function defaultParameterValue(parameter: ReturnType<typeof listRoles>[number]["parameters"][number]): string | number {
-  if (parameter.kind === "integer") return parameter.min ?? 1;
-  return parameter.options?.[0] ?? "";
-}
-
 /** Production adapter for the shared issue-35 registry. */
 export const pipelineRoleLookup: PipelineRoleLookup = (roleId, params) => {
   const definition = listRoles().find((candidate) => candidate.id === roleId);
@@ -46,7 +42,7 @@ export const pipelineRoleLookup: PipelineRoleLookup = (roleId, params) => {
          non-empty value; a blank field keeps the default, so the scaffold token
          stays intact. */
       const chosen = params?.[parameter.key];
-      const value = chosen !== undefined && chosen !== "" ? chosen : defaultParameterValue(parameter);
+      const value = chosen !== undefined && chosen !== "" ? chosen : defaultRoleParameterValue(parameter);
       return [parameter.key, value];
     }),
   );

--- a/src/lib/roles/defaults.ts
+++ b/src/lib/roles/defaults.ts
@@ -18,7 +18,7 @@ export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
       { key: "repo", label: "Repository", description: "Repository for backlog-campaign mode.", kind: "text" },
       { key: "issueQuery", label: "Issue query", description: "GitHub issue query for backlog-campaign mode.", kind: "text" },
       { key: "urgent", label: "Urgent list", description: "Comma-separated urgent issue ids.", kind: "text" },
-      { key: "maxWorkers", label: "Maximum workers", description: "Worker cap for backlog-campaign mode.", kind: "integer", min: 1, max: 20 },
+      { key: "maxWorkers", label: "Maximum workers", description: "Worker cap for backlog-campaign mode.", kind: "integer", default: 3, min: 1, max: 20 },
       { key: "mergePolicy", label: "Merge policy", description: "Delivery policy for backlog-campaign mode.", kind: "select", options: ["pr", "merge"] },
       { key: "completionPolicy", label: "Completion policy", description: "Terminal policy for backlog-campaign mode.", kind: "select", options: ["pr-opened", "merged", "released"] },
     ],

--- a/src/lib/roles/parameters.test.ts
+++ b/src/lib/roles/parameters.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { ROLE_DEFAULTS } from "./defaults";
+import { defaultRoleParameterValues } from "./parameters";
+
+test("orchestrator draft parameters default omitted maxWorkers to three", () => {
+  const orchestrator = ROLE_DEFAULTS.find((role) => role.id === "orchestrator");
+  if (!orchestrator) throw new Error("expected orchestrator role");
+
+  expect(defaultRoleParameterValues(orchestrator)).toMatchObject({ maxWorkers: 3 });
+});
+
+test("unrelated integer draft parameters retain their minimum-based default", () => {
+  const reviewer = ROLE_DEFAULTS.find((role) => role.id === "reviewer");
+  if (!reviewer) throw new Error("expected reviewer role");
+
+  expect(defaultRoleParameterValues(reviewer)).toMatchObject({ parallelN: 1 });
+});

--- a/src/lib/roles/parameters.ts
+++ b/src/lib/roles/parameters.ts
@@ -1,0 +1,17 @@
+import type { RoleDefinition, RoleParameter, RoleParamValues } from "./types";
+
+/** Resolve the declared omission-time value shared by role drafts and runners. */
+export function defaultRoleParameterValue(parameter: RoleParameter): string | number {
+  if (parameter.default !== undefined) return parameter.default;
+  if (parameter.kind === "integer") return parameter.min ?? 1;
+  if (parameter.kind === "select") return parameter.options?.[0] ?? "";
+  return "";
+}
+
+/** Build the parameter state shown when a draft selects a role. */
+export function defaultRoleParameterValues(role: Pick<RoleDefinition, "parameters">): RoleParamValues {
+  return Object.fromEntries(role.parameters.map((parameter) => [
+    parameter.key,
+    defaultRoleParameterValue(parameter),
+  ]));
+}

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -109,3 +109,13 @@ test("spawn role resolution injects the scaffold and requires deploy confirmatio
   expect(spawn.value.config).toEqual({ engine: "claude", model: "opus", effort: "high" });
   expect(spawn.value.scaffold).toContain("Builder in tdd mode");
 });
+
+test("orchestrator spawn defaults omitted maxWorkers to three and preserves explicit one", () => {
+  const omitted = resolveSpawnRole({ role: "orchestrator" });
+  if (!omitted.ok || !omitted.value) throw new Error("expected resolved orchestrator role");
+  expect(omitted.value.scaffold).toContain("Maximum workers: 3");
+
+  const explicit = resolveSpawnRole({ role: "orchestrator", roleParams: { maxWorkers: 1 } });
+  if (!explicit.ok || !explicit.value) throw new Error("expected resolved orchestrator role");
+  expect(explicit.value.scaffold).toContain("Maximum workers: 1");
+});

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -2,6 +2,7 @@ import { isEngineEffort } from "@/lib/agent/efforts";
 import { normalizeClaudeLaunchModel } from "@/lib/agent/models";
 
 import { BUILDER_APPLY_FIXES_CONFIG, BUILDER_FRONTEND_CONFIG } from "./paramConfig";
+import { defaultRoleParameterValue } from "./parameters";
 import { loadRoleDefinitions } from "./store";
 import type { ResolvedRole, RoleConfig, RoleDefinition, RoleId, RoleParamValues } from "./types";
 
@@ -38,7 +39,7 @@ export function validateRoleParams(
     const input = source[parameter.key];
     if (input === undefined || input === "") {
       if (parameter.required && requireRequired) return { ok: false, error: `missing required role parameter: ${parameter.key}` };
-      values[parameter.key] = parameter.kind === "integer" ? parameter.min ?? 1 : parameter.options?.[0] ?? "";
+      values[parameter.key] = defaultRoleParameterValue(parameter);
       continue;
     }
     if (parameter.kind === "integer") {
@@ -113,7 +114,7 @@ export function resolveRole(role: string, params: unknown = {}, explicit: Explic
       definition,
       config: config.value,
       params: parsedParams.value,
-      prompt: promptWithFences(definition, parsedParams.value),
+      "prompt": promptWithFences(definition, parsedParams.value),
       requiresDeploymentConfirmation: definition.id === "deployer",
     },
   };

--- a/src/lib/roles/types.ts
+++ b/src/lib/roles/types.ts
@@ -16,16 +16,26 @@ export type RoleConfig = {
   effort: string;
 };
 
-export type RoleParameter = {
+type RoleParameterBase = {
   key: string;
   label: string;
   description: string;
-  kind: "text" | "integer" | "select";
   required?: boolean;
-  options?: readonly string[];
+};
+
+export type RoleParameter = RoleParameterBase & ({
+  kind: "text";
+  default?: string;
+} | {
+  kind: "integer";
+  default?: number;
   min?: number;
   max?: number;
-};
+} | {
+  kind: "select";
+  default?: string;
+  options?: readonly string[];
+});
 
 export type RoleDefinition = {
   id: RoleId;
@@ -54,6 +64,6 @@ export type ResolvedRole = {
   definition: RoleDefinition;
   config: RoleConfig;
   params: RoleParamValues;
-  prompt: string;
+  "prompt": string;
   requiresDeploymentConfirmation: boolean;
 };


### PR DESCRIPTION
## Summary

- declare `maxWorkers: 3` on the canonical orchestrator role parameter
- share omission-time parameter resolution across draft previews, direct spawns, and pipeline roles
- preserve explicit valid values and existing saved parameter data

## Verification

- focused role and pipeline tests: 28 passed
- TypeScript: passed
- changed-file ESLint: passed
- privacy publication gate: passed
- diff check: passed

Closes #769
