### PR TITLE
Fix cross-conversation launch bubble ownership (#922)

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -23,7 +23,15 @@ import {
   visibleRuntimeLiveTurnItems,
 } from "./conversation/liveTurnHandoff";
 import { orderedConversationTail } from "./conversation/tailOrder";
-import { publishTranscriptEchoes, seedLaunchOutbox, settleLaunchOutboxDelivered, useOutbox, visibleOutbox } from "./conversation/outbox";
+import {
+  publishTranscriptEchoes,
+  seedLaunchOutbox,
+  settleLaunchOutboxDelivered,
+  settleLaunchOutboxFailed,
+  useOutbox,
+  visibleOutbox,
+  type OutboxOwner,
+} from "./conversation/outbox";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
@@ -105,6 +113,12 @@ function nowMs(): number {
   return Date.now();
 }
 
+function launchOutboxState(initialMessage: NonNullable<FileEntry["spawn"]>["initialMessage"]): "delivering" | "delivered" | "failed" {
+  if (initialMessage === "delivered") return "delivered";
+  if (initialMessage === "failed") return "failed";
+  return "delivering";
+}
+
 interface Props {
   file: FileEntry | null;
   showSvc: boolean;
@@ -131,16 +145,31 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      the launch that is still becoming it (issue #569) — the same chips either
      way, because it is the same window. */
   const launch = file?.launch ?? file?.spawn ?? null;
-  /* Pane ownership by durable conversation id (issue #653): a launch bubble is
-     seeded/settled/rendered ONLY when it belongs to THIS pane's conversation. A
-     launch whose own conversation id differs from this file's is a foreign bubble
-     (its pane's structured entry may have gone dead) and must never leak in. When
-     either id is absent (a path-only card, or a legacy payload with no launch
-     conversation id) the check cannot fire, preserving prior behaviour. */
+  /* Exact launch ownership (issue #922): the server canonicalizes aliases and
+     projects the native generation. The client joins on both durable values and
+     never infers ownership from a path, queue key, or alias. */
   const paneConversationId = file?.conversationId ?? null;
-  const launchOwnsThisPane = !launch?.conversationId
-    || !paneConversationId
-    || launch.conversationId === paneConversationId;
+  const paneGeneration = file?.generation ?? null;
+  const paneLaunchOwner = useMemo<OutboxOwner | null>(
+    () => paneConversationId && paneGeneration
+      ? { conversationId: paneConversationId, generation: paneGeneration }
+      : null,
+    [paneConversationId, paneGeneration],
+  );
+  const launchConversationId = launch?.conversationId ?? null;
+  const launchGeneration = launch?.generation ?? null;
+  const launchOwner = useMemo<OutboxOwner | null>(
+    () => launchConversationId && launchGeneration
+      ? { conversationId: launchConversationId, generation: launchGeneration }
+      : null,
+    [launchConversationId, launchGeneration],
+  );
+  const launchOwnsThisPane = Boolean(
+    paneLaunchOwner
+      && launchOwner
+      && paneLaunchOwner.conversationId === launchOwner.conversationId
+      && paneLaunchOwner.generation === launchOwner.generation,
+  );
   /* Live streaming text: `delta` events from the structured host render the
      in-flight assistant reply immediately, ahead of the transcript flush. The
      host is resolved by conversation identity FIRST (round-1 P1#3): during
@@ -496,11 +525,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
          draft but retires on the delivered (possibly scaffolded) transcript
          echo. Reconciled onto a composer-seeded bubble under the same id. */
       ...(launch.promptEcho ? { echoText: launch.promptEcho } : {}),
-      /* Stamp the launch's durable conversation as the bubble's owner so a stale
-         copy under another pane's key is filtered at render (issue #653). */
-      ...(launch.conversationId ? { owner: launch.conversationId } : {}),
+      owner: launchOwner!,
+      state: launchOutboxState(launch.initialMessage),
+      ...(launch.deliveredAt !== undefined ? { settledAt: launch.deliveredAt } : {}),
+      ...(launch.error ? { error: launch.error } : {}),
     });
-  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho, launch?.conversationId, launchOwnsThisPane]);
+  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho, launch?.initialMessage, launch?.deliveredAt, launch?.error, launchOwner, launchOwnsThisPane]);
   /* Settle the launch bubble from the delivery receipt the server projects
      (issue #648), independent of any transcript echo. A structured / MCP spawn's
      first message is journaled as a system row (SDK / agent provenance), so echo
@@ -510,18 +540,26 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      "delivering" forever. Keyed on the launch id and the receipt time only, so it
      still fires on a materialized window that has stripped the prompt fields. */
   useEffect(() => {
-    if (!memoryKey || !launch?.launchId || !launchOwnsThisPane) return;
-    if (launch.initialMessage !== "delivered" || launch.deliveredAt === undefined) return;
-    settleLaunchOutboxDelivered(memoryKey, {
-      id: launch.launchId,
-      at: launch.promptAt ?? launch.deliveredAt,
-      settledAt: launch.deliveredAt,
-    });
-  }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt, launchOwnsThisPane]);
-  /* Render only bubbles owned by this pane's conversation (issue #653). memoryKey
-     is the durable conversation id when the payload carries one; a foreign
-     launch bubble stamped with another conversation id is dropped here. */
-  const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs(), memoryKey ?? undefined) : [];
+    if (!memoryKey || !launch?.launchId || !launchOwnsThisPane || !launchOwner) return;
+    if (launch.initialMessage === "delivered" && launch.deliveredAt !== undefined) {
+      settleLaunchOutboxDelivered(memoryKey, {
+        id: launch.launchId,
+        at: launch.promptAt ?? launch.deliveredAt,
+        settledAt: launch.deliveredAt,
+        owner: launchOwner,
+      });
+    } else if (launch.initialMessage === "failed") {
+      settleLaunchOutboxFailed(memoryKey, {
+        id: launch.launchId,
+        at: launch.promptAt ?? Date.now(),
+        ...(launch.error ? { error: launch.error } : {}),
+        owner: launchOwner,
+      });
+    }
+  }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt, launch?.error, launchOwner, launchOwnsThisPane]);
+  /* Launch bubbles fail closed without exact canonical ownership; ordinary
+     composer entries still render from this conversation-scoped queue. */
+  const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs(), paneLaunchOwner) : [];
   useEffect(() => {
     if (!memoryKey || !file) return;
     adoptCanonicalAssistantClaims(file.path, memoryKey);

--- a/src/components/conversation/issue653Evidence.browser.test.tsx
+++ b/src/components/conversation/issue653Evidence.browser.test.tsx
@@ -111,6 +111,7 @@ function baseFile(over: Partial<FileEntry>): FileEntry {
     pendingQuestion: null,
     waitingInput: null,
     conversationId: PANE_CONVERSATION,
+    generation: 1,
     ...over,
   } as FileEntry;
 }
@@ -120,6 +121,7 @@ function baseFile(over: Partial<FileEntry>): FileEntry {
 const FOREIGN_LAUNCH: StructuredSpawnCardState = {
   launchId: "launch_653_foreign",
   clientAttemptId: null, accountId: "acct_reviewer", conversationId: FOREIGN_CONVERSATION,
+  generation: 1,
   state: "queued", initialMessage: "queued", retrySafe: false, error: null,
   promptImages: 0, promptAt: PROMPT_AT, prompt: FOREIGN_PROMPT, promptEcho: FOREIGN_PROMPT,
 };

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -16,6 +16,7 @@ import {
   resetOutboxForTests,
   seedLaunchOutbox,
   settleLaunchOutboxDelivered,
+  settleLaunchOutboxFailed,
   transcriptEchoCount,
   updateOutbox,
   visibleOutbox,
@@ -1228,6 +1229,29 @@ describe("seedLaunchOutbox (P1#2)", () => {
     expect(readOutbox(conversation).find((entry) => entry.id === "launch_a")?.state).toBe("delivering");
   });
 
+  test("issue 922: a pathless failed launch settles its optimistic bubble and stamps exact ownership", () => {
+    const conversation = "conversation_922_failed_launch";
+    const owner = { conversationId: conversation, generation: 1 };
+    seedLaunchOutbox(conversation, {
+      id: "launch_922_failed", text: "synthetic kickoff", images: 0, at: 1_000,
+    });
+    settleLaunchOutboxFailed(conversation, {
+      id: "launch_922_failed", at: 1_000, error: "runtime admission timed out", owner,
+    });
+    expect(readOutbox(conversation)[0]).toMatchObject({
+      state: "failed",
+      error: "runtime admission timed out",
+      owner,
+    });
+    expect(visibleOutbox(readOutbox(conversation), echoes(), 2_000, owner)).toHaveLength(1);
+    expect(visibleOutbox(
+      readOutbox(conversation),
+      echoes(),
+      2_000,
+      { conversationId: "conversation_922_other", generation: 1 },
+    )).toEqual([]);
+  });
+
   test("issue 648: an echo match still wins when it lands before the delivered receipt is consumed", () => {
     const provisional = "spawn:launch_648_echo_first";
     const text = "launch prompt that DOES echo as a user row";
@@ -1607,27 +1631,28 @@ describe("seedLaunchOutbox (P1#2)", () => {
 });
 
 describe("issue 653: pane ownership by durable conversation id", () => {
+  const owner = (conversationId: string, generation = 1) => ({ conversationId, generation });
   const withOwner = (over: Partial<OutboxEntry>): OutboxEntry => ({
     id: "ccb088d2", text: "Round 2 review PR #618", images: 0, at: 1_000,
     state: "delivering", launchOwned: true, ...over,
   });
 
   test("a foreign-owned launch bubble is never rendered in an unrelated pane", () => {
-    const queue = [withOwner({ owner: "conversation_A" })];
+    const queue = [withOwner({ owner: owner("conversation_A") })];
     /* Conversation B's pane (dead structured entry): the leaked bubble owned by A
        must not render. */
-    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_B")).toEqual([]);
+    expect(visibleOutbox(queue, echoes(), 5_000, owner("conversation_B"))).toEqual([]);
     /* A's own pane still shows it. */
-    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_A").map((entry) => entry.id)).toEqual(["ccb088d2"]);
+    expect(visibleOutbox(queue, echoes(), 5_000, owner("conversation_A")).map((entry) => entry.id)).toEqual(["ccb088d2"]);
   });
 
   test("owner-less composer sends and same-owner launches still render", () => {
     const composer = { id: "k1", text: "hi", images: 0, at: 1, state: "queued" as const };
-    const own = withOwner({ owner: "conversation_B" });
-    expect(visibleOutbox([composer, own], echoes(), 5_000, "conversation_B").map((entry) => entry.id))
+    const own = withOwner({ owner: owner("conversation_B") });
+    expect(visibleOutbox([composer, own], echoes(), 5_000, owner("conversation_B")).map((entry) => entry.id))
       .toEqual(["k1", "ccb088d2"]);
     /* No pane owner supplied (legacy call sites) → no filtering at all. */
-    expect(visibleOutbox([withOwner({ owner: "conversation_A" })], echoes(), 5_000).map((entry) => entry.id))
+    expect(visibleOutbox([withOwner({ owner: owner("conversation_A") })], echoes(), 5_000).map((entry) => entry.id))
       .toEqual(["ccb088d2"]);
   });
 
@@ -1635,12 +1660,38 @@ describe("issue 653: pane ownership by durable conversation id", () => {
     /* A prior mis-seed (or a payload that carried a foreign launch) left A's
        launch bubble in B's queue. */
     seedLaunchOutbox("conversation_B", {
-      id: "ccb088d2", text: "Round 2 review PR #618", images: 0, at: 1_000, owner: "conversation_A",
+      id: "ccb088d2", text: "Round 2 review PR #618", images: 0, at: 1_000, owner: owner("conversation_A"),
     });
     const queue = readOutbox("conversation_B");
-    expect(queue[0]!.owner).toBe("conversation_A");
+    expect(queue[0]!.owner).toEqual(owner("conversation_A"));
     /* B's pane renders nothing; the entry is durably filtered by owner. */
-    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_B")).toEqual([]);
+    expect(visibleOutbox(queue, echoes(), 5_000, owner("conversation_B"))).toEqual([]);
+  });
+
+  test("issue 922: the render join requires canonical conversation and generation, and upgrades a settled optimistic row", () => {
+    const text = "synthetic kickoff for conversation B";
+    seedLaunchOutbox("conversation_B", {
+      id: "launch_B", text, images: 0, at: 1_000,
+    });
+    /* The browser seed has no canonical owner yet. Production rendering fails
+       closed, so it cannot appear on A or on another generation of B. */
+    expect(visibleOutbox(readOutbox("conversation_B"), echoes(), 1_500, owner("conversation_A"))).toEqual([]);
+    expect(visibleOutbox(readOutbox("conversation_B"), echoes(), 1_500, owner("conversation_B", 2))).toEqual([]);
+
+    /* The server-projected delivered receipt joins the same launch id, stamps
+       exact ownership, and settles it atomically. */
+    seedLaunchOutbox("conversation_B", {
+      id: "launch_B", text, images: 0, at: 1_000,
+      owner: owner("conversation_B", 1), state: "delivered", settledAt: 1_400,
+    });
+    const [settled] = visibleOutbox(readOutbox("conversation_B"), echoes(), 1_500, owner("conversation_B", 1));
+    expect(settled).toMatchObject({
+      id: "launch_B",
+      state: "delivered",
+      settledAt: 1_400,
+      owner: owner("conversation_B", 1),
+    });
+    expect(visibleOutbox(readOutbox("conversation_B"), echoes(), 1_500, owner("conversation_A", 1))).toEqual([]);
   });
 });
 

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -25,6 +25,13 @@ import type { ReceiptStatus } from "@/components/runtime/runtimeModel";
 
 export type OutboxState = "queued" | "delivering" | "delivered" | "failed";
 
+/** Exact server-projected launch ownership. A canonical conversation can span
+    several native generations, so both coordinates are required. */
+export interface OutboxOwner {
+  readonly conversationId: string;
+  readonly generation: number;
+}
+
 export interface OutboxEntry {
   /** Idempotency key of this submission — also the bubble's stable identity. */
   id: string;
@@ -71,13 +78,42 @@ export interface OutboxEntry {
       retirement is monotonic across tail eviction, adoption, and refresh. */
   retiredEchoId?: string;
   retiredAt?: number;
-  /** The durable conversation identity that OWNS this bubble (issue #653). A
-      launch-owned bubble records the launch's own conversation id here, so a pane
-      renders it ONLY inside that conversation — never leaked into an unrelated
-      pane whose structured entry went dead. Absent for ordinary composer sends,
-      which are enqueued into their own pane's queue and so are inherently owned
-      by it; absence therefore renders as before. */
-  owner?: string;
+  /** Exact canonical conversation + native generation that owns this launch
+      bubble (issue #922). Ordinary composer sends omit it because their queue is
+      already scoped to the pane. Legacy launch rows with a missing/string owner
+      fail closed on production render until the server projection upgrades them. */
+  owner?: OutboxOwner;
+}
+
+function isOutboxOwner(value: unknown): value is OutboxOwner {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const raw = value as Record<string, unknown>;
+  return typeof raw.conversationId === "string"
+    && Number.isInteger(raw.generation)
+    && (raw.generation as number) > 0;
+}
+
+function sameOutboxOwner(left: unknown, right: OutboxOwner): boolean {
+  return isOutboxOwner(left)
+    && left.conversationId === right.conversationId
+    && left.generation === right.generation;
+}
+
+function normalizeOutboxOwner(entry: OutboxEntry): OutboxEntry {
+  const owner = (entry as { owner?: unknown }).owner;
+  if (owner === undefined || isOutboxOwner(owner)) return entry;
+  const normalized = { ...entry };
+  delete normalized.owner;
+  return normalized;
+}
+
+function reconciledLaunchState(
+  current: OutboxState,
+  projected: Extract<OutboxState, "delivering" | "delivered" | "failed">,
+): OutboxState {
+  if (projected === "delivered") return "delivered";
+  if (projected === "failed" && (current === "queued" || current === "delivering")) return "failed";
+  return current;
 }
 
 /**
@@ -224,7 +260,8 @@ function persistedQueue(cardId: string): readonly OutboxEntry[] {
   try {
     const raw = JSON.parse(sessionStorage.getItem(storageKey(cardId)) ?? "[]") as unknown;
     if (!Array.isArray(raw)) return EMPTY;
-    return raw.filter(isEntry).slice(-OUTBOX_LIMIT).map((entry) => {
+    return raw.filter(isEntry).slice(-OUTBOX_LIMIT).map((rawEntry) => {
+      const entry = normalizeOutboxOwner(rawEntry);
       const images = typeof entry.images === "number" ? entry.images : 0;
       /* The initial launch prompt is owned by the spawn, not the composer: it
          survives a refresh exactly as it was (never re-dispatched, never
@@ -539,13 +576,24 @@ export function enqueueOutbox(cardId: string, entry: Omit<OutboxEntry, "state">)
 /**
  * Seed the initial launch prompt as the conversation's first optimistic user
  * bubble (round-1 P1#2). Idempotent: a re-render or reload-replay that seeds the
- * same launch id is a no-op, preserving whatever state the entry already
- * reached. The entry is `launchOwned` — delivered by the spawn, so it is never
- * dispatched and never blocks the operator's follow-up messages.
+ * same launch id updates that row with authoritative echo, owner, and receipt
+ * state while preserving stronger delivery/response evidence. The entry is
+ * `launchOwned` — delivered by the spawn, so it is never dispatched and never
+ * blocks the operator's follow-up messages.
  */
 export function seedLaunchOutbox(
   cardId: string,
-  entry: { id: string; text: string; images: number; at: number; echoText?: string; owner?: string },
+  entry: {
+    id: string;
+    text: string;
+    images: number;
+    at: number;
+    echoText?: string;
+    owner?: OutboxOwner;
+    state?: Extract<OutboxState, "delivering" | "delivered" | "failed">;
+    settledAt?: number;
+    error?: string;
+  },
 ): void {
   if (!entry.text.trim() && !entry.images) return;
   const currentLaunch = readCurrentLaunch(cardId);
@@ -563,22 +611,38 @@ export function seedLaunchOutbox(
   const queue = readOutbox(cardId);
   const existing = queue.find((item) => item.id === entry.id);
   if (existing) {
-    recordCurrentLaunchEntry(cardId, existing);
-    if (existing.retiredEchoId) {
+    const projectedState = entry.state ?? "delivering";
+    const nextState = reconciledLaunchState(existing.state, projectedState);
+    const updated: OutboxEntry = {
+      ...existing,
+      ...(entry.echoText && entry.echoText !== existing.echoText ? { echoText: entry.echoText } : {}),
+      ...(entry.owner && !sameOutboxOwner(existing.owner, entry.owner) ? { owner: entry.owner } : {}),
+      ...(nextState !== existing.state ? { state: nextState } : {}),
+      ...(nextState === "delivered" && existing.settledAt === undefined
+        ? { settledAt: entry.settledAt ?? entry.at }
+        : {}),
+      ...(nextState === "failed" && entry.error && entry.error !== existing.error ? { error: entry.error } : {}),
+    };
+    const changed = updated.echoText !== existing.echoText
+      || updated.owner !== existing.owner
+      || updated.state !== existing.state
+      || updated.settledAt !== existing.settledAt
+      || updated.error !== existing.error;
+    if (changed) write(cardId, queue.map((item) => (item.id === entry.id ? updated : item)));
+    recordCurrentLaunchEntry(cardId, updated);
+    if (updated.retiredEchoId) {
       recordCurrentLaunchRetirement(cardId, {
         id: entry.id,
         at: entry.at,
-        retiredEchoId: existing.retiredEchoId,
-        ...(existing.retiredAt !== undefined ? { retiredAt: existing.retiredAt } : {}),
+        retiredEchoId: updated.retiredEchoId,
+        ...(updated.retiredAt !== undefined ? { retiredAt: updated.retiredAt } : {}),
       });
     }
-    /* Reconcile the canonical echo identity onto an already-seeded bubble (issue
-       #615): the composer seeds the RAW draft first, without an echo identity (it
-       never composes the role scaffold); the later server projection supplies it.
-       Attach it while preserving the user-facing raw text and the bubble's current
-       state — one bubble, never a second. Idempotent once attached. */
-    if (entry.echoText && entry.echoText !== existing.echoText) {
-      write(cardId, queue.map((item) => (item.id === entry.id ? { ...item, echoText: entry.echoText } : item)));
+    /* The browser seeds before the server knows canonical ownership, echo text,
+       or terminal receipt state. The projection upgrades that same row in one
+       join, so an ownerless stale copy cannot survive and a settled launch can
+       never be repainted as delivering. */
+    if (updated.echoText !== existing.echoText) {
       reconcileEchoRetirements(cardId, readEchoLedger(cardId));
     }
     return;
@@ -598,16 +662,27 @@ export function seedLaunchOutbox(
     });
     return;
   }
-  recordCurrentLaunch(cardId, { id: entry.id, at: entry.at });
+  const projectedState = entry.state ?? "delivering";
   /* A delivered launch compacted out of the recent queue keeps its settlement
      only in the current-launch slot. A reseed inside the TTL window restores
      that delivered state so the bubble stays visibly delivered and still
      retires at the TTL — never a fresh `delivering` entry that no echo or TTL
      could ever retire. */
-  const settledAt = currentLaunch?.id === entry.id ? currentLaunch.settledAt : undefined;
-  const seeded: OutboxEntry = settledAt === undefined
-    ? { ...entry, state: "delivering", launchOwned: true }
-    : { ...entry, state: "delivered", settledAt, launchOwned: true };
+  const settledAt = currentLaunch?.id === entry.id
+    ? currentLaunch.settledAt ?? entry.settledAt
+    : entry.settledAt;
+  const state: OutboxEntry["state"] = settledAt !== undefined ? "delivered" : projectedState;
+  recordCurrentLaunch(cardId, {
+    id: entry.id,
+    at: entry.at,
+    ...(state === "delivered" ? { settledAt: settledAt ?? entry.at } : {}),
+  });
+  const seeded: OutboxEntry = {
+    ...entry,
+    state,
+    ...(state === "delivered" ? { settledAt: settledAt ?? entry.at } : {}),
+    launchOwned: true,
+  };
   writeBounded(cardId, [...queue, seeded]);
   /* A refreshed surface can see the canonical transcript row before the launch
      projection effect seeds its optimistic bubble. Reconcile the persisted row
@@ -661,7 +736,7 @@ export function markOutboxResponded(cardId: string, id: string, at: number): voi
  */
 export function settleLaunchOutboxDelivered(
   cardId: string,
-  launch: { id: string; at: number; settledAt: number },
+  launch: { id: string; at: number; settledAt: number; owner?: OutboxOwner },
 ): void {
   const current = readCurrentLaunch(cardId);
   if (current && current.id !== launch.id) return;
@@ -676,21 +751,59 @@ export function settleLaunchOutboxDelivered(
   const queue = readOutbox(cardId);
   const existing = queue.find((item) => item.id === launch.id);
   if (!existing || !existing.launchOwned) return;
+  const owned = launch.owner && !sameOutboxOwner(existing.owner, launch.owner)
+    ? { ...existing, owner: launch.owner }
+    : existing;
   if (
-    existing.retiredEchoId
-    || existing.responseStartedAt !== undefined
-    || existing.state === "delivered"
-    || existing.state === "failed"
+    owned.retiredEchoId
+    || owned.responseStartedAt !== undefined
+    || owned.state === "delivered"
   ) {
-    recordCurrentLaunchEntry(cardId, existing);
+    if (owned !== existing) write(cardId, queue.map((item) => (item.id === launch.id ? owned : item)));
+    recordCurrentLaunchEntry(cardId, owned);
     return;
   }
   const next = queue.map((item) => (item.id === launch.id
-    ? { ...item, state: "delivered" as const, settledAt: item.settledAt ?? launch.settledAt }
+    ? {
+        ...owned,
+        state: "delivered" as const,
+        settledAt: owned.settledAt ?? launch.settledAt,
+        error: undefined,
+      }
     : item));
   const updated = next.find((item) => item.id === launch.id);
   if (updated) recordCurrentLaunchEntry(cardId, updated);
   write(cardId, next);
+}
+
+/** Settle a launch that died before its first message could start. This covers
+    pathless promote-race failures as well as a terminalized attempts-zero held
+    delivery. Delivered/response evidence remains monotonic and wins. */
+export function settleLaunchOutboxFailed(
+  cardId: string,
+  launch: { id: string; at: number; error?: string; owner?: OutboxOwner },
+): void {
+  const current = readCurrentLaunch(cardId);
+  if (current && current.id !== launch.id) return;
+  recordCurrentLaunch(cardId, { id: launch.id, at: current?.at ?? launch.at });
+  const queue = readOutbox(cardId);
+  const existing = queue.find((item) => item.id === launch.id);
+  if (!existing || !existing.launchOwned) return;
+  const owned = launch.owner && !sameOutboxOwner(existing.owner, launch.owner)
+    ? { ...existing, owner: launch.owner }
+    : existing;
+  if (owned.retiredEchoId || owned.responseStartedAt !== undefined || owned.state === "delivered") {
+    if (owned !== existing) write(cardId, queue.map((item) => (item.id === launch.id ? owned : item)));
+    recordCurrentLaunchEntry(cardId, owned);
+    return;
+  }
+  const updated: OutboxEntry = {
+    ...owned,
+    state: "failed",
+    ...(launch.error ? { error: launch.error } : {}),
+  };
+  recordCurrentLaunchEntry(cardId, updated);
+  write(cardId, queue.map((item) => (item.id === launch.id ? updated : item)));
 }
 
 /** Remove an entry outright — the operator cancelled a message that never left. */
@@ -1023,18 +1136,18 @@ export function visibleOutbox(
   queue: readonly OutboxEntry[],
   transcriptEchoCounts: TranscriptEchoCounts,
   nowMs: number,
-  paneOwner?: string,
+  paneOwner?: OutboxOwner | null,
 ): OutboxEntry[] {
   const consumed = new Map<string, number>();
   const visible: OutboxEntry[] = [];
   for (const entry of queue) {
-    /* Pane ownership by durable conversation id (issue #653): a bubble that
-       records an owner renders ONLY in that conversation's pane. This keeps a
-       launch bubble keyed to another conversation from leaking into an unrelated
-       pane (e.g. when that pane's own structured entry went dead). An owner-less
-       entry — an ordinary composer send — is inherently owned by the pane whose
-       queue holds it, so it renders as before. */
-    if (paneOwner !== undefined && entry.owner !== undefined && entry.owner !== paneOwner) continue;
+    /* Production passes an exact canonical conversation+generation owner. A
+       launch row with a foreign, legacy string, or missing owner fails closed;
+       the server projection upgrades a legitimate ownerless optimistic seed on
+       its own pane. Ordinary composer rows remain scoped by their queue. */
+    if (paneOwner !== undefined && entry.launchOwned) {
+      if (!paneOwner || !sameOutboxOwner(entry.owner, paneOwner)) continue;
+    }
     /* A bubble retires on ITS canonical transcript echo — the delivered text,
        which for a role launch is the scaffold-plus-draft carried on `echoText`,
        not the raw draft it displays (issue #615). */

--- a/src/lib/agent/failedSpawnDelivery.test.ts
+++ b/src/lib/agent/failedSpawnDelivery.test.ts
@@ -152,6 +152,127 @@ test("issue 653: failStructuredSpawn terminalizes the initial held delivery in t
   }
 });
 
+test("issue 922: a never-started spawn whose migration-cancelled delivery is already failed terminalizes its receipt", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-never-started-spawn-delivery-"));
+  try {
+    const filename = path.join(dir, "agent-registry.json");
+    const cwd = path.join(dir, "pipeline");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd, transport: "structured", accountId: "account-a",
+      launchProfile: emptyLaunchProfile({ cwd }),
+      launchDisplay: { prompt: "synthetic kickoff", images: 0, echo: "synthetic kickoff" },
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const { launchId, conversationId } = begun.receipt;
+    const deliveryId = "held-never-started";
+    const snapshot = registry.snapshot();
+    expect(snapshot.conversations[conversationId]).toBeUndefined();
+    snapshot.heldDeliveries[deliveryId] = {
+      id: deliveryId, conversationId, runtimeConversationId: conversationId,
+      text: "synthetic kickoff", createdAt: "2026-08-05T10:00:00.000Z",
+      clientMessageId: `spawn_${launchId}`, payloadKind: "text", runtimeImages: [],
+      contentDigest: null, artifactPaths: [],
+      command: { operationId: `spawn_message_${launchId}`, kind: "send", policy: "queue" },
+      requestDigest: null, state: "failed", generationId: null, attempts: 0,
+      assignedAt: null, deliveredAt: null,
+      error: "delivery cancelled because its owning account migration made no progress; send again",
+    } satisfies HeldDelivery;
+    fs.writeFileSync(filename, JSON.stringify(snapshot));
+
+    const reloaded = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(reloaded.snapshot().receipts[launchId]?.state).not.toBe("failed");
+    expect(reloaded.terminalizeFailedSpawnDeliveries()).toEqual([deliveryId]);
+    expect(reloaded.snapshot().receipts[launchId]).toMatchObject({
+      state: "failed",
+      admissionOwner: null,
+      error: expect.stringContaining("migration made no progress"),
+    });
+    expect(reloaded.snapshot().heldDeliveries[deliveryId]).toMatchObject({ state: "failed", attempts: 0 });
+    expect(reloaded.terminalizeFailedSpawnDeliveries()).toEqual([]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("issue 922: a promote-race spawn failure terminalizes an assigned attempts-zero initial delivery inline", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-promote-race-spawn-delivery-"));
+  try {
+    const filename = path.join(dir, "agent-registry.json");
+    const cwd = path.join(dir, "pipeline");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+    const conversation = registry.ensureConversation("codex", path.join(cwd, "session.jsonl"), "account-a");
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd, transport: "structured", accountId: "account-a",
+      conversationId: conversation.id,
+      launchProfile: emptyLaunchProfile({ cwd }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const delivery = registry.holdDelivery(
+      conversation.id,
+      "synthetic kickoff",
+      `spawn_${begun.receipt.launchId}`,
+      "text",
+      [],
+      null,
+      { operationId: `spawn_message_${begun.receipt.launchId}`, kind: "send", policy: "queue" },
+    );
+    expect(delivery).toMatchObject({ state: "assigned", attempts: 0 });
+
+    registry.failSpawn(begun.receipt.launchId, "runtime host request timed out during release promotion");
+    expect(registry.snapshot().receipts[begun.receipt.launchId]?.state).toBe("failed");
+    expect(registry.snapshot().heldDeliveries[delivery.id]).toMatchObject({
+      state: "failed",
+      attempts: 0,
+      generationId: null,
+      assignedAt: null,
+    });
+    const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot();
+    expect(sqlite.receipts[begun.receipt.launchId]).toEqual(registry.snapshot().receipts[begun.receipt.launchId]);
+    expect(sqlite.heldDeliveries[delivery.id]).toEqual(registry.snapshot().heldDeliveries[delivery.id]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("issue 922: a promote-race failure preserves an attempted delivery whose outcome is uncertain", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-promote-race-uncertain-delivery-"));
+  try {
+    const filename = path.join(dir, "agent-registry.json");
+    const cwd = path.join(dir, "pipeline");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const conversation = registry.ensureConversation("codex", path.join(cwd, "session.jsonl"), "account-a");
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd, transport: "structured", accountId: "account-a",
+      conversationId: conversation.id,
+      launchProfile: emptyLaunchProfile({ cwd }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const delivery = registry.holdDelivery(
+      conversation.id,
+      "synthetic kickoff",
+      `spawn_${begun.receipt.launchId}`,
+      "text",
+      [],
+      null,
+      { operationId: `spawn_message_${begun.receipt.launchId}`, kind: "send", policy: "queue" },
+    );
+    expect(registry.beginDeliveryAttempt(delivery.id, delivery.generationId!)).toMatchObject({
+      state: "delivery-uncertain",
+      attempts: 1,
+    });
+
+    registry.failSpawn(begun.receipt.launchId, "runtime host request timed out during release promotion");
+    expect(registry.snapshot().heldDeliveries[delivery.id]).toMatchObject({
+      state: "delivery-uncertain",
+      attempts: 1,
+    });
+    expect(registry.terminalizeFailedSpawnDeliveries()).toEqual([]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("issue 653: the reaper cycle durably terminalizes a failed spawn's stuck initial held delivery", async () => {
   const fixture = makeFailedSpawnWithHeldDelivery();
   try {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1468,17 +1468,19 @@ function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDeliv
   if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
 }
 
-/** The launch receipt a spawn's initial `spawn_<launchId>` held delivery belongs
-    to, if that receipt is a launch that reached the terminal `failed` state
-    (issue #653). Such a delivery can never actuate — the spawn is gone — so it
-    is registry rot that must be terminalized. */
-function failedSpawnLaunchIdOf(file: RegistryFile, delivery: HeldDelivery): string | null {
+/** Strict initial-message ownership. The idempotency key, operation id, and
+    canonical conversation must all name the same launch; paths and display
+    aliases never participate in this join. */
+function initialSpawnReceiptOf(file: RegistryFile, delivery: HeldDelivery): SpawnReceipt | null {
   const clientMessageId = delivery.clientMessageId;
   if (!clientMessageId || !clientMessageId.startsWith("spawn_")) return null;
   const launchId = clientMessageId.slice("spawn_".length);
+  if (delivery.command.operationId !== `spawn_message_${launchId}`) return null;
   const receipt = file.receipts[launchId];
-  if (!receipt || receipt.purpose !== "launch" || receipt.state !== "failed") return null;
-  return launchId;
+  if (!receipt
+    || receipt.purpose !== "launch"
+    || resolveConversationAlias(file, receipt.conversationId) !== resolveConversationAlias(file, delivery.conversationId)) return null;
+  return receipt;
 }
 
 /** A terminal first-message delivery failure makes its launch receipt terminal
@@ -1486,40 +1488,41 @@ function failedSpawnLaunchIdOf(file: RegistryFile, delivery: HeldDelivery): stri
     without a retry action even though its only prompt can no longer arrive. */
 function failInitialSpawnReceiptForDelivery(file: RegistryFile, delivery: HeldDelivery): void {
   if (delivery.state !== "failed") return;
-  const clientMessageId = delivery.clientMessageId;
-  if (!clientMessageId?.startsWith("spawn_")) return;
-  const launchId = clientMessageId.slice("spawn_".length);
-  if (delivery.command.operationId !== `spawn_message_${launchId}`) return;
-  const receipt = file.receipts[launchId];
-  if (!receipt
-    || receipt.purpose !== "launch"
-    || resolveConversationAlias(file, receipt.conversationId) !== resolveConversationAlias(file, delivery.conversationId)
-    || ["completed", "failed", "conflicted"].includes(receipt.state)) return;
+  const receipt = initialSpawnReceiptOf(file, delivery);
+  if (!receipt || ["completed", "failed", "conflicted"].includes(receipt.state)) return;
   receipt.state = "failed";
   receipt.error = delivery.error ?? "initial prompt delivery failed";
   receipt.admissionOwner = null;
 }
 
-/** Durably terminalize the `spawn_<launchId>` initial delivery of a FAILED
-    structured spawn (issue #653). Only a still-`held` reservation is touched, so
-    a concurrent `beginDeliveryAttempt` — which claims only an `assigned`
-    reservation — is never clobbered, and an in-flight attempt settles on its own
-    outcome. Returns the ids it failed; idempotent, so a terminal reservation is
-    skipped. */
+/** Converge terminal launch and initial-delivery state in both directions.
+
+    - #653: a terminal failed receipt with a never-attempted `held` delivery.
+    - #922: a never-started delivery already cancelled/failed while its receipt
+      stayed pending, or an attempts-zero `assigned` row after a promote race.
+
+    Only attempts-zero held/assigned rows are failed from receipt evidence. An
+    attempted/uncertain delivery keeps its ambiguity and settles from its own
+    journal outcome. Returns changed delivery ids and is idempotent. */
 function terminalizeFailedSpawnDeliveriesInFile(file: RegistryFile): string[] {
-  const failed: string[] = [];
+  const changed: string[] = [];
   for (const delivery of Object.values(file.heldDeliveries)) {
-    if (delivery.state !== "held") continue;
-    if (!failedSpawnLaunchIdOf(file, delivery)) continue;
-    delivery.state = "failed";
-    delivery.generationId = null;
-    delivery.assignedAt = null;
-    delivery.deliveredAt = null;
-    delivery.error = "spawn failed before its initial message was delivered";
-    syncDeliveryOperationOwnerState(file, delivery);
-    failed.push(delivery.id);
+    const receipt = initialSpawnReceiptOf(file, delivery);
+    if (!receipt) continue;
+    if (delivery.state === "failed" && !["completed", "failed", "conflicted"].includes(receipt.state)) {
+      const previousState = receipt.state;
+      failInitialSpawnReceiptForDelivery(file, delivery);
+      if (receipt.state !== previousState) changed.push(delivery.id);
+      continue;
+    }
+    const receiptFailed = receipt.state === "failed" || receipt.state === "conflicted";
+    const neverAttempted = delivery.attempts === 0
+      && (delivery.state === "held" || delivery.state === "assigned");
+    if (!receiptFailed || !neverAttempted) continue;
+    terminalizeHeldDelivery(file, delivery, "spawn failed before its initial message was delivered");
+    changed.push(delivery.id);
   }
-  return failed;
+  return changed;
 }
 
 interface DeliveryReservationInspection {
@@ -4362,18 +4365,30 @@ export class AgentRegistry {
       receipt.state = receipt.pane ? "conflicted" : "failed";
       receipt.error = error;
       if (receipt.state === "conflicted") receipt.verifiedHost = null;
+      /* A promote/admission race can fail through this pre-identity path with a
+         held or assigned attempts-zero initial delivery. Converge it in the
+         same transaction instead of waiting for the reaper. */
+      terminalizeFailedSpawnDeliveriesInFile(file);
     });
   }
 
-  /** Durably terminalize every FAILED structured spawn's stuck initial held
-      delivery (issue #653). The reaper cycle calls this so a spawn that already
-      failed before this fix shipped still stops owing a delivery and stops
-      projecting the ghost "delivering" bubble. Peeks first so a quiet registry
-      stays byte-stable across polls. Returns the reservation ids it failed. */
+  /** Durably reconcile terminal launches and attempts-zero initial deliveries
+      (#653/#922). The reaper repairs historical rows from either ordering of
+      receipt/delivery failure. Peeks first so a quiet registry stays byte-stable
+      across polls. Returns the reservation ids whose durable state changed. */
   terminalizeFailedSpawnDeliveries(): string[] {
     const snapshot = this.readOnlySnapshot();
     const hasCandidate = Object.values(snapshot.heldDeliveries).some(
-      (delivery) => delivery.state === "held" && failedSpawnLaunchIdOf(snapshot, delivery),
+      (delivery) => {
+        const receipt = initialSpawnReceiptOf(snapshot, delivery);
+        if (!receipt) return false;
+        if (delivery.state === "failed") {
+          return !["completed", "failed", "conflicted"].includes(receipt.state);
+        }
+        return (receipt.state === "failed" || receipt.state === "conflicted")
+          && delivery.attempts === 0
+          && (delivery.state === "held" || delivery.state === "assigned");
+      },
     );
     if (!hasCandidate) return [];
     return this.mutate((file) => terminalizeFailedSpawnDeliveriesInFile(file));

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -133,6 +133,49 @@ test("issue 569: a materialized live conversation retires the duplicate launch c
   }
 });
 
+test("issue 922: launch facts project canonical conversation and exact native generation across a durable alias", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-922-canonical-launch-projection-"));
+  const nativeId = "00000000-0000-0000-0000-000000000000";
+  const artifactPath = path.join(directory, `${nativeId}.jsonl`);
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "synthetic kickoff" })}\n`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      launchDisplay: { prompt: "synthetic kickoff", images: 0, echo: "synthetic kickoff" },
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: nativeId },
+      artifactPath, cwd: directory, accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }), status: "idle",
+      host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+    const snapshot = registry.snapshot();
+    const provisionalId = begun.receipt.conversationId;
+    const canonicalId = "conversation_canonical_fixture" as typeof provisionalId;
+    const conversation = snapshot.conversations[provisionalId]!;
+    delete snapshot.conversations[provisionalId];
+    snapshot.conversations[canonicalId] = { ...conversation, id: canonicalId };
+    snapshot.conversationAliases[provisionalId] = canonicalId;
+
+    const file = scannedFile(artifactPath);
+    file.conversationId = canonicalId;
+    file.generation = 1;
+    const projection = projectLaunchConversations([file], snapshot, Date.parse(begun.receipt.createdAt) + 1_000);
+    expect(projection.cards).toEqual([]);
+    expect(projection.facts.get(artifactPath)).toMatchObject({
+      launchId: begun.receipt.launchId,
+      conversationId: canonicalId,
+      generation: 1,
+    });
+    expect(projection.routes[`spawn:${begun.receipt.launchId}`]).toBe(canonicalId);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("issue 569: the launch route resolves to the canonical conversation long after the card retires", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-late-success-route-"));
   try {
@@ -224,7 +267,15 @@ test("issue 614: a transcript-less launch projects the queued prompt as the firs
     /* The queued initial delivery the spawn holds for this launch — the durable
        source of the first user bubble on EVERY surface, not only the browser
        that ran the composer. */
-    registry.holdDelivery(begun.receipt.conversationId, "LLV614_CANONICAL_PROBE_20260723", `spawn_${begun.receipt.launchId}`);
+    registry.holdDelivery(
+      begun.receipt.conversationId,
+      "LLV614_CANONICAL_PROBE_20260723",
+      `spawn_${begun.receipt.launchId}`,
+      "text",
+      [],
+      null,
+      { operationId: `spawn_message_${begun.receipt.launchId}`, kind: "send", policy: "queue" },
+    );
 
     const createdMs = Date.parse(begun.receipt.createdAt);
     /* The launch stays transcript-less across several projection polls (the

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import type { RegistryFile, SpawnReceipt } from "./registry";
+import { readOnlyConversationLookupFromSnapshot, type RegistryFile, type SpawnReceipt } from "./registry";
 import { projectRootForCwd } from "@/lib/scanner/describe";
 import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
@@ -25,10 +25,31 @@ function retiredTerminalReceipt(receipt: SpawnReceipt, nowMs: number): boolean {
   return Number.isFinite(createdMs) && nowMs - createdMs >= PLACEHOLDER_RETIREMENT_MS;
 }
 
+function launchIdentity(snapshot: RegistryFile, receipt: SpawnReceipt): { conversationId: string; generation?: number } {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const conversationId = lookup.canonicalConversationId(receipt.conversationId);
+  const conversation = lookup.conversation(conversationId);
+  const generationIndex = receipt.key
+    ? conversation?.generations.findIndex((generation) => generation.id === receipt.key?.sessionId) ?? -1
+    : -1;
+  if (generationIndex >= 0) return { conversationId, generation: generationIndex + 1 };
+  /* A fresh launch allocates generation one before the provider gives it a
+     native id. Any receipt that already has a key, or targets a conversation
+     with existing generations, is ambiguous when that key cannot be located and
+     therefore projects no generation for the client join. */
+  if (!receipt.key && (!conversation || conversation.generations.length === 0)) {
+    return { conversationId, generation: 1 };
+  }
+  return { conversationId };
+}
+
 function initialDelivery(snapshot: RegistryFile, receipt: SpawnReceipt) {
+  const launch = launchIdentity(snapshot, receipt);
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   return Object.values(snapshot.heldDeliveries).find((delivery) =>
-    delivery.conversationId === receipt.conversationId
-      && delivery.clientMessageId === `spawn_${receipt.launchId}`) ?? null;
+    lookup.canonicalConversationId(delivery.conversationId) === launch.conversationId
+      && delivery.clientMessageId === `spawn_${receipt.launchId}`
+      && delivery.command.operationId === `spawn_message_${receipt.launchId}`) ?? null;
 }
 
 /** The launch DISPLAY payload projected as the conversation's first user bubble
@@ -54,6 +75,7 @@ function launchPromptOf(
 
 function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpawnCardState {
   const delivery = initialDelivery(snapshot, receipt);
+  const identity = launchIdentity(snapshot, receipt);
   const failed = receipt.state === "failed" || receipt.state === "conflicted";
   const delivered = delivery?.state === "delivered" || receipt.state === "completed";
   const queued = Boolean(delivery)
@@ -94,7 +116,8 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     clientAttemptId: receipt.clientAttemptId,
     accountId: receipt.accountId,
     accountPin: receipt.accountPin,
-    conversationId: receipt.conversationId,
+    conversationId: identity.conversationId,
+    ...(identity.generation !== undefined ? { generation: identity.generation } : {}),
     state,
     initialMessage,
     retrySafe: receipt.state === "failed",
@@ -138,7 +161,9 @@ function materializedEntry(
   snapshot: RegistryFile,
   receipt: SpawnReceipt,
 ): FileEntry | null {
-  const generations = snapshot.conversations[receipt.conversationId]?.generations ?? [];
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const conversationId = lookup.canonicalConversationId(receipt.conversationId);
+  const generations = lookup.conversation(conversationId)?.generations ?? [];
   for (let index = generations.length - 1; index >= 0; index -= 1) {
     const candidate = byPath.get(generations[index]!.path);
     if (candidate && !isSpawnPlaceholderPath(candidate.path)) return candidate;
@@ -147,7 +172,7 @@ function materializedEntry(
     const candidate = byPath.get(receipt.artifactPath);
     if (candidate && !isSpawnPlaceholderPath(candidate.path)) return candidate;
   }
-  return files.find((file) => file.conversationId === receipt.conversationId && !isSpawnPlaceholderPath(file.path)) ?? null;
+  return files.find((file) => file.conversationId === conversationId && !isSpawnPlaceholderPath(file.path)) ?? null;
 }
 
 /** A projected launch placeholder path (`spawn:<launchId>`). */
@@ -171,9 +196,10 @@ function allLaunchReceipts(snapshot: RegistryFile): SpawnReceipt[] {
  * never what a deep link RESOLVES to.
  */
 function allLaunchRoutes(snapshot: RegistryFile): Record<string, string> {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   const routes: Record<string, string> = {};
   for (const receipt of allLaunchReceipts(snapshot)) {
-    routes[`spawn:${receipt.launchId}`] = receipt.conversationId;
+    routes[`spawn:${receipt.launchId}`] = lookup.canonicalConversationId(receipt.conversationId);
   }
   return routes;
 }
@@ -185,10 +211,12 @@ function allLaunchRoutes(snapshot: RegistryFile): Record<string, string> {
     This governs CARDS and CHIPS only — routing spans every retained receipt via
     {@link allLaunchRoutes}. */
 function newestLaunchReceipts(snapshot: RegistryFile, nowMs: number): SpawnReceipt[] {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   const byConversation = new Map<string, SpawnReceipt>();
   for (const receipt of allLaunchReceipts(snapshot)) {
-    const current = byConversation.get(receipt.conversationId);
-    if (!current || current.createdAt < receipt.createdAt) byConversation.set(receipt.conversationId, receipt);
+    const conversationId = lookup.canonicalConversationId(receipt.conversationId);
+    const current = byConversation.get(conversationId);
+    if (!current || current.createdAt < receipt.createdAt) byConversation.set(conversationId, receipt);
   }
   return [...byConversation.values()].filter((receipt) => !retiredTerminalReceipt(receipt, nowMs));
 }
@@ -316,9 +344,10 @@ function spawnCard(
   scannedPaths: ReadonlySet<string>,
   nowMs: number,
 ): FileEntry {
+  const conversationId = spawn.conversationId ?? receipt.conversationId;
   /* Pre-admission cards honor the explicit operator project the moment the
      receipt exists; once admitted, the conversation record is authoritative. */
-  const projectOwnership = snapshot.conversations[receipt.conversationId]?.projectOwnership
+  const projectOwnership = snapshot.conversations[conversationId]?.projectOwnership
     ?? (receipt.explicitProject
       ? { project: receipt.explicitProject, source: "operator" as const, setAt: receipt.createdAt, operationId: receipt.launchId }
       : null);
@@ -328,12 +357,12 @@ function spawnCard(
     launchProfileProject: receipt.launchProfile.project,
     fallbackProject: path.basename(receipt.cwd),
   });
-  const edge = snapshot.lineageEdges[receipt.conversationId];
+  const edge = snapshot.lineageEdges[conversationId];
   const parentConversationId = edge?.parentConversationId ?? receipt.parentConversationId;
   const parentPath = parentConversationId
     ? snapshot.conversations[parentConversationId]?.generations.at(-1)?.path ?? null
     : null;
-  const memberships = snapshot.memberships[receipt.conversationId] ?? [];
+  const memberships = snapshot.memberships[conversationId] ?? [];
   return {
     path: `spawn:${receipt.launchId}`,
     root: receipt.engine === "codex" ? "codex-sessions" : "claude-projects",
@@ -365,7 +394,8 @@ function spawnCard(
     plan: receipt.launchProfile.plan,
     goal: receipt.launchProfile.goal,
     waitingInput: null,
-    conversationId: receipt.conversationId,
+    conversationId,
+    generation: spawn.generation,
     ...(edge || memberships.length ? {
       durableLineage: {
         kind: edge?.kind ?? "spawn",

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -948,11 +948,11 @@ export async function runReaperCycle(options: {
   } catch (error) {
     console.error("[reaper] stale undeliverable held-delivery convergence failed", error);
   }
-  /* Durable ghost-delivery convergence (issue #653): a structured spawn that
-     reached the terminal `failed` state can never deliver its initial message,
-     so its stuck `spawn_<launchId>` reservation is failed here — it stops owing a
-     delivery and stops projecting a "delivering" bubble. Pure registry mutation,
-     independent of the runtime client, byte-stable when there is nothing to do. */
+  /* Durable launch/delivery convergence (#653/#922): reconcile either ordering
+     of a terminal launch and its never-attempted initial delivery, including
+     historical migration cancellations and promote-race assignments. Ambiguous
+     attempted deliveries remain untouched. Pure registry mutation, independent
+     of the runtime client, byte-stable when there is nothing to do. */
   try {
     registry.terminalizeFailedSpawnDeliveries();
   } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,9 +47,13 @@ export interface StructuredSpawnCardState {
   /** The durable conversation this launch created/owns (issue #653). The client
       keys the launch-owned optimistic bubble on THIS id, so a pane renders the
       bubble only inside its own conversation — never leaked into an unrelated
-      pane. Absent on legacy payloads, where the client falls back to prior
-      (path-based) behaviour. */
+      pane. A legacy payload that omits it cannot own a launch bubble. */
   conversationId?: string;
+  /** The native generation this launch owns or reserves inside
+      {@link conversationId} (issue #922). Conversation identity alone is
+      insufficient because the outbox intentionally survives account-migration
+      generations. The client joins launch bubbles only when both values match. */
+  generation?: number;
   state: "starting" | "binding" | "queued" | "reconciling" | "recoverable-timeout" | "live-late-success" | "failed" | "recovered";
   initialMessage: "pending" | "queued" | "delivered" | "failed";
   retrySafe: boolean;


### PR DESCRIPTION
Fixes https://github.com/Latand/live-log-viewer-next/issues/922

Prior art:
- https://github.com/Latand/live-log-viewer-next/issues/653
- https://github.com/Latand/live-log-viewer-next/pull/657
- https://github.com/Latand/live-log-viewer-next/issues/648
- https://github.com/Latand/live-log-viewer-next/pull/651

## Root cause

Browser-seeded launch rows entered the persisted outbox before server projection supplied canonical ownership. Re-seeding only reconciled echo text, and the render filter admitted ownerless launch rows across a queue shared by native generations. A delivered row could therefore paint a stale optimistic launch as delivering on a foreign card.

The durable terminalization sweep handled the failed-receipt then held-delivery ordering. Historical migration cancellations and release-promotion races produced the reverse ordering or an assigned attempts-zero row.

## Fix

- Project canonical conversation identity and exact native generation for launch state and routes.
- Join, seed, settle, and render launch rows through that full ownership tuple.
- Fail closed for legacy or ambiguous launch ownership.
- Reconcile receipt and initial-delivery terminality in both orderings.
- Terminalize held or assigned deliveries only while attempts remain zero; preserve attempted uncertain outcomes.
- Keep JSON and SQLite mutations inside the existing mirrored registry transaction.

## Verification

- 82 targeted unit tests across outbox, failed-spawn delivery, and spawn projection
- Browser evidence test at desktop and 390px
- 52 SQLite mirror-parity tests
- TypeScript and changed-file ESLint
- Production build
- Commit-aware privacy publication gate
