### PR TITLE
fix(orchestrator): never seat a successor in the server's own working directory

### DIFF
--- a/src/lib/orchestrator/seatCommand.test.ts
+++ b/src/lib/orchestrator/seatCommand.test.ts
@@ -601,3 +601,60 @@ test("validation refuses a missing project, empty mandate, and malformed request
   expect((await executeOrchestratorSeatRequest({ project: "proj-a", mandate: "  ", clientRequestId: "req_00000007" }, deps)).status).toBe(400);
   expect((await executeOrchestratorSeatRequest({ project: "proj-a", mandate: "m", clientRequestId: "no" }, deps)).status).toBe(400);
 });
+
+/* Issue #903: a spawn falling back to the server's own working directory
+   minted seats in /app — outside every scanner root — that held authority
+   while permanently inert. */
+test("spawn mode without a cwd fails closed instead of inheriting the server process directory", async () => {
+  const previous = process.env.LLV_ORCHESTRATOR_CWD;
+  delete process.env.LLV_ORCHESTRATOR_CWD;
+  try {
+    const { deps, recorded } = dependencies();
+    const request: Record<string, unknown> = { ...spawnRequest("req_00000201") };
+    delete request.cwd;
+    const result = await executeOrchestratorSeatRequest(request, deps);
+    expect(result.status).toBe(400);
+    expect(result.body.code).toBe("cwd_unresolved");
+    expect(recorded.spawns).toHaveLength(0);
+    expect(orchestratorSeatFor("proj-a").active).toBeNull();
+  } finally {
+    if (previous === undefined) delete process.env.LLV_ORCHESTRATOR_CWD;
+    else process.env.LLV_ORCHESTRATOR_CWD = previous;
+  }
+});
+
+test("spawn mode without a cwd honors the operator override", async () => {
+  const previous = process.env.LLV_ORCHESTRATOR_CWD;
+  process.env.LLV_ORCHESTRATOR_CWD = "/operator/checkout";
+  try {
+    const { deps, recorded } = dependencies();
+    const request: Record<string, unknown> = { ...spawnRequest("req_00000202") };
+    delete request.cwd;
+    const result = await executeOrchestratorSeatRequest(request, deps);
+    expect(result.status).toBe(200);
+    expect(recorded.spawns[0]).toMatchObject({ cwd: "/operator/checkout" });
+  } finally {
+    if (previous === undefined) delete process.env.LLV_ORCHESTRATOR_CWD;
+    else process.env.LLV_ORCHESTRATOR_CWD = previous;
+  }
+});
+
+test("rotation without a cwd continues in the predecessor's checkout", async () => {
+  const previous = process.env.LLV_ORCHESTRATOR_CWD;
+  delete process.env.LLV_ORCHESTRATOR_CWD;
+  try {
+    const { deps, recorded } = dependencies();
+    const seeded = await executeOrchestratorSeatRequest(spawnRequest("req_00000203"), deps);
+    expect(seeded.status).toBe(200);
+    const rotated = await executeOrchestratorRotation({
+      project: "proj-a",
+      clientRequestId: "req_00000204",
+    }, deps);
+    expect(rotated.status).toBe(200);
+    expect(recorded.spawns).toHaveLength(2);
+    expect(recorded.spawns[1]).toMatchObject({ cwd: "/workspace" });
+  } finally {
+    if (previous === undefined) delete process.env.LLV_ORCHESTRATOR_CWD;
+    else process.env.LLV_ORCHESTRATOR_CWD = previous;
+  }
+});

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -79,6 +79,34 @@ export type ExistingConversationTarget =
   | { kind: "eligible"; conversationId: string; path: string; cwd: string; project: string }
   | { kind: "ineligible"; code: "conversation_ineligible" | "invalid_cwd" | "missing_transcript" | "missing_project"; error: string };
 
+/** Issue #903: the spawn fallback must never be this server process's own
+    working directory — in the deployed container that is `/app`, a path
+    outside every scanner root, so the successor's transcript lands where the
+    Viewer cannot see it and the seat holds its authority while permanently
+    inert. With no explicit cwd and no operator override, the project's own
+    newest existing checkout is the only honest default; failing the call
+    beats minting a dead seat. */
+function resolveOrchestratorCwd(project: string, requested: unknown): string | null {
+  if (typeof requested === "string" && requested.trim()) return requested.trim();
+  const override = process.env.LLV_ORCHESTRATOR_CWD?.trim();
+  if (override) return override;
+  const usable = (candidate: string | undefined | null): candidate is string => {
+    if (!candidate) return false;
+    try { return fs.statSync(candidate).isDirectory(); } catch { return false; }
+  };
+  const conversations = Object.values(agentRegistry().readOnlySnapshot().conversations)
+    .filter((conversation) => conversation.projectOwnership?.project === project
+      || conversation.generations.some((generation) => generation.launchProfile?.project === project))
+    .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+  for (const conversation of conversations) {
+    for (let index = conversation.generations.length - 1; index >= 0; index -= 1) {
+      const candidate = conversation.generations[index]?.launchProfile?.cwd;
+      if (usable(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
 async function postSpawnInProcess(body: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }> {
   const { executeSpawnRequest } = await import("@/lib/agent/spawnCommand");
   /* An in-process call on the operator's behalf: the seat route has already
@@ -432,16 +460,24 @@ export async function executeOrchestratorSeatRequest(
   const spawnMandate = begun.kind === "replay" ? begun.seat.mandate : mandate;
 
   const spawnFields = ["engine", "model", "cwd", "effort", "fast", "accountId", "images", "roleParams", "allowSubagents"] as const;
+  const cwd = resolveOrchestratorCwd(project, rawBody.cwd);
+  if (!cwd) {
+    failOrchestratorSeatIntent(project, clientRequestId, "orchestrator cwd could not be resolved");
+    return {
+      status: 400,
+      body: {
+        error: "orchestrator cwd could not be resolved — pass cwd explicitly or set LLV_ORCHESTRATOR_CWD",
+        code: "cwd_unresolved",
+        seat: orchestratorSeatFor(project).pending,
+      },
+    };
+  }
   const spawnBody: Record<string, unknown> = {
     ...Object.fromEntries(spawnFields.flatMap((field) => (rawBody[field] === undefined ? [] : [[field, rawBody[field]]]))),
     role: "orchestrator",
     roleParams: rawBody.roleParams ?? { mode: "standard" },
     project,
-    /* A fresh orchestrator spawns in the Viewer's own checkout unless the
-       caller names a directory — same default the legacy chat-button flow uses. */
-    cwd: typeof rawBody.cwd === "string" && rawBody.cwd.trim()
-      ? rawBody.cwd
-      : (process.env.LLV_ORCHESTRATOR_CWD?.trim() || process.cwd()),
+    cwd,
     ["prompt"]: spawnMandate,
     clientAttemptId: clientRequestId,
   };
@@ -555,7 +591,15 @@ export async function executeOrchestratorRotation(
     ...(rawBody.engine !== undefined ? { engine: rawBody.engine } : {}),
     ...(rawBody.model !== undefined ? { model: rawBody.model } : {}),
     ...(rawBody.effort !== undefined ? { effort: rawBody.effort } : {}),
-    ...(rawBody.cwd !== undefined ? { cwd: rawBody.cwd } : {}),
+    /* Issue #903: a rotation without an explicit cwd continues in the
+       predecessor's checkout rather than falling through to the generic
+       resolver — the successor inherits the incumbent's mandate, so it
+       inherits its working directory too. */
+    ...(rawBody.cwd !== undefined
+      ? { cwd: rawBody.cwd }
+      : predecessor
+        ? { cwd: predecessor.cwd }
+        : {}),
     ...(rawBody.accountId !== undefined ? { accountId: rawBody.accountId } : {}),
   }, dependencies);
   return {


### PR DESCRIPTION
## Problem

Issue #903: `rotate_orchestrator` without an explicit `cwd` spawned the successor seat with `cwd=/app` — the viewer container's own working directory. The transcript landed under a `-app` project outside every scanner root, `get_conversation` failed with `selected_conversation_outside_roots`, and the seat held the designated-orchestrator authority while permanently inert, stalling deploys until another rotation. Observed live on 2026-08-04 (seat epoch 50).

Root cause: `executeOrchestratorSeatRequest` defaulted the spawn `cwd` to `LLV_ORCHESTRATOR_CWD || process.cwd()`, and in the deployed container `process.cwd()` is `/app`.

## Fix

- A rotation without a `cwd` continues in the predecessor's checkout (the successor inherits the incumbent's mandate, so it inherits its working directory too; the value comes from `conversationTarget`, which already validates the directory exists).
- A plain spawn resolves, in order: explicit caller `cwd` → `LLV_ORCHESTRATOR_CWD` operator override → the project's newest existing checkout from the registry's conversations. With none of those, the call fails closed with `cwd_unresolved` instead of minting a dead seat.

## Verification

New tests: spawn without cwd fails closed with `cwd_unresolved` and no spawn attempt; the operator override is honored; rotation without cwd records the predecessor's checkout in the spawn body. `bun test src/lib/orchestrator/seatCommand.test.ts` — 27 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)