### PR TITLE
fix(accounts): concurrent quota probes with per-account last-known cache

### DIFF
--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -16,7 +16,7 @@ import { handleOverlayEscape } from "@/lib/overlay";
 
 import { Loader2, SquareTerminal, Trash2, X } from "./icons";
 import { Badge } from "./ui/Badge";
-import { formatResetClock, formatResetEta, windowLabel } from "./rateLimit";
+import { formatCheckedClock, formatResetClock, formatResetEta, windowLabel } from "./rateLimit";
 import { engineTintOf } from "./utils";
 
 /** Amber that clears contrast on the panel background — state legibility never
@@ -89,8 +89,15 @@ function AccountLimitsDetail({ account, engine }: { account: AccountOption; engi
     >
       {/* Freshness is a visible, screen-reader-readable line — not opacity or a
           title tooltip alone (touch has no hover, and `title` AT support is
-          spotty), so historical numbers never read as current. */}
-      {stale ? <div className="text-[9.5px] font-semibold text-secondary">{t("accounts.limitsStale")}</div> : null}
+          spotty), so historical numbers never read as current. The check time
+          renders for fresh reads too — the panel always says when the numbers
+          were last observed. */}
+      {stale || limits.checkedAt ? (
+        <div className="text-[9.5px] font-semibold text-secondary">
+          {stale ? t("accounts.limitsStale") : t("accounts.limitsChecked")}
+          {limits.checkedAt ? ` · ${formatCheckedClock(limits.checkedAt)}` : null}
+        </div>
+      ) : null}
       {windows.map(({ key, label, window: w }) => {
         const left = Math.max(0, Math.min(100, 100 - w.usedPercent));
         const color = capacityColor(left, tint.color);

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -50,6 +50,16 @@ export function windowLabel(t: TFunction, key: WindowKey, windowMinutes: number 
   return t("limits.windowMinutes", { n: Math.round(windowMinutes) });
 }
 
+/** Absolute moment a limits read happened: same-day reads show the hour,
+    older ones the date too. Mirrors {@link formatResetClock} so both timestamps
+    in an account row read identically. */
+export function formatCheckedClock(checkedAt: string): string {
+  const d = new Date(checkedAt);
+  const time = d.toLocaleTimeString(localeBcp47(), { hour: "2-digit", minute: "2-digit", hour12: false });
+  if (Date.now() - d.getTime() < 86_400_000) return time;
+  return d.toLocaleDateString(localeBcp47(), { day: "numeric", month: "short" }) + " " + time;
+}
+
 /** Absolute reset moment: today's resets show the hour, later ones the date too. */
 export function formatResetClock(resetsAt: number, now: number): string {
   const d = new Date(resetsAt * 1000);

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -62,9 +62,15 @@ test("parseAccountLimits keeps fresh/stale reads with their windows and drops th
   expect(parseAccountLimits({ state: "fresh", session: null, weekly: null })).toBeNull();
   // A malformed window is dropped; a valid sibling survives. resetsAt is optional.
   expect(parseAccountLimits({ state: "fresh", session: { usedPercent: "nope" }, weekly: { usedPercent: 40, resetsAt: 1_700_000_000 } }))
-    .toEqual({ freshness: "fresh", session: null, weekly: { usedPercent: 40, resetsAt: 1_700_000_000, windowMinutes: null } });
+    .toEqual({ freshness: "fresh", session: null, weekly: { usedPercent: 40, resetsAt: 1_700_000_000, windowMinutes: null }, checkedAt: null });
   expect(parseAccountLimits({ state: "stale", session: { usedPercent: 88, resetsAt: null }, weekly: null }))
-    .toEqual({ freshness: "stale", session: { usedPercent: 88, resetsAt: null, windowMinutes: null }, weekly: null });
+    .toEqual({ freshness: "stale", session: { usedPercent: 88, resetsAt: null, windowMinutes: null }, weekly: null, checkedAt: null });
+  // The observation timestamp survives the projection so the panel can say
+  // when the numbers were last read; garbage timestamps degrade to null.
+  expect(parseAccountLimits({ state: "stale", session: { usedPercent: 10, resetsAt: null }, weekly: null, checkedAt: "2026-08-04T09:00:00.000Z" })?.checkedAt)
+    .toBe("2026-08-04T09:00:00.000Z");
+  expect(parseAccountLimits({ state: "fresh", session: { usedPercent: 10, resetsAt: null }, weekly: null, checkedAt: "not-a-date" })?.checkedAt)
+    .toBeNull();
 });
 
 test("a store parses per-account session/weekly limit windows for the panel", async () => {
@@ -89,7 +95,7 @@ test("a store parses per-account session/weekly limit windows for the panel", as
   const store = createEngineAccountsStore("claude", { fetcher });
   const unsub = store.subscribe(() => {});
   await advance();
-  expect(store.accounts[0]?.limits).toEqual({ freshness: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000, windowMinutes: null }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000, windowMinutes: null } });
+  expect(store.accounts[0]?.limits).toEqual({ freshness: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000, windowMinutes: null }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000, windowMinutes: null }, checkedAt: null });
   expect(store.accounts[1]?.limits).toBeNull();
   unsub();
 });

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -106,6 +106,8 @@ export type AccountLimits = {
   freshness: "fresh" | "stale";
   session: AccountLimitWindow | null;
   weekly: AccountLimitWindow | null;
+  /** ISO timestamp of the read these numbers come from, when the route sent one. */
+  checkedAt?: string | null;
 };
 
 export type AccountAuthHealth = "authenticated" | "signed_out" | "unknown" | "error";
@@ -151,7 +153,8 @@ export function parseAccountLimits(raw: unknown): AccountLimits | null {
   const session = parseLimitWindow(record.session);
   const weekly = parseLimitWindow(record.weekly);
   if (!session && !weekly) return null;
-  return { freshness, session, weekly };
+  const checkedAt = typeof record.checkedAt === "string" && Number.isFinite(Date.parse(record.checkedAt)) ? record.checkedAt : null;
+  return { freshness, session, weekly, checkedAt };
 }
 export type AccountLoadState = "loading" | "ready" | "error";
 export type AccountOperation = "refresh" | "add" | "switch" | "login" | "remove" | "terminal";

--- a/src/lib/accounts/claudeLogin.ts
+++ b/src/lib/accounts/claudeLogin.ts
@@ -57,7 +57,9 @@ export interface ClaudeLoginPorts {
   pidStartToken(pid: number): string | null;
   isExpectedClaude(pid: number): boolean;
   waitForExit(pid: number, startToken: string): Promise<void>;
-  status(home: string): Promise<{ loggedIn: boolean; method: string | null; email: string | null; plan: string | null }>;
+  /** `indeterminate` marks a status read that failed to observe the account
+      (timeout, spawn failure, bad output) — distinct from a live sign-out. */
+  status(home: string): Promise<{ loggedIn: boolean; method: string | null; email: string | null; plan: string | null; indeterminate?: boolean }>;
   now(): number;
   setTimeout(callback: () => void, ms: number): NodeJS.Timeout;
   clearTimeout(timer: NodeJS.Timeout): void;
@@ -104,20 +106,23 @@ export function claudeStatusEnvironment(home: string): NodeJS.ProcessEnv {
   return isSupervisedClaudeHome(home) ? claudeManagedEnvironment(home) : withoutWakatimeCredential(process.env);
 }
 
-async function structuredStatus(home: string): Promise<{ loggedIn: boolean; method: string | null; email: string | null; plan: string | null }> {
+async function structuredStatus(home: string): Promise<{ loggedIn: boolean; method: string | null; email: string | null; plan: string | null; indeterminate?: boolean }> {
   return await new Promise((resolve) => {
     const child = spawn(resolveBinary("claude"), ["auth", "status", "--json"], { env: claudeStatusEnvironment(home), stdio: ["ignore", "pipe", "ignore"], detached: false });
     let text = "";
     child.stdout?.on("data", (part: Buffer) => { if (text.length < OUTPUT_LIMIT) text += part.toString("utf8"); });
-    const timer = setTimeout(() => { child.kill("SIGKILL"); resolve({ loggedIn: false, method: null, email: null, plan: null }); }, 5_000);
+    /* Timeout, spawn failure, and unparseable output say nothing about the
+       account — `indeterminate` lets callers keep the previous auth reading
+       instead of painting a live sign-out they never observed. */
+    const timer = setTimeout(() => { child.kill("SIGKILL"); resolve({ loggedIn: false, method: null, email: null, plan: null, indeterminate: true }); }, 5_000);
     child.once("close", () => {
       clearTimeout(timer);
       try {
         const raw = JSON.parse(text) as Record<string, unknown>;
         resolve({ loggedIn: raw.loggedIn === true, method: typeof raw.authMethod === "string" ? raw.authMethod : null, email: typeof raw.email === "string" ? raw.email : null, plan: typeof raw.subscriptionType === "string" ? raw.subscriptionType : null });
-      } catch { resolve({ loggedIn: false, method: null, email: null, plan: null }); }
+      } catch { resolve({ loggedIn: false, method: null, email: null, plan: null, indeterminate: true }); }
     });
-    child.once("error", () => { clearTimeout(timer); resolve({ loggedIn: false, method: null, email: null, plan: null }); });
+    child.once("error", () => { clearTimeout(timer); resolve({ loggedIn: false, method: null, email: null, plan: null, indeterminate: true }); });
   });
 }
 

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -44,9 +44,17 @@ export async function reconcileAccountMigrationCycle(
 ): Promise<void> {
   registry.compactDeliveryReservations();
   await yieldToRuntime();
-  await reconcileMigrations(provider, delivery, registry);
-  await yieldToRuntime();
-  await Promise.all([quota.tick("claude"), quota.tick("codex")]);
+  /* Quota ticks run alongside migration reconciliation, not after it: a slow
+     or stuck migration pass (lock contention, wedged provider) must never
+     leave the account panel without fresh limits readings. Migration
+     decisions already consume the previous tick's durable observations, so
+     ordering between the two is immaterial. */
+  const quotaTicks = Promise.all([quota.tick("claude"), quota.tick("codex")]);
+  try {
+    await reconcileMigrations(provider, delivery, registry);
+  } finally {
+    await quotaTicks;
+  }
 }
 
 export function syncCompatibilityRouting(registry: AgentRegistry): void {

--- a/src/lib/accounts/migration/quotaController.test.ts
+++ b/src/lib/accounts/migration/quotaController.test.ts
@@ -38,7 +38,7 @@ test("quota visibility remains fresh when automatic balancing is disabled", asyn
         };
       },
     };
-    const controller = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000000", () => current);
+    const controller = new QuotaController(registry, probe, "boot-visibility-test", () => current);
 
     registry.setAutoBalancePolicy("codex", false);
     await controller.tick("codex");
@@ -83,7 +83,7 @@ test("a failed probe keeps the last known limits instead of blanking them", asyn
           observedAt: now,
         };
       },
-    }, "00000000-0000-4000-8000-000000000041", () => current);
+    }, "boot-carry-forward-test", () => current);
     await controller.tick("codex");
     const firstObservedAt = registry.snapshot().quotaObservations.codex.default!.observedAt;
     fail = true;
@@ -123,7 +123,7 @@ test("a hung probe times out without delaying or blanking the other accounts", a
           observedAt: now,
         };
       },
-    }, "00000000-0000-4000-8000-000000000042", () => Date.parse("2026-07-10T12:00:00.000Z"), 50);
+    }, "boot-hung-probe-test", () => Date.parse("2026-07-10T12:00:00.000Z"), 50);
     await controller.tick("codex");
     expect(registry.snapshot().quotaObservations.codex.default?.provenance).toMatchObject({ source: "unavailable", reason: "quota-probe-timeout" });
     expect(registry.snapshot().quotaObservations.codex.managed?.limits?.session?.usedPercent).toBe(40);
@@ -166,7 +166,7 @@ test("a live sign-out answer replaces the cached limits instead of hiding behind
           observedAt: now,
         };
       },
-    }, "00000000-0000-4000-8000-000000000043", () => current);
+    }, "boot-signout-test", () => current);
     await controller.tick("codex");
     signedOut = true;
     current += 120_000;
@@ -205,7 +205,7 @@ test("a failed home records a closed code while the controller sweeps later home
           observedAt: now,
         };
       },
-    }, "00000000-0000-4000-8000-000000000040", () => Date.parse("2026-07-10T12:00:00.000Z"));
+    }, "boot-sweep-test", () => Date.parse("2026-07-10T12:00:00.000Z"));
     await controller.tick("codex");
     expect(visited.sort()).toEqual(["default", "managed"]);
     expect(registry.snapshot().quotaObservations.codex.default?.provenance.reason).toBe("quota-probe-failed");

--- a/src/lib/accounts/migration/quotaController.test.ts
+++ b/src/lib/accounts/migration/quotaController.test.ts
@@ -59,6 +59,127 @@ test("quota visibility remains fresh when automatic balancing is disabled", asyn
   }
 });
 
+test("a failed probe keeps the last known limits instead of blanking them", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-carry-"));
+  try {
+    const registry = new AgentRegistry(path.join(root, "registry.json"));
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+    ];
+    let current = Date.parse("2026-07-10T12:00:00.000Z");
+    let fail = false;
+    const controller = new QuotaController(registry, {
+      list: () => accounts,
+      active: () => "default",
+      async probe(engine, account, now) {
+        if (fail) throw new Error("provider down");
+        return {
+          engine,
+          accountId: account.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: { session: { usedPercent: 30, resetsAt: null }, weekly: null, plan: "pro", capturedAt: Math.floor(now / 1000) },
+          provenance: { source: "live" as const, reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
+    }, "00000000-0000-4000-8000-000000000041", () => current);
+    await controller.tick("codex");
+    const firstObservedAt = registry.snapshot().quotaObservations.codex.default!.observedAt;
+    fail = true;
+    current += 120_000;
+    await controller.tick("codex");
+    const carried = registry.snapshot().quotaObservations.codex.default!;
+    expect(carried.limits?.session?.usedPercent).toBe(30);
+    expect(carried.authenticated).toBeTrue();
+    expect(carried.provenance).toMatchObject({ source: "cache", reason: "quota-probe-failed" });
+    expect(carried.provenance.staleSince).toBe(firstObservedAt);
+    expect(carried.observedAt).toBe(firstObservedAt);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a hung probe times out without delaying or blanking the other accounts", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-hang-"));
+  try {
+    const registry = new AgentRegistry(path.join(root, "registry.json"));
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+      { id: "managed", label: "Managed", kind: "managed", home: "/homes/managed", sessionsDir: "/homes/managed/sessions", authPresent: true, loginPane: null, createdAt: 1 },
+    ];
+    const controller = new QuotaController(registry, {
+      list: () => accounts,
+      active: () => "default",
+      async probe(engine, account, now) {
+        if (account.id === "default") return await new Promise<never>(() => { /* wedged provider */ });
+        return {
+          engine,
+          accountId: account.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: { session: { usedPercent: 40, resetsAt: null }, weekly: null, plan: "pro", capturedAt: Math.floor(now / 1000) },
+          provenance: { source: "live" as const, reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
+    }, "00000000-0000-4000-8000-000000000042", () => Date.parse("2026-07-10T12:00:00.000Z"), 50);
+    await controller.tick("codex");
+    expect(registry.snapshot().quotaObservations.codex.default?.provenance).toMatchObject({ source: "unavailable", reason: "quota-probe-timeout" });
+    expect(registry.snapshot().quotaObservations.codex.managed?.limits?.session?.usedPercent).toBe(40);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a live sign-out answer replaces the cached limits instead of hiding behind them", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-signout-"));
+  try {
+    const registry = new AgentRegistry(path.join(root, "registry.json"));
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+    ];
+    let current = Date.parse("2026-07-10T12:00:00.000Z");
+    let signedOut = false;
+    const controller = new QuotaController(registry, {
+      list: () => accounts,
+      active: () => "default",
+      async probe(engine, account, now) {
+        if (signedOut) {
+          return {
+            engine,
+            accountId: account.id,
+            authenticated: false,
+            authCheckedAt: now,
+            limits: null,
+            provenance: { source: "live" as const, reason: null, staleSince: null },
+            observedAt: now,
+          };
+        }
+        return {
+          engine,
+          accountId: account.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: { session: { usedPercent: 25, resetsAt: null }, weekly: null, plan: "pro", capturedAt: Math.floor(now / 1000) },
+          provenance: { source: "live" as const, reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
+    }, "00000000-0000-4000-8000-000000000043", () => current);
+    await controller.tick("codex");
+    signedOut = true;
+    current += 120_000;
+    await controller.tick("codex");
+    const observation = registry.snapshot().quotaObservations.codex.default!;
+    expect(observation.authenticated).toBeFalse();
+    expect(observation.limits).toBeNull();
+    expect(observation.provenance.source).toBe("live");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a failed home records a closed code while the controller sweeps later homes", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-sweep-"));
   try {

--- a/src/lib/accounts/migration/quotaController.ts
+++ b/src/lib/accounts/migration/quotaController.ts
@@ -24,7 +24,11 @@ const productionProbe: QuotaProbePort = {
   async probe(engine, account, now) {
     if (engine === "claude") {
       const candidate = account as ClaudeAccount;
-      const auth = await realClaudeLoginPorts.status(candidate.home).catch(() => ({ loggedIn: false }));
+      const auth = await realClaudeLoginPorts.status(candidate.home).catch(() => ({ loggedIn: false, indeterminate: true }));
+      /* An indeterminate status read observed nothing about the account —
+         throwing routes it to the carry-forward path instead of recording a
+         sign-out that never happened. */
+      if (auth.indeterminate) throw new Error("quota-auth-indeterminate");
       const limits = auth.loggedIn
         ? await fetchClaudeLimits(path.join(candidate.home, ".credentials.json"))
         : { data: null, source: "unavailable" as const, reason: "live authentication check failed" };
@@ -55,6 +59,9 @@ const productionProbe: QuotaProbePort = {
       // The reader owns redacted server-local detail and returns a closed code
       // suitable for the durable quota registry.
       const limits = await readCodexLimits({ account: candidate, liveReader: async () => Promise.reject(error) });
+      /* An empty transcript fallback after a failed live probe observed
+         nothing — rethrow so the controller keeps the last known reading. */
+      if (!limits.data) throw error;
       return {
         engine,
         accountId: candidate.id,
@@ -69,17 +76,16 @@ const productionProbe: QuotaProbePort = {
   },
 };
 
-async function mapLimit<T, R>(values: T[], limit: number, visit: (value: T) => Promise<R>): Promise<R[]> {
-  const output = new Array<R>(values.length);
-  let cursor = 0;
-  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, async () => {
-    for (;;) {
-      const index = cursor++;
-      if (index >= values.length) return;
-      output[index] = await visit(values[index]!);
-    }
-  }));
-  return output;
+/* One hung provider (e.g. a wedged Codex app-server) must not delay or blank
+   the other accounts' readings: every account is probed concurrently and a
+   probe that outlives this deadline is treated as failed for this tick. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+function probeTimeout(timeoutMs: number): Promise<never> {
+  return new Promise((_, reject) => {
+    const timer = setTimeout(() => reject(new Error("quota-probe-timeout")), timeoutMs);
+    timer.unref?.();
+  });
 }
 
 export class QuotaController {
@@ -88,27 +94,63 @@ export class QuotaController {
     private readonly probe: QuotaProbePort = productionProbe,
     private readonly bootId = crypto.randomUUID(),
     private readonly now: () => number = () => Date.now(),
+    private readonly probeTimeoutMs: number = PROBE_TIMEOUT_MS,
   ) {}
+
+  /* A failed probe must not erase the last successful reading — the panel
+     always shows the most recent known limits plus when they were observed.
+     The carried observation keeps the previous limits and timestamps and is
+     marked as cache provenance, which keeps it ineligible for auto-balance
+     decisions (those require a fresh live observation). */
+  private carryForward(engine: MigrationEngine, accountId: string, reason: string, now: number): QuotaObservation {
+    const previous = this.registry.readOnlySnapshot().quotaObservations[engine][accountId];
+    if (previous?.limits) {
+      return {
+        engine,
+        accountId,
+        authenticated: previous.authenticated,
+        authCheckedAt: Date.parse(previous.authCheckedAt) || now,
+        limits: previous.limits,
+        provenance: {
+          source: "cache",
+          reason,
+          staleSince: previous.provenance.staleSince ?? previous.observedAt,
+        },
+        observedAt: Date.parse(previous.observedAt) || now,
+        envelope: null,
+      };
+    }
+    return {
+      engine,
+      accountId,
+      authenticated: false,
+      authCheckedAt: now,
+      limits: null,
+      provenance: { source: "unavailable", reason, staleSince: null },
+      observedAt: now,
+      envelope: null,
+    };
+  }
 
   async tick(engine: MigrationEngine): Promise<void> {
     const now = this.now();
     const accounts = this.probe.list(engine);
-    const observations = await mapLimit(accounts, 2, async (account) => {
+    const observations = await Promise.all(accounts.map(async (account) => {
       try {
-        return await this.probe.probe(engine, account, now);
-      } catch {
-        return {
-          engine,
-          accountId: account.id,
-          authenticated: false,
-          authCheckedAt: now,
-          limits: null,
-          provenance: { source: "unavailable" as const, reason: "quota-probe-failed", staleSince: null },
-          observedAt: now,
-          envelope: null,
-        };
+        const observation = await Promise.race([this.probe.probe(engine, account, now), probeTimeout(this.probeTimeoutMs)]);
+        /* An authenticated account whose limits fetch came back empty-handed
+           (rate-limited, provider hiccup) keeps its last known numbers. A live
+           `authenticated: false` answer is a real state change — sign-out must
+           surface, so it records as returned. */
+        if (observation.authenticated && !observation.limits) {
+          return this.carryForward(engine, account.id, observation.provenance.reason ?? "quota-probe-empty", now);
+        }
+        return observation;
+      } catch (error) {
+        const reason = error instanceof Error && error.message === "quota-probe-timeout" ? "quota-probe-timeout" : "quota-probe-failed";
+        return this.carryForward(engine, account.id, reason, now);
       }
-    });
+    }));
     observations.forEach((observation, index) => {
       const account = accounts[index]!;
       logQuotaEvent({

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -191,6 +191,7 @@ export const en = {
   "accounts.effectiveTip": "{window} binds",
   "accounts.effectiveStale": "{window} binds · stale",
   "accounts.limitsAria": "Quota windows for {label}",
+  "accounts.limitsChecked": "Checked",
   "accounts.limitsStale": "Last known values",
   "accounts.limitsStaleTip": "Last known values — not a live read",
   // Claude sign-in slice (#61)

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -185,6 +185,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.effectiveTip": "{window} обмежує",
   "accounts.effectiveStale": "{window} обмежує · застаріло",
   "accounts.limitsAria": "Вікна лімітів для {label}",
+  "accounts.limitsChecked": "Перевірено",
   "accounts.limitsStale": "Останні відомі значення",
   "accounts.limitsStaleTip": "Останні відомі значення — не наживо",
   // Claude sign-in slice (#61)


### PR DESCRIPTION
## Problem

The account panel could show "auth unchecked" / no limit bars for accounts that were fine:

1. Quota probes ran with concurrency 2 and no deadline — one wedged provider (e.g. a hung Codex app-server) delayed or stalled everyone's readings.
2. A failed probe recorded `limits: null` over the last good durable observation, erasing the numbers the panel had.
3. A `claude auth status` timeout/spawn failure resolved as `loggedIn: false` — indistinguishable from a live sign-out, so infra hiccups painted accounts as signed out.
4. Quota ticks ran *after* migration reconciliation in the same cycle, so a stuck migration pass (as in the recent lock outage) starved limits freshness entirely.

## Fix

- Full concurrent fan-out over accounts with a 15s per-probe deadline (injectable for tests).
- Carry-forward: a failed/timed-out/empty probe preserves the last known observation as `cache` provenance with `staleSince`, keeping it visible in the panel but ineligible for auto-balance (which requires fresh live reads). A genuine live `authenticated: false` answer still records as a sign-out.
- `claude auth status` port now reports `indeterminate` reads (timeout, spawn failure, bad output) separately from sign-outs; indeterminate routes to carry-forward.
- Empty Codex transcript fallback after a failed live probe rethrows instead of recording a blank observation.
- Quota ticks run alongside migration reconciliation, so migration stalls can't blank the panel.
- The panel always shows when the numbers were last observed — fresh reads render "Checked · HH:MM", stale reads "Last known values · HH:MM".

## Tests

- failed probe keeps last known limits (cache provenance, staleSince, preserved observedAt)
- hung probe times out without delaying or blanking other accounts
- live sign-out replaces cached limits instead of hiding behind them
- checkedAt survives the client projection; garbage timestamps degrade to null
- existing quota/controller/login/panel suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)