### PR TITLE
Fix candidate MCP health routing

### DIFF
--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -19,10 +19,25 @@ import {
 import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
 import { RuntimeHostFence } from "../src/runtime-host/runtimeHostFence";
 import { serveRuntimeHost } from "../src/runtime-host/socket";
-import { runBootstrapRelease } from "./runtime-host-viewer-adapter";
+import { mcpProbeEnvironment, runBootstrapRelease } from "./runtime-host-viewer-adapter";
 
 const root = path.resolve(import.meta.dir, "..");
 const adapter = path.join(root, "scripts", "runtime-host-viewer-adapter.ts");
+
+test("candidate MCP probes read through the candidate Viewer endpoint", () => {
+  const environment = mcpProbeEnvironment(
+    "http://candidate.invalid",
+    "/state/candidate-target.json",
+    {
+      NODE_ENV: "test",
+      LLV_VIEWER_CONTROL_URL: "http://stable.invalid",
+      LLV_VIEWER_DEPLOY_TARGET: "/state/stable-target.json",
+    },
+  );
+
+  expect(environment.LLV_VIEWER_CONTROL_URL).toBe("http://candidate.invalid");
+  expect(environment.LLV_VIEWER_DEPLOY_TARGET).toBe("/state/candidate-target.json");
+});
 const release = {
   container: "viewer-current",
   endpoint: "http://127.0.0.1:19892",
@@ -97,6 +112,17 @@ test("documented bootstrap input obtains host-owned admission through the final 
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-admission-"));
   const state = path.join(sandbox, "state");
   const socketPath = path.join(state, "runtime-host.sock");
+  const control = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/runtime/deployments") {
+        return Response.json({ count: 0, deployments: [] });
+      }
+      return Response.json({ error: "not found" }, { status: 404 });
+    },
+  });
   const revision = "7".repeat(40);
   const candidate = {
     ...release,
@@ -120,6 +146,7 @@ test("documented bootstrap input obtains host-owned admission through the final 
     LLV_STATE_DIR: state,
     LLV_RUNTIME_EVENTS: "1",
     LLV_RUNTIME_HOST_SOCKET: socketPath,
+    LLV_VIEWER_CONTROL_URL: control.url.origin,
     LLV_AGENT_REGISTRY_SQLITE: "off",
     LLV_CODEX_HOME: path.join(sandbox, "codex"),
     LLV_CLAUDE_HOME: path.join(sandbox, "claude"),
@@ -186,6 +213,7 @@ test("documented bootstrap input obtains host-owned admission through the final 
     successor.acquire();
     successor.release();
   } finally {
+    control.stop(true);
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 }, 20_000);

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -352,6 +352,21 @@ async function verifyViewer(candidate: ViewerReleaseIdentity, endpoint: string, 
   });
 }
 
+export function mcpProbeEnvironment(
+  endpoint: string,
+  deployTarget: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  return {
+    ...Object.fromEntries(Object.entries(withoutWakatimeCredential(env))
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string")),
+    LLV_VIEWER_DEPLOY_TARGET: deployTarget,
+    // Candidate health must exercise the candidate's web/runtime client. The
+    // stable listener still serves the previous generation before promotion.
+    LLV_VIEWER_CONTROL_URL: endpoint,
+  };
+}
+
 async function verify(
   candidate: ViewerReleaseIdentity,
   endpoint: string,
@@ -371,9 +386,7 @@ async function verify(
     ? targetFile
     : path.join(stateDir, `mcp-candidate-probe-${candidate.mcpRuntime.releaseId}.json`);
   if (!promoted) writeReleaseTarget(probeTarget, candidate);
-  const probeEnvironment = Object.fromEntries(Object.entries(withoutWakatimeCredential(process.env))
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
-  probeEnvironment.LLV_VIEWER_DEPLOY_TARGET = probeTarget;
+  const probeEnvironment = mcpProbeEnvironment(endpoint, probeTarget);
   const mcpRuntime = await probeMcpRuntime({
     command: process.execPath,
     args: [path.join(mcpRuntimeRoot, "bin", "mcp-server.mjs")],
@@ -475,9 +488,7 @@ async function reconcileMcpRuntime(
   try {
     mcpRuntimeStore.installStableLauncher(deploymentPackageRoot);
     const publication = switchTarget({ ...previous, mcpRuntime: runtime }, "activate");
-    const probeEnvironment = Object.fromEntries(Object.entries(withoutWakatimeCredential(process.env))
-      .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
-    probeEnvironment.LLV_VIEWER_DEPLOY_TARGET = targetFile;
+    const probeEnvironment = mcpProbeEnvironment(stableEndpoint, targetFile);
     const health = await probeMcpRuntime({
       command: process.execPath,
       args: [path.join(mcpRuntimeRoot, "bin", "mcp-server.mjs")],


### PR DESCRIPTION
Candidate health now probes deployment status through the candidate Viewer endpoint. The stable listener continues serving the previous generation until promotion, so probing it could reject a compatible candidate runtime snapshot. The stable reconciliation path is explicitly pinned to the stable endpoint. Includes an isolated regression test for endpoint selection and final MCP transport admission.