### PR TITLE
perf(scanner): cache projectResolutionStateKey against source-file signatures

### DIFF
--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -75,8 +75,37 @@ function stateJson(name: string): unknown {
   }
 }
 
+const STATE_KEY_FILES = ["flows.json", "workflows.json", "worktree-map.json", "project-aliases.json"] as const;
+let stateKeyCache: { signature: string; key: string } | null = null;
+
+/** Cheap invalidation signature over the four source files: the full key
+    below parses megabytes and hashes them, and production called it for
+    every described entry — ~75 uncached reads of flows.json per second
+    pinned the event loop in a GC storm. Four stats replace that until a
+    source file actually changes. */
+function stateKeySignature(dir: string): string {
+  const parts = [dir];
+  for (const name of STATE_KEY_FILES) {
+    try {
+      const st = fs.statSync(path.join(dir, name), { bigint: true });
+      parts.push(`${name}:${st.mtimeNs}:${st.size}`);
+    } catch {
+      parts.push(`${name}:missing`);
+    }
+  }
+  return parts.join("|");
+}
+
 export function projectResolutionStateKey(): string {
   const dir = stateDir();
+  const signature = stateKeySignature(dir);
+  if (stateKeyCache?.signature === signature) return stateKeyCache.key;
+  const key = computeProjectResolutionStateKey(dir);
+  stateKeyCache = { signature, key };
+  return key;
+}
+
+function computeProjectResolutionStateKey(dir: string): string {
   const hash = crypto.createHash("sha1");
   hash.update(dir);
   hash.update(`\0resolver-version\0${PROJECT_RESOLUTION_VERSION}`);


### PR DESCRIPTION
Live regression found while verifying the release train: the viewer re-entered the GC-storm state (100% CPU, ~66k minor faults/s, timeline 20-25s timeouts). An fd census attributed it to `projectResolutionStateKey()` — no caching, parses flows.json+workflows.json and hashes worktree-map/project-aliases on every call, called per described entry (describe.ts:469, discover.ts:315, projectCatalog.ts:462): 606 flows.json opens in 8s.

Fix: signature cache over the four source files (path:mtimeNs:size), same pattern as the flows/pipelines caches; recompute only when a file changes.

Tests: projectState + describe suites pass in a clean worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)