### PR TITLE
feat(preview): a pasted/bookmarkable #a= URL opens the artifact preview (#884)

### DIFF
--- a/evidence/issue-884/drive.ts
+++ b/evidence/issue-884/drive.ts
@@ -1,0 +1,391 @@
+/**
+ * Real-browser evidence for issue #884 — the `#a=` fragment makes the artifact
+ * preview linkable: a pasted or bookmarked URL opens it directly on load.
+ *
+ *   bun evidence/issue-884/drive.ts
+ *
+ * PRODUCTION-SHAPED, exactly like the issue-875 driver it extends: builds the
+ * EXACT current head (`next build --webpack`), serves it with `next start`
+ * over the ISOLATED demo runtime (fixtures/demo-home + its own LLV_STATE_DIR;
+ * never the operator's viewer state, never ports 8898/8899), and drives real
+ * headless host Chrome over raw CDP. Every artifact fixture is SYNTHETIC and
+ * generated at runtime into the disposable capture home.
+ *
+ * What the checks prove (issue #884 acceptance):
+ *  - a URL pasted into a fresh tab whose fragment names a supported artifact
+ *    opens the preview on load, with no prior conversation context, on
+ *    desktop and in the 396 px mobile viewport;
+ *  - the fragment reads bytes ONLY through /api/artifact — the same
+ *    authorization a clicked link uses — so unsupported (.jsonl included),
+ *    out-of-root and missing paths land on the explicit visible states while
+ *    the URL stays put: never a silent redirect;
+ *  - closing a fragment-opened preview strips the fragment in place (one
+ *    replaceState, zero pushes, no reload) and leaves the app coherent;
+ *  - browser Back closes a hash-opened preview and Forward reopens it, with
+ *    the document alive throughout (#866 focus history untouched);
+ *  - `#f=` keeps resolving conversation transcripts to their card, unchanged;
+ *  - a fragment outside the app's vocabulary shows the explicit
+ *    unknown-fragment notice instead of quietly landing on the default view.
+ *
+ * Output: evidence/issue-884/fragment.json (fixture ids, booleans only) and
+ * screenshots of the rendered states. No absolute paths, no identities.
+ */
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { bootstrapDemoRuntime, demoPort } from "../../scripts/demo-capture";
+import { S_ID, seedArtifacts, seedTranscript } from "../issue-875/seeds";
+
+const CHROME = process.env.LLV_EVIDENCE_CHROME || "/usr/bin/google-chrome-stable";
+const CDP_PORT = 9341;
+
+interface Check {
+  name: string;
+  pass: boolean;
+  detail: unknown;
+}
+
+class Cdp {
+  #ws: WebSocket;
+  #id = 0;
+  #pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+  private constructor(ws: WebSocket) {
+    this.#ws = ws;
+    ws.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (message.id !== undefined && this.#pending.has(message.id)) {
+        const waiter = this.#pending.get(message.id)!;
+        this.#pending.delete(message.id);
+        if (message.error) waiter.reject(new Error(`${message.error.message} (${message.error.code})`));
+        else waiter.resolve(message.result);
+      }
+    });
+  }
+
+  static async connect(url: string): Promise<Cdp> {
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", () => reject(new Error("CDP connect failed")));
+    });
+    return new Cdp(ws);
+  }
+
+  send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const id = ++this.#id;
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+      this.#ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  async eval<T>(expression: string): Promise<T> {
+    const result = (await this.send("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    })) as { result: { value: T }; exceptionDetails?: { text: string; exception?: { description?: string } } };
+    if (result.exceptionDetails) {
+      throw new Error(`page eval failed: ${result.exceptionDetails.exception?.description ?? result.exceptionDetails.text}\n${expression.slice(0, 200)}`);
+    }
+    return result.result.value;
+  }
+
+  async screenshot(file: string): Promise<void> {
+    const shot = (await this.send("Page.captureScreenshot", { format: "png" })) as { data: string };
+    fs.writeFileSync(path.join(import.meta.dir, file), Buffer.from(shot.data, "base64"));
+  }
+
+  close(): void {
+    this.#ws.close();
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function poll(cdp: Cdp, expression: string, label: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await cdp.eval<boolean>(expression)) return;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for: ${label}`);
+    await sleep(250);
+  }
+}
+
+async function click(cdp: Cdp, finder: string, label: string): Promise<void> {
+  const clicked = await cdp.eval<boolean>(`(() => { const el = ${finder}; if (!el) return false; el.click(); return true; })()`);
+  if (!clicked) throw new Error(`click target missing: ${label}`);
+}
+
+/** History writes, document identity and every fetch pathname, installed on
+    every NEW document so load-time requests are captured too. */
+const INSTRUMENT = `(() => {
+  window.__pushes = 0; window.__replaces = 0; window.__marker = "alive";
+  const hp = history.pushState.bind(history);
+  const hr = history.replaceState.bind(history);
+  history.pushState = (...a) => { window.__pushes++; return hp(...a); };
+  history.replaceState = (...a) => { window.__replaces++; return hr(...a); };
+  window.__fetchPaths = [];
+  const of = window.fetch.bind(window);
+  window.fetch = (...a) => {
+    try { window.__fetchPaths.push(new URL(String(a[0] instanceof Request ? a[0].url : a[0]), location.href).pathname + new URL(String(a[0] instanceof Request ? a[0].url : a[0]), location.href).search); } catch {}
+    return of(...a);
+  };
+})()`;
+
+const SHEET = `document.querySelector('[data-artifact-preview]')`;
+const sheetState = (state: string) => `(() => { const s = ${SHEET}; return !!s && s.getAttribute("data-artifact-state") === "${state}"; })()`;
+
+const fragment = (p: string) => `#a=${encodeURIComponent(p)}`;
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(import.meta.dir, "../..");
+  const port = demoPort(process.env.LLV_EVIDENCE_PORT, 3063, "LLV_EVIDENCE_PORT");
+  const devHost = [172, 17, 0, 1].join(".");
+  const checks: Check[] = [];
+  const expect = (name: string, pass: boolean, detail: unknown = null) => {
+    checks.push({ name, pass, detail });
+    console.log(`${pass ? "PASS" : "FAIL"} ${name}${pass ? "" : " — " + JSON.stringify(detail)}`);
+  };
+
+  /* ── The exact-head PRODUCTION build the server below serves ─────────── */
+  const buildHead = execSync("git rev-parse HEAD", { cwd: repoRoot }).toString().trim();
+  if (process.env.LLV_EVIDENCE_SKIP_BUILD !== "1") {
+    console.log(`building production head ${buildHead.slice(0, 12)}…`);
+    const buildEnv = { ...process.env, NODE_ENV: "production" as const };
+    delete (buildEnv as Record<string, unknown>).__NEXT_PRIVATE_STANDALONE_CONFIG;
+    execSync("bunx next build --webpack", { cwd: repoRoot, env: buildEnv, stdio: "inherit" });
+  }
+
+  console.log("booting isolated demo runtime…");
+  const prodPort = port + 1;
+  /* An orphaned server from a crashed run would silently serve a STALE build
+     to every check below. Refuse to start over an occupied port. */
+  for (const candidate of [port, prodPort]) {
+    const occupied = await fetch(`http://127.0.0.1:${candidate}/`, { signal: AbortSignal.timeout(1_000) }).then(() => true).catch(() => false);
+    if (occupied) throw new Error(`port ${candidate} is already serving something — kill the stale server first`);
+  }
+  const runtime = await bootstrapDemoRuntime(repoRoot, port);
+  const outsideDir = fs.mkdtempSync(path.join(runtime.root, "outside-"));
+  let chrome: ChildProcess | null = null;
+  let prodServer: ChildProcess | null = null;
+  try {
+    seedArtifacts(runtime.env.HOME!, outsideDir);
+    const transcript = seedTranscript(runtime.env.HOME!, outsideDir);
+
+    prodServer = spawn(
+      "bunx",
+      ["next", "start", "--hostname", "0.0.0.0", "--port", String(prodPort)],
+      { cwd: repoRoot, env: { ...runtime.env, NODE_ENV: "production" }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const prodDeadline = Date.now() + 60_000;
+    for (;;) {
+      if (prodServer.exitCode !== null) throw new Error(`production server exited with ${prodServer.exitCode}`);
+      try {
+        const response = await fetch(`http://127.0.0.1:${prodPort}/api/files`);
+        if (response.ok) break;
+      } catch {
+        /* still booting */
+      }
+      if (Date.now() > prodDeadline) throw new Error("production server never became ready");
+      await sleep(400);
+    }
+    console.log("production server ready");
+    const baseUrl = `http://${devHost}:${prodPort}`;
+
+    /* ── Headless host Chrome ─────────────────────────────────────────── */
+    const profile = path.join(runtime.root, "chrome-profile");
+    fs.mkdirSync(profile, { recursive: true });
+    chrome = spawn(CHROME, [
+      "--headless=new",
+      `--remote-debugging-port=${CDP_PORT}`,
+      `--user-data-dir=${profile}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-extensions",
+      "--window-size=1440,900",
+      "about:blank",
+    ], { stdio: "ignore" });
+    const cdpDeadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`);
+        break;
+      } catch {
+        if (Date.now() > cdpDeadline) throw new Error("Chrome CDP endpoint never came up");
+        await sleep(300);
+      }
+    }
+    const newTarget = async (): Promise<Cdp> => {
+      const created = await fetch(`http://127.0.0.1:${CDP_PORT}/json/new?about:blank`, { method: "PUT" });
+      const target = (await created.json()) as { webSocketDebuggerUrl: string };
+      const cdp = await Cdp.connect(target.webSocketDebuggerUrl);
+      await cdp.send("Page.enable");
+      await cdp.send("Runtime.enable");
+      await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: INSTRUMENT });
+      return cdp;
+    };
+
+    /* ── Desktop: the pasted-URL open, in a FRESH tab with no app state ── */
+    const tab = await newTarget();
+    await tab.send("Emulation.setDeviceMetricsOverride", { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false });
+    await tab.send("Page.navigate", { url: `${baseUrl}/${fragment("~/artifacts/run.log")}` });
+    await poll(tab, sheetState("ready"), "pasted #a= URL opened the preview on load", 120_000);
+    const pasted = await tab.eval<{ kind: string | null; name: boolean; hash: string; artifactFetches: string[]; nav: number }>(`(() => ({
+      kind: ${SHEET}.getAttribute("data-artifact-kind"),
+      name: (${SHEET}.getAttribute("aria-label") || "").includes("run.log"),
+      hash: location.hash,
+      artifactFetches: window.__fetchPaths.filter((p) => p.includes("run.log")),
+      nav: performance.getEntriesByType("navigation").length,
+    }))()`);
+    expect("a pasted URL opens the text preview directly on load, no conversation context",
+      pasted.kind === "text" && pasted.name && pasted.hash === fragment("~/artifacts/run.log") && pasted.nav === 1,
+      pasted);
+    expect("the fragment read its bytes ONLY through /api/artifact — the clicked-link authorization",
+      pasted.artifactFetches.length > 0 && pasted.artifactFetches.every((p) => p.startsWith("/api/artifact?")),
+      pasted.artifactFetches);
+    await tab.screenshot("desktop-pasted-open.png");
+
+    /* Close: the fragment strips in place; the app stays coherent. */
+    const beforeClose = await tab.eval<{ pushes: number; replaces: number; len: number }>(
+      `({ pushes: window.__pushes, replaces: window.__replaces, len: history.length })`,
+    );
+    await click(tab, `${SHEET}.querySelector('[aria-label="Close preview"]')`, "close button");
+    await poll(tab, `!${SHEET}`, "sheet closed");
+    const afterClose = await tab.eval<{ pushes: number; replaces: number; len: number; hash: string; marker: string; nav: number; alive: boolean }>(`(() => ({
+      pushes: window.__pushes, replaces: window.__replaces, len: history.length,
+      hash: location.hash, marker: window.__marker,
+      nav: performance.getEntriesByType("navigation").length,
+      alive: document.querySelectorAll("body *").length > 50,
+    }))()`);
+    expect("closing the fragment-opened preview strips the fragment in place: one replaceState, zero pushes, no reload, app coherent",
+      afterClose.hash === "" && afterClose.pushes === beforeClose.pushes
+        && afterClose.replaces === beforeClose.replaces + 1 && afterClose.len === beforeClose.len
+        && afterClose.marker === "alive" && afterClose.nav === 1 && afterClose.alive,
+      { beforeClose, afterClose });
+    await tab.screenshot("desktop-after-close.png");
+
+    /* ── Explicit failure states, each from an in-tab pasted fragment ──── */
+    const failureCase = async (target: string, state: string, label: string) => {
+      await tab.eval(`(location.hash = ${JSON.stringify(fragment(target))}, true)`);
+      await poll(tab, sheetState(state), `${label} → ${state}`, 30_000);
+      const held = await tab.eval<{ hash: string; marker: string }>(`({ hash: location.hash, marker: window.__marker })`);
+      expect(`a pasted ${label} lands on the explicit ${state} state with the URL held — no silent redirect`,
+        held.hash === fragment(target) && held.marker === "alive", held);
+    };
+    await failureCase(`~/.claude/projects/x/${S_ID}.jsonl`, "unsupported", ".jsonl transcript fragment");
+    await tab.screenshot("desktop-unsupported-jsonl.png");
+    await failureCase(path.join(outsideDir, "denied.md"), "denied", "out-of-root fragment");
+    await tab.screenshot("desktop-denied.png");
+    await failureCase("~/artifacts/missing.md", "missing", "missing-file fragment");
+    await tab.screenshot("desktop-missing.png");
+
+    /* ── Back/Forward over a hash-opened preview ──────────────────────── */
+    await tab.send("Page.navigate", { url: `${baseUrl}/` });
+    await poll(tab, `document.querySelectorAll("body *").length > 50`, "app shell after clean navigation", 60_000);
+    await tab.eval(`(location.hash = ${JSON.stringify(fragment("~/artifacts/board.png"))}, true)`);
+    await poll(tab, sheetState("ready"), "hash assignment opened the image preview", 30_000);
+    await tab.eval("(history.back(), true)");
+    await poll(tab, `!${SHEET}`, "Back closed the hash-opened preview", 15_000);
+    await tab.eval("(history.forward(), true)");
+    await poll(tab, sheetState("ready"), "Forward reopened the preview", 15_000);
+    const traversal = await tab.eval<{ marker: string; nav: number; hash: string }>(
+      `({ marker: window.__marker, nav: performance.getEntriesByType("navigation").length, hash: location.hash })`,
+    );
+    expect("Back closes and Forward reopens the hash-opened preview with the same document alive",
+      traversal.marker === "alive" && traversal.nav === 1 && traversal.hash === fragment("~/artifacts/board.png"),
+      traversal);
+    await tab.screenshot("desktop-forward-reopened.png");
+
+    /* ── #f= still resolves conversation transcripts to their card ────── */
+    await tab.send("Page.navigate", { url: `${baseUrl}/#f=${encodeURIComponent(transcript)}` });
+    await poll(tab, `!!document.querySelector('[data-scheme-node$="${S_ID}.jsonl"]')`, "#f= transcript deep link resolved to its card", 120_000);
+    const transcriptLink = await tab.eval<{ preview: boolean; notice: boolean }>(`({
+      preview: !!${SHEET},
+      notice: !!document.querySelector("[data-unknown-fragment-notice]"),
+    })`);
+    expect("#f= keeps deep-linking the .jsonl transcript to its conversation card — no preview, no notice",
+      !transcriptLink.preview && !transcriptLink.notice);
+    await tab.screenshot("desktop-transcript-deeplink.png");
+
+    /* ── An uninterpretable fragment says so ──────────────────────────── */
+    await tab.send("Page.navigate", { url: `${baseUrl}/#not-a-known-key` });
+    await poll(tab, `!!document.querySelector("[data-unknown-fragment-notice]")`, "unknown-fragment notice rendered", 60_000);
+    const unknown = await tab.eval<{ text: string; preview: boolean }>(`({
+      text: document.querySelector("[data-unknown-fragment-notice]").textContent || "",
+      preview: !!${SHEET},
+    })`);
+    expect("a fragment the app cannot interpret shows the explicit notice instead of quietly navigating away",
+      unknown.text.length > 0 && !unknown.preview, unknown);
+    await tab.screenshot("desktop-unknown-fragment.png");
+    tab.close();
+
+    /* ── 396 px mobile: the same pasted URL opens the full-height sheet ── */
+    const mob = await newTarget();
+    await mob.send("Emulation.setDeviceMetricsOverride", { width: 396, height: 780, deviceScaleFactor: 2, mobile: true });
+    await mob.send("Emulation.setTouchEmulationEnabled", { enabled: true });
+    await mob.send("Page.navigate", { url: `${baseUrl}/${fragment("~/artifacts/board.png")}` });
+    await poll(mob, sheetState("ready"), "mobile pasted #a= URL opened the preview", 120_000);
+    const mobile = await mob.eval<{ role: string | null; label: boolean; fullHeight: boolean; fullWidth: boolean; closeBox: { w: number; h: number } }>(`(() => {
+      const s = ${SHEET};
+      const rect = s.getBoundingClientRect();
+      const close = s.querySelector('[aria-label="Close preview"]').getBoundingClientRect();
+      return {
+        role: s.getAttribute("role"),
+        label: (s.getAttribute("aria-label") || "").includes("board.png"),
+        fullHeight: Math.round(rect.height) >= window.innerHeight - 1,
+        fullWidth: Math.round(rect.width) >= window.innerWidth - 1,
+        closeBox: { w: Math.round(close.width), h: Math.round(close.height) },
+      };
+    })()`);
+    expect("396px: the pasted URL opens a full-height labelled dialog with 44px close target",
+      mobile.role === "dialog" && mobile.label && mobile.fullHeight && mobile.fullWidth
+        && mobile.closeBox.w >= 44 && mobile.closeBox.h >= 44,
+      mobile);
+    await mob.screenshot("mobile-pasted-open.png");
+    await mob.eval(`(location.hash = ${JSON.stringify(fragment("~/artifacts/missing.md"))}, true)`);
+    await poll(mob, sheetState("missing"), "mobile missing state", 30_000);
+    await mob.screenshot("mobile-missing.png");
+    mob.close();
+
+    const failed = checks.filter((check) => !check.pass);
+    const output = {
+      issue: 884,
+      capturedAt: new Date().toISOString(),
+      buildHead,
+      runner: "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated artifact fixtures; headless host Chrome over raw CDP",
+      screenshots: [
+        "desktop-pasted-open.png", "desktop-after-close.png",
+        "desktop-unsupported-jsonl.png", "desktop-denied.png", "desktop-missing.png",
+        "desktop-forward-reopened.png", "desktop-transcript-deeplink.png",
+        "desktop-unknown-fragment.png",
+        "mobile-pasted-open.png", "mobile-missing.png",
+      ],
+      checks,
+      verdict: failed.length === 0 ? "PASS" : "FAIL",
+    };
+    fs.writeFileSync(
+      path.join(import.meta.dir, "fragment.json"),
+      (JSON.stringify(output, null, 2) + "\n")
+        .replaceAll(repoRoot, "<repo>")
+        .replaceAll(runtime.root, "<capture>")
+        .replaceAll(outsideDir, "<outside>")
+        /* The denied-case detail holds the pasted fragment, which carries the
+           outside dir percent-ENCODED — scrub that spelling too. */
+        .replaceAll(encodeURIComponent(outsideDir), encodeURIComponent("/outside"))
+        .replaceAll(encodeURIComponent(repoRoot), encodeURIComponent("/repo"))
+        .replace(/\b([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "$1-x"),
+    );
+    console.log(`\n${output.verdict}: ${checks.length - failed.length}/${checks.length} checks`);
+    if (failed.length) process.exitCode = 1;
+  } finally {
+    chrome?.kill("SIGKILL");
+    prodServer?.kill("SIGTERM");
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+    await runtime.shutdown();
+  }
+}
+
+await main();

--- a/evidence/issue-884/drive.ts
+++ b/evidence/issue-884/drive.ts
@@ -376,6 +376,10 @@ async function main(): Promise<void> {
            outside dir percent-ENCODED — scrub that spelling too. */
         .replaceAll(encodeURIComponent(outsideDir), encodeURIComponent("/outside"))
         .replaceAll(encodeURIComponent(repoRoot), encodeURIComponent("/repo"))
+        /* The synthetic session id is assembled at runtime so no UUID shape
+           lands in published sources; scrub it from the output too (a %2F
+           prefix defeats the \b in the generic pattern below). */
+        .replaceAll(S_ID, "s-x")
         .replace(/\b([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "$1-x"),
     );
     console.log(`\n${output.verdict}: ${checks.length - failed.length}/${checks.length} checks`);

--- a/evidence/issue-884/fragment.json
+++ b/evidence/issue-884/fragment.json
@@ -1,0 +1,123 @@
+{
+  "issue": 884,
+  "capturedAt": "2026-08-04T06:40:15.722Z",
+  "buildHead": "3a1ccec9c3a4d30404203dd8f98f321c3d5f3114",
+  "runner": "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated artifact fixtures; headless host Chrome over raw CDP",
+  "screenshots": [
+    "desktop-pasted-open.png",
+    "desktop-after-close.png",
+    "desktop-unsupported-jsonl.png",
+    "desktop-denied.png",
+    "desktop-missing.png",
+    "desktop-forward-reopened.png",
+    "desktop-transcript-deeplink.png",
+    "desktop-unknown-fragment.png",
+    "mobile-pasted-open.png",
+    "mobile-missing.png"
+  ],
+  "checks": [
+    {
+      "name": "a pasted URL opens the text preview directly on load, no conversation context",
+      "pass": true,
+      "detail": {
+        "kind": "text",
+        "name": true,
+        "hash": "#a=~%2Fartifacts%2Frun.log",
+        "artifactFetches": [
+          "/api/artifact?path=%7E%2Fartifacts%2Frun.log&mode=meta",
+          "/api/artifact?path=%7E%2Fartifacts%2Frun.log"
+        ],
+        "nav": 1
+      }
+    },
+    {
+      "name": "the fragment read its bytes ONLY through /api/artifact — the clicked-link authorization",
+      "pass": true,
+      "detail": [
+        "/api/artifact?path=%7E%2Fartifacts%2Frun.log&mode=meta",
+        "/api/artifact?path=%7E%2Fartifacts%2Frun.log"
+      ]
+    },
+    {
+      "name": "closing the fragment-opened preview strips the fragment in place: one replaceState, zero pushes, no reload, app coherent",
+      "pass": true,
+      "detail": {
+        "beforeClose": {
+          "pushes": 0,
+          "replaces": 1,
+          "len": 2
+        },
+        "afterClose": {
+          "pushes": 0,
+          "replaces": 2,
+          "len": 2,
+          "hash": "",
+          "marker": "alive",
+          "nav": 1,
+          "alive": true
+        }
+      }
+    },
+    {
+      "name": "a pasted .jsonl transcript fragment lands on the explicit unsupported state with the URL held — no silent redirect",
+      "pass": true,
+      "detail": {
+        "hash": "#a=~%2F.claude%2Fprojects%2Fx%2Fd4d4d4d4-d4d4-4d4d-8d4d-d4d4d4d4d4d4.jsonl",
+        "marker": "alive"
+      }
+    },
+    {
+      "name": "a pasted out-of-root fragment lands on the explicit denied state with the URL held — no silent redirect",
+      "pass": true,
+      "detail": {
+        "hash": "#a=%2Foutside%2Fdenied.md",
+        "marker": "alive"
+      }
+    },
+    {
+      "name": "a pasted missing-file fragment lands on the explicit missing state with the URL held — no silent redirect",
+      "pass": true,
+      "detail": {
+        "hash": "#a=~%2Fartifacts%2Fmissing.md",
+        "marker": "alive"
+      }
+    },
+    {
+      "name": "Back closes and Forward reopens the hash-opened preview with the same document alive",
+      "pass": true,
+      "detail": {
+        "marker": "alive",
+        "nav": 1,
+        "hash": "#a=~%2Fartifacts%2Fboard.png"
+      }
+    },
+    {
+      "name": "#f= keeps deep-linking the .jsonl transcript to its conversation card — no preview, no notice",
+      "pass": true,
+      "detail": null
+    },
+    {
+      "name": "a fragment the app cannot interpret shows the explicit notice instead of quietly navigating away",
+      "pass": true,
+      "detail": {
+        "text": "This link names nothing the viewer recognizes",
+        "preview": false
+      }
+    },
+    {
+      "name": "396px: the pasted URL opens a full-height labelled dialog with 44px close target",
+      "pass": true,
+      "detail": {
+        "role": "dialog",
+        "label": true,
+        "fullHeight": true,
+        "fullWidth": true,
+        "closeBox": {
+          "w": 44,
+          "h": 44
+        }
+      }
+    }
+  ],
+  "verdict": "PASS"
+}

--- a/evidence/issue-884/fragment.json
+++ b/evidence/issue-884/fragment.json
@@ -1,7 +1,7 @@
 {
   "issue": 884,
-  "capturedAt": "2026-08-04T06:40:15.722Z",
-  "buildHead": "3a1ccec9c3a4d30404203dd8f98f321c3d5f3114",
+  "capturedAt": "2026-08-04T06:41:34.750Z",
+  "buildHead": "597e8bf9c7fa3f6587d4ee3be61acb0b44998209",
   "runner": "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated artifact fixtures; headless host Chrome over raw CDP",
   "screenshots": [
     "desktop-pasted-open.png",
@@ -62,7 +62,7 @@
       "name": "a pasted .jsonl transcript fragment lands on the explicit unsupported state with the URL held — no silent redirect",
       "pass": true,
       "detail": {
-        "hash": "#a=~%2F.claude%2Fprojects%2Fx%2Fd4d4d4d4-d4d4-4d4d-8d4d-d4d4d4d4d4d4.jsonl",
+        "hash": "#a=~%2F.claude%2Fprojects%2Fx%2Fs-x.jsonl",
         "marker": "alive"
       }
     },

--- a/src/components/Viewer.test.ts
+++ b/src/components/Viewer.test.ts
@@ -4,7 +4,7 @@ import { filesApiUrl } from "@/hooks/useFiles";
 import { parseConversationHash } from "@/lib/accounts/identity";
 
 import { OVERVIEW } from "./projectModel";
-import { filesRequestPin, initialProjectFromState, reduceCatalogPin } from "./Viewer";
+import { filesRequestPin, initialProjectFromState, recognizedFragment, reduceCatalogPin } from "./Viewer";
 
 test("initialProjectFromState reads a direct project hash before polling", () => {
   expect(initialProjectFromState("#p=example-dispatcher", null)).toBe("example-dispatcher");
@@ -15,6 +15,26 @@ test("initialProjectFromState falls back to saved project only without a project
   expect(initialProjectFromState("", "CelestiaCompose")).toBe("CelestiaCompose");
   expect(initialProjectFromState("#f=/tmp/session.jsonl", "CelestiaCompose")).toBe("CelestiaCompose");
   expect(initialProjectFromState("", null)).toBe(OVERVIEW);
+});
+
+test("initialProjectFromState treats an artifact fragment like any non-project hash", () => {
+  expect(initialProjectFromState("#a=%2Fcheckouts%2Ffigures%2Fdiagram.png", "CelestiaCompose")).toBe("CelestiaCompose");
+});
+
+test("recognizedFragment knows every fragment key the app speaks — and refuses everything else", () => {
+  for (const known of [
+    "",
+    "#c=conversation-1",
+    "#c=conversation-1#question",
+    "#f=%2Fcheckouts%2Fsession.jsonl",
+    "#p=My%20Project",
+    "#a=%2Fcheckouts%2Ffigures%2Fdiagram.png",
+  ]) {
+    expect(recognizedFragment(known)).toBeTrue();
+  }
+  for (const unknown of ["#garbage", "#f=", "#a=", "#x=1", "#=value", "#question"]) {
+    expect(recognizedFragment(unknown)).toBeFalse();
+  }
 });
 
 test("a resolved capped-out catalog open remains pinned after its hash intent clears", () => {

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -56,6 +56,15 @@ export function filesRequestPin(pendingHash: ConversationHash | null, retainedPa
   return pendingHash?.filePath ?? pendingHash?.conversationId ?? retainedPath;
 }
 
+/** Every fragment key this app speaks, each with a payload: conversation
+    (`#c=`), transcript path (`#f=`), project (`#p=`), artifact preview
+    (`#a=`, issue #884 — handled by ArtifactPreviewHost) — plus the empty
+    hash. A pasted URL outside this set means nothing here; quietly landing
+    on the default view read as a broken deployment, so the shell says so. */
+export function recognizedFragment(hash: string): boolean {
+  return hash === "" || /^#(?:c|f|p|a)=./.test(hash);
+}
+
 export type CatalogPinState = { path: string; hydrated: boolean; conversationId: string | null } | null;
 export type CatalogPinEvent =
   | { kind: "open"; path: string; conversationId?: string }
@@ -169,6 +178,9 @@ export function Viewer() {
      is stale — deleted, purged, or beyond this machine. Fails visibly, then the
      rest of the history stays usable. */
   const [staleFocusNotice, setStaleFocusNotice] = useState(false);
+  /* A pasted URL whose fragment the app cannot interpret (issue #884): name
+     the failure instead of quietly showing the default view. */
+  const [unknownFragmentNotice, setUnknownFragmentNotice] = useState(false);
   /* Mirrors for the popstate replay path, which must read the latest values
      from stable event listeners without re-registering them per poll. */
   const filesRef = useRef<FileEntry[]>([]);
@@ -194,6 +206,7 @@ export function Viewer() {
     if (initial.filePath || initial.conversationId) setPendingHash(initial);
     const savedProject = initial.project ?? localStorage.getItem(PROJECT_KEY);
     if (savedProject) setProject(savedProject);
+    if (!recognizedFragment(location.hash)) setUnknownFragmentNotice(true);
   }, []);
 
   useEffect(() => {
@@ -228,6 +241,7 @@ export function Viewer() {
         /* Back cleared the hash entirely: that entry was the overview. */
         else if (!location.hash) setProject(OVERVIEW);
       }
+      if (!recognizedFragment(location.hash)) setUnknownFragmentNotice(true);
     };
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
@@ -281,6 +295,12 @@ export function Viewer() {
     const timer = window.setTimeout(() => setStaleFocusNotice(false), STALE_FOCUS_NOTICE_MS);
     return () => window.clearTimeout(timer);
   }, [staleFocusNotice]);
+
+  useEffect(() => {
+    if (!unknownFragmentNotice) return;
+    const timer = window.setTimeout(() => setUnknownFragmentNotice(false), STALE_FOCUS_NOTICE_MS);
+    return () => window.clearTimeout(timer);
+  }, [unknownFragmentNotice]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   /* The state half of a project selection, shared by routes that write their
@@ -908,6 +928,16 @@ export function Viewer() {
         <div className="pointer-events-none fixed left-1/2 top-10 z-40 -translate-x-1/2" role="status" data-stale-focus-notice>
           <div className="rounded-full border border-warning/45 bg-warning-soft px-3.5 py-1.5 text-[12px] font-semibold text-warning shadow-1 backdrop-blur">
             {t("viewer.staleFocusEntry")}
+          </div>
+        </div>
+      ) : null}
+      {/* A pasted URL whose fragment the app does not speak (issue #884):
+          the silent version of this looked like an undeployed feature. Same
+          anchor as the stale notice; the two intents cannot co-occur. */}
+      {unknownFragmentNotice ? (
+        <div className="pointer-events-none fixed left-1/2 top-10 z-40 -translate-x-1/2" role="status" data-unknown-fragment-notice>
+          <div className="rounded-full border border-warning/45 bg-warning-soft px-3.5 py-1.5 text-[12px] font-semibold text-warning shadow-1 backdrop-blur">
+            {t("viewer.unknownFragment")}
           </div>
         </div>
       ) : null}

--- a/src/components/preview/ArtifactPreviewHost.dom.test.tsx
+++ b/src/components/preview/ArtifactPreviewHost.dom.test.tsx
@@ -4,14 +4,18 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
 import { installActEnv } from "@/test-helpers/actEnv";
+import { formatArtifactFragment } from "@/lib/artifact/fragment";
 import { setLocale } from "@/lib/i18n";
 
 import { ArtifactPreviewHost } from "./ArtifactPreviewHost";
+import { artifactMetaUrl } from "./artifactResource";
 import { openArtifactPreview } from "./previewBus";
 
 installActEnv();
 
-const dom = new Window();
+/* A real http URL so the fragment-routing tests can read and write
+   location.hash and history entries like a served page. */
+const dom = new Window({ url: "http://localhost:3000/" });
 Object.assign(globalThis, {
   window: dom,
   document: dom.document,
@@ -86,6 +90,13 @@ beforeEach(() => {
 afterEach(async () => {
   await act(async () => root?.unmount());
   dom.document.body.replaceChildren();
+  /* The shared window carries its URL across tests: strip any fragment a
+     fragment-routing test left behind so later tests start hash-free, and
+     drain the async hashchange happy-dom schedules for every fragment
+     mutation (the strip here, a close's replaceState inside a test) so no
+     stray event fires into the next test outside act. */
+  dom.history.replaceState(null, "", dom.location.pathname);
+  await new Promise((resolve) => setTimeout(resolve, 0));
 });
 
 const flush = async () => {
@@ -334,6 +345,112 @@ test("mobile pane controls carry the 44px touch-target sizing", async () => {
   for (const label of ["Zoom out", "Zoom in", "Fit to pane"]) {
     expect(surface()!.querySelector(`[aria-label="${label}"]`)!.className).toContain("h-11 w-11");
   }
+});
+
+/* ── #884: the #a= fragment is the preview's own URL entry point ──────── */
+
+/** Set the fragment and drain the hashchange happy-dom schedules on a later
+    task, all inside act — no event may leak across act boundaries or into
+    the next test. */
+async function setHash(hash: string): Promise<void> {
+  await act(async () => {
+    dom.history.replaceState(null, "", hash || dom.location.pathname);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+const navigateHash = setHash;
+
+test("a pasted #a= URL opens the preview on load through the same /api/artifact authorization a click uses", async () => {
+  textRoutes();
+  await setHash(formatArtifactFragment(TEXT_PATH));
+  await render();
+  await flush();
+  await flush();
+
+  const sheet = surface();
+  expect(sheet).not.toBeNull();
+  expect(sheet!.getAttribute("data-artifact-state")).toBe("ready");
+  expect(sheet!.textContent).toContain("build.log");
+  /* The security invariant: the fragment funnels into the exact request a
+     clicked link issues — no other read path exists. */
+  expect(fetchLog[0].url).toBe(artifactMetaUrl(TEXT_PATH));
+  for (const call of fetchLog) expect(call.url.startsWith("/api/artifact")).toBe(true);
+});
+
+test("fragment-named unsupported, out-of-root and missing paths land on the explicit states — never a silent redirect", async () => {
+  routes = [() => ({ status: 415, body: { error: "not a previewable artifact type", code: "unsupported" } })];
+  await setHash(formatArtifactFragment("~/checkouts/session.jsonl"));
+  await render();
+  await flush();
+  expect(surface()!.getAttribute("data-artifact-state")).toBe("unsupported");
+
+  routes = [() => ({ status: 403, body: { error: "path is outside the allowed roots", code: "access-denied" } })];
+  await navigateHash(formatArtifactFragment("/outside/secret.md"));
+  await flush();
+  expect(surface()!.getAttribute("data-artifact-state")).toBe("denied");
+
+  routes = [];
+  await navigateHash(formatArtifactFragment("~/checkouts/gone.png"));
+  await flush();
+  expect(surface()!.getAttribute("data-artifact-state")).toBe("missing");
+});
+
+test("navigating the hash off the artifact fragment closes a fragment-opened preview; a click-opened one stays", async () => {
+  textRoutes();
+  await setHash(formatArtifactFragment(TEXT_PATH));
+  await render();
+  await flush();
+  await flush();
+  expect(surface()).not.toBeNull();
+
+  await navigateHash("#p=board");
+  expect(surface()).toBeNull();
+
+  /* A click-opened preview is pure same-document state (#875): hash
+     navigation elsewhere in the app must not tear it down. */
+  await act(async () => openArtifactPreview(TEXT_PATH));
+  await flush();
+  await flush();
+  expect(surface()).not.toBeNull();
+  await navigateHash("#p=elsewhere");
+  expect(surface()).not.toBeNull();
+});
+
+test("closing a fragment-opened preview strips the fragment in place: no new history entry, no resurrect on reload", async () => {
+  textRoutes();
+  await setHash(formatArtifactFragment(TEXT_PATH));
+  await render();
+  await flush();
+  await flush();
+  expect(surface()).not.toBeNull();
+
+  const length = dom.history.length;
+  await act(async () => {
+    dom.window.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Escape", bubbles: true }) as never);
+    /* Drain the async hashchange the strip's replaceState schedules, inside
+       this act: the closed host must shrug it off (no reopen, no throw). */
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(surface()).toBeNull();
+  expect(dom.location.hash).toBe("");
+  expect(dom.history.length).toBe(length);
+});
+
+test("closing a click-opened preview leaves a foreign hash untouched", async () => {
+  textRoutes();
+  await setHash("#p=board");
+  await render();
+  await act(async () => openArtifactPreview(TEXT_PATH));
+  await flush();
+  await flush();
+  expect(surface()).not.toBeNull();
+
+  await act(async () => {
+    dom.window.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Escape", bubbles: true }) as never);
+  });
+  expect(surface()).toBeNull();
+  expect(dom.location.hash).toBe("#p=board");
 });
 
 test("the mobile sheet is a labelled full-height dialog", async () => {

--- a/src/components/preview/ArtifactPreviewHost.tsx
+++ b/src/components/preview/ArtifactPreviewHost.tsx
@@ -5,6 +5,7 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 
 import { classifyArtifact, type ArtifactKind } from "@/lib/artifact/classify";
+import { parseArtifactFragment } from "@/lib/artifact/fragment";
 import { useLocale, type TFunction } from "@/lib/i18n";
 
 import { useModalLayer } from "../modalLayer";
@@ -34,6 +35,10 @@ interface OpenRequest {
   path: string;
   /** Bumps on every open so re-opening the same path restarts its load. */
   nonce: number;
+  /** The open came from the `#a=` URL fragment (issue #884), not a clicked
+      link: hash navigation away closes it, and a user close strips the
+      fragment so a reload does not resurrect the sheet. */
+  fromFragment?: boolean;
 }
 
 function kindLabel(t: TFunction, kind: ArtifactKind | null): string {
@@ -67,9 +72,18 @@ function storedWidth(): number {
 /**
  * The ONE in-app document preview surface (issue #875). Mounted once in the
  * Viewer shell; any rendered artifact link opens it through the preview bus.
- * Pure same-document React state: opening, switching and closing write nothing
- * to the URL, history, board or transcript, and trigger no snapshot or scan —
- * the only network the surface owns is /api/artifact.
+ * A click-open is pure same-document React state: opening, switching and
+ * closing write nothing to the URL, history, board or transcript, and trigger
+ * no snapshot or scan — the only network the surface owns is /api/artifact.
+ *
+ * The `#a=` fragment (issue #884) is the surface's second entry point: a
+ * pasted or bookmarked URL naming an artifact opens the same sheet on load,
+ * through the same classifier and the same /api/artifact authorization —
+ * unsupported, out-of-root and missing paths land on the explicit failure
+ * states exactly as a click would. Only that entry touches the URL: hash
+ * navigation away closes a fragment-opened sheet, and a user close strips the
+ * fragment in place (replaceState, never push) so Back keeps the browser's
+ * semantics and a reload does not resurrect the preview.
  */
 export function ArtifactPreviewHost({ mobile }: { mobile: boolean }) {
   const [open, setOpen] = useState<OpenRequest | null>(null);
@@ -80,7 +94,32 @@ export function ArtifactPreviewHost({ mobile }: { mobile: boolean }) {
       }),
     [],
   );
-  const close = useCallback(() => setOpen(null), []);
+  /* The initial `#a=` read IS this entry point's load: the fragment is
+     invisible to the server render, so it applies exactly once on mount and
+     then tracks hash navigation. */
+  useEffect(() => {
+    const applyFragment = () => {
+      const path = parseArtifactFragment(window.location.hash);
+      setOpen((previous) => {
+        if (path !== null) return { path, nonce: (previous?.nonce ?? 0) + 1, fromFragment: true };
+        /* The hash moved elsewhere (Back included): a preview the fragment
+           opened follows it closed; a click-opened one is URL-independent
+           state and stays. */
+        return previous?.fromFragment ? null : previous;
+      });
+    };
+    applyFragment();
+    window.addEventListener("hashchange", applyFragment);
+    return () => window.removeEventListener("hashchange", applyFragment);
+  }, []);
+  const close = useCallback(() => {
+    setOpen(null);
+    /* A URL still naming the artifact would resurrect it on reload. Replace
+       in place — never push — so history length and Back stay untouched. */
+    if (parseArtifactFragment(window.location.hash) !== null) {
+      window.history.replaceState(window.history.state, "", window.location.pathname + window.location.search);
+    }
+  }, []);
   if (!open) return null;
   return <PreviewSheet key="sheet" open={open} mobile={mobile} onClose={close} onReload={setOpen} />;
 }
@@ -158,7 +197,7 @@ function PreviewSheet({
   const kind = meta?.kind ?? classifyArtifact(open.path)?.kind ?? null;
   const state = failure ?? (meta ? "ready" : "loading");
   const reload = useCallback(
-    () => onReload({ path: open.path, nonce: open.nonce + 1 }),
+    () => onReload({ ...open, nonce: open.nonce + 1 }),
     [onReload, open],
   );
   const onPaneFailure = useCallback((code: ArtifactFailure) => setFailure(code), []);

--- a/src/lib/accounts/identity.test.ts
+++ b/src/lib/accounts/identity.test.ts
@@ -42,6 +42,9 @@ describe("parseConversationHash", () => {
     expect(parseConversationHash("#p=My%20Project")).toEqual({ conversationId: null, filePath: null, project: "My Project" });
     expect(parseConversationHash("")).toEqual({ conversationId: null, filePath: null, project: null });
   });
+  test("an #a= artifact fragment (issue #884) is never a conversation intent", () => {
+    expect(parseConversationHash("#a=%2Fcheckouts%2Ffigures%2Fdiagram.png")).toEqual({ conversationId: null, filePath: null, project: null });
+  });
 });
 
 describe("formatConversationHash", () => {

--- a/src/lib/artifact/fragment.test.ts
+++ b/src/lib/artifact/fragment.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatArtifactFragment, parseArtifactFragment } from "./fragment";
+
+describe("parseArtifactFragment", () => {
+  test("round-trips absolute and ~-relative paths, spaces and line suffixes included", () => {
+    for (const path of [
+      "/checkouts/report/figures/diagram.png",
+      "~/checkouts/report/figures/diagram.png",
+      "/checkouts/a b/render output.pdf",
+      "~/checkouts/report/src/main.ts:12",
+    ]) {
+      expect(parseArtifactFragment(formatArtifactFragment(path))).toBe(path);
+    }
+  });
+
+  test("the format is one opaque token: the path is fully percent-encoded", () => {
+    expect(formatArtifactFragment("/figures/diagram.png")).toBe("#a=%2Ffigures%2Fdiagram.png");
+  });
+
+  test("every other fragment key stays someone else's: #f=, #c=, #p= and junk are null", () => {
+    for (const foreign of [
+      "#f=%2Fcheckouts%2Fsession.jsonl",
+      "#c=conversation-1",
+      "#p=project",
+      "",
+      "#a=",
+      "#garbage",
+      "#af=%2Fx.png",
+    ]) {
+      expect(parseArtifactFragment(foreign)).toBeNull();
+    }
+  });
+
+  test("malformed percent-encoding degrades to the raw payload instead of throwing", () => {
+    expect(parseArtifactFragment("#a=%E0%A4%A")).toBe("%E0%A4%A");
+  });
+});

--- a/src/lib/artifact/fragment.ts
+++ b/src/lib/artifact/fragment.ts
@@ -1,0 +1,25 @@
+/*
+ * The artifact preview's own URL fragment (issue #884): `#a=<encoded path>`,
+ * parallel to — and deliberately distinct from — the `#f=` conversation card
+ * deep-link. The fragment carries ONLY the path. Everything that decides
+ * whether the path may be read stays where a clicked link already goes:
+ * classification in ./classify.ts and authorization in /api/artifact — so a
+ * pasted URL can never reach a file a click could not.
+ */
+
+export function formatArtifactFragment(path: string): string {
+  return "#a=" + encodeURIComponent(path);
+}
+
+/** The linked path an `#a=` fragment names, or null for every other fragment.
+    Malformed percent-encoding degrades to the raw payload (matching the
+    conversation hash parser) — the server rejects nonsense paths explicitly. */
+export function parseArtifactFragment(hash: string): string | null {
+  const match = hash.match(/^#a=(.+)$/);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    return match[1]!;
+  }
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1694,6 +1694,7 @@ export const en = {
   "viewer.closeProjects": "Close the project list",
   "viewer.agentWaiting": "Agent is waiting for a reply",
   "viewer.staleFocusEntry": "That conversation is no longer available",
+  "viewer.unknownFragment": "This link names nothing the viewer recognizes",
   "viewer.closeNotification": "Close the notification",
 
   // Viewer attention queue

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1636,6 +1636,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "viewer.closeProjects": "Закрити список проєктів",
   "viewer.agentWaiting": "Агент чекає відповіді",
   "viewer.staleFocusEntry": "Ця розмова більше недоступна",
+  "viewer.unknownFragment": "Це посилання не вказує ні на що відоме переглядачу",
   "viewer.closeNotification": "Закрити сповіщення",
 
   "attention.badge": { one: "{count} чекає", few: "{count} чекають", many: "{count} чекають", other: "{count} чекають" },


### PR DESCRIPTION
Closes #884.

## What this builds

The `#a=` fragment: the artifact preview's own URL entry point, parallel to and deliberately distinct from the `#f=` conversation deep-link. A pasted or bookmarked URL naming a supported artifact now opens the preview directly on load, with no prior conversation context — the entry point #875 never had.

### Fragment routing

- `src/lib/artifact/fragment.ts` — the one parser/formatter for `#a=<encoded path>`. The fragment carries ONLY the path; classification stays in `classify.ts` and authorization stays in `/api/artifact`, exactly where a clicked link already goes, so **a URL can never read a file a click could not** (the security invariant, proven in tests and evidence).
- `ArtifactPreviewHost` reads the fragment on mount and on `hashchange`. A fragment-opened sheet follows the hash: navigating away (browser Back included) closes it; a click-opened sheet stays pure same-document state exactly as in #875. Closing a fragment-opened preview strips the fragment **in place** (`replaceState`, never push — per the Native History API guidance the #866 focus history already follows), so history length and Back semantics stay the browser's and a reload does not resurrect the sheet.
- Unsupported extension (`.jsonl` transcripts included — `classify.ts`'s documented boundary is untouched), out-of-root, and missing paths land on the existing explicit unsupported / denied / missing states with the URL held. Never a silent redirect.
- `#f=` keeps resolving conversation transcripts to their card, byte-for-byte unchanged in `identity.ts`.
- A fragment outside the app's vocabulary (`#c=`/`#f=`/`#p=`/`#a=`) now shows an explicit self-dismissing notice (`viewer.unknownFragment`, en + uk) instead of quietly landing on the default view — the silence that made this read as an undeployed feature.

## Tests (written RED first)

- `src/lib/artifact/fragment.test.ts` — round-trips, foreign-key rejection (`#f=`/`#c=`/`#p=`/junk), malformed-encoding degradation.
- `src/components/preview/ArtifactPreviewHost.dom.test.tsx` — pasted-URL open on load issuing the exact `/api/artifact` request a click issues; unsupported/denied/missing states via fragment with no redirect; hashchange-away closes a fragment-opened preview while a click-opened one stays; close strips the fragment with no new history entry; a foreign hash is left untouched; happy-dom's async hashchange drained deterministically (0 act warnings across repeated runs).
- `src/lib/accounts/identity.test.ts` — `#a=` is never a conversation intent.
- `src/components/Viewer.test.ts` — `recognizedFragment` vocabulary, artifact fragments keep the saved project.

128 focused tests pass (by path, isolated env — no shared-state sweeps), `tsc --noEmit` clean, scoped ESLint clean (the 8 pre-existing `Viewer.tsx` findings reproduce identically on the base commit's copy), production `next build --webpack` clean, privacy gate PASS.

## Production rendered evidence — `evidence/issue-884/`

`bun evidence/issue-884/drive.ts` builds the exact head, serves it with `next start` over the isolated demo runtime (fixtures/demo-home, own state dir — never operator state, never 8898/8899), and drives headless host Chrome over raw CDP.

**`fragment.json`: 10/10 checks PASS** at app head `3a1ccec9` (the two later commits touch evidence files only):

- A URL pasted into a fresh tab opens the text preview on load (desktop 1440px) and the image preview at 396px as a full-height labelled dialog with 44px targets; the fragment read its bytes only through `/api/artifact`.
- Pasted `.jsonl`, out-of-root and missing fragments each land on the explicit visible state with the URL held — no silent redirect (screenshots).
- Closing the fragment-opened preview: exactly one `replaceState`, zero pushes, no reload, hash stripped, app coherent.
- Back closes and Forward reopens a hash-opened preview with the same document alive throughout.
- `#f=` still deep-links the transcript to its conversation card — no preview, no notice.
- `#not-a-known-key` renders the explicit unknown-fragment notice.

Screenshots (synthetic fixtures only): desktop pasted-open / after-close / unsupported / denied / missing / forward-reopened / transcript-deeplink / unknown-fragment, mobile pasted-open / missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
