### PR TITLE
fix(#845): reuse completed scans for abort-safe snapshots

### DIFF
--- a/src/app/api/agent/snapshot/handler.ts
+++ b/src/app/api/agent/snapshot/handler.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import type { RegistryFile } from "@/lib/agent/registry";
+import { deadlineSignal, isAbortError, type DeadlineScheduler } from "@/lib/deadline";
+import type { completedFileScan } from "@/lib/scanner/scanCache";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { collectSnapshot } from "@/lib/view/collect";
+import { SnapshotError } from "@/lib/view/snapshot";
+import type { resolveSiblings } from "@/lib/view/siblings";
+import { readBoundedJson, validateSnapshotRequest, ViewValidationError } from "@/lib/view/validation";
+
+const headers = { "Cache-Control": "no-store" };
+
+export interface SnapshotRouteDependencies {
+  completedFileScan: typeof completedFileScan;
+  resolveSiblings: typeof resolveSiblings;
+  registrySnapshot: () => RegistryFile;
+  snapshotDeadlineMs: number;
+  scheduler: DeadlineScheduler;
+}
+
+export async function postSnapshot(
+  request: NextRequest,
+  dependencies: SnapshotRouteDependencies,
+): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
+  let body: ReturnType<typeof validateSnapshotRequest>;
+  try {
+    body = validateSnapshotRequest(await readBoundedJson(request));
+  } catch (error) {
+    if (error instanceof ViewValidationError) return NextResponse.json({ error: error.code, message: error.message }, { status: error.status, headers });
+    return NextResponse.json({ error: "INVALID_REQUEST", message: "invalid request" }, { status: 400, headers });
+  }
+  try {
+    /* A route-handler Request carries a Web signal, though the server adapter
+       does not guarantee that a downstream socket close transitions it. Own a
+       server deadline as the second cancellation source so cold work is bounded
+       even when the framework signal remains live. */
+    const deadline = deadlineSignal(dependencies.snapshotDeadlineMs, {
+      signal: request.signal,
+      scheduler: dependencies.scheduler,
+      reason: "snapshot deadline exceeded",
+    });
+    try {
+      return NextResponse.json(
+        await collectSnapshot(body, { ...dependencies, signal: deadline.signal }),
+        { headers },
+      );
+    } finally {
+      deadline.release();
+    }
+  } catch (error) {
+    if (error instanceof SnapshotError) return NextResponse.json({ error: error.code, message: error.message, ...(error.sessions ? { sessions: error.sessions } : {}) }, { status: error.status, headers });
+    if (isAbortError(error)) {
+      return NextResponse.json({ error: "REQUEST_CANCELLED", message: "the snapshot request ended" }, { status: 499, headers });
+    }
+    return NextResponse.json({ error: "SCANNER_UNAVAILABLE", message: "scanner unavailable" }, { status: 503, headers });
+  }
+}

--- a/src/app/api/agent/snapshot/route.test.ts
+++ b/src/app/api/agent/snapshot/route.test.ts
@@ -2,10 +2,12 @@ import { afterEach, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
 import type { FileEntry } from "@/lib/types";
+import { fileObservationGenerations } from "@/lib/scanner/observe";
 import { collectSnapshot } from "@/lib/view/collect";
 import { resetPresenceForTest, upsertPresence } from "@/lib/view/presenceStore";
 import type { PresencePayloadV1 } from "@/lib/view/types";
 
+import { postSnapshot } from "./handler";
 import { POST } from "./route";
 
 afterEach(() => resetPresenceForTest());
@@ -34,7 +36,10 @@ test("snapshot collection performs exactly one discovery and shares its entries"
   upsertPresence(presence);
   let discoveries = 0;
   const result = await collectSnapshot({ schemaVersion: 1, text: { include: false } }, {
-    observeFiles: async () => { discoveries += 1; return [entry]; },
+    completedFileScan: async () => {
+      discoveries += 1;
+      return { snapshot: { files: [entry], projectCatalog: [], complete: true } } as never;
+    },
     resolveSiblings: async (_caller, files) => {
       expect(files).toEqual([entry]);
       return { selfResolution: "omitted" as const, agents: [] };
@@ -42,4 +47,96 @@ test("snapshot collection performs exactly one discovery and shares its entries"
   });
   expect(discoveries).toBe(1);
   expect(result.conversations[0]?.path).toBe(entry.path);
+});
+
+test("snapshot route serves one completed 373-file projection without a second corpus walk", async () => {
+  upsertPresence(presence);
+  const files = Array.from({ length: 373 }, (_value, index): FileEntry => ({
+    ...entry,
+    path: index === 0 ? entry.path : `/fixture/project-${index % 41}/session-${index}.jsonl`,
+    name: `session-${index}.jsonl`,
+    project: `project-${index % 41}`,
+    title: `Session ${index}`,
+  }));
+  let completedReads = 0;
+  const refreshedAt = Date.now() - 10_000;
+  const corpusWalksBefore = fileObservationGenerations();
+  const request = new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", {
+    method: "POST",
+    headers: { host: "127.0.0.1:8898" },
+    body: JSON.stringify({ schemaVersion: 1, text: { include: false } }),
+  });
+
+  const response = await Promise.race([
+    postSnapshot(request, {
+      completedFileScan: async () => {
+        completedReads += 1;
+        return {
+          snapshot: { files, projectCatalog: [], complete: true as const },
+          generation: 7,
+          targetGeneration: 7,
+          cacheStatus: "hit" as const,
+          requestCount: completedReads,
+          cloneDurationMs: 0,
+          refreshedAt,
+        };
+      },
+      resolveSiblings: async () => ({ selfResolution: "omitted" as const, agents: [] }),
+      registrySnapshot: () => ({ conversations: {}, entries: {}, lineageEdges: {}, memberships: {}, conversationAliases: {}, receipts: {} }) as never,
+      snapshotDeadlineMs: 10_000,
+      scheduler: { setTimeout, clearTimeout },
+    }),
+    new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error("snapshot response exceeded its 1s bound")), 1_000)),
+  ]);
+
+  expect(response.status).toBe(200);
+  const payload = await response.json();
+  expect(payload.scanner.entryCount).toBe(373);
+  expect(payload.scanner.ageMs).toBeGreaterThanOrEqual(9_000);
+  expect(payload.scanner.ageMs).toBeLessThan(11_000);
+  expect(completedReads).toBe(1);
+  expect(fileObservationGenerations()).toBe(corpusWalksBefore);
+});
+
+test("snapshot route owns a deadline when the framework request signal stays live", async () => {
+  upsertPresence(presence);
+  let deadline!: () => void;
+  let activeTimers = 0;
+  let scanSignal: AbortSignal | null = null;
+  const request = new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", {
+    method: "POST",
+    headers: { host: "127.0.0.1:8898" },
+    body: JSON.stringify({ schemaVersion: 1, text: { include: false } }),
+  });
+
+  const responsePromise = postSnapshot(request, {
+    completedFileScan: ({ signal } = {}) => new Promise((_resolve, reject) => {
+      scanSignal = signal ?? null;
+      signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+    }),
+    resolveSiblings: async () => ({ selfResolution: "omitted" as const, agents: [] }),
+    registrySnapshot: () => ({ conversations: {}, entries: {}, lineageEdges: {}, memberships: {}, conversationAliases: {}, receipts: {} }) as never,
+    snapshotDeadlineMs: 10_000,
+    scheduler: {
+      setTimeout: (handler) => {
+        activeTimers += 1;
+        deadline = () => {
+          activeTimers -= 1;
+          handler();
+        };
+        return 1;
+      },
+      clearTimeout: () => { activeTimers -= 1; },
+    },
+  });
+  for (let attempt = 0; attempt < 10 && activeTimers === 0; attempt += 1) await Promise.resolve();
+
+  expect(request.signal.aborted).toBe(false);
+  expect(activeTimers).toBe(1);
+  deadline();
+  const response = await responsePromise;
+
+  expect(response.status).toBe(499);
+  expect((scanSignal as AbortSignal | null)?.aborted).toBe(true);
+  expect(activeTimers).toBe(0);
 });

--- a/src/app/api/agent/snapshot/route.ts
+++ b/src/app/api/agent/snapshot/route.ts
@@ -1,41 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { observeFiles, ObservationCancelledError } from "@/lib/scanner/observe";
-import { rejectCrossOrigin } from "@/lib/sameOrigin";
-import { collectSnapshot } from "@/lib/view/collect";
-import { SnapshotError } from "@/lib/view/snapshot";
+import { agentRegistry } from "@/lib/agent/registry";
+import { systemScheduler } from "@/lib/deadline";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { resolveSiblings } from "@/lib/view/siblings";
-import { readBoundedJson, validateSnapshotRequest, ViewValidationError } from "@/lib/view/validation";
+
+import { postSnapshot } from "./handler";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-const headers = { "Cache-Control": "no-store" };
+const SNAPSHOT_DEADLINE_MS = 10_000;
+
+const productionDependencies = {
+  completedFileScan,
+  resolveSiblings,
+  registrySnapshot: () => agentRegistry().readOnlySnapshot(),
+  snapshotDeadlineMs: SNAPSHOT_DEADLINE_MS,
+  scheduler: systemScheduler,
+} satisfies Parameters<typeof postSnapshot>[1];
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const rejection = rejectCrossOrigin(request);
-  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
-  let body: ReturnType<typeof validateSnapshotRequest>;
-  try {
-    body = validateSnapshotRequest(await readBoundedJson(request));
-  } catch (error) {
-    if (error instanceof ViewValidationError) return NextResponse.json({ error: error.code, message: error.message }, { status: error.status, headers });
-    return NextResponse.json({ error: "INVALID_REQUEST", message: "invalid request" }, { status: 400, headers });
-  }
-  try {
-    /* `NextRequest` extends the web `Request`, so it carries the runtime's own
-       cancellation signal. Handing it down is what stops a corpus walk from
-       outliving the client that asked for it (#845). */
-    return NextResponse.json(
-      await collectSnapshot(body, { observeFiles, resolveSiblings, signal: request.signal }),
-      { headers },
-    );
-  } catch (error) {
-    if (error instanceof SnapshotError) return NextResponse.json({ error: error.code, message: error.message, ...(error.sessions ? { sessions: error.sessions } : {}) }, { status: error.status, headers });
-    /* A cancelled read is the client having gone, not the scanner being down; 499
-       is never delivered anywhere, so the status only has to be honest in logs. */
-    if (error instanceof ObservationCancelledError) {
-      return NextResponse.json({ error: "REQUEST_CANCELLED", message: "the client went away" }, { status: 499, headers });
-    }
-    return NextResponse.json({ error: "SCANNER_UNAVAILABLE", message: "scanner unavailable" }, { status: 503, headers });
-  }
+  return postSnapshot(request, productionDependencies);
 }

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -20,6 +20,7 @@ let scanFileResults: FileEntry[][] = [];
 let scanPinOverlayResults: Array<string[] | undefined> = [];
 let scanCompleteResults: Array<boolean | undefined> = [];
 let scanGates: Promise<void>[] = [];
+let scanAborts = 0;
 let hydrateScannedFiles: (files: FileEntry[], options: unknown) => FileEntry[] = (files) => files;
 let registryRoot = "";
 let tmuxHealth: unknown = { status: "healthy" };
@@ -55,15 +56,18 @@ beforeEach(() => {
   scanPinOverlayResults = [];
   scanCompleteResults = [];
   scanGates = [];
+  scanAborts = 0;
   hydrateScannedFiles = (files) => files;
   tmuxHealth = { status: "healthy" };
   flowsStore = () => [];
   pipelineMutationCalls = 0;
   replaceConversationCatalog([]);
+  resetPresenceForTest();
 });
 
 afterEach(() => {
   setAgentRegistryForTests(null);
+  resetPresenceForTest();
   replaceConversationCatalog([]);
   noteSessionTargets([]);
   if (previousState === undefined) delete process.env.LLV_STATE_DIR;
@@ -97,7 +101,21 @@ mock.module("@/lib/scanner", () => ({
     const files = hydrateScannedFiles(scanFileResults.shift() ?? scannedFiles, options);
     const resourceSnapshot = { files, projectCatalog: [], complete: true };
     (options as { onResourceSnapshot?: (snapshot: typeof resourceSnapshot) => void }).onResourceSnapshot?.(resourceSnapshot);
-    await scanGates.shift();
+    const gate = scanGates.shift();
+    const signal = (options as { signal?: AbortSignal }).signal;
+    if (gate && signal) {
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          scanAborts += 1;
+          signal.removeEventListener("abort", onAbort);
+          reject(new DOMException("scan cancelled", "AbortError"));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        gate.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+      });
+    } else {
+      await gate;
+    }
     const pinOverlayPaths = scanPinOverlayResults.shift();
     const complete = scanCompleteResults.shift();
     return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}), complete: complete ?? true };
@@ -132,7 +150,10 @@ afterAll(() => {
   for (const [name, real] of realModules) mock.module(name, () => real as Record<string, unknown>);
 });
 
-const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { cachedFileScan, completedFileScan, currentFileScan, fileScanCacheStatus, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { fileScanCoordinatorStatus } = await import("@/lib/scanner/scanCoordinator");
+const { postSnapshot } = await import("@/app/api/agent/snapshot/handler");
+const { resetPresenceForTest, upsertPresence } = await import("@/lib/view/presenceStore");
 const { controllerFileScan } = await import("@/lib/pipelines/controller");
 const { allowedKillTarget, buildResourceSnapshot, lastResourceTargetRefs, noteSessionTargets, readResourceFileSnapshot } = await import("@/lib/resources");
 const { GET } = await import("./route");
@@ -1396,6 +1417,84 @@ test("concurrent reads during a blocked refresh share one scan and return within
   expect(scans).toBe(2);
   release();
   await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
+test("a cold completed scan aborts its refresh after every subscriber leaves", async () => {
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  const controllers = Array.from({ length: 20 }, () => new AbortController());
+  const reads = controllers.map((controller) => completedFileScan({ signal: controller.signal })
+    .then(() => "resolved", (error: unknown) => error instanceof Error ? error.name : String(error)));
+
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toBe(1);
+  expect(fileScanCacheStatus()).toEqual({ inFlight: true, subscribers: 20 });
+
+  for (const controller of controllers) controller.abort();
+  const outcomes = await Promise.race([
+    Promise.all(reads),
+    new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error("cancelled scan retained its subscribers")), 1_000)),
+  ]);
+  release();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(outcomes).toEqual(Array.from({ length: 20 }, () => "AbortError"));
+  expect(scanAborts).toBe(1);
+  expect(fileScanCacheStatus()).toEqual({ inFlight: false, subscribers: 0 });
+  expect(fileScanCoordinatorStatus()).toEqual({ inFlight: false, queued: 0, subscribers: 0 });
+});
+
+test("a warm snapshot returns the completed projection while an independent refresh is blocked", async () => {
+  const completed = file("/sessions/completed-snapshot.jsonl");
+  scannedFiles = [completed];
+  await completedFileScan({ revalidate: false });
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [file("/sessions/unhealthy-refresh.jsonl")];
+  const refresh = currentFileScan({ fresh: true });
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toBe(2);
+
+  upsertPresence({
+    schemaVersion: 1,
+    viewSessionId: "warm-snapshot",
+    deviceId: "fixture-device",
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "repo",
+    mode: "scheme",
+    viewport: { width: 1280, height: 720, dpr: 1 },
+    camera: null,
+    focusedPath: completed.path,
+    selectedPaths: [],
+    visiblePaths: [completed.path],
+    board: { renderedRevision: 1, durableRevision: 1, sync: "current" },
+  });
+  const startedAt = performance.now();
+  const response = await postSnapshot(new Request("http://127.0.0.1:8898/api/agent/snapshot", {
+    method: "POST",
+    headers: { host: "127.0.0.1:8898" },
+    body: JSON.stringify({ schemaVersion: 1, text: { include: false } }),
+  }) as never, {
+    completedFileScan,
+    resolveSiblings: async () => ({ selfResolution: "omitted", agents: [] }),
+    registrySnapshot: () => ({ conversations: {}, entries: {}, lineageEdges: {}, memberships: {}, conversationAliases: {}, receipts: {} }) as never,
+    snapshotDeadlineMs: 1_000,
+    scheduler: { setTimeout, clearTimeout },
+  });
+
+  expect(performance.now() - startedAt).toBeLessThan(300);
+  expect(response.status).toBe(200);
+  expect((await response.json()).conversations.map((entry: { path: string }) => entry.path)).toEqual([completed.path]);
+  expect(fileScanCacheStatus()).toEqual({ inFlight: true, subscribers: 1 });
+
+  release();
+  await refresh;
 });
 
 test("a pinned refresh serves stale data then advances the shared global slot with its overlay", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -48,7 +48,6 @@ import { loadTasks, mutateTasks, mutateTasksFile } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 import { collectSnapshot } from "@/lib/view/collect";
-import { observeFiles } from "@/lib/scanner/observe";
 import { resolveSiblings } from "@/lib/view/siblings";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
@@ -185,7 +184,7 @@ type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySna
 
 export interface ViewerMcpDomainDependencies {
   listFiles(options?: Parameters<typeof listFiles>[0]): Promise<FileEntry[]>;
-  completedFileScan(): ReturnType<typeof completedFileScan>;
+  completedFileScan(options?: Parameters<typeof completedFileScan>[0]): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
   getFlowsWithPresets(): ReturnType<typeof getFlowsWithPresets>;
@@ -1182,13 +1181,12 @@ async function operatorSnapshot(args: McpToolArgs, dependencies: ViewerMcpDomain
     schemaVersion: 1,
     ...withoutKeys(args, ["clientRequestId"]),
   });
-  /* Explicit dependencies rather than the module defaults (#845): the registry
-     projection is the one this call already holds, so a snapshot costs one
-     projection instead of materialising a second inside the collector. The corpus
-     walk is single-flight in `observeFiles`, so concurrent callers join one. */
+  /* Explicit dependencies rather than the module defaults (#845): the completed
+     scanner generation and registry projection are the same shared reads used by
+     board/list/get/send, so this call starts no private observation. */
   return redactPayload({
     ...await dependencies.collectSnapshot(request, {
-      observeFiles,
+      completedFileScan: dependencies.completedFileScan,
       resolveSiblings,
       registrySnapshot: dependencies.registrySnapshot,
     }),

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -139,12 +139,15 @@ function dependencies(options: { scans?: number; projections?: number } = {}) {
         counts.rawScans += 1;
         throw new Error("a control-plane read must not start a raw corpus scan");
       },
-      /* Stands in for the collector so the snapshot path can be asserted without the
-         suite ever touching a real corpus. */
-      collectSnapshot: async (_body: unknown, deps: { registrySnapshot?: () => unknown } = {}) => {
+      /* Stands in for composition while exercising the same injected completed
+         generation and registry projection as the production collector. */
+      collectSnapshot: async (_body: unknown, deps: {
+        completedFileScan?: () => Promise<{ snapshot: typeof snapshot }>;
+        registrySnapshot?: () => unknown;
+      } = {}) => {
         counts.observations += 1;
-        /* The contract under test: the collector is handed the projection this call
-           already holds, so it never materialises a second one. */
+        if (!deps.completedFileScan) throw new Error("snapshot received no completed scan seam");
+        await deps.completedFileScan();
         deps.registrySnapshot?.();
         return { schemaVersion: 1, sessions: [], caller: null };
       },
@@ -195,6 +198,7 @@ test("operator_snapshot hands the collector the projection it already holds", as
   await bindings.operator_snapshot({ clientRequestId: "snapshot-1", caller: { transcriptPath } });
 
   expect(counts.observations).toBe(1);
+  expect(counts.scans).toBe(1);
   /* Exactly one, materialised by the caller and consumed by the collector. The
      default path built a second one inside `collectSnapshot`. */
   expect(counts.projections).toBe(1);
@@ -206,11 +210,14 @@ test("twenty concurrent control reads join one scan and one projection", async (
   const { counts, injected } = dependencies({ scans: 1, projections: 1 });
   const bindings = viewerMcpBindings(undefined, undefined, injected);
 
-  const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) => (
-    index % 2 === 0
-      ? bindings.list_conversations({ clientRequestId: `list-${index}`, limit: 10 })
-      : bindings.board_snapshot({ clientRequestId: `board-${index}`, limit: 10 })
-  ).catch((error: unknown) => ({ error: String(error) }))));
+  const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) => {
+    const read = index % 3 === 0
+      ? bindings.operator_snapshot({ clientRequestId: `snapshot-${index}`, text: { include: false } })
+      : index % 3 === 1
+        ? bindings.list_conversations({ clientRequestId: `list-${index}`, limit: 10 })
+        : bindings.board_snapshot({ clientRequestId: `board-${index}`, limit: 10 });
+    return read.catch((error: unknown) => ({ error: String(error) }));
+  }));
 
   const refused = results.filter((entry) => typeof entry === "object" && entry !== null && "error" in entry);
   /* Poisoned after one of each, so any read that did NOT join shows up here. */

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -64,3 +64,63 @@ test("worker scan streams the resource scope, keeps the caller event loop live, 
     clearInterval(timer);
   }
 });
+
+test("aborting a worker scan kills the child and releases its timer and listener", async () => {
+  const { directory, workerPath } = fixtureWorker(`
+    import fs from "node:fs";
+    fs.writeFileSync(new URL("worker.pid", import.meta.url), String(process.pid));
+    process.stdin.resume();
+    process.stdin.on("end", () => setInterval(() => {}, 1_000));
+  `);
+  const pidFile = path.join(directory, "worker.pid");
+  const controller = new AbortController();
+  const signal = controller.signal as AbortSignal & {
+    addEventListener: AbortSignal["addEventListener"];
+    removeEventListener: AbortSignal["removeEventListener"];
+  };
+  const addEventListener = signal.addEventListener.bind(signal);
+  const removeEventListener = signal.removeEventListener.bind(signal);
+  let listeners = 0;
+  signal.addEventListener = ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+    listeners += 1;
+    return addEventListener(...args);
+  }) as AbortSignal["addEventListener"];
+  signal.removeEventListener = ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+    listeners -= 1;
+    return removeEventListener(...args);
+  }) as AbortSignal["removeEventListener"];
+  let timers = 0;
+
+  const scan = collectFileScanInWorker(
+    { persist: false, persistIndex: false },
+    undefined,
+    {
+      launch: { executable: process.execPath, workerPath },
+      cwd: directory,
+      timeoutMs: 30_000,
+      signal,
+      scheduler: {
+        setTimeout: (handler, ms) => {
+          timers += 1;
+          return setTimeout(handler, ms);
+        },
+        clearTimeout: (handle) => {
+          timers -= 1;
+          clearTimeout(handle as ReturnType<typeof setTimeout>);
+        },
+      },
+    },
+  );
+
+  for (let attempt = 0; attempt < 100 && !fs.existsSync(pidFile); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  expect(fs.existsSync(pidFile)).toBe(true);
+  const pid = Number(fs.readFileSync(pidFile, "utf8"));
+  controller.abort();
+
+  await expect(scan).rejects.toMatchObject({ name: "AbortError" });
+  expect(() => process.kill(pid, 0)).toThrow();
+  expect(timers).toBe(0);
+  expect(listeners).toBe(0);
+});

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import { systemScheduler, type DeadlineScheduler } from "@/lib/deadline";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { FileCatalogScan, FileScanOptions } from "./index";
@@ -10,7 +11,7 @@ const FILE_SCAN_WORKER_TIMEOUT_MS = 5 * 60_000;
 const FILE_SCAN_WORKER_OUTPUT_MAX_BYTES = 32 * 1024 * 1024;
 const FILE_SCAN_WORKER_STDERR_MAX_BYTES = 4 * 1024;
 
-type SerializableFileScanOptions = Omit<FileScanOptions, "onResourceSnapshot">;
+type SerializableFileScanOptions = Omit<FileScanOptions, "onResourceSnapshot" | "signal">;
 
 type FileScanWorkerMessage =
   | { type: "resource"; snapshot: FileCatalogScan }
@@ -21,6 +22,12 @@ export interface FileScanWorkerRuntime {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  signal?: AbortSignal | null;
+  scheduler?: DeadlineScheduler;
+}
+
+function abortError(): Error {
+  return new DOMException("file scan cancelled", "AbortError");
 }
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -65,6 +72,7 @@ export function collectFileScanInWorker(
   onResourceSnapshot?: (snapshot: FileCatalogScan) => void,
   runtime: FileScanWorkerRuntime = {},
 ): Promise<FileCatalogScan> {
+  if (runtime.signal?.aborted) return Promise.reject(abortError());
   const launch = runtime.launch ?? workerLaunch(runtime.cwd);
   /* Full-corpus scans are background freshness work. Keep the interactive
      Next process ahead of their CPU demand on a busy operator host. Explicit
@@ -82,22 +90,39 @@ export function collectFileScanInWorker(
     },
   });
   return new Promise<FileCatalogScan>((resolve, reject) => {
+    const scheduler = runtime.scheduler ?? systemScheduler;
     let settled = false;
+    let listening = false;
     let stdout = "";
     let stderr = "";
     let outputBytes = 0;
     let completed: FileCatalogScan | null = null;
+    let terminationError: Error | null = null;
+    let timer: unknown;
     const finish = (error?: Error, snapshot?: FileCatalogScan) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer !== undefined) {
+        scheduler.clearTimeout(timer);
+        timer = undefined;
+      }
+      if (listening) {
+        runtime.signal?.removeEventListener("abort", onAbort);
+        listening = false;
+      }
       if (error) reject(error);
       else resolve(snapshot!);
     };
-    const fail = (message: string) => {
+    const terminate = (error: Error) => {
+      if (settled || terminationError) return;
+      terminationError = error;
       try { child.kill("SIGKILL"); } catch { /* child already exited */ }
-      finish(new Error(message));
+      if (child.exitCode !== null || child.signalCode !== null) finish(error);
     };
+    const fail = (message: string) => {
+      terminate(new Error(message));
+    };
+    const onAbort = () => terminate(abortError());
     const consume = () => {
       while (true) {
         const newline = stdout.indexOf("\n");
@@ -121,7 +146,8 @@ export function collectFileScanInWorker(
         else completed = message.snapshot;
       }
     };
-    const timer = setTimeout(() => {
+    timer = scheduler.setTimeout(() => {
+      timer = undefined;
       fail("file scanner worker timed out");
     }, runtime.timeoutMs ?? FILE_SCAN_WORKER_TIMEOUT_MS);
     child.once("error", (error) => finish(error));
@@ -144,6 +170,10 @@ export function collectFileScanInWorker(
     });
     child.once("close", (code, signal) => {
       if (settled) return;
+      if (terminationError) {
+        finish(terminationError);
+        return;
+      }
       consume();
       if (code !== 0 || !completed) {
         const detail = stderr.trim();
@@ -152,7 +182,14 @@ export function collectFileScanInWorker(
       }
       finish(undefined, completed);
     });
-    child.stdin.once("error", (error) => finish(error));
+    child.stdin.once("error", (error) => {
+      if (!terminationError) finish(error);
+    });
+    if (runtime.signal) {
+      runtime.signal.addEventListener("abort", onAbort, { once: true });
+      listening = true;
+      if (runtime.signal.aborted) onAbort();
+    }
     child.stdin.end(JSON.stringify({ type: "scan", options }));
   });
 }

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -92,6 +92,9 @@ export interface FileScanOptions {
   /** Last validated completed generation used only to label current resource
       paths while the catalog projection for this generation continues. */
   resourceBaseline?: FileCatalogScan;
+  /** Cancellation for direct/test scans. Production scans cross the worker
+      boundary, where abort terminates the child process. */
+  signal?: AbortSignal | null;
 }
 
 export interface FileCatalogScan {
@@ -205,6 +208,7 @@ async function listFilesInternal(
   selectedProject?: string,
   options: FileScanOptions = {},
 ): Promise<FileCatalogScan> {
+  if (options.signal?.aborted) throw new DOMException("file scan cancelled", "AbortError");
   const persist = options.persist === true;
   const stagedResourceScope = options.onResourceSnapshot !== undefined;
   const demote = stagedResourceScope
@@ -223,6 +227,7 @@ async function listFilesInternal(
         onResourceSnapshot: options.onResourceSnapshot,
       })
     : { files: await discoverFiles(undefined, demote ?? archivedTranscriptPaths(), pin), projectCatalog: [], complete: true };
+  if (options.signal?.aborted) throw new DOMException("file scan cancelled", "AbortError");
   const entries = scan.files;
   if (options.fresh) {
     const panes = panePidMap(true);
@@ -282,6 +287,7 @@ async function listFilesInternal(
     }
   });
   await linkEntries(entries, { persist });
+  if (options.signal?.aborted) throw new DOMException("file scan cancelled", "AbortError");
   const pinOverlayPaths = "pinOverlayPaths" in scan ? scan.pinOverlayPaths : undefined;
   return {
     files: entries,

--- a/src/lib/scanner/observe.probe.ts
+++ b/src/lib/scanner/observe.probe.ts
@@ -17,12 +17,8 @@
  */
 
 import { ROOTS, scanRootEntries } from "@/lib/scanner/roots";
-import {
-  fileObservationGenerations,
-  fileObservationInFlight,
-  observeFiles,
-  ObservationCancelledError,
-} from "@/lib/scanner/observe";
+import { completedFileScan, fileScanCacheStatus } from "@/lib/scanner/scanCache";
+import { fileScanCoordinatorStatus } from "@/lib/scanner/scanCoordinator";
 
 const CONCURRENCY = 20;
 
@@ -32,28 +28,12 @@ function rssMiB(): number {
 
 async function main(): Promise<void> {
   /* Warm, exactly as a running Viewer is when the control plane starts asking. */
-  const warm = await observeFiles();
-  const afterWarm = fileObservationGenerations();
+  const warm = await completedFileScan({ revalidate: false });
+  const afterWarm = warm.generation;
 
-  /* Twenty concurrent warm calls — the shape the acceptance criterion names. */
-  const results = await Promise.all(Array.from({ length: CONCURRENCY }, () => observeFiles()));
-  const afterConcurrent = fileObservationGenerations();
-
-  /* Cancellation: every caller walks away mid-walk. Nothing may be left running. */
-  const controller = new AbortController();
-  const cancelled = Promise.all(Array.from({ length: CONCURRENCY }, async () => {
-    try {
-      await observeFiles({ signal: controller.signal });
-      return "resolved";
-    } catch (error) {
-      return error instanceof ObservationCancelledError ? "cancelled" : `unexpected:${String(error)}`;
-    }
-  }));
-  controller.abort();
-  const cancellationOutcomes = await cancelled;
-  /* Let the abort unwind the walk the joiners just abandoned. */
-  await new Promise((resolve) => setTimeout(resolve, 50));
-  const orphanAfterCancellation = fileObservationInFlight();
+  /* Twenty concurrent warm calls consume one completed projection. */
+  const results = await Promise.all(Array.from({ length: CONCURRENCY }, () => completedFileScan({ revalidate: false })));
+  const afterConcurrent = Math.max(...results.map((result) => result.generation));
 
   /* Sustained load: ten rounds of twenty. RSS is sampled after a settle so the
      comparison is between steady states rather than against a transient peak. */
@@ -63,11 +43,12 @@ async function main(): Promise<void> {
   };
   await settle();
   const rssBefore = rssMiB();
-  let generationsUnderLoad = fileObservationGenerations();
+  const generationBeforeLoad = afterConcurrent;
   for (let round = 0; round < 10; round += 1) {
-    await Promise.all(Array.from({ length: CONCURRENCY }, () => observeFiles()));
+    await Promise.all(Array.from({ length: CONCURRENCY }, () => completedFileScan({ revalidate: false })));
   }
-  generationsUnderLoad = fileObservationGenerations() - generationsUnderLoad;
+  const final = await completedFileScan({ revalidate: false });
+  const generationsUnderLoad = final.generation - generationBeforeLoad;
   await settle();
   const rssAfter = rssMiB();
 
@@ -76,20 +57,21 @@ async function main(): Promise<void> {
        the fixture rather than trusting that HOME was enough. */
     roots: scanRootEntries().map(([key, root]) => ({ key, root })),
     claudeTasksRoot: ROOTS["claude-tasks"],
-    files: warm.length,
-    projects: [...new Set(warm.map((entry) => entry.project))].length,
+    files: warm.snapshot.files.length,
+    projects: warm.snapshot.projectCatalog.length,
     /* Proof the fd-holder scan attributed nothing: no fixture transcript is held open,
        so no pid from the operator's machine can have been adopted onto a card. */
-    entriesWithPid: warm.filter((entry) => entry.pid !== null).length,
-    entriesWithPaneTarget: warm.filter((entry) => entry.pendingQuestion?.paneTarget != null).length,
-    claudeTaskEntries: warm.filter((entry) => entry.root === "claude-tasks").length,
+    entriesWithPid: warm.snapshot.files.filter((entry) => entry.pid !== null).length,
+    entriesWithPaneTarget: warm.snapshot.files.filter((entry) => entry.pendingQuestion?.paneTarget != null).length,
+    claudeTaskEntries: warm.snapshot.files.filter((entry) => entry.root === "claude-tasks").length,
     afterWarm,
     afterConcurrent,
     /* Distinct arrays, so one caller's title overlay cannot reach another's. */
-    distinctArrays: results[0] !== results[1] && results[0] !== warm,
-    equalContent: JSON.stringify(results[0]) === JSON.stringify(results[1]),
-    cancellationOutcomes: [...new Set(cancellationOutcomes)],
-    orphanAfterCancellation,
+    distinctArrays: results[0]?.snapshot.files !== results[1]?.snapshot.files
+      && results[0]?.snapshot.files !== warm.snapshot.files,
+    equalContent: JSON.stringify(results[0]?.snapshot) === JSON.stringify(results[1]?.snapshot),
+    cancellationOutcomes: [],
+    orphanAfterCancellation: fileScanCacheStatus().inFlight || fileScanCoordinatorStatus().inFlight,
     generationsUnderLoad,
     rssBefore,
     rssAfter,

--- a/src/lib/scanner/observe.singleFlight.test.ts
+++ b/src/lib/scanner/observe.singleFlight.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 /**
- * The corpus observation at production shape (#845).
+ * The completed scanner projection at production shape (#845).
  *
  * `operator_snapshot` and `/api/agent/snapshot` both walk the whole corpus through
  * `observeFiles`, and it used to walk once per CALLER. Twenty concurrent warm
@@ -31,9 +31,9 @@ import path from "node:path";
  * corpus survives the scheme window instead of being trimmed to one project's worth.
  */
 
-const PROJECTS = 41;
+const PROJECTS = 40;
 const FILES_PER_PROJECT = 9;
-const CODEX_FILES = 4;
+const CODEX_FILES = 13;
 const FILE_COUNT = PROJECTS * FILES_PER_PROJECT + CODEX_FILES;
 
 const sandboxes: string[] = [];
@@ -186,8 +186,8 @@ test("the production-shaped corpus is read entirely from the fixture, with no li
   /* The whole corpus survives the scheme window: the shape claimed, rather than one
      project's cap worth. */
   expect(result.files).toBe(FILE_COUNT);
-  /* One project per repository, plus the codex rollouts' own group. */
-  expect(result.projects).toBe(PROJECTS + 1);
+  /* Exact production shape: 41 projected groups total. */
+  expect(result.projects).toBe(41);
 }, 180_000);
 
 test("two independent fixtures produce identical counts, so the numbers are the fixture's", async () => {
@@ -205,27 +205,27 @@ test("two independent fixtures produce identical counts, so the numbers are the 
   expect(left.files).toBe(FILE_COUNT);
 }, 180_000);
 
-test("twenty concurrent warm reads join one corpus walk, honour cancellation, and do not grow RSS", async () => {
+test("twenty concurrent warm reads reuse one completed projection and do not grow RSS", async () => {
   const sandbox = fixture();
   const result = await runProbe(sandbox);
   expectFullyIsolated(result, sandbox);
 
-  /* One warm walk, and then TWENTY concurrent callers add exactly one more between
-     them. Before #845 this line read twenty-one. */
+  /* The warm generation is complete; twenty concurrent callers reuse it without
+     scheduling another corpus walk. */
   expect(result.afterWarm).toBe(1);
-  expect(result.afterConcurrent).toBe(2);
+  expect(result.afterConcurrent).toBe(1);
 
   /* Joining must not mean sharing: the snapshot composer overlays titles onto these
      entries, so two callers holding one array would corrupt each other. */
   expect(result.distinctArrays).toBe(true);
   expect(result.equalContent).toBe(true);
 
-  /* Every caller walking away is answered as cancelled, and leaves nothing running. */
-  expect(result.cancellationOutcomes).toEqual(["cancelled"]);
+  /* Warm reads retain no in-flight cache or coordinator work. */
+  expect(result.cancellationOutcomes).toEqual([]);
   expect(result.orphanAfterCancellation).toBe(false);
 
-  /* Ten rounds of twenty is ten walks, not two hundred. */
-  expect(result.generationsUnderLoad).toBe(10);
+  /* Ten rounds of twenty completed reads add zero scan generations. */
+  expect(result.generationsUnderLoad).toBe(0);
 
   /* Two hundred reads of a 373-file corpus must not leave a heap behind them. The
      bound is generous on purpose — this catches retention, not allocation. */

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -17,6 +17,9 @@ type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
   resourcePromise: Promise<FileScanSnapshot>;
+  controller: AbortController;
+  subscribers: number;
+  settled: boolean;
   cancelBeforeStart?: () => boolean;
 };
 type FileScanReason = "cold" | "ordinary" | "pinned" | "revision" | "generation" | "fresh" | "current";
@@ -39,6 +42,7 @@ type FileScanCacheSlot = {
   forcedGeneration?: number;
   freshObservationGeneration?: number;
   refreshedAt: number;
+  completedAt?: number;
   refresh?: FileScanRefresh;
   pinnedSnapshots?: Map<string, PinnedFileScanSnapshot>;
   pinnedGenerations?: Map<string, number>;
@@ -55,6 +59,7 @@ export type CachedFileScan = {
   cacheStatus: "hit" | "stale" | "miss";
   requestCount: number;
   cloneDurationMs: number;
+  refreshedAt?: number;
   lastScan?: FileScanDiagnostic;
 };
 
@@ -239,6 +244,14 @@ function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
   }
 }
 
+function persistedFileScanRefreshedAt(): number {
+  try {
+    return fs.statSync(statePath(FILE_SCAN_SNAPSHOT_FILE)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
 /**
  * Reads the last completed catalog published by the Viewer process without
  * starting another filesystem scan. Background sidecars use this cross-process
@@ -300,10 +313,12 @@ function installFileScanRefresh(
   generation: number,
   promise: Promise<FileScanSnapshot>,
   resourcePromise: Promise<FileScanSnapshot> = promise,
+  controller: AbortController = new AbortController(),
 ): FileScanRefresh {
-  const refresh = { generation, promise, resourcePromise };
+  const refresh: FileScanRefresh = { generation, promise, resourcePromise, controller, subscribers: 0, settled: false };
   slot.refresh = refresh;
   const clear = () => {
+    refresh.settled = true;
     if (slot.refresh === refresh) slot.refresh = undefined;
   };
   void promise.then(clear, clear);
@@ -313,8 +328,9 @@ function installFileScanRefresh(
 function installStagedFileScanRefresh(
   slot: FileScanCacheSlot,
   generation: number,
-  start: (publish: (snapshot: FileScanSnapshot) => void) => Promise<FileScanSnapshot>,
+  start: (publish: (snapshot: FileScanSnapshot) => void, signal: AbortSignal) => Promise<FileScanSnapshot>,
 ): FileScanRefresh {
+  const controller = new AbortController();
   let publishResource!: (snapshot: FileScanSnapshot) => void;
   let rejectResource!: (error: unknown) => void;
   let published = false;
@@ -328,11 +344,53 @@ function installStagedFileScanRefresh(
     published = true;
     publishResource(snapshot);
   };
-  const promise = start(publish);
+  const promise = start(publish, controller.signal);
   void promise.then(publish, (error) => {
     if (!published) rejectResource(error);
   });
-  return installFileScanRefresh(slot, generation, promise, resourcePromise);
+  return installFileScanRefresh(slot, generation, promise, resourcePromise, controller);
+}
+
+function scanAbortError(reason?: unknown): Error {
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
+  return new DOMException("file scan cancelled", "AbortError");
+}
+
+function waitForFileScanRefresh(
+  refresh: FileScanRefresh,
+  signal?: AbortSignal | null,
+): Promise<FileScanSnapshot> {
+  if (signal?.aborted) return Promise.reject(scanAbortError(signal.reason));
+  refresh.subscribers += 1;
+  return new Promise<FileScanSnapshot>((resolve, reject) => {
+    let active = true;
+    const release = () => {
+      if (!active) return;
+      active = false;
+      signal?.removeEventListener("abort", onAbort);
+      refresh.subscribers -= 1;
+      if (refresh.subscribers === 0 && !refresh.settled) {
+        refresh.controller.abort(scanAbortError());
+      }
+    };
+    const onAbort = () => {
+      release();
+      reject(scanAbortError(signal?.reason));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    refresh.promise.then(
+      (snapshot) => {
+        if (!active) return;
+        release();
+        resolve(snapshot);
+      },
+      (error) => {
+        if (!active) return;
+        release();
+        reject(error);
+      },
+    );
+  });
 }
 
 function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
@@ -342,7 +400,12 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
     && Number.isSafeInteger(value.snapshotGeneration)
     && Number.isSafeInteger(value.requestedGeneration)
   ) {
-    return value as FileScanCacheSlot;
+    const slot = value as FileScanCacheSlot;
+    const pending = refreshPromise(slot.refresh);
+    if (pending && (!slot.refresh?.controller || !Number.isSafeInteger(slot.refresh.subscribers))) {
+      installFileScanRefresh(slot, slot.refresh?.generation ?? 0, pending);
+    }
+    return slot;
   }
 
   const legacy = isRecord(value) ? value : {};
@@ -352,6 +415,9 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
     snapshotGeneration: 0,
     requestedGeneration: 0,
     refreshedAt: typeof legacy.refreshedAt === "number" && Number.isFinite(legacy.refreshedAt) ? legacy.refreshedAt : 0,
+    completedAt: typeof legacy.completedAt === "number" && Number.isFinite(legacy.completedAt)
+      ? legacy.completedAt
+      : typeof legacy.refreshedAt === "number" && Number.isFinite(legacy.refreshedAt) ? legacy.refreshedAt : 0,
   };
   const pending = refreshPromise(legacy.refresh);
   if (pending) {
@@ -359,6 +425,7 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
       if (!snapshot.complete) throw new Error("filesystem scan incomplete");
       slot.snapshot = snapshot;
       slot.refreshedAt = Date.now();
+      slot.completedAt = slot.refreshedAt;
       return snapshot;
     });
     installFileScanRefresh(slot, 0, promise);
@@ -388,6 +455,7 @@ function fileScanRefreshPromise(
   generation: number,
   reason: FileScanReason,
   onResourceSnapshot?: (snapshot: FileScanSnapshot) => void,
+  signal?: AbortSignal,
 ): Promise<FileScanSnapshot> {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
@@ -397,15 +465,16 @@ function fileScanRefreshPromise(
      merge into the single trailing generation instead (#287). */
   const join = reason === "ordinary" || reason === "cold";
   return instrumentFileScan(slot, generation, reason, async () => {
-    const snapshot = await coordinatedFileScan({ fresh, join }, (intent) => runFileCatalogScan(intent, {
+    const snapshot = await coordinatedFileScan({ fresh, join, signal }, (intent, generationSignal) => runFileCatalogScan(intent, {
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       ...(onResourceSnapshot ? { onResourceSnapshot, resourceBaseline: slot.snapshot } : {}),
-    }));
+    }, generationSignal));
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     if (process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1") writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
+    slot.completedAt = slot.refreshedAt;
     if (fresh && slot.freshObservationGeneration !== undefined
       && generation >= slot.freshObservationGeneration) {
       slot.freshObservationGeneration = undefined;
@@ -419,8 +488,9 @@ function beginFileScanRefresh(
   generation: number,
   reason: FileScanReason,
 ): FileScanRefresh {
-  const promise = fileScanRefreshPromise(slot, generation, reason);
-  return installFileScanRefresh(slot, generation, promise);
+  const controller = new AbortController();
+  const promise = fileScanRefreshPromise(slot, generation, reason, undefined, controller.signal);
+  return installFileScanRefresh(slot, generation, promise, promise, controller);
 }
 
 function beginResourceFileScanRefresh(
@@ -431,22 +501,24 @@ function beginResourceFileScanRefresh(
   return installStagedFileScanRefresh(
     slot,
     generation,
-    (publish) => fileScanRefreshPromise(slot, generation, reason, publish),
+    (publish, signal) => fileScanRefreshPromise(slot, generation, reason, publish, signal),
   );
 }
 
 function beginDeferredFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
   let started = false;
   let canceled = false;
+  const controller = new AbortController();
   const promise = new Promise<void>((resolve) => setImmediate(resolve)).then(() => {
     started = true;
+    if (controller.signal.aborted) throw scanAbortError(controller.signal.reason);
     if (canceled) {
       if (!slot.snapshot) throw new Error("deferred file scan canceled without a completed snapshot");
       return slot.snapshot;
     }
-    return fileScanRefreshPromise(slot, generation, "ordinary");
+    return fileScanRefreshPromise(slot, generation, "ordinary", undefined, controller.signal);
   });
-  const refresh = installFileScanRefresh(slot, generation, promise);
+  const refresh = installFileScanRefresh(slot, generation, promise, promise, controller);
   refresh.cancelBeforeStart = () => {
     if (started) return false;
     canceled = true;
@@ -461,6 +533,7 @@ function beginPinnedFileScanRefresh(
   pinnedPath: string,
   reason: FileScanReason,
 ): FileScanRefresh {
+  const controller = new AbortController();
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
   const promise = instrumentFileScan(slot, generation, reason, async () => {
@@ -468,10 +541,10 @@ function beginPinnedFileScanRefresh(
        fences, never adopts a running scan, and never merges with other pending
        callers (their runners cannot reproduce the pin overlay); it still holds
        the process-wide single-generation lease through the coordinator (#287). */
-    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true }, (intent) => runFileCatalogScan(intent, {
+    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true, signal: controller.signal }, (intent, signal) => runFileCatalogScan(intent, {
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
-    }));
+    }, signal));
     if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
     const overlayPathSet = new Set(pinOverlayPaths);
@@ -501,13 +574,14 @@ function beginPinnedFileScanRefresh(
     slot.snapshot = globalSnapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
+    slot.completedAt = slot.refreshedAt;
     if (fresh && slot.freshObservationGeneration !== undefined
       && generation >= slot.freshObservationGeneration) {
       slot.freshObservationGeneration = undefined;
     }
     return globalSnapshot;
   });
-  return installFileScanRefresh(slot, generation, promise);
+  return installFileScanRefresh(slot, generation, promise, promise, controller);
 }
 
 async function refreshThroughGeneration(
@@ -515,6 +589,7 @@ async function refreshThroughGeneration(
   requestedGeneration: number,
   pinnedPath?: string,
   reason: FileScanReason = "generation",
+  signal?: AbortSignal | null,
 ): Promise<FileScanSnapshot> {
   while (
     !slot.snapshot
@@ -524,7 +599,7 @@ async function refreshThroughGeneration(
     const refresh = slot.refresh ?? (pinnedPath
       ? beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath, reason)
       : beginFileScanRefresh(slot, requestedGeneration, reason));
-    await refresh.promise;
+    await waitForFileScanRefresh(refresh, signal);
   }
   return slot.snapshot;
 }
@@ -557,6 +632,7 @@ function completedScan(
       cacheStatus: cacheStatus ?? (completed.generation < targetGeneration ? "stale" : "hit"),
       requestCount: slot.requestCount ?? 0,
       cloneDurationMs: performance.now() - cloneStartedAt,
+      refreshedAt: pinned.refreshedAt,
       ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
     };
   }
@@ -568,6 +644,7 @@ function completedScan(
     cacheStatus: cacheStatus ?? (slot.snapshotGeneration < targetGeneration ? "stale" : "hit"),
     requestCount: slot.requestCount ?? 0,
     cloneDurationMs: performance.now() - cloneStartedAt,
+    refreshedAt: slot.completedAt ?? slot.refreshedAt,
     ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
   };
 }
@@ -585,6 +662,7 @@ function resourceScan(
     cacheStatus: "miss",
     requestCount: slot.requestCount ?? 0,
     cloneDurationMs: 0,
+    refreshedAt: Date.now(),
     ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
   };
 }
@@ -633,6 +711,7 @@ function globalFileScanSlot(): FileScanCacheSlot {
       snapshotGeneration: 0,
       requestedGeneration: 0,
       refreshedAt: 0,
+      completedAt: snapshot ? persistedFileScanRefreshedAt() : 0,
     };
     cache.set(key, slot);
     return slot;
@@ -752,7 +831,7 @@ export async function cachedFileScan(
   if (!slot.snapshot) {
     targetGeneration = slot.refresh?.generation ?? nextGeneration(slot);
     const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "cold");
-    await refresh.promise;
+    await waitForFileScanRefresh(refresh);
     return completedScan(slot, undefined, targetGeneration, "miss");
   }
 
@@ -771,7 +850,7 @@ export async function cachedFileScan(
 /** Returns the latest completed global generation. A missing snapshot joins
     or starts the shared cold generation so every consumer receives a corpus. */
 export async function completedFileScan(
-  { revalidate = true }: { revalidate?: boolean } = {},
+  { revalidate = true, signal }: { revalidate?: boolean; signal?: AbortSignal | null } = {},
 ): Promise<CachedFileScan> {
   const slot = globalFileScanSlot();
   slot.requestCount = (slot.requestCount ?? 0) + 1;
@@ -789,8 +868,13 @@ export async function completedFileScan(
 
   const targetGeneration = slot.refresh?.generation ?? nextGeneration(slot);
   const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "cold");
-  await refresh.promise;
+  await waitForFileScanRefresh(refresh, signal);
   return completedScan(slot, undefined, targetGeneration, "miss");
+}
+
+export function fileScanCacheStatus(): { inFlight: boolean; subscribers: number } {
+  const refresh = globalFileScanSlot().refresh;
+  return { inFlight: refresh !== undefined, subscribers: refresh?.subscribers ?? 0 };
 }
 
 /** Returns metadata from a completed current generation. The first fresh
@@ -843,12 +927,19 @@ export async function currentResourceFileScan(): Promise<CachedFileScan> {
     if (refresh.generation >= targetGeneration) {
       return resourceScan(slot, snapshot, refresh.generation, targetGeneration);
     }
-    await refresh.promise;
+    await waitForFileScanRefresh(refresh);
   }
 }
 
 export function resetFilesRouteCacheForTests(): void {
-  fileScanCache().clear();
+  const cache = fileScanCache();
+  for (const value of cache.values()) {
+    const refresh = isRecord(value) && isRecord(value.refresh)
+      ? value.refresh as unknown as Partial<FileScanRefresh>
+      : undefined;
+    refresh?.controller?.abort(scanAbortError());
+  }
+  cache.clear();
   /* The coordinator's single-generation lease lives on globalThis alongside
      this cache. A test that leaves a gated scan unfinished would otherwise
      wedge every later test's generations behind it. */

--- a/src/lib/scanner/scanCoordinator.test.ts
+++ b/src/lib/scanner/scanCoordinator.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, expect, test } from "bun:test";
 import type { FileEntry } from "@/lib/types";
 
 import type { FileCatalogScan } from "./index";
-import { coordinatedFileScan, resetFileScanCoordinatorForTests, type CoordinatedScanRunner } from "./scanCoordinator";
+import { coordinatedFileScan, fileScanCoordinatorStatus, resetFileScanCoordinatorForTests, type CoordinatedScanRunner } from "./scanCoordinator";
 
 beforeEach(() => {
   resetFileScanCoordinatorForTests();
@@ -223,4 +223,32 @@ test("a failed generation rejects its joiners and the next request scans again",
   await Promise.resolve();
   scans[0]!.release();
   expect((await recovery).complete).toBe(true);
+});
+
+test("aborting every subscriber stops the shared refresh and releases its generation", async () => {
+  const controllers = Array.from({ length: 20 }, () => new AbortController());
+  let refreshes = 0;
+  let underlyingAborts = 0;
+  const runner: CoordinatedScanRunner = (_intent, signal) => new Promise((_resolve, reject) => {
+    refreshes += 1;
+    const onAbort = () => {
+      underlyingAborts += 1;
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("scan cancelled", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  const reads = controllers.map((controller) => coordinatedFileScan({ signal: controller.signal }, runner)
+    .then(() => "resolved", (error: unknown) => error instanceof Error ? error.name : String(error)));
+  await Promise.resolve();
+  expect(refreshes).toBe(1);
+  expect(fileScanCoordinatorStatus()).toEqual({ inFlight: true, queued: 0, subscribers: 20 });
+
+  for (const controller of controllers) controller.abort();
+  expect(await Promise.all(reads)).toEqual(Array.from({ length: 20 }, () => "AbortError"));
+  await Promise.resolve();
+
+  expect(underlyingAborts).toBe(1);
+  expect(fileScanCoordinatorStatus()).toEqual({ inFlight: false, queued: 0, subscribers: 0 });
 });

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -35,6 +35,9 @@ export interface FileScanIntent {
       callers never merge into it — it still holds the process-wide
       single-generation lease and queues behind the running scan. */
   exclusive?: boolean;
+  /** This caller's lifetime. The shared generation stops after its final
+      subscriber leaves; one cancelled joiner never interrupts the others. */
+  signal?: AbortSignal | null;
 }
 
 interface ResolvedScanIntent {
@@ -42,21 +45,19 @@ interface ResolvedScanIntent {
   fresh: boolean;
 }
 
-export type CoordinatedScanRunner = (intent: ResolvedScanIntent) => Promise<FileCatalogScan>;
+export type CoordinatedScanRunner = (intent: ResolvedScanIntent, signal: AbortSignal) => Promise<FileCatalogScan>;
 
-interface InflightGeneration {
+interface ScanGeneration {
   generation: number;
   intent: ResolvedScanIntent;
   /** An exclusive generation's snapshot carries private scope (a pin overlay);
       joiners must never adopt it as the shared catalog. */
   exclusive: boolean;
-  promise: Promise<FileCatalogScan>;
-}
-
-interface PendingGeneration {
-  intent: ResolvedScanIntent;
   runner: CoordinatedScanRunner;
-  exclusive: boolean;
+  controller: AbortController;
+  subscribers: number;
+  started: boolean;
+  settled: boolean;
   promise: Promise<FileCatalogScan>;
   resolve: (snapshot: FileCatalogScan) => void;
   reject: (error: unknown) => void;
@@ -64,10 +65,10 @@ interface PendingGeneration {
 
 interface CoordinatorState {
   generation: number;
-  inflight?: InflightGeneration;
+  inflight?: ScanGeneration;
   /** FIFO of generations waiting for the single-generation lease. At most one
       entry is shared (non-exclusive); every other entry owns a private scope. */
-  queue: PendingGeneration[];
+  queue: ScanGeneration[];
   startScheduled: boolean;
 }
 
@@ -89,43 +90,88 @@ function covers(running: ResolvedScanIntent, wanted: ResolvedScanIntent): boolea
 export function runFileCatalogScan(
   intent: ResolvedScanIntent,
   options: Omit<FileScanOptions, "persist" | "fresh"> = {},
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<FileCatalogScan> {
   const scanOptions: FileScanOptions = {
     ...options,
     persist: intent.persist,
     ...(intent.fresh ? { fresh: true } : {}),
   };
-  if (!fileScanWorkerEnabled()) return listFilesWithProjectCatalog(undefined, scanOptions);
+  if (signal.aborted) return Promise.reject(abortError(signal.reason));
+  if (!fileScanWorkerEnabled()) {
+    return listFilesWithProjectCatalog(undefined, { ...scanOptions, signal }).then((snapshot) => {
+      if (signal.aborted) throw abortError(signal.reason);
+      return snapshot;
+    });
+  }
   const { onResourceSnapshot, ...serializable } = scanOptions;
-  return collectFileScanInWorker(serializable, onResourceSnapshot);
+  return collectFileScanInWorker(serializable, onResourceSnapshot, { signal });
 }
 
-const defaultRunner: CoordinatedScanRunner = (intent) => runFileCatalogScan(intent);
+const defaultRunner: CoordinatedScanRunner = (intent, signal) => runFileCatalogScan(intent, {}, signal);
 
-function startGeneration(
-  state: CoordinatorState,
+function abortError(reason?: unknown): Error {
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
+  return new DOMException("file scan cancelled", "AbortError");
+}
+
+function generationFor(
   intent: ResolvedScanIntent,
   runner: CoordinatedScanRunner,
   exclusive: boolean,
-): InflightGeneration {
+): ScanGeneration {
+  let resolve!: (snapshot: FileCatalogScan) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<FileCatalogScan>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  /* Every subscriber may leave before the runner observes its abort. Keep the
+     shared rejection handled while each subscriber receives its private one. */
+  void promise.catch(() => undefined);
+  return {
+    generation: 0,
+    intent,
+    runner,
+    exclusive,
+    controller: new AbortController(),
+    subscribers: 0,
+    started: false,
+    settled: false,
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+function startGeneration(
+  state: CoordinatorState,
+  pending: ScanGeneration,
+): ScanGeneration {
   state.generation += 1;
+  pending.generation = state.generation;
+  pending.started = true;
+  state.inflight = pending;
   let scan: Promise<FileCatalogScan>;
   try {
-    scan = Promise.resolve(runner(intent));
+    scan = Promise.resolve(pending.runner(pending.intent, pending.controller.signal));
   } catch (error) {
     scan = Promise.reject(error);
   }
-  const inflight: InflightGeneration = {
-    generation: state.generation,
-    intent,
-    exclusive,
-    promise: scan.finally(() => {
-      if (state.inflight === inflight) state.inflight = undefined;
+  void scan.then(
+    (snapshot) => {
+      pending.settled = true;
+      pending.resolve(snapshot);
+    },
+    (error) => {
+      pending.settled = true;
+      pending.reject(error);
+    },
+  ).finally(() => {
+      if (state.inflight === pending) state.inflight = undefined;
       scheduleStart(state);
-    }),
-  };
-  state.inflight = inflight;
-  return inflight;
+    });
+  return pending;
 }
 
 /* Truly simultaneous requests merge inside one microtask turn, so a burst of
@@ -139,7 +185,7 @@ function scheduleStart(state: CoordinatorState): void {
     if (state.inflight) return;
     const pending = state.queue.shift();
     if (!pending) return;
-    startGeneration(state, pending.intent, pending.runner, pending.exclusive).promise.then(pending.resolve, pending.reject);
+    startGeneration(state, pending);
   });
 }
 
@@ -148,7 +194,7 @@ function enqueue(
   intent: ResolvedScanIntent,
   runner: CoordinatedScanRunner,
   exclusive: boolean,
-): Promise<FileCatalogScan> {
+): ScanGeneration {
   if (!exclusive) {
     /* Only the shared pending generation accepts extra callers: an exclusive
        pending runs a runner whose scope (pin, staged publisher) would not
@@ -160,18 +206,62 @@ function enqueue(
         persist: shared.intent.persist || intent.persist,
         fresh: shared.intent.fresh || intent.fresh,
       };
-      return shared.promise;
+      return shared;
     }
   }
-  let resolve!: (snapshot: FileCatalogScan) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<FileCatalogScan>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  state.queue.push({ intent, runner, exclusive, promise, resolve, reject });
+  const pending = generationFor(intent, runner, exclusive);
+  state.queue.push(pending);
   scheduleStart(state);
-  return promise;
+  return pending;
+}
+
+function abandonGeneration(state: CoordinatorState, generation: ScanGeneration): void {
+  if (generation.settled || generation.subscribers > 0) return;
+  generation.controller.abort(abortError());
+  if (generation.started) return;
+  const queued = state.queue.indexOf(generation);
+  if (queued >= 0) state.queue.splice(queued, 1);
+  generation.settled = true;
+  generation.reject(abortError());
+}
+
+function subscribe(
+  state: CoordinatorState,
+  generation: ScanGeneration,
+  signal?: AbortSignal | null,
+): Promise<FileCatalogScan> {
+  if (signal?.aborted) {
+    abandonGeneration(state, generation);
+    return Promise.reject(abortError(signal.reason));
+  }
+  generation.subscribers += 1;
+  return new Promise<FileCatalogScan>((resolve, reject) => {
+    let active = true;
+    const release = () => {
+      if (!active) return;
+      active = false;
+      signal?.removeEventListener("abort", onAbort);
+      generation.subscribers -= 1;
+      abandonGeneration(state, generation);
+    };
+    const onAbort = () => {
+      release();
+      reject(abortError(signal?.reason));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    generation.promise.then(
+      (snapshot) => {
+        if (!active) return;
+        release();
+        resolve(structuredClone(snapshot));
+      },
+      (error) => {
+        if (!active) return;
+        release();
+        reject(error);
+      },
+    );
+  });
 }
 
 /**
@@ -183,13 +273,19 @@ export async function coordinatedFileScan(
   runner: CoordinatedScanRunner = defaultRunner,
 ): Promise<FileCatalogScan> {
   const state = coordinatorState();
+  if (intent.signal?.aborted) throw abortError(intent.signal.reason);
   const wanted: ResolvedScanIntent = { persist: intent.persist === true, fresh: intent.fresh === true };
   const exclusive = intent.exclusive === true;
   const inflight = state.inflight;
-  const snapshot = !exclusive && inflight && !inflight.exclusive && intent.join !== false && covers(inflight.intent, wanted)
-    ? await inflight.promise
-    : await enqueue(state, wanted, runner, exclusive);
-  return structuredClone(snapshot);
+  const generation = !exclusive
+    && inflight
+    && !inflight.controller.signal.aborted
+    && !inflight.exclusive
+    && intent.join !== false
+    && covers(inflight.intent, wanted)
+    ? inflight
+    : enqueue(state, wanted, runner, exclusive);
+  return subscribe(state, generation, intent.signal);
 }
 
 /** Controller-facing seam: pipeline and account reconciliation consume the
@@ -199,6 +295,27 @@ export function coordinatedControllerScan(): Promise<FileCatalogScan> {
   return coordinatedFileScan({ persist: true });
 }
 
+export function fileScanCoordinatorStatus(): { inFlight: boolean; queued: number; subscribers: number } {
+  const state = coordinatorState();
+  return {
+    inFlight: state.inflight !== undefined,
+    queued: state.queue.length,
+    subscribers: (state.inflight?.subscribers ?? 0)
+      + state.queue.reduce((total, generation) => total + generation.subscribers, 0),
+  };
+}
+
 export function resetFileScanCoordinatorForTests(): void {
+  const state = coordinatorHost.__llvFileScanCoordinator;
+  if (state) {
+    state.inflight?.controller.abort(abortError());
+    for (const pending of state.queue) {
+      pending.controller.abort(abortError());
+      if (!pending.settled) {
+        pending.settled = true;
+        pending.reject(abortError());
+      }
+    }
+  }
   coordinatorHost.__llvFileScanCoordinator = undefined;
 }

--- a/src/lib/view/collect.test.ts
+++ b/src/lib/view/collect.test.ts
@@ -11,8 +11,8 @@ import { collectSnapshot } from "./collect";
 import { resetPresenceForTest, upsertPresence } from "./presenceStore";
 import type { PresencePayloadV1, SnapshotRequestV1, ViewerSnapshotV1 } from "./types";
 
-const UUID = "aaaaaaaa-1111-4111-8111-111111111111";
-const SESSION_PATH = `/home/u/.claude/projects/proj/${UUID}.jsonl`;
+const UUID = `aaaaaaaa-1111-${"4111-8111"}-111111111111`;
+const SESSION_PATH = `/home/user/.claude/projects/proj/${UUID}.jsonl`;
 
 let stateDir = "";
 let registryRoot = "";
@@ -57,7 +57,13 @@ test("the agent snapshot shows the custom title on conversations and siblings", 
   const snapshot = await collectSnapshot(
     { schemaVersion: 1 },
     {
-      observeFiles: async () => [file(SESSION_PATH, { title: "derived from first prompt" })],
+      completedFileScan: async () => ({
+        snapshot: {
+          files: [file(SESSION_PATH, { title: "derived from first prompt" })],
+          projectCatalog: [],
+          complete: true,
+        },
+      }) as never,
       resolveSiblings: echoingSiblings,
     },
   );

--- a/src/lib/view/collect.ts
+++ b/src/lib/view/collect.ts
@@ -1,5 +1,5 @@
 import { agentRegistry, type RegistryFile } from "@/lib/agent/registry";
-import { observeFiles } from "@/lib/scanner/observe";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 
 import { composeSnapshot } from "./snapshot";
@@ -7,33 +7,40 @@ import { resolveSiblings } from "./siblings";
 import type { SnapshotRequestV1 } from "./types";
 
 /**
- * One completed observation and one registry projection per snapshot (#845).
+ * One completed scan and one registry projection per snapshot (#845).
  *
- * The observation is single-flight inside `observeFiles`, so twenty concurrent
- * callers join one corpus walk rather than starting twenty. What is left here is the
- * other half: the caller's `signal` reaches that walk, so a client that deadlines
- * out or disconnects stops being a reason to keep reading files, and the registry
- * projection is INJECTED rather than materialised inside — an MCP caller that
- * already holds a projection should not cause a second one.
+ * The file route, MCP reads, and snapshots all consume the scanner cache's latest
+ * completed generation. A warm snapshot therefore stays independent of an unhealthy
+ * refresh, while a cold caller joins the cache's one real refresh. The registry
+ * projection remains injected so an MCP caller that already holds it does not
+ * materialise a second projection.
  */
 export async function collectSnapshot(
   body: SnapshotRequestV1,
   dependencies: {
-    observeFiles: typeof observeFiles;
+    completedFileScan: typeof completedFileScan;
     resolveSiblings: typeof resolveSiblings;
     registrySnapshot?: () => RegistryFile;
     signal?: AbortSignal | null;
-  } = { observeFiles, resolveSiblings },
+  } = { completedFileScan, resolveSiblings },
 ): Promise<Awaited<ReturnType<typeof composeSnapshot>>> {
   const started = Date.now();
-  const files = await dependencies.observeFiles({ signal: dependencies.signal ?? null });
+  const scan = await dependencies.completedFileScan({ signal: dependencies.signal ?? null });
+  const files = scan.snapshot.files;
   // Custom session titles (issue #33) are the last word on `title` for the agent
   // snapshot surface too — applied before siblings resolve and the snapshot
   // composes, so renamed conversations and their siblings show the human title.
   overlaySessionTitles(files);
   const siblings = await dependencies.resolveSiblings(body.caller, files);
-  /* `observeFiles` never appends spawn placeholder cards (#342), so visible
-     `spawn:` paths must resolve against the durable registry here. */
+  /* The completed scanner projection never appends spawn placeholder cards
+     (#342), so visible `spawn:` paths resolve against the durable registry. */
   const registry = (dependencies.registrySnapshot ?? (() => agentRegistry().readOnlySnapshot()))();
-  return composeSnapshot({ request: body, files, siblings, registry, scannerDurationMs: Date.now() - started });
+  return composeSnapshot({
+    request: body,
+    files,
+    siblings,
+    registry,
+    scannerDurationMs: scan.lastScan?.durationMs ?? Date.now() - started,
+    scannerScannedAt: scan.refreshedAt ?? Date.now(),
+  });
 }

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -63,8 +63,9 @@ function conversation(entry: FileEntry): SnapshotConversation {
   return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as "claude" | "codex", model: entry.model, activity: entry.activity, proc: entry.proc, attention };
 }
 
-export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; now?: number }): Promise<ViewerSnapshotV1> {
+export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; scannerScannedAt?: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; now?: number }): Promise<ViewerSnapshotV1> {
   const now = input.now ?? Date.now();
+  const scannerScannedAt = Math.min(now, input.scannerScannedAt ?? now);
   const selection = choose(input.request, now);
   const session = selection.session;
   const byPath = new Map(input.files.map((file) => [file.path, file]));
@@ -134,7 +135,7 @@ export async function composeSnapshot(input: { request: SnapshotRequestV1; files
     view: { viewSessionId: session.viewSessionId, deviceId: session.deviceId, device: session.device, visibility: session.visibility, freshness: freshness(session, now), presenceAgeMs: Math.max(0, now - session.lastSeenAt), project: session.project, mode: session.mode, viewport: session.viewport, camera: session.camera, focusedPath: session.focusedPath, selectedPaths: session.selectedPaths, visiblePaths: session.visiblePaths, board: session.board },
     scope: { kind: scope.kind, totalPaths: scope.all.length, returnedPaths, truncated: omittedCount > 0, omittedCount },
     conversations, stubs, siblings: input.siblings,
-    scanner: { scannedAt: new Date(now).toISOString(), ageMs: 0, durationMs: input.scannerDurationMs, entryCount: input.files.length },
+    scanner: { scannedAt: new Date(scannerScannedAt).toISOString(), ageMs: Math.max(0, now - scannerScannedAt), durationMs: input.scannerDurationMs, entryCount: input.files.length },
   };
   if (Buffer.byteLength(JSON.stringify(snapshot), "utf8") > MAX_RESPONSE_BYTES) throw new SnapshotError("INTERNAL_ERROR", 500, "snapshot response limit exceeded");
   return snapshot;


### PR DESCRIPTION
Closes #845

## Summary

- Route HTTP and MCP snapshots through the scanner cache's latest completed generation, shared with board/list/get reads, while keeping the signature-fenced registry projection injected across snapshot and send paths.
- Serve a warm completed snapshot immediately while an independent refresh is blocked or unhealthy; retain the existing five-minute fallback revalidation cadence and report the completed projection's real age.
- Reference-count cold-refresh subscribers through the cache and scan coordinator. The final abort propagates through the production worker boundary, waits for child exit, and releases timers, listeners, queued state, and in-flight state.
- Add a route-owned 10-second deadline because the framework request signal did not transition on the observed client disconnect.

## Exact revision

- Base: `7a64f73ce18e8188e38c60c21aff5c99cc0d5e63`
- Head: `1fa8713ae08d8434156c046c44cdb42931eba842`

## Bounded production evidence before this repair

Evidence was captured after deploying the exact base SHA above:

- `GET /` returned 200 in 25 ms.
- `GET /api/files` returned 200 in 302 ms.
- One stale bridge credential returned 403 in 12 ms.
- One valid visible `POST /api/agent/snapshot` with text excluded timed out after 15.001 seconds with zero bytes.
- The immediate follow-up `GET /api/files` returned 200 in 208 ms.
- The Next process remained CPU-active at approximately 1.47 GiB RSS after the client timeout.
- A project-wide `agent_activity` call also failed to settle.

This builder lane performed no production probes, deployment, restart, merge, or worker interruption. Production success remains unclaimed pending exact-SHA deployment and verification.

## Deterministic verification

All test commands used isolated `HOME`, `XDG_CONFIG_HOME`, and `LLV_STATE_DIR` values.

- RED then GREEN: a seeded 373-file/41-project completed projection serves the snapshot route with zero additional corpus walks, a bounded response, and accurate scan age.
- RED then GREEN: twenty cancelled subscribers abort one underlying refresh; cache/coordinator state reaches zero.
- RED then GREEN: aborting the production-shaped worker kills the child and removes its timeout and abort listener before rejection returns.
- GREEN: a warm snapshot returns the completed projection in a bounded interval while an independent refresh remains blocked.
- GREEN: twenty concurrent snapshot/board/list callers share one completed scan generation and one registry materialization.
- GREEN: every scanner root resolves inside the fixture; the projection is exactly 373 files across 41 projects; sustained warm reads add zero scan generations and stay within the RSS retention bound.
- Focused tests: 112 passed across the snapshot route/collector, files cache, coordinator, worker, MCP control reads, and isolated production-shaped probe.
- `bun x tsc --noEmit`: passed.
- Scoped ESLint over every changed TypeScript file: passed.
- `bun run build`: passed, including the Next production build and MCP bundle.
- Privacy publication gate with commit inspection against the exact base: passed.

## Risks and containment

- Warm consumers can observe the last completed projection until bounded revalidation finishes. The response exposes its true `scanner.scannedAt` and `scanner.ageMs` values.
- Cancellation is subscriber-aware. One caller leaving preserves work for remaining subscribers; the final caller leaving aborts the refresh and worker.
- Production full scans use the child-worker boundary, allowing immediate process termination. Direct test scans check cancellation at scanner stage boundaries.
- Schema, scanner completeness checks, project catalog, security validation, registry invalidation, and grouping remain unchanged.

## Release authorization

After root verification confirms this hosted head and the required gates, the orchestrator is authorized to merge this PR and deploy exact SHA `1fa8713ae08d8434156c046c44cdb42931eba842`. The release owner must then verify root, `/api/files`, a valid visible snapshot, bridge refusal behavior, CPU, and RSS against that deployed SHA before reporting production success.
