### PR TITLE
fix(runtime-host): cache the serialized snapshot and sweep producer receipts

### DIFF
--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -5,6 +5,7 @@ import { consumeRuntimeEvent, type RuntimeConsumerPorts } from "@/lib/runtime/co
 import { RuntimeJournal } from "./journal";
 import type { ViewerDeploymentCoordinator } from "./deployment";
 import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+import { PreserializedJson } from "./preserializedJson";
 
 export { RuntimeHostFence } from "./runtimeHostFence";
 
@@ -79,7 +80,7 @@ export class RuntimeHost {
   async handle(request: RuntimeSocketRequest, options: { signal?: AbortSignal } = {}): Promise<RuntimeSocketResponse> {
     try {
       let result: unknown;
-      if (request.method === "snapshot") result = this.journal.snapshot();
+      if (request.method === "snapshot") result = new PreserializedJson(this.journal.snapshotJson());
       else if (request.method === "events") result = this.journal.replay(Number(request.params?.after ?? 0));
       else if (request.method === "wait") result = await this.journal.waitForEvents(
         Number(request.params?.after ?? 0),

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -2591,3 +2591,92 @@ test("issue 367: a failed structured kill leaves the live projection untouched",
   });
   journal.close();
 });
+
+test("snapshotJson rebuilds only when the database has changed", () => {
+  const dir = sandbox("snapshot-cache");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.started", payload: { turnId: "a" } });
+  const first = journal.snapshotJson();
+  expect(JSON.parse(first)).toEqual(JSON.parse(JSON.stringify(journal.snapshot())));
+  // Identity equality proves the cached string was reused, not rebuilt.
+  expect(journal.snapshotJson()).toBe(first);
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.completed", payload: { turnId: "a" } });
+  const second = journal.snapshotJson();
+  expect(second).not.toBe(first);
+  expect(JSON.parse(second).snapshotSeq).toBe(2);
+  journal.close();
+});
+
+test("receipt maintenance keeps only the latest engine receipt per session prefix", () => {
+  const dir = sandbox("receipt-sweep-engine");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  journal.append({
+    scope: runtimeScope("session", "one"),
+    kind: "turn.started",
+    payload: { turnId: "a" },
+    producer: { kind: "codex-app-server", eventKey: "engine-host:codex:legacy-session:50" },
+  });
+  journal.close();
+  // Legacy accumulation predating the append-path dedupe: rows the sweep,
+  // not a future append in the same prefix, must reclaim.
+  const raw = new Database(filename, { strict: true });
+  for (let sequence = 0; sequence < 40; sequence += 1) {
+    raw.query("INSERT INTO producer_receipts(producer_kind, producer_key, event_json) VALUES (?, ?, ?)")
+      .run("codex-app-server", `engine-host:codex:legacy-session:${sequence}`, JSON.stringify({ seq: 1 }));
+  }
+  raw.close();
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 200 });
+  let deleted = 0;
+  for (let pass = 0; pass < 10; pass += 1) {
+    const result = reopened.maintainProducerReceipts(16);
+    deleted += result.deleted;
+    if (result.cycled && result.deleted === 0) break;
+  }
+  expect(deleted).toBe(40);
+  const survivors = new Database(filename, { readonly: true })
+    .query<{ producer_key: string }, []>("SELECT producer_key FROM producer_receipts WHERE producer_key LIKE 'engine-host:codex:legacy-session:%'")
+    .all();
+  expect(survivors.map((row) => row.producer_key)).toEqual(["engine-host:codex:legacy-session:50"]);
+  reopened.close();
+});
+
+test("receipt maintenance expires non-engine receipts below the compaction anchor and keeps the rest", () => {
+  const dir = sandbox("receipt-sweep-anchor");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { maxEvents: 2, now: () => 100 });
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.started", payload: { turnId: "a" }, producerKey: "native:a" });
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.completed", payload: { turnId: "a" }, producerKey: "native:b" });
+  // Third append compacts the first event beneath the anchor.
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.started", payload: { turnId: "b" }, producerKey: "native:c" });
+  const anchor = JSON.parse(journal.snapshotJson()).retentionFloorSeq as number;
+  expect(anchor).toBeGreaterThanOrEqual(1);
+  const before = new Database(filename, { readonly: true })
+    .query<{ n: number }, []>("SELECT COUNT(*) AS n FROM producer_receipts").get()!.n;
+  expect(before).toBe(3);
+  const result = journal.maintainProducerReceipts();
+  expect(result.cycled).toBe(true);
+  expect(result.deleted).toBe(1);
+  const survivors = new Database(filename, { readonly: true })
+    .query<{ producer_key: string }, []>("SELECT producer_key FROM producer_receipts ORDER BY producer_key").all();
+  expect(survivors.map((row) => row.producer_key)).toEqual(["native:b", "native:c"]);
+  journal.close();
+});
+
+test("snapshot over the socket splices the cached frame and stays a valid response", async () => {
+  const dir = sandbox("snapshot-socket-splice");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  journal.append({ scope: runtimeScope("session", "one"), kind: "turn.started", payload: { turnId: "a" } });
+  const host = new RuntimeHost(journal);
+  const socketPath = path.join(dir, "host.sock");
+  const server = serveRuntimeHost(socketPath, host);
+  try {
+    const client = new UnixRuntimeHostClient(socketPath);
+    const snapshot = await client.snapshot();
+    expect(snapshot.snapshotSeq).toBe(1);
+    expect(snapshot.sessions).toHaveLength(1);
+  } finally {
+    server.close();
+    journal.close();
+  }
+});

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -272,6 +272,8 @@ export class RuntimeJournal {
   private readonly secretKey: Buffer;
   private readonly waiters = new Set<() => void>();
   private fault: string | null = null;
+  private snapshotCache: { changes: number; json: string } | null = null;
+  private receiptSweepCursor = 0;
 
   constructor(filename: string, options: RuntimeJournalOptions = {}) {
     this.db = new Database(filename, { create: true, strict: true });
@@ -745,6 +747,26 @@ export class RuntimeJournal {
     }
   }
 
+  /** Serialized snapshot, rebuilt only when the database has changed since the
+      cached build. Concurrent snapshot consumers otherwise stack full O(state)
+      rebuilds on the event loop until every socket request exceeds the
+      client's timeout and the retry storm keeps the host saturated (the
+      2026-08-04 spawn freeze). total_changes() counts every row this
+      connection has written, so no mutation path needs to remember to
+      invalidate. serverTime inside the cached frame dates from the last
+      mutation; no consumer reads it. */
+  snapshotJson(): string {
+    const changes = this.totalChanges();
+    if (this.snapshotCache?.changes === changes) return this.snapshotCache.json;
+    const json = JSON.stringify(this.snapshot());
+    this.snapshotCache = { changes, json };
+    return json;
+  }
+
+  private totalChanges(): number {
+    return Number(this.db.query<{ changes: number }, []>("SELECT total_changes() AS changes").get()?.changes ?? 0);
+  }
+
   replay(after: number, limit = 128): RuntimeReplay {
     this.assertHealthy();
     const floorSeq = Number(this.meta("anchor_seq"));
@@ -1106,6 +1128,67 @@ export class RuntimeJournal {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
     }
+  }
+
+  /** Bounded producer-receipt retention pass; the timer in main.ts owns the
+      cadence. compact() bounds every other table but never touched
+      producer_receipts, which grew to 1.5M rows / 1.66 GB in production —
+      85% of the journal file. Two rules, applied to at most `budget` rows per
+      call so a pass never stalls the socket loop:
+      - engine-cursor receipts (`engine-host:…:<seq>`) keep only the highest
+        sequence per session prefix — the same invariant the append path
+        enforces, extended to prefixes that stopped appending before that
+        dedupe shipped;
+      - other receipts expire once their event falls below the compaction
+        anchor, matching the retention of the operations table. A duplicate
+        eventKey older than the events window re-appends instead of deduping,
+        the trade compact() already made for operations.
+      The cursor is in-memory: a restart rescans from rowid 0, and the pass is
+      idempotent. */
+  maintainProducerReceipts(budget = 4_096): { scanned: number; deleted: number; cycled: boolean } {
+    this.assertHealthy();
+    const limit = Math.max(1, budget);
+    const anchorSeq = Number(this.meta("anchor_seq"));
+    const rows = this.db.query<{ rowid: number; producer_kind: string; producer_key: string; event_seq: number | null }, [number, number]>(
+      "SELECT rowid, producer_kind, producer_key, CAST(json_extract(event_json, '$.seq') AS INTEGER) AS event_seq FROM producer_receipts WHERE rowid > ? ORDER BY rowid LIMIT ?",
+    ).all(this.receiptSweepCursor, limit);
+    const cycled = rows.length < limit;
+    this.receiptSweepCursor = cycled ? 0 : rows[rows.length - 1]!.rowid;
+    const latestByPrefix = new Map<string, string>();
+    const stale: number[] = [];
+    for (const row of rows) {
+      const cursor = engineProducerCursor(row.producer_kind, row.producer_key);
+      if (cursor) {
+        const group = `${row.producer_kind} ${cursor.prefix}`;
+        let latestKey = latestByPrefix.get(group);
+        if (latestKey === undefined) {
+          latestKey = this.db.query<{ producer_key: string }, [string, string, string, string]>(
+            "SELECT producer_key FROM producer_receipts WHERE producer_kind = ? AND producer_key >= ? AND producer_key < ? ORDER BY CAST(substr(producer_key, length(?) + 1) AS INTEGER) DESC LIMIT 1",
+          ).get(row.producer_kind, cursor.prefix, `${cursor.prefix}\uffff`, cursor.prefix)?.producer_key ?? row.producer_key;
+          latestByPrefix.set(group, latestKey);
+        }
+        if (row.producer_key !== latestKey) stale.push(row.rowid);
+      } else if (row.event_seq !== null && row.event_seq <= anchorSeq) {
+        stale.push(row.rowid);
+      }
+    }
+    if (stale.length > 0) {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        for (let start = 0; start < stale.length; start += 500) {
+          const batch = stale.slice(start, start + 500);
+          this.db.query(`DELETE FROM producer_receipts WHERE rowid IN (${batch.map(() => "?").join(", ")})`).run(...batch);
+        }
+        this.db.exec("COMMIT");
+      } catch (error) {
+        try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+        throw error;
+      }
+      // Reclaims pages only where the file was born with auto_vacuum set
+      // (fresh databases); on older files the freed pages are still reused.
+      this.db.exec("PRAGMA incremental_vacuum(2048)");
+    }
+    return { scanned: rows.length, deleted: stale.length, cycled };
   }
 
   close(): void { this.db.close(); }

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -104,9 +104,28 @@ const legacyScheduler = process.env.LLV_RUNTIME_LEGACY_SCHEDULER === "1" ? creat
 const legacyTimer = legacyScheduler ? setInterval(() => {
   void legacyScheduler.runDue().catch(() => console.error("[runtime scheduler] tick failed; next tick will retry"));
 }, 1_000) : null;
+/* Producer-receipt retention runs on wall clock, not on append traffic, so a
+   quiet journal still drains its backlog. Each tick is bounded inside
+   maintainProducerReceipts; the multi-week legacy accumulation drains across
+   ticks while the sweep itself never blocks the socket loop noticeably. */
+let receiptSweepDeleted = 0;
+const receiptSweepTimer = journal.isWritable() ? setInterval(() => {
+  if (!journal.isWritable()) return;
+  try {
+    const pass = journal.maintainProducerReceipts();
+    receiptSweepDeleted += pass.deleted;
+    if (pass.cycled && receiptSweepDeleted > 0) {
+      console.error(`[runtime journal] receipt sweep cycle removed ${receiptSweepDeleted} stale producer receipts`);
+      receiptSweepDeleted = 0;
+    }
+  } catch (error) {
+    console.error(`[runtime journal] receipt sweep failed; next tick will retry: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}, 10_000) : null;
 
 function stop(): void {
   if (legacyTimer) clearInterval(legacyTimer);
+  if (receiptSweepTimer) clearInterval(receiptSweepTimer);
   deploymentProxy?.close();
   server.close(() => {
     journal.close();
@@ -148,6 +167,7 @@ function handOffToStagedSuccessor(context: { deploymentId: string; revision: str
   handoffStarted = true;
   console.error(`[runtime host] deployment ${context.deploymentId} staged successor ${context.successor.image} (${context.revision}); handing off this generation`);
   if (legacyTimer) clearInterval(legacyTimer);
+  if (receiptSweepTimer) clearInterval(receiptSweepTimer);
   deploymentProxy?.close();
   server.close(() => {
     journal.close();

--- a/src/runtime-host/preserializedJson.ts
+++ b/src/runtime-host/preserializedJson.ts
@@ -1,0 +1,6 @@
+/** A response payload that is already serialized. The socket layer splices it
+    into the response frame verbatim, so a multi-megabyte result is stringified
+    once per journal revision instead of once per connection. */
+export class PreserializedJson {
+  constructor(readonly json: string) {}
+}

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
 import type { RuntimeHost } from "./host";
+import { PreserializedJson } from "./preserializedJson";
 
 const MAX_FRAME_BYTES = 512 * 1024;
 const DEFAULT_SOCKET_TIMEOUT_MS = 31_000;
@@ -52,7 +53,12 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHand
       if (settled) return;
       settled = true;
       if (socket.destroyed || socket.writableEnded || !socket.writable) return;
-      socket.end(JSON.stringify(response) + "\n");
+      // A preserialized result (the snapshot) splices into the frame verbatim,
+      // so its megabytes are not re-stringified once per connection.
+      const frame = response.ok && response.result instanceof PreserializedJson
+        ? `{"id":${JSON.stringify(response.id)},"ok":true,"result":${response.result.json}}`
+        : JSON.stringify(response);
+      socket.end(frame + "\n");
     };
     socket.on("data", (chunk) => {
       if (handled) return;


### PR DESCRIPTION
## Problem

Agent creation hung at "connecting host" with `runtime host request timed out`, and queued messages never delivered. The host socket went unresponsive for ~50 s during a spawn.

Two compounding pathologies:

1. **Snapshot herd.** `journal.snapshot()` rebuilds the full runtime state and the socket layer stringifies a ~4.3 MB frame per connection, all synchronously on the host event loop (~0.5 s per call at current state size). Measured live: 8 concurrent snapshot calls each took 2.7–3.3 s — right past the client's 3 s timeout — while a trivial `events` call took 1.2 s. Every consumer (browser tabs, MCP snapshot tools, delivery controller, pipeline engine) times out, retries, and keeps the loop saturated; the spawn `command` call dies inside the storm.
2. **Unbounded producer_receipts.** `compact()` bounds events, outbox, operations, and consumer checkpoints, but never touches `producer_receipts`. The append-path engine dedupe only cleans a prefix when that same session appends again, so retired sessions keep 10–27 k receipt rows forever. In production the table reached 1.5 M rows / 1.66 GB — 85% of the journal file.

## Fix

- `snapshotJson()` caches the serialized snapshot keyed by SQLite `total_changes()`, so any write path invalidates it without having to remember to. The socket layer splices the cached frame verbatim (`PreserializedJson`), so a herd costs one build + N writes instead of N rebuilds.
- A bounded receipt sweep runs on a 10 s host timer: keeps only the highest-sequence engine receipt per session prefix (the invariant the append path already enforces, extended to prefixes that stopped appending), and expires non-engine receipts once their event falls below the compaction anchor — the same retention trade `compact()` already makes for `operations`. At most 4096 rows are examined per tick, so the multi-week backlog drains gradually without stalling the socket.

## Verification

- New tests: cache reuse + invalidation, legacy engine-prefix drain, anchor-based expiry, snapshot over the socket through the spliced frame.
- `bun test src/runtime-host/journal.test.ts src/runtime-host/socket.test.ts` — 69 pass.
- `src/runtime-host/mcpRuntimeProbe.test.ts` has 2 failures that reproduce identically on clean `origin/main` (pre-existing, unrelated).
- Post-deploy plan: replay the 8-concurrent-snapshot probe against the live socket and watch the receipt sweep drain `producer_receipts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)