### PR TITLE
fix(outbox): a delivered operator bubble never renders below the agent's newer output

### DIFF
--- a/src/components/LogFeed.outboxTailOrder.dom.test.tsx
+++ b/src/components/LogFeed.outboxTailOrder.dom.test.tsx
@@ -1,0 +1,211 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { FileEntry } from "@/lib/types";
+import { setLocale } from "@/lib/i18n";
+import { emptyStore } from "@/components/runtime/runtimeModel";
+
+/**
+ * The delivered-bubble ordering invariant (successor of the #922/#933 class):
+ * the window tail renders outbox bubbles AFTER every flushed transcript row, so
+ * a delivered operator bubble may only still render there while nothing in the
+ * transcript is newer than its delivery. Rendered against the redacted
+ * production Codex rollout fixture: a delivered entry whose echo was missed
+ * must NOT render below the agent's newer tool calls and reply; a delivery
+ * newer than the whole transcript still renders at the tail.
+ */
+
+const dom = new HappyWindow({ width: 1280, height: 800 });
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  onchange: null,
+  dispatchEvent: () => false,
+});
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.assign(globalThis, {
+  ResizeObserver: TestResizeObserver,
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  IntersectionObserver: undefined,
+});
+
+const fixtureLines = fs
+  .readFileSync(
+    path.join(import.meta.dir, "conversation", "fixtures", "codex-composer-delivery.jsonl"),
+    "utf8",
+  )
+  .split("\n")
+  .filter(Boolean);
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualLogTail = await import("@/hooks/useLogTail");
+const actualToolCues = await import("@/hooks/useToolActivityCues");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeSessionForConversation: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useLogTail", () => ({
+  ...actualLogTail,
+  useLogTail: () => ({
+    lines: fixtureLines,
+    linesStart: 0,
+    size: 1,
+    loading: false,
+    error: null,
+    tickTime: null,
+    paused: false,
+    setPaused: () => undefined,
+    clear: () => undefined,
+    hasMore: false,
+    loadingOlder: false,
+    loadOlder: async () => 0,
+    prependGen: 0,
+  }),
+}));
+mock.module("@/hooks/useToolActivityCues", () => ({
+  ...actualToolCues,
+  useToolActivityCues: () => undefined,
+}));
+
+const { LogFeed } = await import("./LogFeed");
+const { enqueueOutbox, resetOutboxForTests, updateOutbox } = await import("./conversation/outbox");
+
+/* The newest fixture record: the agent's reply after the tool call. */
+const NEWEST_RECORD_AT = Date.parse("2026-08-06T13:44:33.481Z");
+const NOW = NEWEST_RECORD_AT + 5_000;
+const originalDateNow = Date.now;
+
+const roots = new Set<Root>();
+beforeEach(() => {
+  Date.now = () => NOW;
+  setLocale("en");
+  dom.sessionStorage.clear();
+  resetOutboxForTests();
+});
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+  Date.now = originalDateNow;
+});
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+  mock.module("@/hooks/useToolActivityCues", () => actualToolCues);
+});
+
+const file: FileEntry = {
+  path: "/tmp/x.jsonl",
+  root: "codex-sessions",
+  name: "x.jsonl",
+  project: "project",
+  title: "Conversation pane",
+  engine: "codex",
+  kind: "session",
+  fmt: "codex",
+  parent: null,
+  mtime: NOW,
+  size: 1,
+  activity: "live",
+  proc: "running",
+  pid: 7,
+  model: null,
+  pendingQuestion: null,
+  waitingInput: null,
+  conversationId: "conversation-tail-order",
+} as FileEntry;
+
+function render(): HTMLElement {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  flushSync(() => {
+    root.render(
+      <LogFeed
+        file={file}
+        showSvc={false}
+        lineFilter=""
+        onStatus={() => undefined}
+        paused
+        follow={false}
+        setFollow={() => undefined}
+      />,
+    );
+  });
+  return host as unknown as HTMLElement;
+}
+
+test("a delivered bubble whose echo was missed cannot render below newer transcript rows", () => {
+  /* Delivered BEFORE the fixture's tool call and reply; its text echoes
+     nowhere in the transcript (the missed-echo class: scaffolded payload,
+     tail attached after the echo row). */
+  enqueueOutbox("conversation-tail-order", {
+    id: "delivered-before-reply",
+    text: "cadence acknowledged",
+    images: 0,
+    at: Date.parse("2026-08-06T13:44:20.000Z"),
+  });
+  updateOutbox("conversation-tail-order", "delivered-before-reply", {
+    state: "delivered",
+    settledAt: Date.parse("2026-08-06T13:44:24.000Z"),
+  });
+
+  const host = render();
+  /* The transcript rendered — including records newer than the delivery. */
+  expect(host.querySelectorAll("[data-feed-kind]").length).toBeGreaterThan(0);
+  /* The delivered bubble retired instead of trailing the newer output. */
+  expect(host.querySelector("[data-outbox-entry]")).toBeNull();
+});
+
+test("a delivery newer than the whole transcript still renders its bubble at the tail", () => {
+  enqueueOutbox("conversation-tail-order", {
+    id: "delivered-after-reply",
+    text: "one more question",
+    images: 0,
+    at: NEWEST_RECORD_AT + 1_000,
+  });
+  updateOutbox("conversation-tail-order", "delivered-after-reply", {
+    state: "delivered",
+    settledAt: NEWEST_RECORD_AT + 1_000,
+  });
+
+  const host = render();
+  const bubble = host.querySelector<HTMLElement>("[data-outbox-entry]");
+  expect(bubble?.dataset.outboxState).toBe("delivered");
+  /* Nothing in the transcript is newer than this delivery, so the tail
+     position IS its chronological position. */
+  const rows = [...host.querySelectorAll("[data-feed-kind], [data-outbox-entry]")];
+  expect(rows.at(-1)?.getAttribute("data-outbox-entry")).toBe("delivered-after-reply");
+});

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -557,9 +557,25 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       });
     }
   }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt, launch?.error, launchOwner, launchOwnsThisPane]);
+  /* The newest rendered transcript moment: past a delivered bubble's settle
+     time, it proves the agent's output already moved beyond the delivery and
+     retires the bubble even when its echo was missed (a scaffolded payload, a
+     tail attached after the echo row) — the tail section must never paint the
+     operator's delivered message below newer records. */
+  const newestTranscriptAtMs = useMemo(() => {
+    let newest: number | undefined;
+    for (const { item } of feed.items) {
+      if (!("ts" in item)) continue;
+      const at = typeof item.ts === "number" ? item.ts : Date.parse(String(item.ts ?? ""));
+      if (Number.isFinite(at) && (newest === undefined || at > newest)) newest = at;
+    }
+    return newest;
+  }, [feed.items]);
   /* Launch bubbles fail closed without exact canonical ownership; ordinary
      composer entries still render from this conversation-scoped queue. */
-  const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs(), paneLaunchOwner) : [];
+  const pendingOutbox = file
+    ? visibleOutbox(outbox, transcriptEchoCounts, nowMs(), paneLaunchOwner, newestTranscriptAtMs)
+    : [];
   useEffect(() => {
     if (!memoryKey || !file) return;
     adoptCanonicalAssistantClaims(file.path, memoryKey);

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -32,6 +32,7 @@ import {
   markOutboxResponded,
   outboxHistory,
   outboxStateForReceiptStatus,
+  rebindOutboxEchoText,
   transcriptEchoCount,
   updateOutbox,
   useOutbox,
@@ -1714,6 +1715,14 @@ export function TmuxComposerCore({
          returns to the queue and the dispatcher retries when it clears. */
       if (outboxId) updateOutbox(cardId, outboxId, { state: "queued" });
       return;
+    }
+    /* The wire payload was scaffolded past the raw draft (viewer prelude,
+       drained bridge turn): the transcript will echo the SCAFFOLDED text, so
+       the queued bubble's echo identity re-binds to it before delivery —
+       otherwise its echo never matches and the delivered bubble lingers in the
+       tail below the agent's newer output. */
+    if (outboxId && payloadText !== requestedText) {
+      rebindOutboxEchoText(cardId, outboxId, payloadText);
     }
     /* A legacy dead host keeps its draft local. Structured ownership admits a
        text-only message durably and uses that request to recover its engine host.

--- a/src/components/conversation/fixtures/codex-composer-delivery.jsonl
+++ b/src/components/conversation/fixtures/codex-composer-delivery.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-08-06T13:44:25.317Z","type":"response_item","payload":{"type":"message","id":"msg_fixture_0001","role":"user","content":[{"type":"input_text","text":"<!-- llv:structured-user ctx=eyJmaXh0dXJlIjp0cnVlfQ -->\nevery minute or two"}]}}
+{"timestamp":"2026-08-06T13:44:25.320Z","type":"event_msg","payload":{"type":"user_message","client_id":"client-fixture-0001","message":"<!-- llv:structured-user ctx=eyJmaXh0dXJlIjp0cnVlfQ -->\nevery minute or two"}}
+{"timestamp":"2026-08-06T13:44:31.002Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"bash\",\"-lc\",\"rg --files src\"]}","call_id":"call_fixture_0001"}}
+{"timestamp":"2026-08-06T13:44:31.240Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_fixture_0001","output":"src/example.ts"}}
+{"timestamp":"2026-08-06T13:44:33.481Z","type":"event_msg","payload":{"type":"agent_message","message":"Adjusted the check cadence to every minute."}}

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -10,6 +10,7 @@ import {
   outboxHistory,
   OUTBOX_DELIVERED_TTL_MS,
   OUTBOX_LIMIT,
+  OUTBOX_MTIME_GRACE_MS,
   outboxStateForReceiptStatus,
   publishTranscriptEchoes,
   readOutbox,
@@ -112,6 +113,31 @@ test("a delivered bubble whose echo never arrives still retires at the hard TTL"
   const entry: OutboxEntry = { id: "k1", text: "done", images: 0, at, state: "delivered", settledAt: at };
   expect(visibleOutbox([entry], echoes(), at + 3_000)).toHaveLength(1);
   expect(visibleOutbox([entry], echoes(), at + OUTBOX_DELIVERED_TTL_MS + 1)).toHaveLength(0);
+});
+
+test("a delivered bubble retires once the transcript grew past its delivery, even without its echo", () => {
+  const at = 1_000_000;
+  const entry: OutboxEntry = { id: "k1", text: "steer left", images: 0, at, state: "delivered", settledAt: at };
+  /* No transcript evidence yet → the delivered bubble renders at the tail. */
+  expect(visibleOutbox([entry], echoes(), at + 3_000)).toHaveLength(1);
+  /* The newest rendered record still predates the delivery (plus grace): the
+     bubble IS the newest thing in the conversation and keeps rendering. */
+  expect(visibleOutbox([entry], echoes(), at + 3_000, undefined, at + OUTBOX_MTIME_GRACE_MS - 1))
+    .toHaveLength(1);
+  /* A transcript record newer than the delivery landed (a tool call, the
+     reply) while the echo was missed — the bubble must not trail it. */
+  expect(visibleOutbox([entry], echoes(), at + 3_000, undefined, at + OUTBOX_MTIME_GRACE_MS))
+    .toHaveLength(0);
+});
+
+test("transcript growth never retires queued, delivering, or failed bubbles", () => {
+  const at = 1_000_000;
+  const grown = at + OUTBOX_DELIVERED_TTL_MS;
+  const queued: OutboxEntry = { id: "k1", text: "waiting", images: 0, at, state: "queued" };
+  const delivering: OutboxEntry = { id: "k2", text: "in flight", images: 0, at, state: "delivering" };
+  const failed: OutboxEntry = { id: "k3", text: "broken", images: 0, at, state: "failed" };
+  expect(visibleOutbox([queued, delivering, failed], echoes(), at + 3_000, undefined, grown))
+    .toHaveLength(3);
 });
 
 test("queued / delivering / launch-owned bubbles stay until their echo lands, never by TTL", () => {

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -145,8 +145,11 @@ export function outboxStateForReceiptStatus(status: ReceiptStatus): OutboxState 
 /** Bounded per conversation: the queue is working state plus recent history for
     ArrowUp/ArrowDown, never an archive (the transcript is the archive). */
 export const OUTBOX_LIMIT = 32;
-/** A delivered entry stops rendering once the transcript grew past it — the
-    real bubble has landed. Mirrors DELIVERY_ECHO_MTIME_GRACE_MS. */
+/** A delivered entry stops rendering once the transcript grew past its
+    delivery moment: newer transcript records prove the agent has moved on, so
+    keeping the bubble in the window tail would paint the operator's message
+    BELOW output that came after it. The grace absorbs the echo's own write and
+    small clock skew. Mirrors DELIVERY_ECHO_MTIME_GRACE_MS. */
 export const OUTBOX_MTIME_GRACE_MS = 2_000;
 /** Hard cap so a conversation whose transcript never grows again cannot keep
     optimistic bubbles on screen forever. */
@@ -1157,6 +1160,16 @@ export function useTranscriptEchoes(cardId: string): TranscriptEchoCounts {
  * A `delivered` bubble whose echo never arrives (a lost poll, a finished pane)
  * still retires at a hard TTL so nothing lingers forever.
  *
+ * A `delivered` bubble also retires the moment the rendered transcript holds a
+ * record NEWER than its delivery (`newestTranscriptAtMs` past `settledAt` plus
+ * {@link OUTBOX_MTIME_GRACE_MS}). The window tail renders outbox bubbles after
+ * every flushed transcript row, so a delivered bubble whose echo was missed —
+ * a scaffolded payload, a tail window attached after the echo, a capped tail —
+ * would otherwise pin the operator's message BELOW the agent's newer tool
+ * calls and reply until the TTL. Delivery is already proven; once the
+ * transcript grew past it the bubble must leave the tail. Pending and failed
+ * entries are untouched: they carry state the transcript cannot show.
+ *
  * `transcriptEchoCounts` maps each trimmed transcript user-text to its occurrence
  * count in the rendered transcript.
  */
@@ -1165,6 +1178,7 @@ export function visibleOutbox(
   transcriptEchoCounts: TranscriptEchoCounts,
   nowMs: number,
   paneOwner?: OutboxOwner | null,
+  newestTranscriptAtMs?: number,
 ): OutboxEntry[] {
   const consumed = new Map<string, number>();
   const visible: OutboxEntry[] = [];
@@ -1198,6 +1212,10 @@ export function visibleOutbox(
     if (entry.state === "delivered") {
       const settledAt = entry.settledAt ?? entry.at;
       if (nowMs - settledAt >= OUTBOX_DELIVERED_TTL_MS) continue;
+      if (
+        newestTranscriptAtMs !== undefined
+        && newestTranscriptAtMs >= settledAt + OUTBOX_MTIME_GRACE_MS
+      ) continue;
     }
     visible.push(entry);
   }

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -827,6 +827,34 @@ export function retryOutbox(cardId: string, id: string): void {
   write(cardId, queue.map((item) => (item.id === id ? { ...item, state: "queued", error: undefined } : item)));
 }
 
+/**
+ * Re-bind a queued submission's echo identity to the text the dispatcher will
+ * actually deliver. The composer composes the wire payload at dispatch time —
+ * a viewer-context prelude or a drained bridge turn can scaffold the operator's
+ * draft — and the transcript echoes THAT text, not the raw draft the bubble
+ * displays. Without the re-bind the echo can never match and the delivered
+ * bubble lingers in the tail until the TTL. The submission watermark is
+ * recomputed against the composed key: every current ledger occurrence of the
+ * composed text predates this delivery, so only a LATER echo may retire it.
+ */
+export function rebindOutboxEchoText(cardId: string, id: string, echoText: string): void {
+  const queue = readOutbox(cardId);
+  const entry = queue.find((item) => item.id === id);
+  if (!entry || entry.retiredEchoId) return;
+  const key = echoKey(echoText);
+  if (!key || echoKey(entry.echoText ?? entry.text) === key) return;
+  const baselineIds = readEchoLedger(cardId)
+    .filter((echo) => echo.key === key)
+    .map((echo) => echo.id);
+  write(cardId, queue.map((item) => {
+    if (item.id !== id) return item;
+    const rebound = { ...item, echoText, echoBaseline: baselineIds.length };
+    if (baselineIds.length) rebound.echoBaselineIds = baselineIds;
+    else delete rebound.echoBaselineIds;
+    return rebound;
+  }));
+}
+
 /** Move a whole queue onto a new conversation identity (provisional-id adoption,
     a materialized launch, a migration successor). Records already filed under
     the new identity win, so an adoption is idempotent. */

--- a/src/components/conversation/outboxEchoShapes.test.ts
+++ b/src/components/conversation/outboxEchoShapes.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { Window } from "happy-dom";
+
+import { buildFeed } from "@/components/feed/parse";
+import type { FileEntry } from "@/lib/types";
+
+import {
+  enqueueOutbox,
+  publishTranscriptEchoes,
+  readOutbox,
+  rebindOutboxEchoText,
+  resetOutboxForTests,
+  updateOutbox,
+  visibleOutbox,
+  type TranscriptEchoObservation,
+} from "./outbox";
+
+/**
+ * Echo recognition against the REAL transcript record shapes both engines
+ * journal for a composer delivery (the delivered-bubble successor of the
+ * #922/#933 class). The Codex fixture is a redacted production rollout: the
+ * runtime wraps the operator's draft in the `<!-- llv:structured-user … -->`
+ * marker (with a `ctx` attribute), and the feed parser must hand the outbox an
+ * echo carrying the RAW draft so the delivered bubble retires when it lands.
+ */
+
+const dom = new Window();
+Object.assign(globalThis, { window: dom, sessionStorage: dom.sessionStorage });
+
+beforeEach(() => {
+  dom.sessionStorage.clear();
+  resetOutboxForTests();
+});
+afterEach(() => {
+  dom.sessionStorage.clear();
+  resetOutboxForTests();
+});
+
+const codexFile = { path: "/tmp/x.jsonl", engine: "codex", fmt: "codex", activity: "recent" } as FileEntry;
+const claudeFile = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "recent" } as FileEntry;
+
+/** Exactly what LogFeed publishes: every rendered user row, under its
+    generation and a stable row anchor. */
+function userEchoObservations(file: FileEntry, lines: string[]): TranscriptEchoObservation[] {
+  return buildFeed(file, lines, false, "")
+    .items.flatMap((item, index) => {
+      if (item.kind !== "user" || !("text" in item) || !item.text.trim()) return [];
+      return [{ generation: file.path, id: `row:${index}:0`, text: item.text }];
+    });
+}
+
+test("a Codex composer delivery echo (structured-user marker + ctx) retires the delivered bubble", () => {
+  const lines = fs
+    .readFileSync(path.join(import.meta.dir, "fixtures", "codex-composer-delivery.jsonl"), "utf8")
+    .split("\n")
+    .filter(Boolean);
+  const observations = userEchoObservations(codexFile, lines);
+  /* The parser strips the marker line: the echo carries the raw draft. */
+  expect(observations.map((echo) => echo.text)).toEqual(["every minute or two"]);
+
+  enqueueOutbox("conv", { id: "k1", text: "every minute or two", images: 0, at: 1_000 });
+  updateOutbox("conv", "k1", { state: "delivered", settledAt: 1_500 });
+  publishTranscriptEchoes("conv", observations);
+
+  expect(readOutbox("conv")[0]?.retiredEchoId).toBeString();
+  expect(visibleOutbox(readOutbox("conv"), new Map([["every minute or two", 1]]), 2_000)).toEqual([]);
+});
+
+test("a Claude structured-host user record retires the delivered bubble", () => {
+  const lines = [JSON.stringify({
+    type: "user",
+    timestamp: "2026-08-06T13:44:25.320Z",
+    message: { role: "user", content: [{ type: "text", text: "every minute or two" }] },
+  })];
+  const observations = userEchoObservations(claudeFile, lines);
+  expect(observations.map((echo) => echo.text)).toEqual(["every minute or two"]);
+
+  enqueueOutbox("conv", { id: "k1", text: "every minute or two", images: 0, at: 1_000 });
+  updateOutbox("conv", "k1", { state: "delivered", settledAt: 1_500 });
+  publishTranscriptEchoes("conv", observations);
+
+  expect(readOutbox("conv")[0]?.retiredEchoId).toBeString();
+});
+
+test("a scaffolded dispatch re-binds the echo identity so the scaffolded echo retires the bubble", () => {
+  const draft = "every minute or two";
+  const scaffolded = `[viewer context]\nThe operator is looking at project-a.\n${draft}`;
+
+  /* Without the re-bind the scaffolded transcript echo can never match the
+     raw-draft identity — the delivered bubble would linger in the tail. */
+  enqueueOutbox("conv", { id: "unbound", text: draft, images: 0, at: 1_000 });
+  updateOutbox("conv", "unbound", { state: "delivered", settledAt: 1_500 });
+  publishTranscriptEchoes("conv", [{ generation: "/tmp/x.jsonl", id: "row:0:0", text: scaffolded }]);
+  expect(readOutbox("conv")[0]?.retiredEchoId).toBeUndefined();
+
+  resetOutboxForTests();
+  dom.sessionStorage.clear();
+
+  enqueueOutbox("conv", { id: "bound", text: draft, images: 0, at: 1_000 });
+  rebindOutboxEchoText("conv", "bound", scaffolded);
+  updateOutbox("conv", "bound", { state: "delivered", settledAt: 1_500 });
+  publishTranscriptEchoes("conv", [{ generation: "/tmp/x.jsonl", id: "row:0:0", text: scaffolded }]);
+
+  const entry = readOutbox("conv")[0];
+  /* The bubble still DISPLAYS the raw draft; only its echo identity re-bound. */
+  expect(entry?.text).toBe(draft);
+  expect(entry?.echoText).toBe(scaffolded);
+  expect(entry?.retiredEchoId).toBeString();
+});
+
+test("re-binding recomputes the submission watermark against the composed key", () => {
+  const scaffolded = "[bridge]\n\ngo";
+  /* An identical scaffolded text already echoed once (an earlier delivery). */
+  publishTranscriptEchoes("conv", [{ generation: "/tmp/x.jsonl", id: "row:0:0", text: scaffolded }]);
+
+  enqueueOutbox("conv", { id: "k1", text: "go", images: 0, at: 1_000 });
+  rebindOutboxEchoText("conv", "k1", scaffolded);
+  /* The pre-existing echo belongs to the past — it must not retire the fresh
+     bubble; only its OWN later echo does. */
+  expect(readOutbox("conv")[0]?.retiredEchoId).toBeUndefined();
+
+  publishTranscriptEchoes("conv", [{ generation: "/tmp/x.jsonl", id: "row:1:0", text: scaffolded }]);
+  expect(readOutbox("conv")[0]?.retiredEchoId).toBeString();
+});


### PR DESCRIPTION
## Operator report

A composer message settled to "delivered" and its bubble rendered BELOW the agent's newer output — below subsequent tool calls, and below the finished reply once it streamed (prod, 2026-08-06, a Codex conversation). Successor of the #922/#933 class, now for a delivered bubble and pure intra-conversation ordering.

## Verified mechanism

Inspected the real rollout for the incident window. A composer delivery is journaled as a `response_item` user message plus `event_msg user_message`, both wrapped in the `<!-- llv:structured-user ctx=… -->` marker; the feed parser strips the marker, so a plain send's echo text equals the raw draft and matches. Two real gaps remained:

1. **Scaffolded dispatches can never match.** The composer composes the wire payload at dispatch time — the viewer-context prelude (`prelude\n<draft>`) or a drained bridge turn (`bridge\n\n<draft>`) is prepended — and the transcript echoes the scaffolded text while the bubble's echo identity stays bound to the raw draft. Composer entries never carried `echoText`.
2. **Ordering had no safety net.** The window tail renders outbox bubbles after every flushed transcript row (`tailOrder.ts`), and a delivered bubble only left it on an echo match or the 10-minute `OUTBOX_DELIVERED_TTL_MS`. `OUTBOX_MTIME_GRACE_MS` documented a "stops rendering once the transcript grew past it" retirement, but nothing consumed it. Any missed echo (scaffold, tail window attached after the echo row, capped tail) pinned the delivered message below the agent's newer output for up to 10 minutes — exactly the screenshot.

## Fix (root, in the existing outbox/tailOrder machinery)

- `rebindOutboxEchoText`: the dispatcher re-binds a queued entry's echo identity to the composed payload before delivery, recomputing the submission watermark against the composed key. The bubble still displays the raw draft (same contract as issue #615 launch scaffolds).
- `visibleOutbox` now takes the newest rendered transcript moment; a **delivered** bubble retires when the transcript holds a record newer than its settle time plus `OUTBOX_MTIME_GRACE_MS` — the doc'd retirement, actually wired. LogFeed derives the moment from the rendered feed items. Pending/failed bubbles are untouched (they carry state the transcript cannot show); the TTL stays as the backstop for transcripts that never grow again.
- #922/#933 guarantees intact: exact-owner fail-closed rendering and terminal launch settlement are untouched, and callers passing no transcript moment keep prior behavior (their tests stay green).

## Tests (targeted, by path)

- `outboxEchoShapes.test.ts`: both engines' echo shapes from real (redacted) transcript records — the Codex structured-user marker + `ctx` rollout fixture and the Claude structured-host user record — retire the delivered bubble; a scaffolded echo without the re-bind is proven NOT to match (the defect), and the re-bound watermark ignores pre-existing identical echoes.
- `LogFeed.outboxTailOrder.dom.test.tsx`: renders the production LogFeed against the rollout fixture — a delivered bubble whose echo was missed cannot render below newer transcript rows (**fails on the previous HEAD**, verified in a throwaway worktree); a delivery newer than the whole transcript still renders at the tail.
- `outbox.test.ts`: transcript-growth retirement unit cases (grace boundary; queued/delivering/failed unaffected).

`bun test` on the touched suites: 102 pass. ESLint on touched files and `tsc --noEmit` clean. Privacy gate PASS against the merge base.

Pre-existing, unrelated: `TmuxComposer.queueFirst.dom.test.tsx` fails identically on a clean HEAD checkout; the browser evidence suites need a `next build` CSS artifact absent in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)