### PR TITLE
fix: bound cold project attribution in files projection

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -78,9 +78,20 @@ function projectedProjectCatalog(
 export async function buildFilesResponse(request: Request, dependencies: FilesRouteDependencies): Promise<NextResponse> {
   const timings: string[] = [];
   let timingMark = performance.now();
+  let traceMark = timingMark;
+  const traceStep = (name: string) => {
+    if (process.env.LLV_FILES_RESPONSE_TRACE !== "1") return;
+    const now = performance.now();
+    console.error(`[files projection trace] ${name} ${(now - traceMark).toFixed(1)}ms`);
+    traceMark = now;
+  };
   const markTiming = (name: string) => {
     const now = performance.now();
-    timings.push(`${name};dur=${(now - timingMark).toFixed(1)}`);
+    const duration = now - timingMark;
+    timings.push(`${name};dur=${duration.toFixed(1)}`);
+    if (process.env.LLV_FILES_RESPONSE_TRACE === "1") {
+      console.error(`[files projection] ${name} ${duration.toFixed(1)}ms`);
+    }
     timingMark = now;
   };
   const url = new URL(request.url);
@@ -94,16 +105,19 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   // the external scheduler, keeping repeated GETs byte-stable for state files.
   const registry = agentRegistry();
   const registrySnapshot = registry.readOnlySnapshot();
+  traceStep("registry-snapshot");
   /* One launch read-model (issue #569): a launch either projects the
      conversation window itself (nothing materialized yet) or folds into the
      live conversation as transient chips — never both. */
   const launchProjection = projectLaunchConversations(files, registrySnapshot);
+  traceStep("launch-projection");
   files.push(...launchProjection.cards);
   for (const file of files) {
     const launch = launchProjection.facts.get(file.path);
     if (launch) file.launch = launch;
   }
   const conversationLookup = readOnlyConversationLookupFromSnapshot(registrySnapshot);
+  traceStep("conversation-lookup");
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   for (let index = 0; index < files.length; index += 1) {
@@ -168,6 +182,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     filesByPath.set(parentPath, placeholder);
     if (responsePinOverlayPaths.has(child.path)) responsePinOverlayPaths.add(parentPath);
   }
+  traceStep("parent-closure");
   const scannedPaths = new Set(files.map((file) => file.path));
   /* Receipt-owned conversations (issue #339): a Viewer launch persists a spawn
      receipt against the conversation it created. Those carry `viewer`
@@ -177,6 +192,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   for (const receipt of Object.values(registrySnapshot.receipts)) {
     receiptOwnedConversationIds.add(conversationLookup.canonicalConversationId(receipt.conversationId));
   }
+  traceStep("receipt-owners");
   /* Supersedence lineage (issue #383): the reverse edge map gives each chain
      tail its immediate predecessor and its round number (chain depth + 1),
      bounded so a malformed chain can never hang the scan. */
@@ -188,6 +204,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       supersedencePredecessors.set(successorId, candidate.id);
     }
   }
+  traceStep("supersedence-index");
   const supersedenceRound = (conversationId: string): number => {
     let round = 1;
     const seen = new Set<string>([conversationId]);
@@ -363,6 +380,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       };
     }
   }
+  traceStep("file-registry-overlay");
   markTiming("files-registry");
   /* Custom session titles (issue #33) are the last word on `title`. The shared
      projection runs after the registry has stamped `conversationId` and the
@@ -372,7 +390,10 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      on `autoTitle`; the `renamable` flag is projected too so the client never
      imports the Node-only store. */
   const flowsStartedAt = performance.now();
-  overlaySessionTitles(files, registrySnapshot);
+  /* The scanner rows already carry canonical project roots/display names.
+     Re-resolving every historical worktree cwd here costs tens of seconds on a
+     cold worker and cannot improve this request-level metadata. */
+  overlaySessionTitles(files, registrySnapshot, false);
   markTiming("files-session-titles");
   /* Durable project affinity: a Viewer-launched family whose root transcript
      recorded a bare directory above the repository its lineage works in (an

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -29,8 +29,7 @@ type ProjectionResult = {
   cacheStatus: "hit" | "joined" | "miss";
 };
 
-const PROJECTION_CACHE_MAX = 8;
-const PROJECTION_HEALTH_BUCKET_MS = 60_000;
+const PROJECTION_CACHE_MAX = 32;
 const PROJECTION_STATE_FILES = [
   "flows.json",
   "pipelines.json",
@@ -43,6 +42,7 @@ const PROJECTION_STATE_FILES = [
 const projectionCacheStore = globalThis as typeof globalThis & {
   __llvFilesProjectionCache?: Map<string, ProjectionRepresentation>;
   __llvFilesProjectionInflight?: Map<string, Promise<ProjectionRepresentation>>;
+  __llvFilesProjectionWorkerTail?: Promise<void>;
 };
 
 function projectionCache(): Map<string, ProjectionRepresentation> {
@@ -69,7 +69,6 @@ function projectionKey(
   scan: CachedScan,
   selectedProject: string | undefined,
   pinnedPath: string | undefined,
-  now: number,
 ): string {
   const registryDiagnostics = agentRegistry().storageDiagnostics();
   const hash = createHash("sha1");
@@ -81,9 +80,17 @@ function projectionKey(
     registryRevision: registryDiagnostics.revision,
     registryTransactions: registryDiagnostics.transactionCount,
     stores: PROJECTION_STATE_FILES.map(stateFileSignature),
-    healthBucket: Math.floor(now / PROJECTION_HEALTH_BUCKET_MS),
   }));
   return hash.digest("hex");
+}
+
+function queueProjectionWorker(
+  build: () => Promise<ProjectionRepresentation>,
+): Promise<ProjectionRepresentation> {
+  const previous = projectionCacheStore.__llvFilesProjectionWorkerTail ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(build);
+  projectionCacheStore.__llvFilesProjectionWorkerTail = current.then(() => undefined, () => undefined);
+  return current;
 }
 
 function rememberProjection(key: string, representation: ProjectionRepresentation): void {
@@ -114,12 +121,13 @@ async function projectionFor(
     const snapshot = { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
     let representation: ProjectionRepresentation;
     if (filesResponseWorkerEnabled()) {
-      representation = await buildFilesResponseInWorker({
-        type: "project",
-        url: request.url,
-        headers: [...headers.entries()],
-        snapshot,
-      });
+      representation = await queueProjectionWorker(() =>
+        buildFilesResponseInWorker({
+          type: "project",
+          url: request.url,
+          headers: [...headers.entries()],
+          snapshot,
+        }));
     } else {
       const response = await buildFilesResponse(new Request(request.url, { headers }), {
         listFilesWithProjectCatalog: async () => snapshot,
@@ -186,7 +194,7 @@ export async function GET(request: Request): Promise<Response> {
     return response;
   }
 
-  const key = projectionKey(scan, selectedProject, pinnedPath, Date.now());
+  const key = projectionKey(scan, selectedProject, pinnedPath);
   const projected = await projectionFor(key, request, scan);
   const notModified = request.headers.get("if-none-match") === projected.representation.etag;
   const projectionTiming = [

--- a/src/lib/scanner/filesResponseWorker.ts
+++ b/src/lib/scanner/filesResponseWorker.ts
@@ -91,7 +91,10 @@ export function buildFilesResponseInWorker(
       try { child.kill("SIGKILL"); } catch { /* child already exited */ }
       finish(new Error(message));
     };
-    const timer = setTimeout(() => fail("files response worker timed out"), runtime.timeoutMs ?? FILES_RESPONSE_WORKER_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      const detail = stderr.trim();
+      fail(`files response worker timed out${detail ? `: ${detail}` : ""}`);
+    }, runtime.timeoutMs ?? FILES_RESPONSE_WORKER_TIMEOUT_MS);
     child.once("error", (error) => finish(error));
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {

--- a/src/lib/session/projectResolution.ts
+++ b/src/lib/session/projectResolution.ts
@@ -25,6 +25,9 @@ export type ProjectAttributionSource = "ownership" | "cwd" | "launch-profile" | 
 export interface ProjectAttributionInput {
   projectOwnership?: ConversationProjectOwnership | null;
   cwd?: string | null;
+  /** Optional caller-owned cwd projection cache. Presence, including null,
+      suppresses another disk-backed worktree resolution. */
+  cwdInfo?: ReturnType<typeof projectInfoFromCwd>;
   launchProfileProject?: string | null;
   fallbackProject?: string | null;
 }
@@ -37,7 +40,7 @@ export interface ProjectAttribution {
 
 export function resolveProjectAttribution(input: ProjectAttributionInput): ProjectAttribution {
   const cwd = input.cwd?.trim();
-  const cwdInfo = cwd ? projectInfoFromCwd(cwd) : null;
+  const cwdInfo = Object.hasOwn(input, "cwdInfo") ? input.cwdInfo ?? null : cwd ? projectInfoFromCwd(cwd) : null;
   const ownership = input.projectOwnership?.project.trim();
   if (ownership) {
     return { project: canonicalProject(ownership), ...(cwdInfo?.worktree ? { worktree: cwdInfo.worktree } : {}), source: "ownership" };

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -21,7 +21,9 @@ interface RegistryProjection {
   aliasesByCanonical: Map<string, string[]>;
   ownedPathsByConversation: Map<string, string[]>;
   projectByPath: Map<string, string>;
-  projectMetadataByPath: Map<string, { displayName: string; projectRoot?: string; unresolved?: true }>;
+  projectMetadataByPath: {
+    get(pathname: string): { displayName: string; projectRoot?: string; unresolved?: true } | undefined;
+  };
   archivedPaths: Set<string>;
 }
 
@@ -31,6 +33,7 @@ interface RegistryProjection {
    JSON file without changing the revision and therefore no longer invalidates
    this cache (issue #798). */
 const snapshotProjectionCache = new WeakMap<RegistrySnapshot, RegistryProjection>();
+const snapshotIdentityProjectionCache = new WeakMap<RegistrySnapshot, RegistryProjection>();
 let readOnlyRegistryProjectionCache: RegistryProjection | null = null;
 
 function canonicalConversationId(snapshot: RegistrySnapshot, alias: string): string {
@@ -45,12 +48,16 @@ function canonicalConversationId(snapshot: RegistrySnapshot, alias: string): str
   return current;
 }
 
-function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string): RegistryProjection {
+function projectRegistrySnapshot(
+  snapshot: RegistrySnapshot,
+  signature: string,
+  includeProjects = true,
+): RegistryProjection {
   const conversationByPath = new Map<string, ViewerConversationId>();
   const aliasesByCanonical = new Map<string, string[]>();
   const ownedPathsByConversation = new Map<string, string[]>();
   const projectByPath = new Map<string, string>();
-  const projectMetadataByPath = new Map<string, { displayName: string; projectRoot?: string; unresolved?: true }>();
+  const projectCwdByPath = new Map<string, string>();
   const archivedPaths = new Set<string>();
   for (const conversation of Object.values(snapshot.conversations)) {
     const owned = [...conversation.generations.map((generation) => generation.path), ...conversation.continuityPaths];
@@ -58,20 +65,15 @@ function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string):
     for (const pathname of owned) if (!conversationByPath.has(pathname)) conversationByPath.set(pathname, conversation.id);
     const latest = conversation.generations.at(-1);
     if (!latest) continue;
-    const { project } = resolveProjectAttribution({
-      projectOwnership: conversation.projectOwnership,
-      cwd: latest.launchProfile.cwd,
-      launchProfileProject: latest.launchProfile.project,
-    });
-    if (project) {
-      projectByPath.set(latest.path, project);
-      const cwdInfo = latest.launchProfile.cwd ? projectInfoFromCwd(latest.launchProfile.cwd) : null;
-      if (cwdInfo?.project === project) {
-        projectMetadataByPath.set(latest.path, {
-          displayName: cwdInfo.displayName,
-          ...(cwdInfo.repo ? { projectRoot: cwdInfo.repo } : {}),
-          ...(cwdInfo.unresolved ? { unresolved: true as const } : {}),
-        });
+    if (includeProjects) {
+      const { project } = resolveProjectAttribution({
+        projectOwnership: conversation.projectOwnership,
+        cwd: latest.launchProfile.cwd,
+        launchProfileProject: latest.launchProfile.project,
+      });
+      if (project) {
+        projectByPath.set(latest.path, project);
+        if (latest.launchProfile.cwd) projectCwdByPath.set(latest.path, latest.launchProfile.cwd);
       }
     }
     for (const generation of conversation.generations) {
@@ -87,6 +89,35 @@ function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string):
     const list = aliasesByCanonical.get(canonical);
     if (list) list.push(alias); else aliasesByCanonical.set(canonical, [alias]);
   }
+  /* Resolve disk-backed cwd metadata only for paths a caller actually renders.
+     A historical registry can own thousands of one-off worktree cwd values,
+     while one board response asks for only a few hundred current paths. */
+  const projectMetadataCache = new Map<string, { displayName: string; projectRoot?: string; unresolved?: true } | null>();
+  const projectInfoByCwd = new Map<string, ReturnType<typeof projectInfoFromCwd>>();
+  const projectMetadataByPath = {
+    get(pathname: string) {
+      const cached = projectMetadataCache.get(pathname);
+      if (cached !== undefined) return cached ?? undefined;
+      const cwd = projectCwdByPath.get(pathname);
+      const project = projectByPath.get(pathname);
+      if (!cwd || !project) {
+        projectMetadataCache.set(pathname, null);
+        return undefined;
+      }
+      let cwdInfo = projectInfoByCwd.get(cwd);
+      if (!projectInfoByCwd.has(cwd)) {
+        cwdInfo = projectInfoFromCwd(cwd);
+        projectInfoByCwd.set(cwd, cwdInfo);
+      }
+      const metadata = cwdInfo?.project === project ? {
+        displayName: cwdInfo.displayName,
+        ...(cwdInfo.repo ? { projectRoot: cwdInfo.repo } : {}),
+        ...(cwdInfo.unresolved ? { unresolved: true as const } : {}),
+      } : null;
+      projectMetadataCache.set(pathname, metadata);
+      return metadata ?? undefined;
+    },
+  };
   const projection = {
     signature,
     snapshot,
@@ -108,6 +139,14 @@ export function registryProjectionForSnapshot(snapshot: RegistrySnapshot): Regis
   if (cached) return cached;
   const projection = projectRegistrySnapshot(snapshot, "snapshot");
   snapshotProjectionCache.set(snapshot, projection);
+  return projection;
+}
+
+function registryIdentityProjectionForSnapshot(snapshot: RegistrySnapshot): RegistryProjection {
+  const cached = snapshotIdentityProjectionCache.get(snapshot);
+  if (cached) return cached;
+  const projection = projectRegistrySnapshot(snapshot, "snapshot-identity", false);
+  snapshotIdentityProjectionCache.set(snapshot, projection);
   return projection;
 }
 
@@ -153,10 +192,19 @@ function readOnlyRegistryProjection(): RegistryProjection | null {
  * safe to run after the files response has already stamped identity/launch
  * profile — it never re-derives `autoTitle` once set.
  */
-export function overlaySessionTitles(entries: FileEntry[], registrySnapshot?: RegistrySnapshot): void {
+export function overlaySessionTitles(
+  entries: FileEntry[],
+  registrySnapshot?: RegistrySnapshot,
+  includeProjectMetadata = true,
+): void {
   const project = sessionTitleProjector(
     true,
-    registrySnapshot === undefined ? undefined : registryProjectionForSnapshot(registrySnapshot),
+    registrySnapshot === undefined
+      ? undefined
+      : includeProjectMetadata
+        ? registryProjectionForSnapshot(registrySnapshot)
+        : registryIdentityProjectionForSnapshot(registrySnapshot),
+    includeProjectMetadata,
   );
   for (const entry of entries) project(entry);
 }
@@ -171,6 +219,7 @@ export function overlayResourceSessionTitles(entries: FileEntry[]): void {
 function sessionTitleProjector(
   includeRenameEligibility = true,
   suppliedProjection?: RegistryProjection | null,
+  includeProjectMetadata = true,
 ): (entry: FileEntry) => void {
   const index = indexSessionTitles(loadSessionTitles());
   const projection = suppliedProjection === undefined ? registryProjection(agentRegistry()) : suppliedProjection;
@@ -193,19 +242,21 @@ function sessionTitleProjector(
     const latest = conversation?.generations.at(-1);
     if (latest?.path === entry.path) {
       entry.title = latest.launchProfile.title ?? entry.title;
-      entry.project = resolveProjectAttribution({
-        projectOwnership: conversation?.projectOwnership,
-        cwd: latest.launchProfile.cwd,
-        launchProfileProject: latest.launchProfile.project,
-        fallbackProject: entry.project,
-      }).project ?? entry.project;
-      const projectMetadata = projection?.projectMetadataByPath.get(entry.path);
-      if (projectMetadata) {
-        entry.projectName = projectMetadata.displayName;
-        entry.projectRoot = projectMetadata.projectRoot ?? entry.projectRoot;
-        entry.projectUnresolved = projectMetadata.unresolved;
+      if (includeProjectMetadata) {
+        entry.project = resolveProjectAttribution({
+          projectOwnership: conversation?.projectOwnership,
+          cwd: latest.launchProfile.cwd,
+          launchProfileProject: latest.launchProfile.project,
+          fallbackProject: entry.project,
+        }).project ?? entry.project;
+        const projectMetadata = projection?.projectMetadataByPath.get(entry.path);
+        if (projectMetadata) {
+          entry.projectName = projectMetadata.displayName;
+          entry.projectRoot = projectMetadata.projectRoot ?? entry.projectRoot;
+          entry.projectUnresolved = projectMetadata.unresolved;
+        }
+        if (conversation?.projectOwnership) entry.projectOwnership = { ...conversation.projectOwnership };
       }
-      if (conversation?.projectOwnership) entry.projectOwnership = { ...conversation.projectOwnership };
     }
     if (includeRenameEligibility) entry.renamable = isRenameableSessionEntry(entry);
     if (index.size > 0) {
@@ -246,7 +297,9 @@ export function overlaySessionProjects(entries: FileEntry[]): void {
  * free of another registry parse. */
 export function sessionProjectProjection(surfaceUnexpectedError = false): {
   projectByPath: ReadonlyMap<string, string>;
-  projectMetadataByPath: ReadonlyMap<string, { displayName: string; projectRoot?: string; unresolved?: true }>;
+  projectMetadataByPath: {
+    get(pathname: string): { displayName: string; projectRoot?: string; unresolved?: true } | undefined;
+  };
   archivedPaths: ReadonlySet<string>;
 } {
   const projection = registryProjection(agentRegistry(), surfaceUnexpectedError);


### PR DESCRIPTION
## Summary
- stop resolving disk-backed cwd/project metadata for every historical conversation in a board response
- build an identity-only title projection for rows that already carry scanner project metadata
- resolve project metadata lazily for callers that actually request a path
- serialize distinct cold response workers and retain up to 32 stable board representations

## Production-shaped evidence
- same copied production registry (4,644 conversations) and scanner snapshot
- before: 41,680 ms total; session-title phase 36,738 ms
- after: 4,505 ms through the isolated response worker; session-title phase 59.7 ms
- subsequent unchanged polls use the representation cache

## Verification
- 83 focused route, response, worker, and title-projection tests pass
- TypeScript and focused ESLint pass
- production webpack build includes the updated response worker
- privacy publication gate passes
