### PR TITLE
fix(runtime): keep Codex image echoes within the JSONL frame bound

### DIFF
--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -435,6 +435,12 @@ function normalizeCodexUserContent(content: unknown): CodexUserContent {
     if (partText) text.push(partText);
 
     if (type === "input_image" || type === "image") {
+      const referencedPath = textPart(rec(part.image_url).path) || textPart(rec(part.source).path);
+      const referenced = referencedPath ? inboxImagesFromPath(referencedPath) : [];
+      if (referenced.length) {
+        attachments.push(...referenced);
+        continue;
+      }
       const imageUrl = textPart(part.image_url) || textPart(rec(part.image_url).url) || textPart(part.data);
       const image = codexImageFromDataUrl(imageUrl);
       if (image) attachments.push(image);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -624,6 +624,44 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("an image echo past the old line bound no longer kills the host, and reaches storage bounded", async () => {
+    const server = new FakeAppServer("oversized-thread");
+    server.modelList = [{ id: "gpt-5.6-sol", isDefault: true, inputModalities: ["text", "image"] }];
+    const store = new MemoryEventStore();
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      model: "gpt-5.6-sol",
+      eventStore: store,
+      resolveImagePath: (ref) => `/runtime-images/${ref.sha256}`,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    const body = Buffer.alloc(18 * 1024 * 1024, 9).toString("base64");
+    expect(body.length).toBeGreaterThan(16 * 1024 * 1024);
+    server.notify("item/completed", {
+      threadId: "oversized-thread",
+      turnId: "turn-1",
+      item: {
+        type: "userMessage",
+        clientId: "oversized-image",
+        content: [
+          { type: "input_image", image_url: `data:image/png;base64,${body}` },
+          { type: "text", text: "look at this" },
+        ],
+      },
+    });
+    await Bun.sleep(50);
+
+    expect((await host.health()).status).not.toBe("dead");
+    const items = store.load("oversized-thread").filter((event) => event.kind === "item");
+    expect(items).not.toHaveLength(0);
+    const serialized = JSON.stringify(items);
+    expect(serialized).not.toContain(body.slice(0, 256));
+    expect(serialized.length).toBeLessThan(64 * 1024);
+    expect(serialized).toContain("localImage");
+    await host.release();
+  });
+
   test("keeps image affordance disabled for a text-only selected model", async () => {
     const server = new FakeAppServer("spark-thread");
     const host = await CodexAppServerHost.start({

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -9,7 +9,8 @@ import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
 import { grantedPluginServerNames, grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
-import { runtimeImageStore } from "./runtimeImageStore";
+import { sanitizeCodexImageFrame, type ImageSink } from "./codexImageFrames";
+import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, runtimeImageStore } from "./runtimeImageStore";
 import { STRUCTURED_IMAGE_CAPABILITY, type StructuredImageRef } from "./structuredContent";
 import {
   normalizeVoiceDeliveries,
@@ -213,7 +214,8 @@ const REALTIME_HANGUP_TIMEOUT_MS = 2_000;
 const REALTIME_LIVE_MODEL = "gpt-live-1-codex";
 const MAX_REALTIME_SDP_BYTES = 512 * 1024;
 const MAX_REALTIME_SPEECH_BYTES = 8 * 1024;
-const MAX_LINE_BYTES = 16 * 1024 * 1024;
+const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
+const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
 const MAX_STDERR_TAIL_BYTES = 16 * 1024;
 const MAX_PRE_RESTORE_FRAMES = 256;
 const MAX_PRE_RESTORE_BYTES = 4 * 1024 * 1024;
@@ -1592,6 +1594,20 @@ export class CodexAppServerHost implements EngineHost {
     catch (error) { this.fail(new Error(`Codex app-server stdin failed: ${safeError(error)}`)); }
   }
 
+  private boundImageBodies(item: unknown): unknown {
+    const sink: ImageSink = {
+      store: (data, mime) => {
+        const store = runtimeImageStore();
+        const [ref] = store.putMany([{ base64: data.toString("base64"), mime }]);
+        return ref ? store.pathFor(ref) : null;
+      },
+    };
+    try { return sanitizeCodexImageFrame(item, sink).value; }
+    catch {
+      return item;
+    }
+  }
+
   private acceptStdout(chunk: string): void {
     if (this.dead || this.releasing || this.released) return;
     this.stdoutBuffer += chunk;
@@ -1759,7 +1775,7 @@ export class CodexAppServerHost implements EngineHost {
           this.emit({ kind: "turn-started", turnId: eventTurnId });
         }
       }
-      this.emit({ kind: "item", turnId: eventTurnId, item: params.item, phase });
+      this.emit({ kind: "item", turnId: eventTurnId, item: this.boundImageBodies(params.item), phase });
       return;
     }
     if (method === "turn/completed" && turnId) {

--- a/src/lib/runtime/codexImageFrames.test.ts
+++ b/src/lib/runtime/codexImageFrames.test.ts
@@ -1,0 +1,136 @@
+import crypto from "node:crypto";
+import { expect, test } from "bun:test";
+
+import { sanitizeCodexImageFrame, type ImageSink } from "./codexImageFrames";
+import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES } from "./runtimeImageStore";
+
+const PNG = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6360000002000100ffff03000006000557bfabd4",
+  "hex",
+);
+
+function sink(): ImageSink & { stored: number } {
+  const state = { stored: 0, store: () => { state.stored += 1; return "/runtime-images/stored.png"; } };
+  return state as ImageSink & { stored: number };
+}
+
+function echoedItem(base64: string) {
+  return {
+    id: "item_1",
+    item_type: "user_message",
+    content: [
+      { type: "input_image", image_url: `data:image/png;base64,${base64}` },
+      { type: "text", text: "what is wrong with this screenshot?" },
+    ],
+  };
+}
+
+test("an inlined image body is replaced by its bounded reference", () => {
+  const target = sink();
+  const { value, captured } = sanitizeCodexImageFrame(echoedItem(PNG.toString("base64")), target);
+  const parts = (value as unknown as { content: Record<string, unknown>[] }).content;
+
+  expect(parts[0]).toEqual({
+    type: "input_image",
+    image_url: {
+      type: "localImage",
+      path: "/runtime-images/stored.png",
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      mime: "image/png",
+      bytes: PNG.byteLength,
+    },
+  });
+  expect(parts[1]).toEqual({ type: "text", text: "what is wrong with this screenshot?" });
+  expect(captured).toHaveLength(1);
+  expect(captured[0]).toMatchObject({ mime: "image/png", bytes: PNG.byteLength });
+  expect(target.stored).toBe(1);
+});
+
+test("the serialized frame collapses from the whole image to a bounded reference", () => {
+  const big = Buffer.alloc(3 * 1024 * 1024, 7);
+  const item = echoedItem(big.toString("base64"));
+  const before = Buffer.byteLength(JSON.stringify(item));
+  const { value } = sanitizeCodexImageFrame(item, sink());
+  const after = Buffer.byteLength(JSON.stringify(value));
+
+  expect(before).toBeGreaterThan(4_000_000);
+  expect(after).toBeLessThan(1_000);
+});
+
+test("an image set at the admission ceiling still serializes to a bounded frame", () => {
+  const each = Buffer.alloc(Math.floor((MAX_STRUCTURED_IMAGE_ENCODED_BYTES / 4) * 3 / 4), 3);
+  const item = {
+    id: "item_1",
+    content: Array.from({ length: 4 }, () => ({
+      type: "input_image",
+      image_url: `data:image/png;base64,${each.toString("base64")}`,
+    })),
+  };
+  expect(Buffer.byteLength(JSON.stringify(item))).toBeGreaterThan(MAX_STRUCTURED_IMAGE_ENCODED_BYTES * 0.9);
+
+  const { value, captured } = sanitizeCodexImageFrame(item, sink());
+  expect(captured).toHaveLength(4);
+  expect(Buffer.byteLength(JSON.stringify(value))).toBeLessThan(2_000);
+});
+
+test("a frame with no image body is returned by identity", () => {
+  const item = { id: "item_1", content: [{ type: "text", text: "no attachment here" }] };
+  const { value, captured } = sanitizeCodexImageFrame(item, sink());
+  expect(value).toBe(item);
+  expect(captured).toEqual([]);
+});
+
+test("text that merely looks like a data URL is left alone", () => {
+  const item = { content: [{ type: "text", text: `data:image/png;base64,${PNG.toString("base64")}` }] };
+  const { value, captured } = sanitizeCodexImageFrame(item, sink());
+  expect(value).toBe(item);
+  expect(captured).toEqual([]);
+});
+
+test("a body nested anywhere is found, including under a source object and in an array", () => {
+  const base64 = PNG.toString("base64");
+  const item = {
+    content: [
+      { type: "image", source: `data:image/png;base64,${base64}` },
+      { type: "input_image", image_url: [`data:image/png;base64,${base64}`] },
+    ],
+  };
+  const { value, captured } = sanitizeCodexImageFrame(item, sink());
+
+  expect(captured).toHaveLength(2);
+  const parts = (value as typeof item).content;
+  expect((parts[0] as unknown as { source: { type: string } }).source.type).toBe("localImage");
+  expect((parts[1] as unknown as { image_url: { type: string }[] }).image_url[0]!.type).toBe("localImage");
+});
+
+test("an unusable body is left as it was", () => {
+  const item = {
+    content: [
+      { type: "input_image", image_url: "data:image/png;base64," },
+      { type: "input_image", image_url: "data:application/pdf;base64,JVBERi0=" },
+      { type: "input_image", image_url: "https://example.invalid/a.png" },
+    ],
+  };
+  const { value, captured } = sanitizeCodexImageFrame(item, sink());
+  expect(value).toBe(item);
+  expect(captured).toEqual([]);
+});
+
+test("a store failure still yields a bounded reference", () => {
+  const refusing: ImageSink = { store: () => { throw new Error("quota exceeded"); } };
+  const { value, captured } = sanitizeCodexImageFrame(echoedItem(PNG.toString("base64")), refusing);
+  const parts = (value as unknown as { content: Record<string, unknown>[] }).content;
+
+  expect(parts[0]!.image_url).toMatchObject({
+    type: "localImage",
+    path: "",
+    mime: "image/png",
+    bytes: PNG.byteLength,
+  });
+  expect(captured).toHaveLength(1);
+});
+
+test("the reference digest names the stored image bytes", () => {
+  const { captured } = sanitizeCodexImageFrame(echoedItem(PNG.toString("base64")), sink());
+  expect(captured[0]!.sha256).toBe(crypto.createHash("sha256").update(PNG).digest("hex"));
+});

--- a/src/lib/runtime/codexImageFrames.ts
+++ b/src/lib/runtime/codexImageFrames.ts
@@ -1,0 +1,81 @@
+import crypto from "node:crypto";
+
+import { normalizeStructuredImageMime, type StructuredImageMime, type StructuredImageRef } from "./structuredContent";
+
+export interface RuntimeImageReference {
+  type: "localImage";
+  path: string;
+  sha256: string;
+  mime: string;
+  bytes: number;
+}
+
+const DATA_URL = /^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([\s\S]*)$/i;
+const BODY_KEYS = new Set(["image_url", "imageUrl", "data", "url", "source"]);
+
+export interface ImageSink {
+  store(data: Buffer, mime: StructuredImageMime): string | null;
+}
+
+function referenceFor(data: Buffer, mime: StructuredImageMime, sink: ImageSink): RuntimeImageReference {
+  const sha256 = crypto.createHash("sha256").update(data).digest("hex");
+  let stored: string | null = null;
+  try { stored = sink.store(data, mime); }
+  catch { stored = null; }
+  return { type: "localImage", path: stored ?? "", sha256, mime, bytes: data.byteLength };
+}
+
+function decodeDataUrl(value: string): { data: Buffer; mime: StructuredImageMime } | null {
+  const match = DATA_URL.exec(value.trim());
+  if (!match) return null;
+  const mime = normalizeStructuredImageMime(match[1]!);
+  if (!mime) return null;
+  const data = Buffer.from(match[2]!, "base64");
+  return data.byteLength ? { data, mime } : null;
+}
+
+export interface SanitizeResult<T> {
+  value: T;
+  captured: StructuredImageRef[];
+}
+
+/**
+ * Replace inline image data URLs from Codex app-server items with bounded
+ * references before the frame reaches the durable event ledger.
+ */
+export function sanitizeCodexImageFrame<T>(value: T, sink: ImageSink): SanitizeResult<T> {
+  const captured: StructuredImageRef[] = [];
+
+  const walk = (node: unknown, keyHint: string | null): unknown => {
+    if (typeof node === "string") {
+      if (!keyHint || !BODY_KEYS.has(keyHint)) return node;
+      const decoded = decodeDataUrl(node);
+      if (!decoded) return node;
+      const reference = referenceFor(decoded.data, decoded.mime, sink);
+      captured.push({ sha256: reference.sha256, mime: decoded.mime, bytes: reference.bytes });
+      return reference;
+    }
+    if (Array.isArray(node)) {
+      let changed = false;
+      const next = node.map((item) => {
+        const walked = walk(item, keyHint);
+        if (walked !== item) changed = true;
+        return walked;
+      });
+      return changed ? next : node;
+    }
+    if (!node || typeof node !== "object") return node;
+
+    const source = node as Record<string, unknown>;
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(source)) {
+      const walked = walk(child, key);
+      if (walked !== child) changed = true;
+      next[key] = walked;
+    }
+    return changed ? next : node;
+  };
+
+  return { value: walk(value, null) as T, captured };
+}


### PR DESCRIPTION
## Failure

A Codex structured host dies when app-server echoes an admitted image as an inline data URL larger than the fixed 16 MiB JSONL limit. The dead host then makes the queued text surface `structured host ownership is unavailable` during recovery.

## Fix

- derive the JSONL ceiling from the runtime image admission ceiling plus bounded envelope headroom
- replace inline image bodies with durable runtime-image references before event-ledger persistence
- render those references through the existing feed attachment path
- preserve text-only frames by identity and keep malformed/unusable image values unchanged

## Verification

- RED on current `main`: the 18 MiB image-echo regression killed the host
- GREEN after the fix: Codex host regression (1/1)
- image-frame sanitizer tests (9/9)
- feed parser tests (85/85)
- TypeScript (`tsc --noEmit`)
- focused ESLint
- production build including MCP bundle
- privacy publication gate
