### PR TITLE
fix: collapse concurrent files projection storms

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -26,6 +26,15 @@ let tmuxHealth: unknown = { status: "healthy" };
 let stateDir = "";
 const previousState = process.env.LLV_STATE_DIR;
 
+function resetFilesProjectionCacheForTests(): void {
+  const store = globalThis as typeof globalThis & {
+    __llvFilesProjectionCache?: Map<string, unknown>;
+    __llvFilesProjectionInflight?: Map<string, Promise<unknown>>;
+  };
+  store.__llvFilesProjectionCache = new Map();
+  store.__llvFilesProjectionInflight = new Map();
+}
+
 beforeEach(() => {
   registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-route-"));
   // Sandbox the title store so the integration test's writeSessionTitle never
@@ -34,6 +43,7 @@ beforeEach(() => {
   process.env.LLV_STATE_DIR = stateDir;
   setAgentRegistryForTests(new AgentRegistry(path.join(registryRoot, "registry.json")));
   resetFilesRouteCacheForTests();
+  resetFilesProjectionCacheForTests();
   scans = 0;
   scanProjects = [];
   scannedFiles = [];
@@ -125,6 +135,14 @@ const { GET } = await import("./route");
 
 test("repeated files reads reuse the pure read snapshot and retain ETag behavior", async () => {
   scannedFiles = [];
+  const registry = agentRegistry();
+  const target = registry as unknown as { readOnlySnapshot: AgentRegistry["readOnlySnapshot"] };
+  const realReadOnlySnapshot = target.readOnlySnapshot.bind(registry);
+  let registryReads = 0;
+  target.readOnlySnapshot = () => {
+    registryReads += 1;
+    return realReadOnlySnapshot();
+  };
   const first = await GET(new Request("http://127.0.0.1/api/files"));
   const etag = first.headers.get("etag");
   const second = await GET(new Request("http://127.0.0.1/api/files", { headers: { "if-none-match": etag! } }));
@@ -143,8 +161,11 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   }));
   expect(first.headers.get("x-llv-files-cache")).toBe("miss");
   expect(second.headers.get("x-llv-files-cache")).toBe("hit");
+  expect(first.headers.get("x-llv-files-projection-cache")).toBe("miss");
+  expect(second.headers.get("x-llv-files-projection-cache")).toBe("hit");
   expect(first.headers.get("x-llv-files-cache-requests")).toBe("1");
   expect(second.headers.get("x-llv-files-cache-requests")).toBe("2");
+  expect(registryReads).toBe(1);
   expect(first.headers.get("server-timing")).toMatch(/files-clone;dur=\d+(?:\.\d+)?/);
   expect(first.headers.get("server-timing")).toMatch(/files-scan;dur=\d+(?:\.\d+)?;desc="cold generation 1"/);
   expect(first.headers.get("server-timing")).toMatch(/files-(?:source|registry|flows|authorship|stores|projects|json);dur=\d+(?:\.\d+)?/);
@@ -352,7 +373,15 @@ test("files API surfaces degraded tmux endpoint health", async () => {
   }
 });
 
-test("concurrent cold files reads share one scan", async () => {
+test("concurrent cold files reads share one scan and one projection", async () => {
+  const registry = agentRegistry();
+  const target = registry as unknown as { readOnlySnapshot: AgentRegistry["readOnlySnapshot"] };
+  const realReadOnlySnapshot = target.readOnlySnapshot.bind(registry);
+  let registryReads = 0;
+  target.readOnlySnapshot = () => {
+    registryReads += 1;
+    return realReadOnlySnapshot();
+  };
   const [first, second] = await Promise.all([
     GET(new Request("http://127.0.0.1/api/files")),
     GET(new Request("http://127.0.0.1/api/files")),
@@ -361,6 +390,11 @@ test("concurrent cold files reads share one scan", async () => {
   expect(first.status).toBe(200);
   expect(second.status).toBe(200);
   expect(scans).toBe(1);
+  expect(registryReads).toBe(1);
+  expect([
+    first.headers.get("x-llv-files-projection-cache"),
+    second.headers.get("x-llv-files-projection-cache"),
+  ].sort()).toEqual(["joined", "miss"]);
 });
 
 test("a restart serves the persisted completed snapshot while revalidating", async () => {

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,3 +1,8 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+
+import { agentRegistry } from "@/lib/agent/registry";
+import { statePath } from "@/lib/configDir";
 import { buildFilesResponse } from "./response";
 import { cachedFileScan } from "@/lib/scanner/scanCache";
 
@@ -12,6 +17,121 @@ function generationHeader(request: Request, name: string): number | undefined {
 }
 
 type CachedScan = Awaited<ReturnType<typeof cachedFileScan>>;
+type ProjectionRepresentation = {
+  body: string;
+  contentType: string;
+  etag: string;
+  timing: string;
+};
+type ProjectionResult = {
+  representation: ProjectionRepresentation;
+  cacheStatus: "hit" | "joined" | "miss";
+};
+
+const PROJECTION_CACHE_MAX = 8;
+const PROJECTION_HEALTH_BUCKET_MS = 60_000;
+const PROJECTION_STATE_FILES = [
+  "flows.json",
+  "pipelines.json",
+  "tasks.json",
+  "workflows.json",
+  "project-aliases.json",
+  "worktree-map.json",
+  "reaper-state.json",
+] as const;
+const projectionCacheStore = globalThis as typeof globalThis & {
+  __llvFilesProjectionCache?: Map<string, ProjectionRepresentation>;
+  __llvFilesProjectionInflight?: Map<string, Promise<ProjectionRepresentation>>;
+};
+
+function projectionCache(): Map<string, ProjectionRepresentation> {
+  projectionCacheStore.__llvFilesProjectionCache ??= new Map();
+  return projectionCacheStore.__llvFilesProjectionCache;
+}
+
+function projectionInflight(): Map<string, Promise<ProjectionRepresentation>> {
+  projectionCacheStore.__llvFilesProjectionInflight ??= new Map();
+  return projectionCacheStore.__llvFilesProjectionInflight;
+}
+
+function stateFileSignature(filename: string): string {
+  const pathname = statePath(filename);
+  try {
+    const stat = fs.statSync(pathname);
+    return `${pathname}:${stat.size}:${stat.mtimeMs}`;
+  } catch {
+    return `${pathname}:missing`;
+  }
+}
+
+function projectionKey(
+  scan: CachedScan,
+  selectedProject: string | undefined,
+  pinnedPath: string | undefined,
+  now: number,
+): string {
+  const registryDiagnostics = agentRegistry().storageDiagnostics();
+  const hash = createHash("sha1");
+  hash.update(JSON.stringify({
+    selectedProject: selectedProject ?? null,
+    pinnedPath: pinnedPath ?? null,
+    snapshot: scan.snapshot,
+    pinOverlayPaths: scan.pinOverlayPaths ?? [],
+    registryRevision: registryDiagnostics.revision,
+    registryTransactions: registryDiagnostics.transactionCount,
+    stores: PROJECTION_STATE_FILES.map(stateFileSignature),
+    healthBucket: Math.floor(now / PROJECTION_HEALTH_BUCKET_MS),
+  }));
+  return hash.digest("hex");
+}
+
+function rememberProjection(key: string, representation: ProjectionRepresentation): void {
+  const cache = projectionCache();
+  cache.delete(key);
+  cache.set(key, representation);
+  while (cache.size > PROJECTION_CACHE_MAX) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+async function projectionFor(
+  key: string,
+  request: Request,
+  scan: CachedScan,
+): Promise<ProjectionResult> {
+  const cached = projectionCache().get(key);
+  if (cached) return { representation: cached, cacheStatus: "hit" };
+
+  const current = projectionInflight().get(key);
+  if (current) return { representation: await current, cacheStatus: "joined" };
+
+  const promise = (async () => {
+    const headers = new Headers(request.headers);
+    headers.delete("if-none-match");
+    const projectionRequest = new Request(request.url, { headers });
+    const response = await buildFilesResponse(projectionRequest, {
+      listFilesWithProjectCatalog: async () => {
+        return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
+      },
+    });
+    const representation = {
+      body: await response.text(),
+      contentType: response.headers.get("content-type") ?? "application/json",
+      etag: response.headers.get("etag") ?? "",
+      timing: response.headers.get("server-timing") ?? "",
+    };
+    rememberProjection(key, representation);
+    return representation;
+  })();
+  projectionInflight().set(key, promise);
+  try {
+    return { representation: await promise, cacheStatus: "miss" };
+  } finally {
+    if (projectionInflight().get(key) === promise) projectionInflight().delete(key);
+  }
+}
 
 function applyScanHeaders(response: Response, scan: CachedScan, projectionTiming?: string | null): void {
   response.headers.set("x-llv-files-generation", String(scan.generation));
@@ -57,12 +177,21 @@ export async function GET(request: Request): Promise<Response> {
     return response;
   }
 
-  const response = await buildFilesResponse(request, {
-    listFilesWithProjectCatalog: async () => {
-      return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
+  const key = projectionKey(scan, selectedProject, pinnedPath, Date.now());
+  const projected = await projectionFor(key, request, scan);
+  const notModified = request.headers.get("if-none-match") === projected.representation.etag;
+  const projectionTiming = [
+    projected.representation.timing,
+    `files-projection-cache;dur=0.0;desc="${projected.cacheStatus}"`,
+  ].filter(Boolean).join(", ");
+  const response = new Response(notModified ? null : projected.representation.body, {
+    status: notModified ? 304 : 200,
+    headers: {
+      ETag: projected.representation.etag,
+      ...(notModified ? {} : { "content-type": projected.representation.contentType }),
+      "x-llv-files-projection-cache": projected.cacheStatus,
     },
   });
-  const projectionTiming = response.headers.get("server-timing");
   applyScanHeaders(response, scan, projectionTiming);
   return response;
 }


### PR DESCRIPTION
## Summary
- singleflight identical `/api/files` projections so concurrent polls share one registry/store read
- cache byte-stable representations across unchanged scanner generations
- invalidate on scanner content, registry revision/transactions, and durable store signatures
- keep the cache bounded and refresh volatile health once per minute

## Evidence
- 75 files route/performance tests pass, including one scan + one projection for concurrent cold reads
- production-sized SQLite cold probe stays within its existing budget; warm unchanged requests reuse the representation
- TypeScript, focused ESLint, production build, and privacy publication gate pass
