### PR TITLE
fix(mcp): publish the closed argument sets the servers enforce

### DIFF
--- a/src/app/api/pipelines/[id]/route.ts
+++ b/src/app/api/pipelines/[id]/route.ts
@@ -2,18 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { patchPipeline, type PipelineCloseReport } from "@/lib/pipelines/engine";
-import type { PatchPipelineRequest, Pipeline, PipelineAction, PipelineRepoPreflightErrorCode } from "@/lib/pipelines/types";
+import { PIPELINE_ACTIONS, type PatchPipelineRequest, type Pipeline, type PipelineAction, type PipelineRepoPreflightErrorCode } from "@/lib/pipelines/types";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const ACTIONS = new Set<PipelineAction>([
-  "start", "update-draft", "set-position", "add-stage", "remove-stage", "reorder-stage", "set-edge",
-  "pause", "resume", "retry-stage", "skip-stage", "override-stage", "link-task", "unlink-task", "delete", "close",
-  "set-src",
-]);
+const ACTIONS = new Set<PipelineAction>(PIPELINE_ACTIONS);
 
 const CONTROLLER_ACTIONS = new Set<PipelineAction>(["start", "resume", "retry-stage", "skip-stage"]);
 
@@ -39,7 +35,9 @@ export async function PATCH(
   } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
-  if (!ACTIONS.has(body.action)) return NextResponse.json({ error: "unknown pipeline action" }, { status: 400 });
+  if (!ACTIONS.has(body.action)) {
+    return NextResponse.json({ error: `unknown pipeline action (allowed: ${PIPELINE_ACTIONS.join(", ")})` }, { status: 400 });
+  }
   const { id } = await ctx.params;
   try {
     const result = await patchPipeline(id, body);

--- a/src/lib/board/validation.ts
+++ b/src/lib/board/validation.ts
@@ -17,9 +17,10 @@ import type { BoardMutationV1 } from "@/lib/board/mutations";
 export const MAX_BOARD_BODY_BYTES = 48 * 1024 * 1024;
 export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
 
+/* Names the accepted alternatives so a caller can self-correct (#774). */
 function exact(value: Record<string, unknown>, allowed: readonly string[], field: string): void {
   const unknown = Object.keys(value).find((key) => !allowed.includes(key));
-  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown}`);
+  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown} (allowed: ${allowed.join(", ")})`);
 }
 function record(value: unknown, field: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -6,8 +6,12 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
+import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
+import { SNAPSHOT_CALLER_KEYS, SNAPSHOT_SCOPE_KEYS, SNAPSHOT_TEXT_KEYS, SNAPSHOT_VIEW_KEYS } from "@/lib/view/types";
+
 import {
   MCP_TOOL_NAMES,
+  TOOL_INPUT_SCHEMAS,
   FileMcpReceiptStore,
   MemoryMcpReceiptStore,
   createViewerMcpServer,
@@ -1146,4 +1150,22 @@ describe("MCP tool service", () => {
       await server.close();
     }
   });
+});
+
+/* #774: `pipeline_action.action` was `z.string().min(1)` while the PATCH route
+   admitted a fixed set, and `operator_snapshot`'s nested objects were free-form
+   records against an exact-key validator. Both now read from one constant. */
+test("#774 tool schemas publish the closed sets their servers enforce", () => {
+  const pipelineAction = TOOL_INPUT_SCHEMAS.pipeline_action.shape.action;
+  expect(pipelineAction.options).toEqual([...PIPELINE_ACTIONS]);
+
+  const snapshot = TOOL_INPUT_SCHEMAS.operator_snapshot.shape;
+  expect(Object.keys(snapshot.text.unwrap().shape).sort()).toEqual([...SNAPSHOT_TEXT_KEYS].sort());
+  expect(Object.keys(snapshot.view.unwrap().shape).sort()).toEqual([...SNAPSHOT_VIEW_KEYS].sort());
+  expect(Object.keys(snapshot.scope.unwrap().shape).sort()).toEqual([...SNAPSHOT_SCOPE_KEYS].sort());
+  expect(Object.keys(snapshot.caller.unwrap().shape).sort()).toEqual([...SNAPSHOT_CALLER_KEYS].sort());
+
+  /* Strict, not stripping: an unknown nested key must stay a loud rejection. */
+  expect(snapshot.text.unwrap().safeParse({ mode: "digest" }).success).toBe(false);
+  expect(snapshot.view.unwrap().safeParse({ includeFrame: true }).success).toBe(false);
 });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -7,7 +7,11 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import { statePath } from "@/lib/configDir";
+import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
 import { procBackend } from "@/lib/proc";
+import {
+  MAX_SCOPE_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, VIEW_RESOLUTIONS, VIEW_SCOPE_KINDS,
+} from "@/lib/view/types";
 
 import type { McpToolPolicy } from "./toolAllowlist";
 
@@ -993,7 +997,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
 const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key for this logical call.");
 const entityIdSchema = z.string().min(1);
 
-const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
+export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   spawn_agent: z.object({
     clientRequestId: clientRequestIdSchema,
     cwd: z.string().min(1).describe("Existing working directory for the new agent."),
@@ -1050,7 +1054,8 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   pipeline_action: z.object({
     clientRequestId: clientRequestIdSchema,
     pipelineId: entityIdSchema,
-    action: z.string().min(1),
+    /* #774: was `z.string().min(1)` while the route admitted a fixed set. */
+    action: z.enum(PIPELINE_ACTIONS),
   }).passthrough(),
   link_task_to_pipeline: z.object({
     clientRequestId: clientRequestIdSchema,
@@ -1126,13 +1131,33 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     label: z.string().optional(),
     question: z.string().optional(),
   }).passthrough(),
+  /* #774: these nested objects were `z.record(z.string(), z.unknown())`, so the
+     published schema said "any object" while `validateSnapshotRequest` admitted
+     an exact key set — 119 calls in ten days were rejected for a guessed key the
+     caller had no way to look up. `.strict()` keeps an unknown key a loud
+     rejection; plain `z.object` would silently strip it, which trades a wrong
+     answer for a wasted round trip. */
   operator_snapshot: z.object({
     clientRequestId: clientRequestIdSchema,
     schemaVersion: z.literal(1).optional(),
-    view: z.record(z.string(), z.unknown()).optional(),
-    scope: z.record(z.string(), z.unknown()).optional(),
-    text: z.record(z.string(), z.unknown()).optional(),
-    caller: z.record(z.string(), z.unknown()).optional(),
+    view: z.object({
+      id: z.string().optional(),
+      deviceId: z.string().optional(),
+      resolution: z.enum(VIEW_RESOLUTIONS).optional(),
+    }).strict().optional(),
+    scope: z.object({
+      kind: z.enum(VIEW_SCOPE_KINDS),
+      paths: z.array(z.string()).max(MAX_SCOPE_PATHS).optional().describe("Required for kind=paths, rejected otherwise."),
+    }).strict().optional(),
+    text: z.object({
+      include: z.boolean().optional(),
+      lastMessages: z.number().int().min(1).max(MAX_SNAPSHOT_LAST_MESSAGES).optional(),
+      maxCharsPerConversation: z.number().int().min(1).max(MAX_SNAPSHOT_CHARS_PER_CONVERSATION).optional(),
+    }).strict().optional(),
+    caller: z.object({
+      pid: z.number().int().min(1).optional(),
+      transcriptPath: z.string().optional(),
+    }).strict().optional(),
   }).passthrough(),
   list_tasks: z.object({
     clientRequestId: clientRequestIdSchema,

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -265,24 +265,30 @@ export type CreatePipelineRequest = {
   autoStart?: boolean;
 };
 
-export type PipelineAction =
-  | "start"
-  | "update-draft"
-  | "set-position"
-  | "add-stage"
-  | "remove-stage"
-  | "reorder-stage"
-  | "set-edge"
-  | "pause"
-  | "resume"
-  | "retry-stage"
-  | "skip-stage"
-  | "override-stage"
-  | "link-task"
-  | "unlink-task"
-  | "set-src"
-  | "delete"
-  | "close";
+/* The accepted actions, declared once (#774). The MCP tool schema publishes
+   these to callers and the PATCH route admits exactly this set; an action added
+   to one and forgotten in the other is the defect this constant prevents. */
+export const PIPELINE_ACTIONS = [
+  "start",
+  "update-draft",
+  "set-position",
+  "add-stage",
+  "remove-stage",
+  "reorder-stage",
+  "set-edge",
+  "pause",
+  "resume",
+  "retry-stage",
+  "skip-stage",
+  "override-stage",
+  "link-task",
+  "unlink-task",
+  "set-src",
+  "delete",
+  "close",
+] as const;
+
+export type PipelineAction = (typeof PIPELINE_ACTIONS)[number];
 
 export type PatchPipelineRequest = {
   action: PipelineAction;

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -60,13 +60,19 @@ test("builder parameters select the cheap fixer and the frontend implementation 
 });
 
 test("role registry rejects unknown and missing required parameters with bounded errors", () => {
+  /* #774: a rejection names the accepted alternatives, so the caller can
+     self-correct instead of reading the registry source. */
   expect(resolveRole("reviewer", { lens: "all", unexpected: true })).toEqual({
     ok: false,
-    error: "unknown role parameter: unexpected",
+    error: "unknown role parameter: unexpected (reviewer accepts: diffSource, lens, mode, parallelN)",
   });
   expect(resolveRole("verifier", {})).toEqual({
     ok: false,
     error: "missing required role parameter: claims",
+  });
+  expect(resolveRole("no-such-role", {})).toEqual({
+    ok: false,
+    error: "unknown role: no-such-role (allowed: orchestrator, reviewer, verifier, builder, architect, cleaner, prod-auditor, deployer)",
   });
 });
 

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -32,7 +32,12 @@ export function validateRoleParams(
   const source = (raw ?? {}) as Record<string, unknown>;
   const byKey = new Map(definition.parameters.map((parameter) => [parameter.key, parameter]));
   for (const key of Object.keys(source)) {
-    if (!byKey.has(key)) return { ok: false, error: `unknown role parameter: ${key}` };
+    /* Name the accepted alternatives (#774): the caller can only see the key it
+       guessed wrong, and this role's parameter set is right here. */
+    if (!byKey.has(key)) {
+      const allowed = definition.parameters.map((parameter) => parameter.key).join(", ") || "none";
+      return { ok: false, error: `unknown role parameter: ${key} (${definition.id} accepts: ${allowed})` };
+    }
   }
   const values: RoleParamValues = {};
   for (const parameter of definition.parameters) {
@@ -103,7 +108,7 @@ function resolveConfig(definition: RoleDefinition, params: RoleParamValues, expl
 
 export function resolveRole(role: string, params: unknown = {}, explicit: ExplicitRoleConfig = {}, definitions: RoleDefinition[] = loadRoleDefinitions()): RoleResolution {
   const definition = definitions.find((candidate) => candidate.id === role);
-  if (!definition) return { ok: false, error: "unknown role" };
+  if (!definition) return { ok: false, error: `unknown role: ${role} (allowed: ${definitions.map((candidate) => candidate.id).join(", ")})` };
   const parsedParams = validateRoleParams(definition, params);
   if (!parsedParams.ok) return parsedParams;
   const config = resolveConfig(definition, parsedParams.value, explicit);

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -14,6 +14,20 @@ export type BrowserKind = "chrome" | "firefox" | "safari" | "other";
 export type ViewFreshness = "active" | "background" | "stale";
 export type ViewScopeKind = "focused" | "selected" | "visible" | "focused-selected" | "paths";
 
+/* The accepted shape of a snapshot request, declared once (#774). The MCP tool
+   schema publishes these to callers and `validateSnapshotRequest` enforces
+   them; a key added to one and forgotten in the other is the defect these
+   constants exist to prevent, so both sides must read from here. */
+export const SNAPSHOT_REQUEST_KEYS = ["schemaVersion", "view", "scope", "text", "caller"] as const;
+export const SNAPSHOT_VIEW_KEYS = ["id", "deviceId", "resolution"] as const;
+export const SNAPSHOT_SCOPE_KEYS = ["kind", "paths"] as const;
+export const SNAPSHOT_TEXT_KEYS = ["include", "lastMessages", "maxCharsPerConversation"] as const;
+export const SNAPSHOT_CALLER_KEYS = ["pid", "transcriptPath"] as const;
+export const VIEW_SCOPE_KINDS = ["focused", "selected", "visible", "focused-selected", "paths"] as const satisfies readonly ViewScopeKind[];
+export const VIEW_RESOLUTIONS = ["latest-interaction", "require-explicit"] as const;
+export const MAX_SNAPSHOT_LAST_MESSAGES = 20;
+export const MAX_SNAPSHOT_CHARS_PER_CONVERSATION = 4000;
+
 export interface PresencePayloadV1 {
   schemaVersion: 1;
   viewSessionId: string;

--- a/src/lib/view/validation.allowlists.test.ts
+++ b/src/lib/view/validation.allowlists.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES,
+  SNAPSHOT_CALLER_KEYS, SNAPSHOT_SCOPE_KEYS, SNAPSHOT_TEXT_KEYS, SNAPSHOT_VIEW_KEYS, VIEW_SCOPE_KINDS,
+} from "./types";
+import { validateSnapshotRequest, ViewValidationError } from "./validation";
+
+/**
+ * Issue #774: the MCP tool schema published `z.record(z.string(), z.unknown())`
+ * for every nested snapshot object while this validator enforced an exact key
+ * set. A caller could not see the accepted keys in the schema, and the
+ * rejection named only the key it guessed wrong — 119 calls in ten days died
+ * that way. These pin both halves of the fix: one source of truth for the
+ * accepted keys, and rejections that name the alternatives.
+ */
+describe("snapshot request allowlists (#774)", () => {
+  test("an unknown nested key names the accepted alternatives", () => {
+    for (const [field, body, allowed] of [
+      ["text", { schemaVersion: 1, text: { mode: "digest" } }, SNAPSHOT_TEXT_KEYS],
+      ["view", { schemaVersion: 1, view: { includeFrame: true } }, SNAPSHOT_VIEW_KEYS],
+      ["scope", { schemaVersion: 1, scope: { kind: "visible", project: "x" } }, SNAPSHOT_SCOPE_KEYS],
+      ["caller", { schemaVersion: 1, caller: { transcript: "x" } }, SNAPSHOT_CALLER_KEYS],
+    ] as const) {
+      let caught: unknown;
+      try { validateSnapshotRequest(body); } catch (error) { caught = error; }
+      expect(caught).toBeInstanceOf(ViewValidationError);
+      const message = (caught as ViewValidationError).message;
+      expect(message.startsWith(`unknown ${field}.`)).toBe(true);
+      for (const key of allowed) expect(message).toContain(key);
+    }
+  });
+
+  test("an invalid closed-set value names the accepted alternatives", () => {
+    let caught: unknown;
+    try { validateSnapshotRequest({ schemaVersion: 1, scope: { kind: "everything" } }); } catch (error) { caught = error; }
+    expect((caught as ViewValidationError).message).toBe(`invalid scope.kind (allowed: ${VIEW_SCOPE_KINDS.join(", ")})`);
+  });
+
+  test("every key the published tool schema accepts is admitted by the validator", () => {
+    /* The regression that matters is the two sides drifting apart again. */
+    const request = validateSnapshotRequest({
+      schemaVersion: 1,
+      view: { id: "v", deviceId: "d", resolution: "latest-interaction" },
+      scope: { kind: "paths", paths: ["/a.jsonl"] },
+      text: { include: true, lastMessages: MAX_SNAPSHOT_LAST_MESSAGES, maxCharsPerConversation: MAX_SNAPSHOT_CHARS_PER_CONVERSATION },
+      caller: { pid: 1, transcriptPath: "/t.jsonl" },
+    });
+    expect(Object.keys(request.view ?? {})).toEqual([...SNAPSHOT_VIEW_KEYS]);
+    expect(Object.keys(request.text ?? {})).toEqual([...SNAPSHOT_TEXT_KEYS]);
+    expect(Object.keys(request.caller ?? {})).toEqual([...SNAPSHOT_CALLER_KEYS]);
+    expect(request.scope).toEqual({ kind: "paths", paths: ["/a.jsonl"] });
+  });
+});

--- a/src/lib/view/validation.ts
+++ b/src/lib/view/validation.ts
@@ -1,4 +1,8 @@
-import { MAX_PRESENCE_BYTES, MAX_SCOPE_PATHS, MAX_SELECTED_PATHS, MAX_VISIBLE_PATHS, type PresencePayloadV1, type SnapshotRequestV1 } from "./types";
+import {
+  MAX_PRESENCE_BYTES, MAX_SCOPE_PATHS, MAX_SELECTED_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, MAX_VISIBLE_PATHS,
+  SNAPSHOT_CALLER_KEYS, SNAPSHOT_REQUEST_KEYS, SNAPSHOT_SCOPE_KEYS, SNAPSHOT_TEXT_KEYS, SNAPSHOT_VIEW_KEYS, VIEW_RESOLUTIONS, VIEW_SCOPE_KINDS,
+  type PresencePayloadV1, type SnapshotRequestV1,
+} from "./types";
 
 export class ViewValidationError extends Error {
   constructor(readonly code: "INVALID_REQUEST" | "UNSUPPORTED_SCHEMA_VERSION" | "SCOPE_TOO_LARGE" | "PAYLOAD_TOO_LARGE", message: string, readonly status = 400) { super(message); }
@@ -8,9 +12,12 @@ function record(value: unknown, field = "request"): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
   return value as Record<string, unknown>;
 }
+/* A rejection names the accepted alternatives (#774): a caller can only see the
+   key it guessed wrong, so withholding the allowed set costs it another round
+   trip to discover a list this function already holds. */
 function exact(value: Record<string, unknown>, allowed: readonly string[], field: string): void {
   const unknown = Object.keys(value).find((key) => !allowed.includes(key));
-  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown}`);
+  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown} (allowed: ${allowed.join(", ")})`);
 }
 function string(value: unknown, field: string, options: { nullable?: boolean; max?: number } = {}): string | null {
   if (options.nullable && value === null) return null;
@@ -27,7 +34,7 @@ function integer(value: unknown, field: string, min = 0, max = Number.MAX_SAFE_I
   return parsed;
 }
 function oneOf<T extends string>(value: unknown, field: string, values: readonly T[]): T {
-  if (typeof value !== "string" || !values.includes(value as T)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  if (typeof value !== "string" || !values.includes(value as T)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field} (allowed: ${values.join(", ")})`);
   return value as T;
 }
 function paths(value: unknown, field: string, maximum: number): string[] {
@@ -65,22 +72,22 @@ export function validatePresence(value: unknown): PresencePayloadV1 {
 }
 
 export function validateSnapshotRequest(value: unknown): SnapshotRequestV1 {
-  const body = record(value); exact(body, ["schemaVersion", "view", "scope", "text", "caller"], "request");
+  const body = record(value); exact(body, SNAPSHOT_REQUEST_KEYS, "request");
   if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
-  const view = optionalRecord(body.view, "view"); if (view) exact(view, ["id", "deviceId", "resolution"], "view");
-  const scope = optionalRecord(body.scope, "scope"); if (scope) exact(scope, ["kind", "paths"], "scope");
-  const textOptions = optionalRecord(body.text, "text"); if (textOptions) exact(textOptions, ["include", "lastMessages", "maxCharsPerConversation"], "text");
-  const caller = optionalRecord(body.caller, "caller"); if (caller) exact(caller, ["pid", "transcriptPath"], "caller");
-  const kind = scope ? oneOf(scope.kind, "scope.kind", ["focused", "selected", "visible", "focused-selected", "paths"] as const) : undefined;
+  const view = optionalRecord(body.view, "view"); if (view) exact(view, SNAPSHOT_VIEW_KEYS, "view");
+  const scope = optionalRecord(body.scope, "scope"); if (scope) exact(scope, SNAPSHOT_SCOPE_KEYS, "scope");
+  const textOptions = optionalRecord(body.text, "text"); if (textOptions) exact(textOptions, SNAPSHOT_TEXT_KEYS, "text");
+  const caller = optionalRecord(body.caller, "caller"); if (caller) exact(caller, SNAPSHOT_CALLER_KEYS, "caller");
+  const kind = scope ? oneOf(scope.kind, "scope.kind", VIEW_SCOPE_KINDS) : undefined;
   const scopePaths = scope?.paths === undefined ? undefined : paths(scope.paths, "scope.paths", MAX_SCOPE_PATHS);
   if (kind === "paths" && !scopePaths) throw new ViewValidationError("INVALID_REQUEST", "scope.paths is required");
   if (kind !== "paths" && scopePaths) throw new ViewValidationError("INVALID_REQUEST", "scope.paths requires paths scope");
   if (textOptions?.include !== undefined && typeof textOptions.include !== "boolean") throw new ViewValidationError("INVALID_REQUEST", "invalid text.include");
   return {
     schemaVersion: 1,
-    view: view ? { id: view.id === undefined ? undefined : string(view.id, "view.id")!, deviceId: view.deviceId === undefined ? undefined : string(view.deviceId, "view.deviceId")!, resolution: view.resolution === undefined ? undefined : oneOf(view.resolution, "view.resolution", ["latest-interaction", "require-explicit"] as const) } : undefined,
+    view: view ? { id: view.id === undefined ? undefined : string(view.id, "view.id")!, deviceId: view.deviceId === undefined ? undefined : string(view.deviceId, "view.deviceId")!, resolution: view.resolution === undefined ? undefined : oneOf(view.resolution, "view.resolution", VIEW_RESOLUTIONS) } : undefined,
     scope: kind ? { kind, paths: scopePaths } : undefined,
-    text: textOptions ? { include: textOptions.include as boolean | undefined, lastMessages: textOptions.lastMessages === undefined ? undefined : integer(textOptions.lastMessages, "text.lastMessages", 1, 20), maxCharsPerConversation: textOptions.maxCharsPerConversation === undefined ? undefined : integer(textOptions.maxCharsPerConversation, "text.maxCharsPerConversation", 1, 4000) } : undefined,
+    text: textOptions ? { include: textOptions.include as boolean | undefined, lastMessages: textOptions.lastMessages === undefined ? undefined : integer(textOptions.lastMessages, "text.lastMessages", 1, MAX_SNAPSHOT_LAST_MESSAGES), maxCharsPerConversation: textOptions.maxCharsPerConversation === undefined ? undefined : integer(textOptions.maxCharsPerConversation, "text.maxCharsPerConversation", 1, MAX_SNAPSHOT_CHARS_PER_CONVERSATION) } : undefined,
     caller: caller ? { pid: caller.pid === undefined ? undefined : integer(caller.pid, "caller.pid", 1), transcriptPath: caller.transcriptPath === undefined ? undefined : string(caller.transcriptPath, "caller.transcriptPath")! } : undefined,
   };
 }


### PR DESCRIPTION
Several MCP tools advertised a permissive argument schema and then rejected the call against a stricter server-side allowlist. The tool schema is the only thing a caller can see, so when it says "any object here", the caller guesses — and the guess dies against a list that was never published anywhere.

Neither side was wrong on its own. They disagreed, and only one of them was authoritative.

## Evidence that motivated the scope

Distinct rejection messages across agent transcripts, last 10 days:

| Count | Rejection | Surface |
|---|---|---|
| 131 | `unknown role` | `spawn_agent.role` |
| 24 | `unknown pipeline action` | `pipeline_action.action` |
| 18 | `unknown scope.mode` | `operator_snapshot.scope` |
| 18 | `invalid scope.kind` | `operator_snapshot.scope` |
| 17 | `unknown text.maxChars` | `operator_snapshot.text` |
| 16 | `unknown text.maxRecords` | `operator_snapshot.text` |
| 15 | `unknown view.includeFrame` | `operator_snapshot.view` |
| 11 | `invalid role parameter: lens` | `spawn_agent.roleParams` |
| 8 | `unknown text.mode` | `operator_snapshot.text` |
| 6 each | `view.includeSelection`, `scope.project` | `operator_snapshot` |
| 3 each | `view.includeConversations`, `view.includeBoard`, `view.detail`, `text.maxRecordsPerConversation`, `scope.include` | `operator_snapshot` |
| 5+3+3+3+1+1 | `unknown role parameter:` `confirm`, `src`, `baseRef`, `access`, `task`, `displayName` | `spawn_agent.roleParams` |

`operator_snapshot` alone accounts for **119 rejected calls whose only defect was a guessed key name**. Several of those guesses are real argument names borrowed from a neighbouring tool — `mode` is a genuine `lifecycle_events` argument — which is exactly what an open schema invites.

## Schema mismatch classes this fixes

**1. Open object published against a closed key set.** `operator_snapshot`'s `view` / `scope` / `text` / `caller` were `z.record(z.string(), z.unknown())` while `validateSnapshotRequest` enforced an exact allowlist. They are now real object schemas.

They are `.strict()`, not plain `z.object`. A plain object schema *strips* unknown keys silently, which would have turned a wasted round trip into a wrong answer — the caller's `maxCharsPerConversation` typo would be dropped and the call would succeed with the wrong bound. A loud rejection is the correct trade here.

**2. Open string published against a closed enum.** `pipeline_action.action` was `z.string().min(1)` while the PATCH route admitted a fixed 18-entry set. It is now `z.enum(PIPELINE_ACTIONS)`, single-sourced with the route.

**3. Closed-set rejections that named no alternative.** `exact()` and `oneOf()` in the view and board validators, `unknown role`, and `unknown role parameter` all reported only what was wrong. They now name what is right:

```
unknown text.mode (allowed: include, lastMessages, maxCharsPerConversation)
invalid scope.kind (allowed: focused, selected, visible, focused-selected, paths)
unknown role: no-such-role (allowed: orchestrator, reviewer, verifier, builder, architect, cleaner, prod-auditor, deployer)
unknown role parameter: unexpected (reviewer accepts: diffSource, lens, mode, parallelN)
```

`roleParams` stays an open record in the schema — its valid keys depend on the chosen role, so it cannot be typed statically — but its rejection now enumerates that role's parameters.

## Single-sourcing

The allowlists live in one place each: `SNAPSHOT_*_KEYS`, `VIEW_SCOPE_KINDS`, `VIEW_RESOLUTIONS` and the snapshot bounds in `src/lib/view/types.ts`; `PIPELINE_ACTIONS` in `src/lib/pipelines/types.ts`. The tool schema and the server-side validator both read from those constants, so a key added to one and forgotten in the other cannot happen again. A duplicated literal list is the defect being fixed — reintroducing one would be the same bug wearing a different hat.

## Verification

Run locally; CI on this repo runs only the privacy gates, so green checks here prove very little on their own.

- 61 focused tests pass, 0 fail: `src/lib/view/validation.allowlists.test.ts`, `src/lib/view/view.test.ts`, `src/lib/board/validation.test.ts`, `src/lib/roles/registry.test.ts`, `src/lib/roles/parameters.test.ts`, `src/lib/mcp/server.test.ts`
- TypeScript exit 0
- ESLint exit 0 on all changed files
- privacy publication gate PASS
- `bun run build` exit 0
- `git diff --check` clean

New tests pin both halves: that a rejection names the accepted alternatives, and that the published tool schema and the validator admit the same key set. The second is the regression that actually matters.

One existing expectation changed deliberately — `registry.test.ts` pinned the old bare `unknown role parameter: unexpected` string. It now asserts the enumerated form, plus a new case for `unknown role`.

## Scope

10 files, +184/−46, confined to argument schemas, their validators, and the constants they now share. No runtime, bindings, scanner or component code is touched.

The broader Viewer HTTP ↔ MCP **method-surface** parity question — tools that are missing entirely rather than mis-typed — is deliberately NOT in this PR and remains a separate audit.

Closes #774
