### PR TITLE
Allow bounded runtime snapshot handoff

### DIFF
--- a/src/lib/runtime/client.test.ts
+++ b/src/lib/runtime/client.test.ts
@@ -94,3 +94,16 @@ test("a healthy response resolves once and ignores the pending timeout", async (
   const client = new UnixRuntimeHostClient(socketPath, 5_000, 5_000, 5_000);
   expect(await client.snapshot() as unknown).toEqual({ revision: 7 });
 });
+
+test("snapshot accepts an upgrade-sized frame from the previous runtime host", async () => {
+  const padding = "x".repeat(9 * 1024 * 1024);
+  const socketPath = serve((frame, socket) => {
+    const request = JSON.parse(frame) as { id: string };
+    socket.end(JSON.stringify({ id: request.id, ok: true, result: { padding } }) + "\n");
+  });
+  const client = new UnixRuntimeHostClient(socketPath, 5_000, 5_000, 5_000);
+
+  const snapshot = await client.snapshot() as unknown as { padding: string };
+
+  expect(snapshot.padding.length).toBe(padding.length);
+});

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -3,7 +3,10 @@ import net from "node:net";
 import type { RuntimeEventInput, RuntimeOperationCommand, RuntimeOperationResult, RuntimePendingEffect, RuntimeReceiptStatus, RuntimeReplay, RuntimeRetryOptions, RuntimeSnapshot, RuntimeSocketRequest, RuntimeSocketResponse, ViewerDeploymentReceipt, ViewerDeploymentRequest, ViewerDeploymentStatus } from "./contracts";
 import { runtimeHostSocket } from "./flags";
 
-const MAX_RESPONSE_FRAME_BYTES = 8 * 1024 * 1024;
+// Exact-SHA handoff briefly pairs the new Viewer with the previous runtime
+// host. Its pre-compaction snapshot can exceed 8 MiB; the successor host
+// projects dead-session live text away and returns to the smaller steady state.
+const MAX_RESPONSE_FRAME_BYTES = 16 * 1024 * 1024;
 export const RUNTIME_SNAPSHOT_REQUEST_TIMEOUT_MS = 10_000;
 export const VIEWER_DEPLOYMENT_REQUEST_TIMEOUT_MS = 120_000;
 


### PR DESCRIPTION
An exact-SHA candidate reads one snapshot from the previous runtime host before promotion. The pre-compaction production snapshot is 8.45 MiB, slightly above the old 8 MiB client frame limit, so the deployment health probe cannot reach the successor host that shrinks steady-state snapshots.

Raise the bounded local transport frame to 16 MiB for this upgrade bridge. The successor runtime snapshot projection remains around 4.2 MiB after dead-session transient text is removed.

Validation:
- focused runtime client frame test with a 9 MiB response
- TypeScript typecheck
- production build
- privacy publication gate