### PR TITLE
perf(flows): cache the parsed flow registry against the file signature

### DIFF
--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -170,7 +170,40 @@ export function mergeSeededPresets(presets: FlowPreset[], seeds = seededPresetsF
   return [...missingSeeds, ...custom];
 }
 
+let flowsCache: { signature: string; flows: Flow[] } | null = null;
+
+function flowsFileSignature(): string | null {
+  const filename = flowsFile();
+  try {
+    const stat = fs.statSync(filename, { bigint: true });
+    return `${filename}:${stat.mtimeNs}:${stat.size}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Fresh per-call copies of every layer a caller may write (flow and round
+    rows) — the same freshness depth the parse path produces — so the cached
+    records stay pristine while callers mutate and save their copies. Deeper
+    config leaves are shared; nothing mutates their internals in place. */
+function reviveCachedFlows(flows: Flow[]): Flow[] {
+  return flows.map((flow) => ({ ...flow, rounds: flow.rounds.map((round) => ({ ...round })) }));
+}
+
+/** The parse+normalize of the whole flow registry, cached against the file
+    signature: production read it ~54 times a second from tick loops and
+    runtime consumers, re-parsing 1.6 MB of JSON each time. Every writer goes
+    through an atomic rename, which changes the signature and invalidates. */
 export function loadFlows(): Flow[] {
+  const before = flowsFileSignature();
+  if (before !== null && flowsCache?.signature === before) return reviveCachedFlows(flowsCache.flows);
+  const parsed = parseFlowsFromDisk();
+  const after = flowsFileSignature();
+  if (after !== null && before === after) flowsCache = { signature: after, flows: parsed };
+  return reviveCachedFlows(parsed);
+}
+
+function parseFlowsFromDisk(): Flow[] {
   const raw = readJson(flowsFile()) as FlowFile | null;
   const flows = Array.isArray(raw?.flows) ? raw.flows.filter(isFlow) : [];
   return flows.map((flow) => ({


### PR DESCRIPTION
Second tranche of the 2026-08-05 freeze work (#906, #907). After #906 the Viewer still read ~244 MB/s from page cache in steady state; a high-frequency fd census attributed ~86 MB/s of it to `loadFlows()` — flows.json (1.6 MB) opened and re-parsed ~54×/s from tick loops, reapers and runtime consumers.

- `loadFlows()` now caches the parsed+normalized registry against `{path, mtimeNs, size}` (same pattern as `cachedPipelines()` in the pipelines store).
- Callers receive fresh flow+round copies (`reviveCachedFlows`) — the identical freshness depth the parse path produced, so existing mutate-then-save flows keep their semantics; deeper config leaves are shared and nothing mutates their internals in place (checked all callers).
- Writers invalidate via the atomic rename changing the signature, cross-process included.

Tests: flows store, store-isolation, engine, commands, visibility + runtime serverConsumers — all pass in a clean worktree off origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)