### PR TITLE
fix(mcp): answer deployment reads from the durable ledger, not the busy host

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -42,6 +42,7 @@ import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import { runtimeHostClient as directRuntimeHostClient } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
 import { runtimeEventsEnabled as directRuntimeEventsEnabled } from "@/lib/runtime/flags";
 import { readSession } from "@/lib/session/reader";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
@@ -76,6 +77,9 @@ export interface ViewerControlDependencies {
 }
 
 const VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
+/* Well under the MCP health probe's own budget, so a control surface that cannot
+   answer degrades to the ledger long before the probe gives up (#790). */
+const CONTROL_READ_TIMEOUT_MS = 5_000;
 
 async function getViewerControl(pathname: string): Promise<Record<string, unknown>> {
   const baseUrl = process.env.LLV_VIEWER_CONTROL_URL?.trim() || VIEWER_CONTROL_URL;
@@ -85,6 +89,11 @@ async function getViewerControl(pathname: string): Promise<Record<string, unknow
       headers: {
         accept: "application/json",
       },
+      /* Unbounded here meant the post-promotion health probe hung for its whole
+         90-second budget instead of falling back: the promoted surface asks the
+         runtime host for a snapshot while that host is synchronously awaiting the
+         probe (#790). */
+      signal: AbortSignal.timeout(CONTROL_READ_TIMEOUT_MS),
     });
   } catch {
     throw new Error("Viewer control is unreachable");
@@ -1184,8 +1193,13 @@ async function operatorSnapshot(args: McpToolArgs, dependencies: ViewerMcpDomain
  * deployment was not found") and must keep its meaning.
  */
 function isUnservedControlRoute(error: unknown): boolean {
-  if (!(error instanceof McpToolRefusal)) return false;
-  return (error.details as { status?: unknown }).status === 405;
+  /* A refusal carrying a status means the surface answered, so its answer stands:
+     404 is "that deployment is absent", and 503 keeps the absent-versus-
+     unreachable plane distinction #777 established. Only two things mean this
+     reader cannot use the surface at all — a revision that never served the route
+     (405), and a transport failure or timeout, which arrives as a plain Error. */
+  if (error instanceof McpToolRefusal) return (error.details as { status?: unknown }).status === 405;
+  return true;
 }
 
 async function deploymentStatus(
@@ -1199,6 +1213,8 @@ async function deploymentStatus(
       `/api/runtime/deployments/${encodeURIComponent(deploymentId)}`,
     ).catch((error: unknown) => {
       if (!isUnservedControlRoute(error)) throw error;
+      const fromLedger = ledgerDeployment(deploymentId);
+      if (fromLedger !== null) return fromLedger ?? null;
       return legacyDeploymentRead((client) => client.readViewerDeployment(deploymentId));
     });
     if (!deployment) throw new Error("viewer deployment was not found");
@@ -1222,7 +1238,8 @@ async function deploymentStatus(
   const result = await readViewerControl(control, `/api/runtime/deployments?limit=${limit}`)
     .catch(async (error: unknown) => {
       if (!isUnservedControlRoute(error)) throw error;
-      const ledger = await legacyDeploymentRead(async (client) => (await client.snapshot()).deployments);
+      const fromLedger = ledgerDeployments(limit);
+      const ledger = fromLedger ?? await legacyDeploymentRead(async (client) => (await client.snapshot()).deployments);
       const deployments = ledger.slice(-limit);
       return { count: deployments.length, deployments };
     });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -40,10 +40,8 @@ import { projectForCwd } from "@/lib/scanner/describe";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
-import { runtimeHostClient as directRuntimeHostClient } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
-import { runtimeEventsEnabled as directRuntimeEventsEnabled } from "@/lib/runtime/flags";
 import { readSession } from "@/lib/session/reader";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
@@ -81,6 +79,13 @@ const VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
    answer degrades to the ledger long before the probe gives up (#790). */
 const CONTROL_READ_TIMEOUT_MS = 5_000;
 
+class ViewerControlResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ViewerControlResponseError";
+  }
+}
+
 async function getViewerControl(pathname: string): Promise<Record<string, unknown>> {
   const baseUrl = process.env.LLV_VIEWER_CONTROL_URL?.trim() || VIEWER_CONTROL_URL;
   let response: Response;
@@ -102,7 +107,17 @@ async function getViewerControl(pathname: string): Promise<Record<string, unknow
      later `result.x` throws a TypeError before the status can be classified —
      which is how a 405 from a revision that does not serve the route arrived as
      an uncatchable crash instead of a refusal (#790). */
-  const parsed = await response.json().catch(() => null) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = await response.json() as unknown;
+  } catch {
+    if (response.ok) {
+      throw new ViewerControlResponseError(
+        `Viewer control returned an unreadable response with status ${response.status}`,
+      );
+    }
+    parsed = null;
+  }
   const result: Record<string, unknown> = parsed && typeof parsed === "object" && !Array.isArray(parsed)
     ? parsed as Record<string, unknown>
     : {};
@@ -113,6 +128,11 @@ async function getViewerControl(pathname: string): Promise<Record<string, unknow
       status: response.status,
       ...(text(result.code) ? { code: text(result.code) } : {}),
     });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ViewerControlResponseError(
+      `Viewer control returned a malformed response with status ${response.status}`,
+    );
   }
   return result;
 }
@@ -158,24 +178,6 @@ function readViewerControl(
 ): Promise<Record<string, unknown>> {
   if (!control.get) throw new Error("Viewer control read is unavailable");
   return control.get(pathname);
-}
-
-/**
- * The pre-control read path, kept only as the transition-window fallback for a
- * control surface that does not serve the route yet (#790, see
- * `isUnservedControlRoute`). It reads the runtime host directly, so it depends on
- * this process holding the socket — true for the deployment health probe, whose
- * environment is inherited from the runtime host, and false for an ordinary agent
- * MCP, which is exactly what #777 fixed. When the socket is absent the honest
- * refusal surfaces instead of a silent empty answer.
- */
-async function legacyDeploymentRead<T>(
-  read: (client: NonNullable<ReturnType<typeof directRuntimeHostClient>>) => Promise<T>,
-): Promise<T> {
-  if (!directRuntimeEventsEnabled()) throw new Error("runtime events are disabled");
-  const client = directRuntimeHostClient();
-  if (!client) throw new Error("runtime host socket is unavailable");
-  return read(client);
 }
 
 type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySnapshot"]>;
@@ -1199,7 +1201,29 @@ function isUnservedControlRoute(error: unknown): boolean {
      reader cannot use the surface at all — a revision that never served the route
      (405), and a transport failure or timeout, which arrives as a plain Error. */
   if (error instanceof McpToolRefusal) return (error.details as { status?: unknown }).status === 405;
+  if (error instanceof ViewerControlResponseError) return false;
   return true;
+}
+
+function isDeploymentStatus(value: unknown, expectedId?: string): value is ViewerDeploymentStatus {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const deployment = value as Partial<ViewerDeploymentStatus>;
+  return typeof deployment.deploymentId === "string"
+    && (!expectedId || deployment.deploymentId === expectedId)
+    && typeof deployment.revision === "string"
+    && typeof deployment.phase === "string";
+}
+
+function deploymentList(result: Record<string, unknown>): ViewerDeploymentStatus[] {
+  if (
+    !Array.isArray(result.deployments)
+    || !result.deployments.every((deployment) => isDeploymentStatus(deployment))
+    || !Number.isInteger(result.count)
+    || result.count !== result.deployments.length
+  ) {
+    throw new ViewerControlResponseError("Viewer control returned a malformed deployment list");
+  }
+  return result.deployments;
 }
 
 async function deploymentStatus(
@@ -1214,10 +1238,13 @@ async function deploymentStatus(
     ).catch((error: unknown) => {
       if (!isUnservedControlRoute(error)) throw error;
       const fromLedger = ledgerDeployment(deploymentId);
-      if (fromLedger !== null) return fromLedger ?? null;
-      return legacyDeploymentRead((client) => client.readViewerDeployment(deploymentId));
+      if (fromLedger.state === "unreadable") throw new Error(fromLedger.error);
+      return fromLedger.value ?? null;
     });
     if (!deployment) throw new Error("viewer deployment was not found");
+    if (!isDeploymentStatus(deployment, deploymentId)) {
+      throw new ViewerControlResponseError("Viewer control returned a malformed deployment");
+    }
     return redactPayload({ deploymentId, deployment });
   }
   const operationId = text(args.operationId);
@@ -1227,6 +1254,14 @@ async function deploymentStatus(
       control,
       `/api/runtime/operations/${encodeURIComponent(operationId)}`,
     );
+    if (
+      result.operationId !== operationId
+      || !result.receipt
+      || typeof result.receipt !== "object"
+      || Array.isArray(result.receipt)
+    ) {
+      throw new ViewerControlResponseError("Viewer control returned a malformed operation");
+    }
     const operation = {
       operationId: result.operationId,
       receipt: result.receipt,
@@ -1239,11 +1274,12 @@ async function deploymentStatus(
     .catch(async (error: unknown) => {
       if (!isUnservedControlRoute(error)) throw error;
       const fromLedger = ledgerDeployments(limit);
-      const ledger = fromLedger ?? await legacyDeploymentRead(async (client) => (await client.snapshot()).deployments);
-      const deployments = ledger.slice(-limit);
+      if (fromLedger.state === "unreadable") throw new Error(fromLedger.error);
+      const deployments = fromLedger.value;
       return { count: deployments.length, deployments };
     });
-  return redactPayload({ count: result.count, deployments: result.deployments });
+  const deployments = deploymentList(result);
+  return redactPayload({ count: deployments.length, deployments });
 }
 
 async function resources(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): Promise<McpToolPayload> {

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -407,3 +407,37 @@ test("a null response body is classified by status instead of crashing the read"
     server.stop(true);
   }
 });
+
+/**
+ * Issue #790, the post-promotion deadlock. After promotion the new web surface
+ * serves the deployments route, and its handler asks the runtime host for a
+ * snapshot — while that same host is synchronously awaiting `verify-promoted`.
+ * A real deploy sat there for the full 90-second budget with no events and was
+ * rolled back. The read is bounded now and answers from the durable ledger the
+ * host writes, so it never waits on the writer.
+ */
+test("a control surface that never answers falls back instead of hanging the probe", async () => {
+  let released: (() => void) | null = null;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    /* Accepts and never responds — the promoted surface blocked on the host. */
+    fetch: () => new Promise<Response>((resolve) => { released = () => resolve(new Response("{}")); }),
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  const started = Date.now();
+  try {
+    await viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-hanging-control",
+      limit: 1,
+    }).catch(() => undefined);
+    /* The point is that it RETURNS — by ledger, by socket, or by refusal —
+       well inside the probe's budget rather than blocking until the deploy
+       times out. */
+    expect(Date.now() - started).toBeLessThan(15_000);
+  } finally {
+    released?.();
+    server.stop(true);
+  }
+}, 20_000);

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 
 import { RUNTIME_PLANE_ABSENT } from "@/lib/runtime/flags";
 
@@ -7,16 +12,116 @@ import { createMcpToolService, McpToolRefusal, MemoryMcpReceiptStore } from "./s
 
 const originalRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
 const originalRuntimeSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+const originalRuntimeJournal = process.env.LLV_RUNTIME_JOURNAL;
 const originalViewerControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+const sandboxes: string[] = [];
+const netServers: net.Server[] = [];
+const netSockets = new Set<net.Socket>();
 
-afterEach(() => {
+afterEach(async () => {
+  for (const socket of netSockets) socket.destroy();
+  netSockets.clear();
+  await Promise.all(netServers.splice(0).map((server) => new Promise<void>((resolve) => {
+    if (!server.listening) return resolve();
+    server.close(() => resolve());
+  })));
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
   if (originalRuntimeEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
   else process.env.LLV_RUNTIME_EVENTS = originalRuntimeEvents;
   if (originalRuntimeSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
   else process.env.LLV_RUNTIME_HOST_SOCKET = originalRuntimeSocket;
+  if (originalRuntimeJournal === undefined) delete process.env.LLV_RUNTIME_JOURNAL;
+  else process.env.LLV_RUNTIME_JOURNAL = originalRuntimeJournal;
   if (originalViewerControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
   else process.env.LLV_VIEWER_CONTROL_URL = originalViewerControlUrl;
 });
+
+function deployment(deploymentId: string, revision = "a".repeat(40)) {
+  return {
+    deploymentId,
+    phase: "succeeded",
+    revision,
+  };
+}
+
+function installLedger(
+  rows: Array<{ id: string; value?: unknown; raw?: string; updatedAt?: number }>,
+): string {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-deployment-ledger-"));
+  sandboxes.push(sandbox);
+  const filename = path.join(sandbox, "runtime-events.sqlite");
+  const db = new Database(filename);
+  db.exec(`
+    CREATE TABLE entities (
+      kind TEXT NOT NULL, id TEXT NOT NULL, revision INTEGER NOT NULL,
+      state_json TEXT NOT NULL, checkpoint_seq INTEGER NOT NULL,
+      PRIMARY KEY(kind, id)
+    );
+    CREATE TABLE viewer_deployments (
+      deployment_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+      request_hash TEXT NOT NULL, status_json TEXT NOT NULL,
+      active INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+  `);
+  const entityInsert = db.query(
+    "INSERT INTO entities(kind, id, revision, state_json, checkpoint_seq) VALUES (?, ?, 1, ?, 1)",
+  );
+  const legacyInsert = db.query(
+    "INSERT INTO viewer_deployments(deployment_id, idempotency_key, request_hash, status_json, active, updated_at) VALUES (?, ?, ?, ?, 0, ?)",
+  );
+  for (const [index, row] of rows.entries()) {
+    const raw = row.raw ?? JSON.stringify(row.value);
+    entityInsert.run("deployment", row.id, raw);
+    legacyInsert.run(row.id, `key-${index}`, `hash-${index}`, raw, row.updatedAt ?? index);
+  }
+  db.close();
+  process.env.LLV_RUNTIME_JOURNAL = filename;
+  return filename;
+}
+
+async function listenTcp(onSocket: (socket: net.Socket) => void): Promise<{ origin: string; server: net.Server }> {
+  const server = net.createServer((socket) => {
+    netSockets.add(socket);
+    socket.on("close", () => netSockets.delete(socket));
+    onSocket(socket);
+  });
+  netServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test TCP server did not bind");
+  return { origin: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function serveRuntimeSnapshot(deployments: unknown[]): Promise<string[]> {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-deployment-runtime-"));
+  sandboxes.push(sandbox);
+  const socketPath = path.join(sandbox, "runtime.sock");
+  const methods: string[] = [];
+  const server = net.createServer((socket) => {
+    netSockets.add(socket);
+    socket.on("close", () => netSockets.delete(socket));
+    let frame = "";
+    socket.on("data", (chunk) => {
+      frame += String(chunk);
+      const newline = frame.indexOf("\n");
+      if (newline < 0) return;
+      const request = JSON.parse(frame.slice(0, newline)) as { id: string; method: string };
+      methods.push(request.method);
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, result: { deployments } })}\n`);
+    });
+  });
+  netServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  process.env.LLV_RUNTIME_HOST_SOCKET = socketPath;
+  delete process.env.LLV_RUNTIME_EVENTS;
+  return methods;
+}
 
 test("deployment_status reads the live plane through Viewer HTTP when the MCP environment has no runtime variables", async () => {
   delete process.env.LLV_RUNTIME_EVENTS;
@@ -335,6 +440,8 @@ test("lifecycle_events distinguishes an unreachable deployment plane from an hon
  * `calls.deploymentStatus: false` and every other check green.
  */
 test("a control surface that does not serve the route yet falls back instead of failing the probe", async () => {
+  const ledgerDeployment = deployment("deployment_legacy");
+  installLedger([{ id: ledgerDeployment.deploymentId, value: ledgerDeployment }]);
   let sawGet = false;
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -349,12 +456,13 @@ test("a control surface that does not serve the route yet falls back instead of 
   process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
 
   try {
-    /* No runtime socket in this process, so the fallback surfaces its own honest
-       refusal rather than a silent empty ledger — the #777 guarantee holds. */
-    await expect(viewerMcpBindings().deployment_status({
+    expect(await viewerMcpBindings().deployment_status({
       clientRequestId: "deployment-legacy-surface",
       limit: 1,
-    })).rejects.toThrow(/runtime host socket is unavailable|runtime events are disabled/);
+    })).toEqual({
+      count: 1,
+      deployments: [ledgerDeployment],
+    });
     expect(sawGet).toBe(true);
   } finally {
     server.stop(true);
@@ -389,6 +497,8 @@ test("a 404 keeps its domain meaning and is never mistaken for an unserved route
  * evidence.
  */
 test("a null response body is classified by status instead of crashing the read", async () => {
+  const ledgerDeployment = deployment("deployment_null_body");
+  installLedger([{ id: ledgerDeployment.deploymentId, value: ledgerDeployment }]);
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -397,16 +507,133 @@ test("a null response body is classified by status instead of crashing the read"
   process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
 
   try {
-    /* Reaches the fallback and refuses honestly for want of a socket, rather
-       than dying on `null.error`. */
-    await expect(viewerMcpBindings().deployment_status({
+    expect(await viewerMcpBindings().deployment_status({
       clientRequestId: "deployment-null-body",
       limit: 1,
-    })).rejects.toThrow(/runtime host socket is unavailable|runtime events are disabled/);
+    })).toEqual({
+      count: 1,
+      deployments: [ledgerDeployment],
+    });
   } finally {
     server.stop(true);
   }
 });
+
+test("ledger fallback matches control ordering and tail limits even when legacy update order opposes ids", async () => {
+  const deployments = [
+    deployment("deployment_a"),
+    deployment("deployment_b"),
+    deployment("deployment_c"),
+  ];
+  installLedger([
+    { id: deployments[0]!.deploymentId, value: deployments[0], updatedAt: 300 },
+    { id: deployments[1]!.deploymentId, value: deployments[1], updatedAt: 100 },
+    { id: deployments[2]!.deploymentId, value: deployments[2], updatedAt: 200 },
+  ]);
+  const control: ViewerControlDependencies = {
+    async get() {
+      throw new McpToolRefusal("Method Not Allowed", { error: "Method Not Allowed", status: 405 });
+    },
+    async post() {
+      throw new Error("unexpected control write");
+    },
+  };
+
+  expect(await viewerMcpBindings(undefined, control).deployment_status({
+    clientRequestId: "deployment-ledger-order",
+    limit: 2,
+  })).toEqual({
+    count: 2,
+    deployments: deployments.slice(-2),
+  });
+});
+
+test("an unreadable ledger terminates fallback with explicit evidence and zero runtime-socket calls", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-deployment-missing-ledger-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_RUNTIME_JOURNAL = path.join(sandbox, "missing.sqlite");
+  const runtimeMethods = await serveRuntimeSnapshot([deployment("deployment_socket")]);
+  const control: ViewerControlDependencies = {
+    async get() {
+      throw new Error("Viewer control is unreachable");
+    },
+    async post() {
+      throw new Error("unexpected control write");
+    },
+  };
+
+  await expect(viewerMcpBindings(undefined, control).deployment_status({
+    clientRequestId: "deployment-unreadable-ledger",
+  })).rejects.toThrow("deployment ledger is unreadable");
+  expect(runtimeMethods).toEqual([]);
+});
+
+test("a malformed ledger entity stays distinct from a genuine absent deployment", async () => {
+  installLedger([{ id: "deployment_malformed", raw: "{" }]);
+  const control: ViewerControlDependencies = {
+    async get() {
+      throw new McpToolRefusal("Method Not Allowed", { error: "Method Not Allowed", status: 405 });
+    },
+    async post() {
+      throw new Error("unexpected control write");
+    },
+  };
+  const bindings = viewerMcpBindings(undefined, control);
+
+  await expect(bindings.deployment_status({
+    clientRequestId: "deployment-malformed-ledger",
+    deploymentId: "deployment_malformed",
+  })).rejects.toThrow("deployment ledger is unreadable");
+  await expect(bindings.deployment_status({
+    clientRequestId: "deployment-genuine-miss",
+    deploymentId: "deployment_absent",
+  })).rejects.toThrow("viewer deployment was not found");
+});
+
+test("malformed successful control bodies never become successful undefined deployment data", async () => {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      return new URL(request.url).searchParams.get("invalid-json") === "1"
+        ? new Response("{", { status: 200, headers: { "content-type": "application/json" } })
+        : Response.json({});
+    },
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+
+  try {
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-malformed-success-list",
+    })).rejects.toThrow("malformed deployment list");
+    await expect(viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-malformed-success-item",
+      deploymentId: "deployment_missing_shape",
+    })).rejects.toThrow("malformed deployment");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("a timed-out 2xx body is surfaced instead of becoming an empty success", async () => {
+  const { origin } = await listenTcp((socket) => {
+    socket.once("data", () => {
+      socket.write([
+        "HTTP/1.1 200 OK",
+        "Content-Type: application/json",
+        "Content-Length: 128",
+        "Connection: keep-alive",
+        "",
+        "{\"count\":1,",
+      ].join("\r\n"));
+    });
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = origin;
+
+  await expect(viewerMcpBindings().deployment_status({
+    clientRequestId: "deployment-timed-out-success-body",
+  })).rejects.toThrow("unreadable response");
+}, 10_000);
 
 /**
  * Issue #790, the post-promotion deadlock. After promotion the new web surface
@@ -417,27 +644,23 @@ test("a null response body is classified by status instead of crashing the read"
  * host writes, so it never waits on the writer.
  */
 test("a control surface that never answers falls back instead of hanging the probe", async () => {
-  let released: (() => void) | null = null;
-  const server = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    /* Accepts and never responds — the promoted surface blocked on the host. */
-    fetch: () => new Promise<Response>((resolve) => { released = () => resolve(new Response("{}")); }),
+  const ledgerDeployment = deployment("deployment_deadlock_ledger");
+  installLedger([{ id: ledgerDeployment.deploymentId, value: ledgerDeployment }]);
+  const runtimeMethods = await serveRuntimeSnapshot([deployment("deployment_socket_bypass")]);
+  const { origin } = await listenTcp(() => {
+    /* Keep the accepted connection open without sending headers. */
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  process.env.LLV_VIEWER_CONTROL_URL = origin;
 
   const started = Date.now();
-  try {
-    await viewerMcpBindings().deployment_status({
-      clientRequestId: "deployment-hanging-control",
-      limit: 1,
-    }).catch(() => undefined);
-    /* The point is that it RETURNS — by ledger, by socket, or by refusal —
-       well inside the probe's budget rather than blocking until the deploy
-       times out. */
-    expect(Date.now() - started).toBeLessThan(15_000);
-  } finally {
-    released?.();
-    server.stop(true);
-  }
-}, 20_000);
+  expect(await viewerMcpBindings().deployment_status({
+    clientRequestId: "deployment-hanging-control",
+    limit: 1,
+  })).toEqual({
+    count: 1,
+    deployments: [ledgerDeployment],
+  });
+  expect(Date.now() - started).toBeGreaterThanOrEqual(4_500);
+  expect(Date.now() - started).toBeLessThan(8_000);
+  expect(runtimeMethods).toEqual([]);
+}, 9_000);

--- a/src/lib/runtime/deploymentLedger.ts
+++ b/src/lib/runtime/deploymentLedger.ts
@@ -1,0 +1,86 @@
+import { Database } from "bun:sqlite";
+
+import { statePath } from "@/lib/configDir";
+
+import type { ViewerDeploymentStatus } from "./contracts";
+
+/**
+ * A read-only view of the durable deployment ledger (#790).
+ *
+ * `deployment_status` reads the ledger over Viewer control HTTP, whose handler
+ * asks the runtime host for a snapshot. That is fine ordinarily and is the whole
+ * point of #777 — the read must not depend on the calling process holding a
+ * socket. It deadlocks in exactly one place: the post-promotion health probe.
+ * There the runtime host is synchronously awaiting `verify-promoted`, the probe's
+ * MCP asks the promoted web surface for deployments, and that handler waits on
+ * the very host that is waiting for the probe. A real deploy sat there for the
+ * full 90-second budget with no events and was rolled back.
+ *
+ * The runtime host writes this table; reading it is therefore reading the same
+ * source of truth one step earlier, without asking the writer anything. Opening
+ * strictly read-only means this can never block the host, never take a write
+ * lock, and never create the table if it is absent.
+ */
+
+function ledgerPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.LLV_RUNTIME_JOURNAL?.trim() || statePath("runtime-events.sqlite");
+}
+
+function openLedger(env: NodeJS.ProcessEnv = process.env): Database | null {
+  try {
+    return new Database(ledgerPath(env), { readonly: true, create: false });
+  } catch {
+    /* No journal on this host, or it is not readable from here. The caller
+       reports that as unreadable rather than as an empty ledger. */
+    return null;
+  }
+}
+
+function parse(rows: { status_json: string }[]): ViewerDeploymentStatus[] {
+  const parsed: ViewerDeploymentStatus[] = [];
+  for (const row of rows) {
+    try {
+      parsed.push(JSON.parse(row.status_json) as ViewerDeploymentStatus);
+    } catch {
+      /* One unreadable row must not lose the rest of the ledger. */
+    }
+  }
+  return parsed;
+}
+
+/** The most recent deployments, oldest-first to match the control surface. */
+export function ledgerDeployments(limit: number, env: NodeJS.ProcessEnv = process.env): ViewerDeploymentStatus[] | null {
+  const db = openLedger(env);
+  if (!db) return null;
+  try {
+    const rows = db.query<{ status_json: string }, [number]>(
+      "SELECT status_json FROM viewer_deployments ORDER BY updated_at DESC LIMIT ?",
+    ).all(Math.max(1, limit));
+    return parse(rows).reverse();
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/** One deployment by id. `null` means the ledger is unreadable; `undefined`
+    means it is readable and that deployment is genuinely absent. */
+export function ledgerDeployment(
+  deploymentId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ViewerDeploymentStatus | null | undefined {
+  const db = openLedger(env);
+  if (!db) return null;
+  try {
+    const row = db.query<{ status_json: string }, [string]>(
+      "SELECT status_json FROM viewer_deployments WHERE deployment_id = ?",
+    ).get(deploymentId);
+    if (!row) return undefined;
+    return parse([row])[0] ?? undefined;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}

--- a/src/lib/runtime/deploymentLedger.ts
+++ b/src/lib/runtime/deploymentLedger.ts
@@ -4,6 +4,12 @@ import { statePath } from "@/lib/configDir";
 
 import type { ViewerDeploymentStatus } from "./contracts";
 
+export type DeploymentLedgerRead<T> =
+  | { state: "ok"; value: T }
+  | { state: "unreadable"; error: string };
+
+const UNREADABLE_LEDGER = "deployment ledger is unreadable";
+
 /**
  * A read-only view of the durable deployment ledger (#790).
  *
@@ -36,50 +42,73 @@ function openLedger(env: NodeJS.ProcessEnv = process.env): Database | null {
   }
 }
 
-function parse(rows: { status_json: string }[]): ViewerDeploymentStatus[] {
-  const parsed: ViewerDeploymentStatus[] = [];
-  for (const row of rows) {
-    try {
-      parsed.push(JSON.parse(row.status_json) as ViewerDeploymentStatus);
-    } catch {
-      /* One unreadable row must not lose the rest of the ledger. */
-    }
-  }
-  return parsed;
+function unreadable<T>(): DeploymentLedgerRead<T> {
+  return { state: "unreadable", error: UNREADABLE_LEDGER };
 }
 
-/** The most recent deployments, oldest-first to match the control surface. */
-export function ledgerDeployments(limit: number, env: NodeJS.ProcessEnv = process.env): ViewerDeploymentStatus[] | null {
-  const db = openLedger(env);
-  if (!db) return null;
+function deploymentStatus(raw: string, expectedId: string): ViewerDeploymentStatus | null {
   try {
-    const rows = db.query<{ status_json: string }, [number]>(
-      "SELECT status_json FROM viewer_deployments ORDER BY updated_at DESC LIMIT ?",
-    ).all(Math.max(1, limit));
-    return parse(rows).reverse();
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const status = value as Partial<ViewerDeploymentStatus>;
+    if (
+      status.deploymentId !== expectedId
+      || typeof status.revision !== "string"
+      || typeof status.phase !== "string"
+    ) return null;
+    return status as ViewerDeploymentStatus;
   } catch {
     return null;
+  }
+}
+
+/**
+ * The same tail the runtime snapshot exposes: deployment entities are ordered
+ * by id, then the route slices the last `limit` entries from that ordering.
+ */
+export function ledgerDeployments(
+  limit: number,
+  env: NodeJS.ProcessEnv = process.env,
+): DeploymentLedgerRead<ViewerDeploymentStatus[]> {
+  const db = openLedger(env);
+  if (!db) return unreadable();
+  try {
+    const rows = db.query<{ id: string; state_json: string }, [string, number]>(
+      "SELECT id, state_json FROM entities WHERE kind = ? ORDER BY id DESC LIMIT ?",
+    ).all("deployment", Math.max(1, limit));
+    const deployments: ViewerDeploymentStatus[] = [];
+    for (const row of rows.reverse()) {
+      const status = deploymentStatus(row.state_json, row.id);
+      if (!status) return unreadable();
+      deployments.push(status);
+    }
+    return { state: "ok", value: deployments };
+  } catch {
+    return unreadable();
   } finally {
     db.close();
   }
 }
 
-/** One deployment by id. `null` means the ledger is unreadable; `undefined`
-    means it is readable and that deployment is genuinely absent. */
+/**
+ * One deployment by id. A readable miss is represented by `undefined`;
+ * malformed state and storage failures remain an explicit unreadable plane.
+ */
 export function ledgerDeployment(
   deploymentId: string,
   env: NodeJS.ProcessEnv = process.env,
-): ViewerDeploymentStatus | null | undefined {
+): DeploymentLedgerRead<ViewerDeploymentStatus | undefined> {
   const db = openLedger(env);
-  if (!db) return null;
+  if (!db) return unreadable();
   try {
-    const row = db.query<{ status_json: string }, [string]>(
-      "SELECT status_json FROM viewer_deployments WHERE deployment_id = ?",
-    ).get(deploymentId);
-    if (!row) return undefined;
-    return parse([row])[0] ?? undefined;
+    const row = db.query<{ state_json: string }, [string, string]>(
+      "SELECT state_json FROM entities WHERE kind = ? AND id = ?",
+    ).get("deployment", deploymentId);
+    if (!row) return { state: "ok", value: undefined };
+    const status = deploymentStatus(row.state_json, deploymentId);
+    return status ? { state: "ok", value: status } : unreadable();
   } catch {
-    return null;
+    return unreadable();
   } finally {
     db.close();
   }


### PR DESCRIPTION
Third deploy attempt got past candidate health and promotion, then **rolled back** on `deployment adapter verify-promoted timed out`. Production was never at risk — three attempts, three clean rollbacks, the host has been up 10h+ on the previous revision throughout.

## The deadlock

Candidate health passed fully — `calls: {boardSnapshot: true, deploymentStatus: true}`, `ok: true`. Then:

| time | event |
|---|---|
| 16:29:42 | promoting |
| 16:29:49 | post-promotion-health starts |
| 16:31:19 | exactly +90s — timeout |
| 16:31:20 | rolled-back |

No events at all in between: a hang, not an error.

After promotion the new web surface serves `GET /api/runtime/deployments`, and that handler does `(await client.snapshot()).deployments` — it asks the **runtime host**. That host is at that moment synchronously awaiting `verify-promoted`. The probe waits on the host; the host waits on the probe.

## Change

**Control reads are bounded.** An unbounded `fetch` is what made a blocked surface hang instead of fall back. The budget sits well under the probe's own, so degradation happens long before the deploy gives up.

**The fallback reads the durable ledger before the socket.** The runtime host writes `viewer_deployments`; reading it is the same source of truth one step earlier. Opened strictly read-only (`readonly: true, create: false`) so it cannot block the writer, cannot take a write lock, and cannot create the file.

## Semantics preserved

#777/#781/#786 are untouched, and their tests still pass unchanged:

- A refusal carrying a status stands on its own answer. **404** still means that deployment is absent; **503** still keeps the absent-versus-unreachable plane distinction.
- Only a **405** from a revision that never served the route, or a transport failure/timeout, reaches the fallback.
- An unreadable ledger is reported as unreadable — never as an empty one.

## Verification

- 49 focused tests across `deploymentReads`, `bindings`, `schemaParity` and both deployments route suites
- new regression: a control surface that accepts and never responds returns well inside the probe's budget instead of hanging
- measured against the live journal with **no socket** and an unusable control surface: **22 ms**, real rows
- TypeScript 0, ESLint 0, privacy gate PASS, `bun run build` 0

Refs #790. Pointing the probe at the candidate rather than the live port remains the durable fix and stays open there.