### PR TITLE
fix(projects): re-derive identities cached before the vestigial-git fix

### DIFF
--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -4,9 +4,9 @@ import path from "node:path";
 
 import { stateDir } from "@/lib/configDir";
 
-/* 5: canonicalRemote no longer parses scheme remotes (https://…) through the
-   scp matcher, so identities minted from the misparse must re-derive. */
-export const PROJECT_RESOLUTION_VERSION = 5;
+/* 6: a .git directory without HEAD no longer counts as a repository, so
+   unresolved identities minted from vestigial markers must re-derive. */
+export const PROJECT_RESOLUTION_VERSION = 6;
 
 /* Project summaries depend on the attribution facts consumed by
    persistedProjects(). Hashing these stable projections keeps controller


### PR DESCRIPTION
Follow-up to #896: the project catalog serves cached resolutions until `PROJECT_RESOLUTION_VERSION` changes, so conversations already stamped `project_unresolved` by the vestigial-git bug stayed unresolved after the fix deployed. Version 6 forces a one-time re-derive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)