### PR TITLE
fix: keep catalog refresh off the Viewer event loop

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,13 +10,17 @@ const nextConfig: NextConfig = {
     "*": ["node_modules/@img/**", "node_modules/sharp/**"],
   },
   outputFileTracingIncludes: {
-    "/*": [".next/server/resource-collector-worker.js"],
+    "/*": [
+      ".next/server/file-scanner-worker.js",
+      ".next/server/resource-collector-worker.js",
+    ],
   },
   webpack(config, { isServer, nextRuntime }) {
     if (isServer && nextRuntime === "nodejs") {
       const originalEntry = config.entry;
       config.entry = async () => ({
         ...(typeof originalEntry === "function" ? await originalEntry() : originalEntry),
+        "file-scanner-worker": "./src/lib/fileScanner.worker.ts",
         "resource-collector-worker": "./src/lib/resourceCollector.worker.ts",
       });
     }

--- a/src/lib/fileScanner.worker.ts
+++ b/src/lib/fileScanner.worker.ts
@@ -1,0 +1,54 @@
+import "./fileScanner.workerMode";
+
+import { listFilesWithProjectCatalog, type FileCatalogScan, type FileScanOptions } from "./scanner";
+
+type FileScannerWorkerRequest = {
+  type: "scan";
+  options: Omit<FileScanOptions, "onResourceSnapshot">;
+};
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requestFrom(value: unknown): FileScannerWorkerRequest | null {
+  if (!record(value) || value.type !== "scan" || !record(value.options)) return null;
+  return value as FileScannerWorkerRequest;
+}
+
+function send(type: "resource" | "complete", snapshot: FileCatalogScan): void {
+  process.stdout.write(`${JSON.stringify({ type, snapshot })}\n`);
+}
+
+async function run(value: unknown): Promise<void> {
+  const request = requestFrom(value);
+  if (!request) throw new Error("file scanner worker received an invalid request");
+  const snapshot = await listFilesWithProjectCatalog(undefined, {
+    ...request.options,
+    onResourceSnapshot: (resource) => send("resource", resource),
+  });
+  send("complete", snapshot);
+}
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+  input += chunk;
+  if (Buffer.byteLength(input) > 8 * 1024 * 1024) {
+    process.stderr.write("file scanner worker input exceeded limit\n");
+    process.exitCode = 1;
+    process.stdin.destroy();
+  }
+});
+process.stdin.on("end", () => {
+  if (process.exitCode) return;
+  try {
+    void run(JSON.parse(input)).catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    });
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+});

--- a/src/lib/fileScanner.workerMode.ts
+++ b/src/lib/fileScanner.workerMode.ts
@@ -1,0 +1,1 @@
+process.env.LLV_FILE_SCANNER_WORKER = "1";

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -979,7 +979,7 @@ function addStructuredRestartConversation(
   input: {
     engine?: "codex" | "claude";
     sessionId: string;
-    status: "live" | "dead" | "unhosted";
+    status: "live" | "idle" | "dead" | "unhosted";
     turn: "busy" | "terminal" | "unknown";
     activeTurnRef?: string | null;
     transcriptRecords?: Record<string, unknown>[];
@@ -1154,6 +1154,26 @@ test("unknown Codex durable state continues from runtime-running evidence", asyn
   expect(ledger.writes).toEqual([expect.objectContaining({
     id: `recovery-continuation-${sessionId}-3`,
   })]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("a stale runtime-running projection cannot revive an idle registry host", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-stale-running-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "10000000-0000-0000-0000-000000000001";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "idle",
+    turn: "busy",
+    activeTurnRef: null,
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath, "running");
+
+  expect(await startupAdoptionAttempts(registry, runtimeJournalClient(journal))).toEqual([]);
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -343,8 +343,11 @@ function structuredStartupAdoptionFilter(
     const runtimeHostedRunning = signals.hostedRunningConversationIds.has(conversationId);
     const unfinishedTurn = conversation.turn.state === "busy"
       || Boolean(entry.structuredHost?.activeTurnRef)
-      || runtimeHostedRunning;
-    const liveHost = entry.status === "live" || runtimeHostedRunning;
+      || (entry.status === "live" && runtimeHostedRunning);
+    /* Runtime snapshots survive host epochs. A stale hosted/running row cannot
+       resurrect an idle or dead registry host by itself; the registry's live
+       process evidence remains the startup liveness gate. */
+    const liveHost = entry.status === "live";
     return liveHost && unfinishedTurn;
   };
 }

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function fixtureWorker(source: string): { directory: string; workerPath: string } {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-worker-"));
+  directories.push(directory);
+  const workerPath = path.join(directory, "worker.mjs");
+  fs.writeFileSync(workerPath, source);
+  return { directory, workerPath };
+}
+
+test("production file scans use the worker boundary and test scans stay direct", () => {
+  expect(fileScanWorkerEnabled({ NODE_ENV: "production" })).toBe(true);
+  expect(fileScanWorkerEnabled({ NODE_ENV: "test" })).toBe(false);
+  expect(fileScanWorkerEnabled({ NODE_ENV: "production", LLV_FILE_SCANNER_WORKER: "1" })).toBe(false);
+  expect(fileScanWorkerEnabled({ NODE_ENV: "production", LLV_FILE_SCANNER_WORKER_DISABLED: "1" })).toBe(false);
+});
+
+test("worker scan streams the resource scope, keeps the caller event loop live, and returns completion", async () => {
+  const { directory, workerPath } = fixtureWorker(`
+    process.stdin.resume();
+    process.stdin.on("end", () => {
+      const resource = { files: [], projectCatalog: [], complete: true };
+      setTimeout(() => {
+        process.stdout.write(JSON.stringify({ type: "resource", snapshot: resource }) + "\\n");
+        setTimeout(() => {
+          process.stdout.write(JSON.stringify({
+            type: "complete",
+            snapshot: { files: [], projectCatalog: [{ id: "project-one", name: "one", path: "/one" }], complete: true },
+          }) + "\\n");
+        }, 20);
+      }, 20);
+    });
+  `);
+  let ticks = 0;
+  const timer = setInterval(() => { ticks += 1; }, 1);
+  const resources: unknown[] = [];
+  try {
+    const snapshot = await collectFileScanInWorker(
+      { persist: false, persistIndex: false },
+      (resource) => resources.push(resource),
+      {
+        launch: { executable: process.execPath, workerPath },
+        cwd: directory,
+        timeoutMs: 2_000,
+      },
+    );
+    expect(resources).toEqual([{ files: [], projectCatalog: [], complete: true }]);
+    expect(snapshot.projectCatalog).toHaveLength(1);
+    expect(ticks).toBeGreaterThan(2);
+  } finally {
+    clearInterval(timer);
+  }
+});

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -1,0 +1,151 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
+
+import type { FileCatalogScan, FileScanOptions } from "./index";
+
+const FILE_SCAN_WORKER_TIMEOUT_MS = 5 * 60_000;
+const FILE_SCAN_WORKER_OUTPUT_MAX_BYTES = 32 * 1024 * 1024;
+const FILE_SCAN_WORKER_STDERR_MAX_BYTES = 4 * 1024;
+
+type SerializableFileScanOptions = Omit<FileScanOptions, "onResourceSnapshot">;
+
+type FileScanWorkerMessage =
+  | { type: "resource"; snapshot: FileCatalogScan }
+  | { type: "complete"; snapshot: FileCatalogScan };
+
+export interface FileScanWorkerRuntime {
+  launch?: { executable: string; workerPath: string };
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fileCatalogScan(value: unknown): value is FileCatalogScan {
+  return record(value)
+    && Array.isArray(value.files)
+    && Array.isArray(value.projectCatalog)
+    && typeof value.complete === "boolean"
+    && (value.pinOverlayPaths === undefined || Array.isArray(value.pinOverlayPaths));
+}
+
+function workerMessage(value: unknown): FileScanWorkerMessage | null {
+  if (!record(value)
+    || (value.type !== "resource" && value.type !== "complete")
+    || !fileCatalogScan(value.snapshot)) return null;
+  return value as unknown as FileScanWorkerMessage;
+}
+
+function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: string } {
+  const source = path.join(cwd, "src/lib/fileScanner.worker.ts");
+  const bundled = path.join(cwd, ".next/server/file-scanner-worker.js");
+  if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
+    return { executable: "/usr/local/bin/bun-container", workerPath: source };
+  }
+  if (fs.existsSync(bundled)) return { executable: process.execPath, workerPath: bundled };
+  return { executable: process.execPath, workerPath: source };
+}
+
+export function fileScanWorkerEnabled(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.NODE_ENV !== "test"
+    && env.LLV_FILE_SCANNER_WORKER !== "1"
+    && env.LLV_FILE_SCANNER_WORKER_DISABLED !== "1";
+}
+
+export function collectFileScanInWorker(
+  options: SerializableFileScanOptions,
+  onResourceSnapshot?: (snapshot: FileCatalogScan) => void,
+  runtime: FileScanWorkerRuntime = {},
+): Promise<FileCatalogScan> {
+  const launch = runtime.launch ?? workerLaunch(runtime.cwd);
+  const child = spawn(launch.executable, [launch.workerPath], {
+    cwd: runtime.cwd ?? process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...withoutWakatimeCredential(runtime.env ?? process.env),
+      LLV_FILE_SCANNER_WORKER: "1",
+    },
+  });
+  return new Promise<FileCatalogScan>((resolve, reject) => {
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    let completed: FileCatalogScan | null = null;
+    const finish = (error?: Error, snapshot?: FileCatalogScan) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(snapshot!);
+    };
+    const fail = (message: string) => {
+      try { child.kill("SIGKILL"); } catch { /* child already exited */ }
+      finish(new Error(message));
+    };
+    const consume = () => {
+      while (true) {
+        const newline = stdout.indexOf("\n");
+        if (newline < 0) return;
+        const raw = stdout.slice(0, newline);
+        stdout = stdout.slice(newline + 1);
+        if (!raw) continue;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          fail("file scanner worker emitted invalid JSON");
+          return;
+        }
+        const message = workerMessage(parsed);
+        if (!message) {
+          fail("file scanner worker emitted an invalid message");
+          return;
+        }
+        if (message.type === "resource") onResourceSnapshot?.(message.snapshot);
+        else completed = message.snapshot;
+      }
+    };
+    const timer = setTimeout(() => {
+      fail("file scanner worker timed out");
+    }, runtime.timeoutMs ?? FILE_SCAN_WORKER_TIMEOUT_MS);
+    child.once("error", (error) => finish(error));
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      outputBytes += Buffer.byteLength(chunk);
+      if (outputBytes > FILE_SCAN_WORKER_OUTPUT_MAX_BYTES) {
+        fail("file scanner worker exceeded output limit");
+        return;
+      }
+      stdout += chunk;
+      consume();
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr = `${stderr}${chunk}`;
+      if (Buffer.byteLength(stderr) > FILE_SCAN_WORKER_STDERR_MAX_BYTES) {
+        stderr = Buffer.from(stderr).subarray(-FILE_SCAN_WORKER_STDERR_MAX_BYTES).toString("utf8");
+      }
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      consume();
+      if (code !== 0 || !completed) {
+        const detail = stderr.trim();
+        finish(new Error(`file scanner worker exited before completion (${signal ?? code ?? "unknown"})${detail ? `: ${detail}` : ""}`));
+        return;
+      }
+      finish(undefined, completed);
+    });
+    child.stdin.once("error", (error) => finish(error));
+    child.stdin.end(JSON.stringify({ type: "scan", options }));
+  });
+}

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -8,7 +8,7 @@ import { primeTranscriptTurnEvidence } from "@/lib/scanner/activity";
 import { globalCache } from "@/lib/scanner/caches";
 import { primePersistedLineageFacts } from "@/lib/scanner/links";
 import { QUESTION_CACHE_NAME } from "@/lib/scanner/questions";
-import { coordinatedFileScan, resetFileScanCoordinatorForTests } from "@/lib/scanner/scanCoordinator";
+import { coordinatedFileScan, resetFileScanCoordinatorForTests, runFileCatalogScan } from "@/lib/scanner/scanCoordinator";
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
@@ -388,10 +388,8 @@ function fileScanRefreshPromise(
      merge into the single trailing generation instead (#287). */
   const join = reason === "ordinary" || reason === "cold";
   return instrumentFileScan(slot, generation, reason, async () => {
-    const snapshot = await coordinatedFileScan({ fresh, join }, (intent) => listFilesWithProjectCatalog(undefined, {
-      persist: intent.persist,
+    const snapshot = await coordinatedFileScan({ fresh, join }, (intent) => runFileCatalogScan(intent, {
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
-      ...(intent.fresh ? { fresh: true } : {}),
       ...(onResourceSnapshot ? { onResourceSnapshot, resourceBaseline: slot.snapshot } : {}),
     }));
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
@@ -468,11 +466,9 @@ function beginPinnedFileScanRefresh(
        fences, never adopts a running scan, and never merges with other pending
        callers (their runners cannot reproduce the pin overlay); it still holds
        the process-wide single-generation lease through the coordinator (#287). */
-    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true }, (intent) => listFilesWithProjectCatalog(undefined, {
-      persist: intent.persist,
+    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true }, (intent) => runFileCatalogScan(intent, {
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
-      ...(intent.fresh ? { fresh: true } : {}),
       onResourceSnapshot: publish,
       resourceBaseline: slot.snapshot,
     }));

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -1,4 +1,6 @@
-import { listFilesWithProjectCatalog, type FileCatalogScan } from "@/lib/scanner";
+import { listFilesWithProjectCatalog, type FileCatalogScan, type FileScanOptions } from "@/lib/scanner";
+
+import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
 
 /**
  * Process-wide filesystem scan coordination (#287).
@@ -84,10 +86,21 @@ function covers(running: ResolvedScanIntent, wanted: ResolvedScanIntent): boolea
   return (running.persist || !wanted.persist) && (running.fresh || !wanted.fresh);
 }
 
-const defaultRunner: CoordinatedScanRunner = (intent) => listFilesWithProjectCatalog(undefined, {
-  persist: intent.persist,
-  ...(intent.fresh ? { fresh: true } : {}),
-});
+export function runFileCatalogScan(
+  intent: ResolvedScanIntent,
+  options: Omit<FileScanOptions, "persist" | "fresh"> = {},
+): Promise<FileCatalogScan> {
+  const scanOptions: FileScanOptions = {
+    ...options,
+    persist: intent.persist,
+    ...(intent.fresh ? { fresh: true } : {}),
+  };
+  if (!fileScanWorkerEnabled()) return listFilesWithProjectCatalog(undefined, scanOptions);
+  const { onResourceSnapshot, ...serializable } = scanOptions;
+  return collectFileScanInWorker(serializable, onResourceSnapshot);
+}
+
+const defaultRunner: CoordinatedScanRunner = (intent) => runFileCatalogScan(intent);
 
 function startGeneration(
   state: CoordinatorState,


### PR DESCRIPTION
## Summary
- run full transcript catalog refreshes in a dedicated Bun worker
- stream the early resource scope back to the server while enrichment continues
- prevent stale runtime-only running projections from reviving idle/dead registry hosts
- package the scanner worker in production builds

## Production reproduction
The persisted catalog loaded quickly, then the background full refresh monopolized the Next server event loop for about 57 seconds. During that interval both the page and `/api/files` timed out. The worker boundary returned the early resource scope in about 259 ms while the full refresh continued independently.

## Verification
- targeted scanner/files route suite: 84 passed
- startup and worker suite: 71 passed
- TypeScript and changed-file ESLint passed
- production and MCP builds passed
- publication privacy gate passed
