### PR TITLE
perf(timeline): serve the project timeline from the completed scan generation

### DIFF
--- a/src/app/api/timeline/route.ts
+++ b/src/app/api/timeline/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { listFiles } from "@/lib/scanner";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { projectTimeline } from "@/lib/timeline";
 import type { ActionEvent, ApiError } from "@/lib/types";
@@ -8,7 +8,14 @@ import type { ActionEvent, ApiError } from "@/lib/types";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/** Recent project actions for the timeline map: GET /api/timeline?project=…&limit=… */
+/** Recent project actions for the timeline map: GET /api/timeline?project=…&limit=…
+ *
+ * Serves from the latest completed scan generation. A fresh `listFiles()` here
+ * re-derived the whole corpus (thousands of head/tail reads through 64-entry
+ * caches) per poll and held the project view on skeletons for minutes; the
+ * timeline only needs path/mtime/size/fmt/title for one project's fresh files,
+ * which the cached snapshot already carries. Background revalidation keeps the
+ * generation current. */
 export async function GET(
   req: NextRequest,
 ): Promise<NextResponse<{ events: ActionEvent[] } | ApiError>> {
@@ -16,7 +23,10 @@ export async function GET(
   if (!project) return NextResponse.json({ error: "project required" }, { status: 400 });
   let limit = Number(req.nextUrl.searchParams.get("limit") ?? "240");
   if (!Number.isFinite(limit) || limit <= 0) limit = 240;
-  const files = await listFiles();
+  const completed = await completedFileScan();
+  /* Shallow copies: the overlay stamps titles in place while the completed
+     scan's records are shared with every other consumer of the cache. */
+  const files = completed.snapshot.files.map((entry) => ({ ...entry }));
   overlaySessionTitles(files);
   return NextResponse.json({ events: projectTimeline(files, project, Math.min(limit, 600)) });
 }


### PR DESCRIPTION
Third tranche of the 2026-08-05 lag work (#906, #908, follow-ups in #907).

Opening a large project held the board on skeleton cards for minutes: `GET /api/timeline?project=…` measured **107 s** for a 541-byte answer. The route ran a fresh `listFiles()` per poll — the full corpus derivation pipeline (thousands of head/tail reads through 64-entry caches, guaranteed thrash on a ~6000-transcript corpus) — while `projectTimeline` then keeps ≤18 fresh files of one project.

The route now consumes the latest completed scan generation (`completedFileScan()` — the same cached snapshot the files route and flow pipeline controller read), with shallow per-entry copies so `overlaySessionTitles` never stamps the shared cache. Background revalidation keeps the generation current; timeline staleness is bounded by the scan refresh cadence, which is fine for a "recent actions" rail.

Also noted in #907: `/api/proc`, `/api/tmux` attach, `/api/flows` create, `/api/answer` and tasks curator also call full `listFiles()` on request paths — user-action endpoints, lower frequency, same candidate treatment.

Testing: route export tests pass; tsc clean for the touched file; verified against production that the corpus snapshot carries every field the timeline needs (path/mtime/size/fmt/title/project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)