### PR TITLE
fix(voice): bound persona bootstrap item IDs

### DIFF
--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -6,8 +6,8 @@ import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
 import { POST } from "./route";
 
 const ACCEPTED_PERSONA_BOOTSTRAP = {
-  receiptId: `voice_persona_${"c".repeat(64)}`,
-  itemId: `msg_voice_persona_${"c".repeat(64)}`,
+  receiptId: `voice_persona_${"c".repeat(46)}`,
+  itemId: `msg_voice_persona_${"c".repeat(46)}`,
   insertion: "accepted" as const,
 };
 
@@ -143,8 +143,8 @@ test("keeps validation and backend admission errors bounded", async () => {
 test("returns the canonical persona insertion outcome and rejects a call whose bootstrap was refused", async () => {
   let rejectedStops = 0;
   const acceptedBootstrap = {
-    receiptId: `voice_persona_${"b".repeat(64)}`,
-    itemId: `msg_voice_persona_${"b".repeat(64)}`,
+    receiptId: `voice_persona_${"b".repeat(46)}`,
+    itemId: `msg_voice_persona_${"b".repeat(46)}`,
     insertion: "accepted" as const,
   };
   const accepted = await executeRealtimeControl({
@@ -169,8 +169,8 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
   });
 
   const personaBootstrap = {
-    receiptId: `voice_persona_${"a".repeat(64)}`,
-    itemId: `msg_voice_persona_${"a".repeat(64)}`,
+    receiptId: `voice_persona_${"a".repeat(46)}`,
+    itemId: `msg_voice_persona_${"a".repeat(46)}`,
     insertion: "rejected" as const,
     diagnostic: "Codex app-server request failed: invalid developer item",
   };
@@ -218,7 +218,7 @@ test("refuses a realtime answer that omits the mandatory persona bootstrap recei
 });
 
 test("refuses malformed persona bootstrap receipts before binding the realtime session", async () => {
-  const digest = "d".repeat(64);
+  const digest = "d".repeat(46);
   let stops = 0;
   const malformedReceipts = [
     { itemId: `msg_voice_persona_${digest}`, insertion: "accepted" },

--- a/src/app/api/runtime/realtime/voicePersona.routes.test.ts
+++ b/src/app/api/runtime/realtime/voicePersona.routes.test.ts
@@ -15,7 +15,7 @@ test("canonical voice persona transcripts are discoverable through files and rea
     `rollout-2026-08-02T10-00-00-${sessionId}.jsonl`,
   );
   const persona = "Your name is Alik. Speak the operator's language.";
-  const itemId = `msg_voice_persona_${"a".repeat(64)}`;
+  const itemId = `msg_voice_persona_${"a".repeat(46)}`;
   fs.mkdirSync(sessions, { recursive: true });
   fs.writeFileSync(transcript, [
     JSON.stringify({

--- a/src/components/feed/voicePersona.render.test.tsx
+++ b/src/components/feed/voicePersona.render.test.tsx
@@ -21,7 +21,7 @@ test("the canonical voice persona developer item is first and renders through th
       timestamp: "2026-08-02T10:00:00.000Z",
       payload: {
         type: "message",
-        id: `msg_voice_persona_${"a".repeat(64)}`,
+        id: `msg_voice_persona_${"a".repeat(46)}`,
         role: "developer",
         content: [{ type: "input_text", text: persona }],
       },

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -16,7 +16,7 @@ import type { HostState, RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContent, type StructuredImageRef } from "./structuredContent";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
-import { DEFAULT_VOICE_PERSONA, VOICE_PERSONA_FILE, voicePersona } from "./voicePersona";
+import { DEFAULT_VOICE_PERSONA, VOICE_PERSONA_FILE, legacyVoicePersonaBootstrapItemId, voicePersona } from "./voicePersona";
 
 class MemoryEventStore implements RuntimeEventStore {
   private readonly events = new Map<string, RuntimeEvent[]>();
@@ -463,6 +463,48 @@ describe("CodexAppServerHost", () => {
       else process.env.XDG_CONFIG_HOME = previousConfigHome;
       fs.rmSync(isolated, { recursive: true, force: true });
     }
+  });
+
+  test("recognizes one persisted legacy persona row across repeated host restarts", async () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-legacy-voice-bootstrap-"));
+    const transcriptPath = path.join(isolated, "legacy-voice-thread.jsonl");
+    const threadId = "legacy-voice-thread";
+    const legacyItemId = legacyVoicePersonaBootstrapItemId(threadId);
+    fs.writeFileSync(transcriptPath, `${JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "message",
+        id: legacyItemId,
+        role: "developer",
+        content: [{ type: "input_text", text: "Persisted legacy persona." }],
+      },
+    })}\n`);
+
+    for (const suffix of ["first", "second"]) {
+      const server = new FakeAppServer(threadId);
+      server.threadPath = transcriptPath;
+      const host = await CodexAppServerHost.adopt(threadId, {
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(server),
+      });
+      try {
+        const started = await host.startRealtimeWebRtc(`v=0\r\na=ice-ufrag:${suffix}\r\n`);
+        expect(started.personaBootstrap.insertion).toBe("accepted");
+        expect(started.personaBootstrap.itemId.length).toBeLessThanOrEqual(64);
+        expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+        await host.stopRealtime();
+      } finally {
+        await host.release();
+      }
+    }
+
+    const personaRows = fs.readFileSync(transcriptPath, "utf8").trim().split("\n")
+      .map((line) => JSON.parse(line) as { payload?: { id?: string; role?: string } })
+      .filter((line) => line.payload?.role === "developer" && line.payload.id?.startsWith("msg_voice_persona_"));
+    expect(personaRows).toHaveLength(1);
+    expect(personaRows[0]?.payload?.id).toBe(legacyItemId);
+    fs.rmSync(isolated, { recursive: true, force: true });
   });
 
   test("seeds a resumed realtime call with the interrupted duplex tail in canonical order", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -356,8 +356,8 @@ describe("CodexAppServerHost", () => {
       realtimeSessionId: "realtime-1",
       personaBootstrap: { insertion: "accepted" },
     });
-    expect(started.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{64}$/);
-    expect(started.personaBootstrap.itemId).toMatch(/^msg_voice_persona_[a-f0-9]{64}$/);
+    expect(started.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
+    expect(started.personaBootstrap.itemId).toMatch(/^msg_voice_persona_[a-f0-9]{46}$/);
     // SDP requires a terminal CRLF; a missing one is healed, never trimmed —
     // OpenAI rejects an unterminated offer with "unmarshal SDP: EOF".
     /* The live model is named explicitly (#664): letting the backend choose
@@ -3588,7 +3588,7 @@ test("a refused persona insertion returns a bounded rejected receipt before real
       diagnostic: "Codex app-server request failed: Invalid request: unknown field `role`",
     },
   });
-  expect(rejected.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{64}$/);
+  expect(rejected.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
   expect(rejected.personaBootstrap.diagnostic?.length).toBeLessThanOrEqual(500);
   expect(server.requests.find((request) => request.method === "thread/realtime/start")).toBeUndefined();
   expect(host.currentRealtimeSessionId()).toBeNull();

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -52,6 +52,7 @@ import {
 } from "./eventStore";
 import {
   canonicalVoicePersonaBootstrapExists,
+  legacyVoicePersonaBootstrapItemId,
   voicePersonaBootstrap,
   voicePersonaBootstrapIdentity,
   type VoicePersonaBootstrap,
@@ -1262,7 +1263,15 @@ export class CodexAppServerHost implements EngineHost {
         continue;
       }
 
-      if (await this.scanVoicePersonaBootstrap(identity.itemId, "canonical scan unavailable; refusing insertion")) {
+      const canonicalExists = await this.scanVoicePersonaBootstrap(
+        identity.itemId,
+        "canonical scan unavailable; refusing insertion",
+      );
+      const legacyExists = canonicalExists ? false : await this.scanVoicePersonaBootstrap(
+        legacyVoicePersonaBootstrapItemId(this.identity.threadId),
+        "legacy canonical scan unavailable; refusing insertion",
+      );
+      if (canonicalExists || legacyExists) {
         this.voicePersonaBootstrapAccepted = true;
         this.unresolvedVoicePersonaBootstrap = null;
         break;

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -19,8 +19,8 @@ const NOW = Date.now();
 const DESK = { viewSessionId: "vs-desk-1", deviceId: "dev-desk" };
 const PHONE = { viewSessionId: "vs-phone-1", deviceId: "dev-phone" };
 const ACCEPTED_PERSONA_BOOTSTRAP = {
-  receiptId: `voice_persona_${"d".repeat(64)}`,
-  itemId: `msg_voice_persona_${"d".repeat(64)}`,
+  receiptId: `voice_persona_${"d".repeat(46)}`,
+  itemId: `msg_voice_persona_${"d".repeat(46)}`,
   insertion: "accepted" as const,
 };
 

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -60,7 +60,7 @@ function voicePersonaBootstrapReceipt(value: unknown): VoicePersonaBootstrapRece
   const receipt = value as Record<string, unknown>;
   const receiptId = typeof receipt.receiptId === "string" ? receipt.receiptId : "";
   const itemId = typeof receipt.itemId === "string" ? receipt.itemId : "";
-  if (!/^voice_persona_[a-f0-9]{64}$/.test(receiptId) || itemId !== `msg_${receiptId}`) return null;
+  if (!/^voice_persona_[a-f0-9]{46}$/.test(receiptId) || itemId !== `msg_${receiptId}`) return null;
   if (receipt.insertion !== "accepted" && receipt.insertion !== "rejected") return null;
   if (receipt.diagnostic !== undefined
     && (typeof receipt.diagnostic !== "string" || receipt.diagnostic.length > 500)) return null;

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -7,6 +7,7 @@ import { expect, test } from "bun:test";
 import {
   canonicalVoicePersonaBootstrapExists,
   DEFAULT_VOICE_PERSONA,
+  legacyVoicePersonaBootstrapItemId,
   PERSONA_NAME,
   voicePersona,
   voicePersonaBootstrap,
@@ -71,6 +72,8 @@ test("one durable thread identity produces one stable canonical developer item",
   expect(voicePersonaBootstrapIdentity("thread-voice")).toEqual(identity);
   expect(voicePersonaBootstrapIdentity("thread-other")).not.toEqual(identity);
   expect(identity.itemId.length).toBeLessThanOrEqual(64);
+  expect(legacyVoicePersonaBootstrapItemId("thread-voice")).toStartWith(identity.itemId);
+  expect(legacyVoicePersonaBootstrapItemId("thread-voice").length).toBe(82);
   expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
     item: {
       type: "message",

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -70,6 +70,7 @@ test("one durable thread identity produces one stable canonical developer item",
   const identity = voicePersonaBootstrapIdentity("thread-voice");
   expect(voicePersonaBootstrapIdentity("thread-voice")).toEqual(identity);
   expect(voicePersonaBootstrapIdentity("thread-other")).not.toEqual(identity);
+  expect(identity.itemId.length).toBeLessThanOrEqual(64);
   expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
     item: {
       type: "message",
@@ -84,7 +85,7 @@ test("canonical receipt scanning recognizes reordered fields across a stream chu
   const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-scan-"));
   const transcript = path.join(isolated, "thread.jsonl");
   const linked = path.join(isolated, "linked.jsonl");
-  const itemId = `msg_voice_persona_${"b".repeat(64)}`;
+  const itemId = `msg_voice_persona_${"b".repeat(46)}`;
   const record = JSON.stringify({
     padding: "x".repeat(65_400),
     payload: { role: "developer", content: [], id: itemId, type: "message" },
@@ -105,7 +106,7 @@ test("canonical receipt scanning recognizes reordered fields across a stream chu
 test("canonical receipt scanning ignores malformed rows and marker-like content", async () => {
   const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-structural-scan-"));
   const transcript = path.join(isolated, "thread.jsonl");
-  const itemId = `msg_voice_persona_${"c".repeat(64)}`;
+  const itemId = `msg_voice_persona_${"c".repeat(46)}`;
   const markerLikeText = `"type":"message","id":"${itemId}","role":"developer"`;
   fs.writeFileSync(transcript, [
     `{malformed:${markerLikeText}}`,

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -134,6 +134,9 @@ export type VoicePersonaBootstrapIdentity = Pick<VoicePersonaBootstrapReceipt, "
 /* Larger than the host's maximum admissible app-server frame, while keeping a
    transcript with an oversized unrelated row from growing scanner memory. */
 const MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES = 32 * 1024 * 1024;
+/* Responses API item ids accept at most 64 characters. `msg_voice_persona_`
+   consumes 18, leaving 46 hex characters (184 bits) for the stable digest. */
+const VOICE_PERSONA_ID_DIGEST_HEX = 46;
 
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -178,7 +181,8 @@ export function voicePersonaBootstrapIdentity(
   const digest = createHash("sha256")
     .update("voice-persona-bootstrap\0", "utf8")
     .update(threadId, "utf8")
-    .digest("hex");
+    .digest("hex")
+    .slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
   const receiptId = `voice_persona_${digest}`;
   const itemId = `msg_${receiptId}`;
   return { receiptId, itemId };

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -174,15 +174,23 @@ export function voicePersona(readFile: (path: string) => string = (target) => fs
   return DEFAULT_VOICE_PERSONA;
 }
 
+function voicePersonaBootstrapDigest(threadId: string): string {
+  return createHash("sha256")
+    .update("voice-persona-bootstrap\0", "utf8")
+    .update(threadId, "utf8")
+    .digest("hex");
+}
+
+/** Provider-invalid identity emitted before #870, used only to recognize an existing row. */
+export function legacyVoicePersonaBootstrapItemId(threadId: string): string {
+  return `msg_voice_persona_${voicePersonaBootstrapDigest(threadId)}`;
+}
+
 /** Stable canonical identity shared by every WebRTC attempt on one thread. */
 export function voicePersonaBootstrapIdentity(
   threadId: string,
 ): VoicePersonaBootstrapIdentity {
-  const digest = createHash("sha256")
-    .update("voice-persona-bootstrap\0", "utf8")
-    .update(threadId, "utf8")
-    .digest("hex")
-    .slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
+  const digest = voicePersonaBootstrapDigest(threadId).slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
   const receiptId = `voice_persona_${digest}`;
   const itemId = `msg_${receiptId}`;
   return { receiptId, itemId };


### PR DESCRIPTION
Closes #870.

## What changed

- truncate the deterministic voice-persona digest to 46 hex characters, keeping the provider-visible `msg_voice_persona_*` item ID at 64 characters
- validate the shortened receipt shape at the realtime boundary
- update canonical scan, route, rendering, restart/idempotency, and selected-context fixtures
- assert the provider item-ID limit directly

## Why

A full 64-hex digest plus the message prefix produced an 82-character item ID. Once persisted, later turns and manual compaction failed with a provider `invalid_request_error` for the overlong input ID.

## Verification

- 148 focused tests across the exact voice/realtime/host files, with isolated Viewer state
- ESLint on all changed files
- `bun x tsc --noEmit`
- production build including MCP bundle
- privacy publication gate
- `git diff --check`
