### PR TITLE
fix: restore fast catalog loading, canonical projects, and terminal reaping

### DIFF
--- a/src/app/api/files/response.perf.test.ts
+++ b/src/app/api/files/response.perf.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import {
+  AgentRegistry,
+  readOnlyConversationLookupFromSnapshot,
+  setAgentRegistryForTests,
+  type RegistryFile,
+} from "@/lib/agent/registry";
+import type { FileEntry } from "@/lib/types";
+
+import { buildFilesResponse } from "./response";
+
+let registryRoot = "";
+let stateDir = "";
+const previousState = process.env.LLV_STATE_DIR;
+
+beforeEach(() => {
+  registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-perf-"));
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-perf-state-"));
+  process.env.LLV_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  setAgentRegistryForTests(null);
+  if (previousState === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousState;
+  fs.rmSync(registryRoot, { recursive: true, force: true });
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+const CONVERSATIONS = 4_500;
+const SCANNED_FILES = 400;
+const LINEAGE_EDGES = 2_000;
+const FIXTURE_NOW = "2026-07-30T00:00:00.000Z";
+
+type FixtureConversationId = RegistryFile["conversations"][string]["id"];
+
+function conversationId(index: number): FixtureConversationId {
+  return `conversation_perf-${index}` as FixtureConversationId;
+}
+
+function sessionPath(index: number): string {
+  return `/sessions/perf/rollout-${index}.jsonl`;
+}
+
+/** A production-shaped registry snapshot: thousands of conversations with
+    launch profiles plus a lineage-edge population, built in memory so the
+    fixture never touches a real state directory. */
+function productionShapedSnapshot(registry: AgentRegistry): RegistryFile {
+  const snapshot = registry.snapshot();
+  for (let index = 0; index < CONVERSATIONS; index += 1) {
+    const id = conversationId(index);
+    const pathname = sessionPath(index);
+    snapshot.conversations[id] = {
+      id,
+      engine: "codex",
+      generations: [{
+        id: `generation-perf-${index}`,
+        path: pathname,
+        accountId: null,
+        launchProfile: emptyLaunchProfile({ title: `Perf session ${index}`, project: "perf-project" }),
+        historyHash: null,
+        host: null,
+        createdAt: FIXTURE_NOW,
+        archivedAt: null,
+      }],
+      continuityPaths: [],
+      abandonedContinuityPaths: [],
+      providerForkPaths: [],
+      projectOwnership: null,
+      migration: null,
+      migrationOptOut: null,
+      supersededBy: null,
+      agentRole: null,
+      delegationDepth: null,
+      turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
+      createdAt: FIXTURE_NOW,
+      updatedAt: FIXTURE_NOW,
+    } as RegistryFile["conversations"][string];
+  }
+  for (let index = 1; index <= LINEAGE_EDGES; index += 1) {
+    snapshot.lineageEdges[conversationId(index)] = {
+      childConversationId: conversationId(index),
+      parentConversationId: conversationId(0),
+      childSessionKey: null,
+      parentSessionKey: null,
+      childArtifactPath: sessionPath(index),
+      parentArtifactPath: sessionPath(0),
+      kind: "spawn",
+      role: null,
+      reviewsConversationId: null,
+      source: "viewer-spawn",
+      evidence: { launchId: null, clientAttemptId: null },
+      createdAt: FIXTURE_NOW,
+    };
+  }
+  return snapshot;
+}
+
+function scannedFile(index: number): FileEntry {
+  return {
+    path: sessionPath(index),
+    root: "codex-sessions",
+    name: `rollout-${index}.jsonl`,
+    project: "perf-project",
+    title: "",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+test("issue 798: a production-shaped files projection reads the registry once, stays within budget, and is byte-stable", async () => {
+  const registry = new AgentRegistry(path.join(registryRoot, "registry.json"));
+  const snapshot = productionShapedSnapshot(registry);
+  let registryReads = 0;
+  (registry as unknown as { readOnlySnapshot: () => RegistryFile }).readOnlySnapshot = () => {
+    registryReads += 1;
+    return snapshot;
+  };
+  setAgentRegistryForTests(registry);
+  const dependencies = {
+    listFilesWithProjectCatalog: async () => ({
+      files: Array.from({ length: SCANNED_FILES }, (_, index) => scannedFile(index)),
+      projectCatalog: [],
+      complete: true,
+    }),
+  };
+  const request = () => new Request("http://127.0.0.1/api/files");
+
+  const coldStartedAt = performance.now();
+  const cold = await buildFilesResponse(request(), dependencies);
+  const coldDuration = performance.now() - coldStartedAt;
+  expect(cold.status).toBe(200);
+  /* The whole request holds ONE registry snapshot: identity/lineage stamping,
+     the title overlay, and the project catalog all consume it. A second read
+     is the #798 regression (the title projector re-projecting the registry). */
+  expect(registryReads).toBe(1);
+
+  const warmStartedAt = performance.now();
+  const warm = await buildFilesResponse(request(), dependencies);
+  const warmDuration = performance.now() - warmStartedAt;
+  expect(warm.status).toBe(200);
+  expect(registryReads).toBe(2);
+
+  const coldBody = await cold.json() as { files: Array<{ path: string; conversationId?: string; parent?: string | null }> };
+  expect(coldBody.files).toHaveLength(SCANNED_FILES);
+  expect(coldBody.files[1]?.conversationId).toBe(conversationId(1));
+  expect(coldBody.files[1]?.parent).toBe(sessionPath(0));
+  /* Byte-stable output: identical inputs produce an identical strong ETag, so
+     the projection carries no per-request nondeterminism. */
+  expect(warm.headers.get("etag")).toBe(cold.headers.get("etag"));
+
+  /* Performance contract, isolated state only: generous CI ceilings that the
+     pre-#798 double projection and per-entry deep clones cannot meet at this
+     corpus size, while the single-projection path passes with wide margin. */
+  expect(coldDuration).toBeLessThan(2_000);
+  expect(warmDuration).toBeLessThan(500);
+});
+
+test("issue 798: the read-only conversation lookup shares snapshot structure instead of cloning per call", () => {
+  const registry = new AgentRegistry(path.join(registryRoot, "registry.json"));
+  const snapshot = productionShapedSnapshot(registry);
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const owned = snapshot.conversations[conversationId(7)];
+  expect(lookup.conversationForPath(sessionPath(7))).toBe(owned!);
+  expect(lookup.conversation(conversationId(7))).toBe(owned!);
+  expect(lookup.conversationForPath("/sessions/perf/unknown.jsonl")).toBeNull();
+});

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -5,18 +5,18 @@ import path from "node:path";
 import { NextResponse } from "next/server";
 
 import { listFilesWithProjectCatalog, pinnedPathsFor } from "@/lib/scanner";
-import { agentRegistry, conversationLookupFromSnapshot, supersedenceChainTail } from "@/lib/agent/registry";
+import { agentRegistry, readOnlyConversationLookupFromSnapshot, supersedenceChainTail } from "@/lib/agent/registry";
 import { projectLaunchConversations } from "@/lib/agent/spawnProjection";
 import { conversationCatalogSnapshot } from "@/lib/scanner/conversationCatalog";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { repositoryForProjectRoot } from "@/lib/flows/git";
-import { loadFlows, withFlowSnapshot } from "@/lib/flows/store";
+import { loadFlows } from "@/lib/flows/store";
 import { reviewOutcomeFor } from "@/lib/flows/reviewOutcome";
 import { overlayPromptDisplayTitles } from "@/lib/displayNames";
 import { projectAliasSnapshot } from "@/lib/projects/aliases";
 import { projectRestoredFlows } from "@/lib/flows/visibility";
 import { reconcileEmbeddedReviewFlows } from "@/lib/pipelines/engine";
-import { withPipelineMutation } from "@/lib/pipelines/store";
+import { loadPipelinesForProjection } from "@/lib/pipelines/store";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { filterPipelinesForFileScan } from "@/lib/pipelines/visibility";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
@@ -29,7 +29,7 @@ import { readAuthorshipEvidence } from "@/lib/reaperAuthorship";
 import { overlayLineageProjectAffinity } from "@/lib/session/projectAffinity";
 import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import { overlayRoleSessionTitles } from "@/lib/session/roleTitles";
-import { overlaySessionTitles } from "@/lib/session/titleProjection";
+import { overlaySessionTitles, registryProjectionForSnapshot } from "@/lib/session/titleProjection";
 import { tmuxEndpointHealth } from "@/lib/tmux";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
 import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
@@ -49,34 +49,10 @@ function projectedProjectCatalog(
 ): ProjectCatalogEntry[] {
   const source = conversationCatalogSnapshot();
   if (!source.length) return fallback;
-  const projectByPath = new Map<string, string>();
-  const projectMetadataByPath = new Map<string, { displayName: string; projectRoot?: string }>();
-  const archivedPaths = new Set<string>();
-  for (const conversation of Object.values(snapshot.conversations)) {
-    const latest = conversation.generations.at(-1);
-    if (!latest) continue;
-    const { project } = resolveProjectAttribution({
-      projectOwnership: conversation.projectOwnership,
-      cwd: latest.launchProfile.cwd,
-      launchProfileProject: latest.launchProfile.project,
-    });
-    if (project) {
-      projectByPath.set(latest.path, project);
-      const cwdInfo = latest.launchProfile.cwd ? projectInfoFromCwd(latest.launchProfile.cwd) : null;
-      if (cwdInfo?.project === project) {
-        projectMetadataByPath.set(latest.path, {
-          displayName: cwdInfo.displayName,
-          ...(cwdInfo.repo ? { projectRoot: cwdInfo.repo } : {}),
-        });
-      }
-    }
-    for (const generation of conversation.generations) {
-      if (generation.path !== latest.path) archivedPaths.add(generation.path);
-    }
-    for (const pathname of conversation.continuityPaths) {
-      if (pathname !== latest.path) archivedPaths.add(pathname);
-    }
-  }
+  /* The same per-conversation attribution the title projection computes; the
+     shared per-revision projection replaces a second sweep over every
+     conversation (issue #798). */
+  const { projectByPath, projectMetadataByPath, archivedPaths } = registryProjectionForSnapshot(snapshot);
   const groups = new Map<string, ProjectCatalogEntry>();
   const fallbackMetadata = new Map(fallback.map((entry) => [entry.project, entry] as const));
   for (const entry of source) {
@@ -127,7 +103,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     const launch = launchProjection.facts.get(file.path);
     if (launch) file.launch = launch;
   }
-  const conversationLookup = conversationLookupFromSnapshot(registrySnapshot);
+  const conversationLookup = readOnlyConversationLookupFromSnapshot(registrySnapshot);
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   for (let index = 0; index < files.length; index += 1) {
@@ -396,7 +372,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      on `autoTitle`; the `renamable` flag is projected too so the client never
      imports the Node-only store. */
   const flowsStartedAt = performance.now();
-  overlaySessionTitles(files);
+  overlaySessionTitles(files, registrySnapshot);
   markTiming("files-session-titles");
   /* Durable project affinity: a Viewer-launched family whose root transcript
      recorded a bare directory above the repository its lineage works in (an
@@ -406,9 +382,9 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      with no such lineage are untouched. */
   overlayLineageProjectAffinity(files);
   markTiming("files-project-affinity");
-  let storedFlows = loadFlows();
+  const storedFlows = loadFlows();
   markTiming("files-flow-store");
-  let flows = projectRestoredFlows(storedFlows, files, {
+  const flows = projectRestoredFlows(storedFlows, files, {
     pinnedPaths: visibilityPinnedPaths,
     memberships: registrySnapshot.memberships,
   });
@@ -518,20 +494,14 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   let pipelines: Pipeline[] = [];
   let pipelinesError: string | undefined;
   try {
-    const reconciled = await withPipelineMutation((current, persist) =>
-      withFlowSnapshot((projectionFlows) => {
-        /* Every cross-store lifecycle path acquires pipeline before flow. The
-           flow lock spans parent persistence and captures the exact array
-           returned below, so the returned deck and parent share a generation. */
-        if (reconcileEmbeddedReviewFlows(current, projectionFlows)) persist();
-        return { pipelines: current, flows: [...projectionFlows] };
-      }));
-    storedFlows = reconciled.flows;
-    flows = projectRestoredFlows(storedFlows, files, {
-      pinnedPaths: visibilityPinnedPaths,
-      memberships: registrySnapshot.memberships,
-    });
-    pipelines = filterPipelinesForFileScan(reconciled.pipelines, files, {
+    /* A GET never takes the pipeline lock and never persists (issue #798).
+       The embedded review flow sync is applied to this request's read copy as
+       an overlay against the same flow read above, so the deck and its parent
+       share one request-level generation; the durable claim/sync persists on
+       the controller reconcile pass instead of the request path. */
+    const loaded = loadPipelinesForProjection();
+    reconcileEmbeddedReviewFlows(loaded, storedFlows);
+    pipelines = filterPipelinesForFileScan(loaded, files, {
       pinnedPaths: visibilityPinnedPaths,
       memberships: registrySnapshot.memberships,
     });
@@ -540,9 +510,10 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     console.error("[files] pipelines store unreadable; serving without pipelines", error);
   }
   /* Role titles (issue #325) and the returned flow read model consume the same
-     transaction-captured flow generation as pipelines. A controller advance
-     during the earlier scan can therefore never mix deck/annotation generation
-     N with parent generation N+1. Explicit user titles keep final precedence. */
+     request-level flow read as the pipeline sync overlay above. A controller
+     advance during the earlier scan can therefore never mix deck/annotation
+     generation N with parent generation N+1. Explicit user titles keep final
+     precedence. */
   overlayRoleSessionTitles({ files, flows, tasks: storedTasks, conversationAliases: registrySnapshot.conversationAliases });
   overlayPromptDisplayTitles(files);
   markTiming("files-role-titles");

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
   hydrateScannedFiles = (files) => files;
   tmuxHealth = { status: "healthy" };
   flowsStore = () => [];
+  pipelineMutationCalls = 0;
   replaceConversationCatalog([]);
 });
 
@@ -90,8 +91,16 @@ mock.module("@/lib/scanner", () => ({
 }));
 let pipelinesStore: () => unknown[] = () => [];
 let flowsStore: () => unknown[] = () => [];
+let pipelineMutationCalls = 0;
 mock.module("@/lib/flows/store", () => ({ loadFlows: () => flowsStore() }));
-mock.module("@/lib/pipelines/store", () => ({ loadPipelines: () => pipelinesStore() }));
+mock.module("@/lib/pipelines/store", () => ({
+  loadPipelines: () => pipelinesStore(),
+  withPipelineMutation: (...args: unknown[]) => {
+    pipelineMutationCalls += 1;
+    const real = realModules.get("@/lib/pipelines/store") as { withPipelineMutation: (...call: unknown[]) => unknown };
+    return real.withPipelineMutation(...args);
+  },
+}));
 mock.module("@/lib/pipelines/visibility", () => ({ filterPipelinesForFileScan: () => [] }));
 let boardTasksStore: () => unknown[] = () => [];
 mock.module("@/lib/tasks/store", () => ({
@@ -190,7 +199,7 @@ test("generation completion retries skip the stale projection while its refresh 
   }
 });
 
-test("issue 532: files response returns the transaction-captured flow generation", async () => {
+test("issues 532/798: files response projects exactly one request-level flow read", async () => {
   const oldFlow = {
     id: "flow-atomic-projection", template: "implement-review-loop", project: "demo", cwd: "/repo",
     implementerPath: "/missing/implementer.jsonl", roles: {
@@ -214,11 +223,40 @@ test("issue 532: files response returns the transaction-captured flow generation
 
   const response = await GET(new Request("http://127.0.0.1/api/files"));
   const body = await response.json() as { flows: Array<{ id: string; rounds: Array<{ n: number }> }> };
-  expect(reads).toBeGreaterThanOrEqual(2);
+  /* One flow load per request (issue #798): every consumer — restored flows,
+     the pipeline sync overlay, role titles — shares that single generation, so
+     a store advance mid-request can never mix generations (issue #532). */
+  expect(reads).toBe(1);
   expect(body.flows).toEqual([expect.objectContaining({
-    id: currentFlow.id,
-    rounds: [expect.objectContaining({ n: 1 }), expect.objectContaining({ n: 2 })],
+    id: oldFlow.id,
+    rounds: [expect.objectContaining({ n: 1 })],
   })]);
+});
+
+test("issue 798: a files GET reads the registry once, threads it to titles, and never mutates pipelines", async () => {
+  const sessionPath = "/sessions/threaded-projection.jsonl";
+  const registry = agentRegistry();
+  const conversation = registry.ensureConversation("codex", sessionPath, null);
+  scannedFiles = [file(sessionPath)];
+  const target = registry as unknown as { readOnlySnapshot: AgentRegistry["readOnlySnapshot"] };
+  const realReadOnlySnapshot = target.readOnlySnapshot.bind(registry);
+  let registryReads = 0;
+  target.readOnlySnapshot = () => {
+    registryReads += 1;
+    return realReadOnlySnapshot();
+  };
+  try {
+    const response = await GET(new Request("http://127.0.0.1/api/files"));
+    const body = await response.json() as { files: Array<{ path: string; conversationId?: string }> };
+    expect(response.status).toBe(200);
+    expect(body.files.find((entry) => entry.path === sessionPath)?.conversationId).toBe(conversation.id);
+    /* The single read-only snapshot is threaded to every projection consumer
+       (title overlay included); a second read here is the #798 regression. */
+    expect(registryReads).toBe(1);
+    expect(pipelineMutationCalls).toBe(0);
+  } finally {
+    target.readOnlySnapshot = realReadOnlySnapshot;
+  }
 });
 
 test("volatile registry diagnostics do not invalidate an otherwise stable files ETag", async () => {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1947,6 +1947,20 @@ function recordMembership(
 }
 
 export function conversationLookupFromSnapshot(snapshot: RegistryFile): ConversationLookup {
+  return snapshotConversationLookup(snapshot, clone);
+}
+
+/** Read-only lookup sharing the snapshot's immutable structure. Callers must
+    never mutate the returned conversations; mutating paths keep the cloning
+    `conversationLookupFromSnapshot`. */
+export function readOnlyConversationLookupFromSnapshot(snapshot: RegistryFile): ConversationLookup {
+  return snapshotConversationLookup(snapshot, (conversation) => conversation);
+}
+
+function snapshotConversationLookup(
+  snapshot: RegistryFile,
+  materialize: (conversation: RegistryConversation) => RegistryConversation,
+): ConversationLookup {
   const byPath = new Map<string, RegistryConversation>();
   for (const conversation of Object.values(snapshot.conversations)) {
     for (const generation of conversation.generations) {
@@ -1959,14 +1973,14 @@ export function conversationLookupFromSnapshot(snapshot: RegistryFile): Conversa
   return {
     conversationForPath(artifactPath) {
       const conversation = byPath.get(artifactPath);
-      return conversation ? clone(conversation) : null;
+      return conversation ? materialize(conversation) : null;
     },
     canonicalConversationId(id) {
       return resolveConversationAlias(snapshot, id);
     },
     conversation(id) {
       const conversation = snapshot.conversations[resolveConversationAlias(snapshot, id)];
-      return conversation ? clone(conversation) : null;
+      return conversation ? materialize(conversation) : null;
     },
   };
 }

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2589,7 +2589,11 @@ test("a later exact-head approval replaces a stale startup pause and completes a
     conversationId: "conversation_reviewer",
   });
 
-  const afterCompletion = JSON.stringify(completed);
+  /* The first post-completion tick settles the terminal host reap (#574);
+     from there the record is stable. */
+  await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
+  expect(loadPipelines()[0]!.terminalReap?.settledAt).toBeTruthy();
+  const afterCompletion = JSON.stringify(loadPipelines()[0]);
   await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
   expect(JSON.stringify(loadPipelines()[0])).toBe(afterCompletion);
 });
@@ -2947,7 +2951,11 @@ test("a restarted committing review completes once when its clean head still mat
   expect(completed.state).toBe("completed");
   expect(completed.runs[1]!.attempts[0]).toMatchObject({ state: "passed", reviewHeadSha: ORIGIN_MAIN_SHA });
 
-  const afterCompletion = JSON.stringify(completed);
+  /* The first post-completion tick settles the terminal host reap (#574);
+     from there the record is stable and further ticks change nothing. */
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]!.terminalReap?.settledAt).toBeTruthy();
+  const afterCompletion = JSON.stringify(loadPipelines()[0]);
   expect((await tickPipelines([], h.ports)).changed).toBe(false);
   expect(JSON.stringify(loadPipelines()[0])).toBe(afterCompletion);
 });

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -53,6 +53,7 @@ import type {
   PipelineStage,
   PipelineStageInput,
   PipelineStageAttempt,
+  PipelineTerminalReap,
   PipelineUnconfirmedHost,
 } from "./types";
 import { parseStageVerdict, stageVerdictRejectionReason, type ParsedStageVerdict } from "./verdict";
@@ -2008,6 +2009,96 @@ async function reconcileUnconfirmedHosts(pipeline: Pipeline, ports: PipelinePort
   return true;
 }
 
+/** Ceiling on one terminal reap sweep. Like a close's teardown, the sweep runs
+    inside the pipelines transaction, so a slow host defers the rest of its
+    pipeline's candidates to the next tick instead of stalling every mutation. */
+const TERMINAL_REAP_BUDGET_MS = 5_000;
+/** Sweeps one pipeline's terminal reap may spend before surfacing survivors. */
+const TERMINAL_REAP_MAX_ROUNDS = 5;
+
+/**
+ * Reaps a completed pipeline's finished stage hosts (#574).
+ *
+ * advancePipeline marks the pipeline completed the moment its last stage
+ * passes, but nothing stopped the hosts its stages left behind: every finished
+ * builder kept an idle resume process resident on a paid quota, and a machine
+ * running many pipelines accumulated hundreds of them. A close tears hosts
+ * down (#670); completion now does the same, through the identical
+ * identity-verified control path, with `closed` staying the close action's job
+ * so an operator's acknowledge decision is never overridden by a later sweep.
+ *
+ * Only hosts whose attempt finished its turn (a verdict or a completion stamp)
+ * are candidates, and the runtime gets the last word: a conversation it
+ * reports actively running is preserved, as are the pipeline's creator
+ * conversation and transcript. The sweep is bounded twice — a per-sweep budget
+ * so the transaction cannot stall behind slow kills, and a durable round
+ * ceiling so a host that will not die becomes a visible unconfirmed host
+ * (retired by reconcileUnconfirmedHosts once it is demonstrably gone) instead
+ * of receiving a kill on every tick forever.
+ */
+async function reconcileTerminalStageHosts(pipeline: Pipeline, ports: PipelinePorts): Promise<boolean> {
+  if (pipeline.state !== "completed" || pipeline.terminalReap?.settledAt) return false;
+  const reap: PipelineTerminalReap = pipeline.terminalReap
+    ?? { rounds: 0, stopped: 0, lastAt: ports.now(), settledAt: null };
+  const deadline = ports.monotonicNow() + TERMINAL_REAP_BUDGET_MS;
+  const candidates = launchedStageHosts(pipeline).filter(({ target, turnSettled }) => turnSettled
+    && !(target.conversationId && target.conversationId === pipeline.srcConversationId)
+    && !(target.agentPath && target.agentPath === pipeline.srcPath));
+  const survivors: Array<PipelineStageHostRef & { operationId: string | null; detail: string }> = [];
+  let attempted = false;
+  let deferred = false;
+  for (const [index, { target }] of candidates.entries()) {
+    if (ports.monotonicNow() >= deadline) {
+      deferred = true;
+      /* Normally the next sweep picks these up; recorded here so that a reap
+         whose every round expires still names what it never probed once the
+         round ceiling settles it below. */
+      if (reap.rounds + 1 >= TERMINAL_REAP_MAX_ROUNDS) {
+        survivors.push(...candidates.slice(index).map(({ target: remaining }) => ({
+          ...remaining,
+          operationId: null,
+          detail: "terminal reap budget expired before this host was probed",
+        })));
+      }
+      break;
+    }
+    if (!(await ports.stageHostResident(target))) continue;
+    /* The attempt's own evidence says its turn ended, but a host the runtime
+       still reports mid-turn (an adopted helper on a fresh turn) is live work,
+       so it stays; the idle-TTL reaper owns it from here. */
+    if (target.conversationId && await ports.conversationAgentActive(target.conversationId) === true) continue;
+    attempted = true;
+    const result = await ports.stopStageAgent(target);
+    if (result.outcome === "stopped") reap.stopped += 1;
+    else if (result.outcome === "unconfirmed") survivors.push({ ...target, operationId: result.operationId, detail: result.detail });
+    else if (result.outcome === "failed") survivors.push({ ...target, operationId: null, detail: result.error });
+  }
+  reap.lastAt = ports.now();
+  if (attempted || deferred) reap.rounds += 1;
+  const clean = !deferred && survivors.length === 0;
+  if (clean || reap.rounds >= TERMINAL_REAP_MAX_ROUNDS) {
+    reap.settledAt = reap.lastAt;
+    if (survivors.length > 0) {
+      const known = new Set((pipeline.unconfirmedHosts ?? []).map((host) => `${host.stageId}:${host.attempt}`));
+      pipeline.unconfirmedHosts = [
+        ...(pipeline.unconfirmedHosts ?? []),
+        ...survivors.filter((host) => !known.has(`${host.stageId}:${host.attempt}`)).map((host) => ({
+          stageId: host.stageId,
+          attempt: host.attempt,
+          conversationId: host.conversationId,
+          agentPath: host.agentPath,
+          paneId: host.paneId,
+          operationId: host.operationId,
+          detail: host.detail,
+          at: reap.settledAt!,
+        })),
+      ];
+    }
+  }
+  pipeline.terminalReap = reap;
+  return true;
+}
+
 export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts = defaultPipelinePorts()): Promise<{ pipelines: Pipeline[]; changed: boolean }> {
   if (tickStore.__llvPipelineTick) return { pipelines: [], changed: false };
   tickStore.__llvPipelineTick = true;
@@ -2025,6 +2116,7 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
         pipelineChanged = reconcileParkedStructuredSpawn(pipeline, ports) || pipelineChanged;
         pipelineChanged = reconcileBoundReviewFlow(pipeline, ports) || pipelineChanged;
         pipelineChanged = await reconcileUnconfirmedHosts(pipeline, ports) || pipelineChanged;
+        pipelineChanged = await reconcileTerminalStageHosts(pipeline, ports) || pipelineChanged;
         if (!TERMINAL_STATES.has(pipeline.state) && pipeline.state !== "paused" && pipeline.state !== "needs_decision") {
           pipelineChanged = await tickPipeline(pipeline, entries, ports, persist) || pipelineChanged;
         }

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -11,7 +11,7 @@ import { withFileTransaction, withFileTransactionSync } from "@/lib/state/fileTr
 import type { BoardTask } from "@/lib/tasks/types";
 
 import { MAX_FAIL_EDGE_ROUNDS, MAX_PIPELINE_STAGES } from "./limits";
-import type { EffectivePipelineRole, Pipeline, PipelineCreationIntent, PipelineEdgeActivation, PipelineStage, PipelineUnconfirmedHost } from "./types";
+import type { EffectivePipelineRole, Pipeline, PipelineCreationIntent, PipelineEdgeActivation, PipelineStage, PipelineTerminalReap, PipelineUnconfirmedHost } from "./types";
 import { stageVerdictFrom } from "./verdict";
 
 export const PIPELINES_SCHEMA_VERSION = 4;
@@ -188,6 +188,15 @@ function isUnconfirmedHost(value: unknown): value is PipelineUnconfirmedHost {
     && typeof host.at === "string";
 }
 
+function isTerminalReap(value: unknown): value is PipelineTerminalReap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const reap = value as Partial<PipelineTerminalReap>;
+  return Number.isInteger(reap.rounds) && (reap.rounds as number) >= 0
+    && Number.isInteger(reap.stopped) && (reap.stopped as number) >= 0
+    && typeof reap.lastAt === "string"
+    && isNullableString(reap.settledAt);
+}
+
 function isStage(value: unknown): value is PipelineStage {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const stage = value as Partial<PipelineStage>;
@@ -302,6 +311,7 @@ function isPipeline(value: unknown): value is Pipeline {
     (pipeline.hiddenAt === undefined || isNullableString(pipeline.hiddenAt)) &&
     (pipeline.unconfirmedHosts === undefined
       || (Array.isArray(pipeline.unconfirmedHosts) && pipeline.unconfirmedHosts.every(isUnconfirmedHost))) &&
+    (pipeline.terminalReap === undefined || isTerminalReap(pipeline.terminalReap)) &&
     (pipeline.restored === undefined || typeof pipeline.restored === "boolean") &&
     (pipeline.pos === undefined || (
       typeof pipeline.pos === "object" && pipeline.pos !== null &&
@@ -446,6 +456,7 @@ function reviveLoadedPipeline(pipeline: Pipeline): Pipeline {
     unconfirmedHosts: pipeline.unconfirmedHosts?.length
       ? pipeline.unconfirmedHosts.map((host) => ({ ...host }))
       : undefined,
+    terminalReap: pipeline.terminalReap ? { ...pipeline.terminalReap } : undefined,
     restored: undefined,
     stages: pipeline.stages.map((stage) => ({ ...stage, onFail: stage.onFail ?? null })),
     cursor: pipeline.cursor

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -420,7 +420,14 @@ export function loadPipelines(): Pipeline[] {
   const legacyRecords = file.schemaVersion === 2 ? file.pipelines.map(migrateV2Pipeline) : file.pipelines;
   const records = file.schemaVersion < PIPELINES_SCHEMA_VERSION ? legacyRecords.map(migrateTaskIds) : legacyRecords;
   if (!records.every(isPipeline)) throw new PipelineStoreError("pipeline registry contains malformed records");
-  return records.map((pipeline) => ({
+  return records.map(reviveLoadedPipeline);
+}
+
+/** Fresh per-call copies of every layer a caller may write (pipeline, stage,
+    run, attempt, cursor rows), so cached records stay pristine while callers
+    receive independently mutable structures. Deep config leaves are shared. */
+function reviveLoadedPipeline(pipeline: Pipeline): Pipeline {
+  return {
     ...pipeline,
     project: canonicalProject(pipeline.project),
     taskIds: [...pipeline.taskIds],
@@ -469,7 +476,35 @@ export function loadPipelines(): Pipeline[] {
           }))
         : [],
     })),
-  }));
+  };
+}
+
+let projectionCache: { signature: string; pipelines: Pipeline[] } | null = null;
+
+function pipelinesFileSignature(): string | null {
+  try {
+    const stat = fs.statSync(pipelinesFile(), { bigint: true });
+    return `${stat.mtimeNs}:${stat.size}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Read-only load for request-path projections (issue #798): no lock, and the
+    parse+validation of a large registry is cached against the file signature.
+    Every call still returns independently mutable records via the same revive
+    pass `loadPipelines` uses, so a projection overlay can never write into the
+    cache. Mutating paths keep `withPipelineMutation`, whose persisted rename
+    changes the signature and invalidates this cache. */
+export function loadPipelinesForProjection(): Pipeline[] {
+  const before = pipelinesFileSignature();
+  if (before !== null && projectionCache?.signature === before) {
+    return projectionCache.pipelines.map(reviveLoadedPipeline);
+  }
+  const pipelines = loadPipelines();
+  const after = pipelinesFileSignature();
+  if (after !== null && before === after) projectionCache = { signature: after, pipelines };
+  return pipelines.map(reviveLoadedPipeline);
 }
 
 function savePipelinesUnlocked(pipelines: Pipeline[]): void {

--- a/src/lib/pipelines/terminalReap.test.ts
+++ b/src/lib/pipelines/terminalReap.test.ts
@@ -1,0 +1,286 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/* This suite exercises the terminal-settlement host reap (#574), which
+   terminates agent processes. Every pipeline is constructed directly inside
+   this sandboxed state directory and every port is stubbed — it never reads
+   the shared runtime state directory and can never dispatch a real kill. */
+process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-terminal-reap-"));
+process.env.LLV_STRUCTURED_HOSTS = "0";
+
+const { tickPipelines } = await import("./engine");
+const { registerPipelineTick } = await import("./controllerSignal");
+const { loadPipelines, pipelineIdentity, savePipelines } = await import("./store");
+type Pipeline = import("./types").Pipeline;
+type PipelineStageAttempt = import("./types").PipelineStageAttempt;
+type PipelinePorts = import("./engine").PipelinePorts;
+type PipelineStageStopResult = import("./engine").PipelineStageStopResult;
+
+/* tickPipelines self-schedules a follow-up tick when a pass leaves a pending
+   cursor; keep that wake-up away from the real default ports in this suite. */
+registerPipelineTick(async () => {});
+
+afterAll(() => fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true }));
+
+const ROLE = { roleId: null, engine: "codex", model: "gpt-5.6-sol", effort: null, access: "read-write", promptScaffold: null } as const;
+
+function attempt(n: number, conversation: string, settled: boolean): PipelineStageAttempt {
+  return {
+    n,
+    state: settled ? "passed" : "running",
+    effectiveRole: { ...ROLE },
+    launchId: `launch-${conversation}`,
+    conversationId: conversation,
+    sessionId: null,
+    agentPath: `/codex/${conversation}.jsonl`,
+    paneId: null,
+    flowId: null,
+    startedAt: "2026-07-31T00:00:00.000Z",
+    completedAt: settled ? "2026-07-31T00:10:00.000Z" : null,
+    input: null,
+    activatedBy: null,
+    output: settled ? "done" : null,
+    verdict: settled ? { status: "pass" } : null,
+    error: null,
+  };
+}
+
+function pipelineRecord(input: {
+  id: string;
+  state: Pipeline["state"];
+  attempts: PipelineStageAttempt[];
+}): Pipeline {
+  const task = "Terminal reap";
+  const repoDir = "/repo";
+  return {
+    id: input.id,
+    task,
+    taskIds: [],
+    project: "viewer",
+    repoDir,
+    ...pipelineIdentity(input.id, task, repoDir),
+    baseBranch: "main",
+    baseRef: "48c739bbcc87b3244aee7fb0e2d1b3f8e312548f",
+    lastPassedCommit: "48c739bbcc87b3244aee7fb0e2d1b3f8e312548f",
+    publishedCommit: null,
+    stages: [{ id: "implement", kind: "run", prompt: "{{task}}", next: null, onFail: null, effectiveRole: { ...ROLE } }],
+    runs: [{ stageId: "implement", attempts: input.attempts }],
+    cursor: null,
+    state: input.state,
+    pausedState: null,
+    stateDetail: null,
+    srcPath: "/codex/creator.jsonl",
+    srcConversationId: "conversation_creator",
+    createdAt: "2026-07-31T00:00:00.000Z",
+    closedAt: input.state === "completed" || input.state === "closed" ? "2026-07-31T00:20:00.000Z" : null,
+    hiddenAt: null,
+  };
+}
+
+function harness() {
+  const stops: string[] = [];
+  const resident = new Map<string, boolean>();
+  const stopResults = new Map<string, PipelineStageStopResult>();
+  const active = new Map<string, boolean>();
+  let clock = 1_000_000;
+  let monotonic = 0;
+  let stopCostMs = 0;
+  const ports: PipelinePorts = {
+    exec: () => ({ code: 0, stdout: "", stderr: "" }),
+    preflightRepo: (repoDir) => ({ ok: true, repoDir, gitCommonDir: path.join(repoDir, ".git"), worktreeParent: path.dirname(repoDir) }),
+    roleLookup: () => null,
+    spawnAgent: async () => { throw new Error("the terminal reap must never spawn an agent"); },
+    spawnReceipt: () => null,
+    claimSpawnRetry: () => "claimed",
+    paneAgentAlive: async () => false,
+    stopStageAgent: async (target) => {
+      stops.push(`${target.stageId}:${target.attempt}:${target.conversationId ?? "none"}`);
+      monotonic += stopCostMs;
+      const result = stopResults.get(target.conversationId ?? "") ?? { outcome: "stopped" as const };
+      if (result.outcome === "stopped") resident.set(target.conversationId ?? "", false);
+      return result;
+    },
+    stopStagePane: async () => ({ outcome: "not-running" as const }),
+    stageHostResident: async (target) => resident.get(target.conversationId ?? "") ?? false,
+    monotonicNow: () => monotonic,
+    worktreePresent: () => false,
+    conversationAgentActive: async (conversationId) => active.get(conversationId) ?? null,
+    durableTurnEvidence: async () => null,
+    headCwd: () => null,
+    lastMessage: () => null,
+    pathForConversation: () => null,
+    sourcePathAllowed: () => true,
+    conversationIdForPath: () => null,
+    pipelineAdoptionCandidates: () => [],
+    createFlow: async () => ({ error: "no flows in this suite" }),
+    patchFlow: () => ({}),
+    closeFlow: async () => {},
+    getFlow: () => null,
+    findFlow: () => null,
+    projectForCwd: () => "viewer",
+    now: () => new Date((clock += 1_000)).toISOString(),
+  };
+  return {
+    ports,
+    stops,
+    resident,
+    stopResults,
+    active,
+    setStopCost: (ms: number) => { stopCostMs = ms; },
+  };
+}
+
+test("completion reaps its finished resident builder hosts exactly once", async () => {
+  const h = harness();
+  savePipelines([pipelineRecord({
+    id: "reap-clean",
+    state: "completed",
+    attempts: [attempt(1, "conversation_builder_1", true), attempt(2, "conversation_builder_2", true)],
+  })]);
+  h.resident.set("conversation_builder_1", true);
+  h.resident.set("conversation_builder_2", true);
+
+  await tickPipelines([], h.ports);
+
+  expect(h.stops).toEqual(["implement:1:conversation_builder_1", "implement:2:conversation_builder_2"]);
+  const settled = loadPipelines()[0]!;
+  expect(settled.terminalReap).toMatchObject({ rounds: 1, stopped: 2 });
+  expect(settled.terminalReap!.settledAt).not.toBeNull();
+  expect(settled.unconfirmedHosts).toBeUndefined();
+
+  /* A settled reap is durable: the next tick re-reads it from the store and
+     sends nothing, resident or not. */
+  h.resident.set("conversation_builder_1", true);
+  await tickPipelines([], h.ports);
+  expect(h.stops).toHaveLength(2);
+});
+
+test("the creator, a mid-turn attempt, and a runtime-active session are preserved", async () => {
+  const h = harness();
+  savePipelines([pipelineRecord({
+    id: "reap-preserve",
+    state: "completed",
+    attempts: [
+      attempt(1, "conversation_creator", true),
+      attempt(2, "conversation_midturn", false),
+      attempt(3, "conversation_helper", true),
+    ],
+  })]);
+  h.resident.set("conversation_creator", true);
+  h.resident.set("conversation_midturn", true);
+  h.resident.set("conversation_helper", true);
+  h.active.set("conversation_helper", true);
+
+  await tickPipelines([], h.ports);
+
+  expect(h.stops).toEqual([]);
+  expect(h.resident.get("conversation_creator")).toBe(true);
+  expect(h.resident.get("conversation_midturn")).toBe(true);
+  expect(h.resident.get("conversation_helper")).toBe(true);
+  const settled = loadPipelines()[0]!;
+  expect(settled.terminalReap).toMatchObject({ rounds: 0, stopped: 0 });
+  expect(settled.terminalReap!.settledAt).not.toBeNull();
+});
+
+test("only completed pipelines are swept; closed teardown stays the close action's job", async () => {
+  const h = harness();
+  savePipelines([
+    pipelineRecord({ id: "reap-closed", state: "closed", attempts: [attempt(1, "conversation_closed", true)] }),
+    pipelineRecord({ id: "reap-parked", state: "needs_decision", attempts: [attempt(1, "conversation_parked", true)] }),
+  ]);
+  h.resident.set("conversation_closed", true);
+  h.resident.set("conversation_parked", true);
+
+  await tickPipelines([], h.ports);
+
+  expect(h.stops).toEqual([]);
+  expect(loadPipelines().every((pipeline) => pipeline.terminalReap === undefined)).toBe(true);
+});
+
+test("a host that will not die is bounded and surfaces as an unconfirmed host", async () => {
+  const h = harness();
+  savePipelines([pipelineRecord({
+    id: "reap-stuck",
+    state: "completed",
+    attempts: [attempt(1, "conversation_stuck", true)],
+  })]);
+  h.resident.set("conversation_stuck", true);
+  h.stopResults.set("conversation_stuck", {
+    outcome: "unconfirmed",
+    operationId: "op_stuck",
+    detail: "kill accepted as queued but termination was not confirmed",
+  });
+
+  for (let round = 0; round < 5; round += 1) await tickPipelines([], h.ports);
+
+  expect(h.stops).toHaveLength(5);
+  const settled = loadPipelines()[0]!;
+  expect(settled.terminalReap).toMatchObject({ rounds: 5, stopped: 0 });
+  expect(settled.terminalReap!.settledAt).not.toBeNull();
+  expect(settled.unconfirmedHosts).toMatchObject([{ stageId: "implement", attempt: 1, operationId: "op_stuck" }]);
+
+  /* Settled: no further kills are dispatched, ever. */
+  await tickPipelines([], h.ports);
+  expect(h.stops).toHaveLength(5);
+
+  /* Once the survivor is demonstrably gone, the existing unconfirmed-host
+     reconcile retires it without sending another kill. */
+  h.resident.set("conversation_stuck", false);
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]!.unconfirmedHosts).toBeUndefined();
+  expect(h.stops).toHaveLength(5);
+});
+
+test("a reap whose every round expires still surfaces the hosts it never probed", async () => {
+  const h = harness();
+  savePipelines([pipelineRecord({
+    id: "reap-exhaust",
+    state: "completed",
+    attempts: [attempt(1, "conversation_refusing", true), attempt(2, "conversation_unprobed", true)],
+  })]);
+  h.resident.set("conversation_refusing", true);
+  h.resident.set("conversation_unprobed", true);
+  h.stopResults.set("conversation_refusing", { outcome: "failed", error: "kill was refused" });
+  h.setStopCost(6_000);
+
+  for (let round = 0; round < 5; round += 1) await tickPipelines([], h.ports);
+
+  /* Every round burned its budget on the refusing host, so the second host was
+     never reached — settlement names both instead of dropping the unprobed one. */
+  expect(h.stops).toEqual(Array.from({ length: 5 }, () => "implement:1:conversation_refusing"));
+  const settled = loadPipelines()[0]!;
+  expect(settled.terminalReap).toMatchObject({ rounds: 5, stopped: 0 });
+  expect(settled.terminalReap!.settledAt).not.toBeNull();
+  expect(settled.unconfirmedHosts).toMatchObject([
+    { stageId: "implement", attempt: 1, detail: "kill was refused" },
+    { stageId: "implement", attempt: 2, detail: "terminal reap budget expired before this host was probed" },
+  ]);
+});
+
+test("the sweep budget defers remaining hosts to the next tick instead of stalling it", async () => {
+  const h = harness();
+  savePipelines([pipelineRecord({
+    id: "reap-budget",
+    state: "completed",
+    attempts: [attempt(1, "conversation_slow", true), attempt(2, "conversation_next", true)],
+  })]);
+  h.resident.set("conversation_slow", true);
+  h.resident.set("conversation_next", true);
+  h.setStopCost(6_000);
+
+  await tickPipelines([], h.ports);
+
+  expect(h.stops).toEqual(["implement:1:conversation_slow"]);
+  const partial = loadPipelines()[0]!;
+  expect(partial.terminalReap).toMatchObject({ rounds: 1, stopped: 1, settledAt: null });
+
+  h.setStopCost(0);
+  await tickPipelines([], h.ports);
+
+  expect(h.stops).toEqual(["implement:1:conversation_slow", "implement:2:conversation_next"]);
+  const settled = loadPipelines()[0]!;
+  expect(settled.terminalReap).toMatchObject({ rounds: 2, stopped: 2 });
+  expect(settled.terminalReap!.settledAt).not.toBeNull();
+});

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -196,6 +196,21 @@ export type PipelineCreationIntent = {
   launchId: string;
 };
 
+/** Durable receipt of the terminal-settlement host reap (#574). Completion
+    sweeps the pipeline's finished stage hosts in bounded rounds; persisting the
+    round count and the settlement is what keeps the sweep from re-killing the
+    same survivor on every tick forever, across process restarts included. */
+export type PipelineTerminalReap = {
+  /** Sweeps that dispatched at least one kill, or were cut off by the budget. */
+  rounds: number;
+  /** Hosts whose termination this reap evidenced, across all rounds. */
+  stopped: number;
+  lastAt: string;
+  /** Set once no finished host remains resident, or the round ceiling is
+      reached — survivors then live on as unconfirmed hosts. Never re-entered. */
+  settledAt: string | null;
+};
+
 export type Pipeline = {
   id: string;
   task: string;
@@ -243,6 +258,9 @@ export type Pipeline = {
   /** Hosts the last close could not confirm terminated. Present only while one
       is outstanding; a close that confirms every kill clears it. */
   unconfirmedHosts?: PipelineUnconfirmedHost[];
+  /** Receipt of the finished-host sweep completion triggers (#574). Absent
+      until the pipeline first settles terminally with launched hosts to check. */
+  terminalReap?: PipelineTerminalReap;
   /** Read-model marker set when a hidden container is projected for a pinned
       member, or for a closed lane still holding an unconfirmed host. */
   restored?: boolean;

--- a/src/lib/projects/aliases.test.ts
+++ b/src/lib/projects/aliases.test.ts
@@ -107,23 +107,99 @@ test("one legacy key resolving to two repositories is reported as a conflict", (
   });
 });
 
-test("id collisions introduced by bucket convergence defer the migration", () => {
-  const repository = path.join(SANDBOX, "collision-repository");
+test("one poisoned record cannot block a majority-backed legacy source", () => {
+  const clean = path.join(SANDBOX, "majority-clean");
+  const poison = path.join(SANDBOX, "majority-poison");
+  for (const [repository, name] of [[clean, "shared-repository"], [poison, "unrelated-repository"]] as const) {
+    fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repository, ".git", "config"), [
+      '[remote "origin"]',
+      `\turl = ssh://git@example.invalid/team/${name}.git`,
+      "",
+    ].join("\n"));
+  }
+  fs.mkdirSync(process.env.LLV_STATE_DIR!, { recursive: true });
+  /* One closed flow stamped with the legacy key but pointing at a foreign
+     checkout — the production shape that froze alias persistence entirely. */
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "flows.json"), JSON.stringify({
+    flows: [
+      { project: "-legacy-root-shared-repository", cwd: clean },
+      { project: "-legacy-root-shared-repository", cwd: poison, closedAt: "2026-07-11T00:00:00.000Z" },
+    ],
+  }));
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "pipelines.json"), JSON.stringify({
+    pipelines: [{ id: "pipe0001", project: "-legacy-root-shared-repository", repoDir: clean }],
+  }));
+
+  const identity = projectIdentityFromRepositoryRoot(clean)!;
+  expect(durableProjectAliasCandidates()).toEqual({
+    registrations: [{
+      source: "-legacy-root-shared-repository",
+      target: identity.project,
+      displayName: "shared-repository",
+    }],
+    conflicts: [],
+  });
+});
+
+test("a durable alias from a deleted worktree checkout resolves through the worktree map", () => {
+  const repository = path.join(SANDBOX, "deleted-worktree-main");
   fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
   fs.writeFileSync(path.join(repository, ".git", "config"), [
     '[remote "origin"]',
     "\turl = ssh://git@example.invalid/team/shared-repository.git",
     "",
   ].join("\n"));
+  const deleted = path.join(SANDBOX, "deleted-worktree-sibling");
+  expect(fs.existsSync(deleted)).toBe(false);
+  fs.mkdirSync(process.env.LLV_STATE_DIR!, { recursive: true });
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "worktree-map.json"), JSON.stringify({
+    [deleted]: { repo: repository, worktree: "deleted-worktree-sibling" },
+  }));
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "flows.json"), JSON.stringify({
+    flows: [{ project: "-legacy-root-deleted-worktree", cwd: deleted }],
+  }));
+
+  const identity = projectIdentityFromRepositoryRoot(repository)!;
+  expect(durableProjectAliasCandidates()).toEqual({
+    registrations: [{
+      source: "-legacy-root-deleted-worktree",
+      target: identity.project,
+      displayName: "shared-repository",
+    }],
+    conflicts: [],
+  });
+});
+
+test("id collisions defer only the colliding sources, never the clean batch", () => {
+  const repositories = ["collision", "clean"].map((name) => {
+    const repository = path.join(SANDBOX, `collision-${name}`);
+    fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repository, ".git", "config"), [
+      '[remote "origin"]',
+      `\turl = ssh://git@example.invalid/team/${name}-repository.git`,
+      "",
+    ].join("\n"));
+    return repository;
+  });
   fs.mkdirSync(process.env.LLV_STATE_DIR!, { recursive: true });
   fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "pipelines.json"), JSON.stringify({
     pipelines: [
-      { id: "same-id", project: "legacy-a", repoDir: repository },
-      { id: "same-id", project: "legacy-b", repoDir: repository },
+      { id: "same-id", project: "legacy-a", repoDir: repositories[0] },
+      { id: "same-id", project: "legacy-b", repoDir: repositories[0] },
     ],
   }));
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "flows.json"), JSON.stringify({
+    flows: [{ project: "legacy-clean", cwd: repositories[1] }],
+  }));
 
-  expect(durableProjectAliasCandidates()).toMatchObject({
+  const identity = projectIdentityFromRepositoryRoot(repositories[1]!)!;
+  expect(durableProjectAliasCandidates()).toEqual({
+    registrations: [{
+      source: "legacy-clean",
+      target: identity.project,
+      displayName: "clean-repository",
+    }],
     conflicts: ["pipelines id collision"],
   });
 });

--- a/src/lib/projects/aliases.ts
+++ b/src/lib/projects/aliases.ts
@@ -144,9 +144,13 @@ function collectionRecords(filename: string, collection: string): Record<string,
     : [];
 }
 
-function convergenceIdConflicts(registrations: readonly ProjectAliasRegistration[]): string[] {
+function convergenceIdCollisions(registrations: readonly ProjectAliasRegistration[]): {
+  labels: string[];
+  sources: Set<string>;
+} {
   const proposed = new Map(registrations.map((registration) => [registration.source, registration.target]));
-  const conflicts = new Set<string>();
+  const labels = new Set<string>();
+  const sources = new Set<string>();
   for (const [filename, collection] of [
     ["tasks.json", "tasks"],
     ["flows.json", "flows"],
@@ -161,17 +165,27 @@ function convergenceIdConflicts(registrations: readonly ProjectAliasRegistration
       const target = proposed.get(current) ?? current;
       const key = `${target}\0${record.id}`;
       const held = seen.get(key);
-      if (held && held !== current) conflicts.add(`${collection} id collision`);
-      else seen.set(key, current);
+      if (held && held !== current) {
+        labels.add(`${collection} id collision`);
+        if (proposed.has(held)) sources.add(held);
+        if (proposed.has(current)) sources.add(current);
+      } else {
+        seen.set(key, current);
+      }
     }
   }
-  return [...conflicts];
+  return { labels: [...labels], sources };
 }
+
+type TargetEvidence = { registration: ProjectAliasRegistration; records: number };
 
 /**
  * Pre-change flow, pipeline, and workflow records carry both the legacy
  * project key and a repository path. Re-resolving those paths establishes an
- * alias even when the prior project catalog has already disappeared.
+ * alias even when the prior project catalog has already disappeared. One stale
+ * record stamped with a foreign checkout must not poison a source the rest of
+ * the records agree on, so each source resolves by strict record majority and
+ * only a genuinely split source is reported as a conflict.
  */
 export function durableProjectAliasCandidates(): DurableProjectAliasCandidates {
   const rememberedRepositories = storedWorktreeRepositories();
@@ -180,27 +194,35 @@ export function durableProjectAliasCandidates(): DurableProjectAliasCandidates {
     ...projectPathPairs("pipelines.json", "pipelines", "repoDir"),
     ...projectPathPairs("workflows.json", "workflows", "repoDir"),
   ];
-  const targets = new Map<string, Map<string, ProjectAliasRegistration>>();
+  const targets = new Map<string, Map<string, TargetEvidence>>();
   for (const [source, candidatePath] of pairs) {
     const root = repositoryRootForPath(candidatePath) ?? rememberedRepositories.get(candidatePath);
     const identity = root ? projectIdentityFromRepositoryRoot(root) : null;
     if (!identity || source === identity.project) continue;
-    const sourceTargets = targets.get(source) ?? new Map<string, ProjectAliasRegistration>();
-    sourceTargets.set(identity.project, {
-      source,
-      target: identity.project,
-      displayName: identity.displayName,
-    });
+    const sourceTargets = targets.get(source) ?? new Map<string, TargetEvidence>();
+    const evidence = sourceTargets.get(identity.project) ?? {
+      registration: { source, target: identity.project, displayName: identity.displayName },
+      records: 0,
+    };
+    evidence.records += 1;
+    sourceTargets.set(identity.project, evidence);
     targets.set(source, sourceTargets);
   }
   const registrations: ProjectAliasRegistration[] = [];
   const conflicts: string[] = [];
   for (const [source, sourceTargets] of targets) {
-    if (sourceTargets.size === 1) registrations.push(sourceTargets.values().next().value!);
+    const ranked = [...sourceTargets.values()].sort((left, right) => right.records - left.records);
+    const total = ranked.reduce((sum, evidence) => sum + evidence.records, 0);
+    const leader = ranked[0]!;
+    if (leader.records * 2 > total) registrations.push(leader.registration);
     else conflicts.push(source);
   }
-  conflicts.push(...convergenceIdConflicts(registrations));
-  return { registrations, conflicts };
+  const collisions = convergenceIdCollisions(registrations);
+  conflicts.push(...collisions.labels);
+  return {
+    registrations: registrations.filter((registration) => !collisions.sources.has(registration.source)),
+    conflicts,
+  };
 }
 
 function mergeRegistrations(

--- a/src/lib/projects/identity.test.ts
+++ b/src/lib/projects/identity.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, expect, test } from "bun:test";
+
+import { projectIdentityFromRepositoryRoot } from "./identity";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-identity-"));
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function createRepository(name: string, remote: string): string {
+  const root = path.join(SANDBOX, name);
+  fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "config"), [
+    '[remote "origin"]',
+    `\turl = ${remote}`,
+    "",
+  ].join("\n"));
+  return root;
+}
+
+test("scp, ssh, and https clones of one remote resolve to one identity", () => {
+  const identities = [
+    createRepository("clone-scp", "git@example.invalid:team/shared-repository.git"),
+    createRepository("clone-ssh", "ssh://git@example.invalid/team/shared-repository.git"),
+    createRepository("clone-https", "https://example.invalid/team/shared-repository.git"),
+    createRepository("clone-https-bare", "https://example.invalid/team/shared-repository"),
+  ].map((root) => projectIdentityFromRepositoryRoot(root)!);
+
+  expect(identities.every(Boolean)).toBe(true);
+  expect(new Set(identities.map((identity) => identity.project))).toHaveLength(1);
+  expect(new Set(identities.map((identity) => identity.canonicalRemote)))
+    .toEqual(new Set(["example.invalid/team/shared-repository"]));
+  expect(identities[0]!.displayName).toBe("shared-repository");
+});
+
+test("an https remote never parses as an scp host", () => {
+  const root = createRepository("https-host", "https://example.invalid/team/host-check.git");
+  const identity = projectIdentityFromRepositoryRoot(root)!;
+  expect(identity.canonicalRemote.startsWith("example.invalid/")).toBe(true);
+  expect(identity.canonicalRemote).not.toContain("https");
+});

--- a/src/lib/projects/identity.ts
+++ b/src/lib/projects/identity.ts
@@ -70,7 +70,12 @@ function originRemote(config: string): string | null {
 }
 
 function canonicalRemote(remote: string, root: string): string | null {
-  const scp = /^(?:[^@\s]+@)?([^:/\s]+):(.+)$/.exec(remote);
+  /* A remote with an explicit scheme must never reach the scp-like matcher:
+     `https://host/team/repo` would otherwise parse as host `https`, minting a
+     second identity for a repository that ssh clones resolve correctly. */
+  const scp = /^[a-z][a-z0-9+.-]*:\/\//i.test(remote)
+    ? null
+    : /^(?:[^@\s]+@)?([^:/\s]+):(.+)$/.exec(remote);
   if (scp) {
     const host = scp[1]!.toLowerCase();
     const pathname = scp[2]!.replace(/^\/+|\/+$/g, "").replace(/\.git$/i, "");

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -107,6 +107,49 @@ test("request refreshes persist the per-file scanner index", async () => {
   }
 });
 
+test("a poisoned durable alias source defers only itself in the persist scan", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-poisoned-alias-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    await mkdir(process.env.LLV_STATE_DIR, { recursive: true });
+    const cleanRepo = path.join(base, "clean-checkout");
+    const tieA = path.join(base, "tie-a-checkout");
+    const tieB = path.join(base, "tie-b-checkout");
+    const cleanProject = await createRepository(cleanRepo, "clean-repository");
+    await createRepository(tieA, "tie-a-repository");
+    await createRepository(tieB, "tie-b-repository");
+    /* The production freeze: one legacy source with contradictory records
+       kept every other alias, the board migration, and the catalog write
+       deferred on every scan. */
+    await writeFile(path.join(process.env.LLV_STATE_DIR, "flows.json"), JSON.stringify({
+      flows: [
+        { project: "legacy-clean", cwd: cleanRepo },
+        { project: "legacy-poisoned", cwd: tieA },
+        { project: "legacy-poisoned", cwd: tieB, closedAt: "2026-07-11T00:00:00.000Z" },
+      ],
+    }));
+    const transcript = path.join(roots["codex-sessions"], "poisoned-alias.jsonl");
+    await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: cleanRepo } }) + "\n", 1_700_000_000);
+
+    await discoverFilesWithProjectCatalog(roots, undefined, {});
+
+    const aliases = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-aliases.json"), "utf8"));
+    expect(aliases.aliases).toEqual({ "legacy-clean": cleanProject });
+    expect(existsSync(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"))).toBe(true);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test("project catalog persistence repairs private modes and atomically replaces symlinks", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-private-index-"));
   const previousStateDir = process.env.LLV_STATE_DIR;

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -2,7 +2,9 @@ import type { FileEntry, ProjectCatalogEntry } from "../types";
 import { agentRegistry, RegistryReadError } from "../agent/registry";
 import { forEachCooperatively, yieldToRuntime } from "../cooperative";
 import { tickFlows } from "../flows/engine";
-import { tickPipelines } from "../pipelines/engine";
+import { withFlowSnapshot } from "../flows/store";
+import { reconcileEmbeddedReviewFlows, tickPipelines } from "../pipelines/engine";
+import { withPipelineMutation } from "../pipelines/store";
 import { notifyQuestion } from "../push";
 import { overlaySessionTitles, sessionProjectProjection } from "../session/titleProjection";
 import { tickTaskInbox } from "../tasks/inboxScanner";
@@ -301,6 +303,19 @@ export async function reconcileFileControllers(entries: FileEntry[]): Promise<vo
     if (entry.pendingQuestion || entry.waitingInput) void notifyQuestion(entry);
   });
   await tickFlows(entries);
+  await yieldToRuntime();
+  /* Durable half of the embedded review flow reconcile (issue #798): the files
+     GET applies the same function as a read-model overlay only, so the claim
+     of a flow-first crash recovery and the sync generation persist here, on
+     the controller path, never from a request. */
+  try {
+    await withPipelineMutation((pipelines, persist) =>
+      withFlowSnapshot((flows) => {
+        if (reconcileEmbeddedReviewFlows(pipelines, flows)) persist();
+      }));
+  } catch (error) {
+    console.error("[pipelines] skipping embedded review flow reconcile", error);
+  }
   await yieldToRuntime();
   await tickPipelines(entries);
   await yieldToRuntime();

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -599,13 +599,23 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
           target,
           displayName: groups.get(target)?.displayName ?? displayNameFromProjectIdentity(target),
         }));
+        /* A poisoned durable source must not defer the whole batch: its
+           evidence lives in flows/pipelines/workflows state and is re-derived
+           on every scan, so skipping it here loses nothing while the clean
+           registrations, the board migration, and the catalog write proceed. */
         const durable = durableProjectAliasCandidates();
-        if (durable.conflicts.length > 0) throw new Error("ambiguous durable project identity");
+        let deferredSources = durable.conflicts.length;
         for (const registration of durable.registrations) {
           const held = migrations.get(registration.source);
-          if (held && held !== registration.target) throw new Error("conflicting project migration");
+          if (held && held !== registration.target) {
+            deferredSources += 1;
+            continue;
+          }
           migrations.set(registration.source, registration.target);
           registrations.push(registration);
+        }
+        if (deferredSources > 0) {
+          console.error(`[project catalog] ${deferredSources} durable project alias source(s) unresolved; persisting the clean batch and retrying them on a later scan`);
         }
         boardHealed = projectAliasesCanAccept(registrations);
         if (boardHealed) boardHealed = migrateBoardProjects(migrations);

--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 
 import { stateDir } from "@/lib/configDir";
 
-export const PROJECT_RESOLUTION_VERSION = 4;
+/* 5: canonicalRemote no longer parses scheme remotes (https://…) through the
+   scp matcher, so identities minted from the misparse must re-derive. */
+export const PROJECT_RESOLUTION_VERSION = 5;
 
 /* Project summaries depend on the attribution facts consumed by
    persistedProjects(). Hashing these stable projections keeps controller

--- a/src/lib/session/titleProjection.test.ts
+++ b/src/lib/session/titleProjection.test.ts
@@ -6,11 +6,11 @@ import path from "node:path";
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
-import { overlayResourceSessionTitles, overlaySessionTitles } from "./titleProjection";
+import { overlayResourceSessionTitles, overlaySessionTitles, registryProjectionForSnapshot } from "./titleProjection";
 import { writeSessionTitle } from "./titleStore";
 
-const UUID = "11111111-2222-4333-8444-555555555555";
-const SESSION_PATH = `/home/u/.claude/projects/proj/${UUID}.jsonl`;
+const UUID = "11111111-2222-4333-0444-555555555555";
+const SESSION_PATH = `/home/user/.claude/projects/proj/${UUID}.jsonl`;
 
 let stateDir = "";
 let registryRoot = "";
@@ -80,8 +80,8 @@ test("a title filed under a predecessor/continuity path survives onto the succes
   const conversation = registry.ensureConversation("claude", SESSION_PATH, null);
   // A prior transcript the conversation still owns (e.g. an account-migration
   // predecessor), with its own UUID/path.
-  const predUuid = "22222222-2222-4333-8444-555555555555";
-  const predPath = `/home/u/.claude/projects/proj/${predUuid}.jsonl`;
+  const predUuid = "22222222-2222-4333-0444-555555555555";
+  const predPath = `/home/user/.claude/projects/proj/${predUuid}.jsonl`;
   registry.recordConversationContinuityPath(conversation.id, predPath);
   setAgentRegistryForTests(registry);
   // The title was filed under the predecessor's UUID key.
@@ -96,14 +96,14 @@ test("a title filed under a predecessor/continuity path survives onto the succes
 });
 
 test("a subagent is not renamable and receives no override affordance", () => {
-  const subPath = "/home/u/.claude/projects/proj/abc/subagents/agent-9.jsonl";
+  const subPath = "/home/user/.claude/projects/proj/abc/subagents/agent-9.jsonl";
   const file = entry({ path: subPath, kind: "subagent" });
   overlaySessionTitles([file]);
   expect(file.renamable).toBe(false);
 });
 
 test("the resource projection applies identity and titles without transcript-head eligibility reads", () => {
-  const pathname = `/home/u/.codex/sessions/2026/07/16/rollout-${UUID}.jsonl`;
+  const pathname = `/home/user/.codex/sessions/2026/07/16/rollout-${UUID}.jsonl`;
   const registry = new AgentRegistry(path.join(stateDir, "agent-registry.json"));
   const resourceConversation = registry.ensureConversation("codex", pathname, null);
   setAgentRegistryForTests(registry);
@@ -130,6 +130,35 @@ test("the resource projection applies identity and titles without transcript-hea
   } finally {
     fs.openSync = originalOpen;
   }
+});
+
+test("issue 798: the title overlay consumes the threaded snapshot without re-reading the registry", () => {
+  const registry = new AgentRegistry(path.join(registryRoot, "registry.json"));
+  const conversation = registry.ensureConversation("claude", SESSION_PATH, null);
+  setAgentRegistryForTests(registry);
+  const snapshot = registry.readOnlySnapshot();
+  const target = registry as unknown as { readOnlySnapshot: AgentRegistry["readOnlySnapshot"] };
+  target.readOnlySnapshot = () => {
+    throw new Error("the title projection re-read the registry instead of consuming the threaded snapshot");
+  };
+
+  const file = entry();
+  overlaySessionTitles([file], snapshot);
+  expect(file.conversationId).toBe(conversation.id);
+});
+
+test("issue 798: the registry projection is cached per snapshot revision, not per registry file write", () => {
+  const registry = new AgentRegistry(path.join(registryRoot, "registry.json"));
+  registry.ensureConversation("claude", SESSION_PATH, null);
+  setAgentRegistryForTests(registry);
+  const snapshot = registry.readOnlySnapshot();
+  const projection = registryProjectionForSnapshot(snapshot);
+  /* A sqlite mirror checkpoint rewrites the JSON mirror (new mtime/size
+     signature) while the store revision — and with it the shared snapshot
+     object — is unchanged. The projection must survive that rewrite instead of
+     rebuilding over every conversation. */
+  fs.writeFileSync(registry.filename, fs.readFileSync(registry.filename));
+  expect(registryProjectionForSnapshot(snapshot)).toBe(projection);
 });
 
 function setRegistryConversation() {

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -25,17 +25,13 @@ interface RegistryProjection {
   archivedPaths: Set<string>;
 }
 
-const registryProjectionCache = new WeakMap<Registry, RegistryProjection>();
+/* Keyed on the snapshot object itself: the registry's readOnlySnapshot returns
+   one shared object per revision (sqlite mode) or per file signature (json
+   mode), so identity IS the revision. A sqlite-mirror checkpoint rewrites the
+   JSON file without changing the revision and therefore no longer invalidates
+   this cache (issue #798). */
+const snapshotProjectionCache = new WeakMap<RegistrySnapshot, RegistryProjection>();
 let readOnlyRegistryProjectionCache: RegistryProjection | null = null;
-
-function registrySignature(registry: Registry): string {
-  try {
-    const stat = fs.statSync(registry.filename, { bigint: true });
-    return `${stat.mtimeNs}:${stat.size}`;
-  } catch {
-    return "missing";
-  }
-}
 
 function canonicalConversationId(snapshot: RegistrySnapshot, alias: string): string {
   let current = alias;
@@ -104,10 +100,18 @@ function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string):
   return projection;
 }
 
+/** The one registry projection per snapshot revision. A request that already
+    holds the read-only snapshot threads it here so the projection is computed
+    at most once per revision and never re-reads the registry. */
+export function registryProjectionForSnapshot(snapshot: RegistrySnapshot): RegistryProjection {
+  const cached = snapshotProjectionCache.get(snapshot);
+  if (cached) return cached;
+  const projection = projectRegistrySnapshot(snapshot, "snapshot");
+  snapshotProjectionCache.set(snapshot, projection);
+  return projection;
+}
+
 function registryProjection(registry: Registry, surfaceUnexpectedError = false): RegistryProjection | null {
-  const signature = registrySignature(registry);
-  const cached = registryProjectionCache.get(registry);
-  if (cached?.signature === signature) return cached;
   let snapshot: RegistrySnapshot;
   try {
     snapshot = registry.readOnlySnapshot();
@@ -115,9 +119,7 @@ function registryProjection(registry: Registry, surfaceUnexpectedError = false):
     if (surfaceUnexpectedError && !(error instanceof RegistryReadError)) throw error;
     return null;
   }
-  const projection = projectRegistrySnapshot(snapshot, signature);
-  registryProjectionCache.set(registry, projection);
-  return projection;
+  return registryProjectionForSnapshot(snapshot);
 }
 
 function readOnlyRegistryProjection(): RegistryProjection | null {
@@ -151,8 +153,11 @@ function readOnlyRegistryProjection(): RegistryProjection | null {
  * safe to run after the files response has already stamped identity/launch
  * profile — it never re-derives `autoTitle` once set.
  */
-export function overlaySessionTitles(entries: FileEntry[]): void {
-  const project = sessionTitleProjector();
+export function overlaySessionTitles(entries: FileEntry[], registrySnapshot?: RegistrySnapshot): void {
+  const project = sessionTitleProjector(
+    true,
+    registrySnapshot === undefined ? undefined : registryProjectionForSnapshot(registrySnapshot),
+  );
   for (const entry of entries) project(entry);
 }
 


### PR DESCRIPTION
Closes #798.
Closes #785.
Closes #574.

Integrates the three tested fixes into one production release:

- one registry projection per files request with lock-free pipeline projection;
- durable canonical project aliases with poisoned-source isolation and correct HTTPS remote identity;
- bounded reaping for finished terminal pipeline builders.

Validation:

- 315 targeted tests passed across 10 exact test files using isolated Viewer state;
- production-shaped files projection: 88 ms cold in the integration lane;
- production-sized SQLite route contract: 1.68 s;
- TypeScript, changed-file ESLint, and privacy-publication gate passed.

Review stage intentionally omitted by direct operator decision.
