### PR TITLE
fix(accounts): widen quota controller bootId to string

### DIFF
--- a/src/lib/accounts/migration/quotaController.ts
+++ b/src/lib/accounts/migration/quotaController.ts
@@ -92,7 +92,7 @@ export class QuotaController {
   constructor(
     private readonly registry: AgentRegistry = agentRegistry(),
     private readonly probe: QuotaProbePort = productionProbe,
-    private readonly bootId = crypto.randomUUID(),
+    private readonly bootId: string = crypto.randomUUID(),
     private readonly now: () => number = () => Date.now(),
     private readonly probeTimeoutMs: number = PROBE_TIMEOUT_MS,
   ) {}


### PR DESCRIPTION
One-liner follow-up to #890: the `bootId` constructor parameter inherited the template-literal type of its `crypto.randomUUID()` default, so `tsc --noEmit` rejects the non-UUID boot ids the tests pass (they avoid UUID shapes for the privacy gate). The boot id is an opaque token — type it as `string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)