### PR TITLE
fix(feed): a markdown link inside bold is still a link

### DIFF
--- a/src/components/conversation/OutboxBubbles.tsx
+++ b/src/components/conversation/OutboxBubbles.tsx
@@ -3,6 +3,7 @@
 import { Clock3, RotateCcw, TriangleAlert } from "lucide-react";
 
 import { Loader2, X } from "@/components/icons";
+import { mdBlocks } from "@/components/feed/markdown";
 
 import { type TFunction, useLocale } from "@/lib/i18n";
 
@@ -71,7 +72,10 @@ export function OutboxBubblesView({
           >
             <div className="flex max-w-[75%] flex-col items-end gap-1">
               <div className="w-full whitespace-pre-wrap break-words rounded-surface bg-user px-4 py-2.5 opacity-80">
-                {entry.text}
+                {/* The same markdown grammar the transcript's own user bubble
+                    uses, so nothing changes appearance when it replaces this
+                    one — and a link the operator pasted is a link right away. */}
+                {mdBlocks(entry.text)}
                 {entry.images ? (
                   <span className="mt-1 block text-caption font-semibold text-muted">
                     {t("composer.imagesCount", { count: entry.images })}

--- a/src/components/feed/artifactAnchor.dom.test.tsx
+++ b/src/components/feed/artifactAnchor.dom.test.tsx
@@ -96,6 +96,11 @@ test("ordinary web links keep their normal behavior", async () => {
   expect(opened).toEqual([]);
 });
 
+test("an escaped paren resolves back into the URL", async () => {
+  await renderMd("Read [the page](https://example.com/acme/widgets/wiki/Home_\\(draft\\)) now.");
+  expect(anchor().getAttribute("href")).toBe("https://example.com/acme/widgets/wiki/Home_(draft)");
+});
+
 test("a local link with a :line suffix previews the file itself", async () => {
   await renderMd("Fix [the bug](~/fixtures/src/main.ts:42).");
   await act(async () => {

--- a/src/components/feed/markdown.test.tsx
+++ b/src/components/feed/markdown.test.tsx
@@ -14,6 +14,18 @@ function findAnchor(rendered: ReturnType<typeof md>): ReactElement<AnchorProps> 
   return link;
 }
 
+/* An anchor can sit inside another element (a link wrapped in bold), so collect
+   them by walking the whole rendered tree instead of its top level only. */
+function collectAnchors(node: unknown, found: ReactElement<AnchorProps>[] = []): ReactElement<AnchorProps>[] {
+  for (const child of Children.toArray(node as ReturnType<typeof md>)) {
+    if (!isValidElement(child)) continue;
+    const props = child.props as AnchorProps & { children?: unknown };
+    if (typeof props.href === "string") found.push(child as ReactElement<AnchorProps>);
+    else collectAnchors(props.children, found);
+  }
+  return found;
+}
+
 /* MdImage renders its <img> inside a fragment, so walk the rendered tree for
    the first element carrying an `alt` prop. */
 function findImg(node: unknown): ReactElement<ImgProps> | null {
@@ -41,6 +53,46 @@ describe("feed markdown links", () => {
     const link = findAnchor(md("[docs](https://example.com/docs)"));
     expect(link.props.href).toBe("https://example.com/docs");
     expect(link.props.label).toBe("docs");
+  });
+
+  /* The reported defect: an agent's release note writes its links inside bold,
+     and the bold alternative used to swallow the whole construct and print it
+     as text — brackets, parens and all. */
+  test("a link wrapped in bold is still a link", () => {
+    const [link] = collectAnchors(md("- **[#2722](https://example.com/acme/widgets/pull/2722)** — merged"));
+    expect(link).toBeDefined();
+    expect(link.props.href).toBe("https://example.com/acme/widgets/pull/2722");
+    expect(link.props.label).toBe("#2722");
+  });
+
+  test("a bare URL inside bold is still a link", () => {
+    const [link] = collectAnchors(md("**see https://example.com/acme/widgets/issues/7**"));
+    expect(link).toBeDefined();
+    expect(link.props.href).toBe("https://example.com/acme/widgets/issues/7");
+  });
+
+  test("bold around a link keeps the label bold", () => {
+    const rendered = md("**[#2722](https://example.com/acme/widgets/pull/2722)**");
+    const bold = Children.toArray(rendered).find(
+      (node): node is ReactElement<{ children?: unknown }> => isValidElement(node) && node.type === "b",
+    );
+    expect(bold).toBeDefined();
+    expect(collectAnchors(bold!.props.children).length).toBe(1);
+  });
+
+  /* The Anchor unescapes `\(`/`\)` at render (see artifactAnchor.dom.test.tsx
+     for the resolved href); what matters here is that the target is not cut at
+     the first escaped paren. */
+  test("an escaped paren stays inside the URL", () => {
+    const link = findAnchor(md("see [the page](https://example.com/acme/widgets/wiki/Home_\\(draft\\)) now"));
+    expect(link.props.href).toBe("https://example.com/acme/widgets/wiki/Home_\\(draft\\)");
+    expect(link.props.label).toBe("the page");
+  });
+
+  test("an image wrapped in bold still embeds instead of linking", () => {
+    const rendered = md("**![shot](https://example.com/a.png)**");
+    expect(findImg(rendered)).not.toBeNull();
+    expect(collectAnchors(rendered).length).toBe(0);
   });
 });
 

--- a/src/components/feed/markdown.tsx
+++ b/src/components/feed/markdown.tsx
@@ -13,10 +13,26 @@ import { Lightbox } from "./Lightbox";
 import { ACTION_ANCHOR, ACTION_GUTTER, MESSAGE_ACTION } from "./actionStyles";
 import { tr } from "./parse";
 
+/* A link/image target: one unbroken run, in which a backslash escapes the
+   character after it — the spelling agents use for parens inside a URL
+   (`…/Home_\(draft\)`), which a bare `[^)\s]+` would cut at the first `)`.
+   The two branches are disjoint (the second excludes the backslash), so a
+   target that never closes fails linearly instead of backtracking. */
+const MD_URL = String.raw`(?:\\.|[^)\s\\])+`;
+const MD_IMAGE = String.raw`!\[[^\]]*\]\(${MD_URL}\)`;
+const MD_LINK = String.raw`\[[^\]]+\]\(${MD_URL}\)`;
+
 /* Image markdown wins over the link pattern, so `![alt](url)` embeds instead
-   of leaking a literal «!» and a link. */
-const MD_INLINE_RE = /(!\[[^\]]*\]\([^)\s]+\)|`[^`]+`|\*\*[^*]+\*\*|\[[^\]]+\]\([^)\s]+\)|https?:\/\/[^\s<>"')\]]+)/g;
-const IMAGE_LINE_RE = /^\s*!\[([^\]]*)\]\(([^)\s]+)\)\s*$/;
+   of leaking a literal «!» and a link. Bold comes before the link only so a
+   `**…**` run keeps its emphasis: its body goes back through this same pass
+   (see `md`), so a link inside bold is still a link. */
+const MD_INLINE_RE = new RegExp(
+  `(${MD_IMAGE}|\`[^\`]+\`|\\*\\*[^*]+\\*\\*|${MD_LINK}|https?://[^\\s<>"')\\]]+)`,
+  "g",
+);
+const IMAGE_LINE_RE = new RegExp(String.raw`^\s*!\[([^\]]*)\]\((${MD_URL})\)\s*$`);
+const IMAGE_PART_RE = new RegExp(String.raw`^!\[([^\]]*)\]\((${MD_URL})\)$`);
+const LINK_PART_RE = new RegExp(String.raw`^\[([^\]]+)\]\((${MD_URL})\)$`);
 
 /* Inline monospace chip that copies itself on click. A span, not a button:
    it keeps text flow and selection intact, and inside a <summary> a button
@@ -189,10 +205,15 @@ export function md(text: string): ReactNode {
     if (part.startsWith("`") && part.endsWith("`")) {
       return <InlineCode key={i} text={part.slice(1, -1)} />;
     }
-    if (part.startsWith("**") && part.endsWith("**")) return <b key={i}>{part.slice(2, -2)}</b>;
-    const image = part.match(/^!\[([^\]]*)\]\(([^)\s]+)\)$/);
+    /* A bold run is emphasis around markdown, not a leaf: its body goes back
+       through the pass, so `**[#12](https://…)**` — how an agent writes a
+       release note — renders as a bold LINK instead of literal brackets. The
+       body cannot contain another `**` (the alternative is `[^*]+`), so this
+       recurses exactly once. */
+    if (part.startsWith("**") && part.endsWith("**")) return <b key={i}>{md(part.slice(2, -2))}</b>;
+    const image = part.match(IMAGE_PART_RE);
     if (image) return <MdImage key={i} alt={image[1]} src={image[2]} />;
-    const linked = part.match(/^\[([^\]]+)\]\(([^)\s]+)\)$/);
+    const linked = part.match(LINK_PART_RE);
     if (linked) {
       return <Anchor key={i} href={linked[2]} label={linked[1]} />;
     }

--- a/src/components/feed/messageLinks.dom.test.tsx
+++ b/src/components/feed/messageLinks.dom.test.tsx
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import { setLocale } from "@/lib/i18n";
+import type { ReviewCardItem } from "@/lib/review";
+import { OutboxBubblesView } from "@/components/conversation/OutboxBubbles";
+import { StreamingMd } from "./markdown";
+import { FeedItem } from "./FeedItem";
+import type { Item } from "./parse";
+import { ReviewCard } from "./cards/ReviewCard";
+
+/**
+ * Every message surface renders the full link set (operator report, 2026-08-06).
+ *
+ * The reported message was an agent's release note whose bullets read
+ * `- **[#2722](https://…/pull/2722)** — …`: the link sits INSIDE bold, and the
+ * inline pass used to hand the whole bold run to <b> as raw text, so the
+ * brackets and parens showed verbatim while the bold itself rendered. Each
+ * surface below renders the same sample and must produce the same anchors.
+ */
+
+installActEnv();
+
+const dom = new Window({ url: "http://localhost/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+setLocale("en");
+
+const SAMPLE = [
+  "Shipped **today**:",
+  "",
+  "- **[#2722](https://example.com/acme/widgets/pull/2722)** — merged",
+  "- [#2723](https://example.com/acme/widgets/pull/2723) — open",
+  "",
+  "> **[#2724](https://example.com/acme/widgets/pull/2724)** quoted",
+  "",
+  "Bare https://example.com/acme/widgets/issues/7 too.",
+].join("\n");
+
+/** Every href the sample must produce, in source order. */
+const HREFS = [
+  "https://example.com/acme/widgets/pull/2722",
+  "https://example.com/acme/widgets/pull/2723",
+  "https://example.com/acme/widgets/pull/2724",
+  "https://example.com/acme/widgets/issues/7",
+];
+
+let root: Root | null = null;
+
+beforeEach(() => {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  root = createRoot(host as unknown as HTMLElement);
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  dom.document.body.replaceChildren();
+});
+
+async function render(node: ReactNode): Promise<void> {
+  await act(async () => {
+    root!.render(node);
+  });
+}
+
+/** The links the surface actually rendered — and nothing left literal. */
+function renderedLinks(): string[] {
+  const text = dom.document.body.textContent ?? "";
+  expect(text).not.toContain("](https://");
+  expect(text).not.toContain("**");
+  return [...dom.document.querySelectorAll("a")].map((a) => a.getAttribute("href") ?? "");
+}
+
+function item(partial: Record<string, unknown>): Item {
+  return partial as unknown as Item;
+}
+
+test("a transcript prose message links every reference", async () => {
+  await render(<FeedItem item={item({ kind: "prose", ts: 0, text: SAMPLE, engine: "claude" })} />);
+  expect(renderedLinks()).toEqual(HREFS);
+});
+
+test("a user bubble links every reference", async () => {
+  await render(<FeedItem item={item({ kind: "user", ts: 0, text: SAMPLE })} />);
+  expect(renderedLinks()).toEqual(HREFS);
+});
+
+/* A long teammate message keeps a raw truncated excerpt behind its expander, so
+   this case uses a short body — the card's own markdown render. */
+test("a teammate message card links every reference", async () => {
+  const short = "Shipped: **[#2722](https://example.com/acme/widgets/pull/2722)** — merged";
+  await render(<FeedItem item={item({ kind: "tmsg", ts: 0, dir: "in", peer: "worker", summary: `**[#2723](${HREFS[1]})** landed`, text: short })} />);
+  expect(renderedLinks()).toEqual([HREFS[1], HREFS[0]]);
+});
+
+test("a review card links every reference in its findings", async () => {
+  const review: ReviewCardItem = {
+    kind: "review",
+    ts: 0,
+    verdict: "COMMENT",
+    summary: [SAMPLE],
+    findings: [{ severity: "Low", title: "**[#2722](https://example.com/acme/widgets/pull/2722)** — merged", body: "" }],
+    raw: "",
+  };
+  await render(<ReviewCard item={review} />);
+  expect(renderedLinks()).toEqual([...HREFS, HREFS[0]]);
+});
+
+test("a live streaming row links every reference once its lines settle", async () => {
+  for (let end = 12; end < SAMPLE.length; end += 12) {
+    await render(<StreamingMd text={SAMPLE.slice(0, end)} streaming />);
+  }
+  await render(<StreamingMd text={SAMPLE} streaming={false} />);
+  expect(renderedLinks()).toEqual(HREFS);
+});
+
+test("a queued outbox bubble links every reference, like the bubble that replaces it", async () => {
+  await render(
+    <OutboxBubblesView
+      entries={[{ id: "o1", text: SAMPLE, state: "queued", createdAt: 0 } as never]}
+      t={((key: string) => key) as never}
+      onCancel={() => {}}
+      onRetry={() => {}}
+    />,
+  );
+  expect(renderedLinks()).toEqual(HREFS);
+});

--- a/src/components/feed/messageLinks.dom.test.tsx
+++ b/src/components/feed/messageLinks.dom.test.tsx
@@ -5,9 +5,10 @@ import type { ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
 import { installActEnv } from "@/test-helpers/actEnv";
-import { setLocale } from "@/lib/i18n";
+import { setLocale, translate, type TFunction } from "@/lib/i18n";
 import type { ReviewCardItem } from "@/lib/review";
 import { OutboxBubblesView } from "@/components/conversation/OutboxBubbles";
+import type { OutboxEntry } from "@/components/conversation/outbox";
 import { StreamingMd } from "./markdown";
 import { FeedItem } from "./FeedItem";
 import type { Item } from "./parse";
@@ -90,6 +91,8 @@ function item(partial: Record<string, unknown>): Item {
   return partial as unknown as Item;
 }
 
+const translator = (locale: "en"): TFunction => (key, params) => translate(locale, key, params);
+
 test("a transcript prose message links every reference", async () => {
   await render(<FeedItem item={item({ kind: "prose", ts: 0, text: SAMPLE, engine: "claude" })} />);
   expect(renderedLinks()).toEqual(HREFS);
@@ -130,13 +133,9 @@ test("a live streaming row links every reference once its lines settle", async (
 });
 
 test("a queued outbox bubble links every reference, like the bubble that replaces it", async () => {
+  const entry: OutboxEntry = { id: "o1", text: SAMPLE, images: 0, at: 0, state: "queued" };
   await render(
-    <OutboxBubblesView
-      entries={[{ id: "o1", text: SAMPLE, state: "queued", createdAt: 0 } as never]}
-      t={((key: string) => key) as never}
-      onCancel={() => {}}
-      onRetry={() => {}}
-    />,
+    <OutboxBubblesView entries={[entry]} t={translator("en")} onCancel={() => {}} onRetry={() => {}} />,
   );
   expect(renderedLinks()).toEqual(HREFS);
 });


### PR DESCRIPTION
## The defect

An agent message in the conversation feed printed its links as literal text —
`- **[#2722](https://example.com/acme/widgets/pull/2722)** — description` showed
the brackets and parens verbatim — while `**bold**` in the same message rendered.

## Root cause

`src/components/feed/markdown.tsx` — one shared inline pass, two problems in it:

1. **`markdown.tsx:18` + `markdown.tsx:208` (pre-fix lines).** `MD_INLINE_RE`
   lists the bold alternative (`\*\*[^*]+\*\*`) *before* the link alternative, so
   for `**[#12](url)**` the bold alternative matches first and swallows the whole
   link. `md()` then rendered that part as `<b>{part.slice(2, -2)}</b>` — a raw
   string. Emphasis rendered; everything inside it was printed as text. That is
   exactly the reported asymmetry, and it is why the link alone (`[#12](url)`,
   without the bold) always worked.
2. A link target was `[^)\s]+`, which cuts at the first `)` — so a URL with
   escaped parens (`…/Home_\(draft\)`) lost its tail.

Not the cause, ruled out with the reproduction below: the streaming machine
(`createMdStream`/`advanceMdStream`), the `- ` bullet, the `#` label, the ` — `
em dash, and any surface lacking an inline pass. Every message surface already
goes through `md()`/`mdBlocks()`/`StreamingMd`, so all of them showed the defect
and all of them are fixed by the one change.

## The fix

- A bold run is emphasis **around** markdown: its body goes back through the same
  inline pass. A link, a bare URL, an image or a code chip inside bold now
  renders. The bold alternative cannot contain another `**`, so the recursion is
  depth‑1.
- Link and image targets share one pattern in which a backslash escapes the next
  character, so escaped parens survive. Its two branches are disjoint, so an
  unclosed target fails linearly instead of backtracking.
- `OutboxBubbles` rendered raw text while the transcript's own user bubble
  renders markdown; it now uses the shared renderer, so a queued message does not
  change appearance when the real bubble replaces it.

Image markdown still wins over the link pattern, and the local-artifact `Anchor`
(in-app preview, `#f=` deep link) is untouched.

## Tests

RED first, then green:

- `src/components/feed/messageLinks.dom.test.tsx` (new) — one case per message
  surface: transcript prose, user bubble, teammate card, review card, live
  streaming row, outbox bubble. Each renders the reported bullet shape plus a
  plain link, a blockquoted link and a bare URL, and asserts the anchors and that
  nothing is left literal. All six failed before the fix.
- `src/components/feed/markdown.test.tsx` — link inside bold, bare URL inside
  bold, bold kept around the link, escaped parens, image inside bold.
- `src/components/feed/artifactAnchor.dom.test.tsx` — the escaped-paren href as
  it resolves in the DOM.

Verification: focused suites by path with isolated `HOME`/`XDG_CONFIG_HOME`/
`LLV_STATE_DIR`/`TMPDIR` — `src/components/feed/` 270 pass, each
`src/components/conversation/` file green on its own. The whole-directory
conversation run fails 5–6 files on `document is not defined`; that reproduces
identically at the merge base in a throwaway worktree (known cross-file bun
interference). `tsc --noEmit`, scoped `eslint`, `next build` and the privacy gate
all pass.

## Deliberately not changed

Surfaces that show text verbatim by design keep doing so: the truncated raw
excerpts inside a collapsed `<details>` summary (long teammate/user/think
previews, which can cut a link in half), the `<pre>` payload cards (blob, system
message, record, tool output), and the attention/plan cards. Say the word if the
plan card should render markdown too — that is a design change, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)