### PR TITLE
fix(accounts): judge cross-namespace lock tickets by heartbeat, not pid

### DIFF
--- a/src/lib/accounts/accountMutation.test.ts
+++ b/src/lib/accounts/accountMutation.test.ts
@@ -139,6 +139,117 @@ test("a sync contender fails quickly while another process owns the file lock", 
   });
 });
 
+/* The queue is shared across pid namespaces (viewer container, runtime-host
+   container, host workers). A ticket whose pid collides with a live local
+   process but was written in another namespace must expire by heartbeat age,
+   never survive on the pid match. */
+test("a stale foreign-namespace ticket is reaped even when its pid matches a live process", async () => {
+  const state = path.join(sandbox, "foreign-ns-state");
+  const result = path.join(sandbox, "foreign-ns-result.json");
+  const modulePath = path.join(import.meta.dir, "accountMutation.ts");
+  const procPath = path.join(import.meta.dir, "..", "proc", "index.ts");
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", `
+      process.env.LLV_STATE_DIR = ${JSON.stringify(state)};
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const { procBackend } = await import(${JSON.stringify(procPath)});
+      const queue = path.join(${JSON.stringify(state)}, "account-selection.lock.queue");
+      fs.mkdirSync(queue, { recursive: true, mode: 0o700 });
+      const head = path.join(queue, "0000000000000001-99-foreign.json");
+      fs.writeFileSync(head, JSON.stringify({
+        pid: process.pid,
+        startIdentity: procBackend.processIdentity(process.pid),
+        ns: "pid:[4099999999]",
+        token: "foreign-token",
+      }));
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(head, past, past);
+      const { withAccountMutationLock } = await import(${JSON.stringify(modulePath)});
+      let ran = false;
+      withAccountMutationLock(() => { ran = true; });
+      fs.writeFileSync(${JSON.stringify(result)}, JSON.stringify({ ran, headRemoved: !fs.existsSync(head) }));
+    `],
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const exit = await child.exited;
+  const error = await new Response(child.stderr).text();
+  expect({ exit, error }).toEqual({ exit: 0, error: "" });
+  expect(JSON.parse(fs.readFileSync(result, "utf8"))).toEqual({ ran: true, headRemoved: true });
+});
+
+test("a fresh foreign-namespace ticket keeps its place in the queue", async () => {
+  const state = path.join(sandbox, "foreign-fresh-state");
+  const result = path.join(sandbox, "foreign-fresh-result.json");
+  const modulePath = path.join(import.meta.dir, "accountMutation.ts");
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", `
+      process.env.LLV_STATE_DIR = ${JSON.stringify(state)};
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const queue = path.join(${JSON.stringify(state)}, "account-selection.lock.queue");
+      fs.mkdirSync(queue, { recursive: true, mode: 0o700 });
+      const head = path.join(queue, "0000000000000001-99-foreign.json");
+      fs.writeFileSync(head, JSON.stringify({
+        pid: 99,
+        startIdentity: "99:1",
+        ns: "pid:[4099999999]",
+        token: "foreign-token",
+      }));
+      const { withAccountMutationLock } = await import(${JSON.stringify(modulePath)});
+      let failed = false;
+      try { withAccountMutationLock(() => undefined); }
+      catch { failed = true; }
+      fs.writeFileSync(${JSON.stringify(result)}, JSON.stringify({ failed, headKept: fs.existsSync(head) }));
+    `],
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const exit = await child.exited;
+  const error = await new Response(child.stderr).text();
+  expect({ exit, error }).toEqual({ exit: 0, error: "" });
+  expect(JSON.parse(fs.readFileSync(result, "utf8"))).toEqual({ failed: true, headKept: true });
+});
+
+test("a ticket past the hard age cap is reaped even when its owner looks alive", async () => {
+  const state = path.join(sandbox, "hard-cap-state");
+  const result = path.join(sandbox, "hard-cap-result.json");
+  const modulePath = path.join(import.meta.dir, "accountMutation.ts");
+  const procPath = path.join(import.meta.dir, "..", "proc", "index.ts");
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", `
+      process.env.LLV_STATE_DIR = ${JSON.stringify(state)};
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const { procBackend } = await import(${JSON.stringify(procPath)});
+      let ns = null;
+      try { ns = fs.readlinkSync("/proc/self/ns/pid"); } catch {}
+      const queue = path.join(${JSON.stringify(state)}, "account-selection.lock.queue");
+      fs.mkdirSync(queue, { recursive: true, mode: 0o700 });
+      const head = path.join(queue, "0000000000000001-99-leaked.json");
+      fs.writeFileSync(head, JSON.stringify({
+        pid: process.pid,
+        startIdentity: procBackend.processIdentity(process.pid),
+        ns,
+        token: "leaked-token",
+      }));
+      const past = new Date(Date.now() - 700_000);
+      fs.utimesSync(head, past, past);
+      const { withAccountMutationLock } = await import(${JSON.stringify(modulePath)});
+      let ran = false;
+      withAccountMutationLock(() => { ran = true; });
+      fs.writeFileSync(${JSON.stringify(result)}, JSON.stringify({ ran, headRemoved: !fs.existsSync(head) }));
+    `],
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const exit = await child.exited;
+  const error = await new Response(child.stderr).text();
+  expect({ exit, error }).toEqual({ exit: 0, error: "" });
+  expect(JSON.parse(fs.readFileSync(result, "utf8"))).toEqual({ ran: true, headRemoved: true });
+});
+
 test("a duplicated module copy joins the transaction instead of failing busy", async () => {
   const state = path.join(sandbox, "duplicate-copy-state");
   const result = path.join(sandbox, "duplicate-copy-result.json");

--- a/src/lib/accounts/accountMutation.ts
+++ b/src/lib/accounts/accountMutation.ts
@@ -9,9 +9,15 @@ import { procBackend } from "@/lib/proc";
 const ASYNC_LOCK_ATTEMPTS = 2_000;
 const LOCK_WAIT_MS = 5;
 const LOCK_STALE_MS = 30_000;
+/* No waiter legitimately queues for this long (the async path gives up after
+   ~ASYNC_LOCK_ATTEMPTS * LOCK_WAIT_MS), so a ticket this old is leaked no
+   matter what its pid looks like. Bounds the queue even when pid reuse makes
+   a dead owner look alive. */
+const TICKET_MAX_AGE_MS = 600_000;
+const HEARTBEAT_MS = 10_000;
 const REVISION_VERSION = 1;
 
-type LockOwner = { pid: number; startIdentity: string | null; token: string };
+type LockOwner = { pid: number; startIdentity: string | null; ns: string | null; token: string };
 type TransactionContext = { active: boolean; revision: number };
 type PendingLock = { lock: string; queue: string; owner: LockOwner; ticket: string };
 type AcquiredLock = { context: TransactionContext; release(): void };
@@ -62,19 +68,45 @@ async function acquireLocalAsync(): Promise<() => void> {
   return releaseLocal;
 }
 
-function ownerIsStale(filename: string): boolean {
+/* The state directory is shared across pid namespaces: the viewer container,
+   the runtime-host container, and host-side workers all queue here. A pid is
+   only meaningful inside the namespace that wrote it — the containerized Next
+   server is pid 12 in every container instance, and host pid 12 is a kernel
+   thread with the same start tick, so a dead container's ticket matches a
+   live process everywhere and is never reaped, while a live host worker's
+   pid does not exist inside the container and its ticket is reaped while it
+   still waits. Tickets therefore record the writer's pid-namespace identity;
+   pid liveness is trusted only within the same namespace, and everything
+   else falls back to heartbeat freshness. */
+function selfPidNamespace(): string | null {
+  try {
+    return fs.readlinkSync("/proc/self/ns/pid");
+  } catch {
+    return null;
+  }
+}
+const ownNamespace = selfPidNamespace();
+
+function olderThan(filename: string, ageMs: number): boolean {
+  try { return Date.now() - fs.statSync(filename).mtimeMs > ageMs; }
+  catch { return false; }
+}
+
+function ownerIsStale(filename: string, maxAgeMs: number | null = null): boolean {
+  if (maxAgeMs !== null && olderThan(filename, maxAgeMs)) return true;
   try {
     const owner = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<LockOwner>;
     if (typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0) {
+      const ownerNamespace = typeof owner.ns === "string" ? owner.ns : null;
+      if (ownerNamespace !== ownNamespace) return olderThan(filename, LOCK_STALE_MS);
       if (!procBackend.pidAlive(owner.pid)) return true;
       if (typeof owner.startIdentity !== "string") return false;
       const currentIdentity = procBackend.processIdentity(owner.pid);
       return currentIdentity !== null && currentIdentity !== owner.startIdentity;
     }
-    return Date.now() - fs.statSync(filename).mtimeMs > LOCK_STALE_MS;
+    return olderThan(filename, LOCK_STALE_MS);
   } catch {
-    try { return Date.now() - fs.statSync(filename).mtimeMs > LOCK_STALE_MS; }
-    catch { return false; }
+    return olderThan(filename, LOCK_STALE_MS);
   }
 }
 
@@ -116,17 +148,39 @@ function createPendingLock(): PendingLock {
   const lock = statePath("account-selection.lock");
   const queue = `${lock}.queue`;
   fs.mkdirSync(queue, { recursive: true, mode: 0o700 });
-  const owner: LockOwner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid), token: crypto.randomUUID() };
+  const owner: LockOwner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid), ns: ownNamespace, token: crypto.randomUUID() };
   const ticket = path.join(queue, `${String(Date.now()).padStart(16, "0")}-${process.pid}-${crypto.randomUUID()}.json`);
   fs.writeFileSync(ticket, JSON.stringify(owner), { encoding: "utf8", flag: "wx", mode: 0o600 });
   return { lock, queue, owner, ticket };
+}
+
+/* Keeps a waiting ticket or the held lock visibly fresh for peers in other
+   pid namespaces, which judge it by mtime alone. */
+function touchOwnerFile(filename: string): boolean {
+  const now = new Date();
+  try {
+    fs.utimesSync(filename, now, now);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* A cross-namespace peer may have reaped a ticket in the window before its
+   first heartbeat. The ticket filename is unique to this waiter, so rewriting
+   it is safe and restores the original queue position. The lock file gets no
+   such rewrite — a reaped lock may already belong to someone else. */
+function refreshTicket(pending: PendingLock): void {
+  if (touchOwnerFile(pending.ticket)) return;
+  try { fs.writeFileSync(pending.ticket, JSON.stringify(pending.owner), { encoding: "utf8", mode: 0o600 }); }
+  catch { /* queue directory gone; a later acquisition attempt recreates it */ }
 }
 
 function tryAcquireFile(pending: PendingLock): AcquiredLock | null {
   const liveTickets: string[] = [];
   for (const entry of fs.readdirSync(pending.queue).filter((candidate) => candidate.endsWith(".json")).sort()) {
     const candidate = path.join(pending.queue, entry);
-    if (ownerIsStale(candidate)) {
+    if (candidate !== pending.ticket && ownerIsStale(candidate, TICKET_MAX_AGE_MS)) {
       fs.rmSync(candidate, { force: true });
       continue;
     }
@@ -150,9 +204,12 @@ function tryAcquireFile(pending: PendingLock): AcquiredLock | null {
     throw error;
   }
   const context = { active: true, revision: readRevision() };
+  const heartbeat = setInterval(() => touchOwnerFile(pending.lock), HEARTBEAT_MS);
+  heartbeat.unref?.();
   return {
     context,
     release() {
+      clearInterval(heartbeat);
       context.active = false;
       fs.closeSync(descriptor);
       removeIfOwned(pending.lock, pending.owner.token);
@@ -193,9 +250,14 @@ async function acquireAsync(): Promise<AcquiredLock> {
   let pending: PendingLock | null = null;
   try {
     pending = createPendingLock();
+    let heartbeatAt = Date.now();
     for (let attempt = 0; attempt < ASYNC_LOCK_ATTEMPTS; attempt += 1) {
       const acquired = tryAcquireFile(pending);
       if (acquired) return attachLocalRelease(acquired, release);
+      if (Date.now() - heartbeatAt >= HEARTBEAT_MS) {
+        heartbeatAt = Date.now();
+        refreshTicket(pending);
+      }
       await delay(LOCK_WAIT_MS);
     }
     throw new Error("account mutation is busy; retry shortly");

--- a/src/lib/accounts/manager.interprocess.test.ts
+++ b/src/lib/accounts/manager.interprocess.test.ts
@@ -17,6 +17,11 @@ const { accountMutationRevisionForTests, withAccountMutationLock } = await impor
 const { AgentRegistry } = await import("@/lib/agent/registry");
 const { syncCompatibilityRouting } = await import("./migration/controller");
 
+function selfPidNamespace(): string | null {
+  try { return fs.readlinkSync("/proc/self/ns/pid"); }
+  catch { return null; }
+}
+
 beforeEach(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
   fs.rmSync(path.join(sandbox, "accounts"), { recursive: true, force: true });
@@ -145,6 +150,9 @@ test("simultaneous stale-lock recovery admits one account mutation at a time", a
   fs.writeFileSync(lockPath, JSON.stringify({
     pid: 999_999_999,
     startIdentity: "dead",
+    // Same pid namespace as the contenders — dead-pid recovery is instant
+    // there; a lock from a foreign namespace instead expires by heartbeat age.
+    ns: selfPidNamespace(),
     token: "stale",
   }));
   const managerPath = path.join(import.meta.dir, "manager.ts");


### PR DESCRIPTION
## Problem

Account switching failed persistently with "account mutation is busy; retry shortly", and the account migration controller starved (stuck conversations never migrated). The `account-selection.lock.queue` had accumulated 400+ tickets since the morning deploy, all pinned at the queue head.

## Root cause

The lock queue directory is shared across **pid namespaces** (viewer container, runtime-host container, host-side workers), but ticket staleness was judged by `pid:starttime`, which only means something inside the namespace that wrote it:

- The containerized server is **pid 12 with the same start tick in every container instance**, and the host's pid 12 is a kernel thread with the same start tick. A dead container's tickets therefore matched a live process in every namespace and were never reaped — they blocked the queue head forever, so every acquire failed busy.
- A live host worker's pid doesn't exist inside the container, so the container reaped the worker's ticket while it still waited. The migration controller starved on exactly this (observed spinning at ~85% CPU).

## Fix

- Tickets record the writer's pid-namespace identity (`readlink /proc/self/ns/pid`).
- Pid liveness is trusted only within the same namespace; foreign-namespace and old-format owners expire by mtime (30s) instead.
- Async waiters and lock holders heartbeat their files (10s) so live cross-namespace peers always look fresh. The lock file is only ever touched, never rewritten — a reaped lock may already belong to someone else.
- A hard ticket age cap (10 min) bounds the queue against any future leak.

## Tests

- stale foreign-namespace ticket whose pid collides with a live local process is reaped
- fresh foreign-namespace ticket keeps its queue position
- ticket past the hard age cap is reaped even when its owner looks alive
- existing lock suite passes; the seeded stale-lock fixture now carries `ns` so same-namespace dead-pid recovery stays instant

`manager.interprocess.test.ts` "interprocess mutation matrix" fails identically on a clean checkout in this environment (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)