### PR TITLE
fix(board): keep idle history off the active canvas

### DIFF
--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -6,6 +6,7 @@ import {
   buildArchiveBranchGroups,
   buildBranchGroups,
   buildProjectSummaries,
+  collapsedTrees,
   draftWorkingDirectory,
   descendantCounts,
   isConversation,
@@ -348,6 +349,21 @@ describe("buildBranchGroups", () => {
     const group = groups.find((candidate) => candidate.key === "/parent")!;
     expect(group.columns.map((column) => column.file.path)).toContain("/parent/attn");
   });
+});
+
+test("collapsed tree cards keep unsettled work and leave idle history off the canvas", () => {
+  const idleRoot = entry({ path: "/idle-root" });
+  const idleChild = entry({ path: "/idle-child", parent: idleRoot.path, kind: "subagent" });
+  const stalledRoot = entry({ path: "/stalled-root" });
+  const stalledChild = entry({
+    path: "/stalled-child",
+    parent: stalledRoot.path,
+    kind: "subagent",
+    activity: "stalled",
+  });
+
+  expect(collapsedTrees([idleRoot, idleChild, stalledRoot, stalledChild], "demo", new Set())
+    .map((card) => card.root.path)).toEqual(["/stalled-root"]);
 });
 
 describe("buildArchiveBranchGroups", () => {

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -524,9 +524,9 @@ export interface TreeCard {
 }
 
 /**
- * Quiet trees of the project: root conversations without a dashboard group
- * but with descendants. Shown as compact collapsed cards on the same canvas,
- * expandable in place.
+ * Unsettled trees of the project that have not entered a full dashboard group.
+ * Fully idle history stays in the history surface instead of repopulating the
+ * canvas and minimap with one compact card per old worker tree.
  */
 export function collapsedTrees(files: FileEntry[], project: string, activeRoots: ReadonlySet<string>): TreeCard[] {
   const kids = kidsIndex(files);
@@ -541,7 +541,7 @@ export function collapsedTrees(files: FileEntry[], project: string, activeRoots:
       smt = Math.max(smt, node.mtime);
       band = Math.min(band, activityBand(node)) as ActivityBand;
     }
-    cards.push({ root: file, branchCount: descendants.length, smt, band });
+    if (band < 3) cards.push({ root: file, branchCount: descendants.length, smt, band });
   }
   return cards.sort((a, b) => a.band - b.band || b.smt - a.smt);
 }


### PR DESCRIPTION
## Summary
- keep fully idle conversation trees in the history surface
- reserve canvas and minimap cards for live, recent, or stalled work

## Verification
- `bun test src/components/projectModel.test.ts` (39 pass)
- TypeScript and focused ESLint
- production build
- privacy publication gate
