### PR TITLE
fix(runtime): admit oversized replay envelopes through bounded reduction (#794)

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -65,6 +65,8 @@ class FakeAppServer extends EventEmitter {
   modelListFailuresRemaining = 0;
   realtimeStartError: string | null = null;
   realtimeAppendErrorAt: number | null = null;
+  responseChunkBytes: number | null = null;
+  oversizedTurnStartResult = false;
   readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
@@ -166,6 +168,9 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "turn/start") {
       const turnId = `turn-${++this.turn}`;
+      if (this.oversizedTurnStartResult) {
+        return this.respond(message.id, { turn: { id: turnId }, padding: "p".repeat(26 * 1024 * 1024) });
+      }
       this.respond(message.id, { turn: { id: turnId } });
       this.notify("turn/started", { threadId: this.threadId, turn: { id: turnId } });
       this.completeUserMessage(message, turnId);
@@ -218,7 +223,14 @@ class FakeAppServer extends EventEmitter {
   }
 
   private respond(id: number, result: unknown): void {
-    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+    const line = `${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`;
+    if (this.responseChunkBytes) {
+      for (let offset = 0; offset < line.length; offset += this.responseChunkBytes) {
+        this.stdout.write(line.slice(offset, offset + this.responseChunkBytes));
+      }
+      return;
+    }
+    this.stdout.write(line);
   }
 
   private respondError(id: number, message: string): void {
@@ -884,6 +896,174 @@ describe("CodexAppServerHost", () => {
       .toMatchObject({ threadId });
     expect(await host.health()).toMatchObject({ status: "idle", eventCursor: 5 });
     await host.release();
+  });
+
+  /* An mcpToolCall replay item shaped like the production frame: one turn of
+     Viewer tool calls whose result text dominates the envelope's byte count. */
+  const fatReplayTurn = (turnId: string, itemPrefix: string, count: number, text: string) => ({
+    id: turnId,
+    status: "completed",
+    items: Array.from({ length: count }, (_, index) => ({
+      id: `${itemPrefix}-${index}`,
+      type: "mcpToolCall",
+      status: "completed",
+      result: { Ok: { content: [{ type: "text", text }] } },
+    })),
+  });
+
+  test("recovery survives an oversized thread/resume replay envelope with a bounded ledger", async () => {
+    const threadId = "oversized-resume-thread";
+    const fatText = "x".repeat(1024 * 1024);
+    const server = new FakeAppServer(threadId, threadId, false, [fatReplayTurn("fat-turn", "fat-call", 26, fatText)]);
+    const eventStore = new MemoryEventStore();
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect((await host.health()).status).not.toBe("dead");
+    const items = eventStore.load(threadId).filter((event) => event.kind === "item");
+    expect(items).toHaveLength(26);
+    const serialized = JSON.stringify(items);
+    expect(serialized).toContain("truncated");
+    expect(serialized.length).toBeLessThan(2 * 1024 * 1024);
+    expect(await host.send({ id: "post-recovery", text: "ping" })).toMatchObject({ outcome: "turn-started" });
+    await host.release();
+  });
+
+  test("the oversized replay envelope survives arriving in stream chunks", async () => {
+    const threadId = "chunked-resume-thread";
+    const fatText = "x".repeat(1024 * 1024);
+    const server = new FakeAppServer(threadId, threadId, false, [fatReplayTurn("chunk-turn", "chunk-call", 26, fatText)]);
+    server.responseChunkBytes = 64 * 1024;
+    const eventStore = new MemoryEventStore();
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect((await host.health()).status).not.toBe("dead");
+    expect(eventStore.load(threadId).filter((event) => event.kind === "item")).toHaveLength(26);
+    await host.release();
+  });
+
+  test("inline image history in the replay envelope reaches the ledger only as a bounded reference", async () => {
+    const threadId = "image-replay-thread";
+    const body = Buffer.alloc(1024 * 1024, 5).toString("base64");
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: "image-turn",
+      status: "completed",
+      items: [{
+        id: "image-echo",
+        type: "userMessage",
+        clientId: "image-echo",
+        content: [
+          { type: "input_image", image_url: `data:image/png;base64,${body}` },
+          { type: "text", text: "replayed screenshot" },
+        ],
+      }],
+    }]);
+    const eventStore = new MemoryEventStore();
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      resolveImagePath: (ref) => `/runtime-images/${ref.sha256}`,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect((await host.health()).status).not.toBe("dead");
+    const serialized = JSON.stringify(eventStore.load(threadId).filter((event) => event.kind === "item"));
+    expect(serialized).toContain("localImage");
+    expect(serialized).not.toContain(body.slice(0, 256));
+    expect(serialized.length).toBeLessThan(64 * 1024);
+    await host.release();
+  });
+
+  test("a queued send settles exactly once across an oversized thread/read confirmation replay", async () => {
+    const threadId = "oversized-read-thread";
+    const fatText = "y".repeat(1024 * 1024);
+    const server = new FakeAppServer(threadId, threadId);
+    const fatTurn = fatReplayTurn("persisted-turn", "read-call", 26, fatText);
+    server.readTurns = [{
+      ...fatTurn,
+      items: [
+        ...fatTurn.items,
+        { type: "userMessage", clientId: "operation-recovered", content: [{ type: "text", text: "hello" }] },
+      ],
+    }];
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-recovered", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "persisted-turn",
+    });
+    expect(server.requests.some((request) => request.method === "turn/start" || request.method === "turn/steer")).toBeFalse();
+    expect((await host.health()).status).not.toBe("dead");
+    await host.release();
+  });
+
+  test("an oversized frame that is not the awaited replay envelope still fails closed", async () => {
+    const server = new FakeAppServer("oversized-notification-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
+      signalProcess: (_pid, signal) => {
+        if (signal === "SIGKILL") queueMicrotask(() => server.emit("close", 0, signal));
+      },
+    });
+
+    server.notify("item/completed", {
+      threadId: "oversized-notification-thread",
+      turnId: "turn-9",
+      item: { type: "agentMessage", text: "z".repeat(26 * 1024 * 1024) },
+    });
+    await Bun.sleep(20);
+    expect(await host.health()).toMatchObject({ status: "dead" });
+  });
+
+  test("an oversized response to a pending non-replay request still fails closed", async () => {
+    const server = new FakeAppServer("oversized-turn-start-thread");
+    server.oversizedTurnStartResult = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
+      signalProcess: (_pid, signal) => {
+        if (signal === "SIGKILL") queueMicrotask(() => server.emit("close", 0, signal));
+      },
+    });
+
+    await expect(host.send({ id: "oversized-turn-start", text: "hi" })).rejects.toThrow();
+    expect(await host.health()).toMatchObject({ status: "dead" });
+  });
+
+  test("an oversized response that no replay read is awaiting still fails closed", async () => {
+    const server = new FakeAppServer("oversized-response-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
+      signalProcess: (_pid, signal) => {
+        if (signal === "SIGKILL") queueMicrotask(() => server.emit("close", 0, signal));
+      },
+    });
+
+    server.stdout.write(`{"id":777,"result":{"blob":"${"w".repeat(26 * 1024 * 1024)}"}}\n`);
+    await Bun.sleep(20);
+    expect(await host.health()).toMatchObject({ status: "dead" });
   });
 
   test("managed-home adoption discovers Viewer and resumes with every unrelated MCP server disabled", async () => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -9,7 +9,7 @@ import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
 import { grantedPluginServerNames, grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
-import { sanitizeCodexImageFrame, type ImageSink } from "./codexImageFrames";
+import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
 import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, runtimeImageStore } from "./runtimeImageStore";
 import { STRUCTURED_IMAGE_CAPABILITY, type StructuredImageRef } from "./structuredContent";
 import {
@@ -216,6 +216,31 @@ const MAX_REALTIME_SDP_BYTES = 512 * 1024;
 const MAX_REALTIME_SPEECH_BYTES = 8 * 1024;
 const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
 const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
+/**
+ * A `thread/resume` (or `thread/read`) response replays the whole thread
+ * history as one JSONL frame, and history the operator legally accumulated can
+ * dwarf `MAX_LINE_BYTES` (issue #794: a production resume envelope reached
+ * ~55 MB, dominated by replayed MCP tool-result text). Only the response the
+ * host is itself awaiting for one of these methods may pass the frame guard,
+ * and it is admitted through `CodexReplayFrameReducer`, which bounds every
+ * string token while it streams. Every other oversized frame stays fail-closed.
+ */
+const REPLAY_ENVELOPE_METHODS = new Set(["thread/resume", "thread/read"]);
+const REPLAY_REDUCTION_THRESHOLD_BYTES = MAX_REPLAY_ENVELOPE_BYTES;
+const REPLAY_STRING_UNITS = 16 * 1024;
+const MAX_REPLAY_RAW_UNITS = 512 * 1024 * 1024;
+const MAX_TRACKED_REPLAY_ENVELOPE_REQUESTS = 64;
+/* Codex serializes responses as `{"id":N,"result":…}` (the test fake keeps the
+   `jsonrpc` member first); anything else fails closed like before. */
+const REPLAY_RESPONSE_PREFIX = /^\{(?:"jsonrpc":"2\.0",)?"id":(\d+),"result":/;
+const REPLAY_FRAME_BUDGETS: ReplayFrameBudgets = {
+  maxStringUnits: REPLAY_STRING_UNITS,
+  /* Keep a full admissible image encoding intact (plus data-URL prefix room)
+     so replayed inline images still collapse into bounded references. */
+  maxImageStringUnits: MAX_STRUCTURED_IMAGE_ENCODED_BYTES + 64,
+  maxOutputUnits: MAX_LINE_BYTES,
+  maxRawUnits: MAX_REPLAY_RAW_UNITS,
+};
 const MAX_STDERR_TAIL_BYTES = 16 * 1024;
 const MAX_PRE_RESTORE_FRAMES = 256;
 const MAX_PRE_RESTORE_BYTES = 4 * 1024 * 1024;
@@ -397,6 +422,8 @@ export class CodexAppServerHost implements EngineHost {
   private realtimeFailure: CodexRealtimeFailure | null = null;
   private realtimeSessionId: string | null = null;
   private readonly lateThreadReadResponses = new Map<number, number>();
+  private readonly replayEnvelopeRequestIds = new Set<number>();
+  private replayReduction: CodexReplayFrameReducer | null = null;
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
   private readonly confirmedDeliveries = new Map<string, {
@@ -1296,7 +1323,11 @@ export class CodexAppServerHost implements EngineHost {
       completedItems.set(key, (completedItems.get(key) ?? 0) + 1);
     }
     if (Array.isArray(turn.items)) {
-      for (const item of turn.items) {
+      for (const replayed of turn.items) {
+        /* Replayed history items take the same image bounding as live echoes
+           (#773); the ledger only ever holds bounded references, and the
+           replay key must be computed on the same shape the ledger stores. */
+        const item = this.boundImageBodies(replayed);
         const key = itemReplayKey(item);
         const recorded = completedItems.get(key) ?? 0;
         if (recorded > 0) {
@@ -1551,6 +1582,7 @@ export class CodexAppServerHost implements EngineHost {
   private rpc(method: string, params: JsonObject = {}, timeoutMs = this.requestTimeoutMs): Promise<unknown> {
     if (this.dead || this.releasing || this.released) return Promise.reject(new Error("Codex app-server host is unavailable"));
     const id = this.nextRpcId++;
+    if (REPLAY_ENVELOPE_METHODS.has(method)) this.trackReplayEnvelopeRequest(id);
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
@@ -1609,24 +1641,113 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private acceptStdout(chunk: string): void {
-    if (this.dead || this.releasing || this.released) return;
+    let rest = chunk;
+    while (rest) {
+      if (this.dead || this.releasing || this.released) {
+        this.stdoutBuffer = "";
+        this.replayReduction = null;
+        return;
+      }
+      rest = this.replayReduction ? this.feedReplayReduction(rest) : this.acceptPlainStdout(rest);
+    }
+    if (this.dead || this.releasing || this.released) {
+      this.stdoutBuffer = "";
+      this.replayReduction = null;
+    }
+  }
+
+  /** Plain JSONL admission; returns any bytes to reprocess in replay-reduction mode. */
+  private acceptPlainStdout(chunk: string): string {
     this.stdoutBuffer += chunk;
     let newline = this.stdoutBuffer.indexOf("\n");
     while (newline >= 0) {
       const line = this.stdoutBuffer.slice(0, newline).trim();
       this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
       if (Buffer.byteLength(line) > MAX_LINE_BYTES) {
-        this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
-        return;
+        if (this.awaitedReplayEnvelopeId(line) === null) {
+          this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+          return "";
+        }
+        const remainder = this.stdoutBuffer;
+        this.stdoutBuffer = "";
+        this.replayReduction = new CodexReplayFrameReducer(REPLAY_FRAME_BUDGETS);
+        if (!this.feedReplayFrame(line)) return "";
+        this.finishReplayReduction();
+        return this.dead || this.releasing || this.released ? "" : remainder;
       }
       if (line) this.acceptMessage(line);
       if (this.dead || this.releasing || this.released) {
         this.stdoutBuffer = "";
-        return;
+        return "";
       }
       newline = this.stdoutBuffer.indexOf("\n");
     }
-    if (Buffer.byteLength(this.stdoutBuffer) > MAX_LINE_BYTES) this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+    const bufferedBytes = Buffer.byteLength(this.stdoutBuffer);
+    if (bufferedBytes > REPLAY_REDUCTION_THRESHOLD_BYTES && this.awaitedReplayEnvelopeId(this.stdoutBuffer) !== null) {
+      const buffered = this.stdoutBuffer;
+      this.stdoutBuffer = "";
+      this.replayReduction = new CodexReplayFrameReducer(REPLAY_FRAME_BUDGETS);
+      return buffered;
+    }
+    if (bufferedBytes > MAX_LINE_BYTES) {
+      this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+      this.stdoutBuffer = "";
+    }
+    return "";
+  }
+
+  /** Streams the awaited replay envelope; returns bytes after the frame's newline. */
+  private feedReplayReduction(chunk: string): string {
+    const newline = chunk.indexOf("\n");
+    if (!this.feedReplayFrame(newline === -1 ? chunk : chunk.slice(0, newline))) return "";
+    if (newline === -1) return "";
+    this.finishReplayReduction();
+    return this.dead || this.releasing || this.released ? "" : chunk.slice(newline + 1);
+  }
+
+  private feedReplayFrame(text: string): boolean {
+    try {
+      this.replayReduction!.feed(text);
+      return true;
+    } catch (error) {
+      this.replayReduction = null;
+      this.fail(error instanceof ReplayFrameOverflowError ? error : new Error(safeError(error)));
+      return false;
+    }
+  }
+
+  private finishReplayReduction(): void {
+    const reducer = this.replayReduction!;
+    this.replayReduction = null;
+    let reduced: string;
+    try {
+      reduced = reducer.finish().trim();
+    } catch (error) {
+      this.fail(error instanceof ReplayFrameOverflowError ? error : new Error(safeError(error)));
+      return;
+    }
+    if (Buffer.byteLength(reduced) > MAX_LINE_BYTES) {
+      this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+      return;
+    }
+    if (reduced) this.acceptMessage(reduced);
+  }
+
+  /** The numeric id when this frame opens as the response to an awaited replay read. */
+  private awaitedReplayEnvelopeId(text: string): number | null {
+    const match = REPLAY_RESPONSE_PREFIX.exec(text.slice(0, 64).trimStart());
+    if (!match) return null;
+    const id = Number(match[1]);
+    return this.replayEnvelopeRequestIds.has(id) ? id : null;
+  }
+
+  private trackReplayEnvelopeRequest(id: number): void {
+    this.replayEnvelopeRequestIds.add(id);
+    while (this.replayEnvelopeRequestIds.size > MAX_TRACKED_REPLAY_ENVELOPE_REQUESTS) {
+      const oldest = this.replayEnvelopeRequestIds.values().next().value;
+      if (oldest === undefined) break;
+      this.replayEnvelopeRequestIds.delete(oldest);
+    }
   }
 
   private acceptStderr(chunk: string): void {
@@ -1662,6 +1783,7 @@ export class CodexAppServerHost implements EngineHost {
     const method = typeof message.method === "string" ? message.method : null;
     if ((typeof id === "number" || typeof id === "string") && !method) {
       if (typeof id !== "number") return this.fail(new Error("Codex app-server response id is invalid"));
+      this.replayEnvelopeRequestIds.delete(id);
       const pending = this.pending.get(id);
       if (!pending && this.consumeLateThreadReadResponse(id)) return;
       if (!pending) return this.fail(new Error("Codex app-server response has no matching request"));

--- a/src/lib/runtime/codexImageFrames.test.ts
+++ b/src/lib/runtime/codexImageFrames.test.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { expect, test } from "bun:test";
 
-import { sanitizeCodexImageFrame, type ImageSink } from "./codexImageFrames";
+import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
 import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES } from "./runtimeImageStore";
 
 const PNG = Buffer.from(
@@ -133,4 +133,90 @@ test("a store failure still yields a bounded reference", () => {
 test("the reference digest names the stored image bytes", () => {
   const { captured } = sanitizeCodexImageFrame(echoedItem(PNG.toString("base64")), sink());
   expect(captured[0]!.sha256).toBe(crypto.createHash("sha256").update(PNG).digest("hex"));
+});
+
+const budgets = (overrides: Partial<ReplayFrameBudgets> = {}): ReplayFrameBudgets => ({
+  maxStringUnits: 32,
+  maxImageStringUnits: 4096,
+  maxOutputUnits: 1024 * 1024,
+  maxRawUnits: 16 * 1024 * 1024,
+  ...overrides,
+});
+
+function reduce(line: string, limits = budgets(), chunkUnits?: number): string {
+  const reducer = new CodexReplayFrameReducer(limits);
+  if (chunkUnits === undefined) reducer.feed(line);
+  else for (let offset = 0; offset < line.length; offset += chunkUnits) reducer.feed(line.slice(offset, offset + chunkUnits));
+  return reducer.finish();
+}
+
+test("a frame with only short strings is reproduced verbatim", () => {
+  const line = JSON.stringify({ id: 5, result: { thread: { id: "t-1", turns: [{ id: "turn", status: "completed" }] } } });
+  for (const chunk of [undefined, 1, 3, 7]) {
+    expect(reduce(line, budgets(), chunk)).toBe(line);
+  }
+});
+
+test("a long string token keeps a bounded prefix and a truncation marker", () => {
+  const line = JSON.stringify({ result: { text: "a".repeat(500), after: "intact" } });
+  const reduced = reduce(line);
+  const parsed = JSON.parse(reduced) as { result: { text: string; after: string } };
+  expect(parsed.result.text.startsWith("a".repeat(32))).toBeTrue();
+  expect(parsed.result.text).toContain("…[truncated 468 chars]");
+  expect(parsed.result.after).toBe("intact");
+});
+
+test("escape sequences at the cut point stay atomic and the frame stays valid JSON", () => {
+  const noisy = "\\\"\n".repeat(64);
+  const line = JSON.stringify({ result: { text: noisy, tail: "kept" } });
+  for (const chunk of [undefined, 1, 2, 5]) {
+    const reduced = reduce(line, budgets(), chunk);
+    const parsed = JSON.parse(reduced) as { result: { text: string; tail: string } };
+    expect(parsed.result.text).toContain("truncated");
+    expect(parsed.result.tail).toBe("kept");
+  }
+});
+
+test("a surrogate pair is never split in front of the marker", () => {
+  const line = JSON.stringify({ result: { text: `${"x".repeat(31)}😀${"y".repeat(64)}` } });
+  const reduced = reduce(line);
+  const parsed = JSON.parse(reduced) as { result: { text: string } };
+  expect(parsed.result.text.startsWith("x".repeat(31))).toBeTrue();
+  expect(parsed.result.text).not.toContain("😀"[0]! + "…");
+});
+
+test("an image data URL is exempt from the ordinary string budget", () => {
+  const body = PNG.toString("base64").repeat(8);
+  const line = JSON.stringify({ result: { image_url: `data:image/png;base64,${body}` } });
+  expect(body.length).toBeGreaterThan(64);
+  const reduced = reduce(line, budgets(), 11);
+  const parsed = JSON.parse(reduced) as { result: { image_url: string } };
+  expect(parsed.result.image_url).toBe(`data:image/png;base64,${body}`);
+});
+
+test("an image beyond even the image budget is still cut, not passed through", () => {
+  const line = JSON.stringify({ result: { image_url: `data:image/png;base64,${"A".repeat(8192)}` } });
+  const reduced = reduce(line);
+  const parsed = JSON.parse(reduced) as { result: { image_url: string } };
+  expect(parsed.result.image_url.length).toBeLessThan(4200);
+  expect(parsed.result.image_url).toContain("truncated");
+});
+
+test("a structured-user digest prefix survives reduction of a long user text", () => {
+  const digest = "0123456789abcdef".repeat(4);
+  const wire = `<!-- llv:structured-user sha256=${digest} -->\n${"body ".repeat(200)}`;
+  const reduced = reduce(JSON.stringify({ result: { text: wire } }), budgets({ maxStringUnits: 256 }));
+  const parsed = JSON.parse(reduced) as { result: { text: string } };
+  expect(parsed.result.text.startsWith(`<!-- llv:structured-user sha256=${digest} -->`)).toBeTrue();
+});
+
+test("the raw budget fails the frame closed", () => {
+  const reducer = new CodexReplayFrameReducer(budgets({ maxRawUnits: 100 }));
+  expect(() => reducer.feed("x".repeat(101))).toThrow(ReplayFrameOverflowError);
+});
+
+test("the output budget fails the frame closed", () => {
+  const line = JSON.stringify({ result: { items: Array.from({ length: 64 }, () => ({ text: "t".repeat(31) })) } });
+  const reducer = new CodexReplayFrameReducer(budgets({ maxOutputUnits: 256 }));
+  expect(() => { reducer.feed(line); reducer.finish(); }).toThrow(ReplayFrameOverflowError);
 });

--- a/src/lib/runtime/codexImageFrames.ts
+++ b/src/lib/runtime/codexImageFrames.ts
@@ -79,3 +79,160 @@ export function sanitizeCodexImageFrame<T>(value: T, sink: ImageSink): SanitizeR
 
   return { value: walk(value, null) as T, captured };
 }
+
+export interface ReplayFrameBudgets {
+  /** Retained UTF-16 units per ordinary JSON string token. */
+  maxStringUnits: number;
+  /** Retained units for a string token that opens as a base64 image data URL. */
+  maxImageStringUnits: number;
+  /** Budget for the reduced line; exceeding it fails the frame. */
+  maxOutputUnits: number;
+  /** Budget for the raw frame across all feeds; exceeding it fails the frame. */
+  maxRawUnits: number;
+}
+
+export class ReplayFrameOverflowError extends Error {
+  constructor(budget: "raw" | "output") {
+    super(`Codex replay frame exceeded its bounded ${budget} budget`);
+  }
+}
+
+const STRING_HEAD_SNIFF_UNITS = 64;
+const IMAGE_STRING_PREFIX = /^data:[a-z0-9.+-]+\/[a-z0-9.+-]+;base64,/i;
+
+/**
+ * Streaming reducer for one admitted replay JSONL frame (a `thread/resume` or
+ * `thread/read` response whose serialized history can dwarf the ordinary frame
+ * guard). It rewrites the raw JSON text token by token: every string token
+ * keeps a bounded prefix (plus a truncation marker), except base64 image data
+ * URLs, which keep the full admissible image encoding so the post-parse image
+ * sanitizer can still capture them as bounded references. Everything outside
+ * string tokens passes through verbatim, so the reduced line stays valid JSON
+ * with the original structure, ids, and statuses intact.
+ *
+ * Feeds must not contain the frame-terminating newline; JSON strings cannot
+ * hold a raw newline, so the caller can split frames on `\n` before feeding.
+ */
+export class CodexReplayFrameReducer {
+  private readonly parts: string[] = [];
+  private outputUnits = 0;
+  private rawUnits = 0;
+  private inString = false;
+  private stringParts: string[] = [];
+  private stringUnits = 0;
+  private stringOmitted = 0;
+  private stringHead = "";
+  private stringCap: number;
+  private stringCapSniffed = false;
+  private escapeCarry = "";
+
+  constructor(private readonly budgets: ReplayFrameBudgets) {
+    this.stringCap = budgets.maxStringUnits;
+  }
+
+  feed(chunk: string): void {
+    this.rawUnits += chunk.length;
+    if (this.rawUnits > this.budgets.maxRawUnits) throw new ReplayFrameOverflowError("raw");
+    if (this.escapeCarry) {
+      chunk = this.escapeCarry + chunk;
+      this.escapeCarry = "";
+    }
+    let index = 0;
+    while (index < chunk.length) {
+      if (!this.inString) {
+        const quote = chunk.indexOf('"', index);
+        if (quote === -1) {
+          this.append(chunk.slice(index));
+          return;
+        }
+        this.append(chunk.slice(index, quote + 1));
+        this.inString = true;
+        index = quote + 1;
+        continue;
+      }
+      const quote = chunk.indexOf('"', index);
+      const backslash = chunk.indexOf("\\", index);
+      const stop = quote === -1 ? backslash : backslash === -1 ? quote : Math.min(quote, backslash);
+      if (stop === -1) {
+        this.appendToString(chunk.slice(index));
+        return;
+      }
+      if (stop > index) this.appendToString(chunk.slice(index, stop));
+      if (stop === quote) {
+        this.endString();
+        index = stop + 1;
+        continue;
+      }
+      const escapeUnits = chunk.charCodeAt(stop + 1) === 117 /* u */ ? 6 : 2;
+      const escape = chunk.slice(stop, stop + escapeUnits);
+      if (escape.length < escapeUnits) {
+        this.escapeCarry = escape;
+        return;
+      }
+      this.appendToString(escape, true);
+      index = stop + escapeUnits;
+    }
+  }
+
+  finish(): string {
+    /* A frame that ends mid-string or mid-escape was malformed JSON to begin
+       with; flush what was retained and let the JSON parser fail it closed. */
+    if (this.escapeCarry) {
+      this.appendToString(this.escapeCarry);
+      this.escapeCarry = "";
+    }
+    if (this.inString) this.endString(false);
+    return this.parts.join("");
+  }
+
+  private append(text: string): void {
+    if (!text) return;
+    this.outputUnits += text.length;
+    if (this.outputUnits > this.budgets.maxOutputUnits) throw new ReplayFrameOverflowError("output");
+    this.parts.push(text);
+  }
+
+  private appendToString(run: string, atomic = false): void {
+    if (this.stringHead.length < STRING_HEAD_SNIFF_UNITS) {
+      this.stringHead += run.slice(0, STRING_HEAD_SNIFF_UNITS - this.stringHead.length);
+    }
+    if (!this.stringCapSniffed && this.stringUnits + run.length > this.stringCap) {
+      this.stringCapSniffed = true;
+      if (IMAGE_STRING_PREFIX.test(this.stringHead)) this.stringCap = this.budgets.maxImageStringUnits;
+    }
+    const room = this.stringCap - this.stringUnits;
+    if (room >= run.length) {
+      this.stringParts.push(run);
+      this.stringUnits += run.length;
+      return;
+    }
+    if (atomic || room <= 0) {
+      this.stringOmitted += run.length;
+      return;
+    }
+    this.stringParts.push(run.slice(0, room));
+    this.stringUnits += room;
+    this.stringOmitted += run.length - room;
+  }
+
+  private endString(closeQuote = true): void {
+    if (this.stringOmitted > 0) {
+      const last = this.stringParts[this.stringParts.length - 1];
+      const trailing = last ? last.charCodeAt(last.length - 1) : 0;
+      /* Never leave a cut-off high surrogate in front of the marker. */
+      if (trailing >= 0xd800 && trailing <= 0xdbff) {
+        this.stringParts[this.stringParts.length - 1] = last!.slice(0, -1);
+        this.stringOmitted += 1;
+      }
+      this.stringParts.push(`…[truncated ${this.stringOmitted} chars]`);
+    }
+    this.append(this.stringParts.join("") + (closeQuote ? '"' : ""));
+    this.inString = false;
+    this.stringParts = [];
+    this.stringUnits = 0;
+    this.stringOmitted = 0;
+    this.stringHead = "";
+    this.stringCap = this.budgets.maxStringUnits;
+    this.stringCapSniffed = false;
+  }
+}


### PR DESCRIPTION
Closes #794.

## Bounded diagnosis (anonymized, measured locally)

- The failing recovery's `thread/resume` JSON-RPC response is a single JSONL frame of the shape `{"id":N,"result":{thread:{…,turns:[…]},initialTurnsPage,…}}` measuring **55,491,625 bytes** — more than twice the 25.4 MB `MAX_LINE_BYTES` frame guard.
- The dominant contributor is replayed **`mcpToolCall` history items** (124 of them across 5 turns); inside them, tool-result **`text` string fields total ~50.9 MB** (individual results up to ~1.02 MB, from Viewer MCP conversation reads). This frame contained no inline images at all — image echoes merely ride the same replay path and are covered by the same fix.
- The current codex-cli (0.146.0) silently ignores resume pagination parameters (`initialTurnsPage: {limit, itemsView}`), so the envelope cannot be bounded protocol-side.
- Failure sequence: `acceptStdout` hit the frame guard mid-envelope → host `fail("Codex app-server emitted an oversized JSONL frame")` → adoption rejected → the queued operation failed with `structured host recovery failed`. PR #773's image sanitization runs only after a full line is accepted, so it never got the chance.

## Fix

- The host records the request ids of its own `thread/resume` / `thread/read` reads. Only the response frame it is awaiting for one of those methods may pass the frame guard.
- The admitted frame streams through a new `CodexReplayFrameReducer` (in `codexImageFrames.ts`): every JSON string token keeps a bounded 16 KiB prefix plus a truncation marker; base64 image data URLs are exempt up to the structured-image ceiling so replayed inline images still collapse into bounded ledger references post-parse. Structure, ids, and statuses pass through verbatim; escape sequences and surrogate pairs are cut atomically; raw (512 MiB) and reduced (`MAX_LINE_BYTES`) budgets fail the frame closed.
- `reconcileTurnHistory` now applies the same image bounding to replayed items as #773 applies to live echoes, and computes replay dedup keys on the sanitized shape.
- The structured-user digest sits in a short prefix of the user-message wire text, so tail truncation preserves delivery confirmation: the pending user message settles exactly once against a reduced `thread/read`, with the host healthy.
- Every other oversized frame — notifications, server requests, responses to non-replay requests — keeps the existing fail-closed behavior.

Validation against the real production envelope: 55,491,625 bytes reduce to 12.5 MB in ~430 ms; the reduced frame parses, and all 5 turns / 171 items with ids and statuses survive.

## Tests

RED → GREEN in `codexAppServerHost.test.ts` (all previously failing against the base):
- recovery survives an oversized `thread/resume` envelope with a bounded ledger (single-write and 64 KiB-chunked stream variants)
- inline image history reaches the ledger only as a `localImage` reference
- a queued send settles exactly once across an oversized `thread/read` confirmation replay
- oversized non-replay frames (notification, unsolicited response, response to a pending non-replay request) still fail closed

Reducer unit coverage in `codexImageFrames.test.ts`: verbatim small frames across chunk splits, truncation markers, atomic escapes, surrogate-pair safety, image-data-URL exemption and over-ceiling cut, digest-prefix survival, raw/output budget overflow.

## Mutation proof

| Mutation | Result |
|---|---|
| Reducer never truncates (`room = MAX_SAFE_INTEGER`) — bounding removed | **killed** (5 test failures) |
| `reconcileTurnHistory` skips `boundImageBodies` — replay sanitization removed | **killed** (1 failure) |
| `awaitedReplayEnvelopeId` returns any id — fail-closed gate removed | **killed** (1 failure: oversized response to a pending non-replay request must stay fatal) |

## Verification

- `bun test src/lib/runtime/codexAppServerHost.test.ts src/lib/runtime/codexImageFrames.test.ts` under isolated HOME/XDG/TMP/LLV state: **107 pass, 2 fail** — both failures (`requires an exact opt-in value`, `boot adoption resumes every flagged Codex registry row`) fail identically at the base commit and are unrelated stale flag-default tests.
- `tsc --noEmit`: clean. Focused ESLint on the four touched files: clean.
- `bun run privacy:check`: PASS. `bun run build` (next + MCP bundle): PASS.
- Diff scope: exactly `codexAppServerHost.ts`, `codexImageFrames.ts`, and their test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)