### PR TITLE
fix(delivery): pin the target path into the scan for resume/kill/reconfigure

### DIFF
--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -100,7 +100,7 @@ export async function reconfigureConversation(
   overrides: ReconfigureConversationOverrides = {},
 ): Promise<DeliveryOutcome> {
   if (!filePath || !(overrides.pathAllowed ?? pathAllowed)(filePath)) return failure("the conversation path is required", 400);
-  const entry = (await (overrides.listFiles ?? listFiles)()).find((item) => item.path === filePath);
+  const entry = (await (overrides.listFiles ?? listFiles)({ pin: filePath })).find((item) => item.path === filePath);
   if (!entry || (entry.engine !== "claude" && entry.engine !== "codex")) return failure("conversation is unavailable", 403);
   const registry = overrides.registry ?? agentRegistry();
   const registered = registeredHostForPath(registry.readOnlySnapshot(), filePath);
@@ -360,7 +360,9 @@ export async function resumeConversation(
   } catch (error) {
     return failure(error);
   }
-  const entry = (await (overrides.listFiles ?? listFiles)()).find((item) => item.path === filePath);
+  /* Pinned: the resumable transcript may have aged past the scan's recency
+     cap — a conversation the operator can still open must stay resumable. */
+  const entry = (await (overrides.listFiles ?? listFiles)({ pin: filePath })).find((item) => item.path === filePath);
   if (!entry) return failure("file is unknown to the viewer", 403);
   const profile = registry.launchProfileForPath(entry.path);
   const spec = (overrides.resumeSpecFor ?? resumeSpecFor)(entry.root, entry.path, {
@@ -421,7 +423,7 @@ export async function killConversation(filePath: string, overrides: KillConversa
   if (!filePath || !(overrides.pathAllowed ?? pathAllowed)(filePath)) {
     return failure("the conversation path is required to close", 400);
   }
-  const entry = (await (overrides.listFiles ?? listFiles)()).find((item) => item.path === filePath);
+  const entry = (await (overrides.listFiles ?? listFiles)({ pin: filePath })).find((item) => item.path === filePath);
   /* A branch column shares the root conversation's pane: killing it from a
      branch close would take the whole agent down along with the root card
      that is still on screen. Only a root conversation may kill a pane. */


### PR DESCRIPTION
Resume refused conversations the operator had messaged the same day with `file is unknown to the viewer` (403): the delivery lookups search the capped files shortlist (~450 entries for a ~6000-transcript corpus), and a transcript pushed past the recency cap by fresher pipeline files simply is not on it. Reproduced live: two conversations with operator messages from today were absent from `/api/files` while `agent_activity` resolved them fine.

The scanner's `pin` option exists for exactly this — force one path and its conversation family into the scan past every cap — so `resumeConversation`, `killConversation` and `reconfigureConversation` now pass the target path as a pin.

Testing: `bun test src/lib/delivery.test.ts` — 33 pass in a clean worktree off origin/main (overrides-based tests are unaffected by the new argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)