### PR TITLE
feat(feed): show tool activity in live turns

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -563,8 +563,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   useEffect(() => {
     if (!memoryKey || !file) return;
     adoptCanonicalAssistantClaims(file.path, memoryKey);
-    publishCanonicalAssistantClaims(memoryKey, feed.items);
-  }, [file, memoryKey, feed.items]);
+    publishCanonicalAssistantClaims(memoryKey, feed.items, runtimeLiveTurn);
+  }, [file, memoryKey, feed.items, runtimeLiveTurn]);
   const visibleLiveTurnItems = useMemo(
     () => visibleRuntimeLiveTurnItems(runtimeLiveTurn, feed.items, assistantClaims, runtimeTurn),
     [runtimeLiveTurn, feed.items, assistantClaims, runtimeTurn],

--- a/src/components/conversation/LiveTurnRows.tsx
+++ b/src/components/conversation/LiveTurnRows.tsx
@@ -2,7 +2,20 @@
 
 import type { RuntimeLiveTurnItem } from "@/lib/runtime/liveTurn";
 import { useLocale } from "@/lib/i18n";
+import { GlyphIcon } from "@/components/icons";
 import { StreamingMd } from "@/components/feed/markdown";
+import { summarizeTool } from "@/components/feed/tools";
+
+function toolArgs(item: RuntimeLiveTurnItem): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(item.text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
 
 /* A live row is the same message its transcript echo will carry a moment later,
    so it goes through the same markdown grammar — otherwise the text visibly
@@ -19,7 +32,10 @@ export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] 
           key={item.itemId ?? `${item.startedAt ?? "live"}:${index}`}
           data-live-turn
           data-live-turn-item-id={item.itemId ?? undefined}
-          className="my-2 ml-9 whitespace-pre-wrap [overflow-wrap:anywhere] text-ui text-primary"
+          data-live-turn-tool={item.kind === "tool" ? item.toolName : undefined}
+          className={item.kind === "tool"
+            ? "my-0.5 ml-9 flex min-w-0 items-center gap-2 rounded-control py-0.5 text-ui text-muted"
+            : "my-2 ml-9 whitespace-pre-wrap [overflow-wrap:anywhere] text-ui text-primary"}
         >
           {item.omittedItems ? (
             <span data-live-turn-omitted-items className="text-muted">
@@ -33,8 +49,25 @@ export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] 
               {`${t("feed.liveOmittedChars", { chars: item.omittedChars })}\n`}
             </span>
           ) : null}
-          <StreamingMd text={item.text} streaming={item.phase === "streaming"} />
-          {item.phase === "streaming" && index === items.length - 1 ? (
+          {item.kind === "tool" ? (() => {
+            const toolName = item.toolName || "tool";
+            const summary = summarizeTool(
+              toolName,
+              toolArgs(item),
+              item.toolEngine === "claude" ? "claude" : "codex",
+            );
+            return (
+              <>
+                <GlyphIcon name={summary.icon} className="h-3.5 w-3.5 shrink-0" />
+                <span className="shrink-0 font-mono text-caption text-muted">{toolName}</span>
+                {summary.summary !== toolName ? <span aria-hidden className="shrink-0 text-muted">·</span> : null}
+                <span className="min-w-0 flex-1 truncate text-secondary" title={summary.summary}>
+                  {summary.summary !== toolName ? summary.summary : ""}
+                </span>
+              </>
+            );
+          })() : <StreamingMd text={item.text} streaming={item.phase === "streaming"} />}
+          {item.phase === "streaming" && (item.kind === "tool" || index === items.length - 1) ? (
             <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse rounded-[2px] bg-accent align-text-bottom" aria-hidden />
           ) : null}
         </div>

--- a/src/components/conversation/LiveTurnRows.tsx
+++ b/src/components/conversation/LiveTurnRows.tsx
@@ -29,7 +29,7 @@ export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] 
     <div data-live-turn-group>
       {items.map((item, index) => (
         <div
-          key={item.itemId ?? `${item.startedAt ?? "live"}:${index}`}
+          key={`${item.itemId ?? item.startedAt ?? "live"}:${index}`}
           data-live-turn
           data-live-turn-item-id={item.itemId ?? undefined}
           data-live-turn-tool={item.kind === "tool" ? item.toolName : undefined}

--- a/src/components/conversation/LiveTurnRows.tsx
+++ b/src/components/conversation/LiveTurnRows.tsx
@@ -29,7 +29,7 @@ export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] 
     <div data-live-turn-group>
       {items.map((item, index) => (
         <div
-          key={`${item.itemId ?? item.startedAt ?? "live"}:${index}`}
+          key={item.rowId ?? `${item.itemId ?? item.startedAt ?? "live"}:${index}`}
           data-live-turn
           data-live-turn-item-id={item.itemId ?? undefined}
           data-live-turn-tool={item.kind === "tool" ? item.toolName : undefined}

--- a/src/components/conversation/liveTurnHandoff.test.ts
+++ b/src/components/conversation/liveTurnHandoff.test.ts
@@ -175,3 +175,39 @@ test("a canonical command group publishes claims for every grouped tool call", (
     "grouped-read",
   ]);
 });
+
+test("a canonical outgoing teammate message claims its live SendMessage tool row", () => {
+  const toolId = "send-message-live";
+  const live: RuntimeLiveTurn = {
+    turnId: "turn-send-message",
+    text: "",
+    items: [{
+      kind: "tool",
+      itemId: toolId,
+      text: JSON.stringify({ to: "worker-1", message: "check the branch" }),
+      toolName: "SendMessage",
+      toolEngine: "claude",
+      phase: "streaming",
+      startedAt: "2026-08-06T10:00:00.000Z",
+      completedAt: null,
+    }],
+  };
+  const canonicalFeed = [{
+    anchorKey: "row:50:0",
+    key: "50:0",
+    item: {
+      kind: "tmsg",
+      ts: "2026-08-06T10:00:00.100Z",
+      dir: "out",
+      peer: "worker-1",
+      summary: "",
+      text: "check the branch",
+      sourceId: toolId,
+    },
+  }] as FeedEntry[];
+
+  publishCanonicalAssistantClaims("conversation-send-message", canonicalFeed);
+  const persisted = readCanonicalAssistantClaims("conversation-send-message");
+  expect([...persisted]).toEqual([toolId]);
+  expect(visibleRuntimeLiveTurnItems(live, canonicalFeed, persisted, "running")).toEqual([]);
+});

--- a/src/components/conversation/liveTurnHandoff.test.ts
+++ b/src/components/conversation/liveTurnHandoff.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 
 import type { FeedEntry } from "@/components/feed/parse";
-import type { RuntimeLiveTurn } from "@/lib/runtime/liveTurn";
+import { setLocale } from "@/lib/i18n";
+import type { RuntimeLiveTurn, RuntimeLiveTurnItem } from "@/lib/runtime/liveTurn";
 
 import {
   adoptCanonicalAssistantClaims,
@@ -13,7 +14,8 @@ import {
 } from "./liveTurnHandoff";
 
 const dom = new Window({ url: "http://localhost/" });
-Object.assign(globalThis, { window: dom, sessionStorage: dom.sessionStorage });
+Object.assign(globalThis, { window: dom, navigator: dom.navigator, sessionStorage: dom.sessionStorage });
+setLocale("en");
 
 beforeEach(() => {
   dom.sessionStorage.clear();
@@ -108,13 +110,14 @@ test("issue 626: mixed projections claim one assistant response once", () => {
 });
 
 test("a canonical tool card claims its live tool row during the running turn and after feed eviction", () => {
-  const toolId = "tool-claim-live";
+  const liveToolId = "exec-tool-claim-live";
+  const canonicalToolId = "call_tool_claim_live";
   const live: RuntimeLiveTurn = {
     turnId: "turn-tool-claim",
     text: "",
     items: [{
       kind: "tool",
-      itemId: toolId,
+      itemId: liveToolId,
       text: JSON.stringify({ cmd: "bun test src/components/conversation/liveTurnHandoff.test.ts" }),
       toolName: "exec_command",
       toolEngine: "codex",
@@ -128,7 +131,7 @@ test("a canonical tool card claims its live tool row during the running turn and
     key: "30:0",
     item: {
       kind: "tool",
-      id: toolId,
+      id: canonicalToolId,
       ts: "2026-08-06T09:20:00.100Z",
       srcCall: 30,
       family: "shell",
@@ -144,21 +147,80 @@ test("a canonical tool card claims its live tool row during the running turn and
     },
   }] as FeedEntry[];
 
-  publishCanonicalAssistantClaims("conversation-tool-claim", canonicalFeed);
+  publishCanonicalAssistantClaims("conversation-tool-claim", canonicalFeed, live);
   const persisted = readCanonicalAssistantClaims("conversation-tool-claim");
-  expect([...persisted]).toEqual([toolId]);
+  expect([...persisted]).toEqual([canonicalToolId, liveToolId]);
   expect(visibleRuntimeLiveTurnItems(live, canonicalFeed, persisted, "running")).toEqual([]);
   expect(visibleRuntimeLiveTurnItems(live, [], persisted, "running")).toEqual([]);
 });
 
 test("a canonical command group publishes claims for every grouped tool call", () => {
+  const live: RuntimeLiveTurn = {
+    turnId: "turn-grouped-tools",
+    text: "",
+    items: [
+      {
+        kind: "tool",
+        itemId: "exec-grouped-command",
+        text: JSON.stringify({ cmd: "printf grouped-command" }),
+        toolName: "exec_command",
+        toolEngine: "codex",
+        phase: "awaiting-echo",
+        startedAt: "2026-08-06T09:21:00.000Z",
+        completedAt: null,
+      },
+      {
+        kind: "tool",
+        itemId: "exec-grouped-read",
+        text: JSON.stringify({ file_path: "src/lib/runtime/liveTurn.ts" }),
+        toolName: "Read",
+        toolEngine: "codex",
+        phase: "awaiting-echo",
+        startedAt: "2026-08-06T09:21:01.000Z",
+        completedAt: null,
+      },
+    ],
+  };
   const groupedFeed = [{
     anchorKey: "row:40:0",
     key: "40:0",
     item: {
       kind: "cmd-group",
       ids: ["grouped-command", "grouped-read"],
-      calls: [],
+      calls: [
+        {
+          kind: "tool",
+          id: "grouped-command",
+          ts: "2026-08-06T09:21:00.000Z",
+          srcCall: 40,
+          family: "shell",
+          tool: "exec_command",
+          icon: "shell",
+          summary: "printf grouped-command",
+          chips: [],
+          status: "ok",
+          statusLabel: "Completed",
+          outputPreview: "",
+          outputTruncated: false,
+          open: false,
+        },
+        {
+          kind: "tool",
+          id: "grouped-read",
+          ts: "2026-08-06T09:21:01.000Z",
+          srcCall: 41,
+          family: "read",
+          tool: "Read",
+          icon: "file",
+          summary: "Read liveTurn.ts",
+          chips: [],
+          status: "ok",
+          statusLabel: "Completed",
+          outputPreview: "",
+          outputTruncated: false,
+          open: false,
+        },
+      ],
       t0: "2026-08-06T09:21:00.000Z",
       t1: "2026-08-06T09:21:01.000Z",
       byTool: { exec_command: 1, Read: 1 },
@@ -169,10 +231,12 @@ test("a canonical command group publishes claims for every grouped tool call", (
     },
   }] as FeedEntry[];
 
-  publishCanonicalAssistantClaims("conversation-grouped-tools", groupedFeed);
+  publishCanonicalAssistantClaims("conversation-grouped-tools", groupedFeed, live);
   expect([...readCanonicalAssistantClaims("conversation-grouped-tools")]).toEqual([
     "grouped-command",
     "grouped-read",
+    "exec-grouped-command",
+    "exec-grouped-read",
   ]);
 });
 
@@ -210,4 +274,93 @@ test("a canonical outgoing teammate message claims its live SendMessage tool row
   const persisted = readCanonicalAssistantClaims("conversation-send-message");
   expect([...persisted]).toEqual([toolId]);
   expect(visibleRuntimeLiveTurnItems(live, canonicalFeed, persisted, "running")).toEqual([]);
+});
+
+test("an exact tool id keeps priority over an older semantic alias collision", () => {
+  const command = "printf repeated-command";
+  const tool = (itemId: string): RuntimeLiveTurnItem => ({
+    kind: "tool",
+    itemId,
+    text: JSON.stringify({ cmd: command }),
+    toolName: "exec_command",
+    toolEngine: "codex",
+    phase: "streaming",
+    startedAt: null,
+    completedAt: null,
+  });
+  const live: RuntimeLiveTurn = {
+    turnId: "turn-exact-priority",
+    text: "",
+    items: [tool("exec-older"), tool("call_exact_owner")],
+  };
+  const canonicalFeed = [{
+    anchorKey: "row:60:0",
+    key: "60:0",
+    item: {
+      kind: "tool",
+      id: "call_exact_owner",
+      ts: null,
+      srcCall: 60,
+      family: "shell",
+      tool: "exec_command",
+      icon: "shell",
+      summary: command,
+      chips: [],
+      status: "run",
+      statusLabel: "Executing",
+      outputPreview: "",
+      outputTruncated: false,
+      open: false,
+    },
+  }] as FeedEntry[];
+
+  publishCanonicalAssistantClaims("conversation-exact-priority", canonicalFeed, live);
+  const persisted = readCanonicalAssistantClaims("conversation-exact-priority");
+  expect([...persisted]).toEqual(["call_exact_owner"]);
+  expect(visibleRuntimeLiveTurnItems(live, canonicalFeed, persisted, "running").map((item) => item.itemId))
+    .toEqual(["exec-older"]);
+});
+
+test("an old transcript command cannot claim a newer identical live command", () => {
+  const command = "printf repeated-command";
+  const live: RuntimeLiveTurn = {
+    turnId: "turn-new-command",
+    text: "",
+    items: [{
+      kind: "tool",
+      itemId: "exec-new-command",
+      text: JSON.stringify({ cmd: command }),
+      toolName: "exec_command",
+      toolEngine: "codex",
+      phase: "streaming",
+      startedAt: "2026-08-06T10:00:00.000Z",
+      completedAt: null,
+    }],
+  };
+  const oldFeed = [{
+    anchorKey: "row:70:0",
+    key: "70:0",
+    item: {
+      kind: "tool",
+      id: "call_old_command",
+      ts: "2026-08-06T09:59:55.000Z",
+      srcCall: 70,
+      family: "shell",
+      tool: "exec_command",
+      icon: "shell",
+      summary: command,
+      chips: [],
+      status: "ok",
+      statusLabel: "Completed",
+      outputPreview: "",
+      outputTruncated: false,
+      open: false,
+    },
+  }] as FeedEntry[];
+
+  publishCanonicalAssistantClaims("conversation-new-command", oldFeed, live);
+  const persisted = readCanonicalAssistantClaims("conversation-new-command");
+  expect([...persisted]).toEqual(["call_old_command"]);
+  expect(visibleRuntimeLiveTurnItems(live, oldFeed, persisted, "running").map((item) => item.itemId))
+    .toEqual(["exec-new-command"]);
 });

--- a/src/components/conversation/liveTurnHandoff.test.ts
+++ b/src/components/conversation/liveTurnHandoff.test.ts
@@ -14,7 +14,15 @@ import {
 } from "./liveTurnHandoff";
 
 const dom = new Window({ url: "http://localhost/" });
-Object.assign(globalThis, { window: dom, navigator: dom.navigator, sessionStorage: dom.sessionStorage });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  sessionStorage: dom.sessionStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+});
 setLocale("en");
 
 beforeEach(() => {

--- a/src/components/conversation/liveTurnHandoff.test.ts
+++ b/src/components/conversation/liveTurnHandoff.test.ts
@@ -106,3 +106,72 @@ test("issue 626: mixed projections claim one assistant response once", () => {
     expect.objectContaining({ itemId: null, omittedItems: 3, omittedChars: 120 }),
   ]);
 });
+
+test("a canonical tool card claims its live tool row during the running turn and after feed eviction", () => {
+  const toolId = "tool-claim-live";
+  const live: RuntimeLiveTurn = {
+    turnId: "turn-tool-claim",
+    text: "",
+    items: [{
+      kind: "tool",
+      itemId: toolId,
+      text: JSON.stringify({ cmd: "bun test src/components/conversation/liveTurnHandoff.test.ts" }),
+      toolName: "exec_command",
+      toolEngine: "codex",
+      phase: "streaming",
+      startedAt: "2026-08-06T09:20:00.000Z",
+      completedAt: null,
+    }],
+  };
+  const canonicalFeed = [{
+    anchorKey: "row:30:0",
+    key: "30:0",
+    item: {
+      kind: "tool",
+      id: toolId,
+      ts: "2026-08-06T09:20:00.100Z",
+      srcCall: 30,
+      family: "shell",
+      tool: "exec_command",
+      icon: "shell",
+      summary: "bun test src/components/conversation/liveTurnHandoff.test.ts",
+      chips: [],
+      status: "run",
+      statusLabel: "Executing",
+      outputPreview: "",
+      outputTruncated: false,
+      open: false,
+    },
+  }] as FeedEntry[];
+
+  publishCanonicalAssistantClaims("conversation-tool-claim", canonicalFeed);
+  const persisted = readCanonicalAssistantClaims("conversation-tool-claim");
+  expect([...persisted]).toEqual([toolId]);
+  expect(visibleRuntimeLiveTurnItems(live, canonicalFeed, persisted, "running")).toEqual([]);
+  expect(visibleRuntimeLiveTurnItems(live, [], persisted, "running")).toEqual([]);
+});
+
+test("a canonical command group publishes claims for every grouped tool call", () => {
+  const groupedFeed = [{
+    anchorKey: "row:40:0",
+    key: "40:0",
+    item: {
+      kind: "cmd-group",
+      ids: ["grouped-command", "grouped-read"],
+      calls: [],
+      t0: "2026-08-06T09:21:00.000Z",
+      t1: "2026-08-06T09:21:01.000Z",
+      byTool: { exec_command: 1, Read: 1 },
+      okCount: 2,
+      errCount: 0,
+      hasErr: false,
+      active: false,
+    },
+  }] as FeedEntry[];
+
+  publishCanonicalAssistantClaims("conversation-grouped-tools", groupedFeed);
+  expect([...readCanonicalAssistantClaims("conversation-grouped-tools")]).toEqual([
+    "grouped-command",
+    "grouped-read",
+  ]);
+});

--- a/src/components/conversation/liveTurnHandoff.ts
+++ b/src/components/conversation/liveTurnHandoff.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { FeedEntry } from "@/components/feed/parse";
+import { summarizeTool } from "@/components/feed/tools";
 import { newestTranscriptInstant } from "@/components/feed/transcriptOrder";
 import type { RuntimeTurnAxis } from "@/lib/runtime/contracts";
 import { useSyncExternalStore } from "react";
@@ -18,7 +19,14 @@ interface CanonicalLiveItem {
   at: number | null;
 }
 
-const CLAIM_LIMIT = LIVE_TURN_ITEM_LIMIT + LIVE_TURN_OVERFLOW_LIMIT;
+interface CanonicalToolItem {
+  sourceId: string;
+  family: string;
+  summary: string;
+  at: number | null;
+}
+
+const CLAIM_LIMIT = 2 * (LIVE_TURN_ITEM_LIMIT + LIVE_TURN_OVERFLOW_LIMIT);
 const claims = new Map<string, ReadonlySet<string>>();
 const claimListeners = new Set<() => void>();
 const EMPTY_CLAIMS: ReadonlySet<string> = new Set();
@@ -33,6 +41,87 @@ function sourceIdsOf({ item }: FeedEntry): string[] {
   return "sourceId" in item && typeof item.sourceId === "string" && item.sourceId
     ? [item.sourceId]
     : [];
+}
+
+function canonicalToolItems(feed: readonly FeedEntry[]): CanonicalToolItem[] {
+  return feed.flatMap(({ item }) => {
+    if (item.kind === "tool") {
+      return [{
+        sourceId: item.id,
+        family: item.family,
+        summary: item.summary,
+        at: timestamp(item.ts),
+      }];
+    }
+    if (item.kind === "cmd-group") {
+      return item.calls.map((call) => ({
+        sourceId: call.id,
+        family: call.family,
+        summary: call.summary,
+        at: timestamp(call.ts),
+      }));
+    }
+    return [];
+  });
+}
+
+function liveToolArguments(item: RuntimeLiveTurnItem): Record<string, unknown> {
+  try {
+    const value: unknown = JSON.parse(item.text);
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/** App-server item ids (`exec-*`) and rollout call ids (`call_*`) come from
+    different protocol layers. Pair their tool projections by response order
+    and the same readable family/summary, then persist the live-side alias. */
+function canonicalLiveToolAliases(
+  liveTurn: RuntimeLiveTurn | null | undefined,
+  feed: readonly FeedEntry[],
+): string[] {
+  const candidates = canonicalToolItems(feed);
+  if (!candidates.length) return [];
+  const liveTools = runtimeLiveTurnItems(liveTurn).flatMap((live) => {
+    if (live.kind !== "tool" || !live.itemId) return [];
+    const toolName = live.toolName || "tool";
+    return [{
+      itemId: live.itemId,
+      summary: summarizeTool(
+        toolName,
+        liveToolArguments(live),
+        live.toolEngine === "claude" ? "claude" : "codex",
+      ),
+      at: timestamp(live.startedAt) ?? timestamp(live.completedAt),
+    }];
+  });
+  const consumed = new Set<number>();
+  const matched = new Set<number>();
+  for (const [liveIndex, live] of liveTools.entries()) {
+    const owner = candidates.findIndex((candidate, index) =>
+      !consumed.has(index) && candidate.sourceId === live.itemId);
+    if (owner >= 0) {
+      consumed.add(owner);
+      matched.add(liveIndex);
+    }
+  }
+  for (const [liveIndex, live] of liveTools.entries()) {
+    if (matched.has(liveIndex)) continue;
+    const owner = candidates.findIndex((candidate, index) =>
+        !consumed.has(index)
+        && candidate.family === live.summary.family
+        && candidate.summary === live.summary.summary
+        && live.at !== null
+        && candidate.at !== null
+        && candidate.at >= live.at);
+    if (owner < 0) continue;
+    consumed.add(owner);
+    matched.add(liveIndex);
+  }
+  return liveTools.flatMap((live, index) => matched.has(index) ? [live.itemId] : []);
 }
 
 export function readCanonicalAssistantClaims(conversationId: string): ReadonlySet<string> {
@@ -69,10 +158,11 @@ function writeClaims(conversationId: string, next: ReadonlySet<string>): void {
 export function publishCanonicalAssistantClaims(
   conversationId: string,
   feed: readonly FeedEntry[],
+  liveTurn?: RuntimeLiveTurn | null,
 ): void {
   if (!conversationId) return;
   const previous = readCanonicalAssistantClaims(conversationId);
-  const discovered = feed.flatMap(sourceIdsOf);
+  const discovered = [...feed.flatMap(sourceIdsOf), ...canonicalLiveToolAliases(liveTurn, feed)];
   if (!discovered.some((sourceId) => !previous.has(sourceId))) return;
   const merged = new Set(previous);
   for (const sourceId of discovered) {
@@ -181,7 +271,10 @@ export function visibleRuntimeLiveTurnItems(
   const overlay = runtimeLiveTurnItems(liveTurn);
   if (!overlay.length) return overlay;
   const canonical = canonicalLiveItems(feed);
-  const currentClaims = new Set(canonical.flatMap((item) => item.sourceId ? [item.sourceId] : []));
+  const currentClaims = new Set([
+    ...canonical.flatMap((item) => item.sourceId ? [item.sourceId] : []),
+    ...canonicalLiveToolAliases(liveTurn, feed),
+  ]);
   const transcriptAt = newestTranscriptInstant(feed);
   const claimed = new Set<number>();
   /** The transcript has moved past this item, so the tail must not show it. */

--- a/src/components/conversation/liveTurnHandoff.ts
+++ b/src/components/conversation/liveTurnHandoff.ts
@@ -12,7 +12,7 @@ import {
   type RuntimeLiveTurnItem,
 } from "@/lib/runtime/liveTurn";
 
-interface CanonicalAssistantItem {
+interface CanonicalLiveItem {
   sourceId: string | null;
   text: string;
   at: number | null;
@@ -25,10 +25,14 @@ const EMPTY_CLAIMS: ReadonlySet<string> = new Set();
 
 const storageKey = (conversationId: string) => `llvAssistantClaims:${conversationId}`;
 
-function sourceIdOf({ item }: FeedEntry): string | null {
+function sourceIdsOf({ item }: FeedEntry): string[] {
+  if (item.kind === "tool" && item.id) return [item.id];
+  if (item.kind === "cmd-group") {
+    return [...new Set(item.ids.filter((id) => typeof id === "string" && id.length > 0))];
+  }
   return "sourceId" in item && typeof item.sourceId === "string" && item.sourceId
-    ? item.sourceId
-    : null;
+    ? [item.sourceId]
+    : [];
 }
 
 export function readCanonicalAssistantClaims(conversationId: string): ReadonlySet<string> {
@@ -68,10 +72,7 @@ export function publishCanonicalAssistantClaims(
 ): void {
   if (!conversationId) return;
   const previous = readCanonicalAssistantClaims(conversationId);
-  const discovered = feed.flatMap((entry) => {
-    const sourceId = sourceIdOf(entry);
-    return sourceId ? [sourceId] : [];
-  });
+  const discovered = feed.flatMap(sourceIdsOf);
   if (!discovered.some((sourceId) => !previous.has(sourceId))) return;
   const merged = new Set(previous);
   for (const sourceId of discovered) {
@@ -124,23 +125,22 @@ function timestamp(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function canonicalAssistantItems(feed: readonly FeedEntry[]): CanonicalAssistantItem[] {
+function canonicalLiveItems(feed: readonly FeedEntry[]): CanonicalLiveItem[] {
   return feed.flatMap((entry) => {
     const { item } = entry;
-    const sourceId = sourceIdOf(entry);
+    const sourceIds = sourceIdsOf(entry);
     if (item.kind === "prose") {
       return [{
-        sourceId,
+        sourceId: sourceIds[0] ?? null,
         text: item.text.trim(),
         at: timestamp(item.ts),
       }];
     }
-    if (!sourceId) return [];
-    return [{
+    return sourceIds.map((sourceId) => ({
       sourceId,
       text: "",
       at: item.kind === "review" ? timestamp(item.ts) : null,
-    }];
+    }));
   });
 }
 
@@ -180,7 +180,7 @@ export function visibleRuntimeLiveTurnItems(
 ): RuntimeLiveTurnItem[] {
   const overlay = runtimeLiveTurnItems(liveTurn);
   if (!overlay.length) return overlay;
-  const canonical = canonicalAssistantItems(feed);
+  const canonical = canonicalLiveItems(feed);
   const currentClaims = new Set(canonical.flatMap((item) => item.sourceId ? [item.sourceId] : []));
   const transcriptAt = newestTranscriptInstant(feed);
   const claimed = new Set<number>();
@@ -190,8 +190,8 @@ export function visibleRuntimeLiveTurnItems(
     return transcriptAt !== null && liveAt !== null && liveAt <= transcriptAt;
   };
   return overlay.filter((live) => {
-    if (live.phase === "streaming") return sessionTurn !== "idle" || !transcriptMovedPast(live);
     if (live.itemId && (persistedClaims.has(live.itemId) || currentClaims.has(live.itemId))) return false;
+    if (live.phase === "streaming") return sessionTurn !== "idle" || !transcriptMovedPast(live);
     let owner = live.itemId
       ? canonical.findIndex((item, index) => !claimed.has(index) && item.sourceId === live.itemId)
       : -1;

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -5,7 +5,12 @@ import { createRoot, type Root } from "react-dom/client";
 import type { ReactNode } from "react";
 
 import { setLocale } from "@/lib/i18n";
-import type { RuntimeLiveTurnItem, RuntimeLiveTurnItemPhase } from "@/lib/runtime/liveTurn";
+import {
+  projectRuntimeLiveTurnItem,
+  runtimeLiveTurnItems,
+  type RuntimeLiveTurnItem,
+  type RuntimeLiveTurnItemPhase,
+} from "@/lib/runtime/liveTurn";
 import { advanceMdStream, createMdStream, mdBlocks, type MdStreamState } from "@/components/feed/markdown";
 
 import { LiveTurnRows } from "./LiveTurnRows";
@@ -127,6 +132,42 @@ test("a live tool row renders its readable summary in response order between ass
   expect(rows[1]?.textContent).not.toContain("workdir");
   expect(rows[1]?.querySelector("svg")).not.toBeNull();
   expect(consoleErrors).not.toContain("same key");
+});
+
+test("aggregate trimming keeps every live tool argument valid and its command head readable", () => {
+  let live = projectRuntimeLiveTurnItem(null, "turn-large-tools", {
+    type: "commandExecution",
+    id: "large-command-one",
+    command: `printf first-live-command ${"x".repeat(48 * 1024)}`,
+  }, "started");
+  live = projectRuntimeLiveTurnItem(live, "turn-large-tools", {
+    type: "commandExecution",
+    id: "large-command-two",
+    command: `printf second-live-command ${"y".repeat(48 * 1024)}`,
+  }, "started");
+  const items = runtimeLiveTurnItems(live);
+  expect(items).toHaveLength(2);
+  for (const liveItem of items) expect(() => JSON.parse(liveItem.text)).not.toThrow();
+  expect(items.reduce((bytes, liveItem) => bytes + new TextEncoder().encode(liveItem.text).length, 0))
+    .toBeLessThanOrEqual(64 * 1024);
+
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={items} />);
+  const rows = [...host.querySelectorAll<HTMLElement>("[data-live-turn]")];
+  expect(rows.map((row) => row.textContent)).toEqual([
+    expect.stringContaining("printf first-live-command"),
+    expect.stringContaining("printf second-live-command"),
+  ]);
+});
+
+test("claiming an earlier row preserves the surviving live row DOM node", () => {
+  const first = item("First", "awaiting-echo", { itemId: "shared-response", rowId: "first-block" });
+  const second = item("Second", "awaiting-echo", { itemId: "shared-response", rowId: "second-block" });
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={[first, second]} />);
+  const secondNode = host.querySelectorAll("[data-live-turn]")[1];
+  paint(root, <LiveTurnRows items={[second]} />);
+  expect(host.querySelector("[data-live-turn]")).toBe(secondNode);
 });
 
 test("streaming a message delta by delta lands on exactly the settled rendering", () => {

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -94,6 +94,37 @@ test("a settled live row renders the same markdown as its transcript counterpart
   expect(liveRow(host).querySelector("pre")?.textContent).toBe("const x = 1;");
 });
 
+test("a live tool row renders its readable summary in response order between assistant rows", () => {
+  const { host, root } = mount();
+  const command = "bun test src/components/conversation/liveTurnMarkdown.dom.test.tsx";
+  paint(root, <LiveTurnRows items={[
+    item("I will run the focused DOM test.", "awaiting-echo", { itemId: "assistant-before" }),
+    {
+      kind: "tool",
+      itemId: "tool-live-dom",
+      text: JSON.stringify({ cmd: command, workdir: "/repo" }),
+      toolName: "exec_command",
+      toolEngine: "codex",
+      phase: "streaming",
+      startedAt: "2026-08-06T09:30:00.000Z",
+      completedAt: null,
+    },
+    item("The test completed.", "awaiting-echo", { itemId: "assistant-after" }),
+  ]} />);
+
+  const rows = [...host.querySelectorAll<HTMLElement>("[data-live-turn]")];
+  expect(rows).toHaveLength(3);
+  expect(rows.map((row) => row.dataset.liveTurnItemId)).toEqual([
+    "assistant-before",
+    "tool-live-dom",
+    "assistant-after",
+  ]);
+  expect(rows[1]?.dataset.liveTurnTool).toBe("exec_command");
+  expect(rows[1]?.textContent).toContain(command);
+  expect(rows[1]?.textContent).not.toContain("workdir");
+  expect(rows[1]?.querySelector("svg")).not.toBeNull();
+});
+
 test("streaming a message delta by delta lands on exactly the settled rendering", () => {
   const { host, root } = mount();
   stream(root, SAMPLE, 7);

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 import { Window } from "happy-dom";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
@@ -96,9 +96,10 @@ test("a settled live row renders the same markdown as its transcript counterpart
 
 test("a live tool row renders its readable summary in response order between assistant rows", () => {
   const { host, root } = mount();
+  const consoleError = spyOn(console, "error").mockImplementation(() => undefined);
   const command = "bun test src/components/conversation/liveTurnMarkdown.dom.test.tsx";
   paint(root, <LiveTurnRows items={[
-    item("I will run the focused DOM test.", "awaiting-echo", { itemId: "assistant-before" }),
+    item("I will run the focused DOM test.", "awaiting-echo", { itemId: "assistant-message" }),
     {
       kind: "tool",
       itemId: "tool-live-dom",
@@ -109,20 +110,23 @@ test("a live tool row renders its readable summary in response order between ass
       startedAt: "2026-08-06T09:30:00.000Z",
       completedAt: null,
     },
-    item("The test completed.", "awaiting-echo", { itemId: "assistant-after" }),
+    item("The test completed.", "awaiting-echo", { itemId: "assistant-message" }),
   ]} />);
+  const consoleErrors = consoleError.mock.calls.flat().join(" ");
+  consoleError.mockRestore();
 
   const rows = [...host.querySelectorAll<HTMLElement>("[data-live-turn]")];
   expect(rows).toHaveLength(3);
   expect(rows.map((row) => row.dataset.liveTurnItemId)).toEqual([
-    "assistant-before",
+    "assistant-message",
     "tool-live-dom",
-    "assistant-after",
+    "assistant-message",
   ]);
   expect(rows[1]?.dataset.liveTurnTool).toBe("exec_command");
   expect(rows[1]?.textContent).toContain(command);
   expect(rows[1]?.textContent).not.toContain("workdir");
   expect(rows[1]?.querySelector("svg")).not.toBeNull();
+  expect(consoleErrors).not.toContain("same key");
 });
 
 test("streaming a message delta by delta lands on exactly the settled rendering", () => {

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -127,6 +127,21 @@ describe("feed session parity with one-shot parse", () => {
     expect(item.mcp).toBeUndefined();
   });
 
+  test("keeps a Claude SendMessage tool identity on its canonical message row", () => {
+    const item = buildFeed(
+      claudeFile,
+      [claudeSend("send-message-live", "worker-1", "check the branch")],
+      false,
+      "",
+    ).items[0];
+    expect(item).toMatchObject({
+      kind: "tmsg",
+      dir: "out",
+      peer: "worker-1",
+      sourceId: "send-message-live",
+    });
+  });
+
   test("claude transcript: tools, results, grouping, tmsg delivery, compaction", () => {
     const lines = [
       claudeUser("take the first step"),

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -193,6 +193,8 @@ export type Tmsg = {
   /** Outgoing only: delivery state recovered from the tool result. */
   delivery?: "ok" | "err";
   msgId?: string;
+  /** Outgoing SendMessage tool-use identity for live-turn handoff. */
+  sourceId?: string;
 };
 export type CmdGroupItem = {
   kind: "cmd-group";
@@ -1948,6 +1950,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
           if (typeof message === "string") {
             const { cleaned, cites } = splitCitations(message);
             const review = VERDICT_LINE_RE.test(cleaned) ? parseReview(cleaned, ts) : null;
+            const sourceId = textPart(part.id) || undefined;
             const item: Tmsg = {
               kind: "tmsg",
               ts,
@@ -1955,14 +1958,14 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
               peer: String(input.to ?? ""),
               summary: String(input.summary ?? ""),
               text: review ? "" : cleaned,
+              ...(sourceId ? { sourceId } : {}),
             };
             const seq = push(item);
             if (review) push(review);
             for (const cite of cites) push(cite);
-            const key = textPart(part.id);
-            if (key) {
-              tmsgSeqs.set(key, seq);
-              tmsgKeyBySeq.set(seq, key);
+            if (sourceId) {
+              tmsgSeqs.set(sourceId, seq);
+              tmsgKeyBySeq.set(seq, sourceId);
             }
           } else {
             addSvc(`SendMessage → ${String(input.to ?? "")} · ${textPart(rec(message).type) || tr("render.protocol")}`);

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -178,6 +178,52 @@ describe("live turn delta buffering", () => {
     expect(store.sessions["conv_a"]?.liveTurn?.text).toBe("streaming");
   });
 
+  test("a Codex tool lifecycle projects one live row from start through completion", () => {
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("turn-started", { type: "session", id: "conv_a" }, 4, {
+      conversationId: "conv_a",
+      turnId: "t1",
+    }));
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 5, {
+      conversationId: "conv_a",
+      turnId: "t1",
+      phase: "started",
+      item: {
+        type: "commandExecution",
+        id: "command-live",
+        command: "bun test src/components/runtime/runtimeModel.test.ts",
+        cwd: "/repo",
+      },
+    }));
+    expect(store.sessions["conv_a"]?.liveTurn?.items).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        itemId: "command-live",
+        toolName: "exec_command",
+        phase: "streaming",
+      }),
+    ]);
+
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 6, {
+      conversationId: "conv_a",
+      turnId: "t1",
+      phase: "completed",
+      item: {
+        type: "commandExecution",
+        id: "command-live",
+        command: "bun test src/components/runtime/runtimeModel.test.ts",
+        cwd: "/repo",
+      },
+    }));
+    expect(store.sessions["conv_a"]?.liveTurn?.items).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        itemId: "command-live",
+        phase: "awaiting-echo",
+      }),
+    ]);
+  });
+
   test("issue 626: authoritative completion replaces streamed prefixes and divergent drafts while empty completion preserves the stream", () => {
     const completed = (streamed: string, finalText: string, itemId: string) => {
       let store = installSnapshot(snapshot());

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Flow } from "@/lib/flows/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { projectEngineHostEvent } from "@/lib/runtime/engineHostEvents";
 import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 import {
@@ -66,13 +67,13 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
 }
 
 let seq = 1000;
-function env<P>(kind: string, scope: { type: string; id: string }, revision: number, payload: P): RuntimeEnvelope<P> {
+function env<P>(kind: string, scope: RuntimeEnvelope["scope"], revision: number, payload: P): RuntimeEnvelope<P> {
   seq += 1;
   return {
     schemaVersion: 1,
     seq,
     eventId: `evt_${seq}`,
-    scope: scope as RuntimeEnvelope["scope"],
+    scope,
     revision,
     kind,
     payload,
@@ -170,11 +171,16 @@ describe("live turn delta buffering", () => {
     expect(store.sessions["conv_a"]?.liveTurn?.items).toHaveLength(2);
   });
 
-  test("a started item leaves the live buffer alone", () => {
+  test("a started assistant item leaves the streamed prose alone", () => {
     let store = installSnapshot(snapshot());
     store = apply(store, env("turn-started", { type: "session", id: "conv_a" }, 4, { conversationId: "conv_a", turnId: "t1" }));
     store = apply(store, env("delta", { type: "session", id: "conv_a" }, 5, { conversationId: "conv_a", turnId: "t1", text: "streaming" }));
-    store = apply(store, env("item", { type: "session", id: "conv_a" }, 6, { conversationId: "conv_a", turnId: "t1", phase: "started", item: {} }));
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 6, {
+      conversationId: "conv_a",
+      turnId: "t1",
+      phase: "started",
+      item: { type: "agentMessage", id: "assistant-start", text: "draft" },
+    }));
     expect(store.sessions["conv_a"]?.liveTurn?.text).toBe("streaming");
   });
 
@@ -220,6 +226,47 @@ describe("live turn delta buffering", () => {
         kind: "tool",
         itemId: "command-live",
         phase: "awaiting-echo",
+      }),
+    ]);
+  });
+
+  test("the production event bound preserves a started tool summary through a large completion", () => {
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("turn-started", { type: "session", id: "conv_a" }, 4, {
+      conversationId: "conv_a",
+      turnId: "t1",
+    }));
+    const project = (phase: "started" | "completed", item: unknown, seq: number) => {
+      const projected = projectEngineHostEvent("conv_a", "codex:thread-tool", {
+        kind: "item",
+        turnId: "t1",
+        item,
+        phase,
+        seq,
+      });
+      if (!projected) throw new Error("expected a projected runtime event");
+      if (typeof projected.scope === "string") throw new Error("expected an object runtime scope");
+      store = apply(store, env(projected.kind, projected.scope, phase === "started" ? 5 : 6, projected.payload));
+    };
+    project("started", {
+      type: "commandExecution",
+      id: "bounded-command",
+      command: "bun test src/components/runtime/runtimeModel.test.ts",
+      cwd: "/repo",
+    }, 17);
+    project("completed", {
+      type: "commandExecution",
+      id: "bounded-command",
+      aggregatedOutput: "x".repeat(32 * 1024),
+    }, 18);
+    expect(store.sessions["conv_a"]?.liveTurn?.items).toEqual([
+      expect.objectContaining({
+        itemId: "bounded-command",
+        phase: "awaiting-echo",
+        text: JSON.stringify({
+          cmd: "bun test src/components/runtime/runtimeModel.test.ts",
+          workdir: "/repo",
+        }),
       }),
     ]);
   });

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -26,7 +26,7 @@ import type { RuntimePendingReconfigure, RuntimeSettingsCapability, ViewerDeploy
 import type { RuntimeImageCapability } from "@/lib/runtime/structuredContent";
 import {
   appendRuntimeLiveTurnDelta,
-  completeRuntimeLiveTurnItem,
+  projectRuntimeLiveTurnItem,
   type RuntimeLiveTurn,
 } from "@/lib/runtime/liveTurn";
 import {
@@ -541,16 +541,18 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         item?: unknown;
         voiceResponse?: { responseId?: unknown; text?: unknown };
       };
-      if (p.phase !== "completed") break;
+      if (p.phase !== "started" && p.phase !== "completed") break;
+      const lifecycle = p.phase;
       updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => {
         const turnId = p.turnId ?? s.activeTurnId ?? "unknown";
         const voiceResponse = p.voiceResponse;
         return {
           ...s,
-          liveTurn: completeRuntimeLiveTurnItem(
+          liveTurn: projectRuntimeLiveTurnItem(
             s.liveTurn,
             turnId,
             p.item,
+            lifecycle,
             env.occurredAt ?? env.recordedAt ?? null,
           ),
           voiceDeliveries: typeof voiceResponse?.responseId === "string"

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1305,6 +1305,68 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test("preserves the tool-result identity emitted by Claude for live turn completion", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const sent = host.send({ id: "tool-result-turn", text: "read the file" });
+    child.emitJson({
+      type: "user",
+      isReplay: true,
+      session_id: host.identity.sessionId,
+      uuid: "tool-result-user",
+      message: { role: "user", content: [{ type: "text", text: "read the file" }] },
+    });
+    await sent;
+    const events = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+
+    child.emitJson({
+      type: "assistant",
+      session_id: host.identity.sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-result-call", name: "Read", input: { file_path: "src/lib/runtime/liveTurn.ts" } }],
+      },
+    });
+    expect(await nextEvent(events)).toMatchObject({
+      kind: "item",
+      item: { message: { content: [{ type: "tool_use", id: "tool-result-call" }] } },
+    });
+
+    child.emitJson({
+      type: "user",
+      session_id: host.identity.sessionId,
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tool-result-call", content: "result body ".repeat(4 * 1024) }],
+      },
+    });
+    const resultEvent = await nextEvent(events);
+    expect(resultEvent).toMatchObject({
+      kind: "item",
+      phase: "completed",
+      item: {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool-result-call" }],
+        },
+      },
+    });
+    if (resultEvent.kind !== "item") throw new Error("expected a tool-result item");
+    expect((resultEvent.item as { message: { content: unknown[] } }).message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tool-result-call" },
+    ]);
+    await host.release();
+  });
+
   test("requires subscription OAuth before spawning", async () => {
     let spawned = false;
     await expect(ClaudeStreamBrokerHost.start({

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -397,6 +397,15 @@ function sanitizedUserReplay(
   content: ReturnType<typeof structuredContent> | null,
 ): JsonObject {
   const providerMessage = record(message.message) ?? {};
+  const toolResults = Array.isArray(providerMessage.content)
+    ? providerMessage.content.flatMap((candidate): JsonObject[] => {
+        const block = record(candidate);
+        const toolUseId = stringField(block, "tool_use_id");
+        return block?.type === "tool_result" && toolUseId
+          ? [{ type: "tool_result", tool_use_id: toolUseId }]
+          : [];
+      })
+    : [];
   const sanitizedBlocks: JsonObject[] = content
     ? content.content.images.map((image) => ({
         type: "image",
@@ -408,6 +417,7 @@ function sanitizedUserReplay(
         },
       }))
     : [];
+  sanitizedBlocks.unshift(...toolResults);
   const text = content?.content.text ?? userText(message);
   if (text) sanitizedBlocks.push({ type: "text", text });
   return {

--- a/src/lib/runtime/engineHostEvents.test.ts
+++ b/src/lib/runtime/engineHostEvents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { streamingVoiceDelivery } from "./voiceDelivery";
 import { projectEngineHostEvent } from "./engineHostEvents";
+import { completeRuntimeLiveTurnItem, runtimeLiveTurnItems } from "./liveTurn";
 
 describe("projectEngineHostEvent", () => {
   test("projects a Codex user-input request into a question card", () => {
@@ -172,12 +173,15 @@ describe("projectEngineHostEvent", () => {
         uuid: "claude-tool-message",
         message: {
           role: "assistant",
-          content: [{
-            type: "tool_use",
-            id: "claude-tool-item",
-            name: "Bash",
-            input: { command: `apply_patch ${"x".repeat(32 * 1024)}` },
-          }],
+          content: [
+            { type: "text", text: "p".repeat(30 * 1024) },
+            {
+              type: "tool_use",
+              id: "claude-tool-item",
+              name: "Bash",
+              input: { command: `apply_patch ${"x".repeat(32 * 1024)}` },
+            },
+          ],
         },
       },
       phase: "completed",
@@ -188,14 +192,46 @@ describe("projectEngineHostEvent", () => {
       uuid: "claude-tool-message",
       message: {
         role: "assistant",
-        content: [{
-          type: "tool_use",
-          id: "claude-tool-item",
-          name: "Bash",
-          input: { command: expect.stringContaining("apply_patch") },
-        }],
+        content: [
+          { type: "text", text: "p".repeat(30 * 1024) },
+          {
+            type: "tool_use",
+            id: "claude-tool-item",
+            name: "Bash",
+            input: { command: expect.stringContaining("apply_patch") },
+          },
+        ],
       },
     });
-    expect(JSON.stringify(claude?.payload.item).length).toBeLessThan(12 * 1024);
+    expect(JSON.stringify(claude?.payload.item).length).toBeLessThan(64 * 1024);
+
+    const oversized = projectEngineHostEvent("conversation_claude_tool", "claude:session-tool", {
+      kind: "item",
+      turnId: "turn-claude-tool",
+      item: {
+        type: "assistant",
+        uuid: "claude-oversized-message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "large prose ".repeat(6 * 1024) },
+            { type: "tool_use", id: "claude-small-tool", name: "Read", input: { file_path: "src/lib/runtime/liveTurn.ts" } },
+          ],
+        },
+      },
+      phase: "completed",
+      seq: 17,
+    });
+    const live = completeRuntimeLiveTurnItem(
+      null,
+      "turn-claude-tool",
+      oversized?.payload.item,
+      "2026-08-06T10:10:00.000Z",
+    );
+    expect(runtimeLiveTurnItems(live)[0]).toMatchObject({
+      kind: "assistant",
+      omittedChars: expect.any(Number),
+    });
+    expect(runtimeLiveTurnItems(live)[0]?.omittedChars).toBeGreaterThan(0);
   });
 });

--- a/src/lib/runtime/engineHostEvents.test.ts
+++ b/src/lib/runtime/engineHostEvents.test.ts
@@ -140,4 +140,62 @@ describe("projectEngineHostEvent", () => {
     });
     expect(projected?.payload.voiceResponse).toBeUndefined();
   });
+
+  test("preserves bounded live tool descriptors when completed engine items carry large result bodies", () => {
+    const command = "bun test src/lib/runtime/engineHostEvents.test.ts";
+    const codex = projectEngineHostEvent("conversation_codex_tool", "codex:thread-tool", {
+      kind: "item",
+      turnId: "turn-codex-tool",
+      item: {
+        type: "commandExecution",
+        id: "codex-tool-item",
+        command,
+        cwd: "$HOME/project",
+        aggregatedOutput: "x".repeat(32 * 1024),
+      },
+      phase: "completed",
+      seq: 15,
+    });
+    expect(codex?.payload.item).toMatchObject({
+      type: "commandExecution",
+      id: "codex-tool-item",
+      command,
+      cwd: "$HOME/project",
+    });
+    expect(JSON.stringify(codex?.payload.item)).not.toContain("aggregatedOutput");
+
+    const claude = projectEngineHostEvent("conversation_claude_tool", "claude:session-tool", {
+      kind: "item",
+      turnId: "turn-claude-tool",
+      item: {
+        type: "assistant",
+        uuid: "claude-tool-message",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "tool_use",
+            id: "claude-tool-item",
+            name: "Bash",
+            input: { command: `apply_patch ${"x".repeat(32 * 1024)}` },
+          }],
+        },
+      },
+      phase: "completed",
+      seq: 16,
+    });
+    expect(claude?.payload.item).toMatchObject({
+      type: "assistant",
+      uuid: "claude-tool-message",
+      message: {
+        role: "assistant",
+        content: [{
+          type: "tool_use",
+          id: "claude-tool-item",
+          name: "Bash",
+          input: { command: expect.stringContaining("apply_patch") },
+        }],
+      },
+    });
+    expect(JSON.stringify(claude?.payload.item).length).toBeLessThan(12 * 1024);
+  });
 });

--- a/src/lib/runtime/engineHostEvents.ts
+++ b/src/lib/runtime/engineHostEvents.ts
@@ -1,5 +1,6 @@
 import type { RuntimeAttentionKind, RuntimeAttentionRequest, RuntimeEventInput } from "./contracts";
 import type { RuntimeEvent } from "./engineHost";
+import { LIVE_TURN_TEXT_LIMIT } from "./liveTurn";
 import { terminalVoiceResponse } from "./voiceDelivery";
 
 type JsonObject = Record<string, unknown>;
@@ -28,6 +29,165 @@ function boundedValue(value: unknown, maxBytes = 8 * 1024): unknown {
     ...(text(source.type) ? { type: text(source.type) } : {}),
     ...(text(source.name) ? { name: text(source.name) } : {}),
   };
+}
+
+function boundedToolArguments(value: unknown, maxBytes: number): unknown {
+  let serialized: string;
+  try { serialized = JSON.stringify(value ?? {}); } catch { return {}; }
+  if (Buffer.byteLength(serialized) <= maxBytes) return value ?? {};
+  const source = record(value);
+  const result: JsonObject = { truncated: true };
+  const primaryKeys = [
+    "cmd", "command", "file_path", "path", "input", "query", "url", "pattern",
+    "prompt", "description", "session_id", "cell_id", "chars", "workdir",
+  ];
+  const keys = [...new Set([...primaryKeys, ...Object.keys(source)])];
+  for (const key of keys) {
+    const candidate = source[key];
+    if (candidate === undefined) continue;
+    let projected: unknown;
+    if (typeof candidate === "string") projected = clipped(candidate, Math.min(8 * 1024, Math.max(256, maxBytes - 512)));
+    else if (typeof candidate === "number" || typeof candidate === "boolean" || candidate === null) projected = candidate;
+    else if (Array.isArray(candidate)) projected = candidate.slice(0, 16);
+    else continue;
+    const next = { ...result, [key]: projected };
+    if (Buffer.byteLength(JSON.stringify(next)) <= maxBytes) result[key] = projected;
+  }
+  return result;
+}
+
+function boundedCodexToolItem(source: JsonObject, type: string): unknown | null {
+  const identity = {
+    type,
+    ...(text(source.call_id) ? { call_id: clipped(text(source.call_id)!, 256) } : {}),
+    ...(text(source.id) ? { id: clipped(text(source.id)!, 256) } : {}),
+  };
+  if (type === "commandExecution") {
+    return {
+      ...identity,
+      ...(text(source.command) ? { command: clipped(text(source.command)!, 48 * 1024) } : {}),
+      ...(text(source.cwd) ? { cwd: clipped(text(source.cwd)!, 2 * 1024) } : {}),
+    };
+  }
+  if (type === "fileChange") {
+    const changes = Array.isArray(source.changes) ? source.changes.slice(0, 32).map(record) : [];
+    const diffBytes = Math.max(256, Math.floor((32 * 1024) / Math.max(changes.length, 1)));
+    return {
+      ...identity,
+      changes: changes.map((change) => ({
+        ...(text(change.path) ? { path: clipped(text(change.path)!, 512) } : {}),
+        ...(text(change.diff) ? { diff: clipped(text(change.diff)!, diffBytes) } : {}),
+      })),
+    };
+  }
+  if (type === "mcpToolCall" || type === "dynamicToolCall") {
+    return {
+      ...identity,
+      ...(text(source.server) ? { server: clipped(text(source.server)!, 256) } : {}),
+      ...(text(source.tool) ? { tool: clipped(text(source.tool)!, 256) } : {}),
+      arguments: boundedToolArguments(source.arguments, 48 * 1024),
+    };
+  }
+  if (type === "collabAgentToolCall") {
+    return {
+      ...identity,
+      ...(text(source.tool) ? { tool: clipped(text(source.tool)!, 256) } : {}),
+      ...(text(source.prompt) ? { "prompt": clipped(text(source.prompt)!, 48 * 1024) } : {}),
+      ...(text(source.model) ? { model: clipped(text(source.model)!, 256) } : {}),
+      ...(Array.isArray(source.receiverThreadIds) ? {
+        receiverThreadIds: source.receiverThreadIds
+          .flatMap((candidate) => text(candidate) ? [clipped(text(candidate)!, 256)] : [])
+          .slice(0, 32),
+      } : {}),
+    };
+  }
+  if (type === "webSearch") {
+    return {
+      ...identity,
+      ...(text(source.query) ? { query: clipped(text(source.query)!, 48 * 1024) } : {}),
+      ...(source.action !== undefined ? { action: boundedToolArguments(source.action, 8 * 1024) } : {}),
+    };
+  }
+  if (type === "imageView") return { ...identity, ...(text(source.path) ? { path: clipped(text(source.path)!, 48 * 1024) } : {}) };
+  if (type === "sleep") return { ...identity, ...(typeof source.durationMs === "number" ? { durationMs: source.durationMs } : {}) };
+  if (type === "imageGeneration") {
+    return {
+      ...identity,
+      ...(text(source.revisedPrompt) ? { revisedPrompt: clipped(text(source.revisedPrompt)!, 48 * 1024) } : {}),
+      ...(text(source.savedPath) ? { savedPath: clipped(text(source.savedPath)!, 2 * 1024) } : {}),
+    };
+  }
+  if (type === "function_call") {
+    return {
+      ...identity,
+      ...(text(source.name) ? { name: clipped(text(source.name)!, 256) } : {}),
+      ...(typeof source.arguments === "string" ? { arguments: clipped(source.arguments, 48 * 1024) } : {}),
+    };
+  }
+  if (type === "custom_tool_call") {
+    return {
+      ...identity,
+      ...(text(source.name) ? { name: clipped(text(source.name)!, 256) } : {}),
+      ...(text(source.input) ? { input: clipped(text(source.input)!, 48 * 1024) } : {}),
+    };
+  }
+  if (type === "function_call_output" || type === "custom_tool_call_output") return identity;
+  return null;
+}
+
+function boundedClaudeToolItem(source: JsonObject): unknown | null {
+  const message = record(source.message);
+  const content = Array.isArray(source.content)
+    ? source.content
+    : Array.isArray(message.content) ? message.content : [];
+  if (!content.some((candidate) => {
+    const type = text(record(candidate).type);
+    return type === "tool_use" || type === "tool_result";
+  })) return null;
+  const payloadBytes = Math.max(256, Math.floor((40 * 1024) / Math.max(content.length, 1)));
+  const projectedContent = content.flatMap((candidate): JsonObject[] => {
+    const part = record(candidate);
+    const type = text(part.type);
+    if (type === "text" || type === "input_text" || type === "output_text") {
+      return [{ type, ...(text(part.text) ? { text: clipped(text(part.text)!, payloadBytes) } : {}) }];
+    }
+    if (type === "tool_use") {
+      return [{
+        type,
+        ...(text(part.id) ? { id: clipped(text(part.id)!, 256) } : {}),
+        ...(text(part.name) ? { name: clipped(text(part.name)!, 256) } : {}),
+        input: boundedToolArguments(part.input, payloadBytes),
+      }];
+    }
+    if (type === "tool_result") {
+      return [{
+        type,
+        ...(text(part.tool_use_id) ? { tool_use_id: clipped(text(part.tool_use_id)!, 256) } : {}),
+      }];
+    }
+    return [];
+  });
+  const projectedMessage = {
+    ...(text(source.role, message.role) ? { role: text(source.role, message.role)! } : {}),
+    ...(text(message.id) ? { id: clipped(text(message.id)!, 256) } : {}),
+    content: projectedContent,
+  };
+  return {
+    ...(text(source.type) ? { type: text(source.type)! } : {}),
+    ...(text(source.id) ? { id: clipped(text(source.id)!, 256) } : {}),
+    ...(text(source.uuid) ? { uuid: clipped(text(source.uuid)!, 256) } : {}),
+    ...(Array.isArray(source.content) ? {
+      ...(text(source.role) ? { role: text(source.role)! } : {}),
+      content: projectedContent,
+    } : { message: projectedMessage }),
+  };
+}
+
+function boundedLiveTurnItem(value: unknown): unknown {
+  const source = record(value);
+  const type = text(source.type) ?? "";
+  const descriptor = boundedCodexToolItem(source, type) ?? boundedClaudeToolItem(source);
+  return descriptor ? boundedValue(descriptor, LIVE_TURN_TEXT_LIMIT) : boundedValue(value);
 }
 
 function questionFrom(value: unknown): RuntimeAttentionRequest["question"] | null {
@@ -141,7 +301,7 @@ export function projectEngineHostEvent(
       payload: {
         conversationId,
         turnId: event.turnId,
-        item: boundedValue(event.item),
+        item: boundedLiveTurnItem(event.item),
         phase: event.phase,
         ...(voiceResponse ? { voiceResponse } : {}),
       },

--- a/src/lib/runtime/engineHostEvents.ts
+++ b/src/lib/runtime/engineHostEvents.ts
@@ -135,6 +135,24 @@ function boundedCodexToolItem(source: JsonObject, type: string): unknown | null 
   return null;
 }
 
+function boundedText(value: string, maxBytes: number): { text: string; omittedChars: number } {
+  if (Buffer.byteLength(value) <= maxBytes) return { text: value, omittedChars: 0 };
+  const points = [...value];
+  if (maxBytes < Buffer.byteLength("…")) return { text: "", omittedChars: points.length };
+  let low = 0;
+  let high = points.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = `${points.slice(0, middle).join("")}…`;
+    if (Buffer.byteLength(candidate) <= maxBytes) low = middle;
+    else high = middle - 1;
+  }
+  return {
+    text: `${points.slice(0, low).join("")}…`,
+    omittedChars: points.length - low,
+  };
+}
+
 function boundedClaudeToolItem(source: JsonObject): unknown | null {
   const message = record(source.message);
   const content = Array.isArray(source.content)
@@ -144,19 +162,45 @@ function boundedClaudeToolItem(source: JsonObject): unknown | null {
     const type = text(record(candidate).type);
     return type === "tool_use" || type === "tool_result";
   })) return null;
-  const payloadBytes = Math.max(256, Math.floor((40 * 1024) / Math.max(content.length, 1)));
-  const projectedContent = content.flatMap((candidate): JsonObject[] => {
+  const toolCount = content.filter((candidate) => text(record(candidate).type) === "tool_use").length;
+  const toolBytes = toolCount > 0 ? Math.max(64, Math.floor((8 * 1024) / toolCount)) : 0;
+  const projectedToolInputs = content.map((candidate) => {
+    const part = record(candidate);
+    return text(part.type) === "tool_use"
+      ? boundedToolArguments(part.input, toolBytes)
+      : null;
+  });
+  const usedToolBytes = projectedToolInputs.reduce<number>((total, input) =>
+    total + (input === null ? 0 : Buffer.byteLength(JSON.stringify(input))), 0);
+  const textBudget = Math.max(0, 40 * 1024 - usedToolBytes);
+  const totalTextBytes = content.reduce((total, candidate) => {
+    const part = record(candidate);
+    const type = text(part.type);
+    return type === "text" || type === "input_text" || type === "output_text"
+      ? total + Buffer.byteLength(text(part.text) ?? "")
+      : total;
+  }, 0);
+  const projectedContent = content.flatMap((candidate, index): JsonObject[] => {
     const part = record(candidate);
     const type = text(part.type);
     if (type === "text" || type === "input_text" || type === "output_text") {
-      return [{ type, ...(text(part.text) ? { text: clipped(text(part.text)!, payloadBytes) } : {}) }];
+      const prose = text(part.text) ?? "";
+      const payloadBytes = totalTextBytes <= textBudget
+        ? Buffer.byteLength(prose)
+        : Math.floor(textBudget * (Buffer.byteLength(prose) / Math.max(totalTextBytes, 1)));
+      const bounded = boundedText(prose, payloadBytes);
+      return [{
+        type,
+        ...(bounded.text ? { text: bounded.text } : {}),
+        ...(bounded.omittedChars > 0 ? { omittedChars: bounded.omittedChars } : {}),
+      }];
     }
     if (type === "tool_use") {
       return [{
         type,
         ...(text(part.id) ? { id: clipped(text(part.id)!, 256) } : {}),
         ...(text(part.name) ? { name: clipped(text(part.name)!, 256) } : {}),
-        input: boundedToolArguments(part.input, payloadBytes),
+        input: projectedToolInputs[index] ?? {},
       }];
     }
     if (type === "tool_result") {

--- a/src/lib/runtime/liveTurn.test.ts
+++ b/src/lib/runtime/liveTurn.test.ts
@@ -4,6 +4,7 @@ import {
   appendRuntimeLiveTurnDelta,
   completeRuntimeLiveTurnItem,
   normalizeRuntimeLiveTurn,
+  projectRuntimeLiveTurnItem,
   runtimeLiveTurnItems,
 } from "./liveTurn";
 
@@ -125,4 +126,84 @@ test("issue 626: the ultimate summary counts fully text-trimmed unidentified com
     omittedItems: 7,
   });
   expect(items[0]?.omittedChars).toBeGreaterThan(0);
+});
+
+test("live tool items from Claude and Codex survive projection in response order under the text bound", () => {
+  let live = appendRuntimeLiveTurnDelta(
+    null,
+    "turn-tools",
+    "Checking the relevant files.",
+    "2026-08-06T09:00:00.000Z",
+  );
+  live = completeRuntimeLiveTurnItem(live, "turn-tools", {
+    type: "assistant",
+    uuid: "claude-message",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Checking the relevant files." },
+        {
+          type: "tool_use",
+          id: "claude-read",
+          name: "Read",
+          input: { file_path: `src/${"nested/".repeat(12_000)}liveTurn.ts` },
+        },
+      ],
+    },
+  }, "2026-08-06T09:00:01.000Z");
+  live = completeRuntimeLiveTurnItem(live, "turn-tools", {
+    type: "commandExecution",
+    id: "codex-command",
+    command: "bun test src/lib/runtime/liveTurn.test.ts",
+    cwd: "/repo",
+  }, "2026-08-06T09:00:02.000Z");
+
+  const items = runtimeLiveTurnItems(live);
+  expect(items.map(({ kind, itemId, toolName }) => ({ kind, itemId, toolName }))).toEqual([
+    { kind: "assistant", itemId: "claude-message", toolName: undefined },
+    { kind: "tool", itemId: "claude-read", toolName: "Read" },
+    { kind: "tool", itemId: "codex-command", toolName: "exec_command" },
+  ]);
+  expect(items.reduce((total, item) => total + new TextEncoder().encode(item.text).length, 0))
+    .toBeLessThanOrEqual(64 * 1024);
+  expect(items[1]?.omittedChars).toBeGreaterThan(0);
+  expect(items[2]?.text).toContain("bun test src/lib/runtime/liveTurn.test.ts");
+  expect(live?.text).toBe(items.findLast((item) => item.kind === "assistant")?.text);
+  expect(live?.text).not.toContain("bun test src/lib/runtime/liveTurn.test.ts");
+});
+
+test("a Codex tool start appears immediately and completion updates the same live row", () => {
+  const started = projectRuntimeLiveTurnItem(null, "turn-started-tool", {
+    type: "commandExecution",
+    id: "command-live",
+    command: "bun test src/lib/runtime/liveTurn.test.ts",
+    cwd: "/repo",
+  }, "started", "2026-08-06T09:10:00.000Z");
+  expect(runtimeLiveTurnItems(started)).toEqual([
+    expect.objectContaining({
+      kind: "tool",
+      itemId: "command-live",
+      toolName: "exec_command",
+      phase: "streaming",
+      startedAt: "2026-08-06T09:10:00.000Z",
+      completedAt: null,
+    }),
+  ]);
+
+  const completed = projectRuntimeLiveTurnItem(started, "turn-started-tool", {
+    type: "commandExecution",
+    id: "command-live",
+    command: "bun test src/lib/runtime/liveTurn.test.ts",
+    cwd: "/repo",
+    status: "completed",
+  }, "completed", "2026-08-06T09:10:01.000Z");
+  expect(runtimeLiveTurnItems(completed)).toEqual([
+    expect.objectContaining({
+      kind: "tool",
+      itemId: "command-live",
+      phase: "awaiting-echo",
+      startedAt: "2026-08-06T09:10:00.000Z",
+      completedAt: "2026-08-06T09:10:01.000Z",
+    }),
+  ]);
 });

--- a/src/lib/runtime/liveTurn.test.ts
+++ b/src/lib/runtime/liveTurn.test.ts
@@ -193,8 +193,6 @@ test("a Codex tool start appears immediately and completion updates the same liv
   const completed = projectRuntimeLiveTurnItem(started, "turn-started-tool", {
     type: "commandExecution",
     id: "command-live",
-    command: "bun test src/lib/runtime/liveTurn.test.ts",
-    cwd: "/repo",
     status: "completed",
   }, "completed", "2026-08-06T09:10:01.000Z");
   expect(runtimeLiveTurnItems(completed)).toEqual([
@@ -204,6 +202,74 @@ test("a Codex tool start appears immediately and completion updates the same liv
       phase: "awaiting-echo",
       startedAt: "2026-08-06T09:10:00.000Z",
       completedAt: "2026-08-06T09:10:01.000Z",
+      text: JSON.stringify({
+        cmd: "bun test src/lib/runtime/liveTurn.test.ts",
+        workdir: "/repo",
+      }),
     }),
+  ]);
+});
+
+test("Claude text and tool blocks keep response order until the matching tool result completes the call", () => {
+  let live = appendRuntimeLiveTurnDelta(
+    null,
+    "turn-claude-blocks",
+    "Before the call.After the call.",
+    "2026-08-06T09:40:00.000Z",
+  );
+  live = completeRuntimeLiveTurnItem(live, "turn-claude-blocks", {
+    type: "assistant",
+    uuid: "claude-block-message",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Before the call." },
+        { type: "tool_use", id: "claude-block-tool", name: "Read", input: { file_path: "src/lib/runtime/liveTurn.ts" } },
+        { type: "text", text: "After the call." },
+      ],
+    },
+  }, "2026-08-06T09:40:01.000Z");
+
+  expect(runtimeLiveTurnItems(live).map(({ kind, itemId, text, phase, completedAt }) => ({
+    kind,
+    itemId,
+    text,
+    phase,
+    completedAt,
+  }))).toEqual([
+    {
+      kind: "assistant",
+      itemId: "claude-block-message",
+      text: "Before the call.",
+      phase: "awaiting-echo",
+      completedAt: "2026-08-06T09:40:01.000Z",
+    },
+    {
+      kind: "tool",
+      itemId: "claude-block-tool",
+      text: JSON.stringify({ file_path: "src/lib/runtime/liveTurn.ts" }),
+      phase: "streaming",
+      completedAt: null,
+    },
+    {
+      kind: "assistant",
+      itemId: "claude-block-message",
+      text: "After the call.",
+      phase: "awaiting-echo",
+      completedAt: "2026-08-06T09:40:01.000Z",
+    },
+  ]);
+
+  live = completeRuntimeLiveTurnItem(live, "turn-claude-blocks", {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "claude-block-tool", content: "done" }],
+    },
+  }, "2026-08-06T09:40:02.000Z");
+  expect(runtimeLiveTurnItems(live).map(({ itemId, phase, completedAt }) => ({ itemId, phase, completedAt }))).toEqual([
+    { itemId: "claude-block-message", phase: "awaiting-echo", completedAt: "2026-08-06T09:40:01.000Z" },
+    { itemId: "claude-block-tool", phase: "awaiting-echo", completedAt: "2026-08-06T09:40:02.000Z" },
+    { itemId: "claude-block-message", phase: "awaiting-echo", completedAt: "2026-08-06T09:40:01.000Z" },
   ]);
 });

--- a/src/lib/runtime/liveTurn.ts
+++ b/src/lib/runtime/liveTurn.ts
@@ -85,11 +85,14 @@ interface ProjectedItem {
   text: string;
   toolName?: string;
   toolEngine?: RuntimeLiveTurnToolEngine;
+  lifecycle?: "started" | "completed";
 }
 
 function serializedToolArgs(value: unknown): string {
   try {
-    const serialized = JSON.stringify(value ?? {});
+    const normalized = value ?? {};
+    if (record(normalized) && Object.keys(normalized).length === 0) return "";
+    const serialized = JSON.stringify(normalized);
     return typeof serialized === "string" ? serialized : "";
   } catch {
     return "";
@@ -117,11 +120,13 @@ function projectedTool(
 }
 
 function codexToolIdentity(item: Record<string, unknown>, type: string): ProjectedItem | null {
-  const itemId = text(item.id) || text(item.call_id) || null;
+  const itemId = text(item.call_id) || text(item.id) || null;
   if (type === "commandExecution") {
+    const command = text(item.command);
+    const workdir = text(item.cwd);
     return projectedTool(itemId, "exec_command", {
-      cmd: text(item.command),
-      workdir: text(item.cwd),
+      ...(command ? { cmd: command } : {}),
+      ...(workdir ? { workdir } : {}),
     }, "codex");
   }
   if (type === "fileChange") {
@@ -198,12 +203,15 @@ function itemIdentities(value: unknown): ProjectedItem[] {
         return prose ? [{ kind: "assistant", itemId: parentId, text: prose }] : [];
       }
       if (partType === "tool_use") {
-        return [projectedTool(
-          text(part.id) || null,
-          text(part.name) || "tool",
-          part.input,
-          "claude",
-        )];
+        return [{
+          ...projectedTool(
+            text(part.id) || null,
+            text(part.name) || "tool",
+            part.input,
+            "claude",
+          ),
+          lifecycle: "started",
+        }];
       }
       return [];
     });
@@ -225,6 +233,7 @@ function itemIdentities(value: unknown): ProjectedItem[] {
         text: "",
         toolName: "tool",
         toolEngine: "claude",
+        lifecycle: "completed",
       }]
       : [];
   });
@@ -384,14 +393,19 @@ export function projectRuntimeLiveTurnItem(
   lifecycle: "started" | "completed",
   occurredAt: string | null = null,
 ): RuntimeLiveTurn | null {
-  const identities = itemIdentities(item);
+  const identities = itemIdentities(item).filter((identity) =>
+    lifecycle === "completed" || identity.kind === "tool");
   if (!identities.length) return value ?? null;
-  const phase: RuntimeLiveTurnItemPhase = lifecycle === "started" ? "streaming" : "awaiting-echo";
   let current = itemsForTurn(value, turnId, occurredAt);
+  const matchedIndexes = new Set<number>();
   for (const identity of identities) {
+    const identityLifecycle = identity.lifecycle ?? lifecycle;
+    const phase: RuntimeLiveTurnItemPhase = identityLifecycle === "started" ? "streaming" : "awaiting-echo";
     const existingIndex = identity.itemId
-      ? current.findIndex((candidate) =>
-        candidate.itemId === identity.itemId && (candidate.kind ?? "assistant") === identity.kind)
+      ? current.findIndex((candidate, index) =>
+        !matchedIndexes.has(index)
+        && candidate.itemId === identity.itemId
+        && (candidate.kind ?? "assistant") === identity.kind)
       : -1;
     if (existingIndex >= 0) {
       const existing = current[existingIndex]!;
@@ -411,16 +425,18 @@ export function projectRuntimeLiveTurnItem(
         } : { toolName: undefined, toolEngine: undefined }),
         phase,
         startedAt: existing.startedAt ?? occurredAt,
-        completedAt: lifecycle === "completed" ? occurredAt : existing.completedAt,
+        completedAt: identityLifecycle === "completed" ? occurredAt : null,
       };
       current = items;
+      matchedIndexes.add(existingIndex);
       continue;
     }
     const latest = current.at(-1);
-    if (lifecycle === "completed"
+    if (identityLifecycle === "completed"
       && identity.kind === "assistant"
       && latest?.phase === "streaming"
-      && latest.kind !== "tool") {
+      && latest.kind !== "tool"
+      && !matchedIndexes.has(current.length - 1)) {
       current = [
         ...current.slice(0, -1),
         {
@@ -433,6 +449,7 @@ export function projectRuntimeLiveTurnItem(
           completedAt: occurredAt,
         },
       ];
+      matchedIndexes.add(current.length - 1);
       continue;
     }
     if (identity.kind === "assistant" && !identity.text) continue;
@@ -440,8 +457,9 @@ export function projectRuntimeLiveTurnItem(
       ...identity,
       phase,
       startedAt: occurredAt,
-      completedAt: lifecycle === "completed" ? occurredAt : null,
+      completedAt: identityLifecycle === "completed" ? occurredAt : null,
     }];
+    matchedIndexes.add(current.length - 1);
   }
   return bounded(turnId, current);
 }

--- a/src/lib/runtime/liveTurn.ts
+++ b/src/lib/runtime/liveTurn.ts
@@ -3,10 +3,17 @@ export const LIVE_TURN_ITEM_LIMIT = 32;
 export const LIVE_TURN_OVERFLOW_LIMIT = 512;
 
 export type RuntimeLiveTurnItemPhase = "streaming" | "awaiting-echo";
+export type RuntimeLiveTurnItemKind = "assistant" | "tool";
+export type RuntimeLiveTurnToolEngine = "claude" | "codex";
 
 export interface RuntimeLiveTurnItem {
+  /** Missing only on legacy snapshots, which normalize to assistant prose. */
+  kind?: RuntimeLiveTurnItemKind;
   itemId: string | null;
+  /** Assistant prose, or serialized tool arguments for a tool item. */
   text: string;
+  toolName?: string;
+  toolEngine?: RuntimeLiveTurnToolEngine;
   phase: RuntimeLiveTurnItemPhase;
   startedAt: string | null;
   completedAt: string | null;
@@ -21,7 +28,7 @@ export interface RuntimeLiveTurn {
   turnId: string;
   /** Latest assistant item text retained for compatibility with existing status consumers. */
   text: string;
-  /** Assistant items awaiting canonical transcript ownership, in response order. */
+  /** Assistant and tool items awaiting canonical transcript ownership, in response order. */
   items?: RuntimeLiveTurnItem[];
   /** Older unclaimed items displaced from the 32-item hot window. Descriptors
       remain durable in journal snapshots and preserve response order/identity. */
@@ -72,9 +79,104 @@ function contentText(value: unknown): string {
     .join("\n");
 }
 
-function itemIdentity(value: unknown): { itemId: string | null; text: string } | null {
+interface ProjectedItem {
+  kind: RuntimeLiveTurnItemKind;
+  itemId: string | null;
+  text: string;
+  toolName?: string;
+  toolEngine?: RuntimeLiveTurnToolEngine;
+}
+
+function serializedToolArgs(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value ?? {});
+    return typeof serialized === "string" ? serialized : "";
+  } catch {
+    return "";
+  }
+}
+
+function toolArgs(value: unknown): unknown {
+  const args = record(value);
+  return args ?? (value === undefined ? {} : { input: value });
+}
+
+function projectedTool(
+  itemId: string | null,
+  toolName: string,
+  args: unknown,
+  toolEngine: RuntimeLiveTurnToolEngine,
+): ProjectedItem {
+  return {
+    kind: "tool",
+    itemId,
+    text: serializedToolArgs(toolArgs(args)),
+    toolName: toolName.slice(0, 256) || "tool",
+    toolEngine,
+  };
+}
+
+function codexToolIdentity(item: Record<string, unknown>, type: string): ProjectedItem | null {
+  const itemId = text(item.id) || text(item.call_id) || null;
+  if (type === "commandExecution") {
+    return projectedTool(itemId, "exec_command", {
+      cmd: text(item.command),
+      workdir: text(item.cwd),
+    }, "codex");
+  }
+  if (type === "fileChange") {
+    const changes = Array.isArray(item.changes) ? item.changes.map(record).filter(Boolean) : [];
+    return projectedTool(itemId, "apply_patch", {
+      input: changes.map((change) => text(change?.diff)).filter(Boolean).join("\n"),
+      file_path: text(changes[0]?.path),
+    }, "codex");
+  }
+  if (type === "mcpToolCall") {
+    const server = text(item.server);
+    const name = text(item.tool) || "tool";
+    return projectedTool(itemId, server ? `mcp__${server}__${name}` : name, item.arguments, "codex");
+  }
+  if (type === "dynamicToolCall") {
+    return projectedTool(itemId, text(item.tool) || "tool", item.arguments, "codex");
+  }
+  if (type === "collabAgentToolCall") {
+    return projectedTool(itemId, text(item.tool) || "Agent", {
+      "prompt": text(item.prompt),
+      model: text(item.model),
+      receiverThreadIds: item.receiverThreadIds,
+    }, "codex");
+  }
+  if (type === "webSearch") {
+    return projectedTool(itemId, "WebSearch", {
+      query: text(item.query),
+      action: item.action,
+    }, "codex");
+  }
+  if (type === "imageView") return projectedTool(itemId, "view_image", { path: text(item.path) }, "codex");
+  if (type === "sleep") return projectedTool(itemId, "wait", { yield_time_ms: item.durationMs }, "codex");
+  if (type === "imageGeneration") {
+    return projectedTool(itemId, "imagegen", {
+      "prompt": text(item.revisedPrompt),
+      path: text(item.savedPath),
+    }, "codex");
+  }
+  if (type === "function_call") {
+    let args: unknown = {};
+    try { args = JSON.parse(text(item.arguments) || "{}"); } catch { /* readable generic fallback */ }
+    return projectedTool(itemId, text(item.name) || "tool", args, "codex");
+  }
+  if (type === "custom_tool_call") {
+    return projectedTool(itemId, text(item.name) || "tool", { input: text(item.input) }, "codex");
+  }
+  if (type === "function_call_output" || type === "custom_tool_call_output") {
+    return { kind: "tool", itemId, text: "", toolName: "tool", toolEngine: "codex" };
+  }
+  return null;
+}
+
+function itemIdentities(value: unknown): ProjectedItem[] {
   const item = record(value);
-  if (!item) return null;
+  if (!item) return [];
   const type = text(item.type);
   const message = record(item.message);
   const role = text(item.role) || text(message?.role);
@@ -82,11 +184,53 @@ function itemIdentity(value: unknown): { itemId: string | null; text: string } |
     || type === "agent_message"
     || type === "assistant"
     || (type === "message" && role === "assistant");
-  if (!assistant) return null;
-  return {
-    itemId: text(item.id) || text(item.uuid) || text(message?.id) || null,
-    text: text(item.text) || contentText(item.content) || contentText(message?.content),
-  };
+  const parentId = text(item.id) || text(item.uuid) || text(message?.id) || null;
+  const content = Array.isArray(item.content)
+    ? item.content
+    : Array.isArray(message?.content) ? message.content : null;
+  if (assistant && content) {
+    return content.flatMap((value): ProjectedItem[] => {
+      const part = record(value);
+      if (!part) return [];
+      const partType = text(part.type);
+      if (partType === "text" || partType === "input_text" || partType === "output_text") {
+        const prose = text(part.text);
+        return prose ? [{ kind: "assistant", itemId: parentId, text: prose }] : [];
+      }
+      if (partType === "tool_use") {
+        return [projectedTool(
+          text(part.id) || null,
+          text(part.name) || "tool",
+          part.input,
+          "claude",
+        )];
+      }
+      return [];
+    });
+  }
+  if (assistant) {
+    return [{
+      kind: "assistant",
+      itemId: parentId,
+      text: text(item.text) || contentText(item.content) || contentText(message?.content),
+    }];
+  }
+  const userContent = role === "user" && content ? content : [];
+  const toolResults = userContent.flatMap((value): ProjectedItem[] => {
+    const part = record(value);
+    return part && text(part.type) === "tool_result"
+      ? [{
+        kind: "tool",
+        itemId: text(part.tool_use_id) || null,
+        text: "",
+        toolName: "tool",
+        toolEngine: "claude",
+      }]
+      : [];
+  });
+  if (toolResults.length) return toolResults;
+  const codexTool = codexToolIdentity(item, type);
+  return codexTool ? [codexTool] : [];
 }
 
 function normalizedList(value: unknown): RuntimeLiveTurnItem[] {
@@ -95,10 +239,17 @@ function normalizedList(value: unknown): RuntimeLiveTurnItem[] {
       .filter((item) =>
         item
         && typeof item.text === "string"
-        && (item.text.length > 0 || (item.omittedChars ?? 0) > 0 || (item.omittedItems ?? 0) > 0))
+        && (item.kind === "tool" || item.text.length > 0 || (item.omittedChars ?? 0) > 0 || (item.omittedItems ?? 0) > 0))
       .map((item) => ({
+        kind: item.kind === "tool" ? "tool" as const : "assistant" as const,
         itemId: typeof item.itemId === "string" ? item.itemId : null,
         text: item.text,
+        ...(item.kind === "tool"
+          ? {
+            toolName: typeof item.toolName === "string" && item.toolName ? item.toolName.slice(0, 256) : "tool",
+            toolEngine: item.toolEngine === "claude" ? "claude" as const : "codex" as const,
+          }
+          : {}),
         phase: item.phase === "awaiting-echo" ? "awaiting-echo" : "streaming",
         startedAt: typeof item.startedAt === "string" ? item.startedAt : null,
         completedAt: typeof item.completedAt === "string" ? item.completedAt : null,
@@ -117,6 +268,7 @@ function normalizedItems(value: RuntimeLiveTurn): RuntimeLiveTurnItem[] {
   }
   return value.text
     ? [{
+      kind: "assistant",
       itemId: null,
       text: value.text,
       phase: "streaming",
@@ -134,6 +286,7 @@ function bounded(turnId: string, items: RuntimeLiveTurnItem[]): RuntimeLiveTurn 
   const omitted = items.slice(0, omittedCount);
   let kept = omitted.length
     ? [{
+      kind: "assistant" as const,
       itemId: null,
       text: "",
       phase: "awaiting-echo" as const,
@@ -159,14 +312,13 @@ function bounded(turnId: string, items: RuntimeLiveTurnItem[]): RuntimeLiveTurn 
       };
     });
   }
-  const latest = kept.at(-1);
-  if (!latest) return null;
+  if (!kept.length) return null;
   const activeStart = Math.max(0, kept.length - LIVE_TURN_ITEM_LIMIT);
   const overflow = kept.slice(0, activeStart);
   const active = kept.slice(activeStart);
   return {
     turnId,
-    text: latest.text,
+    text: kept.findLast((item) => item.kind !== "tool")?.text ?? "",
     items: active,
     ...(overflow.length ? { overflow } : {}),
   };
@@ -212,8 +364,10 @@ export function appendRuntimeLiveTurnDelta(
   const current = itemsForTurn(value, turnId, occurredAt);
   const latest = current.at(-1);
   const items = latest?.phase === "streaming"
-    ? [...current.slice(0, -1), { ...latest, text: latest.text + fragment }]
+    && latest.kind !== "tool"
+    ? [...current.slice(0, -1), { ...latest, kind: "assistant" as const, text: latest.text + fragment }]
     : [...current, {
+      kind: "assistant" as const,
       itemId: null,
       text: fragment,
       phase: "streaming" as const,
@@ -223,53 +377,80 @@ export function appendRuntimeLiveTurnDelta(
   return bounded(turnId, items);
 }
 
+export function projectRuntimeLiveTurnItem(
+  value: RuntimeLiveTurn | null | undefined,
+  turnId: string,
+  item: unknown,
+  lifecycle: "started" | "completed",
+  occurredAt: string | null = null,
+): RuntimeLiveTurn | null {
+  const identities = itemIdentities(item);
+  if (!identities.length) return value ?? null;
+  const phase: RuntimeLiveTurnItemPhase = lifecycle === "started" ? "streaming" : "awaiting-echo";
+  let current = itemsForTurn(value, turnId, occurredAt);
+  for (const identity of identities) {
+    const existingIndex = identity.itemId
+      ? current.findIndex((candidate) =>
+        candidate.itemId === identity.itemId && (candidate.kind ?? "assistant") === identity.kind)
+      : -1;
+    if (existingIndex >= 0) {
+      const existing = current[existingIndex]!;
+      const items = current.slice();
+      const preserveToolName = identity.kind === "tool" && identity.toolName === "tool";
+      items[existingIndex] = {
+        ...existing,
+        kind: identity.kind,
+        /* A non-empty completed item is authoritative: it repairs missed streamed
+           suffixes and may legitimately rewrite a divergent draft. Tool-result
+           records carry no arguments and retain the call summary already shown. */
+        text: identity.text || existing.text,
+        ...(identity.text ? { omittedChars: undefined } : {}),
+        ...(identity.kind === "tool" ? {
+          toolName: preserveToolName ? existing.toolName : identity.toolName,
+          toolEngine: identity.toolEngine,
+        } : { toolName: undefined, toolEngine: undefined }),
+        phase,
+        startedAt: existing.startedAt ?? occurredAt,
+        completedAt: lifecycle === "completed" ? occurredAt : existing.completedAt,
+      };
+      current = items;
+      continue;
+    }
+    const latest = current.at(-1);
+    if (lifecycle === "completed"
+      && identity.kind === "assistant"
+      && latest?.phase === "streaming"
+      && latest.kind !== "tool") {
+      current = [
+        ...current.slice(0, -1),
+        {
+          ...latest,
+          kind: "assistant",
+          itemId: identity.itemId,
+          text: identity.text || latest.text,
+          ...(identity.text ? { omittedChars: undefined } : {}),
+          phase: "awaiting-echo",
+          completedAt: occurredAt,
+        },
+      ];
+      continue;
+    }
+    if (identity.kind === "assistant" && !identity.text) continue;
+    current = [...current, {
+      ...identity,
+      phase,
+      startedAt: occurredAt,
+      completedAt: lifecycle === "completed" ? occurredAt : null,
+    }];
+  }
+  return bounded(turnId, current);
+}
+
 export function completeRuntimeLiveTurnItem(
   value: RuntimeLiveTurn | null | undefined,
   turnId: string,
   item: unknown,
   occurredAt: string | null = null,
 ): RuntimeLiveTurn | null {
-  const identity = itemIdentity(item);
-  if (!identity) return value ?? null;
-  const current = itemsForTurn(value, turnId, occurredAt);
-  const existingIndex = identity.itemId
-    ? current.findIndex((candidate) => candidate.itemId === identity.itemId)
-    : -1;
-  if (existingIndex >= 0) {
-    const existing = current[existingIndex]!;
-    const items = current.slice();
-    items[existingIndex] = {
-      ...existing,
-      /* A non-empty completed item is authoritative: it repairs missed streamed
-         suffixes and may legitimately rewrite a divergent draft. Engines that
-         complete with an empty body leave the observed stream intact. */
-      text: identity.text || existing.text,
-      ...(identity.text ? { omittedChars: undefined } : {}),
-      phase: "awaiting-echo",
-      completedAt: occurredAt,
-    };
-    return bounded(turnId, items);
-  }
-  const latest = current.at(-1);
-  if (latest?.phase === "streaming") {
-    return bounded(turnId, [
-      ...current.slice(0, -1),
-      {
-        ...latest,
-        itemId: identity.itemId,
-        text: identity.text || latest.text,
-        ...(identity.text ? { omittedChars: undefined } : {}),
-        phase: "awaiting-echo",
-        completedAt: occurredAt,
-      },
-    ]);
-  }
-  if (!identity.text) return value ?? null;
-  return bounded(turnId, [...current, {
-    itemId: identity.itemId,
-    text: identity.text,
-    phase: "awaiting-echo",
-    startedAt: occurredAt,
-    completedAt: occurredAt,
-  }]);
+  return projectRuntimeLiveTurnItem(value, turnId, item, "completed", occurredAt);
 }

--- a/src/lib/runtime/liveTurn.ts
+++ b/src/lib/runtime/liveTurn.ts
@@ -1,6 +1,7 @@
 export const LIVE_TURN_TEXT_LIMIT = 64 * 1024;
 export const LIVE_TURN_ITEM_LIMIT = 32;
 export const LIVE_TURN_OVERFLOW_LIMIT = 512;
+const LIVE_TURN_TOOL_TEXT_FLOOR = 96;
 
 export type RuntimeLiveTurnItemPhase = "streaming" | "awaiting-echo";
 export type RuntimeLiveTurnItemKind = "assistant" | "tool";
@@ -9,6 +10,8 @@ export type RuntimeLiveTurnToolEngine = "claude" | "codex";
 export interface RuntimeLiveTurnItem {
   /** Missing only on legacy snapshots, which normalize to assistant prose. */
   kind?: RuntimeLiveTurnItemKind;
+  /** Durable projection identity used only for row reconciliation. */
+  rowId?: string;
   itemId: string | null;
   /** Assistant prose, or serialized tool arguments for a tool item. */
   text: string;
@@ -53,6 +56,52 @@ function trimUtf8Start(value: string, bytes: number): {
   };
 }
 
+function boundedToolJson(value: string, maxBytes: number): string {
+  if (maxBytes < 2) return "";
+  let source: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
+    source = parsed as Record<string, unknown>;
+  } catch {
+    return "";
+  }
+  if (utf8Length(value) <= maxBytes) return value;
+  const result: Record<string, unknown> = {};
+  for (const [key, candidate] of Object.entries(source)) {
+    const complete = JSON.stringify({ ...result, [key]: candidate });
+    if (utf8Length(complete) <= maxBytes) {
+      result[key] = candidate;
+      continue;
+    }
+    if (typeof candidate !== "string") continue;
+    const points = [...candidate];
+    let low = 0;
+    let high = points.length;
+    while (low < high) {
+      const middle = Math.ceil((low + high) / 2);
+      const trial = JSON.stringify({ ...result, [key]: points.slice(0, middle).join("") });
+      if (utf8Length(trial) <= maxBytes) low = middle;
+      else high = middle - 1;
+    }
+    const trial = JSON.stringify({ ...result, [key]: points.slice(0, low).join("") });
+    if (utf8Length(trial) <= maxBytes) result[key] = points.slice(0, low).join("");
+  }
+  const serialized = JSON.stringify(result);
+  return utf8Length(serialized) <= maxBytes ? serialized : "";
+}
+
+function trimToolText(value: string, maxBytes: number): {
+  omittedChars: number;
+  text: string;
+} {
+  const boundedText = boundedToolJson(value, maxBytes);
+  return {
+    omittedChars: Math.max(0, [...value].length - [...boundedText].length),
+    text: boundedText,
+  };
+}
+
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -81,11 +130,13 @@ function contentText(value: unknown): string {
 
 interface ProjectedItem {
   kind: RuntimeLiveTurnItemKind;
+  rowId?: string;
   itemId: string | null;
   text: string;
   toolName?: string;
   toolEngine?: RuntimeLiveTurnToolEngine;
   lifecycle?: "started" | "completed";
+  omittedChars?: number;
 }
 
 function serializedToolArgs(value: unknown): string {
@@ -112,6 +163,7 @@ function projectedTool(
 ): ProjectedItem {
   return {
     kind: "tool",
+    ...(itemId ? { rowId: `tool:${itemId}` } : {}),
     itemId,
     text: serializedToolArgs(toolArgs(args)),
     toolName: toolName.slice(0, 256) || "tool",
@@ -194,13 +246,21 @@ function itemIdentities(value: unknown): ProjectedItem[] {
     ? item.content
     : Array.isArray(message?.content) ? message.content : null;
   if (assistant && content) {
-    return content.flatMap((value): ProjectedItem[] => {
+    return content.flatMap((value, blockIndex): ProjectedItem[] => {
       const part = record(value);
       if (!part) return [];
       const partType = text(part.type);
       if (partType === "text" || partType === "input_text" || partType === "output_text") {
         const prose = text(part.text);
-        return prose ? [{ kind: "assistant", itemId: parentId, text: prose }] : [];
+        return prose ? [{
+          kind: "assistant",
+          ...(parentId ? { rowId: `assistant:${parentId}:${blockIndex}` } : {}),
+          itemId: parentId,
+          text: prose,
+          ...(typeof part.omittedChars === "number" && part.omittedChars > 0
+            ? { omittedChars: Math.floor(part.omittedChars) }
+            : {}),
+        }] : [];
       }
       if (partType === "tool_use") {
         return [{
@@ -219,6 +279,7 @@ function itemIdentities(value: unknown): ProjectedItem[] {
   if (assistant) {
     return [{
       kind: "assistant",
+      ...(parentId ? { rowId: `assistant:${parentId}` } : {}),
       itemId: parentId,
       text: text(item.text) || contentText(item.content) || contentText(message?.content),
     }];
@@ -229,6 +290,7 @@ function itemIdentities(value: unknown): ProjectedItem[] {
     return part && text(part.type) === "tool_result"
       ? [{
         kind: "tool",
+        ...(text(part.tool_use_id) ? { rowId: `tool:${text(part.tool_use_id)}` } : {}),
         itemId: text(part.tool_use_id) || null,
         text: "",
         toolName: "tool",
@@ -251,6 +313,7 @@ function normalizedList(value: unknown): RuntimeLiveTurnItem[] {
         && (item.kind === "tool" || item.text.length > 0 || (item.omittedChars ?? 0) > 0 || (item.omittedItems ?? 0) > 0))
       .map((item) => ({
         kind: item.kind === "tool" ? "tool" as const : "assistant" as const,
+        ...(typeof item.rowId === "string" && item.rowId ? { rowId: item.rowId } : {}),
         itemId: typeof item.itemId === "string" ? item.itemId : null,
         text: item.text,
         ...(item.kind === "tool"
@@ -296,6 +359,7 @@ function bounded(turnId: string, items: RuntimeLiveTurnItem[]): RuntimeLiveTurn 
   let kept = omitted.length
     ? [{
       kind: "assistant" as const,
+      rowId: `overflow:${turnId}:${omittedCount}`,
       itemId: null,
       text: "",
       phase: "awaiting-echo" as const,
@@ -312,7 +376,12 @@ function bounded(turnId: string, items: RuntimeLiveTurnItem[]): RuntimeLiveTurn 
     kept = kept.map((item) => {
       if (excess <= 0) return item;
       const before = utf8Length(item.text);
-      const trimmed = trimUtf8Start(item.text, excess);
+      const floor = item.kind === "tool" ? Math.min(before, LIVE_TURN_TOOL_TEXT_FLOOR) : 0;
+      const removedBytes = Math.min(excess, Math.max(0, before - floor));
+      const retainedBytes = before - removedBytes;
+      const trimmed = item.kind === "tool"
+        ? trimToolText(item.text, retainedBytes)
+        : trimUtf8Start(item.text, removedBytes);
       excess -= before - utf8Length(trimmed.text);
       return {
         ...item,
@@ -377,6 +446,7 @@ export function appendRuntimeLiveTurnDelta(
     ? [...current.slice(0, -1), { ...latest, kind: "assistant" as const, text: latest.text + fragment }]
     : [...current, {
       kind: "assistant" as const,
+      rowId: `assistant:${turnId}:${current.length}:${occurredAt ?? "live"}`,
       itemId: null,
       text: fragment,
       phase: "streaming" as const,
@@ -418,7 +488,7 @@ export function projectRuntimeLiveTurnItem(
            suffixes and may legitimately rewrite a divergent draft. Tool-result
            records carry no arguments and retain the call summary already shown. */
         text: identity.text || existing.text,
-        ...(identity.text ? { omittedChars: undefined } : {}),
+        ...(identity.text ? { omittedChars: identity.omittedChars } : {}),
         ...(identity.kind === "tool" ? {
           toolName: preserveToolName ? existing.toolName : identity.toolName,
           toolEngine: identity.toolEngine,
@@ -444,7 +514,7 @@ export function projectRuntimeLiveTurnItem(
           kind: "assistant",
           itemId: identity.itemId,
           text: identity.text || latest.text,
-          ...(identity.text ? { omittedChars: undefined } : {}),
+          ...(identity.text ? { omittedChars: identity.omittedChars } : {}),
           phase: "awaiting-echo",
           completedAt: occurredAt,
         },
@@ -455,6 +525,8 @@ export function projectRuntimeLiveTurnItem(
     if (identity.kind === "assistant" && !identity.text) continue;
     current = [...current, {
       ...identity,
+      rowId: identity.rowId
+        ?? `${identity.kind}:${turnId}:${current.length}:${identity.itemId ?? occurredAt ?? "live"}`,
       phase,
       startedAt: occurredAt,
       completedAt: identityLifecycle === "completed" ? occurredAt : null,


### PR DESCRIPTION
## Summary

- project bounded Claude and Codex tool activity into live turns in response order
- render compact readable tool rows interleaved with live assistant prose
- hand live tool identities to canonical transcript cards, groups, and teammate messages without duplicate rows
- preserve tool summaries across large completion payloads and retain explicit prose omission accounting

## Validation

- 163 targeted tests passed across runtime projection, engine event bounds, parser handoff, runtime model, and isolated DOM rendering
- TypeScript passed with `bunx tsc --noEmit`
- ESLint passed on all changed files
- privacy publication gate passed against `origin/main`
- fresh exact-HEAD independent review approved with mutation checks for bounds and short-gap duplicate-command handoff
