### PR TITLE
feat(runtime): durable compact control for structured conversations

### DIFF
--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -455,6 +455,46 @@ test("/api/tmux admits pane-less kill through the structured control path", asyn
   }
 });
 
+test("/api/tmux carries the caller's compact operation id so a retry replays one receipt", async () => {
+  const previous = process.env.LLV_STRUCTURED_HOSTS;
+  structuredControlCalls = 0;
+  structuredControlRequest = null;
+  structuredControlResult = {
+    status: 202,
+    body: {
+      ok: true,
+      structured: true,
+      target: "conversation-compact",
+      operationId: "compact_gesture-one",
+      receipt: { operationId: "compact_gesture-one", status: "pending" },
+    },
+  };
+  try {
+    process.env.LLV_STRUCTURED_HOSTS = "1";
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await POST(post({
+        path: PATHNAME,
+        conversationId: "conversation-compact",
+        action: "compact",
+        operationId: "compact_gesture-one",
+      }));
+      expect(response.status).toBe(202);
+    }
+    /* Both attempts of one gesture name the same operation, so the journal
+       replays the first receipt instead of admitting a second compaction. */
+    expect(structuredControlCalls).toBe(2);
+    expect((structuredControlRequest as unknown as { operationId?: string }).operationId).toBe("compact_gesture-one");
+
+    structuredControlRequest = null;
+    await POST(post({ path: PATHNAME, conversationId: "conversation-compact", action: "compact" }));
+    expect("operationId" in (structuredControlRequest as unknown as Record<string, unknown>)).toBe(false);
+  } finally {
+    structuredControlResult = null;
+    if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous;
+  }
+});
+
 test("/api/tmux forwards account-aware structured reconfigure as one durable control", async () => {
   const previous = process.env.LLV_STRUCTURED_HOSTS;
   structuredControlCalls = 0;

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -136,13 +136,14 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
-  let body: { pid?: unknown; path?: unknown; conversationId?: unknown; clientMessageId?: unknown; text?: unknown; image?: unknown; images?: unknown; action?: unknown; key?: unknown; label?: unknown; question?: unknown; target?: unknown; model?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown };
+  let body: { pid?: unknown; path?: unknown; conversationId?: unknown; clientMessageId?: unknown; operationId?: unknown; text?: unknown; image?: unknown; images?: unknown; action?: unknown; key?: unknown; label?: unknown; question?: unknown; target?: unknown; model?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown };
   try {
     body = (await req.json()) as {
       pid?: unknown;
       path?: unknown;
       conversationId?: unknown;
       clientMessageId?: unknown;
+      operationId?: unknown;
       text?: unknown;
       image?: unknown;
       images?: unknown;
@@ -214,6 +215,12 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
       conversationId,
       transcriptPath: filePath,
       action: explicitAction,
+      /* #862: the caller owns operation identity for durable controls. Without
+         it every HTTP retry of one user gesture would mint a fresh operation —
+         and a second compaction — instead of replaying the first receipt. */
+      ...(typeof body.operationId === "string" && body.operationId.trim()
+        ? { operationId: body.operationId.trim() }
+        : {}),
       key: typeof body.key === "string" ? body.key : "",
       label: body.label,
       question: body.question,

--- a/src/components/AgentControlStrip.action.test.tsx
+++ b/src/components/AgentControlStrip.action.test.tsx
@@ -266,11 +266,38 @@ test("a rejected compaction is reported as the refusal, not as a started compact
 
   expect(bodies).toHaveLength(1);
   expect(bodies[0]!.action).toBe("compact");
-  expect(statusText(host)).toBe("busy-turn");
+  /* The operator reads a sentence, not the durable record's machine token. */
+  expect(statusText(host)).toBe(translate("en", "receipt.human.turnActive"));
   expect(statusText(host)).not.toBe(translate("en", "composer.compactSent"));
 
-  /* The refusal did not consume the gesture's operation, so a retry replays it
-     rather than admitting a second compaction. */
+  /* The refusal is terminal and stored, and idempotency replays a stored
+     receipt for the same key forever — so the gesture's operation is released
+     and the next attempt is a genuinely new one. Holding the id would answer
+     every later click with this same stale refusal. */
+  await confirmCompact(host);
+  expect(bodies).toHaveLength(2);
+  expect(bodies[1]!.operationId).not.toBe(bodies[0]!.operationId);
+  await act(async () => root.unmount());
+});
+
+test("an ambiguous transport failure keeps the gesture on one operation", async () => {
+  sessionView = structuredCodexView();
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
+    /* The runtime-host socket failed and no receipt came back: the compaction
+       may or may not have been admitted, so the retry must name the same
+       operation rather than risk a second one. */
+    return Promise.resolve({
+      ok: false,
+      json: () => Promise.resolve({ error: "runtime host request timed out" }),
+    } as unknown as Response);
+  }) as typeof fetch;
+
+  const { host, root } = await mount(structuredRoot);
+  await confirmCompact(host);
+  expect(statusText(host)).toBe("runtime host request timed out");
+
   await confirmCompact(host);
   expect(bodies).toHaveLength(2);
   expect(bodies[1]!.operationId).toBe(bodies[0]!.operationId);

--- a/src/components/AgentControlStrip.action.test.tsx
+++ b/src/components/AgentControlStrip.action.test.tsx
@@ -280,6 +280,32 @@ test("a rejected compaction is reported as the refusal, not as a started compact
   await act(async () => root.unmount());
 });
 
+test("a typed capability refusal is localized from its code, not echoed in English", async () => {
+  sessionView = structuredCodexView();
+  const calls: string[] = [];
+  globalThis.fetch = ((url: string) => {
+    calls.push(String(url));
+    return Promise.resolve({
+    ok: false,
+    json: () => Promise.resolve({
+      /* `dispatchStructuredControl`'s capability body: the sentence is a
+         server-side English string, so the code is what the operator reads. */
+      error: "The Claude stream-json protocol has no client-originated compact control; only interrupt is exposed.",
+      code: "unsupported-capability",
+      capability: { control: "compact", engine: "claude", supported: false },
+    }),
+    } as unknown as Response);
+  }) as typeof fetch;
+
+  const { host, root } = await mount(structuredRoot);
+  await confirmCompact(host);
+
+  expect(calls).toEqual(["/api/tmux"]);
+  expect(statusText(host)).toBe(translate("en", "receipt.human.unsupportedCapability"));
+  expect(statusText(host)).not.toContain("stream-json");
+  await act(async () => root.unmount());
+});
+
 test("an ambiguous transport failure keeps the gesture on one operation", async () => {
   sessionView = structuredCodexView();
   const bodies: Array<Record<string, unknown>> = [];

--- a/src/components/AgentControlStrip.action.test.tsx
+++ b/src/components/AgentControlStrip.action.test.tsx
@@ -64,11 +64,13 @@ let rootAxis: HostAxis = "hosted";
 // default shape without a live runtime — a re-mock to the real module does not
 // reliably un-bind already-loaded consumers, but flipping the flag does.
 let planeEnabled = true;
+/* A pane-less structured session for the root-conversation compact tests. */
+let sessionView: RuntimeSessionView | null = null;
 const actual = await import("@/hooks/useRuntime");
 mock.module("@/hooks/useRuntime", () => ({
   ...actual,
   useRuntime: () => ({ enabled: planeEnabled, connection: planeEnabled ? "live" : "offline", resyncedAt: null, store: {} }),
-  useRuntimeSession: () => null,
+  useRuntimeSession: () => sessionView,
   useRuntimeSessionByArtifact: (path: string | null) => (planeEnabled && path === "/root.jsonl" ? rootView(rootKind, rootAxis) : null),
 }));
 
@@ -101,6 +103,7 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   rootKind = "claude-broker";
   rootAxis = "hosted";
+  sessionView = null;
   FakeResizeObserver.instances = [];
   document.body.replaceChildren();
   localStorage.clear();
@@ -197,4 +200,108 @@ test("Stop on a live TMUX-root subagent keeps the canonical /api/tmux child path
   expect(interrupts[0]!.body).toEqual({ action: "interrupt", path: "/child.jsonl" });
   expect(calls.some((c) => c.url.includes("/api/runtime/interrupt"))).toBe(false);
   await act(async () => root.unmount());
+});
+
+/* ------------------------- #862 structured compact ------------------------- */
+
+const structuredRoot: FileEntry = {
+  path: "/root.jsonl", root: "codex-sessions", name: "root.jsonl", project: "viewer", title: "root",
+  engine: "codex", kind: "session", fmt: "codex", parent: null, mtime: 1, size: 1,
+  activity: "live", proc: "running", pid: null, model: "gpt-5.3-codex-spark", effort: "high", fast: false,
+  pendingQuestion: null, waitingInput: null,
+} as FileEntry;
+
+function structuredCodexView(): RuntimeSessionView {
+  return {
+    session: {
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      sessionKey: { engine: "codex", sessionId: "thread-one" },
+      conversationId: "conv-root",
+      capabilities: { steer: true, structuredAttention: true },
+    } as unknown as RuntimeSessionView["session"],
+    uiState: {} as RuntimeSessionView["uiState"],
+    attentions: [],
+    receipts: [],
+    legacy: false,
+    structuredControlsEnabled: true,
+  };
+}
+
+const compactButton = (host: HTMLElement) =>
+  host.querySelector(`button[aria-label^="${translate("en", "composer.compactAria")}"]`) as HTMLButtonElement | null;
+
+async function confirmCompact(host: HTMLElement): Promise<void> {
+  const button = compactButton(host)!;
+  await act(async () => button.click());
+  await act(async () => button.click());
+}
+
+const statusText = (host: HTMLElement) =>
+  (host.querySelector("[aria-live]") as HTMLElement | null)?.textContent ?? "";
+
+test("a rejected compaction is reported as the refusal, not as a started compaction", async () => {
+  sessionView = structuredCodexView();
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
+    /* Structured controls answer 202 `ok` for a receipt the journal REFUSED,
+       so the receipt decides what the operator is told. */
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        structured: true,
+        target: "conv-root",
+        operationId: String(bodies.at(-1)!.operationId),
+        receipt: { operationId: String(bodies.at(-1)!.operationId), status: "rejected", reason: "busy-turn" },
+      }),
+    } as unknown as Response);
+  }) as typeof fetch;
+
+  const { host, root } = await mount(structuredRoot);
+  expect(host.querySelector('[data-strip-surface="structured"]')).not.toBeNull();
+  await confirmCompact(host);
+
+  expect(bodies).toHaveLength(1);
+  expect(bodies[0]!.action).toBe("compact");
+  expect(statusText(host)).toBe("busy-turn");
+  expect(statusText(host)).not.toBe(translate("en", "composer.compactSent"));
+
+  /* The refusal did not consume the gesture's operation, so a retry replays it
+     rather than admitting a second compaction. */
+  await confirmCompact(host);
+  expect(bodies).toHaveLength(2);
+  expect(bodies[1]!.operationId).toBe(bodies[0]!.operationId);
+  await act(async () => root.unmount());
+});
+
+test("compact still mints an operation id without a secure context", async () => {
+  sessionView = structuredCodexView();
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, structured: true, target: "conv-root", receipt: { status: "pending" } }),
+    } as unknown as Response);
+  }) as typeof fetch;
+  /* Plain-http LAN access has no `crypto.randomUUID`. Reaching for it directly
+     would throw outside the try, leaving the button permanently busy. */
+  const cryptoObject = globalThis.crypto as { randomUUID?: unknown };
+  const realRandomUUID = cryptoObject.randomUUID;
+  delete cryptoObject.randomUUID;
+  try {
+    const { host, root } = await mount(structuredRoot);
+    await confirmCompact(host);
+
+    expect(bodies).toHaveLength(1);
+    expect(typeof bodies[0]!.operationId).toBe("string");
+    expect(String(bodies[0]!.operationId).length).toBeGreaterThan(8);
+    expect(statusText(host)).toBe(translate("en", "composer.compactSent"));
+    await act(async () => root.unmount());
+  } finally {
+    if (realRandomUUID !== undefined) cryptoObject.randomUUID = realRandomUUID;
+  }
 });

--- a/src/components/AgentControlStrip.dom.test.tsx
+++ b/src/components/AgentControlStrip.dom.test.tsx
@@ -22,7 +22,18 @@ function file(overrides: Partial<FileEntry> = {}): FileEntry {
 }
 
 function rv(hostKind: HostKind, host: HostAxis): RuntimeSessionView {
-  return { session: { hostKind, host } as RuntimeSessionView["session"], uiState: {} as RuntimeSessionView["uiState"], attentions: [], receipts: [], legacy: false, structuredControlsEnabled: true };
+  return {
+    session: {
+      hostKind,
+      host,
+      sessionKey: { engine: hostKind === "claude-broker" ? "claude" : "codex", sessionId: "session-one" },
+    } as RuntimeSessionView["session"],
+    uiState: {} as RuntimeSessionView["uiState"],
+    attentions: [],
+    receipts: [],
+    legacy: false,
+    structuredControlsEnabled: true,
+  };
 }
 
 function render(f: FileEntry, view: RuntimeSessionView | null, extra: Partial<Parameters<typeof AgentControlStripView>[0]> = {}) {
@@ -67,12 +78,20 @@ test("hidden controls never reach the DOM (resume hides stop/compact/kill)", () 
 });
 
 test("a disabled control keeps aria-disabled and appends the reason to its aria-label", () => {
-  const html = render(file({ proc: "running" }), rv("codex-app-server", "hosted"));
+  // A structured Claude host has no compact control in its protocol (#862), so
+  // that cell is the disabled one and names the engine gap.
+  const html = render(file({ proc: "running" }), rv("claude-broker", "hosted"));
   expect(html).toContain('data-strip-surface="structured"');
-  // compact is disabled with the structured-fence reason appended to the aria-label
-  const reason = translate("en", "strip.structuredUnsupported");
+  const reason = translate("en", "strip.compactEngineUnsupported");
   expect(html).toContain('aria-disabled="true"');
   expect(html).toContain(`context (/compact) — ${reason}`);
+});
+
+test("a structured Codex host renders Compact as a real, enabled control (#862)", () => {
+  const html = render(file({ proc: "running" }), rv("codex-app-server", "hosted"));
+  expect(html).toContain('data-strip-surface="structured"');
+  expect(html).toContain('aria-label="Compact the agent&#x27;s context (/compact)"');
+  expect(html).not.toContain(`context (/compact) — ${translate("en", "strip.compactEngineUnsupported")}`);
 });
 
 test("the structured surface renders no mode chip — the «structured» badge is gone (issue #390)", () => {

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -133,9 +133,18 @@ const visible = (cap: Capability) => cap.state !== "hidden";
  * receipt chips use; anything unmapped falls back to the generic failure line
  * rather than showing a token to someone reading Ukrainian.
  */
-function compactFailureText(t: TFunction, reason: string | null | undefined, error: string | undefined): string {
+function compactFailureText(
+  t: TFunction,
+  reason: string | null | undefined,
+  error: string | undefined,
+  code: string | undefined,
+): string {
   const key = humanReceiptReasonKey(reason);
   if (key) return t(key);
+  /* A refusal that never became a receipt still has a machine code. The
+     capability body's `error` is a server-side English sentence, so the code is
+     what gets translated. */
+  if (code === "unsupported-capability") return t("receipt.human.unsupportedCapability");
   return error ?? t("composer.failedCompact");
 }
 
@@ -427,6 +436,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
       const body = (await response.json()) as {
         ok?: boolean;
         error?: string;
+        code?: string;
         receipt?: { status?: string; reason?: string | null };
       };
       /* A structured control answers 202 `ok` for an admitted receipt AND for
@@ -445,7 +455,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
       if (accepted || settled) compactOperationRef.current = null;
       setStatus(accepted
         ? { kind: "ok", text: t("composer.compactSent") }
-        : { kind: "err", text: compactFailureText(t, body.receipt?.reason, body.error) });
+        : { kind: "err", text: compactFailureText(t, body.receipt?.reason, body.error, body.code) });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -400,8 +400,10 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
     /* #862: one durable operation per confirmed gesture. On a structured host
        this admits a real compaction, so a retry after a timeout or a failed
        response must replay that same operation — the id is only released once
-       the request is known to have landed. */
-    const operationId = compactOperationRef.current ?? `compact_${crypto.randomUUID()}`;
+       the request is known to have landed. `mintIdempotencyKey` is used for the
+       same reason the composer does: `crypto.randomUUID` needs a secure
+       context, and LAN http access gets the fallback. */
+    const operationId = compactOperationRef.current ?? mintIdempotencyKey();
     compactOperationRef.current = operationId;
     try {
       const response = await fetch("/api/tmux", {
@@ -409,10 +411,22 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ action: "compact", path: file.path, operationId }),
       });
-      const body = (await response.json()) as { ok?: boolean; error?: string };
-      const accepted = response.ok && Boolean(body.ok);
+      const body = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        receipt?: { status?: string; reason?: string | null };
+      };
+      /* A structured control answers 202 `ok` for an admitted receipt AND for a
+         one the journal refused, so the receipt — not the HTTP status — decides
+         what the operator is told. Announcing a compaction that was rejected
+         (a live turn is the ordinary case) would leave them waiting for a band
+         that never arrives. */
+      const rejected = body.receipt?.status === "rejected";
+      const accepted = response.ok && Boolean(body.ok) && !rejected;
       if (accepted) compactOperationRef.current = null;
-      setStatus(accepted ? { kind: "ok", text: t("composer.compactSent") } : { kind: "err", text: body.error ?? t("composer.failedCompact") });
+      setStatus(accepted
+        ? { kind: "ok", text: t("composer.compactSent") }
+        : { kind: "err", text: body.receipt?.reason ?? body.error ?? t("composer.failedCompact") });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -295,6 +295,8 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
   const [compactBusy, setCompactBusy] = useState(false);
   const [recheckBusy, setRecheckBusy] = useState(false);
   const [compactArmed, setCompactArmed] = useState(false);
+  /** The durable operation a confirmed compact gesture owns until it lands. */
+  const compactOperationRef = useRef<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [status, setStatus] = useState<{ kind: "ok" | "info" | "err"; text: string } | null>(null);
 
@@ -395,14 +397,22 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
     if (compactBusy) return;
     setCompactBusy(true);
     setStatus(null);
+    /* #862: one durable operation per confirmed gesture. On a structured host
+       this admits a real compaction, so a retry after a timeout or a failed
+       response must replay that same operation — the id is only released once
+       the request is known to have landed. */
+    const operationId = compactOperationRef.current ?? `compact_${crypto.randomUUID()}`;
+    compactOperationRef.current = operationId;
     try {
       const response = await fetch("/api/tmux", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ action: "compact", path: file.path }),
+        body: JSON.stringify({ action: "compact", path: file.path, operationId }),
       });
       const body = (await response.json()) as { ok?: boolean; error?: string };
-      setStatus(response.ok && body.ok ? { kind: "ok", text: t("composer.compactSent") } : { kind: "err", text: body.error ?? t("composer.failedCompact") });
+      const accepted = response.ok && Boolean(body.ok);
+      if (accepted) compactOperationRef.current = null;
+      setStatus(accepted ? { kind: "ok", text: t("composer.compactSent") } : { kind: "err", text: body.error ?? t("composer.failedCompact") });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -12,7 +12,7 @@ import { interruptRuntime, refreshRuntime } from "@/hooks/useRuntime";
 import { useLocale, type MessageKey, type TFunction } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
-import { mintIdempotencyKey } from "@/components/runtime/runtimeModel";
+import { humanReceiptReasonKey, mintIdempotencyKey } from "@/components/runtime/runtimeModel";
 import { useAgentCapabilities } from "./useAgentCapabilities";
 import {
   stripHasVisibleControls,
@@ -125,6 +125,19 @@ export interface AgentControlStripViewProps {
 }
 
 const visible = (cap: Capability) => cap.state !== "hidden";
+
+/**
+ * Operator-facing text for a compact that did not start. Receipt reasons are
+ * machine tokens (`busy-turn`, `stale-generation`, …) meant for the durable
+ * record, so they go through the same reason→sentence map the composer's
+ * receipt chips use; anything unmapped falls back to the generic failure line
+ * rather than showing a token to someone reading Ukrainian.
+ */
+function compactFailureText(t: TFunction, reason: string | null | undefined, error: string | undefined): string {
+  const key = humanReceiptReasonKey(reason);
+  if (key) return t(key);
+  return error ?? t("composer.failedCompact");
+}
 
 /**
  * Presentational unified control strip (issue #241). Pure — its control set,
@@ -416,17 +429,23 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
         error?: string;
         receipt?: { status?: string; reason?: string | null };
       };
-      /* A structured control answers 202 `ok` for an admitted receipt AND for a
+      /* A structured control answers 202 `ok` for an admitted receipt AND for
          one the journal refused, so the receipt — not the HTTP status — decides
          what the operator is told. Announcing a compaction that was rejected
          (a live turn is the ordinary case) would leave them waiting for a band
          that never arrives. */
-      const rejected = body.receipt?.status === "rejected";
-      const accepted = response.ok && Boolean(body.ok) && !rejected;
-      if (accepted) compactOperationRef.current = null;
+      const settled = body.receipt?.status === "rejected" || body.receipt?.status === "failed";
+      const accepted = response.ok && Boolean(body.ok) && !settled;
+      /* The gesture's operation is released as soon as the journal reaches a
+         verdict, refusal included. Idempotency replays a stored receipt for the
+         same key forever, so holding the id past a rejection would answer every
+         later click with that same stale refusal — the button would never
+         compact this conversation again. It is held only while the outcome is
+         genuinely unknown: a transport failure, or a throw below. */
+      if (accepted || settled) compactOperationRef.current = null;
       setStatus(accepted
         ? { kind: "ok", text: t("composer.compactSent") }
-        : { kind: "err", text: body.receipt?.reason ?? body.error ?? t("composer.failedCompact") });
+        : { kind: "err", text: compactFailureText(t, body.receipt?.reason, body.error) });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {

--- a/src/components/agentCapabilities.test.ts
+++ b/src/components/agentCapabilities.test.ts
@@ -40,7 +40,14 @@ function imageCap(supported: boolean): RuntimeImageCapability {
     negotiated image capability. */
 function rv(hostKind: HostKind, host: HostAxis, legacy = false, imageInput?: RuntimeImageCapability): RuntimeSessionView {
   return {
-    session: { hostKind, host, capabilities: { steer: true, structuredAttention: true, ...(imageInput ? { imageInput } : {}) } } as RuntimeSessionView["session"],
+    session: {
+      hostKind,
+      host,
+      /* The engine the host speaks — structured Compact reads it, because the
+         compact control exists on codex-app-server and not on claude-broker. */
+      sessionKey: { engine: hostKind === "claude-broker" ? "claude" : "codex", sessionId: "session-one" },
+      capabilities: { steer: true, structuredAttention: true, ...(imageInput ? { imageInput } : {}) },
+    } as RuntimeSessionView["session"],
     uiState: {} as RuntimeSessionView["uiState"],
     attentions: [],
     receipts: [],
@@ -239,15 +246,17 @@ test("live-subagent: stop enabled (root-interrupt note), compact disabled, runti
   expect(state("images", f, null)).toBe("enabled");
 });
 
-test("structured: stop+terminal+kill+runtime enabled, compact still fenced, images follow the negotiated capability", () => {
+test("structured: stop+terminal+kill+runtime enabled, compact follows the engine, images follow the negotiated capability", () => {
   const f = file({ proc: "running" });
   const view = rv("codex-app-server", "hosted");
   expect(state("stop", f, view)).toBe("enabled");
   expect(state("terminal", f, view)).toBe("enabled");
   // Kill is enabled and routed through the durable structured control channel.
   expect(state("kill", f, view)).toBe("enabled");
-  // Compact stays disabled: dispatchStructuredControl still 409s it.
-  expect(reason("compact", f, view)).toBe("strip.structuredUnsupported");
+  // Compact is a real durable control on codex-app-server (#862)...
+  expect(state("compact", f, view)).toBe("enabled");
+  // ...and a genuine protocol gap on claude-broker, which names the engine.
+  expect(reason("compact", f, rv("claude-broker", "hosted"))).toBe("strip.compactEngineUnsupported");
   // The composer RuntimePill owns runtime selection here (issue #390); per-row
   // honesty comes from the session's negotiated runtimeSettings capability.
   expect(state("runtime", f, view)).toBe("enabled");

--- a/src/components/agentCapabilities.test.ts
+++ b/src/components/agentCapabilities.test.ts
@@ -70,6 +70,12 @@ function rvTurn(turn: "unknown" | "idle" | "running" | "interrupt_requested"): R
   return { ...view, session: { ...view.session, turn } };
 }
 
+/** A hosted codex structured view whose axis says idle while a turn is live. */
+function rvActiveTurn(): RuntimeSessionView {
+  const view = rvTurn("idle");
+  return { ...view, session: { ...view.session, activeTurnId: "turn-live" } };
+}
+
 /** Same view with the structured-hosts rollback flag OFF. */
 function rvGateOff(hostKind: HostKind, host: HostAxis): RuntimeSessionView {
   return { ...rv(hostKind, host), structuredControlsEnabled: false };
@@ -280,6 +286,10 @@ test("structured: stop+terminal+kill+runtime enabled, compact follows the engine
   expect(reason("compact", f, rvTurn("interrupt_requested"))).toBe("strip.compactBusyTurn");
   expect(state("compact", f, rvTurn("idle"))).toBe("enabled");
   expect(state("compact", f, rvTurn("unknown"))).toBe("enabled");
+  /* Admission rejects on the turn axis OR a live activeTurnId, so both halves
+     are read here — an idle-looking session still carrying a turn must not
+     offer a button the journal will refuse. */
+  expect(reason("compact", f, rvActiveTurn())).toBe("strip.compactBusyTurn");
   // The composer RuntimePill owns runtime selection here (issue #390); per-row
   // honesty comes from the session's negotiated runtimeSettings capability.
   expect(state("runtime", f, view)).toBe("enabled");

--- a/src/components/agentCapabilities.test.ts
+++ b/src/components/agentCapabilities.test.ts
@@ -56,6 +56,20 @@ function rv(hostKind: HostKind, host: HostAxis, legacy = false, imageInput?: Run
   };
 }
 
+/** A hosted structured view whose `sessionKey` payload never arrived. */
+function rvWithoutSessionKey(hostKind: HostKind): RuntimeSessionView {
+  const view = rv(hostKind, "hosted");
+  const { sessionKey, ...session } = view.session as RuntimeSessionView["session"] & { sessionKey?: unknown };
+  void sessionKey;
+  return { ...view, session: session as RuntimeSessionView["session"] };
+}
+
+/** A hosted codex structured view on a named turn axis. */
+function rvTurn(turn: "unknown" | "idle" | "running" | "interrupt_requested"): RuntimeSessionView {
+  const view = rv("codex-app-server", "hosted");
+  return { ...view, session: { ...view.session, turn } };
+}
+
 /** Same view with the structured-hosts rollback flag OFF. */
 function rvGateOff(hostKind: HostKind, host: HostAxis): RuntimeSessionView {
   return { ...rv(hostKind, host), structuredControlsEnabled: false };
@@ -257,6 +271,15 @@ test("structured: stop+terminal+kill+runtime enabled, compact follows the engine
   expect(state("compact", f, view)).toBe("enabled");
   // ...and a genuine protocol gap on claude-broker, which names the engine.
   expect(reason("compact", f, rv("claude-broker", "hosted"))).toBe("strip.compactEngineUnsupported");
+  // The cell gates on exactly what the server gates on: host kind as well as
+  // engine. A session view whose sessionKey never arrived defaults its engine to
+  // codex, so the host kind is what keeps a claude-broker cell honest...
+  expect(reason("compact", f, rvWithoutSessionKey("claude-broker"))).toBe("strip.compactEngineUnsupported");
+  // ...and the turn, because admission rejects a compaction that races one.
+  expect(reason("compact", f, rvTurn("running"))).toBe("strip.compactBusyTurn");
+  expect(reason("compact", f, rvTurn("interrupt_requested"))).toBe("strip.compactBusyTurn");
+  expect(state("compact", f, rvTurn("idle"))).toBe("enabled");
+  expect(state("compact", f, rvTurn("unknown"))).toBe("enabled");
   // The composer RuntimePill owns runtime selection here (issue #390); per-row
   // honesty comes from the session's negotiated runtimeSettings capability.
   expect(state("runtime", f, view)).toBe("enabled");

--- a/src/components/agentCapabilities.ts
+++ b/src/components/agentCapabilities.ts
@@ -156,13 +156,15 @@ const structuredImages = (imageInput: RuntimeImageCapability | null | undefined)
  *   require to be codex-app-server (a session view missing `sessionKey`
  *   defaults its engine to codex, so the engine alone is not enough);
  * - the turn, because admission rejects a compaction that would race a live one
- *   — an enabled button there promises something the journal refuses.
+ *   — an enabled button there promises something the journal refuses. Both
+ *   halves of that rejection are read: the turn axis AND a non-null
+ *   `activeTurnId`, which a session can project while its axis still says idle.
  */
 const structuredCompact = (session: RuntimeSessionView["session"] | undefined): Capability => {
   if (session?.hostKind !== "codex-app-server" || session.sessionKey?.engine !== "codex") {
     return disabled("strip.compactEngineUnsupported");
   }
-  if (session.turn === "running" || session.turn === "interrupt_requested") {
+  if (session.turn === "running" || session.turn === "interrupt_requested" || session.activeTurnId) {
     return disabled("strip.compactBusyTurn");
   }
   return ENABLED;

--- a/src/components/agentCapabilities.ts
+++ b/src/components/agentCapabilities.ts
@@ -145,15 +145,28 @@ const structuredImages = (imageInput: RuntimeImageCapability | null | undefined)
   imageInput?.supported ? ENABLED : disabled("composer.structuredImagesProtocol");
 
 /**
- * Compact on a pane-less structured host (#862). The cell is engine-aware
- * because the capability is: codex-app-server exposes `thread/compact/start`
- * and reports completion through the `contextCompaction` item, while the Claude
- * stream-json protocol has no client-originated compact control at all. The
- * disabled cell must say which of those two it is — the old blanket "not
- * supported yet" is now wrong for Codex and imprecise for Claude.
+ * Compact on a pane-less structured host (#862). Three facts decide the cell,
+ * and they are exactly the three the server gates on, so a click can only be
+ * refused for a reason that arrived after the render:
+ *
+ * - the engine: codex-app-server exposes `thread/compact/start` and reports
+ *   completion through the `contextCompaction` item, while the Claude
+ *   stream-json protocol has no client-originated compact control at all;
+ * - the host kind, which `dispatchStructuredControl` and journal admission both
+ *   require to be codex-app-server (a session view missing `sessionKey`
+ *   defaults its engine to codex, so the engine alone is not enough);
+ * - the turn, because admission rejects a compaction that would race a live one
+ *   — an enabled button there promises something the journal refuses.
  */
-const structuredCompact = (engine: string | null | undefined): Capability =>
-  engine === "codex" ? ENABLED : disabled("strip.compactEngineUnsupported");
+const structuredCompact = (session: RuntimeSessionView["session"] | undefined): Capability => {
+  if (session?.hostKind !== "codex-app-server" || session.sessionKey?.engine !== "codex") {
+    return disabled("strip.compactEngineUnsupported");
+  }
+  if (session.turn === "running" || session.turn === "interrupt_requested") {
+    return disabled("strip.compactBusyTurn");
+  }
+  return ENABLED;
+};
 
 /** A structured (pane-less) host that is currently alive. Gated by the
     structured-hosts rollback flag: with `structuredControlsEnabled` off no
@@ -298,7 +311,7 @@ export function capabilitiesFor(file: FileEntry, rv: RuntimeSessionView | null, 
           stop: ENABLED,
           // Compact is a real durable control on a Codex structured host and a
           // genuine protocol gap on a Claude one (#862).
-          compact: structuredCompact(rv?.session.sessionKey?.engine),
+          compact: structuredCompact(rv?.session),
           // The composer runtime pill owns selection here (issue #390): the cell
           // is enabled, and per-turn honesty comes from the session's negotiated
           // `runtimeSettings` capability, which disables individual rows when a

--- a/src/components/agentCapabilities.ts
+++ b/src/components/agentCapabilities.ts
@@ -144,6 +144,17 @@ const enabledWithNote = (note: MessageKey): Capability => ({ state: "enabled", n
 const structuredImages = (imageInput: RuntimeImageCapability | null | undefined): Capability =>
   imageInput?.supported ? ENABLED : disabled("composer.structuredImagesProtocol");
 
+/**
+ * Compact on a pane-less structured host (#862). The cell is engine-aware
+ * because the capability is: codex-app-server exposes `thread/compact/start`
+ * and reports completion through the `contextCompaction` item, while the Claude
+ * stream-json protocol has no client-originated compact control at all. The
+ * disabled cell must say which of those two it is — the old blanket "not
+ * supported yet" is now wrong for Codex and imprecise for Claude.
+ */
+const structuredCompact = (engine: string | null | undefined): Capability =>
+  engine === "codex" ? ENABLED : disabled("strip.compactEngineUnsupported");
+
 /** A structured (pane-less) host that is currently alive. Gated by the
     structured-hosts rollback flag: with `structuredControlsEnabled` off no
     session — however its registry state reads — counts as a structured host, so
@@ -223,12 +234,12 @@ export function surfaceFor(file: FileEntry, rv: RuntimeSessionView | null, opts:
 }
 
 /**
- * Resolve every control's capability for a conversation. Structured Kill ships
- * through the durable structured control channel, and structured images follow
- * the session's negotiated `capabilities.imageInput`. The remaining ⚠ cells —
- * compact and reconfigure on a structured host — stay `disabled` with a tooltip
- * because `dispatchStructuredControl` still rejects them (409); they flip to
- * `enabled` by editing exactly one row here once the host supports them.
+ * Resolve every control's capability for a conversation. Structured Kill and
+ * Compact ship through the durable structured control channel, structured
+ * images follow the session's negotiated `capabilities.imageInput`, and
+ * structured Compact follows the engine's own control protocol
+ * (`structuredCompact`). A cell that stays `disabled` here names a real gap in
+ * the engine or the surface, never a Viewer backlog item.
  */
 export function capabilitiesFor(file: FileEntry, rv: RuntimeSessionView | null, opts: HostOptions = {}): StripCapabilities {
   const surface = surfaceFor(file, rv, opts);
@@ -285,15 +296,16 @@ export function capabilitiesFor(file: FileEntry, rv: RuntimeSessionView | null, 
         surface,
         controls: {
           stop: ENABLED,
-          compact: disabled("strip.structuredUnsupported"),
+          // Compact is a real durable control on a Codex structured host and a
+          // genuine protocol gap on a Claude one (#862).
+          compact: structuredCompact(rv?.session.sessionKey?.engine),
           // The composer runtime pill owns selection here (issue #390): the cell
           // is enabled, and per-turn honesty comes from the session's negotiated
           // `runtimeSettings` capability, which disables individual rows when a
           // host can't honor a live change (never a whole-control fence).
           runtime: ENABLED,
-          // Kill enters the durable structured control channel (one structured
-          // request, never /api/proc). Compact and reconfigure stay fenced:
-          // dispatchStructuredControl still answers them with a 409.
+          // Kill and compact enter the durable structured control channel (one
+          // structured request, never /api/proc).
           kill: ENABLED,
           terminal: ENABLED,
           images: structuredImages(rv?.session.capabilities?.imageInput),

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -107,7 +107,7 @@ export type ReceiptStatus =
   | "failed"
   | "uncertain";
 
-export type OperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn" | "reconfigure";
+export type OperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn" | "reconfigure" | "compact";
 
 /** Client connection state (Fable §2). `resynced` is a transient note, not a state. */
 export type ConnectionState = "live" | "reconnecting" | "degraded" | "offline";

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -775,7 +775,14 @@ export const RECEIPT_REASON_KEYS: Record<string, MessageKey> = {
   "stale-delivery-key": "receipt.human.staleKey",
   "duplicate": "receipt.human.duplicate",
   "turn-active": "receipt.human.turnActive",
+  "busy-turn": "receipt.human.turnActive",
   "no-active-turn": "receipt.human.noTurn",
+  /* #862 compact refusals. `stale-generation` is the same class of fact as a
+     stale delivery key: the operator was pointing at a generation that is no
+     longer the live one. */
+  "stale-generation": "receipt.human.staleKey",
+  "stale-turn": "receipt.human.staleKey",
+  "unsupported-capability": "receipt.human.unsupportedCapability",
 };
 
 /** The human sentence key for a receipt's reason, or null for an unknown one. */

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -350,6 +350,7 @@ export const en = {
   "strip.stopSubagent": "interrupts the root agent",
   "strip.compactSubagent": "not available for subagents",
   "strip.structuredUnsupported": "the structured host does not support this action yet",
+  "strip.compactEngineUnsupported": "this engine has no compact control",
   "strip.resolving": "resolving the agent host…",
 
   // Dead-host banner (issue #247)

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -351,6 +351,7 @@ export const en = {
   "strip.compactSubagent": "not available for subagents",
   "strip.structuredUnsupported": "the structured host does not support this action yet",
   "strip.compactEngineUnsupported": "this engine has no compact control",
+  "strip.compactBusyTurn": "not while a turn is running",
   "strip.resolving": "resolving the agent host…",
 
   // Dead-host banner (issue #247)

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -395,6 +395,7 @@ export const en = {
   "receipt.human.duplicate": "already delivered",
   "receipt.human.turnActive": "the agent is mid-turn",
   "receipt.human.noTurn": "there is no active turn",
+  "receipt.human.unsupportedCapability": "this engine has no such control",
   "receipt.human.verbatim": "not delivered: {reason}",
 
   // DraftAgentPane

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -412,6 +412,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "receipt.human.duplicate": "вже доставлено",
   "receipt.human.turnActive": "агент посеред ходу",
   "receipt.human.noTurn": "немає активного ходу",
+  "receipt.human.unsupportedCapability": "цей двигун не має такої команди",
   "receipt.human.verbatim": "не доставлено: {reason}",
 
   "draft.readPrompt": "Прочитай розмову агента у файлі {src} і продовж роботу звідти: ",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -367,6 +367,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "strip.stopSubagent": "перериває кореневого агента",
   "strip.compactSubagent": "недоступно для субагентів",
   "strip.structuredUnsupported": "структурований хост поки не підтримує цю дію",
+  "strip.compactEngineUnsupported": "цей двигун не має команди стиснення",
   "strip.resolving": "визначаємо середовище агента…",
 
   // Dead-host banner (issue #247)

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -368,6 +368,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "strip.compactSubagent": "недоступно для субагентів",
   "strip.structuredUnsupported": "структурований хост поки не підтримує цю дію",
   "strip.compactEngineUnsupported": "цей двигун не має команди стиснення",
+  "strip.compactBusyTurn": "недоступно, поки триває хід",
   "strip.resolving": "визначаємо середовище агента…",
 
   // Dead-host banner (issue #247)

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -199,6 +199,42 @@ test("the compaction item the wire actually carries is accepted as evidence", as
   await host.release();
 });
 
+test("the deprecated thread/compacted notification is accepted as corroborating evidence", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  /* Every compaction item observed locally came from auto-compaction inside a
+     turn; nothing proves the app-server emits that lifecycle for a manual
+     compact against an idle thread. If it only sends this notification, reading
+     the item alone would leave the control timing out as unverified forever. */
+  server.notify("thread/compacted", { threadId: server.threadId, turnId: "turn-1" });
+
+  expect(await compaction).toEqual({ compactionId: null });
+  await host.release();
+});
+
+test("a compacted notification for another thread is not evidence", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server, { compactEvidenceTimeoutMs: 60 });
+  let settled = false;
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  void compaction.then(() => { settled = true; }, () => { settled = true; });
+  await Bun.sleep(10);
+  server.notify("thread/compacted", { threadId: "someone-elses-thread", turnId: "turn-1" });
+  await Bun.sleep(10);
+
+  expect(settled).toBe(false);
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction" },
+  });
+  expect(await compaction).toEqual({ compactionId: "compaction-one" });
+  await host.release();
+});
+
 test("a compaction that starts and never finishes terminalizes unverified", async () => {
   const server = new CompactAppServer();
   const host = await startHost(server, { compactEvidenceTimeoutMs: 40 });

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -141,7 +141,7 @@ test("compact issues thread/compact/start for the owned thread and never a promp
 
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+    item: { id: "compaction-one", type: "contextCompaction" },
   });
 
   expect(await compaction).toEqual({ compactionId: "compaction-one" });
@@ -162,39 +162,40 @@ test("a compaction that has only started is not yet evidence", async () => {
     threadId: server.threadId,
     item: { id: "message-one", type: "agentMessage", text: "still working" },
   });
-  /* `item/started` carries status `in_progress`: the compaction is running, so
-     reporting success here would release queued sends into a compacting
+  /* The item carries no outcome — `{ id, type }` is its whole shape — so the
+     lifecycle phase is the only signal. A started compaction is still running,
+     and reporting success here would release queued sends into a compacting
      thread. */
   server.notify("item/started", {
     threadId: server.threadId,
-    item: { id: "compaction-two", type: "contextCompaction", status: "in_progress" },
+    item: { id: "compaction-two", type: "contextCompaction" },
   });
   await Bun.sleep(10);
   expect(settled).toBe(false);
 
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-two", type: "contextCompaction", status: "completed" },
+    item: { id: "compaction-two", type: "contextCompaction" },
   });
   expect(await compaction).toEqual({ compactionId: "compaction-two" });
   await host.release();
 });
 
-test("a compaction the engine did not finish is a known failure, not an unverified one", async () => {
+test("the compaction item the wire actually carries is accepted as evidence", async () => {
   const server = new CompactAppServer();
   const host = await startHost(server);
 
   const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
   await Bun.sleep(10);
+  /* `ContextCompactionThreadItem` is exactly `{ id, type }` in the app-server
+     schema — no status, no turn, nothing else. The evidence path must settle on
+     that payload and not on a richer one this repo invented. */
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-two", type: "contextCompaction", status: "failed" },
+    item: { id: "compaction-real", type: "contextCompaction" },
   });
 
-  const error = await compaction.then(() => null, (reason: unknown) => reason);
-  expect(error).toBeInstanceOf(StructuredCompactError);
-  expect((error as StructuredCompactError).phase).toBe("refused");
-  expect((error as Error).message).toContain("failed");
+  expect(await compaction).toEqual({ compactionId: "compaction-real" });
   await host.release();
 });
 
@@ -206,7 +207,7 @@ test("a compaction that starts and never finishes terminalizes unverified", asyn
   await Bun.sleep(10);
   server.notify("item/started", {
     threadId: server.threadId,
-    item: { id: "compaction-two", type: "contextCompaction", status: "in_progress" },
+    item: { id: "compaction-two", type: "contextCompaction" },
   });
 
   const error = await compaction.then(() => null, (reason: unknown) => reason);
@@ -224,7 +225,7 @@ test("evidence that arrives before a failing start response still counts", async
   await Bun.sleep(10);
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+    item: { id: "compaction-one", type: "contextCompaction" },
   });
   await Bun.sleep(10);
   /* The request leg fails only after the app-server already reported the
@@ -249,7 +250,7 @@ test("a slow compact start does not fence the host on the default request budget
   server.releaseCompact();
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+    item: { id: "compaction-one", type: "contextCompaction" },
   });
   expect(await compaction).toEqual({ compactionId: "compaction-one" });
   await host.release();
@@ -319,7 +320,7 @@ test("a repeated compact for one operation awaits the same in-flight control", a
   server.releaseCompact();
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+    item: { id: "compaction-one", type: "contextCompaction" },
   });
 
   expect(await first).toEqual({ compactionId: "compaction-one" });

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -235,6 +235,46 @@ test("a compacted notification for another thread is not evidence", async () => 
   await host.release();
 });
 
+test("a graceful release settles an in-flight compaction instead of leaving it to time out", async () => {
+  const server = new CompactAppServer();
+  /* The evidence budget is minutes in production; the point is that release
+     must not wait for it. */
+  const host = await startHost(server, { compactEvidenceTimeoutMs: 60_000 });
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  /* `close` skips `fail()` while the host is releasing, so this is the one
+     teardown no other rejection path covers. Kill routes through here. */
+  await host.release();
+
+  const error = await compaction.then(() => null, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("unverified");
+});
+
+test("a concurrent compaction on the same thread is refused rather than issued twice", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const first = host.compact({ operationId: "op-one", threadId: server.threadId });
+  await Bun.sleep(10);
+  const second = await host.compact({ operationId: "op-two", threadId: server.threadId })
+    .then(() => null, (reason: unknown) => reason);
+
+  expect(second).toBeInstanceOf(StructuredCompactError);
+  expect((second as StructuredCompactError).phase).toBe("refused");
+  /* One thread compacts once at a time: a second request must not reach the
+     engine, or both waiters would settle on whichever item arrived first. */
+  expect(server.requests.filter((candidate) => candidate.method === "thread/compact/start")).toHaveLength(1);
+
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction" },
+  });
+  expect(await first).toEqual({ compactionId: "compaction-one" });
+  await host.release();
+});
+
 test("a compaction that starts and never finishes terminalizes unverified", async () => {
   const server = new CompactAppServer();
   const host = await startHost(server, { compactEvidenceTimeoutMs: 40 });

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -1,0 +1,245 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { expect, test } from "bun:test";
+
+import { CodexAppServerHost } from "./codexAppServerHost";
+import { StructuredCompactError } from "./engineHost";
+import type { RuntimeEvent } from "./engineHost";
+import type { RuntimeEventStore } from "./eventStore";
+
+class MemoryEventStore implements RuntimeEventStore {
+  private readonly events = new Map<string, RuntimeEvent[]>();
+
+  load(threadId: string): RuntimeEvent[] {
+    return structuredClone(this.events.get(threadId) ?? []);
+  }
+
+  append(threadId: string, event: RuntimeEvent): void {
+    const events = this.events.get(threadId) ?? [];
+    events.push(structuredClone(event));
+    this.events.set(threadId, events);
+  }
+}
+
+/** A minimal app-server double: only the handshake this control needs, plus
+    `thread/compact/start` and the item lifecycle that proves compaction. */
+class CompactAppServer extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 5151;
+  readonly requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  compactError: string | null = null;
+  holdCompact = false;
+  private heldCompactIds: number[] = [];
+  private turn = 0;
+
+  constructor(readonly threadId = "compact-thread") {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += String(chunk);
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line) this.accept(JSON.parse(line) as Record<string, unknown>);
+        newline = buffer.indexOf("\n");
+      }
+    });
+  }
+
+  kill(): boolean {
+    queueMicrotask(() => this.emit("close", 0, "SIGTERM"));
+    return true;
+  }
+
+  notify(method: string, params: Record<string, unknown>): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  releaseCompact(error: string | null = null): void {
+    const id = this.heldCompactIds.shift();
+    if (id === undefined) throw new Error("no held compact request");
+    if (error) this.respondError(id, error);
+    else this.respond(id, {});
+  }
+
+  private accept(message: Record<string, unknown>): void {
+    if (typeof message.id !== "number") return;
+    const method = message.method;
+    if (typeof method !== "string") return;
+    this.requests.push({ method, params: (message.params ?? {}) as Record<string, unknown> });
+    if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.146.0 (Linux)" });
+    if (method === "account/read") {
+      return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
+    }
+    if (method === "model/list") {
+      return this.respond(message.id, { data: [{ id: "gpt-5.3-codex-spark", isDefault: true, inputModalities: ["text"] }] });
+    }
+    if (method === "config/read") return this.respond(message.id, { config: { mcp_servers: {} } });
+    if (method === "thread/start") {
+      return this.respond(message.id, { thread: { id: this.threadId, path: `/sessions/${this.threadId}.jsonl`, turns: [] } });
+    }
+    if (method === "thread/read") {
+      return this.respond(message.id, { thread: { id: this.threadId, path: `/sessions/${this.threadId}.jsonl`, turns: [] } });
+    }
+    if (method === "turn/start") {
+      const turnId = `turn-${++this.turn}`;
+      this.respond(message.id, { turn: { id: turnId } });
+      this.notify("turn/started", { threadId: this.threadId, turn: { id: turnId } });
+      return;
+    }
+    if (method === "thread/compact/start") {
+      if (this.compactError) return this.respondError(message.id, this.compactError);
+      if (this.holdCompact) {
+        this.heldCompactIds.push(message.id);
+        return;
+      }
+      return this.respond(message.id, {});
+    }
+  }
+
+  private respond(id: number, result: Record<string, unknown>): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+
+  private respondError(id: number, message: string): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { message } })}\n`);
+  }
+}
+
+function spawnDouble(server: CompactAppServer) {
+  return () => server as unknown as ChildProcessWithoutNullStreams;
+}
+
+async function startHost(server: CompactAppServer, options: Record<string, unknown> = {}) {
+  return CodexAppServerHost.start({
+    cwd: "/repo",
+    requestTimeoutMs: 500,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: spawnDouble(server),
+    pidAlive: () => true,
+    processIdentity: () => "5151:owned",
+    ...options,
+  });
+}
+
+test("compact issues thread/compact/start for the owned thread and never a prompt", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  const request = server.requests.find((candidate) => candidate.method === "thread/compact/start");
+  expect(request).toBeDefined();
+  expect(request!.params).toEqual({ threadId: server.threadId });
+  /* Nothing about this control may enter the turn/message path. */
+  expect(server.requests.some((candidate) => candidate.method === "turn/start" || candidate.method === "turn/steer")).toBe(false);
+
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction" },
+  });
+
+  expect(await compaction).toEqual({ compactionId: "compaction-one" });
+  await host.release();
+});
+
+test("compact resolves only on correlated compaction evidence", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+  let settled = false;
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  void compaction.then(() => { settled = true; }, () => { settled = true; });
+  await Bun.sleep(10);
+
+  /* Unrelated item traffic is not evidence that the thread was compacted. */
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "message-one", type: "agentMessage", text: "still working" },
+  });
+  await Bun.sleep(10);
+  expect(settled).toBe(false);
+
+  server.notify("item/started", {
+    threadId: server.threadId,
+    item: { id: "compaction-two", type: "contextCompaction" },
+  });
+  expect(await compaction).toEqual({ compactionId: "compaction-two" });
+  await host.release();
+});
+
+test("a refused compact request reports a known-failed outcome", async () => {
+  const server = new CompactAppServer();
+  server.compactError = "compaction is unavailable for this thread";
+  const host = await startHost(server);
+
+  const error = await host.compact({ operationId: "op-compact", threadId: server.threadId })
+    .then(() => null, (reason: unknown) => reason);
+
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("request");
+  expect((error as Error).message).toContain("compaction is unavailable");
+  await host.release();
+});
+
+test("evidence that never arrives terminalizes as an unverified outcome", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server, { compactEvidenceTimeoutMs: 30 });
+
+  const error = await host.compact({ operationId: "op-compact", threadId: server.threadId })
+    .then(() => null, (reason: unknown) => reason);
+
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("evidence");
+  await host.release();
+});
+
+test("compact refuses a foreign thread and an active turn", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const foreign = await host.compact({ operationId: "op-foreign", threadId: "someone-elses-thread" })
+    .then(() => null, (reason: unknown) => reason);
+  expect(foreign).toBeInstanceOf(StructuredCompactError);
+  expect((foreign as Error).message).toContain("thread");
+
+  /* The send is left in flight on purpose: this is the state a compact control
+     must refuse rather than steer. */
+  void host.send({ id: "message-one", text: "start a turn" }).catch(() => undefined);
+  await Bun.sleep(20);
+  expect((await host.health()).activeTurnRef).toBe("turn-1");
+
+  const busy = await host.compact({ operationId: "op-busy", threadId: server.threadId })
+    .then(() => null, (reason: unknown) => reason);
+  expect(busy).toBeInstanceOf(StructuredCompactError);
+  expect((busy as StructuredCompactError).phase).toBe("request");
+  expect(server.requests.filter((candidate) => candidate.method === "thread/compact/start")).toHaveLength(0);
+  await host.release();
+});
+
+test("a repeated compact for one operation awaits the same in-flight control", async () => {
+  const server = new CompactAppServer();
+  server.holdCompact = true;
+  const host = await startHost(server);
+
+  const first = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  const second = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+
+  expect(server.requests.filter((candidate) => candidate.method === "thread/compact/start")).toHaveLength(1);
+  server.releaseCompact();
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction" },
+  });
+
+  expect(await first).toEqual({ compactionId: "compaction-one" });
+  expect(await second).toEqual({ compactionId: "compaction-one" });
+  await host.release();
+});

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -141,14 +141,14 @@ test("compact issues thread/compact/start for the owned thread and never a promp
 
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction" },
+    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
   });
 
   expect(await compaction).toEqual({ compactionId: "compaction-one" });
   await host.release();
 });
 
-test("compact resolves only on correlated compaction evidence", async () => {
+test("a compaction that has only started is not yet evidence", async () => {
   const server = new CompactAppServer();
   const host = await startHost(server);
   let settled = false;
@@ -162,14 +162,96 @@ test("compact resolves only on correlated compaction evidence", async () => {
     threadId: server.threadId,
     item: { id: "message-one", type: "agentMessage", text: "still working" },
   });
+  /* `item/started` carries status `in_progress`: the compaction is running, so
+     reporting success here would release queued sends into a compacting
+     thread. */
+  server.notify("item/started", {
+    threadId: server.threadId,
+    item: { id: "compaction-two", type: "contextCompaction", status: "in_progress" },
+  });
   await Bun.sleep(10);
   expect(settled).toBe(false);
 
-  server.notify("item/started", {
+  server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-two", type: "contextCompaction" },
+    item: { id: "compaction-two", type: "contextCompaction", status: "completed" },
   });
   expect(await compaction).toEqual({ compactionId: "compaction-two" });
+  await host.release();
+});
+
+test("a compaction the engine did not finish is a known failure, not an unverified one", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-two", type: "contextCompaction", status: "failed" },
+  });
+
+  const error = await compaction.then(() => null, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("refused");
+  expect((error as Error).message).toContain("failed");
+  await host.release();
+});
+
+test("a compaction that starts and never finishes terminalizes unverified", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server, { compactEvidenceTimeoutMs: 40 });
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  server.notify("item/started", {
+    threadId: server.threadId,
+    item: { id: "compaction-two", type: "contextCompaction", status: "in_progress" },
+  });
+
+  const error = await compaction.then(() => null, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("unverified");
+  await host.release();
+});
+
+test("evidence that arrives before a failing start response still counts", async () => {
+  const server = new CompactAppServer();
+  server.holdCompact = true;
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+  });
+  await Bun.sleep(10);
+  /* The request leg fails only after the app-server already reported the
+     compaction. A verified fact must not be overwritten by a late error. */
+  server.releaseCompact("the compact request stream was reset");
+
+  expect(await compaction).toEqual({ compactionId: "compaction-one" });
+  await host.release();
+});
+
+test("a slow compact start does not fence the host on the default request budget", async () => {
+  const server = new CompactAppServer();
+  server.holdCompact = true;
+  /* The host's ordinary mutating-RPC budget; the compact request must be
+     budgeted like the compaction it starts, not like an ordinary call. */
+  const host = await startHost(server, { requestTimeoutMs: 30, compactEvidenceTimeoutMs: 5_000 });
+
+  const compaction = host.compact({ operationId: "op-compact", threadId: server.threadId });
+  await Bun.sleep(120);
+
+  expect((await host.health()).status).not.toBe("dead");
+  server.releaseCompact();
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
+  });
+  expect(await compaction).toEqual({ compactionId: "compaction-one" });
   await host.release();
 });
 
@@ -182,7 +264,7 @@ test("a refused compact request reports a known-failed outcome", async () => {
     .then(() => null, (reason: unknown) => reason);
 
   expect(error).toBeInstanceOf(StructuredCompactError);
-  expect((error as StructuredCompactError).phase).toBe("request");
+  expect((error as StructuredCompactError).phase).toBe("refused");
   expect((error as Error).message).toContain("compaction is unavailable");
   await host.release();
 });
@@ -195,7 +277,7 @@ test("evidence that never arrives terminalizes as an unverified outcome", async 
     .then(() => null, (reason: unknown) => reason);
 
   expect(error).toBeInstanceOf(StructuredCompactError);
-  expect((error as StructuredCompactError).phase).toBe("evidence");
+  expect((error as StructuredCompactError).phase).toBe("unverified");
   await host.release();
 });
 
@@ -207,6 +289,7 @@ test("compact refuses a foreign thread and an active turn", async () => {
     .then(() => null, (reason: unknown) => reason);
   expect(foreign).toBeInstanceOf(StructuredCompactError);
   expect((foreign as Error).message).toContain("thread");
+  expect((foreign as StructuredCompactError).phase).toBe("refused");
 
   /* The send is left in flight on purpose: this is the state a compact control
      must refuse rather than steer. */
@@ -217,7 +300,7 @@ test("compact refuses a foreign thread and an active turn", async () => {
   const busy = await host.compact({ operationId: "op-busy", threadId: server.threadId })
     .then(() => null, (reason: unknown) => reason);
   expect(busy).toBeInstanceOf(StructuredCompactError);
-  expect((busy as StructuredCompactError).phase).toBe("request");
+  expect((busy as StructuredCompactError).phase).toBe("refused");
   expect(server.requests.filter((candidate) => candidate.method === "thread/compact/start")).toHaveLength(0);
   await host.release();
 });
@@ -236,7 +319,7 @@ test("a repeated compact for one operation awaits the same in-flight control", a
   server.releaseCompact();
   server.notify("item/completed", {
     threadId: server.threadId,
-    item: { id: "compaction-one", type: "contextCompaction" },
+    item: { id: "compaction-one", type: "contextCompaction", status: "completed" },
   });
 
   expect(await first).toEqual({ compactionId: "compaction-one" });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1083,6 +1083,15 @@ export class CodexAppServerHost implements EngineHost {
    * never completes is caught by `compactEvidenceTimeoutMs` (or sooner by host
    * death), and terminalizes unverified — which is the honest verdict, since
    * nothing on the wire says what became of it.
+   *
+   * Nor is there anything to correlate on. The item's `id` is minted by the
+   * engine and appears for the first time in this notification, so ANY completed
+   * compaction on the owned thread settles the waiter — including an
+   * auto-compaction that happened to land in the same window, whose id the
+   * receipt would then record. Two guards make that window small rather than
+   * closed: `compact()` refuses while a turn is active, and the delivery queue
+   * holds messages behind an unfinished compaction, so the thread should have no
+   * turn running to auto-compact. Recorded as a known limit of `{ id, type }`.
    */
   private acceptCompactionItem(item: unknown, phase: "started" | "completed"): void {
     if (phase !== "completed" || this.pendingCompactions.size === 0) return;

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -989,7 +989,9 @@ export class CodexAppServerHost implements EngineHost {
    * `turn/start`, no `turn/steer`, no message content anywhere in the request.
    * The promise settles only on a *completed* `contextCompaction` item, so the
    * durable receipt cannot claim success from an accepted request, nor from a
-   * compaction that has merely started.
+   * compaction that has merely started. `thread/compact/start` takes exactly
+   * `{ threadId }` and returns an empty ack, so the item lifecycle is the only
+   * place an outcome can come from.
    */
   async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
@@ -1052,28 +1054,26 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   /**
-   * Reads one `contextCompaction` item as compaction evidence. Only a
-   * *completed* compaction settles a waiter: the app-server emits this item
-   * twice, once at `item/started` carrying status `in_progress` and again at
-   * `item/completed`, and treating the first sighting as success would report
-   * `delivered` for a compaction still running — and would release queued
-   * messages into a thread mid-compaction. A completed item whose status is
-   * anything other than `completed` is a compaction the engine did not finish:
-   * that is a known failure, not an unverified one.
+   * Reads one `contextCompaction` item as compaction evidence.
+   *
+   * The item itself carries no outcome — its whole shape is `{ id, type }` per
+   * `ContextCompactionThreadItem` in the app-server schema, and that holds for
+   * every such item in the local event ledgers. The lifecycle *phase* is
+   * therefore the only signal: `item/started` says a compaction began and
+   * `item/completed` says it finished, so only the completed phase settles a
+   * waiter. Settling on the first sighting would report `delivered` for a
+   * compaction still running and release queued messages into a thread
+   * mid-compaction.
+   *
+   * There is consequently no fast failure signal: a compaction that starts and
+   * never completes is caught by `compactEvidenceTimeoutMs` (or sooner by host
+   * death), and terminalizes unverified — which is the honest verdict, since
+   * nothing on the wire says what became of it.
    */
   private acceptCompactionItem(item: unknown, phase: "started" | "completed"): void {
-    if (this.pendingCompactions.size === 0) return;
+    if (phase !== "completed" || this.pendingCompactions.size === 0) return;
     const compaction = record(item);
     if (!compaction) return;
-    const status = stringField(compaction, "status");
-    if (phase !== "completed" || status === "in_progress") return;
-    if (status && status !== "completed") {
-      this.settlePendingCompactions(new StructuredCompactError(
-        `Codex reported the compaction ${status}`,
-        "refused",
-      ));
-      return;
-    }
     this.settlePendingCompactions({ compactionId: stringField(compaction, "id") });
   }
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -987,21 +987,22 @@ export class CodexAppServerHost implements EngineHost {
    * app-server control channel — `thread/compact/start` for the thread this
    * host owns — so there is no path by which it becomes a user turn: no
    * `turn/start`, no `turn/steer`, no message content anywhere in the request.
-   * The promise settles only on `contextCompaction` lifecycle evidence, so the
-   * durable receipt cannot claim success from an accepted request alone.
+   * The promise settles only on a *completed* `contextCompaction` item, so the
+   * durable receipt cannot claim success from an accepted request, nor from a
+   * compaction that has merely started.
    */
   async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
-      throw new StructuredCompactError("Codex app-server host is unavailable", "request");
+      throw new StructuredCompactError("Codex app-server host is unavailable", "refused");
     }
     if (request.threadId && request.threadId !== this.identity.threadId) {
-      throw new StructuredCompactError("compact target thread is not the thread this host owns", "request");
+      throw new StructuredCompactError("compact target thread is not the thread this host owns", "refused");
     }
     /* The boundary refuses a live turn even though admission already fenced it:
        the turn may have started between admission and execution, and compacting
        underneath a running turn is exactly the race this control must not run. */
     if (this.activeTurnId) {
-      throw new StructuredCompactError("a turn is active; compaction would race it", "request");
+      throw new StructuredCompactError("a turn is active; compaction would race it", "refused");
     }
     const existing = this.pendingCompactions.get(request.operationId);
     if (existing) return existing.promise;
@@ -1016,48 +1017,81 @@ export class CodexAppServerHost implements EngineHost {
     this.pendingCompactions.set(request.operationId, settle);
     void promise.catch(() => undefined);
     try {
-      await this.rpc("thread/compact/start", { threadId: this.identity.threadId });
+      /* Budgeted like the compaction itself, not like an ordinary call.
+         `thread/compact/start` is a mutating method, so the default 30 s
+         request budget would fail the whole host — and take the operator's live
+         conversation with it — the moment a large thread takes longer than that
+         to begin compacting. */
+      await this.rpc(
+        "thread/compact/start",
+        { threadId: this.identity.threadId },
+        this.compactEvidenceTimeoutMs,
+      );
     } catch (error) {
+      /* The evidence may have won the race: a compaction the app-server already
+         reported is a fact, and a late failure on the request leg must not
+         overwrite it. */
+      if (this.pendingCompactions.get(request.operationId) !== settle) return promise;
       this.pendingCompactions.delete(request.operationId);
       const message = safeError(error);
       /* A refusal proves nothing was compacted; a request that timed out may
          still have started one, and `thread/compact/start` is registered as
          mutating so the transport says which of the two happened. */
-      throw new StructuredCompactError(message, /outcome is uncertain/.test(message) ? "evidence" : "request");
+      throw new StructuredCompactError(message, /outcome is uncertain/.test(message) ? "unverified" : "refused");
     }
     if (this.pendingCompactions.get(request.operationId) === settle) {
       settle.timer = setTimeout(() => {
         this.pendingCompactions.delete(request.operationId);
         settle.reject(new StructuredCompactError(
           "Codex compaction evidence did not arrive; the outcome is unverified",
-          "evidence",
+          "unverified",
         ));
       }, this.compactEvidenceTimeoutMs);
     }
     return promise;
   }
 
-  /** Every waiter settles on the first compaction the owned thread reports:
-      one thread compacts once at a time, so the item is the evidence. */
-  private resolveCompactions(compactionId: string | null): void {
+  /**
+   * Reads one `contextCompaction` item as compaction evidence. Only a
+   * *completed* compaction settles a waiter: the app-server emits this item
+   * twice, once at `item/started` carrying status `in_progress` and again at
+   * `item/completed`, and treating the first sighting as success would report
+   * `delivered` for a compaction still running — and would release queued
+   * messages into a thread mid-compaction. A completed item whose status is
+   * anything other than `completed` is a compaction the engine did not finish:
+   * that is a known failure, not an unverified one.
+   */
+  private acceptCompactionItem(item: unknown, phase: "started" | "completed"): void {
     if (this.pendingCompactions.size === 0) return;
-    const waiting = [...this.pendingCompactions.values()];
-    this.pendingCompactions.clear();
-    for (const compaction of waiting) {
-      if (compaction.timer) clearTimeout(compaction.timer);
-      compaction.resolve({ compactionId });
+    const compaction = record(item);
+    if (!compaction) return;
+    const status = stringField(compaction, "status");
+    if (phase !== "completed" || status === "in_progress") return;
+    if (status && status !== "completed") {
+      this.settlePendingCompactions(new StructuredCompactError(
+        `Codex reported the compaction ${status}`,
+        "refused",
+      ));
+      return;
     }
+    this.settlePendingCompactions({ compactionId: stringField(compaction, "id") });
   }
 
   /** A host that dies mid-compaction leaves the engine outcome unknown, so the
-      waiters reject in the `evidence` phase and terminalize as uncertain. */
+      waiters reject as `unverified` and terminalize the receipt uncertain. */
   private rejectPendingCompactions(error: Error): void {
+    this.settlePendingCompactions(new StructuredCompactError(safeError(error), "unverified"));
+  }
+
+  /** One thread compacts once at a time, so every waiter shares the outcome. */
+  private settlePendingCompactions(outcome: RuntimeCompactOutcome | StructuredCompactError): void {
     if (this.pendingCompactions.size === 0) return;
     const waiting = [...this.pendingCompactions.values()];
     this.pendingCompactions.clear();
     for (const compaction of waiting) {
       if (compaction.timer) clearTimeout(compaction.timer);
-      compaction.reject(new StructuredCompactError(safeError(error), "evidence"));
+      if (outcome instanceof StructuredCompactError) compaction.reject(outcome);
+      else compaction.resolve(outcome);
     }
   }
 
@@ -2516,8 +2550,7 @@ export class CodexAppServerHost implements EngineHost {
       /* #862: the compaction item is the completion signal for a manual
          compact control. It is read after the emit so the durable event ledger
          carries the evidence before any receipt terminalizes on it. */
-      const item = record(params.item);
-      if (item?.type === "contextCompaction") this.resolveCompactions(stringField(item, "id"));
+      if (record(params.item)?.type === "contextCompaction") this.acceptCompactionItem(params.item, phase);
       return;
     }
     if (method === "turn/completed" && turnId) {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1008,6 +1008,13 @@ export class CodexAppServerHost implements EngineHost {
     }
     const existing = this.pendingCompactions.get(request.operationId);
     if (existing) return existing.promise;
+    /* One compaction per thread at a time. The delivery queue already holds a
+       second request back, so reaching here means something bypassed it — and
+       a concurrent `thread/compact/start` would compact the thread twice and
+       leave both waiters settling on whichever item arrived first. */
+    if (this.pendingCompactions.size > 0) {
+      throw new StructuredCompactError("a compaction is already running on this thread", "refused");
+    }
 
     let settle!: PendingCompaction;
     const promise = new Promise<RuntimeCompactOutcome>((resolve, reject) => {
@@ -1023,7 +1030,14 @@ export class CodexAppServerHost implements EngineHost {
          `thread/compact/start` is a mutating method, so the default 30 s
          request budget would fail the whole host — and take the operator's live
          conversation with it — the moment a large thread takes longer than that
-         to begin compacting. */
+         to begin compacting.
+
+         The fence at the far end of this budget is deliberate, not inherited: a
+         mutating call whose ack never arrives has left the thread in a state
+         this host cannot describe, and every other mutating method here fails
+         closed for that reason. Five minutes of silence on an ack that normally
+         returns at once is that case. The compaction itself terminalizes
+         `unverified` either way. */
       await this.rpc(
         "thread/compact/start",
         { threadId: this.identity.threadId },
@@ -1668,6 +1682,11 @@ export class CodexAppServerHost implements EngineHost {
     this.rejectRealtimeStart(new Error("Codex app-server host released"));
     this.rejectPendingAnswers(new Error("Codex app-server host released"));
     this.rejectPendingDeliveries(new Error("Codex app-server host released"));
+    /* A graceful release is the one teardown `fail()` never sees — `close`
+       skips it while `releasing` is set — so a compaction waiting on evidence
+       would otherwise hang until its own timeout, holding this conversation's
+       queue behind it for minutes after the host is gone (#862). */
+    this.rejectPendingCompactions(new Error("Codex app-server host released"));
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error("Codex app-server host released"));

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -33,9 +33,16 @@ import type {
   EngineHost,
   HostState,
   QueueEntry,
+  RuntimeCompactOutcome,
+  RuntimeCompactRequest,
   RuntimeEvent,
 } from "./engineHost";
-import { normalizeQueueEntry, RuntimeReplayGapError, StructuredHostAdoptionCleanupError } from "./engineHost";
+import {
+  normalizeQueueEntry,
+  RuntimeReplayGapError,
+  StructuredCompactError,
+  StructuredHostAdoptionCleanupError,
+} from "./engineHost";
 import {
   FileRuntimeEventStore,
   nextRuntimeEventSequence,
@@ -88,6 +95,13 @@ type VoicePersonaBootstrapInsertion = {
   owner: PendingRealtimeStart;
   promise: Promise<void>;
 };
+type PendingCompaction = {
+  promise: Promise<RuntimeCompactOutcome>;
+  resolve(outcome: RuntimeCompactOutcome): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout> | undefined;
+};
+
 type PendingDelivery = {
   text: string;
   contentDigest: string;
@@ -165,6 +179,7 @@ export interface CodexAppServerHostOptions {
   realtimePersonaTimeoutMs?: number;
   realtimeStartTimeoutMs?: number;
   deliveryConfirmationTimeoutMs?: number;
+  compactEvidenceTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
   onEventCursorRecovery?: RuntimeEventCursorRecoveryReporter;
@@ -255,6 +270,10 @@ const DESKTOP_ENV_ALLOWLIST = [
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS = 5 * 60_000;
+/** How long a compaction may run before its outcome counts as unverified.
+    Compaction is a model call over the whole thread, so the budget is generous;
+    past it the operation terminalizes visibly rather than hanging (#862). */
+const DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS = 5 * 60_000;
 const ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER = 3;
 const LATE_THREAD_READ_RESPONSE_TTL_MULTIPLIER = 3;
 const MIN_LATE_THREAD_READ_RESPONSE_TTL_MS = 1_000;
@@ -320,6 +339,7 @@ const MUTATING_RPC_METHODS = new Set([
   "thread/realtime/start",
   "thread/realtime/stop",
   "thread/inject_items",
+  "thread/compact/start",
 ]);
 
 function record(value: unknown): JsonObject | null {
@@ -573,6 +593,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly realtimePersonaTimeoutMs: number;
   private readonly realtimeStartTimeoutMs: number;
   private readonly deliveryConfirmationTimeoutMs: number;
+  private readonly compactEvidenceTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly eventStore: RuntimeEventStore;
   private readonly effort: string | undefined;
@@ -603,6 +624,7 @@ export class CodexAppServerHost implements EngineHost {
     contentDigest: string | null;
   }>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
+  private readonly pendingCompactions = new Map<string, PendingCompaction>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
   /* A host's thread id is immutable, so one memo covers its one stable persona
@@ -663,6 +685,7 @@ export class CodexAppServerHost implements EngineHost {
     this.realtimeStartTimeoutMs = options.realtimeStartTimeoutMs ?? REALTIME_START_TIMEOUT_MS;
     this.deliveryConfirmationTimeoutMs = options.deliveryConfirmationTimeoutMs
       ?? DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS;
+    this.compactEvidenceTimeoutMs = options.compactEvidenceTimeoutMs ?? DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.effort = options.effort;
@@ -957,6 +980,85 @@ export class CodexAppServerHost implements EngineHost {
     }
     if (!turnRef || this.activeTurnId !== turnRef) throw new Error("active turn fence is stale");
     await this.rpc("turn/interrupt", { threadId: this.identity.threadId, turnId: turnRef });
+  }
+
+  /**
+   * Manual context compaction as an engine control (#862). It travels the
+   * app-server control channel — `thread/compact/start` for the thread this
+   * host owns — so there is no path by which it becomes a user turn: no
+   * `turn/start`, no `turn/steer`, no message content anywhere in the request.
+   * The promise settles only on `contextCompaction` lifecycle evidence, so the
+   * durable receipt cannot claim success from an accepted request alone.
+   */
+  async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
+    if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
+      throw new StructuredCompactError("Codex app-server host is unavailable", "request");
+    }
+    if (request.threadId && request.threadId !== this.identity.threadId) {
+      throw new StructuredCompactError("compact target thread is not the thread this host owns", "request");
+    }
+    /* The boundary refuses a live turn even though admission already fenced it:
+       the turn may have started between admission and execution, and compacting
+       underneath a running turn is exactly the race this control must not run. */
+    if (this.activeTurnId) {
+      throw new StructuredCompactError("a turn is active; compaction would race it", "request");
+    }
+    const existing = this.pendingCompactions.get(request.operationId);
+    if (existing) return existing.promise;
+
+    let settle!: PendingCompaction;
+    const promise = new Promise<RuntimeCompactOutcome>((resolve, reject) => {
+      settle = { promise: undefined as unknown as Promise<RuntimeCompactOutcome>, resolve, reject, timer: undefined };
+    });
+    settle.promise = promise;
+    /* Registered before the request so a compaction the app-server reports
+       immediately cannot land in the gap and go unobserved. */
+    this.pendingCompactions.set(request.operationId, settle);
+    void promise.catch(() => undefined);
+    try {
+      await this.rpc("thread/compact/start", { threadId: this.identity.threadId });
+    } catch (error) {
+      this.pendingCompactions.delete(request.operationId);
+      const message = safeError(error);
+      /* A refusal proves nothing was compacted; a request that timed out may
+         still have started one, and `thread/compact/start` is registered as
+         mutating so the transport says which of the two happened. */
+      throw new StructuredCompactError(message, /outcome is uncertain/.test(message) ? "evidence" : "request");
+    }
+    if (this.pendingCompactions.get(request.operationId) === settle) {
+      settle.timer = setTimeout(() => {
+        this.pendingCompactions.delete(request.operationId);
+        settle.reject(new StructuredCompactError(
+          "Codex compaction evidence did not arrive; the outcome is unverified",
+          "evidence",
+        ));
+      }, this.compactEvidenceTimeoutMs);
+    }
+    return promise;
+  }
+
+  /** Every waiter settles on the first compaction the owned thread reports:
+      one thread compacts once at a time, so the item is the evidence. */
+  private resolveCompactions(compactionId: string | null): void {
+    if (this.pendingCompactions.size === 0) return;
+    const waiting = [...this.pendingCompactions.values()];
+    this.pendingCompactions.clear();
+    for (const compaction of waiting) {
+      if (compaction.timer) clearTimeout(compaction.timer);
+      compaction.resolve({ compactionId });
+    }
+  }
+
+  /** A host that dies mid-compaction leaves the engine outcome unknown, so the
+      waiters reject in the `evidence` phase and terminalize as uncertain. */
+  private rejectPendingCompactions(error: Error): void {
+    if (this.pendingCompactions.size === 0) return;
+    const waiting = [...this.pendingCompactions.values()];
+    this.pendingCompactions.clear();
+    for (const compaction of waiting) {
+      if (compaction.timer) clearTimeout(compaction.timer);
+      compaction.reject(new StructuredCompactError(safeError(error), "evidence"));
+    }
   }
 
   async startRealtimeWebRtc(sdp: string): Promise<CodexRealtimeWebRtcResult> {
@@ -2411,6 +2513,11 @@ export class CodexAppServerHost implements EngineHost {
         phase,
         ...(voiceResponse !== undefined ? { voiceResponse } : {}),
       });
+      /* #862: the compaction item is the completion signal for a manual
+         compact control. It is read after the emit so the durable event ledger
+         carries the evidence before any receipt terminalizes on it. */
+      const item = record(params.item);
+      if (item?.type === "contextCompaction") this.resolveCompactions(stringField(item, "id"));
       return;
     }
     if (method === "turn/completed" && turnId) {
@@ -2453,6 +2560,7 @@ export class CodexAppServerHost implements EngineHost {
     this.rejectRealtimeStart(error);
     this.rejectPendingAnswers(error);
     this.rejectPendingDeliveries(error);
+    this.rejectPendingCompactions(error);
     this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
@@ -2474,6 +2582,7 @@ export class CodexAppServerHost implements EngineHost {
     this.rejectRealtimeStart(error);
     this.rejectPendingAnswers(error);
     this.rejectPendingDeliveries(error);
+    this.rejectPendingCompactions(error);
     this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -990,8 +990,8 @@ export class CodexAppServerHost implements EngineHost {
    * The promise settles only on a *completed* `contextCompaction` item, so the
    * durable receipt cannot claim success from an accepted request, nor from a
    * compaction that has merely started. `thread/compact/start` takes exactly
-   * `{ threadId }` and returns an empty ack, so the item lifecycle is the only
-   * place an outcome can come from.
+   * `{ threadId }` and returns an empty ack, so nothing about the outcome comes
+   * back on the request leg.
    */
   async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
@@ -1059,8 +1059,8 @@ export class CodexAppServerHost implements EngineHost {
    * The item itself carries no outcome — its whole shape is `{ id, type }` per
    * `ContextCompactionThreadItem` in the app-server schema, and that holds for
    * every such item in the local event ledgers. The lifecycle *phase* is
-   * therefore the only signal: `item/started` says a compaction began and
-   * `item/completed` says it finished, so only the completed phase settles a
+   * therefore the only signal it offers: `item/started` says a compaction began
+   * and `item/completed` says it finished, so only the completed phase settles a
    * waiter. Settling on the first sighting would report `delivered` for a
    * compaction still running and release queued messages into a thread
    * mid-compaction.
@@ -1075,6 +1075,26 @@ export class CodexAppServerHost implements EngineHost {
     const compaction = record(item);
     if (!compaction) return;
     this.settlePendingCompactions({ compactionId: stringField(compaction, "id") });
+  }
+
+  /**
+   * The deprecated `thread/compacted` notification, accepted as a second
+   * evidence channel for the thread this host owns.
+   *
+   * Every `contextCompaction` item observed locally came from auto-compaction
+   * *inside a turn*, and a manual `thread/compact/start` runs against an idle
+   * thread — nothing available here proves the app-server emits the item
+   * lifecycle in that case too. If it only sends this notification, reading the
+   * item alone would leave every manual compaction to time out as unverified
+   * and the control would never once report success. So the item stays the
+   * preferred channel (it is the documented replacement, and it names the
+   * compaction), and this one is a corroborating fallback rather than the
+   * primary source: whichever arrives first settles the waiters.
+   */
+  private acceptCompactedNotification(params: JsonObject): void {
+    if (this.pendingCompactions.size === 0) return;
+    if (stringField(params, "threadId") !== this.identity.threadId) return;
+    this.settlePendingCompactions({ compactionId: null });
   }
 
   /** A host that dies mid-compaction leaves the engine outcome unknown, so the
@@ -2576,6 +2596,10 @@ export class CodexAppServerHost implements EngineHost {
     }
     if (method === "account/rateLimits/updated") {
       this.emit({ kind: "limits", snapshot: params });
+      return;
+    }
+    if (method === "thread/compacted") {
+      this.acceptCompactedNotification(params);
       return;
     }
     if (method === "thread/status/changed") {

--- a/src/lib/runtime/commands.ts
+++ b/src/lib/runtime/commands.ts
@@ -122,8 +122,9 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
   }
 
   /* #862: a compact request is a control, so the parser deliberately reads no
-     content field. Whatever the caller sent alongside it cannot survive into
-     the command and therefore cannot reach the engine as a prompt. */
+     content field and no turn fence. Whatever the caller sent alongside it
+     cannot survive into the command and therefore cannot reach the engine as a
+     prompt. */
   if (kind === "compact") {
     return {
       kind,
@@ -131,7 +132,6 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
       ...(operationId ? { operationId } : {}),
       idempotencyKey,
       sessionKey: runtimeSessionKey(body.sessionKey),
-      ...(turnId !== undefined ? { turnId } : {}),
     };
   }
 

--- a/src/lib/runtime/commands.ts
+++ b/src/lib/runtime/commands.ts
@@ -121,6 +121,20 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
     };
   }
 
+  /* #862: a compact request is a control, so the parser deliberately reads no
+     content field. Whatever the caller sent alongside it cannot survive into
+     the command and therefore cannot reach the engine as a prompt. */
+  if (kind === "compact") {
+    return {
+      kind,
+      conversationId,
+      ...(operationId ? { operationId } : {}),
+      idempotencyKey,
+      sessionKey: runtimeSessionKey(body.sessionKey),
+      ...(turnId !== undefined ? { turnId } : {}),
+    };
+  }
+
   if (kind === "answer") {
     if (!("resolution" in body)) throw new Error("resolution is required");
     return {

--- a/src/lib/runtime/compactControl.test.ts
+++ b/src/lib/runtime/compactControl.test.ts
@@ -32,8 +32,8 @@ test("the compact command parses into a durable operation fenced to one owned ge
   });
 });
 
-test("a compact command carries an optional turn fence and never carries prompt text", () => {
-  const fenced = parseRuntimeCommand("compact", {
+test("a compact command drops every field the engine could read as input or as a turn fence", () => {
+  const parsed = parseRuntimeCommand("compact", {
     conversationId: "conversation_one",
     idempotencyKey: "compact-key",
     sessionKey: { engine: "codex", sessionId: "thread-one" },
@@ -41,11 +41,13 @@ test("a compact command carries an optional turn fence and never carries prompt 
     text: "/compact",
   }) as RuntimeCompactCommand;
 
-  expect(fenced.turnId).toBe("turn-seven");
   /* A compact control is not a message: nothing the caller supplies may reach
-     the engine as user input. */
-  expect("text" in fenced).toBe(false);
-  expect("images" in fenced).toBe(false);
+     the engine as user input. A turn fence is equally meaningless — admission
+     only ever accepts an idle generation, so a named turn could only ever be a
+     busy-turn rejection. */
+  expect("text" in parsed).toBe(false);
+  expect("images" in parsed).toBe(false);
+  expect("turnId" in parsed).toBe(false);
 });
 
 test("a compact command without an owned session key is refused", () => {
@@ -79,9 +81,9 @@ test("a host without a compact control is detected structurally", () => {
 });
 
 test("a compact failure states whether the engine outcome is known", () => {
-  const rejected = new StructuredCompactError("thread/compact/start failed", "request");
-  const unverified = new StructuredCompactError("evidence timed out", "evidence");
-  expect(rejected.phase).toBe("request");
-  expect(unverified.phase).toBe("evidence");
-  expect(rejected).toBeInstanceOf(Error);
+  const refused = new StructuredCompactError("thread/compact/start failed", "refused");
+  const unverified = new StructuredCompactError("evidence timed out", "unverified");
+  expect(refused.phase).toBe("refused");
+  expect(unverified.phase).toBe("unverified");
+  expect(refused).toBeInstanceOf(Error);
 });

--- a/src/lib/runtime/compactControl.test.ts
+++ b/src/lib/runtime/compactControl.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+
+import { parseRuntimeCommand } from "./commands";
+import { runtimeCompactCapability, type RuntimeCompactCommand } from "./contracts";
+import { hostSupportsCompact, StructuredCompactError, type EngineHost } from "./engineHost";
+
+function bareHost(): EngineHost {
+  return {
+    attach: () => ({ async *[Symbol.asyncIterator]() {} }),
+    send: async () => ({ outcome: "rejected", reason: "dead-host" }),
+    interrupt: async () => {},
+    answer: async () => {},
+    health: async () => { throw new Error("unused"); },
+    release: async () => {},
+  };
+}
+
+test("the compact command parses into a durable operation fenced to one owned generation", () => {
+  const command = parseRuntimeCommand("compact", {
+    conversationId: "conversation_one",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  }) as RuntimeCompactCommand;
+
+  expect(command).toEqual({
+    kind: "compact",
+    conversationId: "conversation_one",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+});
+
+test("a compact command carries an optional turn fence and never carries prompt text", () => {
+  const fenced = parseRuntimeCommand("compact", {
+    conversationId: "conversation_one",
+    idempotencyKey: "compact-key",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+    turnId: "turn-seven",
+    text: "/compact",
+  }) as RuntimeCompactCommand;
+
+  expect(fenced.turnId).toBe("turn-seven");
+  /* A compact control is not a message: nothing the caller supplies may reach
+     the engine as user input. */
+  expect("text" in fenced).toBe(false);
+  expect("images" in fenced).toBe(false);
+});
+
+test("a compact command without an owned session key is refused", () => {
+  expect(() => parseRuntimeCommand("compact", {
+    conversationId: "conversation_one",
+    idempotencyKey: "compact-key",
+  })).toThrow("sessionKey is invalid");
+  expect(() => parseRuntimeCommand("compact", {
+    conversationId: "conversation_one",
+    idempotencyKey: "compact-key",
+    sessionKey: { engine: "gemini", sessionId: "thread-one" },
+  })).toThrow("sessionKey is invalid");
+});
+
+test("compact capability is engine-specific and truthful", () => {
+  expect(runtimeCompactCapability("codex")).toEqual({
+    control: "compact",
+    engine: "codex",
+    supported: true,
+  });
+  const claude = runtimeCompactCapability("claude");
+  expect(claude.supported).toBe(false);
+  expect(claude.engine).toBe("claude");
+  expect(claude.reason).toContain("compact");
+});
+
+test("a host without a compact control is detected structurally", () => {
+  const host = bareHost();
+  expect(hostSupportsCompact(host)).toBe(false);
+  expect(hostSupportsCompact(Object.assign(host, { compact: async () => ({ compactionId: null }) }))).toBe(true);
+});
+
+test("a compact failure states whether the engine outcome is known", () => {
+  const rejected = new StructuredCompactError("thread/compact/start failed", "request");
+  const unverified = new StructuredCompactError("evidence timed out", "evidence");
+  expect(rejected.phase).toBe("request");
+  expect(unverified.phase).toBe("evidence");
+  expect(rejected).toBeInstanceOf(Error);
+});

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -294,12 +294,13 @@ export type RuntimePendingReconfigure = Omit<RuntimeReconfigureCommand, "kind" |
  * generation (issue #862). It is a control, never a message: the command
  * carries no text and no images, so no path through the runtime can replay it
  * as a user prompt. `sessionKey` fences the compaction to the exact generation
- * the caller was looking at, and `turnId` is an optional caller fence.
+ * the caller was looking at. There is deliberately no turn fence: a compaction
+ * is only ever admitted against an idle generation, so any turn a caller could
+ * name would already have made the request a `busy-turn` rejection.
  */
 export interface RuntimeCompactCommand extends RuntimeCommandBase {
   kind: "compact";
   sessionKey: { engine: RuntimeEngine; sessionId: string };
-  turnId?: string | null;
 }
 
 /** An engine's truthful support for one client-originated engine control. */

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -42,7 +42,7 @@ export interface RuntimeSessionAxes {
 
 export type RuntimeAttentionKind = "approval" | "permission" | "question" | "waiting_heuristic";
 export type RuntimeAttentionState = "open" | "resolving" | "resolved" | "expired-confirmed" | "cancelled" | "resolution-unknown";
-export type RuntimeOperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn" | "reconfigure";
+export type RuntimeOperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn" | "reconfigure" | "compact";
 export type RuntimeReceiptStatus =
   | "pending"
   | "delivering"
@@ -289,6 +289,45 @@ export type RuntimePendingReconfigure = Omit<RuntimeReconfigureCommand, "kind" |
   operationId: string;
 };
 
+/**
+ * A manual context compaction requested against one owned structured
+ * generation (issue #862). It is a control, never a message: the command
+ * carries no text and no images, so no path through the runtime can replay it
+ * as a user prompt. `sessionKey` fences the compaction to the exact generation
+ * the caller was looking at, and `turnId` is an optional caller fence.
+ */
+export interface RuntimeCompactCommand extends RuntimeCommandBase {
+  kind: "compact";
+  sessionKey: { engine: RuntimeEngine; sessionId: string };
+  turnId?: string | null;
+}
+
+/** An engine's truthful support for one client-originated engine control. */
+export interface RuntimeControlCapability {
+  control: "compact";
+  engine: RuntimeEngine;
+  supported: boolean;
+  reason?: string;
+}
+
+/**
+ * Codex app-server 0.146 exposes `thread/compact/start` and reports completion
+ * through the `contextCompaction` item lifecycle. The Claude stream-json
+ * transport exposes interrupt as its only client-originated control and has no
+ * manual compact subtype, so the capability reports false with the reason
+ * rather than degrading into a `/compact` prompt.
+ */
+export function runtimeCompactCapability(engine: RuntimeEngine): RuntimeControlCapability {
+  return engine === "codex"
+    ? { control: "compact", engine, supported: true }
+    : {
+        control: "compact",
+        engine,
+        supported: false,
+        reason: "The Claude stream-json protocol has no client-originated compact control; only interrupt is exposed.",
+      };
+}
+
 export interface RuntimeAnswerCommand extends RuntimeCommandBase {
   kind: "answer";
   attentionId: string;
@@ -307,7 +346,7 @@ export interface RuntimeSpawnCommand extends RuntimeCommandBase {
   sessionId?: string | null;
 }
 
-export type RuntimeOperationCommand = RuntimeSendCommand | RuntimeInterruptCommand | RuntimeAnswerCommand | RuntimeKillCommand | RuntimeSpawnCommand | RuntimeReconfigureCommand;
+export type RuntimeOperationCommand = RuntimeSendCommand | RuntimeInterruptCommand | RuntimeAnswerCommand | RuntimeKillCommand | RuntimeSpawnCommand | RuntimeReconfigureCommand | RuntimeCompactCommand;
 
 export interface RuntimeOperationResult {
   operationId: string;

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -99,6 +99,43 @@ export interface EngineHost {
   release(): Promise<void>;
 }
 
+export interface RuntimeCompactRequest {
+  /** The durable operation this control belongs to. A repeat for the same id
+      joins the in-flight control instead of issuing a second compaction. */
+  operationId: string;
+  /** The generation the caller admitted the operation against. A mismatch is
+      refused so a re-seated host can never compact someone else's thread. */
+  threadId: string;
+}
+
+/** The compaction the engine actually performed, identified by its lifecycle
+    item so the durable receipt records which compaction closed the operation. */
+export interface RuntimeCompactOutcome {
+  compactionId: string | null;
+}
+
+/** A host whose engine exposes a client-originated compact control (#862). */
+export interface CompactCapableHost extends EngineHost {
+  compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome>;
+}
+
+export function hostSupportsCompact(host: EngineHost): host is CompactCapableHost {
+  return typeof (host as Partial<CompactCapableHost>).compact === "function";
+}
+
+/**
+ * A compact control that did not succeed. `phase` is the whole point: a
+ * `request` failure proves the engine never started compacting, while an
+ * `evidence` failure means the request was accepted and the outcome is
+ * unverified — the two must terminalize differently.
+ */
+export class StructuredCompactError extends Error {
+  constructor(message: string, readonly phase: "request" | "evidence") {
+    super(message);
+    this.name = "StructuredCompactError";
+  }
+}
+
 export class StructuredHostAdoptionCleanupError<Host extends EngineHost = EngineHost> extends Error {
   constructor(message: string, readonly host: Host, options?: ErrorOptions) {
     super(message, options);

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -124,13 +124,13 @@ export function hostSupportsCompact(host: EngineHost): host is CompactCapableHos
 }
 
 /**
- * A compact control that did not succeed. `phase` is the whole point: a
- * `request` failure proves the engine never started compacting, while an
- * `evidence` failure means the request was accepted and the outcome is
- * unverified — the two must terminalize differently.
+ * A compact control that did not succeed. `phase` is the whole point:
+ * `refused` means the engine did not compact the thread and everyone can see
+ * why, while `unverified` means the request may have landed and nothing proved
+ * what became of it — the two must terminalize differently.
  */
 export class StructuredCompactError extends Error {
-  constructor(message: string, readonly phase: "request" | "evidence") {
+  constructor(message: string, readonly phase: "refused" | "unverified") {
     super(message);
     this.name = "StructuredCompactError";
   }

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -82,6 +82,7 @@ const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
   "runtime.answer",
   "runtime.spawn",
   "runtime.reconfigure",
+  "runtime.compact",
 ] as const;
 
 interface StructuredStartupSignals {

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -166,6 +166,48 @@ test("a compaction an earlier executor issued is never issued a second time", as
   expect(transitions[0]![2]).toContain("unverified");
 });
 
+test("a runtime-host that rejects the uncertain status still settles the operation", async () => {
+  const sent: QueueEntry[] = [];
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { throw new StructuredCompactError("Codex app-server host was lost", "unverified"); },
+  });
+  const effects = [
+    compactEffect(),
+    {
+      id: "effect:op-send",
+      kind: "runtime.send",
+      eventSeq: 9,
+      payload: {
+        kind: "send",
+        operationId: "op-send",
+        conversationId: "conversation-one",
+        idempotencyKey: "op-send",
+        text: "continue after the compaction",
+        policy: "queue",
+      },
+    } satisfies StructuredDeliveryEffect,
+  ];
+  const { port, transitions, settled } = recorder(effects);
+  const accept = port.transition;
+  /* A runtime-host from before #862 does not know the status. The operation
+     must still terminalize, or every later pass re-enters the same branch and
+     the conversation's queue never drains again. */
+  port.transition = async (operationId, status, details) => {
+    if (status === "uncertain") throw new Error("runtime operation transition status is invalid");
+    await accept(operationId, status, details);
+  };
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+  await settled;
+  await queue.drain();
+
+  expect(transitions.filter(([, status]) => status === "failed")).toEqual([
+    ["op-compact", "failed", "Codex app-server host was lost"],
+  ]);
+  expect(sent.map((entry) => entry.id)).toEqual(["op-send"]);
+});
+
 test("a busy structured turn fails the compact control instead of steering it", async () => {
   const sent: QueueEntry[] = [];
   let calls = 0;
@@ -197,7 +239,7 @@ test("an engine without a compact control reports a typed capability failure", a
 test("a rejected compact request terminalizes as failed and an unverified one as uncertain", async () => {
   const sent: QueueEntry[] = [];
   const rejecting: CompactCapableHost = Object.assign(baseHost(sent), {
-    compact: async () => { throw new StructuredCompactError("thread/compact/start was refused", "request"); },
+    compact: async () => { throw new StructuredCompactError("thread/compact/start was refused", "refused"); },
   });
   const rejected = recorder([compactEffect()]);
   await new StructuredDeliveryQueue(rejected.port, () => rejecting).drain();
@@ -209,7 +251,7 @@ test("a rejected compact request terminalizes as failed and an unverified one as
   ]);
 
   const losing: CompactCapableHost = Object.assign(baseHost(sent), {
-    compact: async () => { throw new StructuredCompactError("Codex app-server host was lost", "evidence"); },
+    compact: async () => { throw new StructuredCompactError("Codex app-server host was lost", "unverified"); },
   });
   const unverified = recorder([compactEffect()]);
   await new StructuredDeliveryQueue(unverified.port, () => losing).drain();

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -48,14 +48,14 @@ function baseHost(sent: QueueEntry[]): EngineHost {
 
 function compactEffect(overrides: Partial<Record<string, unknown>> = {}): StructuredDeliveryEffect {
   return {
-    id: "effect:op-compact",
+    id: "effect:op-one",
     kind: "runtime.compact",
     eventSeq: 7,
     payload: {
       kind: "compact",
-      operationId: "op-compact",
+      operationId: "op-one",
       conversationId: "conversation-one",
-      idempotencyKey: "op-compact",
+      idempotencyKey: "op-one",
       sessionKey: { engine: "codex", sessionId: "thread-one" },
       ...overrides,
     },
@@ -106,14 +106,14 @@ test("a compact effect issues the engine control and terminalizes on compaction 
 
   /* The control is durably marked in flight before the engine hears about it,
      and it never becomes a message. */
-  expect(transitions).toEqual([["op-compact", "delivering", undefined]]);
-  expect(requests).toEqual([{ operationId: "op-compact", threadId: "thread-one" }]);
+  expect(transitions).toEqual([["op-one", "delivering", undefined]]);
+  expect(requests).toEqual([{ operationId: "op-one", threadId: "thread-one" }]);
   expect(sent).toEqual([]);
 
   releaseEvidence("compaction-one");
   await settled;
 
-  expect(transitions.at(-1)).toEqual(["op-compact", "delivered", "compaction:compaction-one"]);
+  expect(transitions.at(-1)).toEqual(["op-one", "delivered", "compaction:compaction-one"]);
 });
 
 test("a second drain never reissues a compaction that is still awaiting evidence", async () => {
@@ -161,7 +161,7 @@ test("a compaction an earlier executor issued is never issued a second time", as
   expect(calls).toBe(0);
   expect(sent).toEqual([]);
   expect(transitions).toHaveLength(1);
-  expect(transitions[0]![0]).toBe("op-compact");
+  expect(transitions[0]![0]).toBe("op-one");
   expect(transitions[0]![1]).toBe("uncertain");
   expect(transitions[0]![2]).toContain("unverified");
 });
@@ -203,7 +203,7 @@ test("a runtime-host that rejects the uncertain status still settles the operati
   await queue.drain();
 
   expect(transitions.filter(([, status]) => status === "failed")).toEqual([
-    ["op-compact", "failed", "Codex app-server host was lost"],
+    ["op-one", "failed", "Codex app-server host was lost"],
   ]);
   expect(sent.map((entry) => entry.id)).toEqual(["op-send"]);
 });
@@ -260,6 +260,42 @@ test("an in-flight compaction holds messages but never holds kill", async () => 
   expect(transitions.some(([operationId]) => operationId === "op-send")).toBe(false);
 });
 
+test("a second compaction for a thread already compacting waits instead of compacting twice", async () => {
+  const sent: QueueEntry[] = [];
+  const issued: string[] = [];
+  let releaseFirst: () => void = () => {};
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async (request: { operationId: string; threadId: string }) => {
+      issued.push(request.operationId);
+      if (issued.length > 1) return { compactionId: `compaction-${request.operationId}` };
+      return new Promise<{ compactionId: string | null }>((resolve) => {
+        releaseFirst = () => resolve({ compactionId: "compaction-one" });
+      });
+    },
+  });
+  const second = compactEffect({ operationId: "op-two", idempotencyKey: "op-two" });
+  second.id = "effect:op-two";
+  second.eventSeq = 8;
+  const { port, transitions } = recorder([compactEffect(), second], ["delivered", "failed", "uncertain"]);
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+
+  /* Journal admission cannot refuse the second request — a compaction is not a
+     turn — so the queue is what keeps one thread to one compaction. The second
+     effect is left pending and untouched, not failed. */
+  expect(issued).toEqual(["op-one"]);
+  expect(transitions).toEqual([["op-one", "delivering", undefined]]);
+
+  releaseFirst();
+  await Bun.sleep(0);
+  await queue.drain();
+
+  expect(issued).toEqual(["op-one", "op-two"]);
+  expect(transitions.filter(([operationId]) => operationId === "op-two").map(([, status]) => status))
+    .toEqual(["delivering", "delivered"]);
+});
+
 test("a compact effect whose durable receipt cannot be read falls through to the host checks", async () => {
   const sent: QueueEntry[] = [];
   let compactions = 0;
@@ -276,7 +312,7 @@ test("a compact effect whose durable receipt cannot be read falls through to the
   await settled;
 
   expect(compactions).toBe(1);
-  expect(transitions.at(-1)).toEqual(["op-compact", "delivered", "compaction:compaction-one"]);
+  expect(transitions.at(-1)).toEqual(["op-one", "delivered", "compaction:compaction-one"]);
 });
 
 test("a busy structured turn fails the compact control instead of steering it", async () => {
@@ -293,7 +329,7 @@ test("a busy structured turn fails the compact control instead of steering it", 
 
   expect(calls).toBe(0);
   expect(sent).toEqual([]);
-  expect(transitions).toEqual([["op-compact", "failed", "busy-turn"]]);
+  expect(transitions).toEqual([["op-one", "failed", "busy-turn"]]);
 });
 
 test("an engine without a compact control reports a typed capability failure", async () => {
@@ -304,7 +340,7 @@ test("an engine without a compact control reports a typed capability failure", a
   await queue.drain();
 
   expect(sent).toEqual([]);
-  expect(transitions).toEqual([["op-compact", "failed", "unsupported-capability"]]);
+  expect(transitions).toEqual([["op-one", "failed", "unsupported-capability"]]);
 });
 
 test("a rejected compact request terminalizes as failed and an unverified one as uncertain", async () => {
@@ -316,7 +352,7 @@ test("a rejected compact request terminalizes as failed and an unverified one as
   await new StructuredDeliveryQueue(rejected.port, () => rejecting).drain();
   await rejected.settled;
   expect(rejected.transitions.at(-1)).toEqual([
-    "op-compact",
+    "op-one",
     "failed",
     "thread/compact/start was refused",
   ]);
@@ -328,7 +364,7 @@ test("a rejected compact request terminalizes as failed and an unverified one as
   await new StructuredDeliveryQueue(unverified.port, () => losing).drain();
   await unverified.settled;
   expect(unverified.transitions.at(-1)).toEqual([
-    "op-compact",
+    "op-one",
     "uncertain",
     "Codex app-server host was lost",
   ]);
@@ -363,9 +399,9 @@ test("a recovered host lets a queued compaction reach the engine on the next pas
   expect(recoveries).toEqual(["conversation-one"]);
   expect(compactions).toBe(1);
   expect(transitions).toEqual([
-    ["op-compact", "queued", "dead-host"],
-    ["op-compact", "delivering", undefined],
-    ["op-compact", "delivered", "compaction:compaction-one"],
+    ["op-one", "queued", "dead-host"],
+    ["op-one", "delivering", undefined],
+    ["op-one", "delivered", "compaction:compaction-one"],
   ]);
 });
 
@@ -423,7 +459,7 @@ test("a queued message behind an in-flight compaction waits for the control to s
   await queue.drain();
 
   expect(sent).toEqual([]);
-  expect(transitions.map(([operationId]) => operationId)).toEqual(["op-compact"]);
+  expect(transitions.map(([operationId]) => operationId)).toEqual(["op-one"]);
 
   releaseEvidence();
   await settled;

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -296,6 +296,76 @@ test("a second compaction for a thread already compacting waits instead of compa
     .toEqual(["delivering", "delivered"]);
 });
 
+test("a compaction on an unavailable host still lets a kill behind it run in the same pass", async () => {
+  const sent: QueueEntry[] = [];
+  const terminations: string[] = [];
+  const recoveries: string[] = [];
+  const kill = {
+    id: "effect:op-kill",
+    kind: "runtime.kill",
+    eventSeq: 8,
+    payload: {
+      kind: "kill",
+      operationId: "op-kill",
+      conversationId: "conversation-one",
+      idempotencyKey: "op-kill",
+      sessionKey: { engine: "codex", sessionId: "thread-one" },
+    },
+  } satisfies StructuredDeliveryEffect;
+  const { port, transitions } = recorder([compactEffect(), kill], ["delivered", "failed"]);
+  const queue = new StructuredDeliveryQueue(
+    port,
+    () => null,
+    async (conversationId) => { terminations.push(conversationId); return true; },
+    undefined,
+    async (conversationId) => { recoveries.push(conversationId); return false; },
+  );
+
+  await queue.drain();
+
+  /* Compact sorts ahead of the kill because it is a control too, so a barrier
+     here would be the first time one control could stop another. */
+  expect(recoveries).toEqual(["conversation-one"]);
+  expect(terminations).toEqual(["conversation-one"]);
+  expect(transitions.filter(([operationId]) => operationId === "op-kill").map(([, status]) => status))
+    .toEqual(["delivering", "delivered"]);
+  expect(sent).toEqual([]);
+});
+
+test("a compaction admitted before a successful kill is not allowed to respawn the conversation", async () => {
+  const sent: QueueEntry[] = [];
+  let compactions = 0;
+  const recoveries: string[] = [];
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { compactions += 1; return { compactionId: "compaction-one" }; },
+  });
+  /* The durable kill boundary the journal retains for a conversation whose
+     host the operator deliberately terminated. */
+  const boundary = {
+    id: "kill-boundary:conversation-one",
+    kind: "runtime.kill-boundary",
+    eventSeq: 9,
+    payload: { operationId: "op-kill", conversationId: "conversation-one", admissionEventSeq: 9 },
+  } satisfies StructuredDeliveryEffect;
+  const { port, transitions, settled } = recorder([boundary, compactEffect()]);
+  const queue = new StructuredDeliveryQueue(
+    port,
+    () => host,
+    undefined,
+    undefined,
+    async (conversationId) => { recoveries.push(conversationId); return true; },
+  );
+
+  await queue.drain();
+  await settled;
+
+  expect(compactions).toBe(0);
+  expect(recoveries).toEqual([]);
+  expect(transitions).toHaveLength(1);
+  expect(transitions[0]!.slice(0, 2)).toEqual(["op-one", "failed"]);
+  expect(transitions[0]![2]).toContain("intentionally terminated");
+});
+
 test("a compact effect whose durable receipt cannot be read falls through to the host checks", async () => {
   const sent: QueueEntry[] = [];
   let compactions = 0;

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -208,6 +208,77 @@ test("a runtime-host that rejects the uncertain status still settles the operati
   expect(sent.map((entry) => entry.id)).toEqual(["op-send"]);
 });
 
+test("an in-flight compaction holds messages but never holds kill", async () => {
+  const sent: QueueEntry[] = [];
+  const terminations: string[] = [];
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    /* A compaction that never settles: in production this window is minutes. */
+    compact: async () => new Promise<{ compactionId: string | null }>(() => {}),
+  });
+  const effects = [
+    compactEffect(),
+    {
+      id: "effect:op-kill",
+      kind: "runtime.kill",
+      eventSeq: 8,
+      payload: {
+        kind: "kill",
+        operationId: "op-kill",
+        conversationId: "conversation-one",
+        idempotencyKey: "op-kill",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    } satisfies StructuredDeliveryEffect,
+    {
+      id: "effect:op-send",
+      kind: "runtime.send",
+      eventSeq: 9,
+      payload: {
+        kind: "send",
+        operationId: "op-send",
+        conversationId: "conversation-one",
+        idempotencyKey: "op-send",
+        text: "this must wait for the compaction",
+        policy: "queue",
+      },
+    } satisfies StructuredDeliveryEffect,
+  ];
+  const { port, transitions } = recorder(effects, ["delivered"]);
+  const queue = new StructuredDeliveryQueue(port, () => host, async (conversationId) => {
+    terminations.push(conversationId);
+    return true;
+  });
+
+  await queue.drain();
+
+  /* Kill is the operator's safety valve: it must reach the host while the
+     compaction is still running. The message must not. */
+  expect(terminations).toEqual(["conversation-one"]);
+  expect(transitions.filter(([operationId]) => operationId === "op-kill").map(([, status]) => status))
+    .toEqual(["delivering", "delivered"]);
+  expect(sent).toEqual([]);
+  expect(transitions.some(([operationId]) => operationId === "op-send")).toBe(false);
+});
+
+test("a compact effect whose durable receipt cannot be read falls through to the host checks", async () => {
+  const sent: QueueEntry[] = [];
+  let compactions = 0;
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { compactions += 1; return { compactionId: "compaction-one" }; },
+  });
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  /* A drain pass is shared by every conversation, so an unreadable receipt must
+     not take the other groups down with it. */
+  port.status = async () => { throw new Error("runtime host request timed out"); };
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+  await settled;
+
+  expect(compactions).toBe(1);
+  expect(transitions.at(-1)).toEqual(["op-compact", "delivered", "compaction:compaction-one"]);
+});
+
 test("a busy structured turn fails the compact control instead of steering it", async () => {
   const sent: QueueEntry[] = [];
   let calls = 0;
@@ -356,6 +427,10 @@ test("a queued message behind an in-flight compaction waits for the control to s
 
   releaseEvidence();
   await settled;
+  /* The barrier is cleared in the compaction's `finally`, one tick after the
+     terminal transition — production reaches the next pass through the
+     `retrySoon` fired from that same callback. */
+  await Bun.sleep(0);
   await queue.drain();
 
   expect(sent.map((entry) => entry.id)).toEqual(["op-send"]);

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -263,22 +263,63 @@ test("a rejected compact request terminalizes as failed and an unverified one as
   ]);
 });
 
-test("a lost host keeps the compact control queued for recovery", async () => {
-  const { port, transitions } = recorder([compactEffect()], ["failed", "uncertain", "delivered"]);
-  const queue = new StructuredDeliveryQueue(port, () => null);
+test("a recovered host lets a queued compaction reach the engine on the next pass", async () => {
+  /* Controls sort ahead of sends, so a compaction parked in front of the queue
+     must not be the reason nobody asks the host to come back. */
+  const sent: QueueEntry[] = [];
+  let compactions = 0;
+  const recovered: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { compactions += 1; return { compactionId: "compaction-one" }; },
+  });
+  let hosted = false;
+  const recoveries: string[] = [];
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  const queue = new StructuredDeliveryQueue(
+    port,
+    () => (hosted ? recovered : null),
+    undefined,
+    undefined,
+    async (conversationId) => {
+      recoveries.push(conversationId);
+      hosted = true;
+      return true;
+    },
+  );
 
   await queue.drain();
+  await settled;
 
-  expect(transitions).toEqual([]);
+  expect(recoveries).toEqual(["conversation-one"]);
+  expect(compactions).toBe(1);
+  expect(transitions).toEqual([
+    ["op-compact", "queued", "dead-host"],
+    ["op-compact", "delivering", undefined],
+    ["op-compact", "delivered", "compaction:compaction-one"],
+  ]);
+});
 
+test("a dead host asks for recovery and terminalizes the compaction when none starts", async () => {
   const sent: QueueEntry[] = [];
   const dead: CompactCapableHost = Object.assign(baseHost(sent), {
     compact: async () => ({ compactionId: null }),
   });
   dead.health = async () => idleState({ status: "dead" });
-  const deadRun = recorder([compactEffect()], ["queued"]);
-  await new StructuredDeliveryQueue(deadRun.port, () => dead).drain();
-  expect(deadRun.transitions).toEqual([["op-compact", "queued", "dead-host"]]);
+  const recoveries: string[] = [];
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  const queue = new StructuredDeliveryQueue(
+    port,
+    () => dead,
+    undefined,
+    undefined,
+    async (conversationId) => { recoveries.push(conversationId); return false; },
+  );
+
+  await queue.drain();
+  await settled;
+
+  expect(recoveries).toEqual(["conversation-one"]);
+  expect(transitions.map(([, status]) => status)).toEqual(["queued", "failed"]);
+  expect(transitions.at(-1)![2]).toContain("recovery");
 });
 
 test("a queued message behind an in-flight compaction waits for the control to settle", async () => {

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -1,0 +1,279 @@
+import { expect, test } from "bun:test";
+
+import {
+  StructuredCompactError,
+  type CompactCapableHost,
+  type DeliveryReceipt,
+  type EngineHost,
+  type HostState,
+  type QueueEntry,
+  type RuntimeEvent,
+} from "./engineHost";
+import {
+  StructuredDeliveryQueue,
+  type StructuredDeliveryEffect,
+  type StructuredDeliveryQueuePort,
+} from "./structuredDeliveryQueue";
+
+function idleState(overrides: Partial<HostState> = {}): HostState {
+  return {
+    status: "idle",
+    sessionKey: "thread-one",
+    endpoint: "test:host",
+    pid: 1,
+    processStartIdentity: "1",
+    eventCursor: 0,
+    protocolVersion: "test",
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+    account: null,
+    ...overrides,
+  };
+}
+
+function baseHost(sent: QueueEntry[]): EngineHost {
+  return {
+    attach: () => ({ async *[Symbol.asyncIterator](): AsyncIterator<RuntimeEvent> {} }),
+    send: async (entry: QueueEntry): Promise<DeliveryReceipt> => {
+      sent.push(entry);
+      return { outcome: "turn-started", turnId: `turn-${entry.id}` };
+    },
+    interrupt: async () => {},
+    answer: async () => {},
+    health: async () => idleState(),
+    release: async () => {},
+  };
+}
+
+function compactEffect(overrides: Partial<Record<string, unknown>> = {}): StructuredDeliveryEffect {
+  return {
+    id: "effect:op-compact",
+    kind: "runtime.compact",
+    eventSeq: 7,
+    payload: {
+      kind: "compact",
+      operationId: "op-compact",
+      conversationId: "conversation-one",
+      idempotencyKey: "op-compact",
+      sessionKey: { engine: "codex", sessionId: "thread-one" },
+      ...overrides,
+    },
+  };
+}
+
+interface Recorder {
+  port: StructuredDeliveryQueuePort;
+  transitions: Array<[string, string, string | null | undefined]>;
+  settled: Promise<void>;
+}
+
+function recorder(effects: StructuredDeliveryEffect[], terminalStatuses = ["delivered", "failed", "uncertain"]): Recorder {
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  const completed = new Set<string>();
+  let resolveSettled: () => void = () => {};
+  const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
+  const port: StructuredDeliveryQueuePort = {
+    effects: async (_kinds, afterEventSeq = 0) => effects.filter((effect) =>
+      effect.eventSeq > afterEventSeq && !completed.has(String(effect.payload.operationId))),
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+      if (terminalStatuses.includes(status)) {
+        completed.add(operationId);
+        resolveSettled();
+      }
+    },
+  };
+  return { port, transitions, settled };
+}
+
+test("a compact effect issues the engine control and terminalizes on compaction evidence", async () => {
+  const sent: QueueEntry[] = [];
+  const requests: Array<{ operationId: string; threadId: string }> = [];
+  let releaseEvidence: (id: string) => void = () => {};
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async (request: { operationId: string; threadId: string }) => {
+      requests.push(request);
+      return new Promise<{ compactionId: string | null }>((resolve) => {
+        releaseEvidence = (id) => resolve({ compactionId: id });
+      });
+    },
+  });
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+
+  /* The control is durably marked in flight before the engine hears about it,
+     and it never becomes a message. */
+  expect(transitions).toEqual([["op-compact", "delivering", undefined]]);
+  expect(requests).toEqual([{ operationId: "op-compact", threadId: "thread-one" }]);
+  expect(sent).toEqual([]);
+
+  releaseEvidence("compaction-one");
+  await settled;
+
+  expect(transitions.at(-1)).toEqual(["op-compact", "delivered", "compaction:compaction-one"]);
+});
+
+test("a second drain never reissues a compaction that is still awaiting evidence", async () => {
+  const sent: QueueEntry[] = [];
+  let calls = 0;
+  let releaseEvidence: () => void = () => {};
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => {
+      calls += 1;
+      return new Promise<{ compactionId: string | null }>((resolve) => {
+        releaseEvidence = () => resolve({ compactionId: "compaction-one" });
+      });
+    },
+  });
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+  await queue.drain();
+  await queue.drain();
+
+  expect(calls).toBe(1);
+  expect(transitions.filter(([, status]) => status === "delivering")).toHaveLength(1);
+
+  releaseEvidence();
+  await settled;
+  expect(calls).toBe(1);
+});
+
+test("a compaction an earlier executor issued is never issued a second time", async () => {
+  const sent: QueueEntry[] = [];
+  let calls = 0;
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { calls += 1; return { compactionId: "compaction-one" }; },
+  });
+  const { port, transitions, settled } = recorder([compactEffect()]);
+  /* The durable receipt already says `delivering`: the control reached the
+     engine under a Viewer that is no longer running. */
+  port.status = async () => ({ status: "delivering" });
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+  await settled;
+
+  expect(calls).toBe(0);
+  expect(sent).toEqual([]);
+  expect(transitions).toHaveLength(1);
+  expect(transitions[0]![0]).toBe("op-compact");
+  expect(transitions[0]![1]).toBe("uncertain");
+  expect(transitions[0]![2]).toContain("unverified");
+});
+
+test("a busy structured turn fails the compact control instead of steering it", async () => {
+  const sent: QueueEntry[] = [];
+  let calls = 0;
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { calls += 1; return { compactionId: null }; },
+  });
+  host.health = async () => idleState({ status: "active", activeTurnRef: "turn-live" });
+  const { port, transitions } = recorder([compactEffect()]);
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+
+  expect(calls).toBe(0);
+  expect(sent).toEqual([]);
+  expect(transitions).toEqual([["op-compact", "failed", "busy-turn"]]);
+});
+
+test("an engine without a compact control reports a typed capability failure", async () => {
+  const sent: QueueEntry[] = [];
+  const { port, transitions } = recorder([compactEffect({ sessionKey: { engine: "claude", sessionId: "session-one" } })]);
+  const queue = new StructuredDeliveryQueue(port, () => baseHost(sent));
+
+  await queue.drain();
+
+  expect(sent).toEqual([]);
+  expect(transitions).toEqual([["op-compact", "failed", "unsupported-capability"]]);
+});
+
+test("a rejected compact request terminalizes as failed and an unverified one as uncertain", async () => {
+  const sent: QueueEntry[] = [];
+  const rejecting: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { throw new StructuredCompactError("thread/compact/start was refused", "request"); },
+  });
+  const rejected = recorder([compactEffect()]);
+  await new StructuredDeliveryQueue(rejected.port, () => rejecting).drain();
+  await rejected.settled;
+  expect(rejected.transitions.at(-1)).toEqual([
+    "op-compact",
+    "failed",
+    "thread/compact/start was refused",
+  ]);
+
+  const losing: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => { throw new StructuredCompactError("Codex app-server host was lost", "evidence"); },
+  });
+  const unverified = recorder([compactEffect()]);
+  await new StructuredDeliveryQueue(unverified.port, () => losing).drain();
+  await unverified.settled;
+  expect(unverified.transitions.at(-1)).toEqual([
+    "op-compact",
+    "uncertain",
+    "Codex app-server host was lost",
+  ]);
+});
+
+test("a lost host keeps the compact control queued for recovery", async () => {
+  const { port, transitions } = recorder([compactEffect()], ["failed", "uncertain", "delivered"]);
+  const queue = new StructuredDeliveryQueue(port, () => null);
+
+  await queue.drain();
+
+  expect(transitions).toEqual([]);
+
+  const sent: QueueEntry[] = [];
+  const dead: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => ({ compactionId: null }),
+  });
+  dead.health = async () => idleState({ status: "dead" });
+  const deadRun = recorder([compactEffect()], ["queued"]);
+  await new StructuredDeliveryQueue(deadRun.port, () => dead).drain();
+  expect(deadRun.transitions).toEqual([["op-compact", "queued", "dead-host"]]);
+});
+
+test("a queued message behind an in-flight compaction waits for the control to settle", async () => {
+  const sent: QueueEntry[] = [];
+  let releaseEvidence: () => void = () => {};
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => new Promise<{ compactionId: string | null }>((resolve) => {
+      releaseEvidence = () => resolve({ compactionId: "compaction-one" });
+    }),
+  });
+  const effects = [
+    compactEffect(),
+    {
+      id: "effect:op-send",
+      kind: "runtime.send",
+      eventSeq: 9,
+      payload: {
+        kind: "send",
+        operationId: "op-send",
+        conversationId: "conversation-one",
+        idempotencyKey: "op-send",
+        text: "continue with the handoff",
+        policy: "queue",
+      },
+    } satisfies StructuredDeliveryEffect,
+  ];
+  const { port, transitions, settled } = recorder(effects);
+  const queue = new StructuredDeliveryQueue(port, () => host);
+
+  await queue.drain();
+
+  expect(sent).toEqual([]);
+  expect(transitions.map(([operationId]) => operationId)).toEqual(["op-compact"]);
+
+  releaseEvidence();
+  await settled;
+  await queue.drain();
+
+  expect(sent.map((entry) => entry.id)).toEqual(["op-send"]);
+});

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -60,19 +60,126 @@ function structuredConversation(
   return { registry, path: pathname, conversationId: begun.receipt.conversationId };
 }
 
-test.each(["compact", "dialog-key"])(
-  "structured ownership fences the %s control before legacy routing",
-  async (action) => {
-    const fixture = structuredConversation();
-    const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action }, {
-      registry: fixture.registry,
-      client: null,
-      enabled: () => true,
-    });
+test("structured ownership fences the dialog-key control before legacy routing", async () => {
+  const fixture = structuredConversation();
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "dialog-key" }, {
+    registry: fixture.registry,
+    client: null,
+    enabled: () => true,
+  });
 
-    expect(result).toEqual({ status: 409, body: { error: `structured host does not support the ${action} control` } });
-  },
-);
+  expect(result).toEqual({ status: 409, body: { error: "structured host does not support the dialog-key control" } });
+});
+
+test("structured compact enters the durable command channel for the owned codex thread", async () => {
+  const fixture = structuredConversation();
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      return { operationId: "compact-one", receipt: { operationId: "compact-one", status: "pending" }, replayed: false };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "compact" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "compact-one",
+    enabled: () => true,
+  });
+
+  expect(result).toMatchObject({ status: 202, body: { operationId: "compact-one", receipt: { status: "pending" } } });
+  expect(commands).toEqual([{
+    kind: "compact",
+    operationId: "compact-one",
+    idempotencyKey: "compact-one",
+    conversationId: fixture.conversationId,
+    sessionKey: {
+      engine: "codex",
+      sessionId: fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!.generations.at(-1)!.id,
+    },
+  }]);
+});
+
+test("a caller-supplied compact operation id keeps a retry on one durable operation", async () => {
+  const fixture = structuredConversation();
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      return { operationId: "compact-caller", receipt: { operationId: "compact-caller", status: "pending" }, replayed: true };
+    },
+  } as unknown as RuntimeHostClient;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await dispatchStructuredControl({
+      path: fixture.path,
+      conversationId: "",
+      action: "compact",
+      operationId: "compact-caller",
+    }, { registry: fixture.registry, client, enabled: () => true });
+  }
+
+  expect(commands).toEqual([
+    { kind: "compact", operationId: "compact-caller", idempotencyKey: "compact-caller", conversationId: fixture.conversationId, sessionKey: { engine: "codex", sessionId: fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!.generations.at(-1)!.id } },
+    { kind: "compact", operationId: "compact-caller", idempotencyKey: "compact-caller", conversationId: fixture.conversationId, sessionKey: { engine: "codex", sessionId: fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!.generations.at(-1)!.id } },
+  ]);
+});
+
+test("a compact transport failure answers from the durable receipt instead of reissuing", async () => {
+  const fixture = structuredConversation();
+  let commands = 0;
+  const client = {
+    command: async () => {
+      commands += 1;
+      throw new RuntimeHostUnavailableError("runtime host request timed out");
+    },
+    operationStatus: async (operationId: string) => ({
+      operationId,
+      receipt: { operationId, status: "delivered" },
+      replayed: true,
+    }),
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({
+    path: fixture.path,
+    conversationId: "",
+    action: "compact",
+    operationId: "compact-durable",
+  }, { registry: fixture.registry, client, enabled: () => true });
+
+  expect(commands).toBe(1);
+  expect(result).toMatchObject({
+    status: 200,
+    body: { operationId: "compact-durable", receipt: { status: "delivered" } },
+  });
+});
+
+test("a structured claude conversation answers compact with a typed capability error", async () => {
+  const fixture = structuredConversation({ engine: "claude" });
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      throw new Error("an unsupported compact reached the runtime host");
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "compact" }, {
+    registry: fixture.registry,
+    client,
+    enabled: () => true,
+  });
+
+  expect(commands).toEqual([]);
+  expect(result).toMatchObject({
+    status: 409,
+    body: {
+      code: "unsupported-capability",
+      capability: { control: "compact", engine: "claude", supported: false },
+    },
+  });
+});
 
 test("structured reconfigure validates and enters the runtime command channel", async () => {
   const fixture = structuredConversation();
@@ -352,13 +459,13 @@ test("dead structured resume falls through to canonical recovery", async () => {
 
   expect(result).toBeNull();
 
-  // every other control on the dead entry stays fenced (only resume recovers)
-  const compact = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "compact" }, {
+  // controls the structured host does not implement stay fenced (only resume recovers)
+  const dialogKey = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "dialog-key" }, {
     registry: fixture.registry,
     client: null,
     enabled: () => true,
   });
-  expect(compact).toEqual({ status: 409, body: { error: "structured host does not support the compact control" } });
+  expect(dialogKey).toEqual({ status: 409, body: { error: "structured host does not support the dialog-key control" } });
 });
 
 test("structured interrupt uses the runtime command channel", async () => {

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -6,7 +6,7 @@ import { listCodexAccounts } from "@/lib/accounts/codex";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
-import { newOperationId } from "./contracts";
+import { newOperationId, runtimeCompactCapability, type RuntimeControlCapability, type RuntimeOperationCommand } from "./contracts";
 import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverDeadStructuredConversation, structuredHostProcessAlive } from "./structuredRecovery";
@@ -15,7 +15,13 @@ export type StructuredControlResult =
   | { status: 200; body: { ok: true; structured: true; target: string; outcome: "delivered" } }
   | { status: 200; body: { ok: true; structured: true; target: string; outcome: "resumed"; spawned: boolean } }
   | { status: 200 | 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
+  /** A control this engine genuinely does not expose (#862). It is typed, so a
+      caller can tell "this engine cannot" from "this attempt failed", and no
+      prompt-based fallback is ever offered in its place. */
+  | { status: 409; body: { error: string; code: "unsupported-capability"; capability: RuntimeControlCapability } }
   | { status: 400 | 409 | 503; body: { error: string } };
+
+const STRUCTURED_CONTROL_ACTIONS = new Set(["interrupt", "kill", "reconfigure", "compact"]);
 
 export interface StructuredControlRequest {
   path: string;
@@ -67,7 +73,7 @@ export async function dispatchStructuredControl(
     && (conversation.reconfigure?.status === "applying" || completedStructuredOwnership);
   if (!entry.structuredHost && !structuredKill && !structuredReconfigureRestart) return null;
 
-  if (request.action !== "interrupt" && request.action !== "kill" && request.action !== "reconfigure") {
+  if (!STRUCTURED_CONTROL_ACTIONS.has(request.action)) {
     if (request.action === "resume") {
       if (entry.status === "dead" || entry.status === "unhosted") return null;
       try {
@@ -111,10 +117,25 @@ export async function dispatchStructuredControl(
         return { status: 503, body: { error: error instanceof Error ? error.message : String(error) } };
       }
     }
-    const label = ["compact", "dialog-key", "kill", "reconfigure"].includes(request.action)
+    const label = ["dialog-key", "kill", "reconfigure"].includes(request.action)
       ? request.action
       : "requested";
     return { status: 409, body: { error: `structured host does not support the ${label} control` } };
+  }
+
+  if (request.action === "compact") {
+    const capability = runtimeCompactCapability(conversation.engine);
+    if (!capability.supported || entry.structuredHost?.kind !== "codex-app-server") {
+      return {
+        status: 409,
+        body: {
+          error: capability.reason
+            ?? `the ${conversation.engine} structured host does not expose a compact control`,
+          code: "unsupported-capability",
+          capability,
+        },
+      };
+    }
   }
 
   if (structuredKill
@@ -143,35 +164,36 @@ export async function dispatchStructuredControl(
         return { status: 400, body: { error: `account is not available for ${conversation.engine}` } };
       }
     }
-    const result = await client.command(request.action === "kill"
-      ? {
-          kind: "kill",
-          operationId,
-          idempotencyKey: operationId,
-          conversationId: conversation.id,
-          sessionKey: { engine: conversation.engine, sessionId: generation.id },
-        }
-      : request.action === "reconfigure"
-        ? {
-            kind: "reconfigure",
-            operationId,
-            idempotencyKey: operationId,
-            conversationId: conversation.id,
-            sessionKey: { engine: conversation.engine, sessionId: generation.id },
-            ...reconfiguration!.value!,
-            previousProfile: {
-              model: generation.launchProfile.model,
-              effort: generation.launchProfile.effort,
-              fast: generation.launchProfile.fast,
-            },
-          }
-        : {
-          kind: "interrupt",
-          operationId,
-          idempotencyKey: operationId,
-          conversationId: conversation.id,
-          turnId: entry.structuredHost?.activeTurnRef ?? null,
-        });
+    const sessionKey = { engine: conversation.engine, sessionId: generation.id };
+    const command: RuntimeOperationCommand = request.action === "kill"
+      ? { kind: "kill", operationId, idempotencyKey: operationId, conversationId: conversation.id, sessionKey }
+      /* #862: a compact command carries a generation fence and nothing else.
+         There is no text field to fill, so this control cannot degrade into a
+         `/compact` user turn on any path. */
+      : request.action === "compact"
+        ? { kind: "compact", operationId, idempotencyKey: operationId, conversationId: conversation.id, sessionKey }
+        : request.action === "reconfigure"
+          ? {
+              kind: "reconfigure",
+              operationId,
+              idempotencyKey: operationId,
+              conversationId: conversation.id,
+              sessionKey,
+              ...reconfiguration!.value!,
+              previousProfile: {
+                model: generation.launchProfile.model,
+                effort: generation.launchProfile.effort,
+                fast: generation.launchProfile.fast,
+              },
+            }
+          : {
+              kind: "interrupt",
+              operationId,
+              idempotencyKey: operationId,
+              conversationId: conversation.id,
+              turnId: entry.structuredHost?.activeTurnRef ?? null,
+            };
+    const result = await client.command(command);
     (dependencies.kick ?? kickStructuredDeliveryQueue)();
     return {
       status: result.receipt.status === "delivered" ? 200 : 202,
@@ -184,7 +206,8 @@ export async function dispatchStructuredControl(
       },
     };
   } catch (error) {
-    if ((request.action === "kill" || request.action === "reconfigure") && isRuntimeHostTransportFailure(error)) {
+    if ((request.action === "kill" || request.action === "reconfigure" || request.action === "compact")
+      && isRuntimeHostTransportFailure(error)) {
       /* The socket failed after the command may have reached the journal. The
          durable receipt decides whether structured control owns the response. */
       const durable = await client.operationStatus(operationId).catch(() => null);

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -260,6 +260,10 @@ export async function bindStructuredDeliveryQueue(
       status: async (operationId: string) => (await client.operationStatus(operationId))?.receipt ?? null,
       transition: async (operationId, status, details) => {
         const result = await client.transitionOperation(operationId, status, details);
+        /* Only the two states a held delivery can settle into. A compaction's
+           `uncertain` is absent on purpose and costs nothing: this projection
+           is keyed on `heldDeliveries`, which only a composer message ever
+           creates, so a compact operation has no row here to settle (#862). */
         if (status !== "delivered" && status !== "failed") return;
         const conversationId = result.receipt.conversationId;
         if (!conversationId?.startsWith("conversation_")) return;

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -257,6 +257,7 @@ export async function bindStructuredDeliveryQueue(
     {
       effects: (kinds, afterEventSeq) => client.effectBatch(kinds, afterEventSeq),
       ...(typeof client.events === "function" ? { events: (afterEventSeq: number) => client.events(afterEventSeq) } : {}),
+      status: async (operationId: string) => (await client.operationStatus(operationId))?.receipt ?? null,
       transition: async (operationId, status, details) => {
         const result = await client.transitionOperation(operationId, status, details);
         if (status !== "delivered" && status !== "failed") return;

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -316,6 +316,7 @@ test("unrelated outbox effects cannot starve structured message delivery", async
     "runtime.kill",
     "runtime.kill-boundary",
     "runtime.reconfigure",
+    "runtime.compact",
   ]]);
   expect(sent).toEqual(["op-after-spawns"]);
 });

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -587,6 +587,14 @@ export class StructuredDeliveryQueue {
    */
   private async drainCompact(effect: CompactEffect): Promise<ControlDrainResult> {
     if (this.activeCompactions.has(effect.operationId)) return { blocked: false, terminated: false };
+    /* A second compaction admitted for a thread that is already compacting is
+       left pending, untouched. The operator's second request is legitimate once
+       the first lands — journal admission cannot refuse it, because a
+       compaction is not a turn — but issuing both would compact the thread
+       twice and settle both receipts on one piece of evidence. The `retrySoon`
+       fired when the first settles brings this effect back. Holding it does not
+       block the group: kill must still get through. */
+    if (this.compactingConversations.has(effect.conversationId)) return { blocked: false, terminated: false };
     /* An unreadable receipt is not evidence of anything. Treat it as unknown
        and fall through to the host checks rather than aborting a drain pass
        that other conversations share. */

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -1,7 +1,8 @@
 import { parseSelectedContextRef, type SelectedContextRef } from "@/lib/selection/selectedContext";
 
 import type { RuntimeSendSettings } from "./contracts";
-import type { DeliveryReceipt, EngineHost, QueueEntry } from "./engineHost";
+import type { CompactCapableHost, DeliveryReceipt, EngineHost, QueueEntry } from "./engineHost";
+import { hostSupportsCompact, StructuredCompactError } from "./engineHost";
 import type { RuntimeHostClient } from "./client";
 import {
   parseStructuredImageRefs,
@@ -16,7 +17,7 @@ export interface StructuredDeliveryEffect {
   eventSeq: number;
 }
 
-export type StructuredDeliveryTransition = "queued" | "delivering" | "applying" | "delivered" | "applied" | "answered" | "interrupted" | "failed";
+export type StructuredDeliveryTransition = "queued" | "delivering" | "applying" | "delivered" | "applied" | "answered" | "interrupted" | "failed" | "uncertain";
 
 export interface StructuredDeliveryQueuePort {
   effects(kinds?: readonly string[], afterEventSeq?: number): Promise<StructuredDeliveryEffect[]>;
@@ -25,6 +26,10 @@ export interface StructuredDeliveryQueuePort {
     status: StructuredDeliveryTransition,
     details?: { turnId?: string | null; reason?: string | null },
   ): Promise<void>;
+  /** The durable receipt state, when the port can read it. The compact control
+      needs it to tell a control it must issue from one an earlier executor
+      already issued and never settled (#862). */
+  status?(operationId: string): Promise<{ status: string } | null>;
 }
 
 export type StructuredHostResolver = (conversationId: string) => EngineHost | null;
@@ -39,6 +44,7 @@ export function runtimeClientDeliveryPort(client: RuntimeHostClient): Structured
     transition: async (operationId, status, details) => {
       await client.transitionOperation(operationId, status, details);
     },
+    status: async (operationId) => (await client.operationStatus(operationId))?.receipt ?? null,
   };
 }
 
@@ -81,6 +87,17 @@ interface ControlEffect {
   eventSeq: number;
 }
 
+/** A manual compaction (#862): a control fenced to one owned generation that
+    carries no content, so nothing on it can be replayed as user input. */
+interface CompactEffect {
+  operationId: string;
+  conversationId: string;
+  kind: "compact";
+  sessionKey: { engine: "codex" | "claude"; sessionId: string };
+  turnId?: string | null;
+  eventSeq: number;
+}
+
 export interface StructuredReconfigureEffect {
   operationId: string;
   conversationId: string;
@@ -103,7 +120,7 @@ export type StructuredReconfigureHandler = (
   ownership: StructuredReconfigureOwnership,
 ) => Promise<void | "applied" | "pending">;
 
-type DeliveryEffect = SendEffect | ControlEffect | StructuredReconfigureEffect;
+type DeliveryEffect = SendEffect | ControlEffect | CompactEffect | StructuredReconfigureEffect;
 
 interface ControlDrainResult {
   blocked: boolean;
@@ -116,8 +133,12 @@ interface SuccessfulKillBoundary {
   eventSeq: number;
 }
 
-function isControlEffect(effect: DeliveryEffect): effect is ControlEffect {
-  return effect.kind === "answer" || effect.kind === "interrupt" || effect.kind === "kill";
+function isControlEffect(effect: DeliveryEffect): effect is ControlEffect | CompactEffect {
+  return effect.kind === "answer" || effect.kind === "interrupt" || effect.kind === "kill" || effect.kind === "compact";
+}
+
+function isCompactEffect(effect: DeliveryEffect): effect is CompactEffect {
+  return effect.kind === "compact";
 }
 
 function isReconfigureEffect(effect: DeliveryEffect): effect is StructuredReconfigureEffect {
@@ -189,6 +210,27 @@ function controlEffect(effect: StructuredDeliveryEffect): ControlEffect | null {
   return { operationId, conversationId, kind: "interrupt", eventSeq: effect.eventSeq, ...(turnId !== undefined ? { turnId } : {}) };
 }
 
+function compactEffect(effect: StructuredDeliveryEffect): CompactEffect | null {
+  if (effect.kind !== "runtime.compact") return null;
+  const operationId = typeof effect.payload.operationId === "string" ? effect.payload.operationId : "";
+  const conversationId = typeof effect.payload.conversationId === "string" ? effect.payload.conversationId : "";
+  const key = effect.payload.sessionKey;
+  if (!operationId || !conversationId || !key || typeof key !== "object" || Array.isArray(key)) return null;
+  const candidate = key as Record<string, unknown>;
+  if ((candidate.engine !== "codex" && candidate.engine !== "claude") || typeof candidate.sessionId !== "string") return null;
+  const turnId = typeof effect.payload.turnId === "string" || effect.payload.turnId === null
+    ? effect.payload.turnId
+    : undefined;
+  return {
+    operationId,
+    conversationId,
+    kind: "compact",
+    sessionKey: { engine: candidate.engine, sessionId: candidate.sessionId },
+    eventSeq: effect.eventSeq,
+    ...(turnId !== undefined ? { turnId } : {}),
+  };
+}
+
 function reconfigureEffect(effect: StructuredDeliveryEffect): StructuredReconfigureEffect | null {
   if (effect.kind !== "runtime.reconfigure") return null;
   const operationId = typeof effect.payload.operationId === "string" ? effect.payload.operationId : "";
@@ -224,7 +266,7 @@ function reconfigureEffect(effect: StructuredDeliveryEffect): StructuredReconfig
 }
 
 function deliveryEffect(effect: StructuredDeliveryEffect): DeliveryEffect | null {
-  return controlEffect(effect) ?? reconfigureEffect(effect) ?? sendEffect(effect);
+  return controlEffect(effect) ?? compactEffect(effect) ?? reconfigureEffect(effect) ?? sendEffect(effect);
 }
 
 function successfulKillBoundary(effect: StructuredDeliveryEffect): SuccessfulKillBoundary | null {
@@ -263,6 +305,10 @@ export class StructuredDeliveryQueue {
   private rerun = false;
   private readonly interruptAcknowledged = new Set<string>();
   private readonly successfulKillBoundaries = new Map<string, SuccessfulKillBoundary>();
+  /** Compactions whose engine control is issued and whose evidence has not
+      arrived. The effect stays pending in the journal meanwhile, so every later
+      drain pass must find it here and leave it alone (#862). */
+  private readonly activeCompactions = new Map<string, Promise<void>>();
 
   constructor(
     private readonly port: StructuredDeliveryQueuePort,
@@ -310,7 +356,7 @@ export class StructuredDeliveryQueue {
     let afterEventSeq = 0;
     while (true) {
       const page = await this.port.effects(
-        ["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt", "runtime.kill", "runtime.kill-boundary", "runtime.reconfigure"],
+        ["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt", "runtime.kill", "runtime.kill-boundary", "runtime.reconfigure", "runtime.compact"],
         afterEventSeq,
       );
       if (page.length === 0) break;
@@ -389,7 +435,9 @@ export class StructuredDeliveryQueue {
         continue;
       }
       if (isControlEffect(effect)) {
-        const result = await this.drainControl(effect);
+        const result = isCompactEffect(effect)
+          ? await this.drainCompact(effect)
+          : await this.drainControl(effect);
         if (result.blocked) return true;
         if (result.terminated && effect.kind === "kill") {
           if (effect.sessionKey) {
@@ -518,6 +566,80 @@ export class StructuredDeliveryQueue {
       await this.port.transition(effect.operationId, "delivered", { turnId: receipt.turnId });
     }
     return false;
+  }
+
+  /**
+   * Executes a durable compact receipt (#862). The pass never waits for the
+   * compaction itself: it issues the control, reports the conversation blocked
+   * so no message can slip past an unfinished compaction, and lets the evidence
+   * terminalize the receipt out of band. Duplicate execution is impossible
+   * because the operation is registered in flight before the control is issued
+   * and the outbox row is only cleared by the terminal transition.
+   */
+  private async drainCompact(effect: CompactEffect): Promise<ControlDrainResult> {
+    if (this.activeCompactions.has(effect.operationId)) return { blocked: true, terminated: false };
+    const durable = await this.port.status?.(effect.operationId);
+    if (durable?.status === "delivering") {
+      /* An earlier executor issued this control and never settled it — a Viewer
+         restart, or a terminal transition that never landed. This process
+         cannot know whether the thread was compacted, and issuing the control
+         again could compact it twice, so the receipt terminalizes unverified. */
+      await this.port.transition(effect.operationId, "uncertain", {
+        reason: "compaction was issued by an earlier executor; its outcome is unverified",
+      });
+      return { blocked: false, terminated: false };
+    }
+    const host = this.resolveHost(effect.conversationId);
+    if (!host) return { blocked: true, terminated: false };
+    if (!hostSupportsCompact(host)) {
+      await this.port.transition(effect.operationId, "failed", { reason: "unsupported-capability" });
+      return { blocked: false, terminated: false };
+    }
+    const health = await host.health();
+    if (health.status === "dead" || health.status === "unhosted") {
+      await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      return { blocked: true, terminated: false };
+    }
+    /* Admission fenced the durable turn axis; this re-reads the live host, so a
+       turn that started in between fails the control instead of racing it. */
+    if (health.status !== "idle" || health.activeTurnRef) {
+      await this.port.transition(effect.operationId, "failed", { reason: "busy-turn" });
+      return { blocked: false, terminated: false };
+    }
+    if (effect.turnId !== undefined && effect.turnId !== null && effect.turnId !== health.activeTurnRef) {
+      await this.port.transition(effect.operationId, "failed", { reason: "stale-turn" });
+      return { blocked: false, terminated: false };
+    }
+    /* Durable marker first: a restart that finds the receipt in `delivering`
+       knows the control may already have reached the engine and terminalizes it
+       as unverified instead of compacting the thread a second time. */
+    await this.port.transition(effect.operationId, "delivering");
+    const run = this.runCompaction(host, effect).finally(() => {
+      this.activeCompactions.delete(effect.operationId);
+      this.retrySoon();
+    });
+    this.activeCompactions.set(effect.operationId, run);
+    void run.catch(() => undefined);
+    return { blocked: true, terminated: false };
+  }
+
+  private async runCompaction(host: CompactCapableHost, effect: CompactEffect): Promise<void> {
+    try {
+      const outcome = await host.compact({
+        operationId: effect.operationId,
+        threadId: effect.sessionKey.sessionId,
+      });
+      /* The receipt records which compaction closed it: the only durable place
+         the lifecycle evidence survives alongside the operation. */
+      await this.port.transition(effect.operationId, "delivered", {
+        reason: outcome.compactionId ? `compaction:${outcome.compactionId}` : null,
+      });
+    } catch (error) {
+      const unverified = error instanceof StructuredCompactError && error.phase === "evidence";
+      await this.port.transition(effect.operationId, unverified ? "uncertain" : "failed", {
+        reason: failureReason(error),
+      });
+    }
   }
 
   private async drainReconfigure(effect: StructuredReconfigureEffect): Promise<boolean> {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -304,6 +304,10 @@ export class StructuredDeliveryQueue {
       arrived. The effect stays pending in the journal meanwhile, so every later
       drain pass must find it here and leave it alone (#862). */
   private readonly activeCompactions = new Map<string, Promise<void>>();
+  /** The conversations those compactions belong to. Reads block on this rather
+      than on a whole-group barrier, so an unfinished compaction holds messages
+      without holding kill, interrupt, or answer. */
+  private readonly compactingConversations = new Set<string>();
 
   constructor(
     private readonly port: StructuredDeliveryQueuePort,
@@ -417,6 +421,13 @@ export class StructuredDeliveryQueue {
       }
     }
     for (const effect of effects) {
+      /* #862: a compaction in flight holds back everything that would write to
+         the thread — messages and reconfigures — but never another control.
+         Kill is the operator's safety valve and interrupt/answer are how a turn
+         is reached at all; leaving them inert for the length of a compaction
+         would be a worse failure than the one the barrier prevents. Controls
+         sort ahead of these, so by here every one of them has already run. */
+      if (!isControlEffect(effect) && this.compactingConversations.has(effect.conversationId)) return true;
       if (isReconfigureEffect(effect)) {
         if (effect !== currentReconfigure) continue;
         if (effect.sessionKey
@@ -565,15 +576,21 @@ export class StructuredDeliveryQueue {
 
   /**
    * Executes a durable compact receipt (#862). The pass never waits for the
-   * compaction itself: it issues the control, reports the conversation blocked
-   * so no message can slip past an unfinished compaction, and lets the evidence
-   * terminalize the receipt out of band. Duplicate execution is impossible
-   * because the operation is registered in flight before the control is issued
-   * and the outbox row is only cleared by the terminal transition.
+   * compaction itself: it issues the control, records the conversation as
+   * compacting so no message can slip past an unfinished compaction, and lets
+   * the evidence terminalize the receipt out of band. Duplicate execution is
+   * impossible because the operation is registered in flight before the control
+   * is issued and the outbox row is only cleared by the terminal transition.
+   *
+   * It never reports the group blocked for an in-flight compaction: the
+   * remaining control effects — kill above all — must still run.
    */
   private async drainCompact(effect: CompactEffect): Promise<ControlDrainResult> {
-    if (this.activeCompactions.has(effect.operationId)) return { blocked: true, terminated: false };
-    const durable = await this.port.status?.(effect.operationId);
+    if (this.activeCompactions.has(effect.operationId)) return { blocked: false, terminated: false };
+    /* An unreadable receipt is not evidence of anything. Treat it as unknown
+       and fall through to the host checks rather than aborting a drain pass
+       that other conversations share. */
+    const durable = await this.port.status?.(effect.operationId).catch(() => null);
     if (durable?.status === "delivering") {
       /* An earlier executor issued this control and never settled it — a Viewer
          restart, or a terminal transition that never landed. This process
@@ -615,13 +632,17 @@ export class StructuredDeliveryQueue {
        knows the control may already have reached the engine and terminalizes it
        as unverified instead of compacting the thread a second time. */
     await this.port.transition(effect.operationId, "delivering");
+    /* Marked before the run exists: a compaction that settles immediately would
+       otherwise clear the barrier before it was ever raised. */
+    this.compactingConversations.add(effect.conversationId);
     const run = this.runCompaction(host, effect).finally(() => {
       this.activeCompactions.delete(effect.operationId);
+      this.compactingConversations.delete(effect.conversationId);
       this.retrySoon();
     });
     this.activeCompactions.set(effect.operationId, run);
     void run.catch(() => undefined);
-    return { blocked: true, terminated: false };
+    return { blocked: false, terminated: false };
   }
 
   private async runCompaction(host: CompactCapableHost, effect: CompactEffect): Promise<void> {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -94,7 +94,6 @@ interface CompactEffect {
   conversationId: string;
   kind: "compact";
   sessionKey: { engine: "codex" | "claude"; sessionId: string };
-  turnId?: string | null;
   eventSeq: number;
 }
 
@@ -218,16 +217,12 @@ function compactEffect(effect: StructuredDeliveryEffect): CompactEffect | null {
   if (!operationId || !conversationId || !key || typeof key !== "object" || Array.isArray(key)) return null;
   const candidate = key as Record<string, unknown>;
   if ((candidate.engine !== "codex" && candidate.engine !== "claude") || typeof candidate.sessionId !== "string") return null;
-  const turnId = typeof effect.payload.turnId === "string" || effect.payload.turnId === null
-    ? effect.payload.turnId
-    : undefined;
   return {
     operationId,
     conversationId,
     kind: "compact",
     sessionKey: { engine: candidate.engine, sessionId: candidate.sessionId },
     eventSeq: effect.eventSeq,
-    ...(turnId !== undefined ? { turnId } : {}),
   };
 }
 
@@ -584,9 +579,10 @@ export class StructuredDeliveryQueue {
          restart, or a terminal transition that never landed. This process
          cannot know whether the thread was compacted, and issuing the control
          again could compact it twice, so the receipt terminalizes unverified. */
-      await this.port.transition(effect.operationId, "uncertain", {
-        reason: "compaction was issued by an earlier executor; its outcome is unverified",
-      });
+      await this.terminalizeUnverified(
+        effect.operationId,
+        "compaction was issued by an earlier executor; its outcome is unverified",
+      );
       return { blocked: false, terminated: false };
     }
     const host = this.resolveHost(effect.conversationId);
@@ -604,10 +600,6 @@ export class StructuredDeliveryQueue {
        turn that started in between fails the control instead of racing it. */
     if (health.status !== "idle" || health.activeTurnRef) {
       await this.port.transition(effect.operationId, "failed", { reason: "busy-turn" });
-      return { blocked: false, terminated: false };
-    }
-    if (effect.turnId !== undefined && effect.turnId !== null && effect.turnId !== health.activeTurnRef) {
-      await this.port.transition(effect.operationId, "failed", { reason: "stale-turn" });
       return { blocked: false, terminated: false };
     }
     /* Durable marker first: a restart that finds the receipt in `delivering`
@@ -635,10 +627,25 @@ export class StructuredDeliveryQueue {
         reason: outcome.compactionId ? `compaction:${outcome.compactionId}` : null,
       });
     } catch (error) {
-      const unverified = error instanceof StructuredCompactError && error.phase === "evidence";
-      await this.port.transition(effect.operationId, unverified ? "uncertain" : "failed", {
-        reason: failureReason(error),
-      });
+      if (error instanceof StructuredCompactError && error.phase === "unverified") {
+        await this.terminalizeUnverified(effect.operationId, failureReason(error));
+        return;
+      }
+      await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
+    }
+  }
+
+  /**
+   * Terminalizes a compaction whose outcome nothing proved. `uncertain` is a
+   * newer transition than the rest of this channel, so a runtime-host from
+   * before #862 rejects it; the operation must still settle rather than wedge
+   * the conversation's queue behind a receipt no pass can ever clear.
+   */
+  private async terminalizeUnverified(operationId: string, reason: string): Promise<void> {
+    try {
+      await this.port.transition(operationId, "uncertain", { reason });
+    } catch {
+      await this.port.transition(operationId, "failed", { reason });
     }
   }
 

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -586,7 +586,15 @@ export class StructuredDeliveryQueue {
       return { blocked: false, terminated: false };
     }
     const host = this.resolveHost(effect.conversationId);
-    if (!host) return { blocked: true, terminated: false };
+    /* Controls sort ahead of sends, and a compaction can hold that slot for
+       minutes, so an unavailable host must start the same recovery a send would
+       — otherwise every message queued behind this control waits on a host
+       nobody asked to come back. */
+    if (!host) {
+      await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      await this.recoverUnavailableHost(effect);
+      return { blocked: true, terminated: false };
+    }
     if (!hostSupportsCompact(host)) {
       await this.port.transition(effect.operationId, "failed", { reason: "unsupported-capability" });
       return { blocked: false, terminated: false };
@@ -594,6 +602,7 @@ export class StructuredDeliveryQueue {
     const health = await host.health();
     if (health.status === "dead" || health.status === "unhosted") {
       await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      await this.recoverUnavailableHost(effect);
       return { blocked: true, terminated: false };
     }
     /* Admission fenced the durable turn axis; this re-reads the live host, so a
@@ -693,7 +702,7 @@ export class StructuredDeliveryQueue {
     return latest.operationId === effect.operationId && latest.eventSeq === effect.eventSeq;
   }
 
-  private async recoverUnavailableHost(effect: SendEffect): Promise<void> {
+  private async recoverUnavailableHost(effect: Pick<DeliveryEffect, "conversationId" | "operationId">): Promise<void> {
     if (!this.recoverHost) return;
     try {
       if (await this.recoverHost(effect.conversationId)) {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -582,8 +582,10 @@ export class StructuredDeliveryQueue {
    * impossible because the operation is registered in flight before the control
    * is issued and the outbox row is only cleared by the terminal transition.
    *
-   * It never reports the group blocked for an in-flight compaction: the
-   * remaining control effects — kill above all — must still run.
+   * It never reports the group blocked, in any branch: compact is the first
+   * control that can occupy this slot for minutes, and a kill sorted behind it
+   * must still run in the same pass. Messages are held by the per-conversation
+   * barrier instead, which is read only for non-control effects.
    */
   private async drainCompact(effect: CompactEffect): Promise<ControlDrainResult> {
     if (this.activeCompactions.has(effect.operationId)) return { blocked: false, terminated: false };
@@ -610,15 +612,29 @@ export class StructuredDeliveryQueue {
       );
       return { blocked: false, terminated: false };
     }
+    /* A conversation the operator deliberately terminated must not be brought
+       back to compact it. A compact admitted between a kill's admission and its
+       execution is still pending afterwards — kill admission does not move the
+       session's host axis — and the recovery below would otherwise respawn the
+       host purely to run this control. Sends are fenced the same way. */
+    const killBoundary = this.successfulKillBoundaries.get(effect.conversationId);
+    if (killBoundary && effect.eventSeq <= killBoundary.eventSeq) {
+      await this.port.transition(effect.operationId, "failed", {
+        reason: "structured host was intentionally terminated; retry the operation",
+      });
+      return { blocked: false, terminated: false };
+    }
     const host = this.resolveHost(effect.conversationId);
     /* Controls sort ahead of sends, and a compaction can hold that slot for
        minutes, so an unavailable host must start the same recovery a send would
        — otherwise every message queued behind this control waits on a host
-       nobody asked to come back. */
+       nobody asked to come back. The group is not reported blocked: recovery is
+       asynchronous, and a kill behind this effect must not wait a whole pass
+       for it. */
     if (!host) {
       await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
       await this.recoverUnavailableHost(effect);
-      return { blocked: true, terminated: false };
+      return { blocked: false, terminated: false };
     }
     if (!hostSupportsCompact(host)) {
       await this.port.transition(effect.operationId, "failed", { reason: "unsupported-capability" });
@@ -628,7 +644,7 @@ export class StructuredDeliveryQueue {
     if (health.status === "dead" || health.status === "unhosted") {
       await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
       await this.recoverUnavailableHost(effect);
-      return { blocked: true, terminated: false };
+      return { blocked: false, terminated: false };
     }
     /* Admission fenced the durable turn axis; this re-reads the live host, so a
        turn that started in between fails the control instead of racing it. */

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -156,7 +156,10 @@ export class RuntimeHost {
           && status !== "applied"
           && status !== "interrupted"
           && status !== "answered"
-          && status !== "failed") {
+          && status !== "failed"
+          /* #862: a compaction whose evidence never arrived is terminal and
+             unverified, which is a different fact from a failed control. */
+          && status !== "uncertain") {
           throw new Error("runtime operation transition status is invalid");
         }
         const details = request.params?.details;

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -18,6 +18,7 @@ import {
   type RuntimeEventInput,
   RuntimeIdempotencyConflictError,
   newOperationId,
+  runtimeCompactCapability,
   type NormalizedRuntimeEventInput,
   type RuntimeOperationCommand,
   type RuntimeOperationReceipt,
@@ -933,6 +934,15 @@ export class RuntimeJournal {
   }
 
   claimHostEpoch(): number {
+    const epoch = this.claimHostEpochInTransaction();
+    /* Outside the epoch transaction on purpose: the sweep opens transactions of
+       its own, and a claimed epoch must never be undone by a failure to settle
+       an old receipt. */
+    this.terminalizeUnverifiedCompactions();
+    return epoch;
+  }
+
+  private claimHostEpochInTransaction(): number {
     this.assertHealthy();
     this.db.exec("BEGIN IMMEDIATE");
     try {
@@ -972,6 +982,27 @@ export class RuntimeJournal {
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
+    }
+  }
+
+  /**
+   * #862: the executor writes `delivering` before it writes
+   * `thread/compact/start`, so a compact operation still in that state at a new
+   * host epoch is one whose engine outcome this process cannot verify. Replaying
+   * it could compact the thread twice, so it terminalizes visibly instead. A
+   * compact still `pending` was never issued and replays normally; a terminal
+   * one already has a completed outbox row and is never reissued.
+   */
+  private terminalizeUnverifiedCompactions(): void {
+    const rows = this.db.query<{ operation_id: string; request_json: string; receipt_json: string }, []>(
+      "SELECT operation_id, request_json, receipt_json FROM operations ORDER BY event_seq",
+    ).all();
+    for (const row of rows) {
+      const receipt = JSON.parse(row.receipt_json) as RuntimeOperationReceipt;
+      if (receipt.kind !== "compact" || receipt.status !== "delivering") continue;
+      this.transitionOperation(row.operation_id, "uncertain", {
+        reason: "compaction was in flight during a runtime-host restart; its outcome is unverified",
+      });
     }
   }
 
@@ -1160,7 +1191,7 @@ export class RuntimeJournal {
       if (!command.contentDigest) throw new Error("message content digest is required");
     }
     if (command.kind === "answer" && !command.attentionId.trim()) throw new Error("attentionId is required");
-    if ((command.kind === "kill" || (command.kind === "reconfigure" && command.sessionKey))
+    if ((command.kind === "kill" || command.kind === "compact" || (command.kind === "reconfigure" && command.sessionKey))
       && ((!command.sessionKey || (command.sessionKey.engine !== "codex" && command.sessionKey.engine !== "claude"))
         || !command.sessionKey.sessionId?.trim())) {
       throw new Error(`${command.kind} sessionKey is invalid`);
@@ -1273,6 +1304,32 @@ export class RuntimeJournal {
       } else {
         status = "pending";
         turnId = session.activeTurnId;
+      }
+    } else if (command.kind === "compact") {
+      /* #862: admission is the race-safe fence. It is evaluated inside the
+         BEGIN IMMEDIATE that admits the operation, so the durable turn axis it
+         reads cannot move underneath it — a compaction is only ever admitted
+         against a hosted, idle generation on an engine that has the control. */
+      turnId = null;
+      const capability = runtimeCompactCapability(command.sessionKey.engine);
+      if (!session || session.host !== "hosted") {
+        status = "rejected";
+        reason = session?.host === "dead" || session?.host === "unhosted" ? "dead-host" : "no-claim";
+      } else if (!capability.supported || session.hostKind !== "codex-app-server") {
+        status = "rejected";
+        reason = "unsupported-capability";
+      } else if (session.sessionKey.engine !== command.sessionKey.engine
+        || session.sessionKey.sessionId !== command.sessionKey.sessionId) {
+        status = "rejected";
+        reason = "stale-generation";
+      } else if (command.turnId !== undefined && command.turnId !== null && command.turnId !== session.activeTurnId) {
+        status = "rejected";
+        reason = "stale-turn";
+      } else if (session.turn === "running" || session.turn === "interrupt_requested" || session.activeTurnId) {
+        status = "rejected";
+        reason = "busy-turn";
+      } else {
+        status = "pending";
       }
     } else if (command.kind === "answer") {
       const attention = this.entity<RuntimeAttention>("attention", command.attentionId);

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -994,8 +994,14 @@ export class RuntimeJournal {
    * one already has a completed outbox row and is never reissued.
    */
   private terminalizeUnverifiedCompactions(): void {
-    const rows = this.db.query<{ operation_id: string; request_json: string; receipt_json: string }, []>(
-      "SELECT operation_id, request_json, receipt_json FROM operations ORDER BY event_seq",
+    /* Prefiltered in SQL: an epoch claim is on the startup path, and every row
+       this sweep can act on names both tokens in its stored receipt. The JSON
+       parse below still decides — LIKE only keeps the scan off rows that cannot
+       possibly match. */
+    const rows = this.db.query<{ operation_id: string; receipt_json: string }, []>(
+      `SELECT operation_id, receipt_json FROM operations
+       WHERE receipt_json LIKE '%"kind":"compact"%' AND receipt_json LIKE '%"status":"delivering"%'
+       ORDER BY event_seq`,
     ).all();
     for (const row of rows) {
       const receipt = JSON.parse(row.receipt_json) as RuntimeOperationReceipt;

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1004,11 +1004,19 @@ export class RuntimeJournal {
        ORDER BY event_seq`,
     ).all();
     for (const row of rows) {
-      const receipt = JSON.parse(row.receipt_json) as RuntimeOperationReceipt;
-      if (receipt.kind !== "compact" || receipt.status !== "delivering") continue;
-      this.transitionOperation(row.operation_id, "uncertain", {
-        reason: "compaction was in flight during a runtime-host restart; its outcome is unverified",
-      });
+      /* Per row: the epoch is already claimed, so one unreadable receipt or one
+         refused transition must not fail runtime-host startup and leave the
+         claim behind. A row that cannot be settled here stays `delivering` and
+         is swept again at the next epoch. */
+      try {
+        const receipt = JSON.parse(row.receipt_json) as RuntimeOperationReceipt;
+        if (receipt.kind !== "compact" || receipt.status !== "delivering") continue;
+        this.transitionOperation(row.operation_id, "uncertain", {
+          reason: "compaction was in flight during a runtime-host restart; its outcome is unverified",
+        });
+      } catch {
+        console.error(`[runtime journal] compaction ${row.operation_id} could not be settled at this epoch`);
+      }
     }
   }
 

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1322,9 +1322,6 @@ export class RuntimeJournal {
         || session.sessionKey.sessionId !== command.sessionKey.sessionId) {
         status = "rejected";
         reason = "stale-generation";
-      } else if (command.turnId !== undefined && command.turnId !== null && command.turnId !== session.activeTurnId) {
-        status = "rejected";
-        reason = "stale-turn";
       } else if (session.turn === "running" || session.turn === "interrupt_requested" || session.activeTurnId) {
         status = "rejected";
         reason = "busy-turn";

--- a/src/runtime-host/journalCompact.test.ts
+++ b/src/runtime-host/journalCompact.test.ts
@@ -101,6 +101,26 @@ test("a busy turn rejects compact admission instead of racing the running turn",
   journal.close();
 });
 
+test("a caller-supplied turn fence cannot smuggle a compaction past the busy-turn rule", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("no-fence"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-busy", turn: "running", activeTurnId: "turn-live" });
+
+  const result = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-fenced",
+    idempotencyKey: "op-fenced",
+    conversationId: "conv-busy",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+    /* The compact contract has no turn fence; a caller that names the live turn
+       anyway must still land on the busy-turn rejection. */
+    turnId: "turn-live",
+  } as never);
+
+  expect(result.receipt).toMatchObject({ status: "rejected", reason: "busy-turn" });
+  expect(journal.effectBatch()).toHaveLength(0);
+  journal.close();
+});
+
 test("compact admission refuses a lost host, a stale generation, and an unsupported engine", () => {
   const journal = new RuntimeJournal(path.join(sandbox("refusals"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
   hostedCodexSession(journal, { conversationId: "conv-dead", host: "dead" });

--- a/src/runtime-host/journalCompact.test.ts
+++ b/src/runtime-host/journalCompact.test.ts
@@ -1,0 +1,215 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { runtimeScope } from "@/lib/runtime/contracts";
+
+import { RuntimeJournal } from "./journal";
+
+function sandbox(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `llv-compact-${name}-`));
+}
+
+function hostedCodexSession(journal: RuntimeJournal, options: {
+  conversationId: string;
+  sessionId?: string;
+  turn?: "idle" | "running" | "interrupt_requested";
+  activeTurnId?: string | null;
+  hostKind?: string;
+  host?: string;
+  engine?: "codex" | "claude";
+}): void {
+  journal.append({
+    scope: runtimeScope("session", options.conversationId),
+    kind: "session-status",
+    payload: {
+      conversationId: options.conversationId,
+      sessionKey: { engine: options.engine ?? "codex", sessionId: options.sessionId ?? "thread-one" },
+      hostKind: options.hostKind ?? "codex-app-server",
+      host: options.host ?? "hosted",
+      turn: options.turn ?? "idle",
+      provenance: "structured",
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: options.activeTurnId ?? null,
+    },
+  });
+}
+
+test("an idle owned codex conversation admits one durable compact operation with a control effect", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("admit"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-compact" });
+
+  const result = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+
+  expect(result.receipt).toMatchObject({ kind: "compact", status: "pending", turnId: null });
+  const effects = journal.effectBatch();
+  expect(effects).toHaveLength(1);
+  expect(effects[0]!.kind).toBe("runtime.compact");
+  expect(effects[0]!.payload).toMatchObject({
+    kind: "compact",
+    operationId: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+  /* Nothing on the effect can be replayed as user input. */
+  expect(effects[0]!.payload).not.toHaveProperty("text");
+  journal.close();
+});
+
+test("a caller retry replays the admitted compact receipt instead of admitting a second compaction", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("idempotent"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-compact" });
+  const command = {
+    kind: "compact" as const,
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex" as const, sessionId: "thread-one" },
+  };
+
+  const first = journal.executeOperation(command);
+  const retry = journal.executeOperation(command);
+
+  expect(retry.replayed).toBe(true);
+  expect(retry.operationId).toBe(first.operationId);
+  expect(journal.effectBatch().filter((effect) => effect.kind === "runtime.compact")).toHaveLength(1);
+  journal.close();
+});
+
+test("a busy turn rejects compact admission instead of racing the running turn", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("busy"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-busy", turn: "running", activeTurnId: "turn-live" });
+
+  const result = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-busy",
+    idempotencyKey: "op-busy",
+    conversationId: "conv-busy",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+
+  expect(result.receipt).toMatchObject({ status: "rejected", reason: "busy-turn" });
+  expect(journal.effectBatch()).toHaveLength(0);
+  journal.close();
+});
+
+test("compact admission refuses a lost host, a stale generation, and an unsupported engine", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("refusals"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-dead", host: "dead" });
+  hostedCodexSession(journal, { conversationId: "conv-stale", sessionId: "thread-current" });
+  hostedCodexSession(journal, {
+    conversationId: "conv-claude",
+    engine: "claude",
+    hostKind: "claude-broker",
+    sessionId: "session-claude",
+  });
+
+  const dead = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-dead",
+    idempotencyKey: "op-dead",
+    conversationId: "conv-dead",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+  const stale = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-stale",
+    idempotencyKey: "op-stale",
+    conversationId: "conv-stale",
+    sessionKey: { engine: "codex", sessionId: "thread-previous" },
+  });
+  const claude = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-claude",
+    idempotencyKey: "op-claude",
+    conversationId: "conv-claude",
+    sessionKey: { engine: "claude", sessionId: "session-claude" },
+  });
+
+  expect(dead.receipt).toMatchObject({ status: "rejected", reason: "dead-host" });
+  expect(stale.receipt).toMatchObject({ status: "rejected", reason: "stale-generation" });
+  expect(claude.receipt).toMatchObject({ status: "rejected", reason: "unsupported-capability" });
+  expect(journal.effectBatch()).toHaveLength(0);
+  journal.close();
+});
+
+test("a completed compaction is never reissued after a runtime-host restart", () => {
+  const file = path.join(sandbox("restart-done"), "events.sqlite");
+  const journal = new RuntimeJournal(file, { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-compact" });
+  journal.executeOperation({
+    kind: "compact",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+  journal.transitionOperation("op-compact", "delivering");
+  journal.transitionOperation("op-compact", "delivered", { reason: "compaction:compaction-one" });
+  journal.close();
+
+  const restarted = new RuntimeJournal(file, { structuredHosts: true, now: () => 200 });
+  restarted.claimHostEpoch();
+
+  expect(restarted.effectBatch()).toHaveLength(0);
+  expect(restarted.operationResult("op-compact")!.receipt).toMatchObject({
+    status: "delivered",
+    reason: "compaction:compaction-one",
+  });
+  restarted.close();
+});
+
+test("a restart terminalizes an in-flight compaction as uncertain rather than replaying the control", () => {
+  const file = path.join(sandbox("restart-inflight"), "events.sqlite");
+  const journal = new RuntimeJournal(file, { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-compact" });
+  journal.executeOperation({
+    kind: "compact",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+  /* The executor marks `delivering` before it writes thread/compact/start, so
+     this is exactly the window where the engine outcome is unknown. */
+  journal.transitionOperation("op-compact", "delivering");
+  journal.close();
+
+  const restarted = new RuntimeJournal(file, { structuredHosts: true, now: () => 200 });
+  restarted.claimHostEpoch();
+
+  const receipt = restarted.operationResult("op-compact")!.receipt;
+  expect(receipt.status).toBe("uncertain");
+  expect(receipt.reason).toContain("restart");
+  expect(restarted.effectBatch()).toHaveLength(0);
+  restarted.close();
+});
+
+test("a restart replays a compaction the executor never issued", () => {
+  const file = path.join(sandbox("restart-pending"), "events.sqlite");
+  const journal = new RuntimeJournal(file, { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, { conversationId: "conv-compact" });
+  journal.executeOperation({
+    kind: "compact",
+    operationId: "op-compact",
+    idempotencyKey: "op-compact",
+    conversationId: "conv-compact",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
+  journal.close();
+
+  const restarted = new RuntimeJournal(file, { structuredHosts: true, now: () => 200 });
+  restarted.claimHostEpoch();
+
+  expect(restarted.operationResult("op-compact")!.receipt.status).toBe("pending");
+  expect(restarted.effectBatch().map((effect) => effect.kind)).toEqual(["runtime.compact"]);
+  restarted.close();
+});


### PR DESCRIPTION
Closes #862.

`conversation_action(action="compact")` on a Viewer-owned structured Codex
conversation is now a real engine control. Before this it answered HTTP 409
`structured host does not support the compact control`, and the only thing that
did anything was sending `/compact` as a message — which queues an ordinary user
turn and shows up in the transcript as user input.

## What the control does

A compact request admits **one durable runtime operation** and executes it as a
control, never as a message. The command type has no text and no image field
anywhere on its path — parser, journal effect, executor — so there is nothing a
prompt could be built from even by mistake. It carries no turn fence either: a
compaction is only ever admitted against an idle generation, so any turn a
caller could name would already have made the request a `busy-turn` rejection.

**Admission** (`RuntimeJournal.operationReceipt`) is the race-safe fence. It is
evaluated inside the `BEGIN IMMEDIATE` that admits the operation, so the durable
turn axis it reads cannot move underneath it. It refuses, with an explicit
reason on the receipt:

| condition | receipt |
| --- | --- |
| host not hosted | `rejected` / `dead-host` \| `no-claim` |
| engine or host kind without the control | `rejected` / `unsupported-capability` |
| session key is not the current generation | `rejected` / `stale-generation` |
| a turn is running or interrupting | `rejected` / `busy-turn` |

**Execution** (`StructuredDeliveryQueue.drainCompact`) re-reads live host health
— a turn that started between admission and execution fails the control instead
of racing it — then issues `thread/compact/start` for the exact owned thread.
The pass does not wait for the compaction: it raises a per-conversation barrier
and lets the evidence terminalize the receipt out of band. The barrier holds
back what would write to the thread — messages and reconfigures — and nothing
else: kill, interrupt and answer run throughout, in every branch, because
leaving the operator's safety valve inert for the length of a compaction would
be the worse failure. A compaction admitted before a kill that succeeded is
fenced by the same kill boundary sends are, so recovery can never respawn a
conversation the operator terminated just to compact it.

**Completion** is the *completed* `contextCompaction` item and nothing else.
`ContextCompactionThreadItem` is exactly `{ id, type }` in the app-server's
generated schema — it carries no outcome — so the lifecycle phase is the only
signal: `item/started` says a compaction began, `item/completed` says it
finished, and only the second settles the waiter. The host registers its waiter
before it writes the request and records which compaction closed the operation
on the receipt (`compaction:<itemId>`). The deprecated `thread/compacted`
notification is accepted for the owned thread as a corroborating second channel:
every compaction item observable locally came from auto-compaction inside a
turn, and a manual compact runs against an idle one, so if the app-server only
sends the notification there, reading the item alone would leave every manual
compaction timing out as unverified. With no outcome on the item there is no
fast failure signal, so a compaction that starts and never finishes is caught by
the evidence timeout (or sooner by host death) and terminalizes `uncertain`,
alongside a mutating-RPC timeout. An accepted request alone never terminalizes
as success, and neither does a compaction that has merely started.

`thread/compact/start` is budgeted like the compaction it starts rather than
like an ordinary call: it is a mutating method, and the default 30 s request
budget would fail the whole host — taking the operator's live conversation with
it — the first time a large thread took longer than that to begin compacting.
A response that errors *after* the compaction item has already arrived is
dropped in favour of the verified fact.

## Why a compaction cannot happen twice

- A caller timeout or retry replays the admitted receipt through the existing
  idempotency key; a transport failure mid-call reads the durable receipt back
  instead of reissuing. The Compact button mints one operation id per confirmed
  gesture and `/api/tmux` forwards it, so an HTTP retry replays that receipt too.
- The executor writes `delivering` **before** it writes the control. A
  runtime-host restart sweeps any compact still in that state to `uncertain`
  (`terminalizeUnverifiedCompactions`), and a Viewer restart reads the same
  durable state and does the same, so a control whose outcome is unknown is
  never issued again.
- A completed compaction has no pending effect left to replay.
- A compact still `pending` was demonstrably never issued and replays normally.
- One thread compacts once at a time. A second compaction admitted for a thread
  already compacting is left pending until the first settles (admission cannot
  refuse it — a compaction is not a turn), and the host refuses a concurrent
  request outright as a second fence. Without this, two confirmed gestures issue
  two `thread/compact/start` calls and both receipts settle on whichever
  compaction item arrives first.
- A host that goes away mid-compaction — kill, reconfigure, deploy — settles the
  waiter as unverified instead of leaving the conversation's queue held behind
  it for the length of the evidence budget.

An `uncertain` transition rejected by a runtime-host from before this change
degrades to `failed` with the same reason, so the deploy window cannot leave a
receipt no drain pass can clear — which would wedge that conversation's send
queue until the runtime-host was replaced.

An unavailable host queues the control with a reason and starts the same
recovery a send would. Controls sort ahead of sends, and a compaction can hold
that slot for minutes, so messages queued behind it must not be waiting on a
host nobody asked to come back.

The Compact button releases its operation id on any journal verdict, refusal
included. Idempotency replays a stored receipt for the same key forever, so
holding the id past a rejection would answer every later click with that same
stale refusal; it is retained only while the outcome is genuinely unknown.

## Engine capability

`runtimeCompactCapability` is truthful per engine. Codex app-server 0.146
exposes `thread/compact/start` and the `contextCompaction` item lifecycle
(`ContextCompactedNotification` is marked deprecated in favour of the item and
is unused here). Claude's stream-json transport exposes interrupt as its only
client-originated control and has no manual compact subtype, so a structured
Claude conversation gets a typed `unsupported-capability` body carrying the
capability and its reason. No prompt-based fallback stands in for a missing
capability.

The board reflects this. The structured Compact cell gates on exactly the three
facts the server gates on — engine, host kind, and turn — so it is enabled on an
idle codex-app-server session and disabled with a tooltip naming the real reason
otherwise ("this engine has no compact control" / "not while a turn is
running"), replacing the old blanket "the structured host does not support this
action yet". The button mints its operation id through the same secure-context
guarded helper the composer uses, and reads the durable receipt rather than the
HTTP envelope, so a refused compaction is reported as the refusal instead of as
a compaction that started. Legacy tmux panes are untouched and keep their
keystroke path.

## Deployment

Runtime-host protocol surface changed — the journal gained the `compact`
operation kind and the host-epoch sweep, and the socket accepts the `uncertain`
transition. **This needs an exact-SHA runtime-host rebuild**; the Viewer alone
is not enough. Staging on 8899 is untouched.

## Verification

- Focused tests, isolated state, run by path: `compactControl.test.ts`,
  `journalCompact.test.ts`, `structuredCompactDelivery.test.ts`,
  `codexAppServerHost.compact.test.ts`, plus the existing `structuredControls`,
  `structuredDeliveryQueue`, `structuredDeliveryController`, `journal`,
  `socket`, `startup`, `conversation/actions`, `api/tmux/route`,
  `agentCapabilities`, `AgentControlStrip` (dom + action), `runtimeBus`,
  `deliveryState`, `runtimeModel`, `TmuxComposer` and `i18n` suites — 427 pass,
  0 fail.
- `codexAppServerHost.test.ts`: 105 pass, 2 fail — both reproduce identically on
  the merge base and are unrelated to this change.
- TypeScript clean, scoped ESLint clean, `bun run build` succeeds, privacy
  publication gate passes with `--check-commits`.

## Not in this change

- MCP capability text lives in the server bindings owned by open PR #859; the
  public `conversation_action` schema already accepts `compact`. **That branch
  also needs `bindings.ts` to read the receipt rather than the HTTP envelope**:
  it throws only when `body.ok !== true`, and a structured control answers `ok`
  for a receipt the journal rejected — so an orchestrator calling the tool
  during a live turn is told the compaction started. `busy-turn` is the ordinary
  refusal here, so it will be hit routinely. The same trap was fixed on the
  Viewer's own button in this branch.
- The production E2E from the issue (bounded handoff → compact → durable record
  → continue) needs the runtime-host rebuild first, so it belongs to the deploy
  step rather than this branch. **That run is also the first live check of which
  evidence channel a real app-server uses for a manual compact against an idle
  thread** — both are handled here, but only production settles which one fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




