### PR TITLE
fix(runtime): shrink a still-oversized replay envelope instead of failing the resume

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1359,6 +1359,41 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  /* Production 2026-08-04: a 49 MB thread/resume envelope over a Cyrillic-heavy
+     thread stayed above the frame guard even with every string capped, so the
+     resume — and with it every account switch for the conversation — failed
+     with "oversized JSONL frame". The finished frame now shrinks its string
+     caps until it fits instead. */
+  test("a replay envelope still oversized after string reduction shrinks instead of failing the resume", async () => {
+    const threadId = "shrink-resume-thread";
+    /* Every text part sits exactly at the string cap, so the first reduction
+       pass keeps all ~25 MB and only the shrink passes can fit the frame. */
+    const content = Array.from({ length: 1550 }, () => ({ type: "text", text: "z".repeat(16 * 1024) }));
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: "shrink-turn",
+      status: "completed",
+      items: [{
+        id: "shrink-call-0",
+        type: "mcpToolCall",
+        status: "completed",
+        result: { Ok: { content } },
+      }],
+    }]);
+    const eventStore = new MemoryEventStore();
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect((await host.health()).status).not.toBe("dead");
+    const items = eventStore.load(threadId).filter((event) => event.kind === "item");
+    expect(items).toHaveLength(1);
+    expect(JSON.stringify(items)).toContain("truncated");
+    expect(await host.send({ id: "post-shrink", text: "ping" })).toMatchObject({ outcome: "turn-started" });
+    await host.release();
+  }, 30_000);
+
   test("inline image history in the replay envelope reaches the ledger only as a bounded reference", async () => {
     const threadId = "image-replay-thread";
     const body = Buffer.alloc(1024 * 1024, 5).toString("base64");

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -9,7 +9,7 @@ import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
 import { grantedPluginServerNames, grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
-import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
+import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, shrinkReducedReplayFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
 import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, runtimeImageStore } from "./runtimeImageStore";
 import { STRUCTURED_IMAGE_CAPABILITY, type StructuredImageRef } from "./structuredContent";
 import {
@@ -316,6 +316,12 @@ const REPLAY_ENVELOPE_METHODS = new Set(["thread/resume", "thread/read"]);
 const REPLAY_REDUCTION_THRESHOLD_BYTES = MAX_REPLAY_ENVELOPE_BYTES;
 const REPLAY_STRING_UNITS = 16 * 1024;
 const MAX_REPLAY_RAW_UNITS = 512 * 1024 * 1024;
+/* The streaming pass bounds memory, not the final frame: a history-heavy
+   envelope can exceed MAX_LINE_BYTES on structure alone even with every
+   string capped, and unit counts undercount UTF-8 bytes for non-ASCII text.
+   `shrinkReducedReplayFrame` brings the finished frame under MAX_LINE_BYTES
+   with progressively smaller string caps instead of failing the resume. */
+const REPLAY_STREAM_OUTPUT_UNITS = 64 * 1024 * 1024;
 const MAX_TRACKED_REPLAY_ENVELOPE_REQUESTS = 64;
 /* Codex serializes responses as `{"id":N,"result":…}` (the test fake keeps the
    `jsonrpc` member first); anything else fails closed like before. */
@@ -325,7 +331,7 @@ const REPLAY_FRAME_BUDGETS: ReplayFrameBudgets = {
   /* Keep a full admissible image encoding intact (plus data-URL prefix room)
      so replayed inline images still collapse into bounded references. */
   maxImageStringUnits: MAX_STRUCTURED_IMAGE_ENCODED_BYTES + 64,
-  maxOutputUnits: MAX_LINE_BYTES,
+  maxOutputUnits: REPLAY_STREAM_OUTPUT_UNITS,
   maxRawUnits: MAX_REPLAY_RAW_UNITS,
 };
 const MAX_STDERR_TAIL_BYTES = 16 * 1024;
@@ -2439,6 +2445,9 @@ export class CodexAppServerHost implements EngineHost {
     let reduced: string;
     try {
       reduced = reducer.finish().trim();
+      if (Buffer.byteLength(reduced) > MAX_LINE_BYTES) {
+        reduced = shrinkReducedReplayFrame(reduced, MAX_LINE_BYTES, REPLAY_FRAME_BUDGETS).trim();
+      }
     } catch (error) {
       this.fail(error instanceof ReplayFrameOverflowError ? error : new Error(safeError(error)));
       return;

--- a/src/lib/runtime/codexImageFrames.test.ts
+++ b/src/lib/runtime/codexImageFrames.test.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { expect, test } from "bun:test";
 
-import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
+import { CodexReplayFrameReducer, ReplayFrameOverflowError, sanitizeCodexImageFrame, shrinkReducedReplayFrame, type ImageSink, type ReplayFrameBudgets } from "./codexImageFrames";
 import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES } from "./runtimeImageStore";
 
 const PNG = Buffer.from(
@@ -219,4 +219,20 @@ test("the output budget fails the frame closed", () => {
   const line = JSON.stringify({ result: { items: Array.from({ length: 64 }, () => ({ text: "t".repeat(31) })) } });
   const reducer = new CodexReplayFrameReducer(budgets({ maxOutputUnits: 256 }));
   expect(() => { reducer.feed(line); reducer.finish(); }).toThrow(ReplayFrameOverflowError);
+});
+
+test("shrinkReducedReplayFrame re-reduces a frame until it fits the byte budget", () => {
+  const frame = JSON.stringify({ id: 7, result: { items: Array.from({ length: 100 }, (_, index) => ({ id: `item-${index}`, text: "\u0449".repeat(4096) })) } });
+  const shrunk = shrinkReducedReplayFrame(frame, 300 * 1024, budgets({ maxStringUnits: 4096, maxOutputUnits: 64 * 1024 * 1024, maxRawUnits: 256 * 1024 * 1024 }));
+  expect(Buffer.byteLength(shrunk)).toBeLessThanOrEqual(300 * 1024);
+  const parsed = JSON.parse(shrunk) as { id: number; result: { items: Array<{ id: string; text: string }> } };
+  expect(parsed.id).toBe(7);
+  expect(parsed.result.items).toHaveLength(100);
+  expect(parsed.result.items[0]!.id).toBe("item-0");
+  expect(parsed.result.items[0]!.text).toContain("truncated");
+});
+
+test("shrinkReducedReplayFrame returns a frame already inside the budget untouched", () => {
+  const frame = JSON.stringify({ id: 1, result: { text: "short" } });
+  expect(shrinkReducedReplayFrame(frame, 1024, budgets({}))).toBe(frame);
 });

--- a/src/lib/runtime/codexImageFrames.ts
+++ b/src/lib/runtime/codexImageFrames.ts
@@ -99,6 +99,36 @@ export class ReplayFrameOverflowError extends Error {
 
 const STRING_HEAD_SNIFF_UNITS = 64;
 const IMAGE_STRING_PREFIX = /^data:[a-z0-9.+-]+\/[a-z0-9.+-]+;base64,/i;
+const MIN_SHRINK_STRING_UNITS = 64;
+
+/**
+ * Re-reduces an already-reduced replay frame until it fits a byte budget.
+ * One streaming pass bounds each string in UTF-16 units, but a history-heavy
+ * envelope (production: a 49 MB `thread/resume` response over a 100 MB
+ * Cyrillic-dominated thread) can stay over the frame guard on structure alone,
+ * and unit counts undercount UTF-8 bytes for non-ASCII text. Each pass quarters
+ * the string cap; from the second pass inline image strings shrink too — at
+ * that point losing a replayed inline image beats failing the whole resume,
+ * which previously killed account switching for the conversation outright.
+ * Returns the smallest frame achieved; the caller enforces the budget on it.
+ */
+export function shrinkReducedReplayFrame(frame: string, maxBytes: number, budgets: ReplayFrameBudgets): string {
+  let reduced = frame;
+  let cap = budgets.maxStringUnits;
+  let shrinkImages = false;
+  while (Buffer.byteLength(reduced) > maxBytes && cap > MIN_SHRINK_STRING_UNITS) {
+    cap = Math.max(MIN_SHRINK_STRING_UNITS, Math.floor(cap / 4));
+    const reducer = new CodexReplayFrameReducer({
+      ...budgets,
+      maxStringUnits: cap,
+      ...(shrinkImages ? { maxImageStringUnits: cap } : {}),
+    });
+    reducer.feed(reduced);
+    reduced = reducer.finish();
+    shrinkImages = true;
+  }
+  return reduced;
+}
 
 /**
  * Streaming reducer for one admitted replay JSONL frame (a `thread/resume` or


### PR DESCRIPTION
## Problem

Switching the account on a conversation with a large history failed with `successor provider failed a recoverable preflight`. The migration coordinator's log shows the underlying error: `Codex app-server emitted an oversized JSONL frame` during the `verifying` phase — the successor structured host's `thread/resume` died on the frame guard, so the migration rolled back every time and the switch could never succeed.

Measured against the real thread (102 MB rollout, Cyrillic-heavy): the app-server answers `thread/resume` with a single 49.3 MB JSONL frame. The frame is correctly admitted into `CodexReplayFrameReducer`, but with every string capped at 16 Ki UTF-16 units the reduced envelope still exceeds `MAX_LINE_BYTES` (~24.25 MB) — at-cap strings and structure dominate, and unit counts undercount UTF-8 bytes roughly 2× for Cyrillic text. `finishReplayReduction` then failed the frame closed.

## Fix

- `shrinkReducedReplayFrame` (new, in `codexImageFrames.ts`): re-reduces the finished frame with progressively smaller string caps (quartered per pass, floor 64 units) until it fits the byte budget; from the second pass inline image strings shrink too — losing a replayed inline image beats failing the resume outright.
- The streaming pass keeps an output budget purely as a memory bound (64 Mi units) instead of double-enforcing the final frame limit mid-stream.
- Unadmitted oversized frames (not the awaited `thread/resume`/`thread/read` response) stay fail-closed exactly as before.

## Verification

- New unit tests: byte-budget convergence on a Cyrillic frame, identity for frames already inside the budget.
- New host test: an envelope whose first-pass reduction is ~25 MB (all strings at cap) now opens the host, lands the ledger item with truncation markers, and still starts a turn afterwards.
- `bun test` over `codexImageFrames` + all four `codexAppServerHost` test files: 153 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)