### PR TITLE
Keep catalog completion retries off the render path

### DIFF
--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -105,6 +105,36 @@ test("URL-specific 304 responses restore the matching cached representation", as
   expect(cache.read()).toBe(restored);
 });
 
+test("an unchanged generation-wait 304 keeps the mounted snapshot asleep", async () => {
+  let requests = 0;
+  const cache = createFilesClientCache(async () => {
+    requests += 1;
+    if (requests === 1) {
+      return new Response(JSON.stringify({ files: [file("/global", "Global")] }), {
+        headers: { ETag: '"global"', "x-llv-files-generation": "1" },
+      });
+    }
+    return new Response(null, {
+      status: 304,
+      headers: {
+        ETag: '"global"',
+        "x-llv-files-generation": "1",
+        "x-llv-files-target-generation": "2",
+      },
+    });
+  });
+  let updates = 0;
+  const unsubscribe = cache.subscribe(() => { updates += 1; });
+
+  const initial = await cache.revalidate();
+  updates = 0;
+  const waiting = await cache.revalidate();
+  unsubscribe();
+
+  expect(waiting).toBe(initial);
+  expect(updates).toBe(0);
+});
+
 test("client cache subscriptions receive updates only for their request scope", async () => {
   const pinnedPath = "/archive/scoped-pin.jsonl";
   const cache = createFilesClientCache(async (input) => {

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -355,11 +355,17 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     if (response.status === 304) {
       if (!representation) throw new Error("files request returned 304 without a cached representation");
       if (generation < appliedGeneration) return snapshot;
-      snapshot = restoreNotModified(snapshot, representation.data, url);
+      const previousSnapshot = snapshot;
+      if (snapshot !== representation.data || snapshot.requestScope !== url) {
+        snapshot = restoreNotModified(snapshot, representation.data, url);
+      }
       appliedGeneration = generation;
       rememberRepresentation(url, snapshot, representation.etag);
       settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
-      publish(url);
+      // Generation-completion probes commonly return the same bodyless 304
+      // for minutes while a large catalog scan is active. Keep React asleep
+      // until the certified representation or a local pipeline overlay changes.
+      if (snapshot !== previousSnapshot) publish(url);
       if (generationIncomplete && completionTargetGeneration !== undefined) {
         scheduleCompletionRetry(
           url,

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -717,6 +717,12 @@ export class RuntimeJournal {
         filesRevision: Number(this.meta("files_revision")),
         sessions: this.snapshotSessionValues().map((session) => ({
           ...session,
+          // A terminal host has no live stream to resume. The durable entity
+          // retains its audit state while the browser snapshot drops transient
+          // text that can otherwise dominate every reconnect frame.
+          ...((session.host === "dead" || session.host === "unhosted")
+            ? { liveTurn: null }
+            : {}),
           recentReceipts: visibleReceipts(session.recentReceipts).map(runtimePresentationReceipt),
         })),
         attentions: this.entityValues<RuntimeAttention>("attention"),

--- a/src/runtime-host/journalSnapshotBounds.test.ts
+++ b/src/runtime-host/journalSnapshotBounds.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { runtimeScope } from "@/lib/runtime/contracts";
+
+import { RuntimeJournal } from "./journal";
+
+test("dead sessions retain durable audit state without shipping stale live text", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-snapshot-bounds-"));
+  const journal = new RuntimeJournal(path.join(directory, "events.sqlite"), { now: () => 100 });
+  try {
+    journal.append({
+      scope: runtimeScope("session", "conversation-dead"),
+      kind: "session-status",
+      payload: {
+        conversationId: "conversation-dead",
+        sessionKey: { engine: "codex", sessionId: "session-dead" },
+        hostKind: "codex-app-server",
+        host: "dead",
+        turn: "idle",
+        provenance: "structured",
+        capabilities: { steer: true, structuredAttention: true },
+        liveTurn: { turnId: "turn-finished", text: "stale streamed text" },
+      },
+    });
+
+    expect(journal.sessionState("conversation-dead")?.liveTurn?.text).toBe("stale streamed text");
+    expect(journal.snapshot().sessions[0]?.liveTurn).toBeNull();
+  } finally {
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Large catalog generations can remain active for minutes. Repeated bodyless generation-wait 304 responses reused the same data while publishing a fresh React snapshot every second, producing 170–250 ms main-thread tasks and delaying reload input.

Preserve snapshot identity for unchanged 304 responses and omit stale transient live-turn text from dead-session runtime snapshots. The durable journal state remains intact while runtime reconnect frames return below the transport cap.

Validation:
- focused files-cache and runtime snapshot regression tests
- TypeScript typecheck
- production build
- privacy publication gate