### PR TITLE
fix(orchestrator): adopt eligible project seats

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -25,7 +25,7 @@ import { bridgeDirectiveBody, bridgeDirectiveId, type BridgeTrailer } from "@/li
 import { isBridgeReportClass } from "@/lib/bridge/types";
 import { readOrchestratorRecord } from "@/lib/orchestrator/store";
 import { authorizedManagerSeats, type ManagerAuthoritySources } from "@/lib/orchestrator/authority";
-import { activeOrchestratorSeats, orchestratorRevocations, orchestratorSeatFor, type OrchestratorSeat } from "@/lib/orchestrator/seats";
+import { activeOrchestratorSeats, canonicalOrchestratorProject, orchestratorRevocations, orchestratorSeatFor, type OrchestratorSeat } from "@/lib/orchestrator/seats";
 import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
 import { contextReading, readOrchestratorTranscriptFacts, rotationRecommendation } from "@/lib/orchestrator/health";
 import { contextWindowPolicyFor } from "@/lib/orchestrator/contextPolicy";
@@ -797,9 +797,9 @@ function callerCapabilityHeaders(): Record<string, string> {
   return /^[A-Za-z0-9_-]{43}$/.test(capability) ? { [VIEWER_SPAWN_CAPABILITY_HEADER]: capability } : {};
 }
 
-/** Explicitly allowlisted launch fields for the designation routes. NEVER a
-    denylist: `conversationId` (seat an existing session — the self-designation
-    vector) and `promptVersion` (mandate provenance) are server-owned. */
+/** Explicitly allowlisted fields for the designation routes. The seat route
+    authorizes existing-conversation adoption before it writes an intent;
+    mandate provenance stays server-owned. */
 function allowedSeatFields(args: McpToolArgs, keys: readonly string[]): Record<string, unknown> {
   return Object.fromEntries(keys.flatMap((key) => (args[key] === undefined ? [] : [[key, args[key]]])));
 }
@@ -811,7 +811,7 @@ function allowedSeatFields(args: McpToolArgs, keys: readonly string[]): Record<s
  * act on the recommendation automatically.
  */
 async function getOrchestrator(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): Promise<McpToolPayload> {
-  const project = required(args, "project");
+  const project = canonicalOrchestratorProject(required(args, "project"));
   const { active, pending } = orchestratorSeatFor(project);
   const revocations = orchestratorRevocations().filter((revocation) => revocation.project === project);
   const base = {
@@ -912,13 +912,13 @@ async function getOrchestrator(args: McpToolArgs, dependencies: ViewerMcpDomainD
     approved versioned default mandate (or the caller's edited text based on
     it). The seat route owns the durable intent, so a retry replays. */
 async function createOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
-  const project = required(args, "project");
+  const project = canonicalOrchestratorProject(required(args, "project"));
   const result = await control.post("/api/orchestrator/seat", {
     project,
     mandate: text(args.mandate) || ORCHESTRATOR_SYSTEM_PROMPT,
     promptVersion: ORCHESTRATOR_PROMPT_VERSION,
     clientRequestId: spawnAttemptId(requestId(args)),
-    ...allowedSeatFields(args, ["cwd", "engine", "model", "effort", "accountId"]),
+    ...allowedSeatFields(args, ["conversationId", "cwd", "engine", "model", "effort", "accountId"]),
   }, callerCapabilityHeaders());
   return redactPayload({
     project,
@@ -926,7 +926,9 @@ async function createOrchestrator(args: McpToolArgs, control: ViewerControlDepen
     transcriptPath: result.path ?? null,
     seat: result.seat ?? null,
     replayed: result.replayed === true,
+    accepted: result.accepted === true,
     state: result.state ?? null,
+    launchId: result.launchId ?? null,
   });
 }
 
@@ -939,7 +941,7 @@ async function createOrchestrator(args: McpToolArgs, control: ViewerControlDepen
  * duplicating, and the response says which path ran.
  */
 async function sendMessageToOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
-  const project = required(args, "project");
+  const project = canonicalOrchestratorProject(required(args, "project"));
   const message = requiredMessageText(args);
   const key = requestId(args);
 
@@ -980,7 +982,7 @@ async function sendMessageToOrchestrator(args: McpToolArgs, control: ViewerContr
 /** rotate_orchestrator: explicit handoff to a successor. Never called by any
     heuristic — see the rotation command's contract. */
 async function rotateOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
-  const project = required(args, "project");
+  const project = canonicalOrchestratorProject(required(args, "project"));
   const result = await control.post("/api/orchestrator/rotate", {
     project,
     clientRequestId: spawnAttemptId(requestId(args)),

--- a/src/lib/mcp/managerAuthority.test.ts
+++ b/src/lib/mcp/managerAuthority.test.ts
@@ -60,7 +60,7 @@ function activeSeat(conversationId: string, seatEpoch = 1): OrchestratorSeat {
     promptVersion: null,
     predecessorConversationId: null,
     state: "active",
-    intent: { clientRequestId: "req_0000001", mode: "spawn", error: null },
+    intent: { clientRequestId: "req_0000001", mode: "spawn", launchId: null, error: null },
     designatedAt: "2026-07-29T00:00:00.000Z",
     activatedAt: "2026-07-29T00:00:00.000Z",
   };

--- a/src/lib/mcp/managerLifecycleSeams.test.ts
+++ b/src/lib/mcp/managerLifecycleSeams.test.ts
@@ -72,7 +72,7 @@ function activeSeat(conversationId: string, seatEpoch = 1): OrchestratorSeat {
     promptVersion: null,
     predecessorConversationId: null,
     state: "active",
-    intent: { clientRequestId: "req_0000001", mode: "spawn", error: null },
+    intent: { clientRequestId: "req_0000001", mode: "spawn", launchId: null, error: null },
     designatedAt: "2026-07-29T00:00:00.000Z",
     activatedAt: "2026-07-29T00:00:00.000Z",
   };

--- a/src/lib/mcp/orchestratorTools.test.ts
+++ b/src/lib/mcp/orchestratorTools.test.ts
@@ -9,6 +9,7 @@ import { requireOperatorAuthority, setCallerConversationResolverForTests } from 
 import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
 import { beginOrchestratorSeatIntent, completeOrchestratorSeatIntent, orchestratorSeatFor } from "@/lib/orchestrator/seats";
 import { replaceOrchestratorIncumbent } from "@/lib/orchestrator/store";
+import { persistProjectAliases } from "@/lib/projects/aliases";
 
 import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
 
@@ -154,6 +155,25 @@ test("get_orchestrator surfaces bidirectional predecessor lineage after a replac
   }]);
 });
 
+test("get and send resolve a named project alias to its canonical orchestrator seat", async () => {
+  const canonical = "repo-0123456789abcdef0123456789abcdef";
+  expect(persistProjectAliases([
+    { source: "named-project", target: canonical, displayName: "named-project" },
+  ])).toBe(true);
+  seatActive(canonical, SEATED_ID, "/tmp/o.jsonl");
+
+  const { control } = controlStub();
+  const status = await bindingsWith(control).get_orchestrator({ clientRequestId: "get-alias", project: "named-project" });
+  const delivery = await bindingsWith(control).send_message_to_orchestrator({
+    clientRequestId: "send-alias",
+    project: "named-project",
+    text: "status?",
+  });
+
+  expect(status).toMatchObject({ project: canonical, designated: true, conversationId: SEATED_ID });
+  expect(delivery).toMatchObject({ project: canonical, conversationId: SEATED_ID, created: false });
+});
+
 test("create_orchestrator posts the versioned approved default mandate through the seat route", async () => {
   const { posts, control } = controlStub({
     "/api/orchestrator/seat": { ok: true, conversationId: SEATED_ID, path: "/tmp/o.jsonl", seat: { conversationId: SEATED_ID }, state: "settled" },
@@ -169,6 +189,52 @@ test("create_orchestrator posts the versioned approved default mandate through t
     clientRequestId: "create-1",
   });
   expect(result).toMatchObject({ conversationId: SEATED_ID, transcriptPath: "/tmp/o.jsonl" });
+});
+
+test("create_orchestrator adopts an eligible existing conversation through the seat route", async () => {
+  const { posts, control } = controlStub({
+    "/api/orchestrator/seat": { ok: true, conversationId: SEATED_ID, path: "/tmp/o.jsonl", seat: { conversationId: SEATED_ID }, state: "settled" },
+  });
+
+  const result = await bindingsWith(control).create_orchestrator({
+    clientRequestId: "adopt-01",
+    project: "proj-a",
+    conversationId: SEATED_ID,
+  });
+
+  expect(posts).toHaveLength(1);
+  expect(posts[0]!.pathname).toBe("/api/orchestrator/seat");
+  expect(posts[0]!.body).toMatchObject({
+    project: "proj-a",
+    conversationId: SEATED_ID,
+    clientRequestId: "adopt-01",
+  });
+  expect(result).toMatchObject({ conversationId: SEATED_ID, transcriptPath: "/tmp/o.jsonl" });
+});
+
+test("create_orchestrator reports an accepted asynchronous launch with durable identifiers", async () => {
+  const { control } = controlStub({
+    "/api/orchestrator/seat": {
+      ok: true,
+      accepted: true,
+      state: "accepted",
+      conversationId: SEATED_ID,
+      launchId: "launch_async",
+      seat: { conversationId: SEATED_ID },
+    },
+  });
+
+  const result = await bindingsWith(control).create_orchestrator({
+    clientRequestId: "accepted-01",
+    project: "proj-a",
+  });
+
+  expect(result).toMatchObject({
+    accepted: true,
+    state: "accepted",
+    conversationId: SEATED_ID,
+    launchId: "launch_async",
+  });
 });
 
 test("send_message_to_orchestrator resolves the seat server-side and delivers with the caller's idempotency key", async () => {
@@ -237,7 +303,11 @@ test("a NON-OPERATOR caller cannot designate itself or anyone: create, rotate an
     /* All three designation paths run — the tools are ON the surface for this
        session (axis 1) — and every one is refused by the gate that reads the
        forwarded conversation capability, before anything durable changes. */
-    await expect(tools.create_orchestrator({ clientRequestId: "create-x", project: "proj-a" })).rejects.toThrow();
+    await expect(tools.create_orchestrator({
+      clientRequestId: "create-x",
+      project: "proj-a",
+      conversationId: "conversation_worker",
+    })).rejects.toThrow();
     await expect(tools.rotate_orchestrator({ clientRequestId: "rotate-x", project: "proj-a" })).rejects.toThrow();
     await expect(tools.send_message_to_orchestrator({ clientRequestId: "send-x", project: "proj-a", text: "hi" })).rejects.toThrow();
 
@@ -257,20 +327,19 @@ test("an operator-lane caller (no conversation capability) still designates thro
   expect(result).toMatchObject({ conversationId: SEATED_ID });
 });
 
-test("caller-supplied conversationId and promptVersion NEVER reach the seat route", async () => {
+test("the adoption target reaches the authorized seat route while prompt provenance stays server-owned", async () => {
   const { posts, control } = controlStub({
     "/api/orchestrator/seat": { ok: true, conversationId: SEATED_ID, seat: { conversationId: SEATED_ID } },
   });
   await bindingsWith(control).create_orchestrator({
     clientRequestId: "create-z",
     project: "proj-a",
-    /* A caller that could name a conversation here would seat an EXISTING
-       session — itself — instead of spawning a fresh one; a caller that could
-       set promptVersion would forge mandate provenance. Both are dropped. */
+    /* Route-level operator authorization decides whether this existing
+       conversation can be adopted. Prompt provenance remains server-owned. */
     conversationId: "conversation_worker",
     promptVersion: 99,
   });
-  expect(posts[0]!.body).not.toHaveProperty("conversationId");
+  expect(posts[0]!.body.conversationId).toBe("conversation_worker");
   expect(posts[0]!.body.promptVersion).toBe(ORCHESTRATOR_PROMPT_VERSION);
 
   await bindingsWith(control).rotate_orchestrator({

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1133,6 +1133,8 @@ describe("MCP tool service", () => {
       expect(spawnSchema?.properties).toHaveProperty("cwd");
       expect(spawnSchema?.properties).toHaveProperty("prompt");
       expect(spawnSchema?.properties).toHaveProperty("mcpServers");
+      const createOrchestratorSchema = listed.tools.find((tool) => tool.name === "create_orchestrator")?.inputSchema;
+      expect(createOrchestratorSchema?.properties).toHaveProperty("conversationId");
       const deploySchema = listed.tools.find((tool) => tool.name === "deploy_exact_sha")?.inputSchema;
       /* #795: the deploy carries WHAT ships and nothing that claims authority —
          no confirmation flag, no bridge reference, no nonce. */

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -991,7 +991,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   bridge_report: "Append one bounded report to the durable bridge log for the voice gateway to relay. Callable from any session; the origin is labeled server-side and a non-orchestrator report is visibly attributed to its own session.",
   bridge_directive: "Relay the user's intent to the designated manager. The recipient and the delivery id are derived server-side, so a retry of the same root turn is one instruction, never two.",
   get_orchestrator: "Read a project's designated orchestrator: designation, health and activity, model and prompt version, transcript size, message/tool/compaction counts, context usage against its model's configured window (clearly labelled when estimated), predecessor lineage, and a bounded rotation recommendation — STRONGLY_RECOMMEND_ROTATION once usage reaches the configured threshold. Words only: it never rotates, creates, or interrupts anything itself.",
-  create_orchestrator: "Create a project's orchestrator: atomically spawn it, designate it as the project's selected orchestrator, and deliver the approved versioned mandate (editable). Idempotent by clientRequestId.",
+  create_orchestrator: "Create a project's orchestrator or adopt one eligible registered conversation: designate it as the project's selected orchestrator and deliver the approved versioned mandate (editable). Idempotent by clientRequestId.",
   send_message_to_orchestrator: "Deliver a message to the project's selected orchestrator, resolved server-side. A dead selected conversation is resumed; with none designated, one is created first and then delivered to. Idempotent by clientRequestId.",
   rotate_orchestrator: "Explicitly hand a project's orchestrator seat to a fresh successor: bounded handoff (predecessor transcript reference, open tasks, optional notes), atomic designation switch, manager-authority-only revocation of the predecessor, bidirectional lineage. Never triggered automatically.",
 };
@@ -1254,6 +1254,7 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   create_orchestrator: z.object({
     clientRequestId: clientRequestIdSchema,
     project: z.string().min(1).describe("Project key this orchestrator will own."),
+    conversationId: z.string().regex(/^conversation_/).optional().describe("Existing registered conversation to adopt. The Viewer validates its project, cwd, transcript, lifecycle, and operator authority before seating it."),
     mandate: z.string().optional().describe("Edited mandate text; defaults to the approved versioned orchestrator prompt."),
     cwd: z.string().optional().describe("Working directory; defaults to the Viewer's own checkout."),
     engine: z.enum(["claude", "codex"]).optional(),

--- a/src/lib/orchestrator/authority.test.ts
+++ b/src/lib/orchestrator/authority.test.ts
@@ -10,7 +10,7 @@ function seat(overrides: Partial<OrchestratorSeat> & { conversationId: string; p
     promptVersion: null,
     predecessorConversationId: null,
     state: "active",
-    intent: { clientRequestId: "req_0000001", mode: "spawn", error: null },
+    intent: { clientRequestId: "req_0000001", mode: "spawn", launchId: null, error: null },
     designatedAt: "2026-07-29T00:00:00.000Z",
     activatedAt: "2026-07-29T00:00:00.000Z",
     ...overrides,

--- a/src/lib/orchestrator/seatCommand.test.ts
+++ b/src/lib/orchestrator/seatCommand.test.ts
@@ -55,7 +55,13 @@ function dependencies(overrides: Partial<SeatCommandDependencies> = {}): { deps:
       recorded.deliveries.push({ conversationId: input.conversationId, clientMessageId: input.clientMessageId, text: input.text });
       return { ok: true, outcome: "delivered" };
     },
-    conversationTarget: (conversationId) => ({ conversationId, path: `/tmp/${conversationId.slice(-4)}.jsonl` }),
+    conversationTarget: (conversationId) => ({
+      kind: "eligible",
+      conversationId,
+      path: `/tmp/${conversationId.slice(-4)}.jsonl`,
+      cwd: "/workspace",
+      project: "proj-a",
+    }),
     syncLegacyRecord: (input) => { recorded.legacySyncs.push({ conversationId: input.conversationId }); },
     projectTasks: () => [],
     now: () => AT,
@@ -97,8 +103,9 @@ test("an admitted asynchronous spawn activates the seat from its durable convers
     spawn: async () => ({
       status: 202,
       body: {
-        state: "accepted",
-        launched: true,
+        ok: true,
+        state: "starting",
+        launched: false,
         conversationId: NEW_ID,
         launchId: "launch_async",
       },
@@ -108,8 +115,38 @@ test("an admitted asynchronous spawn activates the seat from its durable convers
   const result = await executeOrchestratorSeatRequest(spawnRequest(), deps);
 
   expect(result.status).toBe(202);
+  expect(result.body).toMatchObject({
+    accepted: true,
+    state: "accepted",
+    conversationId: NEW_ID,
+    launchId: "launch_async",
+  });
   expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(NEW_ID);
+  expect(orchestratorSeatFor("proj-a").active?.intent.launchId).toBe("launch_async");
   expect(orchestratorSeatFor("proj-a").pending).toBeNull();
+});
+
+test("a restarted caller replays the accepted launch from the durable seat receipt", async () => {
+  const { deps } = dependencies({
+    spawn: async () => ({
+      status: 202,
+      body: { ok: true, state: "starting", launched: false, conversationId: NEW_ID, launchId: "launch_resume" },
+    }),
+  });
+  await executeOrchestratorSeatRequest(spawnRequest("req_00000015"), deps);
+  const { deps: resumed, recorded } = dependencies({
+    spawn: async () => {
+      throw new Error("a completed accepted launch must replay from durable state");
+    },
+  });
+
+  const replay = await executeOrchestratorSeatRequest(spawnRequest("req_00000015"), resumed);
+
+  expect(replay).toMatchObject({
+    status: 200,
+    body: { replayed: true, accepted: true, state: "accepted", conversationId: NEW_ID, launchId: "launch_resume" },
+  });
+  expect(recorded.spawns).toEqual([]);
 });
 
 test("a failed spawn leaves NEITHER half: no active seat, no legacy record, a recoverable pending intent", async () => {
@@ -171,6 +208,42 @@ test("selecting an EXISTING conversation delivers the mandate without spawning a
   expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(OLD_ID);
 });
 
+test("a replayed adoption keeps its original target during an ABA-shaped retry", async () => {
+  let releaseDelivery: () => void = () => {};
+  const gate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
+  const { deps, recorded } = dependencies({
+    conversationTarget: (conversationId) => ({
+      kind: "eligible",
+      conversationId,
+      path: `/tmp/${conversationId.slice(-4)}.jsonl`,
+      cwd: "/workspace",
+      project: "proj-a",
+    }),
+    deliver: async (input) => {
+      recorded.deliveries.push({ conversationId: input.conversationId, clientMessageId: input.clientMessageId, text: input.text });
+      await gate;
+      return { ok: true, outcome: "delivered" };
+    },
+  });
+  const first = executeOrchestratorSeatRequest({
+    project: "proj-a",
+    mandate: "m",
+    clientRequestId: "req_00000014",
+    conversationId: OLD_ID,
+  }, deps);
+  const replay = executeOrchestratorSeatRequest({
+    project: "proj-a",
+    mandate: "recomposed",
+    clientRequestId: "req_00000014",
+    conversationId: NEW_ID,
+  }, deps);
+
+  expect(recorded.deliveries.map((delivery) => delivery.conversationId)).toEqual([OLD_ID, OLD_ID]);
+  releaseDelivery();
+  await Promise.all([first, replay]);
+  expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(OLD_ID);
+});
+
 test("a failed delivery keeps the incumbent seated and reports a recoverable state", async () => {
   const { deps } = dependencies();
   await executeOrchestratorSeatRequest(spawnRequest(), deps);
@@ -221,6 +294,32 @@ test("an unknown existing conversation is refused before any intent exists", asy
   expect(orchestratorSeatFor("proj-a").pending).toBeNull();
 });
 
+test("adoption refuses a conversation whose project, cwd, transcript, or lifecycle is ineligible before creating an intent", async () => {
+  const candidates = [
+    { kind: "eligible", conversationId: OLD_ID, path: "/tmp/old.jsonl", cwd: "/workspace", project: "proj-b" },
+    { kind: "ineligible", code: "invalid_cwd", error: "conversation cwd is unavailable" },
+    { kind: "ineligible", code: "missing_transcript", error: "conversation transcript is unavailable" },
+    { kind: "ineligible", code: "conversation_ineligible", error: "conversation is superseded" },
+  ];
+
+  for (const [index, candidate] of candidates.entries()) {
+    const { deps, recorded } = dependencies({
+      conversationTarget: () => candidate as never,
+    });
+    const result = await executeOrchestratorSeatRequest({
+      project: "proj-a",
+      mandate: "m",
+      clientRequestId: `req_00000${index}2`,
+      conversationId: OLD_ID,
+    }, deps);
+
+    expect(result.status).toBe(409);
+    expect(recorded.spawns).toEqual([]);
+    expect(recorded.deliveries).toEqual([]);
+    expect(orchestratorSeatFor("proj-a").pending).toBeNull();
+  }
+});
+
 test("rotation composes a bounded handoff, switches designation atomically, and links both cards", async () => {
   const { deps } = dependencies();
   await executeOrchestratorSeatRequest(spawnRequest(), deps);
@@ -264,6 +363,38 @@ test("rotation composes a bounded handoff, switches designation atomically, and 
     successorConversationId: SUCCESSOR,
   })]);
   expect(retiredHosts).toEqual([]);
+});
+
+test("an adoption racing an in-flight rotation is refused while the rotation keeps one durable successor", async () => {
+  const seeded = dependencies();
+  await executeOrchestratorSeatRequest(spawnRequest("req_00000020"), seeded.deps);
+
+  let releaseSpawn: () => void = () => {};
+  const gate = new Promise<void>((resolve) => { releaseSpawn = resolve; });
+  const successor = "conversation_77777777-7777-4777-8777-777777777777";
+  const { deps, recorded } = dependencies({
+    spawn: async (body) => {
+      recorded.spawns.push(body);
+      await gate;
+      return { status: 200, body: { ok: true, conversationId: successor, path: "/tmp/successor.jsonl" } };
+    },
+  });
+  const rotating = executeOrchestratorRotation({ project: "proj-a", clientRequestId: "req_00000021" }, deps);
+  const adoption = await executeOrchestratorSeatRequest({
+    project: "proj-a",
+    mandate: "adopt me",
+    clientRequestId: "req_00000022",
+    conversationId: OLD_ID,
+  }, deps);
+
+  expect(adoption).toMatchObject({ status: 409, body: { code: "seat_intent_in_progress" } });
+  expect(recorded.deliveries).toEqual([]);
+  releaseSpawn();
+  const rotated = await rotating;
+
+  expect(rotated.status).toBe(200);
+  expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(successor);
+  expect(orchestratorRevocations()).toEqual([expect.objectContaining({ conversationId: NEW_ID, successorConversationId: successor })]);
 });
 
 test("HIGH 5: a spawn-mode designation for an ALREADY-SEATED project refuses instead of silently unseating the incumbent", async () => {

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import fs from "node:fs";
 
 import { validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { agentRegistry } from "@/lib/agent/registry";
@@ -6,12 +7,14 @@ import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { deliverConversationMessage } from "@/lib/delivery";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
+import { projectForCwd } from "@/lib/scanner/describe";
 
 import { loadTasks } from "@/lib/tasks/store";
 import {
   beginOrchestratorSeatIntent,
   completeOrchestratorSeatIntent,
   failOrchestratorSeatIntent,
+  canonicalOrchestratorProject,
   orchestratorSeatFor,
   type OrchestratorSeat,
 } from "./seats";
@@ -50,8 +53,8 @@ export interface SeatCommandDependencies {
   /** Deliver the mandate to an existing conversation, idempotent on
       `clientMessageId`. */
   deliver(input: { conversationId: string; path: string | null; clientMessageId: string; text: string }): Promise<{ ok: boolean; error?: string; outcome?: string }>;
-  /** Canonical id + latest transcript path, or null when unknown. */
-  conversationTarget(conversationId: string): { conversationId: string; path: string | null } | null;
+  /** Registry-backed eligibility of a conversation offered for adoption. */
+  conversationTarget(conversationId: string): ExistingConversationTarget | null;
   /** Keep the legacy single-instance manager record pointing at the newest
       operator-selected seat, so the bridge follows the selection. */
   syncLegacyRecord(input: { conversationId: string; path: string | null; engine?: string; model?: string }): void;
@@ -59,6 +62,10 @@ export interface SeatCommandDependencies {
   projectTasks(project: string): { id: string; status: string; text: string }[];
   now(): string;
 }
+
+export type ExistingConversationTarget =
+  | { kind: "eligible"; conversationId: string; path: string; cwd: string; project: string }
+  | { kind: "ineligible"; code: "conversation_ineligible" | "invalid_cwd" | "missing_transcript" | "missing_project"; error: string };
 
 async function postSpawnInProcess(body: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }> {
   const { executeSpawnRequest } = await import("@/lib/agent/spawnCommand");
@@ -111,9 +118,30 @@ export const productionSeatCommandDependencies: SeatCommandDependencies = {
   deliver: deliverMandateInProcess,
   conversationTarget: (conversationId) => {
     const conversation = agentRegistry().conversation(conversationId as `conversation_${string}`);
-    return conversation
-      ? { conversationId: conversation.id, path: conversation.generations.at(-1)?.path ?? null }
-      : null;
+    if (!conversation) return null;
+    if (conversation.supersededBy) {
+      return { kind: "ineligible", code: "conversation_ineligible", error: "conversation is superseded" };
+    }
+    const generation = conversation.generations.at(-1);
+    const transcriptPath = generation?.path?.trim();
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      return { kind: "ineligible", code: "missing_transcript", error: "conversation transcript is unavailable" };
+    }
+    const cwd = generation?.launchProfile?.cwd?.trim();
+    if (!cwd || !fs.existsSync(cwd) || !fs.statSync(cwd).isDirectory()) {
+      return { kind: "ineligible", code: "invalid_cwd", error: "conversation cwd is unavailable" };
+    }
+    const ownedProject = conversation.projectOwnership?.project ?? projectForCwd(cwd);
+    if (!ownedProject) {
+      return { kind: "ineligible", code: "missing_project", error: "conversation project is unavailable" };
+    }
+    return {
+      kind: "eligible",
+      conversationId: conversation.id,
+      path: transcriptPath,
+      cwd,
+      project: canonicalOrchestratorProject(ownedProject),
+    };
   },
   syncLegacyRecord: (input) => {
     replaceOrchestratorIncumbent({
@@ -143,14 +171,28 @@ function text(value: unknown): string {
 }
 
 function replayedSeatResponse(seat: OrchestratorSeat): SeatCommandResult {
+  const accepted = seat.path === null && seat.intent.launchId !== null;
   return {
     status: 200,
     body: {
       ok: true,
       replayed: true,
-      state: seat.path ? "settled" : "starting",
+      state: seat.path ? "settled" : accepted ? "accepted" : "starting",
+      accepted,
       conversationId: seat.conversationId,
       path: seat.path,
+      launchId: seat.intent.launchId,
+      seat,
+    },
+  };
+}
+
+function inProgressSeatResponse(seat: OrchestratorSeat): SeatCommandResult {
+  return {
+    status: 409,
+    body: {
+      error: "an orchestrator seat transition is already in progress for this project",
+      code: "seat_intent_in_progress",
       seat,
     },
   };
@@ -168,7 +210,7 @@ function replayedSeatResponse(seat: OrchestratorSeat): SeatCommandResult {
  * may reach them.
  */
 async function activate(
-  input: { project: string; clientRequestId: string; conversationId: string; path: string | null; engine?: string; model?: string },
+  input: { project: string; clientRequestId: string; conversationId: string; path: string | null; launchId?: string | null; engine?: string; model?: string },
   dependencies: SeatCommandDependencies,
 ): Promise<{ seat: OrchestratorSeat } | null> {
   const completed = completeOrchestratorSeatIntent({
@@ -176,6 +218,7 @@ async function activate(
     clientRequestId: input.clientRequestId,
     conversationId: input.conversationId,
     path: input.path,
+    launchId: input.launchId,
     now: dependencies.now(),
   });
   if (completed.kind === "missing") return null;
@@ -194,8 +237,9 @@ export async function executeOrchestratorSeatRequest(
   rawBody: Record<string, unknown>,
   dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
 ): Promise<SeatCommandResult> {
-  const project = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
-  if (!project) return { status: 400, body: { error: "project must be a valid project key" } };
+  const namedProject = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
+  if (!namedProject) return { status: 400, body: { error: "project must be a valid project key" } };
+  const project = canonicalOrchestratorProject(namedProject);
   const mandate = typeof rawBody.mandate === "string" ? rawBody.mandate : "";
   if (!mandate.trim()) return { status: 400, body: { error: "mandate is required" } };
   if (Buffer.byteLength(mandate, "utf8") > MANDATE_MAX_BYTES) {
@@ -216,6 +260,15 @@ export async function executeOrchestratorSeatRequest(
   if (existingConversationId) {
     const target = dependencies.conversationTarget(existingConversationId);
     if (!target) return { status: 404, body: { error: "conversation is unknown to the registry" } };
+    if (target.kind === "ineligible") {
+      return { status: 409, body: { error: target.error, code: target.code } };
+    }
+    if (target.project !== project) {
+      return {
+        status: 409,
+        body: { error: "conversation belongs to a different project", code: "project_mismatch" },
+      };
+    }
 
     const begun = beginOrchestratorSeatIntent({
       project,
@@ -227,10 +280,23 @@ export async function executeOrchestratorSeatRequest(
       now: dependencies.now(),
     });
     if (begun.kind === "completed") return replayedSeatResponse(begun.seat);
+    if (begun.kind === "in_progress") return inProgressSeatResponse(begun.seat);
+
+    /* The durable intent owns the target on replay. A retried request may carry
+       a different conversation id after a caller restart; following it would
+       let one idempotency key designate a different conversation. */
+    const deliveryTarget = begun.kind === "replay"
+      ? dependencies.conversationTarget(begun.seat.conversationId ?? "")
+      : target;
+    if (!deliveryTarget || deliveryTarget.kind === "ineligible" || deliveryTarget.project !== project) {
+      const error = "the pending adoption target is no longer eligible";
+      failOrchestratorSeatIntent(project, clientRequestId, error);
+      return { status: 409, body: { error, code: "adoption_target_unavailable", seat: orchestratorSeatFor(project).pending } };
+    }
 
     const delivery = await dependencies.deliver({
-      conversationId: target.conversationId,
-      path: target.path,
+      conversationId: deliveryTarget.conversationId,
+      path: deliveryTarget.path,
       /* Derived, never minted: a retry after a lost response reuses the same
          id and the delivery receipts answer it instead of delivering twice. */
       clientMessageId: `orchmandate_${clientRequestId}`,
@@ -253,15 +319,15 @@ export async function executeOrchestratorSeatRequest(
         },
       };
     }
-    const activated = await activate({ project, clientRequestId, conversationId: target.conversationId, path: target.path }, dependencies);
+    const activated = await activate({ project, clientRequestId, conversationId: deliveryTarget.conversationId, path: deliveryTarget.path }, dependencies);
     if (!activated) return { status: 409, body: { error: "seat intent was superseded by a newer designation" } };
     return {
       status: 200,
       body: {
         ok: true,
         state: "settled",
-        conversationId: target.conversationId,
-        path: target.path,
+        conversationId: deliveryTarget.conversationId,
+        path: deliveryTarget.path,
         delivery: delivery.outcome ?? "delivered",
         seat: activated.seat,
       },
@@ -289,6 +355,7 @@ export async function executeOrchestratorSeatRequest(
   }
   const begun = beginOrchestratorSeatIntent({ project, mandate, clientRequestId, mode: "spawn", promptVersion, now: dependencies.now() });
   if (begun.kind === "completed") return replayedSeatResponse(begun.seat);
+  if (begun.kind === "in_progress") return inProgressSeatResponse(begun.seat);
   /* A pending replay spawns the ORIGINAL intent's mandate: the spawn receipt is
      matched by clientAttemptId AND request digest, so a recomposed retry would
      otherwise conflict with its own first attempt. */
@@ -311,9 +378,19 @@ export async function executeOrchestratorSeatRequest(
   const spawned = await dependencies.spawn(spawnBody);
   const spawnedConversationId = text(spawned.body.conversationId);
   const admitted = spawned.status >= 200 && spawned.status < 300 && spawned.body.ok !== false;
+  const launchId = text(spawned.body.launchId);
+  const acceptedPending = admitted
+    && spawned.status === 202
+    && Boolean(spawnedConversationId)
+    && Boolean(launchId);
   const launched = admitted && spawned.body.launched !== false && Boolean(spawnedConversationId);
-  if (!launched) {
-    const error = text(spawned.body.error) || `spawn failed with status ${spawned.status}`;
+  if (!launched && !acceptedPending) {
+    const error = text(spawned.body.error)
+      || (!admitted
+        ? `spawn was rejected with HTTP status ${spawned.status}`
+        : !spawnedConversationId
+          ? "spawn response omitted conversationId"
+          : "spawn did not report an accepted launch");
     failOrchestratorSeatIntent(project, clientRequestId, error);
     return { status: spawned.status, body: { ...spawned.body, seat: orchestratorSeatFor(project).pending } };
   }
@@ -322,6 +399,7 @@ export async function executeOrchestratorSeatRequest(
     clientRequestId,
     conversationId: spawnedConversationId,
     path: typeof spawned.body.path === "string" ? spawned.body.path : null,
+    launchId: launchId || null,
     ...(typeof rawBody.engine === "string" ? { engine: rawBody.engine } : {}),
     ...(typeof rawBody.model === "string" ? { model: rawBody.model } : {}),
   }, dependencies);
@@ -330,6 +408,7 @@ export async function executeOrchestratorSeatRequest(
     status: spawned.status,
     body: {
       ...spawned.body,
+      ...(acceptedPending ? { accepted: true, state: "accepted" } : {}),
       seat: activated.seat,
     },
   };
@@ -359,8 +438,9 @@ export async function executeOrchestratorRotation(
   rawBody: Record<string, unknown>,
   dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
 ): Promise<SeatCommandResult> {
-  const project = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
-  if (!project) return { status: 400, body: { error: "project must be a valid project key" } };
+  const namedProject = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
+  if (!namedProject) return { status: 400, body: { error: "project must be a valid project key" } };
+  const project = canonicalOrchestratorProject(namedProject);
   const clientRequestId = text(rawBody.clientRequestId);
   if (!CLIENT_REQUEST_ID.test(clientRequestId)) {
     return { status: 400, body: { error: "clientRequestId must be 8-128 URL-safe characters" } };
@@ -373,7 +453,8 @@ export async function executeOrchestratorRotation(
     };
   }
 
-  const predecessor = dependencies.conversationTarget(incumbent.conversationId);
+  const predecessorTarget = dependencies.conversationTarget(incumbent.conversationId);
+  const predecessor = predecessorTarget?.kind === "eligible" ? predecessorTarget : null;
   const tasks = dependencies.projectTasks(project).slice(0, HANDOFF_TASK_CAP);
   const notes = text(rawBody.handoffNotes).slice(0, HANDOFF_NOTES_CAP);
   const handoff = [

--- a/src/lib/orchestrator/seats.test.ts
+++ b/src/lib/orchestrator/seats.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { persistProjectAliases } from "@/lib/projects/aliases";
+
 import {
   activeOrchestratorSeats,
   beginOrchestratorSeatIntent,
@@ -103,12 +105,13 @@ test("a failed intent stays pending with its error and never unseats the incumbe
   expect(pending?.intent.error).toBe("spawn failed");
 });
 
-test("completing an unknown or superseded key reports missing instead of guessing", () => {
+test("a concurrent key cannot displace a pending intent, and a stale completion reports missing", () => {
   expect(completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000009", conversationId: "conversation_x", path: null, now: AT }).kind).toBe("missing");
   beginOrchestratorSeatIntent({ project: "proj-a", mandate: "a", clientRequestId: "req_0000001", mode: "spawn", now: AT });
-  beginOrchestratorSeatIntent({ project: "proj-a", mandate: "b", clientRequestId: "req_0000002", mode: "spawn", now: AT });
-  /* The newer intent replaced the abandoned one; the stale key cannot complete. */
-  expect(completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000001", conversationId: "conversation_x", path: null, now: AT }).kind).toBe("missing");
+  const competing = beginOrchestratorSeatIntent({ project: "proj-a", mandate: "b", clientRequestId: "req_0000002", mode: "spawn", now: AT });
+  expect(competing.kind).toBe("in_progress");
+  expect(completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000001", conversationId: "conversation_x", path: null, now: AT }).kind).toBe("activated");
+  expect(completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000002", conversationId: "conversation_y", path: null, now: AT }).kind).toBe("missing");
 });
 
 test("a malformed file reads as empty and the epoch counter postdates everything on file", () => {
@@ -130,4 +133,50 @@ test("seats are independent per project", () => {
   completeOrchestratorSeatIntent({ project: "proj-b", clientRequestId: "req_0000002", conversationId: "conversation_b", path: null, now: AT });
   expect(activeOrchestratorSeats().map((seat) => seat.conversationId).sort()).toEqual(["conversation_a", "conversation_b"]);
   expect(orchestratorRevocations()).toEqual([]);
+});
+
+test("a named project alias and its canonical identity resolve to one seat", () => {
+  const canonical = "repo-0123456789abcdef0123456789abcdef";
+  expect(persistProjectAliases([
+    { source: "named-project", target: canonical, displayName: "named-project" },
+  ])).toBe(true);
+
+  beginOrchestratorSeatIntent({ project: "named-project", mandate: "m", clientRequestId: "req_0000001", mode: "spawn", now: AT });
+  completeOrchestratorSeatIntent({ project: canonical, clientRequestId: "req_0000001", conversationId: "conversation_a", path: null, now: AT });
+
+  expect(orchestratorSeatFor("named-project").active?.conversationId).toBe("conversation_a");
+  expect(orchestratorSeatFor(canonical).active).toMatchObject({ project: canonical, conversationId: "conversation_a" });
+  expect(activeOrchestratorSeats()).toHaveLength(1);
+});
+
+test("a persisted pre-canonical alias seat is recovered under its canonical project", () => {
+  const canonical = "repo-0123456789abcdef0123456789abcdef";
+  expect(persistProjectAliases([
+    { source: "legacy-project", target: canonical, displayName: "legacy-project" },
+  ])).toBe(true);
+  fs.writeFileSync(path.join(sandbox, "orchestrator-seats.json"), JSON.stringify({
+    schemaVersion: 1,
+    nextSeatEpoch: 2,
+    seats: {
+      "legacy-project": {
+        project: "legacy-project",
+        seatEpoch: 1,
+        conversationId: "conversation_a",
+        path: null,
+        mandate: "m",
+        promptVersion: null,
+        predecessorConversationId: null,
+        state: "active",
+        intent: { clientRequestId: "req_0000001", mode: "spawn", launchId: null, error: null },
+        designatedAt: AT,
+        activatedAt: AT,
+      },
+    },
+    pending: {},
+    revocations: [],
+  }), "utf8");
+
+  expect(orchestratorSeatFor(canonical).active).toMatchObject({ project: canonical, conversationId: "conversation_a" });
+  expect(orchestratorSeatFor("legacy-project").active?.conversationId).toBe("conversation_a");
+  expect(activeOrchestratorSeats()).toHaveLength(1);
 });

--- a/src/lib/orchestrator/seats.ts
+++ b/src/lib/orchestrator/seats.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
+import { canonicalProject } from "@/lib/projects/aliases";
 
 /* Operator-selected PER-PROJECT orchestrator seats.
  *
@@ -40,6 +41,8 @@ export interface OrchestratorSeatIntent {
       duplicating. */
   clientRequestId: string;
   mode: "spawn" | "existing";
+  /** Durable launch receipt for an accepted asynchronous spawn. */
+  launchId: string | null;
   /** Terminal error of the last completion attempt; null while none failed. */
   error: string | null;
 }
@@ -89,6 +92,11 @@ interface OrchestratorSeatFile {
 
 const seatsFile = () => statePath("orchestrator-seats.json");
 
+/** One durable namespace for named projects and their repository identities. */
+export function canonicalOrchestratorProject(project: string): string {
+  return canonicalProject(project.trim());
+}
+
 function emptyFile(): OrchestratorSeatFile {
   return { schemaVersion: ORCHESTRATOR_SEATS_SCHEMA_VERSION, nextSeatEpoch: 1, seats: {}, pending: {}, revocations: [] };
 }
@@ -123,10 +131,20 @@ function normalizeSeat(value: unknown): OrchestratorSeat | null {
     promptVersion: typeof seat.promptVersion === "number" && Number.isInteger(seat.promptVersion) ? seat.promptVersion : null,
     predecessorConversationId: typeof seat.predecessorConversationId === "string" ? seat.predecessorConversationId : null,
     state: seat.state,
-    intent: { clientRequestId: intent.clientRequestId, mode: intent.mode, error: typeof intent.error === "string" ? intent.error : null },
+    intent: {
+      clientRequestId: intent.clientRequestId,
+      mode: intent.mode,
+      launchId: typeof intent.launchId === "string" ? intent.launchId : null,
+      error: typeof intent.error === "string" ? intent.error : null,
+    },
     designatedAt: seat.designatedAt,
     activatedAt: seat.activatedAt ?? null,
   };
+}
+
+function retainNewestSeat(collection: Record<string, OrchestratorSeat>, seat: OrchestratorSeat): void {
+  const current = collection[seat.project];
+  if (!current || seat.seatEpoch > current.seatEpoch) collection[seat.project] = seat;
 }
 
 /**
@@ -151,11 +169,15 @@ export function readOrchestratorSeatFile(): OrchestratorSeatFile {
       : 1;
     for (const [project, candidate] of Object.entries(parsed.seats ?? {})) {
       const seat = normalizeSeat(candidate);
-      if (seat && seat.project === project && seat.state === "active" && seat.conversationId) file.seats[project] = seat;
+      if (seat && seat.project === project && seat.state === "active" && seat.conversationId) {
+        retainNewestSeat(file.seats, { ...seat, project: canonicalOrchestratorProject(project) });
+      }
     }
     for (const [project, candidate] of Object.entries(parsed.pending ?? {})) {
       const seat = normalizeSeat(candidate);
-      if (seat && seat.project === project && seat.state === "pending") file.pending[project] = seat;
+      if (seat && seat.project === project && seat.state === "pending") {
+        retainNewestSeat(file.pending, { ...seat, project: canonicalOrchestratorProject(project) });
+      }
     }
     for (const candidate of Array.isArray(parsed.revocations) ? parsed.revocations : []) {
       const revocation = candidate as Partial<OrchestratorRevocation>;
@@ -163,7 +185,7 @@ export function readOrchestratorSeatFile(): OrchestratorSeatFile {
         && typeof revocation.seatEpoch === "number" && Number.isInteger(revocation.seatEpoch)
         && typeof revocation.revokedAt === "string") {
         file.revocations.push({
-          project: revocation.project,
+          project: canonicalOrchestratorProject(revocation.project),
           conversationId: revocation.conversationId,
           seatEpoch: revocation.seatEpoch,
           revokedAt: revocation.revokedAt,
@@ -192,12 +214,15 @@ function writeSeatFile(file: OrchestratorSeatFile): void {
 /** The active seat and any pending intent for one project. */
 export function orchestratorSeatFor(project: string): { active: OrchestratorSeat | null; pending: OrchestratorSeat | null } {
   const file = readOrchestratorSeatFile();
-  return { active: file.seats[project] ?? null, pending: file.pending[project] ?? null };
+  const canonical = canonicalOrchestratorProject(project);
+  return { active: file.seats[canonical] ?? null, pending: file.pending[canonical] ?? null };
 }
 
 export type BeginSeatIntentResult =
   /** A fresh pending intent, or the same intent replayed by its own key. */
   | { kind: "begun" | "replay"; seat: OrchestratorSeat }
+  /** Another request owns the in-flight transition for this project. */
+  | { kind: "in_progress"; seat: OrchestratorSeat }
   /** The same key already completed: designation and injection both happened. */
   | { kind: "completed"; seat: OrchestratorSeat };
 
@@ -218,16 +243,18 @@ export function beginOrchestratorSeatIntent(input: {
   now?: string;
 }): BeginSeatIntentResult {
   const file = readOrchestratorSeatFile();
-  const active = file.seats[input.project];
+  const project = canonicalOrchestratorProject(input.project);
+  const active = file.seats[project];
   if (active && active.intent.clientRequestId === input.clientRequestId) {
     return { kind: "completed", seat: active };
   }
-  const pending = file.pending[input.project];
+  const pending = file.pending[project];
   if (pending && pending.intent.clientRequestId === input.clientRequestId) {
     return { kind: "replay", seat: pending };
   }
+  if (pending) return { kind: "in_progress", seat: pending };
   const seat: OrchestratorSeat = {
-    project: input.project,
+    project,
     seatEpoch: file.nextSeatEpoch,
     conversationId: input.conversationId ?? null,
     path: null,
@@ -235,12 +262,12 @@ export function beginOrchestratorSeatIntent(input: {
     promptVersion: input.promptVersion ?? null,
     predecessorConversationId: null,
     state: "pending",
-    intent: { clientRequestId: input.clientRequestId, mode: input.mode, error: null },
+    intent: { clientRequestId: input.clientRequestId, mode: input.mode, launchId: null, error: null },
     designatedAt: input.now ?? new Date().toISOString(),
     activatedAt: null,
   };
   file.nextSeatEpoch += 1;
-  file.pending[input.project] = seat;
+  file.pending[project] = seat;
   writeSeatFile(file);
   return { kind: "begun", seat };
 }
@@ -262,20 +289,22 @@ export function completeOrchestratorSeatIntent(input: {
   clientRequestId: string;
   conversationId: string;
   path: string | null;
+  launchId?: string | null;
   now?: string;
 }): CompleteSeatIntentResult {
   const file = readOrchestratorSeatFile();
-  const active = file.seats[input.project];
+  const project = canonicalOrchestratorProject(input.project);
+  const active = file.seats[project];
   if (active && active.intent.clientRequestId === input.clientRequestId) {
     return { kind: "replay", seat: active };
   }
-  const pending = file.pending[input.project];
+  const pending = file.pending[project];
   if (!pending || pending.intent.clientRequestId !== input.clientRequestId) return { kind: "missing" };
   const now = input.now ?? new Date().toISOString();
   let revoked: OrchestratorRevocation | null = null;
   if (active && active.conversationId && active.conversationId !== input.conversationId) {
     revoked = {
-      project: input.project,
+      project,
       conversationId: active.conversationId,
       seatEpoch: active.seatEpoch,
       revokedAt: now,
@@ -291,11 +320,11 @@ export function completeOrchestratorSeatIntent(input: {
     path: input.path,
     predecessorConversationId: revoked?.conversationId ?? pending.predecessorConversationId,
     state: "active",
-    intent: { ...pending.intent, error: null },
+    intent: { ...pending.intent, launchId: input.launchId ?? pending.intent.launchId, error: null },
     activatedAt: now,
   };
-  delete file.pending[input.project];
-  file.seats[input.project] = seat;
+  delete file.pending[project];
+  file.seats[project] = seat;
   writeSeatFile(file);
   return { kind: "activated", seat, revoked };
 }
@@ -304,7 +333,8 @@ export function completeOrchestratorSeatIntent(input: {
     recoverable, and the previous active seat (if any) stays authoritative. */
 export function failOrchestratorSeatIntent(project: string, clientRequestId: string, error: string): void {
   const file = readOrchestratorSeatFile();
-  const pending = file.pending[project];
+  const canonical = canonicalOrchestratorProject(project);
+  const pending = file.pending[canonical];
   if (!pending || pending.intent.clientRequestId !== clientRequestId) return;
   pending.intent.error = error.slice(0, 500);
   writeSeatFile(file);


### PR DESCRIPTION
## Summary
- lets an operator-authorized MCP caller adopt an eligible registered conversation without spawning a duplicate
- canonicalizes named project aliases and persisted legacy seat keys to one durable seat
- records accepted 202 structured launches with their durable conversation and launch identifiers
- serializes competing create, adoption, retry, and rotation transitions while preserving ABA guards

Closes #761.

## Verification
- 105 focused orchestration, MCP, API authorization, and lifecycle tests pass under isolated Viewer state
- TypeScript check, changed-file lint, production build, and privacy publication gate pass