### PR TITLE
perf(files): protect request CPU during background refresh

### DIFF
--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -74,7 +74,10 @@ function projectionBaseKey(
   return createHash("sha1").update(JSON.stringify({
     selectedProject: selectedProject ?? null,
     pinnedPath: pinnedPath ?? null,
-    snapshot: scan.snapshot,
+    /* `generation` is the immutable identity of the published snapshot.
+       Re-stringifying every file row on every poll burns the request thread
+       precisely while a new scan is being published. */
+    generation: scan.generation,
     pinOverlayPaths: scan.pinOverlayPaths ?? [],
     stores: PROJECTION_STATE_FILES.map(stateFileSignature),
   })).digest("hex");

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -66,7 +66,14 @@ export function collectFileScanInWorker(
   runtime: FileScanWorkerRuntime = {},
 ): Promise<FileCatalogScan> {
   const launch = runtime.launch ?? workerLaunch(runtime.cwd);
-  const child = spawn(launch.executable, [launch.workerPath], {
+  /* Full-corpus scans are background freshness work. Keep the interactive
+     Next process ahead of their CPU demand on a busy operator host. Explicit
+     test/runtime launch seams retain their exact command. */
+  const useNice = runtime.launch === undefined && fs.existsSync("/usr/bin/nice");
+  const child = spawn(useNice ? "/usr/bin/nice" : launch.executable, [
+    ...(useNice ? ["-n", "10", launch.executable] : []),
+    launch.workerPath,
+  ], {
     cwd: runtime.cwd ?? process.cwd(),
     stdio: ["pipe", "pipe", "pipe"],
     env: {

--- a/src/lib/scanner/filesResponseWorker.ts
+++ b/src/lib/scanner/filesResponseWorker.ts
@@ -67,7 +67,11 @@ export function buildFilesResponseInWorker(
   runtime: FilesResponseWorkerRuntime = {},
 ): Promise<FilesResponseRepresentation> {
   const launch = runtime.launch ?? workerLaunch(runtime.cwd);
-  const child = spawn(launch.executable, [launch.workerPath], {
+  const useNice = runtime.launch === undefined && fs.existsSync("/usr/bin/nice");
+  const child = spawn(useNice ? "/usr/bin/nice" : launch.executable, [
+    ...(useNice ? ["-n", "10", launch.executable] : []),
+    launch.workerPath,
+  ], {
     cwd: runtime.cwd ?? process.cwd(),
     stdio: ["pipe", "pipe", "pipe"],
     env: {


### PR DESCRIPTION
## Summary
- key published snapshots by immutable generation instead of reserializing every row per poll
- lower scheduler priority for full-scan and response-projection worker processes
- preserve fast conditional responses while background freshness work consumes CPU

## Verification
- files route, client cache, and worker suites (102 pass)
- TypeScript and focused ESLint
- production build
- privacy publication gate
