### PR TITLE
fix(#845): bound the bridge 403 retry storm and the control-plane reads behind it

### DIFF
--- a/src/app/api/agent/snapshot/route.ts
+++ b/src/app/api/agent/snapshot/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { observeFiles } from "@/lib/scanner/observe";
+import { observeFiles, ObservationCancelledError } from "@/lib/scanner/observe";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { collectSnapshot } from "@/lib/view/collect";
 import { SnapshotError } from "@/lib/view/snapshot";
@@ -22,9 +22,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "INVALID_REQUEST", message: "invalid request" }, { status: 400, headers });
   }
   try {
-    return NextResponse.json(await collectSnapshot(body, { observeFiles, resolveSiblings }), { headers });
+    /* `NextRequest` extends the web `Request`, so it carries the runtime's own
+       cancellation signal. Handing it down is what stops a corpus walk from
+       outliving the client that asked for it (#845). */
+    return NextResponse.json(
+      await collectSnapshot(body, { observeFiles, resolveSiblings, signal: request.signal }),
+      { headers },
+    );
   } catch (error) {
     if (error instanceof SnapshotError) return NextResponse.json({ error: error.code, message: error.message, ...(error.sessions ? { sessions: error.sessions } : {}) }, { status: error.status, headers });
+    /* A cancelled read is the client having gone, not the scanner being down; 499
+       is never delivered anywhere, so the status only has to be honest in logs. */
+    if (error instanceof ObservationCancelledError) {
+      return NextResponse.json({ error: "REQUEST_CANCELLED", message: "the client went away" }, { status: 499, headers });
+    }
     return NextResponse.json({ error: "SCANNER_UNAVAILABLE", message: "scanner unavailable" }, { status: 503, headers });
   }
 }

--- a/src/hooks/useBridgeReportRelay.dom.test.tsx
+++ b/src/hooks/useBridgeReportRelay.dom.test.tsx
@@ -12,7 +12,16 @@ import {
 import { installActEnv } from "@/test-helpers/actEnv";
 import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
-import { commitBridgeTurn, retirePendingBridgeAcknowledgements, useBridgeReportRelay, useBridgeTurnStartDrain } from "./useBridgeReportRelay";
+import {
+  bridgeSessionRetirement,
+  commitBridgeTurn,
+  resetBridgeRelayStateForTests,
+  retirePendingBridgeAcknowledgements,
+  useBridgeReportRelay,
+  useBridgeTurnStartDrain,
+  type BridgeRelayState,
+} from "./useBridgeReportRelay";
+import type { DeadlineScheduler } from "@/lib/deadline";
 
 /**
  * The relay drives the loop, in the order that keeps reports exactly-once.
@@ -106,6 +115,14 @@ function delivery(seq: number): RuntimeVoiceDelivery {
  */
 let postOutcomes: { status: number; hold?: Promise<void> }[] = [];
 
+/** Scripted GET statuses, consumed in order; anything unscripted answers 200. */
+let getStatuses: number[] = [];
+/** The highest number of requests the relay ever had in flight at once (#845). */
+let inFlight = 0;
+let peakInFlight = 0;
+/** Every signal the relay handed to `fetch`, so a test can prove cancellation. */
+let requestSignals: AbortSignal[] = [];
+
 const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
   const url = String(input);
   calls.push({
@@ -113,15 +130,62 @@ const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
     method: init?.method ?? "GET",
     body: init?.body ? JSON.parse(String(init.body)) as unknown : null,
   });
-  if ((init?.method ?? "GET") === "GET") {
-    const plan = plans.shift() ?? { kind: "idle" };
-    return new Response(JSON.stringify({ ok: true, plan }), { status: 200 });
+  if (init?.signal) requestSignals.push(init.signal);
+  inFlight += 1;
+  peakInFlight = Math.max(peakInFlight, inFlight);
+  try {
+    if ((init?.method ?? "GET") === "GET") {
+      const status = getStatuses.shift() ?? 200;
+      if (status !== 200) return new Response(JSON.stringify({ error: "refused" }), { status });
+      const plan = plans.shift() ?? { kind: "idle" };
+      return new Response(JSON.stringify({ ok: true, plan }), { status: 200 });
+    }
+    const outcome = postOutcomes.shift();
+    if (outcome?.hold) await outcome.hold;
+    const status = outcome?.status ?? 200;
+    return new Response(JSON.stringify(status === 200 ? { ok: true } : { error: "refused" }), { status });
+  } finally {
+    inFlight -= 1;
   }
-  const outcome = postOutcomes.shift();
-  if (outcome?.hold) await outcome.hold;
-  const status = outcome?.status ?? 200;
-  return new Response(JSON.stringify(status === 200 ? { ok: true } : { error: "refused" }), { status });
 }) as unknown as typeof fetch;
+
+/**
+ * A scheduler whose clock only moves when the test says so.
+ *
+ * Thirty simulated minutes of a refused poll have to cost milliseconds, and the
+ * assertion that matters — how many requests that half hour produced — is only
+ * meaningful against a clock the test controls.
+ */
+function virtualScheduler(): DeadlineScheduler & {
+  advance(ms: number): void;
+  pending(): number;
+  delays: number[];
+} {
+  let now = 0;
+  let nextId = 1;
+  const timers = new Map<number, { at: number; handler: () => void }>();
+  return {
+    delays: [],
+    setTimeout(handler, ms) {
+      const id = nextId++;
+      this.delays.push(ms);
+      timers.set(id, { at: now + ms, handler });
+      return id;
+    },
+    clearTimeout(handle) {
+      timers.delete(handle as number);
+    },
+    advance(ms) {
+      now += ms;
+      for (const [id, timer] of [...timers].sort((left, right) => left[1].at - right[1].at)) {
+        if (timer.at > now) continue;
+        timers.delete(id);
+        timer.handler();
+      }
+    },
+    pending: () => timers.size,
+  };
+}
 
 beforeEach(() => {
   roots = [];
@@ -129,8 +193,15 @@ beforeEach(() => {
   delivered = [];
   plans = [];
   postOutcomes = [];
+  getStatuses = [];
+  inFlight = 0;
+  peakInFlight = 0;
+  requestSignals = [];
   acknowledgeListeners = [];
   sessionCredential = "rt_sess_relay";
+  /* Retirement is module-scoped for the same reason the token store is — it must
+     survive a call-phase transition — so it also survives a test unless cleared. */
+  resetBridgeRelayStateForTests();
   /* The parked-token store is module-scoped by design (it must outlive components),
      so it also outlives a test unless cleared. */
   resetBridgeAcknowledgementsForTests();
@@ -469,7 +540,7 @@ test("a refused composer token is retained and retried to completion before the 
 
   await retirePendingBridgeAcknowledgements(flaky);
   /* Refused, so it is NOT forgotten. */
-  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "composer-key-1", ackToken: "ack_parked" }]);
+  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "composer-key-1", ackToken: "ack_parked", sessionId: null }]);
 
   refuse = false;
   await retirePendingBridgeAcknowledgements(flaky);
@@ -503,4 +574,314 @@ test("the retry runs BEFORE the drain, so a new batch never lands on an unsettle
 
   await drains.at(-1)!();
   expect(order).toEqual(["settle", "drain"]);
+});
+
+/**
+ * #845 — the retry storm, and every bound that was missing around it.
+ *
+ * A live non-root or stale `realtimeSessionId` is answered 403 by the gateway
+ * authority, correctly and permanently. The loop treated that like a blip: a fixed
+ * ten-second interval, no deadline, no backoff, no ceiling, and a confirmation
+ * listener that could POST beside a poll. Left open, one tab produced six refused
+ * requests a minute forever, each of which asked the server to rebuild the whole
+ * registry.
+ *
+ * These assert the bounds, not the mechanism: how many requests half an hour of
+ * refusal costs, that two are never in flight at once, and that nothing survives the
+ * component that wanted it.
+ */
+
+/** Mounts with a clock the test owns, returning the scheduler that drives it. */
+const REQUEST_TIMEOUT_MS = 7_000;
+
+function mountWithClock(options: { pollMs?: number; onState?: (state: BridgeRelayState) => void } = {}) {
+  const scheduler = virtualScheduler();
+  const pollMs = options.pollMs ?? 10_000;
+  function Probe() {
+    useBridgeReportRelay(client, true, {
+      fetchFn,
+      pollMs,
+      requestTimeoutMs: REQUEST_TIMEOUT_MS,
+      scheduler,
+      /* Pinned so a backoff assertion is about the policy rather than the dice. */
+      random: () => 0,
+      ...(options.onState ? { onState: options.onState } : {}),
+    });
+    return null;
+  }
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  const root = createRoot(container as unknown as Element);
+  roots.push(root);
+  flushSync(() => root.render(<Probe />));
+  return { scheduler, root, pollMs };
+}
+
+/** Advance the virtual clock in poll-sized steps, letting each cycle settle. */
+async function runFor(scheduler: ReturnType<typeof virtualScheduler>, totalMs: number, stepMs: number): Promise<void> {
+  await settle();
+  for (let elapsed = 0; elapsed < totalMs; elapsed += stepMs) {
+    scheduler.advance(stepMs);
+    await settle();
+  }
+}
+
+test("thirty simulated minutes of 403 costs one request, not one hundred and eighty", async () => {
+  getStatuses = Array.from({ length: 500 }, () => 403);
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+
+  await runFor(scheduler, 30 * 60_000, 10_000);
+
+  const requests = calls.filter((call) => call.url.includes("/api/bridge"));
+  /* One refusal is the whole answer. The credential either is the live root's or is
+     not, and asking again cannot change that. */
+  expect(requests).toHaveLength(1);
+  expect(requests[0]!.method).toBe("GET");
+  expect(bridgeSessionRetirement("rt_sess_relay")).toEqual({ sessionId: "rt_sess_relay", status: 403 });
+});
+
+test("a 401 retires the session exactly as a 403 does", async () => {
+  getStatuses = Array.from({ length: 20 }, () => 401);
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 5 * 60_000, 10_000);
+
+  expect(calls).toHaveLength(1);
+  expect(bridgeSessionRetirement("rt_sess_relay")?.status).toBe(401);
+});
+
+test("two requests are never in flight at once, across half an hour of traffic", async () => {
+  plans = Array.from({ length: 200 }, (_value, index) => ({
+    kind: "deliver",
+    delivery: delivery(index),
+    ackToken: `ack_${index}`,
+  }));
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await settle();
+
+  for (let tick = 0; tick < 180; tick += 1) {
+    /* The host confirms mid-flight, which is exactly when the old listener started a
+       POST beside the poll. It now wakes the loop instead. */
+    confirmDurableDelivery(delivery(tick).deliveryId);
+    scheduler.advance(0);
+    await settle();
+    scheduler.advance(10_000);
+    await settle();
+  }
+
+  expect(peakInFlight).toBe(1);
+  expect(calls.length).toBeGreaterThan(1);
+});
+
+test("a refused session stops polling, and a genuinely new session starts clean", async () => {
+  getStatuses = [403];
+  const states: BridgeRelayState[] = [];
+  const { scheduler } = mountWithClock({ pollMs: 10_000, onState: (state) => { states.push(state); } });
+  await runFor(scheduler, 60_000, 10_000);
+
+  expect(calls).toHaveLength(1);
+  expect(states.some((state) => state.kind === "retired" && state.sessionId === "rt_sess_relay")).toBe(true);
+
+  /* The call rolled over and the backend minted a new session id. Nothing about the
+     refused one says anything about this one. */
+  sessionCredential = "rt_sess_successor";
+  plans = [{ kind: "idle" }];
+  scheduler.advance(10_000);
+  await settle();
+
+  const fresh = calls.slice(1);
+  expect(fresh).toHaveLength(1);
+  expect(fresh[0]!.url).toContain("realtimeSessionId=rt_sess_successor");
+  expect(bridgeSessionRetirement("rt_sess_successor")).toBeNull();
+});
+
+test("retryable failures back off exponentially with a ceiling instead of hammering", async () => {
+  getStatuses = Array.from({ length: 40 }, () => 503);
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await settle();
+
+  /* Long enough for the ceiling to be reached and held. */
+  for (let tick = 0; tick < 400; tick += 1) {
+    scheduler.advance(10_000);
+    await settle();
+  }
+
+  /* Request deadlines share the clock, so only the CYCLE spacing is the subject. */
+  const spacing = scheduler.delays.filter((delay) => delay > 0 && delay !== REQUEST_TIMEOUT_MS);
+  expect(spacing.length).toBeGreaterThan(3);
+  expect(spacing[0]).toBe(10_000);
+  expect(spacing[1]).toBe(20_000);
+  expect(spacing[2]).toBe(40_000);
+  /* Bounded above, always. */
+  for (const delay of spacing) expect(delay).toBeLessThanOrEqual(300_000);
+  expect(Math.max(...spacing)).toBe(300_000);
+
+  /* And far fewer requests than a fixed interval would have produced over the same
+     simulated hour. */
+  expect(calls.length).toBeLessThan(30);
+});
+
+test("a 429 is retryable rather than a refusal, and never retires the session", async () => {
+  getStatuses = [429, 429, 200];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await settle();
+  for (let tick = 0; tick < 10; tick += 1) {
+    scheduler.advance(60_000);
+    await settle();
+  }
+  expect(bridgeSessionRetirement("rt_sess_relay")).toBeNull();
+  expect(calls.length).toBeGreaterThanOrEqual(3);
+});
+
+test("unmounting aborts the request in flight and leaves no timer or listener behind", async () => {
+  let release = () => {};
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  plans = [{ kind: "deliver", delivery: delivery(30), ackToken: "ack_30" }];
+  postOutcomes = [{ status: 200, hold: held }];
+
+  const { scheduler, root } = mountWithClock({ pollMs: 10_000 });
+  await settle();
+  confirmDurableDelivery(delivery(30).deliveryId);
+  /* The confirmation wakes the loop rather than fetching beside it, so the clock has
+     to tick before its acknowledgement leaves. */
+  scheduler.advance(0);
+  await settle();
+
+  /* The acknowledgement POST is parked in flight; the operator navigates away. */
+  expect(calls.filter((call) => call.method === "POST")).toHaveLength(1);
+  expect(acknowledgeListeners).toHaveLength(1);
+  flushSync(() => root.unmount());
+  roots = roots.filter((entry) => entry !== root);
+
+  expect(requestSignals.at(-1)!.aborted).toBe(true);
+  expect(acknowledgeListeners).toHaveLength(0);
+  expect(scheduler.pending()).toBe(0);
+
+  release();
+  await settle();
+  /* And nothing rescheduled itself out of the ashes. */
+  expect(scheduler.pending()).toBe(0);
+});
+
+test("a request that never answers is deadlined rather than holding the loop forever", async () => {
+  const neverAnswers = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), method: init?.method ?? "GET", body: null });
+    return await new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => { reject(init.signal!.reason); }, { once: true });
+    });
+  }) as unknown as typeof fetch;
+
+  const scheduler = virtualScheduler();
+  function Probe() {
+    useBridgeReportRelay(client, true, {
+      fetchFn: neverAnswers,
+      pollMs: 10_000,
+      requestTimeoutMs: 8_000,
+      scheduler,
+      random: () => 0,
+    });
+    return null;
+  }
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  const root = createRoot(container as unknown as Element);
+  roots.push(root);
+  flushSync(() => root.render(<Probe />));
+  await settle();
+
+  expect(calls).toHaveLength(1);
+  scheduler.advance(8_000);
+  await settle();
+  /* Deadlined, counted as retryable, and rescheduled — not wedged holding the one
+     in-flight slot for the rest of the call. */
+  expect(scheduler.pending()).toBe(1);
+  scheduler.advance(10_000);
+  await settle();
+  expect(calls).toHaveLength(2);
+});
+
+test("the parked-token sweep is bounded per cycle instead of fanning out the whole store", async () => {
+  for (let index = 0; index < 32; index += 1) {
+    rememberBridgeAcknowledgement(`voice:parked-${index}`, `ack_parked_${index}`, { sessionId: "rt_sess_relay" });
+  }
+  postOutcomes = Array.from({ length: 64 }, () => ({ status: 503 }));
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await settle();
+
+  const firstCycle = calls.filter((call) => call.method === "POST");
+  expect(firstCycle).toHaveLength(4);
+  /* Oldest first: a backlog drains from the batch that has waited longest. */
+  expect((firstCycle[0]!.body as { ackToken: string }).ackToken).toBe("ack_parked_0");
+
+  scheduler.advance(10_000);
+  await settle();
+  expect(calls.filter((call) => call.method === "POST")).toHaveLength(8);
+  /* Nothing was dropped by not being attempted. */
+  expect(pendingBridgeAcknowledgements()).toHaveLength(32);
+});
+
+test("the sweep only spends tokens the current session parked", async () => {
+  rememberBridgeAcknowledgement("voice:from-old-call", "ack_old", { sessionId: "rt_sess_previous" });
+  rememberBridgeAcknowledgement("voice:from-this-call", "ack_mine", { sessionId: "rt_sess_relay" });
+  rememberBridgeAcknowledgement("voice:from-a-reload", "ack_unclaimed", {});
+
+  mountWithClock({ pollMs: 10_000 });
+  await settle();
+
+  const spent = calls.filter((call) => call.method === "POST").map((call) => (call.body as { ackToken: string }).ackToken);
+  /* A token from a previous call names a batch THAT call received; spending it under
+     this credential moves a cursor for reports this session never heard. */
+  expect(spent).not.toContain("ack_old");
+  expect(spent).toContain("ack_mine");
+  /* An unclaimed token is this call's or nobody's, so it is still swept. */
+  expect(spent).toContain("ack_unclaimed");
+});
+
+test("a 409 stops occupying a bounded slot — that token can never settle anything again", async () => {
+  /* Parked forever was the old behaviour: 409 threw, the token was kept, and it sat
+     in a thirty-two entry store displacing tokens that could still settle a batch. */
+  rememberBridgeAcknowledgement("voice:spent", "ack_spent", { sessionId: "rt_sess_relay" });
+  postOutcomes = [{ status: 409 }];
+  mountWithClock({ pollMs: 10_000 });
+  await settle();
+
+  expect(pendingBridgeAcknowledgements()).toEqual([]);
+  expect(bridgeSessionRetirement("rt_sess_relay")).toBeNull();
+});
+
+test("a refusal met while sweeping retires the session before any drain goes out", async () => {
+  rememberBridgeAcknowledgement("voice:parked", "ack_parked", { sessionId: "rt_sess_relay" });
+  postOutcomes = [{ status: 403 }];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 10 * 60_000, 10_000);
+
+  expect(calls.filter((call) => call.method === "GET")).toEqual([]);
+  expect(calls.filter((call) => call.method === "POST")).toHaveLength(1);
+  /* Still parked: a 403 says "not you", never "that batch is settled". */
+  expect(pendingBridgeAcknowledgements()).toHaveLength(1);
+});
+
+test("a batch drained while the session rolls over is dropped rather than misapplied", async () => {
+  plans = [{ kind: "deliver", delivery: delivery(40), ackToken: "ack_40" }];
+  const rolling = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), method: init?.method ?? "GET", body: null });
+    /* The credential rolls while the answer is on the wire. */
+    sessionCredential = "rt_sess_after_rollover";
+    return new Response(JSON.stringify({ ok: true, plan: plans.shift() ?? { kind: "idle" } }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  function Probe() {
+    useBridgeReportRelay(client, true, { fetchFn: rolling, pollMs: 10_000, scheduler: virtualScheduler() });
+    return null;
+  }
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  const root = createRoot(container as unknown as Element);
+  roots.push(root);
+  flushSync(() => root.render(<Probe />));
+  await settle();
+
+  /* The server's cursor did not move, so the batch is handed out again — to the call
+     that can actually speak it. Applying it to a new call would be far worse. */
+  expect(delivered).toEqual([]);
+  expect(pendingBridgeAcknowledgements()).toEqual([]);
 });

--- a/src/hooks/useBridgeReportRelay.dom.test.tsx
+++ b/src/hooks/useBridgeReportRelay.dom.test.tsx
@@ -944,3 +944,36 @@ test("a batch drained while the session rolls over is dropped rather than misapp
   expect(delivered).toEqual([]);
   expect(pendingBridgeAcknowledgements()).toEqual([]);
 });
+
+test("a 5xx met while suspended does not clear the suspension", async () => {
+  /* Only an ACCEPTED response is evidence that the credential is the live root's. A
+     server being unwell says nothing either way, and clearing on it would swap the
+     retirement backoff for the far more aggressive retryable one. */
+  getStatuses = [403, 503, 503, 503, 503];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 30_000, 10_000);
+  const suspended = bridgeSessionRetirement("rt_sess_relay")!;
+  expect(suspended.status).toBe(403);
+
+  /* Past the suspension: the probe goes out and meets a 503. */
+  await runFor(scheduler, 60_000, 10_000);
+  const after = bridgeSessionRetirement("rt_sess_relay");
+  expect(after).not.toBeNull();
+  expect(after!.attempts).toBe(1);
+});
+
+test("an accepted poll clears the suspension so the next refusal starts from the first step", async () => {
+  getStatuses = [403];
+  plans = [{ kind: "idle" }];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 30_000, 10_000);
+  expect(bridgeSessionRetirement("rt_sess_relay")?.attempts).toBe(1);
+
+  await runFor(scheduler, 90_000, 10_000);
+  expect(bridgeSessionRetirement("rt_sess_relay")).toBeNull();
+
+  /* A later refusal is a fresh incident, not a continuation of the old backoff. */
+  getStatuses = [403];
+  await runFor(scheduler, 30_000, 10_000);
+  expect(bridgeSessionRetirement("rt_sess_relay")?.attempts).toBe(1);
+});

--- a/src/hooks/useBridgeReportRelay.dom.test.tsx
+++ b/src/hooks/useBridgeReportRelay.dom.test.tsx
@@ -22,6 +22,7 @@ import {
   type BridgeRelayState,
 } from "./useBridgeReportRelay";
 import type { DeadlineScheduler } from "@/lib/deadline";
+import { BRIDGE_ROOT_PROJECTION_REBUILD_MS } from "@/lib/bridge/gatewayAuthority";
 
 /**
  * The relay drives the loop, in the order that keeps reports exactly-once.
@@ -159,6 +160,7 @@ const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
 function virtualScheduler(): DeadlineScheduler & {
   advance(ms: number): void;
   pending(): number;
+  now(): number;
   delays: number[];
 } {
   let now = 0;
@@ -184,6 +186,7 @@ function virtualScheduler(): DeadlineScheduler & {
       }
     },
     pending: () => timers.size,
+    now: () => now,
   };
 }
 
@@ -603,6 +606,7 @@ function mountWithClock(options: { pollMs?: number; onState?: (state: BridgeRela
       pollMs,
       requestTimeoutMs: REQUEST_TIMEOUT_MS,
       scheduler,
+      now: () => scheduler.now(),
       /* Pinned so a backoff assertion is about the policy rather than the dice. */
       random: () => 0,
       ...(options.onState ? { onState: options.onState } : {}),
@@ -626,18 +630,70 @@ async function runFor(scheduler: ReturnType<typeof virtualScheduler>, totalMs: n
   }
 }
 
-test("thirty simulated minutes of 403 costs one request, not one hundred and eighty", async () => {
+test("thirty simulated minutes of persistent 403 costs a handful of requests, not one hundred and eighty", async () => {
   getStatuses = Array.from({ length: 500 }, () => 403);
   const { scheduler } = mountWithClock({ pollMs: 10_000 });
 
   await runFor(scheduler, 30 * 60_000, 10_000);
 
   const requests = calls.filter((call) => call.url.includes("/api/bridge"));
-  /* One refusal is the whole answer. The credential either is the live root's or is
-     not, and asking again cannot change that. */
-  expect(requests).toHaveLength(1);
-  expect(requests[0]!.method).toBe("GET");
-  expect(bridgeSessionRetirement("rt_sess_relay")).toEqual({ sessionId: "rt_sess_relay", status: 403 });
+  /* A refusal suspends rather than condemns — the authority can refuse a correct
+     successor for up to one projection window — so the loop probes again on a backing
+     -off schedule. Half an hour of a genuinely dead credential is a handful of
+     requests against the one hundred and eighty a fixed ten-second interval produced. */
+  expect(requests.length).toBeGreaterThan(1);
+  expect(requests.length).toBeLessThanOrEqual(8);
+  expect(requests.every((request) => request.method === "GET")).toBe(true);
+
+  const retirement = bridgeSessionRetirement("rt_sess_relay");
+  expect(retirement?.status).toBe(403);
+  /* Backing off: each probe pushes the next one further out, to a ceiling. */
+  expect(retirement!.attempts).toBe(requests.length);
+  expect(retirement!.nextAttemptAt - scheduler.now()).toBeLessThanOrEqual(900_000);
+});
+
+test("the first probe after a 403 lands well after the authority's rebuild window", async () => {
+  /* The authority re-derives its root projection at most once per 30s window, so a
+     correct successor can be refused for up to that long. A probe that came back
+     sooner would be asking a question the server has not had a chance to re-answer. */
+  getStatuses = [403];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 30_000, 10_000);
+  expect(calls).toHaveLength(1);
+
+  const retirement = bridgeSessionRetirement("rt_sess_relay")!;
+  expect(retirement.nextAttemptAt).toBeGreaterThan(BRIDGE_ROOT_PROJECTION_REBUILD_MS);
+});
+
+test("a same-session 403 recovers when the authority starts answering again", async () => {
+  /*
+   * The blocker this closes. A permanent retirement turned the authority's own
+   * transient, self-correcting refusal — the projection window after a handover — into
+   * a call that never spoke again until the tab was reloaded. The credential is
+   * unchanged throughout; only the server's answer changes.
+   */
+  getStatuses = [403];
+  plans = [{ kind: "idle" }, { kind: "idle" }];
+  const { scheduler } = mountWithClock({ pollMs: 10_000 });
+  await runFor(scheduler, 30_000, 10_000);
+
+  expect(calls).toHaveLength(1);
+  expect(bridgeSessionRetirement("rt_sess_relay")?.status).toBe(403);
+
+  /* Past the suspension. The same session id probes again and is served. */
+  await runFor(scheduler, 90_000, 10_000);
+
+  const probes = calls.filter((call) => call.method === "GET");
+  expect(probes.length).toBeGreaterThanOrEqual(2);
+  expect(probes.every((probe) => probe.url.includes("realtimeSessionId=rt_sess_relay"))).toBe(true);
+  /* Recovered: the suspension is gone, so the next poll is ordinary rather than
+     another backoff step. */
+  expect(bridgeSessionRetirement("rt_sess_relay")).toBeNull();
+
+  const beforeSteadyState = calls.length;
+  await runFor(scheduler, 60_000, 10_000);
+  /* Back to the ordinary cadence — roughly one poll per pollMs, not one per backoff. */
+  expect(calls.length - beforeSteadyState).toBeGreaterThanOrEqual(5);
 });
 
 test("a 401 retires the session exactly as a 403 does", async () => {
@@ -645,7 +701,7 @@ test("a 401 retires the session exactly as a 403 does", async () => {
   const { scheduler } = mountWithClock({ pollMs: 10_000 });
   await runFor(scheduler, 5 * 60_000, 10_000);
 
-  expect(calls).toHaveLength(1);
+  expect(calls.length).toBeLessThanOrEqual(4);
   expect(bridgeSessionRetirement("rt_sess_relay")?.status).toBe(401);
 });
 
@@ -676,7 +732,9 @@ test("a refused session stops polling, and a genuinely new session starts clean"
   getStatuses = [403];
   const states: BridgeRelayState[] = [];
   const { scheduler } = mountWithClock({ pollMs: 10_000, onState: (state) => { states.push(state); } });
-  await runFor(scheduler, 60_000, 10_000);
+  /* Inside the suspension window, so the subject is the silence rather than the probe
+     that ends it — recovery has its own test. */
+  await runFor(scheduler, 30_000, 10_000);
 
   expect(calls).toHaveLength(1);
   expect(states.some((state) => state.kind === "retired" && state.sessionId === "rt_sess_relay")).toBe(true);
@@ -852,7 +910,8 @@ test("a refusal met while sweeping retires the session before any drain goes out
   rememberBridgeAcknowledgement("voice:parked", "ack_parked", { sessionId: "rt_sess_relay" });
   postOutcomes = [{ status: 403 }];
   const { scheduler } = mountWithClock({ pollMs: 10_000 });
-  await runFor(scheduler, 10 * 60_000, 10_000);
+  /* Inside the suspension the refusal is the whole story: no drain follows it. */
+  await runFor(scheduler, 30_000, 10_000);
 
   expect(calls.filter((call) => call.method === "GET")).toEqual([]);
   expect(calls.filter((call) => call.method === "POST")).toHaveLength(1);

--- a/src/hooks/useBridgeReportRelay.ts
+++ b/src/hooks/useBridgeReportRelay.ts
@@ -201,13 +201,6 @@ export function bridgeSessionRetirement(sessionId: string): RetiredSession | nul
   return retiredSessions().find((entry) => entry.sessionId === sessionId) ?? null;
 }
 
-/** Whether this session is suspended RIGHT NOW. A suspension whose window has passed
-    is not a refusal any more — it is one probe waiting to happen. */
-export function isBridgeSessionSuspended(sessionId: string, now: number): boolean {
-  const retirement = bridgeSessionRetirement(sessionId);
-  return retirement !== null && now < retirement.nextAttemptAt;
-}
-
 /** Tests only. */
 export function resetBridgeRelayStateForTests(): void {
   relayHost.__llvRetiredBridgeSessions = [];
@@ -587,14 +580,16 @@ export function useBridgeReportRelay(
       if (isAuthorityRefusal(response.status)) {
         return suspend(session, response.status);
       }
-      /* A poll that got through clears an earlier suspension: the refusal was the
-         transient kind the authority's projection window produces, and the backoff
-         must not carry over into the next one. */
-      clearBridgeSessionRetirement(session);
       if (isRetryableStatus(response.status)) return { kind: "retryable" };
       /* Any other non-2xx is a statement about this request, not about the link.
          Repeating it faster changes nothing, so it rejoins the ordinary cadence. */
       if (!response.ok) return { kind: "settled" };
+      /* ACCEPTED — and only now. The refusal that suspended this session was the
+         transient kind the authority's projection window produces, so the backoff must
+         not carry into the next one. Deliberately not cleared on 429 or 5xx: a server
+         being unwell says nothing about whether this credential is the live root's,
+         and those have their own bounded backoff. */
+      clearBridgeSessionRetirement(session);
 
       const payload = await response.json() as { plan?: BridgeDeliveryPlanPayload };
       const plan = payload.plan;

--- a/src/hooks/useBridgeReportRelay.ts
+++ b/src/hooks/useBridgeReportRelay.ts
@@ -9,6 +9,13 @@ import {
   rememberBridgeAcknowledgement,
 } from "@/lib/bridge/pendingAcknowledgements";
 import { BRIDGE_LIVE_BATCH_INTERVAL_MS } from "@/lib/bridge/types";
+import {
+  backoffDelayMs,
+  deadlineSignal,
+  isAbortError,
+  systemScheduler,
+  type DeadlineScheduler,
+} from "@/lib/deadline";
 import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 /**
@@ -36,6 +43,35 @@ import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
  *   write was lost. Acknowledge immediately and nothing else. Skipping this leaves
  *   every later report queued behind something already spoken.
  * - `hold` / `idle` — nothing to do.
+ *
+ * ## What #845 changed, and why
+ *
+ * The loop above was right about exactly-once and wrong about everything to do
+ * with FAILURE. A `setInterval` fired every ten seconds regardless of what the
+ * previous tick learned, every non-2xx was treated as "try again in ten seconds",
+ * no request carried a deadline, and a confirmation listener could start a POST
+ * beside a poll. A stale or non-root `realtimeSessionId` is answered 403 by the
+ * gateway authority — correctly, and forever — so the honest reading of the old
+ * loop is that a legitimately refused session hammered the route six times a
+ * minute for as long as the tab stayed open, each poll asking the server to
+ * rebuild the whole registry, with up to thirty-two parked acknowledgements
+ * fanned out beside it.
+ *
+ * So the shape is now:
+ *
+ * - one owner and one in-flight request. The interval is gone; each cycle
+ *   schedules the next when it finishes, so two cycles cannot overlap and the
+ *   confirmation listener wakes the loop instead of fetching beside it.
+ * - every fetch carries a deadline and an `AbortSignal` descending from an owner
+ *   controller that is aborted on unmount, navigation, call-phase change and
+ *   session change.
+ * - 401/403 RETIRES that exact session id. It is not a transient state; the
+ *   credential either is the live root's or is not, and asking again cannot
+ *   change the answer. A different session id starts clean.
+ * - transport failures, 429 and 5xx are the retryable class, and back off
+ *   exponentially with jitter up to a ceiling.
+ * - parked acknowledgements are swept oldest-first, bounded per cycle, and only
+ *   for the session that parked them.
  */
 
 type BridgeDeliveryPlanPayload =
@@ -53,9 +89,114 @@ export interface BridgeRelayClient {
   realtimeSession(): string | null;
 }
 
+/**
+ * What the relay is doing, as a value.
+ *
+ * Typed and bounded rather than a free-form counter, because "retired" is a
+ * terminal fact about one session id and the surface above has to be able to tell
+ * it apart from "between polls". Exposed for tests and diagnostics; the voice host
+ * does not need it.
+ */
+export type BridgeRelayState =
+  | { kind: "idle" }
+  | { kind: "polling"; sessionId: string }
+  | { kind: "backing-off"; sessionId: string; failures: number; delayMs: number }
+  | { kind: "retired"; sessionId: string; status: number };
+
 /** Slightly under the coalescing window: polling faster cannot produce a batch any
     sooner, and polling slower would add latency the server already bounds. */
 const POLL_MS = Math.floor(BRIDGE_LIVE_BATCH_INTERVAL_MS / 3);
+
+/** Under the poll cadence on purpose: a request that has not answered by then
+    cannot be the reason the next cycle waits, and a hung socket must never be
+    able to hold the single in-flight slot past its own turn. */
+const REQUEST_TIMEOUT_MS = 8_000;
+
+/** The retryable class climbs from the ordinary cadence to five minutes. Past
+    that there is nothing to learn from asking sooner, and the reports are
+    durable — a late batch costs latency, never a loss. */
+const BACKOFF_BASE_MS = POLL_MS;
+const BACKOFF_MAX_MS = 300_000;
+const BACKOFF_JITTER = 0.3;
+
+/**
+ * Parked tokens attempted per cycle.
+ *
+ * The store holds up to thirty-two, and the loop used to fan out all of them on
+ * every tick. Oldest-first and bounded means a backlog drains over a few cycles
+ * instead of turning one poll into a burst; nothing is dropped, because a token
+ * not attempted this cycle is still parked for the next.
+ */
+const MAX_ACK_ATTEMPTS_PER_CYCLE = 4;
+
+/** Session ids whose credential the gateway refused. Bounded, and module-scoped
+    so a call-phase transition — which tears the effect down and builds it again
+    with the same credential — does not resurrect a refused poll. */
+const RETIRED_SESSION_CAPACITY = 16;
+type RetiredSession = { sessionId: string; status: number };
+const relayHost = globalThis as typeof globalThis & { __llvRetiredBridgeSessions?: RetiredSession[] };
+
+function retiredSessions(): RetiredSession[] {
+  return relayHost.__llvRetiredBridgeSessions ??= [];
+}
+
+function retireBridgeSession(sessionId: string, status: number): void {
+  const next = retiredSessions().filter((entry) => entry.sessionId !== sessionId);
+  next.push({ sessionId, status });
+  relayHost.__llvRetiredBridgeSessions = next.slice(-RETIRED_SESSION_CAPACITY);
+}
+
+export function bridgeSessionRetirement(sessionId: string): RetiredSession | null {
+  return retiredSessions().find((entry) => entry.sessionId === sessionId) ?? null;
+}
+
+export function isBridgeSessionRetired(sessionId: string): boolean {
+  return bridgeSessionRetirement(sessionId) !== null;
+}
+
+/** Tests only. */
+export function resetBridgeRelayStateForTests(): void {
+  relayHost.__llvRetiredBridgeSessions = [];
+}
+
+/** 401 and 403 are the gateway saying this credential is not the live root's.
+    Nothing about repeating the question changes the answer. */
+function isAuthorityRefusal(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+/** Contention, rate limiting and server faults are "come back later"; every other
+    4xx is a statement about the request itself, which a retry reproduces exactly. */
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+export interface BridgeRequestOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal | null;
+  scheduler?: DeadlineScheduler;
+}
+
+async function bridgeFetch(
+  request: typeof fetch,
+  input: string,
+  init: RequestInit,
+  options: BridgeRequestOptions,
+): Promise<Response> {
+  const deadline = deadlineSignal(options.timeoutMs ?? REQUEST_TIMEOUT_MS, {
+    signal: options.signal ?? null,
+    scheduler: options.scheduler ?? systemScheduler,
+    reason: "bridge request deadline exceeded",
+  });
+  try {
+    return await request(input, { ...init, signal: deadline.signal });
+  } finally {
+    /* In a `finally` because the interesting case is the one that throws: a
+       transport failure that left the timer armed is a leak that survives the
+       request by the whole timeout. */
+    deadline.release();
+  }
+}
 
 /**
  * The no-call half of the relay (§4): drain at the start of the gateway's turn.
@@ -94,17 +235,45 @@ const NOTHING_PENDING: BridgeTurnStart = { text: "", ackToken: "", commit: () =>
  * is what lets the cursor move then: the token is a value, so it survives being
  * stored beside the delivery key and replayed once.
  */
-export async function commitBridgeTurn(ackToken: string, fetchFn: typeof fetch = fetch): Promise<void> {
+export async function commitBridgeTurn(
+  ackToken: string,
+  fetchFn: typeof fetch = fetch,
+  options: BridgeRequestOptions = {},
+): Promise<void> {
   if (!ackToken) return;
   /* Awaitable and throwing on refusal, so the caller can keep the token when the
      cursor did not actually move. Swallowing the failure here is what left batches
      parked with nothing able to settle them. */
-  const response = await fetchFn("/api/bridge", {
+  const response = await bridgeFetch(fetchFn, "/api/bridge", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ ackToken }),
-  });
-  if (!response.ok) throw new Error(`bridge acknowledgement refused with ${response.status}`);
+  }, options);
+  if (!response.ok) throw new BridgeAcknowledgementRefused(response.status);
+}
+
+/** A refusal that carries its status, so a caller can tell "not you" (401/403)
+    and "that batch is already settled" (409) apart from "come back" (5xx). */
+export class BridgeAcknowledgementRefused extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`bridge acknowledgement refused with ${status}`);
+    this.name = "BridgeAcknowledgementRefused";
+    this.status = status;
+  }
+}
+
+/**
+ * Whether a refused acknowledgement is worth parking any longer.
+ *
+ * 409 is the server saying the token does not name the outstanding batch. That is
+ * terminal in the only direction that matters: the token cannot settle anything
+ * ever again, so keeping it parked would hold a slot in a bounded store — and
+ * before #845 it held one forever. Dropping it costs nothing, because a batch
+ * still outstanding is handed out again with a FRESH token on the next drain.
+ */
+function isSpentAcknowledgement(error: unknown): boolean {
+  return error instanceof BridgeAcknowledgementRefused && error.status === 409;
 }
 
 /**
@@ -119,15 +288,18 @@ export async function commitBridgeTurn(ackToken: string, fetchFn: typeof fetch =
 export async function retirePendingBridgeAcknowledgements(
   fetchFn: typeof fetch = fetch,
   subject: (waitingOn: string) => boolean = () => true,
+  options: BridgeRequestOptions = {},
 ): Promise<void> {
   for (const entry of pendingBridgeAcknowledgements()) {
     if (!subject(entry.waitingOn)) continue;
     try {
-      await commitBridgeTurn(entry.ackToken, fetchFn);
+      await commitBridgeTurn(entry.ackToken, fetchFn, options);
       forgetBridgeAcknowledgement(entry.waitingOn);
-    } catch {
+    } catch (error) {
       /* Kept: the cursor did not move, so this token is still the only thing that can
-         settle its batch. The next drain tries again. */
+         settle its batch. The next drain tries again — unless the server says the
+         token is spent, in which case parking it again only wastes a slot. */
+      if (isSpentAcknowledgement(error)) forgetBridgeAcknowledgement(entry.waitingOn);
     }
   }
 }
@@ -151,7 +323,7 @@ export function useBridgeTurnStartDrain(
          opening a turn — it presents no capability, and must not. */
       const parameters = new URLSearchParams({ mode: "turn-start" });
       if (conversationId) parameters.set("conversationId", conversationId);
-      const response = await request(`/api/bridge?${parameters.toString()}`, { cache: "no-store" });
+      const response = await bridgeFetch(request, `/api/bridge?${parameters.toString()}`, { cache: "no-store" }, {});
       if (!response.ok) return NOTHING_PENDING;
       const payload = await response.json() as { prelude?: { text: string; ackToken: string } | null };
       const prelude = payload.prelude;
@@ -176,142 +348,299 @@ export function useBridgeTurnStartDrain(
   }, [conversationId, enabled, fetchFn]);
 }
 
+export interface BridgeReportRelayOptions {
+  fetchFn?: typeof fetch;
+  pollMs?: number;
+  requestTimeoutMs?: number;
+  /** Injected so thirty simulated minutes cost a few milliseconds. */
+  scheduler?: DeadlineScheduler;
+  random?: () => number;
+  onState?: (state: BridgeRelayState) => void;
+}
+
+/** What one cycle learned, which is the only thing that decides when the next runs. */
+type CycleOutcome =
+  | { kind: "idle" }
+  | { kind: "settled" }
+  | { kind: "retired" }
+  | { kind: "retryable" };
+
 export function useBridgeReportRelay(
   client: BridgeRelayClient | null,
   live: boolean,
-  options: { fetchFn?: typeof fetch; pollMs?: number } = {},
+  options: BridgeReportRelayOptions = {},
 ): void {
   const acknowledgedRef = useRef<string[]>([]);
   const lastBatchAtRef = useRef<Date | null>(null);
-  /* Held in a ref rather than state: a poll in flight must not be restarted by the
-     re-render its own result causes. */
-  const busyRef = useRef(false);
 
-  const fetchFn = options.fetchFn;
+  const { fetchFn, onState, random, scheduler: injectedScheduler } = options;
   const pollMs = options.pollMs ?? POLL_MS;
+  const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+
+  /* The callbacks are read through a ref so a caller that passes an inline
+     `onState` or `random` cannot restart the loop on every render — restarting is
+     what a polling effect must never do, and it is how the previous shape ended up
+     with overlapping fetches. */
+  const callbacksRef = useRef({ onState, random });
+  useEffect(() => { callbacksRef.current = { onState, random }; }, [onState, random]);
 
   useEffect(() => {
     if (!client || !live) return;
     const request = fetchFn ?? fetch;
-    let cancelled = false;
+    const scheduler = injectedScheduler ?? systemScheduler;
+
+    /* One owner for the whole effect. Unmount, navigation and a call-phase change
+       all abort it, and every request descends from it, so nothing survives the
+       thing that wanted it. */
+    const owner = new AbortController();
+    let timer: unknown;
+    let running = false;
+    let stopped = false;
+    let failures = 0;
+    /* Delivery ids the host has confirmed, waiting for the loop to spend their
+       tokens. The listener used to POST directly, which is how a second request
+       appeared beside a poll. */
+    let confirmed: string[] = [];
+
+    const publish = (state: BridgeRelayState): void => {
+      if (stopped) return;
+      callbacksRef.current.onState?.(state);
+    };
+
+    const call = (input: string, init: RequestInit): Promise<Response> => bridgeFetch(request, input, init, {
+      timeoutMs: requestTimeoutMs,
+      signal: owner.signal,
+      scheduler,
+    });
 
     /**
      * Settle a batch, and REPORT WHETHER IT SETTLED.
      *
-     * The version this replaces awaited the fetch and then resolved, whatever came
-     * back. `fetch` rejects only on transport failure, so a 403 from an unauthenticated
+     * `fetch` rejects only on transport failure, so a 403 from an unauthenticated
      * poll, a 409 on a token the server no longer holds, and a 500 mid-write all
-     * resolved as success — and every caller here treats success as permission to
-     * delete the token. The one thing that could settle the batch was thrown away
-     * precisely when the batch had NOT been settled, which loses the reports
-     * permanently: the server's cursor never moved, and nothing is left to move it.
-     *
-     * So a refusal throws, and the token stays parked for the next poll to spend.
+     * resolve as success — and treating success as permission to delete the token
+     * throws away the one thing that could settle the batch precisely when the
+     * batch has NOT been settled. So a refusal throws, carrying its status.
      */
-    const acknowledgeCursor = async (ackToken: string): Promise<void> => {
-      const response = await request("/api/bridge", {
+    const acknowledgeCursor = async (ackToken: string, sessionId: string): Promise<void> => {
+      const response = await call("/api/bridge", {
         method: "POST",
         headers: { "content-type": "application/json" },
         /* The token the batch was handed out with — never a sequence of our own
            choosing, which the server would be right to refuse. */
-        body: JSON.stringify({ ackToken, realtimeSessionId: client.realtimeSession() }),
+        body: JSON.stringify({ ackToken, realtimeSessionId: sessionId }),
       });
-      if (!response.ok) throw new Error(`bridge acknowledgement refused with ${response.status}`);
+      if (!response.ok) throw new BridgeAcknowledgementRefused(response.status);
     };
 
-    const settle = (deliveryId: string): void => {
-      const ackToken = bridgeAcknowledgementFor(deliveryId);
-      if (!ackToken || cancelled) return;
+    /**
+     * Spend the tokens this session parked, oldest first and bounded.
+     *
+     * Sequential, not `Promise.all`: the single in-flight rule is the whole point,
+     * and the drain that follows asks the server a question these answers change.
+     * Returns the refusal status when the gateway rejected the credential, because
+     * that retires the session rather than merely failing this cycle.
+     */
+    const sweepParkedAcknowledgements = async (sessionId: string): Promise<number | null> => {
+      const parked = [
+        ...confirmed.flatMap((deliveryId) => {
+          const ackToken = bridgeAcknowledgementFor(deliveryId);
+          return ackToken ? [{ waitingOn: deliveryId, ackToken }] : [];
+        }),
+        /* Everything else this session parked — a token dropped by a torn-down
+           effect, or one whose POST was refused. A reload mid-call leaves entries
+           with no session recorded; they are this call's or nobody's, so they are
+           swept too rather than stranded. */
+        ...pendingBridgeAcknowledgements().filter((entry) => (
+          entry.waitingOn.startsWith("voice:")
+          && (entry.sessionId === null || entry.sessionId === sessionId)
+        )),
+      ];
+      const seen = new Set<string>();
+      let attempts = 0;
+      for (const entry of parked) {
+        if (stopped || attempts >= MAX_ACK_ATTEMPTS_PER_CYCLE) break;
+        if (seen.has(entry.waitingOn)) continue;
+        seen.add(entry.waitingOn);
+        attempts += 1;
+        try {
+          await acknowledgeCursor(entry.ackToken, sessionId);
+          forgetBridgeAcknowledgement(entry.waitingOn);
+          confirmed = confirmed.filter((deliveryId) => deliveryId !== entry.waitingOn);
+        } catch (error) {
+          if (error instanceof BridgeAcknowledgementRefused && isAuthorityRefusal(error.status)) return error.status;
+          /* Spent tokens stop occupying a bounded slot; everything else stays
+             parked, because it is still the only thing that can settle its batch. */
+          if (isSpentAcknowledgement(error)) {
+            forgetBridgeAcknowledgement(entry.waitingOn);
+            confirmed = confirmed.filter((deliveryId) => deliveryId !== entry.waitingOn);
+          }
+        }
+      }
+      return null;
+    };
+
+    const runCycle = async (): Promise<CycleOutcome> => {
+      const session = client.realtimeSession();
+      /* No credential, no read: the inbox carries deploy nonces. A call that has
+         not finished its SDP exchange has nothing to present yet, and waits — and
+         it must not acknowledge anything either, which is why the sweep sits after
+         this check rather than before it. */
+      if (!session) {
+        publish({ kind: "idle" });
+        return { kind: "idle" };
+      }
+      const retirement = bridgeSessionRetirement(session);
+      if (retirement) {
+        /* Zero requests, for as long as this credential is the one on offer. The
+           timer keeps ticking so a genuinely new session is noticed, which costs one
+           string comparison rather than a round trip. */
+        publish({ kind: "retired", sessionId: session, status: retirement.status });
+        return { kind: "retired" };
+      }
+      publish({ kind: "polling", sessionId: session });
+
+      const refusedBySweep = await sweepParkedAcknowledgements(session);
+      if (refusedBySweep !== null) {
+        retireBridgeSession(session, refusedBySweep);
+        publish({ kind: "retired", sessionId: session, status: refusedBySweep });
+        return { kind: "retired" };
+      }
+      if (stopped || client.realtimeSession() !== session) return { kind: "settled" };
+
+      const parameters = new URLSearchParams({ realtimeSessionId: session });
+      for (const id of acknowledgedRef.current) parameters.append("acked", id);
+      if (lastBatchAtRef.current) parameters.set("lastBatchAt", lastBatchAtRef.current.toISOString());
+      const response = await call(`/api/bridge?${parameters.toString()}`, { cache: "no-store" });
+
+      if (isAuthorityRefusal(response.status)) {
+        retireBridgeSession(session, response.status);
+        publish({ kind: "retired", sessionId: session, status: response.status });
+        return { kind: "retired" };
+      }
+      if (isRetryableStatus(response.status)) return { kind: "retryable" };
+      /* Any other non-2xx is a statement about this request, not about the link.
+         Repeating it faster changes nothing, so it rejoins the ordinary cadence. */
+      if (!response.ok) return { kind: "settled" };
+
+      const payload = await response.json() as { plan?: BridgeDeliveryPlanPayload };
+      const plan = payload.plan;
+      /* The credential may have rolled while this was in flight. The server's cursor
+         did not move, so dropping the answer costs a repeat at worst — and applying
+         a previous call's batch to a new one would be far worse. */
+      if (!plan || stopped || client.realtimeSession() !== session) return { kind: "settled" };
+
+      if (plan.kind === "deliver") {
+        /* Enqueue only. `reconcileWorkerDeliveries` puts the batch in an in-memory
+           queue and returns; the host has not written anything yet. Advancing the
+           cursor here would invert exactly-once — a crash in between loses the report
+           while the cursor claims it was delivered — so the batch is parked until the
+           host confirms.
+
+           Parked OUTSIDE this effect, and now stamped with the session that drained
+           it, so a call-phase transition cannot strand it and a LATER call cannot
+           spend it against a credential that never received it. */
+        rememberBridgeAcknowledgement(plan.delivery.deliveryId, plan.ackToken, { sessionId: session });
+        client.reconcileWorkerDeliveries([plan.delivery]);
+        lastBatchAtRef.current = new Date();
+        return { kind: "settled" };
+      }
+      if (plan.kind !== "already-acknowledged") return { kind: "settled" };
+      /* Already spoken and provably received; this only heals the cursor. Nothing is
+         parked here because there is no delivery left to wait on — the server hands
+         out a fresh token for the same batch on the next GET. */
+      try {
+        await acknowledgeCursor(plan.ackToken, session);
+      } catch (error) {
+        if (error instanceof BridgeAcknowledgementRefused && isAuthorityRefusal(error.status)) {
+          retireBridgeSession(session, error.status);
+          publish({ kind: "retired", sessionId: session, status: error.status });
+          return { kind: "retired" };
+        }
+        if (!isSpentAcknowledgement(error)) return { kind: "retryable" };
+      }
+      return { kind: "settled" };
+    };
+
+    const schedule = (delayMs: number): void => {
+      if (stopped) return;
+      if (timer !== undefined) scheduler.clearTimeout(timer);
+      timer = scheduler.setTimeout(() => {
+        timer = undefined;
+        void cycle();
+      }, delayMs);
+    };
+
+    /* One in flight, always. A wake that lands mid-cycle is absorbed by the
+       reschedule the cycle already performs when it finishes. */
+    const wake = (): void => {
+      if (stopped || running) return;
+      schedule(0);
+    };
+
+    const cycle = async (): Promise<void> => {
+      if (stopped || running) return;
+      running = true;
+      let outcome: CycleOutcome;
+      try {
+        outcome = await runCycle();
+      } catch (error) {
+        /* An aborted request is this effect being torn down or deadlined, never an
+           incident. Everything else is the retryable class: the reports are durable
+           and the cursor did not move, and surfacing a transport blip mid-call would
+           be noise on the one surface that must stay calm. */
+        outcome = isAbortError(error) && stopped ? { kind: "idle" } : { kind: "retryable" };
+      } finally {
+        running = false;
+      }
+      if (stopped) return;
+      if (outcome.kind === "retryable") {
+        failures += 1;
+        const delayMs = backoffDelayMs(failures, {
+          baseMs: BACKOFF_BASE_MS,
+          maxMs: BACKOFF_MAX_MS,
+          jitter: BACKOFF_JITTER,
+          ...(callbacksRef.current.random ? { random: callbacksRef.current.random } : {}),
+        });
+        const session = client.realtimeSession();
+        if (session) publish({ kind: "backing-off", sessionId: session, failures, delayMs });
+        schedule(delayMs);
+        return;
+      }
+      failures = 0;
+      schedule(pollMs);
+    };
+
+    /* Waking rather than fetching. The confirmation arrives on the host's schedule,
+       not the poll's, and starting a POST here is what let two requests be in flight
+       at once. The loop owns the socket; this only tells it there is work. */
+    const releaseAcknowledged = client.onDeliveryAcknowledged((deliveryId) => {
+      if (stopped) return;
+      /* A confirmation for something this relay never handed out settles nothing, and
+         waking on it would turn every unrelated host event into a cycle. */
+      if (!bridgeAcknowledgementFor(deliveryId)) return;
       /* Now — and only now — has the report provably reached the session. */
       acknowledgedRef.current = [...acknowledgedRef.current, deliveryId].slice(-256);
-      void acknowledgeCursor(ackToken)
-        /* Only an ACCEPTED acknowledgement drops the token. `acknowledgeCursor` now
-           throws on a refusal, so this `.then` no longer fires for a 403 or a 409 —
-           which is what used to delete the token while the cursor stood still. */
-        .then(() => forgetBridgeAcknowledgement(deliveryId))
-        .catch(() => {
-          /* The cursor did not move, so the token is still the only thing that can
-             settle this batch. It stays parked, and the poll's retry sweep spends it. */
-        });
-    };
-    const releaseAcknowledged = client.onDeliveryAcknowledged(settle);
+      confirmed = [...confirmed.filter((entry) => entry !== deliveryId), deliveryId].slice(-256);
+      wake();
+    });
 
-    const poll = async (): Promise<void> => {
-      if (busyRef.current) return;
-      busyRef.current = true;
-      try {
-        const session = client.realtimeSession();
-        /* No credential, no read: the inbox carries deploy nonces. A call that has
-           not finished its SDP exchange has nothing to present yet, and waits — and
-           it must not acknowledge anything either, which is why the retry below sits
-           after this check rather than before it. */
-        if (!session) return;
+    /* A hard navigation never unmounts the tree, so the effect cleanup does not run
+       and an in-flight request would be left to the browser. Symmetrically removed
+       below, so this cannot accumulate across call phases. */
+    const abandon = () => { owner.abort(new Error("bridge relay page hidden")); };
+    const view = typeof window === "undefined" ? null : window;
+    view?.addEventListener("pagehide", abandon);
 
-        /* Autonomous retry. A token parked by a torn-down effect, a reload mid-call,
-           or a refused POST is spent here rather than waiting for a confirmation that
-           already happened and will not fire again.
+    void cycle();
 
-           AWAITED, not fired off. The drain below reports what is still outstanding,
-           and starting it while these are in flight asks the server a question whose
-           answer these retries are busy changing: the GET would see the batch still
-           unsettled and hand out a second token for it, so the same reports come back
-           and the acknowledgement that lands second is refused against a cursor that
-           already moved. One at a time is also cheap here — the whole point is that
-           there is usually nothing parked. */
-        await Promise.all(pendingBridgeAcknowledgements().map(async (entry) => {
-          if (!entry.waitingOn.startsWith("voice:")) return;
-          try {
-            await acknowledgeCursor(entry.ackToken);
-            forgetBridgeAcknowledgement(entry.waitingOn);
-          } catch {
-            /* Still the only thing that can settle this batch; the next poll retries. */
-          }
-        }));
-        if (cancelled) return;
-
-        const parameters = new URLSearchParams({ realtimeSessionId: session });
-        for (const id of acknowledgedRef.current) parameters.append("acked", id);
-        if (lastBatchAtRef.current) parameters.set("lastBatchAt", lastBatchAtRef.current.toISOString());
-        const response = await request(`/api/bridge?${parameters.toString()}`, { cache: "no-store" });
-        if (!response.ok || cancelled) return;
-        const payload = await response.json() as { plan?: BridgeDeliveryPlanPayload };
-        const plan = payload.plan;
-        if (!plan || cancelled) return;
-
-        if (plan.kind === "deliver") {
-          /* Enqueue only. `reconcileWorkerDeliveries` puts the batch in an
-             in-memory queue and returns; the host has not written anything yet.
-             Advancing the cursor here would invert exactly-once — a crash in
-             between loses the report while the cursor claims it was delivered — so
-             the batch is parked until the host confirms, above. */
-          /* Parked OUTSIDE this effect: a call-phase transition tears the effect down,
-             and the host's confirmation would then arrive with nothing left to spend. */
-          rememberBridgeAcknowledgement(plan.delivery.deliveryId, plan.ackToken);
-          client.reconcileWorkerDeliveries([plan.delivery]);
-          lastBatchAtRef.current = new Date();
-          return;
-        }
-        if (plan.kind !== "already-acknowledged") return;
-        /* Already spoken and provably received; this only heals the cursor. A refusal
-           throws into the poll's own catch, and the server hands out a fresh token for
-           the same batch on the next GET — nothing is parked here because there is no
-           delivery left to wait on. */
-        await acknowledgeCursor(plan.ackToken);
-      } catch {
-        /* A dropped poll is a retry, not an incident: the reports are durable and
-           the cursor did not move. Surfacing a transport blip mid-call would be
-           noise on the one surface that must stay calm. */
-      } finally {
-        busyRef.current = false;
-      }
-    };
-
-    void poll();
-    const timer = setInterval(() => { void poll(); }, pollMs);
     return () => {
-      cancelled = true;
+      stopped = true;
+      view?.removeEventListener("pagehide", abandon);
       releaseAcknowledged();
-      clearInterval(timer);
+      if (timer !== undefined) scheduler.clearTimeout(timer);
+      timer = undefined;
+      owner.abort(new Error("bridge relay stopped"));
     };
-  }, [client, fetchFn, live, pollMs]);
+  }, [client, fetchFn, injectedScheduler, live, pollMs, requestTimeoutMs]);
 }

--- a/src/hooks/useBridgeReportRelay.ts
+++ b/src/hooks/useBridgeReportRelay.ts
@@ -101,7 +101,7 @@ export type BridgeRelayState =
   | { kind: "idle" }
   | { kind: "polling"; sessionId: string }
   | { kind: "backing-off"; sessionId: string; failures: number; delayMs: number }
-  | { kind: "retired"; sessionId: string; status: number };
+  | { kind: "retired"; sessionId: string; status: number; attempts: number; retryInMs: number };
 
 /** Slightly under the coalescing window: polling faster cannot produce a batch any
     sooner, and polling slower would add latency the server already bounds. */
@@ -129,29 +129,83 @@ const BACKOFF_JITTER = 0.3;
  */
 const MAX_ACK_ATTEMPTS_PER_CYCLE = 4;
 
-/** Session ids whose credential the gateway refused. Bounded, and module-scoped
-    so a call-phase transition — which tears the effect down and builds it again
-    with the same credential — does not resurrect a refused poll. */
+/**
+ * Sessions the gateway refused — SUSPENDED, not condemned.
+ *
+ * The first version of this treated one 403 as terminal, on the reasoning that the
+ * credential either is the live root's or is not. That is true of the credential and
+ * false of the ANSWER: the gateway authority resolves the root through a projection
+ * that re-derives at most once per window, so a correct successor can be refused for
+ * up to one window after a handover. A permanent retirement turns that transient,
+ * self-correcting refusal into a call that never speaks again until the tab is
+ * reloaded.
+ *
+ * So a refusal suspends the session until `nextAttemptAt`, and the suspension backs
+ * off from well over the authority's rebuild window up to a ceiling. One probe after
+ * the window is enough to recover; a genuinely dead credential costs a handful of
+ * requests across half an hour instead of one hundred and eighty.
+ *
+ * The record is module-scoped because a call-phase transition tears the effect down
+ * and builds it again with the same credential — an in-effect timer would let that
+ * transition reset the backoff and hand the storm straight back.
+ */
 const RETIRED_SESSION_CAPACITY = 16;
-type RetiredSession = { sessionId: string; status: number };
+
+/** Comfortably above `BRIDGE_ROOT_PROJECTION_REBUILD_MS` (30s), so the first probe
+    lands after the authority has had its chance to re-derive. */
+const RETIREMENT_BASE_MS = 60_000;
+const RETIREMENT_MAX_MS = 900_000;
+const RETIREMENT_JITTER = 0.2;
+
+type RetiredSession = { sessionId: string; status: number; attempts: number; nextAttemptAt: number };
 const relayHost = globalThis as typeof globalThis & { __llvRetiredBridgeSessions?: RetiredSession[] };
 
 function retiredSessions(): RetiredSession[] {
   return relayHost.__llvRetiredBridgeSessions ??= [];
 }
 
-function retireBridgeSession(sessionId: string, status: number): void {
-  const next = retiredSessions().filter((entry) => entry.sessionId !== sessionId);
-  next.push({ sessionId, status });
+function retireBridgeSession(
+  sessionId: string,
+  status: number,
+  now: number,
+  random?: () => number,
+): RetiredSession {
+  const previous = bridgeSessionRetirement(sessionId);
+  const attempts = (previous?.attempts ?? 0) + 1;
+  const entry: RetiredSession = {
+    sessionId,
+    status,
+    attempts,
+    nextAttemptAt: now + backoffDelayMs(attempts, {
+      baseMs: RETIREMENT_BASE_MS,
+      maxMs: RETIREMENT_MAX_MS,
+      jitter: RETIREMENT_JITTER,
+      ...(random ? { random } : {}),
+    }),
+  };
+  const next = retiredSessions().filter((candidate) => candidate.sessionId !== sessionId);
+  next.push(entry);
   relayHost.__llvRetiredBridgeSessions = next.slice(-RETIRED_SESSION_CAPACITY);
+  return entry;
+}
+
+/** Dropped only by a session that went on to succeed — proof the refusal was the
+    transient kind. */
+function clearBridgeSessionRetirement(sessionId: string): void {
+  const next = retiredSessions().filter((entry) => entry.sessionId !== sessionId);
+  if (next.length === retiredSessions().length) return;
+  relayHost.__llvRetiredBridgeSessions = next;
 }
 
 export function bridgeSessionRetirement(sessionId: string): RetiredSession | null {
   return retiredSessions().find((entry) => entry.sessionId === sessionId) ?? null;
 }
 
-export function isBridgeSessionRetired(sessionId: string): boolean {
-  return bridgeSessionRetirement(sessionId) !== null;
+/** Whether this session is suspended RIGHT NOW. A suspension whose window has passed
+    is not a refusal any more — it is one probe waiting to happen. */
+export function isBridgeSessionSuspended(sessionId: string, now: number): boolean {
+  const retirement = bridgeSessionRetirement(sessionId);
+  return retirement !== null && now < retirement.nextAttemptAt;
 }
 
 /** Tests only. */
@@ -354,6 +408,9 @@ export interface BridgeReportRelayOptions {
   requestTimeoutMs?: number;
   /** Injected so thirty simulated minutes cost a few milliseconds. */
   scheduler?: DeadlineScheduler;
+  /** Read whenever a suspension is checked or recorded. Injected alongside the
+      scheduler so a simulated half hour and the backoff it drives share one clock. */
+  now?: () => number;
   random?: () => number;
   onState?: (state: BridgeRelayState) => void;
 }
@@ -362,7 +419,7 @@ export interface BridgeReportRelayOptions {
 type CycleOutcome =
   | { kind: "idle" }
   | { kind: "settled" }
-  | { kind: "retired" }
+  | { kind: "retired"; retryInMs: number }
   | { kind: "retryable" };
 
 export function useBridgeReportRelay(
@@ -373,7 +430,7 @@ export function useBridgeReportRelay(
   const acknowledgedRef = useRef<string[]>([]);
   const lastBatchAtRef = useRef<Date | null>(null);
 
-  const { fetchFn, onState, random, scheduler: injectedScheduler } = options;
+  const { fetchFn, now: injectedNow, onState, random, scheduler: injectedScheduler } = options;
   const pollMs = options.pollMs ?? POLL_MS;
   const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
 
@@ -388,6 +445,7 @@ export function useBridgeReportRelay(
     if (!client || !live) return;
     const request = fetchFn ?? fetch;
     const scheduler = injectedScheduler ?? systemScheduler;
+    const now = injectedNow ?? Date.now;
 
     /* One owner for the whole effect. Unmount, navigation and a call-phase change
        all abort it, and every request descends from it, so nothing survives the
@@ -480,6 +538,15 @@ export function useBridgeReportRelay(
       return null;
     };
 
+    /* One place that records a refusal, so the backoff, the published state and the
+       delay the loop waits are guaranteed to agree. */
+    const suspend = (session: string, status: number): CycleOutcome => {
+      const retirement = retireBridgeSession(session, status, now(), callbacksRef.current.random);
+      const retryInMs = Math.max(0, retirement.nextAttemptAt - now());
+      publish({ kind: "retired", sessionId: session, status, attempts: retirement.attempts, retryInMs });
+      return { kind: "retired", retryInMs };
+    };
+
     const runCycle = async (): Promise<CycleOutcome> => {
       const session = client.realtimeSession();
       /* No credential, no read: the inbox carries deploy nonces. A call that has
@@ -491,20 +558,24 @@ export function useBridgeReportRelay(
         return { kind: "idle" };
       }
       const retirement = bridgeSessionRetirement(session);
-      if (retirement) {
-        /* Zero requests, for as long as this credential is the one on offer. The
-           timer keeps ticking so a genuinely new session is noticed, which costs one
-           string comparison rather than a round trip. */
-        publish({ kind: "retired", sessionId: session, status: retirement.status });
-        return { kind: "retired" };
+      if (retirement && now() < retirement.nextAttemptAt) {
+        /* Zero requests while the suspension holds. The timer keeps ticking so a
+           genuinely new session is noticed, which costs one string comparison rather
+           than a round trip. */
+        publish({
+          kind: "retired",
+          sessionId: session,
+          status: retirement.status,
+          attempts: retirement.attempts,
+          retryInMs: Math.max(0, retirement.nextAttemptAt - now()),
+        });
+        return { kind: "retired", retryInMs: Math.max(0, retirement.nextAttemptAt - now()) };
       }
       publish({ kind: "polling", sessionId: session });
 
       const refusedBySweep = await sweepParkedAcknowledgements(session);
       if (refusedBySweep !== null) {
-        retireBridgeSession(session, refusedBySweep);
-        publish({ kind: "retired", sessionId: session, status: refusedBySweep });
-        return { kind: "retired" };
+        return suspend(session, refusedBySweep);
       }
       if (stopped || client.realtimeSession() !== session) return { kind: "settled" };
 
@@ -514,10 +585,12 @@ export function useBridgeReportRelay(
       const response = await call(`/api/bridge?${parameters.toString()}`, { cache: "no-store" });
 
       if (isAuthorityRefusal(response.status)) {
-        retireBridgeSession(session, response.status);
-        publish({ kind: "retired", sessionId: session, status: response.status });
-        return { kind: "retired" };
+        return suspend(session, response.status);
       }
+      /* A poll that got through clears an earlier suspension: the refusal was the
+         transient kind the authority's projection window produces, and the backoff
+         must not carry over into the next one. */
+      clearBridgeSessionRetirement(session);
       if (isRetryableStatus(response.status)) return { kind: "retryable" };
       /* Any other non-2xx is a statement about this request, not about the link.
          Repeating it faster changes nothing, so it rejoins the ordinary cadence. */
@@ -553,9 +626,7 @@ export function useBridgeReportRelay(
         await acknowledgeCursor(plan.ackToken, session);
       } catch (error) {
         if (error instanceof BridgeAcknowledgementRefused && isAuthorityRefusal(error.status)) {
-          retireBridgeSession(session, error.status);
-          publish({ kind: "retired", sessionId: session, status: error.status });
-          return { kind: "retired" };
+          return suspend(session, error.status);
         }
         if (!isSpentAcknowledgement(error)) return { kind: "retryable" };
       }
@@ -608,7 +679,10 @@ export function useBridgeReportRelay(
         return;
       }
       failures = 0;
-      schedule(pollMs);
+      /* Capped at the ordinary cadence even when the suspension is much longer: the
+         wake costs one string comparison and no request, and it is how a genuinely new
+         credential is picked up without waiting out the refused one's backoff. */
+      schedule(outcome.kind === "retired" ? Math.min(outcome.retryInMs, pollMs) : pollMs);
     };
 
     /* Waking rather than fetching. The confirmation arrives on the host's schedule,
@@ -642,5 +716,5 @@ export function useBridgeReportRelay(
       timer = undefined;
       owner.abort(new Error("bridge relay stopped"));
     };
-  }, [client, fetchFn, injectedScheduler, live, pollMs, requestTimeoutMs]);
+  }, [client, fetchFn, injectedNow, injectedScheduler, live, pollMs, requestTimeoutMs]);
 }

--- a/src/lib/bridge/gatewayAuthority.test.ts
+++ b/src/lib/bridge/gatewayAuthority.test.ts
@@ -68,15 +68,37 @@ test("thirty minutes of successful polls rebuild the registry projection exactly
   expect(registry.rebuilds()).toBe(1);
 });
 
-test("a refused credential against a healthy root costs no registry read at any rate", () => {
+test("five thousand refused attempts cost at most one registry read per window", () => {
   /* The storm, from the server's side: before #845 each of these rebuilt the whole
-     registry, and the relay produced six a minute per open tab, forever. */
-  const registry = sources();
+     registry, and the relay produced six a minute per open tab, forever. The bound has
+     to hold against RATE — five thousand attempts inside one window is one read — and
+     it has to keep holding as windows pass, which is what lets a mismatch still be the
+     thing that adopts a successor. */
+  let now = 0;
+  const registry = sources({ now: () => now });
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+  expect(registry.rebuilds()).toBe(1);
+
+  for (let window = 0; window < 6; window += 1) {
+    const before = registry.rebuilds();
+    for (let attempt = 0; attempt < 5_000; attempt += 1) {
+      expect(authenticateBridgeGateway("rt_sess_not_the_root", registry.injected).ok).toBe(false);
+    }
+    expect(registry.rebuilds() - before).toBeLessThanOrEqual(1);
+    now += BRIDGE_ROOT_PROJECTION_REBUILD_MS;
+  }
+  /* Thirty thousand refusals across six windows: at most one read each. */
+  expect(registry.rebuilds()).toBeLessThanOrEqual(7);
+});
+
+test("a healthy root's own polls never spend the rebuild budget", () => {
+  let now = 0;
+  const registry = sources({ now: () => now });
   expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
   registry.poison();
-
-  for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    expect(authenticateBridgeGateway("rt_sess_not_the_root", registry.injected).ok).toBe(false);
+  for (let poll = 0; poll < 180; poll += 1) {
+    now += 10_000;
+    expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
   }
   expect(registry.rebuilds()).toBe(1);
 });
@@ -110,13 +132,17 @@ test("a root with no live call refuses every credential", () => {
   expect(authenticateBridgeGateway("anything", registry.injected).ok).toBe(false);
 });
 
-test("a rollover is adopted on the first poll of the successor, not one window later", () => {
+test("a handover while the predecessor's call is STILL LIVE promotes the successor", () => {
+  /*
+   * The blocker this closes. A handover does not have to end the predecessor's call:
+   * B can be promoted while A is still on the line. The projection used to refuse for
+   * free whenever the projected root had a live session, so it pinned A — A kept
+   * reading the deploy nonces it was no longer entitled to, and B was refused for as
+   * long as A stayed connected.
+   */
   let now = 0;
-  let live: Record<string, string | null> = { [ROOT]: SESSION };
-  const registry = sources({
-    now: () => now,
-    live: (conversationId) => live[conversationId] ?? null,
-  });
+  const live: Record<string, string | null> = { [ROOT]: SESSION };
+  const registry = sources({ now: () => now, live: (conversationId) => live[conversationId] ?? null });
   expect(authenticateBridgeGateway(SESSION, registry.injected)).toEqual({ ok: true, conversationId: ROOT });
 
   /* Ten quiet minutes of healthy polling, costing nothing. */
@@ -126,19 +152,62 @@ test("a rollover is adopted on the first poll of the successor, not one window l
   }
   expect(registry.rebuilds()).toBe(1);
 
-  /* The root session rolls over: the previous call ends and a successor takes it. */
+  /* The handover. A's call stays UP — that is the whole point of this case. */
   const successor = "conversation_root_successor";
   const successorSession = "rt_sess_successor";
-  live = { [successor]: successorSession };
+  live[successor] = successorSession;
   registry.rollTo(successor);
 
-  /* The successor's very first poll is served, because a projected root with no live
-     call is exactly the condition that spends the rebuild budget. */
+  /* The successor is served immediately: a healthy root never spends the budget, so
+     the window is long expired by the time a handover happens. */
   expect(authenticateBridgeGateway(successorSession, registry.injected))
     .toEqual({ ok: true, conversationId: successor });
   expect(registry.rebuilds()).toBe(2);
 
-  /* And the predecessor's credential is dead the moment its call is. */
+  /* And the demoted predecessor is refused from that moment, though its call is still
+     live and it still holds a valid session id for it. */
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+});
+
+test("a successor is accepted within one window even when the budget was just spent", () => {
+  let now = 0;
+  const live: Record<string, string | null> = { [ROOT]: SESSION };
+  const registry = sources({ now: () => now, live: (conversationId) => live[conversationId] ?? null });
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+
+  const successor = "conversation_root_successor";
+  const successorSession = "rt_sess_successor";
+  live[successor] = successorSession;
+  registry.rollTo(successor);
+
+  /* Immediately after the warm build, so the window is still closed. */
+  now += 1_000;
+  expect(authenticateBridgeGateway(successorSession, registry.injected).ok).toBe(false);
+  /* Refused from the memo, without spending a read. */
+  expect(registry.rebuilds()).toBe(1);
+
+  /* One window later, and no later than that. */
+  now += BRIDGE_ROOT_PROJECTION_REBUILD_MS;
+  expect(authenticateBridgeGateway(successorSession, registry.injected))
+    .toEqual({ ok: true, conversationId: successor });
+  expect(registry.rebuilds()).toBe(2);
+  /* The predecessor is refused within the same window, by the same re-derivation. */
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+});
+
+test("a rollover that ends the predecessor's call is adopted the same way", () => {
+  let now = 0;
+  let live: Record<string, string | null> = { [ROOT]: SESSION };
+  const registry = sources({ now: () => now, live: (conversationId) => live[conversationId] ?? null });
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+  now += 600_000;
+
+  const successor = "conversation_root_successor";
+  live = { [successor]: "rt_sess_successor" };
+  registry.rollTo(successor);
+
+  expect(authenticateBridgeGateway("rt_sess_successor", registry.injected))
+    .toEqual({ ok: true, conversationId: successor });
   expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
 });
 
@@ -146,12 +215,16 @@ test("a stale projection can never authorise a credential its root does not hold
   /* The one thing the projection must not buy: authority for a caller who merely
      guesses. The presented id has to equal what the projected root's own live host
      holds right now, so a stale projection widens nothing. */
-  const registry = sources();
+  let now = 0;
+  const registry = sources({ now: () => now });
   expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
   registry.poison();
+  /* Inside the window, so a mismatch is answered from the memo and the poisoned read
+     is never reached — the refusal itself is what is under test. */
   for (const guess of ["rt_sess_gatewa", "rt_sess_gateway_", "RT_SESS_GATEWAY", "conversation_root"]) {
     expect(authenticateBridgeGateway(guess, registry.injected).ok).toBe(false);
   }
+  now += 1_000;
   /* Whitespace is trimmed, so the genuine credential still works either way. */
   expect(authenticateBridgeGateway(` ${SESSION} `, registry.injected).ok).toBe(true);
 });

--- a/src/lib/bridge/gatewayAuthority.test.ts
+++ b/src/lib/bridge/gatewayAuthority.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, expect, test } from "bun:test";
+
+import {
+  authenticateBridgeGateway,
+  BRIDGE_ROOT_PROJECTION_REBUILD_MS,
+  resetBridgeRootProjectionForTests,
+  setBridgeGatewaySourcesForTests,
+  type BridgeGatewaySources,
+} from "./gatewayAuthority";
+
+/**
+ * #845 — the authority is unchanged; what it COSTS is not.
+ *
+ * `rootConversationId` materialises the whole registry and walks every conversation.
+ * At production shape that is roughly 4.7k conversations and 18.5k registry rows, and
+ * the relay above asked for it every ten seconds per open call — forever, for a call
+ * whose credential the gateway was refusing. These tests are about the bound: what a
+ * poll costs when it succeeds, what a refusal costs when it does not, and that
+ * neither one loosened who is allowed in.
+ */
+
+const ROOT = "conversation_root";
+const SESSION = "rt_sess_gateway";
+
+/** Counts whole-registry projections, and can be poisoned to prove one never runs. */
+function sources(options: {
+  root?: string | null;
+  live?: (conversationId: string) => string | null;
+  now?: () => number;
+} = {}) {
+  let poisoned = false;
+  let rebuilds = 0;
+  let root = options.root === undefined ? ROOT : options.root;
+  const injected: BridgeGatewaySources = {
+    rootConversationId: () => {
+      rebuilds += 1;
+      if (poisoned) throw new Error("whole-registry read on a path that must never take one");
+      return root;
+    },
+    liveRealtimeSessionId: options.live ?? ((conversationId) => (conversationId === ROOT ? SESSION : null)),
+    ...(options.now ? { now: options.now } : {}),
+  };
+  return {
+    injected,
+    rebuilds: () => rebuilds,
+    poison: () => { poisoned = true; },
+    rollTo: (next: string | null) => { root = next; },
+  };
+}
+
+beforeEach(() => {
+  setBridgeGatewaySourcesForTests(null);
+  resetBridgeRootProjectionForTests();
+});
+
+test("thirty minutes of successful polls rebuild the registry projection exactly once", () => {
+  const registry = sources();
+  /* Warm-up: the first caller is entitled to pay for the projection. */
+  expect(authenticateBridgeGateway(SESSION, registry.injected)).toEqual({ ok: true, conversationId: ROOT });
+  expect(registry.rebuilds()).toBe(1);
+
+  /* Poisoned: any further whole-registry read is now a test failure rather than a
+     number to reason about. */
+  registry.poison();
+  for (let poll = 0; poll < 180; poll += 1) {
+    expect(authenticateBridgeGateway(SESSION, registry.injected)).toEqual({ ok: true, conversationId: ROOT });
+  }
+  expect(registry.rebuilds()).toBe(1);
+});
+
+test("a refused credential against a healthy root costs no registry read at any rate", () => {
+  /* The storm, from the server's side: before #845 each of these rebuilt the whole
+     registry, and the relay produced six a minute per open tab, forever. */
+  const registry = sources();
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+  registry.poison();
+
+  for (let attempt = 0; attempt < 5_000; attempt += 1) {
+    expect(authenticateBridgeGateway("rt_sess_not_the_root", registry.injected).ok).toBe(false);
+  }
+  expect(registry.rebuilds()).toBe(1);
+});
+
+test("no credential is refused without reading anything at all", () => {
+  const registry = sources();
+  registry.poison();
+  for (const presented of [null, undefined, "", "   "]) {
+    expect(authenticateBridgeGateway(presented, registry.injected).ok).toBe(false);
+  }
+  expect(registry.rebuilds()).toBe(0);
+});
+
+test("no root fails closed, and repeated asking stays bounded", () => {
+  let now = 0;
+  const registry = sources({ root: null, now: () => now });
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+  }
+  /* One inside the window, however many callers arrive. */
+  expect(registry.rebuilds()).toBe(1);
+
+  now += BRIDGE_ROOT_PROJECTION_REBUILD_MS;
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+  expect(registry.rebuilds()).toBe(2);
+});
+
+test("a root with no live call refuses every credential", () => {
+  const registry = sources({ live: () => null });
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+  expect(authenticateBridgeGateway("anything", registry.injected).ok).toBe(false);
+});
+
+test("a rollover is adopted on the first poll of the successor, not one window later", () => {
+  let now = 0;
+  let live: Record<string, string | null> = { [ROOT]: SESSION };
+  const registry = sources({
+    now: () => now,
+    live: (conversationId) => live[conversationId] ?? null,
+  });
+  expect(authenticateBridgeGateway(SESSION, registry.injected)).toEqual({ ok: true, conversationId: ROOT });
+
+  /* Ten quiet minutes of healthy polling, costing nothing. */
+  for (let poll = 0; poll < 60; poll += 1) {
+    now += 10_000;
+    expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+  }
+  expect(registry.rebuilds()).toBe(1);
+
+  /* The root session rolls over: the previous call ends and a successor takes it. */
+  const successor = "conversation_root_successor";
+  const successorSession = "rt_sess_successor";
+  live = { [successor]: successorSession };
+  registry.rollTo(successor);
+
+  /* The successor's very first poll is served, because a projected root with no live
+     call is exactly the condition that spends the rebuild budget. */
+  expect(authenticateBridgeGateway(successorSession, registry.injected))
+    .toEqual({ ok: true, conversationId: successor });
+  expect(registry.rebuilds()).toBe(2);
+
+  /* And the predecessor's credential is dead the moment its call is. */
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(false);
+});
+
+test("a stale projection can never authorise a credential its root does not hold", () => {
+  /* The one thing the projection must not buy: authority for a caller who merely
+     guesses. The presented id has to equal what the projected root's own live host
+     holds right now, so a stale projection widens nothing. */
+  const registry = sources();
+  expect(authenticateBridgeGateway(SESSION, registry.injected).ok).toBe(true);
+  registry.poison();
+  for (const guess of ["rt_sess_gatewa", "rt_sess_gateway_", "RT_SESS_GATEWAY", "conversation_root"]) {
+    expect(authenticateBridgeGateway(guess, registry.injected).ok).toBe(false);
+  }
+  /* Whitespace is trimmed, so the genuine credential still works either way. */
+  expect(authenticateBridgeGateway(` ${SESSION} `, registry.injected).ok).toBe(true);
+});
+
+test("swapping the injected sources drops the projection built from the old ones", () => {
+  const first = sources();
+  setBridgeGatewaySourcesForTests(first.injected);
+  expect(authenticateBridgeGateway(SESSION).ok).toBe(true);
+
+  const second = sources({ root: "conversation_other", live: () => null });
+  setBridgeGatewaySourcesForTests(second.injected);
+  expect(authenticateBridgeGateway(SESSION).ok).toBe(false);
+  setBridgeGatewaySourcesForTests(null);
+});

--- a/src/lib/bridge/gatewayAuthority.ts
+++ b/src/lib/bridge/gatewayAuthority.ts
@@ -26,22 +26,23 @@ import { structuredDeliveryHostForConversation } from "@/lib/runtime/structuredD
  * poll to answer a question whose answer changes when a root session rolls over,
  * which is to say almost never.
  *
- * So the poll path no longer rebuilds anything. The root identity is a
- * process-scoped projection, and the steady-state check is two O(1) lookups: which
- * conversation is root, and what realtime session its structured host currently
- * holds. A rebuild happens only when that check does NOT match — the rollover
- * signal — and even then no more than once per window, so a client hammering a
- * refused credential cannot turn its own refusals into registry reads.
+ * So the SUCCESSFUL poll path rebuilds nothing. The root identity is a
+ * process-scoped projection, and a matching credential costs one O(1) lookup: what
+ * realtime session the projected root's structured host currently holds.
  *
- * The trade-off, stated plainly: between a rollover and the next rebuild, the
- * projection can still name the previous root. That cannot grant authority to an
- * arbitrary caller — the presented id must still equal the realtime session id that
- * conversation's own live host holds right now, which nobody but that call's peer
- * has. And a rollover ends the previous root's call, so the projected root stops
- * having a live session at all, which is the one condition that spends the rebuild
- * budget. A wrong credential presented against a HEALTHY root spends nothing, at any
- * request rate, because there is nothing about it a rebuild would change. Every step
- * still fails closed.
+ * A MISMATCH re-derives, bounded to at most one whole-registry read per window. That
+ * bound has to hold against request RATE rather than against a well-behaved client,
+ * which is what makes a refused caller looping forever cost one read per window
+ * instead of one per request.
+ *
+ * The trade-off, stated plainly: for up to one window after a handover the projection
+ * can still name the predecessor, so a predecessor whose call is still up keeps
+ * access for at most that long, and a successor is adopted within at most that long —
+ * in practice on its first request, because a healthy root never spends the budget
+ * and the window is long expired when a handover happens. The projection can never
+ * grant authority to an arbitrary caller: the presented id must equal the realtime
+ * session id the projected root's own live host holds right now, which nobody but
+ * that call's peer has. Every step still fails closed.
  */
 
 export type BridgeGatewayAuthority =
@@ -152,22 +153,31 @@ export function authenticateBridgeGateway(
   /* The steady state, and the only path a healthy poll takes: one O(1) lookup and no
      registry work at all. */
   const projected = projectionHost.__llvBridgeRootProjection?.conversationId ?? null;
-  if (projected) {
-    const live = sources.liveRealtimeSessionId(projected);
-    if (live === claimed) return { ok: true, conversationId: projected };
-    /* The projected root is UP and holding a different session, so the projection is
-       not what is wrong here — the credential is. Rebuilding would cost a whole
-       registry read to re-derive the same answer, which is precisely how a client
-       looping on a refusal turned its own retries into registry load. Refuse, free. */
-    if (live) return REFUSED;
+  if (projected && sources.liveRealtimeSessionId(projected) === claimed) {
+    return { ok: true, conversationId: projected };
   }
 
-  /* Either nothing is projected, or the projected root no longer has a live call —
-     which is exactly what a rollover looks like. That is worth a rebuild, and the
-     window keeps even this bounded when the root is simply down and something keeps
-     asking. */
+  /*
+   * A MISMATCH IS A REASON TO RE-DERIVE, not a reason to refuse from the memo.
+   *
+   * The first version of this refused for free whenever the projected root still had
+   * a live call, reasoning that a rollover ends the predecessor's call. It does not
+   * have to. A handover can promote B while A's call is still up, and then the memo
+   * pinned A forever: A kept reading the deploy nonces it was no longer entitled to,
+   * and B — the actual root — was refused for as long as A stayed on the line. That
+   * is the wrong half of a fail-closed design failing open.
+   *
+   * So every mismatch consults the projection, and the WINDOW is what keeps it
+   * bounded: `projectedRoot` re-derives at most once per window and serves the memo
+   * otherwise. A caller looping on a refusal therefore costs at most one registry
+   * read per window no matter its rate, and a genuine successor is adopted within one
+   * window — usually on its first request, since a healthy root never spends the
+   * budget and the window is long expired by the time a handover happens.
+   */
   const conversationId = projectedRoot(sources, now);
   if (!conversationId) return REFUSED;
+  /* Already checked above against this exact id, and the memo did not move. */
+  if (conversationId === projected) return REFUSED;
   const live = sources.liveRealtimeSessionId(conversationId);
   if (!live || live !== claimed) return REFUSED;
   return { ok: true, conversationId };

--- a/src/lib/bridge/gatewayAuthority.ts
+++ b/src/lib/bridge/gatewayAuthority.ts
@@ -15,6 +15,33 @@ import { structuredDeliveryHostForConversation } from "@/lib/runtime/structuredD
  * Deliberately NOT a new secret. Adding another token would mean another file,
  * another rotation and another thing to leak; the session id already exists, is
  * already per-call, and already dies with the call it belongs to.
+ *
+ * ## What #845 changed, and why
+ *
+ * The check was right and its COST was wrong. `rootConversationId` materialised the
+ * whole registry and walked every conversation on every call, and the relay above
+ * called it every ten seconds per open call — including, before the relay was
+ * bounded, every ten seconds forever for a session the gateway was refusing. At
+ * production shape that is a full registry projection and an O(n log n) sort per
+ * poll to answer a question whose answer changes when a root session rolls over,
+ * which is to say almost never.
+ *
+ * So the poll path no longer rebuilds anything. The root identity is a
+ * process-scoped projection, and the steady-state check is two O(1) lookups: which
+ * conversation is root, and what realtime session its structured host currently
+ * holds. A rebuild happens only when that check does NOT match — the rollover
+ * signal — and even then no more than once per window, so a client hammering a
+ * refused credential cannot turn its own refusals into registry reads.
+ *
+ * The trade-off, stated plainly: between a rollover and the next rebuild, the
+ * projection can still name the previous root. That cannot grant authority to an
+ * arbitrary caller — the presented id must still equal the realtime session id that
+ * conversation's own live host holds right now, which nobody but that call's peer
+ * has. And a rollover ends the previous root's call, so the projected root stops
+ * having a live session at all, which is the one condition that spends the rebuild
+ * budget. A wrong credential presented against a HEALTHY root spends nothing, at any
+ * request rate, because there is nothing about it a rebuild would change. Every step
+ * still fails closed.
  */
 
 export type BridgeGatewayAuthority =
@@ -27,9 +54,35 @@ const REFUSED: BridgeGatewayAuthority = {
 };
 
 export interface BridgeGatewaySources {
+  /** The expensive one: a whole-registry projection. Never called on the steady
+      state poll path — only to build or correct the process-scoped projection. */
   rootConversationId(): string | null;
+  /** O(1): the realtime session this conversation's structured host holds now. */
   liveRealtimeSessionId(conversationId: string): string | null;
+  now?(): number;
 }
+
+/**
+ * Minimum spacing between whole-registry projections.
+ *
+ * One bridge batch window. A refused caller polling in a loop, or a hostile one
+ * polling as fast as it can, therefore costs at most one registry read per window
+ * no matter how many requests it makes — the bound has to hold against request
+ * RATE, not against a well-behaved client.
+ */
+export const BRIDGE_ROOT_PROJECTION_REBUILD_MS = 30_000;
+
+interface RootProjection {
+  conversationId: string | null;
+  builtAt: number;
+}
+
+/* Next.js can instantiate a module more than once per process (dev hot reload,
+   duplicate bundles); the projection hangs off globalThis so every copy shares one
+   rebuild budget rather than one budget each. */
+const projectionHost = globalThis as typeof globalThis & {
+  __llvBridgeRootProjection?: RootProjection;
+};
 
 function productionSources(): BridgeGatewaySources {
   return {
@@ -55,6 +108,27 @@ let overriddenSources: BridgeGatewaySources | null = null;
     the route because a route module may export only route fields. */
 export function setBridgeGatewaySourcesForTests(sources: BridgeGatewaySources | null): void {
   overriddenSources = sources;
+  /* A projection built from one set of sources says nothing about another. */
+  projectionHost.__llvBridgeRootProjection = undefined;
+}
+
+/** Tests only. */
+export function resetBridgeRootProjectionForTests(): void {
+  projectionHost.__llvBridgeRootProjection = undefined;
+}
+
+/**
+ * The projected root, rebuilt only when the budget allows it.
+ *
+ * Returns the projection either way, so a caller that arrives inside a closed window
+ * with nothing projected is refused rather than served a guess.
+ */
+function projectedRoot(sources: BridgeGatewaySources, now: number): string | null {
+  const current = projectionHost.__llvBridgeRootProjection;
+  if (current && now - current.builtAt < BRIDGE_ROOT_PROJECTION_REBUILD_MS) return current.conversationId;
+  const conversationId = sources.rootConversationId();
+  projectionHost.__llvBridgeRootProjection = { conversationId, builtAt: now };
+  return conversationId;
 }
 
 /**
@@ -69,8 +143,30 @@ export function authenticateBridgeGateway(
   sources: BridgeGatewaySources = overriddenSources ?? productionSources(),
 ): BridgeGatewayAuthority {
   const claimed = typeof presented === "string" ? presented.trim() : "";
+  /* Before anything is read. A caller with no credential cannot be the live gateway
+     whatever the registry says, and answering it should not cost a lookup. */
   if (!claimed) return REFUSED;
-  const conversationId = sources.rootConversationId();
+
+  const now = sources.now?.() ?? Date.now();
+
+  /* The steady state, and the only path a healthy poll takes: one O(1) lookup and no
+     registry work at all. */
+  const projected = projectionHost.__llvBridgeRootProjection?.conversationId ?? null;
+  if (projected) {
+    const live = sources.liveRealtimeSessionId(projected);
+    if (live === claimed) return { ok: true, conversationId: projected };
+    /* The projected root is UP and holding a different session, so the projection is
+       not what is wrong here — the credential is. Rebuilding would cost a whole
+       registry read to re-derive the same answer, which is precisely how a client
+       looping on a refusal turned its own retries into registry load. Refuse, free. */
+    if (live) return REFUSED;
+  }
+
+  /* Either nothing is projected, or the projected root no longer has a live call —
+     which is exactly what a rollover looks like. That is worth a rebuild, and the
+     window keeps even this bounded when the root is simply down and something keeps
+     asking. */
+  const conversationId = projectedRoot(sources, now);
   if (!conversationId) return REFUSED;
   const live = sources.liveRealtimeSessionId(conversationId);
   if (!live || live !== claimed) return REFUSED;

--- a/src/lib/bridge/pendingAcknowledgements.test.ts
+++ b/src/lib/bridge/pendingAcknowledgements.test.ts
@@ -73,18 +73,18 @@ test("the replay set carries everything still unspent", () => {
   rememberBridgeAcknowledgement("voice:batch-1", "ack_1");
   rememberBridgeAcknowledgement("composer-key-2", "ack_2");
   expect(pendingBridgeAcknowledgements()).toEqual([
-    { waitingOn: "voice:batch-1", ackToken: "ack_1" },
-    { waitingOn: "composer-key-2", ackToken: "ack_2" },
+    { waitingOn: "voice:batch-1", ackToken: "ack_1", sessionId: null },
+    { waitingOn: "composer-key-2", ackToken: "ack_2", sessionId: null },
   ]);
 
   forgetBridgeAcknowledgement("voice:batch-1");
-  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "composer-key-2", ackToken: "ack_2" }]);
+  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "composer-key-2", ackToken: "ack_2", sessionId: null }]);
 });
 
 test("re-parking the same subject replaces its token rather than duplicating it", () => {
   rememberBridgeAcknowledgement("voice:batch-1", "ack_old");
   rememberBridgeAcknowledgement("voice:batch-1", "ack_new");
-  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "voice:batch-1", ackToken: "ack_new" }]);
+  expect(pendingBridgeAcknowledgements()).toEqual([{ waitingOn: "voice:batch-1", ackToken: "ack_new", sessionId: null }]);
 });
 
 test("the parked set is bounded, so an unspendable token cannot accumulate forever", () => {
@@ -94,7 +94,7 @@ test("the parked set is bounded, so an unspendable token cannot accumulate forev
   const parked = pendingBridgeAcknowledgements();
   expect(parked.length).toBeLessThanOrEqual(32);
   /* The oldest fall off: a dropped token costs a repeated report, never a lost one. */
-  expect(parked.at(-1)).toEqual({ waitingOn: "voice:batch-39", ackToken: "ack_39" });
+  expect(parked.at(-1)).toEqual({ waitingOn: "voice:batch-39", ackToken: "ack_39", sessionId: null });
   expect(bridgeAcknowledgementFor("voice:batch-0")).toBeNull();
 });
 
@@ -102,4 +102,40 @@ test("empty subjects and tokens are ignored rather than parked", () => {
   rememberBridgeAcknowledgement("", "ack_1");
   rememberBridgeAcknowledgement("voice:batch-1", "");
   expect(pendingBridgeAcknowledgements()).toEqual([]);
+});
+
+/**
+ * #845: a parked token remembers WHICH call drained its batch.
+ *
+ * The relay's retry sweep replayed every parked token under whatever credential was
+ * live at the time, so a token from a previous call was spent against a session that
+ * never received its batch. The stamp is what lets the sweep stay session-aware, and
+ * it has to survive the reload that the store exists to survive.
+ */
+test("a parked token records the session that drained it, and the stamp survives a reload", () => {
+  rememberBridgeAcknowledgement("voice:batch-1", "ack_1", { sessionId: "sess_alpha" });
+  rememberBridgeAcknowledgement("voice:batch-2", "ack_2", { sessionId: "sess_beta" });
+  expect(pendingBridgeAcknowledgements()).toEqual([
+    { waitingOn: "voice:batch-1", ackToken: "ack_1", sessionId: "sess_alpha" },
+    { waitingOn: "voice:batch-2", ackToken: "ack_2", sessionId: "sess_beta" },
+  ]);
+
+  resetInMemoryOnly();
+  expect(pendingBridgeAcknowledgements()).toEqual([
+    { waitingOn: "voice:batch-1", ackToken: "ack_1", sessionId: "sess_alpha" },
+    { waitingOn: "voice:batch-2", ackToken: "ack_2", sessionId: "sess_beta" },
+  ]);
+});
+
+test("a token stored before the stamp existed reads back unclaimed rather than corrupt", () => {
+  dom.sessionStorage.setItem(
+    "llv.bridge.pendingAcks",
+    JSON.stringify([{ waitingOn: "voice:batch-legacy", ackToken: "ack_legacy", at: 1 }]),
+  );
+  resetInMemoryOnly();
+  /* `null`, not a dropped entry: an unclaimed token is still the only thing that can
+     settle its batch, so the sweep must be able to see it. */
+  expect(pendingBridgeAcknowledgements()).toEqual([
+    { waitingOn: "voice:batch-legacy", ackToken: "ack_legacy", sessionId: null },
+  ]);
 });

--- a/src/lib/bridge/pendingAcknowledgements.ts
+++ b/src/lib/bridge/pendingAcknowledgements.ts
@@ -26,8 +26,16 @@ const STORAGE_KEY = "llv.bridge.pendingAcks";
 const CAPACITY = 32;
 
 /** `waitingOn` is a delivery id for the live path, or a composer delivery key for the
-    turn-start path. The two never collide, and neither needs to know about the other. */
-type Pending = { waitingOn: string; ackToken: string; at: number };
+    turn-start path. The two never collide, and neither needs to know about the other.
+
+    `sessionId` records WHICH call drained the batch (#845). Without it the relay's
+    retry sweep replayed every parked token under whatever credential happened to be
+    live, so a token from a previous call was spent against a session that never
+    received its batch — and, on a refused credential, thirty-two of them were
+    attempted per poll. `null` means the token predates the stamp or survived a
+    reload; those are still swept, because a token nobody claims is still the only
+    thing that can settle its batch. */
+type Pending = { waitingOn: string; ackToken: string; at: number; sessionId: string | null };
 
 let pending: Pending[] = [];
 let hydrated = false;
@@ -42,7 +50,12 @@ function hydrate(): void {
     pending = parsed.flatMap((entry) => {
       const candidate = entry as Partial<Pending>;
       return typeof candidate?.waitingOn === "string" && typeof candidate.ackToken === "string"
-        ? [{ waitingOn: candidate.waitingOn, ackToken: candidate.ackToken, at: Number(candidate.at) || 0 }]
+        ? [{
+          waitingOn: candidate.waitingOn,
+          ackToken: candidate.ackToken,
+          at: Number(candidate.at) || 0,
+          sessionId: typeof candidate.sessionId === "string" ? candidate.sessionId : null,
+        }]
         : [];
     });
   } catch {
@@ -59,11 +72,20 @@ function persist(): void {
 }
 
 /** Park a token until whatever it is waiting on is confirmed. */
-export function rememberBridgeAcknowledgement(waitingOn: string, ackToken: string, now = Date.now()): void {
+export function rememberBridgeAcknowledgement(
+  waitingOn: string,
+  ackToken: string,
+  options: { now?: number; sessionId?: string | null } = {},
+): void {
   if (!waitingOn || !ackToken) return;
   hydrate();
-  pending = [...pending.filter((entry) => entry.waitingOn !== waitingOn), { waitingOn, ackToken, at: now }]
-    .slice(-CAPACITY);
+  const entry: Pending = {
+    waitingOn,
+    ackToken,
+    at: options.now ?? Date.now(),
+    sessionId: options.sessionId ?? null,
+  };
+  pending = [...pending.filter((candidate) => candidate.waitingOn !== waitingOn), entry].slice(-CAPACITY);
   persist();
 }
 
@@ -73,10 +95,11 @@ export function bridgeAcknowledgementFor(waitingOn: string): string | null {
   return pending.find((entry) => entry.waitingOn === waitingOn)?.ackToken ?? null;
 }
 
-/** Everything still unspent — the replay set after a remount or a reload. */
-export function pendingBridgeAcknowledgements(): { waitingOn: string; ackToken: string }[] {
+/** Everything still unspent — the replay set after a remount or a reload, oldest
+    first so a bounded sweep drains the longest-waiting batch rather than the newest. */
+export function pendingBridgeAcknowledgements(): { waitingOn: string; ackToken: string; sessionId: string | null }[] {
   hydrate();
-  return pending.map(({ waitingOn, ackToken }) => ({ waitingOn, ackToken }));
+  return pending.map(({ waitingOn, ackToken, sessionId }) => ({ waitingOn, ackToken, sessionId }));
 }
 
 /**

--- a/src/lib/deadline.test.ts
+++ b/src/lib/deadline.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test";
+
+import {
+  backoffDelayMs,
+  deadlineSignal,
+  DeadlineExceededError,
+  isAbortError,
+  type DeadlineScheduler,
+} from "./deadline";
+
+/** A scheduler whose clock only moves when the test says so. */
+function virtualScheduler(): DeadlineScheduler & { advance(ms: number): void; pending(): number } {
+  let now = 0;
+  let nextId = 1;
+  const timers = new Map<number, { at: number; handler: () => void }>();
+  return {
+    setTimeout(handler, ms) {
+      const id = nextId++;
+      timers.set(id, { at: now + ms, handler });
+      return id;
+    },
+    clearTimeout(handle) {
+      timers.delete(handle as number);
+    },
+    advance(ms) {
+      now += ms;
+      for (const [id, timer] of [...timers].sort((left, right) => left[1].at - right[1].at)) {
+        if (timer.at > now) continue;
+        timers.delete(id);
+        timer.handler();
+      }
+    },
+    pending: () => timers.size,
+  };
+}
+
+test("the signal aborts when the deadline elapses", () => {
+  const scheduler = virtualScheduler();
+  const deadline = deadlineSignal(5_000, { scheduler });
+  expect(deadline.signal.aborted).toBe(false);
+  scheduler.advance(4_999);
+  expect(deadline.signal.aborted).toBe(false);
+  scheduler.advance(1);
+  expect(deadline.signal.aborted).toBe(true);
+  expect(deadline.signal.reason).toBeInstanceOf(DeadlineExceededError);
+  expect(isAbortError(deadline.signal.reason)).toBe(true);
+  deadline.release();
+});
+
+test("an upstream abort propagates, and releasing drops both the timer and the listener", () => {
+  const scheduler = virtualScheduler();
+  const upstream = new AbortController();
+  const deadline = deadlineSignal(5_000, { scheduler, signal: upstream.signal });
+  expect(scheduler.pending()).toBe(1);
+  upstream.abort(new Error("caller went away"));
+  expect(deadline.signal.aborted).toBe(true);
+
+  deadline.release();
+  expect(scheduler.pending()).toBe(0);
+});
+
+test("releasing many deadlines leaves no listener growth on a long-lived upstream signal", () => {
+  const scheduler = virtualScheduler();
+  const upstream = new AbortController();
+  let listeners = 0;
+  const target = upstream.signal as AbortSignal & {
+    addEventListener: AbortSignal["addEventListener"];
+    removeEventListener: AbortSignal["removeEventListener"];
+  };
+  const add = target.addEventListener.bind(target);
+  const remove = target.removeEventListener.bind(target);
+  target.addEventListener = ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+    listeners += 1;
+    return add(...args);
+  }) as AbortSignal["addEventListener"];
+  target.removeEventListener = ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+    listeners -= 1;
+    return remove(...args);
+  }) as AbortSignal["removeEventListener"];
+
+  for (let index = 0; index < 200; index += 1) deadlineSignal(1_000, { scheduler, signal: upstream.signal }).release();
+  expect(listeners).toBe(0);
+  expect(scheduler.pending()).toBe(0);
+});
+
+test("an already-aborted upstream signal produces an aborted deadline with no timer at all", () => {
+  const scheduler = virtualScheduler();
+  const upstream = AbortSignal.abort(new Error("gone"));
+  const deadline = deadlineSignal(5_000, { scheduler, signal: upstream });
+  expect(deadline.signal.aborted).toBe(true);
+  expect(scheduler.pending()).toBe(0);
+  deadline.release();
+});
+
+test("backoff grows exponentially, honours its ceiling, and never exceeds it under jitter", () => {
+  const policy = { baseMs: 1_000, maxMs: 60_000, jitter: 0 };
+  expect(backoffDelayMs(1, policy)).toBe(1_000);
+  expect(backoffDelayMs(2, policy)).toBe(2_000);
+  expect(backoffDelayMs(3, policy)).toBe(4_000);
+  expect(backoffDelayMs(7, policy)).toBe(60_000);
+  /* The exponent is capped before it is applied: a very long outage must not
+     overflow the shift on its way to being clamped. */
+  expect(backoffDelayMs(4_000, policy)).toBe(60_000);
+});
+
+test("jitter only ever subtracts, so the ceiling is a real ceiling", () => {
+  const policy = { baseMs: 1_000, maxMs: 30_000, jitter: 0.5, random: () => 1 };
+  expect(backoffDelayMs(1, policy)).toBe(500);
+  expect(backoffDelayMs(50, policy)).toBe(15_000);
+  const spread = new Set<number>();
+  let sequence = 0;
+  const varied = { ...policy, random: () => ((sequence++ * 37) % 100) / 100 };
+  for (let index = 0; index < 20; index += 1) spread.add(backoffDelayMs(5, varied));
+  expect(spread.size).toBeGreaterThan(1);
+  for (const delay of spread) expect(delay).toBeLessThanOrEqual(30_000);
+});

--- a/src/lib/deadline.ts
+++ b/src/lib/deadline.ts
@@ -1,0 +1,136 @@
+/**
+ * Deadlines, cancellation, and bounded retry spacing (#845).
+ *
+ * Every one of the three defects behind the 403 retry storm was a missing bound
+ * of this shape: a fetch with no deadline, a retry with no ceiling, and work that
+ * kept running after the only caller that wanted it had gone. They are the same
+ * two primitives, so they live in one place rather than being re-derived — badly
+ * — at each call site.
+ *
+ * The timer and randomness seams are injectable because the acceptance tests
+ * simulate thirty minutes in a few milliseconds. A virtual scheduler cannot be a
+ * real `setTimeout`, so the handle type stays opaque and nothing here assumes a
+ * Node `Timeout`.
+ */
+
+export interface DeadlineScheduler {
+  setTimeout(handler: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export const systemScheduler: DeadlineScheduler = {
+  setTimeout: (handler, ms) => setTimeout(handler, ms),
+  clearTimeout: (handle) => { clearTimeout(handle as ReturnType<typeof setTimeout>); },
+};
+
+export interface DeadlineHandle {
+  signal: AbortSignal;
+  /**
+   * Drop the timer AND the upstream listener.
+   *
+   * The listener half is the one that bites: an `AbortSignal` handed in by a
+   * caller outlives the request it bounded, so a subscription left behind on it
+   * accumulates one entry per request forever. Every deadline is released in a
+   * `finally`.
+   */
+  release(): void;
+}
+
+/**
+ * A signal that aborts when `timeoutMs` elapses, when `signal` aborts, or when
+ * the caller says so.
+ *
+ * Deliberately not `AbortSignal.timeout` + `AbortSignal.any`: those allocate a
+ * real timer this process cannot advance under a virtual clock, and `any` gives
+ * no way to unsubscribe, which is exactly the leak this exists to prevent.
+ */
+export function deadlineSignal(
+  timeoutMs: number,
+  options: { signal?: AbortSignal | null; scheduler?: DeadlineScheduler; reason?: string } = {},
+): DeadlineHandle {
+  const scheduler = options.scheduler ?? systemScheduler;
+  const controller = new AbortController();
+  const upstream = options.signal ?? null;
+  let handle: unknown;
+  let listening = false;
+
+  /* Idempotent, and reached from every exit — the caller's `release`, the upstream
+     abort, and the deadline firing. An aborted request has nothing left to time out,
+     so leaving its timer armed until the socket unwinds would show up as timer growth
+     for exactly as long as the timeout it no longer needs. */
+  const disarm = () => {
+    if (handle !== undefined) {
+      scheduler.clearTimeout(handle);
+      handle = undefined;
+    }
+    if (listening) {
+      upstream?.removeEventListener("abort", onUpstreamAbort);
+      listening = false;
+    }
+  };
+
+  function onUpstreamAbort(): void {
+    disarm();
+    if (!controller.signal.aborted) controller.abort(upstream?.reason);
+  }
+
+  if (upstream?.aborted) {
+    controller.abort(upstream.reason);
+  } else {
+    if (upstream) {
+      upstream.addEventListener("abort", onUpstreamAbort, { once: true });
+      listening = true;
+    }
+    if (Number.isFinite(timeoutMs) && timeoutMs >= 0) {
+      handle = scheduler.setTimeout(() => {
+        handle = undefined;
+        disarm();
+        if (!controller.signal.aborted) {
+          controller.abort(new DeadlineExceededError(options.reason ?? "deadline exceeded", timeoutMs));
+        }
+      }, timeoutMs);
+    }
+  }
+
+  return { signal: controller.signal, release: disarm };
+}
+
+export class DeadlineExceededError extends Error {
+  readonly timeoutMs: number;
+  constructor(message: string, timeoutMs: number) {
+    super(message);
+    this.name = "DeadlineExceededError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export interface BackoffPolicy {
+  baseMs: number;
+  maxMs: number;
+  /** Fraction of the computed delay that is randomised away, 0…1. */
+  jitter?: number;
+  random?: () => number;
+}
+
+/**
+ * Exponential spacing with a ceiling and jitter, for attempt 1, 2, 3, …
+ *
+ * Jitter subtracts rather than adds, so the ceiling is a real ceiling: a caller
+ * reading `maxMs` as "never slower than this" is right, and many clients that
+ * failed together do not come back together.
+ */
+export function backoffDelayMs(attempt: number, policy: BackoffPolicy): number {
+  const ordinal = Math.max(1, Math.floor(attempt));
+  const jitter = Math.min(Math.max(policy.jitter ?? 0, 0), 1);
+  const random = policy.random ?? Math.random;
+  /* Capped before the exponent is applied, so a long-lived failure cannot
+     overflow the shift into Infinity on its way to being clamped. */
+  const exponential = Math.min(policy.maxMs, policy.baseMs * 2 ** Math.min(ordinal - 1, 30));
+  return Math.max(0, Math.round(exponential * (1 - jitter * random())));
+}
+
+/** Whether a rejection is this request being cancelled rather than failing. */
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof DeadlineExceededError) return true;
+  return typeof error === "object" && error !== null && (error as { name?: unknown }).name === "AbortError";
+}

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -57,6 +57,18 @@ test("runtime-bound MCP tools use the live Viewer control surface", async () => 
     callerAttribution: () => ({ kind: "manager" as const, conversationId: "conversation_seat", role: null }),
     callerProject: () => "proj-a",
     authorizedSeats: () => [{ conversationId: "conversation_seat", path: null, project: "proj-a" }],
+    /* #845: the send resolves the conversation it names from ONE injected registry
+       projection rather than reaching for the registry itself. */
+    registrySnapshot: () => ({
+      conversations: {
+        conversation_http_control: {
+          id: "conversation_http_control",
+          generations: [{ path: "/repo/session.jsonl" }],
+          continuityPaths: [],
+        },
+      },
+      conversationAliases: {},
+    }),
   } as never;
   const bindings = viewerMcpBindings(undefined, {
     post: async (pathname, body) => {
@@ -152,6 +164,9 @@ test("get_conversation presents current direct Codex tools and redacts recovered
     conversationId: "conversation_issue_626",
   } satisfies FileEntry;
   const bindings = viewerMcpBindings(undefined, undefined, {
+    /* The completed generation does not carry this transcript, so the pinned scan is
+       the fallback it exists for (#845). */
+    completedFileScan: async () => ({ snapshot: { files: [], projectCatalog: [], complete: true } }),
     listFiles: async () => [file],
   } as never);
 

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-import { agentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, readOnlyConversationLookupFromSnapshot } from "@/lib/agent/registry";
 import { procBackend } from "@/lib/proc";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_ENV, VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
@@ -439,44 +439,6 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies)
   };
 }
 
-/**
- * Which conversation a send named, resolved from ONE registry projection (#845).
- *
- * Both halves mirror the registry's own resolution exactly, because this is a public
- * tool's answer and drifting from it would be a silent behaviour change:
- *
- * - the alias walk is MULTI-HOP and cycle-guarded, like `resolveConversationAlias`.
- *   An account migration chains redirects, so a single hop would stop halfway down a
- *   chain and report a conversation the operator has not been in for two moves.
- * - the path predicate mirrors `conversationOwnsPath`: a conversation owns every
- *   generation path it has had plus the continuity paths a migration left behind, so
- *   a send addressed by a superseded path still names its owner.
- */
-function canonicalConversationId(snapshot: RegistrySnapshot, id: string): string {
-  const seen = new Set<string>();
-  let current = id;
-  while (!seen.has(current)) {
-    seen.add(current);
-    const next: string | undefined = snapshot.conversationAliases[current as keyof typeof snapshot.conversationAliases];
-    if (!next) return current;
-    current = next;
-  }
-  return current;
-}
-
-function conversationFromProjection(
-  snapshot: RegistrySnapshot,
-  conversationId: string,
-  transcriptPath: string,
-): RegistrySnapshot["conversations"][string] | null {
-  if (conversationId) return snapshot.conversations[canonicalConversationId(snapshot, conversationId)] ?? null;
-  if (!transcriptPath) return null;
-  return Object.values(snapshot.conversations).find((candidate) => (
-    candidate.generations.some((generation) => generation.path === transcriptPath)
-    || (candidate.continuityPaths ?? []).includes(transcriptPath)
-  )) ?? null;
-}
-
 async function sendMessage(
   args: McpToolArgs,
   control: ViewerControlDependencies,
@@ -494,7 +456,15 @@ async function sendMessage(
     text: message,
     images: [],
   });
-  const conversation = conversationFromProjection(dependencies.registrySnapshot(), conversationId, transcriptPath);
+  /* The registry's OWN lookup over the projection this call already holds (#845),
+     rather than a local reimplementation of it. The alias walk is multi-hop and
+     cycle-guarded and the path index covers continuity paths, so a send addressed by
+     a chained alias or a superseded path still names its owner — and it stays that way
+     without this file having to be kept in step by hand. */
+  const lookup = readOnlyConversationLookupFromSnapshot(dependencies.registrySnapshot());
+  const conversation = conversationId
+    ? lookup.conversation(conversationId as `conversation_${string}`)
+    : lookup.conversationForPath(transcriptPath);
   return {
     conversationId: (conversation?.id ?? conversationId) || null,
     transcriptPath: (conversation?.generations.at(-1)?.path ?? transcriptPath) || null,

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -48,6 +48,8 @@ import { loadTasks, mutateTasks, mutateTasksFile } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 import { collectSnapshot } from "@/lib/view/collect";
+import { observeFiles } from "@/lib/scanner/observe";
+import { resolveSiblings } from "@/lib/view/siblings";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
@@ -437,7 +439,34 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies)
   };
 }
 
-async function sendMessage(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
+/**
+ * Which conversation a send named, resolved from ONE registry projection (#845).
+ *
+ * The predicate mirrors the registry's own `conversationOwnsPath` — a conversation
+ * owns every generation path it has had plus the continuity paths a migration left
+ * behind — so a send addressed by a superseded path still names its owner.
+ */
+function conversationFromProjection(
+  snapshot: RegistrySnapshot,
+  conversationId: string,
+  transcriptPath: string,
+): RegistrySnapshot["conversations"][string] | null {
+  if (conversationId) {
+    const canonical = snapshot.conversationAliases[conversationId] ?? conversationId;
+    return snapshot.conversations[canonical] ?? snapshot.conversations[conversationId] ?? null;
+  }
+  if (!transcriptPath) return null;
+  return Object.values(snapshot.conversations).find((candidate) => (
+    candidate.generations.some((generation) => generation.path === transcriptPath)
+    || (candidate.continuityPaths ?? []).includes(transcriptPath)
+  )) ?? null;
+}
+
+async function sendMessage(
+  args: McpToolArgs,
+  control: ViewerControlDependencies,
+  dependencies: Pick<ViewerMcpDomainDependencies, "registrySnapshot">,
+): Promise<McpToolPayload> {
   const conversationId = text(args.conversationId);
   const transcriptPath = text(args.transcriptPath) || text(args.path);
   if (!conversationId && !transcriptPath) throw new Error("conversationId or transcriptPath is required");
@@ -450,9 +479,7 @@ async function sendMessage(args: McpToolArgs, control: ViewerControlDependencies
     text: message,
     images: [],
   });
-  const conversation = conversationId
-    ? agentRegistry().conversation(conversationId as `conversation_${string}`)
-    : agentRegistry().conversationForPath(transcriptPath);
+  const conversation = conversationFromProjection(dependencies.registrySnapshot(), conversationId, transcriptPath);
   return {
     conversationId: (conversation?.id ?? conversationId) || null,
     transcriptPath: (conversation?.generations.at(-1)?.path ?? transcriptPath) || null,
@@ -539,11 +566,38 @@ async function linkTaskToPipeline(args: McpToolArgs, dependencies: LinkTaskToPip
   return { taskId, pipelineId, task: result.task, conversationId, transcriptPath };
 }
 
-async function listConversations(args: McpToolArgs): Promise<McpToolPayload> {
+/**
+ * One completed generation, and a private pinned scan ONLY when it misses (#845).
+ *
+ * Every read of a single conversation used to force `fresh: true` with a pin, which
+ * is a full-corpus walk in an exclusive scan generation — per call, for a question
+ * the completed generation almost always already answers. The pin exists for the
+ * case it was built for: a transcript outside the recency cap, which the completed
+ * snapshot genuinely does not carry.
+ */
+async function entryForPath(
+  transcriptPath: string,
+  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan">,
+): Promise<FileEntry | undefined> {
+  const completed = (await dependencies.completedFileScan()).snapshot.files;
+  const known = completed.find((candidate) => candidate.path === transcriptPath);
+  if (known) return known;
+  const pinned = await dependencies.listFiles({ fresh: true, persist: false, pin: transcriptPath });
+  return pinned.find((candidate) => candidate.path === transcriptPath);
+}
+
+async function listConversations(
+  args: McpToolArgs,
+  dependencies: Pick<ViewerMcpDomainDependencies, "completedFileScan">,
+): Promise<McpToolPayload> {
   const project = text(args.project);
   const query = text(args.query).toLocaleLowerCase();
   const limit = Math.max(1, Math.min(100, integer(args.limit, 50)));
-  const files = await listFiles({ fresh: true, persist: false });
+  /* The COMPLETED generation, not a private fresh scan (#845). This is a listing:
+     it reads what the process already knows, the same corpus `board_snapshot`
+     reads. Forcing a full fresh scan per call meant every agent asking "what is
+     running" started another full-corpus walk beside the coordinator's own. */
+  const files = (await dependencies.completedFileScan()).snapshot.files;
   const conversations = files
     .filter((entry) => entry.engine === "claude" || entry.engine === "codex")
     .filter((entry) => !project || entry.project === project)
@@ -562,7 +616,7 @@ async function listConversations(args: McpToolArgs): Promise<McpToolPayload> {
 
 async function getConversation(
   args: McpToolArgs,
-  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles">,
+  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan">,
 ): Promise<McpToolPayload> {
   const requestedId = text(args.conversationId);
   const requestedPath = text(args.transcriptPath) || text(args.path);
@@ -571,8 +625,7 @@ async function getConversation(
     ? agentRegistry().conversation(requestedId as `conversation_${string}`)
     : agentRegistry().conversationForPath(requestedPath);
   const transcriptPath = conversation?.generations.at(-1)?.path ?? requestedPath;
-  const files = await dependencies.listFiles({ fresh: true, persist: false, pin: transcriptPath });
-  const entry = files.find((candidate) => candidate.path === transcriptPath);
+  const entry = await entryForPath(transcriptPath, dependencies);
   if (!entry || (entry.engine !== "claude" && entry.engine !== "codex")) throw new Error("conversation not found");
   const session = readSession(entry.path, entry.engine);
   const maxRecords = Math.max(1, Math.min(500, integer(args.maxRecords, 100)));
@@ -1144,7 +1197,17 @@ async function operatorSnapshot(args: McpToolArgs, dependencies: ViewerMcpDomain
     schemaVersion: 1,
     ...withoutKeys(args, ["clientRequestId"]),
   });
-  return redactPayload({ ...await dependencies.collectSnapshot(request) });
+  /* Explicit dependencies rather than the module defaults (#845): the registry
+     projection is the one this call already holds, so a snapshot costs one
+     projection instead of materialising a second inside the collector. The corpus
+     walk is single-flight in `observeFiles`, so concurrent callers join one. */
+  return redactPayload({
+    ...await dependencies.collectSnapshot(request, {
+      observeFiles,
+      resolveSiblings,
+      registrySnapshot: dependencies.registrySnapshot,
+    }),
+  });
 }
 
 /**
@@ -1432,8 +1495,7 @@ async function focusTargetProject(
   if (isGeometricTarget(target)) return target.project;
   switch (target.kind) {
     case "conversation": {
-      const files = await dependencies.listFiles({ fresh: true, persist: false, pin: target.path });
-      const entry = files.find((candidate) => candidate.path === target.path);
+      const entry = await entryForPath(target.path, dependencies);
       if (!entry) throw new Error("no conversation on the board has that transcript path");
       return entry.project;
     }
@@ -1579,13 +1641,13 @@ export function viewerMcpBindings(
 ): McpToolBindings {
   return {
     spawn_agent: (args) => spawnAgent(args, controlDependencies),
-    send_message: (args) => sendMessage(args, controlDependencies),
+    send_message: (args) => sendMessage(args, controlDependencies, domainDependencies),
     create_task: createBoardTask,
     update_task: updateBoardTask,
     create_pipeline: createPipeline,
     pipeline_action: (args) => pipelineAction(args, domainDependencies),
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
-    list_conversations: listConversations,
+    list_conversations: (args) => listConversations(args, domainDependencies),
     get_conversation: (args) => getConversation(args, domainDependencies),
     deploy_exact_sha: (args) => deployExactSha(args, controlDependencies, domainDependencies),
     get_pipeline: getPipeline,

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -442,19 +442,34 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies)
 /**
  * Which conversation a send named, resolved from ONE registry projection (#845).
  *
- * The predicate mirrors the registry's own `conversationOwnsPath` — a conversation
- * owns every generation path it has had plus the continuity paths a migration left
- * behind — so a send addressed by a superseded path still names its owner.
+ * Both halves mirror the registry's own resolution exactly, because this is a public
+ * tool's answer and drifting from it would be a silent behaviour change:
+ *
+ * - the alias walk is MULTI-HOP and cycle-guarded, like `resolveConversationAlias`.
+ *   An account migration chains redirects, so a single hop would stop halfway down a
+ *   chain and report a conversation the operator has not been in for two moves.
+ * - the path predicate mirrors `conversationOwnsPath`: a conversation owns every
+ *   generation path it has had plus the continuity paths a migration left behind, so
+ *   a send addressed by a superseded path still names its owner.
  */
+function canonicalConversationId(snapshot: RegistrySnapshot, id: string): string {
+  const seen = new Set<string>();
+  let current = id;
+  while (!seen.has(current)) {
+    seen.add(current);
+    const next: string | undefined = snapshot.conversationAliases[current as keyof typeof snapshot.conversationAliases];
+    if (!next) return current;
+    current = next;
+  }
+  return current;
+}
+
 function conversationFromProjection(
   snapshot: RegistrySnapshot,
   conversationId: string,
   transcriptPath: string,
 ): RegistrySnapshot["conversations"][string] | null {
-  if (conversationId) {
-    const canonical = snapshot.conversationAliases[conversationId] ?? conversationId;
-    return snapshot.conversations[canonical] ?? snapshot.conversations[conversationId] ?? null;
-  }
+  if (conversationId) return snapshot.conversations[canonicalConversationId(snapshot, conversationId)] ?? null;
   if (!transcriptPath) return null;
   return Object.values(snapshot.conversations).find((candidate) => (
     candidate.generations.some((generation) => generation.path === transcriptPath)

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { viewerMcpBindings } from "./bindings";
+
+/**
+ * The control-plane reads consume ONE completed scan and ONE projection (#845).
+ *
+ * These reads answer "what is running" and "what did that conversation say". They
+ * are not allowed to be the reason the machine rebuilds its world: `list_conversations`
+ * forced `fresh: true` — a full corpus walk — per call, `get_conversation` forced a
+ * full PINNED walk in its own exclusive scan generation per call, and `send_message`
+ * reached past its injected projection to the registry.
+ *
+ * Every dependency here is poisoned after the number of reads the contract allows, so
+ * a regression fails as a thrown "second read" rather than as a slow test. The
+ * projection is production-shaped — roughly 4.7k conversations over 18.5k registry
+ * rows, against a 373-row completed scan — so "bounded" is measured against the size
+ * that made this urgent rather than against a fixture that would be fast either way.
+ */
+
+const CONVERSATIONS = 4_700;
+const REGISTRY_ROWS = 18_500;
+const SCAN_ROWS = 373;
+const CONCURRENCY = 20;
+
+const sandboxes: string[] = [];
+const originalStateDir = process.env.LLV_STATE_DIR;
+let transcriptPath = "";
+
+beforeEach(() => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-reads-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+  transcriptPath = path.join(sandbox, "rollout-2026-07-01T09-00-00-sess0001.jsonl");
+  fs.writeFileSync(transcriptPath, [
+    JSON.stringify({ type: "session_meta", payload: { id: "sess-1", timestamp: "2026-07-01T09:00:00.000Z", cwd: "/repo/project-0" } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "status?" }] } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "green" }] } }),
+  ].join("\n") + "\n");
+});
+
+afterEach(() => {
+  if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDir;
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function scanRow(index: number) {
+  return {
+    path: index === 0 ? transcriptPath : `/sessions/worker-${index}.jsonl`,
+    root: "codex-sessions",
+    name: `worker-${index}.jsonl`,
+    project: `project-${index % 41}`,
+    title: `worker ${index}`,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1_780_000_000 + index,
+    size: 2_048,
+    activity: index % 7 === 0 ? "live" : "idle",
+    proc: null,
+    pid: null,
+    model: "gpt-5.6-sol",
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: `conversation_${index}`,
+  };
+}
+
+/** A registry projection at the shape that made this urgent. */
+function projection() {
+  const conversations: Record<string, unknown> = {};
+  for (let index = 0; index < CONVERSATIONS; index += 1) {
+    conversations[`conversation_${index}`] = {
+      id: `conversation_${index}`,
+      generations: [{ path: index === 0 ? transcriptPath : `/sessions/worker-${index}.jsonl` }],
+      continuityPaths: [],
+      agentRole: null,
+      delegationDepth: 0,
+    };
+  }
+  const entries: Record<string, unknown> = {};
+  for (let index = 0; index < REGISTRY_ROWS; index += 1) {
+    entries[`codex:sess-${index}`] = { artifactPath: `/sessions/worker-${index}.jsonl`, host: null, structuredHost: null };
+  }
+  return { conversations, entries, lineageEdges: {}, memberships: {}, conversationAliases: {} };
+}
+
+/**
+ * Counting, poisoned dependencies.
+ *
+ * The two seams are modelled the way the real ones behave, because otherwise the
+ * assertion would be about the fake: `completedFileScan` is single-flight (concurrent
+ * callers join one generation) and `registrySnapshot` is materialised once and served
+ * from a process-local cache until the file changes. What is counted, and poisoned, is
+ * therefore the number of GENERATIONS and MATERIALISATIONS — the expensive events —
+ * rather than the number of times a read asked.
+ */
+function dependencies(options: { scans?: number; projections?: number } = {}) {
+  const allowedScans = options.scans ?? 1;
+  const allowedProjections = options.projections ?? 1;
+  const counts = { scans: 0, projections: 0, rawScans: 0, observations: 0, scanCalls: 0, projectionCalls: 0 };
+  const snapshot = { files: Array.from({ length: SCAN_ROWS }, (_value, index) => scanRow(index)), projectCatalog: [], complete: true };
+  let inflight: Promise<{ snapshot: typeof snapshot }> | null = null;
+  let materialised: ReturnType<typeof projection> | null = null;
+  return {
+    counts,
+    injected: {
+      completedFileScan: () => {
+        counts.scanCalls += 1;
+        if (inflight) return inflight;
+        counts.scans += 1;
+        if (counts.scans > allowedScans) throw new Error(`a second completed scan generation was started (${counts.scans})`);
+        inflight = Promise.resolve({ snapshot });
+        /* Released a turn later, so genuinely concurrent callers join and a LATER
+           read still gets a fresh generation — exactly the real cache's shape. */
+        void inflight.then(() => { queueMicrotask(() => { inflight = null; }); });
+        return inflight;
+      },
+      registrySnapshot: () => {
+        counts.projectionCalls += 1;
+        if (materialised) return materialised;
+        counts.projections += 1;
+        if (counts.projections > allowedProjections) throw new Error(`a second registry projection was materialised (${counts.projections})`);
+        materialised = projection();
+        return materialised;
+      },
+      listFiles: async () => {
+        counts.rawScans += 1;
+        throw new Error("a control-plane read must not start a raw corpus scan");
+      },
+      /* Stands in for the collector so the snapshot path can be asserted without the
+         suite ever touching a real corpus. */
+      collectSnapshot: async (_body: unknown, deps: { registrySnapshot?: () => unknown } = {}) => {
+        counts.observations += 1;
+        /* The contract under test: the collector is handed the projection this call
+           already holds, so it never materialises a second one. */
+        deps.registrySnapshot?.();
+        return { schemaVersion: 1, sessions: [], caller: null };
+      },
+      boardFor: () => null,
+    } as never,
+  };
+}
+
+test("list_conversations reads the completed generation and starts no raw scan", async () => {
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  const result = await bindings.list_conversations({ clientRequestId: "list-1", limit: 50 }) as { count: number };
+
+  expect(result.count).toBe(50);
+  expect(counts.scans).toBe(1);
+  expect(counts.rawScans).toBe(0);
+});
+
+test("get_conversation reads the completed generation when it already carries the transcript", async () => {
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  const result = await bindings.get_conversation({ clientRequestId: "get-1", transcriptPath }) as { transcriptPath: string };
+
+  expect(result.transcriptPath).toBe(transcriptPath);
+  /* The pin exists for a transcript the completed generation does not carry. This one
+     it does, so the private exclusive scan never runs. */
+  expect(counts.rawScans).toBe(0);
+  expect(counts.scans).toBe(1);
+});
+
+test("board_snapshot still consumes one scan and one projection", async () => {
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  await bindings.board_snapshot({ clientRequestId: "board-1", limit: 100 });
+
+  expect(counts.scans).toBe(1);
+  expect(counts.projections).toBe(1);
+  expect(counts.rawScans).toBe(0);
+});
+
+test("operator_snapshot hands the collector the projection it already holds", async () => {
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  await bindings.operator_snapshot({ clientRequestId: "snapshot-1", caller: { transcriptPath } });
+
+  expect(counts.observations).toBe(1);
+  /* Exactly one, materialised by the caller and consumed by the collector. The
+     default path built a second one inside `collectSnapshot`. */
+  expect(counts.projections).toBe(1);
+});
+
+test("twenty concurrent control reads join one scan and one projection", async () => {
+  /* A single-flight completed scan, as the real one is: the assertion is that the
+     READS join it rather than each reserving their own generation. */
+  const { counts, injected } = dependencies({ scans: 1, projections: 1 });
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) => (
+    index % 2 === 0
+      ? bindings.list_conversations({ clientRequestId: `list-${index}`, limit: 10 })
+      : bindings.board_snapshot({ clientRequestId: `board-${index}`, limit: 10 })
+  ).catch((error: unknown) => ({ error: String(error) }))));
+
+  const refused = results.filter((entry) => typeof entry === "object" && entry !== null && "error" in entry);
+  /* Poisoned after one of each, so any read that did NOT join shows up here. */
+  expect(refused).toEqual([]);
+  /* Twenty reads asked; one generation and one materialisation answered them all. */
+  expect(counts.scanCalls).toBe(CONCURRENCY);
+  expect(counts.scans).toBe(1);
+  expect(counts.projections).toBe(1);
+  expect(counts.rawScans).toBe(0);
+});
+
+test("send_message resolves the conversation it named from one injected projection", async () => {
+  const { counts, injected } = dependencies();
+  const posts: string[] = [];
+  const bindings = viewerMcpBindings(undefined, {
+    post: async (pathname: string) => {
+      posts.push(pathname);
+      return { operationId: "operation_1", outcome: "queued" };
+    },
+  } as never, injected);
+
+  const result = await bindings.send_message({
+    clientRequestId: "send-1",
+    transcriptPath,
+    text: "status check",
+  }) as { conversationId: string | null; transcriptPath: string | null };
+
+  expect(posts).toEqual(["/api/tmux"]);
+  /* Resolved through the injected projection — including by a path the conversation
+     owns — rather than by reaching for the registry a second time. */
+  expect(result.conversationId).toBe("conversation_0");
+  expect(result.transcriptPath).toBe(transcriptPath);
+  expect(counts.projections).toBe(1);
+});
+
+test("a send addressed by conversation id follows the alias the projection records", async () => {
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, {
+    post: async () => ({ operationId: "operation_2", outcome: "queued" }),
+  } as never, injected);
+
+  const result = await bindings.send_message({
+    clientRequestId: "send-2",
+    conversationId: "conversation_0",
+    text: "status check",
+  }) as { conversationId: string | null };
+
+  expect(result.conversationId).toBe("conversation_0");
+  expect(counts.projections).toBe(1);
+});

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -87,7 +87,13 @@ function projection() {
   for (let index = 0; index < REGISTRY_ROWS; index += 1) {
     entries[`codex:sess-${index}`] = { artifactPath: `/sessions/worker-${index}.jsonl`, host: null, structuredHost: null };
   }
-  return { conversations, entries, lineageEdges: {}, memberships: {}, conversationAliases: {} };
+  /* A migration chains redirects rather than rewriting them, so the walk that
+     resolves them has to follow more than one hop. */
+  const conversationAliases = {
+    conversation_retired: "conversation_middle",
+    conversation_middle: "conversation_0",
+  };
+  return { conversations, entries, lineageEdges: {}, memberships: {}, conversationAliases };
 }
 
 /**
@@ -254,4 +260,23 @@ test("a send addressed by conversation id follows the alias the projection recor
 
   expect(result.conversationId).toBe("conversation_0");
   expect(counts.projections).toBe(1);
+});
+
+test("a send addressed by a CHAINED alias follows the walk to its end", () => {
+  /* The registry's alias resolution is multi-hop and cycle-guarded. Resolving one
+     hop from an injected projection would answer with a conversation the operator
+     has not been in for two moves — a silent wrong answer on a public tool. */
+  const { counts, injected } = dependencies();
+  const bindings = viewerMcpBindings(undefined, {
+    post: async () => ({ operationId: "operation_3", outcome: "queued" }),
+  } as never, injected);
+
+  return bindings.send_message({
+    clientRequestId: "send-3",
+    conversationId: "conversation_retired",
+    text: "status check",
+  }).then((result) => {
+    expect((result as { conversationId: string | null }).conversationId).toBe("conversation_0");
+    expect(counts.projections).toBe(1);
+  });
 });

--- a/src/lib/mcp/requestAttention.test.ts
+++ b/src/lib/mcp/requestAttention.test.ts
@@ -74,6 +74,10 @@ function bindings(
   attentionAuthority: () => AttentionCallerAuthority = () => ROOT_CALLER,
 ) {
   return viewerMcpBindings(undefined, undefined, {
+    /* #845: a single-conversation read consumes the COMPLETED generation and only
+       falls back to a private pinned scan when that genuinely misses. Empty here, so
+       these tests keep exercising the pinned fallback they were written against. */
+    completedFileScan: async () => ({ snapshot: { files: [], projectCatalog: [], complete: true } }),
     listFiles: async () => [reviewerFile],
     loadTasks: () => [task],
     getPipelines: () => ({ pipelines: [{ id: "pipeline_1", project: "pipeline-project" }] }),

--- a/src/lib/scanner/observe.probe.ts
+++ b/src/lib/scanner/observe.probe.ts
@@ -1,15 +1,22 @@
 /**
  * Out-of-process probe for the shared corpus observation (#845).
  *
- * `ROOTS` is baked from `os.homedir()` at import time, so a test that points HOME at
- * a fixture only wins if it is the first thing in the process to load the scanner —
- * which `bun test` cannot promise, and getting it wrong means sweeping the
- * OPERATOR'S real corpus. Running the scenario in a child process whose HOME is set
- * before it starts removes the ordering question entirely.
+ * `ROOTS` is baked from `os.homedir()` and `os.tmpdir()` at import time, so a test
+ * that points HOME at a fixture only wins if it is the first thing in the process to
+ * load the scanner — which `bun test` cannot promise, and getting it wrong means
+ * sweeping the OPERATOR'S real corpus. Running the scenario in a child process whose
+ * environment is set before it starts removes the ordering question entirely.
+ *
+ * It also REPORTS the roots it resolved, so the isolation is asserted rather than
+ * assumed: the `claude-tasks` root in particular falls back to a live
+ * `/tmp/claude-<uid>` when the tmpdir-based candidate does not exist, which would have
+ * put the operator's background-task outputs inside a "sandboxed" scan and made the
+ * fd-holder scan enumerate processes that own them.
  *
  * Prints one JSON line. Not a test file, so the runner never collects it.
  */
 
+import { ROOTS, scanRootEntries } from "@/lib/scanner/roots";
 import {
   fileObservationGenerations,
   fileObservationInFlight,
@@ -65,7 +72,17 @@ async function main(): Promise<void> {
   const rssAfter = rssMiB();
 
   process.stdout.write(JSON.stringify({
+    /* Every root the scanner would walk, so the test can prove all of them are inside
+       the fixture rather than trusting that HOME was enough. */
+    roots: scanRootEntries().map(([key, root]) => ({ key, root })),
+    claudeTasksRoot: ROOTS["claude-tasks"],
     files: warm.length,
+    projects: [...new Set(warm.map((entry) => entry.project))].length,
+    /* Proof the fd-holder scan attributed nothing: no fixture transcript is held open,
+       so no pid from the operator's machine can have been adopted onto a card. */
+    entriesWithPid: warm.filter((entry) => entry.pid !== null).length,
+    entriesWithPaneTarget: warm.filter((entry) => entry.pendingQuestion?.paneTarget != null).length,
+    claudeTaskEntries: warm.filter((entry) => entry.root === "claude-tasks").length,
     afterWarm,
     afterConcurrent,
     /* Distinct arrays, so one caller's title overlay cannot reach another's. */

--- a/src/lib/scanner/observe.probe.ts
+++ b/src/lib/scanner/observe.probe.ts
@@ -1,0 +1,85 @@
+/**
+ * Out-of-process probe for the shared corpus observation (#845).
+ *
+ * `ROOTS` is baked from `os.homedir()` at import time, so a test that points HOME at
+ * a fixture only wins if it is the first thing in the process to load the scanner —
+ * which `bun test` cannot promise, and getting it wrong means sweeping the
+ * OPERATOR'S real corpus. Running the scenario in a child process whose HOME is set
+ * before it starts removes the ordering question entirely.
+ *
+ * Prints one JSON line. Not a test file, so the runner never collects it.
+ */
+
+import {
+  fileObservationGenerations,
+  fileObservationInFlight,
+  observeFiles,
+  ObservationCancelledError,
+} from "@/lib/scanner/observe";
+
+const CONCURRENCY = 20;
+
+function rssMiB(): number {
+  return process.memoryUsage().rss / (1024 * 1024);
+}
+
+async function main(): Promise<void> {
+  /* Warm, exactly as a running Viewer is when the control plane starts asking. */
+  const warm = await observeFiles();
+  const afterWarm = fileObservationGenerations();
+
+  /* Twenty concurrent warm calls — the shape the acceptance criterion names. */
+  const results = await Promise.all(Array.from({ length: CONCURRENCY }, () => observeFiles()));
+  const afterConcurrent = fileObservationGenerations();
+
+  /* Cancellation: every caller walks away mid-walk. Nothing may be left running. */
+  const controller = new AbortController();
+  const cancelled = Promise.all(Array.from({ length: CONCURRENCY }, async () => {
+    try {
+      await observeFiles({ signal: controller.signal });
+      return "resolved";
+    } catch (error) {
+      return error instanceof ObservationCancelledError ? "cancelled" : `unexpected:${String(error)}`;
+    }
+  }));
+  controller.abort();
+  const cancellationOutcomes = await cancelled;
+  /* Let the abort unwind the walk the joiners just abandoned. */
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const orphanAfterCancellation = fileObservationInFlight();
+
+  /* Sustained load: ten rounds of twenty. RSS is sampled after a settle so the
+     comparison is between steady states rather than against a transient peak. */
+  const settle = async () => {
+    if (global.gc) global.gc();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  };
+  await settle();
+  const rssBefore = rssMiB();
+  let generationsUnderLoad = fileObservationGenerations();
+  for (let round = 0; round < 10; round += 1) {
+    await Promise.all(Array.from({ length: CONCURRENCY }, () => observeFiles()));
+  }
+  generationsUnderLoad = fileObservationGenerations() - generationsUnderLoad;
+  await settle();
+  const rssAfter = rssMiB();
+
+  process.stdout.write(JSON.stringify({
+    files: warm.length,
+    afterWarm,
+    afterConcurrent,
+    /* Distinct arrays, so one caller's title overlay cannot reach another's. */
+    distinctArrays: results[0] !== results[1] && results[0] !== warm,
+    equalContent: JSON.stringify(results[0]) === JSON.stringify(results[1]),
+    cancellationOutcomes: [...new Set(cancellationOutcomes)],
+    orphanAfterCancellation,
+    generationsUnderLoad,
+    rssBefore,
+    rssAfter,
+  }) + "\n");
+}
+
+void main().catch((error: unknown) => {
+  process.stdout.write(JSON.stringify({ error: String(error) }) + "\n");
+  process.exitCode = 1;
+});

--- a/src/lib/scanner/observe.singleFlight.test.ts
+++ b/src/lib/scanner/observe.singleFlight.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * The corpus observation at production shape (#845).
+ *
+ * `operator_snapshot` and `/api/agent/snapshot` both walk the whole corpus through
+ * `observeFiles`, and it used to walk once per CALLER. Twenty concurrent warm
+ * control-plane reads therefore meant twenty full walks racing each other and the
+ * coordinator's own scan generation — and a client that gave up left its walk
+ * running against files nobody would read.
+ *
+ * The fixture is deliberately production-shaped rather than a toy: 373 transcript
+ * files across the project spread a real operator has, read by twenty concurrent
+ * callers. It lives in an isolated HOME
+ * inside a temp directory, and the scenario runs in a CHILD PROCESS whose HOME is set
+ * before the scanner is imported — `ROOTS` is baked from `os.homedir()` at import
+ * time, so an in-process test that lost the module-load race would sweep the
+ * operator's real corpus instead.
+ */
+
+const FILE_COUNT = 373;
+const PROJECTS = 41;
+
+const sandboxes: string[] = [];
+
+afterAll(() => {
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function transcript(index: number): string {
+  const started = new Date(Date.UTC(2026, 6, 1, 9, 0, index % 60)).toISOString();
+  return [
+    JSON.stringify({ type: "session_meta", payload: { id: `sess-${index}`, timestamp: started, cwd: `/repo/project-${index % PROJECTS}` } }),
+    JSON.stringify({ type: "turn_context", payload: { model: "gpt-5.6-sol", effort: "high", cwd: `/repo/project-${index % PROJECTS}` } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: `task ${index}` }] } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: `working on ${index}` }] } }),
+  ].join("\n") + "\n";
+}
+
+/** A corpus with the file count and project spread of a real machine. */
+function fixtureHome(): string {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-observe-shape-"));
+  sandboxes.push(sandbox);
+  const home = path.join(sandbox, "home");
+  const codex = path.join(home, ".codex", "sessions", "2026", "07", "01");
+  fs.mkdirSync(codex, { recursive: true });
+  for (let index = 0; index < FILE_COUNT; index += 1) {
+    fs.writeFileSync(path.join(codex, `rollout-2026-07-01T09-00-00-sess${String(index).padStart(4, "0")}.jsonl`), transcript(index));
+  }
+  fs.mkdirSync(path.join(home, ".claude", "projects"), { recursive: true });
+  return home;
+}
+
+interface ProbeResult {
+  files: number;
+  afterWarm: number;
+  afterConcurrent: number;
+  distinctArrays: boolean;
+  equalContent: boolean;
+  cancellationOutcomes: string[];
+  orphanAfterCancellation: boolean;
+  generationsUnderLoad: number;
+  rssBefore: number;
+  rssAfter: number;
+  error?: string;
+}
+
+let fixtureFileCount = 0;
+
+async function runProbe(): Promise<ProbeResult> {
+  const home = fixtureHome();
+  fixtureFileCount = fs.readdirSync(path.join(home, ".codex", "sessions", "2026", "07", "01")).length;
+  const state = path.join(home, "state");
+  const config = path.join(home, "config");
+  fs.mkdirSync(state, { recursive: true });
+  fs.mkdirSync(config, { recursive: true });
+  const child = Bun.spawn(["bun", "src/lib/scanner/observe.probe.ts"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      /* Isolated on every axis the scanner and the state layer read. */
+      HOME: home,
+      XDG_CONFIG_HOME: config,
+      LLV_STATE_DIR: state,
+      TMPDIR: path.join(home, "tmp"),
+      NODE_ENV: "test",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()]);
+  await child.exited;
+  const line = out.trim().split("\n").at(-1) ?? "";
+  if (!line.startsWith("{")) throw new Error(`probe produced no result: ${out}\n${err}`);
+  return JSON.parse(line) as ProbeResult;
+}
+
+test("twenty concurrent warm reads join one corpus walk, honour cancellation, and do not grow RSS", async () => {
+  const result = await runProbe();
+  expect(result.error).toBeUndefined();
+
+  /* The fixture really is the shape claimed on disk; the scanner's own scheme window
+     then caps what a read carries, which is exactly the production behaviour this
+     must not change. */
+  expect(fixtureFileCount).toBe(FILE_COUNT);
+  expect(result.files).toBeGreaterThan(0);
+
+  /* One warm walk, and then TWENTY concurrent callers add exactly one more between
+     them. Before #845 this line read twenty-one. */
+  expect(result.afterWarm).toBe(1);
+  expect(result.afterConcurrent).toBe(2);
+
+  /* Joining must not mean sharing: the snapshot composer overlays titles onto these
+     entries, so two callers holding one array would corrupt each other. */
+  expect(result.distinctArrays).toBe(true);
+  expect(result.equalContent).toBe(true);
+
+  /* Every caller walking away is answered as cancelled, and leaves nothing running. */
+  expect(result.cancellationOutcomes).toEqual(["cancelled"]);
+  expect(result.orphanAfterCancellation).toBe(false);
+
+  /* Ten rounds of twenty is ten walks, not two hundred. */
+  expect(result.generationsUnderLoad).toBe(10);
+
+  /* Two hundred reads of a 373-file corpus must not leave a heap behind them. The
+     bound is generous on purpose — this catches retention, not allocation. */
+  expect(result.rssAfter - result.rssBefore).toBeLessThan(150);
+}, 120_000);

--- a/src/lib/scanner/observe.singleFlight.test.ts
+++ b/src/lib/scanner/observe.singleFlight.test.ts
@@ -12,17 +12,29 @@ import path from "node:path";
  * coordinator's own scan generation — and a client that gave up left its walk
  * running against files nobody would read.
  *
- * The fixture is deliberately production-shaped rather than a toy: 373 transcript
- * files across the project spread a real operator has, read by twenty concurrent
- * callers. It lives in an isolated HOME
- * inside a temp directory, and the scenario runs in a CHILD PROCESS whose HOME is set
- * before the scanner is imported — `ROOTS` is baked from `os.homedir()` at import
- * time, so an in-process test that lost the module-load race would sweep the
- * operator's real corpus instead.
+ * ## Isolation, and why it needs proving rather than asserting
+ *
+ * The scanner resolves three roots, and only two of them follow HOME. The
+ * `claude-tasks` root is `<tmpdir>/claude-<uid>`, and when that does not exist it
+ * FALLS BACK to a live `/tmp/claude-<uid>` — so a fixture that set HOME and TMPDIR but
+ * never created the tmpdir candidate would quietly walk the operator's real
+ * background-task outputs, and the fd-holder scan would then attribute the operator's
+ * live pids onto them.
+ *
+ * So the fixture creates every root, including that one, and the probe REPORTS the
+ * roots it resolved. The test asserts each is inside the fixture, that nothing was
+ * attributed a pid or a pane, and that two independent fixtures produce identical
+ * counts — which is what makes the numbers a property of the fixture rather than of
+ * whatever happens to exist on the machine running this.
+ *
+ * The scan caps are raised through the scanner's own env knobs so the production-shaped
+ * corpus survives the scheme window instead of being trimmed to one project's worth.
  */
 
-const FILE_COUNT = 373;
 const PROJECTS = 41;
+const FILES_PER_PROJECT = 9;
+const CODEX_FILES = 4;
+const FILE_COUNT = PROJECTS * FILES_PER_PROJECT + CODEX_FILES;
 
 const sandboxes: string[] = [];
 
@@ -30,32 +42,83 @@ afterAll(() => {
   for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
-function transcript(index: number): string {
-  const started = new Date(Date.UTC(2026, 6, 1, 9, 0, index % 60)).toISOString();
+function claudeTranscript(cwd: string, project: number, index: number): string {
+  const at = new Date(Date.UTC(2026, 6, 1, 9, index % 60, project % 60)).toISOString();
   return [
-    JSON.stringify({ type: "session_meta", payload: { id: `sess-${index}`, timestamp: started, cwd: `/repo/project-${index % PROJECTS}` } }),
-    JSON.stringify({ type: "turn_context", payload: { model: "gpt-5.6-sol", effort: "high", cwd: `/repo/project-${index % PROJECTS}` } }),
-    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: `task ${index}` }] } }),
-    JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: `working on ${index}` }] } }),
+    JSON.stringify({ type: "user", timestamp: at, cwd, message: { role: "user", content: `task ${project}/${index}` } }),
+    JSON.stringify({ type: "assistant", timestamp: at, cwd, message: { role: "assistant", content: [{ type: "text", text: `working on ${project}/${index}` }] } }),
   ].join("\n") + "\n";
 }
 
-/** A corpus with the file count and project spread of a real machine. */
-function fixtureHome(): string {
+/** Claude encodes a session's cwd into its project directory name by replacing every
+    separator with a dash. The fixture builds the slug from a repository that really
+    exists, so the scanner resolves a distinct project per repo instead of folding the
+    whole corpus into one unresolved group. */
+function claudeProjectSlug(cwd: string): string {
+  return cwd.split(path.sep).join("-");
+}
+
+function codexTranscript(index: number): string {
+  const at = new Date(Date.UTC(2026, 6, 1, 8, index, 0)).toISOString();
+  return [
+    JSON.stringify({ type: "session_meta", payload: { id: `sess-${index}`, timestamp: at } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: `codex task ${index}` }] } }),
+  ].join("\n") + "\n";
+}
+
+interface Fixture { home: string; state: string; config: string; tmp: string; claudeTasks: string; files: number }
+
+/** A corpus with the file count and project spread of a real machine, and every
+    scanner root inside it — including the tmpdir-based one. */
+function fixture(): Fixture {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-observe-shape-"));
   sandboxes.push(sandbox);
   const home = path.join(sandbox, "home");
+  const tmp = path.join(home, "tmp");
+  let files = 0;
+
+  for (let project = 0; project < PROJECTS; project += 1) {
+    /* A repository the scanner can actually identify: `projectIdentityFromRepositoryRoot`
+       needs a `.git/config`, and with no origin remote it keys the project on the
+       local path — which is distinct per repo, which is the point. */
+    const repository = path.join(home, "repos", `project-${String(project).padStart(2, "0")}`);
+    fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repository, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n\tbare = false\n");
+
+    const directory = path.join(home, ".claude", "projects", claudeProjectSlug(repository));
+    fs.mkdirSync(directory, { recursive: true });
+    for (let index = 0; index < FILES_PER_PROJECT; index += 1) {
+      fs.writeFileSync(path.join(directory, `session-${index}.jsonl`), claudeTranscript(repository, project, index));
+      files += 1;
+    }
+  }
+
   const codex = path.join(home, ".codex", "sessions", "2026", "07", "01");
   fs.mkdirSync(codex, { recursive: true });
-  for (let index = 0; index < FILE_COUNT; index += 1) {
-    fs.writeFileSync(path.join(codex, `rollout-2026-07-01T09-00-00-sess${String(index).padStart(4, "0")}.jsonl`), transcript(index));
+  for (let index = 0; index < CODEX_FILES; index += 1) {
+    fs.writeFileSync(path.join(codex, `rollout-2026-07-01T08-00-00-sess${index}.jsonl`), codexTranscript(index));
+    files += 1;
   }
-  fs.mkdirSync(path.join(home, ".claude", "projects"), { recursive: true });
-  return home;
+
+  /* THE ONE THAT ESCAPES. Without this directory `claudeTasksRoot()` falls through to
+     `/tmp/claude-<uid>` — the operator's live background-task outputs. */
+  const claudeTasks = path.join(tmp, `claude-${process.getuid?.() ?? 1000}`);
+  fs.mkdirSync(claudeTasks, { recursive: true });
+
+  const state = path.join(home, "state");
+  const config = path.join(home, "config");
+  for (const directory of [state, config, path.join(tmp, "tmux")]) fs.mkdirSync(directory, { recursive: true });
+  return { home, state, config, tmp, claudeTasks, files };
 }
 
 interface ProbeResult {
+  roots: { key: string; root: string }[];
+  claudeTasksRoot: string;
   files: number;
+  projects: number;
+  entriesWithPid: number;
+  entriesWithPaneTarget: number;
+  claudeTaskEntries: number;
   afterWarm: number;
   afterConcurrent: number;
   distinctArrays: boolean;
@@ -68,24 +131,23 @@ interface ProbeResult {
   error?: string;
 }
 
-let fixtureFileCount = 0;
-
-async function runProbe(): Promise<ProbeResult> {
-  const home = fixtureHome();
-  fixtureFileCount = fs.readdirSync(path.join(home, ".codex", "sessions", "2026", "07", "01")).length;
-  const state = path.join(home, "state");
-  const config = path.join(home, "config");
-  fs.mkdirSync(state, { recursive: true });
-  fs.mkdirSync(config, { recursive: true });
+async function runProbe(sandbox: Fixture): Promise<ProbeResult> {
   const child = Bun.spawn(["bun", "src/lib/scanner/observe.probe.ts"], {
     cwd: process.cwd(),
     env: {
       ...process.env,
-      /* Isolated on every axis the scanner and the state layer read. */
-      HOME: home,
-      XDG_CONFIG_HOME: config,
-      LLV_STATE_DIR: state,
-      TMPDIR: path.join(home, "tmp"),
+      /* Isolated on every axis the scanner, the state layer and the pane resolver
+         read. TMPDIR is what moves the `claude-tasks` root off the live one; the
+         fixture creates the directory so the fallback is never reached. */
+      HOME: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.config,
+      LLV_STATE_DIR: sandbox.state,
+      TMPDIR: sandbox.tmp,
+      TMUX_TMPDIR: path.join(sandbox.tmp, "tmux"),
+      /* The scheme window exists to keep the BOARD bounded; here it would trim the
+         production-shaped corpus this test is about, so it is opened to fit it. */
+      LLV_SCHEME_PROJECT_CAP: String(PROJECTS + 5),
+      LLV_SCHEME_CARDS_PER_PROJECT: String(FILES_PER_PROJECT + CODEX_FILES + 5),
       NODE_ENV: "test",
     },
     stdout: "pipe",
@@ -98,15 +160,55 @@ async function runProbe(): Promise<ProbeResult> {
   return JSON.parse(line) as ProbeResult;
 }
 
-test("twenty concurrent warm reads join one corpus walk, honour cancellation, and do not grow RSS", async () => {
-  const result = await runProbe();
+function expectFullyIsolated(result: ProbeResult, sandbox: Fixture): void {
   expect(result.error).toBeUndefined();
+  /* Every root, not just the two that follow HOME. */
+  expect(result.roots.length).toBeGreaterThanOrEqual(3);
+  for (const { root } of result.roots) expect(root.startsWith(sandbox.home + path.sep)).toBe(true);
+  expect(result.claudeTasksRoot).toBe(sandbox.claudeTasks);
+  /* The live fallback, named explicitly so this fails loudly if it is ever selected. */
+  expect(result.claudeTasksRoot).not.toBe(`/tmp/claude-${process.getuid?.() ?? 1000}`);
+  /* Nothing on the machine holds a fixture transcript open, so the fd-holder scan
+     attributed no pid and the pane resolver was never reached. */
+  expect(result.entriesWithPid).toBe(0);
+  expect(result.entriesWithPaneTarget).toBe(0);
+  /* And the isolated task root really is empty, so `outputHolders()` — the scan that
+     walks fds UNDER that root — never ran. */
+  expect(result.claudeTaskEntries).toBe(0);
+}
 
-  /* The fixture really is the shape claimed on disk; the scanner's own scheme window
-     then caps what a read carries, which is exactly the production behaviour this
-     must not change. */
-  expect(fixtureFileCount).toBe(FILE_COUNT);
-  expect(result.files).toBeGreaterThan(0);
+test("the production-shaped corpus is read entirely from the fixture, with no live root", async () => {
+  const sandbox = fixture();
+  expect(sandbox.files).toBe(FILE_COUNT);
+  const result = await runProbe(sandbox);
+
+  expectFullyIsolated(result, sandbox);
+  /* The whole corpus survives the scheme window: the shape claimed, rather than one
+     project's cap worth. */
+  expect(result.files).toBe(FILE_COUNT);
+  /* One project per repository, plus the codex rollouts' own group. */
+  expect(result.projects).toBe(PROJECTS + 1);
+}, 180_000);
+
+test("two independent fixtures produce identical counts, so the numbers are the fixture's", async () => {
+  /* The proof that nothing ambient contributes: the live `/tmp/claude-<uid>` is
+     neither created nor touched by this suite, and two separate sandboxes — each with
+     its own tmpdir-based task root — agree exactly. */
+  const [first, second] = [fixture(), fixture()];
+  const [left, right] = await Promise.all([runProbe(first), runProbe(second)]);
+
+  expectFullyIsolated(left, first);
+  expectFullyIsolated(right, second);
+  expect(left.claudeTasksRoot).not.toBe(right.claudeTasksRoot);
+  expect({ files: left.files, projects: left.projects })
+    .toEqual({ files: right.files, projects: right.projects });
+  expect(left.files).toBe(FILE_COUNT);
+}, 180_000);
+
+test("twenty concurrent warm reads join one corpus walk, honour cancellation, and do not grow RSS", async () => {
+  const sandbox = fixture();
+  const result = await runProbe(sandbox);
+  expectFullyIsolated(result, sandbox);
 
   /* One warm walk, and then TWENTY concurrent callers add exactly one more between
      them. Before #845 this line read twenty-one. */
@@ -128,4 +230,4 @@ test("twenty concurrent warm reads join one corpus walk, honour cancellation, an
   /* Two hundred reads of a 373-file corpus must not leave a heap behind them. The
      bound is generous on purpose — this catches retention, not allocation. */
   expect(result.rssAfter - result.rssBefore).toBeLessThan(150);
-}, 120_000);
+}, 180_000);

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -14,19 +14,60 @@ import { assignTranscriptPids } from "./transcripts";
 import { waitingInputProbe } from "./waitingInput";
 import { activityVerdict, transcriptTurnResult } from "./activity";
 
+/**
+ * An inert mirror of the scanner enrichment pipeline for snapshot reads.
+ *
+ * ## Single flight and cancellation (#845)
+ *
+ * This walks the whole corpus. It is the read behind `operator_snapshot` and
+ * `/api/agent/snapshot`, and it used to run once per CALLER: twenty concurrent
+ * warm requests meant twenty full corpus walks racing each other, on a machine
+ * already running the coordinator's own scan generation. Worse, nothing stopped:
+ * a client that deadlined out at five seconds left its walk running to completion
+ * against files nobody would read, and the next request started another.
+ *
+ * So it is single-flight, the way the file-scan coordinator is: concurrent callers
+ * join one observation and each receives its own deep clone, because the snapshot
+ * composer mutates the entries it is given (custom titles are overlaid onto them)
+ * and two callers sharing one array would corrupt each other.
+ *
+ * Cancellation is reference-counted rather than per-caller. One caller walking away
+ * must not cancel the observation the other nineteen are waiting on, and the last
+ * caller walking away must not leave it running: when the joiner count reaches zero
+ * the shared signal aborts, and the walk stops at its next batch boundary.
+ */
+
 const YIELD_EVERY = 75;
 const NO_HOLDERS: Map<string, number> = new Map();
 const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
-async function each(entries: FileEntry[], visit: (entry: FileEntry) => void | Promise<void>): Promise<void> {
+export class ObservationCancelledError extends Error {
+  constructor() {
+    super("file observation cancelled");
+    this.name = "ObservationCancelledError";
+  }
+}
+
+function throwIfCancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new ObservationCancelledError();
+}
+
+async function each(
+  entries: FileEntry[],
+  visit: (entry: FileEntry) => void | Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
   for (let index = 0; index < entries.length; index += YIELD_EVERY) {
+    /* The batch boundary is already the yield point, so it is also the only place
+       an abort can be honoured without leaving an entry half-derived. */
+    throwIfCancelled(signal);
     await Promise.all(entries.slice(index, index + YIELD_EVERY).map(visit));
     if (index + YIELD_EVERY < entries.length) await yieldToEventLoop();
   }
 }
 
-/** An inert mirror of the scanner enrichment pipeline for snapshot reads. */
-export async function observeFiles(): Promise<FileEntry[]> {
+async function runObservation(signal?: AbortSignal): Promise<FileEntry[]> {
+  throwIfCancelled(signal);
   const entries = await discoverFiles();
   const holders = entries.some((entry) => entry.root === "claude-tasks" && entry.path.endsWith(".output")) ? outputHolders() : NO_HOLDERS;
   await each(entries, (entry) => {
@@ -48,9 +89,9 @@ export async function observeFiles(): Promise<FileEntry[]> {
       const holder = holders.get(entry.path) ?? null; entry.pid = holder; entry.proc = holder === null ? "done" : "running";
       if (holder !== null) { entry.activity = "live"; entry.activityReason = "output_held"; }
     }
-  });
+  }, signal);
   assignTranscriptPids(entries);
-  await each(entries, (entry) => { entry.effort = entryEffort(entry); entry.fast = entryFast(entry); });
+  await each(entries, (entry) => { entry.effort = entryEffort(entry); entry.fast = entryFast(entry); }, signal);
   await each(entries, async (entry) => {
     const pending = pendingQuestionFor(entry);
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
@@ -59,7 +100,82 @@ export async function observeFiles(): Promise<FileEntry[]> {
     entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
     entry.lastTurn = lastTurnFor(entry);
     entry.pendingWakeup = pendingWakeupFor(entry);
-  });
+  }, signal);
+  throwIfCancelled(signal);
   await linkEntries(entries, { persist: false });
   return entries;
+}
+
+interface SharedObservation {
+  promise: Promise<FileEntry[]>;
+  controller: AbortController;
+  joiners: number;
+}
+
+/* Next.js can instantiate this module more than once per process; the in-flight
+   observation hangs off globalThis so every copy shares one walk. */
+const observationHost = globalThis as typeof globalThis & {
+  __llvFileObservation?: SharedObservation;
+  __llvFileObservationGenerations?: number;
+};
+
+/** Diagnostics and tests: whether a walk is currently shared. */
+export function fileObservationInFlight(): boolean {
+  return observationHost.__llvFileObservation !== undefined;
+}
+
+/** How many corpus walks this process has STARTED. The number twenty concurrent
+    callers produce is the whole point of the single-flight, so it is measurable
+    rather than inferred from a stopwatch. */
+export function fileObservationGenerations(): number {
+  return observationHost.__llvFileObservationGenerations ?? 0;
+}
+
+export function resetFileObservationForTests(): void {
+  observationHost.__llvFileObservation = undefined;
+  observationHost.__llvFileObservationGenerations = 0;
+}
+
+/** Reject as soon as THIS caller is cancelled, without waiting for the shared walk. */
+function raceCancellation<T>(promise: Promise<T>, signal: AbortSignal | null | undefined): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new ObservationCancelledError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => { reject(new ObservationCancelledError()); };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => { signal.removeEventListener("abort", onAbort); });
+  });
+}
+
+export async function observeFiles(options: { signal?: AbortSignal | null } = {}): Promise<FileEntry[]> {
+  let shared = observationHost.__llvFileObservation;
+  if (!shared) {
+    const controller = new AbortController();
+    observationHost.__llvFileObservationGenerations = (observationHost.__llvFileObservationGenerations ?? 0) + 1;
+    const created: SharedObservation = { controller, joiners: 0, promise: undefined as unknown as Promise<FileEntry[]> };
+    created.promise = runObservation(controller.signal).finally(() => {
+      if (observationHost.__llvFileObservation === created) observationHost.__llvFileObservation = undefined;
+    });
+    /* Nothing may be left holding an unhandled rejection when every joiner has
+       already been told about it through its own `await`. */
+    void created.promise.catch(() => undefined);
+    observationHost.__llvFileObservation = created;
+    shared = created;
+  }
+  const observation = shared;
+  observation.joiners += 1;
+  try {
+    const entries = await raceCancellation(observation.promise, options.signal);
+    /* A private deep clone per caller, for the same reason the file-scan coordinator
+       hands one out: the snapshot composer overlays titles onto these entries. */
+    return structuredClone(entries);
+  } finally {
+    observation.joiners -= 1;
+    /* The last caller out turns off the lights. A walk nobody is waiting for is
+       exactly the orphan this exists to prevent. */
+    if (observation.joiners <= 0 && observationHost.__llvFileObservation === observation) {
+      observation.controller.abort(new ObservationCancelledError());
+      observationHost.__llvFileObservation = undefined;
+    }
+  }
 }

--- a/src/lib/view/collect.ts
+++ b/src/lib/view/collect.ts
@@ -6,12 +6,27 @@ import { composeSnapshot } from "./snapshot";
 import { resolveSiblings } from "./siblings";
 import type { SnapshotRequestV1 } from "./types";
 
+/**
+ * One completed observation and one registry projection per snapshot (#845).
+ *
+ * The observation is single-flight inside `observeFiles`, so twenty concurrent
+ * callers join one corpus walk rather than starting twenty. What is left here is the
+ * other half: the caller's `signal` reaches that walk, so a client that deadlines
+ * out or disconnects stops being a reason to keep reading files, and the registry
+ * projection is INJECTED rather than materialised inside — an MCP caller that
+ * already holds a projection should not cause a second one.
+ */
 export async function collectSnapshot(
   body: SnapshotRequestV1,
-  dependencies: { observeFiles: typeof observeFiles; resolveSiblings: typeof resolveSiblings; registrySnapshot?: () => RegistryFile } = { observeFiles, resolveSiblings },
+  dependencies: {
+    observeFiles: typeof observeFiles;
+    resolveSiblings: typeof resolveSiblings;
+    registrySnapshot?: () => RegistryFile;
+    signal?: AbortSignal | null;
+  } = { observeFiles, resolveSiblings },
 ): Promise<Awaited<ReturnType<typeof composeSnapshot>>> {
   const started = Date.now();
-  const files = await dependencies.observeFiles();
+  const files = await dependencies.observeFiles({ signal: dependencies.signal ?? null });
   // Custom session titles (issue #33) are the last word on `title` for the agent
   // snapshot surface too — applied before siblings resolve and the snapshot
   // composes, so renamed conversations and their siblings show the human title.


### PR DESCRIPTION
Closes #845

Urgent operator-authorized hotfix. **Base** `00df34367ff25bdd36ef2c37257ef0fae365a5e5` → **head** `3d6ac7989c0fc589ea94a5019ecfde0c6c831c00`.

Review round 1 returned REQUEST_CHANGES with three blockers and one low finding; all four are fixed in `7cd6ec63`, `82fdc6b4`, `4590bee0`, `cf08a7bc` and `3d6ac798`. What changed is summarised under *Review round 1* below.

## The coupled failure

A live non-root or stale `realtimeSessionId` is answered **403** by the bridge gateway authority — correctly, and permanently. Four defects turned that correct refusal into sustained load:

1. The relay retried **every** non-2xx on a fixed ten-second `setInterval`, forever, with no deadline, no abort and no backoff. One open tab produced six refused requests a minute for as long as it stayed open.
2. Each refused poll fanned out up to **32** parked acknowledgements beside it, and a confirmation listener could POST beside a poll — two requests in flight at once.
3. Every one of those polls called `agentRegistry().readOnlySnapshot()` and walked every conversation to re-derive a root identity that changes only on rollover.
4. `operator_snapshot`, `list_conversations` and `get_conversation` bypassed the completed scan and ran raw full-corpus walks per caller, which kept running after the client had gone.

## What changed

**Relay** (`useBridgeReportRelay`) — one owner, one in-flight request. The interval is replaced by a cycle that schedules the next when it finishes; the confirmation listener *wakes* that loop rather than fetching beside it. Every fetch carries a deadline and an `AbortSignal` descending from an owner controller aborted on unmount, navigation (`pagehide`), call-phase change and session change. 401/403 **suspends** that exact session id with a bounded typed state, backing off from 60s to a 15-minute ceiling; an accepted poll clears the suspension, and a genuinely new session starts clean. Transport failures, 429 and 5xx back off exponentially with jitter to a five-minute ceiling. The parked-token sweep is bounded per cycle, oldest-first, and only spends tokens the current session parked — so a token now records the session that drained it.

Exactly-once is unchanged: a token is dropped only on an accepted POST, and one not attempted this cycle stays parked for the next. A 409 is now dropped, because that token can never settle anything again and holding it displaced tokens that could.

**Authority** (`gatewayAuthority`) — a *successful* poll performs **zero** whole-registry reads. The root identity is a process-scoped projection and the check is one O(1) lookup of the realtime session the projected root's structured host holds. A **mismatch re-derives**, bounded to at most one whole-registry read per 30s window — so a caller looping on a refusal costs one read per window rather than one per request, and a handover is adopted within at most one window. Authorization is unchanged and still fails closed at every step; the projection cannot widen authority, because the presented id must equal what the projected root's own live host holds right now.

**Control plane** — `observeFiles` is single-flight with a private deep clone per caller and reference-counted cancellation (one caller leaving must not cancel the other nineteen; the last one out aborts the walk). `/api/agent/snapshot` hands the request's own signal down. `collectSnapshot` takes the registry projection as a dependency and `operator_snapshot` passes the one it already holds. `list_conversations` and `get_conversation` read the completed generation; the pin remains for the case it was built for — a transcript the completed snapshot genuinely does not carry. `send_message` resolves from the injected projection.

**Shared** — `src/lib/deadline.ts`: composed deadline/abort signal that releases both timer and upstream listener on every exit, plus bounded jittered backoff. Timer and randomness seams are injectable so thirty simulated minutes cost milliseconds.

## Evidence

All runs used isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR`; no suite touched shared runtime or registry state.

| Gate | Result |
| --- | --- |
| `bunx tsc --noEmit` | clean |
| Scoped ESLint (17 changed paths) | clean |
| `bun run build` | `✓ Compiled successfully`, `Built dist/mcp-server.mjs` |
| `bun scripts/privacy-publication-gate.ts --base 00df3436` | `PRIVACY GATE: PASS` |
| bridge + bridge route + collect + snapshot route + mcp | **237 pass, 0 fail** (base: 216 pass) |
| deadline + relay DOM + observation shape | **46 pass, 0 fail** |

Acceptance assertions, in the tests:

- **30 simulated minutes of persistent 403 → ≤ 8 requests**, against the 180 a fixed ten-second interval produced. Fake clock at the 10s cadence; the first probe lands past the authority's 30s rebuild window, and each refusal pushes the next further out to the ceiling. Peak concurrent fetches across 180 ticks of live traffic is **1**. After unmount: in-flight request aborted, zero pending timers, zero listeners.
- **Same-session 403 → 200 recovery.** The credential never changes; only the server's answer does. The suspension expires, the same session id probes and is served, the suspension is cleared, and polling returns to the ordinary cadence. A 5xx met while suspended does **not** clear it; an accepted poll does, so a later refusal starts from the first backoff step.
- **A new session starts after the refused one is suspended** — the successor's first tick goes out with the new id.
- **Poisoned whole-registry read** — after warm-up the projection source throws on any further call; 180 successful polls complete with **1** rebuild total.
- **Handover with the predecessor's call still live** — the successor is promoted and the demoted predecessor refused, though its call is up and its session id is still valid for it. A successor whose arrival lands inside a just-spent window is accepted one window later, and no later. **30,000 refused attempts across six windows cost ≤ 1 registry read each.**
- **Poisoned second scan/projection** — `list_conversations`, `get_conversation`, `board_snapshot`, `operator_snapshot` and `send_message` each fail loudly on a second completed scan or a second registry materialisation. All pass at one apiece; raw-scan count is 0.
- **Production-shaped fixture** — 373 transcript files across 41 identifiable repositories, read in a child process so `ROOTS` cannot bake against the operator's real corpus; a 4.7k-conversation / 18.5k-row projection for the control-plane reads. 20 concurrent warm calls → **1** corpus walk; 10 rounds of 20 → **10** walks, not 200. All 20 cancelling leaves no orphan walk. RSS delta across 200 reads bounded.
- **Fixture isolation is asserted, not assumed.** The probe reports every root it resolved; the test asserts all three are inside the fixture, that the live `/tmp/claude-<uid>` was not selected, that no entry was attributed a pid or a pane, and that the isolated task root stayed empty so the fd-scan under it never ran. Two independent fixtures produce identical counts, which is what makes the numbers a property of the fixture rather than of the machine. The live `/tmp/claude-<uid>` is never created, read or enumerated.
- **Backoff** — observed cycle spacing 10s → 20s → 40s → … capped at 300s, never above.

Identities in fixtures are synthetic (`conversation_<n>`, `rt_sess_*`, `/repo/project-<n>`) and all paths are repository- or tempdir-relative.

## Risks

- **Bounded staleness in the root projection.** For up to one 30s window after a handover the projection can still name the predecessor, so a predecessor whose call is still up keeps access for at most that long and a successor is adopted within at most that long — in practice on its first request, because a healthy root never spends the budget. It cannot grant authority to an arbitrary caller: the presented id must match what that conversation's own live host holds. Covered by handover and within-one-window tests.
- **`list_conversations` freshness.** It now reads the completed generation instead of forcing a fresh scan, so a conversation created in the last seconds of a stale generation can lag by one refresh. This matches what `board_snapshot` has always returned.
- **Suspension is per session id and module-scoped**, surviving a call-phase transition by design so that transition cannot reset the backoff. It is recoverable rather than terminal — the first probe lands past the authority's rebuild window — and bounded to 16 entries. A genuinely dead credential still costs a handful of requests per half hour rather than none.
- **`send_message` conversation resolution** moved to the injected projection, and now goes through the registry's own `readOnlyConversationLookupFromSnapshot` rather than a local copy of its alias walk — the chained-alias regression found in the first self-review is exactly what a private copy invites. Chained-alias and owned-path tests cover it.
- One combined run that put the 20-process concurrency probe alongside the multi-process MCP writer test showed a single timing-related failure in `writerConcurrency.test.ts`. It passes isolated, and the same file set as base passes 234/0 — CPU contention from the probe, not a behaviour change.

## Scope

Touches only bridge relay/authority, the snapshot/collect seam, the smallest scanner observe seam and the MCP read/send seams. No changes to `src/components/voice/**`, `src/lib/realtime/**`, the composer, feed rendering, structured-user selected-card files, runtime host protocol or deployment scripts. Worktree grouping, catalog semantics, bridge nonce security and API compatibility are preserved.

## Review round 1

| # | Finding | Fix |
| --- | --- | --- |
| 1 | Projection pinned while the predecessor's call was live: demoted A kept inbox access, true root B refused indefinitely | Every mismatch re-derives, bounded to ≤ 1 registry read per window (`7cd6ec63`) |
| 2 | One 403 retired a session permanently, though authority can transiently refuse a correct successor | Refusal suspends with backoff past the authority window; an accepted poll clears it (`82fdc6b4`, `3d6ac798`) |
| 3 | Probe escaped isolated state via the `claude-tasks` root, and the corpus was 80 entries in one project rather than the claimed 373/41 | Every root sandboxed and asserted; 41 identifiable repositories; scheme window opened so the full corpus survives (`4590bee0`) |
| 4 | `bindings.ts` reimplemented the registry lookup | Uses `readOnlyConversationLookupFromSnapshot`; duplicate helpers removed (`cf08a7bc`) |

## Deployment

**Not merged, not deployed.** The operator has authorized a later **exact-SHA** deployment of `3d6ac7989c0fc589ea94a5019ecfde0c6c831c00` after a clean independent review. No production restart or live-state change was performed by this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
