### PR TITLE
fix(spawn): stop fabricating mcp_servers overrides for plugin servers

### DIFF
--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -175,7 +175,7 @@ function normalizedMcpServers(value: readonly string[] | undefined): string[] {
 function configuredCodexMcpServers(home: string, cwd: string): string[] {
   const env: NodeJS.ProcessEnv = { ...process.env, CODEX_HOME: home };
   delete env.LLV_TOKEN;
-  const listed = spawnSync(process.env.LLV_CODEX_BINARY ?? resolveBinary("codex"), ["mcp", "list", "--json"], {
+  const listed = spawnSync(process.env.LLV_CODEX_BINARY ?? resolveBinary("codex"), ["-c", "features.plugins=false", "mcp", "list", "--json"], {
     cwd,
     env,
     encoding: "utf8",
@@ -195,10 +195,20 @@ function configuredCodexMcpServers(home: string, cwd: string): string[] {
 
 function codexMcpRuntimeOverrides(home: string, cwd: string, allowlist: readonly string[]): string[] {
   const enabled = new Set(allowlist);
-  return configuredCodexMcpServers(home, cwd).map((name) => {
-    const key = /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name);
-    return `mcp_servers.${key}.enabled=${enabled.has(name)}`;
-  });
+  return [
+    /* Plugin-contributed servers (computer-use, github, …) carry no
+       `[mcp_servers.*]` block in config.toml, so a fabricated
+       `mcp_servers.<name>.enabled` override for them leaves codex a server
+       table with only `enabled` — its config loader fails the whole launch
+       with "invalid transport". Plugins are off for Viewer-spawned sessions,
+       and the enumeration runs under the same flag so the override list can
+       never name a plugin server. */
+    "features.plugins=false",
+    ...configuredCodexMcpServers(home, cwd).map((name) => {
+      const key = /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name);
+      return `mcp_servers.${key}.enabled=${enabled.has(name)}`;
+    }),
+  ];
 }
 
 function pushClaudePolicyArgs(


### PR DESCRIPTION
Found by the server-lane prod audit: the `agent did not start in the window: Error loading config.toml: invalid transport | in mcp_servers.computer-use` failures that killed codex tmux spawns/resumes are the viewer's own doing. #e6f48463 passes `mcp_servers.<name>.enabled` overrides for every name `codex mcp list --json` returns; on codex 0.146.0 that listing includes plugin-contributed servers (`computer-use`, `github`) with no `[mcp_servers.*]` block, so the override fabricates a table with only `enabled` and the codex config loader fails the launch.

Fix: viewer-spawned codex sessions run with `features.plugins=false` (prepended to the runtime overrides, both arg-assembly sites consume the same list), and `configuredCodexMcpServers` enumerates under the same flag. Verified read-only against installed codex 0.146.0: the flag drops exactly the two plugin servers from the listing. The allowlist fence keeps its semantics — plugins simply never enter viewer-managed sessions.

Testing: `bun test src/lib/agent/cli.test.ts` — 24 pass in a clean worktree off origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)