### PR TITLE
feat(voice): persist personality bootstrap in canonical transcript

### DIFF
--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -213,6 +213,34 @@ test("refuses a realtime answer that omits the mandatory persona bootstrap recei
   });
 });
 
+test("refuses malformed persona bootstrap receipts before binding the realtime session", async () => {
+  const digest = "d".repeat(64);
+  const malformedReceipts = [
+    { itemId: `msg_voice_persona_${digest}`, insertion: "accepted" },
+    { receiptId: `voice_persona_${digest}`, insertion: "accepted" },
+    { receiptId: `voice_persona_${digest}`, itemId: `msg_voice_persona_${digest}` },
+    { receiptId: `voice_persona_${digest}`, itemId: `msg_voice_persona_${digest}`, insertion: "pending" },
+  ];
+  for (const personaBootstrap of malformedReceipts) {
+    const result = await executeRealtimeControl({
+      action: "start",
+      conversationId: "conversation_voice",
+      sdp: "v=0\r\noffer",
+    }, () => ({
+      async startRealtimeWebRtc() {
+        return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-malformed", personaBootstrap };
+      },
+      async appendRealtimeSpeech() {},
+      async stopRealtime() {},
+    }), { operator: true });
+
+    expect(result).toEqual({
+      status: 409,
+      body: { error: "Codex returned an invalid voice persona bootstrap receipt" },
+    });
+  }
+});
+
 test("POST rejects a cross-origin browser before realtime admission", async () => {
   const response = await POST(request(
     { action: "stop", conversationId: "conversation_voice" },

--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -125,6 +125,60 @@ test("keeps validation and backend admission errors bounded", async () => {
   expect(result).toEqual({ status: 409, body: { error: "AVAS 404" } });
 });
 
+test("returns the canonical persona insertion outcome and rejects a call whose bootstrap was refused", async () => {
+  const acceptedBootstrap = {
+    receiptId: `voice_persona_${"b".repeat(64)}`,
+    itemId: `msg_voice_persona_${"b".repeat(64)}`,
+    insertion: "accepted" as const,
+  };
+  const accepted = await executeRealtimeControl({
+    action: "start",
+    conversationId: "conversation_voice",
+    sdp: "v=0\r\noffer",
+  }, () => ({
+    async startRealtimeWebRtc() {
+      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-bootstrap", personaBootstrap: acceptedBootstrap };
+    },
+    async appendRealtimeSpeech() {},
+    async stopRealtime() {},
+  }), { operator: true });
+  expect(accepted).toEqual({
+    status: 200,
+    body: {
+      ok: true,
+      sdp: "v=0\r\nanswer",
+      realtimeSessionId: "live-bootstrap",
+      personaBootstrap: acceptedBootstrap,
+    },
+  });
+
+  const personaBootstrap = {
+    receiptId: `voice_persona_${"a".repeat(64)}`,
+    itemId: `msg_voice_persona_${"a".repeat(64)}`,
+    insertion: "rejected" as const,
+    diagnostic: "Codex app-server request failed: invalid developer item",
+  };
+  const result = await executeRealtimeControl({
+    action: "start",
+    conversationId: "conversation_voice",
+    sdp: "v=0\r\noffer",
+  }, () => ({
+    async startRealtimeWebRtc() {
+      return { sdp: null, realtimeSessionId: null, personaBootstrap };
+    },
+    async appendRealtimeSpeech() {},
+    async stopRealtime() {},
+  }), { operator: true });
+
+  expect(result).toEqual({
+    status: 409,
+    body: {
+      error: "Codex app-server request failed: invalid developer item",
+      personaBootstrap,
+    },
+  });
+});
+
 test("POST rejects a cross-origin browser before realtime admission", async () => {
   const response = await POST(request(
     { action: "stop", conversationId: "conversation_voice" },

--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -5,6 +5,12 @@ import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
 
 import { POST } from "./route";
 
+const ACCEPTED_PERSONA_BOOTSTRAP = {
+  receiptId: `voice_persona_${"c".repeat(64)}`,
+  itemId: `msg_voice_persona_${"c".repeat(64)}`,
+  insertion: "accepted" as const,
+};
+
 function request(body: unknown, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://127.0.0.1/api/runtime/realtime", {
     method: "POST",
@@ -18,7 +24,11 @@ test("starts V3 WebRTC through the active hosted conversation", async () => {
   const host = {
     async startRealtimeWebRtc(sdp: string) {
       calls.push(["start", sdp]);
-      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-1" };
+      return {
+        sdp: "v=0\r\nanswer",
+        realtimeSessionId: "live-1",
+        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+      };
     },
     async appendRealtimeSpeech(text: string) {
       calls.push(["speech", text]);
@@ -48,7 +58,12 @@ test("starts V3 WebRTC through the active hosted conversation", async () => {
   );
   expect(started).toEqual({
     status: 200,
-    body: { ok: true, sdp: "v=0\r\nanswer", realtimeSessionId: "live-1" },
+    body: {
+      ok: true,
+      sdp: "v=0\r\nanswer",
+      realtimeSessionId: "live-1",
+      personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+    },
   });
   await executeRealtimeControl(
     { action: "appendSpeech", conversationId: "conversation_voice", text: "progress" },
@@ -179,6 +194,25 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
   });
 });
 
+test("refuses a realtime answer that omits the mandatory persona bootstrap receipt", async () => {
+  const result = await executeRealtimeControl({
+    action: "start",
+    conversationId: "conversation_voice",
+    sdp: "v=0\r\noffer",
+  }, () => ({
+    async startRealtimeWebRtc() {
+      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-without-bootstrap" };
+    },
+    async appendRealtimeSpeech() {},
+    async stopRealtime() {},
+  }), { operator: true });
+
+  expect(result).toEqual({
+    status: 409,
+    body: { error: "Codex returned no voice persona bootstrap receipt" },
+  });
+});
+
 test("POST rejects a cross-origin browser before realtime admission", async () => {
   const response = await POST(request(
     { action: "stop", conversationId: "conversation_voice" },
@@ -260,7 +294,13 @@ test("the transport authority is required, and an unasked question fails closed"
      site that passes the honest answer for "nobody asked" gets a refusal, never an
      open door. */
   const host = {
-    async startRealtimeWebRtc() { return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-x" }; },
+    async startRealtimeWebRtc() {
+      return {
+        sdp: "v=0\r\nanswer",
+        realtimeSessionId: "live-x",
+        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+      };
+    },
     async appendRealtimeSpeech() {},
     async stopRealtime() {},
   };

--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -188,7 +188,7 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
   expect(result).toEqual({
     status: 409,
     body: {
-      error: "Codex app-server request failed: invalid developer item",
+      error: "Voice persona could not be recorded: Codex app-server request failed: invalid developer item",
       personaBootstrap,
     },
   });

--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -141,6 +141,7 @@ test("keeps validation and backend admission errors bounded", async () => {
 });
 
 test("returns the canonical persona insertion outcome and rejects a call whose bootstrap was refused", async () => {
+  let rejectedStops = 0;
   const acceptedBootstrap = {
     receiptId: `voice_persona_${"b".repeat(64)}`,
     itemId: `msg_voice_persona_${"b".repeat(64)}`,
@@ -182,7 +183,7 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
       return { sdp: null, realtimeSessionId: null, personaBootstrap };
     },
     async appendRealtimeSpeech() {},
-    async stopRealtime() {},
+    async stopRealtime() { rejectedStops += 1; },
   }), { operator: true });
 
   expect(result).toEqual({
@@ -192,9 +193,11 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
       personaBootstrap,
     },
   });
+  expect(rejectedStops).toBe(1);
 });
 
 test("refuses a realtime answer that omits the mandatory persona bootstrap receipt", async () => {
+  let stops = 0;
   const result = await executeRealtimeControl({
     action: "start",
     conversationId: "conversation_voice",
@@ -204,17 +207,19 @@ test("refuses a realtime answer that omits the mandatory persona bootstrap recei
       return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-without-bootstrap" };
     },
     async appendRealtimeSpeech() {},
-    async stopRealtime() {},
+    async stopRealtime() { stops += 1; },
   }), { operator: true });
 
   expect(result).toEqual({
     status: 409,
     body: { error: "Codex returned no voice persona bootstrap receipt" },
   });
+  expect(stops).toBe(1);
 });
 
 test("refuses malformed persona bootstrap receipts before binding the realtime session", async () => {
   const digest = "d".repeat(64);
+  let stops = 0;
   const malformedReceipts = [
     { itemId: `msg_voice_persona_${digest}`, insertion: "accepted" },
     { receiptId: `voice_persona_${digest}`, insertion: "accepted" },
@@ -231,7 +236,7 @@ test("refuses malformed persona bootstrap receipts before binding the realtime s
         return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-malformed", personaBootstrap };
       },
       async appendRealtimeSpeech() {},
-      async stopRealtime() {},
+      async stopRealtime() { stops += 1; },
     }), { operator: true });
 
     expect(result).toEqual({
@@ -239,6 +244,25 @@ test("refuses malformed persona bootstrap receipts before binding the realtime s
       body: { error: "Codex returned an invalid voice persona bootstrap receipt" },
     });
   }
+  expect(stops).toBe(malformedReceipts.length);
+});
+
+test("stops a started backend session whose accepted receipt has no WebRTC answer", async () => {
+  let stops = 0;
+  const result = await executeRealtimeControl({
+    action: "start",
+    conversationId: "conversation_voice",
+    sdp: "v=0\r\noffer",
+  }, () => ({
+    async startRealtimeWebRtc() {
+      return { sdp: null, realtimeSessionId: "live-without-answer", personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP };
+    },
+    async appendRealtimeSpeech() {},
+    async stopRealtime() { stops += 1; },
+  }), { operator: true });
+
+  expect(result).toEqual({ status: 409, body: { error: "Codex returned no WebRTC answer" } });
+  expect(stops).toBe(1);
 });
 
 test("POST rejects a cross-origin browser before realtime admission", async () => {

--- a/src/app/api/runtime/realtime/voicePersona.routes.test.ts
+++ b/src/app/api/runtime/realtime/voicePersona.routes.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+test("canonical voice persona transcripts are discoverable through files and readable through log", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-routes-"));
+  const codexHome = path.join(isolated, "codex");
+  const sessions = path.join(codexHome, "sessions", "2026", "08", "02");
+  const sessionId = ["00000000", "0000", "4000", "8000", "000000000857"].join("-");
+  const transcript = path.join(
+    sessions,
+    `rollout-2026-08-02T10-00-00-${sessionId}.jsonl`,
+  );
+  const persona = "Your name is Alik. Speak the operator's language.";
+  const itemId = `msg_voice_persona_${"a".repeat(64)}`;
+  fs.mkdirSync(sessions, { recursive: true });
+  fs.writeFileSync(transcript, [
+    JSON.stringify({
+      type: "session_meta",
+      timestamp: "2026-08-02T10:00:00.000Z",
+      payload: {
+        id: sessionId,
+        timestamp: "2026-08-02T10:00:00.000Z",
+        cwd: "/workspace/example",
+        model: "test-model",
+      },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-02T10:00:00.100Z",
+      payload: {
+        type: "message",
+        id: itemId,
+        role: "developer",
+        content: [{ type: "input_text", text: persona }],
+      },
+    }),
+  ].join("\n") + "\n");
+
+  const previous = {
+    state: process.env.LLV_STATE_DIR,
+    codex: process.env.LLV_CODEX_HOME,
+    claude: process.env.LLV_CLAUDE_HOME,
+  };
+  process.env.LLV_STATE_DIR = path.join(isolated, "state");
+  process.env.LLV_CODEX_HOME = codexHome;
+  process.env.LLV_CLAUDE_HOME = path.join(isolated, "claude");
+  try {
+    const [{ GET: filesGet }, { GET: logGet }] = await Promise.all([
+      import("@/app/api/files/route"),
+      import("@/app/api/log/route"),
+    ]);
+    const filesResponse = await filesGet(new Request(
+      `http://127.0.0.1/api/files?path=${encodeURIComponent(transcript)}`,
+    ));
+    expect(filesResponse.status).toBe(200);
+    const filesBody = await filesResponse.json() as { files: Array<{ path: string; engine: string }> };
+    expect(filesBody.files).toContainEqual(expect.objectContaining({ path: transcript, engine: "codex" }));
+
+    const logResponse = await logGet(new NextRequest(
+      `http://127.0.0.1/api/log?path=${encodeURIComponent(transcript)}&offset=0`,
+    ));
+    expect(logResponse.status).toBe(200);
+    const logBody = await logResponse.json() as { data: string };
+    expect(logBody.data).toContain(itemId);
+    expect(logBody.data).toContain(persona);
+  } finally {
+    if (previous.state === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previous.state;
+    if (previous.codex === undefined) delete process.env.LLV_CODEX_HOME;
+    else process.env.LLV_CODEX_HOME = previous.codex;
+    if (previous.claude === undefined) delete process.env.LLV_CLAUDE_HOME;
+    else process.env.LLV_CLAUDE_HOME = previous.claude;
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});

--- a/src/components/feed/voicePersona.render.test.tsx
+++ b/src/components/feed/voicePersona.render.test.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { FeedItem } from "./FeedItem";
+import { buildFeed } from "./parse";
+
+const codexFile = {
+  path: "/sessions/conversation_voice.jsonl",
+  engine: "codex",
+  fmt: "codex",
+  activity: "recent",
+} as FileEntry;
+
+test("the canonical voice persona developer item is first and renders through the system card", () => {
+  const persona = "Your name is Alik. Speak the operator's language.";
+  const lines = [
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-02T10:00:00.000Z",
+      payload: {
+        type: "message",
+        id: `msg_voice_persona_${"a".repeat(64)}`,
+        role: "developer",
+        content: [{ type: "input_text", text: persona }],
+      },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-02T10:00:01.000Z",
+      payload: {
+        type: "message",
+        id: "spoken-turn",
+        role: "user",
+        content: [{ type: "input_text", text: "Give me the status." }],
+      },
+    }),
+  ];
+
+  const feed = buildFeed(codexFile, lines, false, "");
+  expect(feed.items.map((item) => item.kind)).toEqual(["sysmsg", "user"]);
+  expect(feed.items[0]).toEqual({ kind: "sysmsg", label: "developer", text: persona });
+
+  const first = feed.items[0];
+  if (!first) throw new Error("voice persona feed item missing");
+  const html = renderToStaticMarkup(<FeedItem item={first} />);
+  expect(html).toContain("<details");
+  expect(html).toContain("developer");
+  expect(html).toContain("Your name is Alik.");
+  expect(html).toContain("Speak the operator&#x27;s language.");
+});

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -72,6 +72,7 @@ class FakeAppServer extends EventEmitter {
   injectItemsError: string | null = null;
   holdInjectItems = false;
   readonly heldInjectItemIds: number[] = [];
+  omitThreadPath = false;
   threadPath: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
@@ -154,7 +155,7 @@ class FakeAppServer extends EventEmitter {
       return this.respond(message.id, {
         thread: {
           id,
-          path: this.threadPath ?? `/sessions/${id}.jsonl`,
+          ...(!this.omitThreadPath ? { path: this.threadPath ?? `/sessions/${id}.jsonl` } : {}),
           turns: this.turns,
           ...(this.resumeStatus ? { status: this.resumeStatus } : {}),
         },
@@ -3589,10 +3590,114 @@ test("an unreadable canonical transcript falls through to authoritative insertio
       "[voice persona bootstrap] canonical scan unavailable; attempting insertion",
       expect.objectContaining({ code: "ELOOP", diagnostic: expect.stringContaining("ELOOP") }),
     );
+    await host.stopRealtime();
+    const repeated = await host.startRealtimeWebRtc("v=0\r\no=- 405 2 IN IP4 127.0.0.1\r\n");
+    expect(repeated.personaBootstrap).toEqual(started.personaBootstrap);
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+    expect(warnings).toHaveBeenCalledTimes(1);
   } finally {
     warnings.mockRestore();
     await host.release();
     fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("a missing transcript path warns once and the host memo prevents repeated insertion", async () => {
+  const warnings = spyOn(console, "warn").mockImplementation(() => {});
+  const server = new FakeAppServer("voice-thread");
+  server.omitThreadPath = true;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const first = await host.startRealtimeWebRtc("v=0\r\no=- 406 2 IN IP4 127.0.0.1\r\n");
+    await host.stopRealtime();
+    const repeated = await host.startRealtimeWebRtc("v=0\r\no=- 407 2 IN IP4 127.0.0.1\r\n");
+    expect(repeated.personaBootstrap).toEqual(first.personaBootstrap);
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+    expect(warnings).toHaveBeenCalledWith(
+      "[voice persona bootstrap] canonical scan unavailable; attempting insertion",
+      expect.objectContaining({
+        code: "NO_TRANSCRIPT_PATH",
+        diagnostic: "canonical transcript path is unavailable",
+      }),
+    );
+    expect(warnings).toHaveBeenCalledTimes(1);
+  } finally {
+    warnings.mockRestore();
+    await host.release();
+  }
+});
+
+test("a persisted persona row recovers an ambiguous insertion failure", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-ambiguous-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = transcriptPath;
+  server.holdInjectItems = true;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const pending = host.startRealtimeWebRtc("v=0\r\no=- 909 2 IN IP4 127.0.0.1\r\n");
+    void pending.catch(() => undefined);
+    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    const request = server.requests.find((candidate) => candidate.method === "thread/inject_items");
+    const item = (request?.params as { items?: unknown[] } | undefined)?.items?.[0];
+    if (!item) throw new Error("persona insertion item missing");
+    fs.appendFileSync(transcriptPath, `${JSON.stringify({ type: "response_item", payload: item })}\n`);
+    server.completeNextInject("thread/inject_items response was lost");
+
+    expect(await pending).toMatchObject({
+      sdp: "v=0\r\nanswer",
+      personaBootstrap: { insertion: "accepted" },
+    });
+    expect(server.requests.filter((candidate) => candidate.method === "thread/realtime/start")).toHaveLength(1);
+  } finally {
+    await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("a successor start joins the cancelled call's in-flight persona insertion", async () => {
+  const server = new FakeAppServer("voice-thread");
+  server.holdInjectItems = true;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const cancelled = host.startRealtimeWebRtc("v=0\r\no=- 1001 2 IN IP4 127.0.0.1\r\n");
+    void cancelled.catch(() => undefined);
+    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    expect(server.heldInjectItemIds).toHaveLength(1);
+    await host.stopRealtime();
+
+    const successor = host.startRealtimeWebRtc("v=0\r\no=- 1002 2 IN IP4 127.0.0.1\r\n");
+    void successor.catch(() => undefined);
+    await Bun.sleep(10);
+    expect(server.heldInjectItemIds).toHaveLength(1);
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+    server.completeNextInject();
+
+    await expect(cancelled).rejects.toThrow("stopped during startup");
+    expect(await successor).toMatchObject({
+      sdp: "v=0\r\nanswer",
+      personaBootstrap: { insertion: "accepted" },
+    });
+    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
+  } finally {
+    await host.release();
   }
 });
 
@@ -3615,13 +3720,14 @@ test("a cancelled persona insertion failure cannot reject the successor start", 
 
     const successor = host.startRealtimeWebRtc("v=0\r\no=- 808 2 IN IP4 127.0.0.1\r\n");
     void successor.catch(() => undefined);
-    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 2; attempt += 1) {
-      await Bun.sleep(1);
-    }
-    expect(server.heldInjectItemIds).toHaveLength(2);
+    await Bun.sleep(10);
+    expect(server.heldInjectItemIds).toHaveLength(1);
     server.completeNextInject("cancelled call insertion failed");
     await expect(cancelled).rejects.toThrow("stopped during startup");
-    await Bun.sleep(0);
+    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(2);
     server.completeNextInject();
 
     expect(await successor).toMatchObject({

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
@@ -70,6 +70,8 @@ class FakeAppServer extends EventEmitter {
   oversizedTurnStartResult = false;
   readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
+  holdInjectItems = false;
+  readonly heldInjectItemIds: number[] = [];
   threadPath: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
@@ -187,6 +189,10 @@ class FakeAppServer extends EventEmitter {
     if (method === "turn/interrupt") return this.respond(message.id, {});
     if (method === "thread/inject_items") {
       if (this.injectItemsError) return this.respondError(message.id, this.injectItemsError);
+      if (this.holdInjectItems) {
+        this.heldInjectItemIds.push(message.id);
+        return;
+      }
       if (this.threadPath) {
         const items = (message.params as { items?: unknown[] }).items ?? [];
         fs.appendFileSync(this.threadPath, items.map((payload) => JSON.stringify({
@@ -229,6 +235,13 @@ class FakeAppServer extends EventEmitter {
     if (method === "thread/realtime/stop") {
       return this.respond(message.id, {});
     }
+  }
+
+  completeNextInject(error: string | null = null): void {
+    const id = this.heldInjectItemIds.shift();
+    if (id === undefined) throw new Error("no held persona insertion");
+    if (error) this.respondError(id, error);
+    else this.respond(id, {});
   }
 
   private respond(id: number, result: unknown): void {
@@ -3558,6 +3571,7 @@ test("an unreadable canonical transcript falls through to authoritative insertio
   const linkedPath = path.join(isolated, "linked-thread.jsonl");
   fs.writeFileSync(transcriptPath, "");
   fs.symlinkSync(transcriptPath, linkedPath);
+  const warnings = spyOn(console, "warn").mockImplementation(() => {});
   const server = new FakeAppServer("voice-thread");
   server.threadPath = linkedPath;
   const host = await CodexAppServerHost.start({
@@ -3571,9 +3585,52 @@ test("an unreadable canonical transcript falls through to authoritative insertio
     expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
       .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
     expect(fs.readFileSync(transcriptPath, "utf8")).toContain(started.personaBootstrap.itemId);
+    expect(warnings).toHaveBeenCalledWith(
+      "[voice persona bootstrap] canonical scan unavailable; attempting insertion",
+      expect.objectContaining({ code: "ELOOP", diagnostic: expect.stringContaining("ELOOP") }),
+    );
   } finally {
+    warnings.mockRestore();
     await host.release();
     fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("a cancelled persona insertion failure cannot reject the successor start", async () => {
+  const server = new FakeAppServer("voice-thread");
+  server.holdInjectItems = true;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const cancelled = host.startRealtimeWebRtc("v=0\r\no=- 707 2 IN IP4 127.0.0.1\r\n");
+    void cancelled.catch(() => undefined);
+    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    expect(server.heldInjectItemIds).toHaveLength(1);
+    await host.stopRealtime();
+
+    const successor = host.startRealtimeWebRtc("v=0\r\no=- 808 2 IN IP4 127.0.0.1\r\n");
+    void successor.catch(() => undefined);
+    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 2; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    expect(server.heldInjectItemIds).toHaveLength(2);
+    server.completeNextInject("cancelled call insertion failed");
+    await expect(cancelled).rejects.toThrow("stopped during startup");
+    await Bun.sleep(0);
+    server.completeNextInject();
+
+    expect(await successor).toMatchObject({
+      sdp: "v=0\r\nanswer",
+      personaBootstrap: { insertion: "accepted" },
+    });
+    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
+  } finally {
+    await host.release();
   }
 });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -65,6 +65,8 @@ class FakeAppServer extends EventEmitter {
   modelList: unknown[] = [{ id: "gpt-5.3-codex-spark", isDefault: true, inputModalities: ["text"] }];
   modelListFailuresRemaining = 0;
   realtimeStartError: string | null = null;
+  realtimeStartDelayMs: number | null = null;
+  suppressRealtimeStartNotifications = false;
   realtimeAppendErrorAt: number | null = null;
   responseChunkBytes: number | null = null;
   oversizedTurnStartResult = false;
@@ -208,23 +210,12 @@ class FakeAppServer extends EventEmitter {
       return this.respond(message.id, {});
     }
     if (method === "thread/realtime/start") {
-      this.respond(message.id, {});
-      if (this.realtimeStartError) {
-        this.notify("thread/realtime/error", {
-          threadId: this.threadId,
-          message: this.realtimeStartError,
-        });
-      } else {
-        this.notify("thread/realtime/started", {
-          threadId: this.threadId,
-          realtimeSessionId: "realtime-1",
-          version: "v3",
-        });
-        this.notify("thread/realtime/sdp", {
-          threadId: this.threadId,
-          sdp: "v=0\r\nanswer",
-        });
+      if (this.realtimeStartDelayMs !== null) {
+        const requestId = message.id;
+        setTimeout(() => this.completeRealtimeStart(requestId), this.realtimeStartDelayMs);
+        return;
       }
+      this.completeRealtimeStart(message.id);
       return;
     }
     if (method === "thread/realtime/appendSpeech") {
@@ -256,6 +247,27 @@ class FakeAppServer extends EventEmitter {
       timestamp: "2026-08-02T10:00:00.000Z",
       payload,
     })).join("\n") + "\n");
+  }
+
+  private completeRealtimeStart(requestId: number): void {
+    this.respond(requestId, {});
+    if (this.suppressRealtimeStartNotifications) return;
+    if (this.realtimeStartError) {
+      this.notify("thread/realtime/error", {
+        threadId: this.threadId,
+        message: this.realtimeStartError,
+      });
+      return;
+    }
+    this.notify("thread/realtime/started", {
+      threadId: this.threadId,
+      realtimeSessionId: "realtime-1",
+      version: "v3",
+    });
+    this.notify("thread/realtime/sdp", {
+      threadId: this.threadId,
+      sdp: "v=0\r\nanswer",
+    });
   }
 
   private respond(id: number, result: unknown): void {
@@ -3579,38 +3591,50 @@ test("a refused persona insertion returns a bounded rejected receipt before real
   await host.release();
 });
 
-test("an unreadable canonical transcript falls through to authoritative insertion", async () => {
+test("replacement hosts reject an unverifiable canonical transcript without reinserting", async () => {
   const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-scan-fault-"));
   const transcriptPath = path.join(isolated, "voice-thread.jsonl");
   const linkedPath = path.join(isolated, "linked-thread.jsonl");
   fs.writeFileSync(transcriptPath, "");
   fs.symlinkSync(transcriptPath, linkedPath);
   const warnings = spyOn(console, "warn").mockImplementation(() => {});
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = linkedPath;
-  const host = await CodexAppServerHost.start({
+  const firstServer = new FakeAppServer("voice-thread");
+  firstServer.threadPath = linkedPath;
+  const firstHost = await CodexAppServerHost.start({
     cwd: "/repo",
     eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
+    spawnProcess: fakeSpawn(firstServer),
   });
+  let replacementHost: CodexAppServerHost | null = null;
   try {
-    const started = await host.startRealtimeWebRtc("v=0\r\no=- 404 2 IN IP4 127.0.0.1\r\n");
-    expect(started.personaBootstrap.insertion).toBe("accepted");
-    expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
-      .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
-    expect(fs.readFileSync(transcriptPath, "utf8")).toContain(started.personaBootstrap.itemId);
+    const first = await firstHost.startRealtimeWebRtc("v=0\r\no=- 404 2 IN IP4 127.0.0.1\r\n");
+    expect(first).toMatchObject({
+      sdp: null,
+      personaBootstrap: { insertion: "rejected", diagnostic: expect.stringContaining("ELOOP") },
+    });
+    await firstHost.release();
+
+    const replacementServer = new FakeAppServer("voice-thread");
+    replacementServer.threadPath = linkedPath;
+    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(replacementServer),
+    });
+    const replacement = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 405 2 IN IP4 127.0.0.1\r\n");
+    expect(replacement.personaBootstrap).toEqual(first.personaBootstrap);
+    expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+    expect(fs.readFileSync(transcriptPath, "utf8")).toBe("");
     expect(warnings).toHaveBeenCalledWith(
-      "[voice persona bootstrap] canonical scan unavailable; attempting insertion",
+      "[voice persona bootstrap] canonical scan unavailable; refusing insertion",
       expect.objectContaining({ code: "ELOOP", diagnostic: expect.stringContaining("ELOOP") }),
     );
-    await host.stopRealtime();
-    const repeated = await host.startRealtimeWebRtc("v=0\r\no=- 405 2 IN IP4 127.0.0.1\r\n");
-    expect(repeated.personaBootstrap).toEqual(started.personaBootstrap);
-    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
-    expect(warnings).toHaveBeenCalledTimes(1);
+    expect(warnings).toHaveBeenCalledTimes(2);
   } finally {
     warnings.mockRestore();
-    await host.release();
+    await replacementHost?.release();
+    await firstHost.release();
     fs.rmSync(isolated, { recursive: true, force: true });
   }
 });
@@ -3750,6 +3774,55 @@ test("an uncertain persona insertion timeout fences the writer and recovers on a
     await replacementHost?.release();
     await firstHost.release();
     fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("persona bootstrap completes before the single fenced realtime-start deadline begins", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-realtime-start-deadline-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = transcriptPath;
+  server.injectItemsDelayMs = 20;
+  server.realtimeStartDelayMs = 20;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+    realtimePersonaTimeoutMs: 50,
+    realtimeStartTimeoutMs: 30,
+  });
+  try {
+    expect(await host.startRealtimeWebRtc("v=0\r\no=- 912 2 IN IP4 127.0.0.1\r\n")).toMatchObject({
+      sdp: "v=0\r\nanswer",
+      realtimeSessionId: "realtime-1",
+      personaBootstrap: { insertion: "accepted" },
+    });
+    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
+  } finally {
+    await Bun.sleep(25);
+    if (host.currentRealtimeSessionId()) await host.stopRealtime();
+    await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("the realtime notification deadline poisons a writer after the start RPC succeeds", async () => {
+  const server = new FakeAppServer("voice-thread");
+  server.suppressRealtimeStartNotifications = true;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+    realtimeStartTimeoutMs: 10,
+  });
+  try {
+    await expect(host.startRealtimeWebRtc("v=0\r\no=- 913 2 IN IP4 127.0.0.1\r\n"))
+      .rejects.toThrow("thread/realtime/start timed out; outcome is uncertain");
+    expect((await host.health()).status).toBe("dead");
+    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
+  } finally {
+    await host.release();
   }
 });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -70,9 +70,11 @@ class FakeAppServer extends EventEmitter {
   oversizedTurnStartResult = false;
   readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
+  injectItemsDelayMs: number | null = null;
   holdInjectItems = false;
   readonly heldInjectItemIds: number[] = [];
   omitThreadPath = false;
+  omitThreadReadPath = false;
   threadPath: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
@@ -166,7 +168,7 @@ class FakeAppServer extends EventEmitter {
       return this.respond(message.id, {
         thread: {
           id: this.threadId,
-          path: `/sessions/${this.threadId}.jsonl`,
+          ...(!this.omitThreadReadPath ? { path: this.threadPath ?? `/sessions/${this.threadId}.jsonl` } : {}),
           turns: this.readTurns ?? this.turns,
         },
       });
@@ -194,14 +196,15 @@ class FakeAppServer extends EventEmitter {
         this.heldInjectItemIds.push(message.id);
         return;
       }
-      if (this.threadPath) {
-        const items = (message.params as { items?: unknown[] }).items ?? [];
-        fs.appendFileSync(this.threadPath, items.map((payload) => JSON.stringify({
-          type: "response_item",
-          timestamp: "2026-08-02T10:00:00.000Z",
-          payload,
-        })).join("\n") + "\n");
+      if (this.injectItemsDelayMs !== null) {
+        const requestId = message.id;
+        setTimeout(() => {
+          this.persistInjectedItems(message);
+          this.respond(requestId, {});
+        }, this.injectItemsDelayMs);
+        return;
       }
+      this.persistInjectedItems(message);
       return this.respond(message.id, {});
     }
     if (method === "thread/realtime/start") {
@@ -243,6 +246,16 @@ class FakeAppServer extends EventEmitter {
     if (id === undefined) throw new Error("no held persona insertion");
     if (error) this.respondError(id, error);
     else this.respond(id, {});
+  }
+
+  private persistInjectedItems(message: Record<string, unknown>): void {
+    if (!this.threadPath) return;
+    const items = (message.params as { items?: unknown[] }).items ?? [];
+    fs.appendFileSync(this.threadPath, items.map((payload) => JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-02T10:00:00.000Z",
+      payload,
+    })).join("\n") + "\n");
   }
 
   private respond(id: number, result: unknown): void {
@@ -3602,10 +3615,10 @@ test("an unreadable canonical transcript falls through to authoritative insertio
   }
 });
 
-test("a missing transcript path warns once and the host memo prevents repeated insertion", async () => {
-  const warnings = spyOn(console, "warn").mockImplementation(() => {});
+test("an unrecoverable transcript path rejects before persona insertion", async () => {
   const server = new FakeAppServer("voice-thread");
   server.omitThreadPath = true;
+  server.omitThreadReadPath = true;
   const host = await CodexAppServerHost.start({
     cwd: "/repo",
     eventStore: new MemoryEventStore(),
@@ -3613,21 +3626,56 @@ test("a missing transcript path warns once and the host memo prevents repeated i
   });
   try {
     const first = await host.startRealtimeWebRtc("v=0\r\no=- 406 2 IN IP4 127.0.0.1\r\n");
-    await host.stopRealtime();
     const repeated = await host.startRealtimeWebRtc("v=0\r\no=- 407 2 IN IP4 127.0.0.1\r\n");
     expect(repeated.personaBootstrap).toEqual(first.personaBootstrap);
-    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
-    expect(warnings).toHaveBeenCalledWith(
-      "[voice persona bootstrap] canonical scan unavailable; attempting insertion",
-      expect.objectContaining({
-        code: "NO_TRANSCRIPT_PATH",
+    expect(first).toMatchObject({
+      sdp: null,
+      personaBootstrap: {
+        insertion: "rejected",
         diagnostic: "canonical transcript path is unavailable",
-      }),
-    );
-    expect(warnings).toHaveBeenCalledTimes(1);
+      },
+    });
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(0);
   } finally {
-    warnings.mockRestore();
     await host.release();
+  }
+});
+
+test("replacement hosts recover an omitted canonical path and persist one persona row", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-path-recovery-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const firstServer = new FakeAppServer("voice-thread");
+  firstServer.omitThreadPath = true;
+  firstServer.threadPath = transcriptPath;
+  const firstHost = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(firstServer),
+  });
+  let replacementHost: CodexAppServerHost | null = null;
+  try {
+    const first = await firstHost.startRealtimeWebRtc("v=0\r\no=- 408 2 IN IP4 127.0.0.1\r\n");
+    await firstHost.release();
+
+    const replacementServer = new FakeAppServer("voice-thread");
+    replacementServer.omitThreadPath = true;
+    replacementServer.threadPath = transcriptPath;
+    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(replacementServer),
+    });
+    const recovered = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 409 2 IN IP4 127.0.0.1\r\n");
+    expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
+    expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+    expect(fs.readFileSync(transcriptPath, "utf8").split(recovered.personaBootstrap.itemId)).toHaveLength(2);
+  } finally {
+    await replacementHost?.release();
+    await firstHost.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
   }
 });
 
@@ -3662,6 +3710,45 @@ test("a persisted persona row recovers an ambiguous insertion failure", async ()
     expect(server.requests.filter((candidate) => candidate.method === "thread/realtime/start")).toHaveLength(1);
   } finally {
     await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("an uncertain persona insertion timeout fences the writer and recovers on a replacement host", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-timeout-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const firstServer = new FakeAppServer("voice-thread", "voice-thread", true);
+  firstServer.threadPath = transcriptPath;
+  firstServer.injectItemsDelayMs = 25;
+  const firstHost = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(firstServer),
+    realtimePersonaTimeoutMs: 10,
+    shutdownGraceMs: 50,
+  });
+  let replacementHost: CodexAppServerHost | null = null;
+  try {
+    await expect(firstHost.startRealtimeWebRtc("v=0\r\no=- 910 2 IN IP4 127.0.0.1\r\n"))
+      .rejects.toThrow("thread/inject_items timed out; outcome is uncertain");
+    await Bun.sleep(40);
+    expect((await firstHost.health()).status).toBe("dead");
+
+    const replacementServer = new FakeAppServer("voice-thread");
+    replacementServer.threadPath = transcriptPath;
+    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(replacementServer),
+    });
+    const recovered = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 911 2 IN IP4 127.0.0.1\r\n");
+    expect(recovered.personaBootstrap.insertion).toBe("accepted");
+    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+    expect(fs.readFileSync(transcriptPath, "utf8").split(recovered.personaBootstrap.itemId)).toHaveLength(2);
+  } finally {
+    await replacementHost?.release();
+    await firstHost.release();
     fs.rmSync(isolated, { recursive: true, force: true });
   }
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -70,6 +70,7 @@ class FakeAppServer extends EventEmitter {
   oversizedTurnStartResult = false;
   readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
+  threadPath: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
 
@@ -151,7 +152,7 @@ class FakeAppServer extends EventEmitter {
       return this.respond(message.id, {
         thread: {
           id,
-          path: `/sessions/${id}.jsonl`,
+          path: this.threadPath ?? `/sessions/${id}.jsonl`,
           turns: this.turns,
           ...(this.resumeStatus ? { status: this.resumeStatus } : {}),
         },
@@ -185,9 +186,16 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "turn/interrupt") return this.respond(message.id, {});
     if (method === "thread/inject_items") {
-      return this.injectItemsError
-        ? this.respondError(message.id, this.injectItemsError)
-        : this.respond(message.id, {});
+      if (this.injectItemsError) return this.respondError(message.id, this.injectItemsError);
+      if (this.threadPath) {
+        const items = (message.params as { items?: unknown[] }).items ?? [];
+        fs.appendFileSync(this.threadPath, items.map((payload) => JSON.stringify({
+          type: "response_item",
+          timestamp: "2026-08-02T10:00:00.000Z",
+          payload,
+        })).join("\n") + "\n");
+      }
+      return this.respond(message.id, {});
     }
     if (method === "thread/realtime/start") {
       this.respond(message.id, {});
@@ -303,10 +311,14 @@ describe("CodexAppServerHost", () => {
       spawnProcess: fakeSpawn(server),
     });
 
-    await expect(host.startRealtimeWebRtc("v=0\r\noffer")).resolves.toEqual({
+    const started = await host.startRealtimeWebRtc("v=0\r\noffer");
+    expect(started).toMatchObject({
       sdp: "v=0\r\nanswer",
       realtimeSessionId: "realtime-1",
+      personaBootstrap: { insertion: "accepted" },
     });
+    expect(started.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{64}$/);
+    expect(started.personaBootstrap.itemId).toMatch(/^msg_voice_persona_[a-f0-9]{64}$/);
     // SDP requires a terminal CRLF; a missing one is healed, never trimmed —
     // OpenAI rejects an unterminated offer with "unmarshal SDP: EOF".
     /* The live model is named explicitly (#664): letting the backend choose
@@ -329,8 +341,12 @@ describe("CodexAppServerHost", () => {
     expect((injected?.params as { threadId?: string })?.threadId).toBe("voice-thread");
     /* Shape and ordering only. Which text arrives is pinned by the override
        test below, where the expected string cannot also be the default. */
-    expect((injected?.params as { items?: { role?: string; text?: string }[] })?.items)
-      .toEqual([{ role: "developer", text: voicePersona() }]);
+    expect((injected?.params as { items?: unknown[] })?.items).toEqual([{
+      type: "message",
+      id: started.personaBootstrap.itemId,
+      role: "developer",
+      content: [{ type: "input_text", text: voicePersona() }],
+    }]);
     expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
       .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
 
@@ -344,6 +360,65 @@ describe("CodexAppServerHost", () => {
       threadId: "voice-thread",
     });
     await host.release();
+  });
+
+  test("reuses one canonical persona row and stable receipt after duplicate start and host restart", async () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-"));
+    const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+    fs.writeFileSync(transcriptPath, "");
+    const configDirectory = path.join(isolated, "config");
+    const overridePath = path.join(configDirectory, "agent-log-viewer", ...VOICE_PERSONA_FILE.split("/"));
+    fs.mkdirSync(path.dirname(overridePath), { recursive: true });
+    fs.writeFileSync(overridePath, "First resolved call persona.\n");
+
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configDirectory;
+    let firstHost: CodexAppServerHost | null = null;
+    let resumedHost: CodexAppServerHost | null = null;
+    try {
+      const firstServer = new FakeAppServer("voice-thread");
+      firstServer.threadPath = transcriptPath;
+      firstHost = await CodexAppServerHost.start({
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(firstServer),
+      });
+      const first = await firstHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      expect(first.personaBootstrap.insertion).toBe("accepted");
+      await firstHost.stopRealtime();
+
+      fs.writeFileSync(overridePath, "Changed after the call was resolved.\n");
+      const duplicate = await firstHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      expect(duplicate.personaBootstrap).toEqual(first.personaBootstrap);
+      expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+      await firstHost.stopRealtime();
+      await firstHost.release();
+      firstHost = null;
+
+      fs.writeFileSync(overridePath, "Changed again after host restart.\n");
+      const resumedServer = new FakeAppServer("voice-thread");
+      resumedServer.threadPath = transcriptPath;
+      resumedHost = await CodexAppServerHost.adopt("voice-thread", {
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(resumedServer),
+      });
+      const recovered = await resumedHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
+      expect(resumedServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+
+      const canonical = fs.readFileSync(transcriptPath, "utf8").trim().split("\n")
+        .map((line) => JSON.parse(line) as { payload: { id?: string; content?: Array<{ text?: string }> } })
+        .filter((line) => line.payload.id === first.personaBootstrap.itemId);
+      expect(canonical).toHaveLength(1);
+      expect(canonical[0]?.payload.content?.[0]?.text).toBe("First resolved call persona.");
+    } finally {
+      if (firstHost) await firstHost.release();
+      if (resumedHost) await resumedHost.release();
+      if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previousConfigHome;
+      fs.rmSync(isolated, { recursive: true, force: true });
+    }
   });
 
   test("seeds a resumed realtime call with the interrupted duplex tail in canonical order", async () => {
@@ -708,8 +783,14 @@ describe("CodexAppServerHost", () => {
       await host.startRealtimeWebRtc("v=0\r\noffer");
 
       const injected = server.requests.find((request) => request.method === "thread/inject_items");
-      expect((injected?.params as { items?: { role?: string; text?: string }[] })?.items)
-        .toEqual([{ role: "developer", text: override }]);
+      const item = (injected?.params as {
+        items?: Array<{ type?: string; role?: string; content?: Array<{ type?: string; text?: string }> }>;
+      })?.items?.[0];
+      expect(item).toMatchObject({
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: override }],
+      });
       await host.release();
     } finally {
       if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
@@ -3441,9 +3522,7 @@ describe("CodexAppServerHost", () => {
   });
 });
 
-test("a refused persona injection still yields a working call", async () => {
-  /* The persona is a nicety; the call is not. An app-server that refuses the
-     item shape — or the method outright — must cost the operator nothing. */
+test("a refused persona insertion returns a bounded rejected receipt before realtime starts", async () => {
   const server = new FakeAppServer("voice-thread");
   server.injectItemsError = "Invalid request: unknown field `role`";
   const host = await CodexAppServerHost.start({
@@ -3452,11 +3531,62 @@ test("a refused persona injection still yields a working call", async () => {
     spawnProcess: fakeSpawn(server),
   });
 
-  await expect(host.startRealtimeWebRtc("v=0\r\noffer")).resolves.toEqual({
-    sdp: "v=0\r\nanswer",
-    realtimeSessionId: "realtime-1",
+  const rejected = await host.startRealtimeWebRtc("v=0\r\noffer");
+  expect(rejected).toMatchObject({
+    sdp: null,
+    realtimeSessionId: null,
+    personaBootstrap: {
+      insertion: "rejected",
+      diagnostic: "Codex app-server request failed: Invalid request: unknown field `role`",
+    },
   });
+  expect(rejected.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{64}$/);
+  expect(rejected.personaBootstrap.diagnostic?.length).toBeLessThanOrEqual(500);
+  expect(server.requests.find((request) => request.method === "thread/realtime/start")).toBeUndefined();
+  expect(host.currentRealtimeSessionId()).toBeNull();
   await host.release();
+});
+
+test("a rejected persona insertion retries the same resolved payload and stable receipt", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-retry-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const configDirectory = path.join(isolated, "config");
+  const overridePath = path.join(configDirectory, "agent-log-viewer", ...VOICE_PERSONA_FILE.split("/"));
+  fs.mkdirSync(path.dirname(overridePath), { recursive: true });
+  fs.writeFileSync(overridePath, "Resolved before the rejected insertion.\n");
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = configDirectory;
+
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = transcriptPath;
+  server.injectItemsError = "temporary insertion refusal";
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const rejected = await host.startRealtimeWebRtc("v=0\r\nretry-offer");
+    expect(rejected.personaBootstrap.insertion).toBe("rejected");
+
+    fs.writeFileSync(overridePath, "A later edit must not change this call.\n");
+    server.injectItemsError = null;
+    const accepted = await host.startRealtimeWebRtc("v=0\r\nretry-offer");
+    expect(accepted.personaBootstrap.receiptId).toBe(rejected.personaBootstrap.receiptId);
+    expect(accepted.personaBootstrap.itemId).toBe(rejected.personaBootstrap.itemId);
+    expect(accepted.personaBootstrap.insertion).toBe("accepted");
+
+    const attempts = server.requests.filter((request) => request.method === "thread/inject_items");
+    expect(attempts).toHaveLength(2);
+    expect((attempts[1]?.params as { items: Array<{ content: Array<{ text: string }> }> }).items[0]?.content[0]?.text)
+      .toBe("Resolved before the rejected insertion.");
+  } finally {
+    await host.release();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
 });
 
 test("releasing the host hangs up a live call so the account's slot is freed", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -375,6 +375,11 @@ describe("CodexAppServerHost", () => {
     process.env.XDG_CONFIG_HOME = configDirectory;
     let firstHost: CodexAppServerHost | null = null;
     let resumedHost: CodexAppServerHost | null = null;
+    const offers = [
+      "v=0\r\no=- 101 2 IN IP4 127.0.0.1\r\na=ice-ufrag:first\r\na=ice-pwd:first-password\r\na=fingerprint:sha-256 11:22\r\n",
+      "v=0\r\no=- 202 2 IN IP4 127.0.0.1\r\na=ice-ufrag:second\r\na=ice-pwd:second-password\r\na=fingerprint:sha-256 33:44\r\n",
+      "v=0\r\no=- 303 2 IN IP4 127.0.0.1\r\na=ice-ufrag:third\r\na=ice-pwd:third-password\r\na=fingerprint:sha-256 55:66\r\n",
+    ] as const;
     try {
       const firstServer = new FakeAppServer("voice-thread");
       firstServer.threadPath = transcriptPath;
@@ -383,12 +388,12 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(firstServer),
       });
-      const first = await firstHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      const first = await firstHost.startRealtimeWebRtc(offers[0]);
       expect(first.personaBootstrap.insertion).toBe("accepted");
       await firstHost.stopRealtime();
 
       fs.writeFileSync(overridePath, "Changed after the call was resolved.\n");
-      const duplicate = await firstHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      const duplicate = await firstHost.startRealtimeWebRtc(offers[1]);
       expect(duplicate.personaBootstrap).toEqual(first.personaBootstrap);
       expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
       await firstHost.stopRealtime();
@@ -403,7 +408,7 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(resumedServer),
       });
-      const recovered = await resumedHost.startRealtimeWebRtc("v=0\r\nstable-offer");
+      const recovered = await resumedHost.startRealtimeWebRtc(offers[2]);
       expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
       expect(resumedServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
 
@@ -3547,6 +3552,31 @@ test("a refused persona insertion returns a bounded rejected receipt before real
   await host.release();
 });
 
+test("an unreadable canonical transcript falls through to authoritative insertion", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-scan-fault-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  const linkedPath = path.join(isolated, "linked-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  fs.symlinkSync(transcriptPath, linkedPath);
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = linkedPath;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const started = await host.startRealtimeWebRtc("v=0\r\no=- 404 2 IN IP4 127.0.0.1\r\n");
+    expect(started.personaBootstrap.insertion).toBe("accepted");
+    expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
+      .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
+    expect(fs.readFileSync(transcriptPath, "utf8")).toContain(started.personaBootstrap.itemId);
+  } finally {
+    await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
 test("a rejected persona insertion retries the same resolved payload and stable receipt", async () => {
   const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-retry-"));
   const transcriptPath = path.join(isolated, "voice-thread.jsonl");
@@ -3567,12 +3597,16 @@ test("a rejected persona insertion retries the same resolved payload and stable 
     spawnProcess: fakeSpawn(server),
   });
   try {
-    const rejected = await host.startRealtimeWebRtc("v=0\r\nretry-offer");
+    const rejected = await host.startRealtimeWebRtc(
+      "v=0\r\no=- 505 2 IN IP4 127.0.0.1\r\na=ice-ufrag:rejected\r\n",
+    );
     expect(rejected.personaBootstrap.insertion).toBe("rejected");
 
     fs.writeFileSync(overridePath, "A later edit must not change this call.\n");
     server.injectItemsError = null;
-    const accepted = await host.startRealtimeWebRtc("v=0\r\nretry-offer");
+    const accepted = await host.startRealtimeWebRtc(
+      "v=0\r\no=- 606 2 IN IP4 127.0.0.1\r\na=ice-ufrag:retry\r\n",
+    );
     expect(accepted.personaBootstrap.receiptId).toBe(rejected.personaBootstrap.receiptId);
     expect(accepted.personaBootstrap.itemId).toBe(rejected.personaBootstrap.itemId);
     expect(accepted.personaBootstrap.insertion).toBe("accepted");
@@ -3581,6 +3615,7 @@ test("a rejected persona insertion retries the same resolved payload and stable 
     expect(attempts).toHaveLength(2);
     expect((attempts[1]?.params as { items: Array<{ content: Array<{ text: string }> }> }).items[0]?.content[0]?.text)
       .toBe("Resolved before the rejected insertion.");
+    expect(fs.readFileSync(transcriptPath, "utf8").split(accepted.personaBootstrap.itemId)).toHaveLength(2);
   } finally {
     await host.release();
     if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -78,7 +78,7 @@ export type CodexRealtimeFailure = {
 type PendingRealtimeStart = {
   resolve(result: CodexRealtimeWebRtcResult): void;
   reject(error: Error): void;
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | undefined;
   started: boolean;
   realtimeSessionId: string | null;
   sdp: string | null;
@@ -163,6 +163,7 @@ export interface CodexAppServerHostOptions {
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
   realtimePersonaTimeoutMs?: number;
+  realtimeStartTimeoutMs?: number;
   deliveryConfirmationTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
@@ -570,6 +571,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
   private readonly realtimePersonaTimeoutMs: number;
+  private readonly realtimeStartTimeoutMs: number;
   private readonly deliveryConfirmationTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly eventStore: RuntimeEventStore;
@@ -658,6 +660,7 @@ export class CodexAppServerHost implements EngineHost {
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.realtimePersonaTimeoutMs = options.realtimePersonaTimeoutMs ?? REALTIME_PERSONA_TIMEOUT_MS;
+    this.realtimeStartTimeoutMs = options.realtimeStartTimeoutMs ?? REALTIME_START_TIMEOUT_MS;
     this.deliveryConfirmationTimeoutMs = options.deliveryConfirmationTimeoutMs
       ?? DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
@@ -976,13 +979,10 @@ export class CodexAppServerHost implements EngineHost {
 
     let pendingStart!: PendingRealtimeStart;
     const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.rejectRealtimeStart(new Error("thread/realtime/start timed out"));
-      }, REALTIME_START_TIMEOUT_MS);
       pendingStart = {
         resolve,
         reject,
-        timer,
+        timer: undefined,
         started: false,
         realtimeSessionId: null,
         sdp: null,
@@ -1019,6 +1019,10 @@ export class CodexAppServerHost implements EngineHost {
       durableTail: realtimeContext.diagnosticItems,
       truncated: realtimeContext.truncated,
     });
+    pendingStart.timer = setTimeout(() => {
+      if (this.pendingRealtimeStart !== pendingStart) return;
+      this.fail(new Error("thread/realtime/start timed out; outcome is uncertain"));
+    }, this.realtimeStartTimeoutMs);
     try {
       await this.rpc("thread/realtime/start", {
         threadId: this.identity.threadId,
@@ -1033,7 +1037,7 @@ export class CodexAppServerHost implements EngineHost {
            durable tail only when a streamed assistant response has no
            committed item; provider startup context owns the persisted history. */
         ...(realtimeContext.items.length > 0 ? { initialItems: realtimeContext.items } : {}),
-      }, REALTIME_START_TIMEOUT_MS);
+      }, this.realtimeStartTimeoutMs);
     } catch (error) {
       this.rejectRealtimeStart(error instanceof Error ? error : new Error(safeError(error)));
     }
@@ -1058,7 +1062,7 @@ export class CodexAppServerHost implements EngineHost {
         continue;
       }
 
-      if (await this.scanVoicePersonaBootstrap(identity.itemId, "canonical scan unavailable; attempting insertion")) {
+      if (await this.scanVoicePersonaBootstrap(identity.itemId, "canonical scan unavailable; refusing insertion")) {
         this.voicePersonaBootstrapAccepted = true;
         this.unresolvedVoicePersonaBootstrap = null;
         break;
@@ -1124,7 +1128,7 @@ export class CodexAppServerHost implements EngineHost {
         code: (error as NodeJS.ErrnoException).code ?? "unknown",
         diagnostic: safeError(error),
       });
-      return false;
+      throw error;
     }
   }
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -254,9 +254,8 @@ const MIN_LATE_THREAD_READ_RESPONSE_TTL_MS = 1_000;
 const MAX_LATE_THREAD_READ_RESPONSES = 32;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const REALTIME_START_TIMEOUT_MS = 90_000;
-/* The persona is optional; never let it hold the microphone waiting. An
-   app-server that rejects the method answers immediately, so this bound only
-   covers one that accepts it and then stalls. */
+/* First speech waits for the persona's durable insertion outcome. Keep that
+   gate bounded when an app-server accepts the method and then stalls. */
 const REALTIME_PERSONA_TIMEOUT_MS = 3_000;
 /* Releasing the host must not block on a wedged app-server, but the hangup is
    worth a moment: skipping it strands the account's realtime slot. */
@@ -275,7 +274,6 @@ const MAX_REALTIME_SPEECH_BYTES = 8 * 1024;
 const MAX_REALTIME_CONTEXT_ITEMS = 12;
 const MAX_REALTIME_CONTEXT_ITEM_BYTES = 8 * 1024;
 const MAX_REALTIME_CONTEXT_BYTES = 24 * 1024;
-const MAX_UNRESOLVED_VOICE_BOOTSTRAPS = 8;
 const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
 const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
 /**
@@ -597,7 +595,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
-  private readonly unresolvedVoicePersonaBootstraps = new Map<string, VoicePersonaBootstrap>();
+  private unresolvedVoicePersonaBootstrap: VoicePersonaBootstrap | null = null;
   private readonly pendingVoiceChunks = new Map<string, string>();
   private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
@@ -989,31 +987,28 @@ export class CodexAppServerHost implements EngineHost {
         this.identity.path,
         personaBootstrapIdentity.itemId,
       );
-    } catch {
+    } catch (error) {
       /* The insertion RPC is authoritative. A rollout that cannot be scanned
          still gets one attempt to persist the canonical item. */
-      console.warn("[voice persona bootstrap] canonical scan unavailable; attempting insertion");
+      console.warn("[voice persona bootstrap] canonical scan unavailable; attempting insertion", {
+        code: (error as NodeJS.ErrnoException).code ?? "unknown",
+        diagnostic: safeError(error),
+      });
     }
     if (!exists) {
       try {
-        const personaBootstrap = this.unresolvedVoicePersonaBootstraps.get(personaBootstrapIdentity.receiptId)
+        const personaBootstrap = this.unresolvedVoicePersonaBootstrap
           ?? voicePersonaBootstrap(personaBootstrapIdentity);
-        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
-        this.unresolvedVoicePersonaBootstraps.set(personaBootstrapIdentity.receiptId, personaBootstrap);
-        while (this.unresolvedVoicePersonaBootstraps.size > MAX_UNRESOLVED_VOICE_BOOTSTRAPS) {
-          const oldest = this.unresolvedVoicePersonaBootstraps.keys().next().value;
-          if (typeof oldest !== "string") break;
-          this.unresolvedVoicePersonaBootstraps.delete(oldest);
-        }
+        this.unresolvedVoicePersonaBootstrap = personaBootstrap;
         await this.rpc("thread/inject_items", {
           threadId: this.identity.threadId,
           items: [personaBootstrap.item],
         }, REALTIME_PERSONA_TIMEOUT_MS);
-        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
+        this.unresolvedVoicePersonaBootstrap = null;
       } catch (error) {
-        const pending = this.pendingRealtimeStart;
+        if (this.pendingRealtimeStart !== pendingStart) return answer;
+        const pending = pendingStart;
         this.pendingRealtimeStart = null;
-        if (!pending) return answer;
         clearTimeout(pending.timer);
         const rejected: CodexRealtimeWebRtcRejection = {
           sdp: null,
@@ -1028,7 +1023,7 @@ export class CodexAppServerHost implements EngineHost {
         return answer;
       }
     } else {
-      this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
+      this.unresolvedVoicePersonaBootstrap = null;
     }
     if (this.pendingRealtimeStart !== pendingStart) return answer;
     const realtimeContext = selectRealtimeContext(this.events);
@@ -1434,6 +1429,7 @@ export class CodexAppServerHost implements EngineHost {
       this.realtimeSessionId = null;
     }
     this.releasing = true;
+    this.unresolvedVoicePersonaBootstrap = null;
     this.rejectRealtimeStart(new Error("Codex app-server host released"));
     this.rejectPendingAnswers(new Error("Codex app-server host released"));
     this.rejectPendingDeliveries(new Error("Codex app-server host released"));

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -48,6 +48,7 @@ import {
   voicePersonaBootstrap,
   voicePersonaBootstrapIdentity,
   type VoicePersonaBootstrap,
+  type VoicePersonaBootstrapIdentity,
   type VoicePersonaBootstrapReceipt,
 } from "./voicePersona";
 
@@ -82,6 +83,10 @@ type PendingRealtimeStart = {
   realtimeSessionId: string | null;
   sdp: string | null;
   personaBootstrap: VoicePersonaBootstrapReceipt;
+};
+type VoicePersonaBootstrapInsertion = {
+  owner: PendingRealtimeStart;
+  promise: Promise<void>;
 };
 type PendingDelivery = {
   text: string;
@@ -595,7 +600,11 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
+  /* A host's thread identity is immutable, so one memo covers its one stable
+     persona item. Successor starts join the same insertion promise. */
   private unresolvedVoicePersonaBootstrap: VoicePersonaBootstrap | null = null;
+  private voicePersonaBootstrapInsertion: VoicePersonaBootstrapInsertion | null = null;
+  private voicePersonaBootstrapAccepted = false;
   private readonly pendingVoiceChunks = new Map<string, string>();
   private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
@@ -979,51 +988,25 @@ export class CodexAppServerHost implements EngineHost {
     this.pendingRealtimeStart = pendingStart;
     void answer.catch(() => undefined);
 
-    /* The canonical item is the gate for first speech. Its stable id makes a
-       flushed insertion observable after a lost response or host restart. */
-    let exists = false;
     try {
-      exists = await canonicalVoicePersonaBootstrapExists(
-        this.identity.path,
-        personaBootstrapIdentity.itemId,
-      );
+      const outcome = await this.ensureVoicePersonaBootstrap(personaBootstrapIdentity, pendingStart);
+      if (outcome === "superseded") return answer;
     } catch (error) {
-      /* The insertion RPC is authoritative. A rollout that cannot be scanned
-         still gets one attempt to persist the canonical item. */
-      console.warn("[voice persona bootstrap] canonical scan unavailable; attempting insertion", {
-        code: (error as NodeJS.ErrnoException).code ?? "unknown",
-        diagnostic: safeError(error),
-      });
-    }
-    if (!exists) {
-      try {
-        const personaBootstrap = this.unresolvedVoicePersonaBootstrap
-          ?? voicePersonaBootstrap(personaBootstrapIdentity);
-        this.unresolvedVoicePersonaBootstrap = personaBootstrap;
-        await this.rpc("thread/inject_items", {
-          threadId: this.identity.threadId,
-          items: [personaBootstrap.item],
-        }, REALTIME_PERSONA_TIMEOUT_MS);
-        this.unresolvedVoicePersonaBootstrap = null;
-      } catch (error) {
-        if (this.pendingRealtimeStart !== pendingStart) return answer;
-        const pending = pendingStart;
-        this.pendingRealtimeStart = null;
-        clearTimeout(pending.timer);
-        const rejected: CodexRealtimeWebRtcRejection = {
-          sdp: null,
-          realtimeSessionId: null,
-          personaBootstrap: {
-            ...personaBootstrapIdentity,
-            insertion: "rejected",
-            diagnostic: safeError(error),
-          },
-        };
-        pending.resolve(rejected);
-        return answer;
-      }
-    } else {
-      this.unresolvedVoicePersonaBootstrap = null;
+      if (this.pendingRealtimeStart !== pendingStart) return answer;
+      const pending = pendingStart;
+      this.pendingRealtimeStart = null;
+      clearTimeout(pending.timer);
+      const rejected: CodexRealtimeWebRtcRejection = {
+        sdp: null,
+        realtimeSessionId: null,
+        personaBootstrap: {
+          ...personaBootstrapIdentity,
+          insertion: "rejected",
+          diagnostic: safeError(error),
+        },
+      };
+      pending.resolve(rejected);
+      return answer;
     }
     if (this.pendingRealtimeStart !== pendingStart) return answer;
     const realtimeContext = selectRealtimeContext(this.events);
@@ -1051,6 +1034,75 @@ export class CodexAppServerHost implements EngineHost {
       this.rejectRealtimeStart(error instanceof Error ? error : new Error(safeError(error)));
     }
     return answer;
+  }
+
+  private async ensureVoicePersonaBootstrap(
+    identity: VoicePersonaBootstrapIdentity,
+    pendingStart: PendingRealtimeStart,
+  ): Promise<"accepted" | "superseded"> {
+    while (!this.voicePersonaBootstrapAccepted) {
+      const active = this.voicePersonaBootstrapInsertion;
+      if (active) {
+        try {
+          await active.promise;
+        } catch (error) {
+          if (this.pendingRealtimeStart !== pendingStart) return "superseded";
+          if (active.owner === pendingStart) throw error;
+          continue;
+        }
+        continue;
+      }
+
+      if (await this.scanVoicePersonaBootstrap(identity.itemId, "canonical scan unavailable; attempting insertion")) {
+        this.voicePersonaBootstrapAccepted = true;
+        this.unresolvedVoicePersonaBootstrap = null;
+        break;
+      }
+      if (this.pendingRealtimeStart !== pendingStart) return "superseded";
+      if (this.voicePersonaBootstrapInsertion) continue;
+
+      const bootstrap = this.unresolvedVoicePersonaBootstrap ?? voicePersonaBootstrap(identity);
+      this.unresolvedVoicePersonaBootstrap = bootstrap;
+      const promise = this.insertVoicePersonaBootstrap(bootstrap, identity.itemId);
+      const insertion = { owner: pendingStart, promise };
+      this.voicePersonaBootstrapInsertion = insertion;
+      const clearInsertion = () => {
+        if (this.voicePersonaBootstrapInsertion === insertion) this.voicePersonaBootstrapInsertion = null;
+      };
+      void promise.then(clearInsertion, clearInsertion);
+      try {
+        await promise;
+      } catch (error) {
+        if (this.pendingRealtimeStart !== pendingStart) return "superseded";
+        throw error;
+      }
+    }
+    return "accepted";
+  }
+
+  private async insertVoicePersonaBootstrap(bootstrap: VoicePersonaBootstrap, itemId: string): Promise<void> {
+    try {
+      await this.rpc("thread/inject_items", {
+        threadId: this.identity.threadId,
+        items: [bootstrap.item],
+      }, REALTIME_PERSONA_TIMEOUT_MS);
+    } catch (error) {
+      if (!await this.scanVoicePersonaBootstrap(itemId, "recovery scan unavailable")) throw error;
+    }
+    this.voicePersonaBootstrapAccepted = true;
+    this.unresolvedVoicePersonaBootstrap = null;
+  }
+
+  private async scanVoicePersonaBootstrap(itemId: string, warning: string): Promise<boolean> {
+    try {
+      return await canonicalVoicePersonaBootstrapExists(this.identity.path, itemId);
+    } catch (error) {
+      console.warn(`[voice persona bootstrap] ${warning}`, {
+        code: (error as NodeJS.ErrnoException).code ?? "unknown",
+        diagnostic: safeError(error),
+      });
+      return false;
+    }
   }
 
   async appendRealtimeSpeech(text: string): Promise<void> {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -162,6 +162,7 @@ export interface CodexAppServerHostOptions {
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
+  realtimePersonaTimeoutMs?: number;
   deliveryConfirmationTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
@@ -317,6 +318,7 @@ const MUTATING_RPC_METHODS = new Set([
   "turn/interrupt",
   "thread/realtime/start",
   "thread/realtime/stop",
+  "thread/inject_items",
 ]);
 
 function record(value: unknown): JsonObject | null {
@@ -567,6 +569,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
+  private readonly realtimePersonaTimeoutMs: number;
   private readonly deliveryConfirmationTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly eventStore: RuntimeEventStore;
@@ -600,8 +603,8 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
-  /* A host's thread identity is immutable, so one memo covers its one stable
-     persona item. Successor starts join the same insertion promise. */
+  /* A host's thread id is immutable, so one memo covers its one stable persona
+     item. Successor starts join the same insertion promise. */
   private unresolvedVoicePersonaBootstrap: VoicePersonaBootstrap | null = null;
   private voicePersonaBootstrapInsertion: VoicePersonaBootstrapInsertion | null = null;
   private voicePersonaBootstrapAccepted = false;
@@ -654,6 +657,7 @@ export class CodexAppServerHost implements EngineHost {
     this.child = child;
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.realtimePersonaTimeoutMs = options.realtimePersonaTimeoutMs ?? REALTIME_PERSONA_TIMEOUT_MS;
     this.deliveryConfirmationTimeoutMs = options.deliveryConfirmationTimeoutMs
       ?? DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
@@ -1040,6 +1044,7 @@ export class CodexAppServerHost implements EngineHost {
     identity: VoicePersonaBootstrapIdentity,
     pendingStart: PendingRealtimeStart,
   ): Promise<"accepted" | "superseded"> {
+    await this.ensureCanonicalTranscriptPath();
     while (!this.voicePersonaBootstrapAccepted) {
       const active = this.voicePersonaBootstrapInsertion;
       if (active) {
@@ -1080,12 +1085,30 @@ export class CodexAppServerHost implements EngineHost {
     return "accepted";
   }
 
+  private async ensureCanonicalTranscriptPath(): Promise<void> {
+    if (this.identity.path) return;
+    const result = await this.rpc("thread/read", {
+      threadId: this.identity.threadId,
+      includeTurns: true,
+    });
+    const recovered = threadFromResult(result, "thread/read");
+    if (recovered.threadId !== this.identity.threadId) {
+      throw new Error("thread/read returned a different thread id");
+    }
+    if (!recovered.path) {
+      const error = new Error("canonical transcript path is unavailable") as NodeJS.ErrnoException;
+      error.code = "NO_TRANSCRIPT_PATH";
+      throw error;
+    }
+    this.identity.path = recovered.path;
+  }
+
   private async insertVoicePersonaBootstrap(bootstrap: VoicePersonaBootstrap, itemId: string): Promise<void> {
     try {
       await this.rpc("thread/inject_items", {
         threadId: this.identity.threadId,
         items: [bootstrap.item],
-      }, REALTIME_PERSONA_TIMEOUT_MS);
+      }, this.realtimePersonaTimeoutMs);
     } catch (error) {
       if (!await this.scanVoicePersonaBootstrap(itemId, "recovery scan unavailable")) throw error;
     }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -961,7 +961,7 @@ export class CodexAppServerHost implements EngineHost {
        be reported against this one. */
     this.realtimeFailure = null;
     this.realtimeSessionId = null;
-    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId, offer);
+    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId);
 
     let pendingStart!: PendingRealtimeStart;
     const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
@@ -983,14 +983,22 @@ export class CodexAppServerHost implements EngineHost {
 
     /* The canonical item is the gate for first speech. Its stable id makes a
        flushed insertion observable after a lost response or host restart. */
+    let exists = false;
     try {
-      const exists = await canonicalVoicePersonaBootstrapExists(
+      exists = await canonicalVoicePersonaBootstrapExists(
         this.identity.path,
         personaBootstrapIdentity.itemId,
       );
-      if (!exists) {
+    } catch {
+      /* The insertion RPC is authoritative. A rollout that cannot be scanned
+         still gets one attempt to persist the canonical item. */
+      console.warn("[voice persona bootstrap] canonical scan unavailable; attempting insertion");
+    }
+    if (!exists) {
+      try {
         const personaBootstrap = this.unresolvedVoicePersonaBootstraps.get(personaBootstrapIdentity.receiptId)
           ?? voicePersonaBootstrap(personaBootstrapIdentity);
+        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
         this.unresolvedVoicePersonaBootstraps.set(personaBootstrapIdentity.receiptId, personaBootstrap);
         while (this.unresolvedVoicePersonaBootstraps.size > MAX_UNRESOLVED_VOICE_BOOTSTRAPS) {
           const oldest = this.unresolvedVoicePersonaBootstraps.keys().next().value;
@@ -1002,25 +1010,25 @@ export class CodexAppServerHost implements EngineHost {
           items: [personaBootstrap.item],
         }, REALTIME_PERSONA_TIMEOUT_MS);
         this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
-      } else {
-        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
+      } catch (error) {
+        const pending = this.pendingRealtimeStart;
+        this.pendingRealtimeStart = null;
+        if (!pending) return answer;
+        clearTimeout(pending.timer);
+        const rejected: CodexRealtimeWebRtcRejection = {
+          sdp: null,
+          realtimeSessionId: null,
+          personaBootstrap: {
+            ...personaBootstrapIdentity,
+            insertion: "rejected",
+            diagnostic: safeError(error),
+          },
+        };
+        pending.resolve(rejected);
+        return answer;
       }
-    } catch (error) {
-      const pending = this.pendingRealtimeStart;
-      this.pendingRealtimeStart = null;
-      if (!pending) return answer;
-      clearTimeout(pending.timer);
-      const rejected: CodexRealtimeWebRtcRejection = {
-        sdp: null,
-        realtimeSessionId: null,
-        personaBootstrap: {
-          ...personaBootstrapIdentity,
-          insertion: "rejected",
-          diagnostic: safeError(error),
-        },
-      };
-      pending.resolve(rejected);
-      return answer;
+    } else {
+      this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
     }
     if (this.pendingRealtimeStart !== pendingStart) return answer;
     const realtimeContext = selectRealtimeContext(this.events);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -43,7 +43,13 @@ import {
   type RuntimeEventCursorRecoveryReporter,
   type RuntimeEventStore,
 } from "./eventStore";
-import { voicePersona } from "./voicePersona";
+import {
+  canonicalVoicePersonaBootstrapExists,
+  voicePersonaBootstrap,
+  voicePersonaBootstrapIdentity,
+  type VoicePersonaBootstrap,
+  type VoicePersonaBootstrapReceipt,
+} from "./voicePersona";
 
 type JsonObject = Record<string, unknown>;
 type PendingRpc = {
@@ -69,12 +75,13 @@ export type CodexRealtimeFailure = {
   realtimeSessionId: string | null;
 };
 type PendingRealtimeStart = {
-  resolve(result: CodexRealtimeWebRtcAnswer): void;
+  resolve(result: CodexRealtimeWebRtcResult): void;
   reject(error: Error): void;
   timer: ReturnType<typeof setTimeout>;
   started: boolean;
   realtimeSessionId: string | null;
   sdp: string | null;
+  personaBootstrap: VoicePersonaBootstrapReceipt;
 };
 type PendingDelivery = {
   text: string;
@@ -173,7 +180,19 @@ export interface CodexThreadIdentity {
 export interface CodexRealtimeWebRtcAnswer {
   sdp: string;
   realtimeSessionId: string | null;
+  personaBootstrap: VoicePersonaBootstrapReceipt;
 }
+
+export interface CodexRealtimeWebRtcRejection {
+  sdp: null;
+  realtimeSessionId: null;
+  personaBootstrap: VoicePersonaBootstrapReceipt & {
+    insertion: "rejected";
+    diagnostic: string;
+  };
+}
+
+export type CodexRealtimeWebRtcResult = CodexRealtimeWebRtcAnswer | CodexRealtimeWebRtcRejection;
 
 const CHILD_ENV_ALLOWLIST = [
   "PATH",
@@ -256,6 +275,7 @@ const MAX_REALTIME_SPEECH_BYTES = 8 * 1024;
 const MAX_REALTIME_CONTEXT_ITEMS = 12;
 const MAX_REALTIME_CONTEXT_ITEM_BYTES = 8 * 1024;
 const MAX_REALTIME_CONTEXT_BYTES = 24 * 1024;
+const MAX_UNRESOLVED_VOICE_BOOTSTRAPS = 8;
 const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
 const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
 /**
@@ -577,6 +597,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
+  private readonly unresolvedVoicePersonaBootstraps = new Map<string, VoicePersonaBootstrap>();
   private readonly pendingVoiceChunks = new Map<string, string>();
   private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
@@ -924,7 +945,7 @@ export class CodexAppServerHost implements EngineHost {
     await this.rpc("turn/interrupt", { threadId: this.identity.threadId, turnId: turnRef });
   }
 
-  async startRealtimeWebRtc(sdp: string): Promise<CodexRealtimeWebRtcAnswer> {
+  async startRealtimeWebRtc(sdp: string): Promise<CodexRealtimeWebRtcResult> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       throw new Error("Codex app-server host is unavailable");
     }
@@ -940,36 +961,68 @@ export class CodexAppServerHost implements EngineHost {
        be reported against this one. */
     this.realtimeFailure = null;
     this.realtimeSessionId = null;
+    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId, offer);
 
-    const answer = new Promise<CodexRealtimeWebRtcAnswer>((resolve, reject) => {
+    let pendingStart!: PendingRealtimeStart;
+    const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.rejectRealtimeStart(new Error("thread/realtime/start timed out"));
       }, REALTIME_START_TIMEOUT_MS);
-      this.pendingRealtimeStart = {
+      pendingStart = {
         resolve,
         reject,
         timer,
         started: false,
         realtimeSessionId: null,
         sdp: null,
+        personaBootstrap: { ...personaBootstrapIdentity, insertion: "accepted" },
       };
     });
+    this.pendingRealtimeStart = pendingStart;
     void answer.catch(() => undefined);
 
-    /* The persona is a durable thread item, so `includeStartupContext` carries
-       it into every call and reconnect. Best effort by construction — a
-       rejected injection must never cost the operator their call, so the start
-       proceeds with whatever instructions the thread already holds. */
+    /* The canonical item is the gate for first speech. Its stable id makes a
+       flushed insertion observable after a lost response or host restart. */
     try {
-      await this.rpc("thread/inject_items", {
-        threadId: this.identity.threadId,
-        items: [{ role: "developer", text: voicePersona() }],
-      }, REALTIME_PERSONA_TIMEOUT_MS);
-    } catch {
-      /* Swallowed on purpose: the app-server records the rejected RPC in its
-         own log, which is where a wrong item shape gets diagnosed, and the
-         operator gets their call either way. */
+      const exists = await canonicalVoicePersonaBootstrapExists(
+        this.identity.path,
+        personaBootstrapIdentity.itemId,
+      );
+      if (!exists) {
+        const personaBootstrap = this.unresolvedVoicePersonaBootstraps.get(personaBootstrapIdentity.receiptId)
+          ?? voicePersonaBootstrap(personaBootstrapIdentity);
+        this.unresolvedVoicePersonaBootstraps.set(personaBootstrapIdentity.receiptId, personaBootstrap);
+        while (this.unresolvedVoicePersonaBootstraps.size > MAX_UNRESOLVED_VOICE_BOOTSTRAPS) {
+          const oldest = this.unresolvedVoicePersonaBootstraps.keys().next().value;
+          if (typeof oldest !== "string") break;
+          this.unresolvedVoicePersonaBootstraps.delete(oldest);
+        }
+        await this.rpc("thread/inject_items", {
+          threadId: this.identity.threadId,
+          items: [personaBootstrap.item],
+        }, REALTIME_PERSONA_TIMEOUT_MS);
+        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
+      } else {
+        this.unresolvedVoicePersonaBootstraps.delete(personaBootstrapIdentity.receiptId);
+      }
+    } catch (error) {
+      const pending = this.pendingRealtimeStart;
+      this.pendingRealtimeStart = null;
+      if (!pending) return answer;
+      clearTimeout(pending.timer);
+      const rejected: CodexRealtimeWebRtcRejection = {
+        sdp: null,
+        realtimeSessionId: null,
+        personaBootstrap: {
+          ...personaBootstrapIdentity,
+          insertion: "rejected",
+          diagnostic: safeError(error),
+        },
+      };
+      pending.resolve(rejected);
+      return answer;
     }
+    if (this.pendingRealtimeStart !== pendingStart) return answer;
     const realtimeContext = selectRealtimeContext(this.events);
     console.info("[realtime context] selected", {
       providerStartupContext: true,
@@ -2386,6 +2439,7 @@ export class CodexAppServerHost implements EngineHost {
     pending.resolve({
       sdp: pending.sdp,
       realtimeSessionId: pending.realtimeSessionId,
+      personaBootstrap: pending.personaBootstrap,
     });
   }
 

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -18,6 +18,11 @@ import { resetVoiceViewBindings, voiceSelectedContext } from "./voiceViewBinding
 const NOW = Date.now();
 const DESK = { viewSessionId: "vs-desk-1", deviceId: "dev-desk" };
 const PHONE = { viewSessionId: "vs-phone-1", deviceId: "dev-phone" };
+const ACCEPTED_PERSONA_BOOTSTRAP = {
+  receiptId: `voice_persona_${"d".repeat(64)}`,
+  itemId: `msg_voice_persona_${"d".repeat(64)}`,
+  insertion: "accepted" as const,
+};
 
 function reference(identity: { viewSessionId: string; deviceId: string }, card = "conversation_atlas_a"): SelectedContextRef {
   return captureSelectedContext({
@@ -33,7 +38,11 @@ function reference(identity: { viewSessionId: string; deviceId: string }, card =
 function hostFor(spoken: string[]) {
   return {
     async startRealtimeWebRtc() {
-      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-1" };
+      return {
+        sdp: "v=0\r\nanswer",
+        realtimeSessionId: "live-1",
+        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+      };
     },
     async appendRealtimeSpeech(text: string) {
       spoken.push(text);

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -19,7 +19,7 @@ interface RealtimeHost {
   startRealtimeWebRtc(sdp: string): Promise<{
     sdp: string | null;
     realtimeSessionId: string | null;
-    personaBootstrap?: VoicePersonaBootstrapReceipt;
+    personaBootstrap: VoicePersonaBootstrapReceipt;
   }>;
   appendRealtimeSpeech(text: string): Promise<void>;
   deliverRealtimeWorkerResponse?(delivery: RuntimeVoiceDelivery): Promise<{
@@ -112,7 +112,10 @@ export async function executeRealtimeControl(
         return { status: 400, body: { error: "a valid WebRTC SDP offer is required" } };
       }
       const answer = await host.startRealtimeWebRtc(sdp);
-      if (answer.personaBootstrap?.insertion === "rejected") {
+      if (!answer.personaBootstrap) {
+        return { status: 409, body: { error: "Codex returned no voice persona bootstrap receipt" } };
+      }
+      if (answer.personaBootstrap.insertion === "rejected") {
         const diagnostic = redactCodexHostDiagnostic(answer.personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
         return {
           status: 409,

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -55,6 +55,18 @@ function byteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
 }
 
+function voicePersonaBootstrapReceipt(value: unknown): VoicePersonaBootstrapReceipt | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const receipt = value as Record<string, unknown>;
+  const receiptId = typeof receipt.receiptId === "string" ? receipt.receiptId : "";
+  const itemId = typeof receipt.itemId === "string" ? receipt.itemId : "";
+  if (!/^voice_persona_[a-f0-9]{64}$/.test(receiptId) || itemId !== `msg_${receiptId}`) return null;
+  if (receipt.insertion !== "accepted" && receipt.insertion !== "rejected") return null;
+  if (receipt.diagnostic !== undefined
+    && (typeof receipt.diagnostic !== "string" || receipt.diagnostic.length > 500)) return null;
+  return receipt as VoicePersonaBootstrapReceipt;
+}
+
 export async function executeRealtimeControl(
   body: unknown,
   resolveHost: (conversationId: string) => unknown = structuredDeliveryHostForConversation,
@@ -115,14 +127,18 @@ export async function executeRealtimeControl(
       if (!answer.personaBootstrap) {
         return { status: 409, body: { error: "Codex returned no voice persona bootstrap receipt" } };
       }
-      if (answer.personaBootstrap.insertion === "rejected") {
-        const diagnostic = redactCodexHostDiagnostic(answer.personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
+      const personaBootstrap = voicePersonaBootstrapReceipt(answer.personaBootstrap);
+      if (!personaBootstrap) {
+        return { status: 409, body: { error: "Codex returned an invalid voice persona bootstrap receipt" } };
+      }
+      if (personaBootstrap.insertion === "rejected") {
+        const diagnostic = redactCodexHostDiagnostic(personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
         const error = redactCodexHostDiagnostic(`Voice persona could not be recorded: ${diagnostic}`);
         return {
           status: 409,
           body: {
             error,
-            personaBootstrap: { ...answer.personaBootstrap, diagnostic },
+            personaBootstrap: { ...personaBootstrap, diagnostic },
           },
         };
       }
@@ -136,7 +152,7 @@ export async function executeRealtimeControl(
       if (answer.realtimeSessionId) {
         bindVoiceSession(conversationId, answer.realtimeSessionId, parseVoiceViewBinding(request.view));
       }
-      return { status: 200, body: { ok: true, ...answer } };
+      return { status: 200, body: { ok: true, ...answer, personaBootstrap } };
     }
     /**
      * The browser's utterance boundary (#844 §2).

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -4,6 +4,7 @@ import { redactCodexHostDiagnostic } from "./codexAppServerHost";
 import { structuredDeliveryHostForConversation } from "./structuredDeliveryController";
 import { permitRealtimeAction, type RealtimeCaller } from "./realtimeInjection";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
+import type { VoicePersonaBootstrapReceipt } from "./voicePersona";
 import {
   admitVoiceSelectedContext,
   bindVoiceSession,
@@ -15,7 +16,11 @@ const MAX_SDP_BYTES = 512 * 1024;
 const MAX_SPEECH_BYTES = 8 * 1024;
 
 interface RealtimeHost {
-  startRealtimeWebRtc(sdp: string): Promise<{ sdp: string; realtimeSessionId: string | null }>;
+  startRealtimeWebRtc(sdp: string): Promise<{
+    sdp: string | null;
+    realtimeSessionId: string | null;
+    personaBootstrap?: VoicePersonaBootstrapReceipt;
+  }>;
   appendRealtimeSpeech(text: string): Promise<void>;
   deliverRealtimeWorkerResponse?(delivery: RuntimeVoiceDelivery): Promise<{
     deliveryId: string;
@@ -107,6 +112,19 @@ export async function executeRealtimeControl(
         return { status: 400, body: { error: "a valid WebRTC SDP offer is required" } };
       }
       const answer = await host.startRealtimeWebRtc(sdp);
+      if (answer.personaBootstrap?.insertion === "rejected") {
+        const diagnostic = redactCodexHostDiagnostic(answer.personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
+        return {
+          status: 409,
+          body: {
+            error: diagnostic,
+            personaBootstrap: { ...answer.personaBootstrap, diagnostic },
+          },
+        };
+      }
+      if (!answer.sdp) {
+        return { status: 409, body: { error: "Codex returned no WebRTC answer" } };
+      }
       /* #844 §4: the call belongs to the window that opened it, from here on.
          A browser that presents no usable view/device binds to nothing, which
          refuses every later selected-card reference rather than accepting the

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -67,6 +67,24 @@ function voicePersonaBootstrapReceipt(value: unknown): VoicePersonaBootstrapRece
   return receipt as VoicePersonaBootstrapReceipt;
 }
 
+async function rejectStartedRealtimeContract(
+  host: RealtimeHost,
+  body: Record<string, unknown>,
+): Promise<RealtimeControlResult> {
+  try {
+    await host.stopRealtime();
+    return { status: 409, body };
+  } catch (error) {
+    return {
+      status: 409,
+      body: {
+        ...body,
+        error: redactCodexHostDiagnostic(`${String(body.error)}; realtime cleanup failed: ${redactCodexHostDiagnostic(error)}`),
+      },
+    };
+  }
+}
+
 export async function executeRealtimeControl(
   body: unknown,
   resolveHost: (conversationId: string) => unknown = structuredDeliveryHostForConversation,
@@ -125,25 +143,22 @@ export async function executeRealtimeControl(
       }
       const answer = await host.startRealtimeWebRtc(sdp);
       if (!answer.personaBootstrap) {
-        return { status: 409, body: { error: "Codex returned no voice persona bootstrap receipt" } };
+        return rejectStartedRealtimeContract(host, { error: "Codex returned no voice persona bootstrap receipt" });
       }
       const personaBootstrap = voicePersonaBootstrapReceipt(answer.personaBootstrap);
       if (!personaBootstrap) {
-        return { status: 409, body: { error: "Codex returned an invalid voice persona bootstrap receipt" } };
+        return rejectStartedRealtimeContract(host, { error: "Codex returned an invalid voice persona bootstrap receipt" });
       }
       if (personaBootstrap.insertion === "rejected") {
         const diagnostic = redactCodexHostDiagnostic(personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
         const error = redactCodexHostDiagnostic(`Voice persona could not be recorded: ${diagnostic}`);
-        return {
-          status: 409,
-          body: {
-            error,
-            personaBootstrap: { ...personaBootstrap, diagnostic },
-          },
-        };
+        return rejectStartedRealtimeContract(host, {
+          error,
+          personaBootstrap: { ...personaBootstrap, diagnostic },
+        });
       }
       if (!answer.sdp) {
-        return { status: 409, body: { error: "Codex returned no WebRTC answer" } };
+        return rejectStartedRealtimeContract(host, { error: "Codex returned no WebRTC answer" });
       }
       /* #844 §4: the call belongs to the window that opened it, from here on.
          A browser that presents no usable view/device binds to nothing, which

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -117,10 +117,11 @@ export async function executeRealtimeControl(
       }
       if (answer.personaBootstrap.insertion === "rejected") {
         const diagnostic = redactCodexHostDiagnostic(answer.personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
+        const error = redactCodexHostDiagnostic(`Voice persona could not be recorded: ${diagnostic}`);
         return {
           status: 409,
           body: {
-            error: diagnostic,
+            error,
             personaBootstrap: { ...answer.personaBootstrap, diagnostic },
           },
         };

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -66,10 +66,10 @@ test("an empty or whitespace override falls back instead of muting the persona",
   expect(voicePersona(() => "   \n  ")).toBe(DEFAULT_VOICE_PERSONA);
 });
 
-test("one call identity produces one stable canonical developer item", () => {
-  const identity = voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nstable-offer\r\n");
-  expect(voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nstable-offer\r\n")).toEqual(identity);
-  expect(voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nnew-offer\r\n")).not.toEqual(identity);
+test("one durable thread identity produces one stable canonical developer item", () => {
+  const identity = voicePersonaBootstrapIdentity("thread-voice");
+  expect(voicePersonaBootstrapIdentity("thread-voice")).toEqual(identity);
+  expect(voicePersonaBootstrapIdentity("thread-other")).not.toEqual(identity);
   expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
     receipt: { ...identity, insertion: "accepted" },
     item: {

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -71,7 +71,6 @@ test("one durable thread identity produces one stable canonical developer item",
   expect(voicePersonaBootstrapIdentity("thread-voice")).toEqual(identity);
   expect(voicePersonaBootstrapIdentity("thread-other")).not.toEqual(identity);
   expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
-    receipt: { ...identity, insertion: "accepted" },
     item: {
       type: "message",
       id: identity.itemId,

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -55,8 +55,8 @@ test("the built-in persona stands when no override file exists", () => {
 });
 
 test("an operator override replaces the built-in persona wholesale", () => {
-  /* Editing wording between two calls and hearing the difference on the second
-     is the entire point of the override, so it is read per call. */
+  /* A new thread resolves the current override wholesale; an established
+     thread keeps the developer item it already persisted. */
   const persona = voicePersona(() => "  You are the coordinator. Keep it short.  ");
   expect(persona).toBe("You are the coordinator. Keep it short.");
   expect(persona).not.toBe(DEFAULT_VOICE_PERSONA);
@@ -80,22 +80,47 @@ test("one durable thread identity produces one stable canonical developer item",
   });
 });
 
-test("canonical receipt scanning survives a stream chunk boundary and refuses a symlink", async () => {
+test("canonical receipt scanning recognizes reordered fields across a stream chunk boundary and refuses a symlink", async () => {
   const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-scan-"));
   const transcript = path.join(isolated, "thread.jsonl");
   const linked = path.join(isolated, "linked.jsonl");
   const itemId = `msg_voice_persona_${"b".repeat(64)}`;
   const record = JSON.stringify({
+    padding: "x".repeat(65_400),
+    payload: { role: "developer", content: [], id: itemId, type: "message" },
     type: "response_item",
-    payload: { type: "message", id: itemId, role: "developer", content: [] },
   });
-  fs.writeFileSync(transcript, `${"x".repeat(65_500)}${record}\n`);
+  fs.writeFileSync(transcript, `${record}\n`);
   fs.symlinkSync(transcript, linked);
   try {
     expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeTrue();
     await expect(canonicalVoicePersonaBootstrapExists(linked, itemId)).rejects.toThrow();
     await expect(canonicalVoicePersonaBootstrapExists(null, itemId))
       .rejects.toThrow("canonical transcript path is unavailable");
+  } finally {
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("canonical receipt scanning ignores malformed rows and marker-like content", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-structural-scan-"));
+  const transcript = path.join(isolated, "thread.jsonl");
+  const itemId = `msg_voice_persona_${"c".repeat(64)}`;
+  const markerLikeText = `"type":"message","id":"${itemId}","role":"developer"`;
+  fs.writeFileSync(transcript, [
+    `{malformed:${markerLikeText}}`,
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "message",
+        id: "ordinary-system-row",
+        role: "developer",
+        content: [{ type: "input_text", text: markerLikeText }],
+      },
+    }),
+  ].join("\n") + "\n");
+  try {
+    expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeFalse();
   } finally {
     fs.rmSync(isolated, { recursive: true, force: true });
   }

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -1,6 +1,17 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { expect, test } from "bun:test";
 
-import { DEFAULT_VOICE_PERSONA, PERSONA_NAME, voicePersona } from "./voicePersona";
+import {
+  canonicalVoicePersonaBootstrapExists,
+  DEFAULT_VOICE_PERSONA,
+  PERSONA_NAME,
+  voicePersona,
+  voicePersonaBootstrap,
+  voicePersonaBootstrapIdentity,
+} from "./voicePersona";
 
 /* Language names the prompt must never speak of, in the forms a hard pin would
    plausibly arrive in: the English name, and the Latin-script autonym for the
@@ -53,6 +64,40 @@ test("an operator override replaces the built-in persona wholesale", () => {
 
 test("an empty or whitespace override falls back instead of muting the persona", () => {
   expect(voicePersona(() => "   \n  ")).toBe(DEFAULT_VOICE_PERSONA);
+});
+
+test("one call identity produces one stable canonical developer item", () => {
+  const identity = voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nstable-offer\r\n");
+  expect(voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nstable-offer\r\n")).toEqual(identity);
+  expect(voicePersonaBootstrapIdentity("thread-voice", "v=0\r\nnew-offer\r\n")).not.toEqual(identity);
+  expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
+    receipt: { ...identity, insertion: "accepted" },
+    item: {
+      type: "message",
+      id: identity.itemId,
+      role: "developer",
+      content: [{ type: "input_text", text: "Resolved call persona." }],
+    },
+  });
+});
+
+test("canonical receipt scanning survives a stream chunk boundary and refuses a symlink", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-scan-"));
+  const transcript = path.join(isolated, "thread.jsonl");
+  const linked = path.join(isolated, "linked.jsonl");
+  const itemId = `msg_voice_persona_${"b".repeat(64)}`;
+  const record = JSON.stringify({
+    type: "response_item",
+    payload: { type: "message", id: itemId, role: "developer", content: [] },
+  });
+  fs.writeFileSync(transcript, `${"x".repeat(65_500)}${record}\n`);
+  fs.symlinkSync(transcript, linked);
+  try {
+    expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeTrue();
+    await expect(canonicalVoicePersonaBootstrapExists(linked, itemId)).rejects.toThrow();
+  } finally {
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
 });
 
 test("the shipped persona pins no spoken language anywhere", () => {

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -94,6 +94,8 @@ test("canonical receipt scanning survives a stream chunk boundary and refuses a 
   try {
     expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeTrue();
     await expect(canonicalVoicePersonaBootstrapExists(linked, itemId)).rejects.toThrow();
+    await expect(canonicalVoicePersonaBootstrapExists(null, itemId))
+      .rejects.toThrow("canonical transcript path is unavailable");
   } finally {
     fs.rmSync(isolated, { recursive: true, force: true });
   }

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -110,7 +110,7 @@ Do not ask permission for what you can check yourself.
 
 Stay silent until you are spoken to: this text is context, and there is nothing here to greet.`;
 
-/** Operator override, read at call time so wording changes need no deploy. */
+/** Operator override, resolved once per thread; edits apply when a new thread starts. */
 export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
 
 export type VoicePersonaBootstrapReceipt = {
@@ -121,7 +121,6 @@ export type VoicePersonaBootstrapReceipt = {
 };
 
 export type VoicePersonaBootstrap = {
-  receipt: VoicePersonaBootstrapReceipt;
   item: {
     type: "message";
     id: string;
@@ -134,9 +133,9 @@ export type VoicePersonaBootstrapIdentity = Pick<VoicePersonaBootstrapReceipt, "
 
 /**
  * The persona text for a starting call: the operator's override when the file
- * exists and holds anything, otherwise {@link DEFAULT_VOICE_PERSONA}. Read per
- * call rather than cached — the point of the override is editing it between
- * two calls and hearing the difference on the second.
+ * exists and holds anything, otherwise {@link DEFAULT_VOICE_PERSONA}. The host
+ * invokes this resolver only while the thread has no canonical persona item,
+ * so that thread keeps its resolved wording and a new thread picks up edits.
  */
 export function voicePersona(readFile: (path: string) => string = (target) => fs.readFileSync(target, "utf8")): string {
   try {
@@ -168,7 +167,6 @@ export function voicePersonaBootstrap(
 ): VoicePersonaBootstrap {
   const text = voicePersona(readFile);
   return {
-    receipt: { ...identity, insertion: "accepted" },
     item: {
       type: "message",
       id: identity.itemId,
@@ -188,7 +186,10 @@ export async function canonicalVoicePersonaBootstrapExists(
   itemId: string,
 ): Promise<boolean> {
   if (!transcriptPath) return false;
-  const marker = `\"type\":\"message\",\"id\":\"${itemId}\",\"role\":\"developer\"`;
+  /* Codex app-server 0.146.0 serializes injected response items in this field
+     order. A serializer reorder makes this scan return false and can cause a
+     reinsertion, so upgrades must keep the live protocol probe current. */
+  const marker = `"type":"message","id":"${itemId}","role":"developer"`;
   let handle: fs.promises.FileHandle;
   try {
     handle = await fs.promises.open(

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -185,7 +185,11 @@ export async function canonicalVoicePersonaBootstrapExists(
   transcriptPath: string | null,
   itemId: string,
 ): Promise<boolean> {
-  if (!transcriptPath) return false;
+  if (!transcriptPath) {
+    const error = new Error("canonical transcript path is unavailable") as NodeJS.ErrnoException;
+    error.code = "NO_TRANSCRIPT_PATH";
+    throw error;
+  }
   /* Codex app-server 0.146.0 serializes injected response items in this field
      order. A serializer reorder makes this scan return false and can cause a
      reinsertion, so upgrades must keep the live protocol probe current. */

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 
 import { configFilePath } from "@/lib/configDir";
 
@@ -112,6 +113,25 @@ Stay silent until you are spoken to: this text is context, and there is nothing 
 /** Operator override, read at call time so wording changes need no deploy. */
 export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
 
+export type VoicePersonaBootstrapReceipt = {
+  receiptId: string;
+  itemId: string;
+  insertion: "accepted" | "rejected";
+  diagnostic?: string;
+};
+
+export type VoicePersonaBootstrap = {
+  receipt: VoicePersonaBootstrapReceipt;
+  item: {
+    type: "message";
+    id: string;
+    role: "developer";
+    content: [{ type: "input_text"; text: string }];
+  };
+};
+
+export type VoicePersonaBootstrapIdentity = Pick<VoicePersonaBootstrapReceipt, "receiptId" | "itemId">;
+
 /**
  * The persona text for a starting call: the operator's override when the file
  * exists and holds anything, otherwise {@link DEFAULT_VOICE_PERSONA}. Read per
@@ -126,4 +146,85 @@ export function voicePersona(readFile: (path: string) => string = (target) => fs
     /* no override on disk — the built-in persona stands */
   }
   return DEFAULT_VOICE_PERSONA;
+}
+
+/** Stable canonical identity for one thread-scoped WebRTC call attempt. */
+export function voicePersonaBootstrapIdentity(
+  threadId: string,
+  callIdentity: string,
+): VoicePersonaBootstrapIdentity {
+  const digest = createHash("sha256")
+    .update(threadId, "utf8")
+    .update("\0", "utf8")
+    .update(callIdentity, "utf8")
+    .digest("hex");
+  const receiptId = `voice_persona_${digest}`;
+  const itemId = `msg_${receiptId}`;
+  return { receiptId, itemId };
+}
+
+/** Canonical developer item resolved once after its identity is known absent. */
+export function voicePersonaBootstrap(
+  identity: VoicePersonaBootstrapIdentity,
+  readFile?: (path: string) => string,
+): VoicePersonaBootstrap {
+  const text = voicePersona(readFile);
+  return {
+    receipt: { ...identity, insertion: "accepted" },
+    item: {
+      type: "message",
+      id: identity.itemId,
+      role: "developer",
+      content: [{ type: "input_text", text }],
+    },
+  };
+}
+
+/**
+ * Check the app-server-owned canonical JSONL without loading a possibly large
+ * transcript into memory. A successful inject flushes this item before its RPC
+ * response, so finding the stable id is the durable idempotency receipt.
+ */
+export async function canonicalVoicePersonaBootstrapExists(
+  transcriptPath: string | null,
+  itemId: string,
+): Promise<boolean> {
+  if (!transcriptPath) return false;
+  const marker = `\"type\":\"message\",\"id\":\"${itemId}\",\"role\":\"developer\"`;
+  let handle: fs.promises.FileHandle;
+  try {
+    handle = await fs.promises.open(
+      transcriptPath,
+      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw error;
+  }
+  return new Promise<boolean>((resolve, reject) => {
+    const stream = handle.createReadStream({
+      encoding: "utf8",
+      autoClose: true,
+    });
+    let settled = false;
+    let carry = "";
+    const finish = (found: boolean) => {
+      if (settled) return;
+      settled = true;
+      stream.destroy();
+      resolve(found);
+    };
+    stream.on("data", (chunk) => {
+      const scanned = carry + String(chunk);
+      if (scanned.includes(marker)) return finish(true);
+      carry = scanned.slice(-(marker.length - 1));
+    });
+    stream.on("end", () => finish(false));
+    stream.on("error", (error: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+  });
 }

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -131,6 +131,30 @@ export type VoicePersonaBootstrap = {
 
 export type VoicePersonaBootstrapIdentity = Pick<VoicePersonaBootstrapReceipt, "receiptId" | "itemId">;
 
+/* Larger than the host's maximum admissible app-server frame, while keeping a
+   transcript with an oversized unrelated row from growing scanner memory. */
+const MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES = 32 * 1024 * 1024;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function isCanonicalVoicePersonaRecord(line: Buffer, itemId: string): boolean {
+  let row: Record<string, unknown> | null = null;
+  try {
+    row = record(JSON.parse(line.toString("utf8")));
+  } catch {
+    return false;
+  }
+  const payload = record(row?.payload);
+  return row?.type === "response_item"
+    && payload?.type === "message"
+    && payload.id === itemId
+    && payload.role === "developer";
+}
+
 /**
  * The persona text for a starting call: the operator's override when the file
  * exists and holds anything, otherwise {@link DEFAULT_VOICE_PERSONA}. The host
@@ -190,10 +214,6 @@ export async function canonicalVoicePersonaBootstrapExists(
     error.code = "NO_TRANSCRIPT_PATH";
     throw error;
   }
-  /* Codex app-server 0.146.0 serializes injected response items in this field
-     order. A serializer reorder makes this scan return false and can cause a
-     reinsertion, so upgrades must keep the live protocol probe current. */
-  const marker = `"type":"message","id":"${itemId}","role":"developer"`;
   let handle: fs.promises.FileHandle;
   try {
     handle = await fs.promises.open(
@@ -206,24 +226,62 @@ export async function canonicalVoicePersonaBootstrapExists(
     throw error;
   }
   return new Promise<boolean>((resolve, reject) => {
-    const stream = handle.createReadStream({
-      encoding: "utf8",
-      autoClose: true,
-    });
+    const stream = handle.createReadStream({ autoClose: true });
     let settled = false;
-    let carry = "";
+    let pending: Buffer[] = [];
+    let pendingBytes = 0;
+    let skippingRecord = false;
     const finish = (found: boolean) => {
       if (settled) return;
       settled = true;
       stream.destroy();
       resolve(found);
     };
+    const resetLine = () => {
+      pending = [];
+      pendingBytes = 0;
+      skippingRecord = false;
+    };
     stream.on("data", (chunk) => {
-      const scanned = carry + String(chunk);
-      if (scanned.includes(marker)) return finish(true);
-      carry = scanned.slice(-(marker.length - 1));
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      let cursor = 0;
+      while (cursor <= bytes.length) {
+        const newline = bytes.indexOf(0x0a, cursor);
+        if (newline === -1) {
+          const rest = bytes.length - cursor;
+          if (!skippingRecord && rest > 0) {
+            if (pendingBytes + rest > MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES) {
+              pending = [];
+              pendingBytes = 0;
+              skippingRecord = true;
+            } else {
+              pending.push(Buffer.from(bytes.subarray(cursor)));
+              pendingBytes += rest;
+            }
+          }
+          return;
+        }
+        if (!skippingRecord) {
+          const segment = bytes.subarray(cursor, newline);
+          if (pendingBytes + segment.length <= MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES) {
+            const line = pendingBytes
+              ? Buffer.concat([...pending, segment], pendingBytes + segment.length)
+              : segment;
+            if (isCanonicalVoicePersonaRecord(line, itemId)) return finish(true);
+          }
+        }
+        resetLine();
+        cursor = newline + 1;
+      }
     });
-    stream.on("end", () => finish(false));
+    stream.on("end", () => {
+      if (!skippingRecord && pendingBytes > 0
+        && isCanonicalVoicePersonaRecord(Buffer.concat(pending, pendingBytes), itemId)) {
+        finish(true);
+        return;
+      }
+      finish(false);
+    });
     stream.on("error", (error: NodeJS.ErrnoException) => {
       if (settled) return;
       settled = true;

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -148,15 +148,13 @@ export function voicePersona(readFile: (path: string) => string = (target) => fs
   return DEFAULT_VOICE_PERSONA;
 }
 
-/** Stable canonical identity for one thread-scoped WebRTC call attempt. */
+/** Stable canonical identity shared by every WebRTC attempt on one thread. */
 export function voicePersonaBootstrapIdentity(
   threadId: string,
-  callIdentity: string,
 ): VoicePersonaBootstrapIdentity {
   const digest = createHash("sha256")
+    .update("voice-persona-bootstrap\0", "utf8")
     .update(threadId, "utf8")
-    .update("\0", "utf8")
-    .update(callIdentity, "utf8")
     .digest("hex");
   const receiptId = `voice_persona_${digest}`;
   const itemId = `msg_${receiptId}`;


### PR DESCRIPTION
## Summary

- Resolve one voice personality payload per durable thread identity and inject its canonical developer message before realtime startup.
- Return a stable accepted or rejected bootstrap receipt, then recover distinct-offer retries and host restart from the canonical transcript.
- Preserve startup context and durable-tail ordering while surfacing bounded insertion failures as HTTP 409.
- Reject unverifiable canonical scan faults before insertion so replacement hosts cannot duplicate the item.
- Fence late insertion failures to their originating start so a successor call remains independent.
- Share one in-flight insertion across cancelled and successor starts, then memoize the accepted item for the host lifetime.
- Recover ambiguous insertion failures from the canonical rollout and add voice-persona context to operator-facing refusals.
- Fence uncertain `thread/inject_items` timeouts as writer failures, then recover the accepted receipt from durable persistence on a replacement host.
- Scan canonical JSONL records structurally with bounded memory, independent of serializer field order and stream chunking.
- Recover rollout paths omitted from startup through `thread/read`, fail closed when no canonical path exists, and validate complete receipts at the route boundary.
- Begin the fenced realtime-start deadline after persona persistence and poison the writer when session notifications miss that deadline.
- Stop any backend session before returning a post-start receipt or SDP contract failure.
- Prove discovery through `/api/files`, retrieval through `/api/log`, and rendered output through the existing developer/system card.

## Verification

- Focused runtime, route, transcript, and render tests: 41 passed.
- Focused realtime host tests: 19 passed, 88 filtered.
- Realtime route injection and browser transport tests: 17 passed.
- `bun x tsc --noEmit`
- Scoped ESLint on all nine changed files.
- `bun run build` including the MCP bundle.
- `bun run privacy:check`

## Scope

- Production UI source remains unchanged; the rendered regression exercises the existing `SysMsgCard` path.
- Shared runtime state, staging, services, and deployments were untouched.

Closes #857
