### PR TITLE
fix(#845): lazily resolve snapshot spawn placeholders

### DIFF
--- a/src/app/api/agent/snapshot/handler.ts
+++ b/src/app/api/agent/snapshot/handler.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import type { RegistryFile } from "@/lib/agent/registry";
+import type { RegistryFile, SnapshotSpawnProjection } from "@/lib/agent/registry";
 import { deadlineSignal, isAbortError, type DeadlineScheduler } from "@/lib/deadline";
 import type { completedFileScan } from "@/lib/scanner/scanCache";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
@@ -14,7 +14,8 @@ const headers = { "Cache-Control": "no-store" };
 export interface SnapshotRouteDependencies {
   completedFileScan: typeof completedFileScan;
   resolveSiblings: typeof resolveSiblings;
-  registrySnapshot: () => RegistryFile;
+  registrySnapshot?: () => RegistryFile;
+  snapshotSpawns?: (launchIds: readonly string[]) => SnapshotSpawnProjection;
   snapshotDeadlineMs: number;
   scheduler: DeadlineScheduler;
 }

--- a/src/app/api/agent/snapshot/route.test.ts
+++ b/src/app/api/agent/snapshot/route.test.ts
@@ -49,7 +49,7 @@ test("snapshot collection performs exactly one discovery and shares its entries"
   expect(result.conversations[0]?.path).toBe(entry.path);
 });
 
-test("snapshot route serves one completed 373-file projection without a second corpus walk", async () => {
+test("transcript-only snapshot serves one completed 373-file projection without reading the registry", async () => {
   upsertPresence(presence);
   const files = Array.from({ length: 373 }, (_value, index): FileEntry => ({
     ...entry,
@@ -58,13 +58,19 @@ test("snapshot route serves one completed 373-file projection without a second c
     project: `project-${index % 41}`,
     title: `Session ${index}`,
   }));
+  const projectCatalog = Array.from({ length: 41 }, (_value, index) => ({
+    project: `project-${index}`,
+    smt: 1,
+    conversations: files.filter((file) => file.project === `project-${index}`).length,
+  }));
   let completedReads = 0;
+  let registryReads = 0;
   const refreshedAt = Date.now() - 10_000;
   const corpusWalksBefore = fileObservationGenerations();
   const request = new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", {
     method: "POST",
     headers: { host: "127.0.0.1:8898" },
-    body: JSON.stringify({ schemaVersion: 1, text: { include: false } }),
+    body: JSON.stringify({ schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } }),
   });
 
   const response = await Promise.race([
@@ -72,7 +78,7 @@ test("snapshot route serves one completed 373-file projection without a second c
       completedFileScan: async () => {
         completedReads += 1;
         return {
-          snapshot: { files, projectCatalog: [], complete: true as const },
+          snapshot: { files, projectCatalog, complete: true as const },
           generation: 7,
           targetGeneration: 7,
           cacheStatus: "hit" as const,
@@ -82,7 +88,10 @@ test("snapshot route serves one completed 373-file projection without a second c
         };
       },
       resolveSiblings: async () => ({ selfResolution: "omitted" as const, agents: [] }),
-      registrySnapshot: () => ({ conversations: {}, entries: {}, lineageEdges: {}, memberships: {}, conversationAliases: {}, receipts: {} }) as never,
+      registrySnapshot: () => {
+        registryReads += 1;
+        throw new Error("transcript-only snapshot touched the poisoned registry");
+      },
       snapshotDeadlineMs: 10_000,
       scheduler: { setTimeout, clearTimeout },
     }),
@@ -95,7 +104,54 @@ test("snapshot route serves one completed 373-file projection without a second c
   expect(payload.scanner.ageMs).toBeGreaterThanOrEqual(9_000);
   expect(payload.scanner.ageMs).toBeLessThan(11_000);
   expect(completedReads).toBe(1);
+  expect(registryReads).toBe(0);
   expect(fileObservationGenerations()).toBe(corpusWalksBefore);
+});
+
+test("twenty concurrent transcript-only snapshots retain no registry or response corpus", async () => {
+  upsertPresence(presence);
+  const files = Array.from({ length: 373 }, (_value, index): FileEntry => ({
+    ...entry,
+    path: index === 0 ? entry.path : `/fixture/project-${index % 41}/session-${index}.jsonl`,
+    name: `session-${index}.jsonl`,
+    project: `project-${index % 41}`,
+    title: `Session ${index}`,
+  }));
+  let wholeRegistrySnapshots = 0;
+  let compactSpawnLookups = 0;
+  Bun.gc(true);
+  const rssBefore = process.memoryUsage.rss();
+  let responses: Response[] | null = await Promise.all(Array.from({ length: 20 }, () => postSnapshot(
+    new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", {
+      method: "POST",
+      headers: { host: "127.0.0.1:8898" },
+      body: JSON.stringify({ schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } }),
+    }),
+    {
+      completedFileScan: async () => ({ snapshot: { files, projectCatalog: [], complete: true } }) as never,
+      resolveSiblings: async () => ({ selfResolution: "omitted" as const, agents: [] }),
+      registrySnapshot: () => {
+        wholeRegistrySnapshots += 1;
+        throw new Error("transcript-only snapshot materialized the whole registry");
+      },
+      snapshotSpawns: () => {
+        compactSpawnLookups += 1;
+        return {};
+      },
+      snapshotDeadlineMs: 10_000,
+      scheduler: { setTimeout, clearTimeout },
+    },
+  )));
+
+  expect(responses.every((response) => response.status === 200)).toBe(true);
+  await Promise.all(responses.map((response) => response.text()));
+  expect(wholeRegistrySnapshots).toBe(0);
+  expect(compactSpawnLookups).toBe(0);
+  responses = null;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  Bun.gc(true);
+  const retainedRss = process.memoryUsage.rss() - rssBefore;
+  expect(retainedRss).toBeLessThan(16 * 1024 * 1024);
 });
 
 test("snapshot route owns a deadline when the framework request signal stays live", async () => {

--- a/src/app/api/agent/snapshot/route.ts
+++ b/src/app/api/agent/snapshot/route.ts
@@ -14,7 +14,7 @@ const SNAPSHOT_DEADLINE_MS = 10_000;
 const productionDependencies = {
   completedFileScan,
   resolveSiblings,
-  registrySnapshot: () => agentRegistry().readOnlySnapshot(),
+  snapshotSpawns: (launchIds: readonly string[]) => agentRegistry().snapshotSpawns(launchIds),
   snapshotDeadlineMs: SNAPSHOT_DEADLINE_MS,
   scheduler: systemScheduler,
 } satisfies Parameters<typeof postSnapshot>[1];

--- a/src/app/api/agent/snapshot/standalone.integration.test.ts
+++ b/src/app/api/agent/snapshot/standalone.integration.test.ts
@@ -1,0 +1,247 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { AgentRegistry, normalizeRegistry } from "@/lib/agent/registry";
+import { SqliteAgentRegistryStore } from "@/lib/agent/sqliteRegistryStore";
+import type { FileEntry } from "@/lib/types";
+import type { PresencePayloadV1, ViewerSnapshotV1 } from "@/lib/view/types";
+
+const standaloneServer = path.join(process.cwd(), ".next", "standalone", "server.js");
+const required = process.env.LLV_REQUIRE_STANDALONE_SNAPSHOT_TEST === "1";
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForServer(origin: string, server: ReturnType<typeof Bun.spawn>): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) throw new Error(`standalone server exited with ${server.exitCode}`);
+    try {
+      const response = await fetch(origin, { signal: AbortSignal.timeout(1_000) });
+      if (response.status === 200) return;
+    } catch {
+      // Startup is still in progress.
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error("standalone server did not become ready");
+}
+
+function rssBytes(pid: number): number {
+  const status = fs.readFileSync(`/proc/${pid}/status`, "utf8");
+  const kib = Number(/^VmRSS:\s+(\d+)\s+kB$/m.exec(status)?.[1] ?? Number.NaN);
+  if (!Number.isFinite(kib)) throw new Error("standalone RSS is unavailable");
+  return kib * 1024;
+}
+
+function seedCompletedFiles(sandbox: string, stateDir: string): FileEntry[] {
+  const files = Array.from({ length: 373 }, (_value, index): FileEntry => {
+    const project = `project-${index % 41}`;
+    const uuid = `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+    const pathname = path.join(sandbox, "home", ".claude", "projects", project, `${uuid}.jsonl`);
+    fs.mkdirSync(path.dirname(pathname), { recursive: true });
+    fs.writeFileSync(pathname, `${JSON.stringify({
+      type: "user",
+      timestamp: "2026-07-31T00:00:00.000Z",
+      message: { content: `fixture ${index}` },
+    })}\n`);
+    const stat = fs.statSync(pathname);
+    return {
+      path: pathname,
+      root: "claude-projects",
+      name: path.basename(pathname),
+      project,
+      title: `Session ${index}`,
+      engine: "claude",
+      kind: "session",
+      fmt: "claude",
+      parent: null,
+      mtime: stat.mtimeMs / 1_000,
+      size: stat.size,
+      activity: "idle",
+      proc: null,
+      pid: null,
+      model: null,
+      pendingQuestion: null,
+      waitingInput: null,
+    };
+  });
+  const projectCatalog = Array.from({ length: 41 }, (_value, index) => ({
+    project: `project-${index}`,
+    smt: 1,
+    conversations: files.filter((entry) => entry.project === `project-${index}`).length,
+  }));
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), `${JSON.stringify({
+    version: 1,
+    schemaVersion: 9,
+    snapshot: { files, projectCatalog, complete: true },
+  })}\n`);
+  return files;
+}
+
+function seedLargeRegistry(stateDir: string): { store: SqliteAgentRegistryStore; churnLaunchId: string } {
+  const filename = path.join(stateDir, "agent-registry.json");
+  const seed = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+  const template = seed.beginSpawn("codex", "/fixture/repository");
+  const initial = seed.snapshot();
+  const diagnostic = "synthetic-registry-payload-".padEnd(768, "x");
+  for (let index = 0; index < 10_000; index += 1) {
+    const launchId = `large-registry-${String(index).padStart(5, "0")}`;
+    initial.receipts[launchId] = {
+      ...structuredClone(template),
+      launchId,
+      state: "failed",
+      error: `${diagnostic}${index}`,
+    };
+  }
+  const store = new SqliteAgentRegistryStore(path.join(stateDir, "agent-registry.sqlite"), {
+    initialSnapshot: initial,
+    normalize: normalizeRegistry,
+  });
+  return { store, churnLaunchId: "large-registry-05000" };
+}
+
+function presence(focusedPath: string): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "standalone-route-view",
+    deviceId: "standalone-route-device",
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "project-0",
+    mode: "scheme",
+    viewport: { width: 1200, height: 800, dpr: 1 },
+    camera: null,
+    focusedPath,
+    selectedPaths: [],
+    visiblePaths: [focusedPath],
+    board: { renderedRevision: null, durableRevision: null, sync: "unavailable" },
+  };
+}
+
+async function stopServer(server: ReturnType<typeof Bun.spawn>): Promise<void> {
+  if (server.exitCode !== null) return;
+  server.kill("SIGTERM");
+  const stopped = await Promise.race([
+    server.exited.then(() => true),
+    Bun.sleep(5_000).then(() => false),
+  ]);
+  if (!stopped) {
+    server.kill("SIGKILL");
+    await server.exited;
+  }
+}
+
+test.skipIf(!required && !fs.existsSync(standaloneServer))(
+  "built standalone snapshot route stays bounded during large external registry churn",
+  async () => {
+    expect(fs.existsSync(standaloneServer)).toBe(true);
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-snapshot-standalone-"));
+    const stateDir = path.join(sandbox, "state");
+    const files = seedCompletedFiles(sandbox, stateDir);
+    const { store, churnLaunchId } = seedLargeRegistry(stateDir);
+    const port = await freePort();
+    const origin = `http://127.0.0.1:${port}`;
+    const server = Bun.spawn([process.execPath, standaloneServer], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        NEXT_TELEMETRY_DISABLED: "1",
+        HOSTNAME: "127.0.0.1",
+        PORT: String(port),
+        HOME: path.join(sandbox, "home"),
+        XDG_CONFIG_HOME: path.join(sandbox, "config"),
+        XDG_CACHE_HOME: path.join(sandbox, "cache"),
+        LLV_STATE_DIR: stateDir,
+        LLV_AGENT_REGISTRY_SQLITE: "sqlite",
+        LLV_STRUCTURED_HOSTS: "0",
+        LLV_RUNTIME_EVENTS: "0",
+        LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+        LLV_FILES_RESPONSE_WORKER_DISABLED: "1",
+      },
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    try {
+      await waitForServer(origin, server);
+      const filesResponse = await fetch(`${origin}/api/files`, { signal: AbortSignal.timeout(10_000) });
+      expect(filesResponse.status).toBe(200);
+      const filesPayload = await filesResponse.json() as { files: FileEntry[] };
+      expect(filesPayload.files).toHaveLength(373);
+
+      const presenceResponse = await fetch(`${origin}/api/view/presence`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(presence(files[0]!.path)),
+        signal: AbortSignal.timeout(1_000),
+      });
+      expect(presenceResponse.status).toBe(200);
+
+      const rssBefore = rssBytes(server.pid);
+      let peakRss = rssBefore;
+      const churn = (async () => {
+        for (let revision = 0; revision < 100; revision += 1) {
+          store.mutate((file) => {
+            file.receipts[churnLaunchId]!.error = `external revision ${revision}`;
+          }, false);
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+      })();
+      const measurements = await Promise.all(Array.from({ length: 20 }, async () => {
+        const startedAt = performance.now();
+        const response = await fetch(`${origin}/api/agent/snapshot`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } }),
+          signal: AbortSignal.timeout(1_000),
+        });
+        const durationMs = performance.now() - startedAt;
+        const payload = await response.json() as ViewerSnapshotV1;
+        peakRss = Math.max(peakRss, rssBytes(server.pid));
+        return { status: response.status, durationMs, payload };
+      }));
+      await churn;
+      await Bun.sleep(100);
+      const rssAfter = rssBytes(server.pid);
+      peakRss = Math.max(peakRss, rssAfter);
+
+      expect(measurements.every((measurement) => measurement.status === 200)).toBe(true);
+      expect(Math.max(...measurements.map((measurement) => measurement.durationMs))).toBeLessThan(1_000);
+      expect(measurements.every((measurement) => measurement.payload.scanner.entryCount === 373)).toBe(true);
+      expect(peakRss - rssBefore).toBeLessThan(48 * 1024 * 1024);
+      expect(rssAfter - rssBefore).toBeLessThan(32 * 1024 * 1024);
+      console.log(JSON.stringify({
+        files: filesPayload.files.length,
+        registryRows: 10_001,
+        churnRevisions: 100,
+        snapshots: measurements.length,
+        maxSnapshotMs: Math.round(Math.max(...measurements.map((measurement) => measurement.durationMs))),
+        rssBeforeMiB: Math.round(rssBefore / (1024 * 1024)),
+        peakRssMiB: Math.round(peakRss / (1024 * 1024)),
+        rssAfterMiB: Math.round(rssAfter / (1024 * 1024)),
+      }));
+    } finally {
+      await stopServer(server);
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  },
+  120_000,
+);

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -48,6 +48,65 @@ test("a keyed SQLite mutation reads only the targeted row payload", () => {
   expect(store.snapshot().file.receipts["row-read-1000"]?.error).toBe("updated");
 });
 
+test("a compact spawn lookup reads only requested receipts and their alias chain", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-spawn-lookup-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const seed = new AgentRegistry(filename);
+  const begun = seed.beginSpawn("codex", "/spawn-lookup-seed");
+  const artifactPath = "/sessions/spawn-lookup.jsonl";
+  const settled = seed.settleSpawn(begun.launchId, {
+    key: { engine: "codex", sessionId: "spawn-lookup" },
+    artifactPath,
+    cwd: "/spawn-lookup-seed",
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: "/spawn-lookup-seed" }),
+    status: "unhosted",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error("expected settled seed spawn");
+  const initial = seed.snapshot();
+  const canonicalId = settled.conversation.id;
+  const aliasA = "conversation_00000000-0000-4000-8000-000000000001" as typeof canonicalId;
+  const aliasB = "conversation_00000000-0000-4000-8000-000000000002" as typeof canonicalId;
+  initial.receipts[begun.launchId]!.conversationId = aliasA;
+  initial.conversationAliases[aliasA] = aliasB;
+  initial.conversationAliases[aliasB] = canonicalId;
+  for (let index = 0; index < 2_000; index += 1) {
+    const launchId = `unrelated-${String(index).padStart(4, "0")}`;
+    initial.receipts[launchId] = { ...structuredClone(begun), launchId };
+  }
+  const reads = new Map<string, number>();
+  let snapshotLoads = 0;
+  const store = new SqliteAgentRegistryStore(path.join(directory, "agent-registry.sqlite"), {
+    initialSnapshot: initial,
+    normalize: normalizeRegistry,
+    onSnapshotLoad: () => { snapshotLoads += 1; },
+    onRowPayloadRead: (collection, count) => {
+      reads.set(collection, (reads.get(collection) ?? 0) + count);
+    },
+  });
+  reads.clear();
+  snapshotLoads = 0;
+
+  const projection = store.snapshotSpawns([begun.launchId, "unknown-launch"]);
+
+  expect(projection[begun.launchId]).toMatchObject({
+    launchId: begun.launchId,
+    state: "completed",
+    materializedPath: artifactPath,
+  });
+  expect(projection["unknown-launch"]).toBeUndefined();
+  expect(reads).toEqual(new Map([
+    ["receipts", 1],
+    ["conversationAliases", 2],
+    ["conversations", 1],
+  ]));
+  expect(snapshotLoads).toBe(0);
+});
+
 test("a committed SQLite mutation patches the read-only snapshot and parsed-row cache", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-row-cache-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -455,6 +455,23 @@ export interface RegistryFile {
   pendingSupersedence: Record<string, PendingSupersedence>;
 }
 
+/** Compact read model for resolving the bounded `spawn:<launchId>` paths that
+    can appear in one Viewer snapshot. It intentionally excludes launch profile,
+    account, host, lineage, and membership data from the snapshot seam. */
+export interface SnapshotSpawnProjectionEntry {
+  launchId: string;
+  state: SpawnReceipt["state"];
+  error: string | null;
+  engine: SpawnReceipt["engine"];
+  cwd: string;
+  createdAt: string;
+  materializedPath: string | null;
+}
+
+export type SnapshotSpawnProjection = Record<string, SnapshotSpawnProjectionEntry>;
+
+const SNAPSHOT_SPAWN_ALIAS_LIMIT = 64;
+
 export interface ConversationLookup {
   conversationForPath(artifactPath: string): RegistryConversation | null;
   canonicalConversationId(id: ViewerConversationId): ViewerConversationId;
@@ -1813,6 +1830,37 @@ function resolveConversationAlias(file: Pick<RegistryFile, "conversationAliases"
     current = next;
   }
   return current;
+}
+
+export function snapshotSpawnsFromRegistry(
+  file: Pick<RegistryFile, "receipts" | "conversations" | "conversationAliases">,
+  launchIds: readonly string[],
+): SnapshotSpawnProjection {
+  const projection: SnapshotSpawnProjection = {};
+  for (const launchId of new Set(launchIds)) {
+    const receipt = file.receipts[launchId];
+    if (!receipt) continue;
+    const seen = new Set<ViewerConversationId>();
+    let conversationId: ViewerConversationId | null = receipt.conversationId;
+    for (let hop = 0; hop < SNAPSHOT_SPAWN_ALIAS_LIMIT && conversationId; hop += 1) {
+      if (seen.has(conversationId)) break;
+      seen.add(conversationId);
+      const alias: ViewerConversationId | undefined = file.conversationAliases[conversationId];
+      if (!alias) break;
+      conversationId = hop + 1 === SNAPSHOT_SPAWN_ALIAS_LIMIT ? null : alias;
+    }
+    projection[launchId] = {
+      launchId: receipt.launchId,
+      state: receipt.state,
+      error: receipt.error,
+      engine: receipt.engine,
+      cwd: receipt.cwd,
+      createdAt: receipt.createdAt,
+      materializedPath: (conversationId ? file.conversations[conversationId] : undefined)?.generations.at(-1)?.path
+        ?? receipt.artifactPath,
+    };
+  }
+  return projection;
 }
 
 const SUPERSEDENCE_CHAIN_LIMIT = 64;
@@ -3306,6 +3354,13 @@ export class AgentRegistry {
       return snapshot;
     }
     return readFile(this.filename, this.mcpGrantPolicy);
+  }
+
+  /** Resolves only the requested snapshot placeholders. SQLite-backed modes use
+      one consistent keyed read; JSON mode retains its compatibility fallback. */
+  snapshotSpawns(launchIds: readonly string[]): SnapshotSpawnProjection {
+    if (this.sqliteStore) return this.sqliteStore.snapshotSpawns(launchIds);
+    return snapshotSpawnsFromRegistry(this.readOnlySnapshot(), launchIds);
   }
 
   spawnReceiptForClientAttempt(clientAttemptId: string): SpawnReceipt | null {

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -5,13 +5,14 @@ import { isDeepStrictEqual } from "node:util";
 import type { Database as BunDatabase } from "bun:sqlite";
 
 import { reboundAssembledMcpGrants, rowClaimsBeyondBaselineGrant, type McpGrantPolicy } from "./mcpAllowlist";
-import type { RegistryFile } from "./registry";
+import type { RegistryFile, SnapshotSpawnProjection } from "./registry";
 
 /** The collections the MCP grant decision reads and writes. Touching any one of
     them requires the decision to have run over ALL of them, because an entry or
     a receipt is only decidable against the conversations and lineage edges that
     attest to it (#739). */
 const GRANT_COLLECTIONS = new Set(["entries", "receipts", "conversations", "lineageEdges"]);
+const SNAPSHOT_SPAWN_ALIAS_LIMIT = 64;
 
 const ROW_COLLECTIONS = [
   "entries",
@@ -260,6 +261,66 @@ export class SqliteAgentRegistryStore {
     if (this.readOnlyCache?.revision === revision) return this.readOnlyCache;
     this.readOnlyCache = this.loadSnapshot(true);
     return this.readOnlyCache;
+  }
+
+  /** One transaction and keyed row reads for the at-most-bounded spawn paths in
+      a Viewer snapshot. No collection enumeration or whole snapshot occurs. */
+  snapshotSpawns(launchIds: readonly string[]): SnapshotSpawnProjection {
+    this.db.exec("BEGIN");
+    try {
+      const readRow = (collection: RowCollection, key: string): unknown => {
+        const stored = this.db.query<Pick<StoredRow, "value_json">, [string, string]>(
+          "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+        ).get(collection, key);
+        this.onRowPayloadRead?.(collection, stored ? 1 : 0);
+        return stored ? this.parseRow(collection, key, stored.value_json, true) : undefined;
+      };
+      const normalizeRow = <Collection extends "receipts" | "conversations">(
+        collection: Collection,
+        key: string,
+        value: unknown,
+      ): RegistryFile[Collection][string] | undefined => {
+        const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
+        input[collection] = { [key]: value };
+        return this.normalize(input)[collection][key] as RegistryFile[Collection][string] | undefined;
+      };
+      const projection: SnapshotSpawnProjection = {};
+      for (const launchId of new Set(launchIds)) {
+        const rawReceipt = readRow("receipts", launchId);
+        if (rawReceipt === undefined) continue;
+        const receipt = normalizeRow("receipts", launchId, rawReceipt);
+        if (!receipt) continue;
+
+        const seen = new Set<string>();
+        let conversationId: string = receipt.conversationId;
+        let aliasLimitReached = false;
+        while (!seen.has(conversationId) && seen.size < SNAPSHOT_SPAWN_ALIAS_LIMIT) {
+          seen.add(conversationId);
+          const alias = readRow("conversationAliases", conversationId);
+          if (typeof alias !== "string" || !alias.startsWith("conversation_")) break;
+          conversationId = alias;
+          aliasLimitReached = seen.size === SNAPSHOT_SPAWN_ALIAS_LIMIT;
+        }
+        const rawConversation = aliasLimitReached ? undefined : readRow("conversations", conversationId);
+        const conversation = rawConversation === undefined
+          ? undefined
+          : normalizeRow("conversations", conversationId, rawConversation);
+        projection[launchId] = {
+          launchId: receipt.launchId,
+          state: receipt.state,
+          error: receipt.error,
+          engine: receipt.engine,
+          cwd: receipt.cwd,
+          createdAt: receipt.createdAt,
+          materializedPath: conversation?.generations.at(-1)?.path ?? receipt.artifactPath,
+        };
+      }
+      this.db.exec("COMMIT");
+      return projection;
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   mutate<T>(operation: (file: RegistryFile) => T, includeSnapshot = true): SqliteRegistryMutation<T> {

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -139,8 +139,8 @@ function dependencies(options: { scans?: number; projections?: number } = {}) {
         counts.rawScans += 1;
         throw new Error("a control-plane read must not start a raw corpus scan");
       },
-      /* Stands in for composition while exercising the same injected completed
-         generation and registry projection as the production collector. */
+      /* Stands in for transcript-only composition: the completed generation is
+         consumed while the injected registry projection remains lazy. */
       collectSnapshot: async (_body: unknown, deps: {
         completedFileScan?: () => Promise<{ snapshot: typeof snapshot }>;
         registrySnapshot?: () => unknown;
@@ -148,7 +148,6 @@ function dependencies(options: { scans?: number; projections?: number } = {}) {
         counts.observations += 1;
         if (!deps.completedFileScan) throw new Error("snapshot received no completed scan seam");
         await deps.completedFileScan();
-        deps.registrySnapshot?.();
         return { schemaVersion: 1, sessions: [], caller: null };
       },
       boardFor: () => null,
@@ -191,7 +190,7 @@ test("board_snapshot still consumes one scan and one projection", async () => {
   expect(counts.rawScans).toBe(0);
 });
 
-test("operator_snapshot hands the collector the projection it already holds", async () => {
+test("operator_snapshot keeps the transcript-only registry projection lazy", async () => {
   const { counts, injected } = dependencies();
   const bindings = viewerMcpBindings(undefined, undefined, injected);
 
@@ -199,9 +198,8 @@ test("operator_snapshot hands the collector the projection it already holds", as
 
   expect(counts.observations).toBe(1);
   expect(counts.scans).toBe(1);
-  /* Exactly one, materialised by the caller and consumed by the collector. The
-     default path built a second one inside `collectSnapshot`. */
-  expect(counts.projections).toBe(1);
+  expect(counts.projections).toBe(0);
+  expect(counts.projectionCalls).toBe(0);
 });
 
 test("twenty concurrent control reads join one scan and one projection", async () => {

--- a/src/lib/view/collect.test.ts
+++ b/src/lib/view/collect.test.ts
@@ -73,3 +73,69 @@ test("the agent snapshot shows the custom title on conversations and siblings", 
   const sibling = snapshot.siblings.agents.find((agent) => agent.transcriptPath === SESSION_PATH);
   expect(sibling?.title).toBe("Renamed by user");
 });
+
+test("spawn paths request one compact projection containing only their launch ids", async () => {
+  const spawnPath = "spawn:known-launch";
+  const failedSpawnPath = "spawn:failed-launch";
+  const unknownSpawnPath = "spawn:unknown-launch";
+  const artifactPath = "/sessions/spawned.jsonl";
+  upsertPresence(presence({ visiblePaths: [SESSION_PATH, spawnPath, failedSpawnPath, unknownSpawnPath] }));
+  const requested: string[][] = [];
+
+  const snapshot = await collectSnapshot(
+    { schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } },
+    {
+      completedFileScan: async () => ({
+        snapshot: {
+          files: [file(SESSION_PATH), file(artifactPath, { engine: "codex", fmt: "codex", root: "codex-sessions" })],
+          projectCatalog: [],
+          complete: true,
+        },
+      }) as never,
+      resolveSiblings: async () => ({ selfResolution: "omitted", agents: [] }),
+      snapshotSpawns: (launchIds) => {
+        requested.push([...launchIds]);
+        return {
+          "known-launch": {
+            launchId: "known-launch",
+            state: "completed",
+            error: null,
+            engine: "codex",
+            cwd: "/repo",
+            createdAt: "2026-07-31T00:00:00.000Z",
+            materializedPath: artifactPath,
+          },
+          "failed-launch": {
+            launchId: "failed-launch",
+            state: "failed",
+            error: "launch admission failed",
+            engine: "codex",
+            cwd: "/repo",
+            createdAt: "2026-07-31T00:00:00.000Z",
+            materializedPath: null,
+          },
+        };
+      },
+    },
+  );
+
+  expect(requested).toEqual([["known-launch", "failed-launch", "unknown-launch"]]);
+  expect(snapshot.conversations).toEqual(expect.arrayContaining([
+    expect.objectContaining({ path: SESSION_PATH }),
+    expect.objectContaining({ path: artifactPath, resolvedFrom: spawnPath }),
+  ]));
+  expect(snapshot.stubs).toEqual([{
+    path: failedSpawnPath,
+    kind: "spawn-stub",
+    launch: {
+      launchId: "failed-launch",
+      state: "failed",
+      error: "launch admission failed",
+      retrySafe: true,
+      engine: "codex",
+      cwd: "/repo",
+      createdAt: "2026-07-31T00:00:00.000Z",
+    },
+  }]);
+  expect(snapshot.scope).toMatchObject({ truncated: true, omittedCount: 1 });
+});

--- a/src/lib/view/collect.ts
+++ b/src/lib/view/collect.ts
@@ -1,4 +1,4 @@
-import { agentRegistry, type RegistryFile } from "@/lib/agent/registry";
+import { agentRegistry, type RegistryFile, type SnapshotSpawnProjection } from "@/lib/agent/registry";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 
@@ -7,20 +7,23 @@ import { resolveSiblings } from "./siblings";
 import type { SnapshotRequestV1 } from "./types";
 
 /**
- * One completed scan and one registry projection per snapshot (#845).
+ * One completed scan and at most one bounded spawn projection per snapshot (#845).
  *
  * The file route, MCP reads, and snapshots all consume the scanner cache's latest
  * completed generation. A warm snapshot therefore stays independent of an unhealthy
  * refresh, while a cold caller joins the cache's one real refresh. The registry
- * projection remains injected so an MCP caller that already holds it does not
- * materialise a second projection.
+ * Spawn lookup stays injected so a caller that already holds registry evidence can
+ * reuse it, while transcript-only scopes never open the registry.
  */
 export async function collectSnapshot(
   body: SnapshotRequestV1,
   dependencies: {
     completedFileScan: typeof completedFileScan;
     resolveSiblings: typeof resolveSiblings;
+    /** Compatibility seam for callers compiled against the completed-registry
+        projection. Snapshot composition leaves it untouched. */
     registrySnapshot?: () => RegistryFile;
+    snapshotSpawns?: (launchIds: readonly string[]) => SnapshotSpawnProjection;
     signal?: AbortSignal | null;
   } = { completedFileScan, resolveSiblings },
 ): Promise<Awaited<ReturnType<typeof composeSnapshot>>> {
@@ -32,14 +35,11 @@ export async function collectSnapshot(
   // composes, so renamed conversations and their siblings show the human title.
   overlaySessionTitles(files);
   const siblings = await dependencies.resolveSiblings(body.caller, files);
-  /* The completed scanner projection never appends spawn placeholder cards
-     (#342), so visible `spawn:` paths resolve against the durable registry. */
-  const registry = (dependencies.registrySnapshot ?? (() => agentRegistry().readOnlySnapshot()))();
   return composeSnapshot({
     request: body,
     files,
     siblings,
-    registry,
+    snapshotSpawns: dependencies.snapshotSpawns ?? ((launchIds) => agentRegistry().snapshotSpawns(launchIds)),
     scannerDurationMs: scan.lastScan?.durationMs ?? Date.now() - started,
     scannerScannedAt: scan.refreshedAt ?? Date.now(),
   });

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -1,4 +1,4 @@
-import { conversationLookupFromSnapshot, type RegistryFile } from "@/lib/agent/registry";
+import { snapshotSpawnsFromRegistry, type RegistryFile, type SnapshotSpawnProjection } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
 import { compactText } from "./compactText";
@@ -63,7 +63,7 @@ function conversation(entry: FileEntry): SnapshotConversation {
   return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as "claude" | "codex", model: entry.model, activity: entry.activity, proc: entry.proc, attention };
 }
 
-export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; scannerScannedAt?: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; now?: number }): Promise<ViewerSnapshotV1> {
+export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; scannerScannedAt?: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; snapshotSpawns?: (launchIds: readonly string[]) => SnapshotSpawnProjection; now?: number }): Promise<ViewerSnapshotV1> {
   const now = input.now ?? Date.now();
   const scannerScannedAt = Math.min(now, input.scannerScannedAt ?? now);
   const selection = choose(input.request, now);
@@ -76,17 +76,22 @@ export async function composeSnapshot(input: { request: SnapshotRequestV1; files
      (#342): resolve each to its materialized conversation when the scan has
      it, otherwise report a typed stub with the durable launch state. Silent
      omission is reserved for genuinely unknown paths and budget truncation. */
-  const lookup = input.registry ? conversationLookupFromSnapshot(input.registry) : null;
+  const launchIds = [...new Set(scope.all.flatMap((pathname) =>
+    pathname.startsWith("spawn:") ? [pathname.slice("spawn:".length)] : []))];
+  const spawnProjection = launchIds.length === 0
+    ? {}
+    : input.registry
+      ? snapshotSpawnsFromRegistry(input.registry, launchIds)
+      : input.snapshotSpawns?.(launchIds) ?? {};
   const stubs: SnapshotSpawnStub[] = [];
   const resolvedEntries: Array<{ entry: FileEntry; resolvedFrom?: string }> = [];
   const seenPaths = new Set<string>();
   for (const pathname of scope.all) {
     if (resolvedEntries.length + stubs.length >= MAX_SCOPE_PATHS) break;
     const launchId = pathname.startsWith("spawn:") ? pathname.slice("spawn:".length) : null;
-    const receipt = launchId && input.registry ? input.registry.receipts[launchId] : undefined;
+    const receipt = launchId ? spawnProjection[launchId] : undefined;
     if (receipt) {
-      const materializedPath = lookup?.conversation(receipt.conversationId)?.generations.at(-1)?.path
-        ?? receipt.artifactPath;
+      const materializedPath = receipt.materializedPath;
       const entry = materializedPath ? transcriptEntry(byPath, materializedPath) : undefined;
       if (entry) {
         if (!seenPaths.has(entry.path)) {


### PR DESCRIPTION
Closes #845

## Outcome

Snapshot composition now opens the registry only after scope resolution finds an actual `spawn:<launchId>` placeholder. Ordinary transcript-only visible snapshots consume the completed scanner projection and perform zero registry reads.

Spawn placeholders use a compact projection. The SQLite implementation performs keyed receipt, alias, and conversation reads in one transaction, with duplicate launch IDs removed and alias traversal capped at 64 hops.

## Exact revision

- Base: `d5ac63d94847368b3de5727547c4791cf84695c2`
- Head: `8307abde44f35d278c9fc7c9255e7d56c00e440a`

## Failed production deployments that led here

### Deployment 1

Exact deployed merge revision: `7a64f73ce18e8188e38c60c21aff5c99cc0d5e63`

- `GET /`: 200 in 25 ms
- `GET /api/files`: 200 in 302 ms
- one stale-session `GET /api/bridge`: 403 in 12 ms
- one valid visible `POST /api/agent/snapshot`: timed out after 15.001 s with zero bytes
- immediate `GET /api/files`: 200 in 208 ms
- Next remained CPU-active at approximately 1.47 GiB RSS

That deployment bounded bridge retries and shared several control-plane reads. The snapshot path could still begin a raw corpus scan and outlive client cancellation.

### Deployment 2

Exact deployed merge revision and this PR's base: `d5ac63d94847368b3de5727547c4791cf84695c2`

- release health: green
- `GET /`: 200 in 150 ms
- `GET /api/files`: 200 in 241 ms
- one stale-session `GET /api/bridge`: 403 in 14 ms
- one warm valid visible `POST /api/agent/snapshot`: timed out after 15.003 s with zero bytes
- Next RSS rose from approximately 869 MiB to 1.26 GiB during the request

The completed scan was shared successfully. The remaining synchronous whole-registry materialization blocked the event loop before the route-owned timer could fire.

This builder lane made no production request, deployment, restart, merge, or worker interruption.

## Deterministic RED to GREEN evidence

- The 373-file/41-project visible-route regression injected a full-registry dependency that throws on contact. RED returned 503; GREEN returns 200 within the one-second bound, reads one completed scan, preserves scanner age, and records zero registry calls.
- The compact SQLite regression initially failed because the keyed seam did not exist. GREEN resolves a known materialized spawn through a two-hop alias chain, returns no entry for an unknown launch, reads one receipt payload, two alias payloads, one conversation payload, and records zero whole-snapshot loads despite 2,000 unrelated receipts.
- The collector regression initially requested no launch IDs. GREEN makes one compact request containing only the scoped launch IDs, resolves the known transcript, emits a retry-safe typed failed stub, and counts the unknown path as an omission.
- Existing focused coverage remains green for materialized spawns, pending typed stubs, unknown paths, schema validation, same-origin security, scanner age, cancellation, and route deadlines.
- Twenty concurrent transcript-only route snapshots record zero whole-registry snapshots, zero compact spawn lookups, and less than 16 MiB post-GC RSS retention.

## Built Next standalone boundary

The production build was exercised as an actual standalone Next process with isolated `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `LLV_STATE_DIR`.

The fixture seeded:

- 373 completed transcript files across 41 projects
- active visible presence
- 10,001 SQLite registry receipts
- 100 external registry revisions during 20 concurrent transcript-only snapshots
- a preceding `GET /api/files` through the built route bundle

Observed result:

```json
{"files":373,"registryRows":10001,"churnRevisions":100,"snapshots":20,"maxSnapshotMs":327,"rssBeforeMiB":366,"peakRssMiB":384,"rssAfterMiB":332}
```

All 20 snapshots returned 200 within the one-second bound. Peak growth was 18 MiB, and final RSS finished below the starting measurement.

## Local gates

All tests were run by specific file path against isolated fixture state.

- snapshot route: 6 passed
- snapshot collector: 2 passed
- snapshot composition: 25 passed
- MCP control-plane reads: 8 passed
- SQLite registry: 51 passed
- built standalone route: 1 passed, 9 assertions
- TypeScript: `bun x tsc --noEmit` passed
- scoped ESLint over all 11 changed paths passed
- production standalone build: Next build and MCP bundle passed
- `bun scripts/privacy-publication-gate.ts --base d5ac63d94847368b3de5727547c4791cf84695c2`: `PRIVACY GATE: PASS`
- staged diff whitespace check passed

## Semantics and risks

- Snapshot schema, same-origin rejection, explicit-path membership checks, spawn stub fields, retry safety, scanner timestamps, and response budgets are unchanged.
- Alias traversal is capped at 64 hops and cycle-guarded. A malformed chain beyond the cap falls back to the receipt artifact or a typed stub.
- Production SQLite spawn resolution is bounded by the number of scoped spawn placeholders. JSON-only compatibility mode retains its cached registry fallback for actual spawn placeholders; transcript-only snapshots remain registry-free in every mode.
- The compact projection intentionally excludes launch profiles, accounts, hosts, lineage, memberships, and other registry collections.
- No scanner cache, coordinator, worker, bridge, voice, selected-card, composer/feed, runtime host, deployment, or grouping source changed.

## Release authorization

After the hosted head and required checks are green, root is authorized to merge this PR and deploy exact SHA `8307abde44f35d278c9fc7c9255e7d56c00e440a`. Root must verify the deployed SHA and perform the single authorized bounded production verification before reporting production success.

Production success remains unclaimed by this PR.
