### PR TITLE
fix(scheme): standalone viewer-spawned conversation keeps a root card in its own project

### DIFF
--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -251,6 +251,26 @@ describe("buildBranchGroups", () => {
     expect(isConversation(entry({ path: "/root", parent: "/older" }))).toBe(false);
   });
 
+  test("a standalone viewer-spawned conversation stays a root despite its spawner parent", () => {
+    const lineage = {
+      kind: "spawn" as const,
+      role: "builder",
+      depth: 1,
+      parentConversationId: "conversation_parent",
+      reviewsConversationId: null,
+      memberships: [],
+    };
+    expect(isConversation(entry({ path: "/spawned", parent: "/other-project/orchestrator", durableLineage: lineage }))).toBe(true);
+    /* Pipeline/flow members keep their container placement. */
+    const member = {
+      ...lineage,
+      memberships: [{ kind: "pipeline" as const, containerId: "p1", role: "builder", slot: "s", stageId: null, stageOrder: null, round: null, parentConversationId: null }],
+    };
+    expect(isConversation(entry({ path: "/member", parent: "/other", durableLineage: member }))).toBe(false);
+    /* A handoff branch keeps rendering under its source. */
+    expect(isConversation(entry({ path: "/handoff", parent: "/source", handoff: true, durableLineage: lineage }))).toBe(false);
+  });
+
   test("idle roots with active descendants are marked for quiet history", () => {
     const files = [
       entry({ path: "/idle-root", activity: "idle", mtime: 10 }),

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -26,7 +26,17 @@ export function activityBand(file: FileEntry): ActivityBand {
 export function isConversation(file: FileEntry): boolean {
   // A claude session with a parent is a compaction-chain predecessor: it
   // belongs to its successor's tree, so it no longer counts as a root.
-  if (file.root === "claude-projects") return file.kind === "session" && !file.parent;
+  if (file.root === "claude-projects") {
+    if (file.kind !== "session") return false;
+    if (!file.parent) return true;
+    /* A viewer-spawned conversation outside any pipeline/flow container is a
+       root in its own project: its `parent` names the spawner's transcript —
+       often a conversation of a different project — never a compaction
+       predecessor of this one. Without this it renders nowhere: not a root,
+       not a child (no handoff), and its parent's tree lives on another board. */
+    const lineage = file.durableLineage;
+    return lineage?.kind === "spawn" && !lineage.memberships.length && !file.handoff;
+  }
   if (file.root === "codex-sessions") return !file.parent;
   return false;
 }


### PR DESCRIPTION
A claude session with a `parent` was always classified as a compaction-chain predecessor ("quiet history"). For a viewer-spawned conversation the `parent` field names the spawner's transcript — often a conversation of a **different project** — so the spawned conversation rendered nowhere on its own project's map: it was no root, no child (`handoff` absent), and its parent's tree lives on another board.

Observed live: the operator's shuboku conversation `f769cfc6` (spawned this morning by the LLV orchestrator, `durableLineage.kind=spawn`, `memberships=[]`, parent transcript in `repo-d8378326`) was present in `/api/files` yet had no card on the shuboku board.

Fix: `isConversation` treats a spawn-lineage entry with no pipeline/flow membership as a conversation root. Pipeline/flow members and handoff branches keep their current placement. Projection measured impact: 10 entries across 6 projects gain a root card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)