### PR TITLE
fix(delivery): pin the target path in the deliverMessage reopen lookup too

### DIFF
--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -646,7 +646,9 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     if (!filePath || !(overrides.pathAllowed ?? pathAllowed)(filePath)) {
       return settle(failure("process is not in a tmux session", 409));
     }
-    const all = await (overrides.listFiles ?? listFiles)();
+    /* Pinned: the reopenable transcript may have aged past the scan's recency
+       cap — a conversation the operator can still message must stay openable. */
+    const all = await (overrides.listFiles ?? listFiles)({ pin: filePath });
     const entry = all.find((item) => item.path === filePath);
     if (!entry) {
       return settle(failure("file is unknown to the viewer", 403));


### PR DESCRIPTION
Follow-up to #910: the fourth `listFiles()` lookup (deliverMessage's no-live-pane reopen path) was missed, so MCP `conversation_action resume` and message delivery to an aged conversation still returned `file is unknown to the viewer` after #910 deployed. Verified live. Same one-line pin treatment; delivery tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)