### PR TITLE
Bound catalog reconciliation to the open project

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Layers, List, ListTodo, Menu, MessageSquarePlus, MoreHorizontal, Network, Plus, Redo2 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { useBoardActionHistory } from "@/hooks/useBoardActionHistory";
 import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
@@ -310,7 +310,7 @@ function HeaderMenuItem({ icon, label, onSelect, disabled = false, checked }: { 
   );
 }
 
-export function ProjectDashboard({
+function ProjectDashboardView({
   files,
   flows: rawFlows,
   pipelines: rawPipelines,
@@ -1928,3 +1928,5 @@ export function ProjectDashboard({
     </FavoritesProvider>
   );
 }
+
+export const ProjectDashboard = memo(ProjectDashboardView);

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 
 import { createFreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { useLocale } from "@/lib/i18n";
@@ -11,6 +11,7 @@ import { AttachControls } from "./resources/AttachControls";
 import { activityDot, engineTintOf, fmtAge } from "./utils";
 
 const POLL_MS = 30_000;
+const INITIAL_POLL_DELAY_MS = 1_500;
 const GIB = 1024 ** 3;
 const MIB = 1024 ** 2;
 const BULK_HOURS = [2, 6, 12] as const;
@@ -123,23 +124,37 @@ export function ResourcesFooter() {
      hands the panel a way to force a fresh snapshot right after a kill. */
   const loadRef = useRef<(fresh?: boolean) => Promise<void>>(async () => {});
   useEffect(() => {
+    let disposed = false;
     const loader = createResourcesLoader(
       fetch,
       (json, at) => {
-        setSnap((prev) => stickySnap(prev, json, at));
+        startTransition(() => {
+          if (!disposed) setSnap((prev) => stickySnap(prev, json, at));
+        });
       },
       (at) => {
-        setSnap((prev) => (prev ? { ...prev, staleSince: prev.staleSince ?? at } : prev));
+        startTransition(() => {
+          if (!disposed) setSnap((prev) => (prev ? { ...prev, staleSince: prev.staleSince ?? at } : prev));
+        });
       },
     );
     const load = async (fresh = false) => {
       await loader.load(fresh);
     };
     loadRef.current = load;
-    void load();
-    const timer = setInterval(() => void load(), POLL_MS);
+    /* Board, limits and presence mount in the same frame. Starting this probe
+       slightly later keeps their first responses and recurring work out of one
+       main-thread burst. Reschedule after completion so later polls retain the
+       separation instead of snapping back to the page-load clock. */
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      await load();
+      if (!disposed) timer = setTimeout(() => void poll(), POLL_MS);
+    };
+    timer = setTimeout(() => void poll(), INITIAL_POLL_DELAY_MS);
     return () => {
-      clearInterval(timer);
+      disposed = true;
+      if (timer) clearTimeout(timer);
       loader.dispose();
       loadRef.current = async () => {};
     };

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -124,6 +124,19 @@ export function Viewer() {
      card — every surface below sees only current generations. A no-op (same
      array identity) until something actually migrates. */
   const files = useMemo(() => withoutArchivedPredecessors(allFiles), [allFiles]);
+  const dashboardFilesRef = useRef<{ project: string; files: FileEntry[] } | null>(null);
+  const dashboardFiles = useMemo(() => {
+    if (project === OVERVIEW) return [];
+    const selected = files.filter((file) => projectKey(file) === project);
+    const previous = dashboardFilesRef.current;
+    const stable = previous?.project === project
+      && previous.files.length === selected.length
+      && selected.every((file, index) => file === previous.files[index])
+      ? previous.files
+      : selected;
+    dashboardFilesRef.current = { project, files: stable };
+    return stable;
+  }, [files, project]);
   useEffect(() => {
     publishConversationAvailability(new Set(allFiles.flatMap((file) => file.conversationId ? [file.conversationId] : [])));
   }, [allFiles]);
@@ -696,7 +709,7 @@ export function Viewer() {
           />
         ) : (
           <ProjectDashboard
-            files={files}
+            files={dashboardFiles}
             flows={flows}
             pipelines={pipelines}
             pipelinesError={pipelinesError}

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -43,6 +43,9 @@ test("global client cache serves stale rows while revalidation patches changed f
   expect(second.files.map((entry) => entry.title)).toEqual(["A", "B2", "C"]);
   expect(second.files[0]).toBe(first.files[0]);
   expect(second.files[1]).not.toBe(first.files[1]);
+  expect(second.pipelines).toBe(first.pipelines);
+  expect(second.workflows).toBe(first.workflows);
+  expect(second.tasks).toBe(first.tasks);
 });
 
 test("an ordinary hydration waits for an in-flight forced revision refresh", async () => {

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -86,7 +86,10 @@ export interface FilesClientCache {
   /** Return only the representation previously certified for this request URL. */
   readScope(pinnedPath?: string | null): FilesData;
   revalidate(pinnedPath?: string | null, revision?: number): Promise<FilesData>;
-  subscribe(listener: (data: FilesData) => void, pinnedPath?: string | null): () => void;
+  subscribe(
+    listener: (data: FilesData, priority?: "background" | "urgent") => void,
+    pinnedPath?: string | null,
+  ): () => void;
   /** Layer one pipeline record over the server snapshot without a refetch — an
       optimistic local mutation (`confirmed: false`, held until reverted or
       confirmed) or a PATCH/POST echo (`confirmed: true`, held only until a scan
@@ -109,10 +112,13 @@ function equalValue(left: unknown, right: unknown): boolean {
 
 function patchRows<T>(previous: readonly T[], incoming: readonly T[], keyOf: (value: T) => string): T[] {
   const previousByKey = new Map(previous.map((value) => [keyOf(value), value] as const));
-  return incoming.map((value) => {
+  const patched = incoming.map((value) => {
     const cached = previousByKey.get(keyOf(value));
     return cached !== undefined && equalValue(cached, value) ? cached : value;
   });
+  return patched.length === previous.length && patched.every((value, index) => value === previous[index])
+    ? previous as T[]
+    : patched;
 }
 
 function parsedFilesData(parsed: FilesResponse | FileEntry[], requestScope: string): FilesData {
@@ -178,7 +184,10 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   let snapshot = EMPTY;
   let disposed = false;
   const representations = new Map<string, { data: FilesData; etag?: string }>();
-  const listeners = new Map<(data: FilesData) => void, string>();
+  const listeners = new Map<
+    (data: FilesData, priority?: "background" | "urgent") => void,
+    string
+  >();
   const completionRetries = new Map<string, CompletionRetry>();
   let requestedGeneration = 0;
   let appliedGeneration = 0;
@@ -226,14 +235,17 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   const exactScopeSnapshot = (pinnedPath?: string | null): FilesData =>
     exactScopeRepresentation(filesApiUrl(undefined, pinnedPath));
 
-  const publish = (requestScope?: string) => {
+  const publish = (
+    requestScope?: string,
+    priority: "background" | "urgent" = "background",
+  ) => {
     if (disposed) return;
     for (const [listener, scope] of listeners) {
       if (requestScope !== undefined) {
-        if (requestScope === scope) listener(withCatalogFailures(snapshot));
+        if (requestScope === scope) listener(withCatalogFailures(snapshot), priority);
         continue;
       }
-      listener(exactScopeRepresentation(scope));
+      listener(exactScopeRepresentation(scope), priority);
     }
   };
 
@@ -244,7 +256,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     const next = ok ? 0 : catalogFailures + 1;
     if (next === catalogFailures) return;
     catalogFailures = next;
-    publish();
+    publish(undefined, "urgent");
   };
 
   const hasSubscriber = (requestScope: string): boolean =>
@@ -526,17 +538,20 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       minGeneration: confirmed ? requestedGeneration + 1 : Number.POSITIVE_INFINITY,
     });
     composePipelines();
-    publish();
+    publish(undefined, "urgent");
   };
 
   const revertPipeline = (id: string) => {
     if (disposed) return;
     if (!pipelineOverlays.delete(id)) return;
     composePipelines();
-    publish();
+    publish(undefined, "urgent");
   };
 
-  const subscribe = (listener: (data: FilesData) => void, pinnedPath?: string | null) => {
+  const subscribe = (
+    listener: (data: FilesData, priority?: "background" | "urgent") => void,
+    pinnedPath?: string | null,
+  ) => {
     if (disposed) return () => {};
     const requestScope = filesApiUrl(undefined, pinnedPath);
     listeners.set(listener, requestScope);
@@ -628,7 +643,11 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
         if (alive) setData(next);
       });
     };
-    const unsubscribeCache = cache.subscribe((next) => {
+    const unsubscribeCache = cache.subscribe((next, priority) => {
+      if (priority === "urgent") {
+        if (alive) setData(next);
+        return;
+      }
       publishBackgroundData(next);
     }, pinnedPath);
     const performLoad = async (revision?: number): Promise<boolean> => {


### PR DESCRIPTION
Sparse scanner generations now retain collection identity for unchanged files data. The open dashboard receives a stable project-scoped file selection and is memoized, so activity in another project does not recompute the full board. User-driven pipeline updates retain urgent synchronous publication; scanner updates remain interruptible. Focused tests: 43 passed. Typecheck, production build, privacy gate, and diff validation passed.