### PR TITLE
fix: isolate files projection from the HTTP runtime

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     "/*": [
       ".next/server/file-scanner-worker.js",
+      ".next/server/files-response-worker.js",
       ".next/server/resource-collector-worker.js",
     ],
   },
@@ -21,6 +22,7 @@ const nextConfig: NextConfig = {
       config.entry = async () => ({
         ...(typeof originalEntry === "function" ? await originalEntry() : originalEntry),
         "file-scanner-worker": "./src/lib/fileScanner.worker.ts",
+        "files-response-worker": "./src/lib/filesResponse.worker.ts",
         "resource-collector-worker": "./src/lib/resourceCollector.worker.ts",
       });
     }

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -5,6 +5,7 @@ import { agentRegistry } from "@/lib/agent/registry";
 import { statePath } from "@/lib/configDir";
 import { buildFilesResponse } from "./response";
 import { cachedFileScan } from "@/lib/scanner/scanCache";
+import { buildFilesResponseInWorker, filesResponseWorkerEnabled } from "@/lib/scanner/filesResponseWorker";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -110,18 +111,26 @@ async function projectionFor(
   const promise = (async () => {
     const headers = new Headers(request.headers);
     headers.delete("if-none-match");
-    const projectionRequest = new Request(request.url, { headers });
-    const response = await buildFilesResponse(projectionRequest, {
-      listFilesWithProjectCatalog: async () => {
-        return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
-      },
-    });
-    const representation = {
-      body: await response.text(),
-      contentType: response.headers.get("content-type") ?? "application/json",
-      etag: response.headers.get("etag") ?? "",
-      timing: response.headers.get("server-timing") ?? "",
-    };
+    const snapshot = { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
+    let representation: ProjectionRepresentation;
+    if (filesResponseWorkerEnabled()) {
+      representation = await buildFilesResponseInWorker({
+        type: "project",
+        url: request.url,
+        headers: [...headers.entries()],
+        snapshot,
+      });
+    } else {
+      const response = await buildFilesResponse(new Request(request.url, { headers }), {
+        listFilesWithProjectCatalog: async () => snapshot,
+      });
+      representation = {
+        body: await response.text(),
+        contentType: response.headers.get("content-type") ?? "application/json",
+        etag: response.headers.get("etag") ?? "",
+        timing: response.headers.get("server-timing") ?? "",
+      };
+    }
     rememberProjection(key, representation);
     return representation;
   })();

--- a/src/lib/filesResponse.worker.ts
+++ b/src/lib/filesResponse.worker.ts
@@ -1,0 +1,58 @@
+import { buildFilesResponse } from "@/app/api/files/response";
+import type { FilesResponseWorkerRequest } from "@/lib/scanner/filesResponseWorker";
+
+const INPUT_MAX_BYTES = 8 * 1024 * 1024;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function workerRequest(value: unknown): FilesResponseWorkerRequest | null {
+  if (!record(value)
+    || value.type !== "project"
+    || typeof value.url !== "string"
+    || !Array.isArray(value.headers)
+    || !record(value.snapshot)
+    || !Array.isArray(value.snapshot.files)
+    || !Array.isArray(value.snapshot.projectCatalog)) return null;
+  return value as unknown as FilesResponseWorkerRequest;
+}
+
+async function run(value: unknown): Promise<void> {
+  const request = workerRequest(value);
+  if (!request) throw new Error("files response worker received an invalid request");
+  const response = await buildFilesResponse(new Request(request.url, {
+    headers: new Headers(request.headers),
+  }), {
+    listFilesWithProjectCatalog: async () => request.snapshot,
+  });
+  process.stdout.write(JSON.stringify({
+    body: await response.text(),
+    contentType: response.headers.get("content-type") ?? "application/json",
+    etag: response.headers.get("etag") ?? "",
+    timing: response.headers.get("server-timing") ?? "",
+  }));
+}
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+  input += chunk;
+  if (Buffer.byteLength(input) > INPUT_MAX_BYTES) {
+    process.stderr.write("files response worker input exceeded limit\n");
+    process.exitCode = 1;
+    process.stdin.destroy();
+  }
+});
+process.stdin.on("end", () => {
+  if (process.exitCode) return;
+  try {
+    void run(JSON.parse(input)).catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    });
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+});

--- a/src/lib/scanner/filesResponseWorker.test.ts
+++ b/src/lib/scanner/filesResponseWorker.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { buildFilesResponseInWorker } from "./filesResponseWorker";
+
+test("files response projection runs in an isolated worker process", async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-response-worker-"));
+  try {
+    const result = await buildFilesResponseInWorker({
+      type: "project",
+      url: "http://127.0.0.1/api/files",
+      headers: [],
+      snapshot: { files: [], projectCatalog: [], complete: true },
+    }, {
+      launch: {
+        executable: process.execPath,
+        workerPath: path.resolve(import.meta.dir, "../filesResponse.worker.ts"),
+      },
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        LLV_STATE_DIR: stateDir,
+        LLV_AGENT_REGISTRY_SQLITE: "off",
+        LLV_FILES_RESPONSE_WORKER: "1",
+      },
+      timeoutMs: 10_000,
+    });
+    expect(result.etag).toMatch(/^"[a-f0-9]{40}"$/);
+    expect(result.contentType).toContain("application/json");
+    expect(JSON.parse(result.body)).toMatchObject({
+      files: [],
+      projectCatalog: [],
+      flows: [],
+      pipelines: [],
+      workflows: [],
+      tasks: [],
+    });
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/src/lib/scanner/filesResponseWorker.ts
+++ b/src/lib/scanner/filesResponseWorker.ts
@@ -1,0 +1,133 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
+
+import type { FileCatalogScan } from "./index";
+
+const FILES_RESPONSE_WORKER_TIMEOUT_MS = 60_000;
+const FILES_RESPONSE_WORKER_OUTPUT_MAX_BYTES = 16 * 1024 * 1024;
+const FILES_RESPONSE_WORKER_STDERR_MAX_BYTES = 4 * 1024;
+
+export type FilesResponseRepresentation = {
+  body: string;
+  contentType: string;
+  etag: string;
+  timing: string;
+};
+
+export type FilesResponseWorkerRequest = {
+  type: "project";
+  url: string;
+  headers: Array<[string, string]>;
+  snapshot: FileCatalogScan;
+};
+
+export interface FilesResponseWorkerRuntime {
+  launch?: { executable: string; workerPath: string };
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function representation(value: unknown): FilesResponseRepresentation | null {
+  if (!record(value)
+    || typeof value.body !== "string"
+    || typeof value.contentType !== "string"
+    || typeof value.etag !== "string"
+    || typeof value.timing !== "string") return null;
+  return value as unknown as FilesResponseRepresentation;
+}
+
+function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: string } {
+  const source = path.join(cwd, "src/lib/filesResponse.worker.ts");
+  const bundled = path.join(cwd, ".next/server/files-response-worker.js");
+  if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
+    return { executable: "/usr/local/bin/bun-container", workerPath: source };
+  }
+  if (fs.existsSync(bundled)) return { executable: process.execPath, workerPath: bundled };
+  return { executable: process.execPath, workerPath: source };
+}
+
+export function filesResponseWorkerEnabled(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.NODE_ENV !== "test"
+    && env.LLV_FILES_RESPONSE_WORKER !== "1"
+    && env.LLV_FILES_RESPONSE_WORKER_DISABLED !== "1";
+}
+
+export function buildFilesResponseInWorker(
+  request: FilesResponseWorkerRequest,
+  runtime: FilesResponseWorkerRuntime = {},
+): Promise<FilesResponseRepresentation> {
+  const launch = runtime.launch ?? workerLaunch(runtime.cwd);
+  const child = spawn(launch.executable, [launch.workerPath], {
+    cwd: runtime.cwd ?? process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...withoutWakatimeCredential(runtime.env ?? process.env),
+      LLV_FILES_RESPONSE_WORKER: "1",
+    },
+  });
+  return new Promise<FilesResponseRepresentation>((resolve, reject) => {
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    const finish = (error?: Error, result?: FilesResponseRepresentation) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    const fail = (message: string) => {
+      try { child.kill("SIGKILL"); } catch { /* child already exited */ }
+      finish(new Error(message));
+    };
+    const timer = setTimeout(() => fail("files response worker timed out"), runtime.timeoutMs ?? FILES_RESPONSE_WORKER_TIMEOUT_MS);
+    child.once("error", (error) => finish(error));
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      outputBytes += Buffer.byteLength(chunk);
+      if (outputBytes > FILES_RESPONSE_WORKER_OUTPUT_MAX_BYTES) {
+        fail("files response worker exceeded output limit");
+        return;
+      }
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr = `${stderr}${chunk}`;
+      if (Buffer.byteLength(stderr) > FILES_RESPONSE_WORKER_STDERR_MAX_BYTES) {
+        stderr = Buffer.from(stderr).subarray(-FILES_RESPONSE_WORKER_STDERR_MAX_BYTES).toString("utf8");
+      }
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        const detail = stderr.trim();
+        finish(new Error(`files response worker emitted invalid JSON${detail ? `: ${detail}` : ""}`));
+        return;
+      }
+      const result = representation(parsed);
+      if (code !== 0 || !result) {
+        const detail = stderr.trim();
+        finish(new Error(`files response worker exited before completion (${signal ?? code ?? "unknown"})${detail ? `: ${detail}` : ""}`));
+        return;
+      }
+      finish(undefined, result);
+    });
+    child.stdin.once("error", (error) => finish(error));
+    child.stdin.end(JSON.stringify(request));
+  });
+}


### PR DESCRIPTION
## Summary
- run cold `/api/files` projection work in a bounded worker process
- keep the HTTP event loop responsive while large registry/flow/pipeline snapshots are projected
- preserve keyed singleflight and representation caching for identical board requests
- bundle the worker in standalone releases and cap input, output, stderr, and runtime

## Evidence
- isolated worker integration test passes
- 76 focused files route, projection performance, and worker tests pass
- TypeScript and focused ESLint pass
- production webpack build includes `files-response-worker.js`
- privacy publication gate passes
