### PR TITLE
fix(mcp): classify a null control response by status instead of crashing

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -89,7 +89,14 @@ async function getViewerControl(pathname: string): Promise<Record<string, unknow
   } catch {
     throw new Error("Viewer control is unreachable");
   }
-  const result = await response.json().catch(() => ({})) as Record<string, unknown>;
+  /* A body of literal `null` is valid JSON, so `.catch` never fires and every
+     later `result.x` throws a TypeError before the status can be classified —
+     which is how a 405 from a revision that does not serve the route arrived as
+     an uncatchable crash instead of a refusal (#790). */
+  const parsed = await response.json().catch(() => null) as unknown;
+  const result: Record<string, unknown> = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
   if (!response.ok) {
     const error = text(result.error) || `Viewer control request failed with status ${response.status}`;
     throw new McpToolRefusal(error, {
@@ -117,7 +124,14 @@ async function postViewerControl(
     },
     body: JSON.stringify(body),
   });
-  const result = await response.json().catch(() => ({})) as Record<string, unknown>;
+  /* A body of literal `null` is valid JSON, so `.catch` never fires and every
+     later `result.x` throws a TypeError before the status can be classified —
+     which is how a 405 from a revision that does not serve the route arrived as
+     an uncatchable crash instead of a refusal (#790). */
+  const parsed = await response.json().catch(() => null) as unknown;
+  const result: Record<string, unknown> = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
   if (result.error || (!response.ok && result.state !== "busy")) {
     throw new Error(text(result.error) || `Viewer control request failed with status ${response.status}`);
   }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -40,7 +40,9 @@ import { projectForCwd } from "@/lib/scanner/describe";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
+import { runtimeHostClient as directRuntimeHostClient } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { runtimeEventsEnabled as directRuntimeEventsEnabled } from "@/lib/runtime/flags";
 import { readSession } from "@/lib/session/reader";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
@@ -133,6 +135,24 @@ function readViewerControl(
 ): Promise<Record<string, unknown>> {
   if (!control.get) throw new Error("Viewer control read is unavailable");
   return control.get(pathname);
+}
+
+/**
+ * The pre-control read path, kept only as the transition-window fallback for a
+ * control surface that does not serve the route yet (#790, see
+ * `isUnservedControlRoute`). It reads the runtime host directly, so it depends on
+ * this process holding the socket — true for the deployment health probe, whose
+ * environment is inherited from the runtime host, and false for an ordinary agent
+ * MCP, which is exactly what #777 fixed. When the socket is absent the honest
+ * refusal surfaces instead of a silent empty answer.
+ */
+async function legacyDeploymentRead<T>(
+  read: (client: NonNullable<ReturnType<typeof directRuntimeHostClient>>) => Promise<T>,
+): Promise<T> {
+  if (!directRuntimeEventsEnabled()) throw new Error("runtime events are disabled");
+  const client = directRuntimeHostClient();
+  if (!client) throw new Error("runtime host socket is unavailable");
+  return read(client);
 }
 
 type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySnapshot"]>;
@@ -1134,6 +1154,26 @@ async function operatorSnapshot(args: McpToolArgs, dependencies: ViewerMcpDomain
   return redactPayload({ ...await dependencies.collectSnapshot(request) });
 }
 
+/**
+ * Whether a control-plane refusal means "this Viewer does not serve that route"
+ * rather than "that thing is not there" (#790).
+ *
+ * Blue/green promotes the web surface before the successor runtime host takes
+ * over, and the deployment health gate probes a CANDIDATE's MCP while the
+ * PREVIOUS revision is still answering on the control port. A read that moved
+ * onto a route introduced in the same revision therefore meets a Viewer that has
+ * never heard of it, and answers 405. Treating that as a hard failure made the
+ * gate unpassable for the very change that added the route, so the transition
+ * window has to be survivable rather than fatal.
+ *
+ * Deliberately 405 only: a 404 from these routes is the domain answer ("that
+ * deployment was not found") and must keep its meaning.
+ */
+function isUnservedControlRoute(error: unknown): boolean {
+  if (!(error instanceof McpToolRefusal)) return false;
+  return (error.details as { status?: unknown }).status === 405;
+}
+
 async function deploymentStatus(
   args: McpToolArgs,
   control: ViewerControlDependencies,
@@ -1143,7 +1183,11 @@ async function deploymentStatus(
     const deployment = await readViewerControl(
       control,
       `/api/runtime/deployments/${encodeURIComponent(deploymentId)}`,
-    );
+    ).catch((error: unknown) => {
+      if (!isUnservedControlRoute(error)) throw error;
+      return legacyDeploymentRead((client) => client.readViewerDeployment(deploymentId));
+    });
+    if (!deployment) throw new Error("viewer deployment was not found");
     return redactPayload({ deploymentId, deployment });
   }
   const operationId = text(args.operationId);
@@ -1161,7 +1205,13 @@ async function deploymentStatus(
     return redactPayload({ operationId, operation });
   }
   const limit = Math.max(1, Math.min(100, integer(args.limit, 25)));
-  const result = await readViewerControl(control, `/api/runtime/deployments?limit=${limit}`);
+  const result = await readViewerControl(control, `/api/runtime/deployments?limit=${limit}`)
+    .catch(async (error: unknown) => {
+      if (!isUnservedControlRoute(error)) throw error;
+      const ledger = await legacyDeploymentRead(async (client) => (await client.snapshot()).deployments);
+      const deployments = ledger.slice(-limit);
+      return { count: deployments.length, deployments };
+    });
   return redactPayload({ count: result.count, deployments: result.deployments });
 }
 

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -378,3 +378,32 @@ test("a 404 keeps its domain meaning and is never mistaken for an unserved route
     server.stop(true);
   }
 });
+
+/**
+ * Issue #790, the actual root cause. A revision that does not serve the route
+ * answers 405 with a body of literal `null`, which is valid JSON — so the
+ * `.catch` guarding the parse never fires and `result.error` threw a TypeError
+ * before the status could be classified. The failure therefore never became a
+ * refusal carrying 405, and no status-based fallback could ever match it. Two
+ * real deploys failed this way with `calls.deploymentStatus: false` as the only
+ * evidence.
+ */
+test("a null response body is classified by status instead of crashing the read", async () => {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("null", { status: 405, headers: { "content-type": "application/json" } }),
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    /* Reaches the fallback and refuses honestly for want of a socket, rather
+       than dying on `null.error`. */
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-null-body",
+      limit: 1,
+    })).rejects.toThrow(/runtime host socket is unavailable|runtime events are disabled/);
+  } finally {
+    server.stop(true);
+  }
+});

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -324,3 +324,57 @@ test("lifecycle_events distinguishes an unreachable deployment plane from an hon
     { pipelines: [], deliveries: [], deployments: [] },
   ]);
 });
+
+/**
+ * Issue #790: blue/green promotes the web surface before the successor runtime
+ * host takes over, so the deployment health gate probes a CANDIDATE's MCP while
+ * the PREVIOUS revision still answers on the control port. A read that moved onto
+ * a route introduced in the same revision meets a Viewer that has never served it
+ * and gets 405. Treating that as fatal made the gate unpassable for the very
+ * change that added the route — one real deploy failed exactly this way, with
+ * `calls.deploymentStatus: false` and every other check green.
+ */
+test("a control surface that does not serve the route yet falls back instead of failing the probe", async () => {
+  let sawGet = false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      sawGet = true;
+      expect(new URL(request.url).pathname).toBe("/api/runtime/deployments");
+      /* What the previous revision answers: the route exists for POST only. */
+      return new Response("Method Not Allowed", { status: 405 });
+    },
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    /* No runtime socket in this process, so the fallback surfaces its own honest
+       refusal rather than a silent empty ledger — the #777 guarantee holds. */
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-legacy-surface",
+      limit: 1,
+    })).rejects.toThrow(/runtime host socket is unavailable|runtime events are disabled/);
+    expect(sawGet).toBe(true);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("a 404 keeps its domain meaning and is never mistaken for an unserved route", async () => {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({ error: "viewer deployment was not found" }, { status: 404 }),
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-404-domain",
+      deploymentId: "deployment_absent",
+    })).rejects.toThrow(/not found/);
+  } finally {
+    server.stop(true);
+  }
+});


### PR DESCRIPTION
Two deploys failed their own health gate with `MCP runtime read probes failed`, with `calls.deploymentStatus: false` as the only recorded evidence. Production was never promoted either time.

## Root cause

Blue/green promotes the web surface before the successor runtime host takes over, so the gate probes a **candidate's** MCP while the **previous** revision still answers the control port. `deployment_status` reads `GET /api/runtime/deployments`, a route added in the same revision, so the previous revision answers **405**.

That part was expected. What was not: the 405 body is literal `null`, which is valid JSON. So

```ts
const result = await response.json().catch(() => ({})) as Record<string, unknown>;
if (!response.ok) { const error = text(result.error) ... }
```

never fires its `.catch`, `result` is `null`, and `result.error` throws `TypeError: null is not an object` **before the status is ever looked at**. The failure therefore never became a refusal carrying 405, and no status-based handling could match it. Reproduced directly against the live control surface:

```
THREW: TypeError | null is not an object (evaluating 'result.error')
```

After the fix, the same call against the same surface returns real data.

## Change

Both control readers treat a non-object body as absent and classify by status. A 405 becomes a refusal that the transition-window fallback recognises and answers from the runtime host directly.

Preserved:
- **404 keeps its domain meaning** — that deployment is genuinely absent.
- **An explicitly absent plane keeps its code** — the #777 distinction between a rolled-back plane and an unreachable one is unchanged, and its test still passes.
- When the fallback has no socket it refuses honestly, so an unreadable plane is still never a silent empty answer.

## Verification

- 41 focused tests across `deploymentReads`, `bindings` and both deployments route suites
- regression test for the null body, and one for the unserved route
- reproduced the original crash and the fix against the live control surface
- TypeScript 0, ESLint 0, privacy gate PASS, `bun run build` 0

Refs #790. Pointing the probe at the candidate rather than at the live port remains the durable fix and stays open there; this makes the transition window survivable so that fix can ship at all.