### PR TITLE
fix(projects): a member's repository projectRoot never renames a folder group

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -167,10 +167,19 @@ export function consolidateProjectCatalogByRepository(
   const projectRemap = new Map<string, string>();
   const projectCatalog: ProjectCatalogEntry[] = [];
   for (const group of groups.values()) {
-    const repositoryIdentity = group
+    /* A directory group keeps its directory identity even when a member's
+       registry metadata carries a repository checkout as projectRoot (a
+       session in a plain folder administering a repo records that root) —
+       letting that root's identity name the group re-absorbs the folder
+       into the repository project past the grouping-key guard above. */
+    const directoryProject = group
+      .find(({ aliasedProject }) => aliasedProject.startsWith("dir-") && isCanonicalProjectId(aliasedProject))
+      ?.aliasedProject;
+    const repositoryIdentity = directoryProject ? null : group
       .map(({ entry }) => entry.projectRoot ? projectIdentityFromRepositoryRoot(entry.projectRoot) : null)
       .find((identity) => identity !== null);
-    const canonical = repositoryIdentity?.project
+    const canonical = directoryProject
+      ?? repositoryIdentity?.project
       ?? group.find(({ aliasedProject }) => isCanonicalProjectId(aliasedProject))?.aliasedProject
       ?? group[0]!.aliasedProject;
     for (const { entry } of group) projectRemap.set(entry.project, canonical);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -214,6 +214,37 @@ test("a repository binding on one member never absorbs a directory project", () 
   expect(result.projectRemap.get("dir-22222222222222222222222222222222")).toBe("dir-22222222222222222222222222222222");
 });
 
+test("a repository checkout recorded as a folder group's projectRoot never renames it", () => {
+  // A session in a plain folder that administers a repository records the
+  // checkout as its projectRoot metadata — the folder group must keep its
+  // directory identity anyway.
+  const repositoryRoot = process.cwd();
+  const repoIdentity = projectInfoFromCwd(repositoryRoot)!;
+  const result = consolidateProjectCatalogByRepository([
+    {
+      project: "dir-33333333333333333333333333333333",
+      displayName: "home-operator",
+      smt: 50,
+      conversations: 600,
+      projectRoot: repositoryRoot,
+    },
+    {
+      project: repoIdentity.project,
+      displayName: repoIdentity.displayName,
+      smt: 40,
+      conversations: 12,
+      projectRoot: repositoryRoot,
+      repository: "owner/shared-repository",
+    },
+  ]);
+
+  const projects = result.projectCatalog.map((entry) => entry.project).sort();
+  expect(projects).toEqual(["dir-33333333333333333333333333333333", repoIdentity.project].sort());
+  expect(result.projectRemap.get("dir-33333333333333333333333333333333")).toBe("dir-33333333333333333333333333333333");
+  const folder = result.projectCatalog.find((entry) => entry.project.startsWith("dir-"))!;
+  expect(folder.displayName).toBe("home-operator");
+});
+
 test("catalog aliases collapse a legacy dashed-path variant before grouping", () => {
   const canonical = "repo-0123456789abcdef0123456789abcdef";
   const result = consolidateProjectCatalogByRepository(


### PR DESCRIPTION
Second hole behind the same symptom as #900, found live after deploying it: the grouping-**key** guard kept folder groups separate, but the canonical **naming** step still consulted `projectIdentityFromRepositoryRoot(entry.projectRoot)` — and a folder session administering a repository records that checkout as its registry projectRoot metadata. The root's identity then renamed the whole folder group into the repository project, reproducing the absorption past the key guard.

Directory groups now canonicalize to their directory identity unconditionally; repository-root naming applies only to groups without one.

Regression test: a folder entry whose projectRoot points at a real repository checkout keeps its `dir-` id and display name beside the repo project. Files-route suite green (84 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)