### PR TITLE
fix(feed): explicit dismiss on the live question card (#765)

### DIFF
--- a/src/components/feed/QuestionCard.dismiss.dom.test.tsx
+++ b/src/components/feed/QuestionCard.dismiss.dom.test.tsx
@@ -1,0 +1,209 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { en } from "@/lib/i18n/en";
+import { uk } from "@/lib/i18n/uk";
+import type { FileEntry } from "@/lib/types";
+
+import { QuestionCard, isQuestionDismissed, questionDismissKey, rememberQuestionDismissed } from "./QuestionCard";
+
+/*
+ * Issue #765, explicit-dismiss half (the automatic half shipped in #775): a
+ * skipped question card stayed pinned to the composer forever with nothing on
+ * it to close it. The dismiss control must retire the card from the live
+ * composer region — the same exit scanner-side retirement takes, leaving the
+ * transcript's tool record as the history — and the dismissal must hold
+ * across a reload, per question, without ever touching the answer API.
+ */
+
+/* Mobile is driven through the same viewport query `useIsMobile` consults. */
+let narrowViewport = false;
+
+const dom = new Window({ url: "http://localhost/" });
+const matchMediaStub = (query: string) => ({
+  matches: narrowViewport && String(query).replace(/\s+/g, "") === "(max-width:767px)",
+  media: String(query),
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent() { return false; },
+});
+dom.matchMedia = matchMediaStub as unknown as typeof dom.matchMedia;
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+});
+
+const originalFetch = globalThis.fetch;
+const roots: Root[] = [];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  narrowViewport = false;
+  for (const root of roots.splice(0)) flushSync(() => { root.unmount(); });
+  document.body.replaceChildren();
+  dom.localStorage.clear();
+});
+
+function questionFile(overrides: { toolUseId?: string; paneTarget?: string | null } = {}): FileEntry {
+  return {
+    path: "/sessions/q.jsonl",
+    root: "claude-projects",
+    name: "q.jsonl",
+    project: "demo",
+    title: "Question",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 1,
+    activity: "live",
+    proc: "running",
+    pid: 4_242,
+    model: null,
+    waitingInput: null,
+    pendingQuestion: {
+      kind: "question",
+      toolUseId: overrides.toolUseId ?? "tool-1",
+      transcriptPath: "/sessions/q.jsonl",
+      pid: 4_242,
+      paneTarget: overrides.paneTarget === undefined ? "%1" : overrides.paneTarget,
+      askedAt: "2026-07-26T00:00:00.000Z",
+      questions: [
+        {
+          question: "Which transport?",
+          header: "Transport",
+          multiSelect: false,
+          options: [
+            { label: "Structured", description: "pane-less", recommended: true },
+            { label: "Terminal", description: "tmux pane" },
+          ],
+        },
+      ],
+    },
+  } as unknown as FileEntry;
+}
+
+function renderCard(file: FileEntry): HTMLElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.push(root);
+  flushSync(() => { root.render(<QuestionCard file={file} />); });
+  return host as unknown as HTMLElement;
+}
+
+const dismissControl = (host: HTMLElement): HTMLButtonElement | undefined =>
+  [...host.querySelectorAll("button")].find(
+    (node) => node.getAttribute("aria-label") === en["question.dismiss"],
+  ) as HTMLButtonElement | undefined;
+
+test("dismiss retires the card from the composer region without any API call", () => {
+  let posts = 0;
+  globalThis.fetch = mock(async () => {
+    posts += 1;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const host = renderCard(questionFile());
+  expect(host.textContent).toContain(en["question.waiting"]);
+
+  const dismiss = dismissControl(host);
+  expect(dismiss).toBeTruthy();
+  /* A native, labelled button: focusable and keyboard-operable by contract,
+     and never a submit trigger inside a future form. */
+  expect(dismiss!.getAttribute("type")).toBe("button");
+  expect(dismiss!.hasAttribute("disabled")).toBe(false);
+
+  flushSync(() => { dismiss!.click(); });
+
+  /* The composer region is empty — the card no longer presents itself as
+     awaiting input anywhere. The transcript history is untouched by
+     construction: this component only ever owned the composer card. */
+  expect(host.textContent).toBe("");
+  expect(host.querySelector("#question")).toBeNull();
+  expect(posts).toBe(0);
+});
+
+test("a dismissal is remembered across a remount (reload) of the same question", () => {
+  const host = renderCard(questionFile());
+  flushSync(() => { dismissControl(host)!.click(); });
+
+  /* A fresh mount — what a reload or a second pane of the conversation is. */
+  const remounted = renderCard(questionFile());
+  expect(remounted.textContent).toBe("");
+  expect(remounted.querySelector("#question")).toBeNull();
+});
+
+test("a dismissal is keyed to its question: the next question still renders", () => {
+  const host = renderCard(questionFile({ toolUseId: "tool-1" }));
+  flushSync(() => { dismissControl(host)!.click(); });
+
+  const next = renderCard(questionFile({ toolUseId: "tool-2" }));
+  expect(next.textContent).toContain(en["question.waiting"]);
+  expect(next.querySelector("#question")).not.toBeNull();
+});
+
+test("the pane-less variant of the card carries the same dismiss control", () => {
+  const host = renderCard(questionFile({ paneTarget: null }));
+  expect(host.textContent).toContain(en["question.noPane"]);
+
+  const dismiss = dismissControl(host);
+  expect(dismiss).toBeTruthy();
+  flushSync(() => { dismiss!.click(); });
+  expect(host.textContent).toBe("");
+});
+
+test("on a phone the dismiss control meets the 44px touch target", () => {
+  narrowViewport = true;
+  const host = renderCard(questionFile());
+  const dismiss = dismissControl(host)!;
+  /* h-11/w-11 is the repo's 44px minimum for phone transcript question
+     actions — the same classes the composer's receipt dismiss uses. */
+  expect(dismiss.className).toContain("h-11");
+  expect(dismiss.className).toContain("w-11");
+});
+
+test("both locales label the control", () => {
+  expect(typeof en["question.dismiss"]).toBe("string");
+  expect(en["question.dismiss"]).not.toBe("");
+  expect(typeof uk["question.dismiss"]).toBe("string");
+  expect(uk["question.dismiss"]).not.toBe("");
+});
+
+test("the dismissal store is per question and safe against a broken storage", () => {
+  const q1 = { transcriptPath: "/sessions/a.jsonl", toolUseId: "t1" };
+  const q2 = { transcriptPath: "/sessions/a.jsonl", toolUseId: "t2" };
+  expect(questionDismissKey(q1)).not.toBe(questionDismissKey(q2));
+
+  const store = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+  };
+  expect(isQuestionDismissed(storage, q1)).toBe(false);
+  rememberQuestionDismissed(storage, q1);
+  expect(isQuestionDismissed(storage, q1)).toBe(true);
+  expect(isQuestionDismissed(storage, q2)).toBe(false);
+
+  /* Safari private mode and quota errors throw; dismissal must not. */
+  const throwing = {
+    getItem: () => { throw new Error("blocked"); },
+    setItem: () => { throw new Error("blocked"); },
+  };
+  expect(isQuestionDismissed(throwing, q1)).toBe(false);
+  expect(() => rememberQuestionDismissed(throwing, q1)).not.toThrow();
+  expect(isQuestionDismissed(null, q1)).toBe(false);
+});

--- a/src/components/feed/QuestionCard.tsx
+++ b/src/components/feed/QuestionCard.tsx
@@ -10,6 +10,44 @@ import type { FileEntry, PendingQuestionItem } from "@/lib/types";
 
 type CardState = "pending" | "delivering" | "answered" | "superseded" | "failed";
 
+/*
+ * Issue #765: an explicit dismiss on the live composer card. Dismissal is a
+ * view decision, so it mirrors what scanner-side retirement (#775) already
+ * does to the composer region — the card stops rendering there — while the
+ * transcript's own tool record stays as history (#757: nothing vanishes from
+ * the transcript). It is remembered in localStorage per question, the same
+ * store the deck disclosure pins use, so a dead card does not return on every
+ * reload — which is exactly the friction the issue describes.
+ */
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+type QuestionIdentity = { transcriptPath: string; toolUseId: string };
+
+export function questionDismissKey(question: QuestionIdentity): string {
+  return `llvQuestionDismissed:${question.transcriptPath}:${question.toolUseId}`;
+}
+
+export function isQuestionDismissed(storage: StorageLike | null, question: QuestionIdentity): boolean {
+  try {
+    return storage?.getItem(questionDismissKey(question)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function rememberQuestionDismissed(storage: StorageLike | null, question: QuestionIdentity): void {
+  try {
+    storage?.setItem(questionDismissKey(question), "1");
+  } catch { /* best-effort: a full or blocked store only costs durability */ }
+}
+
+function browserStorage(): StorageLike | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
 /** A submitted answer, kept so a failure can offer a labelled retry (#697). */
 interface Attempt {
   payload: Record<string, unknown>;
@@ -68,6 +106,10 @@ export function QuestionCard({ file }: { file: FileEntry }) {
      (a multi-question form is several decisions), and leaving them looking
      chosen asserted an acceptance that never happened. */
   const [failedAnswers, setFailedAnswers] = useState<Record<number, number[]> | null>(null);
+  /* Issue #765: the toolUseId the operator dismissed in this mount. Keyed by
+     id — the component instance survives one pending question being replaced
+     by the next, and a dismissal must never carry over to the newcomer. */
+  const [dismissedFor, setDismissedFor] = useState<string | null>(null);
   const hasPane = pending ? pending.paneTarget !== null : file.pid !== null && file.proc === "running";
 
   const selectedLabel = useMemo(() => {
@@ -187,6 +229,29 @@ export function QuestionCard({ file }: { file: FileEntry }) {
     );
   }
 
+  /* Issue #765: a dismissed question leaves the composer region entirely —
+     the same exit scanner-side retirement takes — and the transcript's tool
+     record remains the history. The storage read covers a dismissal recorded
+     before this mount (a reload, another pane of the same conversation). */
+  if (dismissedFor === pending.toolUseId || isQuestionDismissed(browserStorage(), pending)) return null;
+
+  const dismiss = () => {
+    rememberQuestionDismissed(browserStorage(), pending);
+    setDismissedFor(pending.toolUseId);
+  };
+  const dismissButton = (
+    <button
+      type="button"
+      aria-label={t("question.dismiss")}
+      className={`ml-auto inline-flex shrink-0 items-center justify-center rounded text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+        isMobile ? "h-11 w-11" : "px-0.5"
+      }`}
+      onClick={dismiss}
+    >
+      <X className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />
+    </button>
+  );
+
   const submit = async (payload: Record<string, unknown>, optimistic: string, selection: Record<number, number[]> | null = null) => {
     setState("delivering");
     setMessage("");
@@ -281,8 +346,11 @@ export function QuestionCard({ file }: { file: FileEntry }) {
   if (pending && !hasPane) {
     return (
       <div id="question" className="my-4 rounded-[8px] border border-warning/45 bg-warning-soft p-4 shadow-1">
-        <div className="mb-2 inline-flex items-center gap-1.5 rounded-full bg-warning-soft px-2 py-0.5 text-[11px] font-bold text-warning">
-          <Pause className="h-3.5 w-3.5" aria-hidden /> {t("question.waiting")}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-warning-soft px-2 py-0.5 text-[11px] font-bold text-warning">
+            <Pause className="h-3.5 w-3.5" aria-hidden /> {t("question.waiting")}
+          </span>
+          {dismissButton}
         </div>
         <div className="text-[13px] font-semibold text-danger">{t("question.noPane")}</div>
         {pending.kind === "plan" ? (
@@ -310,6 +378,7 @@ export function QuestionCard({ file }: { file: FileEntry }) {
           <Pause className="h-3.5 w-3.5" aria-hidden /> {t("question.waiting")}
         </span>
         {!hasPane ? <span className="text-[12px] font-semibold text-danger">{t("question.noPane")}</span> : null}
+        {dismissButton}
       </div>
       {pending.kind === "plan" ? (
         <>

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -739,6 +739,9 @@ export const en = {
   "question.approve": "Approve",
   "question.reject": "Reject",
   "question.ownAnswer": "Your own answer…",
+  // Explicit dismiss (issue #765) — retires the card from the composer
+  // region; the transcript's own tool record stays as history.
+  "question.dismiss": "Dismiss the question card",
   // Delivery failure (issue #697) — translated at the boundary, never the
   // server's own exception text.
   "question.deliveryFailed": "Delivery failed",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -708,6 +708,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "question.approve": "Затвердити",
   "question.reject": "Відхилити",
   "question.ownAnswer": "Своя відповідь…",
+  "question.dismiss": "Прибрати картку запитання",
   "question.deliveryFailed": "Доставка не вдалася",
   "question.failedChoice": "не доставлено",
   "question.retryAnswer": "Спробувати ще",


### PR DESCRIPTION
Completes the explicit-dismiss half of #765 left open by #775 (which shipped the automatic-retirement half; that scanner logic is untouched here).

## What

A skipped question card stayed pinned to the composer forever with no way to close it. The card header now carries a labelled dismiss control (`aria-label`, lucide `X`), on both the pane and the pane-less card variants.

Dismissing takes the same exit that scanner-side retirement already takes: the card stops rendering in the live composer region entirely and stops presenting itself as awaiting input, while the transcript's own tool record remains as history — consistent with #757 (nothing vanishes from the transcript; the checked convention is that retirement removes only the composer card).

## Persistence decision

Dismissal **persists across a reload**, client-locally: it is remembered in `localStorage` per question, keyed by transcript path + `toolUseId` (`llvQuestionDismissed:…`), following the existing convention of the review-deck disclosure pins (`reviewDeckDisclosure.ts`). Rationale: without persistence the dead card returns on every reload, recreating exactly the friction the issue describes; no durable server store or API exists for question dismissal, and inventing one was out of scope. A dismissal never carries over to the next question — the state is keyed by `toolUseId`, covering the case where a newer pending question replaces the dismissed one without the component unmounting.

## Accessibility / mobile

Native `type="button"` with a translated `aria-label` (EN + UK), keyboard-operable by contract, `focus-visible` ring. On phone widths it uses the `h-11`/`w-11` (44px) sizing the composer's receipt dismiss already uses, meeting the repo's phone touch-target rule.

## Tests (all red-proven by mutation on a pristine archive copy)

`src/components/feed/QuestionCard.dismiss.dom.test.tsx` — 7 tests:
- dismiss retires the card from the composer region, with **zero** answer-API calls;
- the dismissal survives a remount (reload) of the same question;
- it is keyed per question — the next `toolUseId` still renders;
- the pane-less variant carries the same control;
- 44px touch target on phone widths;
- both locales label the control;
- storage helpers are per-question and safe against a throwing/absent storage.

Mutations proven red on a `git archive` copy of main outside the worktree: (a) no product change at all → suite fails; (b) early return removed (control present but card never retires) → 3 fail; (c) `setItem` dropped (no persistence) → 2 fail; (d) mobile `h-11 w-11` sizing removed → 1 fail.

## Verification

- `bunx tsc --noEmit` — clean
- `eslint` on the four changed files — clean
- `bun test src/components/feed/QuestionCard.dismiss.dom.test.tsx src/components/feed/QuestionCard.delivery.dom.test.tsx` (isolated HOME/XDG/TMPDIR/LLV_STATE_DIR) — 12 pass
- `bun scripts/privacy-publication-gate.ts` — PASS
- `bun run build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)