### PR TITLE
feat(projects): directory-derived projects for repository-less cwds

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -14,7 +14,7 @@ import { loadFlows } from "@/lib/flows/store";
 import { reviewOutcomeFor } from "@/lib/flows/reviewOutcome";
 import { overlayPromptDisplayTitles, projectDisplayName } from "@/lib/displayNames";
 import { projectAliasSnapshot } from "@/lib/projects/aliases";
-import { projectIdentityFromRepositoryRoot, UNRESOLVED_PROJECT, UNRESOLVED_PROJECT_NAME } from "@/lib/projects/identity";
+import { isCanonicalProjectId, projectIdentityFromRepositoryRoot, UNRESOLVED_PROJECT, UNRESOLVED_PROJECT_NAME } from "@/lib/projects/identity";
 import { projectRestoredFlows } from "@/lib/flows/visibility";
 import { reconcileEmbeddedReviewFlows } from "@/lib/pipelines/engine";
 import { loadPipelinesForProjection } from "@/lib/pipelines/store";
@@ -107,7 +107,7 @@ export function consolidateProjectCatalogByRepository(
     const identity = entry.projectRoot ? projectIdentityFromRepositoryRoot(entry.projectRoot) : null;
     const aliasedProject = resolveCatalogAlias(entry.project, aliases);
     const displayCandidate = identity?.project
-      ?? (/^repo-[0-9a-f]{32}$/.test(aliasedProject) ? aliasedProject : null);
+      ?? (isCanonicalProjectId(aliasedProject) ? aliasedProject : null);
     if (displayCandidate) {
       const displayName = (identity?.displayName
         ?? displayNames[displayCandidate]
@@ -122,7 +122,7 @@ export function consolidateProjectCatalogByRepository(
     if (!entry.repository) continue;
     const repository = entry.repository.toLowerCase();
     const candidate = identity?.project
-      ?? (/^repo-[0-9a-f]{32}$/.test(aliasedProject) ? aliasedProject : null);
+      ?? (isCanonicalProjectId(aliasedProject) ? aliasedProject : null);
     if (candidate && (identity || !repositoryProjects.has(repository))) {
       repositoryProjects.set(repository, candidate);
     }
@@ -159,7 +159,7 @@ export function consolidateProjectCatalogByRepository(
       .map(({ entry }) => entry.projectRoot ? projectIdentityFromRepositoryRoot(entry.projectRoot) : null)
       .find((identity) => identity !== null);
     const canonical = repositoryIdentity?.project
-      ?? group.find(({ aliasedProject }) => /^repo-[0-9a-f]{32}$/.test(aliasedProject))?.aliasedProject
+      ?? group.find(({ aliasedProject }) => isCanonicalProjectId(aliasedProject))?.aliasedProject
       ?? group[0]!.aliasedProject;
     for (const { entry } of group) projectRemap.set(entry.project, canonical);
     const preferred = group.find(({ aliasedProject }) => aliasedProject === canonical)?.entry ?? group[0]!.entry;

--- a/src/lib/projects/identity.test.ts
+++ b/src/lib/projects/identity.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { afterAll, expect, test } from "bun:test";
 
-import { projectIdentityFromRepositoryRoot, repositoryRootForPath } from "./identity";
+import { isCanonicalProjectId, projectIdentityFromDirectory, projectIdentityFromRepositoryRoot, repositoryRootForPath } from "./identity";
 
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-identity-"));
 
@@ -76,4 +76,18 @@ test("a vestigial .git directory without HEAD is not a repository", () => {
 
   expect(projectIdentityFromRepositoryRoot(root)).toBeNull();
   expect(repositoryRootForPath(path.join(root, "nested", "dir"))).toBeNull();
+});
+
+test("a cwd without a repository resolves to a directory-derived project", () => {
+  const plain = path.join(SANDBOX, "plain-folder");
+  fs.mkdirSync(plain, { recursive: true });
+  const identity = projectIdentityFromDirectory(plain)!;
+  expect(identity.displayName).toBe("plain-folder");
+  expect(identity.project).toMatch(/^dir-[0-9a-f]{32}$/);
+  expect(isCanonicalProjectId(identity.project)).toBeTrue();
+  // Stable across calls and path spellings.
+  expect(projectIdentityFromDirectory(path.join(plain, "."))).toEqual(identity);
+  // The home directory reads as home-<name>, never like a repository.
+  const home = projectIdentityFromDirectory(os.homedir())!;
+  expect(home.displayName).toBe(`home-${path.basename(os.homedir())}`);
 });

--- a/src/lib/projects/identity.ts
+++ b/src/lib/projects/identity.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 export interface RepositoryProjectIdentity {
@@ -10,6 +11,33 @@ export interface RepositoryProjectIdentity {
 
 export const UNRESOLVED_PROJECT = "project_unresolved";
 export const UNRESOLVED_PROJECT_NAME = "Unresolved project";
+
+export interface DirectoryProjectIdentity {
+  project: string;
+  displayName: string;
+}
+
+/** Both durable project id shapes the resolver mints: repository identities
+    and directory identities. Everything else is an operator alias slug. */
+export function isCanonicalProjectId(project: string): boolean {
+  return /^(?:repo|dir)-[0-9a-f]{32}$/.test(project);
+}
+
+/** Stable identity for a cwd with no repository (operator decision,
+    2026-08-04): the directory itself is the project, so sessions in plain
+    folders group by folder instead of pooling in "Unresolved project". The
+    home directory gets a `home-` prefixed name — bare "latand" would read
+    like a repository. */
+export function projectIdentityFromDirectory(cwd: string): DirectoryProjectIdentity | null {
+  const resolved = (() => {
+    try { return fs.realpathSync.native(cwd); } catch { return path.resolve(cwd); }
+  })();
+  const base = path.basename(resolved);
+  if (!base || resolved === path.sep) return null;
+  const displayName = resolved === os.homedir() ? `home-${base}` : base;
+  const digest = crypto.createHash("sha256").update(`dir:${resolved}`).digest("hex").slice(0, 32);
+  return { project: `dir-${digest}`, displayName };
+}
 
 export function displayNameFromProjectIdentity(project: string): string {
   if (project === UNRESOLVED_PROJECT) return UNRESOLVED_PROJECT_NAME;

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -121,14 +121,16 @@ test("repository identity is independent of the resolver HOME", () => {
   expect(new Set(projects)).toHaveLength(1);
 });
 
-test("an unidentifiable cwd is projected into one visible unresolved state", () => {
+test("a cwd with no repository projects into its directory-derived project", () => {
+  // Even a deleted cwd keeps a stable directory identity — sessions survive
+  // their folder being removed, mirroring the worktree-grouping invariant.
   const missing = path.join(SANDBOX, "missing-repository");
   expect(fs.existsSync(missing)).toBe(false);
-  expect(projectInfoFromCwd(missing)).toEqual({
-    project: "project_unresolved",
-    displayName: "Unresolved project",
-    unresolved: true,
-  });
+  const info = projectInfoFromCwd(missing)!;
+  expect(info.displayName).toBe("missing-repository");
+  expect(info.project).toMatch(/^dir-[0-9a-f]{32}$/);
+  expect(info.unresolved).toBeUndefined();
+  expect(projectInfoFromCwd(missing)).toEqual(info);
 });
 
 test("search text hydration retries after a transient filesystem failure", () => {

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -5,6 +5,8 @@ import { stateDir } from "@/lib/configDir";
 import { canonicalProject, projectAliasSnapshot } from "@/lib/projects/aliases";
 import {
   displayNameFromProjectIdentity,
+  isCanonicalProjectId,
+  projectIdentityFromDirectory,
   projectIdentityFromRepositoryRoot,
   repositoryRootForPath,
   UNRESOLVED_PROJECT,
@@ -326,7 +328,7 @@ function aliasedProjectInfo(
   repo?: string,
 ): ProjectInfo {
   const canonical = canonicalProject(project);
-  if (canonical === project && canonical !== UNRESOLVED_PROJECT && !/^repo-[0-9a-f]{32}$/.test(canonical)) {
+  if (canonical === project && canonical !== UNRESOLVED_PROJECT && !isCanonicalProjectId(canonical)) {
     return unresolvedProjectInfo(worktree);
   }
   const repositoryIdentity = repo ? projectIdentityFromRepositoryRoot(repo) : null;
@@ -549,19 +551,27 @@ export function projectInfoFromCwd(cwd: string): ProjectInfo | null {
       }
     }
   }
+  /* No repository claims the cwd: the directory itself is the project
+     (operator decision, 2026-08-04). "Unresolved project" remains only for
+     cwds that name nothing at all. */
+  const directoryProjectInfo = (): ProjectInfo => {
+    const identity = projectIdentityFromDirectory(cwd);
+    return identity
+      ? { project: identity.project, displayName: identity.displayName, ...(worktree?.worktree ? { worktree: worktree.worktree } : {}) }
+      : unresolvedProjectInfo(worktree?.worktree);
+  };
   const root = worktree?.repo || repositoryRootForPath(cwd);
   if (!root) {
-    const hinted = codexWorktree?.projectHint
+    const resolvedInfo = codexWorktree?.projectHint
       ? aliasedProjectInfo(codexWorktree.projectHint, worktree?.worktree)
-      : unresolvedProjectInfo(worktree?.worktree);
-    const unresolved = hinted;
-    projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolutionState, unresolved]);
-    return unresolved;
+      : directoryProjectInfo();
+    projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolutionState, resolvedInfo]);
+    return resolvedInfo;
   }
   const identity = projectIdentityFromRepositoryRoot(root);
   const resolved = identity
     ? { project: identity.project, displayName: identity.displayName, worktree: worktree?.worktree, repo: root }
-    : unresolvedProjectInfo(worktree?.worktree);
+    : directoryProjectInfo();
   projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolutionState, resolved]);
   return resolved;
 }

--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -4,9 +4,10 @@ import path from "node:path";
 
 import { stateDir } from "@/lib/configDir";
 
-/* 6: a .git directory without HEAD no longer counts as a repository, so
-   unresolved identities minted from vestigial markers must re-derive. */
-export const PROJECT_RESOLUTION_VERSION = 6;
+/* 7: a cwd with no repository resolves to a directory-derived project
+   (dir-<hash>) instead of "Unresolved project", so pooled unresolved
+   identities must re-derive. */
+export const PROJECT_RESOLUTION_VERSION = 7;
 
 /* Project summaries depend on the attribution facts consumed by
    persistedProjects(). Hashing these stable projections keeps controller


### PR DESCRIPTION
Operator decision follow-up to #896/#897: sessions whose cwd has no git repository pooled into a single "Unresolved project" bucket (1100+ files, including every home-directory session). Folder = project now:

- `projectIdentityFromDirectory` mints a stable `dir-<hash-of-realpath>` identity, displayed by folder name; the home directory reads `home-<name>` so it never looks like a repository.
- `projectInfoFromCwd` falls back to it both when no repository root exists and when a root yields no identity. Deleted cwds keep their recorded identity — mirroring the deleted-worktree grouping invariant.
- "Unresolved project" remains only for cwds that name nothing at all (empty/root paths).
- `isCanonicalProjectId` accepts both `repo-` and `dir-` shapes at the alias guard and the files-response preference sites.
- `PROJECT_RESOLUTION_VERSION` → 7 to re-derive the pooled identities once.

Tests: directory identity (stability, home naming, canonical shape), missing-cwd stability, full describe/identity/projectState/files-route suites green (118 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)