### PR TITLE
fix(mcp): bound the list_pipelines projection and let a caller's deadline stop it

### DIFF
--- a/spikes/issue-863/README.md
+++ b/spikes/issue-863/README.md
@@ -1,7 +1,8 @@
-# Issue #863 — slow structured `list_pipelines`: phase profile, RED proof, integration plan
+# Issue #863 — slow structured `list_pipelines`: phase profile, RED proof, repair
 
-Status: **diagnosis complete, repair fenced.** Every file the repair must edit is
-also modified by open PR #859, so no product source was changed here.
+Status: **repaired.** `red.ts` is GREEN on the same fixture that produced every
+number below; see "The repair" at the end for what shipped and what it cost.
+The diagnosis sections are kept verbatim as the record of the measured baseline.
 
 ## Reproducing
 
@@ -9,7 +10,7 @@ All three scripts seed their own `LLV_STATE_DIR` sandbox under `$TMPDIR` and
 delete it on exit. None of them read or write live viewer state.
 
 ```
-bun spikes/issue-863/red.ts        # acceptance assertions — currently 6 RED
+bun spikes/issue-863/red.ts        # acceptance assertions — 6 RED before the repair, all GREEN after
 bun spikes/issue-863/endToEnd.ts   # per-phase aggregate timings
 COUNT=1000 CONCURRENCY=16 bun spikes/issue-863/red.ts
 ```
@@ -98,7 +99,81 @@ PASS all concurrent calls succeeded — 8/8 ok
 Filter and ordering semantics already agree with HTTP, so the repair must
 preserve them rather than establish them.
 
-## Why the repair is fenced
+## The repair (shipped)
+
+The lane was un-fenced when PR #859 was parked, so the whole repair landed at
+once rather than in the two disjoint halves drafted in the appendix.
+
+1. **`src/lib/pipelines/listProjection.ts`** (new) — `PipelineListRow` and
+   `projectPipelineListRows`. Board-card fields only: identity, placement, state,
+   cursor stage + state, attempt counts, and per-stage
+   `{ id, kind, roleId, engine, model, effort, access, next, onFail, attempts,
+   latestAttempt }`. Filters and stops at `limit` in ONE pass before any row is
+   materialized, so nested history is never touched for a record that was going
+   to be dropped. Operator free text (`task`, `stateDetail`, an attempt `error`)
+   is clamped, which is what gives a row a length bound the registry does not
+   have. `latestAttempt` uses the shared `latestOperationalStageAttempt`, so a
+   lineage-adopted historical attempt is never reported as current work.
+2. **`src/lib/pipelines/store.ts`** — `loadPipelinesForList()`, which shares the
+   signature-keyed parse cache `loadPipelinesForProjection` already kept (no
+   second copy of the registry in memory) and skips the per-caller
+   `reviveLoadedPipeline` deep copy, because a row copies scalars and retains
+   nothing. This is where the 265 ms read and the 8x re-parse under concurrency
+   went. The registry is a single JSON file, so it admits no indexed read; the
+   materialization the filter now precedes is the revive, not the parse.
+3. **`src/lib/mcp/bindings.ts`** — `listPipelines` is async, projects, and
+   redacts the projected rows; the tool table entry forwards `context`. The
+   filter, ordering and `limit` bound are byte-for-byte the previous semantics.
+   `get_pipeline` is untouched and remains the full-detail read.
+4. **Cancellation** — the binding passes `throwIfCallEnded(context)` as the
+   projection's checkpoint, and the projection yields to the event loop between
+   row batches so the 30 s deadline timer can actually fire instead of waiting
+   for a synchronous walk to release the loop. `createMcpToolService` skips
+   `receipts.complete` for a `deadline`/`cancelled` outcome, so an abandoned call
+   leaves no receipt row and does not burn its `clientRequestId`; every outcome
+   that produced a real answer still writes, so replay is unchanged.
+5. **`src/lib/pipelines/engine.ts` and `types.ts` were not touched.** The list
+   row type lives with the projection, and `getPipelines` stays the HTTP/detail
+   seam — the binding reaches the bounded read through an optional
+   `listPipelineRecords` dependency instead.
+
+### Same fixture, after
+
+```
+PASS bounded list rows — 1 KB per row (budget 64 KB)
+PASS no attempt history in list rows — rows carry no attempts
+PASS no stage prompts in list rows — rows carry no prompts
+PASS no spec body in list rows — rows carry no spec
+PASS HTTP/MCP count parity — http 100 vs mcp 100
+PASS HTTP/MCP ordering parity — id sequences compared
+PASS concurrent x8 within 5000 ms — 37 ms wall
+PASS bounded RSS growth under concurrency — +6 MB (583 -> 589 MB)
+PASS all concurrent calls succeeded — 8/8 ok
+```
+
+| measure | before | after |
+| --- | --- | --- |
+| response, 100 rows | 37.33 MB | 0.12 MB |
+| per row | 365 KB | 1 KB |
+| `binding` p95 (x8) | 10 345 ms | 221 ms |
+| `claim` p95 (x8) | 9 025 ms | 1 ms |
+| `completion` p95 (x8) | 1 276 ms | 1 ms |
+| `serviceTotal` p95 (x8) | 11 844 ms | 223 ms |
+| wall, 8 concurrent | 11 878 ms | 37 ms |
+| RSS growth, 8 concurrent | +2 115 MB | +6 MB |
+
+The remaining 221 ms binding max is the one cold-cache registry parse; every
+later call inside the signature window is about 1 ms.
+
+The 500-pipeline builder now lives at `src/lib/pipelines/fixtures/corpus.ts` and
+is imported by both `corpus.ts` here and
+`src/lib/pipelines/listProjection.test.ts`, so the measured shape and the tested
+shape cannot drift apart. The suite asserts the structural bars (response bytes,
+which fields exist, filter/ordering parity, cancellation); wall clock and RSS
+stay in `red.ts`, where they are not flaky host-speed assertions in CI.
+
+## Appendix: why the repair was originally fenced
+
 
 | file the repair needs | why | also modified by |
 | --- | --- | --- |
@@ -113,7 +188,7 @@ editing `bindings.ts`: the tool table is a literal in that file. PR #859's edits
 are textually distant from `listPipelines`, so the conflict is ownership, not
 merge mechanics.
 
-## Disjoint integration plan (after #859 lands)
+### Disjoint integration plan as drafted (superseded by "The repair" above)
 
 1. **New file `src/lib/pipelines/listProjection.ts`** — owned by nobody today.
    Export `PipelineListRow` (id, task, project, state, stateDetail, branch,

--- a/spikes/issue-863/README.md
+++ b/spikes/issue-863/README.md
@@ -1,0 +1,147 @@
+# Issue #863 — slow structured `list_pipelines`: phase profile, RED proof, integration plan
+
+Status: **diagnosis complete, repair fenced.** Every file the repair must edit is
+also modified by open PR #859, so no product source was changed here.
+
+## Reproducing
+
+All three scripts seed their own `LLV_STATE_DIR` sandbox under `$TMPDIR` and
+delete it on exit. None of them read or write live viewer state.
+
+```
+bun spikes/issue-863/red.ts        # acceptance assertions — currently 6 RED
+bun spikes/issue-863/endToEnd.ts   # per-phase aggregate timings
+COUNT=1000 CONCURRENCY=16 bun spikes/issue-863/red.ts
+```
+
+`corpus.ts` builds the production-shaped fixture: 500 pipelines, two staged
+roles each, six attempts per stage with realistic prompt/input/output bodies and
+a spec — 189 MB of registry, one quarter of it closed, spread over eight
+projects so `project`/`state`/`includeClosed` filters all discriminate.
+
+## Measured phase profile
+
+`list_pipelines(project: "viewer", includeClosed: false, limit: 100)` against
+that registry, through the real `createMcpToolService` + `SqliteMcpReceiptStore`:
+
+| phase | single call | 8 concurrent (p95) |
+| --- | --- | --- |
+| store read (`loadPipelines`) | 265 ms | — |
+| filter + slice | 0.4 ms | — |
+| redaction (`redactPayload`) | 1089 ms | — |
+| `binding` (read + filter + redact) | — | 11 175 ms |
+| `claim` (SQLite receipt) | — | 9 862 ms |
+| `completion` (receipt write) | — | 1 359 ms |
+| `serialization` | — | 35 ms |
+| `serviceTotal` | — | 12 766 ms |
+
+Response size: **37.33 MB for 100 rows** — 365 KB per row. RSS grows **+2 300 MB**
+across 8 concurrent calls (629 MB → 2 928 MB).
+
+## Root cause
+
+The store read is not the problem: it costs 265 ms, and `GET /api/pipelines`
+calls the very same `getPipelines()` — which is why direct HTTP answered in
+about 200 ms. The cost is everything the MCP path does *after* the read, all of
+it scaling with full nested history that a list row never needs.
+
+`src/lib/mcp/bindings.ts:1400` — `listPipelines`:
+
+```ts
+const pipelines = dependencies.getPipelines().pipelines
+  .filter(...).filter(...).filter(...)
+  .slice(0, limit);
+return redactPayload({ count: pipelines.length, pipelines });
+```
+
+Four compounding effects:
+
+1. **No projection.** The 100 surviving rows are whole `Pipeline` records —
+   `stages[].prompt`, `stages[].effectiveRole.promptScaffold`, `spec`, and
+   `runs[].attempts[]` with every `input`/`output` transcript body. That is the
+   365 KB per row and the 37 MB response.
+2. **Redaction walks the whole graph.** `redactPayload` recurses every key and
+   runs `hardenedRedact` on every string, so it pays for history the caller
+   discarded: 1.1 s of pure CPU per call.
+3. **The 37 MB payload is then serialized four more times** — `JSON.stringify`
+   for the receipt row, again for `resultSizeBytes`, again for the `content`
+   text block, and again by the SDK for `structuredContent` over stdio. The
+   receipt store additionally writes the 37 MB blob into SQLite and re-walks
+   `storage_bytes` retention pruning, which is where `claim` and `completion`
+   contention comes from under concurrency.
+4. **Cancellation cannot land.** `bindings.ts:1918` binds the tool as
+   `(args) => Promise.resolve(listPipelines(args, domainDependencies))` — the
+   `McpToolCallContext` (and therefore `signal` and `deadlineAt`) is dropped, and
+   the body is fully synchronous. The 30 s `deadlineSignal` in
+   `createViewerMcpServer` is a timer that cannot fire while that synchronous
+   walk owns the event loop, so a timed-out caller leaves the work running to
+   completion and still pays the receipt write.
+
+At 500 pipelines this already costs 12.8 s wall at concurrency 8. The reported
+70 s is the same curve on a larger corpus with stdio framing of ~74 MB per
+response (content text + structuredContent).
+
+## RED assertions (current behaviour)
+
+```
+RED  bounded list rows — 365 KB per row (budget 64 KB)
+RED  no attempt history in list rows — rows carry runs[].attempts[]
+RED  no stage prompts in list rows — rows carry stages[].prompt
+RED  no spec body in list rows — rows carry spec
+PASS HTTP/MCP count parity — http 100 vs mcp 100
+PASS HTTP/MCP ordering parity — id sequences compared
+RED  concurrent x8 within 5000 ms — 12798 ms wall
+RED  bounded RSS growth under concurrency — +2300 MB (629 → 2928 MB)
+PASS all concurrent calls succeeded — 8/8 ok
+```
+
+Filter and ordering semantics already agree with HTTP, so the repair must
+preserve them rather than establish them.
+
+## Why the repair is fenced
+
+| file the repair needs | why | also modified by |
+| --- | --- | --- |
+| `src/lib/mcp/bindings.ts` | `listPipelines` body + the tool binding that must forward `context` | PR #859 (`PIPELINE_CONTROLLER_ACTIONS`, line ~72) |
+| `src/lib/mcp/server.ts` | cooperative deadline checks / receipt-write skip on abort | PR #859 (`TOOL_INPUT_SCHEMAS.pipeline_action`) |
+| `src/lib/pipelines/store.ts` | bounded indexed read variant | PR #859 |
+| `src/lib/pipelines/types.ts` | the list-row type | PR #859 |
+| `src/lib/pipelines/engine.ts` | `getPipelines` seam | PR #859 **and** PR #842 |
+
+There is no seam that lets a new module replace the bound handler without
+editing `bindings.ts`: the tool table is a literal in that file. PR #859's edits
+are textually distant from `listPipelines`, so the conflict is ownership, not
+merge mechanics.
+
+## Disjoint integration plan (after #859 lands)
+
+1. **New file `src/lib/pipelines/listProjection.ts`** — owned by nobody today.
+   Export `PipelineListRow` (id, task, project, state, stateDetail, branch,
+   worktreeDir, createdAt, closedAt, cursor stage id + state, per-stage
+   `{ id, kind, roleId, engine }`, and `attemptCounts` per stage) plus
+   `projectPipelineListRows(pipelines, { project, state, includeClosed, limit, signal })`.
+   Filter first, `slice` to `limit`, then project — so nested history is never
+   copied for a row that was going to be dropped. Budget: ≤ 4 KB per row.
+2. **New file `src/lib/pipelines/listProjection.test.ts`** — port the RED
+   assertions from `red.ts` into the suite, including the HTTP/MCP parity and
+   post-close visibility cases, and keep the 500-pipeline fixture by importing
+   `corpus.ts`'s builder (move it to `src/lib/pipelines/__fixtures__` at that
+   point).
+3. **`src/lib/mcp/bindings.ts` — three lines.** `listPipelines` calls
+   `projectPipelineListRows(...)` and redacts the projected rows; the tool table
+   entry becomes `(args, context) => Promise.resolve(listPipelines(args, domainDependencies, context))`
+   so `signal`/`deadlineAt` reach the projection.
+4. **Cancellation.** `projectPipelineListRows` checks `signal.aborted` between
+   filter and projection and throws the existing `DeadlineExceededError`;
+   `createMcpToolService` skips `receipts.complete` when the signal aborted
+   before the binding returned, so a timed-out caller leaves no receipt row and
+   no orphan SQLite write.
+5. **`get_pipeline` is untouched** — it already returns the full record and
+   remains the full-detail read.
+6. **Re-run** `bun spikes/issue-863/red.ts` to GREEN, plus
+   `bun test src/lib/pipelines/listProjection.test.ts src/lib/mcp/bindings.test.ts`
+   by path only.
+
+Expected after the repair: ≤ 400 KB per response instead of 37 MB, redaction
+under 20 ms, and concurrency-8 wall inside the 5 s budget with RSS growth in the
+tens of MB.

--- a/spikes/issue-863/README.md
+++ b/spikes/issue-863/README.md
@@ -129,9 +129,13 @@ once rather than in the two disjoint halves drafted in the appendix.
    projection's checkpoint, and the projection yields to the event loop between
    row batches so the 30 s deadline timer can actually fire instead of waiting
    for a synchronous walk to release the loop. `createMcpToolService` skips
-   `receipts.complete` for a `deadline`/`cancelled` outcome, so an abandoned call
-   leaves no receipt row and does not burn its `clientRequestId`; every outcome
-   that produced a real answer still writes, so replay is unchanged.
+   `receipts.complete` for a `deadline`/`cancelled` outcome **on bounded reads
+   only**, so an abandoned list call leaves no receipt row and its
+   `clientRequestId` returns with the bounded lease. Durable mutation claims are
+   excluded deliberately: `pruneBoundedReceipts` sweeps an unsettled claim only
+   for `retention = 'bounded'`, so skipping the write for a mutating tool would
+   strand a permanent `result_json IS NULL` row. Every outcome that produced a
+   real answer still writes, so replay is unchanged.
 5. **`src/lib/pipelines/engine.ts` and `types.ts` were not touched.** The list
    row type lives with the projection, and `getPipelines` stays the HTTP/detail
    seam — the binding reaches the bounded read through an optional

--- a/spikes/issue-863/corpus.ts
+++ b/spikes/issue-863/corpus.ts
@@ -1,76 +1,15 @@
 /* Production-shaped pipeline registry for issue #863 profiling. Requires
-   LLV_STATE_DIR to already point at an isolated sandbox. */
+   LLV_STATE_DIR to already point at an isolated sandbox. The builder itself now
+   lives with the suite that asserts against it
+   (`src/lib/pipelines/fixtures/corpus.ts`), so the measured shape and the tested
+   shape cannot drift apart. */
 import fs from "node:fs";
 import path from "node:path";
 
-import { buildPipeline, savePipelines } from "@/lib/pipelines/store";
-import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+import { pipelineCorpus } from "@/lib/pipelines/fixtures/corpus";
+import { savePipelines } from "@/lib/pipelines/store";
 
-function stages(): PipelineStage[] {
-  return [
-    {
-      id: "build",
-      kind: "run",
-      role: { roleId: "builder" }, prompt: "build ".repeat(400),
-      next: "review",
-      effectiveRole: { roleId: "builder", engine: "codex", model: "gpt-5.6-sol", effort: "medium", access: "read-write", promptScaffold: "builder scaffold ".repeat(200) },
-    },
-    {
-      id: "review",
-      kind: "review-loop",
-      role: { roleId: "reviewer" }, prompt: "review ".repeat(400),
-      next: null,
-      effectiveRole: { roleId: "reviewer", engine: "codex", model: "gpt-5.6-sol", effort: "xhigh", access: "read-only", promptScaffold: "reviewer scaffold ".repeat(200) },
-    },
-  ];
-}
-
-export function pipelineCorpus(count: number, attemptsPerStage = 6): Pipeline[] {
-  const corpus: Pipeline[] = [];
-  for (let index = 0; index < count; index += 1) {
-    const pipeline = buildPipeline({
-      id: `p${String(index).padStart(7, "0")}`,
-      task: `task ${index}`,
-      project: index % 3 === 0 ? "viewer" : `project-${index % 7}`,
-      repoDir: "/repo",
-      stages: stages(),
-      srcPath: null,
-      srcConversationId: null,
-      now: new Date(Date.now() - index * 60_000).toISOString(),
-    });
-    pipeline.spec = "acceptance criteria ".repeat(500);
-    if (index % 4 === 0) {
-      pipeline.state = "closed";
-      pipeline.cursor = null;
-      pipeline.closedAt = new Date().toISOString();
-    } else {
-      pipeline.state = "running";
-    }
-    pipeline.runs = pipeline.stages.map((stage) => ({
-      stageId: stage.id,
-      attempts: Array.from({ length: attemptsPerStage }, (_value, attempt) => ({
-        n: attempt + 1,
-        state: "passed" as const,
-        effectiveRole: stage.effectiveRole,
-        launchId: null,
-        conversationId: null,
-        sessionId: null,
-        agentPath: null,
-        paneId: null,
-        flowId: null,
-        startedAt: new Date().toISOString(),
-        completedAt: new Date().toISOString(),
-        input: "prompt input ".repeat(600),
-        activatedBy: null,
-        output: "agent output transcript tail ".repeat(600),
-        verdict: { status: "pass" as const },
-        error: null,
-      })),
-    }));
-    corpus.push(pipeline);
-  }
-  return corpus;
-}
+export { pipelineCorpus };
 
 /** Seeds the sandbox registry and returns its on-disk size in bytes. */
 export function seedPipelineCorpus(count: number, attemptsPerStage = 6): number {

--- a/spikes/issue-863/corpus.ts
+++ b/spikes/issue-863/corpus.ts
@@ -1,0 +1,79 @@
+/* Production-shaped pipeline registry for issue #863 profiling. Requires
+   LLV_STATE_DIR to already point at an isolated sandbox. */
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildPipeline, savePipelines } from "@/lib/pipelines/store";
+import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+
+function stages(): PipelineStage[] {
+  return [
+    {
+      id: "build",
+      kind: "run",
+      role: { roleId: "builder" }, prompt: "build ".repeat(400),
+      next: "review",
+      effectiveRole: { roleId: "builder", engine: "codex", model: "gpt-5.6-sol", effort: "medium", access: "read-write", promptScaffold: "builder scaffold ".repeat(200) },
+    },
+    {
+      id: "review",
+      kind: "review-loop",
+      role: { roleId: "reviewer" }, prompt: "review ".repeat(400),
+      next: null,
+      effectiveRole: { roleId: "reviewer", engine: "codex", model: "gpt-5.6-sol", effort: "xhigh", access: "read-only", promptScaffold: "reviewer scaffold ".repeat(200) },
+    },
+  ];
+}
+
+export function pipelineCorpus(count: number, attemptsPerStage = 6): Pipeline[] {
+  const corpus: Pipeline[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const pipeline = buildPipeline({
+      id: `p${String(index).padStart(7, "0")}`,
+      task: `task ${index}`,
+      project: index % 3 === 0 ? "viewer" : `project-${index % 7}`,
+      repoDir: "/repo",
+      stages: stages(),
+      srcPath: null,
+      srcConversationId: null,
+      now: new Date(Date.now() - index * 60_000).toISOString(),
+    });
+    pipeline.spec = "acceptance criteria ".repeat(500);
+    if (index % 4 === 0) {
+      pipeline.state = "closed";
+      pipeline.cursor = null;
+      pipeline.closedAt = new Date().toISOString();
+    } else {
+      pipeline.state = "running";
+    }
+    pipeline.runs = pipeline.stages.map((stage) => ({
+      stageId: stage.id,
+      attempts: Array.from({ length: attemptsPerStage }, (_value, attempt) => ({
+        n: attempt + 1,
+        state: "passed" as const,
+        effectiveRole: stage.effectiveRole,
+        launchId: null,
+        conversationId: null,
+        sessionId: null,
+        agentPath: null,
+        paneId: null,
+        flowId: null,
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        input: "prompt input ".repeat(600),
+        activatedBy: null,
+        output: "agent output transcript tail ".repeat(600),
+        verdict: { status: "pass" as const },
+        error: null,
+      })),
+    }));
+    corpus.push(pipeline);
+  }
+  return corpus;
+}
+
+/** Seeds the sandbox registry and returns its on-disk size in bytes. */
+export function seedPipelineCorpus(count: number, attemptsPerStage = 6): number {
+  savePipelines(pipelineCorpus(count, attemptsPerStage));
+  return fs.statSync(path.join(process.env.LLV_STATE_DIR!, "pipelines.json")).size;
+}

--- a/spikes/issue-863/endToEnd.ts
+++ b/spikes/issue-863/endToEnd.ts
@@ -1,0 +1,50 @@
+/* Issue #863 end-to-end phase profile: MCP entry → store read → filter/projection
+   → redaction → receipt persistence → envelope serialization. Isolated state dir. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { seedPipelineCorpus } from "./corpus";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-863-e2e-"));
+process.env.LLV_STATE_DIR = sandbox;
+
+const registryBytes = seedPipelineCorpus(Number(process.env.COUNT ?? 500));
+
+const { createMcpToolService, SqliteMcpReceiptStore, McpToolTimingAggregate } = await import("@/lib/mcp/server");
+const { viewerMcpBindings } = await import("@/lib/mcp/bindings");
+
+const timings = new McpToolTimingAggregate();
+const service = createMcpToolService(
+  viewerMcpBindings(),
+  new SqliteMcpReceiptStore(path.join(sandbox, "mcp-receipts.sqlite")),
+  undefined,
+  { timings },
+);
+
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 4);
+const started = performance.now();
+const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) =>
+  service.callTool("list_pipelines", {
+    clientRequestId: `profile-${index}-${Date.now()}`,
+    project: "viewer",
+    includeClosed: false,
+    limit: 100,
+  }, { deadlineAt: Date.now() + 30_000 })));
+const wallMs = performance.now() - started;
+
+const snapshot = timings.snapshot().find((entry) => entry.toolName === "list_pipelines");
+console.log(`registry ${(registryBytes / 1e6).toFixed(1)} MB · concurrency ${CONCURRENCY}`);
+console.log(`wall ${wallMs.toFixed(0)} ms · rss ${(process.memoryUsage.rss() / 1e6).toFixed(0)} MB`);
+for (const result of results) {
+  const payload = result as unknown as { count?: number; ok: boolean };
+  console.log(`  ok=${payload.ok} count=${payload.count}`);
+}
+if (snapshot) {
+  for (const [phase, measure] of Object.entries(snapshot.phases)) {
+    if (measure.samples === 0) continue;
+    console.log(`  ${phase.padEnd(16)} n=${measure.samples} p95=${measure.p95.toFixed(1)} ms max=${measure.max.toFixed(1)} ms total=${measure.total.toFixed(1)} ms`);
+  }
+  console.log(`  resultSizeBytes    max=${(snapshot.resultSizeBytes.max / 1e6).toFixed(2)} MB`);
+}
+fs.rmSync(sandbox, { recursive: true, force: true });

--- a/spikes/issue-863/red.ts
+++ b/spikes/issue-863/red.ts
@@ -1,0 +1,119 @@
+/* Issue #863 RED proof. Runs the real MCP tool service against a 500-pipeline
+   nested-history registry in an isolated LLV_STATE_DIR and asserts the four
+   acceptance properties the repair must establish. Every assertion below fails
+   on the current implementation; none of them touch live state.
+
+   Kept as a script rather than a `.test.ts` so `bun test` on this branch stays
+   green while the repair itself is fenced behind PR #859's ownership of
+   src/lib/mcp/bindings.ts and src/lib/mcp/server.ts. */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { seedPipelineCorpus } from "./corpus";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-863-red-"));
+process.env.LLV_STATE_DIR = sandbox;
+
+const PIPELINE_COUNT = Number(process.env.COUNT ?? 500);
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 8);
+/* A list row is a board card: identity, project, state, cursor, counts. Nested
+   stage prompts, attempt inputs/outputs and specs belong to get_pipeline. 64 KB
+   per row leaves generous headroom over that shape. */
+const ROW_BUDGET_BYTES = 64 * 1024;
+const LIST_DEADLINE_MS = 5_000;
+
+const registryBytes = seedPipelineCorpus(PIPELINE_COUNT);
+
+const { createMcpToolService, SqliteMcpReceiptStore, McpToolTimingAggregate } = await import("@/lib/mcp/server");
+const { viewerMcpBindings } = await import("@/lib/mcp/bindings");
+
+const timings = new McpToolTimingAggregate();
+const service = createMcpToolService(
+  viewerMcpBindings(),
+  new SqliteMcpReceiptStore(path.join(sandbox, "mcp-receipts.sqlite")),
+  undefined,
+  { timings },
+);
+
+const failures: string[] = [];
+const expect = (label: string, held: boolean, detail: string) => {
+  console.log(`${held ? "PASS" : "RED "} ${label} — ${detail}`);
+  if (!held) failures.push(label);
+};
+
+const call = (index: number, args: Record<string, unknown>, deadlineMs = 30_000) =>
+  service.callTool("list_pipelines", {
+    clientRequestId: `red-${index}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    ...args,
+  }, { deadlineAt: Date.now() + deadlineMs });
+
+/* AC: list rows exclude nested prompts, transcript tails and attempt history. */
+const single = await call(0, { project: "viewer", includeClosed: false, limit: 100 }) as unknown as {
+  count: number;
+  pipelines: { id: string; project: string; state: string; runs?: unknown; stages?: { prompt?: string }[]; spec?: string }[];
+};
+const rowBytes = Buffer.byteLength(JSON.stringify(single.pipelines)) / Math.max(1, single.pipelines.length);
+expect(
+  "bounded list rows",
+  rowBytes <= ROW_BUDGET_BYTES,
+  `${(rowBytes / 1024).toFixed(0)} KB per row (budget ${ROW_BUDGET_BYTES / 1024} KB)`,
+);
+const carriesHistory = single.pipelines.some((row) => Array.isArray((row as { runs?: unknown[] }).runs)
+  && ((row as { runs: { attempts?: unknown[] }[] }).runs).some((run) => (run.attempts?.length ?? 0) > 0));
+expect("no attempt history in list rows", !carriesHistory, carriesHistory ? "rows carry runs[].attempts[]" : "rows carry no attempts");
+const carriesPrompts = single.pipelines.some((row) => (row.stages ?? []).some((stage) => typeof stage.prompt === "string"));
+expect("no stage prompts in list rows", !carriesPrompts, carriesPrompts ? "rows carry stages[].prompt" : "rows carry no prompts");
+const carriesSpec = single.pipelines.some((row) => typeof row.spec === "string");
+expect("no spec body in list rows", !carriesSpec, carriesSpec ? "rows carry spec" : "rows carry no spec");
+
+/* AC: HTTP and MCP agree on filters, ordering and count. */
+const { getPipelines } = await import("@/lib/pipelines/engine");
+const httpRows = getPipelines().pipelines
+  .filter((pipeline) => pipeline.project === "viewer")
+  .filter((pipeline) => pipeline.state !== "closed")
+  .slice(0, 100);
+expect(
+  "HTTP/MCP count parity",
+  httpRows.length === single.count,
+  `http ${httpRows.length} vs mcp ${single.count}`,
+);
+expect(
+  "HTTP/MCP ordering parity",
+  httpRows.map((pipeline) => pipeline.id).join(",") === single.pipelines.map((row) => row.id).join(","),
+  "id sequences compared",
+);
+
+/* AC: production-shaped concurrency stays inside a deadline without unbounded RSS. */
+Bun.gc(true);
+const rssBefore = process.memoryUsage.rss();
+const started = performance.now();
+const concurrent = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) =>
+  call(index + 1, { project: "viewer", includeClosed: false, limit: 100 })));
+const wallMs = performance.now() - started;
+const rssPeak = process.memoryUsage.rss();
+expect(
+  `concurrent x${CONCURRENCY} within ${LIST_DEADLINE_MS} ms`,
+  wallMs <= LIST_DEADLINE_MS,
+  `${wallMs.toFixed(0)} ms wall`,
+);
+expect(
+  "bounded RSS growth under concurrency",
+  rssPeak - rssBefore <= 256e6,
+  `+${((rssPeak - rssBefore) / 1e6).toFixed(0)} MB (${(rssBefore / 1e6).toFixed(0)} → ${(rssPeak / 1e6).toFixed(0)} MB)`,
+);
+expect("all concurrent calls succeeded", concurrent.every((result) => result.ok), `${concurrent.filter((r) => r.ok).length}/${CONCURRENCY} ok`);
+
+const summary = timings.snapshot().find((entry) => entry.toolName === "list_pipelines");
+console.log(`\nregistry ${(registryBytes / 1e6).toFixed(1)} MB · ${PIPELINE_COUNT} pipelines · concurrency ${CONCURRENCY}`);
+if (summary) {
+  for (const [phase, measure] of Object.entries(summary.phases)) {
+    if (measure.samples === 0) continue;
+    console.log(`  ${phase.padEnd(14)} n=${measure.samples} p95=${measure.p95.toFixed(0)} ms max=${measure.max.toFixed(0)} ms`);
+  }
+  console.log(`  resultSize     max=${(summary.resultSizeBytes.max / 1e6).toFixed(2)} MB`);
+}
+fs.rmSync(sandbox, { recursive: true, force: true });
+
+console.log(`\n${failures.length === 0 ? "GREEN" : `RED (${failures.length}): ${failures.join("; ")}`}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
+import { DeadlineExceededError } from "@/lib/deadline";
+import { CORPUS_BODY_MARKERS, pipelineCorpus } from "@/lib/pipelines/fixtures/corpus";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
@@ -475,14 +477,54 @@ test("list_pipelines applies project, state, and closed filters to the durable r
     ] }),
   } as never);
 
-  expect(await bindings.list_pipelines({
+  const listed = await bindings.list_pipelines({
     clientRequestId: "list-pipelines",
     project: "viewer",
     state: "running",
-  })).toEqual({
-    count: 1,
-    pipelines: [{ id: "pipeline_live", project: "viewer", state: "running" }],
-  });
+  }) as { count: number; pipelines: { id: string; project: string; state: string }[] };
+  expect(listed.count).toBe(1);
+  expect(listed.pipelines.map((row) => ({ id: row.id, project: row.project, state: row.state })))
+    .toEqual([{ id: "pipeline_live", project: "viewer", state: "running" }]);
+});
+
+/* #863: the list is a board-card projection, not the registry records. Detail —
+   the spec body, stage prompts, and every attempt's relay input and transcript
+   tail — belongs to get_pipeline, which still returns the whole record. */
+test("list_pipelines returns bounded rows and leaves prompts, specs and transcripts to get_pipeline", async () => {
+  const pipeline = {
+    ...pipelineCorpus(1)[0],
+    id: "pipeline_detail",
+    project: "viewer",
+    state: "running",
+    stateDetail: "waiting on review",
+  };
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    getPipelines: () => ({ pipelines: [pipeline] }),
+  } as never);
+
+  const listed = await bindings.list_pipelines({ clientRequestId: "list-bounded", project: "viewer" });
+  const serialized = JSON.stringify(listed.pipelines);
+  for (const marker of Object.values(CORPUS_BODY_MARKERS)) expect(serialized).not.toContain(marker);
+  expect(listed.pipelines).toMatchObject([{
+    id: "pipeline_detail",
+    project: "viewer",
+    state: "running",
+    stateDetail: "waiting on review",
+    hasSpec: true,
+    attemptCount: 12,
+  }]);
+  expect(Buffer.byteLength(serialized)).toBeLessThan(4 * 1024);
+});
+
+test("list_pipelines abandons the read when the caller's deadline has already passed", async () => {
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    getPipelines: () => ({ pipelines: pipelineCorpus(1) }),
+  } as never);
+
+  await expect(bindings.list_pipelines(
+    { clientRequestId: "list-expired" },
+    { deadlineAt: Date.now() - 1 },
+  )).rejects.toThrow(DeadlineExceededError);
 });
 
 test("task read tools expose the pipeline-linked durable read model", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -37,7 +37,9 @@ import { createPipelineFromRequest, getPipelines, patchPipeline } from "@/lib/pi
 import { latestOperationalPipelineAttempt } from "@/lib/pipelines/attemptSelection";
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
-import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
+import { PIPELINE_LIST_DEFAULT_LIMIT, projectPipelineListRows } from "@/lib/pipelines/listProjection";
+import { loadPipelinesForList } from "@/lib/pipelines/store";
+import type { CreatePipelineRequest, PatchPipelineRequest, Pipeline, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
 import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
 import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
@@ -211,6 +213,11 @@ export interface ViewerMcpDomainDependencies {
   cancelRound: typeof cancelRound;
   closeFlow: typeof closeFlow;
   getPipelines: typeof getPipelines;
+  /** #863: the bounded list read — the shared cached registry parse, with none
+      of the per-caller revive `getPipelines` pays, because a list row copies
+      scalars and keeps nothing. Optional so partial test harnesses that stub
+      only `getPipelines` still project from it. */
+  listPipelineRecords?(): readonly Pipeline[];
   patchPipeline: typeof patchPipeline;
   loadTasks: typeof loadTasks;
   collectSnapshot: typeof collectSnapshot;
@@ -384,6 +391,7 @@ const productionDomainDependencies: ViewerMcpDomainDependencies = {
   cancelRound,
   closeFlow,
   getPipelines,
+  listPipelineRecords: loadPipelinesForList,
   patchPipeline,
   loadTasks,
   collectSnapshot,
@@ -1397,16 +1405,24 @@ async function flowAction(args: McpToolArgs, dependencies: ViewerMcpDomainDepend
   return redactPayload({ flowId, flow: result.flow, ...mutationReceipt(operationId) });
 }
 
-function listPipelines(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): McpToolPayload {
-  const project = text(args.project);
-  const state = text(args.state);
-  const includeClosed = args.includeClosed === true;
-  const limit = Math.max(1, Math.min(200, integer(args.limit, 100)));
-  const pipelines = dependencies.getPipelines().pipelines
-    .filter((pipeline) => !project || pipeline.project === project)
-    .filter((pipeline) => !state || pipeline.state === state)
-    .filter((pipeline) => includeClosed || pipeline.state !== "closed")
-    .slice(0, limit);
+/** #863: bounded board-card rows, never whole `Pipeline` records. The filters,
+    ordering and `limit` bound are unchanged — only what a surviving row carries
+    is, and `get_pipeline` remains the full-detail read. `context` reaches the
+    projection so a caller's deadline can abandon the call. */
+async function listPipelines(
+  args: McpToolArgs,
+  dependencies: ViewerMcpDomainDependencies,
+  context: McpToolCallContext = {},
+): Promise<McpToolPayload> {
+  const pipelines = await projectPipelineListRows({
+    project: text(args.project),
+    state: text(args.state),
+    includeClosed: args.includeClosed === true,
+    limit: integer(args.limit, PIPELINE_LIST_DEFAULT_LIMIT),
+  }, {
+    checkpoint: () => throwIfCallEnded(context),
+    source: dependencies.listPipelineRecords ?? (() => dependencies.getPipelines().pipelines),
+  });
   return redactPayload({ count: pipelines.length, pipelines });
 }
 
@@ -1915,7 +1931,7 @@ export function viewerMcpBindings(
     list_flows: (args) => Promise.resolve(listFlows(args, domainDependencies)),
     get_flow: (args) => Promise.resolve(getFlow(args, domainDependencies)),
     flow_action: (args) => flowAction(args, domainDependencies),
-    list_pipelines: (args) => Promise.resolve(listPipelines(args, domainDependencies)),
+    list_pipelines: (args, context) => listPipelines(args, domainDependencies, context),
     list_tasks: (args) => Promise.resolve(listTasks(args, domainDependencies)),
     get_task: (args) => Promise.resolve(getTask(args, domainDependencies)),
     operator_snapshot: (args) => operatorSnapshot(args, domainDependencies),

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -449,7 +449,7 @@ describe("MCP tool service", () => {
      a large read is the exact cost the deadline was meant to stop. A caller that
      already gave up must not pay it, and must not have its clientRequestId burned
      on an answer it never received. */
-  test("an abandoned call writes no receipt, while a completed one still replays", async () => {
+  test("an abandoned bounded read writes no receipt, while a completed one still replays", async () => {
     const completed: string[] = [];
     const store: McpReceiptStore = {
       claim: () => ({ kind: "fresh" }),
@@ -473,6 +473,28 @@ describe("MCP tool service", () => {
 
     await service.callTool("list_pipelines", { clientRequestId: "answered" });
     expect(completed).toEqual(["list_pipelines:answered"]);
+  });
+
+  /* The skip is a bounded-read affordance. `pruneBoundedReceipts` sweeps an
+     unsettled claim only for retention='bounded', so leaving a durable mutation
+     claim open would strand a permanent result_json IS NULL row and answer that
+     clientRequestId with `call_interrupted` forever. */
+  test("an abandoned durable mutation still settles its claim", async () => {
+    const completed: string[] = [];
+    const store: McpReceiptStore = {
+      claim: () => ({ kind: "fresh" }),
+      complete: (key, _digest, _result, retention) => { completed.push(`${key}:${retention}`); },
+    };
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.conversation_action = async (_args, context) => {
+      if (context?.signal?.aborted) throw context.signal.reason;
+      return {};
+    };
+    const abandoned = new AbortController();
+    abandoned.abort(new DeadlineExceededError("fixture deadline", 5_000));
+    await createMcpToolService(bindings, store)
+      .callTool("conversation_action", { clientRequestId: "abandoned-mutation" }, { signal: abandoned.signal });
+    expect(completed).toEqual(["conversation_action:abandoned-mutation:durable"]);
   });
 
   test("an ordinary tool failure still writes its receipt", async () => {

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -445,6 +445,48 @@ describe("MCP tool service", () => {
     expect(ended.cancellation.cancelled).toBe(1);
   });
 
+  /* #863: the completion write serializes and persists the whole result, which on
+     a large read is the exact cost the deadline was meant to stop. A caller that
+     already gave up must not pay it, and must not have its clientRequestId burned
+     on an answer it never received. */
+  test("an abandoned call writes no receipt, while a completed one still replays", async () => {
+    const completed: string[] = [];
+    const store: McpReceiptStore = {
+      claim: () => ({ kind: "fresh" }),
+      complete: (key) => { completed.push(key); },
+    };
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_pipelines = async (_args, context) => {
+      if (context?.signal?.aborted) throw context.signal.reason;
+      return { count: 0, pipelines: [] };
+    };
+    const service = createMcpToolService(bindings, store);
+
+    const deadline = new AbortController();
+    deadline.abort(new DeadlineExceededError("fixture deadline", 5_000));
+    const cancelled = new AbortController();
+    cancelled.abort(new DOMException("fixture cancelled", "AbortError"));
+    const timedOut = await service.callTool("list_pipelines", { clientRequestId: "abandoned-deadline" }, { signal: deadline.signal });
+    await service.callTool("list_pipelines", { clientRequestId: "abandoned-cancel" }, { signal: cancelled.signal });
+    expect(timedOut.ok).toBe(false);
+    expect(completed).toEqual([]);
+
+    await service.callTool("list_pipelines", { clientRequestId: "answered" });
+    expect(completed).toEqual(["list_pipelines:answered"]);
+  });
+
+  test("an ordinary tool failure still writes its receipt", async () => {
+    const completed: string[] = [];
+    const store: McpReceiptStore = {
+      claim: () => ({ kind: "fresh" }),
+      complete: (key) => { completed.push(key); },
+    };
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    bindings.list_pipelines = async () => { throw new Error("registry unreadable"); };
+    await createMcpToolService(bindings, store).callTool("list_pipelines", { clientRequestId: "failed" });
+    expect(completed).toEqual(["list_pipelines:failed"]);
+  });
+
   test("each v1 tool returns structured ids and replays a duplicate clientRequestId", async () => {
     const calls = new Map<string, number>();
     const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1403,6 +1403,16 @@ export function createMcpToolService(
         } finally {
           phaseDurations.binding = performance.now() - bindingStartedAt;
         }
+        /* #863: a caller that has already given up gets no receipt row. The
+           completion write serializes the whole result and persists it, which on
+           a large read is exactly the cost the deadline existed to stop — and it
+           would burn the clientRequestId on an answer nobody received, so the
+           obvious retry would replay a stale timeout forever. The claim is left
+           unsettled instead, which is what "the previous call did not finish"
+           already means: a retry gets `call_interrupted`, retryable. Every
+           outcome that produced a real answer still writes, so idempotent replay
+           of a completed call is untouched. */
+        if (outcome === "deadline" || outcome === "cancelled") return settled;
         const completionStartedAt = performance.now();
         await receipts.complete(key, digest, settled, retention);
         phaseDurations.completion = performance.now() - completionStartedAt;

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1409,10 +1409,19 @@ export function createMcpToolService(
            would burn the clientRequestId on an answer nobody received, so the
            obvious retry would replay a stale timeout forever. The claim is left
            unsettled instead, which is what "the previous call did not finish"
-           already means: a retry gets `call_interrupted`, retryable. Every
-           outcome that produced a real answer still writes, so idempotent replay
-           of a completed call is untouched. */
-        if (outcome === "deadline" || outcome === "cancelled") return settled;
+           already means: a retry gets `call_interrupted`, retryable, and the
+           bounded lease sweeps the row so the id comes back.
+
+           Bounded reads only. `pruneBoundedReceipts` deletes an unsettled claim
+           exclusively for `retention = 'bounded'` — durable mutation claims never
+           enter that expiry path by design — so skipping the write for a
+           mutating tool would strand a permanent `result_json IS NULL` row and
+           make its clientRequestId answer `call_interrupted` forever. A mutation
+           that was abandoned still settles, as it did before.
+
+           Every outcome that produced a real answer still writes, so idempotent
+           replay of a completed call is untouched. */
+        if (retention === "bounded" && (outcome === "deadline" || outcome === "cancelled")) return settled;
         const completionStartedAt = performance.now();
         await receipts.complete(key, digest, settled, retention);
         phaseDurations.completion = performance.now() - completionStartedAt;
@@ -1444,7 +1453,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   list_flows: "List durable implement-review flows.",
   get_flow: "Read one implement-review flow by durable id.",
   flow_action: "Apply a supported action to an implement-review flow.",
-  list_pipelines: "List durable pipelines.",
+  list_pipelines: "List durable pipelines as bounded board cards: id, task, project, branch/worktree, state and stateDetail, cursor stage, task links, and a per-stage summary (role, engine, attempt count, latest attempt's state and verdict). Deliberately carries no bodies — the spec, stage prompts, role scaffolds and every attempt's input/output transcript are read with get_pipeline, which still returns the whole record. hasSpec tells you a spec exists; long free text is truncated.",
   conversation_action: "Interrupt, kill, resume, compact, or answer a dialog for a Viewer conversation. Names the conversation by id, transcript path, or the selected-card reference the operator's turn carried — the last resolves directly, with no operator_snapshot call.",
   operator_snapshot: "Read the bounded, secret-redacted Viewer state currently visible to the operator.",
   list_tasks: "List durable board tasks.",

--- a/src/lib/pipelines/fixtures/corpus.ts
+++ b/src/lib/pipelines/fixtures/corpus.ts
@@ -1,0 +1,102 @@
+/**
+ * The production-shaped pipeline registry issue #863 was measured against.
+ *
+ * 500 pipelines, two staged roles each, six attempts per stage with realistic
+ * prompt/input/output bodies and a spec — 189 MB of registry, one quarter of it
+ * closed, spread over eight projects so `project`/`state`/`includeClosed` all
+ * discriminate. The bodies matter: they are what a list row must not carry, so
+ * every marker below is asserted absent from a projected page.
+ */
+import { buildPipeline } from "../store";
+import type { Pipeline, PipelineStage } from "../types";
+
+/** Marker substrings the tests assert never reach a list row. */
+export const CORPUS_BODY_MARKERS = {
+  stagePrompt: "build ",
+  promptScaffold: "builder scaffold ",
+  spec: "acceptance criteria ",
+  attemptInput: "prompt input ",
+  attemptOutput: "agent output transcript tail ",
+} as const;
+
+function stages(): PipelineStage[] {
+  return [
+    {
+      id: "build",
+      kind: "run",
+      role: { roleId: "builder" },
+      "prompt": CORPUS_BODY_MARKERS.stagePrompt.repeat(400),
+      next: "review",
+      effectiveRole: {
+        roleId: "builder",
+        engine: "codex",
+        model: "gpt-5.6-sol",
+        effort: "medium",
+        access: "read-write",
+        promptScaffold: CORPUS_BODY_MARKERS.promptScaffold.repeat(200),
+      },
+    },
+    {
+      id: "review",
+      kind: "review-loop",
+      role: { roleId: "reviewer" },
+      "prompt": "review ".repeat(400),
+      next: null,
+      effectiveRole: {
+        roleId: "reviewer",
+        engine: "codex",
+        model: "gpt-5.6-sol",
+        effort: "xhigh",
+        access: "read-only",
+        promptScaffold: "reviewer scaffold ".repeat(200),
+      },
+    },
+  ];
+}
+
+export function pipelineCorpus(count: number, attemptsPerStage = 6): Pipeline[] {
+  const corpus: Pipeline[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const pipeline = buildPipeline({
+      id: `p${String(index).padStart(7, "0")}`,
+      task: `task ${index}`,
+      project: index % 3 === 0 ? "viewer" : `project-${index % 7}`,
+      repoDir: "/repo",
+      stages: stages(),
+      srcPath: null,
+      srcConversationId: null,
+      now: new Date(Date.now() - index * 60_000).toISOString(),
+    });
+    pipeline.spec = CORPUS_BODY_MARKERS.spec.repeat(500);
+    if (index % 4 === 0) {
+      pipeline.state = "closed";
+      pipeline.cursor = null;
+      pipeline.closedAt = new Date().toISOString();
+    } else {
+      pipeline.state = "running";
+    }
+    pipeline.runs = pipeline.stages.map((stage) => ({
+      stageId: stage.id,
+      attempts: Array.from({ length: attemptsPerStage }, (_value, attempt) => ({
+        n: attempt + 1,
+        state: "passed" as const,
+        effectiveRole: stage.effectiveRole,
+        launchId: null,
+        conversationId: null,
+        sessionId: null,
+        agentPath: null,
+        paneId: null,
+        flowId: null,
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        input: CORPUS_BODY_MARKERS.attemptInput.repeat(600),
+        activatedBy: null,
+        output: CORPUS_BODY_MARKERS.attemptOutput.repeat(600),
+        verdict: { status: "pass" as const },
+        error: null,
+      })),
+    }));
+    corpus.push(pipeline);
+  }
+  return corpus;
+}

--- a/src/lib/pipelines/listProjection.test.ts
+++ b/src/lib/pipelines/listProjection.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Issue #863. The acceptance properties the bounded `list_pipelines` projection
+ * establishes, asserted against the same 500-pipeline production-shaped registry
+ * the profile was measured on (`spikes/issue-863/`).
+ *
+ * The bars here are STRUCTURAL — response bytes, which fields exist, which
+ * filters and ordering hold, whether a checkpoint can abandon the walk. Wall
+ * clock and RSS stay in the spike script: they are the reason this exists, but
+ * they are host-speed measurements and would make this suite flaky.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { CORPUS_BODY_MARKERS, pipelineCorpus } from "./fixtures/corpus";
+import {
+  PIPELINE_LIST_MAX_LIMIT,
+  pipelineListRow,
+  projectPipelineListRows,
+  selectPipelineListRecords,
+} from "./listProjection";
+import type { Pipeline } from "./types";
+
+const CORPUS_SIZE = 500;
+/* A board card is identity, placement, state, cursor and per-stage counts. The
+   profiled rows were 365 KB each; 4 KB is the bar that keeps a 100-row page
+   under half a megabyte instead of 37 MB. */
+const ROW_BUDGET_BYTES = 4 * 1024;
+
+const corpus = pipelineCorpus(CORPUS_SIZE);
+const source = () => corpus;
+
+/** The naive filter the previous binding applied, kept as the parity oracle. */
+function naiveFilter(
+  pipelines: readonly Pipeline[],
+  { project, state, includeClosed }: { project?: string; state?: string; includeClosed?: boolean },
+): Pipeline[] {
+  return pipelines
+    .filter((pipeline) => !project || pipeline.project === project)
+    .filter((pipeline) => !state || pipeline.state === state)
+    .filter((pipeline) => includeClosed || pipeline.state !== "closed");
+}
+
+const listPage = (filter: Parameters<typeof projectPipelineListRows>[0]) =>
+  projectPipelineListRows(filter, { source });
+
+describe("bounded list rows", () => {
+  test("a 100-row page stays within the row budget", async () => {
+    const rows = await listPage({ project: "viewer", includeClosed: false, limit: 100 });
+    expect(rows).toHaveLength(100);
+    const bytes = Buffer.byteLength(JSON.stringify(rows));
+    expect(bytes / rows.length).toBeLessThanOrEqual(ROW_BUDGET_BYTES);
+  });
+
+  test("no stage prompt, scaffold, spec body, relay input or transcript tail reaches a row", async () => {
+    const serialized = JSON.stringify(await listPage({ project: "viewer", limit: 100 }));
+    for (const marker of Object.values(CORPUS_BODY_MARKERS)) {
+      expect(serialized).not.toContain(marker);
+    }
+  });
+
+  test("rows carry no attempt history, only counts and the latest attempt's outcome", async () => {
+    const [row] = await listPage({ project: "viewer", limit: 1 });
+    expect(row).not.toHaveProperty("runs");
+    expect(row).not.toHaveProperty("spec");
+    expect(row.hasSpec).toBe(true);
+    /* 2 stages x 6 attempts in the fixture. */
+    expect(row.attemptCount).toBe(12);
+    expect(row.stages.map((stage) => stage.attempts)).toEqual([6, 6]);
+    for (const stage of row.stages) {
+      expect(stage).not.toHaveProperty("prompt");
+      expect(stage).not.toHaveProperty("effectiveRole");
+      expect(stage.latestAttempt).toMatchObject({ n: 6, state: "passed", verdict: "pass" });
+      expect(stage.latestAttempt).not.toHaveProperty("input");
+      expect(stage.latestAttempt).not.toHaveProperty("output");
+    }
+  });
+
+  test("the operator-useful identity, placement and cursor survive", async () => {
+    const [record] = naiveFilter(corpus, { project: "viewer" });
+    const [row] = await listPage({ project: "viewer", limit: 1 });
+    expect(row).toMatchObject({
+      id: record.id,
+      task: record.task,
+      project: "viewer",
+      repoDir: record.repoDir,
+      worktreeDir: record.worktreeDir,
+      branch: record.branch,
+      state: record.state,
+      createdAt: record.createdAt,
+      cursor: record.cursor && { stageId: record.cursor.stageId, state: record.cursor.state },
+    });
+    expect(row.stages.map((stage) => ({ id: stage.id, kind: stage.kind, roleId: stage.roleId, next: stage.next })))
+      .toEqual([
+        { id: "build", kind: "run", roleId: "builder", next: "review" },
+        { id: "review", kind: "review-loop", roleId: "reviewer", next: null },
+      ]);
+  });
+
+  test("operator free text is clamped, so a row has a length bound the registry does not", async () => {
+    const long = "x".repeat(5_000);
+    const row = pipelineListRow({ ...corpus[1], task: long, stateDetail: long });
+    expect(row.task.length).toBeLessThan(600);
+    expect(row.stateDetail!.length).toBeLessThan(600);
+    expect(row.task.startsWith("x".repeat(400))).toBe(true);
+  });
+
+  /* A lineage-adopted attempt is evidence, never the stage's current work — the
+     same rule `latestOperationalStageAttempt` enforces everywhere else. */
+  test("a trailing historical attempt is not reported as the stage's latest", () => {
+    const record = corpus[1];
+    const [firstRun, ...rest] = record.runs;
+    const adopted = { ...firstRun.attempts[0], n: 99, state: "failed" as const, historical: true };
+    const row = pipelineListRow({
+      ...record,
+      runs: [{ ...firstRun, attempts: [...firstRun.attempts, adopted] }, ...rest],
+    });
+    expect(row.stages[0].attempts).toBe(7);
+    expect(row.stages[0].latestAttempt).toMatchObject({ n: 6, state: "passed" });
+    expect(row.attemptCount).toBe(13);
+  });
+
+  test("a record with no runs projects an empty history rather than throwing", () => {
+    const row = pipelineListRow({ ...corpus[1], runs: undefined as never });
+    expect(row.attemptCount).toBe(0);
+    expect(row.stages.map((stage) => stage.latestAttempt)).toEqual([null, null]);
+  });
+
+  test("a row aliases nothing from the source record", async () => {
+    const [row] = await listPage({ project: "viewer", limit: 1 });
+    const [record] = naiveFilter(corpus, { project: "viewer" });
+    expect(row.taskIds).not.toBe(record.taskIds);
+    row.taskIds.push("mutated");
+    expect(record.taskIds).not.toContain("mutated");
+  });
+});
+
+describe("filter, ordering and limit semantics are unchanged", () => {
+  const cases: { name: string; filter: { project?: string; state?: string; includeClosed?: boolean } }[] = [
+    { name: "unfiltered open pipelines", filter: {} },
+    { name: "project", filter: { project: "viewer" } },
+    { name: "state", filter: { state: "running" } },
+    { name: "project + state", filter: { project: "project-2", state: "running" } },
+    { name: "includeClosed", filter: { project: "viewer", includeClosed: true } },
+    { name: "closed only", filter: { state: "closed", includeClosed: true } },
+    { name: "a project with no pipelines", filter: { project: "absent" } },
+  ];
+
+  for (const { name, filter } of cases) {
+    test(`${name} selects the same records, in registry order`, async () => {
+      const expected = naiveFilter(corpus, filter).slice(0, 100);
+      const rows = await listPage({ ...filter, limit: 100 });
+      expect(rows.map((row) => row.id)).toEqual(expected.map((pipeline) => pipeline.id));
+      expect(rows).toHaveLength(expected.length);
+    });
+  }
+
+  test("closed pipelines are excluded unless includeClosed asks for them", async () => {
+    const open = await listPage({ limit: PIPELINE_LIST_MAX_LIMIT });
+    expect(open.some((row) => row.state === "closed")).toBe(false);
+    const all = await listPage({ includeClosed: true, limit: PIPELINE_LIST_MAX_LIMIT });
+    expect(all.some((row) => row.state === "closed")).toBe(true);
+    /* A closed lane still reports when it closed — the board needs it to render. */
+    expect(all.find((row) => row.state === "closed")!.closedAt).toBeString();
+  });
+
+  test("limit is clamped to the published bounds", async () => {
+    expect(await listPage({ limit: 0 })).toHaveLength(1);
+    expect(await listPage({ limit: -5 })).toHaveLength(1);
+    expect(await listPage({ limit: 10_000 })).toHaveLength(PIPELINE_LIST_MAX_LIMIT);
+    expect(await listPage({ limit: null })).toHaveLength(100);
+    expect(await listPage({})).toHaveLength(100);
+  });
+
+  test("selection stops at the limit instead of filtering the whole registry first", () => {
+    const selected = selectPipelineListRecords(corpus, { project: "viewer", limit: 5 });
+    expect(selected).toHaveLength(5);
+    expect(selected.map((pipeline) => pipeline.id))
+      .toEqual(naiveFilter(corpus, { project: "viewer" }).slice(0, 5).map((pipeline) => pipeline.id));
+  });
+});
+
+describe("cancellation", () => {
+  test("a checkpoint that throws abandons the projection", async () => {
+    const boom = new Error("deadline exceeded");
+    let calls = 0;
+    await expect(projectPipelineListRows({ limit: 100 }, {
+      source,
+      checkpoint: () => { calls += 1; if (calls > 1) throw boom; },
+    })).rejects.toThrow("deadline exceeded");
+  });
+
+  test("the projection yields, so a deadline armed by the caller can actually land", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("caller gave up")), 0);
+    await expect(projectPipelineListRows({ limit: PIPELINE_LIST_MAX_LIMIT }, {
+      source,
+      checkpoint: () => {
+        if (controller.signal.aborted) throw controller.signal.reason as Error;
+      },
+    })).rejects.toThrow("caller gave up");
+  });
+
+  test("a page that fits inside one batch still completes without a checkpoint", async () => {
+    expect(await projectPipelineListRows({ limit: 3 }, { source })).toHaveLength(3);
+  });
+});

--- a/src/lib/pipelines/listProjection.ts
+++ b/src/lib/pipelines/listProjection.ts
@@ -1,0 +1,268 @@
+/**
+ * The bounded list projection behind `list_pipelines` (issue #863).
+ *
+ * `list_pipelines` used to filter the registry, slice it to `limit`, and hand
+ * back whole `Pipeline` records. Each surviving row therefore still carried
+ * `spec`, `stages[].prompt`, `stages[].effectiveRole.promptScaffold` and
+ * `runs[].attempts[]` with every persisted `input`/`output` transcript body —
+ * 365 KB per row, a 37 MB response for 100 rows. Everything downstream then paid
+ * for that graph again: redaction walked it (1.1 s of CPU), and it was serialized
+ * for the receipt row, the size metric, the content block and the SDK's
+ * `structuredContent` before being written into SQLite. At concurrency 8 that was
+ * a 12 s service p95 and gigabytes of RSS.
+ *
+ * A list row is a board card: identity, placement, state, cursor, and per-stage
+ * counts. Full prompts, specs, relay inputs and transcript tails stay behind
+ * `get_pipeline`, which is unchanged and remains the detail read.
+ *
+ * Ordering, the project/state/includeClosed predicates and the `limit` bound are
+ * exactly the ones the previous implementation applied, so MCP stays at parity
+ * with `GET /api/pipelines` filtered the same way.
+ */
+import type { FlowEngine } from "@/lib/flows/types";
+
+import { latestOperationalStageAttempt } from "./attemptSelection";
+import { loadPipelinesForList } from "./store";
+import type {
+  Pipeline,
+  PipelineAccess,
+  PipelineAttemptState,
+  PipelineCursorState,
+  PipelineRoleId,
+  PipelineStage,
+  PipelineStageAttempt,
+  PipelineStageKind,
+  PipelineState,
+  StageVerdictStatus,
+} from "./types";
+
+export const PIPELINE_LIST_DEFAULT_LIMIT = 100;
+export const PIPELINE_LIST_MAX_LIMIT = 200;
+
+/** Free text an operator authored (a task title, a state detail, an attempt
+    error) has no length bound in the registry, so a row would not have one
+    either. Clamped rather than dropped: the first lines are what identifies a
+    lane on the board, and `get_pipeline` still returns the untruncated value. */
+const MAX_ROW_TEXT = 400;
+
+/** Rows are projected in batches, yielding to the event loop between them, so a
+    caller's deadline timer can actually fire mid-call instead of waiting for a
+    synchronous walk to release the loop. */
+const YIELD_EVERY_ROWS = 25;
+
+export type PipelineListFilter = {
+  project?: string | null;
+  state?: string | null;
+  includeClosed?: boolean;
+  limit?: number | null;
+};
+
+/** The bounded view of one attempt: who ran, how it ended, where to look next. */
+export type PipelineListAttempt = {
+  n: number;
+  state: PipelineAttemptState;
+  verdict: StageVerdictStatus | null;
+  conversationId: string | null;
+  flowId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  /** Clamped; present only when the attempt recorded one. */
+  error: string | null;
+};
+
+export type PipelineListStage = {
+  id: string;
+  kind: PipelineStageKind;
+  roleId: PipelineRoleId | null;
+  engine: FlowEngine | null;
+  model: string | null;
+  effort: string | null;
+  access: PipelineAccess | null;
+  next: string | null;
+  onFail: { to: string; maxRounds: number } | null;
+  attempts: number;
+  latestAttempt: PipelineListAttempt | null;
+};
+
+export type PipelineListRow = {
+  id: string;
+  /** Clamped title. */
+  task: string;
+  taskIds: string[];
+  project: string;
+  repoDir: string;
+  worktreeDir: string;
+  branch: string;
+  baseBranch: string;
+  state: PipelineState;
+  pausedState: Pipeline["pausedState"];
+  /** Clamped. */
+  stateDetail: string | null;
+  /** Whether a pinned specification exists — the body itself is a get_pipeline read. */
+  hasSpec: boolean;
+  createdAt: string;
+  closedAt: string | null;
+  hiddenAt: string | null;
+  cursor: { stageId: string; state: PipelineCursorState } | null;
+  attemptCount: number;
+  unconfirmedHostCount: number;
+  stages: PipelineListStage[];
+  pos: { x: number; y: number } | null;
+};
+
+export type PipelineListProjectionOptions = {
+  /**
+   * Cancellation checkpoint, invoked around the registry read and between row
+   * batches. Throwing abandons the projection — which is the point: the MCP
+   * binding passes the call's deadline/abort check here so a caller that has
+   * already given up stops the work rather than paying for a result nobody will
+   * read. The registry parse itself is one synchronous step that cannot be
+   * interrupted, so it is bracketed by checkpoints rather than split.
+   */
+  checkpoint?: () => void;
+  /** Record source; defaults to the bounded, cached store read. */
+  source?: () => readonly Pipeline[];
+};
+
+function clampText(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  return value.length <= MAX_ROW_TEXT ? value : `${value.slice(0, MAX_ROW_TEXT)}…`;
+}
+
+function boundedLimit(limit: number | null | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return PIPELINE_LIST_DEFAULT_LIMIT;
+  return Math.max(1, Math.min(PIPELINE_LIST_MAX_LIMIT, Math.trunc(limit)));
+}
+
+/**
+ * The registry rows a list call selects, in registry order.
+ *
+ * Filters and stops at `limit` in one pass, before any row is materialized, so
+ * nested history is never touched for a record that was going to be dropped.
+ */
+export function selectPipelineListRecords(
+  pipelines: readonly Pipeline[],
+  filter: PipelineListFilter,
+): readonly Pipeline[] {
+  const limit = boundedLimit(filter.limit);
+  const project = filter.project || null;
+  const state = filter.state || null;
+  const includeClosed = filter.includeClosed === true;
+  const selected: Pipeline[] = [];
+  for (const pipeline of pipelines) {
+    if (project && pipeline.project !== project) continue;
+    if (state && pipeline.state !== state) continue;
+    if (!includeClosed && pipeline.state === "closed") continue;
+    selected.push(pipeline);
+    if (selected.length >= limit) break;
+  }
+  return selected;
+}
+
+function attemptRow(attempt: PipelineStageAttempt | null): PipelineListAttempt | null {
+  if (!attempt) return null;
+  return {
+    n: attempt.n,
+    state: attempt.state,
+    verdict: attempt.verdict?.status ?? null,
+    conversationId: attempt.conversationId ?? null,
+    flowId: attempt.flowId ?? null,
+    startedAt: attempt.startedAt ?? null,
+    completedAt: attempt.completedAt ?? null,
+    error: clampText(attempt.error),
+  };
+}
+
+function stageRow(
+  pipeline: Pipeline,
+  stage: PipelineStage,
+  attempts: readonly PipelineStageAttempt[],
+): PipelineListStage {
+  const role = stage.effectiveRole;
+  return {
+    id: stage.id,
+    kind: stage.kind,
+    roleId: role?.roleId ?? stage.role?.roleId ?? null,
+    engine: role?.engine ?? stage.engine ?? null,
+    model: role?.model ?? stage.model ?? null,
+    effort: role?.effort ?? stage.effort ?? null,
+    access: role?.access ?? stage.access ?? null,
+    next: stage.next,
+    onFail: stage.onFail ? { to: stage.onFail.to, maxRounds: stage.onFail.maxRounds } : null,
+    attempts: attempts.length,
+    /* The canonical selector, not "the last element": a lineage-adopted
+       historical attempt is evidence, never the stage's current work. */
+    latestAttempt: attemptRow(latestOperationalStageAttempt(pipeline, stage.id)),
+  };
+}
+
+/** One registry record as a board card. Every field is a scalar copy: no part of
+    the source record is aliased into the row, so nothing the caller receives can
+    retain the cached registry graph. */
+export function pipelineListRow(record: Pipeline): PipelineListRow {
+  /* Partial harnesses hand in records without runs; normalizing once here keeps
+     every reader below — including the shared attempt selector — on the type. */
+  const pipeline: Pipeline = record.runs ? record : { ...record, runs: [] };
+  const attemptsByStage = new Map<string, readonly PipelineStageAttempt[]>();
+  let attemptCount = 0;
+  for (const run of pipeline.runs) {
+    const attempts = run.attempts ?? [];
+    attemptsByStage.set(run.stageId, attempts);
+    attemptCount += attempts.length;
+  }
+  return {
+    id: pipeline.id,
+    task: clampText(pipeline.task) ?? "",
+    taskIds: [...(pipeline.taskIds ?? [])],
+    project: pipeline.project,
+    repoDir: pipeline.repoDir,
+    worktreeDir: pipeline.worktreeDir,
+    branch: pipeline.branch,
+    baseBranch: pipeline.baseBranch,
+    state: pipeline.state,
+    pausedState: pipeline.pausedState ?? null,
+    stateDetail: clampText(pipeline.stateDetail),
+    hasSpec: typeof pipeline.spec === "string" && pipeline.spec.length > 0,
+    createdAt: pipeline.createdAt,
+    closedAt: pipeline.closedAt ?? null,
+    hiddenAt: pipeline.hiddenAt ?? null,
+    cursor: pipeline.cursor ? { stageId: pipeline.cursor.stageId, state: pipeline.cursor.state } : null,
+    attemptCount,
+    unconfirmedHostCount: pipeline.unconfirmedHosts?.length ?? 0,
+    stages: (pipeline.stages ?? []).map((stage) => stageRow(pipeline, stage, attemptsByStage.get(stage.id) ?? [])),
+    pos: pipeline.pos ? { x: pipeline.pos.x, y: pipeline.pos.y } : null,
+  };
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+}
+
+/**
+ * Read, filter, slice and project a bounded page of list rows.
+ *
+ * Async on purpose. The old binding was one synchronous walk, so the 30 s
+ * deadline timer `createViewerMcpServer` arms could not fire while it owned the
+ * event loop: a timed-out caller left the work running to completion and still
+ * paid for the receipt write. Yielding between row batches gives that timer a
+ * turn, and `checkpoint` is what turns it into an abandoned call.
+ */
+export async function projectPipelineListRows(
+  filter: PipelineListFilter,
+  options: PipelineListProjectionOptions = {},
+): Promise<PipelineListRow[]> {
+  const checkpoint = options.checkpoint ?? (() => {});
+  checkpoint();
+  const records = (options.source ?? loadPipelinesForList)();
+  checkpoint();
+  const selected = selectPipelineListRecords(records, filter);
+  const rows: PipelineListRow[] = [];
+  for (const pipeline of selected) {
+    if (rows.length > 0 && rows.length % YIELD_EVERY_ROWS === 0) {
+      await yieldToEventLoop();
+      checkpoint();
+    }
+    rows.push(pipelineListRow(pipeline));
+  }
+  return rows;
+}

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -501,21 +501,42 @@ function pipelinesFileSignature(): string | null {
   }
 }
 
+/** The parse+validation of a large registry, cached against the file signature.
+    Mutating paths keep `withPipelineMutation`, whose persisted rename changes the
+    signature and invalidates this cache. The records are the cache itself — only
+    the exported readers below decide what a caller may do with them. */
+function cachedPipelines(): Pipeline[] {
+  const before = pipelinesFileSignature();
+  if (before !== null && projectionCache?.signature === before) return projectionCache.pipelines;
+  const pipelines = loadPipelines();
+  const after = pipelinesFileSignature();
+  if (after !== null && before === after) projectionCache = { signature: after, pipelines };
+  return pipelines;
+}
+
 /** Read-only load for request-path projections (issue #798): no lock, and the
     parse+validation of a large registry is cached against the file signature.
     Every call still returns independently mutable records via the same revive
     pass `loadPipelines` uses, so a projection overlay can never write into the
-    cache. Mutating paths keep `withPipelineMutation`, whose persisted rename
-    changes the signature and invalidates this cache. */
+    cache. */
 export function loadPipelinesForProjection(): Pipeline[] {
-  const before = pipelinesFileSignature();
-  if (before !== null && projectionCache?.signature === before) {
-    return projectionCache.pipelines.map(reviveLoadedPipeline);
-  }
-  const pipelines = loadPipelines();
-  const after = pipelinesFileSignature();
-  if (after !== null && before === after) projectionCache = { signature: after, pipelines };
-  return pipelines.map(reviveLoadedPipeline);
+  return cachedPipelines().map(reviveLoadedPipeline);
+}
+
+/** The registry read behind bounded list projections (issue #863).
+ *
+ * Deliberately skips the per-caller `reviveLoadedPipeline` pass that every other
+ * reader pays: a list page filters and slices these records and then copies only
+ * the handful of scalars a row needs, so materializing mutable copies of 500
+ * pipelines' nested stage/attempt history — for rows that are about to be
+ * dropped, out of fields a list never returns — is pure waste.
+ *
+ * The price is that these ARE the cached records. Read them; never write them.
+ * Anything that mutates a pipeline goes through `withPipelineMutation`, and
+ * anything that overlays one takes `loadPipelinesForProjection`.
+ */
+export function loadPipelinesForList(): readonly Pipeline[] {
+  return cachedPipelines();
 }
 
 function savePipelinesUnlocked(pipelines: Pipeline[]): void {


### PR DESCRIPTION
Closes #863.

## The problem, measured

`list_pipelines` filtered the registry, sliced to `limit`, and returned whole `Pipeline` records. Each surviving row therefore still carried `spec`, `stages[].prompt`, `stages[].effectiveRole.promptScaffold` and `runs[].attempts[]` with every persisted `input`/`output` transcript body.

Profiled against a production-shaped fixture — 500 pipelines, two staged roles each, six attempts per stage, 189 MB of registry — through the real `createMcpToolService` + `SqliteMcpReceiptStore`:

- **365 KB per row, 37.33 MB for a 100-row response.**
- Redaction then walked that graph: 1.1 s of CPU per call.
- The payload was serialized four more times (receipt row, `resultSizeBytes`, content block, SDK `structuredContent`) and written into SQLite, which is where `claim`/`completion` contention came from.
- The binding dropped `McpToolCallContext`, so `signal`/`deadlineAt` never reached the body — and the body was fully synchronous, so the server's 30 s deadline timer could not fire while it owned the event loop. A timed-out caller left the work running and still paid the receipt write.

The store read was never the cost (265 ms), which is why direct HTTP answered in ~200 ms on the same data.

## What changed

**`src/lib/pipelines/listProjection.ts`** (new) — `PipelineListRow` and `projectPipelineListRows`. A list row is a board card: identity, placement, state, `stateDetail`, cursor stage + state, attempt counts, and per-stage `{ id, kind, roleId, engine, model, effort, access, next, onFail, attempts, latestAttempt }`. Filtering and `limit` are applied in one pass **before** any row is materialized. Operator free text (`task`, `stateDetail`, an attempt `error`) is clamped, which is what gives a row a length bound the registry does not have. `latestAttempt` goes through the shared `latestOperationalStageAttempt`, so a lineage-adopted historical attempt is never reported as the stage's current work.

**`src/lib/pipelines/store.ts`** — `loadPipelinesForList()` shares the signature-keyed parse cache `loadPipelinesForProjection` already kept (no second copy of the registry in memory) and skips the per-caller `reviveLoadedPipeline` deep copy: a row copies scalars and retains nothing, so deep-copying nested history for records about to be dropped was pure waste. The registry is a single JSON file and admits no indexed read, so the materialization the filter now precedes is the revive, not the parse.

**`src/lib/mcp/bindings.ts`** — `listPipelines` is async, projects, and redacts the projected rows; the tool table entry forwards `context`. The bounded read arrives through an optional `listPipelineRecords` dependency, so `getPipelines` stays the HTTP/detail seam and partial test harnesses still work.

**`src/lib/mcp/server.ts`** — `receipts.complete` is skipped for a `deadline`/`cancelled` outcome **on bounded reads only**. The completion write serializes and persists the whole result, which on a large read is exactly the cost the deadline existed to stop, and it would burn the `clientRequestId` on an answer nobody received. The claim is left unsettled instead — which is what "the previous call did not finish" already means, so a retry gets `call_interrupted`, retryable, and the bounded lease sweeps the row so the id comes back. Durable mutation claims are excluded deliberately: `pruneBoundedReceipts` sweeps an unsettled claim only for `retention = 'bounded'`, so skipping the write for a mutating tool would strand a permanent `result_json IS NULL` row. Every outcome that produced a real answer still writes, so idempotent replay of a completed call is untouched.

**Tool description** — `list_pipelines` now describes the board-card shape and points at `get_pipeline` for bodies, since MCP clients choose tools from these strings.

`get_pipeline` is unchanged and remains the full-detail read. `src/lib/pipelines/engine.ts` and `types.ts` were not touched.

## Semantics preserved

Ordering, the `project`/`state`/`includeClosed` predicates, the `limit` bound (1–200, default 100) and HTTP/MCP count + ordering parity are the previous behaviour exactly. The suite keeps the old naive filter as a parity oracle across seven filter combinations.

## Results, same fixture

| measure | before | after |
| --- | --- | --- |
| response, 100 rows | 37.33 MB | 0.12 MB |
| per row | 365 KB | 1 KB |
| `binding` p95 (x8) | 10 345 ms | 221 ms |
| `claim` p95 (x8) | 9 025 ms | 1 ms |
| `completion` p95 (x8) | 1 276 ms | 1 ms |
| `serviceTotal` p95 (x8) | 11 844 ms | 223 ms |
| wall, 8 concurrent | 11 878 ms | 37 ms |
| RSS growth, 8 concurrent | +2 115 MB | +6 MB |

The remaining 221 ms binding max is the one cold-cache registry parse; every later call inside the signature window is about 1 ms.

`spikes/issue-863/red.ts` went from 6 RED to all nine GREEN. The 500-pipeline builder moved to `src/lib/pipelines/fixtures/corpus.ts` and is imported by both the spike and the suite, so the measured shape and the tested shape cannot drift apart. The suite asserts **structural** bars only — response bytes, which fields exist, filter/ordering parity, cancellation — while wall clock and RSS stay in the spike script rather than becoming flaky host-speed assertions in CI.

## Verification

- `bun spikes/issue-863/red.ts` — 9/9 GREEN (was 6 RED); `endToEnd.ts` phase profile re-measured.
- `bun test` by path: `src/lib/pipelines/listProjection.test.ts` (21), `src/lib/mcp/bindings.test.ts` (21), `src/lib/mcp/server.test.ts` (31), `src/lib/pipelines/store.test.ts`, `engine.test.ts`, `visibility.test.ts`, `taskBinding.test.ts` (173), the ten isolated MCP suites (100), `src/lib/mcp/stdio.integration.test.ts`, and `src/app/api/files/route.test.ts` (82, the other `loadPipelinesForProjection` consumer). All pass. No broad sweep of runtime/registry directories.
- `bunx tsc --noEmit` clean; `bun run lint src/lib/pipelines/ src/lib/mcp/` clean.
- `bun run build` (Next production build + `dist/mcp-server.mjs`) succeeds.
- `bun scripts/privacy-publication-gate.ts --base 3f4b9955` PASS.

## Note on ownership

PR #859 is parked with no active worker, so this lane temporarily owns the overlapping `bindings.ts` / `server.ts` / `store.ts` read seam. Its edits are textually distant from `listPipelines`; #859 rebases afterward, and its decision-recovery semantics are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
