### PR TITLE
perf(files): keep worker payloads off the request pipe

### DIFF
--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -136,6 +136,7 @@ async function projectionFor(
     const headers = new Headers(request.headers);
     headers.delete("if-none-match");
     const snapshot = { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
+    const persistedSnapshot = statePath("files-scan-snapshot.json");
     let representation: ProjectionRepresentation;
     if (filesResponseWorkerEnabled()) {
       representation = await queueProjectionWorker(() =>
@@ -143,7 +144,9 @@ async function projectionFor(
           type: "project",
           url: request.url,
           headers: [...headers.entries()],
-          snapshot,
+          ...(scan.pinOverlayPaths?.length || !fs.existsSync(persistedSnapshot)
+            ? { snapshot }
+            : { snapshotFile: persistedSnapshot }),
         }));
     } else {
       const response = await buildFilesResponse(new Request(request.url, { headers }), {

--- a/src/lib/filesResponse.worker.ts
+++ b/src/lib/filesResponse.worker.ts
@@ -1,4 +1,9 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
 import { buildFilesResponse } from "@/app/api/files/response";
+import { statePath } from "@/lib/configDir";
 import type { FilesResponseWorkerRequest } from "@/lib/scanner/filesResponseWorker";
 
 const INPUT_MAX_BYTES = 8 * 1024 * 1024;
@@ -12,22 +17,43 @@ function workerRequest(value: unknown): FilesResponseWorkerRequest | null {
     || value.type !== "project"
     || typeof value.url !== "string"
     || !Array.isArray(value.headers)
-    || !record(value.snapshot)
-    || !Array.isArray(value.snapshot.files)
-    || !Array.isArray(value.snapshot.projectCatalog)) return null;
+    || (value.snapshotFile !== undefined && typeof value.snapshotFile !== "string")
+    || (value.snapshot === undefined && value.snapshotFile === undefined)
+    || (value.snapshot !== undefined && (
+      !record(value.snapshot)
+      || !Array.isArray(value.snapshot.files)
+      || !Array.isArray(value.snapshot.projectCatalog)
+    ))) return null;
   return value as unknown as FilesResponseWorkerRequest;
+}
+
+function snapshotFor(request: FilesResponseWorkerRequest): NonNullable<FilesResponseWorkerRequest["snapshot"]> {
+  if (request.snapshot) return request.snapshot;
+  const persisted = JSON.parse(fs.readFileSync(request.snapshotFile!, "utf8")) as unknown;
+  if (!record(persisted)
+    || !record(persisted.snapshot)
+    || !Array.isArray(persisted.snapshot.files)
+    || !Array.isArray(persisted.snapshot.projectCatalog)) {
+    throw new Error("files response worker snapshot file is invalid");
+  }
+  return persisted.snapshot as unknown as NonNullable<FilesResponseWorkerRequest["snapshot"]>;
 }
 
 async function run(value: unknown): Promise<void> {
   const request = workerRequest(value);
   if (!request) throw new Error("files response worker received an invalid request");
+  const snapshot = snapshotFor(request);
   const response = await buildFilesResponse(new Request(request.url, {
     headers: new Headers(request.headers),
   }), {
-    listFilesWithProjectCatalog: async () => request.snapshot,
+    listFilesWithProjectCatalog: async () => snapshot,
   });
+  const resultDirectory = statePath("files-response-results");
+  fs.mkdirSync(resultDirectory, { recursive: true, mode: 0o700 });
+  const bodyFile = path.join(resultDirectory, `${process.pid}-${crypto.randomUUID()}.json`);
+  fs.writeFileSync(bodyFile, await response.text(), { encoding: "utf8", mode: 0o600 });
   process.stdout.write(JSON.stringify({
-    body: await response.text(),
+    bodyFile,
     contentType: response.headers.get("content-type") ?? "application/json",
     etag: response.headers.get("etag") ?? "",
     timing: response.headers.get("server-timing") ?? "",

--- a/src/lib/scanner/filesResponseWorker.ts
+++ b/src/lib/scanner/filesResponseWorker.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import { statePath } from "@/lib/configDir";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { FileCatalogScan } from "./index";
@@ -21,7 +22,8 @@ export type FilesResponseWorkerRequest = {
   type: "project";
   url: string;
   headers: Array<[string, string]>;
-  snapshot: FileCatalogScan;
+  snapshot?: FileCatalogScan;
+  snapshotFile?: string;
 };
 
 export interface FilesResponseWorkerRuntime {
@@ -35,13 +37,17 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function representation(value: unknown): FilesResponseRepresentation | null {
+type FilesResponseWorkerWireRepresentation = Omit<FilesResponseRepresentation, "body"> & {
+  bodyFile: string;
+};
+
+function representation(value: unknown): FilesResponseWorkerWireRepresentation | null {
   if (!record(value)
-    || typeof value.body !== "string"
+    || typeof value.bodyFile !== "string"
     || typeof value.contentType !== "string"
     || typeof value.etag !== "string"
     || typeof value.timing !== "string") return null;
-  return value as unknown as FilesResponseRepresentation;
+  return value as unknown as FilesResponseWorkerWireRepresentation;
 }
 
 function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: string } {
@@ -132,7 +138,21 @@ export function buildFilesResponseInWorker(
         finish(new Error(`files response worker exited before completion (${signal ?? code ?? "unknown"})${detail ? `: ${detail}` : ""}`));
         return;
       }
-      finish(undefined, result);
+      const resultDirectory = runtime.env?.LLV_STATE_DIR
+        ? path.resolve(runtime.env.LLV_STATE_DIR, "files-response-results")
+        : path.resolve(statePath("files-response-results"));
+      const bodyFile = path.resolve(result.bodyFile);
+      if (path.dirname(bodyFile) !== resultDirectory) {
+        finish(new Error("files response worker returned an invalid body path"));
+        return;
+      }
+      try {
+        const body = fs.readFileSync(bodyFile, "utf8");
+        fs.rmSync(bodyFile, { force: true });
+        finish(undefined, { ...result, body });
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error("files response worker body is unavailable"));
+      }
     });
     child.stdin.once("error", (error) => finish(error));
     child.stdin.end(JSON.stringify(request));


### PR DESCRIPTION
## Summary
- let projection workers read the persisted scan snapshot directly
- return large response bodies through a private state file instead of escaped child stdout
- keep the parent process payload small during scan-generation transitions

## Verification
- files route, client cache, scanner, and projection worker suites (102 pass)
- TypeScript and focused ESLint
- production build
- privacy publication gate
