### PR TITLE
fix(scheme): one canonical lineage model behind the board graph (#828)

### DIFF
--- a/src/components/scheme/SchemeBoard.lineage.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.lineage.dom.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * The operator-visible half of issue #828, through the real SchemeBoard.
+ *
+ * The screenshot in the report showed one arrow running from a Builder card
+ * down to the Codex session two generations above it. These cases render the
+ * board from fixtures shaped like those records and read the drawn graph back
+ * out of the DOM: which card each arrow leaves, which generations it spans, and
+ * what a card says when its parent is not on the board at all. The last case
+ * moves the intermediate ancestor through the activity states that made the
+ * defect intermittent and asserts the drawn hierarchy does not move with it.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { FileEntry } from "@/lib/types";
+
+const dom = new Window();
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = () => ({
+  matches: false,
+  media: "",
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  onchange: null,
+  dispatchEvent: () => false,
+});
+
+const requestFrame = (callback: FrameRequestCallback) => dom.setTimeout(() => callback(0), 0);
+function bindDomGlobals() {
+  Object.assign(globalThis, {
+    window: dom,
+    document: dom.document,
+    navigator: dom.navigator,
+    Node: dom.Node,
+    HTMLElement: dom.HTMLElement,
+    HTMLButtonElement: dom.HTMLButtonElement,
+    HTMLDivElement: dom.HTMLDivElement,
+    Event: dom.Event,
+    CustomEvent: dom.CustomEvent,
+    MouseEvent: dom.MouseEvent,
+    PointerEvent: dom.PointerEvent,
+    KeyboardEvent: dom.KeyboardEvent,
+    WheelEvent: dom.WheelEvent,
+    sessionStorage: dom.sessionStorage,
+    localStorage: dom.localStorage,
+    ResizeObserver: TestResizeObserver,
+    IntersectionObserver: undefined,
+    requestAnimationFrame: requestFrame,
+    cancelAnimationFrame: (id: number) => dom.clearTimeout(id as never),
+  });
+}
+bindDomGlobals();
+
+const { buildBranchGroups } = await import("@/components/projectModel");
+const { SchemeBoard } = await import("./SchemeBoard");
+
+const roots = new Set<Root>();
+let previousFetch: typeof fetch;
+beforeEach(() => {
+  bindDomGlobals();
+  previousFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = previousFetch;
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "lineage",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+/* Recorded depth was 0 at every level of the live chain, so nothing here may
+   depend on it. */
+function lineage(parentConversationId: string | null, role: string | null = null, kind: "spawn" | "review" = "spawn") {
+  return { kind, role, depth: 0, parentConversationId, reviewsConversationId: null, memberships: [] } as FileEntry["durableLineage"];
+}
+
+const coordinator = entry({
+  path: "/coordinator", conversationId: "conversation_coordinator", root: "codex-sessions", engine: "codex",
+  title: "Voice Coordinator", activity: "live",
+});
+const codexSession = entry({
+  path: "/codex-session", conversationId: "conversation_codex", root: "codex-sessions", engine: "codex",
+  title: "Codex session", activity: "live", parent: coordinator.path, durableLineage: lineage("conversation_coordinator"),
+});
+const orchestrator = entry({
+  path: "/orchestrator", conversationId: "conversation_orchestrator", title: "Orchestrator", activity: "live",
+  parent: codexSession.path, durableLineage: lineage("conversation_codex", "orchestrator"),
+});
+const builder = entry({
+  path: "/builder", conversationId: "conversation_builder", title: "Builder — plain", activity: "live",
+  parent: orchestrator.path, durableLineage: lineage("conversation_orchestrator", "builder"),
+});
+
+/** The true chain, top-down: an index further left is further up the lineage. */
+const CHAIN = ["/coordinator", "/codex-session", "/orchestrator", "/builder"];
+
+function mount(files: FileEntry[]): { host: HTMLElement; render: (next: FileEntry[]) => void } {
+  const host = dom.document.createElement("div") as unknown as HTMLElement;
+  dom.document.body.append(host as never);
+  const root = createRoot(host);
+  roots.add(root);
+  const render = (next: FileEntry[]) =>
+    flushSync(() =>
+      root.render(
+        <SchemeBoard
+          project="lineage"
+          groups={buildBranchGroups(next, "lineage")}
+          manual={[]}
+          files={next}
+          flows={[]}
+          tasks={[]}
+          drafts={[]}
+          focus={null}
+          onSelect={() => {}}
+          onClose={() => {}}
+          onDraftClose={() => {}}
+          onDraftSpawned={() => {}}
+        />,
+      ),
+    );
+  render(files);
+  return { host, render };
+}
+
+/** Drawn lineage arrows as parent → child pairs, read off the edge layer. */
+const drawnEdges = (host: HTMLElement): Array<[string | null, string | null]> =>
+  [...host.querySelectorAll("[data-scheme-edge]")].map((edge) => [
+    edge.getAttribute("data-scheme-edge-from"),
+    edge.getAttribute("data-scheme-edge"),
+  ]);
+
+const nodePaths = (host: HTMLElement): string[] =>
+  [...host.querySelectorAll("[data-scheme-node]")].map((node) => node.getAttribute("data-scheme-node")!);
+
+const nodeAt = (host: HTMLElement, path: string) => host.querySelector(`[data-scheme-node="${path}"]`)!;
+
+test("a transcript pointer naming a descendant never draws the builder as its coordinator's parent", () => {
+  /* The reported frame, reduced to what the board could see: the codex session
+     carried a pointer to the builder BELOW it, and both real parents were off
+     the window. */
+  const files = [{ ...builder, parent: null }, { ...codexSession, parent: "/builder" }];
+  const { host } = mount(files);
+
+  expect(nodePaths(host).sort()).toEqual(["/builder", "/codex-session"]);
+  expect(drawnEdges(host)).not.toContainEqual(["/builder", "/codex-session"]);
+  expect(drawnEdges(host)).toEqual([]);
+  /* Neither card claims the other: each says its own parent is off the board. */
+  for (const path of ["/builder", "/codex-session"]) {
+    expect(nodeAt(host, path).getAttribute("data-scheme-node-host")).toBeNull();
+    expect(nodeAt(host, path).querySelector("[data-scheme-ancestry-chip]")?.getAttribute("aria-label"))
+      .toBe("Parent conversation is not on this board");
+  }
+});
+
+test("an ancestor the board does not draw is marked on the edge and on the card", () => {
+  const quiet = { ...orchestrator, activity: "idle" as const };
+  const { host } = mount([coordinator, codexSession, quiet, builder]);
+
+  expect(nodePaths(host)).not.toContain("/orchestrator");
+  expect(drawnEdges(host)).toContainEqual(["/codex-session", "/builder"]);
+  const spanning = host.querySelector('[data-scheme-edge="/builder"]')!;
+  expect(spanning.getAttribute("data-scheme-edge-elided")).toBe("1");
+  const chip = nodeAt(host, "/builder").querySelector("[data-scheme-ancestry-chip]")!;
+  expect(chip.getAttribute("aria-label")).toBe("Parent not drawn on this board: Orchestrator");
+  expect(nodeAt(host, "/builder").getAttribute("data-scheme-node-host")).toBe("/codex-session");
+});
+
+test("the whole chain reads coordinator → codex session → orchestrator → builder, in DOM order too", () => {
+  const { host } = mount([coordinator, codexSession, orchestrator, builder]);
+
+  expect(drawnEdges(host).sort()).toEqual([
+    ["/codex-session", "/orchestrator"],
+    ["/coordinator", "/codex-session"],
+    ["/orchestrator", "/builder"],
+  ]);
+  /* Assistive order follows the hierarchy: a generation precedes the one it
+     spawned, so the board is walkable top-down. */
+  expect(nodePaths(host)).toEqual(["/coordinator", "/codex-session", "/orchestrator", "/builder"]);
+  expect(host.querySelectorAll("[data-scheme-ancestry-chip]")).toHaveLength(0);
+});
+
+test("the drawn hierarchy holds while the intermediate ancestor moves between live, stalled and idle", () => {
+  const { host, render } = mount([coordinator, codexSession, orchestrator, builder]);
+  const seen: string[] = [];
+
+  for (const activity of ["stalled", "idle", "live", "recent", "idle"] as const) {
+    render([coordinator, codexSession, { ...orchestrator, activity }, builder]);
+    /* Whatever the board can draw, every arrow leaves a genuine ancestor of the
+       card it enters — no frame turns a descendant into a spawner. */
+    for (const [from, to] of drawnEdges(host)) {
+      expect({ from, to, ancestor: CHAIN.indexOf(from!) >= 0 && CHAIN.indexOf(from!) < CHAIN.indexOf(to!) })
+        .toEqual({ from, to, ancestor: true });
+    }
+    /* The builder hangs under the nearest ancestor still drawn, never lower. */
+    const host_ = nodeAt(host, "/builder").getAttribute("data-scheme-node-host");
+    expect(["/orchestrator", "/codex-session"]).toContain(host_!);
+    seen.push(host_!);
+    /* Cards never disappear and never duplicate as the state moves. */
+    expect(nodePaths(host).filter((path) => path === "/builder")).toHaveLength(1);
+  }
+  /* The activity transitions did change what is drawn — the fixture is not
+     accidentally static — and every frame stayed correctly directed. */
+  expect(new Set(seen).size).toBeGreaterThan(1);
+});

--- a/src/components/scheme/domOrder.ts
+++ b/src/components/scheme/domOrder.ts
@@ -5,6 +5,20 @@ export function stableDomOrder<T>(items: readonly T[], keyOf: (item: T) => strin
   return [...items].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
 }
 
+/**
+ * Reading order of the board's conversation panes: the canonical lineage
+ * (issue #828), so an assistive reader walks a generation before the one it
+ * spawned instead of an alphabetical shuffle of the same cards. The key is a
+ * function of identity alone — never of activity or geometry — so a node going
+ * quiet, or an ancestor leaving the board, still keeps every stateful host
+ * attached where React left it.
+ */
 export function stableNodeDomOrder(nodes: readonly SchemeNode[]): SchemeNode[] {
-  return stableDomOrder(nodes, (node) => node.file.path);
+  const keyOf = (node: SchemeNode) => node.lineageOrderKey ?? node.file.path;
+  return [...nodes].sort((a, b) => {
+    const left = keyOf(a);
+    const right = keyOf(b);
+    if (left === right) return a.file.path.localeCompare(b.file.path);
+    return left < right ? -1 : 1;
+  });
 }

--- a/src/components/scheme/layout.lineage.test.ts
+++ b/src/components/scheme/layout.lineage.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Lineage direction on the scheme (issue #828).
+ *
+ * The reported frame drew ONE edge from a Builder down to the Codex session two
+ * generations ABOVE it, with the Orchestrator between them missing — delegation
+ * read backwards, so a worker looked like it had taken over coordination. The
+ * follow-up showed the same region rendering correctly minutes later with no
+ * code change: parentage was being re-derived at render time from several
+ * disagreeing signals, so the hierarchy moved with transient process state.
+ *
+ * These cases drive `buildSchemeLayout` from fixtures shaped like those live
+ * records — a chain whose recorded depth is 0 at every level, an intermediate
+ * ancestor that comes and goes, and a scanner pointer that names a descendant
+ * as the parent — and hold the rendered graph to the canonical lineage: parent
+ * → child always, elided generations represented, one edge per pair.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+import { buildBranchGroups } from "@/components/projectModel";
+
+import { buildSchemeLayout, type SchemeLayout } from "./layout";
+import { buildSchemeLineage } from "./lineageModel";
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "demo",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+/* Every live record in the report carried `depth: 0`, whatever its position. */
+function lineage(parentConversationId: string | null, role: string | null = null, kind: "spawn" | "review" = "spawn") {
+  return { kind, role, depth: 0, parentConversationId, reviewsConversationId: null, memberships: [] } as FileEntry["durableLineage"];
+}
+
+/* The chain from the issue: Voice Coordinator → Codex session → Orchestrator →
+   Builder → reviewer, four generations deep across both engines. */
+const coordinator = entry({
+  path: "/coordinator", conversationId: "conversation_coordinator", root: "codex-sessions", engine: "codex",
+  title: "Voice Coordinator", activity: "live",
+});
+const codexSession = entry({
+  path: "/codex-session", conversationId: "conversation_codex", root: "codex-sessions", engine: "codex",
+  title: "Codex session", activity: "live", parent: coordinator.path, durableLineage: lineage("conversation_coordinator"),
+});
+const orchestrator = entry({
+  path: "/orchestrator", conversationId: "conversation_orchestrator", title: "Orchestrator", activity: "live",
+  parent: codexSession.path, durableLineage: lineage("conversation_codex", "orchestrator"),
+});
+const builder = entry({
+  path: "/builder", conversationId: "conversation_builder", title: "Builder — plain", activity: "live",
+  parent: orchestrator.path, durableLineage: lineage("conversation_orchestrator", "builder"),
+});
+const reviewer = entry({
+  path: "/reviewer", conversationId: "conversation_reviewer", root: "codex-sessions", engine: "codex",
+  title: "reviewer", activity: "live", parent: builder.path,
+  durableLineage: lineage("conversation_builder", "reviewer", "review"),
+});
+
+const boardOf = (files: FileEntry[]): SchemeLayout =>
+  buildSchemeLayout(buildBranchGroups(files, "demo"), [], files);
+
+const edgePairs = (layout: SchemeLayout): Array<[string | undefined, string]> =>
+  layout.edges.filter((edge) => layout.nodes.some((node) => node.file.path === edge.to)).map((edge) => [edge.from, edge.to]);
+
+const ancestryOf = (layout: SchemeLayout, path: string) =>
+  layout.nodes.find((node) => node.file.path === path)?.ancestry;
+
+/** Every drawn lineage edge leaves a genuine ancestor of the node it enters. */
+function expectNoInvertedEdge(layout: SchemeLayout, files: FileEntry[]): void {
+  const model = buildSchemeLineage(files);
+  for (const [from, to] of edgePairs(layout)) {
+    expect(from).toBeTruthy();
+    expect({ from, to, ancestor: model.isAncestorOf(from!, to) }).toEqual({ from, to, ancestor: true });
+  }
+}
+
+describe("scheme lineage direction", () => {
+  test("the whole chain draws one downward edge per generation", () => {
+    const files = [coordinator, codexSession, orchestrator, builder, reviewer];
+    const layout = boardOf(files);
+
+    expect(edgePairs(layout).sort()).toEqual([
+      [builder.path, reviewer.path],
+      [codexSession.path, orchestrator.path],
+      [coordinator.path, codexSession.path],
+      [orchestrator.path, builder.path],
+    ]);
+    expectNoInvertedEdge(layout, files);
+    expect(layout.nodes.map((node) => node.ancestry?.depth)).toEqual(layout.nodes.map((node) => buildSchemeLineage(files).depthOf(node.file.path)));
+  });
+
+  test("a scanner pointer naming a DESCENDANT as the parent never draws a builder over its own ancestor", () => {
+    /* The reported frame: the codex session's transcript pointer named the
+       builder — two generations below it — as its parent. */
+    const inverted = { ...codexSession, parent: builder.path };
+    const files = [{ ...builder, parent: null }, inverted, reviewer];
+    const layout = boardOf(files);
+
+    expect(edgePairs(layout)).toEqual([[builder.path, reviewer.path]]);
+    expect(edgePairs(layout)).not.toContainEqual([builder.path, inverted.path]);
+    expectNoInvertedEdge(layout, files);
+    /* Both survivors keep their real parent named, unrendered — neither borrows
+       the other as a spawner. */
+    expect(ancestryOf(layout, inverted.path)).toMatchObject({ hostPath: null, unresolvedParentId: "conversation_coordinator" });
+    expect(ancestryOf(layout, builder.path)).toMatchObject({ hostPath: null, unresolvedParentId: "conversation_orchestrator" });
+  });
+
+  test("an ancestor the board does not draw is elided on the edge, not skipped in silence", () => {
+    /* The Orchestrator goes quiet and leaves the column set; the Builder keeps
+       hanging under the generation above it, and the edge reports the gap. */
+    const quiet = { ...orchestrator, activity: "idle" as const };
+    const files = [coordinator, codexSession, quiet, builder, reviewer];
+    const layout = boardOf(files);
+
+    expect(layout.nodes.some((node) => node.file.path === quiet.path)).toBe(false);
+    expect(edgePairs(layout)).toContainEqual([codexSession.path, builder.path]);
+    expect(ancestryOf(layout, builder.path)).toMatchObject({ hostPath: codexSession.path, unresolvedParentId: null });
+    expect(ancestryOf(layout, builder.path)?.elided.map((file) => file.path)).toEqual([quiet.path]);
+    const spanning = layout.edges.find((edge) => edge.to === builder.path);
+    expect(spanning?.via?.map((file) => file.path)).toEqual([quiet.path]);
+    expect(spanning?.dashed).toBe(true);
+    expectNoInvertedEdge(layout, files);
+  });
+
+  test("direction survives the intermediate ancestor moving through live, stalled and idle", () => {
+    const model = buildSchemeLineage([coordinator, codexSession, orchestrator, builder, reviewer]);
+    const chain = [orchestrator.path, codexSession.path, coordinator.path];
+
+    for (const activity of ["live", "stalled", "recent", "idle"] as const) {
+      const files = [coordinator, codexSession, { ...orchestrator, activity }, builder, reviewer];
+      const layout = boardOf(files);
+      expectNoInvertedEdge(layout, files);
+      /* Whatever the board can draw, the builder's ancestors stay the same
+         ordered chain — the visible host plus the elided prefix above it. */
+      const ancestry = ancestryOf(layout, builder.path)!;
+      expect([...ancestry.elided.map((file) => file.path), ancestry.hostPath])
+        .toEqual(chain.slice(0, chain.indexOf(ancestry.hostPath!) + 1));
+      expect(model.isAncestorOf(ancestry.hostPath!, builder.path)).toBe(true);
+    }
+  });
+
+  test("the same scan renders the same graph twice — a refresh never reshuffles lineage", () => {
+    const files = [coordinator, codexSession, { ...orchestrator, activity: "stalled" as const }, builder, reviewer];
+    const first = boardOf(files);
+    const second = boardOf([...files].reverse());
+
+    expect(edgePairs(second).sort()).toEqual(edgePairs(first).sort());
+    expect(second.nodes.map((node) => node.lineageOrderKey).sort()).toEqual(first.nodes.map((node) => node.lineageOrderKey).sort());
+  });
+
+  test("every node has at most one incoming lineage edge", () => {
+    const files = [coordinator, codexSession, orchestrator, builder, reviewer];
+    const targets = edgePairs(boardOf(files)).map(([, to]) => to);
+
+    expect(new Set(targets).size).toBe(targets.length);
+  });
+
+  test("a deleted parent worktree leaves an explicit continuation, not a borrowed parent", () => {
+    /* The parent transcript is gone with its checkout; the tombstone is the
+       only statement left, and it must not be replaced by the nearest card. */
+    const survivor = entry({
+      path: "/survivor", conversationId: "conversation_survivor", title: "Builder — plain", activity: "live",
+      parentRemoved: { conversationId: "conversation_gone", path: "/gone" },
+    });
+    const files = [coordinator, codexSession, survivor];
+    const layout = boardOf(files);
+
+    expect(layout.nodes.map((node) => node.file.path)).toContain(survivor.path);
+    expect(edgePairs(layout)).not.toContainEqual([codexSession.path, survivor.path]);
+    expect(ancestryOf(layout, survivor.path)).toMatchObject({ hostPath: null, unresolvedParentId: "conversation_gone" });
+  });
+
+  test("a restored conversation keeps its children after the transcript generation changes", () => {
+    /* An account migration re-homes the parent onto a new transcript; the
+       durable edge names the conversation, so the child follows the successor. */
+    const archived = entry({ path: "/parent-gen1", conversationId: "conversation_parent", title: "Orchestrator", migratedTo: "/parent-gen2" });
+    const successor = entry({ path: "/parent-gen2", conversationId: "conversation_parent", generation: 2, predecessorPath: "/parent-gen1", title: "Orchestrator", activity: "live" });
+    const child = entry({
+      path: "/child", conversationId: "conversation_child", title: "Builder — plain", activity: "live",
+      kind: "subagent", parent: successor.path, durableLineage: lineage("conversation_parent", "builder"),
+    });
+    const files = [archived, successor, child];
+    const layout = boardOf(files);
+
+    expect(edgePairs(layout)).toContainEqual([successor.path, child.path]);
+    expect(ancestryOf(layout, child.path)).toMatchObject({ hostPath: successor.path, unresolvedParentId: null });
+  });
+
+  test("a pipeline's stage conversations keep the chain that spawned them", () => {
+    /* Stage windows are placed by the pipeline's own chain geometry; their
+       lineage must still read builder-under-architect, and the halo that
+       encloses them must not become the parent of everything inside it. */
+    const stages = [
+      { id: "architect", kind: "run", prompt: "", next: "builder" },
+      { id: "builder", kind: "run", prompt: "", next: null },
+    ];
+    const pipeline = {
+      id: "p828", task: "Ship it", project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b", baseBranch: "main",
+      baseRef: "a", lastPassedCommit: "a", stages,
+      runs: [
+        { stageId: "architect", attempts: [{ n: 1, state: "passed", agentPath: "/architect", flowId: null }] },
+        { stageId: "builder", attempts: [{ n: 1, state: "running", agentPath: "/stage-builder", flowId: null }] },
+      ],
+      cursor: { stageId: "builder" }, state: "running", pausedState: null, stateDetail: null, srcPath: null,
+      srcConversationId: null, createdAt: "1970", closedAt: null,
+    } as unknown as Pipeline;
+
+    const architect = entry({ path: "/architect", conversationId: "conversation_architect", title: "Architect", activity: "live" });
+    const stageBuilder = entry({
+      path: "/stage-builder", conversationId: "conversation_stage_builder", title: "Builder", activity: "live",
+      kind: "subagent", parent: architect.path, durableLineage: lineage("conversation_architect", "builder"),
+    });
+    const files = [architect, stageBuilder];
+    const layout = buildSchemeLayout(buildBranchGroups(files, "demo"), [], files, [], [], [pipeline], [pipeline]);
+
+    expect(edgePairs(layout)).toEqual([[architect.path, stageBuilder.path]]);
+    expectNoInvertedEdge(layout, files);
+  });
+
+  test("a descendant drawn in another tree is still owned by its ancestor, in one edge", () => {
+    /* The builder's own group lost its root (its parent pointer never resolved),
+       so it opens a separate tree — the ancestor edge crosses to it instead of
+       leaving the card reading as a root of its own lineage. */
+    const detached = { ...builder, parent: null };
+    const files = [coordinator, codexSession, orchestrator, detached, reviewer];
+    const layout = boardOf(files);
+    const incoming = layout.edges.filter((edge) => edge.to === detached.path);
+
+    expect(incoming).toHaveLength(1);
+    expect(incoming[0]!.from).toBe(orchestrator.path);
+    expectNoInvertedEdge(layout, files);
+  });
+});

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -21,6 +21,7 @@ import {
   type SchemeGroupSpec,
 } from "./agentLinks";
 import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts, stageRowCollapsible } from "@/components/pipelines/pipelineModel";
+import { buildSchemeLineage } from "./lineageModel";
 import { linkedPipelineTasks } from "./pipelineAnchor";
 import { TASK_W, isPlacedTask, taskBoxHeight } from "./taskGeometry";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf } from "@/components/projectModel";
@@ -115,6 +116,23 @@ export interface SchemeRect {
   h: number;
 }
 
+/** How a placed node stands in the canonical lineage (issue #828): what the
+    board drew it under, and what it could not draw. Every board surface reads
+    this instead of re-deriving parentage from the raw signals. */
+export interface NodeAncestry {
+  /** The rendered ancestor this node hangs under, or null when it has none. */
+  hostPath: string | null;
+  /** Ancestors between this node and `hostPath` that the board does not draw —
+      the generation an edge would otherwise silently skip. */
+  elided: readonly FileEntry[];
+  /** The parent conversation named by the durable record but absent from the
+      scan (an off-window ancestor, a deleted worktree). The node renders as an
+      explicit continuation instead of borrowing another node's parent. */
+  unresolvedParentId: string | null;
+  /** Generations above this node in the canonical chain. */
+  depth: number;
+}
+
 export interface SchemeNode extends SchemeRect {
   file: FileEntry;
   /** Live background tasks docked inside the pane as collapsed strips. */
@@ -122,6 +140,13 @@ export interface SchemeNode extends SchemeRect {
   /** Quiet history lying "under" the node: previous chats, finished tasks. */
   under: FileEntry[];
   isRoot: boolean;
+  /** Canonical lineage standing of this node (issue #828). Always set by
+      {@link buildSchemeLayout}; optional for the fixtures and mobile
+      projections that assemble a bare rect. */
+  ancestry?: NodeAncestry;
+  /** Lineage sort key: ancestors sort before descendants, independent of
+      activity, so the DOM order follows the hierarchy and never reshuffles. */
+  lineageOrderKey?: string;
 }
 
 /** Not-yet-spawned conversation drafted straight on the scheme. */
@@ -134,9 +159,16 @@ export interface DraftNode extends SchemeRect {
 
 export interface SchemeEdge {
   to: string;
+  /** Board key the edge leaves — the PARENT side. Present on every lineage
+      edge (issue #828) so direction is carried by the model, not inferred from
+      the geometry the layout happened to produce. */
+  from?: string;
   /** Stable lineage identities used by the optional subagent badge anchor. */
   sourceConversationId?: string;
   targetConversationId?: string;
+  /** Canonical ancestors this edge spans without drawing (issue #828): the
+      edge is a "descends from", not a "spawned by", and says so. */
+  via?: readonly FileEntry[];
   x1: number;
   y1: number;
   x2: number;
@@ -309,6 +341,11 @@ export function buildSchemeLayout(
   taskTextExpanded: ReadonlySet<string> = new Set(),
 ): SchemeLayout {
   const byAll = new Map(files.map((file) => [file.path, file]));
+  /* The board's single parentage authority (issue #828). Resolved once per
+     scan, before anything is placed, so hosting, edges, node ancestry and DOM
+     order all read the same forest — and a transient activity/process change
+     can no longer reverse or flatten a relationship at render time. */
+  const lineage = buildSchemeLineage(files);
   const kids = kidsIndex(files);
   const nodes: SchemeNode[] = [];
   const edges: SchemeEdge[] = [];
@@ -719,6 +756,7 @@ export function buildSchemeLayout(
       const placeChild = (child: { file: FileEntry; tasks: FileEntry[] }, atX: number): number => {
         edges.push({
           to: child.file.path,
+          from: col.file.path,
           sourceConversationId: conversationIdentity(col.file),
           targetConversationId: conversationIdentity(child.file),
           x1: x + 40,
@@ -854,29 +892,32 @@ export function buildSchemeLayout(
   const placeGroup = (group: BranchGroup, bandTop: number) => {
     const cols = group.columns;
     if (!cols.length) return;
-    const topPath = cols[0]!.file.path;
     const inGroup = new Set(cols.map((col) => col.file.path));
 
-    /* Nearest displayed ancestor: intermediate quiet nodes are skipped, an
-       unresolvable chain attaches to the group top. */
-    const hostOf = (file: FileEntry): string => {
-      let up: string | null = file.parent;
-      const seen = new Set<string>([file.path]);
-      while (up && !seen.has(up) && !inGroup.has(up)) {
-        seen.add(up);
-        up = byAll.get(up)?.parent ?? null;
-      }
-      return up && inGroup.has(up) && up !== file.path ? up : topPath;
-    };
+    /* Nearest CANONICAL ancestor the group also draws (issue #828): quiet
+       intermediate generations are skipped (the edge reports them as elided),
+       and a column whose chain leaves the group opens a tree of its own. It is
+       never re-hosted on the group's first column — that column may itself be a
+       descendant, which is exactly how a builder came to look like the spawner
+       of its own coordinator. */
+    const hostOf = (file: FileEntry): string | null => lineage.resolveHost(file.path, inGroup).host;
 
     const childrenOf = new Map<string, typeof cols>();
+    const roots: typeof cols = [];
     for (const col of cols) {
-      if (col.file.path === topPath) continue;
-      const parent = hostOf(col.file);
-      const list = childrenOf.get(parent);
+      const host = hostOf(col.file);
+      if (!host) {
+        roots.push(col);
+        continue;
+      }
+      const list = childrenOf.get(host);
       if (list) list.push(col);
-      else childrenOf.set(parent, [col]);
+      else childrenOf.set(host, [col]);
     }
+    /* Hosting follows an acyclic chain, so a non-empty group always has a root;
+       the guard keeps a column from being dropped if that ever stops holding. */
+    if (!roots.length) roots.push(cols[0]!);
+    const topPath = roots[0]!.file.path;
 
     /* Quiet child conversations stay visible on the diagram as mini cards
        wired to their parent; everything else (bash tasks, codex job logs,
@@ -886,7 +927,7 @@ export function buildSchemeLayout(
     for (const file of [...group.returnable, ...group.finished]) {
       if (claimed.has(file.path)) continue;
       if (isChildConversation(file)) {
-        const host = hostOf(file);
+        const host = hostOf(file) ?? topPath;
         const list = stackFor.get(host);
         if (list) list.push(file);
         else stackFor.set(host, [file]);
@@ -895,7 +936,10 @@ export function buildSchemeLayout(
       }
     }
     const deck = new Map<string, FileEntry[]>([[topPath, deckItems]]);
-    cursor += placeTree(cols[0]!, childrenOf, stackFor, deck, group.key, bandTop) + GROUP_GAP;
+    /* Each canonical root is the top of its own tree, so a group whose first
+       column turned out to be a descendant does not leave a child card marked
+       as the root of the branch. */
+    for (const root of roots) cursor += placeTree(root, childrenOf, stackFor, deck, root.file.path, bandTop) + GROUP_GAP;
   };
 
   const placeManual = (file: FileEntry, bandTop: number) => {
@@ -1209,6 +1253,69 @@ export function buildSchemeLayout(
      edge can route into (or out of) a future stage that has no materialized node
      yet — the rail stays continuous inside the halo (#353). */
   for (const slot of slots) anchors.set(slot.key, slot.key);
+  /* ── Canonical lineage reconciliation (issue #828) ────────────────────────
+     Placement has drawn what the board CAN show; this pass makes what it draws
+     agree with the one lineage model. Every placed node records the ancestor it
+     hangs under, the generations that ancestor edge skips, and a parent the scan
+     does not carry at all. Structural edges are then reconciled against that
+     record: an edge the model does not endorse is dropped instead of asserting a
+     spawn that never happened, a node whose canonical ancestor is drawn
+     elsewhere on the board gains exactly one incoming edge, and no pair is ever
+     joined twice or in both directions. */
+  const placedNodePaths = new Set(nodes.map((node) => node.file.path));
+  const nodeByPath = new Map(nodes.map((node) => [node.file.path, node] as const));
+  for (const node of nodes) {
+    const resolution = lineage.resolveHost(node.file.path, placedNodePaths);
+    node.ancestry = {
+      hostPath: resolution.host,
+      elided: resolution.elided.map((path) => byAll.get(path)).filter((file): file is FileEntry => Boolean(file)),
+      unresolvedParentId: resolution.unresolvedParentId,
+      depth: lineage.depthOf(node.file.path),
+    };
+    node.lineageOrderKey = lineage.orderKey(node.file.path);
+  }
+  const lineageEdgeTargets = new Set<string>();
+  const reconciled: SchemeEdge[] = [];
+  for (const edge of edges) {
+    const target = nodeByPath.get(edge.to);
+    /* Stack, deck and draft connectors are attachments, not lineage. */
+    if (!target) {
+      reconciled.push(edge);
+      continue;
+    }
+    const host = target.ancestry?.hostPath ?? null;
+    if (!host || edge.from !== host || lineageEdgeTargets.has(edge.to)) continue;
+    const via = target.ancestry?.elided ?? [];
+    reconciled.push(via.length ? { ...edge, via, dashed: true } : edge);
+    lineageEdgeTargets.add(edge.to);
+  }
+  /* A canonical ancestor the board draws in ANOTHER tree (its own group, a
+     manual placement, a pipeline region) still owns the descendant: the edge
+     spans the boards' trees instead of leaving the node reading as a root. */
+  for (const node of nodes) {
+    const host = node.ancestry?.hostPath;
+    if (!host || lineageEdgeTargets.has(node.file.path)) continue;
+    const source = nodeByPath.get(host);
+    if (!source) continue;
+    reconciled.push({
+      to: node.file.path,
+      from: source.file.path,
+      sourceConversationId: conversationIdentity(source.file),
+      targetConversationId: conversationIdentity(node.file),
+      x1: source.x + 40,
+      y1: source.y + source.h,
+      x2: node.x + node.w / 2,
+      y2: node.y,
+      color: engineColor(node.file),
+      live: node.file.activity === "live",
+      dashed: true,
+      via: node.ancestry?.elided ?? [],
+    });
+    lineageEdgeTargets.add(node.file.path);
+  }
+  edges.length = 0;
+  for (const edge of reconciled) edges.push(edge);
+
   const byPath = new Map<string, SchemeRect>([
     ...nodes.map((node) => [node.file.path, node] as const),
     ...drafts.map((draft) => [draft.key, draft] as const),
@@ -1231,7 +1338,6 @@ export function buildSchemeLayout(
      — a descendant OWNED by a different flow/pipeline is never absorbed (nor is
        its subtree), so one colored region can never swallow another's cards and
        force the two dashed outlines to intersect. */
-  const placedNodePaths = new Set(nodes.map((node) => node.file.path));
   const deckKeyByImplementer = new Map(decks.map((deck) => [deck.flow.implementerPath, deck.key] as const));
   const attachmentKeysOf = (path: string): string[] => {
     const keys: string[] = [];

--- a/src/components/scheme/lineageModel.test.ts
+++ b/src/components/scheme/lineageModel.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { buildSchemeLineage, durableParentConversationId } from "./lineageModel";
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "demo",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+/** The durable record a spawn writes: parent + role, memberships unused here. */
+function lineage(parentConversationId: string | null, role: string | null = null, kind: "spawn" | "review" = "spawn") {
+  return { kind, role, parentConversationId, reviewsConversationId: null, memberships: [] } as FileEntry["durableLineage"];
+}
+
+/* The chain from issue #828, captured from `durableLineage` on live records:
+   coordinator → codex session → orchestrator → builder → reviewer. */
+const coordinator = entry({
+  path: "/coordinator", conversationId: "conversation_coordinator", root: "codex-sessions", engine: "codex",
+  title: "Voice Coordinator", activity: "live",
+});
+const codexSession = entry({
+  path: "/codex-session", conversationId: "conversation_codex", root: "codex-sessions", engine: "codex",
+  title: "Codex session", activity: "live", durableLineage: lineage("conversation_coordinator"),
+});
+const orchestrator = entry({
+  path: "/orchestrator", conversationId: "conversation_orchestrator", title: "Orchestrator", activity: "stalled",
+  durableLineage: lineage("conversation_codex", "orchestrator"),
+});
+const builder = entry({
+  path: "/builder", conversationId: "conversation_builder", title: "Builder — plain", activity: "live",
+  durableLineage: lineage("conversation_orchestrator", "builder"),
+});
+const reviewer = entry({
+  path: "/reviewer", conversationId: "conversation_reviewer", root: "codex-sessions", engine: "codex",
+  title: "reviewer", activity: "live", durableLineage: lineage("conversation_builder", "reviewer", "review"),
+});
+
+describe("buildSchemeLineage precedence", () => {
+  test("a durable parent outranks a transcript pointer that inverts the chain", () => {
+    /* The exact defect: the scanner's pointer named the DESCENDANT builder as
+       the codex session's parent, so the board drew the grandparent as a child. */
+    const inverted = { ...codexSession, parent: builder.path };
+    const model = buildSchemeLineage([coordinator, inverted, orchestrator, builder, reviewer]);
+
+    expect(model.parentPathOf(inverted.path)).toBe(coordinator.path);
+    expect(model.isAncestorOf(inverted.path, builder.path)).toBe(true);
+    expect(model.isAncestorOf(builder.path, inverted.path)).toBe(false);
+    expect(model.ancestorsOf(builder.path)).toEqual([orchestrator.path, codexSession.path, coordinator.path]);
+  });
+
+  test("depth comes from the resolved chain, not from the recorded value", () => {
+    /* Every live record in the report carried `depth: 0` regardless of its
+       position, so the board must derive tiers from the chain itself. */
+    const flattened = [coordinator, codexSession, orchestrator, builder, reviewer]
+      .map((file) => (file.durableLineage ? { ...file, durableLineage: { ...file.durableLineage, depth: 0 } } : file));
+    const model = buildSchemeLineage(flattened);
+
+    expect(flattened.map((file) => model.depthOf(file.path))).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("a record with no durable statement keeps the scanner's transcript pointer", () => {
+    const main = entry({ path: "/main", conversationId: "conversation_main" });
+    const subagent = entry({ path: "/main/subagents/agent-1", kind: "subagent", parent: "/main" });
+    const model = buildSchemeLineage([main, subagent]);
+
+    expect(model.linkOf(subagent.path)).toEqual({
+      parentConversationId: "conversation_main",
+      parentPath: "/main",
+      source: "transcript",
+    });
+  });
+
+  test("a transcript pointer at a conversation outside the scan is not a parent", () => {
+    const orphan = entry({ path: "/orphan", parent: "/gone" });
+    expect(buildSchemeLineage([orphan]).linkOf(orphan.path)).toBeNull();
+  });
+
+  test("a deleted parent worktree keeps its tombstone as the parent statement", () => {
+    const child = entry({
+      path: "/child", conversationId: "conversation_child",
+      parentRemoved: { conversationId: "conversation_gone", path: "/gone" },
+    });
+    const stranger = entry({ path: "/stranger", conversationId: "conversation_stranger", activity: "live" });
+    const model = buildSchemeLineage([stranger, child]);
+
+    expect(durableParentConversationId(child)).toBe("conversation_gone");
+    expect(model.parentPathOf(child.path)).toBeNull();
+    expect(model.resolveHost(child.path, new Set([stranger.path]))).toEqual({
+      host: null,
+      elided: [],
+      unresolvedParentId: "conversation_gone",
+    });
+  });
+
+  test("a durable parent resolves through the successor of a migrated conversation", () => {
+    const predecessor = entry({ path: "/parent-gen1", conversationId: "conversation_parent", migratedTo: "/parent-gen2" });
+    const successor = entry({ path: "/parent-gen2", conversationId: "conversation_parent", generation: 2, predecessorPath: "/parent-gen1" });
+    const child = entry({ path: "/child", conversationId: "conversation_child", durableLineage: lineage("conversation_parent") });
+    const model = buildSchemeLineage([predecessor, successor, child]);
+
+    expect(model.parentPathOf(child.path)).toBe(successor.path);
+  });
+
+  test("two disagreeing statements that close a cycle leave a forest", () => {
+    const a = entry({ path: "/a", conversationId: "conversation_a", durableLineage: lineage("conversation_b") });
+    const b = entry({ path: "/b", conversationId: "conversation_b", durableLineage: lineage("conversation_a") });
+    const forward = buildSchemeLineage([a, b]);
+    const reversed = buildSchemeLineage([b, a]);
+
+    expect(forward.ancestorsOf("/a")).toEqual(reversed.ancestorsOf("/a"));
+    expect(forward.ancestorsOf("/b")).toEqual(reversed.ancestorsOf("/b"));
+    /* Whichever link is cut, neither node may end up its own ancestor. */
+    expect(forward.isAncestorOf("/a", "/a")).toBe(false);
+    expect(forward.isAncestorOf("/b", "/b")).toBe(false);
+  });
+
+  test("a record naming itself as its parent is a root", () => {
+    const self = entry({ path: "/self", conversationId: "conversation_self", durableLineage: lineage("conversation_self") });
+    expect(buildSchemeLineage([self]).linkOf("/self")).toBeNull();
+  });
+});
+
+describe("resolveHost", () => {
+  const files = [coordinator, codexSession, orchestrator, builder, reviewer];
+
+  test("an unrendered ancestor is elided, never reversed: the host stays above", () => {
+    const model = buildSchemeLineage(files);
+    const visible = new Set([coordinator.path, codexSession.path, builder.path, reviewer.path]);
+
+    expect(model.resolveHost(builder.path, visible)).toEqual({
+      host: codexSession.path,
+      elided: [orchestrator.path],
+      unresolvedParentId: null,
+    });
+    expect(model.resolveHost(codexSession.path, visible).host).toBe(coordinator.path);
+  });
+
+  test("hosting is identical whether the intermediate ancestor is live or stalled", () => {
+    const stalled = buildSchemeLineage(files);
+    const live = buildSchemeLineage(files.map((file) => ({ ...file, activity: "live" as const })));
+    const visible = new Set([coordinator.path, codexSession.path, builder.path]);
+
+    expect(live.resolveHost(builder.path, visible)).toEqual(stalled.resolveHost(builder.path, visible));
+  });
+
+  test("a child whose whole chain is off the board reports an unresolved ancestor", () => {
+    /* Only the builder and the codex session survive the scan window: the
+       builder's parent is unknown here, so it must NOT borrow the codex
+       session — which is its grandparent — as a spawner. */
+    const model = buildSchemeLineage([codexSession, builder]);
+    const visible = new Set([codexSession.path, builder.path]);
+
+    expect(model.resolveHost(builder.path, visible)).toEqual({
+      host: null,
+      elided: [],
+      unresolvedParentId: "conversation_orchestrator",
+    });
+  });
+});
+
+describe("orderKey", () => {
+  test("lists a generation before the one it spawned, whatever the activity", () => {
+    const files = [reviewer, builder, orchestrator, codexSession, coordinator];
+    const model = buildSchemeLineage(files);
+    const order = (input: FileEntry[]) =>
+      [...input].sort((a, b) => (model.orderKey(a.path) < model.orderKey(b.path) ? -1 : 1)).map((file) => file.path);
+
+    expect(order(files)).toEqual([coordinator.path, codexSession.path, orchestrator.path, builder.path, reviewer.path]);
+    expect(order(files.map((file) => ({ ...file, activity: "idle" as const, mtime: 5 })))).toEqual(order(files));
+  });
+});

--- a/src/components/scheme/lineageModel.ts
+++ b/src/components/scheme/lineageModel.ts
@@ -1,0 +1,215 @@
+import type { FileEntry } from "@/lib/types";
+
+import { conversationIdentity, isArchivedPredecessor } from "@/lib/accounts/identity";
+
+/*
+ * The board's ONE lineage read model (issue #828).
+ *
+ * Parentage arrives on a scanned entry through several non-agreeing signals:
+ * the durable edge recorded at spawn (`durableLineage.parentConversationId`),
+ * the durable tombstone of a deleted parent (`parentRemoved`), and the
+ * scanner's transcript pointer (`file.parent`, itself derived from native
+ * thread headers, provider fork sources, /proc ancestry and handoff receipts).
+ * When the board re-derived the hierarchy from whichever of those happened to
+ * be populated, the rendered graph changed with transient process state: a
+ * stalled ancestor dropped out, an inferred pointer reattached a grandparent as
+ * a CHILD, and a builder read as the spawner of its own coordinator.
+ *
+ * So parentage is resolved exactly once, here, from a fixed precedence, and
+ * every board surface (nodes, edges, layout hosting, badges, tray membership,
+ * DOM order) consumes the result instead of re-inferring:
+ *
+ *   1. A durable edge that NAMES a parent wins outright. The transcript pointer
+ *      is then never consulted — a record that knows its own parent can only be
+ *      misplaced by a competing guess. When that parent is outside the scanned
+ *      window the node keeps an explicit unresolved-ancestor state; it is never
+ *      re-attached to some other visible node.
+ *   2. A `parentRemoved` tombstone is the same statement about a parent whose
+ *      transcript is gone (a deleted worktree), so it resolves the same way.
+ *   3. Only a record with NO durable parent statement falls back to the
+ *      scanner's transcript pointer — engine-native subagents, compaction
+ *      chains and handoffs, which is where that pointer is authoritative.
+ *
+ * The result is a forest: cycles (which two disagreeing signals can close) are
+ * broken deterministically, so direction is a property of the model rather than
+ * of the order the files happened to arrive in.
+ */
+
+/* Sorts below every character a transcript path can hold, so a parent's order
+   key is an exact prefix of each child's and a codepoint comparison lists a
+   generation before the one it spawned. */
+const LINEAGE_ORDER_SEPARATOR = "\u0001";
+
+export type LineageSource = "durable" | "transcript";
+
+/** One resolved parent statement about a scanned conversation. */
+export interface LineageLink {
+  /** Stable identity of the parent conversation, when the record names one. */
+  parentConversationId: string | null;
+  /** Scanned transcript of that parent, or null when it is outside the window. */
+  parentPath: string | null;
+  source: LineageSource;
+}
+
+/** Where a conversation attaches on a board that renders only `visible`. */
+export interface HostResolution {
+  /** Nearest canonical ancestor that the board actually renders, else null. */
+  host: string | null;
+  /** Scanned ancestors skipped on the way to `host`, nearest first. Non-empty
+      means the drawn edge spans an elided generation and must say so. */
+  elided: string[];
+  /** Set when the chain ends at a parent that is not in the scan at all: the
+      node continues a lineage the board cannot show, and must render that
+      instead of borrowing someone else's parent. */
+  unresolvedParentId: string | null;
+}
+
+export interface SchemeLineage {
+  /** Canonical parent statement for a scanned path, or null for a root. */
+  linkOf(path: string): LineageLink | null;
+  /** Canonical parent transcript, or null for a root / an off-window parent. */
+  parentPathOf(path: string): string | null;
+  /** Scanned ancestors, nearest first. Stops at the first off-window parent. */
+  ancestorsOf(path: string): readonly string[];
+  /** Generations above this node, counting an off-window parent as one. */
+  depthOf(path: string): number;
+  isAncestorOf(candidate: string, path: string): boolean;
+  resolveHost(path: string, visible: ReadonlySet<string>): HostResolution;
+  /** Sort key placing ancestors before descendants, independent of activity —
+      the board's DOM order, which must not reshuffle when a node goes quiet. */
+  orderKey(path: string): string;
+}
+
+/** The durable parent this record NAMES, or null when it names none. Exported
+    for the surfaces that only need the per-record statement (tray membership,
+    badge children) and must apply the same precedence as the graph. */
+export function durableParentConversationId(file: FileEntry): string | null {
+  const named = file.durableLineage?.parentConversationId ?? null;
+  if (named) return named;
+  return file.parentRemoved?.conversationId ?? null;
+}
+
+/** Current-generation transcript per stable conversation identity: a migrated
+    card is addressed by its successor, so a durable edge recorded against the
+    conversation still resolves after the account move (#40 identity contract). */
+function transcriptByIdentity(files: readonly FileEntry[]): Map<string, string> {
+  const byIdentity = new Map<string, FileEntry>();
+  for (const file of files) {
+    const id = conversationIdentity(file);
+    const current = byIdentity.get(id);
+    if (!current) {
+      byIdentity.set(id, file);
+      continue;
+    }
+    /* An archived predecessor never wins over its successor; otherwise the
+       newer generation, then the fresher transcript, then the stable path. */
+    const rank = (entry: FileEntry): number => (isArchivedPredecessor(entry) ? -1 : entry.generation ?? 0);
+    const better =
+      rank(file) > rank(current) ||
+      (rank(file) === rank(current) && file.mtime > current.mtime) ||
+      (rank(file) === rank(current) && file.mtime === current.mtime && file.path < current.path);
+    if (better) byIdentity.set(id, file);
+  }
+  return new Map([...byIdentity].map(([id, file]) => [id, file.path]));
+}
+
+/**
+ * Break every cycle two disagreeing parent statements can close, dropping the
+ * link of the lexicographically greatest path on the cycle. Which link is cut
+ * matters less than that the cut is a function of the identities alone: the
+ * same scan must always produce the same forest, whatever order it arrived in.
+ */
+function breakCycles(links: Map<string, LineageLink>): void {
+  const state = new Map<string, "visiting" | "done">();
+  for (const start of [...links.keys()].sort()) {
+    if (state.get(start) === "done") continue;
+    const stack: string[] = [];
+    let cursor: string | null = start;
+    while (cursor && state.get(cursor) !== "done") {
+      if (state.get(cursor) === "visiting") {
+        const cycle = stack.slice(stack.indexOf(cursor));
+        links.delete([...cycle].sort().at(-1)!);
+        break;
+      }
+      state.set(cursor, "visiting");
+      stack.push(cursor);
+      cursor = links.get(cursor)?.parentPath ?? null;
+    }
+    for (const path of stack) state.set(path, "done");
+  }
+}
+
+/**
+ * Resolve the whole scan into one lineage forest. Pure: the same file set
+ * always yields the same graph, so a board refresh, an activity transition, or
+ * a visibility change can never reverse or flatten an edge.
+ */
+export function buildSchemeLineage(files: readonly FileEntry[]): SchemeLineage {
+  const byPath = new Map(files.map((file) => [file.path, file]));
+  const pathByIdentity = transcriptByIdentity(files);
+  const links = new Map<string, LineageLink>();
+  const unresolved = new Map<string, string>();
+
+  for (const file of files) {
+    const durableParent = durableParentConversationId(file);
+    if (durableParent) {
+      const parentPath = pathByIdentity.get(durableParent) ?? null;
+      if (parentPath === file.path) continue;
+      if (parentPath === null) unresolved.set(file.path, durableParent);
+      else links.set(file.path, { parentConversationId: durableParent, parentPath, source: "durable" });
+      continue;
+    }
+    /* No durable statement: the scanner's transcript pointer is the only claim
+       about this record, and it is the authoritative one for the layouts it
+       covers (engine-native subagents, compaction chains, handoffs). */
+    const pointer = file.parent;
+    if (!pointer || pointer === file.path) continue;
+    const parent = byPath.get(pointer);
+    if (!parent) continue;
+    links.set(file.path, {
+      parentConversationId: conversationIdentity(parent),
+      parentPath: parent.path,
+      source: "transcript",
+    });
+  }
+  breakCycles(links);
+
+  const ancestorCache = new Map<string, string[]>();
+  const ancestorsOf = (path: string): string[] => {
+    const cached = ancestorCache.get(path);
+    if (cached) return cached;
+    const chain: string[] = [];
+    const seen = new Set<string>([path]);
+    let cursor = links.get(path)?.parentPath ?? null;
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      chain.push(cursor);
+      cursor = links.get(cursor)?.parentPath ?? null;
+    }
+    ancestorCache.set(path, chain);
+    return chain;
+  };
+  /* The chain's far end names a parent the scan does not carry: every node
+     below it continues a lineage the board cannot draw. */
+  const unresolvedAt = (path: string): string | null => {
+    const chain = ancestorsOf(path);
+    return unresolved.get(chain.at(-1) ?? path) ?? null;
+  };
+
+  return {
+    linkOf: (path) => links.get(path) ?? null,
+    parentPathOf: (path) => links.get(path)?.parentPath ?? null,
+    ancestorsOf,
+    depthOf: (path) => ancestorsOf(path).length + (unresolvedAt(path) ? 1 : 0),
+    isAncestorOf: (candidate, path) => ancestorsOf(path).includes(candidate),
+    resolveHost: (path, visible) => {
+      const elided: string[] = [];
+      for (const ancestor of ancestorsOf(path)) {
+        if (visible.has(ancestor)) return { host: ancestor, elided, unresolvedParentId: null };
+        elided.push(ancestor);
+      }
+      return { host: null, elided, unresolvedParentId: unresolvedAt(path) };
+    },
+    orderKey: (path) => [...ancestorsOf(path)].reverse().concat(path).join(LINEAGE_ORDER_SEPARATOR),
+  };
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -59,6 +59,7 @@ import {
   type DraftNode,
   type FlowLoop,
   type MiniStack,
+  type NodeAncestry,
   type SchemeEdge,
   type SchemeGroup,
   type SchemeLayout,
@@ -151,8 +152,18 @@ export const EdgesLayer = memo(function EdgesLayer({
         const lift = Math.max(36, (edge.y2 - y1) * 0.5);
         const curve = `M ${x1} ${y1} C ${x1} ${y1 + lift}, ${edge.x2} ${edge.y2 - lift}, ${edge.x2} ${edge.y2 - 7}`;
         const head = `M ${edge.x2 - 5} ${edge.y2 - 9} L ${edge.x2 + 5} ${edge.y2 - 9} L ${edge.x2} ${edge.y2 - 1} Z`;
+        /* Ancestors the edge spans without drawing them (issue #828): the arrow
+           still runs parent → child, and the marker says how many generations
+           it skipped, so an elided chain can never read as a direct spawn. */
+        const elided = edge.via?.length ?? 0;
         return (
-          <g key={edge.to} opacity={edge.live ? 0.9 : 0.5}>
+          <g
+            key={edge.to}
+            opacity={edge.live ? 0.9 : 0.5}
+            data-scheme-edge={edge.to}
+            data-scheme-edge-from={edge.from}
+            data-scheme-edge-elided={elided ? String(elided) : undefined}
+          >
             <path
               d={curve}
               style={{ d: `path("${curve}")`, transition: `d ${MOVE_MS}ms ${MOVE_EASE}` } as React.CSSProperties}
@@ -180,6 +191,21 @@ export const EdgesLayer = memo(function EdgesLayer({
               style={{ d: `path("${head}")`, transition: `d ${MOVE_MS}ms ${MOVE_EASE}` } as React.CSSProperties}
               fill={edge.color}
             />
+            {elided ? (
+              <>
+                <circle cx={(x1 + edge.x2) / 2} cy={(y1 + edge.y2) / 2} r={12} fill="var(--color-canvas)" stroke={edge.color} strokeWidth={1.5} />
+                <text
+                  x={(x1 + edge.x2) / 2}
+                  y={(y1 + edge.y2) / 2 + 4}
+                  textAnchor="middle"
+                  fontSize={12}
+                  fontWeight={700}
+                  fill={edge.color}
+                >
+                  ⋯{elided}
+                </text>
+              </>
+            ) : null}
           </g>
         );
       })}
@@ -528,6 +554,39 @@ function RecencyChip({ file, className }: { file: FileEntry; className?: string 
   return (
     <span className={`${className ?? ""} shrink-0 tabular-nums text-muted`} title={info.idleTitle ?? undefined}>
       {fmtAge(file.mtime)}
+    </span>
+  );
+}
+
+/**
+ * What the board could NOT draw about this node's lineage (issue #828).
+ *
+ * A card whose parent generation is off the board must say so on the card
+ * itself: either the ancestors the incoming arrow skips, or — when the durable
+ * record names a parent that is not in the scan at all (an old window, a deleted
+ * worktree) — that the conversation continues a lineage the board cannot show.
+ * Without this the same card reads as a root, which is how delegation came to
+ * look inverted; the chip is the explicit alternative to guessing an owner.
+ */
+function AncestryChip({ ancestry }: { ancestry?: NodeAncestry }) {
+  const { t } = useLocale();
+  if (!ancestry) return null;
+  const nearest = ancestry.elided[0];
+  const label = nearest
+    ? t("scheme.ancestorElided", { count: ancestry.elided.length, title: cleanTitle(nearest.title, 60) })
+    : ancestry.unresolvedParentId
+      ? t("scheme.ancestorOffBoard")
+      : null;
+  if (!label) return null;
+  return (
+    <span
+      data-scheme-ancestry-chip
+      className="pointer-events-none absolute -top-3 left-3 z-[7] inline-flex h-6 max-w-[62%] items-center gap-1 rounded-full border border-border bg-card px-2 text-[10.5px] font-bold text-muted shadow-1"
+      title={label}
+      aria-label={label}
+    >
+      <span aria-hidden className="text-[12px] leading-none">↑</span>
+      <span className="truncate">{nearest ? cleanTitle(nearest.title, 40) : label}</span>
     </span>
   );
 }
@@ -936,6 +995,9 @@ function NodeShell({
   return (
     <div
       data-scheme-node={node.file.path}
+      data-scheme-node-host={node.ancestry?.hostPath ?? undefined}
+      data-scheme-node-elided={node.ancestry?.elided.length ? String(node.ancestry.elided.length) : undefined}
+      data-scheme-node-unresolved-parent={node.ancestry?.unresolvedParentId ?? undefined}
       data-pipeline-stage-card={pipelineStage ? `${pipelineStage.pipeline.id}::${pipelineStage.stage.id}` : undefined}
       data-pipeline-stage-state={pipelineStage ? stageChipState(pipelineStage.pipeline, pipelineStage.stage) : undefined}
       data-lasso-selected={marked ? "true" : undefined}
@@ -956,6 +1018,7 @@ function NodeShell({
         /* The promised member tint: readable at far zoom, panes stay legible. */
         <div aria-hidden className="pointer-events-none absolute inset-0 z-[4] rounded-[10px] bg-accent/[0.06]" />
       ) : null}
+      <AncestryChip ancestry={node.ancestry} />
       {pipelineStage ? (
         <span
           className="pointer-events-none absolute -top-3 right-3 z-[7] inline-flex h-6 max-w-[78%] items-center gap-1.5 rounded-full border border-accent/35 bg-card px-2 text-[10.5px] font-bold text-accent shadow-1"

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -2,6 +2,8 @@ import { attentionId } from "@/components/attention";
 import { conversationIdentity, isArchivedPredecessor } from "@/lib/accounts/identity";
 import type { EpochSeconds, Engine, FileEntry } from "@/lib/types";
 
+import { durableParentConversationId } from "./lineageModel";
+
 /*
  * Engine-native subagent tray — the single presence projection for issue #142
  * slice S2 (docs/design/board-presence-cards.md §1.2/§1.4).
@@ -205,8 +207,14 @@ export function currentGenerationChildrenOf(
     if (entry.engine === "shell") continue;
     const id = conversationIdentity(entry);
     if (id === conversationId) continue;
-    const durableParent = entry.durableLineage?.parentConversationId;
-    if (durableParent !== conversationId && (!entry.parent || !parentPaths.has(entry.parent))) continue;
+    /* Same precedence the board's lineage model applies (issue #828): a record
+       that NAMES its parent is a child of that conversation and of no other, so
+       a stale transcript pointer can never hand it to a second host — which is
+       how a tray/badge could show a conversation under its own descendant. */
+    const durableParent = durableParentConversationId(entry);
+    if (durableParent !== null) {
+      if (durableParent !== conversationId) continue;
+    } else if (!entry.parent || !parentPaths.has(entry.parent)) continue;
     if (!filter(entry)) continue;
     const current = currentById.get(id);
     const generation = entry.generation ?? 0;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1341,6 +1341,9 @@ export const en = {
   "scheme.flowTitle": "Run the implement → review cycle for this conversation",
   "scheme.flow": "Flow",
   "scheme.collapsedTitle": "Collapsed branches and tasks of this conversation",
+  /* Lineage the board cannot draw in full (issue #828). */
+  "scheme.ancestorElided": { one: "Parent not drawn on this board: {title}", other: "{count} ancestors not drawn on this board, nearest: {title}" },
+  "scheme.ancestorOffBoard": "Parent conversation is not on this board",
   "scheme.underneath": "underneath",
   "scheme.handTool": "Hand — drag the canvas (H, or hold Space)",
   "scheme.selectTool": "Select — click and work with conversations (V)",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1296,6 +1296,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "scheme.flowTitle": "Запустити цикл implement → review для цієї розмови",
   "scheme.flow": "Флоу",
   "scheme.collapsedTitle": "Згорнуті гілки й задачі цієї розмови",
+  /* Лінія походження, яку дошка не може показати повністю (issue #828). */
+  "scheme.ancestorElided": { one: "Батьківську розмову не показано: {title}", few: "{count} предків не показано, найближчий: {title}", many: "{count} предків не показано, найближчий: {title}", other: "{count} предків не показано, найближчий: {title}" },
+  "scheme.ancestorOffBoard": "Батьківської розмови немає на цій дошці",
   "scheme.underneath": "під сподом",
   "scheme.handTool": "Рука — тягнути полотно (H, або тримай Space)",
   "scheme.selectTool": "Виділення — клік і робота з розмовами (V)",


### PR DESCRIPTION
Closes #828.

## The defect

The Scheme drew delegation backwards. The reported frame ran one arrow from a **Builder** card down to the **Codex session two generations above it**, with the Orchestrator between them missing — the worker read as its coordinator's spawner. The follow-up comment showed the same region rendering correctly minutes later with no code change, which reframed the issue: the hierarchy was not statically wrong, it was **re-derived at render time from several disagreeing signals** and moved with transient process state.

Reproduced before touching the fix, from fixtures shaped like the live records (whole chain at `depth: 0`, an intermediate ancestor that comes and goes, a scanner pointer naming a descendant as the parent). On `main` the layout emits the extra inverted edge:

```
edges: [ { from: undefined, to: "/codex-session" }, { from: undefined, to: "/reviewer" } ]
```

`/codex-session` is the builder's **grandparent**, drawn as its child.

## One model, consumed everywhere

`src/components/scheme/lineageModel.ts` resolves parentage once per scan, from a fixed precedence:

1. a durable record that **names** a parent wins outright — the transcript pointer is then never consulted, and when that parent is outside the window the node keeps an explicit unresolved-ancestor state instead of being re-attached to another card;
2. a `parentRemoved` tombstone is the same statement about a parent whose checkout was deleted;
3. only a record with no durable parent falls back to the scanner's transcript pointer, where it is authoritative (engine-native subagents, compaction chains, handoffs).

Cycles that two disagreeing signals can close are broken deterministically, and depth is derived from the resolved chain — every live record in the report claimed `depth: 0` whatever its position, so the board can no longer depend on it.

## What changed on the board

- **Hosting.** A group hosts each column under its nearest canonical ancestor that the board also draws; a column whose chain leaves the group opens its own tree instead of being re-hosted on the group's first column (which may itself be a descendant — exactly how the builder came to look like the spawner).
- **Reconciliation.** Every placed node records the ancestor it hangs under, the generations that edge skips, and a parent absent from the scan. Edges the model does not endorse are dropped rather than asserting a spawn that never happened; a descendant drawn in another tree gains exactly one edge from its ancestor; no pair is joined twice or in both directions.
- **Elided ancestors.** An edge spanning an unrendered generation draws dashed with a `⋯n` marker; the card carries an ancestor chip naming the nearest generation not drawn.
- **Off-board parents.** A card whose parent is not in the scan says so on the card (en/uk) instead of silently reading as a root.
- **DOM/accessibility order** follows the hierarchy (a generation before the one it spawned) via a key that is a function of identity alone, so a card going quiet never reshuffles a stateful host.
- **Tray/badge membership** applies the same precedence, so a conversation can never appear under its own descendant.

## Verification

- `bun test src/components/scheme/` — 645 pass, 0 fail across 55 files (includes the three new suites).
- New focused regressions, all RED on `main` (verified in a throwaway checkout of the merge base): `lineageModel.test.ts` (12), `layout.lineage.test.ts` (10), `SchemeBoard.lineage.dom.test.tsx` (4). They cover the exact issue chain, the inverted pointer, elided/idle ancestors, deleted parent worktrees, restored (migrated) conversations, pipeline stage members, mixed-engine lineage, a refresh rendering the same graph, and the hierarchy holding while the intermediate ancestor moves through live/stalled/recent/idle.
- `bunx tsc --noEmit` clean; `eslint` clean on every touched file (the repo's pre-existing lint errors are in untouched files); `bun run build` succeeds.
- Privacy publication gate against the merge base: **PASS**.

## Out of scope, reported not edited

Two defects from the original report live in the durable writer, outside this lane's file ownership, and are left untouched:

- **recorded-at-birth depth is written as 0** regardless of the caller's depth (`src/lib/agent/spawnAdmission.ts`), which also weakens the `nesting_depth_exceeded` admission ceiling;
- **reviewer conversations inherit the reviewed conversation's title**, so a reviewer is visually indistinguishable from the builder it reviews.

The board no longer depends on either: depth is derived from the resolved chain, and lineage direction no longer varies with titles. Both still need a fix at the source.

## Refreshed onto main `091da89c`

Main merged into the branch as a merge commit (no rebase, history additive). The lineage work touches only `src/components/scheme/` and the two i18n catalogues while main moved in `mcp/`, `scanner/`, `bridge/` and the release scripts, so the merge was conflict-free and the diff against main is unchanged: 10 files, +1114/−23.

Re-run at this head:

- `bun test src/components/scheme/` — **645 pass, 0 fail** across 55 files.
- The three lineage suites alone — **26 pass, 0 fail**.
- Focused scanner/identity suites the model reads through (`describe`, `links`, `conversationCatalog`, `transcripts`, `scanCoordinator`, `fileScanWorker`, `filesResponseWorker`, `observe.singleFlight`, `accounts/identity`) — **86 pass, 0 fail**.
- `bunx tsc --noEmit` clean; `eslint` clean on all ten touched files; `bun run build` succeeds (Next build + MCP bundle).
- Privacy publication gate against `091da89c`: **PASS**.

Still RED on `091da89c`: `SchemeBoard.lineage.dom.test.tsx`, copied unchanged into a throwaway checkout of main, fails **4/4**. Because the `data-scheme-edge` instrumentation is added by this branch, that alone would not prove direction, so the same fixture was also driven through main's `buildSchemeLayout` in that checkout. It reproduces the reported frame directly: with the codex session's transcript pointer naming the builder below it, main emits `edges: [{to: "/codex-session"}, {to: "/reviewer"}]` and the first arrow physically leaves the **Builder** card and enters `/codex-session`, its own grandparent. With the Orchestrator idle, main draws `/codex-session → /builder` straight across the elided generation with no marker.

One caveat on how to read the suites: a whole-tree `bun test src/components/` run is unreliable in this repo through cross-file module-mock interference — it fails 131 tests on `091da89c` itself and 106 at this head. The per-directory and per-file runs above are the meaningful gates.

No deploy is part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

