### PR TITLE
fix(projects): reject cross-repository alias poisoning

### DIFF
--- a/src/lib/projects/aliases.test.ts
+++ b/src/lib/projects/aliases.test.ts
@@ -142,6 +142,33 @@ test("one poisoned record cannot block a majority-backed legacy source", () => {
   });
 });
 
+test("a canonical repository id with foreign records never aliases to another repository", () => {
+  const repositories = ["current-repository", "foreign-repository"].map((name) => {
+    const repository = path.join(SANDBOX, name);
+    fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repository, ".git", "config"), [
+      '[remote "origin"]',
+      `\turl = ssh://git@example.invalid/team/${name}.git`,
+      "",
+    ].join("\n"));
+    return repository;
+  });
+  const current = projectIdentityFromRepositoryRoot(repositories[0]!)!;
+  fs.mkdirSync(process.env.LLV_STATE_DIR!, { recursive: true });
+  fs.writeFileSync(path.join(process.env.LLV_STATE_DIR!, "flows.json"), JSON.stringify({
+    flows: [
+      { project: current.project, cwd: repositories[0] },
+      { project: current.project, cwd: repositories[1] },
+      { project: current.project, cwd: repositories[1] },
+    ],
+  }));
+
+  expect(durableProjectAliasCandidates()).toEqual({
+    registrations: [],
+    conflicts: [current.project],
+  });
+});
+
 test("a durable alias from a deleted worktree checkout resolves through the worktree map", () => {
   const repository = path.join(SANDBOX, "deleted-worktree-main");
   fs.mkdirSync(path.join(repository, ".git"), { recursive: true });

--- a/src/lib/projects/aliases.ts
+++ b/src/lib/projects/aliases.ts
@@ -198,7 +198,7 @@ export function durableProjectAliasCandidates(): DurableProjectAliasCandidates {
   for (const [source, candidatePath] of pairs) {
     const root = repositoryRootForPath(candidatePath) ?? rememberedRepositories.get(candidatePath);
     const identity = root ? projectIdentityFromRepositoryRoot(root) : null;
-    if (!identity || source === identity.project) continue;
+    if (!identity) continue;
     const sourceTargets = targets.get(source) ?? new Map<string, TargetEvidence>();
     const evidence = sourceTargets.get(identity.project) ?? {
       registration: { source, target: identity.project, displayName: identity.displayName },
@@ -211,6 +211,14 @@ export function durableProjectAliasCandidates(): DurableProjectAliasCandidates {
   const registrations: ProjectAliasRegistration[] = [];
   const conflicts: string[] = [];
   for (const [source, sourceTargets] of targets) {
+    /* A repository id that still points at its own repository is already a
+       valid canonical identity. Historical records stamped with that same id
+       while rooted in another repository are per-record corruption; turning
+       them into a global alias would merge two unrelated boards. */
+    if (sourceTargets.has(source)) {
+      if (sourceTargets.size > 1) conflicts.push(source);
+      continue;
+    }
     const ranked = [...sourceTargets.values()].sort((left, right) => right.records - left.records);
     const total = ranked.reduce((sum, evidence) => sum + evidence.records, 0);
     const leader = ranked[0]!;


### PR DESCRIPTION
## Summary
- count canonical self-evidence when deriving durable project aliases
- reject a global alias when one repository id appears in records rooted in another repository
- preserve separate repository boards despite poisoned historical records

## Verification
- focused project alias and board model suites (47 pass)
- TypeScript and focused ESLint
- production build
- privacy publication gate
