### PR TITLE
Preserve duplex context across realtime voice turns

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -10,6 +10,7 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 import { CodexAppServerHost, redactCodexHostDiagnostic } from "./codexAppServerHost";
+import { encodeCodexStructuredUserText } from "./codexStructuredUserText";
 import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 import type { HostState, RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
@@ -320,14 +321,10 @@ describe("CodexAppServerHost", () => {
       clientManagedHandoffs: true,
       codexResponsesAsItems: true,
       includeStartupContext: true,
-      /* The voice persona rides in as the call's first item: the thread's own
-         instructions assume a text agent, which does not survive being read
-         aloud. */
     });
 
-    /* The persona rides into the THREAD before the call, never into the live
-       session: an initial item on the session opened the sideband channel that
-       every 9-second kill arrived on. */
+    /* The thread owns the persona while a current V3 call may also receive a
+       bounded unresolved conversation tail through its creation payload. */
     const injected = server.requests.find((request) => request.method === "thread/inject_items");
     expect((injected?.params as { threadId?: string })?.threadId).toBe("voice-thread");
     /* Shape and ordering only. Which text arrives is pinned by the override
@@ -346,6 +343,164 @@ describe("CodexAppServerHost", () => {
     expect(server.requests.find((request) => request.method === "thread/realtime/stop")?.params).toEqual({
       threadId: "voice-thread",
     });
+    await host.release();
+  });
+
+  test("seeds a resumed realtime call with the interrupted duplex tail in canonical order", async () => {
+    const threadId = "voice-context-thread";
+    const turnId = "turn-overlap";
+    const firstUser = {
+      type: "userMessage",
+      id: "user-first",
+      content: [{ type: "text", text: encodeCodexStructuredUserText("Give the first status.") }],
+    };
+    const followUpText = `<realtime_delegation>
+  <input>Repeat the previous status.</input>
+  <transcript_delta>[redacted incomplete duplex delta]</transcript_delta>
+</realtime_delegation>`;
+    const followUp = {
+      type: "userMessage",
+      id: "user-follow-up",
+      content: [{ type: "text", text: encodeCodexStructuredUserText(followUpText) }],
+    };
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 1 });
+    eventStore.append(threadId, { kind: "item", turnId, item: firstUser, phase: "completed", seq: 2 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: "The first status is", seq: 3 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: " ready.", seq: 4 });
+    eventStore.append(threadId, {
+      kind: "item",
+      turnId,
+      item: { type: "contextCompaction", id: "compaction-one" },
+      phase: "completed",
+      seq: 5,
+    });
+    eventStore.append(threadId, { kind: "item", turnId, item: followUp, phase: "completed", seq: 6 });
+    eventStore.append(threadId, { kind: "turn-ended", turnId, status: "interrupted", seq: 7 });
+    eventStore.append(threadId, { kind: "session-status", status: "idle", seq: 8 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "interrupted",
+      items: [firstUser, { type: "contextCompaction", id: "compaction-one" }, followUp],
+    }], { type: "idle" });
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 8,
+      spawnProcess: fakeSpawn(server),
+    });
+    const diagnostics: unknown[][] = [];
+    const originalInfo = console.info;
+    console.info = (...values: unknown[]) => { diagnostics.push(values); };
+    try {
+      await host.startRealtimeWebRtc("v=0\r\noffer");
+    } finally {
+      console.info = originalInfo;
+    }
+
+    expect(server.requests.find((request) => request.method === "thread/realtime/start")?.params)
+      .toMatchObject({
+        initialItems: [
+          { role: "assistant", text: "The first status is ready." },
+          { role: "user", text: followUpText },
+        ],
+      });
+    expect(diagnostics).toEqual([["[realtime context] selected", {
+      providerStartupContext: true,
+      durableTail: [
+        { role: "assistant", source: "durable-delta", bytes: 26 },
+        { role: "user", source: "durable-item", bytes: Buffer.byteLength(followUpText, "utf8") },
+      ],
+      truncated: false,
+    }]]);
+    expect(JSON.stringify(diagnostics)).not.toContain("The first status");
+    expect(JSON.stringify(diagnostics)).not.toContain("realtime_delegation");
+    await host.release();
+  });
+
+  test("leaves committed assistant context with the provider startup selector", async () => {
+    const server = new FakeAppServer("voice-committed-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    server.notify("turn/started", {
+      threadId: "voice-committed-thread",
+      turn: { id: "turn-committed" },
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId: "voice-committed-thread",
+      turnId: "turn-committed",
+      delta: "Committed status.",
+    });
+    server.notify("item/completed", {
+      threadId: "voice-committed-thread",
+      turnId: "turn-committed",
+      item: { type: "agentMessage", id: "assistant-committed", text: "Committed status." },
+    });
+    await Bun.sleep(0);
+
+    await host.startRealtimeWebRtc("v=0\r\noffer");
+
+    const params = server.requests.find((request) => request.method === "thread/realtime/start")?.params;
+    expect(params).toMatchObject({ includeStartupContext: true });
+    expect((params as { initialItems?: unknown[] }).initialItems).toBeUndefined();
+    await host.release();
+  });
+
+  test("bounds the unresolved realtime tail by UTF-8 bytes and item count", async () => {
+    const server = new FakeAppServer("voice-bounded-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    server.notify("turn/started", {
+      threadId: "voice-bounded-thread",
+      turn: { id: "turn-bounded" },
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId: "voice-bounded-thread",
+      turnId: "turn-bounded",
+      delta: "🙂".repeat(3_000),
+    });
+    for (let index = 0; index < 20; index += 1) {
+      server.notify("item/completed", {
+        threadId: "voice-bounded-thread",
+        turnId: "turn-bounded",
+        item: {
+          type: "userMessage",
+          id: `user-${index}`,
+          content: [{
+            type: "text",
+            text: encodeCodexStructuredUserText(`${"界".repeat(3_000)} follow-up-${index}`),
+          }],
+        },
+      });
+    }
+    await Bun.sleep(0);
+    const diagnostics: unknown[][] = [];
+    const originalInfo = console.info;
+    console.info = (...values: unknown[]) => { diagnostics.push(values); };
+    try {
+      await host.startRealtimeWebRtc("v=0\r\noffer");
+    } finally {
+      console.info = originalInfo;
+    }
+
+    const params = server.requests.find((request) => request.method === "thread/realtime/start")?.params;
+    const items = (params as { initialItems: Array<{ role: string; text: string }> }).initialItems;
+    expect(items).toHaveLength(3);
+    expect(items.map((item) => item.role)).toEqual(["assistant", "user", "user"]);
+    expect(items[1]?.text.endsWith("follow-up-18")).toBeTrue();
+    expect(items[2]?.text.endsWith("follow-up-19")).toBeTrue();
+    expect(items.every((item) => Buffer.byteLength(item.text, "utf8") <= 8 * 1024)).toBeTrue();
+    expect(items.reduce((total, item) => total + Buffer.byteLength(item.text, "utf8"), 0))
+      .toBeLessThanOrEqual(24 * 1024);
+    expect(items.every((item) => !item.text.includes("�"))).toBeTrue();
+    expect(diagnostics).toMatchObject([["[realtime context] selected", { truncated: true }]]);
+    expect(JSON.stringify(diagnostics)).not.toContain("follow-up-19");
     await host.release();
   });
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -91,6 +91,23 @@ type RealtimeDeliveryState = {
   offset: number;
   acknowledged: boolean;
 };
+type RealtimeInitialItem = {
+  role: "user" | "assistant";
+  text: string;
+};
+type RealtimeContextCandidate = RealtimeInitialItem & {
+  turnId: string | null;
+  source: "durable-delta" | "durable-item";
+};
+type RealtimeContextSelection = {
+  items: RealtimeInitialItem[];
+  diagnosticItems: Array<{
+    role: RealtimeInitialItem["role"];
+    source: RealtimeContextCandidate["source"];
+    bytes: number;
+  }>;
+  truncated: boolean;
+};
 type UnsequencedEvent = RuntimeEvent extends infer Event
   ? Event extends RuntimeEvent ? Omit<Event, "seq"> : never
   : never;
@@ -214,6 +231,9 @@ const REALTIME_HANGUP_TIMEOUT_MS = 2_000;
 const REALTIME_LIVE_MODEL = "gpt-live-1-codex";
 const MAX_REALTIME_SDP_BYTES = 512 * 1024;
 const MAX_REALTIME_SPEECH_BYTES = 8 * 1024;
+const MAX_REALTIME_CONTEXT_ITEMS = 12;
+const MAX_REALTIME_CONTEXT_ITEM_BYTES = 8 * 1024;
+const MAX_REALTIME_CONTEXT_BYTES = 24 * 1024;
 const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
 const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
 /**
@@ -381,6 +401,107 @@ function userMessageText(value: JsonObject): string | null {
     if (text !== null) parts.push(text);
   }
   return parts.length > 0 ? parts.join("") : null;
+}
+
+function realtimeMessage(value: unknown): RealtimeInitialItem | null {
+  const item = record(value);
+  if (!item) return null;
+  const type = stringField(item, "type");
+  const message = record(item.message);
+  const role = stringField(item, "role") ?? stringField(message, "role");
+  const user = type === "userMessage"
+    || type === "user_message"
+    || type === "user"
+    || (type === "message" && role === "user");
+  const assistant = type === "agentMessage"
+    || type === "agent_message"
+    || type === "assistant"
+    || (type === "message" && role === "assistant");
+  if (!user && !assistant) return null;
+  const wireText = stringField(item, "text")
+    ?? userMessageText(item)
+    ?? (message ? stringField(message, "text") ?? userMessageText(message) : null);
+  if (!wireText) return null;
+  return user
+    ? { role: "user", text: decodeCodexStructuredUserText(wireText).text }
+    : { role: "assistant", text: wireText };
+}
+
+function utf8Tail(value: string, maxBytes: number): { text: string; truncated: boolean } {
+  const encoded = Buffer.from(value, "utf8");
+  if (encoded.byteLength <= maxBytes) return { text: value, truncated: false };
+  let start = encoded.byteLength - maxBytes;
+  while (start < encoded.byteLength && (encoded[start]! & 0xc0) === 0x80) start += 1;
+  return { text: encoded.subarray(start).toString("utf8"), truncated: true };
+}
+
+function selectRealtimeContext(events: readonly RuntimeEvent[]): RealtimeContextSelection {
+  let selected: RealtimeContextCandidate[] = [];
+  let truncated = false;
+  for (const event of events) {
+    if (event.kind === "delta") {
+      if (!event.text) continue;
+      const latest = selected.at(-1);
+      if (latest?.role === "assistant" && latest.turnId === event.turnId) {
+        const bounded = utf8Tail(latest.text + event.text, MAX_REALTIME_CONTEXT_ITEM_BYTES);
+        latest.text = bounded.text;
+        truncated ||= bounded.truncated;
+      } else {
+        const bounded = utf8Tail(event.text, MAX_REALTIME_CONTEXT_ITEM_BYTES);
+        selected = [{
+          role: "assistant",
+          text: bounded.text,
+          turnId: event.turnId,
+          source: "durable-delta",
+        }];
+        truncated = bounded.truncated;
+      }
+      continue;
+    }
+    if (event.kind !== "item" || event.phase !== "completed") continue;
+    const message = realtimeMessage(event.item);
+    if (!message) continue;
+    if (message.role === "user") {
+      if (selected.length === 0) continue;
+      const bounded = utf8Tail(message.text, MAX_REALTIME_CONTEXT_ITEM_BYTES);
+      selected.push({
+        ...message,
+        text: bounded.text,
+        turnId: event.turnId,
+        source: "durable-item",
+      });
+      truncated ||= bounded.truncated;
+      if (selected.length > MAX_REALTIME_CONTEXT_ITEMS) {
+        selected = [selected[0]!, ...selected.slice(-(MAX_REALTIME_CONTEXT_ITEMS - 1))];
+        truncated = true;
+      }
+      continue;
+    }
+    const draftIndex = selected.findLastIndex((candidate) =>
+      candidate.role === "assistant"
+      && (event.turnId === null || candidate.turnId === event.turnId));
+    if (draftIndex >= 0) {
+      selected = [];
+      truncated = false;
+    }
+  }
+  selected = selected.filter((candidate) => candidate.text.length > 0);
+  let selectedBytes = selected.reduce((total, candidate) =>
+    total + Buffer.byteLength(candidate.text, "utf8"), 0);
+  while (selectedBytes > MAX_REALTIME_CONTEXT_BYTES && selected.length > 1) {
+    const removed = selected.splice(1, 1)[0]!;
+    selectedBytes -= Buffer.byteLength(removed.text, "utf8");
+    truncated = true;
+  }
+  return {
+    items: selected.map(({ role, text }) => ({ role, text })),
+    diagnosticItems: selected.map(({ role, source, text }) => ({
+      role,
+      source,
+      bytes: Buffer.byteLength(text, "utf8"),
+    })),
+    truncated,
+  };
 }
 
 function threadStatus(value: unknown): ThreadStatus | null {
@@ -805,12 +926,10 @@ export class CodexAppServerHost implements EngineHost {
     });
     void answer.catch(() => undefined);
 
-    /* The persona reaches the call through the THREAD, never through the live
-       session: `includeStartupContext` pulls the thread in at start, while an
-       initial item on the session made codex open the sideband channel that
-       every 9-second kill arrived on. Best effort by construction — a rejected
-       injection must never cost the operator their call, so the failure is
-       swallowed and the start proceeds with whatever the thread already holds. */
+    /* The persona is a durable thread item, so `includeStartupContext` carries
+       it into every call and reconnect. Best effort by construction — a
+       rejected injection must never cost the operator their call, so the start
+       proceeds with whatever instructions the thread already holds. */
     try {
       await this.rpc("thread/inject_items", {
         threadId: this.identity.threadId,
@@ -821,6 +940,12 @@ export class CodexAppServerHost implements EngineHost {
          own log, which is where a wrong item shape gets diagnosed, and the
          operator gets their call either way. */
     }
+    const realtimeContext = selectRealtimeContext(this.events);
+    console.info("[realtime context] selected", {
+      providerStartupContext: true,
+      durableTail: realtimeContext.diagnosticItems,
+      truncated: realtimeContext.truncated,
+    });
     try {
       await this.rpc("thread/realtime/start", {
         threadId: this.identity.threadId,
@@ -831,12 +956,10 @@ export class CodexAppServerHost implements EngineHost {
         clientManagedHandoffs: true,
         codexResponsesAsItems: true,
         includeStartupContext: true,
-        /* NO initial items. Sending any made codex open the sideband channel
-           `wss://api.openai.com/v1/live/<call-id>`, and every call that opened
-           it was killed 9 seconds later with rate_limit_error, while calls
-           without it ran for tens of minutes on the same build, account, and
-           model. The persona has to reach the call through the thread instead,
-           which `includeStartupContext` already pulls in. */
+        /* Current V3 clients carry initial items in call creation. Add the
+           durable tail only when a streamed assistant response has no
+           committed item; provider startup context owns the persisted history. */
+        ...(realtimeContext.items.length > 0 ? { initialItems: realtimeContext.items } : {}),
       }, REALTIME_START_TIMEOUT_MS);
     } catch (error) {
       this.rejectRealtimeStart(error instanceof Error ? error : new Error(safeError(error)));


### PR DESCRIPTION
## Summary

- Seed current V3 realtime call creation with a bounded role-bearing tail when the newest assistant response remains uncommitted.
- Preserve canonical assistant-then-user ordering across overlap, interruption, compaction, and host adoption.
- Keep committed history under provider startup-context ownership and emit content-free source/byte diagnostics.

## Confirmed cause

Realtime startup context is assembled from persisted thread items. Duplex assistant text first arrives as durable `item/agentMessage/delta` events, so a follow-up can commit before the preceding assistant item reaches `item/completed`. Reconnect then starts from persisted items and omits that assistant response. The durable records remain distinct and ordered, which rules out Viewer transcript rendering as the source.

## Changed contract

When the newest assistant response has no committed item, `thread/realtime/start` receives a bounded `initialItems` suffix beginning with the durable assistant draft and followed by later committed user items. A committed assistant item clears that suffix. Limits are 12 items, 8 KiB per item, and 24 KiB total, preserving UTF-8 boundaries.

## Verification

- Focused host regressions: 3 passed (resume/interruption/compaction, committed selection, UTF-8 and item bounds)
- Full host test file: 92 passed; 2 unchanged legacy opt-in assertions fail against the current rollback-default contract on `main`
- `bunx tsc --noEmit`
- ESLint on both changed files
- Privacy publication gate with commit inspection
- Self-review: no unresolved findings

Closes #833
