### PR TITLE
chore(release): prepare v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to `agent-log-viewer` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
-versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
+versions follow [SemVer](https://semver.org/), including its compatibility
+guarantees for the 1.x series.
 
 ## [Unreleased]
+
+## [1.0.0] — 2026-07-31
 
 ### Fixed
 - An agent asking for the operator's attention reaches the desktop that is
@@ -460,7 +463,8 @@ Initial public release, packaged as `agent-log-viewer` with a `bunx` CLI.
 - Implement→review flows with fresh headless reviewer rounds.
 - Remote access over Tailscale behind a token gate.
 
-[Unreleased]: https://github.com/Latand/live-log-viewer-next/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/Latand/live-log-viewer-next/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/Latand/live-log-viewer-next/compare/v0.11.7...v1.0.0
 [0.11.2]: https://github.com/Latand/live-log-viewer-next/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Latand/live-log-viewer-next/compare/v0.10.0...v0.11.1
 [0.10.0]: https://github.com/Latand/live-log-viewer-next/compare/v0.9.3...v0.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-log-viewer",
-  "version": "0.11.7",
+  "version": "1.0.0",
   "bin": {
     "agent-log-viewer": "bin/cli.mjs",
     "agent-log-viewer-mcp": "bin/mcp-server.mjs"


### PR DESCRIPTION
## Summary

- Set the `agent-log-viewer` package version from `0.11.7` to `1.0.0`.
- Promote the accumulated Unreleased notes into `1.0.0 — 2026-07-31` and retain an empty Unreleased section.
- Update the changelog stability statement for SemVer 1.x and advance the comparison links from `v0.11.7` through `v1.0.0`.

## Verification

- Release metadata, JSON, changelog section, and comparison-link consistency assertions: PASS.
- Accumulated changelog content preservation: 16,758 bytes preserved byte-for-byte.
- `npm publish --dry-run --json`: PASS, including the Next.js production build, TypeScript, and MCP bundle.
- Package inventory: `agent-log-viewer@1.0.0`, 2,388 entries, 7,991,092-byte tarball, with roots limited to `LICENSE`, `README.md`, `bin`, `dist`, and `package.json`.
- Privacy publication gate with known-value and commit scanning against exact base `3cc98786a34f9a9a827f7692e0c32a18bb4a05b3`: PASS.
- `git diff --check 3cc98786a34f9a9a827f7692e0c32a18bb4a05b3..HEAD`: PASS.
- npm registry preflight: `agent-log-viewer@1.0.0` is currently unpublished.

## Root-owned post-merge release sequence

1. Confirm the immutable PR head, fresh read-only review, and required CI, then merge.
2. Deploy the exact merge SHA and verify the hosted Viewer at that SHA.
3. Create and push `v1.0.0` at the verified deployed SHA.
4. Verify the tag-triggered trusted npm publication, including version, integrity, package roots, and CLI/MCP entry points.
5. Create the GitHub Release from the same `v1.0.0` tag with the 1.0.0 changelog notes, then verify the hosted release.
