### PR TITLE
fix(state): keep terminal deliveries and settled pipelines out of hot state

### DIFF
--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -129,14 +129,14 @@ async function reconcileControllerRuntime(registry: AgentRegistry, files: Contro
   const transcriptHosts = await readTranscriptHosts(true, files);
   try {
     await runReaperCycle({ registry, hosts: transcriptHosts.hosts, files });
-  } catch {
-    console.error("[agent reaper] lifecycle reconciliation failed");
+  } catch (error) {
+    console.error("[agent reaper] lifecycle reconciliation failed", error);
   }
   try {
     const report = await runHeadlessProcessReaper({ hosts: transcriptHosts.hosts, flows: loadFlows() });
     if (report.signaled > 0) console.warn(`[headless process reaper] terminated ${report.signaled} stale process group(s)`);
-  } catch {
-    console.error("[headless process reaper] reconciliation failed");
+  } catch (error) {
+    console.error("[headless process reaper] reconciliation failed", error);
   }
 }
 
@@ -246,8 +246,8 @@ const globalController = globalThis as unknown as {
 function startInventoryController(registry: AgentRegistry, quota: QuotaController): void {
   const controller = globalController.__llvAccountMigrationController ??= new AccountMigrationController(registry, quota);
   if (!globalController.__llvAccountMigrationTimer) {
-    const timer = setInterval(() => void controller.poll().catch(() => {
-      console.error("[account migration controller] durable reconciliation tick failed");
+    const timer = setInterval(() => void controller.poll().catch((error) => {
+      console.error("[account migration controller] durable reconciliation tick failed", error);
     }), CONTROLLER_INTERVAL_MS);
     timer.unref?.();
     globalController.__llvAccountMigrationTimer = timer;
@@ -256,8 +256,8 @@ function startInventoryController(registry: AgentRegistry, quota: QuotaControlle
     globalController.__llvAccountMigrationBootstrapStarted = true;
     const timer = setTimeout(() => {
       globalController.__llvAccountMigrationInitialTimer = undefined;
-      void controller.poll().catch(() => {
-        console.error("[account migration controller] initial inventory reconciliation failed");
+      void controller.poll().catch((error) => {
+        console.error("[account migration controller] initial inventory reconciliation failed", error);
       });
     }, INITIAL_INVENTORY_DELAY_MS);
     timer.unref?.();
@@ -323,8 +323,8 @@ export async function startAccountMigrationController(): Promise<void> {
     () => reconcileAccountMigrationCycle(registry, quota),
   );
   registerAccountMigrationTick(() => fastController.tick());
-  void fastController.tick().catch(() => {
-    console.error("[account migration controller] initial durable reconciliation failed");
+  void fastController.tick().catch((error) => {
+    console.error("[account migration controller] initial durable reconciliation failed", error);
   });
   startInventoryControllerWorker();
 }

--- a/src/lib/accounts/migration/controllerSignal.ts
+++ b/src/lib/accounts/migration/controllerSignal.ts
@@ -28,8 +28,8 @@ export function requestAccountMigrationTick(): void {
     signal.scheduled = false;
     const tick = signal.tick;
     if (tick === null) return;
-    void tick().catch(() => {
-      console.error("[account migration controller] requested reconciliation failed");
+    void tick().catch((error) => {
+      console.error("[account migration controller] requested reconciliation failed", error);
     });
   });
 }

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -91,11 +91,12 @@ describe("agent registry", () => {
     const snapshot = store.snapshot();
     for (let index = 0; index < 105; index += 1) {
       const id = `legacy-${String(index).padStart(3, "0")}`;
+      const settledAt = new Date(Date.now() - (105 - index) * 1_000).toISOString();
       snapshot.heldDeliveries[id] = {
         id,
         conversationId: conversation.id,
         text: `legacy body ${index}`,
-        createdAt: `2026-07-11T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
+        createdAt: settledAt,
         clientMessageId: id,
         payloadKind: "text",
         runtimeImages: [],
@@ -105,7 +106,7 @@ describe("agent registry", () => {
         generationId: conversation.generations.at(-1)!.id,
         attempts: 1,
         assignedAt: null,
-        deliveredAt: `2026-07-11T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
+        deliveredAt: settledAt,
         error: null,
       } as unknown as (typeof snapshot.heldDeliveries)[string];
     }
@@ -119,6 +120,43 @@ describe("agent registry", () => {
     expect(retained.every((delivery) => delivery.text === "")).toBe(true);
     expect(retained.map((delivery) => delivery.id)).not.toContain("legacy-000");
     expect(retained.map((delivery) => delivery.id)).toContain("legacy-104");
+  });
+
+  test("startup compaction expires terminal deliveries past the retention window", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/expired-deliveries.jsonl", "default");
+    const snapshot = store.snapshot();
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000).toISOString();
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1_000).toISOString();
+    const seed = (id: string, state: "delivered" | "failed", settledAt: string) => {
+      snapshot.heldDeliveries[id] = {
+        id,
+        conversationId: conversation.id,
+        text: "",
+        createdAt: settledAt,
+        clientMessageId: id,
+        payloadKind: "text",
+        runtimeImages: [],
+        contentDigest: null,
+        artifactPaths: [],
+        state,
+        generationId: conversation.generations.at(-1)!.id,
+        attempts: 1,
+        assignedAt: null,
+        deliveredAt: state === "delivered" ? settledAt : null,
+        error: state === "failed" ? "structured host delivery failed" : null,
+      } as unknown as (typeof snapshot.heldDeliveries)[string];
+    };
+    seed("expired-delivered", "delivered", eightDaysAgo);
+    seed("expired-failed", "failed", eightDaysAgo);
+    seed("recent-delivered", "delivered", oneHourAgo);
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    const restarted = new AgentRegistry(store.filename);
+    const retained = restarted.snapshot().heldDeliveries;
+    expect(retained["expired-delivered"]).toBeUndefined();
+    expect(retained["expired-failed"]).toBeUndefined();
+    expect(retained["recent-delivered"]).toMatchObject({ state: "delivered" });
   });
 
   test("compaction retains explicit operation ownership after its delivery tombstone expires", () => {
@@ -346,11 +384,12 @@ describe("agent registry", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-delivered-retry.jsonl", "default");
     const snapshot = store.snapshot();
+    const legacySettledAt = new Date(Date.now() - 60 * 60 * 1_000).toISOString();
     snapshot.heldDeliveries["legacy-delivered"] = {
       id: "legacy-delivered",
       conversationId: conversation.id,
       text: "",
-      createdAt: "2026-07-11T00:00:00.000Z",
+      createdAt: legacySettledAt,
       clientMessageId: "legacy-client-message",
       payloadKind: "text",
       runtimeImages: [],
@@ -359,8 +398,8 @@ describe("agent registry", () => {
       state: "delivered",
       generationId: conversation.generations.at(-1)!.id,
       attempts: 1,
-      assignedAt: "2026-07-11T00:00:01.000Z",
-      deliveredAt: "2026-07-11T00:00:02.000Z",
+      assignedAt: legacySettledAt,
+      deliveredAt: legacySettledAt,
       error: null,
     } as unknown as (typeof snapshot.heldDeliveries)[string];
     fs.writeFileSync(store.filename, JSON.stringify(snapshot));
@@ -433,7 +472,7 @@ describe("agent registry", () => {
     ).id).toBe(held.id);
   });
 
-  test("a retirement-aged delivered reservation still replays exactly and conflicts by digest", () => {
+  test("a delivered reservation inside the retention window replays exactly; past it the key releases", () => {
     const store = registry();
     const conversation = store.ensureConversation("claude", "/retired-tombstone.jsonl", "default");
     const refs = [{ sha256: "a".repeat(64), mime: "image/png" as const, bytes: 67 }];
@@ -441,19 +480,26 @@ describe("agent registry", () => {
     const held = store.holdDelivery(conversation.id, content.content.text, "retired-key", "runtime-images", refs, content.contentDigest);
     store.beginDeliveryAttempt(held.id, conversation.generations.at(-1)!.id);
     store.recordDeliveryOutcome(held.id, "delivered");
-    /* Age the tombstone far past the reachability retirement grace: blob refs
-       may retire from quota accounting, but the digest tombstone itself keeps
-       replay and conflict semantics untouched. */
-    const snapshot = store.snapshot();
+    /* Inside the terminal retention window the digest tombstone keeps replay
+       and conflict semantics untouched. */
+    const withinRetention = new AgentRegistry(store.filename);
+    expect(withinRetention.holdDelivery(conversation.id, content.content.text, "retired-key", "runtime-images", refs, content.contentDigest))
+      .toMatchObject({ id: held.id, state: "delivered" });
+    const changed = structuredContent("retired but idempotent", [{ sha256: "b".repeat(64), mime: "image/png" as const, bytes: 91 }]);
+    expect(() => withinRetention.holdDelivery(conversation.id, changed.content.text, "retired-key", "runtime-images", changed.content.images, changed.contentDigest))
+      .toThrow(DeliveryReservationConflictError);
+
+    /* Past the retention window startup compaction expires the tombstone, so
+       the client message key releases and a new payload admits as a fresh
+       reservation instead of replaying the long-settled one. */
+    const snapshot = withinRetention.snapshot();
     snapshot.heldDeliveries[held.id]!.deliveredAt = "2026-01-01T00:00:00.000Z";
     fs.writeFileSync(store.filename, JSON.stringify(snapshot));
     const restarted = new AgentRegistry(store.filename);
-
-    expect(restarted.holdDelivery(conversation.id, content.content.text, "retired-key", "runtime-images", refs, content.contentDigest))
-      .toMatchObject({ id: held.id, state: "delivered" });
-    const changed = structuredContent("retired but idempotent", [{ sha256: "b".repeat(64), mime: "image/png" as const, bytes: 91 }]);
-    expect(() => restarted.holdDelivery(conversation.id, changed.content.text, "retired-key", "runtime-images", changed.content.images, changed.contentDigest))
-      .toThrow(DeliveryReservationConflictError);
+    expect(restarted.snapshot().heldDeliveries[held.id]).toBeUndefined();
+    const readmitted = restarted.holdDelivery(conversation.id, changed.content.text, "retired-key", "runtime-images", changed.content.images, changed.contentDigest);
+    expect(readmitted.id).not.toBe(held.id);
+    expect(readmitted.state).toBe("assigned");
   });
 
   test("a new payload supersedes a stale terminal failed reservation instead of poisoning the key", () => {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1720,7 +1720,18 @@ function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?:
   }
 }
 
-function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
+/* Terminal deliveries only serve duplicate-send absorption; a week covers every
+   replay window while keeping thousands of dead rows out of the hot snapshot
+   (4.3k terminal rows from a single month froze the Viewer's event loop). */
+const TERMINAL_DELIVERY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+function terminalDeliveryExpired(delivery: HeldDelivery, nowMs: number | undefined): boolean {
+  if (nowMs === undefined) return false;
+  const settledAt = Date.parse(delivery.deliveredAt ?? delivery.createdAt);
+  return Number.isFinite(settledAt) && nowMs - settledAt > TERMINAL_DELIVERY_RETENTION_MS;
+}
+
+function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId, nowMs?: number): number {
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
     file.deliveryOperationOwners[delivery.command.operationId] ??= {
@@ -1754,6 +1765,20 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     }
   }
   let removed = 0;
+  for (const groups of [deliveredGroups, failedGroups]) {
+    for (const [conversationId, deliveries] of groups) {
+      const kept: HeldDelivery[] = [];
+      for (const delivery of deliveries) {
+        if (terminalDeliveryExpired(delivery, nowMs)) {
+          delete file.heldDeliveries[delivery.id];
+          removed += 1;
+        } else {
+          kept.push(delivery);
+        }
+      }
+      groups.set(conversationId, kept);
+    }
+  }
   for (const deliveries of deliveredGroups.values()) {
     deliveries.sort((left, right) => (right.deliveredAt ?? right.createdAt).localeCompare(left.deliveredAt ?? left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(100)) {
@@ -2975,7 +3000,7 @@ export class AgentRegistry {
       }
       throw error;
     }
-    compactDeliveryReservations(file);
+    compactDeliveryReservations(file, undefined, this.now());
     if (serializeRegistry(file) !== original) writeAtomic(this.filename, file);
   }
 
@@ -5987,7 +6012,7 @@ export class AgentRegistry {
         deliveredAt: null,
         error: null,
       };
-      compactDeliveryReservations(file, canonicalId);
+      compactDeliveryReservations(file, canonicalId, this.now());
       const count = Object.values(file.heldDeliveries).filter((item) =>
         item.conversationId === canonicalId
         && ["held", "assigned", "delivery-uncertain"].includes(item.state)).length;
@@ -6051,7 +6076,7 @@ export class AgentRegistry {
   }
 
   compactDeliveryReservations(): number {
-    return this.mutate((file) => compactDeliveryReservations(file));
+    return this.mutate((file) => compactDeliveryReservations(file, undefined, this.now()));
   }
 
   queueSuccessorCleanup(conversationId: ViewerConversationId, receipt: ProviderReceipt): void {
@@ -6130,7 +6155,7 @@ export class AgentRegistry {
       if (state === "failed") failInitialSpawnReceiptForDelivery(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       const settled = clone(delivery);
-      if (state === "delivered" || state === "failed") compactDeliveryReservations(file, delivery.conversationId);
+      if (state === "delivered" || state === "failed") compactDeliveryReservations(file, delivery.conversationId, this.now());
       return settled;
     });
   }
@@ -6190,7 +6215,7 @@ export class AgentRegistry {
         return clone(delivery);
       });
       for (const compactConversationId of compactConversations) {
-        compactDeliveryReservations(file, compactConversationId);
+        compactDeliveryReservations(file, compactConversationId, this.now());
       }
       return settled;
     });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -44,7 +44,7 @@ import { latestOperationalPipelineAttempt } from "@/lib/pipelines/attemptSelecti
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import { PIPELINE_LIST_DEFAULT_LIMIT, projectPipelineListRows } from "@/lib/pipelines/listProjection";
-import { loadPipelinesForList } from "@/lib/pipelines/store";
+import { findPipelineRecord, loadPipelinesForList } from "@/lib/pipelines/store";
 import type { CreatePipelineRequest, PatchPipelineRequest, Pipeline, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
 import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
@@ -1327,7 +1327,7 @@ async function rotateOrchestrator(args: McpToolArgs, control: ViewerControlDepen
 
 async function getPipeline(args: McpToolArgs): Promise<McpToolPayload> {
   const pipelineId = required(args, "pipelineId");
-  const pipeline = getPipelines().pipelines.find((candidate) => candidate.id === pipelineId);
+  const pipeline = findPipelineRecord(pipelineId);
   if (!pipeline) throw new Error("pipeline not found");
   return redactPayload({ pipelineId, pipeline });
 }

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -9,6 +9,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { registerPipelineTick } from "./controllerSignal";
 import { tickPipelines } from "./engine";
+import { archiveSettledPipelines } from "./store";
 
 export type FlowPipelineControllerPhase = "pipelines" | "scan" | "flows" | "idle";
 export type FlowPipelineControllerHeartbeatState =
@@ -67,6 +68,7 @@ type PhaseOutcome<T> =
 
 const DEFAULT_PHASE_DEADLINE_MS = 15_000;
 const DEFAULT_MAX_PASSES = 8;
+const ARCHIVE_SWEEP_INTERVAL_MS = 60 * 60 * 1_000;
 export const FLOW_PIPELINE_WATCHDOG_MS = 30_000;
 const HEARTBEAT_FILE = "flow-pipeline-controller-heartbeat.json";
 
@@ -104,6 +106,7 @@ export class FlowPipelineController {
   private trailingCycleRequested = false;
   private trailingTrigger = "signal";
   private cycle = 0;
+  private lastArchiveSweepAt = 0;
   private readonly activePhases = new Map<Exclude<FlowPipelineControllerPhase, "idle">, ActivePhase>();
   private readonly ports: Required<FlowPipelineControllerPorts>;
   private readonly phaseDeadlineMs: number;
@@ -190,6 +193,7 @@ export class FlowPipelineController {
         || (scanOutcome?.state === "completed" && scanOutcome.value.complete);
       if (!changed) break;
     }
+    this.sweepSettledArchive();
     const blocked = [...this.activePhases.entries()]
       .sort((left, right) => left[1].startedAt - right[1].startedAt)[0];
     if (blocked) {
@@ -211,6 +215,19 @@ export class FlowPipelineController {
         startedAt: this.ports.now(),
       });
     }
+  }
+
+  /** Hourly, off the cycle's critical path: move settled pipeline records to
+      the cold archive so the hot registry stays small. */
+  private sweepSettledArchive(): void {
+    const now = this.ports.now();
+    if (now - this.lastArchiveSweepAt < ARCHIVE_SWEEP_INTERVAL_MS) return;
+    this.lastArchiveSweepAt = now;
+    void archiveSettledPipelines(now).then((archived) => {
+      if (archived > 0) this.ports.log(`[flow pipeline controller] archived ${archived} settled pipeline record(s)`);
+    }).catch((error) => {
+      this.ports.log("[flow pipeline controller] settled pipeline archive sweep failed", error);
+    });
   }
 
   private async runPhase<T>(

--- a/src/lib/pipelines/controllerSignal.ts
+++ b/src/lib/pipelines/controllerSignal.ts
@@ -48,8 +48,8 @@ export function requestPipelineTick(): void {
     signal.scheduled = false;
     const tick = signal.tick;
     if (tick === null) return;
-    void tick().catch(() => {
-      console.error("[pipeline controller] requested tick failed");
+    void tick().catch((error) => {
+      console.error("[pipeline controller] requested tick failed", error);
     });
   });
 }

--- a/src/lib/pipelines/listProjection.ts
+++ b/src/lib/pipelines/listProjection.ts
@@ -22,7 +22,7 @@
 import type { FlowEngine } from "@/lib/flows/types";
 
 import { latestOperationalStageAttempt } from "./attemptSelection";
-import { loadPipelinesForList } from "./store";
+import { loadArchivedPipelines, loadPipelinesForList } from "./store";
 import type {
   Pipeline,
   PipelineAccess,
@@ -253,7 +253,12 @@ export async function projectPipelineListRows(
 ): Promise<PipelineListRow[]> {
   const checkpoint = options.checkpoint ?? (() => {});
   checkpoint();
-  const records = (options.source ?? loadPipelinesForList)();
+  const hot = (options.source ?? loadPipelinesForList)();
+  /* Settled records live in the cold archive; only a closed-inclusive list
+     pays for reading them. */
+  const records = filter.includeClosed === true && !options.source
+    ? [...hot, ...loadArchivedPipelines()]
+    : hot;
   checkpoint();
   const selected = selectPipelineListRecords(records, filter);
   const rows: PipelineListRow[] = [];

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { buildPipeline, loadPipelines, PIPELINES_SCHEMA_VERSION, savePipelines, withPipelineMutation } from "./store";
+import { archiveSettledPipelines, buildPipeline, findPipelineRecord, loadArchivedPipelines, loadPipelines, PIPELINES_SCHEMA_VERSION, savePipelines, withPipelineMutation } from "./store";
 import type { Pipeline, PipelineStage } from "./types";
 
 test("pipelines round-trip through a schema-versioned state file", () => {
@@ -354,5 +354,42 @@ test("an unconfirmed host record survives a round trip and rejects a malformed o
     fs.rmSync(sandbox, { recursive: true, force: true });
     if (previous === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previous;
+  }
+});
+
+test("settled pipelines archive out of the hot registry and stay readable", async () => {
+  const previous = process.env.LLV_STATE_DIR;
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipelines-archive-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  try {
+    const stages: PipelineStage[] = [
+      { id: "build", kind: "run", prompt: "build", next: null, effectiveRole: { roleId: null, engine: "codex", model: "gpt-5.6-sol", effort: "medium", access: "read-write", promptScaffold: null } },
+    ];
+    const record = (id: string, overrides: Partial<Pipeline>): Pipeline => ({
+      ...buildPipeline({ id, task: `task ${id}`, project: "viewer", repoDir: "/repo", stages, srcPath: null, srcConversationId: null, now: "2026-07-01T00:00:00.000Z" }),
+      ...overrides,
+    });
+    const nowMs = Date.parse("2026-08-05T12:00:00.000Z");
+    const oldClosed = record("aaaa0001", { state: "closed", closedAt: "2026-07-10T00:00:00.000Z", cursor: null });
+    const freshClosed = record("aaaa0002", { state: "closed", closedAt: "2026-08-05T00:00:00.000Z", cursor: null });
+    const hiddenDraft = record("aaaa0003", { state: "draft", hiddenAt: "2026-07-15T00:00:00.000Z" });
+    const running = record("aaaa0004", { state: "running" });
+    savePipelines([oldClosed, freshClosed, hiddenDraft, running]);
+
+    expect(await archiveSettledPipelines(nowMs)).toBe(2);
+    const hotIds = loadPipelines().map((pipeline) => pipeline.id).sort();
+    expect(hotIds).toEqual(["aaaa0002", "aaaa0004"]);
+    const archivedIds = loadArchivedPipelines().map((pipeline) => pipeline.id).sort();
+    expect(archivedIds).toEqual(["aaaa0001", "aaaa0003"]);
+
+    /* By-id reads still resolve archived records; re-sweeping is idempotent. */
+    expect(findPipelineRecord("aaaa0001")?.task).toBe("task aaaa0001");
+    expect(findPipelineRecord("aaaa0004")?.state).toBe("running");
+    expect(findPipelineRecord("missing0")).toBeNull();
+    expect(await archiveSettledPipelines(nowMs)).toBe(0);
+  } finally {
+    if (previous === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previous;
+    fs.rmSync(sandbox, { recursive: true, force: true });
   }
 });

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -561,6 +561,67 @@ export function savePipelines(pipelines: Pipeline[]): void {
   withFileTransactionSync(pipelinesFile(), "pipeline state is busy", () => savePipelinesUnlocked(pipelines));
 }
 
+const pipelinesArchiveFile = () => statePath("pipelines-archive.json");
+
+/** Settled records leave the hot registry after this long; the archive keeps
+    the full record for the closed list and by-id reads. */
+const SETTLED_PIPELINE_ARCHIVE_AFTER_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Lenient read: the archive is cold storage, so a malformed or legacy record
+    is skipped with a log line instead of poisoning every closed-list read. */
+export function loadArchivedPipelines(): Pipeline[] {
+  const raw = readJson(pipelinesArchiveFile());
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return [];
+  const file = raw as Partial<PipelineFile>;
+  if (typeof file.schemaVersion !== "number" || !MIGRATABLE_SCHEMA_VERSIONS.has(file.schemaVersion) || !Array.isArray(file.pipelines)) return [];
+  const legacyRecords = file.schemaVersion === 2 ? file.pipelines.map(migrateV2Pipeline) : file.pipelines;
+  const migrated = file.schemaVersion < PIPELINES_SCHEMA_VERSION ? legacyRecords.map(migrateTaskIds) : legacyRecords;
+  const records = migrated.filter(isPipeline);
+  if (records.length !== migrated.length) {
+    console.error(`[pipelines] skipped ${migrated.length - records.length} malformed archived pipeline record(s)`);
+  }
+  return records.map(reviveLoadedPipeline);
+}
+
+function pipelineSettledForArchive(pipeline: Pipeline, nowMs: number): boolean {
+  /* Closed records archive on closedAt; hidden drafts never close, so their
+     hiddenAt stands in. Anything still actionable (running, needs_decision,
+     visible drafts) stays hot. */
+  const settledAt = pipeline.closedAt ?? (pipeline.state === "draft" ? pipeline.hiddenAt : null);
+  if (!settledAt) return false;
+  const parsed = Date.parse(settledAt);
+  return Number.isFinite(parsed) && nowMs - parsed > SETTLED_PIPELINE_ARCHIVE_AFTER_MS;
+}
+
+/** Move settled records out of the hot registry. Every mutation re-parses and
+    rewrites the whole pipelines.json, so hundreds of closed records tax each
+    tick (a 7.2 MB hot registry helped freeze the production Viewer). */
+export async function archiveSettledPipelines(nowMs = Date.now()): Promise<number> {
+  return withPipelineMutation((pipelines, persist) => {
+    const settled = pipelines.filter((pipeline) => pipelineSettledForArchive(pipeline, nowMs));
+    if (settled.length === 0) return 0;
+    const archived = loadArchivedPipelines();
+    const archivedIds = new Set(archived.map((pipeline) => pipeline.id));
+    atomicWriteJson(pipelinesArchiveFile(), {
+      schemaVersion: PIPELINES_SCHEMA_VERSION,
+      pipelines: [...archived, ...settled.filter((pipeline) => !archivedIds.has(pipeline.id))],
+    });
+    const settledIds = new Set(settled.map((pipeline) => pipeline.id));
+    const active = pipelines.filter((pipeline) => !settledIds.has(pipeline.id));
+    pipelines.length = 0;
+    pipelines.push(...active);
+    persist();
+    return settled.length;
+  });
+}
+
+/** Full-record read by id: the hot registry first, then the archive. */
+export function findPipelineRecord(pipelineId: string): Pipeline | null {
+  return loadPipelines().find((pipeline) => pipeline.id === pipelineId)
+    ?? loadArchivedPipelines().find((pipeline) => pipeline.id === pipelineId)
+    ?? null;
+}
+
 /** Validates durable task membership at the pipeline store seam. */
 export function pipelineTaskLinkError(
   pipeline: Pick<Pipeline, "project">,


### PR DESCRIPTION
## Why

Production Viewer froze for 2–16 minutes at a stretch (event loop pinned at 100% CPU, RSS sawtooth 3–7 GB, ~74k minor faults/s, 29 TB cumulative page-cache re-reads over 18 h). Two hot-state feeders:

- `heldDeliveries` carried **4295 terminal rows** (oldest 2026-07-11, all `delivered`/`failed`) spread over 1545 conversations — the per-conversation caps (100 delivered / 50 failed) never bite at ~2.8 rows per conversation, so the 26 MB registry snapshot only ever grew, and every cross-process revision bump re-sweeps it in full.
- `pipelines.json` was **7.2 MB with 494 of 516 records closed**; every mutation re-parses and rewrites all of it, and `GET /api/pipelines` serialized all of it per board load.

## What

- **registry:** terminal held deliveries expire 7 days after settling (`deliveredAt ?? createdAt`); caps stay as the secondary bound; migration-cancellation markers and non-terminal states are untouched. `deliveryOperationOwners` are untouched, so operation replay dedup survives the tombstone. Semantic change: a client-message-id replay older than 7 days admits as a fresh reservation — the aged-tombstone test now pins the bounded-retention behavior.
- **pipelines:** settled records (closed, or drafts hidden >3 days) move to a cold `pipelines-archive.json` via an hourly `FlowPipelineController` sweep. Closed-inclusive list projections and `get_pipeline` fall back to the archive; hot paths stop paying for settled records.
- **controllers:** swallowed `catch` blocks log the error object, so the next incident's logs name the culprit.

## Testing

- `bun test` on all 7 touched test files in a clean worktree off `origin/main`: **187 pass, 0 fail** (includes new TTL and archive round-trip cases).
- `eslint` clean on all touched files; `tsc --noEmit` clean apart from pre-existing `PdfPane.tsx`/`pdfjs-dist` errors.
- Privacy gate: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)