### PR TITLE
fix(mcp): close deployment and schema review findings

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -88,7 +88,7 @@ async function getViewerControl(pathname: string): Promise<Record<string, unknow
     throw new Error("Viewer control is unreachable");
   }
   const result = await response.json().catch(() => ({})) as Record<string, unknown>;
-  if (result.error || !response.ok) {
+  if (!response.ok) {
     const error = text(result.error) || `Viewer control request failed with status ${response.status}`;
     throw new McpToolRefusal(error, {
       error,

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -90,6 +90,52 @@ test("the production Viewer control adapter reads a live plane with no runtime v
   }
 });
 
+test("the production Viewer control adapter returns a failed deployment domain object and preserves 404", async () => {
+  const deployment = {
+    deploymentId: "deployment_http_failed",
+    phase: "failed",
+    revision: "d".repeat(40),
+    error: "candidate health check failed",
+  };
+  let missing = false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      expect(new URL(request.url).pathname).toBe("/api/runtime/deployments/deployment_http_failed");
+      return missing
+        ? Response.json({ error: "viewer deployment was not found" }, { status: 404 })
+        : Response.json(deployment);
+    },
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  const bindings = viewerMcpBindings();
+
+  try {
+    expect(await bindings.deployment_status({
+      clientRequestId: "deployment-production-failed",
+      deploymentId: "deployment_http_failed",
+    })).toEqual({
+      deploymentId: "deployment_http_failed",
+      deployment,
+    });
+
+    missing = true;
+    await expect(bindings.deployment_status({
+      clientRequestId: "deployment-production-missing",
+      deploymentId: "deployment_http_failed",
+    })).rejects.toMatchObject({
+      message: "viewer deployment was not found",
+      details: {
+        error: "viewer deployment was not found",
+        status: 404,
+      },
+    });
+  } finally {
+    server.stop(true);
+  }
+});
+
 test("deployment_status exposes the absent-plane code and keeps an unreachable plane distinct", async () => {
   let runtimeUnavailable = false;
   const server = Bun.serve({

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "bun:test";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { listRoles, resolveRole } from "@/lib/roles/registry";
+import {
+  MAX_SCOPE_PATHS,
+  MAX_SNAPSHOT_CHARS_PER_CONVERSATION,
+  MAX_SNAPSHOT_LAST_MESSAGES,
+  MAX_SNAPSHOT_STRING_LENGTH,
+} from "@/lib/view/types";
+import { validateSnapshotRequest } from "@/lib/view/validation";
+
+import {
+  MCP_TOOL_NAMES,
+  TOOL_INPUT_SCHEMAS,
+  MemoryMcpReceiptStore,
+  createMcpToolService,
+  createViewerMcpServer,
+  type McpToolBindings,
+} from "./server";
+
+function inertBindings(overrides: Partial<McpToolBindings> = {}): McpToolBindings {
+  return {
+    ...Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])),
+    ...overrides,
+  } as McpToolBindings;
+}
+
+async function withProtocolClient<T>(
+  bindings: McpToolBindings,
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const server = createViewerMcpServer(createMcpToolService(bindings, new MemoryMcpReceiptStore()));
+  const client = new Client({ name: "schema-parity-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    return await run(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function requiredRoleParams(role: ReturnType<typeof listRoles>[number]): Record<string, string | number> {
+  return Object.fromEntries(role.parameters.map((parameter) => {
+    if (parameter.default !== undefined) return [parameter.key, parameter.default];
+    if (parameter.kind === "integer") return [parameter.key, parameter.min ?? 1];
+    if (parameter.kind === "select") return [parameter.key, parameter.options?.[0] ?? "value"];
+    return [parameter.key, "value"];
+  }));
+}
+
+test("spawn_agent publishes the registry role ids once and rejects unknown roles at the protocol boundary", async () => {
+  const roleIds = listRoles().map((role) => role.id);
+  let spawnCalls = 0;
+
+  await withProtocolClient(inertBindings({
+    spawn_agent: async () => {
+      spawnCalls += 1;
+      return {};
+    },
+  }), async (client) => {
+    const listed = await client.listTools();
+    const spawnSchema = listed.tools.find((tool) => tool.name === "spawn_agent")?.inputSchema;
+    const roleSchema = spawnSchema?.properties?.role as { enum?: string[] } | undefined;
+
+    expect(roleSchema?.enum).toEqual(roleIds);
+    expect(new Set(roleSchema?.enum).size).toBe(roleIds.length);
+
+    const unknownRole = await client.callTool({
+      name: "spawn_agent",
+      arguments: {
+        clientRequestId: "spawn-unknown-role",
+        cwd: ".",
+        "prompt": "Run the assigned check.",
+        role: "unknown-role",
+      },
+    });
+    expect(unknownRole.isError).toBe(true);
+    expect(spawnCalls).toBe(0);
+
+    for (const role of roleIds) {
+      await client.callTool({
+        name: "spawn_agent",
+        arguments: {
+          clientRequestId: `spawn-valid-${role}`,
+          cwd: ".",
+          "prompt": "Run the assigned check.",
+          role,
+          roleParams: { roleSpecificField: true },
+        },
+      });
+    }
+    expect(spawnCalls).toBe(roleIds.length);
+  });
+});
+
+test("every registry role resolves and unknown-role errors enumerate the same alternatives", () => {
+  const roles = listRoles();
+  for (const role of roles) {
+    expect(resolveRole(role.id, requiredRoleParams(role))).toMatchObject({ ok: true });
+  }
+
+  const unknown = resolveRole("unknown-role");
+  expect(unknown).toEqual({
+    ok: false,
+    error: `unknown role: unknown-role (allowed: ${roles.map((role) => role.id).join(", ")})`,
+  });
+});
+
+test("operator_snapshot publishes a strict conditional schema and rejects invalid paths at the protocol boundary", async () => {
+  const oversized = "x".repeat(MAX_SNAPSHOT_STRING_LENGTH + 1);
+  let snapshotCalls = 0;
+
+  await withProtocolClient(inertBindings({
+    operator_snapshot: async () => {
+      snapshotCalls += 1;
+      return {};
+    },
+  }), async (client) => {
+    const listed = await client.listTools();
+    const snapshotSchema = listed.tools.find((tool) => tool.name === "operator_snapshot")?.inputSchema;
+    expect(snapshotSchema?.additionalProperties).toBe(false);
+
+    const invalidArguments = [
+      { unexpected: true },
+      { scope: { kind: "paths" } },
+      { scope: { kind: "visible", paths: ["sessions/a.jsonl"] } },
+      { scope: { kind: "paths", paths: [""] } },
+      { scope: { kind: "paths", paths: [oversized] } },
+      { scope: { kind: "paths", paths: ["sessions/a.jsonl", "sessions/a.jsonl"] } },
+    ];
+    for (const [index, invalid] of invalidArguments.entries()) {
+      const rejected = await client.callTool({
+        name: "operator_snapshot",
+        arguments: {
+          clientRequestId: `snapshot-invalid-${index}`,
+          ...invalid,
+        },
+      });
+      expect(rejected.isError).toBe(true);
+    }
+    expect(snapshotCalls).toBe(0);
+  });
+});
+
+test("every generated operator_snapshot schema combination is admitted by request validation", () => {
+  const schema = TOOL_INPUT_SCHEMAS.operator_snapshot;
+  const views = [
+    undefined,
+    {},
+    { id: "view-a" },
+    { deviceId: "device-a" },
+    { resolution: "latest-interaction" },
+    { id: "view-a", deviceId: "device-a", resolution: "require-explicit" },
+  ];
+  const scopes = [
+    undefined,
+    { kind: "focused" },
+    { kind: "selected" },
+    { kind: "visible" },
+    { kind: "focused-selected" },
+    { kind: "paths", paths: [] },
+    { kind: "paths", paths: Array.from({ length: MAX_SCOPE_PATHS }, (_, index) => `sessions/${index}.jsonl`) },
+  ];
+  const textOptions = [
+    undefined,
+    {},
+    { include: false },
+    { lastMessages: 1 },
+    { lastMessages: MAX_SNAPSHOT_LAST_MESSAGES },
+    { maxCharsPerConversation: 1 },
+    { maxCharsPerConversation: MAX_SNAPSHOT_CHARS_PER_CONVERSATION },
+  ];
+  const callers = [
+    undefined,
+    {},
+    { pid: 1 },
+    { transcriptPath: "sessions/caller.jsonl" },
+    { pid: Number.MAX_SAFE_INTEGER, transcriptPath: "sessions/caller.jsonl" },
+  ];
+
+  let accepted = 0;
+  for (const schemaVersion of [undefined, 1]) {
+    for (const view of views) {
+      for (const scope of scopes) {
+        for (const text of textOptions) {
+          for (const caller of callers) {
+            const candidate = {
+              clientRequestId: `snapshot-parity-${accepted}`,
+              ...(schemaVersion === undefined ? {} : { schemaVersion }),
+              ...(view === undefined ? {} : { view }),
+              ...(scope === undefined ? {} : { scope }),
+              ...(text === undefined ? {} : { text }),
+              ...(caller === undefined ? {} : { caller }),
+            };
+            const parsed = schema.safeParse(candidate);
+            if (!parsed.success) continue;
+            accepted += 1;
+            const validatorInput = Object.fromEntries(
+              Object.entries(parsed.data).filter(([key]) => key !== "clientRequestId"),
+            );
+            expect(() => validateSnapshotRequest({
+              schemaVersion: 1,
+              ...validatorInput,
+            })).not.toThrow();
+          }
+        }
+      }
+    }
+  }
+  expect(accepted).toBeGreaterThan(1_000);
+});

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -203,6 +203,7 @@ test("operator_snapshot bounds snapshot strings and rejects duplicate paths at t
 
 test("every generated operator_snapshot schema combination is admitted by request validation", () => {
   const schema = TOOL_INPUT_SCHEMAS.operator_snapshot;
+  const oversized = "x".repeat(MAX_SNAPSHOT_STRING_LENGTH + 1);
   const views = [
     undefined,
     {},
@@ -240,6 +241,18 @@ test("every generated operator_snapshot schema combination is admitted by reques
   ];
 
   let accepted = 0;
+  const compareAcceptedShape = (candidate: Record<string, unknown>) => {
+    const parsed = schema.safeParse(candidate);
+    if (!parsed.success) return;
+    accepted += 1;
+    const validatorInput = Object.fromEntries(
+      Object.entries(parsed.data).filter(([key]) => key !== "clientRequestId"),
+    );
+    expect(() => validateSnapshotRequest({
+      schemaVersion: 1,
+      ...validatorInput,
+    })).not.toThrow();
+  };
   for (const schemaVersion of [undefined, 1]) {
     for (const view of views) {
       for (const scope of scopes) {
@@ -253,20 +266,27 @@ test("every generated operator_snapshot schema combination is admitted by reques
               ...(text === undefined ? {} : { text }),
               ...(caller === undefined ? {} : { caller }),
             };
-            const parsed = schema.safeParse(candidate);
-            if (!parsed.success) continue;
-            accepted += 1;
-            const validatorInput = Object.fromEntries(
-              Object.entries(parsed.data).filter(([key]) => key !== "clientRequestId"),
-            );
-            expect(() => validateSnapshotRequest({
-              schemaVersion: 1,
-              ...validatorInput,
-            })).not.toThrow();
+            compareAcceptedShape(candidate);
           }
         }
       }
     }
+  }
+  for (const [index, divergent] of [
+    { unexpected: true },
+    { scope: { kind: "paths" } },
+    { scope: { kind: "visible", paths: ["sessions/a.jsonl"] } },
+    { scope: { kind: "paths", paths: [""] } },
+    { scope: { kind: "paths", paths: [oversized] } },
+    { scope: { kind: "paths", paths: ["sessions/a.jsonl", "sessions/a.jsonl"] } },
+    { view: { id: "" } },
+    { view: { deviceId: oversized } },
+    { caller: { transcriptPath: "" } },
+  ].entries()) {
+    compareAcceptedShape({
+      clientRequestId: `snapshot-divergence-${index}`,
+      ...divergent,
+    });
   }
   expect(accepted).toBeGreaterThan(1_000);
 });

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -53,7 +53,20 @@ function requiredRoleParams(role: ReturnType<typeof listRoles>[number]): Record<
   }));
 }
 
-test("spawn_agent publishes the registry role ids once and rejects unknown roles at the protocol boundary", async () => {
+test("spawn_agent listTools publishes every registry role exactly once", async () => {
+  const roleIds = listRoles().map((role) => role.id);
+
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    const spawnSchema = listed.tools.find((tool) => tool.name === "spawn_agent")?.inputSchema;
+    const roleSchema = spawnSchema?.properties?.role as { enum?: string[] } | undefined;
+
+    expect(roleSchema?.enum).toEqual(roleIds);
+    expect(new Set(roleSchema?.enum).size).toBe(roleIds.length);
+  });
+});
+
+test("spawn_agent rejects unknown roles at the protocol boundary while valid roles and roleParams remain admitted", async () => {
   const roleIds = listRoles().map((role) => role.id);
   let spawnCalls = 0;
 
@@ -63,25 +76,6 @@ test("spawn_agent publishes the registry role ids once and rejects unknown roles
       return {};
     },
   }), async (client) => {
-    const listed = await client.listTools();
-    const spawnSchema = listed.tools.find((tool) => tool.name === "spawn_agent")?.inputSchema;
-    const roleSchema = spawnSchema?.properties?.role as { enum?: string[] } | undefined;
-
-    expect(roleSchema?.enum).toEqual(roleIds);
-    expect(new Set(roleSchema?.enum).size).toBe(roleIds.length);
-
-    const unknownRole = await client.callTool({
-      name: "spawn_agent",
-      arguments: {
-        clientRequestId: "spawn-unknown-role",
-        cwd: ".",
-        "prompt": "Run the assigned check.",
-        role: "unknown-role",
-      },
-    });
-    expect(unknownRole.isError).toBe(true);
-    expect(spawnCalls).toBe(0);
-
     for (const role of roleIds) {
       await client.callTool({
         name: "spawn_agent",
@@ -94,6 +88,18 @@ test("spawn_agent publishes the registry role ids once and rejects unknown roles
         },
       });
     }
+    expect(spawnCalls).toBe(roleIds.length);
+
+    const unknownRole = await client.callTool({
+      name: "spawn_agent",
+      arguments: {
+        clientRequestId: "spawn-unknown-role",
+        cwd: ".",
+        "prompt": "Run the assigned check.",
+        role: "unknown-role",
+      },
+    });
+    expect(unknownRole.isError).toBe(true);
     expect(spawnCalls).toBe(roleIds.length);
   });
 });
@@ -111,8 +117,7 @@ test("every registry role resolves and unknown-role errors enumerate the same al
   });
 });
 
-test("operator_snapshot publishes a strict conditional schema and rejects invalid paths at the protocol boundary", async () => {
-  const oversized = "x".repeat(MAX_SNAPSHOT_STRING_LENGTH + 1);
+test("operator_snapshot publishes a strict top-level schema", async () => {
   let snapshotCalls = 0;
 
   await withProtocolClient(inertBindings({
@@ -125,19 +130,68 @@ test("operator_snapshot publishes a strict conditional schema and rejects invali
     const snapshotSchema = listed.tools.find((tool) => tool.name === "operator_snapshot")?.inputSchema;
     expect(snapshotSchema?.additionalProperties).toBe(false);
 
+    const rejected = await client.callTool({
+      name: "operator_snapshot",
+      arguments: {
+        clientRequestId: "snapshot-invalid-top-level",
+        unexpected: true,
+      },
+    });
+    expect(rejected.isError).toBe(true);
+    expect(snapshotCalls).toBe(0);
+  });
+});
+
+test("operator_snapshot scope discriminates paths from non-path kinds at the protocol boundary", async () => {
+  let snapshotCalls = 0;
+
+  await withProtocolClient(inertBindings({
+    operator_snapshot: async () => {
+      snapshotCalls += 1;
+      return {};
+    },
+  }), async (client) => {
     const invalidArguments = [
-      { unexpected: true },
       { scope: { kind: "paths" } },
       { scope: { kind: "visible", paths: ["sessions/a.jsonl"] } },
-      { scope: { kind: "paths", paths: [""] } },
-      { scope: { kind: "paths", paths: [oversized] } },
-      { scope: { kind: "paths", paths: ["sessions/a.jsonl", "sessions/a.jsonl"] } },
     ];
     for (const [index, invalid] of invalidArguments.entries()) {
       const rejected = await client.callTool({
         name: "operator_snapshot",
         arguments: {
-          clientRequestId: `snapshot-invalid-${index}`,
+          clientRequestId: `snapshot-invalid-scope-${index}`,
+          ...invalid,
+        },
+      });
+      expect(rejected.isError).toBe(true);
+    }
+    expect(snapshotCalls).toBe(0);
+  });
+});
+
+test("operator_snapshot bounds snapshot strings and rejects duplicate paths at the protocol boundary", async () => {
+  const oversized = "x".repeat(MAX_SNAPSHOT_STRING_LENGTH + 1);
+  let snapshotCalls = 0;
+
+  await withProtocolClient(inertBindings({
+    operator_snapshot: async () => {
+      snapshotCalls += 1;
+      return {};
+    },
+  }), async (client) => {
+    const invalidArguments = [
+      { scope: { kind: "paths", paths: [""] } },
+      { scope: { kind: "paths", paths: [oversized] } },
+      { scope: { kind: "paths", paths: ["sessions/a.jsonl", "sessions/a.jsonl"] } },
+      { view: { id: "" } },
+      { view: { deviceId: oversized } },
+      { caller: { transcriptPath: "" } },
+    ];
+    for (const [index, invalid] of invalidArguments.entries()) {
+      const rejected = await client.callTool({
+        name: "operator_snapshot",
+        arguments: {
+          clientRequestId: `snapshot-invalid-string-${index}`,
           ...invalid,
         },
       });
@@ -156,6 +210,7 @@ test("every generated operator_snapshot schema combination is admitted by reques
     { deviceId: "device-a" },
     { resolution: "latest-interaction" },
     { id: "view-a", deviceId: "device-a", resolution: "require-explicit" },
+    { id: "v".repeat(MAX_SNAPSHOT_STRING_LENGTH) },
   ];
   const scopes = [
     undefined,
@@ -181,6 +236,7 @@ test("every generated operator_snapshot schema combination is admitted by reques
     { pid: 1 },
     { transcriptPath: "sessions/caller.jsonl" },
     { pid: Number.MAX_SAFE_INTEGER, transcriptPath: "sessions/caller.jsonl" },
+    { transcriptPath: "t".repeat(MAX_SNAPSHOT_STRING_LENGTH) },
   ];
 
   let accepted = 0;

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1162,10 +1162,18 @@ test("#774 tool schemas publish the closed sets their servers enforce", () => {
   const snapshot = TOOL_INPUT_SCHEMAS.operator_snapshot.shape;
   expect(Object.keys(snapshot.text.unwrap().shape).sort()).toEqual([...SNAPSHOT_TEXT_KEYS].sort());
   expect(Object.keys(snapshot.view.unwrap().shape).sort()).toEqual([...SNAPSHOT_VIEW_KEYS].sort());
-  expect(Object.keys(snapshot.scope.unwrap().shape).sort()).toEqual([...SNAPSHOT_SCOPE_KEYS].sort());
+  expect([
+    ...new Set(snapshot.scope.unwrap().options.flatMap(
+      (option: { shape: Record<string, unknown> }) => Object.keys(option.shape),
+    )),
+  ].sort()).toEqual([...SNAPSHOT_SCOPE_KEYS].sort());
   expect(Object.keys(snapshot.caller.unwrap().shape).sort()).toEqual([...SNAPSHOT_CALLER_KEYS].sort());
 
   /* Strict, not stripping: an unknown nested key must stay a loud rejection. */
   expect(snapshot.text.unwrap().safeParse({ mode: "digest" }).success).toBe(false);
   expect(snapshot.view.unwrap().safeParse({ includeFrame: true }).success).toBe(false);
+  expect(TOOL_INPUT_SCHEMAS.operator_snapshot.safeParse({
+    clientRequestId: "snapshot-extra-key",
+    unknown: true,
+  }).success).toBe(false);
 });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -9,8 +9,10 @@ import { z } from "zod";
 import { statePath } from "@/lib/configDir";
 import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
 import { procBackend } from "@/lib/proc";
+import { ROLE_IDS } from "@/lib/roles/types";
 import {
-  MAX_SCOPE_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, VIEW_RESOLUTIONS, VIEW_SCOPE_KINDS,
+  MAX_SCOPE_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, MAX_SNAPSHOT_STRING_LENGTH,
+  MIN_SNAPSHOT_STRING_LENGTH, VIEW_RESOLUTIONS, VIEW_SCOPE_KINDS,
 } from "@/lib/view/types";
 
 import type { McpToolPolicy } from "./toolAllowlist";
@@ -996,6 +998,23 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
 
 const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key for this logical call.");
 const entityIdSchema = z.string().min(1);
+const snapshotStringSchema = z.string()
+  .min(MIN_SNAPSHOT_STRING_LENGTH)
+  .max(MAX_SNAPSHOT_STRING_LENGTH);
+const snapshotPathsSchema = z.array(snapshotStringSchema)
+  .max(MAX_SCOPE_PATHS)
+  .refine((paths) => new Set(paths).size === paths.length, {
+    message: "scope.paths must contain unique paths",
+  });
+const snapshotScopeSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.enum(VIEW_SCOPE_KINDS).exclude(["paths"]),
+  }).strict(),
+  z.object({
+    kind: z.literal("paths"),
+    paths: snapshotPathsSchema,
+  }).strict(),
+]);
 
 export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   spawn_agent: z.object({
@@ -1005,7 +1024,7 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     engine: z.enum(["claude", "codex"]).optional(),
     model: z.string().optional(),
     effort: z.string().optional(),
-    role: z.string().optional(),
+    role: z.enum(ROLE_IDS).optional(),
     roleParams: z.record(z.string(), z.unknown()).optional(),
     reviews: z.string().optional(),
     parentConversationId: z.string().optional(),
@@ -1141,14 +1160,11 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     clientRequestId: clientRequestIdSchema,
     schemaVersion: z.literal(1).optional(),
     view: z.object({
-      id: z.string().optional(),
-      deviceId: z.string().optional(),
+      id: snapshotStringSchema.optional(),
+      deviceId: snapshotStringSchema.optional(),
       resolution: z.enum(VIEW_RESOLUTIONS).optional(),
     }).strict().optional(),
-    scope: z.object({
-      kind: z.enum(VIEW_SCOPE_KINDS),
-      paths: z.array(z.string()).max(MAX_SCOPE_PATHS).optional().describe("Required for kind=paths, rejected otherwise."),
-    }).strict().optional(),
+    scope: snapshotScopeSchema.optional(),
     text: z.object({
       include: z.boolean().optional(),
       lastMessages: z.number().int().min(1).max(MAX_SNAPSHOT_LAST_MESSAGES).optional(),
@@ -1156,9 +1172,9 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     }).strict().optional(),
     caller: z.object({
       pid: z.number().int().min(1).optional(),
-      transcriptPath: z.string().optional(),
+      transcriptPath: snapshotStringSchema.optional(),
     }).strict().optional(),
-  }).passthrough(),
+  }).strict(),
   list_tasks: z.object({
     clientRequestId: clientRequestIdSchema,
     project: z.string().optional(),

--- a/src/lib/roles/store.ts
+++ b/src/lib/roles/store.ts
@@ -6,7 +6,7 @@ import { isEngineEffort } from "@/lib/agent/efforts";
 import { normalizeClaudeLaunchModel } from "@/lib/agent/models";
 
 import { ROLE_DEFAULTS } from "./defaults";
-import type { RoleDefinition, RoleId, RoleOverride, RoleOverridesFile } from "./types";
+import { ROLE_IDS, type RoleDefinition, type RoleId, type RoleOverride, type RoleOverridesFile } from "./types";
 
 export const ROLE_OVERRIDES_SCHEMA_VERSION = 1;
 
@@ -31,7 +31,7 @@ function atomicWriteJson(filePath: string, value: unknown): void {
 }
 
 function isRoleId(value: unknown): value is RoleId {
-  return ROLE_DEFAULTS.some((role) => role.id === value);
+  return typeof value === "string" && (ROLE_IDS as readonly string[]).includes(value);
 }
 
 function isOverride(value: unknown): value is RoleOverride {

--- a/src/lib/roles/types.ts
+++ b/src/lib/roles/types.ts
@@ -1,12 +1,15 @@
-export type RoleId =
-  | "orchestrator"
-  | "reviewer"
-  | "verifier"
-  | "builder"
-  | "architect"
-  | "cleaner"
-  | "prod-auditor"
-  | "deployer";
+export const ROLE_IDS = [
+  "orchestrator",
+  "reviewer",
+  "verifier",
+  "builder",
+  "architect",
+  "cleaner",
+  "prod-auditor",
+  "deployer",
+] as const;
+
+export type RoleId = typeof ROLE_IDS[number];
 
 export type RoleEngine = "claude" | "codex";
 

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -27,6 +27,8 @@ export const VIEW_SCOPE_KINDS = ["focused", "selected", "visible", "focused-sele
 export const VIEW_RESOLUTIONS = ["latest-interaction", "require-explicit"] as const;
 export const MAX_SNAPSHOT_LAST_MESSAGES = 20;
 export const MAX_SNAPSHOT_CHARS_PER_CONVERSATION = 4000;
+export const MIN_SNAPSHOT_STRING_LENGTH = 1;
+export const MAX_SNAPSHOT_STRING_LENGTH = 4096;
 
 export interface PresencePayloadV1 {
   schemaVersion: 1;

--- a/src/lib/view/validation.ts
+++ b/src/lib/view/validation.ts
@@ -1,5 +1,6 @@
 import {
-  MAX_PRESENCE_BYTES, MAX_SCOPE_PATHS, MAX_SELECTED_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, MAX_VISIBLE_PATHS,
+  MAX_PRESENCE_BYTES, MAX_SCOPE_PATHS, MAX_SELECTED_PATHS, MAX_SNAPSHOT_CHARS_PER_CONVERSATION, MAX_SNAPSHOT_LAST_MESSAGES, MAX_SNAPSHOT_STRING_LENGTH, MAX_VISIBLE_PATHS,
+  MIN_SNAPSHOT_STRING_LENGTH,
   SNAPSHOT_CALLER_KEYS, SNAPSHOT_REQUEST_KEYS, SNAPSHOT_SCOPE_KEYS, SNAPSHOT_TEXT_KEYS, SNAPSHOT_VIEW_KEYS, VIEW_RESOLUTIONS, VIEW_SCOPE_KINDS,
   type PresencePayloadV1, type SnapshotRequestV1,
 } from "./types";
@@ -21,7 +22,11 @@ function exact(value: Record<string, unknown>, allowed: readonly string[], field
 }
 function string(value: unknown, field: string, options: { nullable?: boolean; max?: number } = {}): string | null {
   if (options.nullable && value === null) return null;
-  if (typeof value !== "string" || value.length === 0 || value.length > (options.max ?? 4096)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  if (
+    typeof value !== "string"
+    || value.length < MIN_SNAPSHOT_STRING_LENGTH
+    || value.length > (options.max ?? MAX_SNAPSHOT_STRING_LENGTH)
+  ) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
   return value;
 }
 function finite(value: unknown, field: string, min = -1_000_000_000, max = 1_000_000_000): number {


### PR DESCRIPTION
## Summary

- Keep HTTP 200 failed-deployment records readable as structured domain status while preserving 404 and 503 control-plane refusals.
- Publish `spawn_agent.role` from the canonical fixed role-ID tuple; keep `roleParams` open and preserve registry resolution and alternative enumeration.
- Publish `operator_snapshot` as a strict conditional schema with bounded strings, discriminated path scope, and duplicate-path rejection.

## Review findings closed

This closes all three HIGH findings from the [#781 review](https://github.com/Latand/live-log-viewer-next/pull/781#issuecomment-5131032313) and [#778 review](https://github.com/Latand/live-log-viewer-next/pull/778#issuecomment-5131035458).

## Verification

- Final head: `1ff44c7f297a4778dc54364b0c995ae8ffebc3c5`
- 95 focused tests across 9 affected test files: pass
- Final-head `git archive` mutations: failed-deployment guard 1 RED; open role schema 2 RED; old snapshot schema 4 RED
- TypeScript: pass
- Changed-file ESLint: pass
- Commit-aware privacy publication gate: pass
- Full production build and MCP bundle: pass

Closes #777
Refs #774
