### PR TITLE
feat(accounts): registry-first transcript ownership (#891 phase 0)

### DIFF
--- a/src/app/api/attach-command/route.ts
+++ b/src/app/api/attach-command/route.ts
@@ -15,6 +15,16 @@ import type { FileEntry, ApiError } from "@/lib/types";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/* Registry-first ownership (issue #891, phase 0): the durable generation or
+   receipt record names the owning account; the path-layout regex remains only
+   as recovery for artifacts the registry never saw. */
+function registryFirstAccountIdForPath(pathname: string): string {
+  const registry = agentRegistry();
+  return registry.transcriptAccountId("claude", pathname)
+    ?? registry.transcriptAccountId("codex", pathname)
+    ?? accountIdFromPath(pathname);
+}
+
 /** Best-effort account id → human label; falls back to the id itself. */
 function accountLabelFor(engine: AgentEngine, accountId: string): string {
   try {
@@ -83,7 +93,7 @@ function resolveLaunchPath(launchId: string, files: FileEntry[]): NextResponse<A
     resolveByPath: (target) => resolveAttachCommand(target, {
       files,
       resumeSpecFor,
-      accountIdForPath: accountIdFromPath,
+      accountIdForPath: registryFirstAccountIdForPath,
       accountLabelFor,
       launchProfileForPath: (p) => registry.launchProfileForPath(p),
     }),
@@ -149,7 +159,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<AttachCommand 
     const resolution = resolveAttachCommand(path, {
       files,
       resumeSpecFor,
-      accountIdForPath: accountIdFromPath,
+      accountIdForPath: registryFirstAccountIdForPath,
       accountLabelFor,
       launchProfileForPath: (p) => agentRegistry().launchProfileForPath(p),
     });

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -121,6 +121,20 @@ export const accountManager: AccountManager = {
       : selected;
   },
   resolveTranscriptOwner(engine, transcript) {
+    /* Registry first (issue #891, phase 0): the durable generation record
+       names the owning account directly. Path-layout derivation below stays
+       as recovery for artifacts the registry never saw — it collapses once
+       transcript roots stop being account-scoped. */
+    const recorded = agentRegistry().transcriptAccountId(engine, transcript);
+    if (recorded) {
+      if (engine === "claude") {
+        const item = listClaudeAccounts().find((candidate) => candidate.id === recorded);
+        if (item) return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(item.home) : withoutWakatimeCredential(process.env) };
+      } else {
+        const item = listCodexAccounts().find((candidate) => candidate.id === recorded);
+        if (item) return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.sessionsDir, env: { ...withoutWakatimeCredential(process.env), CODEX_HOME: item.home } };
+      }
+    }
     if (engine === "claude") { const home = claudeHomeOwningTranscript(transcript); if (!home) return null; const item = listClaudeAccounts().find((candidate) => candidate.home === home); return item ? { engine, accountId: item.id, kind: item.kind, home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(home) : withoutWakatimeCredential(process.env) } : null; }
     const home = codexHomeOwningSessionPath(transcript); if (!home) return null; const item = listCodexAccounts().find((candidate) => candidate.home === home); return item ? { engine, accountId: item.id, kind: item.kind, home, transcriptRoot: item.sessionsDir, env: { ...withoutWakatimeCredential(process.env), CODEX_HOME: home } } : null;
   },

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -3736,3 +3736,20 @@ describe("account migration retry identity (#708)", () => {
     expect(retried.migration!.operationId).toBe(operationId);
   });
 });
+
+describe("transcript ownership (issue #891 phase 0)", () => {
+  test("transcriptAccountId reads durable ownership for a settled spawn artifact", () => {
+    const store = registry();
+    const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: "terra" });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const entry = spawnEntry("/sessions/rollout-terra-session.jsonl", null as unknown as string);
+    store.completeObservedSpawn(begun.receipt.launchId, entry);
+
+    expect(store.transcriptAccountId("codex", entry.artifactPath)).toBe("terra");
+    // Engine scoping: the same path under the other engine names nobody.
+    expect(store.transcriptAccountId("claude", entry.artifactPath)).toBeNull();
+    // Unregistered artifacts stay unresolved — path-layout recovery in the
+    // account manager remains the only signal for those.
+    expect(store.transcriptAccountId("codex", "/sessions/rollout-unseen.jsonl")).toBeNull();
+  });
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5086,6 +5086,25 @@ export class AgentRegistry {
     return receipt ? clone(receipt.launchProfile) : null;
   }
 
+  /** Durable account ownership for a transcript path (issue #891, phase 0).
+      The generation record is the source of truth for which account owns a
+      conversation; deriving the account from the path layout stays in the
+      account manager only as recovery for artifacts the registry never saw. */
+  transcriptAccountId(engine: Extract<AgentEngine, "claude" | "codex">, artifactPath: string): string | null {
+    const snapshot = this.readOnlySnapshot();
+    for (const conversation of Object.values(snapshot.conversations)) {
+      if (conversation.engine !== engine) continue;
+      const generation = conversation.generations.find((item) => item.path === artifactPath);
+      if (generation?.accountId) return generation.accountId;
+      if (conversation.continuityPaths.includes(artifactPath)) {
+        const current = conversation.generations.at(-1);
+        if (current?.accountId) return current.accountId;
+      }
+    }
+    const receipt = Object.values(snapshot.receipts).find((item) => item.artifactPath === artifactPath && item.engine === engine);
+    return receipt?.accountId ?? null;
+  }
+
   updateConversationLaunchProfile(
     id: ViewerConversationId,
     patch: Pick<LaunchProfile, "model" | "effort" | "fast">,


### PR DESCRIPTION
Phase 0 of #891 (shared transcript store): stop trusting the path layout for account ownership.

- New `AgentRegistry.transcriptAccountId(engine, path)` — durable ownership lookup mirroring `launchProfileForPath` (generations → continuity paths → spawn receipts), engine-scoped.
- `resolveTranscriptOwner` consults the registry record first; path-layout derivation (`claudeHomeOwningTranscript` / `codexHomeOwningSessionPath`) remains only as recovery for artifacts the registry never saw.
- attach-command account resolution goes registry-first with the same fallback.

Why: every generation and spawn receipt already records its `accountId`; the path regex is a weaker duplicate that silently returns the first-listed account once transcript roots share a realpath (see the #891 research — the "semantic breaker"). With ownership decoupled from the path, per-account transcript roots become droppable in phase 1.

Tests: new registry ownership case (settled spawn artifact resolves to its requested account; engine-scoped; unregistered paths stay unresolved). attachCommand / migration controller / coordinator suites pass; `manager.interprocess` matrix failure is the known pre-existing standalone flake (fails identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)