### PR TITLE
perf(mcp): bound receipt persistence and conversation misses

### DIFF
--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 
 import { agentRegistry, readOnlyConversationLookupFromSnapshot } from "@/lib/agent/registry";
 import { procBackend } from "@/lib/proc";
@@ -12,6 +14,7 @@ import { geometricFrameRect, isFocusTarget, isGeometricTarget } from "@/lib/atte
 import type { FocusIntent, FocusTarget, ZoomIntent } from "@/lib/attention/types";
 import { boardFor } from "@/lib/board/store";
 import { applyConversationAction } from "@/lib/conversation/actions";
+import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { cancelRound, closeFlow, patchFlow } from "@/lib/flows/commands";
 import { getFlowsWithPresets } from "@/lib/flows/engine";
 import type { PatchFlowRequest } from "@/lib/flows/types";
@@ -35,13 +38,15 @@ import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
-import { projectForCwd } from "@/lib/scanner/describe";
+import { describe, projectForCwd } from "@/lib/scanner/describe";
+import { scanRootEntries } from "@/lib/scanner/roots";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
 import { readSession } from "@/lib/session/reader";
+import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
 import { loadTasks, mutateTasks, mutateTasksFile } from "@/lib/tasks/store";
@@ -52,7 +57,7 @@ import { resolveSiblings } from "@/lib/view/siblings";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
-import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolPayload } from "./server";
+import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolCallContext, type McpToolPayload } from "./server";
 import { mcpCallerIdentity, mcpToolPolicy, type ManagerTarget, type McpToolPolicy } from "./toolAllowlist";
 
 const PIPELINE_CONTROLLER_ACTIONS = new Set<PipelineAction>(["start", "resume", "retry-stage", "skip-stage"]);
@@ -184,6 +189,7 @@ type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySna
 
 export interface ViewerMcpDomainDependencies {
   listFiles(options?: Parameters<typeof listFiles>[0]): Promise<FileEntry[]>;
+  targetedFileEntry?(pathname: string, options?: McpToolCallContext): Promise<FileEntry | undefined>;
   completedFileScan(options?: Parameters<typeof completedFileScan>[0]): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
@@ -355,6 +361,7 @@ function attentionCallerSources(): AttentionCallerSources {
 
 const productionDomainDependencies: ViewerMcpDomainDependencies = {
   listFiles,
+  targetedFileEntry: targetedFileEntry,
   completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
   boardFor,
@@ -550,24 +557,109 @@ async function linkTaskToPipeline(args: McpToolArgs, dependencies: LinkTaskToPip
   return { taskId, pipelineId, task: result.task, conversationId, transcriptPath };
 }
 
+function throwIfCallEnded(context: McpToolCallContext): void {
+  if (context.signal?.aborted) {
+    const reason = context.signal.reason;
+    throw reason instanceof Error ? reason : new DOMException("MCP tool cancelled", "AbortError");
+  }
+  if (context.deadlineAt !== undefined && Date.now() >= context.deadlineAt) {
+    throw new DeadlineExceededError("MCP tool deadline exceeded", 0);
+  }
+}
+
+function rootForTranscript(pathname: string): ReturnType<typeof scanRootEntries>[number] | undefined {
+  const absolute = path.resolve(pathname);
+  return scanRootEntries().find(([, root]) => {
+    const relative = path.relative(path.resolve(root), absolute);
+    return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  });
+}
+
+/** Hydrate metadata for one known transcript with bounded head/tail reads. */
+async function targetedFileEntry(
+  pathname: string,
+  context: McpToolCallContext = {},
+): Promise<FileEntry | undefined> {
+  throwIfCallEnded(context);
+  const rooted = rootForTranscript(pathname);
+  if (!rooted) return undefined;
+  const [rootName, root] = rooted;
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(pathname);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  throwIfCallEnded(context);
+  if (!stat.isFile() || stat.size === 0) return undefined;
+  const metadata = describe(rootName, root, pathname, stat);
+  const entry: FileEntry = {
+    path: pathname,
+    root: rootName,
+    name: path.relative(root, pathname),
+    project: metadata.project,
+    projectName: metadata.projectName,
+    projectUnresolved: metadata.projectUnresolved,
+    worktree: metadata.worktree,
+    cwd: metadata.cwd,
+    sessionStartedAt: metadata.sessionStartedAt,
+    nativeParentThreadId: metadata.nativeParentThreadId,
+    nativeForkSourceThreadId: metadata.nativeForkSourceThreadId,
+    projectRoot: metadata.projectRoot,
+    title: metadata.title,
+    engine: metadata.engine,
+    kind: metadata.kind,
+    fmt: metadata.fmt,
+    parent: null,
+    mtime: stat.mtimeMs / 1_000,
+    size: stat.size,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+  overlaySessionTitles([entry]);
+  throwIfCallEnded(context);
+  return entry;
+}
+
 /**
- * One completed generation, and a private pinned scan ONLY when it misses (#845).
- *
- * Every read of a single conversation used to force `fresh: true` with a pin, which
- * is a full-corpus walk in an exclusive scan generation — per call, for a question
- * the completed generation almost always already answers. The pin exists for the
- * case it was built for: a transcript outside the recency cap, which the completed
- * snapshot genuinely does not carry.
+ * Read one completed generation, then hydrate only the requested transcript on
+ * a miss. Production never reserves a private full-corpus scan for this lookup.
  */
 async function entryForPath(
   transcriptPath: string,
-  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan">,
+  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan" | "targetedFileEntry">,
+  context: McpToolCallContext = {},
 ): Promise<FileEntry | undefined> {
-  const completed = (await dependencies.completedFileScan()).snapshot.files;
-  const known = completed.find((candidate) => candidate.path === transcriptPath);
-  if (known) return known;
-  const pinned = await dependencies.listFiles({ fresh: true, persist: false, pin: transcriptPath });
-  return pinned.find((candidate) => candidate.path === transcriptPath);
+  throwIfCallEnded(context);
+  const timeoutMs = context.deadlineAt === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(0, context.deadlineAt - Date.now());
+  const deadline = deadlineSignal(timeoutMs, {
+    signal: context.signal,
+    reason: "MCP tool deadline exceeded",
+  });
+  try {
+    const completed = (await dependencies.completedFileScan({ signal: deadline.signal })).snapshot.files;
+    const known = completed.find((candidate) => candidate.path === transcriptPath);
+    if (known) return known;
+    if (dependencies.targetedFileEntry) {
+      return await dependencies.targetedFileEntry(transcriptPath, {
+        signal: deadline.signal,
+        deadlineAt: context.deadlineAt,
+      });
+    }
+    /* Compatibility for older injected test adapters. Production always owns
+       the targeted seam above. */
+    const pinned = await dependencies.listFiles({ fresh: true, persist: false, pin: transcriptPath, signal: deadline.signal });
+    return pinned.find((candidate) => candidate.path === transcriptPath);
+  } finally {
+    deadline.release();
+  }
 }
 
 async function listConversations(
@@ -600,8 +692,10 @@ async function listConversations(
 
 async function getConversation(
   args: McpToolArgs,
-  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan">,
+  dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan" | "targetedFileEntry">,
+  context: McpToolCallContext = {},
 ): Promise<McpToolPayload> {
+  throwIfCallEnded(context);
   const requestedId = text(args.conversationId);
   const requestedPath = text(args.transcriptPath) || text(args.path);
   if (!requestedId && !requestedPath) throw new Error("conversationId or transcriptPath is required");
@@ -609,9 +703,11 @@ async function getConversation(
     ? agentRegistry().conversation(requestedId as `conversation_${string}`)
     : agentRegistry().conversationForPath(requestedPath);
   const transcriptPath = conversation?.generations.at(-1)?.path ?? requestedPath;
-  const entry = await entryForPath(transcriptPath, dependencies);
+  const entry = await entryForPath(transcriptPath, dependencies, context);
   if (!entry || (entry.engine !== "claude" && entry.engine !== "codex")) throw new Error("conversation not found");
+  throwIfCallEnded(context);
   const session = readSession(entry.path, entry.engine);
+  throwIfCallEnded(context);
   const maxRecords = Math.max(1, Math.min(500, integer(args.maxRecords, 100)));
   return redactPayload({
     conversationId: (conversation?.id ?? entry.conversationId ?? requestedId) || null,
@@ -1631,7 +1727,7 @@ export function viewerMcpBindings(
     pipeline_action: (args) => pipelineAction(args, domainDependencies),
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
     list_conversations: (args) => listConversations(args, domainDependencies),
-    get_conversation: (args) => getConversation(args, domainDependencies),
+    get_conversation: (args, context) => getConversation(args, domainDependencies, context),
     deploy_exact_sha: (args) => deployExactSha(args, controlDependencies, domainDependencies),
     get_pipeline: getPipeline,
     board_snapshot: (args) => boardSnapshot(args, domainDependencies),

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { agentRegistry, readOnlyConversationLookupFromSnapshot } from "@/lib/agent/registry";
@@ -38,14 +39,14 @@ import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
-import { describe, projectForCwd } from "@/lib/scanner/describe";
-import { scanRootEntries } from "@/lib/scanner/roots";
+import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
+import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
-import { readSession } from "@/lib/session/reader";
+import { readSession, type SessionReadResult } from "@/lib/session/reader";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
@@ -189,7 +190,7 @@ type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySna
 
 export interface ViewerMcpDomainDependencies {
   listFiles(options?: Parameters<typeof listFiles>[0]): Promise<FileEntry[]>;
-  targetedFileEntry?(pathname: string, options?: McpToolCallContext): Promise<FileEntry | undefined>;
+  targetedFileEntry?(pathname: string, options?: McpToolCallContext): Promise<TargetedConversationRead | FileEntry | undefined>;
   completedFileScan(options?: Parameters<typeof completedFileScan>[0]): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
@@ -567,63 +568,173 @@ function throwIfCallEnded(context: McpToolCallContext): void {
   }
 }
 
-function rootForTranscript(pathname: string): ReturnType<typeof scanRootEntries>[number] | undefined {
-  const absolute = path.resolve(pathname);
-  return scanRootEntries().find(([, root]) => {
-    const relative = path.relative(path.resolve(root), absolute);
-    return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+function contained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function rootForTranscript(
+  pathname: string,
+  roots: ReturnType<typeof scanRootEntries>,
+): ReturnType<typeof scanRootEntries>[number] | undefined {
+  let canonical: string;
+  try { canonical = fs.realpathSync(pathname); } catch { return undefined; }
+  return roots.find(([, root]) => {
+    try { return contained(fs.realpathSync(root), canonical); } catch { return false; }
   });
 }
 
-/** Hydrate metadata for one known transcript with bounded head/tail reads. */
+export interface TargetedConversationRead {
+  entry: FileEntry;
+  session: SessionReadResult;
+}
+
+export interface TargetedConversationDependencies {
+  roots: ReturnType<typeof scanRootEntries>;
+  pathAllowed(candidate: string): boolean;
+  /** Deterministic race seam used by the focused security test. */
+  afterOpen?(): void;
+}
+
+function sameOpenedTranscript(
+  pathname: string,
+  root: string,
+  opened: fs.Stats,
+  allowed: (candidate: string) => boolean,
+): boolean {
+  if (!allowed(pathname)) return false;
+  try {
+    const listed = fs.lstatSync(pathname);
+    const canonicalRoot = fs.realpathSync(root);
+    const canonicalPath = fs.realpathSync(pathname);
+    return listed.isFile()
+      && !listed.isSymbolicLink()
+      && listed.dev === opened.dev
+      && listed.ino === opened.ino
+      && contained(canonicalRoot, canonicalPath);
+  } catch {
+    return false;
+  }
+}
+
+function descriptorPath(descriptor: number): string {
+  return process.platform === "linux" ? `/proc/self/fd/${descriptor}` : `/dev/fd/${descriptor}`;
+}
+
+/**
+ * Hydrate and parse one known transcript through a pinned descriptor.
+ *
+ * The public path is canonicalized against the registered scanner roots, then
+ * opened with O_NOFOLLOW. Metadata and tail parsing use a private alias to that
+ * descriptor, so a parent or leaf swap can only make the final identity check
+ * reject the result; it cannot redirect either bounded read.
+ */
+export async function targetedConversationAtPath(
+  pathname: string,
+  context: McpToolCallContext = {},
+  injectedDependencies?: TargetedConversationDependencies,
+): Promise<TargetedConversationRead | undefined> {
+  const dependencies = injectedDependencies ?? { roots: scanRootEntries(), pathAllowed };
+  throwIfCallEnded(context);
+  if (!dependencies.pathAllowed(pathname)) return undefined;
+  const rooted = rootForTranscript(pathname, dependencies.roots);
+  if (!rooted) return undefined;
+  const [rootName, root] = rooted;
+  let descriptor: number | null = null;
+  let sidecarDescriptor: number | null = null;
+  let sidecarPath: string | null = null;
+  let sidecarStat: fs.Stats | null = null;
+  let stableDirectory: string | null = null;
+  try {
+    descriptor = fs.openSync(pathname, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP" || code === "EACCES") return undefined;
+    throw error;
+  }
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile() || stat.size === 0) return undefined;
+    dependencies.afterOpen?.();
+    if (!sameOpenedTranscript(pathname, root, stat, dependencies.pathAllowed)) return undefined;
+    throwIfCallEnded(context);
+
+    if (rootName === "claude-projects" && path.basename(pathname).startsWith("agent-") && pathname.endsWith(".jsonl")) {
+      const candidate = pathname.slice(0, -".jsonl".length) + ".meta.json";
+      if (dependencies.pathAllowed(candidate)) {
+        try {
+          sidecarDescriptor = fs.openSync(candidate, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+          const openedSidecar = fs.fstatSync(sidecarDescriptor);
+          if (openedSidecar.isFile() && sameOpenedTranscript(candidate, root, openedSidecar, dependencies.pathAllowed)) {
+            sidecarPath = candidate;
+            sidecarStat = openedSidecar;
+          } else {
+            fs.closeSync(sidecarDescriptor);
+            sidecarDescriptor = null;
+          }
+        } catch {
+          if (sidecarDescriptor !== null) fs.closeSync(sidecarDescriptor);
+          sidecarDescriptor = null;
+        }
+      }
+    }
+
+    stableDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-targeted-"));
+    fs.chmodSync(stableDirectory, 0o700);
+    const stablePath = path.join(stableDirectory, path.basename(pathname));
+    fs.symlinkSync(descriptorPath(descriptor), stablePath);
+    if (sidecarDescriptor !== null && sidecarPath !== null) {
+      fs.symlinkSync(descriptorPath(sidecarDescriptor), stablePath.slice(0, -".jsonl".length) + ".meta.json");
+    }
+    const pinnedMetadata = describe(rootName, root, stablePath, stat);
+    const metadata = reprojectFileDescription(rootName, root, pathname, pinnedMetadata);
+    const entry: FileEntry = {
+      path: pathname,
+      root: rootName,
+      name: path.relative(root, pathname),
+      project: metadata.project,
+      projectName: metadata.projectName,
+      projectUnresolved: metadata.projectUnresolved,
+      worktree: metadata.worktree,
+      cwd: metadata.cwd,
+      sessionStartedAt: metadata.sessionStartedAt,
+      nativeParentThreadId: metadata.nativeParentThreadId,
+      nativeForkSourceThreadId: metadata.nativeForkSourceThreadId,
+      projectRoot: metadata.projectRoot,
+      title: metadata.title,
+      engine: metadata.engine,
+      kind: metadata.kind,
+      fmt: metadata.fmt,
+      parent: null,
+      mtime: stat.mtimeMs / 1_000,
+      size: stat.size,
+      activity: "idle",
+      proc: null,
+      pid: null,
+      model: null,
+      pendingQuestion: null,
+      waitingInput: null,
+    };
+    overlaySessionTitles([entry]);
+    if (entry.engine !== "claude" && entry.engine !== "codex") return undefined;
+    const session = { ...readSession(stablePath, entry.engine), path: pathname };
+    throwIfCallEnded(context);
+    if (!sameOpenedTranscript(pathname, root, stat, dependencies.pathAllowed)) return undefined;
+    if (sidecarDescriptor !== null && sidecarPath !== null && sidecarStat !== null
+      && !sameOpenedTranscript(sidecarPath, root, sidecarStat, dependencies.pathAllowed)) return undefined;
+    return { entry, session };
+  } finally {
+    if (stableDirectory !== null) fs.rmSync(stableDirectory, { recursive: true, force: true });
+    if (sidecarDescriptor !== null) fs.closeSync(sidecarDescriptor);
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
 async function targetedFileEntry(
   pathname: string,
   context: McpToolCallContext = {},
-): Promise<FileEntry | undefined> {
-  throwIfCallEnded(context);
-  const rooted = rootForTranscript(pathname);
-  if (!rooted) return undefined;
-  const [rootName, root] = rooted;
-  let stat: fs.Stats;
-  try {
-    stat = await fs.promises.stat(pathname);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw error;
-  }
-  throwIfCallEnded(context);
-  if (!stat.isFile() || stat.size === 0) return undefined;
-  const metadata = describe(rootName, root, pathname, stat);
-  const entry: FileEntry = {
-    path: pathname,
-    root: rootName,
-    name: path.relative(root, pathname),
-    project: metadata.project,
-    projectName: metadata.projectName,
-    projectUnresolved: metadata.projectUnresolved,
-    worktree: metadata.worktree,
-    cwd: metadata.cwd,
-    sessionStartedAt: metadata.sessionStartedAt,
-    nativeParentThreadId: metadata.nativeParentThreadId,
-    nativeForkSourceThreadId: metadata.nativeForkSourceThreadId,
-    projectRoot: metadata.projectRoot,
-    title: metadata.title,
-    engine: metadata.engine,
-    kind: metadata.kind,
-    fmt: metadata.fmt,
-    parent: null,
-    mtime: stat.mtimeMs / 1_000,
-    size: stat.size,
-    activity: "idle",
-    proc: null,
-    pid: null,
-    model: null,
-    pendingQuestion: null,
-    waitingInput: null,
-  };
-  overlaySessionTitles([entry]);
-  throwIfCallEnded(context);
-  return entry;
+): Promise<TargetedConversationRead | undefined> {
+  return targetedConversationAtPath(pathname, context);
 }
 
 /**
@@ -634,7 +745,7 @@ async function entryForPath(
   transcriptPath: string,
   dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan" | "targetedFileEntry">,
   context: McpToolCallContext = {},
-): Promise<FileEntry | undefined> {
+): Promise<{ entry: FileEntry; session?: SessionReadResult } | undefined> {
   throwIfCallEnded(context);
   const timeoutMs = context.deadlineAt === undefined
     ? Number.POSITIVE_INFINITY
@@ -646,17 +757,20 @@ async function entryForPath(
   try {
     const completed = (await dependencies.completedFileScan({ signal: deadline.signal })).snapshot.files;
     const known = completed.find((candidate) => candidate.path === transcriptPath);
-    if (known) return known;
+    if (known) return { entry: known };
     if (dependencies.targetedFileEntry) {
-      return await dependencies.targetedFileEntry(transcriptPath, {
+      const targeted = await dependencies.targetedFileEntry(transcriptPath, {
         signal: deadline.signal,
         deadlineAt: context.deadlineAt,
       });
+      if (!targeted) return undefined;
+      return "entry" in targeted ? targeted : { entry: targeted };
     }
     /* Compatibility for older injected test adapters. Production always owns
        the targeted seam above. */
     const pinned = await dependencies.listFiles({ fresh: true, persist: false, pin: transcriptPath, signal: deadline.signal });
-    return pinned.find((candidate) => candidate.path === transcriptPath);
+    const entry = pinned.find((candidate) => candidate.path === transcriptPath);
+    return entry ? { entry } : undefined;
   } finally {
     deadline.release();
   }
@@ -703,10 +817,11 @@ async function getConversation(
     ? agentRegistry().conversation(requestedId as `conversation_${string}`)
     : agentRegistry().conversationForPath(requestedPath);
   const transcriptPath = conversation?.generations.at(-1)?.path ?? requestedPath;
-  const entry = await entryForPath(transcriptPath, dependencies, context);
+  const targeted = await entryForPath(transcriptPath, dependencies, context);
+  const entry = targeted?.entry;
   if (!entry || (entry.engine !== "claude" && entry.engine !== "codex")) throw new Error("conversation not found");
   throwIfCallEnded(context);
-  const session = readSession(entry.path, entry.engine);
+  const session = targeted.session ?? readSession(entry.path, entry.engine);
   throwIfCallEnded(context);
   const maxRecords = Math.max(1, Math.min(500, integer(args.maxRecords, 100)));
   return redactPayload({
@@ -1574,9 +1689,9 @@ async function focusTargetProject(
   if (isGeometricTarget(target)) return target.project;
   switch (target.kind) {
     case "conversation": {
-      const entry = await entryForPath(target.path, dependencies);
-      if (!entry) throw new Error("no conversation on the board has that transcript path");
-      return entry.project;
+      const targeted = await entryForPath(target.path, dependencies);
+      if (!targeted) throw new Error("no conversation on the board has that transcript path");
+      return targeted.entry.project;
     }
     case "pipeline":
     case "stage": {

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -106,11 +106,19 @@ function projection() {
  * therefore the number of GENERATIONS and MATERIALISATIONS — the expensive events —
  * rather than the number of times a read asked.
  */
-function dependencies(options: { scans?: number; projections?: number } = {}) {
+function dependencies(options: { scans?: number; projections?: number; completedTranscript?: boolean } = {}) {
   const allowedScans = options.scans ?? 1;
   const allowedProjections = options.projections ?? 1;
-  const counts = { scans: 0, projections: 0, rawScans: 0, observations: 0, scanCalls: 0, projectionCalls: 0 };
-  const snapshot = { files: Array.from({ length: SCAN_ROWS }, (_value, index) => scanRow(index)), projectCatalog: [], complete: true };
+  const counts = { scans: 0, projections: 0, rawScans: 0, targetedReads: 0, observations: 0, scanCalls: 0, projectionCalls: 0 };
+  const completedTranscript = options.completedTranscript ?? true;
+  const snapshot = {
+    files: Array.from({ length: SCAN_ROWS }, (_value, index) => completedTranscript || index > 0
+      ? scanRow(index)
+      : { ...scanRow(index), path: "/sessions/completed-generation-other.jsonl" }),
+    projectCatalog: [],
+    complete: true,
+  };
+  const targetedCalls: Array<{ pathname: string; signal: AbortSignal | undefined; deadlineAt: number | undefined }> = [];
   let inflight: Promise<{ snapshot: typeof snapshot }> | null = null;
   let materialised: ReturnType<typeof projection> | null = null;
   return {
@@ -139,6 +147,11 @@ function dependencies(options: { scans?: number; projections?: number } = {}) {
         counts.rawScans += 1;
         throw new Error("a control-plane read must not start a raw corpus scan");
       },
+      targetedFileEntry: async (pathname: string, options: { signal?: AbortSignal; deadlineAt?: number } = {}) => {
+        counts.targetedReads += 1;
+        targetedCalls.push({ pathname, signal: options.signal, deadlineAt: options.deadlineAt });
+        return pathname === transcriptPath ? scanRow(0) : undefined;
+      },
       /* Stands in for transcript-only composition: the completed generation is
          consumed while the injected registry projection remains lazy. */
       collectSnapshot: async (_body: unknown, deps: {
@@ -152,6 +165,7 @@ function dependencies(options: { scans?: number; projections?: number } = {}) {
       },
       boardFor: () => null,
     } as never,
+    targetedCalls,
   };
 }
 
@@ -177,6 +191,79 @@ test("get_conversation reads the completed generation when it already carries th
      it does, so the private exclusive scan never runs. */
   expect(counts.rawScans).toBe(0);
   expect(counts.scans).toBe(1);
+});
+
+test("get_conversation hydrates one known transcript after a completed miss and propagates its bound", async () => {
+  const { counts, injected, targetedCalls } = dependencies({ completedTranscript: false });
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+  const controller = new AbortController();
+  const deadlineAt = Date.now() + 1_000;
+
+  const result = await bindings.get_conversation(
+    { clientRequestId: "get-targeted", transcriptPath },
+    { signal: controller.signal, deadlineAt },
+  ) as { transcriptPath: string };
+
+  expect(result.transcriptPath).toBe(transcriptPath);
+  expect(counts.scans).toBe(1);
+  expect(counts.targetedReads).toBe(1);
+  expect(counts.rawScans).toBe(0);
+  expect(targetedCalls).toEqual([{ pathname: transcriptPath, signal: controller.signal, deadlineAt }]);
+});
+
+test("get_conversation cancels a targeted miss when its caller leaves", async () => {
+  const { counts, injected } = dependencies({ completedTranscript: false });
+  let started!: () => void;
+  const targetedStarted = new Promise<void>((resolve) => { started = resolve; });
+  let targetedSignal: AbortSignal | undefined;
+  const domain = injected as unknown as {
+    targetedFileEntry(pathname: string, options?: { signal?: AbortSignal; deadlineAt?: number }): Promise<ReturnType<typeof scanRow> | undefined>;
+  };
+  domain.targetedFileEntry = async (_pathname, options = {}) => new Promise((_resolve, reject) => {
+    targetedSignal = options.signal;
+    started();
+    options.signal?.addEventListener("abort", () => reject(options.signal?.reason), { once: true });
+  });
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+  const controller = new AbortController();
+  const call = bindings.get_conversation(
+    { clientRequestId: "get-cancelled", transcriptPath },
+    { signal: controller.signal, deadlineAt: Date.now() + 1_000 },
+  );
+  const startState = await Promise.race([
+    targetedStarted.then(() => "targeted" as const),
+    call.then(() => "resolved" as const, () => "rejected" as const),
+    Bun.sleep(250).then(() => "timed-out" as const),
+  ]);
+  expect(startState).toBe("targeted");
+  controller.abort(new DOMException("caller left", "AbortError"));
+
+  await expect(call).rejects.toMatchObject({ name: "AbortError" });
+  expect(targetedSignal?.aborted).toBeTrue();
+  expect(counts.targetedReads).toBe(0);
+  expect(counts.rawScans).toBe(0);
+});
+
+test("get_conversation deadlines a targeted miss without orphan work", async () => {
+  const { counts, injected } = dependencies({ completedTranscript: false });
+  let targetedSignal: AbortSignal | undefined;
+  const domain = injected as unknown as {
+    targetedFileEntry(pathname: string, options?: { signal?: AbortSignal; deadlineAt?: number }): Promise<ReturnType<typeof scanRow> | undefined>;
+  };
+  domain.targetedFileEntry = async (_pathname, options = {}) => new Promise((_resolve, reject) => {
+    targetedSignal = options.signal;
+    options.signal?.addEventListener("abort", () => reject(options.signal?.reason), { once: true });
+  });
+  const bindings = viewerMcpBindings(undefined, undefined, injected);
+
+  const call = bindings.get_conversation(
+    { clientRequestId: "get-deadline", transcriptPath },
+    { deadlineAt: Date.now() + 20 },
+  );
+
+  await expect(call).rejects.toMatchObject({ name: "DeadlineExceededError" });
+  expect(targetedSignal?.aborted).toBeTrue();
+  expect(counts.rawScans).toBe(0);
 });
 
 test("board_snapshot still consumes one scan and one projection", async () => {

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { viewerMcpBindings } from "./bindings";
+import { targetedConversationAtPath, viewerMcpBindings, type TargetedConversationDependencies } from "./bindings";
 
 /**
  * The control-plane reads consume ONE completed scan and ONE projection (#845).
@@ -264,6 +264,91 @@ test("get_conversation deadlines a targeted miss without orphan work", async () 
   await expect(call).rejects.toMatchObject({ name: "DeadlineExceededError" });
   expect(targetedSignal?.aborted).toBeTrue();
   expect(counts.rawScans).toBe(0);
+});
+
+test("targeted conversation opens one canonical regular transcript and retains its title", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-targeted-open-"));
+  sandboxes.push(directory);
+  const root = path.join(directory, "sessions");
+  fs.mkdirSync(root);
+  const pathname = path.join(root, "rollout.jsonl");
+  fs.writeFileSync(pathname, [
+    JSON.stringify({ type: "session_meta", payload: { id: "fixture", timestamp: "2026-07-01T09:00:00.000Z", cwd: "/repo/fixture" } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "canonical title" }] } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "bounded answer" }] } }),
+  ].join("\n") + "\n");
+
+  const targeted = await targetedConversationAtPath(pathname, {}, {
+    roots: [["codex-sessions", root]],
+    pathAllowed: (candidate) => fs.realpathSync(candidate).startsWith(fs.realpathSync(root) + path.sep),
+  });
+
+  expect(targeted?.entry).toMatchObject({ path: pathname, title: "canonical title", engine: "codex" });
+  expect(targeted?.session.messages.at(-1)?.text).toBe("bounded answer");
+});
+
+test("targeted conversation retains a safely opened Claude subagent sidecar title", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-targeted-sidecar-"));
+  sandboxes.push(directory);
+  const root = path.join(directory, "projects");
+  const project = path.join(root, "-repo-fixture");
+  fs.mkdirSync(project, { recursive: true });
+  const pathname = path.join(project, "agent-fixture.jsonl");
+  fs.writeFileSync(pathname, `${JSON.stringify({ type: "user", cwd: "/repo/fixture", message: { content: "fallback title" } })}\n`);
+  fs.writeFileSync(pathname.replace(/\.jsonl$/, ".meta.json"), JSON.stringify({ description: "sidecar title" }));
+  const pathAllowed = (candidate: string) => {
+    try { return fs.realpathSync(candidate).startsWith(fs.realpathSync(root) + path.sep); } catch { return false; }
+  };
+
+  const targeted = await targetedConversationAtPath(pathname, {}, {
+    roots: [["claude-projects", root]],
+    pathAllowed,
+  });
+
+  expect(targeted?.entry).toMatchObject({ title: "sidecar title", engine: "claude", kind: "subagent" });
+});
+
+test("targeted conversation rejects external symlinks and a path swapped after safe open", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-targeted-race-"));
+  sandboxes.push(directory);
+  const root = path.join(directory, "sessions");
+  const external = path.join(directory, "external");
+  fs.mkdirSync(root);
+  fs.mkdirSync(external);
+  const externalPath = path.join(external, "outside.jsonl");
+  const externalBody = `${JSON.stringify({ type: "session_meta", payload: { cwd: "/outside" } })}\n`;
+  fs.writeFileSync(externalPath, externalBody);
+  const symlinkPath = path.join(root, "external-link.jsonl");
+  fs.symlinkSync(externalPath, symlinkPath);
+  const pathAllowed = (candidate: string) => {
+    try { return fs.realpathSync(candidate).startsWith(fs.realpathSync(root) + path.sep); } catch { return false; }
+  };
+
+  const targetedDependencies: TargetedConversationDependencies = {
+    roots: [["codex-sessions", root]],
+    pathAllowed,
+  };
+  expect(await targetedConversationAtPath(symlinkPath, {}, targetedDependencies)).toBeUndefined();
+  const { injected } = dependencies({ completedTranscript: false });
+  const domain = injected as unknown as {
+    targetedFileEntry(pathname: string, options?: { signal?: AbortSignal; deadlineAt?: number }): ReturnType<typeof targetedConversationAtPath>;
+  };
+  domain.targetedFileEntry = (candidate, options = {}) => targetedConversationAtPath(candidate, options, targetedDependencies);
+  await expect(viewerMcpBindings(undefined, undefined, injected).get_conversation({
+    clientRequestId: "external-symlink",
+    transcriptPath: symlinkPath,
+  })).rejects.toThrow("conversation not found");
+
+  const swappedPath = path.join(root, "swapped.jsonl");
+  fs.writeFileSync(swappedPath, `${JSON.stringify({ type: "session_meta", payload: { cwd: "/inside" } })}\n`);
+  expect(await targetedConversationAtPath(swappedPath, {}, {
+    roots: [["codex-sessions", root]],
+    pathAllowed,
+    afterOpen: () => {
+      fs.unlinkSync(swappedPath);
+      fs.symlinkSync(externalPath, swappedPath);
+    },
+  })).toBeUndefined();
 });
 
 test("board_snapshot still consumes one scan and one projection", async () => {

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+
+import {
+  MCP_TOOL_NAMES,
+  SqliteMcpReceiptStore,
+  createMcpToolService,
+  type McpToolBindings,
+} from "./server";
+
+function waitFor(filename: string): void {
+  while (!fs.existsSync(filename)) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+  }
+}
+
+const filename = process.argv[2]!;
+const readyPath = process.argv[3]!;
+const startPath = process.argv[4]!;
+const ownerReadyPath = process.argv[5]!;
+const ownerReleasePath = process.argv[6]!;
+const ownerCountPath = process.argv[7]!;
+const resultPath = process.argv[8]!;
+const index = Number(process.argv[9]!);
+
+const store = new SqliteMcpReceiptStore(filename);
+let peakRssBytes = process.memoryUsage().rss;
+fs.writeFileSync(readyPath, JSON.stringify({ index, steadyRssBytes: peakRssBytes }));
+waitFor(startPath);
+
+const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+bindings.list_tasks = async () => {
+  peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
+  fs.appendFileSync(ownerCountPath, `${index}\n`);
+  fs.writeFileSync(ownerReadyPath, String(index), { flag: "wx" });
+  waitFor(ownerReleasePath);
+  peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
+  return { ownerIndex: index, count: 1 };
+};
+
+const startedAt = performance.now();
+const result = await createMcpToolService(bindings, store).callTool("list_tasks", {
+  clientRequestId: "twenty-process-owner",
+  limit: 1,
+});
+peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
+store.close();
+fs.writeFileSync(resultPath, JSON.stringify({
+  index,
+  durationMs: performance.now() - startedAt,
+  peakRssBytes,
+  result,
+}));

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -8,15 +8,19 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
 import { SNAPSHOT_CALLER_KEYS, SNAPSHOT_SCOPE_KEYS, SNAPSHOT_TEXT_KEYS, SNAPSHOT_VIEW_KEYS } from "@/lib/view/types";
+import { DeadlineExceededError } from "@/lib/deadline";
 
 import {
   MCP_TOOL_NAMES,
   TOOL_INPUT_SCHEMAS,
   FileMcpReceiptStore,
   MemoryMcpReceiptStore,
+  McpToolTimingAggregate,
+  SqliteMcpReceiptStore,
   createViewerMcpServer,
   createMcpToolService,
   type McpToolBindings,
+  type McpReceiptStore,
 } from "./server";
 
 const scratch: string[] = [];
@@ -67,6 +71,237 @@ async function childResult(child: { exited: Promise<number>; stderr: ReadableStr
 }
 
 describe("MCP tool service", () => {
+  test("production-shaped receipts stay bounded under twenty concurrent fresh calls and replays", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-sqlite-"));
+    scratch.push(directory);
+    const legacyPath = path.join(directory, "mcp-receipts.json");
+    const sqlitePath = path.join(directory, "mcp-receipts.sqlite");
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    const durableArgs = { clientRequestId: "durable-before-sqlite", conversationId: "conversation_fixture", text: "hello" };
+
+    /* Produce one real legacy receipt through the public seam so migration is
+       checked against the same digest/idempotency contract as production. */
+    const legacyService = createMcpToolService(bindings, new FileMcpReceiptStore(legacyPath));
+    const durableResult = await legacyService.callTool("send_message", durableArgs);
+    const legacy = JSON.parse(fs.readFileSync(legacyPath, "utf8")) as {
+      version: 2;
+      readReceipts: Record<string, unknown>;
+      mutationReceipts: Record<string, unknown>;
+    };
+    const digest = "a".repeat(64);
+    for (let index = 0; index < 2_100; index += 1) {
+      const clientRequestId = `durable-fixture-${index}`;
+      legacy.mutationReceipts[`send_message:${clientRequestId}`] = {
+        digest,
+        result: {
+          ok: true,
+          toolName: "send_message",
+          clientRequestId,
+          replayed: false,
+          operationId: `operation_fixture_${index}`,
+        },
+      };
+    }
+    const bulkyResults = [
+      ...Array.from({ length: 22 }, () => ["list_pipelines", "x".repeat(400_000)] as const),
+      ...Array.from({ length: 79 }, () => ["get_conversation", "x".repeat(55_000)] as const),
+      ...Array.from({ length: 6 }, () => ["list_flows", "x".repeat(385_000)] as const),
+      ...Array.from({ length: 393 }, () => ["list_tasks", "x".repeat(8_000)] as const),
+    ];
+    for (const [index, [toolName, payload]] of bulkyResults.entries()) {
+      const clientRequestId = `read-fixture-${index}`;
+      legacy.readReceipts[`${toolName}:${clientRequestId}`] = {
+        digest,
+        result: { ok: true, toolName, clientRequestId, replayed: false, payload },
+      };
+    }
+    fs.writeFileSync(legacyPath, JSON.stringify(legacy));
+
+    let bindingCalls = 0;
+    bindings.list_tasks = async () => {
+      bindingCalls += 1;
+      return { count: 1, tasks: [{ state: "ready" }] };
+    };
+    const store = new SqliteMcpReceiptStore(sqlitePath, { legacyFilePath: legacyPath });
+    const service = createMcpToolService(bindings, store);
+    expect(await service.callTool("send_message", durableArgs)).toEqual({ ...durableResult, replayed: true });
+    expect(await service.callTool("send_message", { ...durableArgs, text: "changed" })).toMatchObject({
+      ok: false,
+      code: "idempotency_conflict",
+      replayed: true,
+    });
+
+    const measure = async (clientRequestId: string) => {
+      const startedAt = performance.now();
+      const result = await service.callTool("list_tasks", { clientRequestId, limit: 1 });
+      return { durationMs: performance.now() - startedAt, result };
+    };
+    const fresh = await Promise.all(Array.from({ length: 20 }, (_value, index) => measure(`concurrent-${index}`)));
+    const replay = await Promise.all(Array.from({ length: 20 }, (_value, index) => measure(`concurrent-${index}`)));
+    const percentile = (values: number[], quantile: number) => values.toSorted((left, right) => left - right)[Math.ceil(values.length * quantile) - 1]!;
+
+    expect(fresh.every(({ result }) => result.ok && !result.replayed)).toBeTrue();
+    expect(replay.every(({ result }) => result.ok && result.replayed)).toBeTrue();
+    expect(bindingCalls).toBe(20);
+    expect(percentile(fresh.map(({ durationMs }) => durationMs), 0.95)).toBeLessThan(250);
+    expect(percentile(replay.map(({ durationMs }) => durationMs), 0.95)).toBeLessThan(100);
+
+    store.close();
+    expect(fs.statSync(sqlitePath).size).toBeLessThan(12 * 1024 * 1024);
+    fs.writeFileSync(legacyPath, "legacy import must not run twice");
+    const restarted = createMcpToolService(bindings, new SqliteMcpReceiptStore(sqlitePath, { legacyFilePath: legacyPath }));
+    expect(await restarted.callTool("send_message", durableArgs)).toEqual({ ...durableResult, replayed: true });
+  }, 30_000);
+
+  test("SQLite read receipt count retention expires the oldest completed replay", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-count-"));
+    scratch.push(directory);
+    let bindingCalls = 0;
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_tasks = async () => ({ bindingCall: ++bindingCalls });
+    const store = new SqliteMcpReceiptStore(path.join(directory, "receipts.sqlite"), {
+      readReceiptCountCap: 2,
+      readReceiptByteCap: 1_000_000,
+    });
+    const service = createMcpToolService(bindings, store);
+
+    for (const clientRequestId of ["count-1", "count-2", "count-3"]) {
+      expect((await service.callTool("list_tasks", { clientRequestId })).replayed).toBeFalse();
+    }
+    expect((await service.callTool("list_tasks", { clientRequestId: "count-1" })).replayed).toBeFalse();
+    expect(bindingCalls).toBe(4);
+    store.close();
+  });
+
+  test("SQLite read receipt byte retention expires oversized completed replays", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-bytes-"));
+    scratch.push(directory);
+    let bindingCalls = 0;
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_tasks = async () => ({ bindingCall: ++bindingCalls, payload: "x".repeat(512) });
+    const store = new SqliteMcpReceiptStore(path.join(directory, "receipts.sqlite"), {
+      readReceiptCountCap: 100,
+      readReceiptByteCap: 1_000,
+    });
+    const service = createMcpToolService(bindings, store);
+
+    await service.callTool("list_tasks", { clientRequestId: "bytes-1" });
+    await service.callTool("list_tasks", { clientRequestId: "bytes-2" });
+    expect((await service.callTool("list_tasks", { clientRequestId: "bytes-1" })).replayed).toBeFalse();
+    expect(bindingCalls).toBe(3);
+    store.close();
+  });
+
+  test("separate SQLite store instances preserve one durable mutation owner", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-instances-"));
+    scratch.push(directory);
+    const filename = path.join(directory, "receipts.sqlite");
+    let release!: () => void;
+    let started!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const bindingStarted = new Promise<void>((resolve) => { started = resolve; });
+    let bindingCalls = 0;
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.send_message = async () => {
+      bindingCalls += 1;
+      started();
+      await held;
+      return { operationId: "operation-sqlite-owner" };
+    };
+    const firstStore = new SqliteMcpReceiptStore(filename);
+    const secondStore = new SqliteMcpReceiptStore(filename);
+    const args = { clientRequestId: "sqlite-owner", conversationId: "conversation_fixture", text: "hello" };
+    const first = createMcpToolService(bindings, firstStore).callTool("send_message", args);
+    await bindingStarted;
+
+    expect(await createMcpToolService(bindings, secondStore).callTool("send_message", args)).toMatchObject({
+      ok: false,
+      code: "call_interrupted",
+      retryable: true,
+      replayed: true,
+    });
+    expect(bindingCalls).toBe(1);
+    release();
+    const completed = await first;
+    firstStore.close();
+    secondStore.close();
+
+    const restartedStore = new SqliteMcpReceiptStore(filename);
+    expect(await createMcpToolService(bindings, restartedStore).callTool("send_message", args))
+      .toEqual({ ...completed, replayed: true });
+    expect(bindingCalls).toBe(1);
+    restartedStore.close();
+  });
+
+  test("tool timing aggregates expose numeric phases and retain no call data", async () => {
+    const timings = new McpToolTimingAggregate();
+    const privateSentinel = "PRIVATE_TIMING_SENTINEL";
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_tasks = async () => ({ resultBody: privateSentinel, count: 1 });
+    const service = createMcpToolService(bindings, new MemoryMcpReceiptStore(), undefined, { timings });
+
+    const args = {
+      clientRequestId: `request-${privateSentinel}`,
+      "prompt": privateSentinel,
+      transcriptPath: `/private/${privateSentinel}.jsonl`,
+      accountId: `account-${privateSentinel}`,
+    };
+    await service.callTool("list_tasks", args, { deadlineAt: Date.now() + 5_000 });
+    await service.callTool("list_tasks", args, { deadlineAt: Date.now() + 5_000 });
+    await service.callTool("list_tasks", { ...args, "prompt": "changed" }, { deadlineAt: Date.now() + 5_000 });
+
+    const snapshot = timings.snapshot();
+    const listTasks = snapshot.find((entry) => entry.toolName === "list_tasks")!;
+    expect(snapshot).toHaveLength(MCP_TOOL_NAMES.length);
+    expect(listTasks.calls).toBe(3);
+    expect(listTasks.outcomes).toMatchObject({ success: 1, replay: 1, conflict: 1 });
+    expect(listTasks.phases.claim.samples).toBe(3);
+    expect(listTasks.phases.binding.samples).toBe(1);
+    expect(listTasks.phases.completion.samples).toBe(1);
+    expect(listTasks.phases.serialization.samples).toBe(3);
+    expect(listTasks.phases.rpcDeliveryWait.samples).toBe(3);
+    expect(listTasks.phases.replay.samples).toBe(1);
+    expect(listTasks.resultSizeBytes.max).toBeGreaterThan(0);
+    expect(listTasks.deadline.callsWithDeadline).toBe(3);
+    expect(JSON.stringify(snapshot)).not.toContain(privateSentinel);
+  });
+
+  test("tool timing aggregates classify deadline, cancellation, and unfinished age", async () => {
+    const pendingTimings = new McpToolTimingAggregate();
+    const pendingStore: McpReceiptStore = {
+      claim: () => ({ kind: "pending", unfinishedAgeMs: 4_321 }),
+      complete: () => { throw new Error("pending receipt must not complete"); },
+    };
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    await createMcpToolService(bindings, pendingStore, undefined, { timings: pendingTimings })
+      .callTool("list_tasks", { clientRequestId: "pending-age" });
+
+    const deadlineTimings = new McpToolTimingAggregate();
+    bindings.list_tasks = async (_args, context) => {
+      if (context?.signal?.aborted) throw context.signal.reason;
+      return {};
+    };
+    const deadlineController = new AbortController();
+    deadlineController.abort(new DeadlineExceededError("fixture deadline", 5_000));
+    const cancelledController = new AbortController();
+    cancelledController.abort(new DOMException("fixture cancelled", "AbortError"));
+    const service = createMcpToolService(bindings, new MemoryMcpReceiptStore(), undefined, { timings: deadlineTimings });
+    await service.callTool("list_tasks", { clientRequestId: "deadline" }, {
+      signal: deadlineController.signal,
+      deadlineAt: Date.now(),
+    });
+    await service.callTool("list_tasks", { clientRequestId: "cancelled" }, {
+      signal: cancelledController.signal,
+    });
+
+    const pending = pendingTimings.snapshot().find((entry) => entry.toolName === "list_tasks")!;
+    expect(pending.outcomes.pending).toBe(1);
+    expect(pending.unfinishedAgeMs).toMatchObject({ samples: 1, max: 4_321 });
+    const ended = deadlineTimings.snapshot().find((entry) => entry.toolName === "list_tasks")!;
+    expect(ended.deadline).toMatchObject({ callsWithDeadline: 1, exceeded: 1 });
+    expect(ended.cancellation.cancelled).toBe(1);
+  });
+
   test("each v1 tool returns structured ids and replays a duplicate clientRequestId", async () => {
     const calls = new Map<string, number>();
     const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { Database } from "bun:sqlite";
+
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
@@ -48,6 +50,15 @@ async function waitForFile(filename: string, timeoutMs = 3_000): Promise<boolean
   return fs.existsSync(filename);
 }
 
+async function waitForFileCount(directory: string, prefix: string, count: number, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.readdirSync(directory).filter((entry) => entry.startsWith(prefix)).length >= count) return true;
+    await Bun.sleep(10);
+  }
+  return fs.readdirSync(directory).filter((entry) => entry.startsWith(prefix)).length >= count;
+}
+
 function recoveryArtifacts(directory: string): string[] {
   return fs.readdirSync(directory)
     .filter((entry) => entry.includes(".recovering") || entry.includes(".recovery-owner"));
@@ -71,7 +82,7 @@ async function childResult(child: { exited: Promise<number>; stderr: ReadableStr
 }
 
 describe("MCP tool service", () => {
-  test("production-shaped receipts stay bounded under twenty concurrent fresh calls and replays", async () => {
+  test("production-shaped legacy receipts import once and stay bounded", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-sqlite-"));
     scratch.push(directory);
     const legacyPath = path.join(directory, "mcp-receipts.json");
@@ -131,26 +142,102 @@ describe("MCP tool service", () => {
       replayed: true,
     });
 
-    const measure = async (clientRequestId: string) => {
-      const startedAt = performance.now();
-      const result = await service.callTool("list_tasks", { clientRequestId, limit: 1 });
-      return { durationMs: performance.now() - startedAt, result };
-    };
-    const fresh = await Promise.all(Array.from({ length: 20 }, (_value, index) => measure(`concurrent-${index}`)));
-    const replay = await Promise.all(Array.from({ length: 20 }, (_value, index) => measure(`concurrent-${index}`)));
-    const percentile = (values: number[], quantile: number) => values.toSorted((left, right) => left - right)[Math.ceil(values.length * quantile) - 1]!;
-
-    expect(fresh.every(({ result }) => result.ok && !result.replayed)).toBeTrue();
-    expect(replay.every(({ result }) => result.ok && result.replayed)).toBeTrue();
-    expect(bindingCalls).toBe(20);
-    expect(percentile(fresh.map(({ durationMs }) => durationMs), 0.95)).toBeLessThan(250);
-    expect(percentile(replay.map(({ durationMs }) => durationMs), 0.95)).toBeLessThan(100);
+    const fresh = await service.callTool("list_tasks", { clientRequestId: "post-import-read", limit: 1 });
+    expect(fresh).toMatchObject({ ok: true, replayed: false });
+    expect(await service.callTool("list_tasks", { clientRequestId: "post-import-read", limit: 1 }))
+      .toEqual({ ...fresh, replayed: true });
+    expect(bindingCalls).toBe(1);
 
     store.close();
     expect(fs.statSync(sqlitePath).size).toBeLessThan(12 * 1024 * 1024);
     fs.writeFileSync(legacyPath, "legacy import must not run twice");
     const restarted = createMcpToolService(bindings, new SqliteMcpReceiptStore(sqlitePath, { legacyFilePath: legacyPath }));
     expect(await restarted.callTool("send_message", durableArgs)).toEqual({ ...durableResult, replayed: true });
+  }, 30_000);
+
+  test("twenty processes deterministically share one SQLite receipt owner and restart replay", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-processes-"));
+    scratch.push(directory);
+    const sqlitePath = path.join(directory, "receipts.sqlite");
+    new SqliteMcpReceiptStore(sqlitePath).close();
+    const childPath = path.join(import.meta.dir, "receiptStoreProbeChild.ts");
+    const startPath = path.join(directory, "start");
+    const ownerReadyPath = path.join(directory, "owner-ready");
+    const ownerReleasePath = path.join(directory, "owner-release");
+    const ownerCountPath = path.join(directory, "owner-count");
+    const children = Array.from({ length: 20 }, (_value, index) => Bun.spawn({
+      cmd: [
+        process.execPath,
+        childPath,
+        sqlitePath,
+        path.join(directory, `ready-${index}.json`),
+        startPath,
+        ownerReadyPath,
+        ownerReleasePath,
+        ownerCountPath,
+        path.join(directory, `result-${index}.json`),
+        String(index),
+      ],
+      cwd: import.meta.dir,
+      env: { ...process.env, LLV_STATE_DIR: path.join(directory, "state", String(index)) },
+      stdout: "pipe",
+      stderr: "pipe",
+    }));
+
+    expect(await waitForFileCount(directory, "ready-", 20)).toBeTrue();
+    const ready = Array.from({ length: 20 }, (_value, index) => JSON.parse(
+      fs.readFileSync(path.join(directory, `ready-${index}.json`), "utf8"),
+    ) as { index: number; steadyRssBytes: number });
+    expect(ready.map(({ index }) => index).toSorted((left, right) => left - right))
+      .toEqual(Array.from({ length: 20 }, (_value, index) => index));
+    expect(ready.every(({ steadyRssBytes }) => Number.isFinite(steadyRssBytes) && steadyRssBytes > 0)).toBeTrue();
+
+    fs.writeFileSync(startPath, "start");
+    expect(await waitForFile(ownerReadyPath, 10_000)).toBeTrue();
+    expect(await waitForFileCount(directory, "result-", 19, 10_000)).toBeTrue();
+    const ownerIndex = Number(fs.readFileSync(ownerReadyPath, "utf8"));
+    expect(fs.readFileSync(ownerCountPath, "utf8").trim().split("\n")).toEqual([String(ownerIndex)]);
+    fs.writeFileSync(ownerReleasePath, "release");
+
+    const childOutcomes = await Promise.all(children.map(childResult));
+    expect(childOutcomes).toEqual(Array.from({ length: 20 }, () => ({ exit: 0, error: "" })));
+    const results = Array.from({ length: 20 }, (_value, index) => JSON.parse(
+      fs.readFileSync(path.join(directory, `result-${index}.json`), "utf8"),
+    ) as {
+      index: number;
+      durationMs: number;
+      peakRssBytes: number;
+      result: { ok: boolean; replayed: boolean; code?: string; ownerIndex?: number };
+    });
+    const winners = results.filter(({ result }) => result.ok);
+    const contenders = results.filter(({ result }) => result.code === "call_interrupted");
+    expect(winners).toHaveLength(1);
+    expect(winners[0]).toMatchObject({ index: ownerIndex, result: { replayed: false, ownerIndex } });
+    expect(contenders).toHaveLength(19);
+    expect(contenders.every(({ result }) => result.replayed)).toBeTrue();
+
+    let restartBindingCalls = 0;
+    const restartBindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    restartBindings.list_tasks = async () => ({ restartBindingCall: ++restartBindingCalls });
+    const restartedStore = new SqliteMcpReceiptStore(sqlitePath);
+    const restartedService = createMcpToolService(restartBindings, restartedStore);
+    expect(await restartedService.callTool("list_tasks", { clientRequestId: "twenty-process-owner", limit: 1 }))
+      .toMatchObject({ ok: true, replayed: true, ownerIndex });
+    expect(await restartedService.callTool("list_tasks", { clientRequestId: "twenty-process-owner", limit: 2 }))
+      .toMatchObject({ ok: false, replayed: true, code: "idempotency_conflict" });
+    expect(restartBindingCalls).toBe(0);
+    restartedStore.close();
+
+    const percentile = (values: number[], quantile: number) => values.toSorted((left, right) => left - right)[Math.ceil(values.length * quantile) - 1]!;
+    const durations = results.map(({ durationMs }) => durationMs);
+    const steadyRss = ready.map(({ steadyRssBytes }) => steadyRssBytes);
+    const peaks = results.map(({ peakRssBytes }) => peakRssBytes);
+    console.info("[mcp-sqlite-20-process]", JSON.stringify({
+      processes: 20,
+      latencyMs: { p50: percentile(durations, 0.5), p95: percentile(durations, 0.95), max: Math.max(...durations) },
+      steadyRssMiB: { total: steadyRss.reduce((sum, value) => sum + value, 0) / 1024 / 1024, max: Math.max(...steadyRss) / 1024 / 1024 },
+      peakRssMiB: { max: Math.max(...peaks) / 1024 / 1024 },
+    }));
   }, 30_000);
 
   test("SQLite read receipt count retention expires the oldest completed replay", async () => {
@@ -190,6 +277,59 @@ describe("MCP tool service", () => {
     expect((await service.callTool("list_tasks", { clientRequestId: "bytes-1" })).replayed).toBeFalse();
     expect(bindingCalls).toBe(3);
     store.close();
+  });
+
+  test("SQLite restart reclaims expired bounded claims within count and byte budgets", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-expired-"));
+    scratch.push(directory);
+    const filename = path.join(directory, "receipts.sqlite");
+    let now = 10_000;
+    let bindingCalls = 0;
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_tasks = async () => ({ bindingCall: ++bindingCalls });
+    const initial = new SqliteMcpReceiptStore(filename, {
+      readReceiptCountCap: 100,
+      readReceiptByteCap: 1_000_000,
+      boundedPendingTtlMs: 100,
+      now: () => now,
+    });
+    const service = createMcpToolService(bindings, initial);
+    const completedArgs = { clientRequestId: "completed-before-abandonment" };
+    const completed = await service.callTool("list_tasks", completedArgs);
+    const digest = "a".repeat(64);
+    for (let index = 0; index < 8; index += 1) {
+      expect(initial.claim(`list_tasks:abandoned-${index}`, digest, "bounded")).toEqual({ kind: "fresh" });
+    }
+    expect(initial.claim("send_message:durable-pending", digest, "durable")).toEqual({ kind: "fresh" });
+    initial.close();
+
+    now += 101;
+    const restarted = new SqliteMcpReceiptStore(filename, {
+      readReceiptCountCap: 2,
+      readReceiptByteCap: 1_000,
+      boundedPendingTtlMs: 100,
+      now: () => now,
+    });
+    expect(await createMcpToolService(bindings, restarted).callTool("list_tasks", completedArgs))
+      .toEqual({ ...completed, replayed: true });
+    expect(restarted.claim("list_tasks:abandoned-0", digest, "bounded")).toEqual({ kind: "fresh" });
+    expect(restarted.claim("send_message:durable-pending", digest, "durable")).toMatchObject({ kind: "pending" });
+    expect(restarted.claim("send_message:durable-pending", "b".repeat(64), "durable")).toEqual({ kind: "conflict" });
+    restarted.close();
+
+    const database = new Database(filename, { readonly: true, strict: true });
+    const bounded = database.query<{ count: number; bytes: number; pending: number }, []>(`
+      SELECT COUNT(*) AS count,
+             COALESCE(SUM(storage_bytes), 0) AS bytes,
+             SUM(CASE WHEN result_json IS NULL THEN 1 ELSE 0 END) AS pending
+      FROM mcp_receipts
+      WHERE retention = 'bounded'
+    `).get()!;
+    database.close();
+    expect(bounded.count).toBeLessThanOrEqual(2);
+    expect(bounded.bytes).toBeLessThanOrEqual(1_000);
+    expect(bounded.pending).toBe(1);
+    expect(bindingCalls).toBe(1);
   });
 
   test("separate SQLite store instances preserve one durable mutation owner", async () => {
@@ -259,8 +399,11 @@ describe("MCP tool service", () => {
     expect(listTasks.phases.binding.samples).toBe(1);
     expect(listTasks.phases.completion.samples).toBe(1);
     expect(listTasks.phases.serialization.samples).toBe(3);
-    expect(listTasks.phases.rpcDeliveryWait.samples).toBe(3);
+    expect(listTasks.phases.serviceTotal.samples).toBe(3);
     expect(listTasks.phases.replay.samples).toBe(1);
+    expect(listTasks.phases.serviceTotal.max).toBeGreaterThanOrEqual(listTasks.phases.binding.max);
+    expect(listTasks.phases.serviceTotal.max).toBeGreaterThanOrEqual(listTasks.phases.claim.max);
+    expect(listTasks.phases).not.toHaveProperty("rpcDeliveryWait");
     expect(listTasks.resultSizeBytes.max).toBeGreaterThan(0);
     expect(listTasks.deadline.callsWithDeadline).toBe(3);
     expect(JSON.stringify(snapshot)).not.toContain(privateSentinel);

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2,11 +2,14 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import type { Database as BunDatabase } from "bun:sqlite";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
 import { statePath } from "@/lib/configDir";
+import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
 import { procBackend } from "@/lib/proc";
 import { ROLE_IDS } from "@/lib/roles/types";
@@ -94,7 +97,11 @@ const MUTATING_MCP_TOOL_NAMES = new Set<McpToolName>([
 
 export type McpToolArgs = Record<string, unknown> & { clientRequestId?: unknown };
 export type McpToolPayload = Record<string, unknown>;
-export type McpToolBinding = (args: McpToolArgs) => Promise<McpToolPayload>;
+export interface McpToolCallContext {
+  signal?: AbortSignal;
+  deadlineAt?: number;
+}
+export type McpToolBinding = (args: McpToolArgs, context?: McpToolCallContext) => Promise<McpToolPayload>;
 export type McpToolBindings = Record<McpToolName, McpToolBinding>;
 
 export type McpToolSuccess = McpToolPayload & {
@@ -134,7 +141,7 @@ type Receipt = {
 
 export type ReceiptClaim =
   | { kind: "fresh" }
-  | { kind: "pending" }
+  | { kind: "pending"; unfinishedAgeMs?: number }
   | { kind: "replay"; result: McpToolResult }
   | { kind: "conflict" };
 
@@ -170,6 +177,7 @@ type ReceiptFile = {
 };
 
 const FILE_RECEIPT_CAP = 500;
+const SQLITE_READ_RECEIPT_BYTE_CAP = 8 * 1024 * 1024;
 const LOCK_WAIT_MS = 5_000;
 const LOCK_STALE_MS = 30_000;
 type ReceiptLockOwner = { pid: number; startIdentity: string | null; token: string };
@@ -856,6 +864,232 @@ export class FileMcpReceiptStore implements McpReceiptStore {
   }
 }
 
+type StoredSqliteReceipt = {
+  digest: string;
+  result_json: string | null;
+  claimed_at: number;
+};
+
+export interface SqliteMcpReceiptStoreOptions {
+  legacyFilePath?: string;
+  readReceiptCountCap?: number;
+  readReceiptByteCap?: number;
+}
+
+/**
+ * Keyed durable receipts for the production MCP server.
+ *
+ * One row carries one idempotency claim. Reads therefore touch one indexed row;
+ * durable mutations survive restarts without sharing a retention budget with
+ * large read responses. The legacy JSON import is validated by the same parser
+ * as the legacy adapter and committed atomically with its import marker.
+ */
+export class SqliteMcpReceiptStore implements McpReceiptStore {
+  private readonly db: BunDatabase;
+  private readonly readReceiptCountCap: number;
+  private readonly readReceiptByteCap: number;
+
+  constructor(readonly filename: string, options: SqliteMcpReceiptStoreOptions = {}) {
+    fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
+    if (!sqlite) throw new Error("SQLite MCP receipts require the Bun runtime");
+    this.db = new sqlite.Database(filename, { create: true, strict: true });
+    this.readReceiptCountCap = Math.max(1, Math.floor(options.readReceiptCountCap ?? FILE_RECEIPT_CAP));
+    this.readReceiptByteCap = Math.max(1, Math.floor(options.readReceiptByteCap ?? SQLITE_READ_RECEIPT_BYTE_CAP));
+    this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA auto_vacuum = INCREMENTAL;");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS mcp_receipt_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS mcp_receipts (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        receipt_key TEXT NOT NULL UNIQUE,
+        digest TEXT NOT NULL,
+        retention TEXT NOT NULL CHECK(retention IN ('bounded', 'durable')),
+        result_json TEXT,
+        storage_bytes INTEGER NOT NULL,
+        claimed_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS mcp_receipts_retention_sequence
+      ON mcp_receipts(retention, sequence);
+    `);
+    this.importLegacyFile(options.legacyFilePath);
+    this.secureFiles();
+  }
+
+  claim(key: string, digest: string, retention: ReceiptRetention): ReceiptClaim {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const receipt = this.db.query<StoredSqliteReceipt, [string]>(`
+        SELECT digest, result_json, claimed_at
+        FROM mcp_receipts
+        WHERE receipt_key = ?
+      `).get(key);
+      if (receipt) {
+        this.db.exec("COMMIT");
+        if (receipt.digest !== digest) return { kind: "conflict" };
+        if (receipt.result_json === null) {
+          return { kind: "pending", unfinishedAgeMs: Math.max(0, Date.now() - receipt.claimed_at) };
+        }
+        return { kind: "replay", result: this.parseResult(key, receipt.result_json) };
+      }
+      const now = Date.now();
+      const storageBytes = this.storageBytes(key, digest, null);
+      this.db.query<unknown, [string, string, ReceiptRetention, number, number]>(`
+        INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at)
+        VALUES (?, ?, ?, NULL, ?, ?)
+      `).run(key, digest, retention, storageBytes, now);
+      this.pruneBoundedReceipts();
+      this.db.exec("COMMIT");
+      return { kind: "fresh" };
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  complete(key: string, digest: string, result: McpToolResult, retention: ReceiptRetention): void {
+    const resultJson = JSON.stringify(result);
+    const storageBytes = this.storageBytes(key, digest, resultJson);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const receipt = this.db.query<Pick<StoredSqliteReceipt, "digest"> & { retention: ReceiptRetention }, [string]>(`
+        SELECT digest, retention
+        FROM mcp_receipts
+        WHERE receipt_key = ?
+      `).get(key);
+      if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
+      const effectiveRetention = receipt.retention === "durable" ? "durable" : retention;
+      this.db.query<unknown, [ReceiptRetention, string, number, string]>(`
+        UPDATE mcp_receipts
+        SET retention = ?, result_json = ?, storage_bytes = ?
+        WHERE receipt_key = ?
+      `).run(effectiveRetention, resultJson, storageBytes, key);
+      this.pruneBoundedReceipts();
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private importLegacyFile(legacyFilePath: string | undefined): void {
+    if (!legacyFilePath || this.meta("legacy_import_v2") === "complete") return;
+    let state: ReceiptFile;
+    try {
+      state = readReceiptFile(legacyFilePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (!fs.existsSync(legacyFilePath)) return;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const insert = this.db.query<unknown, [string, string, ReceiptRetention, string | null, number, number]>(`
+        INSERT OR IGNORE INTO mcp_receipts(
+          receipt_key, digest, retention, result_json, storage_bytes, claimed_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      let claimedAt = Date.now() - Object.keys(state.readReceipts).length - Object.keys(state.mutationReceipts).length;
+      const importCollection = (receipts: Record<string, Receipt>, retention: ReceiptRetention) => {
+        for (const [key, receipt] of Object.entries(receipts)) {
+          const resultJson = receipt.result === undefined ? null : JSON.stringify(receipt.result);
+          insert.run(key, receipt.digest, retention, resultJson, this.storageBytes(key, receipt.digest, resultJson), claimedAt);
+          claimedAt += 1;
+        }
+      };
+      importCollection(state.mutationReceipts, "durable");
+      importCollection(state.readReceipts, "bounded");
+      this.pruneBoundedReceipts();
+      this.db.query<unknown, [string, string]>(`
+        INSERT INTO mcp_receipt_meta(key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `).run("legacy_import_v2", "complete");
+      this.db.exec("COMMIT");
+      /* The legacy payload can be much larger than the retained read budget.
+         Compact once after its one-time import so deleted response pages never
+         become the new long-lived database baseline. */
+      this.db.exec("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  private pruneBoundedReceipts(): void {
+    this.db.query<unknown, [number]>(`
+      DELETE FROM mcp_receipts
+      WHERE sequence IN (
+        SELECT sequence
+        FROM mcp_receipts
+        WHERE retention = 'bounded' AND result_json IS NOT NULL
+        ORDER BY sequence ASC
+        LIMIT MAX(0, (
+          SELECT COUNT(*) - ? FROM mcp_receipts WHERE retention = 'bounded'
+        ))
+      )
+    `).run(this.readReceiptCountCap);
+    const aggregate = this.db.query<{ storage_bytes: number }, []>(`
+      SELECT COALESCE(SUM(storage_bytes), 0) AS storage_bytes
+      FROM mcp_receipts
+      WHERE retention = 'bounded'
+    `).get()?.storage_bytes ?? 0;
+    let excessBytes = aggregate - this.readReceiptByteCap;
+    if (excessBytes <= 0) return;
+    const completed = this.db.query<{ sequence: number; storage_bytes: number }, []>(`
+      SELECT sequence, storage_bytes
+      FROM mcp_receipts
+      WHERE retention = 'bounded' AND result_json IS NOT NULL
+      ORDER BY sequence ASC
+    `).all();
+    const expired: number[] = [];
+    for (const receipt of completed) {
+      if (excessBytes <= 0) break;
+      expired.push(receipt.sequence);
+      excessBytes -= receipt.storage_bytes;
+    }
+    const remove = this.db.query<unknown, [number]>("DELETE FROM mcp_receipts WHERE sequence = ?");
+    for (const sequence of expired) remove.run(sequence);
+  }
+
+  private parseResult(key: string, serialized: string): McpToolResult {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(serialized);
+    } catch (error) {
+      throw new Error("invalid MCP receipt database result JSON", { cause: error });
+    }
+    const parts = receiptKeyParts(key);
+    if (!parts || !validReceiptResult(parsed, parts.toolName, parts.requestId)) {
+      throw new Error("invalid MCP receipt database result");
+    }
+    return parsed;
+  }
+
+  private storageBytes(key: string, digest: string, resultJson: string | null): number {
+    return Buffer.byteLength(key) + Buffer.byteLength(digest) + (resultJson === null ? 0 : Buffer.byteLength(resultJson));
+  }
+
+  private meta(key: string): string | null {
+    return this.db.query<{ value: string }, [string]>("SELECT value FROM mcp_receipt_meta WHERE key = ?").get(key)?.value ?? null;
+  }
+
+  private secureFiles(): void {
+    for (const target of [this.filename, `${this.filename}-wal`, `${this.filename}-shm`]) {
+      try {
+        fs.chmodSync(target, 0o600);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+  }
+}
+
 function stable(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stable);
   if (!value || typeof value !== "object") return value;
@@ -885,7 +1119,150 @@ function failure(
 }
 
 export interface McpToolService {
-  callTool(toolName: string, args: McpToolArgs): Promise<McpToolResult>;
+  callTool(toolName: string, args: McpToolArgs, context?: McpToolCallContext): Promise<McpToolResult>;
+}
+
+type McpTimingOutcome = "success" | "failure" | "replay" | "conflict" | "pending" | "deadline" | "cancelled";
+type McpTimingPhase = "claim" | "binding" | "completion" | "serialization" | "rpcDeliveryWait" | "replay";
+
+interface McpToolTimingSample {
+  toolName: McpToolName;
+  outcome: McpTimingOutcome;
+  phases: Partial<Record<McpTimingPhase, number>>;
+  resultSizeBytes?: number;
+  deadlineBudgetMs?: number;
+  unfinishedAgeMs?: number;
+}
+
+export interface McpAggregateMeasure {
+  samples: number;
+  total: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+}
+
+export interface McpToolTimingSummary {
+  toolName: McpToolName;
+  calls: number;
+  outcomes: Record<McpTimingOutcome, number>;
+  phases: Record<McpTimingPhase, McpAggregateMeasure>;
+  resultSizeBytes: McpAggregateMeasure;
+  deadline: {
+    callsWithDeadline: number;
+    exceeded: number;
+    budgetMs: McpAggregateMeasure;
+  };
+  cancellation: { cancelled: number };
+  unfinishedAgeMs: McpAggregateMeasure;
+}
+
+const TIMING_SAMPLE_CAP = 2_048;
+
+class AggregateMeasure {
+  private readonly recent: number[] = [];
+  private count = 0;
+  private total = 0;
+  private maximum = 0;
+
+  add(value: number | undefined): void {
+    if (value === undefined || !Number.isFinite(value) || value < 0) return;
+    this.count += 1;
+    this.total += value;
+    this.maximum = Math.max(this.maximum, value);
+    if (this.recent.length < TIMING_SAMPLE_CAP) this.recent.push(value);
+    else this.recent[(this.count - 1) % TIMING_SAMPLE_CAP] = value;
+  }
+
+  snapshot(): McpAggregateMeasure {
+    const values = this.recent.toSorted((left, right) => left - right);
+    const percentile = (quantile: number) => values.length
+      ? values[Math.max(0, Math.ceil(values.length * quantile) - 1)]!
+      : 0;
+    return {
+      samples: this.count,
+      total: this.total,
+      p50: percentile(0.5),
+      p95: percentile(0.95),
+      p99: percentile(0.99),
+      max: this.maximum,
+    };
+  }
+}
+
+type MutableToolTiming = {
+  calls: number;
+  outcomes: Record<McpTimingOutcome, number>;
+  phases: Record<McpTimingPhase, AggregateMeasure>;
+  resultSizeBytes: AggregateMeasure;
+  deadlineBudgetMs: AggregateMeasure;
+  unfinishedAgeMs: AggregateMeasure;
+};
+
+const MCP_TIMING_OUTCOMES: McpTimingOutcome[] = [
+  "success", "failure", "replay", "conflict", "pending", "deadline", "cancelled",
+];
+const MCP_TIMING_PHASES: McpTimingPhase[] = [
+  "claim", "binding", "completion", "serialization", "rpcDeliveryWait", "replay",
+];
+
+function mutableToolTiming(): MutableToolTiming {
+  return {
+    calls: 0,
+    outcomes: Object.fromEntries(MCP_TIMING_OUTCOMES.map((outcome) => [outcome, 0])) as Record<McpTimingOutcome, number>,
+    phases: Object.fromEntries(MCP_TIMING_PHASES.map((phase) => [phase, new AggregateMeasure()])) as Record<McpTimingPhase, AggregateMeasure>,
+    resultSizeBytes: new AggregateMeasure(),
+    deadlineBudgetMs: new AggregateMeasure(),
+    unfinishedAgeMs: new AggregateMeasure(),
+  };
+}
+
+/** Numeric-only per-tool aggregates. No request or response values enter this module. */
+export class McpToolTimingAggregate {
+  private readonly tools = new Map<McpToolName, MutableToolTiming>(
+    MCP_TOOL_NAMES.map((toolName) => [toolName, mutableToolTiming()]),
+  );
+
+  observe(sample: McpToolTimingSample): void {
+    const timing = this.tools.get(sample.toolName)!;
+    timing.calls += 1;
+    timing.outcomes[sample.outcome] += 1;
+    for (const phase of MCP_TIMING_PHASES) timing.phases[phase].add(sample.phases[phase]);
+    timing.resultSizeBytes.add(sample.resultSizeBytes);
+    timing.deadlineBudgetMs.add(sample.deadlineBudgetMs);
+    timing.unfinishedAgeMs.add(sample.unfinishedAgeMs);
+  }
+
+  snapshot(): McpToolTimingSummary[] {
+    return MCP_TOOL_NAMES.map((toolName) => {
+      const timing = this.tools.get(toolName)!;
+      return {
+        toolName,
+        calls: timing.calls,
+        outcomes: { ...timing.outcomes },
+        phases: Object.fromEntries(MCP_TIMING_PHASES.map((phase) => [phase, timing.phases[phase].snapshot()])) as Record<McpTimingPhase, McpAggregateMeasure>,
+        resultSizeBytes: timing.resultSizeBytes.snapshot(),
+        deadline: {
+          callsWithDeadline: timing.deadlineBudgetMs.snapshot().samples,
+          exceeded: timing.outcomes.deadline,
+          budgetMs: timing.deadlineBudgetMs.snapshot(),
+        },
+        cancellation: { cancelled: timing.outcomes.cancelled },
+        unfinishedAgeMs: timing.unfinishedAgeMs.snapshot(),
+      };
+    });
+  }
+}
+
+const productionMcpToolTimings = new McpToolTimingAggregate();
+
+export function mcpToolTimingSnapshot(): McpToolTimingSummary[] {
+  return productionMcpToolTimings.snapshot();
+}
+
+export interface McpToolServiceOptions {
+  timings?: McpToolTimingAggregate;
 }
 
 export function createMcpToolService(
@@ -894,17 +1271,41 @@ export function createMcpToolService(
   /** #691 §6: the per-identity fence. Absent means "no fence", which is what every
       existing caller of this factory means and gets. */
   policy?: McpToolPolicy,
+  options: McpToolServiceOptions = {},
 ): McpToolService {
   const inFlight = new Map<string, { digest: string; result: Promise<McpToolResult> }>();
   return {
-    async callTool(toolName, args) {
+    async callTool(toolName, args, context = {}) {
       if (!(MCP_TOOL_NAMES as readonly string[]).includes(toolName)) {
         return failure(toolName, clientRequestId(args), "unknown_tool", `Unknown viewer tool: ${toolName}`, false);
       }
       const typedTool = toolName as McpToolName;
+      const callStartedAt = performance.now();
+      const phaseDurations: Partial<Record<McpTimingPhase, number>> = {};
+      const deadlineBudgetMs = context.deadlineAt === undefined
+        ? undefined
+        : Math.max(0, context.deadlineAt - Date.now());
+      const finish = (result: McpToolResult, outcome: McpTimingOutcome, unfinishedAgeMs?: number): McpToolResult => {
+        const serializationStartedAt = performance.now();
+        let resultSizeBytes: number | undefined;
+        try {
+          resultSizeBytes = Buffer.byteLength(JSON.stringify(result));
+        } catch { /* timing must never change a tool outcome */ }
+        phaseDurations.serialization = performance.now() - serializationStartedAt;
+        phaseDurations.rpcDeliveryWait = serializationStartedAt - callStartedAt;
+        options.timings?.observe({
+          toolName: typedTool,
+          outcome,
+          phases: phaseDurations,
+          resultSizeBytes,
+          deadlineBudgetMs,
+          unfinishedAgeMs,
+        });
+        return result;
+      };
       const retention: ReceiptRetention = MUTATING_MCP_TOOL_NAMES.has(typedTool) ? "durable" : "bounded";
       const requestId = clientRequestId(args);
-      if (!requestId) return failure(toolName, null, "invalid_request", "clientRequestId is required", false);
+      if (!requestId) return finish(failure(toolName, null, "invalid_request", "clientRequestId is required", false), "failure");
 
       /* Refused before the receipt is claimed, on purpose. A refusal is a
          property of who is calling, not of the operation, so it must not burn the
@@ -912,7 +1313,7 @@ export function createMcpToolService(
          grants the tool, and a spent receipt would answer it with a stale no. */
       const verdict = policy?.permit(typedTool, args);
       if (verdict && !verdict.allowed) {
-        return failure(typedTool, requestId, verdict.code, verdict.error, false);
+        return finish(failure(typedTool, requestId, verdict.code, verdict.error, false), "failure");
       }
 
       const digest = requestDigest(typedTool, args);
@@ -920,24 +1321,48 @@ export function createMcpToolService(
       const active = inFlight.get(key);
       if (active) {
         if (active.digest !== digest) {
-          return failure(toolName, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
+          return finish(failure(toolName, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true), "conflict");
         }
-        return { ...await active.result, replayed: true };
+        const replayStartedAt = performance.now();
+        const replayed = { ...await active.result, replayed: true };
+        phaseDurations.replay = performance.now() - replayStartedAt;
+        return finish(replayed, "replay");
       }
+      let outcome: McpTimingOutcome = "failure";
+      let unfinishedAgeMs: number | undefined;
       const result = (async (): Promise<McpToolResult> => {
+        const claimStartedAt = performance.now();
         const claim = await receipts.claim(key, digest, retention);
+        phaseDurations.claim = performance.now() - claimStartedAt;
         if (claim.kind === "conflict") {
+          outcome = "conflict";
           return failure(toolName, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
         }
         if (claim.kind === "pending") {
+          outcome = "pending";
+          unfinishedAgeMs = claim.unfinishedAgeMs;
           return failure(toolName, requestId, "call_interrupted", "The previous MCP process ended before this call completed", true, true);
         }
-        if (claim.kind === "replay") return { ...claim.result, replayed: true };
+        if (claim.kind === "replay") {
+          const replayStartedAt = performance.now();
+          const replayed = { ...claim.result, replayed: true };
+          phaseDurations.replay = performance.now() - replayStartedAt;
+          outcome = "replay";
+          return replayed;
+        }
         let settled: McpToolResult;
+        const bindingStartedAt = performance.now();
         try {
-          const payload = await bindings[typedTool](args);
+          const payload = await bindings[typedTool](args, context);
           settled = { ...payload, ok: true, toolName: typedTool, clientRequestId: requestId, replayed: false };
+          outcome = "success";
         } catch (error) {
+          const reason = context.signal?.aborted ? context.signal.reason : error;
+          outcome = reason instanceof DeadlineExceededError
+            ? "deadline"
+            : context.signal?.aborted
+              ? "cancelled"
+              : "failure";
           settled = failure(
             typedTool,
             requestId,
@@ -947,13 +1372,17 @@ export function createMcpToolService(
             false,
             error instanceof McpToolRefusal ? error.details : undefined,
           );
+        } finally {
+          phaseDurations.binding = performance.now() - bindingStartedAt;
         }
+        const completionStartedAt = performance.now();
         await receipts.complete(key, digest, settled, retention);
+        phaseDurations.completion = performance.now() - completionStartedAt;
         return settled;
       })();
       inFlight.set(key, { digest, result });
       try {
-        return await result;
+        return finish(await result, outcome, unfinishedAgeMs);
       } finally {
         if (inFlight.get(key)?.result === result) inFlight.delete(key);
       }
@@ -1286,13 +1715,25 @@ export function createViewerMcpServer(service: McpToolService): McpServer {
     server.registerTool(toolName, {
       description: TOOL_DESCRIPTIONS[toolName],
       inputSchema: TOOL_INPUT_SCHEMAS[toolName],
-    }, async (args) => {
-      const result = await service.callTool(toolName, args as McpToolArgs);
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(result) }],
-        structuredContent: result,
-        ...(result.ok ? {} : { isError: true }),
-      };
+    }, async (args, extra) => {
+      const timeoutMs = 30_000;
+      const deadline = deadlineSignal(timeoutMs, {
+        signal: extra.signal,
+        reason: "MCP tool deadline exceeded",
+      });
+      try {
+        const result = await service.callTool(toolName, args as McpToolArgs, {
+          signal: deadline.signal,
+          deadlineAt: Date.now() + timeoutMs,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          structuredContent: result,
+          ...(result.ok ? {} : { isError: true }),
+        };
+      } finally {
+        deadline.release();
+      }
     });
   }
   return server;
@@ -1306,8 +1747,11 @@ export async function startViewerMcpServer(): Promise<void> {
   const hostHealthProbe = await admittedMcpHealthProbe(healthProbeCapability);
   const service = createMcpToolService(
     viewerMcpBindings(),
-    new FileMcpReceiptStore(statePath("mcp-receipts.json")),
+    new SqliteMcpReceiptStore(statePath("mcp-receipts.sqlite"), {
+      legacyFilePath: statePath("mcp-receipts.json"),
+    }),
     viewerMcpToolPolicy(undefined, hostHealthProbe),
+    { timings: productionMcpToolTimings },
   );
   const server = createViewerMcpServer(service);
   const transport = new StdioServerTransport();

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -178,6 +178,7 @@ type ReceiptFile = {
 
 const FILE_RECEIPT_CAP = 500;
 const SQLITE_READ_RECEIPT_BYTE_CAP = 8 * 1024 * 1024;
+const SQLITE_BOUNDED_PENDING_TTL_MS = 60_000;
 const LOCK_WAIT_MS = 5_000;
 const LOCK_STALE_MS = 30_000;
 type ReceiptLockOwner = { pid: number; startIdentity: string | null; token: string };
@@ -874,6 +875,8 @@ export interface SqliteMcpReceiptStoreOptions {
   legacyFilePath?: string;
   readReceiptCountCap?: number;
   readReceiptByteCap?: number;
+  boundedPendingTtlMs?: number;
+  now?: () => number;
 }
 
 /**
@@ -888,6 +891,8 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
   private readonly db: BunDatabase;
   private readonly readReceiptCountCap: number;
   private readonly readReceiptByteCap: number;
+  private readonly boundedPendingTtlMs: number;
+  private readonly now: () => number;
 
   constructor(readonly filename: string, options: SqliteMcpReceiptStoreOptions = {}) {
     fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
@@ -896,6 +901,8 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
     this.db = new sqlite.Database(filename, { create: true, strict: true });
     this.readReceiptCountCap = Math.max(1, Math.floor(options.readReceiptCountCap ?? FILE_RECEIPT_CAP));
     this.readReceiptByteCap = Math.max(1, Math.floor(options.readReceiptByteCap ?? SQLITE_READ_RECEIPT_BYTE_CAP));
+    this.boundedPendingTtlMs = Math.max(1, Math.floor(options.boundedPendingTtlMs ?? SQLITE_BOUNDED_PENDING_TTL_MS));
+    this.now = options.now ?? Date.now;
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA auto_vacuum = INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS mcp_receipt_meta (
@@ -915,12 +922,22 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
       ON mcp_receipts(retention, sequence);
     `);
     this.importLegacyFile(options.legacyFilePath);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.pruneBoundedReceipts(this.now());
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
     this.secureFiles();
   }
 
   claim(key: string, digest: string, retention: ReceiptRetention): ReceiptClaim {
     this.db.exec("BEGIN IMMEDIATE");
     try {
+      const now = this.now();
+      this.pruneBoundedReceipts(now);
       const receipt = this.db.query<StoredSqliteReceipt, [string]>(`
         SELECT digest, result_json, claimed_at
         FROM mcp_receipts
@@ -930,17 +947,16 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
         this.db.exec("COMMIT");
         if (receipt.digest !== digest) return { kind: "conflict" };
         if (receipt.result_json === null) {
-          return { kind: "pending", unfinishedAgeMs: Math.max(0, Date.now() - receipt.claimed_at) };
+          return { kind: "pending", unfinishedAgeMs: Math.max(0, now - receipt.claimed_at) };
         }
         return { kind: "replay", result: this.parseResult(key, receipt.result_json) };
       }
-      const now = Date.now();
       const storageBytes = this.storageBytes(key, digest, null);
       this.db.query<unknown, [string, string, ReceiptRetention, number, number]>(`
         INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at)
         VALUES (?, ?, ?, NULL, ?, ?)
       `).run(key, digest, retention, storageBytes, now);
-      this.pruneBoundedReceipts();
+      this.pruneBoundedReceipts(now);
       this.db.exec("COMMIT");
       return { kind: "fresh" };
     } catch (error) {
@@ -966,7 +982,7 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
         SET retention = ?, result_json = ?, storage_bytes = ?
         WHERE receipt_key = ?
       `).run(effectiveRetention, resultJson, storageBytes, key);
-      this.pruneBoundedReceipts();
+      this.pruneBoundedReceipts(this.now());
       this.db.exec("COMMIT");
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
@@ -995,7 +1011,7 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
           receipt_key, digest, retention, result_json, storage_bytes, claimed_at
         ) VALUES (?, ?, ?, ?, ?, ?)
       `);
-      let claimedAt = Date.now() - Object.keys(state.readReceipts).length - Object.keys(state.mutationReceipts).length;
+      let claimedAt = this.now() - Object.keys(state.readReceipts).length - Object.keys(state.mutationReceipts).length;
       const importCollection = (receipts: Record<string, Receipt>, retention: ReceiptRetention) => {
         for (const [key, receipt] of Object.entries(receipts)) {
           const resultJson = receipt.result === undefined ? null : JSON.stringify(receipt.result);
@@ -1005,7 +1021,7 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
       };
       importCollection(state.mutationReceipts, "durable");
       importCollection(state.readReceipts, "bounded");
-      this.pruneBoundedReceipts();
+      this.pruneBoundedReceipts(this.now());
       this.db.query<unknown, [string, string]>(`
         INSERT INTO mcp_receipt_meta(key, value) VALUES (?, ?)
         ON CONFLICT(key) DO UPDATE SET value = excluded.value
@@ -1021,7 +1037,18 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
     }
   }
 
-  private pruneBoundedReceipts(): void {
+  private pruneBoundedReceipts(now: number): void {
+    /* Bounded reads have a lease longer than the SDK's 30-second call budget.
+       A crash cannot strand their claims forever; after the lease, a restart or
+       any later receipt transaction removes them before completed replay rows
+       are considered for count/byte retention. Durable mutation claims never
+       enter this expiry path. */
+    this.db.query<unknown, [number]>(`
+      DELETE FROM mcp_receipts
+      WHERE retention = 'bounded'
+        AND result_json IS NULL
+        AND claimed_at <= ?
+    `).run(now - this.boundedPendingTtlMs);
     this.db.query<unknown, [number]>(`
       DELETE FROM mcp_receipts
       WHERE sequence IN (
@@ -1123,7 +1150,7 @@ export interface McpToolService {
 }
 
 type McpTimingOutcome = "success" | "failure" | "replay" | "conflict" | "pending" | "deadline" | "cancelled";
-type McpTimingPhase = "claim" | "binding" | "completion" | "serialization" | "rpcDeliveryWait" | "replay";
+type McpTimingPhase = "claim" | "binding" | "completion" | "serialization" | "serviceTotal" | "replay";
 
 interface McpToolTimingSample {
   toolName: McpToolName;
@@ -1204,7 +1231,7 @@ const MCP_TIMING_OUTCOMES: McpTimingOutcome[] = [
   "success", "failure", "replay", "conflict", "pending", "deadline", "cancelled",
 ];
 const MCP_TIMING_PHASES: McpTimingPhase[] = [
-  "claim", "binding", "completion", "serialization", "rpcDeliveryWait", "replay",
+  "claim", "binding", "completion", "serialization", "serviceTotal", "replay",
 ];
 
 function mutableToolTiming(): MutableToolTiming {
@@ -1292,7 +1319,7 @@ export function createMcpToolService(
           resultSizeBytes = Buffer.byteLength(JSON.stringify(result));
         } catch { /* timing must never change a tool outcome */ }
         phaseDurations.serialization = performance.now() - serializationStartedAt;
-        phaseDurations.rpcDeliveryWait = serializationStartedAt - callStartedAt;
+        phaseDurations.serviceTotal = serializationStartedAt - callStartedAt;
         options.timings?.observe({
           toolName: typedTool,
           outcome,


### PR DESCRIPTION
Closes #850

## What changed

- Targeted `get_conversation` misses now canonicalize against registered scanner roots, open regular transcripts with `O_NOFOLLOW`, pin bounded metadata/session reads to the opened descriptor, and verify path identity before returning. External symlinks and swap races resolve to `conversation not found`; title projection, Claude sidecar titles, deadline, and cancellation behavior remain covered.
- Bounded SQLite read claims now use a 60-second lease. Expired pending reads are reclaimed before count/byte retention on startup and later receipt transactions. Completed read replay remains available within the 500-row/8 MiB budget, while pending and completed mutation receipts remain durable with digest-conflict protection.
- The receipt concurrency evidence now uses 20 isolated Bun processes behind a shared start/owner barrier. Exactly one process owns and completes the binding, 19 observe the pending receipt, and restart replay executes zero bindings.
- Numeric-only fixed-cardinality telemetry now reports `serviceTotal` for service execution latency. Claim, binding, completion, serialization, replay, outcome, result size, deadline/cancellation, and unfinished age remain phase-tested without recording arguments, ids, paths, prompts, transcript content, response bodies, or account data.

## Exact range

- Base: `eb8c18e7e738ab0e0cb9f4e02e296a39e0f6d1fe`
- Head: `3a4e72b11db011b6f808322ca53b5e863f7c26df`

## Bounded concurrency, latency, and RSS evidence

The final isolated barrier probe ran 20 independent Bun processes against one SQLite receipt database:

| Measure | Result |
| --- | ---: |
| Ownership | 1 fresh owner; 19 pending contenders |
| Binding executions | 1 before completion; 0 on restart replay |
| Restart | completed result replayed; changed digest conflicted |
| Latency measurement | p50 4.27 ms; p95 9.10 ms; max 26.09 ms |
| Steady RSS sample | 1,856.72 MiB aggregate; 98.57 MiB max/process |
| Peak RSS sample | 101.04 MiB max/process |

Latency values are reported measurements. Deterministic ownership, contender count, replay, digest conflict, and RSS sample presence are the assertions.

## Verification

- Isolated focused tests: `bun test src/lib/mcp/server.test.ts src/lib/mcp/controlPlaneReads.test.ts` — 43 passed, 425 assertions.
- Scoped ESLint over the five changed files — passed.
- `tsc --noEmit --pretty false` — passed.
- Production `bun run build` — passed, including Next.js TypeScript and packaged MCP output.
- Exact-base privacy publication gate with known-value and commit checks against `eb8c18e7e738ab0e0cb9f4e02e296a39e0f6d1fe` — passed.
- Worktree source changes are limited to MCP server, bindings, focused tests, and the isolated receipt probe child.

No production probes, runtime restarts, merges, or deployments were performed.
