### PR TITLE
fix(files): keep scan-generation transitions responsive

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -243,6 +243,21 @@ test("registry heartbeat writes do not invalidate the completed files projection
   expect(second.headers.get("x-llv-files-projection-cache")).toBe("stale");
 });
 
+test("a stable scope serves its prior conditional representation while projection inputs advance", async () => {
+  scannedFiles = [file("/sessions/current.jsonl")];
+  const first = await GET(new Request("http://127.0.0.1/api/files"));
+  const etag = first.headers.get("etag");
+
+  fs.writeFileSync(path.join(stateDir, "flows.json"), JSON.stringify({ schemaVersion: 1, flows: [] }));
+  const second = await GET(new Request("http://127.0.0.1/api/files", {
+    headers: { "if-none-match": etag! },
+  }));
+
+  expect(second.status).toBe(304);
+  expect(second.headers.get("x-llv-files-generation")).toBe("1");
+  expect(second.headers.get("x-llv-files-projection-cache")).toBe("stale");
+});
+
 test("generation completion retries skip the stale projection while its refresh is running", async () => {
   scannedFiles = [file("/sessions/generation-1.jsonl")];
   const initial = await GET(new Request("http://127.0.0.1/api/files"));

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -80,6 +80,13 @@ function projectionBaseKey(
   })).digest("hex");
 }
 
+function projectionScopeKey(
+  selectedProject: string | undefined,
+  pinnedPath: string | undefined,
+): string {
+  return JSON.stringify([selectedProject ?? null, pinnedPath ?? null]);
+}
+
 function projectionKey(baseKey: string): string {
   const registryDiagnostics = agentRegistry().storageDiagnostics();
   return `${baseKey}:${registryDiagnostics.revision ?? "json"}:${registryDiagnostics.transactionCount}`;
@@ -94,10 +101,10 @@ function queueProjectionWorker(
   return current;
 }
 
-function rememberProjection(baseKey: string, key: string, representation: ProjectionRepresentation): void {
+function rememberProjection(scopeKey: string, key: string, representation: ProjectionRepresentation): void {
   const cache = projectionCache();
-  cache.delete(baseKey);
-  cache.set(baseKey, { key, representation });
+  cache.delete(scopeKey);
+  cache.set(scopeKey, { key, representation });
   while (cache.size > PROJECTION_CACHE_MAX) {
     const oldest = cache.keys().next().value as string | undefined;
     if (oldest === undefined) break;
@@ -106,15 +113,15 @@ function rememberProjection(baseKey: string, key: string, representation: Projec
 }
 
 async function projectionFor(
-  baseKey: string,
+  scopeKey: string,
   key: string,
   request: Request,
   scan: CachedScan,
 ): Promise<ProjectionResult> {
-  const cached = projectionCache().get(baseKey);
+  const cached = projectionCache().get(scopeKey);
   if (cached?.key === key) return { representation: cached.representation, cacheStatus: "hit" };
 
-  const current = projectionInflight().get(baseKey);
+  const current = projectionInflight().get(scopeKey);
   if (current) {
     if (cached && request.headers.has("if-none-match")) {
       return { representation: cached.representation, cacheStatus: "stale" };
@@ -146,12 +153,12 @@ async function projectionFor(
         timing: response.headers.get("server-timing") ?? "",
       };
     }
-    rememberProjection(baseKey, key, representation);
+    rememberProjection(scopeKey, key, representation);
     return representation;
   })();
-  projectionInflight().set(baseKey, promise);
+  projectionInflight().set(scopeKey, promise);
   void promise.catch(() => undefined).finally(() => {
-    if (projectionInflight().get(baseKey) === promise) projectionInflight().delete(baseKey);
+    if (projectionInflight().get(scopeKey) === promise) projectionInflight().delete(scopeKey);
   });
   if (cached && request.headers.has("if-none-match")) {
     return { representation: cached.representation, cacheStatus: "stale" };
@@ -159,7 +166,7 @@ async function projectionFor(
   try {
     return { representation: await promise, cacheStatus: "miss" };
   } finally {
-    if (projectionInflight().get(baseKey) === promise) projectionInflight().delete(baseKey);
+    if (projectionInflight().get(scopeKey) === promise) projectionInflight().delete(scopeKey);
   }
 }
 
@@ -209,7 +216,8 @@ export async function GET(request: Request): Promise<Response> {
 
   const baseKey = projectionBaseKey(scan, selectedProject, pinnedPath);
   const key = projectionKey(baseKey);
-  const projected = await projectionFor(baseKey, key, request, scan);
+  const scopeKey = projectionScopeKey(selectedProject, pinnedPath);
+  const projected = await projectionFor(scopeKey, key, request, scan);
   const notModified = request.headers.get("if-none-match") === projected.representation.etag;
   const projectionTiming = [
     projected.representation.timing,

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -345,9 +345,13 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     if (completionRetry && !ownsCompletionRetry(url, completionRetry)) return snapshot;
     const servedGeneration = responseGeneration(response, "x-llv-files-generation");
     const targetGeneration = responseGeneration(response, "x-llv-files-target-generation");
-    const generationIncomplete = servedGeneration !== undefined
+    const projectionIncomplete = response.headers.get("x-llv-files-projection-cache") === "stale";
+    const completionTargetGeneration = targetGeneration ?? servedGeneration ?? requiredGeneration;
+    const generationIncomplete = completionTargetGeneration !== undefined && (
+      projectionIncomplete || (servedGeneration !== undefined
       && targetGeneration !== undefined
-      && servedGeneration < targetGeneration;
+      && servedGeneration < targetGeneration)
+    );
     if (response.status === 304) {
       if (!representation) throw new Error("files request returned 304 without a cached representation");
       if (generation < appliedGeneration) return snapshot;
@@ -356,12 +360,12 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       rememberRepresentation(url, snapshot, representation.etag);
       settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
       publish(url);
-      if (generationIncomplete) {
+      if (generationIncomplete && completionTargetGeneration !== undefined) {
         scheduleCompletionRetry(
           url,
           pinnedPath,
           revision,
-          targetGeneration,
+          completionTargetGeneration,
           logicalGeneration ?? generation,
           completionRetryAttempt,
           completionRetry,
@@ -390,12 +394,12 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     rememberRepresentation(url, snapshot, etag ?? undefined);
     settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
     publish(url);
-    if (generationIncomplete) {
+    if (generationIncomplete && completionTargetGeneration !== undefined) {
       scheduleCompletionRetry(
         url,
         pinnedPath,
         revision,
-        targetGeneration,
+        completionTargetGeneration,
         logicalGeneration ?? generation,
         completionRetryAttempt,
         completionRetry,


### PR DESCRIPTION
## Summary
- retain the latest completed representation per request scope across scan/store generations
- serve conditional clients immediately while one fresh projection runs
- keep bounded completion retries active until the fresh representation replaces stale data

## Verification
- files route and client cache suites (99 pass)
- TypeScript and focused ESLint
- production build
- privacy publication gate
