### PR TITLE
Stop background sidecars from duplicating catalog scans

### DIFF
--- a/src/lib/accountMigrationController.worker.ts
+++ b/src/lib/accountMigrationController.worker.ts
@@ -1,5 +1,3 @@
-import "./fileScanner.workerMode";
-
 import { startAccountMigrationController } from "./accounts/migration/controller";
 
 await startAccountMigrationController();

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { loadFlows, reconcileFlowConversationOwnershipCooperatively } from "@/lib/flows/store";
 import { reconcileHandoffConversationOwnershipCooperatively } from "@/lib/handoffLineage";
 import { listFilesWithProjectCatalog, reconcileFileControllers } from "@/lib/scanner";
+import { persistedFileScanSnapshot } from "@/lib/scanner/scanCache";
 import { coordinatedControllerScan } from "@/lib/scanner/scanCoordinator";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { runReaperCycle } from "@/lib/reaperRuntime";
@@ -87,6 +88,21 @@ type InventorySnapshot = Awaited<ReturnType<typeof reconcileMigrationInventory>>
 type ConversationLookup = ReturnType<typeof conversationLookupFromSnapshot>;
 type ControllerScan = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
 
+const INCOMPLETE_CONTROLLER_SCAN: ControllerScan = {
+  files: [],
+  projectCatalog: [],
+  complete: false,
+};
+
+export function accountControllerScan(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  persisted: () => ControllerScan | undefined = persistedFileScanSnapshot,
+  live: () => Promise<ControllerScan> = coordinatedControllerScan,
+): Promise<ControllerScan> {
+  if (env.LLV_ACCOUNT_CONTROLLER_INVENTORY_WORKER !== "1") return live();
+  return Promise.resolve(persisted() ?? INCOMPLETE_CONTROLLER_SCAN);
+}
+
 export interface AccountMigrationControllerCyclePorts {
   scan: () => ReturnType<typeof listFilesWithProjectCatalog>;
   reconcileInventory: (registry: AgentRegistry, files: ControllerScan["files"]) => Promise<InventorySnapshot>;
@@ -135,9 +151,9 @@ function reconcileControllerTasks(registry: AgentRegistry, files: ControllerScan
 }
 
 const DEFAULT_CONTROLLER_CYCLE_PORTS: AccountMigrationControllerCyclePorts = {
-  // Reconciliation consumes the process-wide scan generation; it never fans
-  // out an extra scanner run alongside the HTTP cache or the pipeline watchdog.
-  scan: () => coordinatedControllerScan(),
+  // The inventory sidecar consumes the completed snapshot published by the
+  // Viewer. Process-wide coordination cannot cover a separate OS process.
+  scan: () => accountControllerScan(),
   reconcileInventory: reconcileMigrationInventory,
   reconcileFlowOwnership: reconcileFlowConversationOwnershipCooperatively,
   reconcileWorkflowOwnership: reconcileWorkflowConversationOwnershipCooperatively,

--- a/src/lib/accounts/migration/controllerScan.test.ts
+++ b/src/lib/accounts/migration/controllerScan.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+
+import { accountControllerScan } from "./controller";
+
+test("inventory sidecar reuses the Viewer snapshot without launching a corpus scan", async () => {
+  const persisted = { files: [], projectCatalog: [], complete: true };
+  let liveScans = 0;
+
+  const snapshot = await accountControllerScan(
+    { LLV_ACCOUNT_CONTROLLER_INVENTORY_WORKER: "1" },
+    () => persisted,
+    async () => {
+      liveScans += 1;
+      return { files: [], projectCatalog: [], complete: true };
+    },
+  );
+
+  expect(snapshot).toBe(persisted);
+  expect(liveScans).toBe(0);
+});
+
+test("inventory sidecar waits for the Viewer to publish its first snapshot", async () => {
+  let liveScans = 0;
+
+  const snapshot = await accountControllerScan(
+    { LLV_ACCOUNT_CONTROLLER_INVENTORY_WORKER: "1" },
+    () => undefined,
+    async () => {
+      liveScans += 1;
+      return { files: [], projectCatalog: [], complete: true };
+    },
+  );
+
+  expect(snapshot).toEqual({ files: [], projectCatalog: [], complete: false });
+  expect(liveScans).toBe(0);
+});

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -12,7 +12,7 @@ import { coordinatedFileScan, resetFileScanCoordinatorForTests, runFileCatalogSc
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
-type FileScanSnapshot = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
+export type FileScanSnapshot = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
 type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
@@ -237,6 +237,15 @@ function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Reads the last completed catalog published by the Viewer process without
+ * starting another filesystem scan. Background sidecars use this cross-process
+ * seam so one container owns one full-corpus scan generation.
+ */
+export function persistedFileScanSnapshot(): FileScanSnapshot | undefined {
+  return readPersistedFileScanSnapshot();
 }
 
 function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {

--- a/src/lib/wakatime/sync.test.ts
+++ b/src/lib/wakatime/sync.test.ts
@@ -11,6 +11,7 @@ import {
   readProductionWakatimeCredential,
   readWakatimeCredentialFile,
   startWakatimeSync,
+  wakatimeProductionScan,
   type WakatimeStateV1,
   type WakatimeSyncDependencies,
 } from "./sync";
@@ -21,6 +22,46 @@ const TURN_START = NOW + 1_000;
 const TURN_END = NOW + 31_000;
 const PATH = "/sessions/current.jsonl";
 const TEST_CREDENTIAL = ["fixture", "wakatime", "value"].join("-");
+
+test("WakaTime sidecar reuses the Viewer snapshot without launching a corpus scan", async () => {
+  const persisted = { files: [], projectCatalog: [], complete: true };
+  let liveScans = 0;
+
+  const snapshot = await wakatimeProductionScan(
+    { LLV_WAKATIME_SYNC_WORKER: "1" },
+    () => persisted,
+    async () => {
+      liveScans += 1;
+      return {
+        snapshot: { files: [], projectCatalog: [], complete: true },
+        generation: 1,
+        targetGeneration: 1,
+        cacheStatus: "hit",
+        requestCount: 1,
+        cloneDurationMs: 0,
+      };
+    },
+  );
+
+  expect(snapshot).toBe(persisted);
+  expect(liveScans).toBe(0);
+});
+
+test("WakaTime sidecar waits for the Viewer to publish its first snapshot", async () => {
+  let liveScans = 0;
+
+  const snapshot = await wakatimeProductionScan(
+    { LLV_WAKATIME_SYNC_WORKER: "1" },
+    () => undefined,
+    async () => {
+      liveScans += 1;
+      throw new Error("live scan should stay in the Viewer process");
+    },
+  );
+
+  expect(snapshot).toEqual({ files: [], projectCatalog: [], complete: false });
+  expect(liveScans).toBe(0);
+});
 
 function entry(overrides: Partial<FileEntry> = {}): FileEntry {
   return {

--- a/src/lib/wakatime/sync.ts
+++ b/src/lib/wakatime/sync.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 
 import { agentRegistry, conversationLookupFromSnapshot, type RegistryFile } from "@/lib/agent/registry";
 import { configFilePath, statePath } from "@/lib/configDir";
-import { currentFileScan } from "@/lib/scanner/scanCache";
+import {
+  currentFileScan,
+  persistedFileScanSnapshot,
+  type FileScanSnapshot,
+} from "@/lib/scanner/scanCache";
 import { recentTurnWindowsFor, type RecentTurnWindows } from "@/lib/scanner/turnDuration";
 import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import type { FileEntry, TurnBoundary } from "@/lib/types";
@@ -950,9 +954,26 @@ function writeProductionState(state: WakatimeStateV1): void {
 
 const singleton = globalThis as typeof globalThis & { __llvWakatimeSync?: WakatimeSync };
 
+const INCOMPLETE_WAKATIME_SCAN: FileScanSnapshot = {
+  files: [],
+  projectCatalog: [],
+  complete: false,
+};
+
+export async function wakatimeProductionScan(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  persisted: () => FileScanSnapshot | undefined = persistedFileScanSnapshot,
+  live: typeof currentFileScan = currentFileScan,
+): Promise<FileScanSnapshot> {
+  if (env.LLV_WAKATIME_SYNC_WORKER === "1") {
+    return persisted() ?? INCOMPLETE_WAKATIME_SCAN;
+  }
+  return (await live()).snapshot;
+}
+
 function productionDependencies(): WakatimeSyncDependencies {
   return {
-    scan: async () => (await currentFileScan()).snapshot,
+    scan: () => wakatimeProductionScan(),
     registrySnapshot: () => agentRegistry().readOnlySnapshot(),
     recentTurnWindows: recentTurnWindowsFor,
     readCredential: readProductionWakatimeCredential,

--- a/src/lib/wakatimeSync.worker.ts
+++ b/src/lib/wakatimeSync.worker.ts
@@ -1,5 +1,3 @@
-import "./fileScanner.workerMode";
-
 import { startWakatimeSync } from "./wakatime/sync";
 
 startWakatimeSync();


### PR DESCRIPTION
Production catalog refreshes were multiplied across isolated sidecar processes, saturating CPU and delaying API responses and browser reloads. Reuse the Viewer-published completed snapshot in the account inventory and WakaTime sidecars, and wait for the first snapshot without launching a second corpus scan.

Validation:
- focused account inventory and WakaTime tests
- TypeScript typecheck
- production build
- privacy publication gate