### PR TITLE
fix(mcp): survive a control surface that does not serve the route yet

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -40,7 +40,9 @@ import { projectForCwd } from "@/lib/scanner/describe";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
+import { runtimeHostClient as directRuntimeHostClient } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { runtimeEventsEnabled as directRuntimeEventsEnabled } from "@/lib/runtime/flags";
 import { readSession } from "@/lib/session/reader";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
@@ -133,6 +135,24 @@ function readViewerControl(
 ): Promise<Record<string, unknown>> {
   if (!control.get) throw new Error("Viewer control read is unavailable");
   return control.get(pathname);
+}
+
+/**
+ * The pre-control read path, kept only as the transition-window fallback for a
+ * control surface that does not serve the route yet (#790, see
+ * `isUnservedControlRoute`). It reads the runtime host directly, so it depends on
+ * this process holding the socket — true for the deployment health probe, whose
+ * environment is inherited from the runtime host, and false for an ordinary agent
+ * MCP, which is exactly what #777 fixed. When the socket is absent the honest
+ * refusal surfaces instead of a silent empty answer.
+ */
+async function legacyDeploymentRead<T>(
+  read: (client: NonNullable<ReturnType<typeof directRuntimeHostClient>>) => Promise<T>,
+): Promise<T> {
+  if (!directRuntimeEventsEnabled()) throw new Error("runtime events are disabled");
+  const client = directRuntimeHostClient();
+  if (!client) throw new Error("runtime host socket is unavailable");
+  return read(client);
 }
 
 type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySnapshot"]>;
@@ -1134,6 +1154,26 @@ async function operatorSnapshot(args: McpToolArgs, dependencies: ViewerMcpDomain
   return redactPayload({ ...await dependencies.collectSnapshot(request) });
 }
 
+/**
+ * Whether a control-plane refusal means "this Viewer does not serve that route"
+ * rather than "that thing is not there" (#790).
+ *
+ * Blue/green promotes the web surface before the successor runtime host takes
+ * over, and the deployment health gate probes a CANDIDATE's MCP while the
+ * PREVIOUS revision is still answering on the control port. A read that moved
+ * onto a route introduced in the same revision therefore meets a Viewer that has
+ * never heard of it, and answers 405. Treating that as a hard failure made the
+ * gate unpassable for the very change that added the route, so the transition
+ * window has to be survivable rather than fatal.
+ *
+ * Deliberately 405 only: a 404 from these routes is the domain answer ("that
+ * deployment was not found") and must keep its meaning.
+ */
+function isUnservedControlRoute(error: unknown): boolean {
+  if (!(error instanceof McpToolRefusal)) return false;
+  return (error.details as { status?: unknown }).status === 405;
+}
+
 async function deploymentStatus(
   args: McpToolArgs,
   control: ViewerControlDependencies,
@@ -1143,7 +1183,11 @@ async function deploymentStatus(
     const deployment = await readViewerControl(
       control,
       `/api/runtime/deployments/${encodeURIComponent(deploymentId)}`,
-    );
+    ).catch((error: unknown) => {
+      if (!isUnservedControlRoute(error)) throw error;
+      return legacyDeploymentRead((client) => client.readViewerDeployment(deploymentId));
+    });
+    if (!deployment) throw new Error("viewer deployment was not found");
     return redactPayload({ deploymentId, deployment });
   }
   const operationId = text(args.operationId);
@@ -1161,7 +1205,13 @@ async function deploymentStatus(
     return redactPayload({ operationId, operation });
   }
   const limit = Math.max(1, Math.min(100, integer(args.limit, 25)));
-  const result = await readViewerControl(control, `/api/runtime/deployments?limit=${limit}`);
+  const result = await readViewerControl(control, `/api/runtime/deployments?limit=${limit}`)
+    .catch(async (error: unknown) => {
+      if (!isUnservedControlRoute(error)) throw error;
+      const ledger = await legacyDeploymentRead(async (client) => (await client.snapshot()).deployments);
+      const deployments = ledger.slice(-limit);
+      return { count: deployments.length, deployments };
+    });
   return redactPayload({ count: result.count, deployments: result.deployments });
 }
 

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -324,3 +324,57 @@ test("lifecycle_events distinguishes an unreachable deployment plane from an hon
     { pipelines: [], deliveries: [], deployments: [] },
   ]);
 });
+
+/**
+ * Issue #790: blue/green promotes the web surface before the successor runtime
+ * host takes over, so the deployment health gate probes a CANDIDATE's MCP while
+ * the PREVIOUS revision still answers on the control port. A read that moved onto
+ * a route introduced in the same revision meets a Viewer that has never served it
+ * and gets 405. Treating that as fatal made the gate unpassable for the very
+ * change that added the route — one real deploy failed exactly this way, with
+ * `calls.deploymentStatus: false` and every other check green.
+ */
+test("a control surface that does not serve the route yet falls back instead of failing the probe", async () => {
+  let sawGet = false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      sawGet = true;
+      expect(new URL(request.url).pathname).toBe("/api/runtime/deployments");
+      /* What the previous revision answers: the route exists for POST only. */
+      return new Response("Method Not Allowed", { status: 405 });
+    },
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    /* No runtime socket in this process, so the fallback surfaces its own honest
+       refusal rather than a silent empty ledger — the #777 guarantee holds. */
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-legacy-surface",
+      limit: 1,
+    })).rejects.toThrow(/runtime host socket is unavailable|runtime events are disabled/);
+    expect(sawGet).toBe(true);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("a 404 keeps its domain meaning and is never mistaken for an unserved route", async () => {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({ error: "viewer deployment was not found" }, { status: 404 }),
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-404-domain",
+      deploymentId: "deployment_absent",
+    })).rejects.toThrow(/not found/);
+  } finally {
+    server.stop(true);
+  }
+});


### PR DESCRIPTION
The deploy of `033d175c` failed its own health gate with `MCP runtime read probes failed`. Production was never promoted and stayed healthy, but the gate was unpassable by construction and no retry could have changed that.

## The deadlock

Blue/green promotes the web surface before the successor runtime host takes over, so the health gate probes a **candidate's** MCP while the **previous** revision still answers on the control port.

`deployment_status` moved onto `GET /api/runtime/deployments` — a route introduced in the same revision. The previous revision serves that path for POST only, so it answers **405**, verified directly against the live surface:

```
GET /api/runtime/deployments?limit=1  ->  405
```

`!response.ok` became a refusal, `calls.deploymentStatus` came back `false`, and the gate failed. Every other probe was green: all assets 200, `authenticatedStatus: 200`, MCP process ready, full tool list, `board_snapshot` passing.

The probe environment cannot be fixed from this side: `probeMcpRuntime` and the deploy adapter both run from the **already-deployed** revision, so a change there only takes effect after a deploy that this same gate is blocking. The candidate's MCP artifact is built from the new revision and is what gets probed, so the transition window has to be survivable there.

## Change

A 405 from these routes falls back to reading the runtime host directly for the duration of the transition window.

- **404 keeps its domain meaning.** "That deployment was not found" is an answer, not an unserved route, and the two are never conflated.
- **The #777 guarantee holds.** When the fallback has no socket it raises its own refusal, so an unreadable plane is still never a silent empty answer. The health probe inherits the runtime host's environment and does have the socket, which is why the gate can pass.

## Verification

- 47 focused tests pass across `deploymentReads`, `bindings`, `schemaParity` and both deployments route suites
- new test is RED against unfixed main — verified on a `git archive` copy outside the worktree
- TypeScript 0, ESLint 0, privacy gate PASS, `bun run build` 0

Refs #790. The probe-targeting half of #790 — pointing the candidate's MCP at the candidate rather than at the live port — remains open and is the durable fix; this makes the transition survivable so that fix can ship at all.