### PR TITLE
Stream assistant replies to voice in bounded semantic chunks

### DIFF
--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Flow } from "@/lib/flows/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 import {
   applyEvent,
@@ -210,6 +211,28 @@ describe("live turn delta buffering", () => {
 });
 
 describe("canonical voice delivery reconciliation", () => {
+  test("publishes a ready semantic chunk before turn completion and removes it on interruption", () => {
+    const delivery = streamingVoiceDelivery({
+      sourceTurnId: "streaming-turn",
+      chunkIndex: 0,
+      startOffset: 0,
+      endOffset: 19,
+      text: "substantial phrase ",
+    });
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("voice-chunk", { type: "session", id: "conv_a" }, 4, {
+      conversationId: "conv_a",
+      voiceDelivery: delivery,
+    }));
+    expect(store.sessions.conv_a?.voiceDeliveries).toEqual([delivery]);
+    store = apply(store, env("turn-ended", { type: "session", id: "conv_a" }, 5, {
+      conversationId: "conv_a",
+      turnId: "streaming-turn",
+      outcome: "interrupted",
+    }));
+    expect(store.sessions.conv_a?.voiceDeliveries).toEqual([]);
+  });
+
   test("hydrates an unseen completed multi-item turn and keeps rerenders idempotent", () => {
     const unicode = `${"🙂界".repeat(8_000)}\nfinished`;
     let store = installSnapshot(snapshot());

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -31,6 +31,7 @@ import {
 } from "@/lib/runtime/liveTurn";
 import {
   acknowledgeVoiceDelivery,
+  appendReadyVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
   normalizeAcknowledgedVoiceDeliveryIds,
@@ -561,6 +562,20 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
             : s.voiceDeliveries,
         };
       });
+      break;
+    }
+    case "voice-chunk": {
+      const p = env.payload as {
+        conversationId?: string;
+        voiceDelivery?: unknown;
+      };
+      const delivery = normalizeVoiceDeliveries([p.voiceDelivery])[0];
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => ({
+        ...s,
+        voiceDeliveries: delivery
+          ? appendReadyVoiceDelivery(s.voiceDeliveries, delivery)
+          : s.voiceDeliveries,
+      }));
       break;
     }
     case "turn-ended": {

--- a/src/hooks/useCodexRealtime.ts
+++ b/src/hooks/useCodexRealtime.ts
@@ -26,7 +26,10 @@ export interface RealtimeSurface {
   start(): Promise<void>;
   stop(): Promise<void>;
   updateWorkerProgress(turnId: string, progress: string, running: boolean): void;
-  reconcileWorkerDeliveries(deliveries: readonly RuntimeVoiceDelivery[]): void;
+  reconcileWorkerDeliveries(
+    deliveries: readonly RuntimeVoiceDelivery[],
+    options?: { authoritative?: boolean },
+  ): void;
   /** #691 §6: this call's credential, presented on every write into it and on every
       read of the inbox that carries its deploy nonces. */
   realtimeSession(): string | null;
@@ -147,7 +150,7 @@ export function useCodexRealtime(
     client.updateWorkerProgress(workerTurnId, workerProgress, workerRunning);
   }, [client, snapshot.phase, workerProgress, workerRunning, workerTurnId]);
   useEffect(() => {
-    client?.reconcileWorkerDeliveries(workerDeliveries);
+    client?.reconcileWorkerDeliveries(workerDeliveries, { authoritative: true });
   }, [client, snapshot.phase, workerDeliveries]);
 
   /* The ambient lease deliberately does NOT live here any more: this hook is

--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -2,6 +2,7 @@ import { afterAll, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 
 import { codexRealtimeClient } from "./codexRealtimeClient";
+import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 const dom = new Window();
 Object.assign(globalThis, {
@@ -442,6 +443,31 @@ test("hydrated completed responses queue in order before Live Mode opens", async
   StubPeerConnection.latest?.channel.onopen?.();
   await flushAsync();
   expect(delivered).toEqual([first, second]);
+  await client.stop();
+});
+
+test("authoritative interruption removes a queued semantic chunk before Live Mode opens", async () => {
+  const delivered: unknown[] = [];
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    if (body.action === "deliverWorkerResponse") delivered.push(body.delivery);
+    return jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" });
+  }) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_interrupted_chunk");
+  const chunk = streamingVoiceDelivery({
+    sourceTurnId: "turn-interrupted",
+    chunkIndex: 0,
+    startOffset: 0,
+    endOffset: 19,
+    text: "substantial phrase ",
+  });
+  client.reconcileWorkerDeliveries([chunk], { authoritative: true });
+  client.reconcileWorkerDeliveries([], { authoritative: true });
+
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  await flushAsync();
+  expect(delivered).toEqual([]);
   await client.stop();
 });
 

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -351,8 +351,20 @@ class CodexRealtimeClient {
     this.writeLine(`progress:${turnId}`, "progress", text, !running, "replace");
   }
 
-  reconcileWorkerDeliveries(value: readonly RuntimeVoiceDelivery[] | null | undefined): void {
-    for (const delivery of normalizeVoiceDeliveries(value)) {
+  reconcileWorkerDeliveries(
+    value: readonly RuntimeVoiceDelivery[] | null | undefined,
+    options: { authoritative?: boolean } = {},
+  ): void {
+    const deliveries = normalizeVoiceDeliveries(value);
+    if (options.authoritative) {
+      const current = new Set(deliveries.map((delivery) => delivery.deliveryId));
+      for (const [deliveryId, delivery] of this.pendingWorkerDeliveries) {
+        if (delivery.sourceTurnId && !current.has(deliveryId)) {
+          this.pendingWorkerDeliveries.delete(deliveryId);
+        }
+      }
+    }
+    for (const delivery of deliveries) {
       if (!delivery.ready || this.acknowledgedWorkerDeliveries.has(delivery.deliveryId)) continue;
       this.pendingWorkerDeliveries.set(delivery.deliveryId, delivery);
     }

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -449,6 +449,91 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("publishes a semantic voice chunk before the assistant response completes", async () => {
+    const threadId = "voice-semantic-stream-thread";
+    const turnId = "turn-semantic-stream";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+    await host.startRealtimeWebRtc("v=0\r\noffer");
+    server.notify("turn/started", {
+      threadId,
+      turn: { id: turnId },
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId,
+      turnId,
+      delta: "The first substantial part is ready and can be spoken while the remaining investigation continues, while enough related detail stays together to preserve the meaning and keep the spoken reply natural. ",
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId,
+      turnId,
+      delta: "This second sentence starts the next semantic batch.",
+    });
+    await Bun.sleep(0);
+
+    const streamed = eventStore.load(threadId).filter((event) =>
+      (event as { kind: string }).kind === "voice-chunk");
+    expect(streamed).toHaveLength(1);
+    expect(streamed[0]).toMatchObject({
+      kind: "voice-chunk",
+      turnId,
+      delivery: {
+        sourceTurnId: turnId,
+        streamChunk: { index: 0 },
+      },
+    });
+    expect(eventStore.load(threadId).some((event) => event.kind === "item")).toBeFalse();
+
+    const terminalText = "The first substantial part is ready and can be spoken while the remaining investigation continues, while enough related detail stays together to preserve the meaning and keep the spoken reply natural. This second sentence starts the next semantic batch.";
+    server.notify("item/completed", {
+      threadId,
+      turnId,
+      item: { type: "agentMessage", id: "assistant-semantic-stream", text: terminalText },
+    });
+    await Bun.sleep(0);
+    const completedEvents = eventStore.load(threadId);
+    const finalItem = completedEvents.findLast((event) => event.kind === "item");
+    const voiceResponse = finalItem && "voiceResponse" in finalItem
+      ? finalItem.voiceResponse
+      : undefined;
+    const streamedText = completedEvents
+      .filter((event) => event.kind === "voice-chunk")
+      .map((event) => event.delivery.responses[0]!.text)
+      .join("");
+    expect(streamedText + (voiceResponse?.text ?? "")).toBe(terminalText);
+    await host.release();
+  });
+
+  test("bounds unacknowledged semantic chunks instead of forwarding every delta", async () => {
+    const threadId = "voice-semantic-backpressure-thread";
+    const turnId = "turn-semantic-backpressure";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+    await host.startRealtimeWebRtc("v=0\r\noffer");
+    server.notify("turn/started", { threadId, turn: { id: turnId } });
+    for (let index = 0; index < 10; index += 1) {
+      server.notify("item/agentMessage/delta", {
+        threadId,
+        turnId,
+        delta: `${index}: ${"One cohesive explanation remains in a single speech request to keep quota use bounded and delivery natural. ".repeat(2)}`,
+      });
+    }
+    await Bun.sleep(0);
+
+    expect(eventStore.load(threadId).filter((event) => event.kind === "voice-chunk")).toHaveLength(6);
+    await host.release();
+  });
+
   test("bounds the unresolved realtime tail by UTF-8 bytes and item count", async () => {
     const server = new FakeAppServer("voice-bounded-thread");
     const host = await CodexAppServerHost.start({

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, type Hash } from "node:crypto";
 
 import { isKnownEffortTier } from "@/lib/agent/efforts";
 import { procBackend } from "@/lib/proc";
@@ -14,9 +14,19 @@ import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, runtimeImageStore } from "./runtime
 import { STRUCTURED_IMAGE_CAPABILITY, type StructuredImageRef } from "./structuredContent";
 import {
   normalizeVoiceDeliveries,
+  streamingVoiceDelivery,
+  terminalVoiceResponse,
   utf8ChunkAt,
   type RuntimeVoiceDelivery,
+  type RuntimeVoiceResponse,
 } from "./voiceDelivery";
+import {
+  takeVoiceStreamChunk,
+  VOICE_STREAM_BUFFER_LIMIT_BYTES,
+  VOICE_STREAM_FLUSH_DELAY_MS,
+  VOICE_STREAM_MAX_PENDING,
+  type VoiceStreamFlushMode,
+} from "./voiceStreamChunks";
 
 import type {
   DeliveryReceipt,
@@ -90,6 +100,18 @@ type RealtimeDeliveryState = {
   responseIndex: number;
   offset: number;
   acknowledged: boolean;
+};
+type VoiceStreamState = {
+  turnId: string;
+  segmentIndex: number;
+  nextChunkIndex: number;
+  buffer: string;
+  observedChars: number;
+  emittedChars: number;
+  observedHash: Hash;
+  emittedHash: Hash;
+  fallbackToTerminal: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
 };
 type RealtimeInitialItem = {
   role: "user" | "assistant";
@@ -554,6 +576,9 @@ export class CodexAppServerHost implements EngineHost {
   }>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
+  private readonly voiceStreams = new Map<string, VoiceStreamState>();
+  private readonly pendingVoiceChunks = new Map<string, string>();
+  private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
     digest: string;
     promise: Promise<{ deliveryId: string; acknowledged: true }>;
@@ -977,12 +1002,171 @@ export class CodexAppServerHost implements EngineHost {
     });
   }
 
+  private voiceStream(turnId: string): VoiceStreamState {
+    const existing = this.voiceStreams.get(turnId);
+    if (existing) return existing;
+    const created: VoiceStreamState = {
+      turnId,
+      segmentIndex: 0,
+      nextChunkIndex: 0,
+      buffer: "",
+      observedChars: 0,
+      emittedChars: 0,
+      observedHash: createHash("sha256"),
+      emittedHash: createHash("sha256"),
+      fallbackToTerminal: false,
+      timer: null,
+    };
+    this.voiceStreams.set(turnId, created);
+    return created;
+  }
+
+  private observeVoiceDelta(turnId: string, text: string): void {
+    if (!text || this.cancelledVoiceTurns.has(turnId)) return;
+    const stream = this.voiceStream(turnId);
+    stream.buffer += text;
+    stream.observedChars += text.length;
+    stream.observedHash.update(text);
+    if (Buffer.byteLength(stream.buffer, "utf8") > VOICE_STREAM_BUFFER_LIMIT_BYTES) {
+      stream.fallbackToTerminal = true;
+      stream.buffer = "";
+      this.clearVoiceStreamTimer(stream);
+      return;
+    }
+    if (!this.realtimeSessionId || stream.fallbackToTerminal) return;
+    this.flushVoiceStream(stream, "eager");
+    this.scheduleVoiceStreamFlush(stream);
+  }
+
+  private flushVoiceStream(stream: VoiceStreamState, mode: VoiceStreamFlushMode): boolean {
+    if (!this.realtimeSessionId
+      || stream.fallbackToTerminal
+      || this.cancelledVoiceTurns.has(stream.turnId)
+      || this.pendingVoiceChunks.size >= VOICE_STREAM_MAX_PENDING) return false;
+    const chunk = takeVoiceStreamChunk(stream.buffer, mode);
+    if (!chunk) return false;
+    const startOffset = stream.emittedChars;
+    const endOffset = startOffset + chunk.text.length;
+    const delivery = streamingVoiceDelivery({
+      sourceTurnId: stream.turnId,
+      chunkIndex: stream.nextChunkIndex,
+      startOffset,
+      endOffset,
+      text: chunk.text,
+    });
+    this.emit({ kind: "voice-chunk", turnId: stream.turnId, delivery });
+    if (this.ledgerFailed) return false;
+    this.pendingVoiceChunks.set(delivery.deliveryId, stream.turnId);
+    stream.nextChunkIndex += 1;
+    stream.emittedChars = endOffset;
+    stream.emittedHash.update(chunk.text);
+    stream.buffer = chunk.remainder;
+    return true;
+  }
+
+  private scheduleVoiceStreamFlush(stream: VoiceStreamState): void {
+    this.clearVoiceStreamTimer(stream);
+    if (!stream.buffer
+      || !this.realtimeSessionId
+      || stream.fallbackToTerminal
+      || this.cancelledVoiceTurns.has(stream.turnId)) return;
+    stream.timer = setTimeout(() => {
+      stream.timer = null;
+      const flushed = this.flushVoiceStream(stream, "deadline");
+      if (flushed && stream.buffer.length > 0 && this.pendingVoiceChunks.size < VOICE_STREAM_MAX_PENDING) {
+        this.scheduleVoiceStreamFlush(stream);
+      }
+    }, VOICE_STREAM_FLUSH_DELAY_MS);
+  }
+
+  private clearVoiceStreamTimer(stream: VoiceStreamState): void {
+    if (!stream.timer) return;
+    clearTimeout(stream.timer);
+    stream.timer = null;
+  }
+
+  private clearVoiceStreamTimers(): void {
+    for (const stream of this.voiceStreams.values()) this.clearVoiceStreamTimer(stream);
+  }
+
+  private resetVoiceStreamSegment(stream: VoiceStreamState): void {
+    this.clearVoiceStreamTimer(stream);
+    stream.segmentIndex += 1;
+    stream.buffer = "";
+    stream.observedChars = 0;
+    stream.emittedChars = 0;
+    stream.observedHash = createHash("sha256");
+    stream.emittedHash = createHash("sha256");
+    stream.fallbackToTerminal = false;
+  }
+
+  private finalizeVoiceStreamItem(turnId: string, item: unknown): RuntimeVoiceResponse | null | undefined {
+    const stream = this.voiceStreams.get(turnId);
+    const terminal = terminalVoiceResponse(item, `voice-final:${turnId}:${stream?.segmentIndex ?? 0}`);
+    if (!terminal) return undefined;
+    /* Legacy terminal-only turns keep the historical event shape. The
+       projection layer derives their complete voice response. An explicit
+       override is needed only after streaming has emitted or buffered text. */
+    if (!stream || stream.observedChars === 0) return undefined;
+    this.clearVoiceStreamTimer(stream);
+    const emittedPrefix = terminal.text.slice(0, stream.emittedChars);
+    const emittedMatches = createHash("sha256").update(emittedPrefix).digest("hex")
+      === stream.emittedHash.copy().digest("hex");
+    const observedPrefix = terminal.text.slice(0, stream.observedChars);
+    const observedMatches = stream.observedChars <= terminal.text.length
+      && createHash("sha256").update(observedPrefix).digest("hex")
+        === stream.observedHash.copy().digest("hex");
+    if (emittedMatches && observedMatches && !stream.fallbackToTerminal) {
+      this.flushVoiceStream(stream, "final");
+    }
+    const offset = emittedMatches ? stream.emittedChars : 0;
+    const suffix = terminal.text.slice(offset);
+    if (!emittedMatches || !observedMatches) {
+      console.warn("[realtime voice stream] terminal reconciliation used bounded fallback", {
+        turnId,
+        emittedChars: stream.emittedChars,
+        observedChars: stream.observedChars,
+        emittedMatches,
+        observedMatches,
+      });
+    }
+    this.resetVoiceStreamSegment(stream);
+    if (!suffix) return null;
+    return {
+      responseId: offset > 0 ? `${terminal.responseId}:suffix:${offset}` : terminal.responseId,
+      text: suffix,
+    };
+  }
+
+  private cancelVoiceStream(turnId: string): void {
+    const stream = this.voiceStreams.get(turnId);
+    if (stream) this.clearVoiceStreamTimer(stream);
+    this.voiceStreams.delete(turnId);
+    this.cancelledVoiceTurns.add(turnId);
+    for (const [deliveryId, sourceTurnId] of this.pendingVoiceChunks) {
+      if (sourceTurnId === turnId) this.pendingVoiceChunks.delete(deliveryId);
+    }
+  }
+
+  private resumeVoiceStreams(): void {
+    if (!this.realtimeSessionId) return;
+    for (const stream of this.voiceStreams.values()) {
+      if (this.cancelledVoiceTurns.has(stream.turnId)) continue;
+      stream.fallbackToTerminal = false;
+      this.flushVoiceStream(stream, "eager");
+      this.scheduleVoiceStreamFlush(stream);
+    }
+  }
+
   async deliverRealtimeWorkerResponse(
     value: RuntimeVoiceDelivery,
   ): Promise<{ deliveryId: string; acknowledged: true }> {
     const delivery = normalizeVoiceDeliveries([value])[0];
     if (!delivery || !delivery.ready || delivery.deliveryId !== value.deliveryId) {
       throw new Error("Realtime worker delivery is invalid");
+    }
+    if (delivery.sourceTurnId && this.cancelledVoiceTurns.has(delivery.sourceTurnId)) {
+      throw new Error("Realtime worker delivery belongs to an interrupted turn");
     }
     const digest = createHash("sha256")
       .update(JSON.stringify(delivery.responses))
@@ -1066,6 +1250,15 @@ export class CodexAppServerHost implements EngineHost {
       offset,
       acknowledged: true,
     });
+    const sourceTurnId = this.pendingVoiceChunks.get(delivery.deliveryId);
+    if (sourceTurnId) {
+      this.pendingVoiceChunks.delete(delivery.deliveryId);
+      const stream = this.voiceStreams.get(sourceTurnId);
+      if (stream && !this.cancelledVoiceTurns.has(sourceTurnId)) {
+        this.flushVoiceStream(stream, "eager");
+        this.scheduleVoiceStreamFlush(stream);
+      }
+    }
     return { deliveryId: delivery.deliveryId, acknowledged: true };
   }
 
@@ -1079,6 +1272,10 @@ export class CodexAppServerHost implements EngineHost {
     /* An operator hanging up is not a failure to report back to them. */
     this.realtimeFailure = null;
     this.realtimeSessionId = null;
+    for (const stream of this.voiceStreams.values()) {
+      this.clearVoiceStreamTimer(stream);
+      stream.fallbackToTerminal = true;
+    }
   }
 
   async answer(attentionRef: string, value: unknown): Promise<void> {
@@ -1223,6 +1420,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private finishRelease(): void {
     if (this.released) return;
+    this.clearVoiceStreamTimers();
     if (this.failureCleanupTimer) {
       clearTimeout(this.failureCleanupTimer);
       this.failureCleanupTimer = null;
@@ -1352,6 +1550,10 @@ export class CodexAppServerHost implements EngineHost {
     const stored = this.eventStore.load(this.identity.threadId);
     const currentAttentions = new Map([...this.attentions].filter(([, attention]) => attention.origin === "current"));
     this.attentions.clear();
+    this.clearVoiceStreamTimers();
+    this.voiceStreams.clear();
+    this.pendingVoiceChunks.clear();
+    this.cancelledVoiceTurns.clear();
     this.events.splice(0, this.events.length, ...stored);
     this.cursor = reconcileRuntimeEventCursor(
       this.identity.threadId,
@@ -1360,8 +1562,40 @@ export class CodexAppServerHost implements EngineHost {
       this.onEventCursorRecovery,
     );
     for (const event of stored) {
-      if (event.kind === "turn-started") this.activeTurnId = event.turnId;
-      if (event.kind === "turn-ended" && event.turnId === this.activeTurnId) this.activeTurnId = null;
+      if (event.kind === "turn-started") {
+        this.cancelledVoiceTurns.delete(event.turnId);
+        this.activeTurnId = event.turnId;
+      }
+      if (event.kind === "delta") this.observeVoiceDelta(event.turnId, event.text);
+      if (event.kind === "voice-chunk") {
+        const delivery = normalizeVoiceDeliveries([event.delivery])[0];
+        const response = delivery?.responses[0];
+        const stream = delivery?.sourceTurnId ? this.voiceStream(delivery.sourceTurnId) : null;
+        if (delivery?.streamChunk && response && stream
+          && delivery.streamChunk.startOffset === stream.emittedChars
+          && stream.buffer.startsWith(response.text)) {
+          stream.buffer = stream.buffer.slice(response.text.length);
+          stream.emittedChars = delivery.streamChunk.endOffset;
+          stream.emittedHash.update(response.text);
+          stream.nextChunkIndex = Math.max(stream.nextChunkIndex, delivery.streamChunk.index + 1);
+          this.pendingVoiceChunks.set(delivery.deliveryId, delivery.sourceTurnId!);
+        } else if (stream) {
+          stream.fallbackToTerminal = true;
+          stream.buffer = "";
+        }
+      }
+      if (event.kind === "item" && event.phase === "completed" && event.turnId
+        && terminalVoiceResponse(event.item, "restored")) {
+        const stream = this.voiceStreams.get(event.turnId);
+        if (stream) this.resetVoiceStreamSegment(stream);
+      }
+      if (event.kind === "turn-ended") {
+        if (event.turnId === this.activeTurnId) this.activeTurnId = null;
+        const stream = this.voiceStreams.get(event.turnId);
+        if (stream) this.clearVoiceStreamTimer(stream);
+        this.voiceStreams.delete(event.turnId);
+        if (event.status !== "completed") this.cancelledVoiceTurns.add(event.turnId);
+      }
       if (event.kind === "attention") {
         this.attentions.set(event.id, { rpcId: "restored", method: event.method, origin: "restored" });
       }
@@ -1382,6 +1616,7 @@ export class CodexAppServerHost implements EngineHost {
           offset: previous?.offset ?? 0,
           acknowledged: true,
         });
+        this.pendingVoiceChunks.delete(event.deliveryId);
       }
       if (event.kind === "session-status") {
         this.engineStatus = event.status;
@@ -1936,6 +2171,7 @@ export class CodexAppServerHost implements EngineHost {
       pending.started = true;
       pending.realtimeSessionId = stringField(params, "realtimeSessionId");
       this.realtimeSessionId = pending.realtimeSessionId;
+      this.resumeVoiceStreams();
       this.resolveRealtimeStart();
       return;
     }
@@ -1988,6 +2224,7 @@ export class CodexAppServerHost implements EngineHost {
         const historicalTerminal = this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId);
         if (historicalStart && (historicalTerminal || this.activeTurnId !== null)) return;
       }
+      this.cancelledVoiceTurns.delete(turnId);
       this.activeTurnId = turnId;
       this.emit({ kind: "turn-started", turnId });
       return;
@@ -1998,7 +2235,10 @@ export class CodexAppServerHost implements EngineHost {
         turnId: turnId ?? this.activeTurnId ?? "unknown",
         text: stringField(params, "delta") ?? "",
       };
-      if (!reconcileBufferedLifecycle || !this.consumeBufferedNotification(event)) this.emit(event);
+      if (!reconcileBufferedLifecycle || !this.consumeBufferedNotification(event)) {
+        this.emit(event);
+        this.observeVoiceDelta(event.turnId, event.text);
+      }
       return;
     }
     if ((method === "item/started" || method === "item/completed") && "item" in params) {
@@ -2020,7 +2260,16 @@ export class CodexAppServerHost implements EngineHost {
           this.emit({ kind: "turn-started", turnId: eventTurnId });
         }
       }
-      this.emit({ kind: "item", turnId: eventTurnId, item: this.boundImageBodies(params.item), phase });
+      const voiceResponse = phase === "completed" && eventTurnId
+        ? this.finalizeVoiceStreamItem(eventTurnId, params.item)
+        : undefined;
+      this.emit({
+        kind: "item",
+        turnId: eventTurnId,
+        item: this.boundImageBodies(params.item),
+        phase,
+        ...(voiceResponse !== undefined ? { voiceResponse } : {}),
+      });
       return;
     }
     if (method === "turn/completed" && turnId) {
@@ -2033,6 +2282,13 @@ export class CodexAppServerHost implements EngineHost {
       if (reconcileBufferedLifecycle
         && !this.events.some((event) => event.kind === "turn-started" && event.turnId === turnId)) {
         this.emit({ kind: "turn-started", turnId });
+      }
+      if (status !== "completed") {
+        this.cancelVoiceStream(turnId);
+      } else {
+        const stream = this.voiceStreams.get(turnId);
+        if (stream) this.clearVoiceStreamTimer(stream);
+        this.voiceStreams.delete(turnId);
       }
       this.emit({ kind: "turn-ended", turnId, status });
       return;
@@ -2049,6 +2305,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private fail(error: Error, activeFlags: string[] = []): void {
     if (this.dead || this.released) return;
+    this.clearVoiceStreamTimers();
     this.dead = true;
     this.failure = error;
     this.activeTurnId = null;

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -1,4 +1,5 @@
 import type { RuntimeSendSettings } from "./contracts";
+import type { RuntimeVoiceDelivery, RuntimeVoiceResponse } from "./voiceDelivery";
 import {
   structuredContent,
   type StructuredImageRef,
@@ -49,7 +50,8 @@ export type DeliveryReceipt =
 export type RuntimeEvent =
   | { kind: "turn-started"; turnId: string; seq: number }
   | { kind: "delta"; turnId: string; text: string; seq: number }
-  | { kind: "item"; turnId: string | null; item: unknown; phase: "started" | "completed"; seq: number }
+  | { kind: "item"; turnId: string | null; item: unknown; phase: "started" | "completed"; voiceResponse?: RuntimeVoiceResponse | null; seq: number }
+  | { kind: "voice-chunk"; turnId: string; delivery: RuntimeVoiceDelivery; seq: number }
   | { kind: "turn-ended"; turnId: string; status: "completed" | "interrupted" | "error"; seq: number }
   | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
   | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted" | "server-resolved"; seq: number }

--- a/src/lib/runtime/engineHostEvents.test.ts
+++ b/src/lib/runtime/engineHostEvents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { streamingVoiceDelivery } from "./voiceDelivery";
 import { projectEngineHostEvent } from "./engineHostEvents";
 
 describe("projectEngineHostEvent", () => {
@@ -85,6 +86,33 @@ describe("projectEngineHostEvent", () => {
     });
     expect(new TextEncoder().encode((projected?.payload.voiceResponse as { text: string }).text).length)
       .toBeGreaterThan(64 * 1024);
+  });
+
+  test("projects an early semantic chunk and lets an explicit terminal override suppress replay", () => {
+    const delivery = streamingVoiceDelivery({
+      sourceTurnId: "turn-stream",
+      chunkIndex: 0,
+      startOffset: 0,
+      endOffset: 19,
+      text: "substantial phrase ",
+    });
+    expect(projectEngineHostEvent("conversation_voice", "codex:thread-voice", {
+      kind: "voice-chunk",
+      turnId: "turn-stream",
+      delivery,
+      seq: 13,
+    })).toMatchObject({
+      kind: "voice-chunk",
+      payload: { conversationId: "conversation_voice", turnId: "turn-stream", voiceDelivery: delivery },
+    });
+    expect(projectEngineHostEvent("conversation_voice", "codex:thread-voice", {
+      kind: "item",
+      turnId: "turn-stream",
+      item: { type: "agentMessage", id: "response-stream", text: "substantial phrase " },
+      phase: "completed",
+      voiceResponse: null,
+      seq: 14,
+    })?.payload.voiceResponse).toBeUndefined();
   });
 
   test("projects durable receiver acknowledgement onto the pending session delivery", () => {

--- a/src/lib/runtime/engineHostEvents.ts
+++ b/src/lib/runtime/engineHostEvents.ts
@@ -118,10 +118,23 @@ export function projectEngineHostEvent(
   if (event.kind === "delta") {
     return { ...base, kind: "delta", payload: { conversationId, turnId: event.turnId, text: clipped(event.text, 8 * 1024) } };
   }
+  if (event.kind === "voice-chunk") {
+    return {
+      ...base,
+      kind: "voice-chunk",
+      payload: {
+        conversationId,
+        turnId: event.turnId,
+        voiceDelivery: event.delivery,
+      },
+    };
+  }
   if (event.kind === "item") {
-    const voiceResponse = engine === "codex" && event.phase === "completed"
-      ? terminalVoiceResponse(event.item, `engine-host:${hostKey}:${event.seq}`)
-      : null;
+    const voiceResponse = "voiceResponse" in event
+      ? event.voiceResponse
+      : engine === "codex" && event.phase === "completed"
+        ? terminalVoiceResponse(event.item, `engine-host:${hostKey}:${event.seq}`)
+        : null;
     return {
       ...base,
       kind: "item",

--- a/src/lib/runtime/voiceDelivery.test.ts
+++ b/src/lib/runtime/voiceDelivery.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import {
   acknowledgeVoiceDelivery,
+  appendReadyVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
   rememberAcknowledgedVoiceDelivery,
   terminalVoiceResponse,
+  streamingVoiceDelivery,
   utf8ChunkAt,
   type RuntimeVoiceDelivery,
 } from "./voiceDelivery";
@@ -68,6 +70,31 @@ describe("canonical voice delivery state", () => {
     expect(completeVoiceTurn(withDraft, "turn-interrupted", "interrupted")).toEqual(pending);
     expect(acknowledgeVoiceDelivery(pending, pending[0]!.deliveryId)).toEqual([]);
     expect(acknowledgeVoiceDelivery(pending, "unknown")).toEqual(pending);
+  });
+
+  test("keeps immutable streamed chunks distinct and removes their interrupted source turn", () => {
+    const first = streamingVoiceDelivery({
+      sourceTurnId: "turn-streamed",
+      chunkIndex: 0,
+      startOffset: 0,
+      endOffset: 11,
+      text: "first part ",
+    });
+    const second = streamingVoiceDelivery({
+      sourceTurnId: "turn-streamed",
+      chunkIndex: 1,
+      startOffset: 11,
+      endOffset: 22,
+      text: "second part",
+    });
+    const once = appendReadyVoiceDelivery([], first);
+    expect(appendReadyVoiceDelivery(once, first)).toEqual(once);
+    const queued = appendReadyVoiceDelivery(once, second);
+    expect(queued.map((delivery) => delivery.responses[0]!.text)).toEqual([
+      "first part ",
+      "second part",
+    ]);
+    expect(completeVoiceTurn(queued, "turn-streamed", "interrupted")).toEqual([]);
   });
 
   test("bounds durable acknowledgement identities and retires a replayed delivery", () => {

--- a/src/lib/runtime/voiceDelivery.ts
+++ b/src/lib/runtime/voiceDelivery.ts
@@ -8,6 +8,13 @@ export interface RuntimeVoiceDelivery {
   turnId: string;
   responses: RuntimeVoiceResponse[];
   ready: boolean;
+  /** Original backend turn for an immutable pre-terminal speech chunk. */
+  sourceTurnId?: string;
+  streamChunk?: {
+    index: number;
+    startOffset: number;
+    endOffset: number;
+  };
 }
 
 export interface Utf8Chunk {
@@ -82,13 +89,73 @@ export function normalizeVoiceDeliveries(value: unknown): RuntimeVoiceDelivery[]
       })
       : [];
     if (!turnId || responses.length === 0) return [];
+    const sourceTurnId = string(delivery?.sourceTurnId);
+    const streamChunk = record(delivery?.streamChunk);
+    const index = streamChunk?.index;
+    const startOffset = streamChunk?.startOffset;
+    const endOffset = streamChunk?.endOffset;
+    const validStreamChunk = sourceTurnId
+      && Number.isInteger(index)
+      && Number.isInteger(startOffset)
+      && Number.isInteger(endOffset)
+      && (index as number) >= 0
+      && (startOffset as number) >= 0
+      && (endOffset as number) > (startOffset as number);
     return [{
       deliveryId: deliveryId(turnId, responses),
       turnId,
       responses,
       ready: delivery?.ready === true,
+      ...(validStreamChunk ? {
+        sourceTurnId,
+        streamChunk: {
+          index: index as number,
+          startOffset: startOffset as number,
+          endOffset: endOffset as number,
+        },
+      } : {}),
     }];
   });
+}
+
+export function streamingVoiceDelivery(options: {
+  sourceTurnId: string;
+  chunkIndex: number;
+  startOffset: number;
+  endOffset: number;
+  text: string;
+}): RuntimeVoiceDelivery {
+  const turnId = `voice-stream:${options.sourceTurnId}:${options.chunkIndex}:${options.startOffset}:${options.endOffset}`;
+  const responseId = `${turnId}:response`;
+  return normalizeVoiceDeliveries([{
+    deliveryId: "derived",
+    turnId,
+    sourceTurnId: options.sourceTurnId,
+    streamChunk: {
+      index: options.chunkIndex,
+      startOffset: options.startOffset,
+      endOffset: options.endOffset,
+    },
+    responses: [{ responseId, text: options.text }],
+    ready: true,
+  }])[0]!;
+}
+
+export function appendReadyVoiceDelivery(
+  value: readonly RuntimeVoiceDelivery[] | null | undefined,
+  delivery: RuntimeVoiceDelivery,
+): RuntimeVoiceDelivery[] {
+  const deliveries = normalizeVoiceDeliveries(value);
+  const normalized = normalizeVoiceDeliveries([delivery])[0];
+  if (!normalized?.ready) return deliveries;
+  const existing = deliveries.find((candidate) => candidate.deliveryId === normalized.deliveryId);
+  if (existing) {
+    if (JSON.stringify(existing) !== JSON.stringify(normalized)) {
+      throw new Error("voice delivery id belongs to different content");
+    }
+    return deliveries;
+  }
+  return [...deliveries, normalized];
 }
 
 export function normalizeAcknowledgedVoiceDeliveryIds(value: unknown): string[] {
@@ -151,10 +218,11 @@ export function completeVoiceTurn(
 ): RuntimeVoiceDelivery[] {
   const deliveries = normalizeVoiceDeliveries(value);
   const index = deliveries.findIndex((delivery) => delivery.turnId === turnId);
-  if (index < 0) return deliveries;
   if (outcome !== "completed") {
-    return deliveries.filter((_, deliveryIndex) => deliveryIndex !== index);
+    return deliveries.filter((delivery) =>
+      delivery.turnId !== turnId && delivery.sourceTurnId !== turnId);
   }
+  if (index < 0) return deliveries;
   if (deliveries[index]!.ready) return deliveries;
   if (normalizeAcknowledgedVoiceDeliveryIds(acknowledgedDeliveryIds)
     .includes(deliveries[index]!.deliveryId)) {

--- a/src/lib/runtime/voiceStreamChunks.test.ts
+++ b/src/lib/runtime/voiceStreamChunks.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  VOICE_STREAM_DEADLINE_MIN_CHARS,
+  VOICE_STREAM_MAX_BYTES,
+  VOICE_STREAM_MIN_SENTENCE_CHARS,
+  takeVoiceStreamChunk,
+} from "./voiceStreamChunks";
+
+describe("semantic realtime voice chunks", () => {
+  test("holds token-sized fragments until a complete substantial sentence exists", () => {
+    const short = "Small token fragment. ".repeat(4);
+    expect(short.length).toBeLessThan(VOICE_STREAM_MIN_SENTENCE_CHARS);
+    expect(takeVoiceStreamChunk(short, "eager")).toBeNull();
+
+    const first = `${"One related idea stays in this batch long enough to sound natural, clear, and complete. ".repeat(3)}`;
+    const second = "The next sentence remains buffered.";
+    const chunk = takeVoiceStreamChunk(first + second, "eager");
+    expect(chunk).toEqual({ text: first, remainder: second });
+  });
+
+  test("flushes a meaningful partial phrase after the deadline", () => {
+    const text = "a useful phrase with related context ".repeat(5);
+    expect(text.length).toBeGreaterThanOrEqual(VOICE_STREAM_DEADLINE_MIN_CHARS);
+    expect(takeVoiceStreamChunk(text, "deadline")).toEqual({ text, remainder: "" });
+  });
+
+  test("preserves exact Unicode content while respecting the byte ceiling", () => {
+    const text = `🙂界${"context ".repeat(400)}`;
+    const chunk = takeVoiceStreamChunk(text, "eager")!;
+    expect(chunk.text + chunk.remainder).toBe(text);
+    expect(Buffer.byteLength(chunk.text, "utf8")).toBeLessThanOrEqual(VOICE_STREAM_MAX_BYTES);
+    expect(chunk.text).not.toContain("\ufffd");
+  });
+
+  test("flushes the final residual exactly once", () => {
+    expect(takeVoiceStreamChunk("short final answer", "final")).toEqual({
+      text: "short final answer",
+      remainder: "",
+    });
+  });
+});

--- a/src/lib/runtime/voiceStreamChunks.ts
+++ b/src/lib/runtime/voiceStreamChunks.ts
@@ -1,0 +1,64 @@
+import { utf8ChunkAt } from "./voiceDelivery";
+
+export const VOICE_STREAM_FLUSH_DELAY_MS = 1_100;
+export const VOICE_STREAM_MIN_SENTENCE_CHARS = 180;
+export const VOICE_STREAM_DEADLINE_MIN_CHARS = 140;
+export const VOICE_STREAM_TARGET_CHARS = 560;
+export const VOICE_STREAM_MAX_BYTES = 1_800;
+export const VOICE_STREAM_MAX_PENDING = 6;
+export const VOICE_STREAM_BUFFER_LIMIT_BYTES = 24 * 1024;
+
+export type VoiceStreamFlushMode = "eager" | "deadline" | "final";
+
+export interface VoiceStreamChunk {
+  text: string;
+  remainder: string;
+}
+
+const sentenceBoundary = /[.!?…](?:["')\]}»”’]+)?\s+/gu;
+
+function lastBoundary(value: string, minimum: number): number {
+  sentenceBoundary.lastIndex = 0;
+  let boundary = -1;
+  for (const match of value.matchAll(sentenceBoundary)) {
+    const end = (match.index ?? 0) + match[0].length;
+    if (end >= minimum) boundary = end;
+  }
+  return boundary;
+}
+
+function whitespaceBoundary(value: string, preferred: number, minimum: number): number {
+  const before = value.slice(0, preferred + 1).search(/\s+\S*$/u);
+  if (before >= minimum) return before + value.slice(before).match(/^\s+/u)![0].length;
+  const after = value.slice(preferred).search(/\s/u);
+  return after >= 0 ? preferred + after + 1 : value.length;
+}
+
+/**
+ * Select one immutable, human-sized speech chunk from an accumulated assistant
+ * draft. Callers keep the remainder and decide when to invoke the module again;
+ * token cadence, timers, delivery acknowledgements, and interruption stay hidden
+ * from this interface.
+ */
+export function takeVoiceStreamChunk(
+  buffer: string,
+  mode: VoiceStreamFlushMode,
+): VoiceStreamChunk | null {
+  if (!buffer) return null;
+  const bounded = utf8ChunkAt(buffer, 0, VOICE_STREAM_MAX_BYTES)!;
+  const window = bounded.text;
+  const hardBounded = bounded.nextOffset < buffer.length;
+  const sentence = lastBoundary(window, VOICE_STREAM_MIN_SENTENCE_CHARS);
+
+  let cut = -1;
+  if (sentence >= 0) cut = sentence;
+  else if (mode === "final") cut = window.length;
+  else if (hardBounded || buffer.length >= VOICE_STREAM_TARGET_CHARS) {
+    cut = whitespaceBoundary(window, Math.min(VOICE_STREAM_TARGET_CHARS, window.length), VOICE_STREAM_MIN_SENTENCE_CHARS);
+  } else if (mode === "deadline" && buffer.length >= VOICE_STREAM_DEADLINE_MIN_CHARS) {
+    cut = whitespaceBoundary(window, window.length, VOICE_STREAM_DEADLINE_MIN_CHARS);
+  }
+
+  if (cut <= 0) return null;
+  return { text: buffer.slice(0, cut), remainder: buffer.slice(cut) };
+}

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -13,6 +13,7 @@ import { UnixRuntimeHostClient } from "@/lib/runtime/client";
 import { runtimePresentationReceipt, runtimeScope } from "@/lib/runtime/contracts";
 import { projectEngineHostEvent } from "@/lib/runtime/engineHostEvents";
 import { structuredContentDigest, type StructuredImageRef } from "@/lib/runtime/structuredContent";
+import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 import { RuntimeHost, RuntimeHostFence } from "./host";
 import { RuntimeJournal, RuntimeJournalFault } from "./journal";
@@ -185,6 +186,39 @@ test("canonical voice deliveries survive missed-running recovery and compaction 
   });
   expect(recovered.snapshot().sessions[0]?.voiceDeliveries).toEqual([]);
   recovered.close();
+});
+
+test("semantic voice chunks become ready immediately and interruption removes their queued suffix", () => {
+  const dir = sandbox("voice-semantic-chunks");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  const delivery = streamingVoiceDelivery({
+    sourceTurnId: "turn-streaming",
+    chunkIndex: 0,
+    startOffset: 0,
+    endOffset: 19,
+    text: "substantial phrase ",
+  });
+  journal.append({
+    scope: runtimeScope("session", "conversation_streaming"),
+    kind: "voice-chunk",
+    payload: {
+      conversationId: "conversation_streaming",
+      turnId: "turn-streaming",
+      voiceDelivery: delivery,
+    },
+  });
+  expect(journal.snapshot().sessions[0]?.voiceDeliveries).toEqual([delivery]);
+  journal.append({
+    scope: runtimeScope("session", "conversation_streaming"),
+    kind: "turn-ended",
+    payload: {
+      conversationId: "conversation_streaming",
+      turnId: "turn-streaming",
+      outcome: "interrupted",
+    },
+  });
+  expect(journal.snapshot().sessions[0]?.voiceDeliveries).toEqual([]);
+  journal.close();
 });
 
 test("acknowledged voice delivery stays retired after reload and terminal replay while an undelivered response hydrates", () => {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/runtime/contracts";
 import {
   acknowledgeVoiceDelivery,
+  appendReadyVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
   normalizeAcknowledgedVoiceDeliveryIds,
@@ -1640,6 +1641,18 @@ export class RuntimeJournal {
         revision: event.revision,
         liveTurn,
         ...(voiceDeliveries ? { voiceDeliveries } : {}),
+      }, event.seq);
+      return;
+    }
+    if (event.kind === "voice-chunk") {
+      const previous = this.entity<RuntimeSession>("session", scope.id) ?? baseSession(scope.id, {}, 0);
+      const delivery = normalizeVoiceDeliveries([payload.voiceDelivery])[0];
+      this.upsertEntity("session", scope.id, event.revision, {
+        ...previous,
+        revision: event.revision,
+        voiceDeliveries: delivery
+          ? appendReadyVoiceDelivery(previous.voiceDeliveries, delivery)
+          : previous.voiceDeliveries,
       }, event.seq);
       return;
     }


### PR DESCRIPTION
Closes #837

## Outcome
- publishes substantial sentence-sized assistant chunks before backend completion
- coalesces token deltas with sentence, size, and 1.1-second deadline boundaries
- caps unacknowledged chunks at six and keeps a bounded residual buffer
- reconciles the terminal response so already-spoken prefixes are never replayed
- drops queued suffixes after interruption and preserves durable retry/ack behavior

## Verification
- 118 focused runtime, journal, reducer, transport, and chunking tests passed
- 7 focused structured-host streaming/recovery tests passed
- TypeScript passed
- ESLint passed for all changed files
- production build passed
- privacy publication gate passed