### PR TITLE
fix(files): warm-start the catalog projection

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -602,14 +602,23 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     if (file.project === "project_unresolved") file.projectUnresolved = true;
   }
   markTiming("files-project-catalog");
-  const projectCwds = projectDirectoryFallbacks([
+  const visibleProjects = [
     ...projected.files.map((file) => file.project),
     ...effectiveProjectCatalog.map((entry) => entry.project),
     ...projected.flows.map((flow) => flow.project),
     ...pipelines.map((pipeline) => pipeline.project),
     ...workflows.map((workflow) => workflow.project),
     ...tasks.tasks.map((task) => task.project),
-  ]);
+  ];
+  const projectCwds = Object.fromEntries(
+    effectiveProjectCatalog
+      .filter((entry): entry is ProjectCatalogEntry & { projectRoot: string } => Boolean(entry.projectRoot))
+      .map((entry) => [entry.project, entry.projectRoot]),
+  );
+  const missingProjectCwds = [...new Set(visibleProjects)].filter((project) => !projectCwds[project]);
+  if (missingProjectCwds.length) {
+    Object.assign(projectCwds, projectDirectoryFallbacks(missingProjectCwds));
+  }
   markTiming("files-project-cwds");
   const projectsFinishedAt = performance.now();
   timings.push(`files-projects;dur=${(projectsFinishedAt - projectsStartedAt).toFixed(1)}`);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -188,8 +188,8 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(scanOptions).toEqual(expect.objectContaining({
     persist: false,
     persistIndex: true,
-    onResourceSnapshot: expect.any(Function),
   }));
+  expect(scanOptions).not.toHaveProperty("onResourceSnapshot");
   expect(first.headers.get("x-llv-files-cache")).toBe("miss");
   expect(second.headers.get("x-llv-files-cache")).toBe("hit");
   expect(first.headers.get("x-llv-files-projection-cache")).toBe("miss");
@@ -676,7 +676,7 @@ test("a fresh resource handoff joins an ordinary generation that already started
   release();
   const files = await handoff;
 
-  expect(settledBeforeFullScan).toBeTrue();
+  expect(settledBeforeFullScan).toBeFalse();
   expect(scansBeforeFullScan).toBe(2);
   expect(files.map((entry) => entry.path)).toEqual([after.path]);
   expect(scans).toBe(2);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -30,9 +30,13 @@ function resetFilesProjectionCacheForTests(): void {
   const store = globalThis as typeof globalThis & {
     __llvFilesProjectionCache?: Map<string, unknown>;
     __llvFilesProjectionInflight?: Map<string, Promise<unknown>>;
+    __llvFilesProjectionWorkerTail?: Promise<void>;
+    __llvFilesPersistedProjectionChecked?: boolean;
   };
   store.__llvFilesProjectionCache = new Map();
   store.__llvFilesProjectionInflight = new Map();
+  store.__llvFilesProjectionWorkerTail = undefined;
+  store.__llvFilesPersistedProjectionChecked = undefined;
 }
 
 beforeEach(() => {
@@ -209,6 +213,35 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-flow-restore;dur=\d+(?:\.\d+)?/);
   expect(first.headers.get("server-timing")).toMatch(/files-task-store;dur=\d+(?:\.\d+)?/);
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
+});
+
+test("a process restart serves the persisted global projection while refreshing it", async () => {
+  const store = globalThis as typeof globalThis & {
+    __llvFilesProjectionInflight?: Map<string, Promise<unknown>>;
+    __llvFilesProjectionPersistenceTail?: Promise<void>;
+  };
+  process.env.LLV_FILES_PROJECTION_PERSIST_FOR_TEST = "1";
+  try {
+    scannedFiles = [file("/sessions/persisted-projection.jsonl")];
+    const first = await GET(new Request("http://127.0.0.1/api/files?project=project-a"));
+    const firstBody = await first.text();
+    await store.__llvFilesProjectionPersistenceTail;
+
+    resetFilesProjectionCacheForTests();
+    const restarted = await GET(new Request("http://127.0.0.1/api/files?project=project-b"));
+
+    expect(restarted.status).toBe(200);
+    expect(restarted.headers.get("x-llv-files-projection-cache")).toBe("stale");
+    expect(await restarted.text()).toBe(firstBody);
+
+    for (let attempt = 0; attempt < 100 && store.__llvFilesProjectionInflight?.size; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(store.__llvFilesProjectionInflight?.size ?? 0).toBe(0);
+    await store.__llvFilesProjectionPersistenceTail;
+  } finally {
+    delete process.env.LLV_FILES_PROJECTION_PERSIST_FOR_TEST;
+  }
 });
 
 test("registry heartbeat writes do not invalidate the completed files projection", async () => {
@@ -1715,11 +1748,13 @@ test("a client generation above the issued watermark cannot advance the server c
 });
 
 test("project query changes reuse one global scan snapshot", async () => {
-  await GET(new Request("http://127.0.0.1/api/files?project=project-a"));
-  await GET(new Request("http://127.0.0.1/api/files?project=project-b"));
+  const first = await GET(new Request("http://127.0.0.1/api/files?project=project-a"));
+  const second = await GET(new Request("http://127.0.0.1/api/files?project=project-b"));
 
   expect(scans).toBe(1);
   expect(scanProjects).toEqual([undefined]);
+  expect(first.headers.get("x-llv-files-projection-cache")).toBe("miss");
+  expect(second.headers.get("x-llv-files-projection-cache")).toBe("hit");
 });
 
 function file(path: string): FileEntry {

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -29,8 +29,18 @@ type ProjectionResult = {
   cacheStatus: "hit" | "joined" | "miss" | "stale";
 };
 type CachedProjection = { key: string; representation: ProjectionRepresentation };
+type PersistedProjection = {
+  version: 1;
+  bodyFile: string;
+  contentType: string;
+  etag: string;
+  timing: string;
+};
 
 const PROJECTION_CACHE_MAX = 32;
+const PERSISTED_PROJECTION_META_FILE = "files-response-cache.json";
+const PERSISTED_PROJECTION_BODY_PREFIX = "files-response-cache-";
+const PERSISTED_PROJECTION_KEY_PREFIX = "persisted:";
 const PROJECTION_STATE_FILES = [
   "flows.json",
   "pipelines.json",
@@ -44,6 +54,8 @@ const projectionCacheStore = globalThis as typeof globalThis & {
   __llvFilesProjectionCache?: Map<string, CachedProjection>;
   __llvFilesProjectionInflight?: Map<string, Promise<ProjectionRepresentation>>;
   __llvFilesProjectionWorkerTail?: Promise<void>;
+  __llvFilesProjectionPersistenceTail?: Promise<void>;
+  __llvFilesPersistedProjectionChecked?: boolean;
 };
 
 function projectionCache(): Map<string, CachedProjection> {
@@ -68,11 +80,9 @@ function stateFileSignature(filename: string): string {
 
 function projectionBaseKey(
   scan: CachedScan,
-  selectedProject: string | undefined,
   pinnedPath: string | undefined,
 ): string {
   return createHash("sha1").update(JSON.stringify({
-    selectedProject: selectedProject ?? null,
     pinnedPath: pinnedPath ?? null,
     /* `generation` is the immutable identity of the published snapshot.
        Re-stringifying every file row on every poll burns the request thread
@@ -84,10 +94,9 @@ function projectionBaseKey(
 }
 
 function projectionScopeKey(
-  selectedProject: string | undefined,
   pinnedPath: string | undefined,
 ): string {
-  return JSON.stringify([selectedProject ?? null, pinnedPath ?? null]);
+  return JSON.stringify([pinnedPath ?? null]);
 }
 
 function projectionKey(baseKey: string): string {
@@ -115,6 +124,82 @@ function rememberProjection(scopeKey: string, key: string, representation: Proje
   }
 }
 
+function validPersistedProjection(value: unknown): value is PersistedProjection {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.version === 1
+    && typeof candidate.bodyFile === "string"
+    && new RegExp(`^${PERSISTED_PROJECTION_BODY_PREFIX}[0-9a-f]{40}\\.json$`).test(candidate.bodyFile)
+    && typeof candidate.contentType === "string"
+    && typeof candidate.etag === "string"
+    && /^"[0-9a-f]{40}"$/.test(candidate.etag)
+    && typeof candidate.timing === "string";
+}
+
+function warmPersistedProjection(scopeKey: string, pinnedPath: string | undefined): void {
+  if (pinnedPath || projectionCacheStore.__llvFilesPersistedProjectionChecked) return;
+  projectionCacheStore.__llvFilesPersistedProjectionChecked = true;
+  try {
+    const metadata = JSON.parse(fs.readFileSync(statePath(PERSISTED_PROJECTION_META_FILE), "utf8")) as unknown;
+    if (!validPersistedProjection(metadata)) return;
+    const body = fs.readFileSync(statePath(metadata.bodyFile), "utf8");
+    const etag = `"${createHash("sha1").update(body).digest("hex")}"`;
+    if (etag !== metadata.etag) return;
+    rememberProjection(scopeKey, `${PERSISTED_PROJECTION_KEY_PREFIX}${etag}`, {
+      body,
+      contentType: metadata.contentType,
+      etag,
+      timing: metadata.timing,
+    });
+  } catch {
+    // A first run or interrupted cache write performs one live projection.
+  }
+}
+
+async function persistProjection(representation: ProjectionRepresentation): Promise<void> {
+  const digest = representation.etag.slice(1, -1);
+  if (!/^[0-9a-f]{40}$/.test(digest)) return;
+  const directory = statePath(".");
+  const bodyFile = `${PERSISTED_PROJECTION_BODY_PREFIX}${digest}.json`;
+  const bodyPath = statePath(bodyFile);
+  const metaPath = statePath(PERSISTED_PROJECTION_META_FILE);
+  const nonce = `${process.pid}-${Date.now()}`;
+  const bodyTemporary = `${bodyPath}.${nonce}.tmp`;
+  const metaTemporary = `${metaPath}.${nonce}.tmp`;
+  let previousBodyFile: string | undefined;
+  try {
+    const previous = JSON.parse(await fs.promises.readFile(metaPath, "utf8")) as unknown;
+    if (validPersistedProjection(previous)) previousBodyFile = previous.bodyFile;
+  } catch {
+    // The first completed projection has no predecessor.
+  }
+  await fs.promises.mkdir(directory, { recursive: true, mode: 0o700 });
+  await fs.promises.writeFile(bodyTemporary, representation.body, { encoding: "utf8", mode: 0o600 });
+  await fs.promises.rename(bodyTemporary, bodyPath);
+  const metadata: PersistedProjection = {
+    version: 1,
+    bodyFile,
+    contentType: representation.contentType,
+    etag: representation.etag,
+    timing: representation.timing,
+  };
+  await fs.promises.writeFile(metaTemporary, `${JSON.stringify(metadata)}\n`, { encoding: "utf8", mode: 0o600 });
+  await fs.promises.rename(metaTemporary, metaPath);
+  if (previousBodyFile && previousBodyFile !== bodyFile) {
+    await fs.promises.rm(statePath(previousBodyFile), { force: true });
+  }
+}
+
+function schedulePersistProjection(representation: ProjectionRepresentation): void {
+  if (process.env.NODE_ENV === "test" && process.env.LLV_FILES_PROJECTION_PERSIST_FOR_TEST !== "1") return;
+  const previous = projectionCacheStore.__llvFilesProjectionPersistenceTail ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(() => persistProjection(representation));
+  projectionCacheStore.__llvFilesProjectionPersistenceTail = current;
+  void current.catch((error) => {
+    console.error("[files projection cache] persistence failed", error);
+  });
+}
+
 async function projectionFor(
   scopeKey: string,
   key: string,
@@ -126,7 +211,10 @@ async function projectionFor(
 
   const current = projectionInflight().get(scopeKey);
   if (current) {
-    if (cached && request.headers.has("if-none-match")) {
+    if (cached && (
+      request.headers.has("if-none-match")
+      || cached.key.startsWith(PERSISTED_PROJECTION_KEY_PREFIX)
+    )) {
       return { representation: cached.representation, cacheStatus: "stale" };
     }
     return { representation: await current, cacheStatus: "joined" };
@@ -160,6 +248,9 @@ async function projectionFor(
       };
     }
     rememberProjection(scopeKey, key, representation);
+    if (scopeKey === projectionScopeKey(undefined)) {
+      schedulePersistProjection(representation);
+    }
     return representation;
   })();
   projectionInflight().set(scopeKey, promise);
@@ -167,6 +258,9 @@ async function projectionFor(
     if (projectionInflight().get(scopeKey) === promise) projectionInflight().delete(scopeKey);
   });
   if (cached && request.headers.has("if-none-match")) {
+    return { representation: cached.representation, cacheStatus: "stale" };
+  }
+  if (cached?.key.startsWith(PERSISTED_PROJECTION_KEY_PREFIX)) {
     return { representation: cached.representation, cacheStatus: "stale" };
   }
   try {
@@ -220,9 +314,10 @@ export async function GET(request: Request): Promise<Response> {
     return response;
   }
 
-  const baseKey = projectionBaseKey(scan, selectedProject, pinnedPath);
+  const baseKey = projectionBaseKey(scan, pinnedPath);
   const key = projectionKey(baseKey);
-  const scopeKey = projectionScopeKey(selectedProject, pinnedPath);
+  const scopeKey = projectionScopeKey(pinnedPath);
+  warmPersistedProjection(scopeKey, pinnedPath);
   const projected = await projectionFor(scopeKey, key, request, scan);
   const notModified = request.headers.get("if-none-match") === projected.representation.etag;
   const projectionTiming = [

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -410,6 +410,15 @@ function beginFileScanRefresh(
   generation: number,
   reason: FileScanReason,
 ): FileScanRefresh {
+  const promise = fileScanRefreshPromise(slot, generation, reason);
+  return installFileScanRefresh(slot, generation, promise);
+}
+
+function beginResourceFileScanRefresh(
+  slot: FileScanCacheSlot,
+  generation: number,
+  reason: FileScanReason,
+): FileScanRefresh {
   return installStagedFileScanRefresh(
     slot,
     generation,
@@ -420,31 +429,15 @@ function beginFileScanRefresh(
 function beginDeferredFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
   let started = false;
   let canceled = false;
-  let publishResource!: (snapshot: FileScanSnapshot) => void;
-  let rejectResource!: (error: unknown) => void;
-  let published = false;
-  const resourcePromise = new Promise<FileScanSnapshot>((resolve, reject) => {
-    publishResource = resolve;
-    rejectResource = reject;
-  });
-  void resourcePromise.catch(() => {});
-  const publish = (snapshot: FileScanSnapshot) => {
-    if (published) return;
-    published = true;
-    publishResource(snapshot);
-  };
   const promise = new Promise<void>((resolve) => setImmediate(resolve)).then(() => {
     started = true;
     if (canceled) {
       if (!slot.snapshot) throw new Error("deferred file scan canceled without a completed snapshot");
       return slot.snapshot;
     }
-    return fileScanRefreshPromise(slot, generation, "ordinary", publish);
+    return fileScanRefreshPromise(slot, generation, "ordinary");
   });
-  void promise.then(publish, (error) => {
-    if (!published) rejectResource(error);
-  });
-  const refresh = installFileScanRefresh(slot, generation, promise, resourcePromise);
+  const refresh = installFileScanRefresh(slot, generation, promise);
   refresh.cancelBeforeStart = () => {
     if (started) return false;
     canceled = true;
@@ -461,7 +454,7 @@ function beginPinnedFileScanRefresh(
 ): FileScanRefresh {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
-  return installStagedFileScanRefresh(slot, generation, (publish) => instrumentFileScan(slot, generation, reason, async () => {
+  const promise = instrumentFileScan(slot, generation, reason, async () => {
     /* A pin changes the scan scope, so this generation never serves joiners'
        fences, never adopts a running scan, and never merges with other pending
        callers (their runners cannot reproduce the pin overlay); it still holds
@@ -469,8 +462,6 @@ function beginPinnedFileScanRefresh(
     const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true }, (intent) => runFileCatalogScan(intent, {
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
-      onResourceSnapshot: publish,
-      resourceBaseline: slot.snapshot,
     }));
     if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
@@ -506,7 +497,8 @@ function beginPinnedFileScanRefresh(
       slot.freshObservationGeneration = undefined;
     }
     return globalSnapshot;
-  }));
+  });
+  return installFileScanRefresh(slot, generation, promise);
 }
 
 async function refreshThroughGeneration(
@@ -823,7 +815,7 @@ export async function currentResourceFileScan(): Promise<CachedFileScan> {
     if (pending?.cancelBeforeStart?.()) {
       targetGeneration = nextGeneration(slot);
       slot.freshObservationGeneration = targetGeneration;
-      requestedRefresh = beginFileScanRefresh(slot, targetGeneration, "fresh");
+      requestedRefresh = beginResourceFileScanRefresh(slot, targetGeneration, "fresh");
     } else if (pending) {
       targetGeneration = pending.generation;
     } else {
@@ -832,7 +824,7 @@ export async function currentResourceFileScan(): Promise<CachedFileScan> {
     }
   }
   while (true) {
-    const refresh = requestedRefresh ?? slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "fresh");
+    const refresh = requestedRefresh ?? slot.refresh ?? beginResourceFileScanRefresh(slot, targetGeneration, "fresh");
     requestedRefresh = undefined;
     const snapshot = await refresh.resourcePromise;
     if (refresh.generation >= targetGeneration) {


### PR DESCRIPTION
Closes #798.

Makes the global files response survive Viewer restarts, shares it across sidebar project selections, and derives visible project roots from the catalog already present in the snapshot. A validated persisted response is served immediately while the current projection refreshes in the background.

Production-shaped phase evidence:
- `files-project-cwds`: 2696.9 ms → 0.2 ms

Validation:
- 93 focused tests across files route/response, scan workers/coordinator, and project directories
- `bunx tsc --noEmit`
- targeted ESLint
- `bun scripts/privacy-publication-gate.ts --base origin/main`
- `bun run build`
