### PR TITLE
fix(projects): a .git directory without HEAD is not a repository

### DIFF
--- a/src/lib/projects/identity.test.ts
+++ b/src/lib/projects/identity.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { afterAll, expect, test } from "bun:test";
 
-import { projectIdentityFromRepositoryRoot } from "./identity";
+import { projectIdentityFromRepositoryRoot, repositoryRootForPath } from "./identity";
 
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-identity-"));
 
@@ -15,6 +15,7 @@ afterAll(() => {
 function createRepository(name: string, remote: string): string {
   const root = path.join(SANDBOX, name);
   fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
   fs.writeFileSync(path.join(root, ".git", "config"), [
     '[remote "origin"]',
     `\turl = ${remote}`,
@@ -26,6 +27,7 @@ function createRepository(name: string, remote: string): string {
 function createLocalRepository(name: string): string {
   const root = path.join(SANDBOX, name);
   fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
   fs.writeFileSync(path.join(root, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n");
   return root;
 }
@@ -63,4 +65,15 @@ test("a local repository without origin still has one stable non-unresolved iden
     canonicalRemote: `local:${root}`,
   });
   expect(first?.project).toMatch(/^repo-[a-f0-9]{32}$/);
+});
+
+test("a vestigial .git directory without HEAD is not a repository", () => {
+  const root = path.join(SANDBOX, "vestigial-home");
+  // Tooling plants auxiliary files like info/exclude without ever running
+  // `git init` to completion — git itself refuses such a directory.
+  fs.mkdirSync(path.join(root, ".git", "info"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "info", "exclude"), "**/ignored\n");
+
+  expect(projectIdentityFromRepositoryRoot(root)).toBeNull();
+  expect(repositoryRootForPath(path.join(root, "nested", "dir"))).toBeNull();
 });

--- a/src/lib/projects/identity.ts
+++ b/src/lib/projects/identity.ts
@@ -16,15 +16,27 @@ export function displayNameFromProjectIdentity(project: string): string {
   return project;
 }
 
+/* Every real git directory carries HEAD; tooling sometimes plants a vestigial
+   `.git/` holding only auxiliary files (a bare `info/exclude` in the operator's
+   home directory swallowed 1000+ conversations into "Unresolved project").
+   Git itself refuses such a directory, so the identity walk must too — an
+   unvalidated marker turns the whole subtree into a phantom repository root. */
+function looksLikeGitDirectory(directory: string): boolean {
+  try { return fs.statSync(path.join(directory, "HEAD")).isFile(); }
+  catch { return false; }
+}
+
 function gitDirectory(root: string): string | null {
   const marker = path.join(root, ".git");
   try {
     const stat = fs.lstatSync(marker);
-    if (stat.isDirectory()) return marker;
+    if (stat.isDirectory()) return looksLikeGitDirectory(marker) ? marker : null;
     if (!stat.isFile()) return null;
     const pointer = fs.readFileSync(marker, "utf8").slice(0, 4096);
     const target = /^gitdir:\s*(.+?)\s*$/im.exec(pointer)?.[1];
-    return target ? path.resolve(root, target) : null;
+    if (!target) return null;
+    const resolved = path.resolve(root, target);
+    return looksLikeGitDirectory(resolved) ? resolved : null;
   } catch {
     return null;
   }

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -28,6 +28,7 @@ function createRepository(
   remote = "ssh://git@example.invalid/team/shared-repository.git",
 ) {
   fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
   fs.writeFileSync(path.join(root, ".git", "config"), [
     '[remote "origin"]',
     `\turl = ${remote}`,
@@ -346,6 +347,7 @@ test("a project-state change recomputes only the overlay, never transcript metad
   // The checkout appears (reconciliation would rewrite the project state and
   // change the resolution state key with it).
   fs.mkdirSync(path.join(repo, ".git", "worktrees", "live-log-viewer-split-branch"), { recursive: true });
+  fs.writeFileSync(path.join(repo, ".git", "worktrees", "live-log-viewer-split-branch", "HEAD"), "ref: refs/heads/main\n");
   fs.mkdirSync(worktree, { recursive: true });
   fs.writeFileSync(
     path.join(worktree, ".git"),
@@ -411,6 +413,7 @@ test("a wrong-HOME durable mapping is corrected by repository evidence after wor
   const identity = createRepository(repo);
   const worktree = path.join(base, "live-log-viewer-branchx");
   fs.mkdirSync(path.join(repo, ".git", "worktrees", "live-log-viewer-branchx"), { recursive: true });
+  fs.writeFileSync(path.join(repo, ".git", "worktrees", "live-log-viewer-branchx", "HEAD"), "ref: refs/heads/main\n");
   fs.mkdirSync(worktree, { recursive: true });
   fs.writeFileSync(
     path.join(worktree, ".git"),


### PR DESCRIPTION
A vestigial `.git/` holding only `info/exclude` (planted by tooling, never a completed `git init`) in the operator's home directory made the identity walk treat the home as a repository root; reading its config failed, and every conversation whose cwd sat under it — 1000+ — collapsed into "Unresolved project".

Git itself refuses a git dir without HEAD, so `gitDirectory()` now does too, for both directory markers and `gitdir:` pointer targets. The repository walk then continues past vestigial markers (usually to no repo at all), and normal path-derived project naming applies.

Tests: vestigial `.git` yields null identity and no repository root; existing identity/describe fixtures now write HEAD like every real repository; full describe suite green (28 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)