### PR TITLE
perf(liveness): bound project-scoped agent_activity to one completed generation

### DIFF
--- a/src/lib/lifecycle/inventorySelection.test.ts
+++ b/src/lib/lifecycle/inventorySelection.test.ts
@@ -1,0 +1,277 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import type { FileEntry } from "@/lib/types";
+
+import {
+  completedGenerationSelection,
+  hydrateWithBudget,
+  selectConversationEntries,
+  type CompletedGenerationRead,
+} from "./inventorySelection";
+
+/**
+ * #860 — the selection seam that bounds project-scoped catalog reads.
+ *
+ * Every assertion here is about work NOT done: rows filtered before hydration,
+ * one completed generation instead of a private fresh sweep, and a hydration
+ * pass that stops at its concurrency, byte and time bounds instead of walking
+ * whatever the corpus happens to hold.
+ */
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects" as FileEntry["root"],
+    name: path.basename(overrides.path),
+    project: "viewer",
+    title: "agent",
+    engine: "codex",
+    kind: "session",
+    fmt: "claude" as FileEntry["fmt"],
+    parent: null,
+    mtime: 1_700_000_000,
+    size: 4096,
+    activity: "idle",
+    activityReason: "mtime_old",
+    proc: null,
+    pid: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+/** 10,000 historical rows, 1,000 of them in the requested project, six live. */
+function productionShapedCorpus(): FileEntry[] {
+  const files: FileEntry[] = [];
+  for (let index = 0; index < 10_000; index += 1) {
+    const inProject = index % 10 === 0;
+    files.push(entry({
+      path: `/corpus/${inProject ? "viewer" : `other-${index % 37}`}/session-${index}.jsonl`,
+      project: inProject ? "viewer" : `other-${index % 37}`,
+      mtime: 1_700_000_000 - index,
+      activity: inProject && index < 60 && index % 10 === 0 ? "live" : "idle",
+      engine: index % 3 === 0 ? "claude" : "codex",
+    }));
+  }
+  return files;
+}
+
+test("selection filters project, engine and liveness and applies the row limit before any hydration", () => {
+  const files = productionShapedCorpus();
+
+  const selection = selectConversationEntries(files, { project: "viewer", liveOnly: true, limit: 10 });
+
+  expect(selection.scanned).toBe(10_000);
+  /* Six live rows exist; the limit never had to truncate them, and the 994
+     other project rows were dropped before anything opened a transcript. */
+  expect(selection.matched).toBe(6);
+  expect(selection.entries).toHaveLength(6);
+  expect(selection.entries.every((row) => row.project === "viewer")).toBe(true);
+  expect(selection.entries.every((row) => row.activity === "live")).toBe(true);
+});
+
+test("the row limit truncates the project selection before hydration, newest first", () => {
+  const files = productionShapedCorpus();
+
+  const selection = selectConversationEntries(files, { project: "viewer", limit: 10 });
+
+  expect(selection.matched).toBe(1_000);
+  expect(selection.entries).toHaveLength(10);
+  expect(selection.entries[0]!.path).toBe("/corpus/viewer/session-0.jsonl");
+  expect(selection.entries.at(-1)!.path).toBe("/corpus/viewer/session-90.jsonl");
+});
+
+test("shell rows never enter a conversation selection", () => {
+  const selection = selectConversationEntries(
+    [entry({ path: "/corpus/viewer/shell.log", engine: "shell" }), entry({ path: "/corpus/viewer/a.jsonl" })],
+    { limit: 10 },
+  );
+
+  expect(selection.entries.map((row) => row.path)).toEqual(["/corpus/viewer/a.jsonl"]);
+});
+
+test("a runtime-hosted path passes the liveness filter the completed generation still projects as idle", () => {
+  /* The completed generation predates this launch: its projection says idle
+     while the registry holds a live host for it. Dropping the row here is what
+     forced the fresh whole-corpus sweep this seam replaces. */
+  const files = [
+    entry({ path: "/corpus/viewer/just-launched.jsonl", activity: "idle" }),
+    entry({ path: "/corpus/viewer/old.jsonl", activity: "idle" }),
+  ];
+
+  const selection = selectConversationEntries(files, {
+    liveOnly: true,
+    limit: 10,
+    hostedPaths: new Set(["/corpus/viewer/just-launched.jsonl"]),
+  });
+
+  expect(selection.entries.map((row) => row.path)).toEqual(["/corpus/viewer/just-launched.jsonl"]);
+});
+
+test("the query filter matches title, project and path", () => {
+  const files = [
+    entry({ path: "/corpus/viewer/a.jsonl", title: "Bound the latency" }),
+    entry({ path: "/corpus/viewer/b.jsonl", title: "something else" }),
+  ];
+
+  expect(selectConversationEntries(files, { query: "LATENCY", limit: 10 }).entries.map((row) => row.path))
+    .toEqual(["/corpus/viewer/a.jsonl"]);
+});
+
+test("the completed-generation read consumes the published generation and never asks for a fresh scan", async () => {
+  const reads: Array<{ revalidate?: boolean; signal?: AbortSignal | null }> = [];
+  const read: CompletedGenerationRead = async (options) => {
+    reads.push(options ?? {});
+    return {
+      snapshot: { files: productionShapedCorpus(), projectCatalog: [], complete: true },
+      generation: 7,
+      targetGeneration: 7,
+      cacheStatus: "hit",
+      requestCount: 1,
+      cloneDurationMs: 0,
+    };
+  };
+
+  const selection = await completedGenerationSelection({ project: "viewer", liveOnly: true, limit: 10 }, { completedFileScan: read });
+
+  expect(selection.generation).toBe(7);
+  expect(selection.cacheStatus).toBe("hit");
+  expect(selection.freshScan).toBe(false);
+  expect(selection.entries).toHaveLength(6);
+  expect(reads).toHaveLength(1);
+  expect(selection.selectionMs).toBeGreaterThanOrEqual(0);
+});
+
+test("an already-cancelled caller never reaches the generation", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let reads = 0;
+  const read: CompletedGenerationRead = async () => {
+    reads += 1;
+    throw new Error("unreachable");
+  };
+
+  await expect(completedGenerationSelection({ limit: 10 }, { completedFileScan: read, signal: controller.signal }))
+    .rejects.toMatchObject({ name: "AbortError" });
+  expect(reads).toBe(0);
+});
+
+test("hydration never runs more than its concurrency and reports the bytes it charged", async () => {
+  const items = Array.from({ length: 20 }, (_, index) => ({ index, size: 1_000 }));
+  let inFlight = 0;
+  let peak = 0;
+
+  const outcome = await hydrateWithBudget(
+    items,
+    (item) => item.size,
+    async (item) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return item.index;
+    },
+    { concurrency: 4, maxBytes: 1_000_000, deadlineAt: null },
+  );
+
+  expect(peak).toBeLessThanOrEqual(4);
+  expect(outcome.hydrated).toBe(20);
+  expect(outcome.skipped).toBe(0);
+  expect(outcome.bytes).toBe(20_000);
+  expect(outcome.stopped).toBe("complete");
+  expect([...outcome.results.keys()]).toHaveLength(20);
+});
+
+test("hydration stops at the byte budget and reports the rows it refused", async () => {
+  const items = Array.from({ length: 20 }, (_, index) => ({ index, size: 100 }));
+  const started: number[] = [];
+
+  const outcome = await hydrateWithBudget(
+    items,
+    (item) => item.size,
+    async (item) => {
+      started.push(item.index);
+      return item.index;
+    },
+    { concurrency: 1, maxBytes: 500, deadlineAt: null },
+  );
+
+  expect(started).toHaveLength(5);
+  expect(outcome.hydrated).toBe(5);
+  expect(outcome.skipped).toBe(15);
+  expect(outcome.bytes).toBe(500);
+  expect(outcome.stopped).toBe("byte_budget");
+});
+
+test("hydration stops at its deadline and leaves the remaining rows unread", async () => {
+  const items = Array.from({ length: 10 }, (_, index) => ({ index, size: 1 }));
+  const started: number[] = [];
+  let clock = 1_000;
+
+  const outcome = await hydrateWithBudget(
+    items,
+    () => 1,
+    async (item) => {
+      started.push(item.index);
+      clock += 10;
+      return item.index;
+    },
+    { concurrency: 1, maxBytes: 1_000, deadlineAt: 1_030, now: () => clock },
+  );
+
+  expect(started).toEqual([0, 1, 2]);
+  expect(outcome.hydrated).toBe(3);
+  expect(outcome.skipped).toBe(7);
+  expect(outcome.stopped).toBe("deadline");
+});
+
+test("a cancelled caller stops the hydration pass and starts no further reads", async () => {
+  const controller = new AbortController();
+  const items = Array.from({ length: 20 }, (_, index) => ({ index, size: 1 }));
+  const started: number[] = [];
+
+  const pending = hydrateWithBudget(
+    items,
+    () => 1,
+    async (item) => {
+      started.push(item.index);
+      if (item.index === 2) controller.abort();
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return item.index;
+    },
+    { concurrency: 1, maxBytes: 1_000, deadlineAt: null, signal: controller.signal },
+  );
+
+  await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  const settled = started.length;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(started.length).toBe(settled);
+  expect(settled).toBeLessThanOrEqual(3);
+});
+
+test("a cancelled pass with several workers in flight leaves no unhandled rejection behind", async () => {
+  const controller = new AbortController();
+  const items = Array.from({ length: 40 }, (_, index) => ({ index, size: 1 }));
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const pending = hydrateWithBudget(
+      items,
+      () => 1,
+      async (item) => {
+        if (item.index === 3) controller.abort();
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        return item.index;
+      },
+      { concurrency: 4, maxBytes: 1_000, deadlineAt: null, signal: controller.signal },
+    );
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    /* Three siblings were mid-read when the fourth aborted; each rejects after
+       the pass already failed. */
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(unhandled).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});

--- a/src/lib/lifecycle/inventorySelection.ts
+++ b/src/lib/lifecycle/inventorySelection.ts
@@ -54,9 +54,13 @@ export interface ConversationSelectionRequest {
    *
    * A completed generation can predate a launch by up to its refresh cadence, so
    * liveness filtered on the scan projection alone would drop a conversation
-   * that started a minute ago. Carrying the runtime's own answer here is what
-   * makes serving `liveOnly` from a completed generation correct instead of
-   * merely fast.
+   * whose row the scan still projects as idle. Carrying the runtime's own answer
+   * here is what makes serving `liveOnly` from a completed generation correct
+   * instead of merely fast.
+   *
+   * This rescues only rows the generation HAS. A launch newer than the
+   * generation has no row at all; `hostedSeen` in the result tells the caller
+   * which hosted paths were missing so it can recover them by identity.
    */
   hostedPaths?: ReadonlySet<string>;
 }
@@ -68,6 +72,16 @@ export interface ConversationSelection {
   matched: number;
   /** Conversation rows in the generation. */
   scanned: number;
+  /**
+   * Which `hostedPaths` the generation actually contains, whatever the filters
+   * did with them.
+   *
+   * Widening the liveness filter can only rescue a row the generation already
+   * has. A launch NEWER than the generation has no row to widen onto, and the
+   * caller has to recover it by identity. This set is how the caller knows
+   * which ones those are without a second pass over the corpus.
+   */
+  hostedSeen: ReadonlySet<string>;
   generation: number;
   cacheStatus: CachedFileScan["cacheStatus"];
   /** Always false: a selection consumes a completed generation, never a sweep. */
@@ -98,15 +112,19 @@ function isConversationRow(entry: FileEntry): boolean {
 export function selectConversationEntries(
   files: readonly FileEntry[],
   request: ConversationSelectionRequest,
-): Pick<ConversationSelection, "entries" | "matched" | "scanned"> {
+): Pick<ConversationSelection, "entries" | "matched" | "scanned" | "hostedSeen"> {
   const limit = Math.max(0, Math.floor(request.limit));
   const query = request.query ? request.query.toLocaleLowerCase() : "";
   const entries: FileEntry[] = [];
+  const hostedSeen = new Set<string>();
   let matched = 0;
   let scanned = 0;
   for (const entry of files) {
     if (!isConversationRow(entry)) continue;
     scanned += 1;
+    /* Recorded before the filters: a hosted row this generation holds under a
+       different project is still a row the caller need not recover. */
+    if (request.hostedPaths?.has(entry.path)) hostedSeen.add(entry.path);
     if (request.project && entry.project !== request.project) continue;
     if (request.liveOnly
       && entry.activity !== "live"
@@ -116,7 +134,7 @@ export function selectConversationEntries(
     matched += 1;
     if (entries.length < limit) entries.push(entry);
   }
-  return { entries, matched, scanned };
+  return { entries, matched, scanned, hostedSeen };
 }
 
 export type CompletedGenerationRead = (
@@ -219,7 +237,11 @@ export async function hydrateWithBudget<T, R>(
      handler — an unhandled rejection per cancelled call. Every worker is
      collected, then the first failure is rethrown. */
   const settled = await Promise.allSettled(Array.from(
-    { length: Math.max(1, Math.min(Math.floor(budget.concurrency), items.length || 1)) },
+    /* Never zero workers: `Array.from({ length: NaN })` is empty, which would
+       skip every row while still reporting the pass as complete. */
+    { length: Number.isFinite(budget.concurrency)
+      ? Math.max(1, Math.min(Math.floor(budget.concurrency), items.length || 1))
+      : 1 },
     () => worker(),
   ));
   const failure = settled.find((result) => result.status === "rejected");

--- a/src/lib/lifecycle/inventorySelection.ts
+++ b/src/lib/lifecycle/inventorySelection.ts
@@ -86,8 +86,14 @@ function isConversationRow(entry: FileEntry): boolean {
 
 /**
  * Project/liveness/query filters and the row limit, applied to a completed
- * generation's rows. Pure and allocation-light: it never copies the corpus, it
- * walks it once and stops collecting at `limit` while it keeps counting matches.
+ * generation's rows. Pure: one walk, collecting at most `limit` rows while it
+ * keeps counting matches.
+ *
+ * This function copies nothing, but the read that feeds it does:
+ * `completedFileScan` hands every caller a `structuredClone` of the snapshot,
+ * so twenty concurrent readers deep-copy the corpus twenty times. That clone
+ * dominates the warm cost of a project read and is the next lever if the bar
+ * tightens; it is not something selection can avoid from here.
  */
 export function selectConversationEntries(
   files: readonly FileEntry[],

--- a/src/lib/lifecycle/inventorySelection.ts
+++ b/src/lib/lifecycle/inventorySelection.ts
@@ -1,0 +1,223 @@
+import { completedFileScan, type CachedFileScan } from "@/lib/scanner/scanCache";
+import type { FileEntry } from "@/lib/types";
+
+/**
+ * #860 — bounded selection for project-scoped catalog reads.
+ *
+ * The stall this exists to remove: `agent_activity(project, liveOnly, limit:10)`
+ * ran `listFiles({ fresh: true, persist: false })` first — root discovery, a
+ * process-table refresh, a tmux pane map and a tail read for every transcript in
+ * the corpus — and only then applied `project`, `liveOnly` and `limit`. Ten rows
+ * of answer cost one whole-corpus sweep, and a caller that gave up left the
+ * sweep running.
+ *
+ * Two primitives replace it, both usable by any catalog surface (`agent_activity`
+ * today, `list_conversations` next):
+ *
+ * 1. `selectConversationEntries` — pure. Filters and limits rows from ONE already
+ *    completed scanner generation, so the cost of selection is a pass over
+ *    metadata the process already holds.
+ * 2. `hydrateWithBudget` — everything after selection (a transcript tail per
+ *    selected row) runs at bounded concurrency under byte and time budgets and
+ *    stops the moment its caller cancels.
+ *
+ * Neither ever starts a scan of its own. `completedGenerationSelection` reads the
+ * published generation through `completedFileScan`, which joins the process-wide
+ * single-generation lease rather than opening a private one.
+ *
+ * `list_conversations` reads the completed generation already but still filters
+ * and slices the whole cloned corpus inline in `mcp/bindings.ts`. Its adoption is
+ * one call — the filters below are the same set it applies:
+ *
+ * ```ts
+ * const selection = await completedGenerationSelection(
+ *   { project, query, limit },
+ *   { completedFileScan, signal: deadline.signal },
+ * );
+ * ```
+ *
+ * That file belongs to another lane at the time of writing (#859), so the
+ * adoption lands with it; nothing here needs to change for it.
+ */
+
+export type ConversationEngine = "claude" | "codex";
+
+export interface ConversationSelectionRequest {
+  project?: string;
+  /** Restrict to rows the scan projects as live/stalled or the runtime hosts. */
+  liveOnly?: boolean;
+  /** Case-insensitive substring over title, project and path. */
+  query?: string;
+  limit: number;
+  /**
+   * Transcript paths the injected registry/runtime projection currently hosts.
+   *
+   * A completed generation can predate a launch by up to its refresh cadence, so
+   * liveness filtered on the scan projection alone would drop a conversation
+   * that started a minute ago. Carrying the runtime's own answer here is what
+   * makes serving `liveOnly` from a completed generation correct instead of
+   * merely fast.
+   */
+  hostedPaths?: ReadonlySet<string>;
+}
+
+export interface ConversationSelection {
+  /** At most `limit` rows, in the generation's own newest-first order. */
+  entries: FileEntry[];
+  /** Rows matching every filter, before the limit truncated them. */
+  matched: number;
+  /** Conversation rows in the generation. */
+  scanned: number;
+  generation: number;
+  cacheStatus: CachedFileScan["cacheStatus"];
+  /** Always false: a selection consumes a completed generation, never a sweep. */
+  freshScan: boolean;
+  selectionMs: number;
+}
+
+function abortError(reason?: unknown): Error {
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
+  return new DOMException("catalog selection cancelled", "AbortError");
+}
+
+function isConversationRow(entry: FileEntry): boolean {
+  return entry.engine === "claude" || entry.engine === "codex";
+}
+
+/**
+ * Project/liveness/query filters and the row limit, applied to a completed
+ * generation's rows. Pure and allocation-light: it never copies the corpus, it
+ * walks it once and stops collecting at `limit` while it keeps counting matches.
+ */
+export function selectConversationEntries(
+  files: readonly FileEntry[],
+  request: ConversationSelectionRequest,
+): Pick<ConversationSelection, "entries" | "matched" | "scanned"> {
+  const limit = Math.max(0, Math.floor(request.limit));
+  const query = request.query ? request.query.toLocaleLowerCase() : "";
+  const entries: FileEntry[] = [];
+  let matched = 0;
+  let scanned = 0;
+  for (const entry of files) {
+    if (!isConversationRow(entry)) continue;
+    scanned += 1;
+    if (request.project && entry.project !== request.project) continue;
+    if (request.liveOnly
+      && entry.activity !== "live"
+      && entry.activity !== "stalled"
+      && !request.hostedPaths?.has(entry.path)) continue;
+    if (query && !`${entry.title}\n${entry.project}\n${entry.path}`.toLocaleLowerCase().includes(query)) continue;
+    matched += 1;
+    if (entries.length < limit) entries.push(entry);
+  }
+  return { entries, matched, scanned };
+}
+
+export type CompletedGenerationRead = (
+  options?: { revalidate?: boolean; signal?: AbortSignal | null },
+) => Promise<CachedFileScan>;
+
+export interface CompletedGenerationSelectionDependencies {
+  completedFileScan: CompletedGenerationRead;
+  signal?: AbortSignal | null;
+}
+
+/**
+ * The seam a catalog surface consumes: one completed generation, filtered and
+ * limited before anything opens a transcript. Cancellation reaches the scanner,
+ * so a caller that gives up releases the generation it was waiting on.
+ */
+export async function completedGenerationSelection(
+  request: ConversationSelectionRequest,
+  dependencies: CompletedGenerationSelectionDependencies = { completedFileScan },
+): Promise<ConversationSelection> {
+  const startedAt = performance.now();
+  if (dependencies.signal?.aborted) throw abortError(dependencies.signal.reason);
+  const scan = await dependencies.completedFileScan({ signal: dependencies.signal ?? null });
+  if (dependencies.signal?.aborted) throw abortError(dependencies.signal.reason);
+  const selected = selectConversationEntries(scan.snapshot.files, request);
+  return {
+    ...selected,
+    generation: scan.generation,
+    cacheStatus: scan.cacheStatus,
+    freshScan: false,
+    selectionMs: performance.now() - startedAt,
+  };
+}
+
+export interface HydrationBudget {
+  /** Reads in flight at once. */
+  concurrency: number;
+  /** Ceiling on the bytes this pass may charge itself across all reads. */
+  maxBytes: number;
+  /** Epoch milliseconds after which no further read starts; null for none. */
+  deadlineAt: number | null;
+  signal?: AbortSignal | null;
+  now?: () => number;
+}
+
+export interface HydrationOutcome<R> {
+  /** Hydrated values by their index in the input, so skipped rows stay absent
+      rather than being represented by a fabricated value. */
+  results: Map<number, R>;
+  hydrated: number;
+  skipped: number;
+  bytes: number;
+  stopped: "complete" | "byte_budget" | "deadline";
+}
+
+/**
+ * Runs `hydrate` over `items` at bounded concurrency until the byte budget or
+ * the deadline is reached, then reports what it refused instead of silently
+ * finishing the list. A caller abort rejects: the work has no consumer left.
+ */
+export async function hydrateWithBudget<T, R>(
+  items: readonly T[],
+  cost: (item: T) => number,
+  hydrate: (item: T, signal: AbortSignal | null) => Promise<R>,
+  budget: HydrationBudget,
+): Promise<HydrationOutcome<R>> {
+  const now = budget.now ?? Date.now;
+  const signal = budget.signal ?? null;
+  const results = new Map<number, R>();
+  let cursor = 0;
+  let bytes = 0;
+  let stopped: HydrationOutcome<R>["stopped"] = "complete";
+
+  if (signal?.aborted) throw abortError(signal.reason);
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      if (signal?.aborted) throw abortError(signal.reason);
+      if (stopped !== "complete") return;
+      if (cursor >= items.length) return;
+      if (budget.deadlineAt !== null && now() >= budget.deadlineAt) {
+        stopped = "deadline";
+        return;
+      }
+      const index = cursor;
+      const item = items[index]!;
+      const charge = Math.max(0, cost(item));
+      if (bytes + charge > budget.maxBytes) {
+        stopped = "byte_budget";
+        return;
+      }
+      cursor = index + 1;
+      bytes += charge;
+      results.set(index, await hydrate(item, signal));
+    }
+  };
+
+  /* Settled, not raced: when one worker throws on the caller's abort, the others
+     are mid-read. Rejecting on the first would leave their rejections without a
+     handler — an unhandled rejection per cancelled call. Every worker is
+     collected, then the first failure is rethrown. */
+  const settled = await Promise.allSettled(Array.from(
+    { length: Math.max(1, Math.min(Math.floor(budget.concurrency), items.length || 1)) },
+    () => worker(),
+  ));
+  const failure = settled.find((result) => result.status === "rejected");
+  if (failure?.status === "rejected") throw failure.reason;
+
+  return { results, hydrated: results.size, skipped: items.length - results.size, bytes, stopped };
+}

--- a/src/lib/lifecycle/liveness.test.ts
+++ b/src/lib/lifecycle/liveness.test.ts
@@ -601,7 +601,12 @@ test("a project-scoped live read serves one completed generation, hydrates only 
     budget: "complete",
   });
   expect(generation.starts()).toBe(1);
-  /* Warm, on the production-shaped corpus, well inside the 500 ms bar. */
+  expect(snapshot.selection.recovered).toBe(0);
+  /* The structural assertions above are what actually holds the repair: one
+     generation, six rows selected out of 10,001, six tails read. The wall clock
+     is a coarse backstop against a regression the counters cannot see — 26 ms
+     measured against a 500 ms bar, so a loaded runner has to be nineteen times
+     slower before it means anything. */
   expect(elapsedMs).toBeLessThan(500);
 });
 
@@ -688,10 +693,11 @@ test("twenty concurrent project reads share one completed generation and stay bo
   expect(generation.reads()).toBe(20);
   expect(snapshots.every((snapshot) => snapshot.selection.generation === 12)).toBe(true);
   expect(snapshots.every((snapshot) => snapshot.count === 6)).toBe(true);
-  /* Twenty readers of a 10,000-row generation, each hydrating six tails. The
-     RSS bar tracks what this actually costs — ~85 MiB of transient snapshot
-     clones — with room for GC timing, not a catastrophe guard: a regression
-     that reintroduced per-caller corpus work has to move this number. */
+  expect(snapshots.every((snapshot) => snapshot.selection.hydrated === 6)).toBe(true);
+  /* Sharing is proved by the counters above; the two resource bars are coarse
+     backstops for what counters cannot see. The RSS bar tracks what this
+     actually costs — ~85 MiB of transient snapshot clones — with room for GC
+     timing, so a regression that reintroduced per-caller corpus work moves it. */
   expect(elapsedMs).toBeLessThan(2_000);
   expect(rssDeltaBytes).toBeLessThan(256 * 1024 * 1024);
 });
@@ -954,4 +960,193 @@ test("a tail that was read and could not be used is unreadable, not unattempted 
   expect(snapshot.selection.hydrated).toBe(snapshot.count - snapshot.selection.projected);
   /* An unusable tail is no evidence at all, so it is not journaled either. */
   expect(projectLivenessEvents(snapshot.conversations.filter((record) => record.evidenceSource === "unreadable"))).toEqual([]);
+});
+
+/** One transcript described the way `describeTranscriptPath` describes it, with
+    no scan projection to carry — the shape identity recovery works from. */
+function describedTranscript(transcriptPath: string, project: string, mtimeMs: number): LivenessTranscript {
+  return {
+    path: transcriptPath,
+    project,
+    title: "just spawned",
+    engine: "claude",
+    mtimeMs,
+    sizeBytes: fs.statSync(transcriptPath).size,
+    conversationId: null,
+    activity: null,
+    activityReason: null,
+  };
+}
+
+test("a launch newer than the completed generation is recovered by identity, not missed (#860)", async () => {
+  const dir = sandbox();
+  /* The orchestrator spawned this a moment ago and is polling to confirm it
+     started. The generation predates the file, so no filter widening can reach
+     it — only the registry knows it exists. */
+  const spawned = path.join(dir, "just-spawned.jsonl");
+  fs.writeFileSync(spawned, liveTranscriptText(NOW - 1_000), "utf8");
+  const older = path.join(dir, "older.jsonl");
+  const generation = publishedGeneration([fileEntry({
+    path: older,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: "conversation_older",
+    activity: "idle",
+    activityReason: "mtime_old",
+    mtime: Math.floor((NOW - 7_200_000) / 1000),
+  })]);
+  const described: string[] = [];
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: { "claude:just-spawned": structuredEntry(spawned, 4242) },
+        conversations: {},
+      }) as unknown as RegistryFile,
+      describeTranscript: async (transcriptPath) => {
+        described.push(transcriptPath);
+        return describedTranscript(transcriptPath, PROJECT, NOW - 1_000);
+      },
+    }),
+  );
+
+  expect(snapshot.conversations.map((record) => record.transcriptPath)).toEqual([spawned]);
+  expect(snapshot.conversations[0]!.lifecycle).toBe("running");
+  expect(snapshot.conversations[0]!.evidenceSource).toBe("transcript");
+  /* One stat per unseen active host, and the report says the catalog was behind
+     rather than presenting a clean empty answer. */
+  expect(described).toEqual([spawned]);
+  expect(snapshot.selection).toMatchObject({ recovered: 1, matched: 1, selected: 1, hydrated: 1 });
+});
+
+test("identity recovery honours the project filter and the row limit (#860)", async () => {
+  const dir = sandbox();
+  const mine = path.join(dir, "mine.jsonl");
+  const theirs = path.join(dir, "theirs.jsonl");
+  for (const target of [mine, theirs]) fs.writeFileSync(target, liveTranscriptText(NOW - 1_000), "utf8");
+  const stale = path.join(dir, "stale-live.jsonl");
+  fs.writeFileSync(stale, liveTranscriptText(NOW - 600_000), "utf8");
+  const generation = publishedGeneration([fileEntry({
+    path: stale,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: "conversation_stale",
+    activity: "live",
+    activityReason: "jsonl_turn_open",
+    mtime: Math.floor((NOW - 600_000) / 1000),
+  })]);
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 1 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: {
+          "claude:mine": structuredEntry(mine, 4242),
+          "claude:theirs": structuredEntry(theirs, 4243),
+        },
+        conversations: {},
+      }) as unknown as RegistryFile,
+      describeTranscript: async (transcriptPath) => describedTranscript(
+        transcriptPath,
+        transcriptPath === theirs ? "another-project" : PROJECT,
+        NOW - 1_000,
+      ),
+    }),
+  );
+
+  /* The other project's host is described and dropped; the recovered row is
+     newer than the generation's, so it takes the single slot. */
+  expect(snapshot.conversations.map((record) => record.transcriptPath)).toEqual([mine]);
+  expect(snapshot.selection).toMatchObject({ recovered: 1, selected: 1 });
+});
+
+test("a hosted transcript the generation already contains is never re-described (#860)", async () => {
+  const dir = sandbox();
+  const hosted = path.join(dir, "hosted.jsonl");
+  fs.writeFileSync(hosted, liveTranscriptText(NOW - 1_000), "utf8");
+  const generation = publishedGeneration([fileEntry({
+    path: hosted,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: "conversation_hosted",
+    activity: "idle",
+    activityReason: "mtime_old",
+  })]);
+  let describes = 0;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: { "claude:hosted": structuredEntry(hosted, 4242) },
+        conversations: {},
+      }) as unknown as RegistryFile,
+      describeTranscript: async (transcriptPath) => {
+        describes += 1;
+        return describedTranscript(transcriptPath, PROJECT, NOW - 1_000);
+      },
+    }),
+  );
+
+  expect(snapshot.conversations.map((record) => record.transcriptPath)).toEqual([hosted]);
+  expect(describes).toBe(0);
+  expect(snapshot.selection.recovered).toBe(0);
+});
+
+test("a non-finite evidence concurrency falls back to the default instead of hydrating nothing (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10, evidenceConcurrency: Number.NaN },
+    corpusSources(generation),
+  );
+
+  /* Zero workers would read nothing while still reporting `complete`: the one
+     way the report's two halves could disagree. */
+  expect(snapshot.selection).toMatchObject({ hydrated: 6, projected: 0, budget: "complete" });
+  expect(snapshot.conversations.every((record) => record.evidenceSource === "transcript")).toBe(true);
+});
+
+test("the projection timing covers the per-row host and lineage resolution (#860)", async () => {
+  const dir = sandbox();
+  const paths = ["a.jsonl", "b.jsonl", "c.jsonl"].map((name) => path.join(dir, name));
+  for (const target of paths) fs.writeFileSync(target, liveTranscriptText(NOW - 1_000), "utf8");
+  const generation = publishedGeneration(paths.map((target, index) => fileEntry({
+    path: target,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: `conversation_timing_${index}`,
+    activity: "live",
+    activityReason: "jsonl_turn_open",
+  })));
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: Object.fromEntries(paths.map((target, index) => [`claude:timing-${index}`, structuredEntry(target, 4242 + index)])),
+        conversations: {},
+      }) as unknown as RegistryFile,
+      probe: {
+        now: () => NOW,
+        /* Host resolution with a measurable cost, spun rather than slept so the
+           phase it lands in is not a scheduling accident. */
+        pidAlive: () => {
+          const until = performance.now() + 5;
+          while (performance.now() < until) { /* spin */ }
+          return true;
+        },
+        processIdentity: () => "start-token-of-a-dead-host",
+      },
+    }),
+  );
+
+  expect(snapshot.count).toBe(3);
+  /* Three rows, five milliseconds of host resolution each: the projection
+     phase owns it, not serialization. */
+  expect(snapshot.timings.journalProjectionMs).toBeGreaterThanOrEqual(10);
+  expect(snapshot.timings.serializationMs).toBeLessThan(snapshot.timings.journalProjectionMs);
 });

--- a/src/lib/lifecycle/liveness.test.ts
+++ b/src/lib/lifecycle/liveness.test.ts
@@ -10,6 +10,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { completedGenerationSelection, type CompletedGenerationRead } from "./inventorySelection";
 import { agentLivenessSnapshot, evaluateLiveness, type AgentLivenessSources } from "./liveness";
+import { projectLivenessEvents } from "./projector";
 import { readLivenessTranscriptEvidence, type LivenessTranscript, type LivenessTranscriptEvidence } from "./transcript";
 
 const sandboxes: string[] = [];
@@ -687,9 +688,12 @@ test("twenty concurrent project reads share one completed generation and stay bo
   expect(generation.reads()).toBe(20);
   expect(snapshots.every((snapshot) => snapshot.selection.generation === 12)).toBe(true);
   expect(snapshots.every((snapshot) => snapshot.count === 6)).toBe(true);
-  /* Twenty readers of a 10,000-row generation, each hydrating six tails. */
+  /* Twenty readers of a 10,000-row generation, each hydrating six tails. The
+     RSS bar tracks what this actually costs — ~85 MiB of transient snapshot
+     clones — with room for GC timing, not a catastrophe guard: a regression
+     that reintroduced per-caller corpus work has to move this number. */
   expect(elapsedMs).toBeLessThan(2_000);
-  expect(rssDeltaBytes).toBeLessThan(768 * 1024 * 1024);
+  expect(rssDeltaBytes).toBeLessThan(256 * 1024 * 1024);
 });
 
 test("a cancelled caller stops the read and starts no further transcript evidence (#860)", async () => {
@@ -832,4 +836,122 @@ test("a targeted read never consults the completed generation (#860)", async () 
   expect(snapshot.count).toBe(1);
   expect(snapshot.selection.scope).toBe("targeted");
   expect(generation.reads()).toBe(0);
+});
+
+test("rows the evidence budget degraded never reach the journal as durable alarms (#860)", async () => {
+  const dir = sandbox();
+  /* Three mid-turn transcripts under live hosts, all six hours silent: every
+     one of them reads as `stalled`. Only the row whose tail was actually read
+     may be journaled. */
+  const paths = ["read.jsonl", "degraded-a.jsonl", "degraded-b.jsonl"].map((name) => path.join(dir, name));
+  for (const target of paths) fs.writeFileSync(target, liveTranscriptText(FROZEN_AT), "utf8");
+  const generation = publishedGeneration(paths.map((target, index) => fileEntry({
+    path: target,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: `conversation_budget_${index}`,
+    activity: "live",
+    activityReason: "jsonl_turn_open",
+    mtime: Math.floor(FROZEN_AT / 1000),
+    size: 4096,
+  })));
+
+  const snapshot = await agentLivenessSnapshot(
+    /* One row's worth of budget: the first is read, the rest are projected. */
+    { project: PROJECT, limit: 10, evidenceByteBudget: 4096 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: Object.fromEntries(paths.map((target, index) => [`claude:budget-${index}`, structuredEntry(target, 4242 + index)])),
+        conversations: {},
+      }) as unknown as RegistryFile,
+      transcriptEvidence: async () => ({ turn: "busy" as const, lastRecordTs: FROZEN_AT }),
+    }),
+  );
+
+  expect(snapshot.count).toBe(3);
+  expect(snapshot.stalledCount).toBe(3);
+  expect(snapshot.selection).toMatchObject({ hydrated: 1, unreadable: 0, projected: 2, budget: "byte_budget" });
+
+  const events = projectLivenessEvents(snapshot.conversations);
+  expect(events.map((event) => event.type)).toEqual(["agent_stalled"]);
+  expect(events[0]!.conversationId).toBe("conversation_budget_0");
+});
+
+test("a cold generation does not spend the hydration deadline before hydration starts (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  let clock = NOW;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10, evidenceDeadlineMs: 2_000 },
+    corpusSources(generation, {
+      now: () => clock,
+      selectInventory: async (request, options) => {
+        const selection = await completedGenerationSelection(request, {
+          completedFileScan: generation.read,
+          signal: options?.signal ?? null,
+        });
+        /* The cold generation took thirty seconds to publish — ten times the
+           hydration budget, and none of it hydration's to spend. */
+        clock += 30_000;
+        return selection;
+      },
+    }),
+  );
+
+  expect(snapshot.selection).toMatchObject({ hydrated: 6, projected: 0, budget: "complete" });
+  expect(snapshot.conversations.every((record) => record.evidenceSource === "transcript")).toBe(true);
+});
+
+test("the hydration deadline stops the pass and leaves the remaining rows on the projection (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  let clock = NOW;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, limit: 10, evidenceDeadlineMs: 1_000, evidenceConcurrency: 1 },
+    corpusSources(generation, {
+      now: () => clock,
+      transcriptEvidence: async () => {
+        /* Four hundred milliseconds a tail: the budget buys three. */
+        clock += 400;
+        return { turn: "busy" as const, lastRecordTs: clock - 1_000 };
+      },
+    }),
+  );
+
+  expect(snapshot.selection).toMatchObject({ hydrated: 3, unreadable: 0, projected: 7, budget: "deadline" });
+  expect(snapshot.conversations.filter((record) => record.evidenceSource === "transcript")).toHaveLength(3);
+  expect(snapshot.conversations.filter((record) => record.evidenceSource === "projection")).toHaveLength(7);
+});
+
+test("a tail that was read and could not be used is unreadable, not unattempted (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const torn = corpus.livePaths[0]!;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      /* `readLivenessTranscriptEvidence` answers null for a torn or racing
+         tail. That is a read that failed, and the report must not present it as
+         a read that never happened. */
+      transcriptEvidence: async (_engine, transcriptPath) => transcriptPath === torn
+        ? null
+        : { turn: "busy" as const, lastRecordTs: NOW - 10_000 },
+    }),
+  );
+
+  expect(snapshot.selection).toMatchObject({ hydrated: 6, unreadable: 1, projected: 0, budget: "complete" });
+  const labels = snapshot.conversations.map((record) => record.evidenceSource);
+  expect(labels.filter((label) => label === "unreadable")).toHaveLength(1);
+  expect(labels.filter((label) => label === "transcript")).toHaveLength(5);
+  /* The two halves of the report agree by construction. */
+  expect(labels.filter((label) => label === "projection")).toHaveLength(snapshot.selection.projected);
+  expect(snapshot.selection.hydrated).toBe(snapshot.count - snapshot.selection.projected);
+  /* An unusable tail is no evidence at all, so it is not journaled either. */
+  expect(projectLivenessEvents(snapshot.conversations.filter((record) => record.evidenceSource === "unreadable"))).toEqual([]);
 });

--- a/src/lib/lifecycle/liveness.test.ts
+++ b/src/lib/lifecycle/liveness.test.ts
@@ -5,8 +5,10 @@ import path from "node:path";
 
 import type { AgentRegistryEntry, RegistryFile } from "@/lib/agent/registry";
 import type { Pipeline, PipelineStageAttempt } from "@/lib/pipelines/types";
+import type { FileScanSnapshot } from "@/lib/scanner/scanCache";
 import type { FileEntry } from "@/lib/types";
 
+import { completedGenerationSelection, type CompletedGenerationRead } from "./inventorySelection";
 import { agentLivenessSnapshot, evaluateLiveness, type AgentLivenessSources } from "./liveness";
 import { readLivenessTranscriptEvidence, type LivenessTranscript, type LivenessTranscriptEvidence } from "./transcript";
 
@@ -432,4 +434,402 @@ test("a targeted query with an unknown conversation id returns an empty snapshot
 
   expect(snapshot.count).toBe(0);
   expect(snapshot.conversations).toEqual([]);
+});
+
+/* ------------------------------------------------------------------------- *
+ * #860 — bounded project-scoped selection.
+ *
+ * The incident: `agent_activity(project, liveOnly, limit: 10)` had not returned
+ * after seventy seconds on a corpus this shape, while a targeted read of the
+ * same deployment answered in 290 ms. Everything below is production-shaped and
+ * isolated: a 10,000-row corpus, 1,000 rows in the requested project, six live
+ * conversations and one multi-gigabyte transcript whose body is never opened.
+ * ------------------------------------------------------------------------- */
+
+const PROJECT = "viewer";
+/** 3 GiB, allocated sparsely: the row exists, its bytes are never read. */
+const HUGE_TRANSCRIPT_BYTES = 3 * 1024 ** 3;
+
+function liveTranscriptText(at: number): string {
+  return [
+    { type: "assistant", timestamp: new Date(at - 5_000).toISOString(), message: { content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }], stop_reason: "tool_use" } },
+    { type: "user", timestamp: new Date(at).toISOString(), message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] } },
+  ].map((row) => JSON.stringify(row)).join("\n") + "\n";
+}
+
+interface ProductionCorpus {
+  files: FileEntry[];
+  livePaths: string[];
+  hugePath: string;
+}
+
+/** 10,000 historical conversations, 1,000 in `PROJECT`, six live, one huge. */
+function productionShapedCorpus(dir: string): ProductionCorpus {
+  const files: FileEntry[] = [];
+  const livePaths: string[] = [];
+  for (let index = 0; index < 10_000; index += 1) {
+    const inProject = index % 10 === 0;
+    const project = inProject ? PROJECT : `other-${index % 41}`;
+    const live = inProject && livePaths.length < 6;
+    const transcriptPath = live
+      ? path.join(dir, `live-${index}.jsonl`)
+      : `${dir}/history/${project}/session-${index}.jsonl`;
+    if (live) {
+      fs.writeFileSync(transcriptPath, liveTranscriptText(NOW - 10_000), "utf8");
+      livePaths.push(transcriptPath);
+    }
+    files.push(fileEntry({
+      path: transcriptPath,
+      project,
+      engine: index % 3 === 0 ? "claude" : "codex",
+      conversationId: `conversation_${index}`,
+      mtime: Math.floor((NOW - index * 1_000) / 1000),
+      activity: live ? "live" : "idle",
+      activityReason: live ? "jsonl_turn_open" : "mtime_old",
+      size: 4096,
+    }));
+  }
+  /* The multi-gigabyte transcript: a real sparse file, in the project, idle.
+     Metadata-only selection must never open it. */
+  const hugePath = path.join(dir, "huge-history.jsonl");
+  const handle = fs.openSync(hugePath, "w");
+  fs.ftruncateSync(handle, HUGE_TRANSCRIPT_BYTES);
+  const tail = Buffer.from(liveTranscriptText(NOW - 3_600_000).repeat(1_400), "utf8");
+  fs.writeSync(handle, tail, 0, tail.length, HUGE_TRANSCRIPT_BYTES);
+  fs.closeSync(handle);
+  files.push(fileEntry({
+    path: hugePath,
+    project: PROJECT,
+    engine: "claude",
+    conversationId: "conversation_huge",
+    mtime: Math.floor((NOW - 3_600_000) / 1000),
+    activity: "idle",
+    activityReason: "mtime_old",
+    size: HUGE_TRANSCRIPT_BYTES + tail.length,
+  }));
+  files.sort((left, right) => right.mtime - left.mtime);
+  return { files, livePaths, hugePath };
+}
+
+interface GenerationStub {
+  read: CompletedGenerationRead;
+  starts: () => number;
+  reads: () => number;
+}
+
+/** One published generation, cloned per read exactly as `completedFileScan`
+    does, so the measured cost is the production cost. */
+function publishedGeneration(files: FileEntry[], options: { coldDelayMs?: number } = {}): GenerationStub {
+  const snapshot = { files, projectCatalog: [], complete: true } as FileScanSnapshot;
+  let starts = 0;
+  let reads = 0;
+  let published: Promise<void> | null = null;
+  const read: CompletedGenerationRead = async (readOptions) => {
+    reads += 1;
+    if (!published) {
+      starts += 1;
+      published = new Promise((resolve) => setTimeout(resolve, options.coldDelayMs ?? 0));
+    }
+    await published;
+    if (readOptions?.signal?.aborted) throw new DOMException("cancelled", "AbortError");
+    return {
+      snapshot: structuredClone(snapshot),
+      generation: 12,
+      targetGeneration: 12,
+      cacheStatus: "hit",
+      requestCount: reads,
+      cloneDurationMs: 0,
+    };
+  };
+  return { read, starts: () => starts, reads: () => reads };
+}
+
+function corpusSources(
+  generation: GenerationStub,
+  overrides: Partial<AgentLivenessSources> = {},
+): AgentLivenessSources {
+  return {
+    now: () => NOW,
+    probe: { now: () => NOW, pidAlive: () => true, processIdentity: () => "start-token-of-a-dead-host" },
+    listFiles: async () => {
+      throw new Error("a project-scoped read must never sweep the whole corpus");
+    },
+    selectInventory: (request, options) => completedGenerationSelection(request, {
+      completedFileScan: generation.read,
+      signal: options?.signal ?? null,
+    }),
+    describeTranscript: async () => {
+      throw new Error("a project-scoped read describes nothing by path");
+    },
+    registrySnapshot: () => ({ entries: {}, conversations: {} }) as unknown as RegistryFile,
+    pipelines: () => [],
+    transcriptEvidence: readLivenessTranscriptEvidence,
+    ...overrides,
+  };
+}
+
+test("a project-scoped live read serves one completed generation, hydrates only the rows it returns, and never sweeps the corpus (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const hydrated: string[] = [];
+
+  const startedAt = performance.now();
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      transcriptEvidence: async (engine, transcriptPath) => {
+        hydrated.push(transcriptPath);
+        return readLivenessTranscriptEvidence(engine, transcriptPath);
+      },
+    }),
+  );
+  const elapsedMs = performance.now() - startedAt;
+
+  expect(snapshot.count).toBe(6);
+  expect(hydrated).toHaveLength(6);
+  expect(hydrated.every((entry) => corpus.livePaths.includes(entry))).toBe(true);
+  expect(snapshot.selection).toMatchObject({
+    scope: "project",
+    scanned: 10_001,
+    matched: 6,
+    selected: 6,
+    hydrated: 6,
+    freshScan: false,
+    generation: 12,
+    budget: "complete",
+  });
+  expect(generation.starts()).toBe(1);
+  /* Warm, on the production-shaped corpus, well inside the 500 ms bar. */
+  expect(elapsedMs).toBeLessThan(500);
+});
+
+test("a limit of ten hydrates at most ten transcript tails out of a thousand project rows (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  let hydrations = 0;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, limit: 10 },
+    corpusSources(generation, {
+      transcriptEvidence: async () => {
+        hydrations += 1;
+        return { turn: "idle" as const, lastRecordTs: NOW - 60_000 };
+      },
+    }),
+  );
+
+  expect(snapshot.count).toBe(10);
+  expect(hydrations).toBe(10);
+  expect(snapshot.selection.matched).toBe(1_001);
+  expect(snapshot.selection.selected).toBe(10);
+});
+
+test("the multi-gigabyte transcript is selected from metadata and never opened for a metadata-only read (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const opened: string[] = [];
+
+  const liveRead = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      transcriptEvidence: async (engine, transcriptPath) => {
+        opened.push(transcriptPath);
+        return readLivenessTranscriptEvidence(engine, transcriptPath);
+      },
+    }),
+  );
+
+  /* Present in the generation, absent from every read. */
+  expect(corpus.files.some((entry) => entry.path === corpus.hugePath)).toBe(true);
+  expect(liveRead.conversations.map((record) => record.transcriptPath)).not.toContain(corpus.hugePath);
+  expect(opened).not.toContain(corpus.hugePath);
+
+  /* When it IS selected, the evidence read stays a bounded tail: three
+     gigabytes of body would never come back in this budget. */
+  const startedAt = performance.now();
+  const hugeRead = await agentLivenessSnapshot(
+    { project: PROJECT, limit: 1, stallAfterMs: 60_000 },
+    corpusSources(generation, {
+      selectInventory: async (request, options) => {
+        const selection = await completedGenerationSelection(
+          { ...request, query: "huge-history" },
+          { completedFileScan: generation.read, signal: options?.signal ?? null },
+        );
+        return selection;
+      },
+    }),
+  );
+  const elapsedMs = performance.now() - startedAt;
+
+  expect(hugeRead.conversations[0]!.transcriptPath).toBe(corpus.hugePath);
+  expect(hugeRead.conversations[0]!.evidenceSource).toBe("transcript");
+  expect(elapsedMs).toBeLessThan(1_000);
+});
+
+test("twenty concurrent project reads share one completed generation and stay bounded (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files, { coldDelayMs: 5 });
+
+  const before = process.memoryUsage().rss;
+  const startedAt = performance.now();
+  const snapshots = await Promise.all(Array.from({ length: 20 }, () => agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation),
+  )));
+  const elapsedMs = performance.now() - startedAt;
+  const rssDeltaBytes = process.memoryUsage().rss - before;
+
+  expect(generation.starts()).toBe(1);
+  expect(generation.reads()).toBe(20);
+  expect(snapshots.every((snapshot) => snapshot.selection.generation === 12)).toBe(true);
+  expect(snapshots.every((snapshot) => snapshot.count === 6)).toBe(true);
+  /* Twenty readers of a 10,000-row generation, each hydrating six tails. */
+  expect(elapsedMs).toBeLessThan(2_000);
+  expect(rssDeltaBytes).toBeLessThan(768 * 1024 * 1024);
+});
+
+test("a cancelled caller stops the read and starts no further transcript evidence (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const controller = new AbortController();
+  const started: string[] = [];
+
+  const pending = agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10, signal: controller.signal },
+    corpusSources(generation, {
+      transcriptEvidence: async (_engine, transcriptPath) => {
+        started.push(transcriptPath);
+        if (started.length === 1) controller.abort();
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        return { turn: "busy" as const, lastRecordTs: NOW - 1_000 };
+      },
+    }),
+  );
+
+  await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  const settled = started.length;
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(started.length).toBe(settled);
+  expect(settled).toBeLessThan(6);
+});
+
+test("a caller cancelled before the generation is read never touches it (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10, signal: controller.signal },
+    corpusSources(generation),
+  )).rejects.toMatchObject({ name: "AbortError" });
+  expect(generation.reads()).toBe(0);
+});
+
+test("phase timings are reported as bare numbers, carrying no identity (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation),
+  );
+
+  expect(Object.keys(snapshot.timings).sort()).toEqual([
+    "evidenceReadMs",
+    "inventorySelectionMs",
+    "journalProjectionMs",
+    "serializationMs",
+    "totalMs",
+  ]);
+  for (const value of Object.values(snapshot.timings)) {
+    expect(typeof value).toBe("number");
+    expect(Number.isFinite(value)).toBe(true);
+    expect(value).toBeGreaterThanOrEqual(0);
+  }
+  /* Nothing in the phase report can name a path, a project or an account. */
+  const reported = { ...snapshot.timings, ...snapshot.selection };
+  for (const [key, value] of Object.entries(reported)) {
+    if (key === "scope" || key === "cacheStatus" || key === "budget") continue;
+    expect(typeof value === "number" || typeof value === "boolean").toBe(true);
+  }
+});
+
+test("the evidence budget degrades extra rows to the scan projection instead of reading unbounded tails (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  let hydrations = 0;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, limit: 50, evidenceByteBudget: 4 * 4096 },
+    corpusSources(generation, {
+      transcriptEvidence: async () => {
+        hydrations += 1;
+        return { turn: "busy" as const, lastRecordTs: NOW - 1_000 };
+      },
+    }),
+  );
+
+  expect(hydrations).toBe(4);
+  expect(snapshot.count).toBe(50);
+  expect(snapshot.selection).toMatchObject({ hydrated: 4, projected: 46, budget: "byte_budget" });
+  /* The unread rows still answer honestly, from the generation's projection. */
+  expect(snapshot.conversations.filter((record) => record.evidenceSource === "projection")).toHaveLength(46);
+});
+
+test("a runtime-hosted conversation survives the liveness filter the completed generation still calls idle (#860)", async () => {
+  const dir = sandbox();
+  const agentPath = path.join(dir, "just-launched.jsonl");
+  fs.writeFileSync(agentPath, liveTranscriptText(NOW - 1_000), "utf8");
+  const generation = publishedGeneration([
+    fileEntry({ path: agentPath, project: PROJECT, engine: "claude", activity: "idle", activityReason: "mtime_old", conversationId: "conversation_new" }),
+    fileEntry({ path: path.join(dir, "old.jsonl"), project: PROJECT, activity: "idle", activityReason: "mtime_old", conversationId: "conversation_old" }),
+  ]);
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: { "claude:just-launched": structuredEntry(agentPath, 4242) },
+        conversations: {},
+      }) as unknown as RegistryFile,
+    }),
+  );
+
+  expect(snapshot.conversations.map((record) => record.transcriptPath)).toEqual([agentPath]);
+});
+
+test("a targeted read never consults the completed generation (#860)", async () => {
+  const dir = sandbox();
+  const agentPath = path.join(dir, "targeted.jsonl");
+  fs.writeFileSync(agentPath, liveTranscriptText(NOW - 1_000), "utf8");
+  const generation = publishedGeneration([]);
+
+  const snapshot = await agentLivenessSnapshot(
+    { transcriptPath: agentPath, limit: 1 },
+    corpusSources(generation, {
+      describeTranscript: async (transcriptPath) => ({
+        path: transcriptPath,
+        project: PROJECT,
+        title: "targeted agent",
+        engine: "claude",
+        mtimeMs: NOW - 1_000,
+        conversationId: null,
+        activity: null,
+        activityReason: null,
+      }),
+    }),
+  );
+
+  expect(snapshot.count).toBe(1);
+  expect(snapshot.selection.scope).toBe("targeted");
+  expect(generation.reads()).toBe(0);
 });

--- a/src/lib/lifecycle/liveness.test.ts
+++ b/src/lib/lifecycle/liveness.test.ts
@@ -9,7 +9,7 @@ import type { FileScanSnapshot } from "@/lib/scanner/scanCache";
 import type { FileEntry } from "@/lib/types";
 
 import { completedGenerationSelection, type CompletedGenerationRead } from "./inventorySelection";
-import { agentLivenessSnapshot, evaluateLiveness, type AgentLivenessSources } from "./liveness";
+import { agentLivenessSnapshot, evaluateLiveness, HOSTED_RECOVERY_MAX, type AgentLivenessSources } from "./liveness";
 import { projectLivenessEvents } from "./projector";
 import { readLivenessTranscriptEvidence, type LivenessTranscript, type LivenessTranscriptEvidence } from "./transcript";
 
@@ -876,6 +876,10 @@ test("rows the evidence budget degraded never reach the journal as durable alarm
 
   expect(snapshot.count).toBe(3);
   expect(snapshot.stalledCount).toBe(3);
+  /* The headline count carries every stalled row; the confirmed count carries
+     only the ones a transcript read stands behind — the same discipline the
+     journal applies, so an operator subtitle can prefer it. */
+  expect(snapshot.stalledConfirmedCount).toBe(1);
   expect(snapshot.selection).toMatchObject({ hydrated: 1, unreadable: 0, projected: 2, budget: "byte_budget" });
 
   const events = projectLivenessEvents(snapshot.conversations);
@@ -1149,4 +1153,103 @@ test("the projection timing covers the per-row host and lineage resolution (#860
      phase owns it, not serialization. */
   expect(snapshot.timings.journalProjectionMs).toBeGreaterThanOrEqual(10);
   expect(snapshot.timings.serializationMs).toBeLessThan(snapshot.timings.journalProjectionMs);
+});
+
+test("the default byte budget covers the default row limit (#860)", async () => {
+  const dir = sandbox();
+  /* A hundred rows whose transcripts are far bigger than one tail, so every row
+     charges the full 128 KiB. A fixed 8 MiB budget stopped at row 64 on every
+     call, deterministically, and the journal then never recorded those rows. */
+  const rows = Array.from({ length: 100 }, (_, index) => fileEntry({
+    path: path.join(dir, `big-${index}.jsonl`),
+    project: PROJECT,
+    engine: "claude",
+    conversationId: `conversation_big_${index}`,
+    activity: "live",
+    activityReason: "jsonl_turn_open",
+    mtime: Math.floor((NOW - index * 1_000) / 1000),
+    size: 4 * 1024 * 1024,
+  }));
+  const generation = publishedGeneration(rows);
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT },
+    corpusSources(generation, {
+      transcriptEvidence: async () => ({ turn: "busy" as const, lastRecordTs: NOW - 1_000 }),
+    }),
+  );
+
+  expect(snapshot.count).toBe(100);
+  expect(snapshot.selection).toMatchObject({ hydrated: 100, projected: 0, budget: "complete" });
+  expect(snapshot.selection.evidenceBytes).toBe(100 * 131_072);
+});
+
+test("an over-cap identity recovery keeps the newest hosts and says it was truncated (#860)", async () => {
+  const dir = sandbox();
+  /* Registry entries iterate oldest-first. The rot at the front — active
+     statuses whose transcripts no longer exist — would fill every cap slot on
+     every call and crowd out the launch recovery exists for. */
+  const hosted = Array.from({ length: HOSTED_RECOVERY_MAX + 2 }, (_, index) => path.join(dir, `host-${index}.jsonl`));
+  for (const target of hosted) fs.writeFileSync(target, liveTranscriptText(NOW - 1_000), "utf8");
+  const generation = publishedGeneration([]);
+  const described: string[] = [];
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 200 },
+    corpusSources(generation, {
+      registrySnapshot: () => ({
+        entries: Object.fromEntries(hosted.map((target, index) => [`claude:host-${index}`, structuredEntry(target, 4242 + index)])),
+        conversations: {},
+      }) as unknown as RegistryFile,
+      describeTranscript: async (transcriptPath) => {
+        described.push(transcriptPath);
+        return describedTranscript(transcriptPath, PROJECT, NOW - 1_000);
+      },
+      transcriptEvidence: async () => ({ turn: "busy" as const, lastRecordTs: NOW - 1_000 }),
+    }),
+  );
+
+  expect(described).toHaveLength(HOSTED_RECOVERY_MAX);
+  expect(described).toContain(hosted.at(-1)!);
+  expect(described).not.toContain(hosted[0]!);
+  expect(snapshot.selection).toMatchObject({ recovered: HOSTED_RECOVERY_MAX, recoveryTruncated: true });
+});
+
+test("a transcript read that throws costs one row, not the whole snapshot (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const broken = corpus.livePaths[0]!;
+
+  const snapshot = await agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10 },
+    corpusSources(generation, {
+      transcriptEvidence: async (_engine, transcriptPath) => {
+        if (transcriptPath === broken) throw new Error("EIO reading the tail");
+        return { turn: "busy" as const, lastRecordTs: NOW - 10_000 };
+      },
+    }),
+  );
+
+  expect(snapshot.count).toBe(6);
+  expect(snapshot.selection).toMatchObject({ hydrated: 6, unreadable: 1, projected: 0 });
+  expect(snapshot.conversations.find((record) => record.transcriptPath === broken)!.evidenceSource).toBe("unreadable");
+});
+
+test("a cancelled caller still stops the pass when a read throws (#860)", async () => {
+  const dir = sandbox();
+  const corpus = productionShapedCorpus(dir);
+  const generation = publishedGeneration(corpus.files);
+  const controller = new AbortController();
+
+  await expect(agentLivenessSnapshot(
+    { project: PROJECT, liveOnly: true, limit: 10, signal: controller.signal },
+    corpusSources(generation, {
+      transcriptEvidence: async () => {
+        controller.abort();
+        /* The per-row catch must not swallow the caller going away. */
+        throw new DOMException("cancelled", "AbortError");
+      },
+    }),
+  )).rejects.toMatchObject({ name: "AbortError" });
 });

--- a/src/lib/lifecycle/liveness.ts
+++ b/src/lib/lifecycle/liveness.ts
@@ -101,9 +101,20 @@ export interface AgentLivenessRecord {
       `gone` lifecycle; null when it is not stalled. */
   stalledForMs: number | null;
   pipeline: AgentLivenessPipelineRef | null;
-  /** Whether this row's turn state came from its own transcript tail or from
-      the scan projection because the read budget was already spent (#860). */
-  evidenceSource: "transcript" | "projection";
+  /**
+   * Where this row's turn state came from (#860). The three states an operator
+   * diagnosing a degraded snapshot has to tell apart:
+   *
+   * - `transcript` — the tail was read and interpreted.
+   * - `unreadable` — the tail was read and could not be used (torn or racing
+   *   append), so the scan projection answered.
+   * - `projection` — no read was attempted: the evidence budget was already
+   *   spent when this row came up.
+   *
+   * Only `transcript` rows become durable journal events; see
+   * `projectLivenessEvents`.
+   */
+  evidenceSource: "transcript" | "unreadable" | "projection";
 }
 
 /**
@@ -133,9 +144,13 @@ export interface AgentLivenessSelectionReport {
   /** Rows matching project/liveness before the row limit. */
   matched: number;
   selected: number;
+  /** Rows a transcript tail read was attempted for; `unreadable` is the subset
+      of those whose tail could not be used. */
   hydrated: number;
-  /** Selected rows answered from the scan projection because the read budget
-      was exhausted before they were reached. */
+  unreadable: number;
+  /** Selected rows no read was attempted for, because the budget was exhausted
+      before they came up. Equals the number of `evidenceSource: "projection"`
+      records by construction. */
   projected: number;
   generation: number | null;
   cacheStatus: ConversationSelection["cacheStatus"] | null;
@@ -169,7 +184,14 @@ export interface AgentLivenessRequest {
   /** The caller's lifetime. Cancelling it stops the generation read and starts
       no further transcript tails. */
   signal?: AbortSignal | null;
-  /** Wall-clock ceiling on transcript-tail hydration for this call. */
+  /**
+   * Wall-clock ceiling on transcript-tail hydration, measured from the moment
+   * hydration STARTS — not from the start of the call. Selection may have
+   * waited on a cold generation for tens of seconds; charging that wait to this
+   * budget would spend it before the first tail is opened and answer the whole
+   * request from the scan projection, exactly when the operator is asking why
+   * nothing responds.
+   */
   evidenceDeadlineMs?: number;
   /** Byte ceiling on transcript-tail hydration for this call. */
   evidenceByteBudget?: number;
@@ -466,7 +488,9 @@ export async function agentLivenessSnapshot(
 
   const selectionStartedAt = performance.now();
   let entries: LivenessTranscript[];
-  let selection: Omit<AgentLivenessSelectionReport, "hydrated" | "projected" | "evidenceBytes" | "budget">;
+  /* Everything the selection phase knows; the hydration counters are filled in
+     once the evidence pass has run. */
+  let selection: Omit<AgentLivenessSelectionReport, "hydrated" | "unreadable" | "projected" | "evidenceBytes" | "budget">;
   if (targeted) {
     /* The targeted branch. A caller that named a specific target gets back what
        it named and nothing else — even an empty set. Falling through to the
@@ -538,7 +562,10 @@ export async function agentLivenessSnapshot(
     {
       concurrency: Math.max(1, Math.floor(request.evidenceConcurrency ?? DEFAULT_EVIDENCE_CONCURRENCY)),
       maxBytes: Math.max(0, Math.floor(request.evidenceByteBudget ?? DEFAULT_EVIDENCE_BYTE_BUDGET)),
-      deadlineAt: now + deadlineMs,
+      /* Anchored HERE, on the same clock the budget reads. A cold generation can
+         take tens of seconds to publish; anchoring at the start of the call
+         would hand hydration an already-expired budget. */
+      deadlineAt: sources.now() + deadlineMs,
       signal,
       now: sources.now,
     },
@@ -548,8 +575,15 @@ export async function agentLivenessSnapshot(
 
   const serializationStartedAt = performance.now();
   const conversations: AgentLivenessRecord[] = [];
+  let unreadable = 0;
   for (const [index, entry] of hydratable.entries()) {
+    /* Three outcomes, kept apart: a read that produced evidence, a read that
+       produced none, and a row the budget never reached. The counters below are
+       derived from the same distinction, so the report and the per-row labels
+       cannot disagree. */
+    const attempted = hydration.results.has(index);
     const evidence = hydration.results.get(index) ?? null;
+    if (attempted && evidence === null) unreadable += 1;
     const turnState = turnStateFromEvidence(evidence, entry);
     /* Freshness is the newest RECORD, tool traffic included. Reading it off the
        last assistant prose message reports a live agent in a long tool stretch
@@ -576,7 +610,7 @@ export async function agentLivenessSnapshot(
       pipeline: (conversationId ? pipelines.byConversation.get(conversationId) : undefined)
         ?? pipelines.byPath.get(entry.path)
         ?? null,
-      evidenceSource: evidence !== null ? "transcript" : "projection",
+      evidenceSource: !attempted ? "projection" : evidence !== null ? "transcript" : "unreadable",
     });
   }
   const serializationMs = performance.now() - serializationStartedAt;
@@ -590,6 +624,7 @@ export async function agentLivenessSnapshot(
     selection: {
       ...selection,
       hydrated: hydration.hydrated,
+      unreadable,
       projected: hydratable.length - hydration.hydrated,
       evidenceBytes: hydration.bytes,
       budget: hydration.stopped,

--- a/src/lib/lifecycle/liveness.ts
+++ b/src/lib/lifecycle/liveness.ts
@@ -3,9 +3,17 @@ import type { AgentRegistryEntry, RegistryFile } from "@/lib/agent/registry";
 import { agentRegistry } from "@/lib/agent/registry";
 import { getPipelines } from "@/lib/pipelines/engine";
 import type { Pipeline, PipelineStageAttempt } from "@/lib/pipelines/types";
-import { listFiles } from "@/lib/scanner";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import type { Engine, FileEntry } from "@/lib/types";
 
+import {
+  completedGenerationSelection,
+  hydrateWithBudget,
+  selectConversationEntries,
+  type CompletedGenerationRead,
+  type ConversationSelection,
+  type ConversationSelectionRequest,
+} from "./inventorySelection";
 import {
   describeTranscriptPath,
   readLivenessTranscriptEvidence,
@@ -93,6 +101,48 @@ export interface AgentLivenessRecord {
       `gone` lifecycle; null when it is not stalled. */
   stalledForMs: number | null;
   pipeline: AgentLivenessPipelineRef | null;
+  /** Whether this row's turn state came from its own transcript tail or from
+      the scan projection because the read budget was already spent (#860). */
+  evidenceSource: "transcript" | "projection";
+}
+
+/**
+ * Phase timings, in milliseconds and nothing else (#860).
+ *
+ * Deliberately identity-free: a timing report travels through logs and PR
+ * bodies, so it carries numbers a reader can act on and never a path, a project
+ * or an account.
+ */
+export interface AgentLivenessTimings {
+  /** Reading the completed generation and applying filters and the row limit. */
+  inventorySelectionMs: number;
+  /** Registry, host and pipeline-lineage projection over the selected rows. */
+  journalProjectionMs: number;
+  /** Bounded transcript-tail hydration. */
+  evidenceReadMs: number;
+  /** Assembling the records this call returns. */
+  serializationMs: number;
+  totalMs: number;
+}
+
+export interface AgentLivenessSelectionReport {
+  /** `targeted` names a conversation or path; the others read the catalog. */
+  scope: "targeted" | "project" | "corpus";
+  /** Conversation rows in the generation this call consumed. */
+  scanned: number;
+  /** Rows matching project/liveness before the row limit. */
+  matched: number;
+  selected: number;
+  hydrated: number;
+  /** Selected rows answered from the scan projection because the read budget
+      was exhausted before they were reached. */
+  projected: number;
+  generation: number | null;
+  cacheStatus: ConversationSelection["cacheStatus"] | null;
+  /** True only on the legacy whole-inventory adapter. */
+  freshScan: boolean;
+  evidenceBytes: number;
+  budget: "complete" | "byte_budget" | "deadline";
 }
 
 export interface AgentLivenessSnapshot {
@@ -103,39 +153,85 @@ export interface AgentLivenessSnapshot {
       number instead of scanning the list. */
   stalledCount: number;
   conversations: AgentLivenessRecord[];
+  selection: AgentLivenessSelectionReport;
+  timings: AgentLivenessTimings;
 }
 
 export interface AgentLivenessRequest {
   conversationId?: string;
   transcriptPath?: string;
   project?: string;
-  /** Restrict to conversations the scan still projects as live or stalled. */
+  /** Restrict to conversations the scan still projects as live or stalled, or
+      that the registry projection currently hosts. */
   liveOnly?: boolean;
   stallAfterMs?: number;
   limit?: number;
+  /** The caller's lifetime. Cancelling it stops the generation read and starts
+      no further transcript tails. */
+  signal?: AbortSignal | null;
+  /** Wall-clock ceiling on transcript-tail hydration for this call. */
+  evidenceDeadlineMs?: number;
+  /** Byte ceiling on transcript-tail hydration for this call. */
+  evidenceByteBudget?: number;
+  /** Tail reads in flight at once. */
+  evidenceConcurrency?: number;
 }
+
+/** Tail reads in flight at once. Small on purpose: a `limit: 10` read is ten
+    reads total, and twenty concurrent callers must not multiply into a storm. */
+export const DEFAULT_EVIDENCE_CONCURRENCY = 4;
+/** Bytes one call may charge to transcript evidence. A tail read is clamped to
+    128 KiB, so this is a ceiling of roughly sixty-four tails. */
+export const DEFAULT_EVIDENCE_BYTE_BUDGET = 8 * 1024 * 1024;
+/** Wall clock one call may spend on transcript evidence before the remaining
+    rows fall back to the scan projection. */
+export const DEFAULT_EVIDENCE_DEADLINE_MS = 2_000;
+/** What one tail read actually costs, mirroring `readStableTailRecords`. */
+const EVIDENCE_TAIL_BYTES = 131_072;
 
 export interface AgentLivenessSources {
   now(): number;
   /**
-   * The whole inventory. In production this is the scanner sweep: root
-   * discovery, a process-table refresh, a tmux pane map and a tail read per
-   * transcript. Only a request that names no single conversation calls it.
+   * Bounded selection over ONE completed scanner generation (#860): filters and
+   * the row limit are applied to metadata the process already published, before
+   * anything opens a transcript. Only a request that names no single
+   * conversation calls it.
    */
-  listFiles(): Promise<FileEntry[]>;
+  selectInventory?(
+    request: ConversationSelectionRequest,
+    options?: { signal?: AbortSignal | null },
+  ): Promise<ConversationSelection>;
+  /**
+   * The legacy whole-inventory adapter, kept for injected callers that predate
+   * the selection seam. Production never installs it: it is the fresh
+   * whole-corpus sweep #860 exists to remove.
+   */
+  listFiles?(): Promise<FileEntry[]>;
   /** One transcript by path, described with no sweep of any kind. */
   describeTranscript(transcriptPath: string): Promise<LivenessTranscript | null>;
   registrySnapshot(): Pick<RegistryFile, "entries" | "conversations">;
   pipelines(): Pipeline[];
   /** Turn state and newest-record freshness from ONE tail read. */
-  transcriptEvidence(engine: "claude" | "codex", transcriptPath: string): Promise<LivenessTranscriptEvidence | null>;
+  transcriptEvidence(
+    engine: "claude" | "codex",
+    transcriptPath: string,
+    options?: { signal?: AbortSignal | null },
+  ): Promise<LivenessTranscriptEvidence | null>;
   probe: LivenessProbe;
 }
 
-export function productionLivenessSources(): AgentLivenessSources {
+export function productionLivenessSources(
+  dependencies: { completedFileScan?: CompletedGenerationRead } = {},
+): AgentLivenessSources {
+  const read = dependencies.completedFileScan ?? completedFileScan;
   return {
     now: () => Date.now(),
-    listFiles: () => listFiles({ fresh: true, persist: false }),
+    /* Consumes the COMPLETED generation the process already published. One scan
+       generation serves every catalog read; this one opens none of its own. */
+    selectInventory: (request, options) => completedGenerationSelection(request, {
+      completedFileScan: read,
+      signal: options?.signal ?? null,
+    }),
     describeTranscript: describeTranscriptPath,
     registrySnapshot: () => agentRegistry().readOnlySnapshot(),
     pipelines: () => getPipelines().pipelines,
@@ -286,6 +382,7 @@ function transcriptFromEntry(entry: FileEntry): LivenessTranscript {
     title: entry.title,
     engine: entry.engine,
     mtimeMs: Number.isFinite(entry.mtime) ? entry.mtime * 1000 : Number.NaN,
+    sizeBytes: Number.isFinite(entry.size) ? entry.size : undefined,
     conversationId: entry.conversationId ?? null,
     activity: entry.activity ?? null,
     activityReason: entry.activityReason ?? null,
@@ -305,17 +402,56 @@ function conversationIdForPath(
   return null;
 }
 
+/** The transcripts the registry projection currently hosts. A completed
+    generation can predate a launch by its whole refresh cadence, so liveness
+    filtered on the scan projection alone would drop a conversation that started
+    a minute ago — the correctness half of not sweeping the corpus (#860). */
+function hostedTranscriptPaths(snapshot: Pick<RegistryFile, "entries">): Set<string> {
+  const hosted = new Set<string>();
+  for (const entry of Object.values(snapshot.entries)) {
+    if (entry.status !== "starting" && entry.status !== "live" && entry.status !== "idle" && entry.status !== "handoff") continue;
+    if (entry.artifactPath) hosted.add(entry.artifactPath);
+  }
+  return hosted;
+}
+
+function livenessAbortError(reason?: unknown): Error {
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
+  return new DOMException("liveness snapshot cancelled", "AbortError");
+}
+
+function roundMs(value: number): number {
+  return Math.round(Math.max(0, value) * 100) / 100;
+}
+
+/**
+ * The liveness answer for a request, bounded end to end (#860).
+ *
+ * The order is the whole repair: project, liveness and the row limit are
+ * applied to one COMPLETED scanner generation, and only the rows that survive
+ * are hydrated — at bounded concurrency, under byte and time budgets, with the
+ * caller's cancellation reaching both phases. Before this, ten rows of answer
+ * cost a fresh whole-corpus sweep plus a sequential tail read per surviving row,
+ * and a caller that timed out left all of it running.
+ */
 export async function agentLivenessSnapshot(
   request: AgentLivenessRequest,
   sources: AgentLivenessSources,
 ): Promise<AgentLivenessSnapshot> {
+  const startedAt = performance.now();
   const now = sources.now();
+  const signal = request.signal ?? null;
+  if (signal?.aborted) throw livenessAbortError(signal.reason);
   const stallAfterMs = Number.isFinite(request.stallAfterMs) && (request.stallAfterMs as number) > 0
     ? Math.floor(request.stallAfterMs as number)
     : DEFAULT_STALL_AFTER_MS;
   const limit = Math.max(1, Math.min(200, Number.isInteger(request.limit) ? request.limit as number : 100));
+
+  const projectionStartedAt = performance.now();
   const registry = sources.registrySnapshot();
   const pipelines = pipelineIndex(sources.pipelines());
+  const hostedPaths = hostedTranscriptPaths(registry);
+  const journalProjectionMs = performance.now() - projectionStartedAt;
 
   /* A conversation id names its current generation's transcript; that is the
      only path whose liveness is meaningful. */
@@ -328,26 +464,92 @@ export async function agentLivenessSnapshot(
     if (path) requestedPaths.add(path);
   }
 
-  /* The targeted branch. A caller that named a specific target gets back what
-     it named and nothing else — even an empty set. Falling through to the full
-     inventory would turn a stale alias into an unrelated sweep. */
-  const entries: LivenessTranscript[] = targeted
-    ? (requestedPaths.size > 0
+  const selectionStartedAt = performance.now();
+  let entries: LivenessTranscript[];
+  let selection: Omit<AgentLivenessSelectionReport, "hydrated" | "projected" | "evidenceBytes" | "budget">;
+  if (targeted) {
+    /* The targeted branch. A caller that named a specific target gets back what
+       it named and nothing else — even an empty set. Falling through to the
+       catalog would turn a stale alias into an unrelated read. */
+    entries = requestedPaths.size > 0
       ? (await Promise.all([...requestedPaths].slice(0, limit).map((path) => sources.describeTranscript(path))))
         .filter((entry): entry is LivenessTranscript => entry !== null)
-      : [])
-    : (await sources.listFiles())
-      .filter((entry) => entry.engine === "claude" || entry.engine === "codex")
-      .filter((entry) => !request.project || entry.project === request.project)
-      .filter((entry) => !request.liveOnly || entry.activity === "live" || entry.activity === "stalled")
-      .slice(0, limit)
-      .map(transcriptFromEntry);
+      : [];
+    selection = {
+      scope: "targeted",
+      scanned: requestedPaths.size,
+      matched: entries.length,
+      selected: entries.length,
+      generation: null,
+      cacheStatus: null,
+      freshScan: false,
+    };
+  } else {
+    const selectionRequest: ConversationSelectionRequest = {
+      project: request.project,
+      liveOnly: request.liveOnly,
+      limit,
+      hostedPaths,
+    };
+    if (sources.selectInventory) {
+      const selected = await sources.selectInventory(selectionRequest, { signal });
+      entries = selected.entries.map(transcriptFromEntry);
+      selection = {
+        scope: request.project ? "project" : "corpus",
+        scanned: selected.scanned,
+        matched: selected.matched,
+        selected: selected.entries.length,
+        generation: selected.generation,
+        cacheStatus: selected.cacheStatus,
+        freshScan: selected.freshScan,
+      };
+    } else if (sources.listFiles) {
+      const selected = selectConversationEntries(await sources.listFiles(), selectionRequest);
+      entries = selected.entries.map(transcriptFromEntry);
+      selection = {
+        scope: request.project ? "project" : "corpus",
+        scanned: selected.scanned,
+        matched: selected.matched,
+        selected: selected.entries.length,
+        generation: null,
+        cacheStatus: null,
+        freshScan: true,
+      };
+    } else {
+      throw new Error("liveness needs an inventory source: install selectInventory");
+    }
+  }
+  const inventorySelectionMs = performance.now() - selectionStartedAt;
+  if (signal?.aborted) throw livenessAbortError(signal.reason);
 
+  const hydratable = entries.filter((entry) => entry.engine === "claude" || entry.engine === "codex");
+  const evidenceStartedAt = performance.now();
+  const deadlineMs = Number.isFinite(request.evidenceDeadlineMs) && (request.evidenceDeadlineMs as number) > 0
+    ? Math.floor(request.evidenceDeadlineMs as number)
+    : DEFAULT_EVIDENCE_DEADLINE_MS;
+  const hydration = await hydrateWithBudget(
+    hydratable,
+    (entry) => Math.min(Number.isFinite(entry.sizeBytes) ? entry.sizeBytes as number : EVIDENCE_TAIL_BYTES, EVIDENCE_TAIL_BYTES),
+    async (entry, hydrationSignal) => sources.transcriptEvidence(
+      entry.engine as "claude" | "codex",
+      entry.path,
+      { signal: hydrationSignal },
+    ),
+    {
+      concurrency: Math.max(1, Math.floor(request.evidenceConcurrency ?? DEFAULT_EVIDENCE_CONCURRENCY)),
+      maxBytes: Math.max(0, Math.floor(request.evidenceByteBudget ?? DEFAULT_EVIDENCE_BYTE_BUDGET)),
+      deadlineAt: now + deadlineMs,
+      signal,
+      now: sources.now,
+    },
+  );
+  const evidenceReadMs = performance.now() - evidenceStartedAt;
+  if (signal?.aborted) throw livenessAbortError(signal.reason);
+
+  const serializationStartedAt = performance.now();
   const conversations: AgentLivenessRecord[] = [];
-  for (const entry of entries) {
-    if (entry.engine !== "claude" && entry.engine !== "codex") continue;
-    const engine = entry.engine;
-    const evidence = await sources.transcriptEvidence(engine, entry.path);
+  for (const [index, entry] of hydratable.entries()) {
+    const evidence = hydration.results.get(index) ?? null;
     const turnState = turnStateFromEvidence(evidence, entry);
     /* Freshness is the newest RECORD, tool traffic included. Reading it off the
        last assistant prose message reports a live agent in a long tool stretch
@@ -374,8 +576,10 @@ export async function agentLivenessSnapshot(
       pipeline: (conversationId ? pipelines.byConversation.get(conversationId) : undefined)
         ?? pipelines.byPath.get(entry.path)
         ?? null,
+      evidenceSource: evidence !== null ? "transcript" : "projection",
     });
   }
+  const serializationMs = performance.now() - serializationStartedAt;
 
   return {
     observedAt: new Date(now).toISOString(),
@@ -383,5 +587,19 @@ export async function agentLivenessSnapshot(
     count: conversations.length,
     stalledCount: conversations.filter((record) => record.lifecycle === "stalled").length,
     conversations,
+    selection: {
+      ...selection,
+      hydrated: hydration.hydrated,
+      projected: hydratable.length - hydration.hydrated,
+      evidenceBytes: hydration.bytes,
+      budget: hydration.stopped,
+    },
+    timings: {
+      inventorySelectionMs: roundMs(inventorySelectionMs),
+      journalProjectionMs: roundMs(journalProjectionMs),
+      evidenceReadMs: roundMs(evidenceReadMs),
+      serializationMs: roundMs(serializationMs),
+      totalMs: roundMs(performance.now() - startedAt),
+    },
   };
 }

--- a/src/lib/lifecycle/liveness.ts
+++ b/src/lib/lifecycle/liveness.ts
@@ -127,7 +127,8 @@ export interface AgentLivenessRecord {
 export interface AgentLivenessTimings {
   /** Reading the completed generation and applying filters and the row limit. */
   inventorySelectionMs: number;
-  /** Registry, host and pipeline-lineage projection over the selected rows. */
+  /** Registry, host and pipeline-lineage projection: the index build plus the
+      per-row host and lineage resolution for every selected row. */
   journalProjectionMs: number;
   /** Bounded transcript-tail hydration. */
   evidenceReadMs: number;
@@ -144,6 +145,10 @@ export interface AgentLivenessSelectionReport {
   /** Rows matching project/liveness before the row limit. */
   matched: number;
   selected: number;
+  /** Rows resolved by identity because the generation did not contain them yet:
+      hosts younger than the generation. Non-zero means the catalog is behind
+      the runtime, which is the one thing a clean-looking report must not hide. */
+  recovered: number;
   /** Rows a transcript tail read was attempted for; `unreadable` is the subset
       of those whose tail could not be used. */
   hydrated: number;
@@ -437,6 +442,58 @@ function hostedTranscriptPaths(snapshot: Pick<RegistryFile, "entries">): Set<str
   return hosted;
 }
 
+/** Ceiling on identity recovery. Bounded by the registry's active hosts in
+    practice; the cap keeps a rotted registry from turning a catalog read into a
+    walk. */
+const HOSTED_RECOVERY_MAX = 64;
+
+/**
+ * The hosts the generation has not caught up with yet, resolved by identity.
+ *
+ * Widening the liveness filter rescues a hosted row the generation CONTAINS.
+ * A launch newer than the generation has no row to widen onto: an orchestrator
+ * that spawns an agent and immediately polls `agent_activity(project, liveOnly)`
+ * would not see it until the next completed generation — up to the ordinary
+ * refresh cadence away on a host with nothing else driving scans. The fresh
+ * whole-corpus sweep this change removes used to hide that.
+ *
+ * One `stat`-and-describe per unseen active host, so the recovery cost tracks
+ * the number of running agents rather than the size of the corpus.
+ */
+async function recoverHostedTranscripts(
+  hostedPaths: ReadonlySet<string>,
+  hostedSeen: ReadonlySet<string>,
+  project: string | undefined,
+  describe: AgentLivenessSources["describeTranscript"],
+): Promise<LivenessTranscript[]> {
+  const missing: string[] = [];
+  for (const path of hostedPaths) {
+    if (hostedSeen.has(path)) continue;
+    missing.push(path);
+    if (missing.length >= HOSTED_RECOVERY_MAX) break;
+  }
+  if (missing.length === 0) return [];
+  const described = await Promise.all(missing.map(async (path) => {
+    try {
+      return await describe(path);
+    } catch {
+      /* A host whose transcript cannot be described is not evidence of
+         anything; the rest of the answer still stands. */
+      return null;
+    }
+  }));
+  return described.filter((entry): entry is LivenessTranscript => entry !== null
+    && (entry.engine === "claude" || entry.engine === "codex")
+    && (!project || entry.project === project));
+}
+
+/** Newest first, with an unreadable mtime ranked last rather than poisoning the
+    comparator. */
+function byNewest(left: LivenessTranscript, right: LivenessTranscript): number {
+  const rank = (entry: LivenessTranscript) => Number.isFinite(entry.mtimeMs) ? entry.mtimeMs : Number.NEGATIVE_INFINITY;
+  return rank(right) - rank(left);
+}
+
 function livenessAbortError(reason?: unknown): Error {
   if (reason instanceof Error && reason.name === "AbortError") return reason;
   return new DOMException("liveness snapshot cancelled", "AbortError");
@@ -473,7 +530,7 @@ export async function agentLivenessSnapshot(
   const registry = sources.registrySnapshot();
   const pipelines = pipelineIndex(sources.pipelines());
   const hostedPaths = hostedTranscriptPaths(registry);
-  const journalProjectionMs = performance.now() - projectionStartedAt;
+  const indexProjectionMs = performance.now() - projectionStartedAt;
 
   /* A conversation id names its current generation's transcript; that is the
      only path whose liveness is meaningful. */
@@ -504,6 +561,7 @@ export async function agentLivenessSnapshot(
       scanned: requestedPaths.size,
       matched: entries.length,
       selected: entries.length,
+      recovered: 0,
       generation: null,
       cacheStatus: null,
       freshScan: false,
@@ -515,14 +573,17 @@ export async function agentLivenessSnapshot(
       limit,
       hostedPaths,
     };
+    let hostedSeen: ReadonlySet<string>;
     if (sources.selectInventory) {
       const selected = await sources.selectInventory(selectionRequest, { signal });
       entries = selected.entries.map(transcriptFromEntry);
+      hostedSeen = selected.hostedSeen ?? new Set(selected.entries.map((entry) => entry.path));
       selection = {
         scope: request.project ? "project" : "corpus",
         scanned: selected.scanned,
         matched: selected.matched,
         selected: selected.entries.length,
+        recovered: 0,
         generation: selected.generation,
         cacheStatus: selected.cacheStatus,
         freshScan: selected.freshScan,
@@ -530,17 +591,35 @@ export async function agentLivenessSnapshot(
     } else if (sources.listFiles) {
       const selected = selectConversationEntries(await sources.listFiles(), selectionRequest);
       entries = selected.entries.map(transcriptFromEntry);
+      hostedSeen = selected.hostedSeen;
       selection = {
         scope: request.project ? "project" : "corpus",
         scanned: selected.scanned,
         matched: selected.matched,
         selected: selected.entries.length,
+        recovered: 0,
         generation: null,
         cacheStatus: null,
         freshScan: true,
       };
     } else {
       throw new Error("liveness needs an inventory source: install selectInventory");
+    }
+
+    /* Hosts the generation has not caught up with yet. Newest-first ordering is
+       restored only when recovery actually found something, so the ordinary
+       path returns the generation's own order untouched. */
+    const recovered = await recoverHostedTranscripts(hostedPaths, hostedSeen, request.project, sources.describeTranscript);
+    const known = new Set(entries.map((entry) => entry.path));
+    const added = recovered.filter((entry) => !known.has(entry.path));
+    if (added.length > 0) {
+      entries = [...entries, ...added].sort(byNewest).slice(0, limit);
+      selection = {
+        ...selection,
+        matched: selection.matched + added.length,
+        selected: entries.length,
+        recovered: added.length,
+      };
     }
   }
   const inventorySelectionMs = performance.now() - selectionStartedAt;
@@ -560,7 +639,9 @@ export async function agentLivenessSnapshot(
       { signal: hydrationSignal },
     ),
     {
-      concurrency: Math.max(1, Math.floor(request.evidenceConcurrency ?? DEFAULT_EVIDENCE_CONCURRENCY)),
+      concurrency: Number.isFinite(request.evidenceConcurrency)
+        ? Math.max(1, Math.floor(request.evidenceConcurrency as number))
+        : DEFAULT_EVIDENCE_CONCURRENCY,
       maxBytes: Math.max(0, Math.floor(request.evidenceByteBudget ?? DEFAULT_EVIDENCE_BYTE_BUDGET)),
       /* Anchored HERE, on the same clock the budget reads. A cold generation can
          take tens of seconds to publish; anchoring at the start of the call
@@ -573,10 +654,12 @@ export async function agentLivenessSnapshot(
   const evidenceReadMs = performance.now() - evidenceStartedAt;
   if (signal?.aborted) throw livenessAbortError(signal.reason);
 
-  const serializationStartedAt = performance.now();
-  const conversations: AgentLivenessRecord[] = [];
+  /* Projection, then assembly, as two passes over the same rows — so each phase
+     timing measures the phase it is named after instead of splitting the
+     per-row registry and lineage lookups across both. */
+  const rowProjectionStartedAt = performance.now();
   let unreadable = 0;
-  for (const [index, entry] of hydratable.entries()) {
+  const projected = hydratable.map((entry, index) => {
     /* Three outcomes, kept apart: a read that produced evidence, a read that
        produced none, and a row the budget never reached. The counters below are
        derived from the same distinction, so the report and the per-row labels
@@ -590,29 +673,41 @@ export async function agentLivenessSnapshot(
        as stalled — the exact question this surface exists to answer. */
     const lastRecordMs = evidence?.lastRecordTs ?? (Number.isFinite(entry.mtimeMs) ? entry.mtimeMs : null);
     const silentForMs = lastRecordMs !== null ? Math.max(0, now - lastRecordMs) : null;
-    const registryEntry = entryForPath(registry, entry.path);
-    const host = hostEvidence(registryEntry, sources.probe);
-    const { lifecycle, reason } = evaluateLiveness({ host, turnState, silentForMs, stallAfterMs });
+    const host = hostEvidence(entryForPath(registry, entry.path), sources.probe);
     const conversationId = entry.conversationId ?? conversationIdForPath(registry, entry.path);
-    conversations.push({
+    return {
+      entry,
       conversationId,
-      transcriptPath: entry.path,
-      project: entry.project,
-      engine: entry.engine,
-      title: entry.title,
-      lastRecordAt: isoOrNull(lastRecordMs),
       turnState,
-      host,
-      lifecycle,
-      reason,
+      lastRecordMs,
       silentForMs,
-      stalledForMs: lifecycle === "stalled" || lifecycle === "gone" ? silentForMs : null,
+      host,
+      ...evaluateLiveness({ host, turnState, silentForMs, stallAfterMs }),
       pipeline: (conversationId ? pipelines.byConversation.get(conversationId) : undefined)
         ?? pipelines.byPath.get(entry.path)
         ?? null,
-      evidenceSource: !attempted ? "projection" : evidence !== null ? "transcript" : "unreadable",
-    });
-  }
+      evidenceSource: (!attempted ? "projection" : evidence !== null ? "transcript" : "unreadable") as AgentLivenessRecord["evidenceSource"],
+    };
+  });
+  const journalProjectionMs = indexProjectionMs + (performance.now() - rowProjectionStartedAt);
+
+  const serializationStartedAt = performance.now();
+  const conversations: AgentLivenessRecord[] = projected.map((row) => ({
+    conversationId: row.conversationId,
+    transcriptPath: row.entry.path,
+    project: row.entry.project,
+    engine: row.entry.engine,
+    title: row.entry.title,
+    lastRecordAt: isoOrNull(row.lastRecordMs),
+    turnState: row.turnState,
+    host: row.host,
+    lifecycle: row.lifecycle,
+    reason: row.reason,
+    silentForMs: row.silentForMs,
+    stalledForMs: row.lifecycle === "stalled" || row.lifecycle === "gone" ? row.silentForMs : null,
+    pipeline: row.pipeline,
+    evidenceSource: row.evidenceSource,
+  }));
   const serializationMs = performance.now() - serializationStartedAt;
 
   return {

--- a/src/lib/lifecycle/liveness.ts
+++ b/src/lib/lifecycle/liveness.ts
@@ -1,6 +1,7 @@
 import { identityAlive, livenessProbe, type LivenessProbe } from "@/lib/agent/accountLiveness";
 import type { AgentRegistryEntry, RegistryFile } from "@/lib/agent/registry";
 import { agentRegistry } from "@/lib/agent/registry";
+import { isAbortError } from "@/lib/deadline";
 import { getPipelines } from "@/lib/pipelines/engine";
 import type { Pipeline, PipelineStageAttempt } from "@/lib/pipelines/types";
 import { completedFileScan } from "@/lib/scanner/scanCache";
@@ -149,6 +150,10 @@ export interface AgentLivenessSelectionReport {
       hosts younger than the generation. Non-zero means the catalog is behind
       the runtime, which is the one thing a clean-looking report must not hide. */
   recovered: number;
+  /** More active hosts were missing from the generation than one call recovers,
+      so the newest `HOSTED_RECOVERY_MAX` of them were resolved and the rest
+      were not looked at. */
+  recoveryTruncated: boolean;
   /** Rows a transcript tail read was attempted for; `unreadable` is the subset
       of those whose tail could not be used. */
   hydrated: number;
@@ -172,6 +177,16 @@ export interface AgentLivenessSnapshot {
   /** Conversations whose lifecycle is `stalled`, so a poller can branch on one
       number instead of scanning the list. */
   stalledCount: number;
+  /**
+   * The subset of `stalledCount` whose silence was measured from a transcript
+   * read rather than the generation's file mtime (#860).
+   *
+   * A generation can be a refresh cadence old while the stall threshold is ten
+   * minutes, so a projection-backed row can read as stalled after resuming.
+   * This is the number that carries the same discipline the journal applies —
+   * a headline "N stalled" should prefer it.
+   */
+  stalledConfirmedCount: number;
   conversations: AgentLivenessRecord[];
   selection: AgentLivenessSelectionReport;
   timings: AgentLivenessTimings;
@@ -198,7 +213,9 @@ export interface AgentLivenessRequest {
    * nothing responds.
    */
   evidenceDeadlineMs?: number;
-  /** Byte ceiling on transcript-tail hydration for this call. */
+  /** Byte ceiling on transcript-tail hydration for this call. Defaults to the
+      row limit's worth of full tails, so the budget can always cover the rows
+      the limit admits. */
   evidenceByteBudget?: number;
   /** Tail reads in flight at once. */
   evidenceConcurrency?: number;
@@ -207,14 +224,25 @@ export interface AgentLivenessRequest {
 /** Tail reads in flight at once. Small on purpose: a `limit: 10` read is ten
     reads total, and twenty concurrent callers must not multiply into a storm. */
 export const DEFAULT_EVIDENCE_CONCURRENCY = 4;
-/** Bytes one call may charge to transcript evidence. A tail read is clamped to
-    128 KiB, so this is a ceiling of roughly sixty-four tails. */
-export const DEFAULT_EVIDENCE_BYTE_BUDGET = 8 * 1024 * 1024;
 /** Wall clock one call may spend on transcript evidence before the remaining
     rows fall back to the scan projection. */
 export const DEFAULT_EVIDENCE_DEADLINE_MS = 2_000;
 /** What one tail read actually costs, mirroring `readStableTailRecords`. */
-const EVIDENCE_TAIL_BYTES = 131_072;
+export const EVIDENCE_TAIL_BYTES = 131_072;
+
+/**
+ * The default byte budget follows the row limit, so the two agree.
+ *
+ * A fixed budget cannot: at 8 MiB it admitted exactly sixty-four full tails
+ * while the default limit is a hundred, so a default corpus read degraded rows
+ * 65+ to the scan projection on EVERY call — deterministically the same rows,
+ * and the journal gate then never recorded a stall for any of them. The budget
+ * exists to stop a call from reading an unbounded volume; the row limit is
+ * already that bound, and it is clamped to 200, so the ceiling here is 25 MiB.
+ */
+export function defaultEvidenceByteBudget(limit: number): number {
+  return Math.max(1, limit) * EVIDENCE_TAIL_BYTES;
+}
 
 export interface AgentLivenessSources {
   now(): number;
@@ -445,7 +473,7 @@ function hostedTranscriptPaths(snapshot: Pick<RegistryFile, "entries">): Set<str
 /** Ceiling on identity recovery. Bounded by the registry's active hosts in
     practice; the cap keeps a rotted registry from turning a catalog read into a
     walk. */
-const HOSTED_RECOVERY_MAX = 64;
+export const HOSTED_RECOVERY_MAX = 64;
 
 /**
  * The hosts the generation has not caught up with yet, resolved by identity.
@@ -465,15 +493,19 @@ async function recoverHostedTranscripts(
   hostedSeen: ReadonlySet<string>,
   project: string | undefined,
   describe: AgentLivenessSources["describeTranscript"],
-): Promise<LivenessTranscript[]> {
+): Promise<{ entries: LivenessTranscript[]; truncated: boolean }> {
   const missing: string[] = [];
   for (const path of hostedPaths) {
-    if (hostedSeen.has(path)) continue;
-    missing.push(path);
-    if (missing.length >= HOSTED_RECOVERY_MAX) break;
+    if (!hostedSeen.has(path)) missing.push(path);
   }
-  if (missing.length === 0) return [];
-  const described = await Promise.all(missing.map(async (path) => {
+  if (missing.length === 0) return { entries: [], truncated: false };
+  /* The registry iterates oldest-entry-first, and recovery exists for the
+     newest launches. Taking the head of an over-cap list would keep the stale
+     active-status rot — permanently absent from every generation, so it fills
+     the same slots on every call — and drop the agent that just started. */
+  const truncated = missing.length > HOSTED_RECOVERY_MAX;
+  const candidates = truncated ? missing.slice(-HOSTED_RECOVERY_MAX) : missing;
+  const described = await Promise.all(candidates.map(async (path) => {
     try {
       return await describe(path);
     } catch {
@@ -482,9 +514,12 @@ async function recoverHostedTranscripts(
       return null;
     }
   }));
-  return described.filter((entry): entry is LivenessTranscript => entry !== null
-    && (entry.engine === "claude" || entry.engine === "codex")
-    && (!project || entry.project === project));
+  return {
+    entries: described.filter((entry): entry is LivenessTranscript => entry !== null
+      && (entry.engine === "claude" || entry.engine === "codex")
+      && (!project || entry.project === project)),
+    truncated,
+  };
 }
 
 /** Newest first, with an unreadable mtime ranked last rather than poisoning the
@@ -562,6 +597,7 @@ export async function agentLivenessSnapshot(
       matched: entries.length,
       selected: entries.length,
       recovered: 0,
+      recoveryTruncated: false,
       generation: null,
       cacheStatus: null,
       freshScan: false,
@@ -584,6 +620,7 @@ export async function agentLivenessSnapshot(
         matched: selected.matched,
         selected: selected.entries.length,
         recovered: 0,
+        recoveryTruncated: false,
         generation: selected.generation,
         cacheStatus: selected.cacheStatus,
         freshScan: selected.freshScan,
@@ -598,6 +635,7 @@ export async function agentLivenessSnapshot(
         matched: selected.matched,
         selected: selected.entries.length,
         recovered: 0,
+        recoveryTruncated: false,
         generation: null,
         cacheStatus: null,
         freshScan: true,
@@ -609,16 +647,18 @@ export async function agentLivenessSnapshot(
     /* Hosts the generation has not caught up with yet. Newest-first ordering is
        restored only when recovery actually found something, so the ordinary
        path returns the generation's own order untouched. */
-    const recovered = await recoverHostedTranscripts(hostedPaths, hostedSeen, request.project, sources.describeTranscript);
+    const recovery = await recoverHostedTranscripts(hostedPaths, hostedSeen, request.project, sources.describeTranscript);
     const known = new Set(entries.map((entry) => entry.path));
-    const added = recovered.filter((entry) => !known.has(entry.path));
-    if (added.length > 0) {
-      entries = [...entries, ...added].sort(byNewest).slice(0, limit);
+    const added = recovery.entries.filter((entry) => !known.has(entry.path));
+    if (added.length > 0 || recovery.truncated) {
+      if (added.length > 0) entries = [...entries, ...added].sort(byNewest).slice(0, limit);
       selection = {
         ...selection,
         matched: selection.matched + added.length,
         selected: entries.length,
         recovered: added.length,
+        /* A capped recovery must not read as a complete one. */
+        recoveryTruncated: recovery.truncated,
       };
     }
   }
@@ -633,16 +673,23 @@ export async function agentLivenessSnapshot(
   const hydration = await hydrateWithBudget(
     hydratable,
     (entry) => Math.min(Number.isFinite(entry.sizeBytes) ? entry.sizeBytes as number : EVIDENCE_TAIL_BYTES, EVIDENCE_TAIL_BYTES),
-    async (entry, hydrationSignal) => sources.transcriptEvidence(
-      entry.engine as "claude" | "codex",
-      entry.path,
-      { signal: hydrationSignal },
-    ),
+    async (entry, hydrationSignal) => {
+      try {
+        return await sources.transcriptEvidence(entry.engine as "claude" | "codex", entry.path, { signal: hydrationSignal });
+      } catch (error) {
+        /* One bad row costs one row. Cancellation is the exception: it is the
+           caller going away, and it must still stop the pass. */
+        if (hydrationSignal?.aborted || isAbortError(error)) throw error;
+        return null;
+      }
+    },
     {
       concurrency: Number.isFinite(request.evidenceConcurrency)
         ? Math.max(1, Math.floor(request.evidenceConcurrency as number))
         : DEFAULT_EVIDENCE_CONCURRENCY,
-      maxBytes: Math.max(0, Math.floor(request.evidenceByteBudget ?? DEFAULT_EVIDENCE_BYTE_BUDGET)),
+      maxBytes: Number.isFinite(request.evidenceByteBudget)
+        ? Math.max(0, Math.floor(request.evidenceByteBudget as number))
+        : defaultEvidenceByteBudget(limit),
       /* Anchored HERE, on the same clock the budget reads. A cold generation can
          take tens of seconds to publish; anchoring at the start of the call
          would hand hydration an already-expired budget. */
@@ -715,6 +762,8 @@ export async function agentLivenessSnapshot(
     stallAfterMs,
     count: conversations.length,
     stalledCount: conversations.filter((record) => record.lifecycle === "stalled").length,
+    stalledConfirmedCount: conversations
+      .filter((record) => record.lifecycle === "stalled" && record.evidenceSource === "transcript").length,
     conversations,
     selection: {
       ...selection,

--- a/src/lib/lifecycle/projector.test.ts
+++ b/src/lib/lifecycle/projector.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, afterEach, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -18,6 +18,15 @@ const { queryLifecycleEvents } = await import("./journal");
 const { refreshLifecycleJournal } = await import("./projector");
 
 afterAll(() => fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true }));
+
+/* The projection throttle is a `globalThis` stamp, so it outlives this file: a
+   stamp left behind here silently throttles the next test file's real
+   projection — and which file that is depends on the order the runner picks.
+   Every case here forces its own projection, so clearing the stamps between
+   them costs nothing and keeps the leak inside this file. */
+afterEach(() => {
+  delete (globalThis as typeof globalThis & { __llvLifecycleProjectionAt?: Record<string, number> }).__llvLifecycleProjectionAt;
+});
 
 const T0 = "2026-07-26T09:00:00.000Z";
 
@@ -151,6 +160,7 @@ function livenessRecord(overrides: Partial<AgentLivenessRecord>): AgentLivenessR
     silentForMs: 600_000,
     stalledForMs: 600_000,
     pipeline: null,
+    evidenceSource: "transcript",
     ...overrides,
   };
 }
@@ -220,6 +230,8 @@ test("a sweep journals agent_gone for an unfinished stage and agent_resumed when
 });
 
 test("a liveness-only refresh does not throttle a lifecycle refresh and vice versa", () => {
+  /* A minute ahead of the clock, so the second call in each domain is throttled
+     without the test sleeping through the window. */
   const now = Date.now() + 60_000;
 
   const livenessInput: Parameters<typeof refreshLifecycleJournal>[0] = {

--- a/src/lib/lifecycle/projector.test.ts
+++ b/src/lib/lifecycle/projector.test.ts
@@ -259,3 +259,41 @@ test("a liveness-only refresh does not throttle a lifecycle refresh and vice ver
   const fourth = refreshLifecycleJournal(pipelineInput, { now });
   expect(fourth.throttled).toBe(true);
 });
+
+test("only a reading backed by a transcript read becomes a durable alarm (#860)", () => {
+  const stale = "2026-07-26T03:00:00.000Z";
+
+  /* The evidence budget was spent before this row came up, so its turn state
+     and freshness are the scan generation's — which may be minutes old. A
+     conversation that resumed since that generation completed would earn a
+     durable stall here that never happened. */
+  refreshLifecycleJournal({
+    liveness: [livenessRecord({
+      conversationId: "conversation_budget_degraded",
+      lastRecordAt: stale,
+      evidenceSource: "projection",
+    })],
+  }, { force: true });
+  expect(queryLifecycleEvents({ conversationId: "conversation_budget_degraded" }).count).toBe(0);
+
+  /* A tail that was read and could not be used says just as little. */
+  refreshLifecycleJournal({
+    liveness: [livenessRecord({
+      conversationId: "conversation_torn_tail",
+      lastRecordAt: stale,
+      evidenceSource: "unreadable",
+    })],
+  }, { force: true });
+  expect(queryLifecycleEvents({ conversationId: "conversation_torn_tail" }).count).toBe(0);
+
+  /* The same reading, with the tail actually read, is news. */
+  refreshLifecycleJournal({
+    liveness: [livenessRecord({
+      conversationId: "conversation_read_tail",
+      lastRecordAt: stale,
+      evidenceSource: "transcript",
+    })],
+  }, { force: true });
+  expect(queryLifecycleEvents({ conversationId: "conversation_read_tail" }).events.map((event) => event.type))
+    .toEqual(["agent_stalled"]);
+});

--- a/src/lib/lifecycle/projector.ts
+++ b/src/lib/lifecycle/projector.ts
@@ -240,6 +240,17 @@ export function lastObservedAgentState(file: LifecycleJournalFile): Map<string, 
  * agents nobody is waiting on. It is recorded only for a conversation the
  * Viewer still expects work from: one whose pipeline attempt has not reached a
  * terminal state, or one the journal already saw stall.
+ *
+ * Only readings backed by an actual transcript read become durable events
+ * (#860). A row whose turn state came from the scan projection — because the
+ * evidence budget was spent before it, or because its tail was torn — is
+ * honest enough to display, and it stays in the caller's snapshot, but its
+ * freshness is the generation's file mtime. A generation may be minutes old, so
+ * a conversation that resumed since it completed would cross the stall
+ * threshold and earn a durable `agent_stalled` that never happened, followed by
+ * an `agent_resumed` retiring it once a real read landed. An alarm surface that
+ * fabricates alarm/all-clear pairs is worse than one that waits for the next
+ * sweep to read the tail.
  */
 export function projectLivenessEvents(
   records: AgentLivenessRecord[],
@@ -247,6 +258,7 @@ export function projectLivenessEvents(
 ): LifecycleEventInput[] {
   const events: LifecycleEventInput[] = [];
   for (const record of records) {
+    if (record.evidenceSource !== "transcript") continue;
     const subject = record.conversationId ?? record.transcriptPath;
     const marker = record.lastRecordAt ?? "unknown";
     const at = record.lastRecordAt ?? new Date().toISOString();

--- a/src/lib/lifecycle/projector.ts
+++ b/src/lib/lifecycle/projector.ts
@@ -251,6 +251,12 @@ export function lastObservedAgentState(file: LifecycleJournalFile): Map<string, 
  * an `agent_resumed` retiring it once a real read landed. An alarm surface that
  * fabricates alarm/all-clear pairs is worse than one that waits for the next
  * sweep to read the tail.
+ *
+ * The gate suppresses the all-clear as well as the alarm, and an actively
+ * appending transcript is the one most likely to lose the identity race that
+ * reports `unreadable` — so an outstanding `agent_stalled` can survive a poll
+ * cycle longer than it used to. The race window is sub-millisecond against a
+ * repeated sweep, so it retires on the next reading rather than persisting.
  */
 export function projectLivenessEvents(
   records: AgentLivenessRecord[],

--- a/src/lib/lifecycle/transcript.ts
+++ b/src/lib/lifecycle/transcript.ts
@@ -42,6 +42,10 @@ export interface LivenessTranscript {
   title: string;
   engine: Engine;
   mtimeMs: number;
+  /** File size, for the caller's read budget. A tail read is clamped well below
+      it — a multi-gigabyte transcript costs the same bounded tail as any other
+      — but the budget is charged before the read, so it needs the number. */
+  sizeBytes?: number;
   /** The scan's own conversation attribution. Null for a targeted lookup, which
       resolves the owner from the registry snapshot it already holds. */
   conversationId: string | null;
@@ -118,6 +122,7 @@ export async function describeTranscriptPath(transcriptPath: string): Promise<Li
     title: description.title,
     engine: description.engine,
     mtimeMs: stat.mtimeMs,
+    sizeBytes: stat.size,
     conversationId: null,
     activity: null,
     activityReason: null,


### PR DESCRIPTION
Refs #860. Deliberately not `Closes` — two acceptance items remain open, listed at the bottom.

## The stall

Project-scoped `agent_activity(project, liveOnly: true, limit: 10)` ran `listFiles({ fresh: true, persist: false })` **first** — root discovery, a process-table refresh, a tmux pane map and a tail read for every transcript in the corpus — and only then applied `project`, `liveOnly` and `limit`. Ten rows of answer cost a whole-corpus sweep; evidence was then read sequentially for each surviving row; and the request carried no deadline or `AbortSignal`, so a caller that gave up left the sweep and the tail reads running.

## The repair

New seam, `src/lib/lifecycle/inventorySelection.ts`, usable by any catalog surface:

| primitive | what it bounds |
| --- | --- |
| `selectConversationEntries` | engine/project/liveness filters and the row limit over **one completed generation**, before anything opens a transcript |
| `completedGenerationSelection` | reads that generation through `completedFileScan`, joining the process-wide single-generation lease; cancellation reaches the scanner |
| `hydrateWithBudget` | tail reads at bounded concurrency under byte and time budgets, stopping on caller cancellation |

`agentLivenessSnapshot` consumes both. Notable details:

- **Liveness stays correct without a fresh sweep**, in both halves. A hosted row the generation still projects as `idle` is rescued by widening the filter. A launch the generation predates entirely has no row to widen onto, so those are recovered by identity: selection reports which hosted paths it saw, and the snapshot resolves the rest through `describeTranscript` — one stat per unseen active host, capped, tracking the number of running agents rather than the size of the corpus. `selection.recovered` reports them, so a catalog that is behind the runtime says so instead of returning a clean empty answer.
- **Evidence quality is carried, and it gates the journal.** Every row says where its turn state came from — `transcript` (read and interpreted), `unreadable` (read, tail unusable), `projection` (budget spent before this row). Degraded rows are still returned to the caller, but `projectLivenessEvents` journals durable alarms only from `transcript` rows. Freshness for the other two is the generation's file mtime, which can be minutes old; alarming on it fabricates stall/resume pairs on the operator's alarm surface.
- **The hydration deadline is anchored where hydration begins**, not at the start of the call, so a cold generation's wait is not deducted from it.
- **The evidence budget follows the row limit** (`limit × 128 KiB`), so the default budget can always cover the rows the default limit admits. A fixed budget silently degraded rows 65+ of a hundred on every call.
- **Phase timings are identity-free numbers only** — `inventorySelectionMs`, `journalProjectionMs`, `evidenceReadMs`, `serializationMs`, `totalMs`, plus a `selection` report of counts, generation and which budget stopped the pass.
- **Targeted reads are untouched.** `conversationId`/`transcriptPath` still describe exactly what was named and consult no generation.
- The legacy `listFiles` source stays supported for injected callers that predate the seam; production installs `selectInventory` only.

Also clears the `globalThis` projection-throttle stamp between `projector.test.ts` cases. Left behind, a stamp a minute in the future silently throttled the real projection in whichever test file the runner ran next — the pair passed in only one of the two orders.

## Behaviour changes callers should know about

- **`liveOnly` is slightly wider.** A registry-hosted conversation now survives the filter even while the completed generation still projects it `idle`, and comes back as `waiting`. This is what makes serving `liveOnly` from a completed generation correct, but orchestration callers that read `liveOnly` as "needs attention" will see rows they did not before. Hosted rows compete for the same `limit` in newest-first order, so a just-launched hosted row still loses to `limit` newer project rows.
- **Snapshot payload gains additive fields**: `selection`, `timings`, and `evidenceSource` per record.
- **The journal is quieter under budget pressure.** A degraded sweep records nothing rather than recording a guess; the next sweep that reads the tail records it.
- **`stalledConfirmedCount` accompanies `stalledCount`.** The existing total counts projection-backed stalls too, which is right for a display total; the new count carries only stalls a transcript read stands behind. An operator headline (`mcp/presentation.ts` renders "N stalled") should prefer it — that file belongs to another lane, so the adoption is left to it.

## Evidence

Production-shaped fixture, isolated Viewer state: **10,001 conversation rows, 1,001 in the requested project, six live, one 3 GiB sparse transcript** (3.00 GiB apparent, 412 KiB allocated).

| measurement | result | bar |
| --- | --- | --- |
| warm `agent_activity(project, liveOnly, limit: 10)` | **32.2 ms** (selection 29.8, evidence 2.3, projection 0.04, serialization 0.02) | 500 ms |
| `limit: 10` over 1,001 matched project rows | **10 tails hydrated**, 29 ms | ≤ 10 |
| whole-corpus sweeps performed | **0** (`freshScan: false`, `generation: 12`, `cacheStatus: "hit"`) | none |
| 3 GiB transcript, hydrated | **131 072 bytes charged**, 33.4 ms, `evidenceSource: "transcript"` | body never read |
| 20 concurrent project reads | **1 generation start / 20 reads**, all `generation: 12`, 641 ms, RSS delta **81.2 MiB** | bounded |
| caller cancellation | rejects `AbortError`, **1** evidence read started, **0** started after abort | no surviving work |

Checks: 90 focused tests green (`src/lib/lifecycle/` + `src/lib/mcp/bindings.test.ts`, both file orders, isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`), `tsc --noEmit` clean, `eslint src/lib/lifecycle/` clean, `bun run build` (Next + MCP bundle) clean, privacy publication gate PASS against the merge base. Every review-round fix has a test that fails against the previous commit. No broad suite was run against live state; nothing was deployed.

## Remaining dependencies

1. **`list_conversations` adoption is blocked by file ownership.** It already reads the completed generation (#845) but still filters and slices the cloned corpus inline in `src/lib/mcp/bindings.ts`, which the #859 branch owns. The adoption is a one-call substitution, spelled out in the module doc comment.
2. **Acceptance criterion 4's cancellation half is seam-only until #859 wires it.** `agentActivity` is dispatched as `(args) => …` and never receives the `McpToolCallContext`, so it passes no `signal` and no deadline-derived budget — `get_conversation` and `conversation_action` already take `(args, context)` and build `deadlineSignal` from `context.deadlineAt` at `bindings.ts:766`. The concurrency, byte and time BOUNDS all apply by default, so the latency goal lands; what does not yet land is client cancellation stopping outstanding work, and a cold-generation `completedFileScan` still waits unbounded. Stating that plainly rather than letting the criterion read as checked.
3. **Exact-SHA deploy and production verification are not part of this change.** A Builder does not deploy, so the cold-call bar (≤ 2 s) is unverified against a real cold scanner generation; the fixture stubs the generation deliberately, since sweeping the operator's live corpus in a test is what this repo forbids. This change removes a *second* private fresh sweep layered on top of the cold generation; it does not make the cold generation itself faster.

## Noted, not done

`completedFileScan` deep-clones the whole snapshot per reader — 29.8 of the warm 32.2 ms, and the 85 MiB RSS delta across twenty readers. A read-only borrow would remove both, but it changes shared scanner cache semantics for every consumer, outside this lane's fence. Filed here as the next lever, ~16× inside the current bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
