### PR TITLE
fix: scope bridge reports to project seats

### DIFF
--- a/src/app/api/bridge/route.test.ts
+++ b/src/app/api/bridge/route.test.ts
@@ -8,8 +8,10 @@ import { NextRequest } from "next/server";
 import { setCallerConversationResolverForTests } from "@/lib/agent/operatorAuthority";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { setBridgeGatewaySourcesForTests } from "@/lib/bridge/gatewayAuthority";
-import { recordManagerReport } from "@/lib/bridge/service";
+import { setBridgeScopeResolverForTests } from "@/lib/bridge/routing";
+import { recordManagerReport as recordBridgeReport } from "@/lib/bridge/service";
 import { readBridgeChannel } from "@/lib/bridge/store";
+import type { BridgeReportInput } from "@/lib/bridge/types";
 import { recordRootSession } from "@/lib/root/store";
 
 import { GET, POST } from "./route";
@@ -28,12 +30,29 @@ const originalStateDir = process.env.LLV_STATE_DIR;
 
 afterEach(() => {
   setBridgeGatewaySourcesForTests(null);
+  setBridgeScopeResolverForTests(null);
   if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
   else process.env.LLV_STATE_DIR = originalStateDir;
   for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
 const SESSION = "rt_sess_gateway";
+const SCOPE = {
+  project: "repo-project-a",
+  seatConversationId: "conversation_root",
+};
+const SCOPE_B = {
+  project: "repo-project-b",
+  seatConversationId: "conversation_project_b_seat",
+};
+
+function recordManagerReport(input: BridgeReportInput) {
+  return recordBridgeReport({
+    ...input,
+    project: SCOPE.project,
+    targetSeatConversationId: SCOPE.seatConversationId,
+  });
+}
 
 function sandbox(): void {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-bridge-route-"));
@@ -48,6 +67,8 @@ function sandbox(): void {
     rootConversationId: () => "conversation_root",
     liveRealtimeSessionId: () => SESSION,
   });
+  setBridgeScopeResolverForTests((conversationId) =>
+    conversationId === SCOPE.seatConversationId ? SCOPE : null);
 }
 
 const ORIGIN = "http://127.0.0.1";
@@ -79,7 +100,7 @@ test("an empty bridge drains nothing and creates the channel for the live root",
   const payload = await (await get()).json() as { ok: boolean; plan: { kind: string } };
   expect(payload.ok).toBe(true);
   expect(payload.plan.kind).toBe("idle");
-  expect(readBridgeChannel()?.rootId).toMatch(/^root_/);
+  expect(readBridgeChannel(SCOPE)?.rootId).toMatch(/^root_/);
 });
 
 test("a manager report is drained through the route and only acknowledged when the caller says so", async () => {
@@ -99,10 +120,10 @@ test("a manager report is drained through the route and only acknowledged when t
 
   /* GET must not have moved the cursor: a batch lost between here and the call has
      to arrive again. */
-  expect(readBridgeChannel()?.managerReportCursor).toBe(0);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(0);
 
   expect((await post({ ackToken: drained.plan.ackToken })).status).toBe(200);
-  expect(readBridgeChannel()?.managerReportCursor).toBe(1);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(1);
 
   const after = await (await get()).json() as { plan: { kind: string } };
   expect(after.plan.kind).toBe("idle");
@@ -143,11 +164,11 @@ test("an acknowledgement cannot name a sequence the caller never received", asyn
      acknowledgement settles the batch it was HANDED, by its token. */
   const forged = await post({ ackToken: "ack_made_up" });
   expect(forged.status).toBe(409);
-  expect(readBridgeChannel()?.managerReportCursor ?? 0).toBe(0);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor ?? 0).toBe(0);
 
   const drained = await (await get()).json() as { plan: { ackToken: string } };
   expect((await post({ ackToken: drained.plan.ackToken })).status).toBe(200);
-  expect(readBridgeChannel()?.managerReportCursor).toBe(3);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(3);
 });
 
 test("an acknowledgement from an AGENT is refused; the operator's own browser settles the batch", async () => {
@@ -167,7 +188,7 @@ test("an acknowledgement from an AGENT is refused; the operator's own browser se
     body: JSON.stringify({ ackToken: drained.plan.ackToken }),
   })) as unknown as Response;
   expect(refused.status).toBe(403);
-  expect(readBridgeChannel()?.managerReportCursor).toBe(0);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(0);
   setCallerConversationResolverForTests(null);
 
   /* The Viewer's own same-origin POST presents nothing and settles it — the tab
@@ -198,7 +219,7 @@ test("a client that already played a batch gets a healing token, not silence", a
   expect(healing.plan.kind).toBe("already-acknowledged");
 
   await post({ ackToken: healing.plan.ackToken });
-  expect(readBridgeChannel()?.managerReportCursor).toBe(1);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(1);
 });
 
 test("acknowledging refuses a missing or malformed token", async () => {
@@ -247,7 +268,7 @@ test("turn-start drains with NO live call at all — the situation it exists for
   });
   recordManagerReport({ key: "a", class: "blocked", at: new Date().toISOString(), body: "needs a decision" });
 
-  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start`, {
+  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE.seatConversationId}`, {
     headers: { host: "127.0.0.1" },
   })) as unknown as Response;
 
@@ -257,16 +278,44 @@ test("turn-start drains with NO live call at all — the situation it exists for
   expect(payload.prelude?.ackToken).toBeTruthy();
 });
 
+test("a project B turn cannot receive or consume project A's report", async () => {
+  sandbox();
+  setBridgeScopeResolverForTests((conversationId) => {
+    if (conversationId === SCOPE.seatConversationId) return SCOPE;
+    if (conversationId === SCOPE_B.seatConversationId) return SCOPE_B;
+    return null;
+  });
+  recordManagerReport({
+    key: "project-a-only",
+    class: "blocked",
+    at: new Date().toISOString(),
+    body: "project A needs a decision",
+  });
+
+  const wrong = await GET(new NextRequest(
+    `${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE_B.seatConversationId}`,
+    { headers: { host: "127.0.0.1" } },
+  )) as unknown as Response;
+  expect((await wrong.json() as { prelude: unknown }).prelude).toBeNull();
+
+  const intended = await GET(new NextRequest(
+    `${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE.seatConversationId}`,
+    { headers: { host: "127.0.0.1" } },
+  )) as unknown as Response;
+  const payload = await intended.json() as { prelude: { text: string } | null };
+  expect(payload.prelude?.text).toContain("project A needs a decision");
+});
+
 test("turn-start serves the Viewer's own same-origin drain, and refuses an agent", async () => {
   sandbox();
   recordManagerReport({ key: "a", class: "status", at: new Date().toISOString(), body: "one" });
-  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start`, {
+  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE.seatConversationId}`, {
     headers: { host: "127.0.0.1" },
   })) as unknown as Response;
   expect(response.status).toBe(200);
 
   setCallerConversationResolverForTests(() => "conversation_worker");
-  const agent = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start`, {
+  const agent = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE.seatConversationId}`, {
     headers: { host: "127.0.0.1", [VIEWER_SPAWN_CAPABILITY_HEADER]: "a".repeat(43) },
   })) as unknown as Response;
   expect(agent.status).toBe(403);
@@ -277,7 +326,7 @@ test("turn-start serves the Viewer's own same-origin drain, and refuses an agent
 test("turn-start keeps the cross-origin perimeter: the payload carries deploy nonces", async () => {
   sandbox();
   recordManagerReport({ key: "a", class: "status", at: new Date().toISOString(), body: "one" });
-  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start`, {
+  const response = await GET(new NextRequest(`${ORIGIN}/api/bridge?mode=turn-start&conversationId=${SCOPE.seatConversationId}`, {
     headers: { host: "127.0.0.1", origin: "https://evil.example", "sec-fetch-site": "cross-site" },
   })) as unknown as Response;
   expect(response.status).toBe(403);

--- a/src/app/api/bridge/route.ts
+++ b/src/app/api/bridge/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/bridge/service";
 import { requireOperatorAuthority } from "@/lib/agent/operatorAuthority";
 import { authenticateBridgeGateway } from "@/lib/bridge/gatewayAuthority";
+import { bridgeChannelScopeForConversation } from "@/lib/bridge/routing";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { FileTransactionBusyError } from "@/lib/state/fileTransaction";
 
@@ -64,12 +65,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     if (rejection) return rejection;
     const operator = requireOperatorAuthority(request);
     if (!operator.ok) return NextResponse.json({ error: operator.error }, { status: operator.status, headers });
+    const scope = bridgeChannelScopeForConversation(parameters.get("conversationId"));
+    if (!scope) {
+      return NextResponse.json(
+        { error: "the bridge inbox is available only to a validated project seat" },
+        { status: 403, headers },
+      );
+    }
     try {
-      const prelude = bridgeTurnStartPrelude({ now: new Date() });
+      const prelude = bridgeTurnStartPrelude({ now: new Date(), scope });
       return NextResponse.json({
         ok: true,
         prelude: prelude
-          ? { text: prelude.text, ackToken: issueBridgeAcknowledgementToken(prelude.throughSeq) }
+          ? {
+            text: prelude.text,
+            ackToken: issueBridgeAcknowledgementToken(prelude.throughSeq, new Date(), scope),
+          }
           : null,
       }, { headers });
     } catch (error) {
@@ -81,6 +92,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
      proof writing into the call does. */
   const gateway = authenticateBridgeGateway(parameters.get("realtimeSessionId"));
   if (!gateway.ok) return NextResponse.json({ error: gateway.error }, { status: 403, headers });
+  const scope = bridgeChannelScopeForConversation(gateway.conversationId);
+  if (!scope) {
+    return NextResponse.json(
+      { error: "the live bridge gateway is not a validated project seat" },
+      { status: 403, headers },
+    );
+  }
 
   const acknowledgedDeliveryIds = parameters.getAll("acked").slice(-MAX_ACKNOWLEDGED_IDS);
   const lastBatchAtRaw = parameters.get("lastBatchAt");
@@ -89,13 +107,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     : null;
 
   try {
-    const plan = pendingBridgeDelivery({ now: new Date(), lastBatchAt, acknowledgedDeliveryIds });
+    const plan = pendingBridgeDelivery({
+      now: new Date(),
+      lastBatchAt,
+      acknowledgedDeliveryIds,
+      scope,
+    });
     /* The seq never leaves; the token does. A caller settles the batch it was given
        and cannot name another. */
     if (plan.kind === "idle" || plan.kind === "hold") {
       return NextResponse.json({ ok: true, plan }, { headers });
     }
-    const ackToken = issueBridgeAcknowledgementToken(plan.throughSeq);
+    const ackToken = issueBridgeAcknowledgementToken(plan.throughSeq, new Date(), scope);
     return NextResponse.json({
       ok: true,
       plan: plan.kind === "deliver"

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1110,7 +1110,7 @@ export function TmuxComposerCore({
   });
   /* Pulls the bridge inbox once, at the start of a turn, and only for the voice
      conversation. Returns "" for every other card and whenever nothing is pending. */
-  const drainBridgeTurnStart = useBridgeTurnStartDrain(voiceEnabled);
+  const drainBridgeTurnStart = useBridgeTurnStartDrain(voiceEnabled, { conversationId: cardId });
   const { text, textRef, setText, setTextState, inputRef, setStatus, busy, setBusy, voiceSending, attachments } = composer;
   const attachmentDraftHydrated = useRef(false);
   const isMobile = useIsMobile();

--- a/src/hooks/useBridgeReportRelay.dom.test.tsx
+++ b/src/hooks/useBridgeReportRelay.dom.test.tsx
@@ -289,7 +289,10 @@ test("turn-start drains with NO live call — that is the path it exists for", a
   /* Published from an effect, so the probe stays a pure component. */
   const drains: (() => Promise<{ text: string; ackToken: string; commit: () => void }>)[] = [];
   function Probe({ publish }: { publish: (drain: () => Promise<{ text: string; ackToken: string; commit: () => void }>) => void }) {
-    const drain = useBridgeTurnStartDrain(true, { fetchFn: turnFetch });
+    const drain = useBridgeTurnStartDrain(true, {
+      fetchFn: turnFetch,
+      conversationId: "conversation_project_a_seat",
+    });
     useEffect(() => { publish(drain); }, [drain, publish]);
     return null;
   }
@@ -306,6 +309,7 @@ test("turn-start drains with NO live call — that is the path it exists for", a
   expect(turn.ackToken).toBe("ack_turn");
   /* No session id anywhere in the request: there is no call to have one. */
   expect(requests[0]!.url).not.toContain("realtimeSessionId");
+  expect(requests[0]!.url).toContain("conversationId=conversation_project_a_seat");
 
   /* And nothing was acknowledged by draining alone. */
   expect(requests.filter((entry) => entry.method === "POST")).toEqual([]);

--- a/src/hooks/useBridgeReportRelay.ts
+++ b/src/hooks/useBridgeReportRelay.ts
@@ -134,9 +134,10 @@ export async function retirePendingBridgeAcknowledgements(
 
 export function useBridgeTurnStartDrain(
   enabled: boolean,
-  options: { fetchFn?: typeof fetch } = {},
+  options: { fetchFn?: typeof fetch; conversationId?: string | null } = {},
 ): () => Promise<BridgeTurnStart> {
   const fetchFn = options.fetchFn;
+  const conversationId = options.conversationId?.trim() ?? "";
   return useCallback(async () => {
     if (!enabled) return NOTHING_PENDING;
     const request = fetchFn ?? fetch;
@@ -148,7 +149,9 @@ export function useBridgeTurnStartDrain(
          requiring one would mean the inbox drains only while it is not needed. This
          is the Viewer's own same-origin fetch, which is what says it is the operator
          opening a turn — it presents no capability, and must not. */
-      const response = await request("/api/bridge?mode=turn-start", { cache: "no-store" });
+      const parameters = new URLSearchParams({ mode: "turn-start" });
+      if (conversationId) parameters.set("conversationId", conversationId);
+      const response = await request(`/api/bridge?${parameters.toString()}`, { cache: "no-store" });
       if (!response.ok) return NOTHING_PENDING;
       const payload = await response.json() as { prelude?: { text: string; ackToken: string } | null };
       const prelude = payload.prelude;
@@ -170,7 +173,7 @@ export function useBridgeTurnStartDrain(
          again. A blocked send would be a far worse failure than a late report. */
       return NOTHING_PENDING;
     }
-  }, [enabled, fetchFn]);
+  }, [conversationId, enabled, fetchFn]);
 }
 
 export function useBridgeReportRelay(

--- a/src/lib/bridge/recovery.test.ts
+++ b/src/lib/bridge/recovery.test.ts
@@ -159,17 +159,17 @@ test("the manager appending the same report through two hosts yields one deliver
   expect(plan.delivery.responses).toHaveLength(1);
 });
 
-test("a channel opened for a different root identity does not inherit the old cursor", () => {
+test("a second root identity does not reset the existing channel cursor", () => {
   sandbox();
   openBridgeChannel(ROOT_ID);
   appendBridgeReports([report("a")]);
   acknowledgeBridgeReports(1);
 
-  /* Not a rollover — a genuinely different minted root identity. Its position in
-     the manager's stream was never established, so it starts from the top. */
+  /* A root is an opener of the durable channel. The project seat owns the
+     cursor, so another root appearing cannot replay its consumed history. */
   const other = openBridgeChannel("root_0000deadbeef");
-  expect(other.managerReportCursor).toBe(0);
-  expect(drainBridgeReports().reports.map((entry) => entry.seq)).toEqual([1]);
+  expect(other.managerReportCursor).toBe(1);
+  expect(drainBridgeReports().reports).toEqual([]);
 });
 
 test("a lost cursor write cannot hide every later report behind a batch already spoken", () => {

--- a/src/lib/bridge/routing.ts
+++ b/src/lib/bridge/routing.ts
@@ -1,0 +1,59 @@
+import { agentRegistry } from "@/lib/agent/registry";
+import {
+  authorizedManagerSeats,
+  type ManagerAuthoritySources,
+} from "@/lib/orchestrator/authority";
+import {
+  activeOrchestratorSeats,
+  orchestratorRevocations,
+} from "@/lib/orchestrator/seats";
+import { readOrchestratorRecord } from "@/lib/orchestrator/store";
+
+import type { BridgeChannelScope } from "./types";
+
+type BridgeScopeResolver = (conversationId: string) => BridgeChannelScope | null;
+
+let scopeResolverForTests: BridgeScopeResolver | null = null;
+
+function productionManagerAuthoritySources(): ManagerAuthoritySources {
+  const registry = agentRegistry();
+  return {
+    activeSeats: activeOrchestratorSeats,
+    revocations: orchestratorRevocations,
+    legacyManagerConversationId: () => readOrchestratorRecord()?.conversationId ?? null,
+    conversationFacts: (conversationId) => {
+      const conversation = registry.conversation(conversationId as `conversation_${string}`);
+      if (!conversation) return null;
+      return {
+        superseded: conversation.supersededBy !== null,
+        hasGeneration: conversation.generations.length > 0,
+        project: conversation.projectOwnership?.project ?? null,
+      };
+    },
+    resolveAlias: (conversationId) =>
+      registry.conversation(conversationId as `conversation_${string}`)?.id ?? conversationId,
+  };
+}
+
+/** Resolve a browser/live-gateway conversation to its validated project seat.
+    The conversation id selects a durable lookup. Server-side records supply
+    project identity and authority. */
+export function bridgeChannelScopeForConversation(
+  conversationId: string | null | undefined,
+): BridgeChannelScope | null {
+  const candidate = conversationId?.trim();
+  if (!candidate) return null;
+  if (scopeResolverForTests) return scopeResolverForTests(candidate);
+  const canonical = agentRegistry()
+    .conversation(candidate as `conversation_${string}`)?.id ?? candidate;
+  const seat = authorizedManagerSeats(productionManagerAuthoritySources())
+    .find((entry) => entry.conversationId === canonical && entry.project);
+  return seat?.project
+    ? { project: seat.project, seatConversationId: seat.conversationId }
+    : null;
+}
+
+/** Tests only. Null restores production authority resolution. */
+export function setBridgeScopeResolverForTests(resolver: BridgeScopeResolver | null): void {
+  scopeResolverForTests = resolver;
+}

--- a/src/lib/bridge/scoping.test.ts
+++ b/src/lib/bridge/scoping.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  acknowledgeBridgeReports,
+  appendBridgeReports,
+  bridgeChannelPath,
+  bridgeReportLogPath,
+  drainBridgeReports,
+  openBridgeChannel,
+  readBridgeChannel,
+  readBridgeReportLog,
+} from "./store";
+import {
+  BRIDGE_REPORT_CAPACITY,
+  type BridgeChannelScope,
+  type BridgeReportInput,
+} from "./types";
+
+const sandboxes: string[] = [];
+const originalStateDir = process.env.LLV_STATE_DIR;
+
+afterEach(() => {
+  if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDir;
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function sandbox(): void {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-bridge-scope-"));
+  sandboxes.push(directory);
+  process.env.LLV_STATE_DIR = path.join(directory, "state");
+}
+
+const NOW = new Date("2026-07-30T12:00:00.000Z");
+const PROJECT_A: BridgeChannelScope = {
+  project: "repo-project-a",
+  seatConversationId: "conversation_seat_a",
+};
+const PROJECT_B: BridgeChannelScope = {
+  project: "repo-project-b",
+  seatConversationId: "conversation_seat_b",
+};
+const PROJECT_A_OTHER_SEAT: BridgeChannelScope = {
+  project: PROJECT_A.project,
+  seatConversationId: "conversation_seat_a_other",
+};
+
+function report(
+  key: string,
+  scope: BridgeChannelScope,
+  overrides: Partial<BridgeReportInput> = {},
+): BridgeReportInput {
+  return {
+    key,
+    class: "status",
+    at: NOW.toISOString(),
+    body: `report ${key}`,
+    project: scope.project,
+    targetSeatConversationId: scope.seatConversationId,
+    ...overrides,
+  };
+}
+
+test("project B cannot receive or consume project A's report", () => {
+  sandbox();
+  appendBridgeReports([report("project-a-status", PROJECT_A)]);
+  openBridgeChannel("root_b", NOW, PROJECT_B);
+
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_B }).reports).toEqual([]);
+
+  openBridgeChannel("root_a", NOW, PROJECT_A);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A }).reports.map((entry) => entry.body))
+    .toEqual(["report project-a-status"]);
+});
+
+test("interleaved project channels keep independent cursors", () => {
+  sandbox();
+  appendBridgeReports([
+    report("a-1", PROJECT_A),
+    report("b-1", PROJECT_B),
+    report("a-2", PROJECT_A),
+    report("b-2", PROJECT_B),
+  ]);
+  openBridgeChannel("root_a", NOW, PROJECT_A);
+  openBridgeChannel("root_b", NOW, PROJECT_B);
+
+  const firstA = drainBridgeReports({ now: NOW, limit: 1, scope: PROJECT_A });
+  expect(firstA.reports.map((entry) => entry.body)).toEqual(["report a-1"]);
+  acknowledgeBridgeReports(firstA.throughSeq, NOW, PROJECT_A);
+
+  const firstB = drainBridgeReports({ now: NOW, limit: 1, scope: PROJECT_B });
+  expect(firstB.reports.map((entry) => entry.body)).toEqual(["report b-1"]);
+  acknowledgeBridgeReports(firstB.throughSeq, NOW, PROJECT_B);
+
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A }).reports.map((entry) => entry.body))
+    .toEqual(["report a-2"]);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_B }).reports.map((entry) => entry.body))
+    .toEqual(["report b-2"]);
+  expect(readBridgeChannel(PROJECT_A)?.managerReportCursor).toBe(1);
+  expect(readBridgeChannel(PROJECT_B)?.managerReportCursor).toBe(2);
+});
+
+test("a second root identity cannot reset a project seat's cursor", () => {
+  sandbox();
+  appendBridgeReports([report("a-1", PROJECT_A)]);
+  openBridgeChannel("root_a_first", NOW, PROJECT_A);
+  acknowledgeBridgeReports(
+    drainBridgeReports({ now: NOW, scope: PROJECT_A }).throughSeq,
+    NOW,
+    PROJECT_A,
+  );
+
+  const reopened = openBridgeChannel("root_a_second", NOW, PROJECT_A);
+  expect(reopened.managerReportCursor).toBe(1);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A }).reports).toEqual([]);
+
+  appendBridgeReports([report("a-2", PROJECT_A)]);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A }).reports.map((entry) => entry.body))
+    .toEqual(["report a-2"]);
+});
+
+test("an unroutable report is surfaced without being delivered", () => {
+  sandbox();
+  appendBridgeReports([
+    report("waiting-for-seat", PROJECT_A, { targetSeatConversationId: null }),
+  ]);
+  openBridgeChannel("root_a", NOW, PROJECT_A);
+
+  const batch = drainBridgeReports({ now: NOW, scope: PROJECT_A });
+  expect(batch.reports).toEqual([]);
+  expect(batch.unrouted).toEqual({ count: 1, legacy: 0, forProject: 1 });
+});
+
+test("pre-change channel and report records load with projectless rows quarantined", () => {
+  sandbox();
+  fs.mkdirSync(path.dirname(bridgeChannelPath()), { recursive: true });
+  fs.writeFileSync(bridgeChannelPath(), JSON.stringify({
+    schemaVersion: 1,
+    rootId: "root_legacy",
+    managerRecordRef: "orchestrator",
+    managerReportCursor: 7,
+    updatedAt: NOW.toISOString(),
+  }));
+  fs.writeFileSync(bridgeReportLogPath(), JSON.stringify({
+    schemaVersion: 1,
+    lastSeq: 8,
+    trimmedThroughSeq: 0,
+    reports: [{
+      seq: 8,
+      id: "rpt_legacy",
+      at: NOW.toISOString(),
+      class: "status",
+      body: "legacy report body",
+    }],
+    retired: [],
+  }));
+
+  expect(readBridgeChannel()?.managerReportCursor).toBe(7);
+  openBridgeChannel("root_a", NOW, PROJECT_A);
+  const scoped = drainBridgeReports({ now: NOW, scope: PROJECT_A });
+  expect(scoped.reports).toEqual([]);
+  expect(scoped.unrouted).toEqual({ count: 1, legacy: 1, forProject: 0 });
+  expect(readBridgeChannel()?.managerReportCursor).toBe(7);
+
+  appendBridgeReports(Array.from(
+    { length: BRIDGE_REPORT_CAPACITY + 5 },
+    (_, index) => report(`new-${index}`, PROJECT_A),
+  ));
+  expect(readBridgeReportLog().reports.some((entry) => entry.id === "rpt_legacy")).toBe(true);
+});
+
+test("a confirmation request is deliverable only to the seat that minted it", () => {
+  sandbox();
+  appendBridgeReports([
+    report("confirm-a", PROJECT_A, {
+      class: "confirmation_request",
+      confirmation: {
+        sha: "a".repeat(40),
+        nonce: "nonce-a",
+        expiresAt: "2026-07-30T12:10:00.000Z",
+      },
+    }),
+  ]);
+  openBridgeChannel("root_other", NOW, PROJECT_A_OTHER_SEAT);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A_OTHER_SEAT }).reports).toEqual([]);
+
+  openBridgeChannel("root_a", NOW, PROJECT_A);
+  expect(drainBridgeReports({ now: NOW, scope: PROJECT_A }).reports.map((entry) => entry.class))
+    .toEqual(["confirmation_request"]);
+});

--- a/src/lib/bridge/service.test.ts
+++ b/src/lib/bridge/service.test.ts
@@ -11,9 +11,10 @@ import {
   authorizeBridgeDeploy,
   bridgeTurnStartPrelude,
   pendingBridgeDelivery,
-  recordManagerReport,
+  recordManagerReport as recordBridgeReport,
 } from "./service";
 import { appendBridgeReports, drainBridgeReports, openBridgeChannel, readBridgeChannel } from "./store";
+import type { BridgeReportInput } from "./types";
 
 /**
  * The production orchestration — the layer the reviewer found missing.
@@ -45,6 +46,18 @@ const NOW = new Date("2026-07-27T12:00:00.000Z");
 const SHA = "4f3c1b9a8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a";
 
 const rootIdentity = () => ROOT_ID;
+const SCOPE = {
+  project: "repo-project-a",
+  seatConversationId: "conversation_manager_a",
+};
+
+function recordManagerReport(input: BridgeReportInput) {
+  return recordBridgeReport({
+    ...input,
+    project: SCOPE.project,
+    targetSeatConversationId: SCOPE.seatConversationId,
+  });
+}
 
 test("the manager's report reaches a live call as one delivery, through one call", () => {
   sandbox();
@@ -55,7 +68,7 @@ test("the manager's report reaches a live call as one delivery, through one call
     body: "builder finished #726",
   });
 
-  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null });
+  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null, scope: SCOPE });
   expect(pending.kind).toBe("deliver");
   if (pending.kind !== "deliver") throw new Error("unreachable");
   expect(pending.delivery.responses[0]!.text).toContain("builder finished #726");
@@ -63,7 +76,7 @@ test("the manager's report reaches a live call as one delivery, through one call
 
   /* Opening the channel is part of the production path, not something a caller
      has to remember: a first report on a fresh install must still be deliverable. */
-  expect(readBridgeChannel()?.rootId).toBe(ROOT_ID);
+  expect(readBridgeChannel(SCOPE)?.rootId).toBe(ROOT_ID);
 });
 
 test("acknowledging advances the durable cursor so the next call starts clean", () => {
@@ -71,55 +84,63 @@ test("acknowledging advances the durable cursor so the next call starts clean", 
   recordManagerReport({ key: "a", class: "status", at: NOW.toISOString(), body: "one" });
   recordManagerReport({ key: "b", class: "status", at: NOW.toISOString(), body: "two" });
 
-  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null });
+  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null, scope: SCOPE });
   if (pending.kind !== "deliver") throw new Error("expected a delivery");
-  acknowledgeBridgeDelivery(pending.throughSeq);
+  acknowledgeBridgeDelivery(pending.throughSeq, NOW, SCOPE);
 
-  expect(readBridgeChannel()?.managerReportCursor).toBe(2);
-  expect(pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null }).kind).toBe("idle");
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(2);
+  expect(pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null, scope: SCOPE }).kind).toBe("idle");
 });
 
 test("a lost cursor write heals through the production path instead of wedging it", () => {
   sandbox();
   recordManagerReport({ key: "a", class: "status", at: NOW.toISOString(), body: "one" });
 
-  const first = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null });
+  const first = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null, scope: SCOPE });
   if (first.kind !== "deliver") throw new Error("expected a delivery");
   const tombstones = rememberAcknowledgedVoiceDelivery([], first.delivery.deliveryId);
   /* Ack lost: the cursor never moved. */
-  expect(readBridgeChannel()?.managerReportCursor).toBe(0);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(0);
 
   const healing = pendingBridgeDelivery({
     rootIdentity,
     now: new Date(NOW.getTime() + 60_000),
     lastBatchAt: null,
     acknowledgedDeliveryIds: tombstones,
+    scope: SCOPE,
   });
   expect(healing).toEqual({ kind: "already-acknowledged", throughSeq: 1 });
-  acknowledgeBridgeDelivery(healing.kind === "already-acknowledged" ? healing.throughSeq : 0);
-  expect(readBridgeChannel()?.managerReportCursor).toBe(1);
+  acknowledgeBridgeDelivery(healing.kind === "already-acknowledged" ? healing.throughSeq : 0, NOW, SCOPE);
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(1);
 });
 
 test("the coalescing window is enforced on the production path, not just in the planner", () => {
   sandbox();
   recordManagerReport({ key: "a", class: "status", at: NOW.toISOString(), body: "one" });
   const justNow = new Date(NOW.getTime() - 1_000);
-  expect(pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: justNow })).toEqual({ kind: "hold" });
+  expect(pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: justNow, scope: SCOPE })).toEqual({ kind: "hold" });
 });
 
 test("a trim that outran the cursor delivers the gap notice rather than dropping it (§7.12)", () => {
   sandbox();
-  openBridgeChannel(ROOT_ID);
+  openBridgeChannel(ROOT_ID, NOW, SCOPE);
   for (let index = 0; index < 520; index += 1) {
-    appendBridgeReports([{ key: `r${index}`, class: "status", at: NOW.toISOString(), body: `report ${index}` }]);
+    appendBridgeReports([{
+      key: `r${index}`,
+      class: "status",
+      at: NOW.toISOString(),
+      body: `report ${index}`,
+      project: SCOPE.project,
+      targetSeatConversationId: SCOPE.seatConversationId,
+    }]);
   }
 
-  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null });
+  const pending = pendingBridgeDelivery({ rootIdentity, now: NOW, lastBatchAt: null, scope: SCOPE });
   if (pending.kind !== "deliver") throw new Error("expected a delivery");
   expect(pending.delivery.responses[0]!.text).toContain("no longer available");
   /* And it is acknowledgeable, so the gap is crossed once rather than every poll. */
-  acknowledgeBridgeDelivery(pending.throughSeq);
-  expect(readBridgeChannel()!.managerReportCursor).toBeGreaterThanOrEqual(20);
+  acknowledgeBridgeDelivery(pending.throughSeq, NOW, SCOPE);
+  expect(readBridgeChannel(SCOPE)!.managerReportCursor).toBeGreaterThanOrEqual(20);
 });
 
 /* §4 deploy round trip, end to end through the production authorization path. */
@@ -194,7 +215,7 @@ test("a turn opened after a quiet night carries one bounded batch, once", () => 
     recordManagerReport({ key: `r${index}`, class: "completed", at: NOW.toISOString(), body: `finished ${index}` });
   }
 
-  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW });
+  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE });
   expect(prelude).not.toBeNull();
   expect(prelude!.text).toContain("finished 0");
   expect(prelude!.text).toContain("finished 4");
@@ -210,25 +231,25 @@ test("a turn opened after a quiet night carries one bounded batch, once", () => 
 test("the turn-start drain does not consume anything by itself", () => {
   sandbox();
   recordManagerReport({ key: "a", class: "status", at: NOW.toISOString(), body: "one" });
-  bridgeTurnStartPrelude({ rootIdentity, now: NOW });
+  bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE });
 
   /* A turn that never reached the agent must not have eaten the report. */
-  expect(readBridgeChannel()?.managerReportCursor).toBe(0);
-  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW })).not.toBeNull();
+  expect(readBridgeChannel(SCOPE)?.managerReportCursor).toBe(0);
+  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE })).not.toBeNull();
 });
 
 test("an acknowledged turn-start batch never arrives a second time", () => {
   sandbox();
   recordManagerReport({ key: "a", class: "blocked", at: NOW.toISOString(), body: "needs a decision" });
-  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW })!;
-  acknowledgeBridgeDelivery(prelude.throughSeq);
+  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE })!;
+  acknowledgeBridgeDelivery(prelude.throughSeq, NOW, SCOPE);
 
-  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW })).toBeNull();
+  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE })).toBeNull();
 });
 
 test("a turn with an empty inbox opens with nothing at all", () => {
   sandbox();
-  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW })).toBeNull();
+  expect(bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE })).toBeNull();
 });
 
 /* ── HIGH 3 (#758 review): the delivery composer must READ origin ────────── */
@@ -250,7 +271,7 @@ test("a mixed batch never covers a non-manager row with the manager-voice header
     origin: { kind: "agent", conversationId: "conversation_builder", role: "builder" },
   });
 
-  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW });
+  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE });
   expect(prelude).not.toBeNull();
   const text = prelude!.text;
 
@@ -278,7 +299,7 @@ test("a batch of only non-manager rows carries no manager-voice header at all", 
     origin: { kind: "agent", conversationId: "conversation_builder", role: "builder" },
   });
 
-  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW });
+  const prelude = bridgeTurnStartPrelude({ rootIdentity, now: NOW, scope: SCOPE });
   expect(prelude!.text).not.toContain("the manager reported");
   expect(prelude!.text).toContain("NOT the manager");
 });

--- a/src/lib/bridge/service.ts
+++ b/src/lib/bridge/service.ts
@@ -14,7 +14,12 @@ import {
   openBridgeChannel,
   redeemBridgeAckToken,
 } from "./store";
-import { bridgeReportOriginLabel, type BridgeReportInput, type BridgeReportV1 } from "./types";
+import {
+  bridgeReportOriginLabel,
+  type BridgeChannelScope,
+  type BridgeReportInput,
+  type BridgeReportV1,
+} from "./types";
 
 /**
  * The bridge's production orchestration (#691 §4).
@@ -39,6 +44,8 @@ import { bridgeReportOriginLabel, type BridgeReportInput, type BridgeReportV1 } 
 export interface BridgeDeliveryRequest {
   /** The root's durable identity. Injected so tests need no lineage file. */
   rootIdentity?: () => string;
+  /** Server-resolved repository identity and designated recipient seat. */
+  scope: BridgeChannelScope;
   now: Date;
   /** When the previous interjection batch reached this call, or null for none. */
   lastBatchAt: Date | null;
@@ -64,9 +71,9 @@ export function recordManagerReport(input: BridgeReportInput): BridgeReportV1 | 
  */
 export function pendingBridgeDelivery(request: BridgeDeliveryRequest): BridgeDeliveryPlan {
   const identity = (request.rootIdentity ?? readRootIdentity)();
-  openBridgeChannel(identity, request.now);
+  openBridgeChannel(identity, request.now, request.scope);
   return planBridgeReportDelivery({
-    batch: drainBridgeReports({ now: request.now }),
+    batch: drainBridgeReports({ now: request.now, scope: request.scope }),
     now: request.now,
     lastBatchAt: request.lastBatchAt,
     acknowledgedDeliveryIds: request.acknowledgedDeliveryIds,
@@ -83,8 +90,12 @@ export function pendingBridgeDelivery(request: BridgeDeliveryRequest): BridgeDel
  * Internal: the HTTP surface goes through {@link redeemBridgeAcknowledgement}, which
  * takes the token the batch was handed out with rather than a caller-named sequence.
  */
-export function acknowledgeBridgeDelivery(throughSeq: number, now = new Date()): void {
-  acknowledgeBridgeReports(throughSeq, now);
+export function acknowledgeBridgeDelivery(
+  throughSeq: number,
+  now = new Date(),
+  scope?: BridgeChannelScope,
+): void {
+  acknowledgeBridgeReports(throughSeq, now, scope);
 }
 
 /** Settle the outstanding batch by the token issued with it. */
@@ -99,8 +110,12 @@ export function redeemBridgeAcknowledgement(token: string, now = new Date()): { 
  * is evidence of having RECEIVED that batch — which is what an acknowledgement is
  * supposed to attest.
  */
-export function issueBridgeAcknowledgementToken(throughSeq: number, now = new Date()): string {
-  return issueBridgeAckToken(throughSeq, now);
+export function issueBridgeAcknowledgementToken(
+  throughSeq: number,
+  now = new Date(),
+  scope?: BridgeChannelScope,
+): string {
+  return issueBridgeAckToken(throughSeq, now, scope);
 }
 
 /**
@@ -116,11 +131,11 @@ export function issueBridgeAcknowledgementToken(throughSeq: number, now = new Da
  * night arrives as one batch, oldest first, not as a night's worth of messages.
  */
 export function bridgeTurnStartPrelude(
-  request: Omit<BridgeDeliveryRequest, "lastBatchAt" | "acknowledgedDeliveryIds"> = { now: new Date() },
+  request: Omit<BridgeDeliveryRequest, "lastBatchAt" | "acknowledgedDeliveryIds">,
 ): { text: string; throughSeq: number } | null {
   const identity = (request.rootIdentity ?? readRootIdentity)();
-  openBridgeChannel(identity, request.now);
-  const batch = drainBridgeReports({ now: request.now });
+  openBridgeChannel(identity, request.now, request.scope);
+  const batch = drainBridgeReports({ now: request.now, scope: request.scope });
   if (batch.reports.length === 0) return null;
 
   /* Framed from the row's server-authenticated ORIGIN, never from the body a

--- a/src/lib/bridge/store.test.ts
+++ b/src/lib/bridge/store.test.ts
@@ -46,6 +46,8 @@ function report(key: string, overrides: Partial<BridgeReportInput> = {}): Bridge
     class: "status",
     at: "2026-07-27T12:00:00.000Z",
     body: `report ${key}`,
+    project: "repo-project-a",
+    targetSeatConversationId: "conversation_seat_a",
     ...overrides,
   };
 }

--- a/src/lib/bridge/store.ts
+++ b/src/lib/bridge/store.ts
@@ -16,6 +16,7 @@ import {
   isBridgeReportClass,
   MANAGER_RECORD_REF,
   type BridgeChannelV1,
+  type BridgeChannelScope,
   type BridgeConfirmation,
   type BridgeReportBatch,
   type BridgeReportInput,
@@ -42,8 +43,21 @@ import {
 const BRIDGE_CHANNEL_BUSY = "bridge channel is busy";
 const BRIDGE_LOG_BUSY = "bridge report log is busy";
 
-export function bridgeChannelPath(): string {
-  return statePath("bridge.json");
+function bridgeChannelKey(scope: BridgeChannelScope): string {
+  return crypto.createHash("sha256")
+    .update(`${scope.project}\0${scope.seatConversationId}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function bridgeChannelPath(scope?: BridgeChannelScope): string {
+  return scope
+    ? statePath("bridge-channels", `${bridgeChannelKey(scope)}.json`)
+    : statePath("bridge.json");
+}
+
+function bridgeChannelPathFromKey(key: string): string {
+  return statePath("bridge-channels", `${key}.json`);
 }
 
 export function bridgeReportLogPath(): string {
@@ -142,6 +156,12 @@ function normalizeReport(value: unknown): BridgeReportV1 | null {
     ? normalizeConfirmation(candidate.confirmation)
     : undefined;
   const origin = normalizeOrigin(candidate.origin);
+  const project = typeof candidate.project === "string"
+    ? candidate.project
+    : candidate.project === null ? null : undefined;
+  const targetSeatConversationId = typeof candidate.targetSeatConversationId === "string"
+    ? candidate.targetSeatConversationId
+    : candidate.targetSeatConversationId === null ? null : undefined;
   return {
     id: candidate.id,
     seq: candidate.seq as number,
@@ -149,6 +169,8 @@ function normalizeReport(value: unknown): BridgeReportV1 | null {
     class: candidate.class,
     body: typeof candidate.body === "string" ? candidate.body : "",
     ...(origin ? { origin } : {}),
+    ...(project !== undefined ? { project } : {}),
+    ...(targetSeatConversationId !== undefined ? { targetSeatConversationId } : {}),
     ...(typeof candidate.correlatesDirective === "string" ? { correlatesDirective: candidate.correlatesDirective } : {}),
     ...(confirmation ? { confirmation } : {}),
   };
@@ -159,6 +181,7 @@ function emptyLog(): BridgeReportLogV1 {
     schemaVersion: BRIDGE_REPORT_LOG_SCHEMA_VERSION,
     lastSeq: 0,
     trimmedThroughSeq: 0,
+    trimmedThroughByChannel: {},
     reports: [],
     retired: [],
   };
@@ -193,6 +216,13 @@ function normalizeLog(value: unknown, target: string): BridgeReportLogV1 {
     /* The oldest retained seq is the authority on what was trimmed: a recorded
        value that disagrees would let a gap pass unannounced. */
     trimmedThroughSeq: Math.max(recordedTrim, oldest > 0 ? oldest - 1 : 0),
+    trimmedThroughByChannel: file.trimmedThroughByChannel
+      && typeof file.trimmedThroughByChannel === "object"
+      && !Array.isArray(file.trimmedThroughByChannel)
+      ? Object.fromEntries(Object.entries(file.trimmedThroughByChannel)
+        .filter((entry): entry is [string, number] =>
+          Number.isInteger(entry[1]) && entry[1] > 0))
+      : {},
     reports,
     retired: Array.isArray(file.retired) ? file.retired.filter((id): id is string => typeof id === "string") : [],
   };
@@ -208,17 +238,32 @@ export function readBridgeReportLog(): BridgeReportLogV1 {
   return readLog();
 }
 
-function normalizeChannel(value: unknown, target: string): BridgeChannelV1 | null {
+function normalizeChannel(
+  value: unknown,
+  target: string,
+  scope?: BridgeChannelScope,
+): BridgeChannelV1 | null {
   if (value === null) return null;
   if (typeof value !== "object" || Array.isArray(value)) {
     throw new BridgeStateCorruptError(target, "its contents are not a channel object");
   }
   const file = value as Partial<BridgeChannelV1>;
   if (typeof file.rootId !== "string" || !file.rootId) return null;
+  if (scope && (file.project !== scope.project || file.seatConversationId !== scope.seatConversationId)) {
+    throw new BridgeStateCorruptError(target, "its project or seat does not match the scoped channel path");
+  }
   const outstanding = file.outstanding;
   return {
     schemaVersion: BRIDGE_CHANNEL_SCHEMA_VERSION,
     rootId: file.rootId,
+    ...(scope
+      ? { project: scope.project, seatConversationId: scope.seatConversationId }
+      : {
+        ...(typeof file.project === "string" ? { project: file.project } : {}),
+        ...(typeof file.seatConversationId === "string"
+          ? { seatConversationId: file.seatConversationId }
+          : {}),
+      }),
     managerRecordRef: MANAGER_RECORD_REF,
     managerReportCursor: Number.isInteger(file.managerReportCursor) && (file.managerReportCursor as number) > 0
       ? file.managerReportCursor as number
@@ -240,12 +285,19 @@ function normalizeChannel(value: unknown, target: string): BridgeChannelV1 | nul
  * and the cursor is monotonic anyway, so a stale token can only ever try to settle a
  * position already passed.
  */
-export function issueBridgeAckToken(throughSeq: number, now = new Date()): string {
-  return withFileTransactionSync(bridgeChannelPath(), BRIDGE_CHANNEL_BUSY, () => {
-    const current = readBridgeChannel();
+export function issueBridgeAckToken(
+  throughSeq: number,
+  now = new Date(),
+  scope?: BridgeChannelScope,
+): string {
+  const target = bridgeChannelPath(scope);
+  return withFileTransactionSync(target, BRIDGE_CHANNEL_BUSY, () => {
+    const current = readBridgeChannel(scope);
     if (!current) throw new Error("the bridge channel is not open");
-    const token = `ack_${crypto.randomBytes(18).toString("hex")}`;
-    writeJsonDurably(bridgeChannelPath(), {
+    const token = scope
+      ? `ack_${bridgeChannelKey(scope)}_${crypto.randomBytes(18).toString("hex")}`
+      : `ack_${crypto.randomBytes(18).toString("hex")}`;
+    writeJsonDurably(target, {
       ...current,
       outstanding: { token, throughSeq, issuedAt: now.toISOString() },
     } satisfies BridgeChannelV1);
@@ -260,8 +312,20 @@ export function issueBridgeAckToken(throughSeq: number, now = new Date()): strin
  * retire reports it never received by naming their sequence.
  */
 export function redeemBridgeAckToken(token: string, now = new Date()): { ok: boolean; throughSeq: number } {
-  return withFileTransactionSync(bridgeChannelPath(), BRIDGE_CHANNEL_BUSY, () => {
-    const current = readBridgeChannel();
+  const scopedKey = /^ack_([0-9a-f]{32})_[0-9a-f]{36}$/.exec(token)?.[1];
+  const target = scopedKey ? bridgeChannelPathFromKey(scopedKey) : bridgeChannelPath();
+  return withFileTransactionSync(target, BRIDGE_CHANNEL_BUSY, () => {
+    const current = normalizeChannel(readJsonFile(target), target);
+    if (scopedKey && current && (
+      !current.project
+      || !current.seatConversationId
+      || bridgeChannelKey({
+        project: current.project,
+        seatConversationId: current.seatConversationId,
+      }) !== scopedKey
+    )) {
+      throw new BridgeStateCorruptError(target, "its stored scope does not match its acknowledgement token");
+    }
     if (!current?.outstanding || current.outstanding.token !== token) {
       return { ok: false, throughSeq: current?.managerReportCursor ?? 0 };
     }
@@ -272,15 +336,15 @@ export function redeemBridgeAckToken(token: string, now = new Date()): { ok: boo
       updatedAt: now.toISOString(),
     };
     delete next.outstanding;
-    writeJsonDurably(bridgeChannelPath(), next);
+    writeJsonDurably(target, next);
     return { ok: true, throughSeq };
   });
 }
 
 /** Channel state as stored, or null when the bridge was never opened. */
-export function readBridgeChannel(): BridgeChannelV1 | null {
-  const target = bridgeChannelPath();
-  return normalizeChannel(readJsonFile(target), target);
+export function readBridgeChannel(scope?: BridgeChannelScope): BridgeChannelV1 | null {
+  const target = bridgeChannelPath(scope);
+  return normalizeChannel(readJsonFile(target), target, scope);
 }
 
 /**
@@ -290,22 +354,27 @@ export function readBridgeChannel(): BridgeChannelV1 | null {
  * root rollover calls it with the same `rootId` the lineage minted once — so
  * neither event may reset how far the manager's reports have been consumed.
  */
-export function openBridgeChannel(rootId: string, now = new Date()): BridgeChannelV1 {
+export function openBridgeChannel(
+  rootId: string,
+  now = new Date(),
+  scope?: BridgeChannelScope,
+): BridgeChannelV1 {
   if (!rootId.trim()) throw new Error("bridge channel requires a root identity");
-  return withFileTransactionSync(bridgeChannelPath(), BRIDGE_CHANNEL_BUSY, () => {
-    const current = readBridgeChannel();
-    if (current && current.rootId === rootId) return current;
+  const target = bridgeChannelPath(scope);
+  return withFileTransactionSync(target, BRIDGE_CHANNEL_BUSY, () => {
+    const current = readBridgeChannel(scope);
+    /* The project seat owns the durable channel and cursor. Root identity
+       records its first opener; additional roots preserve the position. */
+    if (current) return current;
     const channel: BridgeChannelV1 = {
       schemaVersion: BRIDGE_CHANNEL_SCHEMA_VERSION,
       rootId,
+      ...(scope ? { project: scope.project, seatConversationId: scope.seatConversationId } : {}),
       managerRecordRef: MANAGER_RECORD_REF,
-      /* A different rootId means the operator minted a new root identity
-         wholesale, not a session rollover. Its cursor starts clean; the previous
-         root's position was about a conversation that no longer exists. */
-      managerReportCursor: current && current.rootId === rootId ? current.managerReportCursor : 0,
+      managerReportCursor: 0,
       updatedAt: now.toISOString(),
     };
-    writeJsonDurably(bridgeChannelPath(), channel);
+    writeJsonDurably(target, channel);
     return channel;
   });
 }
@@ -344,6 +413,14 @@ export function appendBridgeReports(
         class: input.class,
         body: bridgeReportBody(input.body),
         ...(input.origin ? { origin: normalizeOrigin(input.origin) } : {}),
+        ...("project" in input ? { project: typeof input.project === "string" ? input.project : null } : {}),
+        ...("targetSeatConversationId" in input
+          ? {
+            targetSeatConversationId: typeof input.targetSeatConversationId === "string"
+              ? input.targetSeatConversationId
+              : null,
+          }
+          : {}),
         ...(input.correlatesDirective ? { correlatesDirective: input.correlatesDirective } : {}),
         ...(confirmation ? { confirmation } : {}),
       };
@@ -352,8 +429,38 @@ export function appendBridgeReports(
     }
     if (appended.length === 0) return { appended, skipped };
     if (file.reports.length > BRIDGE_REPORT_CAPACITY) {
-      const trimmed = file.reports.splice(0, file.reports.length - BRIDGE_REPORT_CAPACITY);
-      file.trimmedThroughSeq = Math.max(file.trimmedThroughSeq, trimmed.at(-1)!.seq);
+      const legacyCursor = readBridgeChannel()?.managerReportCursor ?? 0;
+      let remaining = file.reports.length - BRIDGE_REPORT_CAPACITY;
+      const trimmed: BridgeReportV1[] = [];
+      const retained: BridgeReportV1[] = [];
+      for (const report of file.reports) {
+        /* Unrouted rows are the quarantine. Trimming them would turn "visible
+           and waiting" into silent loss, including every pre-#787 row whose
+           intended project cannot be reconstructed safely. */
+        const quarantined = !report.targetSeatConversationId
+          || (report.project == null && report.seq > legacyCursor);
+        if (remaining > 0 && !quarantined) {
+          trimmed.push(report);
+          remaining -= 1;
+        } else {
+          retained.push(report);
+        }
+      }
+      file.reports = retained;
+      const oldestRetained = retained[0]?.seq ?? file.lastSeq + 1;
+      file.trimmedThroughSeq = Math.max(file.trimmedThroughSeq, oldestRetained - 1);
+      file.trimmedThroughByChannel ??= {};
+      for (const report of trimmed) {
+        if (!report.project || !report.targetSeatConversationId) continue;
+        const key = bridgeChannelKey({
+          project: report.project,
+          seatConversationId: report.targetSeatConversationId,
+        });
+        file.trimmedThroughByChannel[key] = Math.max(
+          file.trimmedThroughByChannel[key] ?? 0,
+          report.seq,
+        );
+      }
       file.retired = [...file.retired, ...trimmed.map((report) => report.id)].slice(-BRIDGE_RETIRED_ID_CAPACITY);
     }
     writeJsonDurably(bridgeReportLogPath(), file);
@@ -385,18 +492,38 @@ function gapNotice(cursor: number, resumedAtSeq: number, missedThroughSeq: numbe
  * again rather than vanish.
  */
 export function drainBridgeReports(
-  options: { limit?: number; now?: Date } = {},
+  options: { limit?: number; now?: Date; scope?: BridgeChannelScope } = {},
 ): BridgeReportBatch {
+  const scope = options.scope;
   const limit = Math.max(1, Math.min(BRIDGE_DRAIN_BATCH_MAX, options.limit ?? BRIDGE_DRAIN_BATCH_MAX));
-  const cursor = readBridgeChannel()?.managerReportCursor ?? 0;
+  const cursor = readBridgeChannel(scope)?.managerReportCursor ?? 0;
   const file = readLog();
-  const pending = file.reports.filter((report) => report.seq > cursor);
+  const pending = file.reports.filter((report) =>
+    report.seq > cursor
+    && (!scope
+      || (
+        report.project === scope.project
+        && report.targetSeatConversationId === scope.seatConversationId
+      )));
+  const legacyCursor = readBridgeChannel()?.managerReportCursor ?? 0;
+  const legacyUnrouted = scope
+    ? file.reports.filter((report) =>
+      report.project == null && report.seq > legacyCursor).length
+    : 0;
+  const projectUnrouted = scope
+    ? file.reports.filter((report) =>
+      report.project === scope.project
+      && !report.targetSeatConversationId).length
+    : 0;
 
   /* §7.12 — the log outran this consumer. Resuming at the head is the only
      option left, so the batch says so in a row the gateway will read out rather
      than skipping history in silence. */
-  const gap = cursor < file.trimmedThroughSeq
-    ? { resumedAtSeq: file.trimmedThroughSeq + 1, missedThroughSeq: file.trimmedThroughSeq }
+  const trimmedThrough = scope
+    ? file.trimmedThroughByChannel?.[bridgeChannelKey(scope)] ?? 0
+    : file.trimmedThroughSeq;
+  const gap = cursor < trimmedThrough
+    ? { resumedAtSeq: trimmedThrough + 1, missedThroughSeq: trimmedThrough }
     : null;
   const notice = gap
     ? [gapNotice(cursor, gap.resumedAtSeq, gap.missedThroughSeq, (options.now ?? new Date()).toISOString())]
@@ -408,6 +535,15 @@ export function drainBridgeReports(
     throughSeq,
     remaining: notice.length + pending.length - reports.length,
     gap,
+    ...(scope
+      ? {
+        unrouted: {
+          count: legacyUnrouted + projectUnrouted,
+          legacy: legacyUnrouted,
+          forProject: projectUnrouted,
+        },
+      }
+      : {}),
   };
 }
 
@@ -416,14 +552,19 @@ export function drainBridgeReports(
  * batch that a newer one already superseded must not re-open reports the user
  * has already heard.
  */
-export function acknowledgeBridgeReports(throughSeq: number, now = new Date()): BridgeChannelV1 | null {
-  if (!Number.isInteger(throughSeq) || throughSeq < 1) return readBridgeChannel();
-  return withFileTransactionSync(bridgeChannelPath(), BRIDGE_CHANNEL_BUSY, () => {
-    const current = readBridgeChannel();
+export function acknowledgeBridgeReports(
+  throughSeq: number,
+  now = new Date(),
+  scope?: BridgeChannelScope,
+): BridgeChannelV1 | null {
+  if (!Number.isInteger(throughSeq) || throughSeq < 1) return readBridgeChannel(scope);
+  const target = bridgeChannelPath(scope);
+  return withFileTransactionSync(target, BRIDGE_CHANNEL_BUSY, () => {
+    const current = readBridgeChannel(scope);
     if (!current) return null;
     if (throughSeq <= current.managerReportCursor) return current;
     const next: BridgeChannelV1 = { ...current, managerReportCursor: throughSeq, updatedAt: now.toISOString() };
-    writeJsonDurably(bridgeChannelPath(), next);
+    writeJsonDurably(target, next);
     return next;
   });
 }

--- a/src/lib/bridge/types.ts
+++ b/src/lib/bridge/types.ts
@@ -38,7 +38,8 @@ export const BRIDGE_REPORT_LOG_SCHEMA_VERSION = 1 as const;
 export const MANAGER_RECORD_REF = "orchestrator" as const;
 export type ManagerRecordRef = typeof MANAGER_RECORD_REF;
 
-/** Reports retained in the log. Older ones are trimmed, their ids retired. */
+/** Routable reports retained in the log. Quarantined rows stay durable until
+    an operator-facing resolution path exists. */
 export const BRIDGE_REPORT_CAPACITY = 500;
 /** Retired ids kept so a trimmed report cannot be re-appended by a late replay. */
 export const BRIDGE_RETIRED_ID_CAPACITY = 2_000;
@@ -96,6 +97,14 @@ export interface BridgeReportOrigin {
   role: string | null;
 }
 
+/** Durable routing identity for one project's designated orchestrator seat.
+    Project is the repository-derived identity key; the display label never
+    participates. */
+export interface BridgeChannelScope {
+  project: string;
+  seatConversationId: string;
+}
+
 /**
  * How a report's origin reads on the way OUT — the label every delivery
  * composer must frame a non-manager row with (HIGH 3 of the #758 review: an
@@ -120,6 +129,12 @@ export interface BridgeReportV1 {
   /** Server-derived origin. Absent on rows written before origin labeling
       existed, which were manager-only by the gate of that era. */
   origin?: BridgeReportOrigin;
+  /** Server-derived repository identity. Absent only on pre-#787 rows. Null
+      means the sender could not be resolved and the row is quarantined. */
+  project?: string | null;
+  /** Server-selected recipient seat. Null or absent rows are unrouted and are
+      never handed to a conversation. */
+  targetSeatConversationId?: string | null;
   /** `clientRequestId` of the directive this answers, when it answers one. */
   correlatesDirective?: string;
   /** Bounded and secret-redacted at write. Transcript payloads never reach it. */
@@ -138,6 +153,9 @@ export interface BridgeReportInput {
   at: string;
   /** Server-derived origin label; callers never supply one. */
   origin?: BridgeReportOrigin | null;
+  /** Server-derived routing fields. MCP callers cannot supply either field. */
+  project?: string | null;
+  targetSeatConversationId?: string | null;
   correlatesDirective?: string | null;
   /** Raw candidate text; bounded and redacted before it is stored. */
   body?: string | null;
@@ -150,6 +168,9 @@ export interface BridgeReportLogV1 {
   /** Highest seq that trimming has removed. A cursor at or below this can no
       longer be resumed exactly, which the drain must say out loud (§7.12). */
   trimmedThroughSeq: number;
+  /** Highest trimmed seq per routable project-seat channel. Missing on
+      pre-#787 files, whose projectless rows are quarantined. */
+  trimmedThroughByChannel?: Record<string, number>;
   reports: BridgeReportV1[];
   retired: string[];
 }
@@ -158,6 +179,9 @@ export interface BridgeChannelV1 {
   schemaVersion: typeof BRIDGE_CHANNEL_SCHEMA_VERSION;
   /** `RootLineageV1.rootId` — survives every root session rollover. */
   rootId: string;
+  /** Present on project-scoped channels; absent on the pre-#787 global file. */
+  project?: string;
+  seatConversationId?: string;
   /** The manager's designation record, by name. Never a conversationId. */
   managerRecordRef: ManagerRecordRef;
   /** Last report seq the gateway has fully consumed. */
@@ -189,4 +213,7 @@ export interface BridgeReportBatch {
   /** Pending reports that did not fit under the batch cap. */
   remaining: number;
   gap: { resumedAtSeq: number; missedThroughSeq: number } | null;
+  /** Quarantined rows visible to this channel without exposing their bodies.
+      `legacy` covers pre-#787 rows whose project is absent. */
+  unrouted?: { count: number; legacy: number; forProject: number };
 }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -603,6 +603,12 @@ function bridgeReport(args: McpToolArgs, dependencies: ViewerMcpDomainDependenci
   if (!body) throw new Error("body is required");
 
   const origin = attributionOf(dependencies);
+  const project = dependencies.callerProject ? dependencies.callerProject() : productionCallerProject();
+  const seats = dependencies.authorizedSeats?.()
+    ?? authorizedManagerSeats(productionManagerAuthoritySources());
+  const targetSeat = project
+    ? seats.find((seat) => seat.project === project)
+    : undefined;
   const requested = args.confirmation && typeof args.confirmation === "object" && !Array.isArray(args.confirmation)
     ? args.confirmation as { sha?: unknown; expiresMinutes?: unknown }
     : null;
@@ -616,6 +622,19 @@ function bridgeReport(args: McpToolArgs, dependencies: ViewerMcpDomainDependenci
     throw new McpToolRefusal(
       "only the designated orchestrator may request a deployment confirmation",
       { code: "confirmation_not_permitted" },
+    );
+  }
+  if (
+    reportClass === "confirmation_request"
+    && (
+      !project
+      || !origin.conversationId
+      || targetSeat?.conversationId !== origin.conversationId
+    )
+  ) {
+    throw new McpToolRefusal(
+      "a deployment confirmation must stay bound to the project seat that minted it",
+      { code: "confirmation_seat_unresolved" },
     );
   }
   const confirmation = requested
@@ -638,6 +657,8 @@ function bridgeReport(args: McpToolArgs, dependencies: ViewerMcpDomainDependenci
     class: reportClass,
     at: new Date().toISOString(),
     origin,
+    project,
+    targetSeatConversationId: targetSeat?.conversationId ?? null,
     body: attributedBody,
     correlatesDirective: text(args.correlatesDirective) || null,
     confirmation,

--- a/src/lib/mcp/bridgeReportOrigin.test.ts
+++ b/src/lib/mcp/bridgeReportOrigin.test.ts
@@ -32,12 +32,19 @@ afterEach(() => {
 function serviceAs(attribution: CallerAttribution) {
   const bindings = viewerMcpBindings(undefined, undefined, {
     callerAttribution: () => attribution,
+    callerProject: () => PROJECT,
+    authorizedSeats: () => [{
+      conversationId: MANAGER.conversationId!,
+      path: null,
+      project: PROJECT,
+    }],
   } as never);
   return createMcpToolService(bindings, new MemoryMcpReceiptStore());
 }
 
 const MANAGER: CallerAttribution = { kind: "manager", conversationId: "conversation_mgr", role: "orchestrator" };
 const WORKER: CallerAttribution = { kind: "agent", conversationId: "conversation_builder", role: "builder" };
+const PROJECT = "repo-project-a";
 
 const report = (overrides: Record<string, unknown> = {}) => ({
   clientRequestId: "rep-1",
@@ -54,6 +61,8 @@ test("a worker's report is recorded with its server-derived origin and a visible
 
   const row = readBridgeReportLog().reports[0]!;
   expect(row.origin).toEqual({ kind: "agent", conversationId: "conversation_builder", role: "builder" });
+  expect(row.project).toBe(PROJECT);
+  expect(row.targetSeatConversationId).toBe(MANAGER.conversationId);
   expect(row.body).toBe("[builder conversation_builder — not the manager] stage settled");
 });
 
@@ -114,4 +123,15 @@ test("MEDIUM 7 (#758 review): an origin supplied in the TOOL ARGS is ignored —
   const row = readBridgeReportLog().reports[0]!;
   expect(row.origin).toEqual({ kind: "agent", conversationId: "conversation_builder", role: "builder" });
   expect(row.body).toStartWith("[builder conversation_builder — not the manager] ");
+});
+
+test("a caller-supplied project cannot override server-derived report routing", async () => {
+  await serviceAs(WORKER).callTool("bridge_report", report({
+    project: "repo-project-b",
+    targetSeatConversationId: "conversation_seat_b",
+  }));
+
+  const row = readBridgeReportLog().reports[0]!;
+  expect(row.project).toBe(PROJECT);
+  expect(row.targetSeatConversationId).toBe(MANAGER.conversationId);
 });


### PR DESCRIPTION
## Summary

- capture the repository-derived project and validated destination seat server-side on every new bridge report
- keep cursors and acknowledgement tokens per project-seat channel, preserving cursor position when another root appears
- quarantine projectless legacy rows and reports without a matching seat; their bodies are withheld and their unrouted status remains visible
- carry the current turn-start conversation identity to the bridge route and validate it against durable seat authority before draining
- bind each confirmation request to the exact seat that minted it

## Verification

- 140 focused tests passed across the bridge store/service, MCP bridge paths, bridge route, relay hook, composer, and deploy-confirmation consumers
- mutation proofs made each acceptance guarantee fail independently in a `git archive` copy: project isolation, independent cursors, root stability, unrouted visibility, legacy quarantine, confirmation seat binding, server-side project capture, stored project presence, and turn-start seat identity
- TypeScript: `bunx tsc --noEmit`
- ESLint: changed files only
- privacy publication gate: pass, including known-value and commit checks
- production build: `bun run build` exited 0, including the MCP bundle

Closes #787
