### PR TITLE
Fix account-pinned concurrent spawns and migration delivery safety

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -9,6 +9,7 @@ import { agentRegistry, AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { codexSessionRoots, createManagedCodexAccount } from "@/lib/accounts/codex";
 import { spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
+import { projectLaunchConversations } from "@/lib/agent/spawnProjection";
 import { rotateOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { spawnReplayStatus, spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
 import { resolveSpawnLineage, resolveSpawnLineageParent, resolveSpawnParent, SpawnParentError } from "@/lib/agent/spawnParent";
@@ -85,6 +86,140 @@ test("spawn admission rejects malformed MCP allowlists", async () => {
 
   expect(response.status).toBe(400);
   expect(await response.json()).toEqual({ error: "mcpServers must be an array of non-empty server names" });
+});
+
+test("an explicit spawn account is durably pinned while an omitted account uses the selected fallback", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "account-pin-"));
+  const store = registry();
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const dependencies = {
+      ...structuredRouteDependencies(cwd),
+      registry: () => store,
+      resolveHealthySpawnAccount: async (_engine: "claude" | "codex", requested?: string | null) => ({
+        engine: "claude" as const,
+        accountId: requested ?? "selected",
+        kind: "managed" as const,
+        home: path.join(cwd, requested ?? "selected"),
+        transcriptRoot: path.join(cwd, "projects"),
+        env: { NODE_ENV: "test" as const },
+      }),
+      defer: () => {},
+    };
+    const post = async (clientAttemptId: string, accountId?: string) => await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
+      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", clientAttemptId, ...(accountId ? { accountId } : {}) }),
+    }), dependencies);
+
+    expect((await post("account_pin_20260731", "pinned")).status).toBe(202);
+    expect(store.spawnReceiptForClientAttempt("account_pin_20260731")).toMatchObject({
+      accountId: "pinned",
+      accountPin: true,
+    });
+
+    expect((await post("account_fallback_20260731")).status).toBe(202);
+    expect(store.spawnReceiptForClientAttempt("account_fallback_20260731")).toMatchObject({
+      accountId: "selected",
+      accountPin: false,
+    });
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
+test("an unusable explicit account creates a terminal retryable pinned receipt and card", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "unusable-account-pin-"));
+  const store = registry();
+  const previous = {
+    transport: process.env.LLV_SPAWN_TRANSPORT,
+    hosts: process.env.LLV_STRUCTURED_HOSTS,
+    events: process.env.LLV_RUNTIME_EVENTS,
+    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
+    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
+  };
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
+      body: JSON.stringify({
+        engine: "claude",
+        model: "claude-sonnet-4-6",
+        cwd,
+        ["prompt"]: "inspect",
+        accountId: "unusable-pin",
+        clientAttemptId: "unusable_pin_20260731",
+      }),
+    }), {
+      ...structuredRouteDependencies(cwd),
+      registry: () => store,
+      resolveHealthySpawnAccount: async () => ({
+        engine: "claude" as const,
+        accountId: "selected-account",
+        kind: "managed" as const,
+        home: path.join(cwd, "selected-account"),
+        transcriptRoot: path.join(cwd, "selected-account", "projects"),
+        env: { NODE_ENV: "test" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      state: "failed",
+      initialMessage: "failed",
+      retrySafe: true,
+      error: "the requested account is not available for this launch",
+    });
+    const receipt = store.spawnReceiptForClientAttempt("unusable_pin_20260731");
+    expect(receipt).toMatchObject({
+      accountId: "unusable-pin",
+      accountPin: true,
+      state: "failed",
+      error: "the requested account is not available for this launch",
+    });
+    const card = projectLaunchConversations([], store.snapshot(), Date.now()).cards[0]?.spawn;
+    expect(card).toMatchObject({
+      accountId: "unusable-pin",
+      accountPin: true,
+      state: "failed",
+      retrySafe: true,
+      error: "the requested account is not available for this launch",
+    });
+  } finally {
+    if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previous.transport;
+    if (previous.hosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous.hosts;
+    if (previous.events === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previous.events;
+    if (previous.socket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previous.socket;
+    if (previous.ui === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previous.ui;
+  }
 });
 
 test("spawn admission grants MCP servers by session origin and refuses ungranted names", async () => {

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -162,18 +162,7 @@ test("an unusable explicit account creates a terminal retryable pinned receipt a
   process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
   process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
   try {
-    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
-      method: "POST",
-      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
-      body: JSON.stringify({
-        engine: "claude",
-        model: "claude-sonnet-4-6",
-        cwd,
-        ["prompt"]: "inspect",
-        accountId: "unusable-pin",
-        clientAttemptId: "unusable_pin_20260731",
-      }),
-    }), {
+    const dependencies = {
       ...structuredRouteDependencies(cwd),
       registry: () => store,
       resolveHealthySpawnAccount: async () => ({
@@ -182,21 +171,65 @@ test("an unusable explicit account creates a terminal retryable pinned receipt a
         kind: "managed" as const,
         home: path.join(cwd, "selected-account"),
         transcriptRoot: path.join(cwd, "selected-account", "projects"),
-        env: { NODE_ENV: "test" },
+        env: { NODE_ENV: "test" as const },
       }),
-    });
+    };
+    const capability = rotateOperatorSpawnCapability();
+    const baseRequest = {
+      engine: "claude",
+      model: "claude-sonnet-4-6",
+      cwd,
+      ["prompt"]: "inspect",
+      accountId: "unusable-pin",
+      clientAttemptId: "unusable_pin_20260731",
+    };
+    const post = async (overrides: Record<string, unknown> = {}) => await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: {
+        origin: "http://127.0.0.1",
+        host: "127.0.0.1",
+        "content-type": "application/json",
+        "sec-fetch-site": "same-origin",
+        "x-llv-spawn-capability": capability,
+      },
+      body: JSON.stringify({
+        ...baseRequest,
+        ...overrides,
+      }),
+    }), dependencies);
 
+    const response = await post();
+    const responseBody = await response.json();
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
+    expect(responseBody).toMatchObject({
       state: "failed",
       initialMessage: "failed",
       retrySafe: true,
       error: "the requested account is not available for this launch",
     });
+    const replay = await post();
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ launchId: responseBody.launchId, state: "failed" });
+
+    const parent = store.ensureConversation("claude", path.join(cwd, "parent.jsonl"), "parent-account");
+    const conflicts = [
+      { accountId: "other-unusable-pin" },
+      { ["prompt"]: "inspect a different target" },
+      { parentConversationId: parent.id },
+      { role: "builder" },
+      { allowSubagents: true },
+    ];
+    for (const changed of conflicts) {
+      const conflict = await post(changed);
+      expect(conflict.status).toBe(409);
+      expect(await conflict.json()).toEqual({ error: "spawn attempt conflicts with its original request" });
+    }
+
     const receipt = store.spawnReceiptForClientAttempt("unusable_pin_20260731");
     expect(receipt).toMatchObject({
       accountId: "unusable-pin",
       accountPin: true,
+      requestDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
       state: "failed",
       error: "the requested account is not available for this launch",
     });

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -121,9 +121,17 @@ test("an explicit spawn account is durably pinned while an omitted account uses 
       body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", clientAttemptId, ...(accountId ? { accountId } : {}) }),
     }), dependencies);
 
-    expect((await post("account_pin_20260731", "pinned")).status).toBe(202);
-    expect(store.spawnReceiptForClientAttempt("account_pin_20260731")).toMatchObject({
-      accountId: "pinned",
+    const pinnedResponses = await Promise.all([
+      post("account_pin_a_20260731", "pinned-a"),
+      post("account_pin_b_20260731", "pinned-b"),
+    ]);
+    expect(pinnedResponses.map((response) => response.status)).toEqual([202, 202]);
+    expect(store.spawnReceiptForClientAttempt("account_pin_a_20260731")).toMatchObject({
+      accountId: "pinned-a",
+      accountPin: true,
+    });
+    expect(store.spawnReceiptForClientAttempt("account_pin_b_20260731")).toMatchObject({
+      accountId: "pinned-b",
       accountPin: true,
     });
 
@@ -241,6 +249,130 @@ test("an unusable explicit account creates a terminal retryable pinned receipt a
       retrySafe: true,
       error: "the requested account is not available for this launch",
     });
+  } finally {
+    if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previous.transport;
+    if (previous.hosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous.hosts;
+    if (previous.events === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previous.events;
+    if (previous.socket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previous.socket;
+    if (previous.ui === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previous.ui;
+  }
+});
+
+test("a failed pinned reviewer preserves canonical child and pipeline lineage", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "failed-pinned-lineage-"));
+  const store = registry();
+  const sourceSessionId = crypto.randomUUID();
+  const sourceAccount = createManagedCodexAccount(`failed-pinned-lineage-${sourceSessionId}`);
+  const sourcePath = path.join(sourceAccount.sessionsDir, `${sourceSessionId}.jsonl`);
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, "{}\n");
+  const source = store.ensureConversation("codex", sourcePath, "source-account");
+  const reviewed = store.ensureConversation("codex", path.join(cwd, "reviewed.jsonl"), "reviewed-account");
+  const predecessor = store.ensureConversation("codex", path.join(cwd, "predecessor.jsonl"), "predecessor-account");
+  const previous = {
+    transport: process.env.LLV_SPAWN_TRANSPORT,
+    hosts: process.env.LLV_STRUCTURED_HOSTS,
+    events: process.env.LLV_RUNTIME_EVENTS,
+    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
+    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
+  };
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const dependencies = {
+      ...structuredRouteDependencies(cwd),
+      registry: () => store,
+      resolveHealthySpawnAccount: async () => ({
+        engine: "codex" as const,
+        accountId: "selected-account",
+        kind: "managed" as const,
+        home: path.join(cwd, "selected-account"),
+        transcriptRoot: path.join(cwd, "selected-account", "sessions"),
+        env: { CODEX_HOME: path.join(cwd, "selected-account"), NODE_ENV: "test" as const },
+      }),
+      pipelineAttemptTargetForSource: () => ({
+        pipelineId: "pipeline-failed-pin",
+        stageId: "review",
+        stageOrder: 2,
+        role: "reviewer",
+      }),
+    } satisfies SpawnRouteTestDependencies;
+    const body = {
+      engine: "codex",
+      model: "gpt-5.6-sol",
+      cwd,
+      ["prompt"]: "inspect account-pinned lineage",
+      accountId: "unavailable-account",
+      clientAttemptId: "failed_pinned_lineage_20260803",
+      src: sourcePath,
+      role: "reviewer",
+      roleParams: { diffSource: "PR 842", lens: "correctness" },
+      reviews: reviewed.id,
+      project: "account-pinned-project",
+      supersedes: predecessor.id,
+      mcpServers: ["viewer"],
+    };
+    const post = () => POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+      method: "POST",
+      headers: {
+        origin: "http://127.0.0.1:8898",
+        host: "127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }), dependencies);
+
+    const first = await post();
+    expect(first.status).toBe(200);
+    const firstBody = await first.json() as { launchId: string };
+    const replay = await post();
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ launchId: firstBody.launchId, state: "failed" });
+
+    const receipt = store.spawnReceiptForClientAttempt(body.clientAttemptId)!;
+    expect(receipt).toMatchObject({
+      accountId: body.accountId,
+      accountPin: true,
+      state: "failed",
+      parentConversationId: source.id,
+      parentSource: "explicit",
+      agentRole: "reviewer",
+      delegationDepth: 0,
+      explicitProject: body.project,
+      supersedes: { conversationId: predecessor.id, reason: "recovery-spawn" },
+      launchProfile: {
+        parentConversationId: source.id,
+        mcpServers: ["viewer"],
+        plugins: [],
+      },
+    });
+    expect(store.snapshot().lineageEdges[receipt.conversationId]).toMatchObject({
+      parentConversationId: source.id,
+      parentArtifactPath: sourcePath,
+      kind: "review",
+      role: "reviewer",
+      reviewsConversationId: reviewed.id,
+    });
+    expect(store.snapshot().memberships[receipt.conversationId]).toEqual([
+      expect.objectContaining({
+        kind: "pipeline",
+        containerId: "pipeline-failed-pin",
+        role: "reviewer",
+        stageId: "review",
+        stageOrder: 2,
+        parentConversationId: source.id,
+        runtime: { engine: "codex", model: "gpt-5.6-sol", effort: "xhigh" },
+      }),
+    ]);
   } finally {
     if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previous.transport;

--- a/src/app/api/tasks/[id]/spawn/route.test.ts
+++ b/src/app/api/tasks/[id]/spawn/route.test.ts
@@ -397,6 +397,7 @@ test("retryOfLaunchId relaunches a pathless failed assignment with a fresh attem
     updatedAt: "2026-07-19T10:00:00.000Z",
   }];
   let failNextSpawn = true;
+  let rerouteRetryBeforeSettlement = false;
   const dependencies = {
     registry: () => registry,
     loadTasks: () => tasks,
@@ -416,6 +417,15 @@ test("retryOfLaunchId relaunches a pathless failed assignment with a fresh attem
     resolveSpawnedTranscriptPath: async () => artifactPath,
     spawnAgentWithPrompt: async (_spec: unknown, _prompt: string, receipt: SpawnReceipt) => {
       if (failNextSpawn) throw new Error("pane allocation failed before binding");
+      if (rerouteRetryBeforeSettlement) {
+        registry.commitMigrationIntent({
+          engine: "claude",
+          targetId: "claude-healthy",
+          origin: "manual",
+          requestId: "task-retry-routing-change",
+          expectedRevision: registry.engineRouting("claude").revision,
+        });
+      }
       const binding = {
         endpoint: "/tmp",
         server: { pid: 91, startIdentity: "91:one" },
@@ -468,6 +478,7 @@ test("retryOfLaunchId relaunches a pathless failed assignment with a fresh attem
   }), context, dependencies)).status).toBe(400);
 
   failNextSpawn = false;
+  rerouteRetryBeforeSettlement = true;
   const retried = await POST.withDependencies(request({ retryOfLaunchId: failedBody.launchId }), context, dependencies);
   const retriedBody = await retried.json();
   expect(retried.status).toBe(200);
@@ -478,12 +489,18 @@ test("retryOfLaunchId relaunches a pathless failed assignment with a fresh attem
   const original = snapshot.receipts[failedBody.launchId]!;
   const fresh = snapshot.receipts[retriedBody.launchId]!;
   expect(original.state).toBe("failed");
+  expect(original.accountPin).toBeFalse();
   expect(fresh.clientAttemptId).not.toBe(original.clientAttemptId);
   expect(fresh).toMatchObject({
     engine: "claude",
     cwd: original.cwd,
     accountId: original.accountId,
+    accountPin: true,
     launchProfile: expect.objectContaining({ model: "opus", effort: "high" }),
+  });
+  expect(registry.conversation(fresh.conversationId)).toMatchObject({
+    pinnedAccountId: fresh.accountId,
+    migration: null,
   });
   /* The failed audit assignment survives beside the fresh delivered one. */
   expect(tasks[0]!.assignments).toEqual([

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -252,6 +252,8 @@ async function postTaskSpawn(
   const clientAttemptId = typeof body.clientAttemptId === "string"
     ? body.clientAttemptId
     : nextTaskAttemptId(registry, task, shape);
+  const accountPin = registry.spawnReceiptForClientAttempt(clientAttemptId)?.accountPin
+    ?? (previous !== null);
   const specBase = freshSpecFor(engine, cwdResult.cwd, {
     model: selectedModel.model,
     effort: reasoning.effort,
@@ -275,6 +277,7 @@ async function postTaskSpawn(
     cwd: cwdResult.cwd,
     transport: "tmux",
     accountId: account.accountId,
+    accountPin,
     origin: { kind: "operator" },
     ownStartingActuation: true,
     launchProfile: spec.launchProfile,

--- a/src/lib/agent/registry.reseat.test.ts
+++ b/src/lib/agent/registry.reseat.test.ts
@@ -96,6 +96,12 @@ for (const mode of ["off", "sqlite"] as const) {
   test(`stopped migration delivery settlement survives a ${mode === "off" ? "JSON" : "SQLite"} registry restart`, () => {
     const filename = registryFile();
     const { store, id } = seededRegistry(mode, filename);
+    const held = store.holdDelivery(id, "fixture", `stop-parity-${mode}`);
+    const generation = store.conversation(id)!.generations.at(-1)!;
+    expect(store.beginDeliveryAttempt(held.id, generation.id)).toMatchObject({
+      state: "delivery-uncertain",
+      attempts: 1,
+    });
     const intent = store.commitMigrationIntent({
       engine: "codex",
       targetId: "healthy",
@@ -103,14 +109,13 @@ for (const mode of ["off", "sqlite"] as const) {
       requestId: `stop-parity-${mode}`,
       expectedRevision: store.engineRouting("codex").revision,
     });
-    const held = store.holdDelivery(id, "fixture", `stop-parity-${mode}`);
     store.setMigrationIntentState(intent.id, "stopped", intent.revision);
 
     const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: mode });
     expect(reopened.snapshot().migrationIntents[intent.id]).toMatchObject({ state: "stopped" });
     expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
       state: "failed",
-      attempts: 0,
+      attempts: 1,
       generationId: null,
       deliveredAt: null,
       error: expect.stringContaining("migration was stopped"),
@@ -123,8 +128,95 @@ for (const mode of ["off", "sqlite"] as const) {
       state: "failed",
       error: expect.stringContaining("migration was stopped"),
     });
+    expect(reopened.recordDeliveryOutcome(held.id, "delivered")).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("migration was stopped"),
+    });
+    expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("migration was stopped"),
+    });
+  });
+
+  test(`rolled-back migration delivery settlement survives a ${mode === "off" ? "JSON" : "SQLite"} registry restart`, () => {
+    const filename = registryFile();
+    const { store, id } = seededRegistry(mode, filename);
+    const held = store.holdDelivery(id, "fixture", `rollback-parity-${mode}`);
+    const generation = store.conversation(id)!.generations.at(-1)!;
+    expect(store.beginDeliveryAttempt(held.id, generation.id)).toMatchObject({
+      state: "delivery-uncertain",
+      attempts: 1,
+    });
+    const requested = store.requestConversationReseat(id, "healthy");
+    store.rollbackConversationMigration(id, requested.migration!.revision);
+
+    const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: mode });
+    expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "failed",
+      attempts: 1,
+      generationId: null,
+      deliveredAt: null,
+      error: expect.stringContaining("migration was rolled back"),
+    });
+    expect(reopened.recordDeliveryOutcomeForOperation(id, held.command.operationId, "delivered")).toBeNull();
+    expect(reopened.recordDeliveryOutcome(held.id, "delivered")).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("migration was rolled back"),
+    });
+  });
+
+  test(`committed migration delivery settlement survives a ${mode === "off" ? "JSON" : "SQLite"} registry restart`, () => {
+    const filename = registryFile();
+    const { store, id } = seededRegistry(mode, filename);
+    const held = store.holdDelivery(id, "fixture", `commit-parity-${mode}`);
+    const generation = store.conversation(id)!.generations.at(-1)!;
+    expect(store.beginDeliveryAttempt(held.id, generation.id)).toMatchObject({
+      state: "delivery-uncertain",
+      attempts: 1,
+    });
+    const requested = store.requestConversationReseat(id, "healthy");
+    const revision = requested.migration!.revision;
+    store.transitionConversationMigration(id, revision, ["waiting-turn", "requested"], { phase: "preparing" });
+    const starting = store.transitionConversationMigration(id, revision, ["preparing"], { phase: "successor-starting" });
+    const receipt = providerReceipt(starting.migration!.operationId, `committed-successor-${mode}`, `/sessions/committed-${mode}.jsonl`);
+    store.persistMigrationProviderReceipt(id, revision, starting.migration!.operationId, receipt);
+    store.commitSuccessor(id, {
+      id: receipt.nativeId,
+      path: receipt.path,
+      accountId: "healthy",
+      historyHash: receipt.historyHash,
+      host: receipt.host,
+    }, revision, starting.migration!.operationId, receipt);
+
+    const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: mode });
+    expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "failed",
+      attempts: 1,
+      generationId: null,
+      deliveredAt: null,
+      error: expect.stringContaining("migration committed"),
+    });
+    expect(reopened.recordDeliveryOutcomeForOperation(id, held.command.operationId, "delivered")).toBeNull();
+    expect(reopened.recordDeliveryOutcome(held.id, "delivered")).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("migration committed"),
+    });
   });
 }
+
+test("direct settlement can still recover a failure unrelated to migration cancellation", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  const held = store.holdDelivery(id, "fixture", "ordinary-direct-recovery");
+  expect(store.recordDeliveryOutcome(held.id, "failed", "temporary provider failure")).toMatchObject({
+    state: "failed",
+    error: "temporary provider failure",
+  });
+  expect(store.recordDeliveryOutcome(held.id, "delivered")).toMatchObject({
+    state: "delivered",
+    deliveredAt: expect.any(String),
+    error: null,
+  });
+});
 
 test("a conversation reseat never reuses or retargets the single engine drain intent", () => {
   const { store, id } = seededRegistry("off", registryFile());

--- a/src/lib/agent/registry.reseat.test.ts
+++ b/src/lib/agent/registry.reseat.test.ts
@@ -115,6 +115,14 @@ for (const mode of ["off", "sqlite"] as const) {
       deliveredAt: null,
       error: expect.stringContaining("migration was stopped"),
     });
+    /* A late journal report from the abandoned generation is evidence only.
+       It cannot release the cancelled message after either persistence mode
+       restarts; a fresh operator action owns any later delivery. */
+    expect(reopened.recordDeliveryOutcomeForOperation(id, held.command.operationId, "delivered")).toBeNull();
+    expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("migration was stopped"),
+    });
   });
 }
 
@@ -243,6 +251,74 @@ test("stopped and non-active-target intents cannot adopt unrelated spawns", () =
   }
 });
 
+test("an explicit account pin stays outside an active engine drain while an unpinned launch follows the selected account", () => {
+  const { store } = seededRegistry("off", registryFile());
+  store.setEngineRouting("codex", "selected");
+  store.commitMigrationIntent({
+    engine: "codex",
+    targetId: "selected",
+    origin: "manual",
+    requestId: "selected-engine-drain",
+    expectedRevision: store.engineRouting("codex").revision,
+  });
+
+  const pinned = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo/checkout",
+    transport: "structured",
+    accountId: "pinned",
+    accountPin: true,
+  });
+  if (pinned.kind !== "created") throw new Error("expected pinned launch receipt");
+  const staged = store.stageStructuredSpawn(pinned.receipt.launchId, {
+    key: { engine: "codex", sessionId: "pinned-session" },
+    artifactPath: "/sessions/pinned-session.jsonl",
+    cwd: "/repo/checkout",
+    accountId: "pinned",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("expected pinned launch staging");
+
+  expect(staged.receipt).toMatchObject({ accountId: "pinned", accountPin: true, state: "path-pending" });
+  expect(staged.conversation).toMatchObject({ pinnedAccountId: "pinned", migration: null });
+
+  store.setEngineRouting("codex", "reselected");
+  expect(store.requestConversationMigrationToActiveAccount(staged.conversation.id)).toMatchObject({
+    pinnedAccountId: "pinned",
+    migration: null,
+  });
+
+  const unpinned = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo/checkout",
+    transport: "structured",
+    accountId: "reselected",
+    accountPin: false,
+  });
+  if (unpinned.kind !== "created") throw new Error("expected fallback launch receipt");
+  const settled = store.settleSpawn(unpinned.receipt.launchId, {
+    key: { engine: "codex", sessionId: "fallback-session" },
+    artifactPath: "/sessions/fallback-session.jsonl",
+    cwd: "/repo/checkout",
+    accountId: "reselected",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  if (settled.kind !== "settled") throw new Error("expected fallback launch settlement");
+
+  store.setEngineRouting("codex", "next-selected");
+  expect(store.requestConversationMigrationToActiveAccount(settled.conversation.id).migration).toMatchObject({
+    targetId: "next-selected",
+  });
+});
+
 test("resume generation rollover cannot revive delivery cancelled by Stop", () => {
   const { store, id } = seededRegistry("off", registryFile());
   const intent = store.commitMigrationIntent({
@@ -355,6 +431,44 @@ test("stopping a migration records that an uncertain delivery may already have l
     generationId: null,
     error: expect.stringContaining("may have been delivered"),
   });
+});
+
+test("a successful migration preserves both prior and fenced prompts as cancelled evidence", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  const source = store.conversation(id)!.generations.at(-1)!;
+  const predecessorOwned = store.holdDelivery(id, "old owner payload", "old-owner-prompt");
+  const requested = store.requestConversationReseat(id, "healthy");
+  const fenced = store.holdDelivery(id, "fenced payload", "fenced-prompt");
+  const revision = requested.migration!.revision;
+  store.transitionConversationMigration(id, revision, ["requested"], { phase: "preparing" });
+  const starting = store.transitionConversationMigration(id, revision, ["preparing"], { phase: "successor-starting" });
+  const receipt = providerReceipt(starting.migration!.operationId, "verified-successor", "/sessions/verified-successor.jsonl");
+  store.persistMigrationProviderReceipt(id, revision, starting.migration!.operationId, receipt);
+  const committed = store.commitSuccessor(id, {
+    id: receipt.nativeId,
+    path: receipt.path,
+    accountId: "healthy",
+    historyHash: receipt.historyHash,
+    host: receipt.host,
+  }, revision, starting.migration!.operationId, receipt);
+
+  expect(committed.migration).toMatchObject({ phase: "committed" });
+  expect(store.snapshot().heldDeliveries[predecessorOwned.id]).toMatchObject({
+    state: "failed",
+    generationId: null,
+    text: "",
+    error: expect.stringContaining("migration committed"),
+  });
+  expect(store.snapshot().heldDeliveries[fenced.id]).toMatchObject({
+    state: "failed",
+    generationId: null,
+    text: "",
+    error: expect.stringContaining("migration committed"),
+  });
+  expect(store.conversation(id)?.generations).toMatchObject([
+    { id: source.id, archivedAt: expect.any(String) },
+    { id: receipt.nativeId, accountId: "healthy", archivedAt: null },
+  ]);
 });
 
 test("repeat reseat clicks never mint a second successor operation", () => {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1458,6 +1458,11 @@ function terminalDeliveryState(
   return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
 }
 
+function migrationDeliveryCancellationIsAbsorbing(delivery: HeldDelivery): boolean {
+  return delivery.state === "failed"
+    && delivery.error?.startsWith(MIGRATION_DELIVERY_CANCELLATION_PREFIX) === true;
+}
+
 function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDelivery): void {
   const owner = file.deliveryOperationOwners[delivery.command.operationId];
   if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
@@ -6070,7 +6075,9 @@ export class AgentRegistry {
     return this.mutate((file) => {
       const delivery = file.heldDeliveries[id];
       if (!delivery) throw new Error("held delivery is unknown");
-      if (delivery.state === "delivered") return clone(delivery);
+      if (delivery.state === "delivered" || migrationDeliveryCancellationIsAbsorbing(delivery)) {
+        return clone(delivery);
+      }
       const conversation = file.conversations[resolveConversationAlias(file, delivery.conversationId)];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
       const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
@@ -6126,7 +6133,7 @@ export class AgentRegistry {
         if (!delivery || delivery.state === "delivered") return delivery ? clone(delivery) : null;
         const retryRecovered = delivery.state === "failed"
           && outcome.state === "delivered"
-          && !delivery.error?.startsWith(MIGRATION_DELIVERY_CANCELLATION_PREFIX);
+          && !migrationDeliveryCancellationIsAbsorbing(delivery);
         if (delivery.state !== "delivery-uncertain" && !retryRecovered) return null;
         const conversation = file.conversations[canonicalId];
         const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -167,6 +167,10 @@ export interface SpawnReceipt {
   engine: AgentEngine;
   cwd: string;
   accountId: string | null;
+  /** An explicit launch account is a durable routing authority for this
+      conversation. The selected engine account remains a fallback for
+      receipts without this marker. */
+  accountPin: boolean;
   parentConversationId: ViewerConversationId | null;
   /** How the durable parent was attributed (#341): an explicit selector in the
       request body, or inference from the authenticated caller conversation.
@@ -267,6 +271,8 @@ export interface SpawnRequest {
   requestDigest?: string | null;
   spawnCapabilityDigest?: string | null;
   accountId?: string | null;
+  /** True only when the caller explicitly selected accountId. */
+  accountPin?: boolean;
   parentConversationId?: ViewerConversationId | null;
   /** Attribution of the resolved parent (#341): explicit request selector or
       inference from the authenticated caller conversation. */
@@ -396,6 +402,9 @@ export interface RegistryConversation {
       cwd-attributed conversations; projections then fall back to canonical
       cwd, the launch-profile hint, and the scanner slug in that order. */
   projectOwnership: ConversationProjectOwnership | null;
+  /** Explicit launch pin carried from a receipt into the conversation. A
+      selected-account change cannot reseat this conversation. */
+  pinnedAccountId?: string | null;
   /** Durable compare-and-set owner for live structured profile changes. */
   reconfigure?: ConversationReconfigureState | null;
   migration: ConversationMigration | null;
@@ -806,6 +815,7 @@ function migrationScopeCounts(
   const index = migrationReadinessIndex(file);
   for (const conversation of Object.values(file.conversations)) {
     if (conversation.engine !== engine) continue;
+    if (conversation.pinnedAccountId) continue;
     const source = conversation.generations.at(-1);
     if (!source || source.accountId === null) continue;
     if (source.accountId === targetId) {
@@ -894,6 +904,7 @@ function terminalizeHeldDelivery(
   delivery.assignedAt = null;
   delivery.deliveredAt = null;
   delivery.error = terminalReason.slice(0, 240);
+  failInitialSpawnReceiptForDelivery(file, delivery);
   syncDeliveryOperationOwnerState(file, delivery);
 }
 
@@ -1304,6 +1315,9 @@ function normalizeConversation(value: RegistryConversation, policy?: McpGrantPol
     abandonedContinuityPaths,
     providerForkPaths,
     projectOwnership: normalizeProjectOwnership((value as Partial<RegistryConversation>).projectOwnership),
+    pinnedAccountId: typeof (value as Partial<RegistryConversation>).pinnedAccountId === "string"
+      ? (value as Partial<RegistryConversation>).pinnedAccountId
+      : null,
     reconfigure: normalizeConversationReconfigure((value as Partial<RegistryConversation>).reconfigure),
     migration,
     migrationOptOut,
@@ -1460,6 +1474,25 @@ function failedSpawnLaunchIdOf(file: RegistryFile, delivery: HeldDelivery): stri
   const receipt = file.receipts[launchId];
   if (!receipt || receipt.purpose !== "launch" || receipt.state !== "failed") return null;
   return launchId;
+}
+
+/** A terminal first-message delivery failure makes its launch receipt terminal
+    too. Leaving the receipt path-pending would keep the operator card live
+    without a retry action even though its only prompt can no longer arrive. */
+function failInitialSpawnReceiptForDelivery(file: RegistryFile, delivery: HeldDelivery): void {
+  if (delivery.state !== "failed") return;
+  const clientMessageId = delivery.clientMessageId;
+  if (!clientMessageId?.startsWith("spawn_")) return;
+  const launchId = clientMessageId.slice("spawn_".length);
+  if (delivery.command.operationId !== `spawn_message_${launchId}`) return;
+  const receipt = file.receipts[launchId];
+  if (!receipt
+    || receipt.purpose !== "launch"
+    || resolveConversationAlias(file, receipt.conversationId) !== resolveConversationAlias(file, delivery.conversationId)
+    || ["completed", "failed", "conflicted"].includes(receipt.state)) return;
+  receipt.state = "failed";
+  receipt.error = delivery.error ?? "initial prompt delivery failed";
+  receipt.admissionOwner = null;
 }
 
 /** Durably terminalize the `spawn_<launchId>` initial delivery of a FAILED
@@ -2328,6 +2361,7 @@ function normalizeReceipt(value: SpawnReceipt, policy?: McpGrantPolicy): SpawnRe
       ? value.pathCorrelation
       : null,
     accountId: typeof value.accountId === "string" ? value.accountId : null,
+    accountPin: value.accountPin === true,
     parentConversationId: typeof value.parentConversationId === "string" && value.parentConversationId.startsWith("conversation_")
       ? value.parentConversationId as ViewerConversationId
       : null,
@@ -3498,6 +3532,7 @@ export class AgentRegistry {
             && existing.engine === input.engine
             && existing.cwd === input.cwd
             && existing.transport === (input.transport ?? null)
+            && existing.accountPin === (input.accountPin === true)
             && existing.explicitProject === explicitProject
             && (existing.supersedes?.conversationId ?? null) === supersedes
             && existing.launchProfile.permissionMode === profile.permissionMode;
@@ -3596,6 +3631,7 @@ export class AgentRegistry {
         engine: input.engine,
         cwd: input.cwd,
         accountId: input.accountId ?? null,
+        accountPin: input.accountPin === true,
         parentConversationId,
         parentSource: parentConversationId
           && (input.parentSource === "explicit" || input.parentSource === "inferred-caller")
@@ -3950,6 +3986,7 @@ export class AgentRegistry {
       abandonedContinuityPaths: [],
       providerForkPaths: [],
       projectOwnership: null,
+      pinnedAccountId: receipt.accountPin ? receipt.accountId : null,
       migration: null,
       migrationOptOut: null,
       supersededBy: null,
@@ -3964,6 +4001,9 @@ export class AgentRegistry {
        re-derive or demote it. */
     conversation.agentRole ??= receipt.agentRole;
     conversation.delegationDepth ??= receipt.delegationDepth;
+    if (receipt.purpose === "launch" && receipt.accountPin && receipt.accountId) {
+      conversation.pinnedAccountId = receipt.accountId;
+    }
     if (conversation.engine !== receipt.engine) return conflict("spawn_identity_conflict");
     if (receipt.purpose === "resume-successor" && !resumeCanRebaseMigration(conversation.migration)) {
       return conflict("spawn_identity_conflict");
@@ -4059,7 +4099,7 @@ export class AgentRegistry {
       && engineScopedIntent(intent)
       && migrationIntentCanEnroll(file, intent, Date.parse(createdAt)));
     const source = conversation.generations.at(-1);
-    if (activeIntent && source && source.accountId !== activeIntent.targetId && !conversation.migration) {
+    if (activeIntent && !conversation.pinnedAccountId && source && source.accountId !== activeIntent.targetId && !conversation.migration) {
       conversation.migration = {
         intentId: activeIntent.id,
         phase: migrationTurnIsBusy(file, conversation) ? "waiting-turn" : "requested",
@@ -4650,6 +4690,7 @@ export class AgentRegistry {
         abandonedContinuityPaths: [],
         providerForkPaths: [],
         projectOwnership: null,
+        pinnedAccountId: null,
         migration: null,
         migrationOptOut: null,
         supersededBy: null,
@@ -4826,6 +4867,7 @@ export class AgentRegistry {
             abandonedContinuityPaths: [],
             providerForkPaths: [],
             projectOwnership: null,
+            pinnedAccountId: null,
             migration: null,
             migrationOptOut: null,
             supersededBy: null,
@@ -5237,6 +5279,7 @@ export class AgentRegistry {
       let scoped = 0;
       for (const conversation of Object.values(file.conversations)) {
         if (conversation.engine !== input.engine) continue;
+        if (conversation.pinnedAccountId) continue;
         if (input.origin === "manual" && conversation.migrationOptOut?.targetId === input.targetId) {
           conversation.migrationOptOut = null;
         }
@@ -5275,6 +5318,7 @@ export class AgentRegistry {
       const canonicalId = resolveConversationAlias(file, id);
       const conversation = file.conversations[canonicalId];
       if (!conversation) throw new Error("viewer conversation is unknown");
+      if (conversation.pinnedAccountId) return clone(conversation);
       const targetId = file.engineRouting[conversation.engine].activeAccountId;
       const source = conversation.generations.at(-1);
       if (!targetId || !source || source.accountId === null || source.accountId === targetId) return clone(conversation);
@@ -6034,6 +6078,7 @@ export class AgentRegistry {
       delivery.deliveredAt = state === "delivered" ? now() : null;
       delivery.error = error?.slice(0, 240) ?? null;
       if (state === "delivered") delivery.text = "";
+      if (state === "failed") failInitialSpawnReceiptForDelivery(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       const settled = clone(delivery);
       if (state === "delivered" || state === "failed") compactDeliveryReservations(file, delivery.conversationId);
@@ -6079,7 +6124,9 @@ export class AgentRegistry {
         const canonicalId = resolveConversationAlias(file, outcome.conversationId);
         const delivery = deliveries.get(keyFor(canonicalId, outcome.operationId));
         if (!delivery || delivery.state === "delivered") return delivery ? clone(delivery) : null;
-        const retryRecovered = delivery.state === "failed" && outcome.state === "delivered";
+        const retryRecovered = delivery.state === "failed"
+          && outcome.state === "delivered"
+          && !delivery.error?.startsWith(MIGRATION_DELIVERY_CANCELLATION_PREFIX);
         if (delivery.state !== "delivery-uncertain" && !retryRecovered) return null;
         const conversation = file.conversations[canonicalId];
         const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
@@ -6088,6 +6135,7 @@ export class AgentRegistry {
         delivery.deliveredAt = outcome.state === "delivered" ? now() : null;
         delivery.error = outcome.error?.slice(0, 240) ?? null;
         if (outcome.state === "delivered") delivery.text = "";
+        if (outcome.state === "failed") failInitialSpawnReceiptForDelivery(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         compactConversations.add(delivery.conversationId);
         return clone(delivery);

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -301,9 +301,55 @@ export async function executeSpawnRequest(
   try {
     const clientAttemptId = typeof body.clientAttemptId === "string" ? body.clientAttemptId : null;
     const existingAttempt = clientAttemptId ? registry.spawnReceiptForClientAttempt(clientAttemptId) : null;
-    const account = existingAttempt && body.accountId === undefined && existingAttempt.accountId !== null
-      ? dependencies.resolveSpawnAccount(existingAttempt.engine, existingAttempt.accountId)
-      : await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
+    const terminalizePinnedAccountFailure = (failure: unknown): NextResponse<SpawnResponse | ApiError> => {
+      const accountId = body.accountId as string;
+      const reason = (failure instanceof Error ? failure.message : String(failure)).slice(0, 240);
+      const begun = registry.beginSpawnRequest({
+        engine,
+        cwd,
+        transport,
+        accountId,
+        accountPin: true,
+        launchProfile: emptyLaunchProfile({
+          cwd,
+          model: selectedModel.model,
+          effort: reasoning.effort,
+          fast: reasoning.fast,
+        }),
+        clientAttemptId,
+        /* Account preflight has no session to start. Its failed receipt is an
+           idempotent terminal account of this request, while the Retry action
+           intentionally starts a fresh client attempt after the operator fixes
+           credentials or chooses another pin. */
+        requestDigest: null,
+        launchDisplay: (userPrompt.trim() || images.length)
+          ? { prompt: userPrompt, images: images.length, echo: prompt }
+          : null,
+      });
+      if (begun.kind === "conflict") {
+        return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
+      }
+      if (begun.kind === "created") {
+        if (transport === "structured") registry.failStructuredSpawn(begun.receipt.launchId, reason);
+        else registry.failSpawn(begun.receipt.launchId, reason);
+      }
+      const receipt = registry.readOnlySnapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
+      return NextResponse.json(spawnResponseForReceipt(receipt, receipt.artifactPath, {
+        structured: transport === "structured",
+      }));
+    };
+    let account;
+    try {
+      account = existingAttempt && body.accountId === undefined && existingAttempt.accountId !== null
+        ? dependencies.resolveSpawnAccount(existingAttempt.engine, existingAttempt.accountId)
+        : await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
+    } catch (error) {
+      if (body.accountId === undefined) throw error;
+      return terminalizePinnedAccountFailure(error);
+    }
+    if (body.accountId !== undefined && account.accountId !== body.accountId) {
+      return terminalizePinnedAccountFailure(new Error("the requested account is not available for this launch"));
+    }
     const lineage = resolveSpawnLineage(spawnLineageSelectorForCaller(authenticatedCaller, {
       ...body,
       role: role.value?.role,
@@ -414,6 +460,7 @@ export async function executeSpawnRequest(
       cwd,
       transport,
       accountId: account.accountId,
+      accountPin: body.accountId !== undefined,
       parentConversationId,
       parentSource,
       parentSessionKey,

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -9,7 +9,7 @@ import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } fr
 import { accountManager, resolveHealthySpawnAccount } from "@/lib/accounts/manager";
 import { emptyLaunchProfile, validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
-import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
+import { agentRegistry, SpawnChildLimitError, type SpawnRequest } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { mcpServersForSession, normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 import { normalizeSpawnPlugins, pluginAllowlistForSession, sessionOriginFor } from "@/lib/agent/pluginAllowlist";
@@ -372,30 +372,86 @@ export async function executeSpawnRequest(
       prompt,
       images: images.map((image) => ({ mime: image.mime, digest: spawnContentDigest({ image: image.base64 }) })),
     });
+    const pipelineAttemptTarget = pipelineSourceConversationId && dependencies.pipelineAttemptTargetForSource
+      ? dependencies.pipelineAttemptTargetForSource(pipelineSourceConversationId)
+      : null;
+    const launchDisplay = (userPrompt.trim() || images.length)
+      ? { ["prompt"]: userPrompt, images: images.length, echo: prompt }
+      : null;
+    /* Both a runnable launch and an explicit-account preflight failure reserve
+       the same durable launch identity. Keep the request assembled at this
+       seam so the terminal receipt retains the lineage, origin, grants and
+       pipeline evidence a runnable receipt would carry. */
+    const canonicalSpawnRequest = (
+      accountId: string,
+      launchProfile: ReturnType<typeof emptyLaunchProfile>,
+      requestDigest: string,
+    ): SpawnRequest => ({
+      engine,
+      cwd,
+      transport,
+      accountId,
+      accountPin: body.accountId !== undefined,
+      parentConversationId,
+      parentSource,
+      parentSessionKey,
+      parentArtifactPath,
+      role: role.value?.role ?? null,
+      reviewsConversationId: reviewedConversationId,
+      explicitProject,
+      supersedes: supersedesConversationId,
+      supersedesReason: "recovery-spawn",
+      liveChildrenCap: authenticatedCaller?.liveChildrenCap,
+      /* Initiating origin (#393): the authenticated capability caller is the
+         origin of agent-lane launches; same-origin UI and operator-capability
+         launches are depth-0 roots. Lineage parents stay projection metadata. */
+      origin: authenticatedCaller?.kind === "agent"
+        ? { kind: "agent", conversationId: authenticatedCaller.conversationId }
+        : { kind: "operator" },
+      launchProfile,
+      clientAttemptId,
+      requestDigest,
+      /* Durable launch DISPLAY payload (issue #614/#615): the RAW operator
+         draft and canonical delivered echo persist through scan lag. */
+      launchDisplay,
+      memberships: pipelineAttemptTarget && pipelineSourceConversationId ? [{
+        kind: "pipeline",
+        containerId: pipelineAttemptTarget.pipelineId,
+        role: pipelineAttemptTarget.role,
+        slot: `adopt:${pipelineAttemptTarget.stageId}:${requestDigest.slice(0, 24)}`,
+        stageId: pipelineAttemptTarget.stageId,
+        stageOrder: pipelineAttemptTarget.stageOrder,
+        round: null,
+        parentConversationId: pipelineSourceConversationId as `conversation_${string}`,
+        runtime: {
+          engine,
+          model: launchProfile.model,
+          effort: launchProfile.effort,
+        },
+      }] : [],
+    });
+    const preflightLaunchProfile = emptyLaunchProfile({
+      cwd,
+      model: selectedModel.model,
+      effort: reasoning.effort,
+      fast: reasoning.fast,
+      parentConversationId,
+      allowSubagents: body.allowSubagents === true,
+      mcpServers: grantedServers,
+      plugins,
+      ...(explicitProject ? { project: explicitProject } : {}),
+    });
     const terminalizePinnedAccountFailure = (failure: unknown): NextResponse<SpawnResponse | ApiError> => {
       const accountId = body.accountId as string;
       const reason = (failure instanceof Error ? failure.message : String(failure)).slice(0, 240);
-      const begun = registry.beginSpawnRequest({
-        engine,
-        cwd,
-        transport,
+      const begun = registry.beginSpawnRequest(canonicalSpawnRequest(
         accountId,
-        accountPin: true,
-        launchProfile: emptyLaunchProfile({
-          cwd,
-          model: selectedModel.model,
-          effort: reasoning.effort,
-          fast: reasoning.fast,
-        }),
-        clientAttemptId,
+        preflightLaunchProfile,
         /* The digest binds this terminal preflight to the same canonical public
            launch identity as a runnable request. Prompt and image bytes enter
            durable identity only through one-way hashes. */
-        requestDigest: requestDigestForAccount(accountId),
-        launchDisplay: (userPrompt.trim() || images.length)
-          ? { ["prompt"]: userPrompt, images: images.length, echo: prompt }
-          : null,
-      });
+        requestDigestForAccount(accountId),
+      ));
       if (begun.kind === "conflict") {
         return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
       }
@@ -421,9 +477,6 @@ export async function executeSpawnRequest(
       return terminalizePinnedAccountFailure(new Error("the requested account is not available for this launch"));
     }
     const digest = requestDigestForAccount(account.accountId);
-    const pipelineAttemptTarget = pipelineSourceConversationId && dependencies.pipelineAttemptTargetForSource
-      ? dependencies.pipelineAttemptTargetForSource(pipelineSourceConversationId)
-      : null;
     const specBase = freshSpecFor(engine, cwd, {
       model: selectedModel.model,
       effort: reasoning.effort,
@@ -455,56 +508,7 @@ export async function executeSpawnRequest(
         ...(explicitProject ? { project: explicitProject } : {}),
       }),
     };
-    const begun = registry.beginSpawnRequest({
-      engine,
-      cwd,
-      transport,
-      accountId: account.accountId,
-      accountPin: body.accountId !== undefined,
-      parentConversationId,
-      parentSource,
-      parentSessionKey,
-      parentArtifactPath,
-      role: role.value?.role ?? null,
-      reviewsConversationId: reviewedConversationId,
-      explicitProject,
-      supersedes: supersedesConversationId,
-      supersedesReason: "recovery-spawn",
-      liveChildrenCap: authenticatedCaller?.liveChildrenCap,
-      /* Initiating origin (#393): the authenticated capability caller is the
-         origin of agent-lane launches; same-origin UI and operator-capability
-         launches are depth-0 roots. Lineage parents stay projection metadata. */
-      origin: authenticatedCaller?.kind === "agent"
-        ? { kind: "agent", conversationId: authenticatedCaller.conversationId }
-        : { kind: "operator" },
-      launchProfile: spec.launchProfile,
-      clientAttemptId,
-      requestDigest: digest,
-      /* Durable launch DISPLAY payload (issue #614/#615): the RAW operator draft
-         for the first user bubble, the scaffold-composed delivered text as its
-         canonical transcript-echo identity, and the image count — persisted with
-         the receipt so a surface that never ran the composer shows the bubble
-         through starting, scan-lag and text-scrubbed delivery, and retires it on
-         the real (possibly scaffolded) transcript echo. */
-      launchDisplay: (userPrompt.trim() || images.length)
-        ? { prompt: userPrompt, images: images.length, echo: prompt }
-        : null,
-      memberships: pipelineAttemptTarget && pipelineSourceConversationId ? [{
-        kind: "pipeline",
-        containerId: pipelineAttemptTarget.pipelineId,
-        role: pipelineAttemptTarget.role,
-        slot: `adopt:${pipelineAttemptTarget.stageId}:${digest.slice(0, 24)}`,
-        stageId: pipelineAttemptTarget.stageId,
-        stageOrder: pipelineAttemptTarget.stageOrder,
-        round: null,
-        parentConversationId: pipelineSourceConversationId as `conversation_${string}`,
-        runtime: {
-          engine,
-          model: spec.launchProfile.model,
-          effort: spec.launchProfile.effort,
-        },
-      }] : [],
-    });
+    const begun = registry.beginSpawnRequest(canonicalSpawnRequest(account.accountId, spec.launchProfile, digest));
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
     const adoptMaterializedAttempt = async (receipt: typeof begun.receipt, agentPath: string): Promise<void> => {
       if (!pipelineSourceConversationId || !dependencies.adoptPipelineAttemptFromSource) return;

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -301,55 +301,6 @@ export async function executeSpawnRequest(
   try {
     const clientAttemptId = typeof body.clientAttemptId === "string" ? body.clientAttemptId : null;
     const existingAttempt = clientAttemptId ? registry.spawnReceiptForClientAttempt(clientAttemptId) : null;
-    const terminalizePinnedAccountFailure = (failure: unknown): NextResponse<SpawnResponse | ApiError> => {
-      const accountId = body.accountId as string;
-      const reason = (failure instanceof Error ? failure.message : String(failure)).slice(0, 240);
-      const begun = registry.beginSpawnRequest({
-        engine,
-        cwd,
-        transport,
-        accountId,
-        accountPin: true,
-        launchProfile: emptyLaunchProfile({
-          cwd,
-          model: selectedModel.model,
-          effort: reasoning.effort,
-          fast: reasoning.fast,
-        }),
-        clientAttemptId,
-        /* Account preflight has no session to start. Its failed receipt is an
-           idempotent terminal account of this request, while the Retry action
-           intentionally starts a fresh client attempt after the operator fixes
-           credentials or chooses another pin. */
-        requestDigest: null,
-        launchDisplay: (userPrompt.trim() || images.length)
-          ? { prompt: userPrompt, images: images.length, echo: prompt }
-          : null,
-      });
-      if (begun.kind === "conflict") {
-        return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
-      }
-      if (begun.kind === "created") {
-        if (transport === "structured") registry.failStructuredSpawn(begun.receipt.launchId, reason);
-        else registry.failSpawn(begun.receipt.launchId, reason);
-      }
-      const receipt = registry.readOnlySnapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
-      return NextResponse.json(spawnResponseForReceipt(receipt, receipt.artifactPath, {
-        structured: transport === "structured",
-      }));
-    };
-    let account;
-    try {
-      account = existingAttempt && body.accountId === undefined && existingAttempt.accountId !== null
-        ? dependencies.resolveSpawnAccount(existingAttempt.engine, existingAttempt.accountId)
-        : await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
-    } catch (error) {
-      if (body.accountId === undefined) throw error;
-      return terminalizePinnedAccountFailure(error);
-    }
-    if (body.accountId !== undefined && account.accountId !== body.accountId) {
-      return terminalizePinnedAccountFailure(new Error("the requested account is not available for this launch"));
-    }
     const lineage = resolveSpawnLineage(spawnLineageSelectorForCaller(authenticatedCaller, {
       ...body,
       role: role.value?.role,
@@ -403,13 +354,13 @@ export async function executeSpawnRequest(
     /* Same shape for MCP: a delegated launch holds the Viewer baseline whatever
        it asked for, so a granted connector cannot travel down a spawn chain. */
     const grantedServers = mcpServersForSession({ origin: sessionOrigin, requested: requestedMcpServers });
-    const digest = spawnRequestDigest({
+    const requestDigestForAccount = (accountId: string) => spawnRequestDigest({
       engine,
       cwd,
       model: selectedModel.model,
       effort: reasoning.effort,
       fast: reasoning.fast,
-      accountId: account.accountId,
+      accountId,
       role: role.value?.role ?? null,
       mcpServers: grantedServers,
       ...(plugins.length ? { plugins } : {}),
@@ -421,6 +372,55 @@ export async function executeSpawnRequest(
       prompt,
       images: images.map((image) => ({ mime: image.mime, digest: spawnContentDigest({ image: image.base64 }) })),
     });
+    const terminalizePinnedAccountFailure = (failure: unknown): NextResponse<SpawnResponse | ApiError> => {
+      const accountId = body.accountId as string;
+      const reason = (failure instanceof Error ? failure.message : String(failure)).slice(0, 240);
+      const begun = registry.beginSpawnRequest({
+        engine,
+        cwd,
+        transport,
+        accountId,
+        accountPin: true,
+        launchProfile: emptyLaunchProfile({
+          cwd,
+          model: selectedModel.model,
+          effort: reasoning.effort,
+          fast: reasoning.fast,
+        }),
+        clientAttemptId,
+        /* The digest binds this terminal preflight to the same canonical public
+           launch identity as a runnable request. Prompt and image bytes enter
+           durable identity only through one-way hashes. */
+        requestDigest: requestDigestForAccount(accountId),
+        launchDisplay: (userPrompt.trim() || images.length)
+          ? { ["prompt"]: userPrompt, images: images.length, echo: prompt }
+          : null,
+      });
+      if (begun.kind === "conflict") {
+        return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
+      }
+      if (begun.kind === "created") {
+        if (transport === "structured") registry.failStructuredSpawn(begun.receipt.launchId, reason);
+        else registry.failSpawn(begun.receipt.launchId, reason);
+      }
+      const receipt = registry.readOnlySnapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
+      return NextResponse.json(spawnResponseForReceipt(receipt, receipt.artifactPath, {
+        structured: transport === "structured",
+      }));
+    };
+    let account;
+    try {
+      account = existingAttempt && body.accountId === undefined && existingAttempt.accountId !== null
+        ? dependencies.resolveSpawnAccount(existingAttempt.engine, existingAttempt.accountId)
+        : await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
+    } catch (error) {
+      if (body.accountId === undefined) throw error;
+      return terminalizePinnedAccountFailure(error);
+    }
+    if (body.accountId !== undefined && account.accountId !== body.accountId) {
+      return terminalizePinnedAccountFailure(new Error("the requested account is not available for this launch"));
+    }
+    const digest = requestDigestForAccount(account.accountId);
     const pipelineAttemptTarget = pipelineSourceConversationId && dependencies.pipelineAttemptTargetForSource
       ? dependencies.pipelineAttemptTargetForSource(pipelineSourceConversationId)
       : null;

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -93,6 +93,7 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     launchId: receipt.launchId,
     clientAttemptId: receipt.clientAttemptId,
     accountId: receipt.accountId,
+    accountPin: receipt.accountPin,
     conversationId: receipt.conversationId,
     state,
     initialMessage,

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -345,6 +345,45 @@ test("a flow reviewer reserves the canonical review edge before process launch",
   });
 });
 
+test("a flow reviewer keeps its frozen account through a routing change before settlement", () => {
+  const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "review-account-pin-registry.json"));
+  const implementer = registry.ensureConversation("codex", "/sessions/pinned-implementer.jsonl", "limited");
+  const flow = {
+    id: "flow-account-pin",
+    cwd: "/repo",
+    implementerPath: "/sessions/pinned-implementer.jsonl",
+    implementerConversationId: implementer.id,
+    roles: { reviewer: { engine: "codex", model: null, effort: "xhigh" } },
+    rounds: [],
+  } as unknown as Flow;
+  const round = newRound(flow, "button", null);
+  const begun = reserveReviewerSpawn(flow, round, flow.roles.reviewer, "limited", registry);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "healthy",
+    origin: "manual",
+    requestId: "flow-routing-change",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const settled = registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: crypto.randomUUID() },
+    artifactPath: "/sessions/pinned-reviewer.jsonl",
+    cwd: flow.cwd,
+    accountId: "limited",
+    launchProfile: begun.receipt.launchProfile,
+    status: "starting",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  if (settled.kind === "conflict") throw new Error(settled.code);
+
+  expect(settled.receipt).toMatchObject({ accountId: "limited", accountPin: true });
+  expect(settled.conversation).toMatchObject({ pinnedAccountId: "limited", migration: null });
+});
+
 test("reviewer retries reserve distinct immutable membership slots", () => {
   const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "review-retry-lineage-registry.json"));
   const implementer = registry.ensureConversation("codex", "/sessions/retry-implementer.jsonl", "terra");

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -188,6 +188,7 @@ export function reserveReviewerSpawn(
     engine: role.engine,
     cwd: flow.cwd,
     accountId,
+    accountPin: accountId !== null,
     parentConversationId: owner.id,
     parentSessionKey: sessionKeyFromTranscript(owner.engine, parentPath),
     parentArtifactPath: parentPath,

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -8,6 +8,7 @@ import type { Flow } from "@/lib/flows/types";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 import type { AgentRegistry as AgentRegistryType } from "@/lib/agent/registry";
+import { accountManager } from "@/lib/accounts/manager";
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-engine-"));
 const engineModule = await import("./engine");
@@ -50,6 +51,82 @@ test("default pipeline projections reuse one registry parse across the historica
   } finally {
     fileReads.mockRestore();
     reads.mockRestore();
+    setAgentRegistryForTests(null);
+  }
+});
+
+test("a pipeline stage keeps its reserved account through a routing change before settlement", async () => {
+  const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "pipeline-account-pin-registry.json"));
+  const cwd = process.env.LLV_STATE_DIR!;
+  setAgentRegistryForTests(registry);
+  const resolveSpawn = spyOn(accountManager, "resolveSpawn").mockImplementation(() => ({
+    engine: "codex",
+    accountId: "limited",
+    kind: "managed",
+    home: process.env.LLV_STATE_DIR!,
+    transcriptRoot: process.env.LLV_STATE_DIR!,
+    env: { NODE_ENV: "test" },
+  }));
+  const reservations: Array<{ launchId: string; conversationId: string }> = [];
+  try {
+    const ports = defaultPipelinePorts();
+    await expect(ports.spawnAgent({
+      role: {
+        roleId: "builder",
+        engine: "codex",
+        model: "gpt-5.6-sol",
+        effort: "xhigh",
+        access: "read-write",
+        promptScaffold: "Builder guidance",
+      },
+      cwd,
+      ["prompt"]: "Build the scoped change",
+      parentPath: null,
+      clientAttemptId: "pipeline_account_pin_attempt",
+      membership: {
+        kind: "pipeline",
+        containerId: "pipeline-account-pin",
+        role: "builder",
+        slot: "build:1",
+        stageId: "build",
+        stageOrder: 0,
+        round: 1,
+        parentConversationId: null,
+      },
+      creatorConversationId: null,
+    }, (created) => {
+      reservations.push(created);
+      registry.commitMigrationIntent({
+        engine: "codex",
+        targetId: "healthy",
+        origin: "manual",
+        requestId: "pipeline-routing-change",
+        expectedRevision: registry.engineRouting("codex").revision,
+      });
+      throw new Error("reservation captured");
+    })).rejects.toThrow("reservation captured");
+    const reservation = reservations[0];
+    if (!reservation) throw new Error("pipeline reservation was not captured");
+    const receipt = registry.snapshot().receipts[reservation.launchId]!;
+    const settled = registry.stageStructuredSpawn(receipt.launchId, {
+      key: { engine: "codex", sessionId: crypto.randomUUID() },
+      artifactPath: path.join(cwd, "pinned-pipeline-stage.jsonl"),
+      cwd,
+      accountId: "limited",
+      launchProfile: receipt.launchProfile,
+      status: "starting",
+      host: null,
+      structuredHost: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: "spawn",
+    });
+    if (settled.kind !== "settled") throw new Error("pipeline settlement conflicted");
+
+    expect(settled.receipt).toMatchObject({ accountId: "limited", accountPin: true });
+    expect(settled.conversation).toMatchObject({ pinnedAccountId: "limited", migration: null });
+  } finally {
+    resolveSpawn.mockRestore();
     setAgentRegistryForTests(null);
   }
 });

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -257,6 +257,7 @@ async function spawnPipelineAgent(
     cwd: input.cwd,
     transport: "structured",
     accountId: account.accountId,
+    accountPin: true,
     parentConversationId: parent.conversationId,
     parentSessionKey: parent.sessionKey,
     parentArtifactPath: parent.conversationId ? input.parentPath : null,

--- a/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
@@ -6,14 +6,15 @@ import { afterAll, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 import { advanceConversationMigration, drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
-import { emptyLaunchProfile, type HeldDelivery, type SuccessorProviderPort, type TurnState } from "@/lib/accounts/migration/contracts";
+import { emptyLaunchProfile, type SuccessorProviderPort, type TurnState } from "@/lib/accounts/migration/contracts";
+import { projectLaunchConversations } from "@/lib/agent/spawnProjection";
 import type { RuntimeHostClient } from "./client";
 import type { RuntimeSnapshot, RuntimeTurnAxis } from "./contracts";
 import { runtimeImageCapability } from "./runtimeImageStore";
 import type { StructuredImageRef } from "./structuredContent";
 import { StructuredDeliveryControllerUnavailableError } from "./structuredDeliveryController";
 
-import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 
 const artifactPath = "/sessions/native-source.jsonl";
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-reseat-"));
@@ -141,6 +142,196 @@ function recordStructuredOwner(
     pendingAction: null,
   });
 }
+
+test("a pinned first prompt bypasses selected-account migration and terminal delivery failure settles its receipt", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    transport: "structured",
+    accountId: "pinned",
+    accountPin: true,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+  });
+  if (begun.kind !== "created") throw new Error("expected pinned launch receipt");
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "native-source" },
+    artifactPath,
+    cwd: "/repo",
+    accountId: "pinned",
+    launchProfile: begun.receipt.launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:pinned-account",
+      process: { pid: 101, startIdentity: "pinned-account" },
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:pinned-account",
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("expected staged pinned launch");
+  registry.setEngineRouting("codex", "selected");
+
+  const client: RuntimeHostClient = {
+    snapshot: async () => snapshot(staged.conversation.id),
+    command: async (command: { operationId: string; idempotencyKey: string; conversationId: string }) => ({
+      operationId: command.operationId,
+      replayed: false,
+      receipt: {
+        operationId: command.operationId,
+        idempotencyKey: command.idempotencyKey,
+        conversationId: command.conversationId,
+        kind: "send",
+        status: "failed",
+        reason: "pinned account cannot accept the first prompt",
+        at: "2026-07-31T12:00:00.000Z",
+        revision: 1,
+      },
+    }),
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: staged.conversation.id,
+    clientMessageId: `spawn_${begun.receipt.launchId}`,
+    operationId: `spawn_message_${begun.receipt.launchId}`,
+    text: "first prompt",
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+    kick: () => {},
+  });
+
+  expect(result).toMatchObject({ ok: false, outcome: "failed", error: "pinned account cannot accept the first prompt" });
+  expect(registry.conversation(staged.conversation.id)).toMatchObject({ pinnedAccountId: "pinned", migration: null });
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    accountId: "pinned",
+    accountPin: true,
+    state: "failed",
+    error: "pinned account cannot accept the first prompt",
+  });
+  expect(registry.pendingDeliveries(staged.conversation.id)).toMatchObject([{
+    state: "failed",
+    attempts: 1,
+    error: "pinned account cannot accept the first prompt",
+  }]);
+  const card = projectLaunchConversations([], registry.snapshot()).cards.find((item) => item.conversationId === staged.conversation.id);
+  expect(card?.spawn).toMatchObject({ accountId: "pinned", accountPin: true, state: "failed", retrySafe: true, error: "pinned account cannot accept the first prompt" });
+});
+
+test("simultaneous pinned first prompts deliver independently after the selected account changes", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
+  const stagePinned = (accountId: string, sessionId: string) => {
+    const receipt = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      transport: "structured",
+      accountId,
+      accountPin: true,
+      launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    });
+    if (receipt.kind !== "created") throw new Error("expected a pinned launch receipt");
+    const path = `/sessions/${sessionId}.jsonl`;
+    const staged = registry.stageStructuredSpawn(receipt.receipt.launchId, {
+      key: { engine: "codex", sessionId },
+      artifactPath: path,
+      cwd: "/repo",
+      accountId,
+      launchProfile: receipt.receipt.launchProfile,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: `stdio:${sessionId}`,
+        process: { pid: 100 + sessionId.length, startIdentity: sessionId },
+        eventCursor: 0,
+        protocolVersion: "v2",
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: `structured-host:${sessionId}`,
+      pendingAction: "spawn",
+    });
+    if (staged.kind !== "settled") throw new Error("expected a staged pinned launch");
+    return { receipt: receipt.receipt, conversation: staged.conversation, path, sessionId };
+  };
+
+  const first = stagePinned("account-one", "pinned-one");
+  const second = stagePinned("account-two", "pinned-two");
+  registry.setEngineRouting("codex", "selected-before");
+  registry.setEngineRouting("codex", "selected-after");
+  const staged = [first, second];
+  const commands: string[] = [];
+  const client: RuntimeHostClient = {
+    snapshot: async () => {
+      const result = snapshot(first.conversation.id);
+      result.sessions = staged.map((item) => ({
+        ...result.sessions[0]!,
+        conversationId: item.conversation.id,
+        sessionKey: { engine: "codex", sessionId: item.sessionId },
+        artifactPath: item.path,
+      }));
+      return result;
+    },
+    command: async (command: { operationId: string; idempotencyKey: string; conversationId: string }) => {
+      commands.push(command.conversationId);
+      return {
+        operationId: command.operationId,
+        replayed: false,
+        receipt: {
+          operationId: command.operationId,
+          idempotencyKey: command.idempotencyKey,
+          conversationId: command.conversationId,
+          kind: "send" as const,
+          status: "delivered" as const,
+          at: "2026-07-31T12:00:00.000Z",
+          revision: 1,
+        },
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const results = await Promise.all(staged.map(async (item) => await enqueueStructuredMessage({
+    path: item.path,
+    conversationId: item.conversation.id,
+    clientMessageId: `spawn_${item.receipt.launchId}`,
+    operationId: `spawn_message_${item.receipt.launchId}`,
+    text: `first prompt for ${item.sessionId}`,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+    kick: () => {},
+  })));
+
+  expect(results).toEqual(staged.map((item) => expect.objectContaining({
+    ok: true,
+    outcome: "delivered",
+    target: item.conversation.id,
+  })));
+  expect(commands.sort()).toEqual(staged.map((item) => item.conversation.id).sort());
+  for (const item of staged) {
+    expect(registry.conversation(item.conversation.id)).toMatchObject({
+      pinnedAccountId: item.receipt.accountId,
+      migration: null,
+      generations: [{ accountId: item.receipt.accountId }],
+    });
+  }
+});
 
 type RuntimeSynchronization = "live" | "absent-client" | "snapshot-failure" | "missing-session";
 
@@ -272,7 +463,7 @@ async function expectWaitingTurnReseatRestart(
   expect({ predecessorCommands, successorCreates, successorDeliveries }).toEqual({
     predecessorCommands: 0,
     successorCreates: 1,
-    successorDeliveries: [clientMessageId],
+    successorDeliveries: [],
   });
   expect(restarted.conversation(conversation.id)).toMatchObject({
     id: conversation.id,
@@ -282,37 +473,44 @@ async function expectWaitingTurnReseatRestart(
       { id: successorId, path: successorPath, accountId: "seat-active", archivedAt: null },
     ],
   });
+  expect(restarted.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId,
+    state: "failed",
+    text: "",
+    generationId: null,
+    error: expect.stringContaining("migration committed"),
+  }]);
 }
 
-test("a newly admitted busy-turn reseat stays held through restart and drains once to the successor", async () => {
+test("a newly admitted busy-turn reseat stays held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("busy");
 });
 
-test("a newly admitted unknown-turn reseat stays held through restart and drains once to the successor", async () => {
+test("a newly admitted unknown-turn reseat stays held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("unknown");
 });
 
-test("an absent runtime client keeps a busy-turn reseat held through restart and drains once to the successor", async () => {
+test("an absent runtime client keeps a busy-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("busy", "absent-client");
 });
 
-test("an absent runtime client keeps an unknown-turn reseat held through restart and drains once to the successor", async () => {
+test("an absent runtime client keeps an unknown-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("unknown", "absent-client");
 });
 
-test("a failed runtime snapshot keeps a busy-turn reseat held through restart and drains once to the successor", async () => {
+test("a failed runtime snapshot keeps a busy-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("busy", "snapshot-failure");
 });
 
-test("a failed runtime snapshot keeps an unknown-turn reseat held through restart and drains once to the successor", async () => {
+test("a failed runtime snapshot keeps an unknown-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("unknown", "snapshot-failure");
 });
 
-test("a missing runtime session keeps a busy-turn reseat held through restart and drains once to the successor", async () => {
+test("a missing runtime session keeps a busy-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("busy", "missing-session");
 });
 
-test("a missing runtime session keeps an unknown-turn reseat held through restart and drains once to the successor", async () => {
+test("a missing runtime session keeps an unknown-turn reseat held through restart and becomes cancelled evidence", async () => {
   await expectWaitingTurnReseatRestart("unknown", "missing-session");
 });
 
@@ -697,7 +895,7 @@ test("an explicit migration opt-out keeps a synchronization hold assigned to the
   expect(sourceDeliveries).toEqual(["synchronization-opted-out-send"]);
 });
 
-test("a fresh empty-turn spawn on a draining source account reaches one successor", async () => {
+test("a fresh empty-turn prompt on a draining source account becomes cancelled evidence", async () => {
   const { registry, conversation } = registryWithConversation("seat-source", "codex", "unknown", "empty");
   registry.setEngineRouting("codex", "seat-active");
   let predecessorCommands = 0;
@@ -747,12 +945,18 @@ test("a fresh empty-turn spawn on a draining source account reaches one successo
 
   expect({ successorCreates, delivered }).toEqual({
     successorCreates: 1,
-    delivered: ["fresh-empty-turn-send"],
+    delivered: [],
   });
   expect(registry.conversation(conversation.id)?.migration?.phase).toBe("committed");
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "fresh-empty-turn-send",
+    state: "failed",
+    text: "",
+    error: expect.stringContaining("migration committed"),
+  }]);
 });
 
-test("a post-rollback stale busy owner recovers its missing host and drains once", async () => {
+test("a post-rollback stale busy owner remains cancelled after its host returns", async () => {
   const { registry, conversation } = registryWithConversation("seat-source", "codex", "busy");
   recordStructuredOwner(registry, conversation);
   registry.setEngineRouting("codex", "seat-active");
@@ -770,63 +974,23 @@ test("a post-rollback stale busy owner recovers its missing host and drains once
   expect(admitted).toMatchObject({ ok: true, outcome: "held" });
   registry.rollbackConversationMigration(conversation.id, registry.conversation(conversation.id)!.migration!.revision);
 
-  let hostAvailable = false;
-  let recoveries = 0;
-  let commands = 0;
-  const client = {
-    snapshot: async () => hostAvailable ? snapshot(conversation.id, "codex", "hosted", "idle") : {
-      ...snapshot(conversation.id, "codex", "dead", "unknown"),
-      sessions: [],
-    },
-    command: async (command: { operationId: string; idempotencyKey: string; conversationId: string }) => {
-      commands += 1;
-      return {
-        operationId: command.operationId,
-        replayed: false,
-        receipt: {
-          operationId: command.operationId,
-          idempotencyKey: command.idempotencyKey,
-          conversationId: command.conversationId,
-          kind: "send" as const,
-          status: "delivered" as const,
-          at: "2026-07-22T00:00:00.000Z",
-          revision: 1,
-        },
-      };
-    },
-    operationStatus: async () => null,
-  } as unknown as RuntimeHostClient;
+  let oldPromptDeliveries = 0;
   const port = {
-    async deliver(input: { delivery: { id: string; conversationId: string; text: string; command: HeldDelivery["command"] }; path: string; clientMessageId: string }) {
-      return await deliverHeldStructuredMessage({
-        conversationId: input.delivery.conversationId,
-        path: input.path,
-        deliveryId: input.delivery.id,
-        clientMessageId: input.clientMessageId,
-        text: input.delivery.text,
-        command: input.delivery.command,
-      }, {
-        enabled: () => true,
-        client: () => client,
-        registry: () => registry,
-        kick: () => {},
-        recover: async () => {
-          recoveries += 1;
-          hostAvailable = true;
-          return { target: null, path: artifactPath, conversationId: conversation.id, spawned: true };
-        },
-      }) ?? "delivery-uncertain";
+    async deliver() {
+      oldPromptDeliveries += 1;
+      return "delivered" as const;
     },
   };
   await drainHeldDeliveries(conversation.id, port, registry);
   await drainHeldDeliveries(conversation.id, port, registry);
-  await drainHeldDeliveries(conversation.id, port, registry);
 
-  expect({ recoveries, commands }).toEqual({ recoveries: 1, commands: 1 });
+  expect(oldPromptDeliveries).toBe(0);
   expect(Object.values(registry.snapshot().heldDeliveries)).toMatchObject([{
     clientMessageId: "stale-busy-post-rollback",
-    state: "delivered",
-    attempts: 2,
+    state: "failed",
+    text: "",
+    attempts: 0,
+    error: expect.stringContaining("migration was rolled back"),
   }]);
 });
 
@@ -925,7 +1089,7 @@ test("an exact retry reuses one account migration and one held delivery", async 
   }]);
 });
 
-test("restart preserves one Viewer conversation and drains once after account adoption", async () => {
+test("restart preserves one Viewer conversation and retains old held input as cancelled evidence", async () => {
   const { registry, conversation } = registryWithConversation();
   registry.setEngineRouting("codex", "seat-active");
   const sourceGeneration = conversation.generations.at(-1)!;
@@ -999,16 +1163,17 @@ test("restart preserves one Viewer conversation and drains once after account ad
   await drainHeldDeliveries(conversation.id, delivery, restarted);
   await drainHeldDeliveries(conversation.id, delivery, restarted);
 
-  expect(delivered).toEqual(["restart-safe-account-reseat"]);
+  expect(delivered).toEqual([]);
   expect(Object.values(restarted.snapshot().heldDeliveries)).toMatchObject([{
     clientMessageId: "restart-safe-account-reseat",
-    state: "delivered",
+    state: "failed",
     text: "",
-    generationId: successorId,
+    generationId: null,
+    error: expect.stringContaining("migration committed"),
   }]);
 });
 
-test("controller startup retry publishes one selected-account successor and drains once for both engines", async () => {
+test("controller startup retry publishes one selected-account successor and cancels held input for both engines", async () => {
   for (const engine of ["claude", "codex"] as const) {
     const { registry, conversation } = registryWithConversation("seat-source", engine);
     registry.setEngineRouting(engine, "seat-active");
@@ -1082,8 +1247,14 @@ test("controller startup retry publishes one selected-account successor and drai
     expect({ creates, publications, delivered }).toEqual({
       creates: 1,
       publications: 2,
-      delivered: [clientMessageId],
+      delivered: [],
     });
     expect(controllerReady.conversation(conversation.id)?.migration?.phase).toBe("committed");
+    expect(controllerReady.pendingDeliveries(conversation.id)).toMatchObject([{
+      clientMessageId,
+      state: "failed",
+      text: "",
+      error: expect.stringContaining("migration committed"),
+    }]);
   }
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,9 @@ export interface StructuredSpawnCardState {
   launchId: string;
   clientAttemptId: string | null;
   accountId: string | null;
+  /** The displayed account came from an explicit launch pin, so account
+      selection changes cannot retarget this launch. */
+  accountPin?: boolean;
   /** The durable conversation this launch created/owns (issue #653). The client
       keys the launch-owned optimistic bubble on THIS id, so a pane renders the
       bubble only inside its own conversation — never leaked into an unrelated


### PR DESCRIPTION
## Summary
- Keep explicit spawn-account pins authoritative through direct first delivery and later routing changes.
- Record unavailable pins and terminal first-delivery failures as retryable, terminal launch receipts with visible account evidence.
- Preserve cancelled migration deliveries across restart and prevent late outcomes from releasing an earlier prompt.

## Validation
- `bunx tsc --noEmit`
- focused isolated registry, migration, structured-delivery, projection, and spawn-route tests (216 passing)
- scoped lint and production build
- privacy publication gate against the merge base

Closes #784
Closes #782
Closes #655