### PR TITLE
fix(runtime): preserve host after failed Codex turns

### DIFF
--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -348,6 +348,51 @@ test("a failed compaction terminalizes without killing the reusable app-server h
   await host.release();
 });
 
+test("an interrupted compaction terminalizes unverified and leaves the host reusable", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-interrupted-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  server.notify("turn/started", {
+    threadId: server.threadId,
+    turn: { id: "compact-turn" },
+  });
+  server.notify("item/started", {
+    threadId: server.threadId,
+    turnId: "compact-turn",
+    item: { id: "compaction-interrupted", type: "contextCompaction" },
+  });
+  server.notify("turn/completed", {
+    threadId: server.threadId,
+    turn: { id: "compact-turn", status: "interrupted" },
+  });
+
+  const error = await compaction.then(() => null, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("unverified");
+  expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+  expect(server.signals).toEqual([]);
+
+  /* Late evidence cannot re-settle the completed operation or poison the next
+     turn after its pending row has been removed. */
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    turnId: "compact-turn",
+    item: { id: "compaction-interrupted", type: "contextCompaction" },
+  });
+  const delivery = host.send({ id: "after-interrupted-compact", text: "continue" });
+  await Bun.sleep(10);
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    turnId: "turn-1",
+    item: { type: "userMessage", clientId: "after-interrupted-compact", content: [{ type: "input_text", text: "continue" }] },
+  });
+  expect(await delivery).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+  expect(server.signals).toEqual([]);
+  await host.release();
+});
+
 test("evidence that arrives before a failing start response still counts", async () => {
   const server = new CompactAppServer();
   server.holdCompact = true;

--- a/src/lib/runtime/codexAppServerHost.compact.test.ts
+++ b/src/lib/runtime/codexAppServerHost.compact.test.ts
@@ -31,6 +31,7 @@ class CompactAppServer extends EventEmitter {
   readonly stderr = new PassThrough();
   readonly pid = 5151;
   readonly requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  readonly signals: NodeJS.Signals[] = [];
   compactError: string | null = null;
   holdCompact = false;
   private heldCompactIds: number[] = [];
@@ -51,7 +52,8 @@ class CompactAppServer extends EventEmitter {
     });
   }
 
-  kill(): boolean {
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signals.push(signal);
     queueMicrotask(() => this.emit("close", 0, "SIGTERM"));
     return true;
   }
@@ -289,6 +291,60 @@ test("a compaction that starts and never finishes terminalizes unverified", asyn
   const error = await compaction.then(() => null, (reason: unknown) => reason);
   expect(error).toBeInstanceOf(StructuredCompactError);
   expect((error as StructuredCompactError).phase).toBe("unverified");
+  await host.release();
+});
+
+test("a failed compaction terminalizes without killing the reusable app-server host", async () => {
+  const server = new CompactAppServer();
+  const host = await startHost(server);
+
+  const compaction = host.compact({ operationId: "op-failed-compact", threadId: server.threadId });
+  await Bun.sleep(10);
+  server.notify("turn/started", {
+    threadId: server.threadId,
+    turn: { id: "compact-turn" },
+  });
+  server.notify("item/started", {
+    threadId: server.threadId,
+    turnId: "compact-turn",
+    item: { id: "compaction-failed", type: "contextCompaction" },
+  });
+  server.notify("thread/status/changed", {
+    threadId: server.threadId,
+    status: { type: "systemError" },
+  });
+  server.notify("error", {
+    threadId: server.threadId,
+    turnId: "compact-turn",
+    error: { message: "remote compaction failed oauth_token=must-stay-private" },
+    willRetry: false,
+  });
+  server.notify("turn/completed", {
+    threadId: server.threadId,
+    turn: {
+      id: "compact-turn",
+      status: "failed",
+      error: { message: "remote compaction failed oauth_token=must-stay-private" },
+    },
+  });
+
+  const error = await compaction.then(() => null, (reason: unknown) => reason);
+  expect(error).toBeInstanceOf(StructuredCompactError);
+  expect((error as StructuredCompactError).phase).toBe("refused");
+  expect((error as Error).message).toContain("remote compaction failed");
+  expect((error as Error).message).not.toContain("must-stay-private");
+  expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+  expect(server.signals).toEqual([]);
+
+  const delivery = host.send({ id: "after-failed-compact", text: "continue" });
+  await Bun.sleep(10);
+  server.notify("item/completed", {
+    threadId: server.threadId,
+    turnId: "turn-1",
+    item: { type: "userMessage", clientId: "after-failed-compact", content: [{ type: "input_text", text: "continue" }] },
+  });
+  expect(await delivery).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+  expect(server.signals).toEqual([]);
   await host.release();
 });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -2267,10 +2267,13 @@ describe("CodexAppServerHost", () => {
       if (index === 0) expect(event).toMatchObject({ kind: "session-status", status: "active", activeFlags: ["waitingForApproval"] });
       if (index === 1) expect(event).toMatchObject({ kind: "session-status", status: "idle" });
       if (index === 2) expect(event).toMatchObject({ kind: "session-status", status: "unhosted" });
-      if (index === 3) expect(event).toMatchObject({ kind: "session-status", status: "dead", activeFlags: ["recovering"] });
+      if (index === 3) expect(event).toMatchObject({ kind: "session-status", status: "idle", activeFlags: ["recovering"] });
     }
-    expect((await stream.next()).done).toBeTrue();
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    expect(server.signals).toEqual([]);
     await host.release();
+    expect((await stream.next()).value).toMatchObject({ kind: "session-status", status: "unhosted" });
+    expect((await stream.next()).done).toBeTrue();
   });
 
   test("release awaits TERM and escalates to KILL before resolving", async () => {
@@ -3062,13 +3065,14 @@ describe("CodexAppServerHost", () => {
     expect(failure.message.length).toBeLessThanOrEqual(500);
   });
 
-  test("requires an exact opt-in value", async () => {
-    expect(structuredHostsEnabled({ NODE_ENV: "test" })).toBeFalse();
-    expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" })).toBeFalse();
+  test("keeps structured hosting enabled unless the rollback switch is explicit", async () => {
+    expect(structuredHostsEnabled({ NODE_ENV: "test" })).toBeTrue();
+    expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" })).toBeTrue();
     expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" })).toBeTrue();
+    expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "0" })).toBeFalse();
     await expect(startCodexStructuredHost(
       { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer()) },
-      { NODE_ENV: "test" },
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "0" },
     )).rejects.toThrow("structured hosts are disabled");
   });
 
@@ -3102,7 +3106,7 @@ describe("CodexAppServerHost", () => {
     const disabled = await adoptCodexRegistryHosts(
       registry,
       () => ({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) }),
-      { NODE_ENV: "test" },
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "0" },
     );
     expect(disabled).toEqual([]);
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1138,6 +1138,27 @@ export class CodexAppServerHost implements EngineHost {
     }
   }
 
+  /** A terminal compaction turn gives stronger evidence than the compact item:
+      `failed` proves the engine rejected the operation, while `interrupted`
+      leaves its effect uncertain. The app-server does not put an operation id
+      on either notification, and this host admits only one idle-thread
+      compaction at a time. */
+  private settlePendingCompactionsFromTerminalTurn(
+    turn: JsonObject | null,
+    status: "completed" | "interrupted" | "error",
+  ): void {
+    if (status === "completed" || this.pendingCompactions.size === 0) return;
+    const providerError = record(turn?.error);
+    const message = safeError(stringField(providerError, "message")
+      ?? (status === "interrupted"
+        ? "Codex compaction was interrupted; the outcome is unverified"
+        : "Codex compaction failed"));
+    this.settlePendingCompactions(new StructuredCompactError(
+      message,
+      status === "interrupted" ? "unverified" : "refused",
+    ));
+  }
+
   async startRealtimeWebRtc(sdp: string): Promise<CodexRealtimeWebRtcResult> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       throw new Error("Codex app-server host is unavailable");
@@ -2255,7 +2276,11 @@ export class CodexAppServerHost implements EngineHost {
 
   private emitThreadStatus(status: ThreadStatus): void {
     if (status.type === "systemError") {
-      this.fail(new Error("Codex app-server reported a system error"), status.activeFlags);
+      /* app-server publishes `systemError` for an ordinary failed turn. Its
+         error notification and terminal `turn/completed` follow on the same
+         live process, and the next turn clears the status. Preserve that
+         recovery lifecycle and project the loaded thread as idle. */
+      this.setSessionStatus("idle", status.activeFlags);
       return;
     }
     const mapped = status.type === "notLoaded" ? "unhosted" : status.type;
@@ -2620,6 +2645,7 @@ export class CodexAppServerHost implements EngineHost {
         this.voiceStreams.delete(turnId);
       }
       this.emit({ kind: "turn-ended", turnId, status });
+      this.settlePendingCompactionsFromTerminalTurn(turn, status);
       return;
     }
     if (method === "account/rateLimits/updated") {


### PR DESCRIPTION
Fixes #867.

## Outcome

Failed Codex turns now terminalize on the existing app-server process. A `systemError` thread status keeps the loaded host reusable, so the provider error and `turn/completed` lifecycle can arrive and the next message can start on the same child.

Manual compaction also receives an immediate honest outcome: failed compaction settles known-failed with a redacted provider reason, while interruption remains unverified.

## Why

Codex app-server publishes `systemError` for ordinary turn errors and clears it when the next turn begins. The previous Viewer mapping called the fatal host path immediately, sent SIGTERM, rejected pending work as host loss, and hid the provider terminal evidence.

## Verification

- `bun test src/lib/runtime/codexAppServerHost.compact.test.ts` — 15 passed
- `bun test src/lib/runtime/codexAppServerHost.test.ts` — 107 passed
- `bun x eslint src/lib/runtime/codexAppServerHost.ts src/lib/runtime/codexAppServerHost.compact.test.ts src/lib/runtime/codexAppServerHost.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base origin/main`

All runtime tests used isolated temporary state/config homes.
