### PR TITLE
feat(accounts): shared Claude transcript store + unclipped account menu (#891 phase 1)

### DIFF
--- a/scripts/cutover-shared-claude-projects.test.ts
+++ b/scripts/cutover-shared-claude-projects.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-cutover-test-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+const OLD_HOME = process.env.LLV_CLAUDE_HOME;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
+
+const { mergeRoot, rewriteStateFiles, scanRoot, transcriptRoots } = await import("./cutover-shared-claude-projects");
+const { sharedClaudeProjectsRoot } = await import("../src/lib/accounts/claude");
+
+afterAll(() => {
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE;
+  if (OLD_HOME === undefined) delete process.env.LLV_CLAUDE_HOME; else process.env.LLV_CLAUDE_HOME = OLD_HOME;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function seedRoot(root: string, project: string, file: string, content: string): string {
+  const dir = path.join(root, project);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const transcript = path.join(dir, file);
+  fs.writeFileSync(transcript, content, { mode: 0o600 });
+  return transcript;
+}
+
+test("cutover merges disjoint roots, symlinks them, and rewrites state paths", () => {
+  const legacyRoot = path.join(process.env.LLV_CLAUDE_HOME!, "projects");
+  const managedRoot = path.join(SANDBOX, "accounts", "claude", "work", "projects");
+  seedRoot(legacyRoot, "-repo-a", "one.jsonl", "legacy\n");
+  seedRoot(managedRoot, "-repo-a", "two.jsonl", "managed\n");
+  seedRoot(managedRoot, "-repo-b", "three.jsonl", "managed-b\n");
+
+  const roots = transcriptRoots();
+  expect(roots.sort()).toEqual([legacyRoot, managedRoot].sort());
+
+  const seen = new Map<string, string>();
+  const collisions = roots.flatMap((root) => scanRoot(root, seen).collisions);
+  expect(collisions).toEqual([]);
+
+  const stateFile = path.join(process.env.LLV_STATE_DIR!, "agent-registry.json");
+  fs.mkdirSync(process.env.LLV_STATE_DIR!, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(stateFile, JSON.stringify({ path: path.join(managedRoot, "-repo-a", "two.jsonl") }), { mode: 0o600 });
+
+  const shared = sharedClaudeProjectsRoot();
+  fs.mkdirSync(shared, { recursive: true, mode: 0o700 });
+  for (const root of roots) mergeRoot(root, shared);
+  const rewrites = rewriteStateFiles(roots, shared, true);
+
+  // Both roots are now symlinks to the shared store.
+  for (const root of roots) {
+    expect(fs.lstatSync(root).isSymbolicLink()).toBeTrue();
+    expect(fs.realpathSync(root)).toBe(fs.realpathSync(shared));
+  }
+  // Every transcript arrived, same-named projects merged without loss.
+  expect(fs.readFileSync(path.join(shared, "-repo-a", "one.jsonl"), "utf8")).toBe("legacy\n");
+  expect(fs.readFileSync(path.join(shared, "-repo-a", "two.jsonl"), "utf8")).toBe("managed\n");
+  expect(fs.readFileSync(path.join(shared, "-repo-b", "three.jsonl"), "utf8")).toBe("managed-b\n");
+  // Old absolute paths still resolve through the symlink.
+  expect(fs.readFileSync(path.join(managedRoot, "-repo-b", "three.jsonl"), "utf8")).toBe("managed-b\n");
+  // State file now carries the canonical prefix.
+  expect(rewrites).toEqual([{ file: stateFile, replaced: 1 }]);
+  expect(JSON.parse(fs.readFileSync(stateFile, "utf8")).path).toBe(path.join(shared, "-repo-a", "two.jsonl"));
+});
+
+test("a collision aborts the plan before anything moves", () => {
+  const rootA = path.join(SANDBOX, "collide", "a", "projects");
+  const rootB = path.join(SANDBOX, "collide", "b", "projects");
+  seedRoot(rootA, "-repo", "same.jsonl", "a\n");
+  seedRoot(rootB, "-repo", "same.jsonl", "b\n");
+  const seen = new Map<string, string>();
+  const collisions = [rootA, rootB].flatMap((root) => scanRoot(root, seen).collisions);
+  expect(collisions).toHaveLength(1);
+  expect(collisions[0]).toContain(path.join("-repo", "same.jsonl"));
+});

--- a/scripts/cutover-shared-claude-projects.ts
+++ b/scripts/cutover-shared-claude-projects.ts
@@ -1,0 +1,172 @@
+/**
+ * One-time cutover to the shared Claude transcript store (issue #891 phase 1).
+ *
+ * Merges every Claude transcript root (legacy home, live managed accounts,
+ * retained retired-account archives) into the viewer-owned shared root and
+ * replaces each source `projects` directory with a symlink to it. Absolute
+ * transcript paths inside the durable state files are rewritten to the
+ * canonical shared prefix so registry/board/continuity identities keep
+ * matching what the scanner emits afterwards.
+ *
+ * Dry-run by default — prints the full plan and exits. `--execute` performs
+ * the cutover. Execution refuses to proceed while viewer containers are
+ * running (state files are rewritten) unless `--allow-live` is passed.
+ * Old paths keep resolving through the symlinks, so nothing that recorded a
+ * pre-cutover absolute path breaks even if it is missed by the rewrite.
+ */
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { legacyClaudeHome, claudeAccountsRoot, sharedClaudeProjectsRoot } from "../src/lib/accounts/claude";
+import { stateDir } from "../src/lib/configDir";
+
+const EXECUTE = process.argv.includes("--execute");
+const ALLOW_LIVE = process.argv.includes("--allow-live");
+
+export function transcriptRoots(): string[] {
+  const roots: string[] = [];
+  const legacy = path.join(legacyClaudeHome(), "projects");
+  if (fs.existsSync(legacy)) roots.push(legacy);
+  const accounts = claudeAccountsRoot();
+  if (fs.existsSync(accounts)) {
+    for (const entry of fs.readdirSync(accounts)) {
+      const candidate = path.join(accounts, entry, "projects");
+      if (fs.existsSync(candidate)) roots.push(candidate);
+    }
+  }
+  return roots.filter((root) => {
+    const stat = fs.lstatSync(root);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  });
+}
+
+type Plan = { root: string; files: number; bytes: number };
+
+export function scanRoot(root: string, seen: Map<string, string>): { plan: Plan; collisions: string[] } {
+  let files = 0; let bytes = 0; const collisions: string[] = [];
+  for (const project of fs.readdirSync(root)) {
+    const projectDir = path.join(root, project);
+    if (!fs.lstatSync(projectDir).isDirectory()) continue;
+    for (const file of fs.readdirSync(projectDir)) {
+      const relative = path.join(project, file);
+      const holder = seen.get(relative);
+      if (holder) collisions.push(`${relative}: ${holder} vs ${root}`);
+      else seen.set(relative, root);
+      files += 1;
+      try { bytes += fs.statSync(path.join(projectDir, file)).size; } catch { /* raced away */ }
+    }
+  }
+  return { plan: { root, files, bytes }, collisions };
+}
+
+function llvContainersRunning(): string[] {
+  try {
+    return execSync("docker ps --format {{.Names}}", { encoding: "utf8" })
+      .split("\n").filter((name) => name.startsWith("llv-"));
+  } catch { return []; }
+}
+
+export function mergeRoot(root: string, shared: string): void {
+  for (const project of fs.readdirSync(root)) {
+    const source = path.join(root, project);
+    if (!fs.lstatSync(source).isDirectory()) continue;
+    const target = path.join(shared, project);
+    if (!fs.existsSync(target)) { fs.renameSync(source, target); continue; }
+    for (const file of fs.readdirSync(source)) {
+      const destination = path.join(target, file);
+      if (fs.existsSync(destination)) throw new Error(`collision surfaced during merge: ${project}/${file}`);
+      fs.renameSync(path.join(source, file), destination);
+    }
+    fs.rmdirSync(source);
+  }
+  // Stray top-level files (none expected) stay behind in the retired dir.
+  const leftovers = fs.readdirSync(root);
+  const retired = `${root}.pre-shared-store`;
+  fs.renameSync(root, retired);
+  if (leftovers.length === 0) fs.rmdirSync(retired);
+  fs.symlinkSync(shared, root);
+}
+
+export function rewriteStateFiles(roots: string[], shared: string, write: boolean): Array<{ file: string; replaced: number }> {
+  const results: Array<{ file: string; replaced: number }> = [];
+  const state = stateDir();
+  if (!fs.existsSync(state)) return results;
+  for (const entry of fs.readdirSync(state)) {
+    if (!entry.endsWith(".json")) continue;
+    const file = path.join(state, entry);
+    if (!fs.lstatSync(file).isFile()) continue;
+    let text: string;
+    try { text = fs.readFileSync(file, "utf8"); } catch { continue; }
+    let replaced = 0;
+    for (const root of roots) {
+      const needle = root + path.sep;
+      const replacement = shared + path.sep;
+      const parts = text.split(needle);
+      replaced += parts.length - 1;
+      text = parts.join(replacement);
+    }
+    if (replaced > 0) {
+      if (write) {
+        const temporary = `${file}.cutover.tmp`;
+        fs.writeFileSync(temporary, text, { mode: 0o600 });
+        fs.renameSync(temporary, file);
+      }
+      results.push({ file, replaced });
+    }
+  }
+  return results;
+}
+
+function main(): void {
+  const shared = sharedClaudeProjectsRoot();
+  const roots = transcriptRoots().filter((root) => {
+    try { return fs.realpathSync(root) !== fs.realpathSync(shared); } catch { return true; }
+  });
+  if (roots.length === 0) { console.log("nothing to cut over — every root already points at the shared store"); return; }
+
+  const seen = new Map<string, string>();
+  const plans: Plan[] = []; const collisions: string[] = [];
+  for (const root of roots) {
+    const { plan, collisions: found } = scanRoot(root, seen);
+    plans.push(plan); collisions.push(...found);
+  }
+  console.log(`shared root: ${shared}`);
+  for (const plan of plans) console.log(`  ${plan.root}: ${plan.files} files, ${(plan.bytes / 1e6).toFixed(1)} MB`);
+  if (collisions.length > 0) {
+    console.error(`\nABORT: ${collisions.length} collision(s):`);
+    for (const line of collisions) console.error(`  ${line}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("collisions: 0");
+
+  const rewrites = rewriteStateFiles(roots, shared, false);
+  for (const { file, replaced } of rewrites) console.log(`  state rewrite: ${path.basename(file)} — ${replaced} path(s)`);
+
+  if (!EXECUTE) { console.log("\ndry-run only — pass --execute to perform the cutover"); return; }
+
+  const running = llvContainersRunning();
+  if (running.length > 0 && !ALLOW_LIVE) {
+    console.error(`ABORT: viewer containers running (${running.join(", ")}); stop them or pass --allow-live`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const backup = path.join(path.dirname(stateDir()), `state-backup-cutover-${Date.now()}`);
+  fs.mkdirSync(backup, { recursive: true, mode: 0o700 });
+  for (const entry of fs.readdirSync(stateDir())) {
+    if (entry.endsWith(".json")) {
+      try { fs.copyFileSync(path.join(stateDir(), entry), path.join(backup, entry)); } catch { /* transient lock artifacts */ }
+    }
+  }
+  console.log(`state backup: ${backup}`);
+
+  fs.mkdirSync(shared, { recursive: true, mode: 0o700 });
+  fs.chmodSync(shared, 0o700);
+  for (const root of roots) { mergeRoot(root, shared); console.log(`merged + symlinked: ${root}`); }
+  rewriteStateFiles(roots, shared, true);
+  console.log("cutover complete");
+}
+
+if (import.meta.main) main();

--- a/src/components/AccountBadge.dom.test.tsx
+++ b/src/components/AccountBadge.dom.test.tsx
@@ -92,7 +92,7 @@ test("the card account chip queues a conversation-scoped switch and disables sig
 
   const chip = host.querySelector("[data-conversation-account-chip]")!;
   await act(async () => { chip.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event); });
-  const menu = host.querySelector("[data-conversation-account-menu]")!;
+  const menu = document.querySelector("[data-conversation-account-menu]")!;
   const rows = [...menu.querySelectorAll('[role="menuitemradio"]')] as HTMLButtonElement[];
   expect(rows.map((row) => row.textContent?.trim())).toEqual(["Source", "Target", "Signed out"]);
   expect(rows[2]!.disabled).toBe(true);
@@ -124,7 +124,7 @@ test("a legacy account switch settles when scanner ownership reaches the target 
     host.querySelector<HTMLElement>("[data-conversation-account-chip]")!
       .dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
   });
-  const rows = [...host.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
+  const rows = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
   await act(async () => {
     rows[1]!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -147,7 +147,7 @@ test("a failed legacy account switch clears its pending badge and re-enables cho
     host.querySelector<HTMLElement>("[data-conversation-account-chip]")!
       .dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
   });
-  const rows = [...host.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
+  const rows = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
   await act(async () => {
     rows[1]!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -175,7 +175,7 @@ test("a failed legacy account switch clears its pending badge and re-enables cho
     host.querySelector<HTMLElement>("[data-conversation-account-chip]")!
       .dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
   });
-  const reopenedRows = [...host.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
+  const reopenedRows = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
   expect(reopenedRows[1]!.disabled).toBeFalse();
   await act(async () => root.unmount());
 });
@@ -195,7 +195,7 @@ test("an account switch carries the latest conversation runtime profile", async 
     host.querySelector<HTMLElement>("[data-conversation-account-chip]")!
       .dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
   });
-  const rows = [...host.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
+  const rows = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')];
   await act(async () => {
     rows[1]!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/components/AccountBadge.tsx
+++ b/src/components/AccountBadge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { Check, ChevronDown, Loader2 } from "@/components/icons";
 import { type AccountAuthHealth, useEngineAccounts } from "@/hooks/useEngineAccounts";
@@ -89,6 +90,11 @@ export function AccountBadge({
   const accounts = useEngineAccounts(engine);
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState(false);
+  /* The menu renders through a portal with fixed positioning: card headers
+     clip overflow, so an in-flow absolute menu was cut off and unreachable. */
+  const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null);
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const operationRef = useRef<string | null>(null);
   const targetAccountRef = useRef<string | null>(null);
   const migrationBaselineRef = useRef<string | null>(null);
@@ -126,6 +132,42 @@ export function AccountBadge({
     setPending(false);
     pushTaskToast("ok", t("accounts.conversationApplied"));
   }, [accountId, pending, t]);
+
+  /* Confirmation flows through runtime receipts and the migration projection —
+     both go silent when the conversation's host is dead (a session-limit stop,
+     a crashed pane). Without this escape a switch attempt on such a card left
+     `pending` stuck forever and every menu item disabled. */
+  useEffect(() => {
+    if (!pending) return;
+    const timer = window.setTimeout(() => {
+      operationRef.current = null;
+      targetAccountRef.current = null;
+      migrationBaselineRef.current = null;
+      setPending(false);
+      pushTaskToast("err", t("accounts.conversationUnconfirmed"));
+    }, 60_000);
+    return () => window.clearTimeout(timer);
+  }, [pending, t]);
+
+  /* Portal menu closes on any press outside the chip or the menu itself. */
+  useEffect(() => {
+    if (!open) return;
+    const onPress = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (anchorRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPress);
+    return () => document.removeEventListener("pointerdown", onPress);
+  }, [open]);
+
+  const toggleMenu = () => {
+    if (!open) {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      setMenuPosition(rect ? { top: rect.bottom + 4, right: Math.max(8, window.innerWidth - rect.right) } : { top: 8, right: 8 });
+    }
+    setOpen((value) => !value);
+  };
 
   useEffect(() => {
     const migration = file?.migration;
@@ -183,7 +225,7 @@ export function AccountBadge({
   const button = (
     <button
       type="button"
-      onClick={() => file ? setOpen((value) => !value) : requestAccountPanel(engine, accountId)}
+      onClick={() => file ? toggleMenu() : requestAccountPanel(engine, accountId)}
       aria-label={aria}
       aria-haspopup={file ? "menu" : undefined}
       aria-expanded={file ? open : undefined}
@@ -211,45 +253,51 @@ export function AccountBadge({
     </button>
   );
 
-  return (
-    <span className="relative inline-flex" onPointerDown={(event) => event.stopPropagation()}>
-      <Hint label={label}>{button}</Hint>
-      {open && file ? (
-        <div
-          role="menu"
-          data-conversation-account-menu
-          className="absolute right-0 top-full z-50 mt-1 min-w-52 rounded-surface border border-border bg-raised p-1.5 font-sans text-ui shadow-2"
-        >
-          <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted">
-            {t("accounts.conversationTitle")}
-          </div>
-          {accounts.accounts.map((account) => {
-            const available = account.authPresent && !account.loginPending;
-            return (
-              <button
-                key={account.id}
-                type="button"
-                role="menuitemradio"
-                aria-checked={account.id === accountId}
-                disabled={!available || pending}
-                onClick={() => void switchConversation(account.id)}
-                className="flex min-h-9 w-full items-center gap-2 rounded-control px-2 py-1.5 text-left hover:bg-sunken disabled:opacity-45"
-              >
-                <span className="min-w-0 flex-1 truncate">{account.label}</span>
-                {account.id === accountId ? <Check className="h-3.5 w-3.5 text-accent" aria-hidden /> : null}
-              </button>
-            );
-          })}
+  const menu = open && file && menuPosition ? createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      data-conversation-account-menu
+      onPointerDown={(event) => event.stopPropagation()}
+      style={{ top: menuPosition.top, right: menuPosition.right }}
+      className="fixed z-[95] min-w-52 rounded-surface border border-border bg-raised p-1.5 font-sans text-ui shadow-2"
+    >
+      <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted">
+        {t("accounts.conversationTitle")}
+      </div>
+      {accounts.accounts.map((account) => {
+        const available = account.authPresent && !account.loginPending;
+        return (
           <button
+            key={account.id}
             type="button"
-            role="menuitem"
-            onClick={() => { setOpen(false); requestAccountPanel(engine, accountId); }}
-            className="mt-1 w-full border-t border-border px-2 pt-2 text-left text-[11px] font-semibold text-accent"
+            role="menuitemradio"
+            aria-checked={account.id === accountId}
+            disabled={!available || pending}
+            onClick={() => void switchConversation(account.id)}
+            className="flex min-h-9 w-full items-center gap-2 rounded-control px-2 py-1.5 text-left hover:bg-sunken disabled:opacity-45"
           >
-            {t("accounts.manage")}
+            <span className="min-w-0 flex-1 truncate">{account.label}</span>
+            {account.id === accountId ? <Check className="h-3.5 w-3.5 text-accent" aria-hidden /> : null}
           </button>
-        </div>
-      ) : null}
+        );
+      })}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => { setOpen(false); requestAccountPanel(engine, accountId); }}
+        className="mt-1 w-full border-t border-border px-2 pt-2 text-left text-[11px] font-semibold text-accent"
+      >
+        {t("accounts.manage")}
+      </button>
+    </div>,
+    document.body,
+  ) : null;
+
+  return (
+    <span ref={anchorRef} className="relative inline-flex" onPointerDown={(event) => event.stopPropagation()}>
+      <Hint label={label}>{button}</Hint>
+      {menu}
       {pending ? <span className="sr-only" role="status">{t("accounts.conversationPending")}</span> : null}
     </span>
   );

--- a/src/lib/accounts/claude.test.ts
+++ b/src/lib/accounts/claude.test.ts
@@ -217,3 +217,36 @@ test("concurrent child processes create and select accounts without losing regis
   expect(await left.exited).toBe(0); expect(await right.exited).toBe(0);
   expect(["child-a", "child-b"]).toContain(mod.activeClaudeAccountId());
 });
+
+test("a home whose projects symlinks into the shared store reports the canonical root", () => {
+  const shared = mod.sharedClaudeProjectsRoot();
+  fs.mkdirSync(shared, { recursive: true, mode: 0o700 });
+  const home = process.env.LLV_CLAUDE_HOME!;
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  fs.symlinkSync(shared, path.join(home, "projects"));
+  try {
+    const main = mod.listClaudeAccounts()[0]!;
+    expect(main.projectsDir).toBe(shared);
+    // Inside the shared store the path names no owner: ownership is the
+    // registry's job (phase 0), so containment refuses to guess.
+    const project = path.join(shared, "-repo");
+    fs.mkdirSync(project, { recursive: true, mode: 0o700 });
+    const transcript = path.join(project, "session.jsonl");
+    fs.writeFileSync(transcript, "{}\n", { mode: 0o600 });
+    expect(mod.claudeHomeOwningTranscript(transcript)).toBeNull();
+  } finally {
+    fs.rmSync(path.join(SANDBOX, "shared"), { recursive: true, force: true });
+  }
+});
+
+test("a home with a real projects directory keeps its local root", () => {
+  const home = process.env.LLV_CLAUDE_HOME!;
+  const local = path.join(home, "projects");
+  fs.mkdirSync(local, { recursive: true, mode: 0o700 });
+  expect(mod.listClaudeAccounts()[0]!.projectsDir).toBe(local);
+  const project = path.join(local, "-repo");
+  fs.mkdirSync(project, { recursive: true, mode: 0o700 });
+  const transcript = path.join(project, "session.jsonl");
+  fs.writeFileSync(transcript, "{}\n", { mode: 0o600 });
+  expect(mod.claudeHomeOwningTranscript(transcript)).toBe(home);
+});

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -43,6 +43,26 @@ export function legacyClaudeHome(): string { return path.resolve(process.env.LLV
 export function claudeAccountsRoot(): string { return path.join(path.dirname(stateDir()), "accounts", "claude"); }
 export function claudeRegistryPath(): string { return statePath("claude-accounts.json"); }
 export function claudeCapabilitiesRoot(): string { return path.join(path.dirname(stateDir()), "shared", "claude"); }
+
+/* Shared transcript store (issue #891, phase 1). Transcripts are viewer data,
+   not credentials — the per-account layout was a side effect of per-account
+   CLI config homes, never an isolation requirement. When an account home's
+   `projects` is a symlink into this root, the account reports the canonical
+   shared path: every consumer (scanner, spawn specs, migration provider)
+   then addresses one store while the CLI keeps writing through its own
+   $CLAUDE_CONFIG_DIR/projects. Homes not yet cut over keep their local dir,
+   so the store can be adopted per account. */
+export function sharedClaudeProjectsRoot(): string { return path.join(claudeCapabilitiesRoot(), "projects"); }
+
+function projectsDirFor(home: string): string {
+  const local = path.join(home, "projects");
+  try {
+    if (!fs.lstatSync(local).isSymbolicLink()) return local;
+    const shared = sharedClaudeProjectsRoot();
+    if (fs.realpathSync(local) === fs.realpathSync(shared)) return shared;
+  } catch { /* unresolved link or missing dir: treat as not cut over */ }
+  return local;
+}
 function managedHome(id: string): string { return path.join(claudeAccountsRoot(), id); }
 function defaults(): Registry { return { version: VERSION, active: DEFAULT_ID, accounts: [], retired: [] }; }
 function key(file: string): string { try { const s = fs.statSync(file); return `${s.mtimeMs}:${s.size}`; } catch { return "missing"; } }
@@ -141,20 +161,29 @@ export function managedClaudeCredentialIsSafe(home: string, required = false): b
   try { const s = fs.lstatSync(file); return s.isFile() && !s.isSymbolicLink() && s.uid === (process.getuid?.() ?? s.uid) && (s.mode & 0o077) === 0; } catch { return !required; }
 }
 function credentialIsSafe(home: string): boolean { return managedClaudeCredentialIsSafe(home, true); }
-function account(stored: StoredAccount): ClaudeAccount { const home = managedHome(stored.id); return { ...stored, home, projectsDir: path.join(home, "projects"), authPresent: credentialIsSafe(home) }; }
-function main(): ClaudeAccount { const home = legacyClaudeHome(); return { id: DEFAULT_ID, label: "Main", kind: "legacy", home, projectsDir: path.join(home, "projects"), authPresent: credentialIsSafe(home), createdAt: 0 }; }
+function account(stored: StoredAccount): ClaudeAccount { const home = managedHome(stored.id); return { ...stored, home, projectsDir: projectsDirFor(home), authPresent: credentialIsSafe(home) }; }
+function main(): ClaudeAccount { const home = legacyClaudeHome(); return { id: DEFAULT_ID, label: "Main", kind: "legacy", home, projectsDir: projectsDirFor(home), authPresent: credentialIsSafe(home), createdAt: 0 }; }
 export function listClaudeAccounts(): ClaudeAccount[] { return [main(), ...readRegistry().registry.accounts.map(account)]; }
 export function activeClaudeAccountId(): string { const active = readRegistry().registry.active; return listClaudeAccounts().some((item) => item.id === active) ? active : DEFAULT_ID; }
 export function claudeAccountsMutationLocked(): boolean { return readRegistry().corrupt; }
 export function claudeAccountForSpawn(requested?: string | null): Pick<ClaudeAccount, "id" | "kind" | "home" | "projectsDir"> { const found = listClaudeAccounts().find((item) => item.id === (requested ?? activeClaudeAccountId())); if (!found) throw new UnknownClaudeAccountError(requested ?? ""); if (found.kind === "managed" && (!managedClaudeHomeIsSafe(found.id, true) || !managedClaudeCredentialIsSafe(found.home))) throw new UnsafeClaudeHomeError(); return { id: found.id, kind: found.kind, home: found.home, projectsDir: found.projectsDir }; }
 export function setActiveClaudeAccount(id: string): void { withRegistryLock(() => { cached = null; const registry = mutable(); if (!listClaudeAccounts().some((item) => item.id === id)) throw new UnknownClaudeAccountError(id); write({ ...registry, active: id }); }); }
 /** Transcript trees kept by removed accounts (issue #643). Their homes hold nothing else. */
-export function retiredClaudeProjectRoots(): string[] { return readRegistry().registry.retired.map((item) => path.join(managedHome(item.id), "projects")); }
+export function retiredClaudeProjectRoots(): string[] { return readRegistry().registry.retired.map((item) => projectsDirFor(managedHome(item.id))); }
 /** Every Claude transcript root the scanner reads: live accounts first, then retained archives. */
 export function claudeProjectRoots(): string[] { return [...new Set([...listClaudeAccounts().map((item) => item.projectsDir), ...retiredClaudeProjectRoots()])]; }
 
 export function claudeHomeOwningTranscript(pathname: string): string | null {
   let real: string; try { real = fs.realpathSync(pathname); } catch { return null; }
+  /* Inside the shared store the path names no owner — every cut-over account
+     resolves to the same realpath, so a containment match would return
+     whichever account lists first. Ownership there is the registry's job
+     (transcriptAccountId, phase 0); refusing to guess beats a plausible
+     wrong answer. */
+  try {
+    const shared = fs.realpathSync(sharedClaudeProjectsRoot());
+    if (real.startsWith(shared + path.sep)) return null;
+  } catch { /* store not provisioned: per-account layout still authoritative */ }
   for (const item of listClaudeAccounts()) {
     try { const root = fs.realpathSync(item.projectsDir); if (real.startsWith(root + path.sep)) return item.home; } catch { /* missing home */ }
   }

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { accountManager } from "@/lib/accounts/manager";
 import type { AccountContext, AccountManager } from "@/lib/accounts/contracts";
 import { CodexAppServerClient, CodexAppServerError } from "@/lib/accounts/codexAppServer";
+import { sharedClaudeProjectsRoot } from "@/lib/accounts/claude";
 import { realClaudeLoginPorts } from "@/lib/accounts/claudeLogin";
 import { claudeSuccessorSpecFor } from "@/lib/agent/cli";
 import { agentRegistry, type AgentRegistry, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
@@ -897,12 +898,23 @@ export async function authorizeCodexForkRetry(
   });
 }
 
+/* The shared Claude transcript store (issue #891, phase 1) is the one
+   transcript root that legitimately lives outside every account home; a
+   cut-over account reports its canonical path directly. */
+function isSharedClaudeTranscriptRoot(transcriptRoot: string): boolean {
+  try { return fs.realpathSync(transcriptRoot) === fs.realpathSync(sharedClaudeProjectsRoot()); }
+  catch { return false; }
+}
+
 function ensureTargetRoot(account: AccountContext): void {
   const home = fs.lstatSync(account.home);
   if (!home.isDirectory() || home.isSymbolicLink() || (process.getuid && home.uid !== process.getuid()) || (home.mode & 0o022) !== 0) {
     throw new Error("target account home failed safety checks");
   }
-  if (path.dirname(path.resolve(account.transcriptRoot)) !== path.resolve(account.home)) throw new Error("target transcript root is outside its account home");
+  if (path.dirname(path.resolve(account.transcriptRoot)) !== path.resolve(account.home)
+    && !(account.engine === "claude" && isSharedClaudeTranscriptRoot(account.transcriptRoot))) {
+    throw new Error("target transcript root is outside its account home");
+  }
   try { fs.mkdirSync(account.transcriptRoot, { mode: 0o700 }); } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
   }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -140,6 +140,7 @@ export const en = {
   "accounts.conversationTitle": "Run this conversation on",
   "accounts.conversationPending": "Account switch pending",
   "accounts.conversationApplied": "Conversation account switched",
+  "accounts.conversationUnconfirmed": "Account switch got no confirmation — try again",
   "accounts.manage": "Manage accounts…",
   "accounts.addFailed": "Could not add account",
   "accounts.loginOpened": "Device login opened in {target}",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -134,6 +134,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.conversationTitle": "Запустити цю розмову через",
   "accounts.conversationPending": "Зміна акаунта очікує",
   "accounts.conversationApplied": "Акаунт розмови змінено",
+  "accounts.conversationUnconfirmed": "Зміна акаунта без підтвердження — спробуйте ще раз",
   "accounts.manage": "Керувати акаунтами…",
   "accounts.addFailed": "Не вдалося додати акаунт",
   "accounts.loginOpened": "Вхід через пристрій відкрито в {target}",


### PR DESCRIPTION
Phase 1 of #891, plus the conversation account-menu fix reported today.

## Shared Claude transcript store (dual-mode)

- `sharedClaudeProjectsRoot()` under the existing viewer-owned shared root. A home whose `projects` symlinks into it reports the **canonical** shared path as its `projectsDir` — scanner roots (realpath-deduped), spawn specs, and the migration provider then all address one store while the CLI keeps writing through its own `$CLAUDE_CONFIG_DIR/projects`. Homes not yet cut over keep their local dir, so adoption is per account and this deploys safely before any cutover.
- `claudeHomeOwningTranscript` refuses to guess inside the shared store (every cut-over account resolves to the same realpath; a containment match would name whichever account lists first). Ownership there is the registry's job since phase 0 (#892).
- `ensureTargetRoot` accepts the shared root as the one transcript root legitimately outside an account home (claude only).
- `scripts/cutover-shared-claude-projects.ts` — one-time merge: collision-checked (aborts before moving anything), dry-run by default, `--execute` merges via rename, symlinks every source root (legacy home, live accounts, retired archives), rewrites absolute transcript paths in durable state JSON to the canonical prefix, and backs the state files up first. Refuses to run beside live viewer containers unless `--allow-live`. Old absolute paths keep resolving through the symlinks either way.

## Conversation account menu (clipped + wedged)

- The per-conversation switcher rendered `absolute` inside the card header and got clipped by its overflow; it now renders through a fixed-position portal (`z-[95]`), positioned from the chip, closing on any outside press.
- Items could stay disabled forever: switch confirmation flows through runtime receipts and the migration projection, both silent when the conversation's host is dead (session-limit stop). An unconfirmed switch now clears `pending` after 60s with a retryable error toast.

## Tests

- dual-mode `projectsDir` (symlinked → canonical, real dir → local) and shared-store ownership refusal
- cutover: disjoint-root merge + symlinks + state rewrite; collision aborts the plan
- badge menu suites updated for the portal; new-and-old suites green (161 tests across the affected files); tsc + eslint clean

Codex is phase 2: the binary canonicalizes `CODEX_HOME`, so a live probe of symlinked `sessions/` comes first (per the #891 research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)