### PR TITLE
fix(scheme): automatic cards follow a tunable age horizon on the project map

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ All optional. Transcription variables are documented in full in
 | `LLV_REAPER_ENABLED` | `1` enables verified pane and detached-reviewer process cleanup by the deterministic agent reaper. Unset keeps dry-run mode and exposes its latest report at `GET /api/lifecycle/reaper`. |
 | `LLV_SCHEME_PROJECT_CAP` | Number of most-recent projects rendered by the scheme feed (default `10`). List and search remain complete. |
 | `LLV_SCHEME_CARDS_PER_PROJECT` | Maximum scanner entries rendered per scheme project (default `80`). List and search remain complete. |
+| `NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS` | Age horizon in hours for automatic card placement on the project scheme (default `48`). A root conversation with activity inside the horizon keeps an automatic card even while idle; older roots leave the canvas for quiet history and «All conversations». Live or running conversations and manually placed cards are never removed by the horizon. Inlined at build time (`NEXT_PUBLIC_*`). |
 | `LLV_HEADLESS_REAPER_THRESHOLD_MS` | Minimum age in milliseconds for the always-active leaked Codex/MCP safety reaper (default `7200000`, two hours; minimum accepted value `60000`). |
 | `LLV_DOCKER_NSENTER_SHIMS` | `1` makes the agent CLI resolver prefer the container's `/usr/local/bin` nsenter shims for host CLIs. Set automatically by the Docker image; leave unset on a host runtime. See [docs/docker.md](docs/docker.md). |
 

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -700,8 +700,8 @@ function ProjectDashboardView({
      the projection partitions each engine child into a promoted node or a
      folded tray row. The final group build consumes that single authority. */
   const baseGroups = useMemo(
-    () => buildBranchGroups(sceneFiles, project, { expandedConversationPaths: expandedConversations }),
-    [sceneFiles, project, expandedConversations],
+    () => buildBranchGroups(sceneFiles, project, { expandedConversationPaths: expandedConversations, now: nowSeconds }),
+    [sceneFiles, project, expandedConversations, nowSeconds],
   );
   const engineProjection = useMemo(() => {
     const hiddenPaths = new Set(prefs.hidden);
@@ -736,9 +736,10 @@ function ProjectDashboardView({
       ? buildBranchGroups(sceneFiles, project, {
         expandedConversationPaths: expandedConversations,
         enginePlacement: { promotedEnginePaths: engineProjection.promotedPaths, foldedEnginePaths: engineProjection.foldedPaths },
+        now: nowSeconds,
       })
       : baseGroups),
-    [sceneFiles, project, expandedConversations, engineProjection, baseGroups],
+    [sceneFiles, project, expandedConversations, engineProjection, baseGroups, nowSeconds],
   );
   const activeRoots = useMemo(() => new Set(groups.map((group) => group.key)), [groups]);
   const cards = useMemo(() => collapsedTrees(sceneFiles, project, activeRoots), [sceneFiles, project, activeRoots]);

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -16,6 +16,7 @@ import {
   projectDraftWorkingDirectory,
   residualItems,
   resolveProjectView,
+  schemeAgeHorizonSeconds,
   subtree,
 } from "./projectModel";
 
@@ -368,6 +369,118 @@ describe("buildBranchGroups", () => {
     expect(groups.map((group) => group.key)).toContain("/parent");
     const group = groups.find((candidate) => candidate.key === "/parent")!;
     expect(group.columns.map((column) => column.file.path)).toContain("/parent/attn");
+  });
+});
+
+describe("automatic placement age horizon", () => {
+  const HOUR = 3_600;
+  const NOW = 1_754_500_000;
+
+  test("an idle root active earlier today keeps an automatic card", () => {
+    const root = entry({ path: "/idle-today", activity: "idle", mtime: NOW - 2 * HOUR });
+    expect(buildBranchGroups([root], "demo", { now: NOW }).map((group) => group.key)).toEqual(["/idle-today"]);
+  });
+
+  test("a stalled root from yesterday keeps an automatic card", () => {
+    const root = entry({ path: "/stalled-yesterday", activity: "stalled", mtime: NOW - 13 * HOUR });
+    expect(buildBranchGroups([root], "demo", { now: NOW }).map((group) => group.key)).toEqual(["/stalled-yesterday"]);
+  });
+
+  test("a root beyond the horizon loses its automatic card yet stays in quiet history", () => {
+    const stale = entry({ path: "/stale", activity: "stalled", mtime: NOW - 120 * HOUR });
+    const fresh = entry({ path: "/fresh", activity: "idle", mtime: NOW - HOUR });
+    const files = [stale, fresh];
+    expect(buildBranchGroups(files, "demo", { now: NOW }).map((group) => group.key)).toEqual(["/fresh"]);
+    expect(quietHistoryRows(files, "demo").map((file) => file.path)).toContain("/stale");
+  });
+
+  test("a live or running conversation keeps its card whatever its age", () => {
+    const live = entry({ path: "/live-old", activity: "live", mtime: NOW - 400 * HOUR });
+    const running = entry({ path: "/running-old", activity: "idle", proc: "running", mtime: NOW - 400 * HOUR });
+    expect(buildBranchGroups([live, running], "demo", { now: NOW }).map((group) => group.key).sort())
+      .toEqual(["/live-old", "/running-old"]);
+  });
+
+  test("an explicitly expanded root beyond the horizon still renders", () => {
+    const stale = entry({ path: "/stale-expanded", activity: "idle", mtime: NOW - 200 * HOUR });
+    const groups = buildBranchGroups([stale], "demo", {
+      now: NOW,
+      expandedConversationPaths: new Set(["/stale-expanded"]),
+    });
+    expect(groups.map((group) => group.key)).toEqual(["/stale-expanded"]);
+  });
+
+  test("a recently active child keeps its stale root's card on the canvas", () => {
+    const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 200 * HOUR });
+    const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "idle", mtime: NOW - 13 * HOUR });
+    expect(buildBranchGroups([root, child], "demo", { now: NOW }).map((group) => group.key)).toEqual(["/old-root"]);
+  });
+
+  test("a cross-project segment follows the horizon once its child is quiet", () => {
+    const projectRoot = entry({ path: "/seg-root", project: "viewer", activity: "idle", mtime: NOW - HOUR });
+    const foreignParent = entry({
+      path: "/foreign",
+      project: "latand",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: "/seg-root",
+      activity: "idle",
+      mtime: NOW - 200 * HOUR,
+    });
+    const freshSegment = entry({
+      path: "/seg-fresh",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: "/foreign",
+      activity: "idle",
+      mtime: NOW - 13 * HOUR,
+    });
+    const staleSegment = entry({
+      path: "/seg-stale",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: "/foreign",
+      activity: "stalled",
+      mtime: NOW - 200 * HOUR,
+    });
+    const groups = buildBranchGroups([projectRoot, foreignParent, freshSegment, staleSegment], "viewer", { now: NOW });
+    expect(groups.map((group) => group.key).sort()).toEqual(["/seg-fresh", "/seg-root"]);
+  });
+
+  test("a narrowed horizon governs placement", () => {
+    const groups = buildBranchGroups([
+      entry({ path: "/two-hours", activity: "idle", mtime: NOW - 2 * HOUR }),
+      entry({ path: "/thirteen-hours", activity: "idle", mtime: NOW - 13 * HOUR }),
+    ], "demo", { now: NOW, ageHorizonSeconds: 6 * HOUR });
+    expect(groups.map((group) => group.key)).toEqual(["/two-hours"]);
+  });
+
+  test("without a clock (hydration) placement follows the activity rule unchanged", () => {
+    const idleOld = entry({ path: "/idle", activity: "idle", mtime: 1_000 });
+    const recent = entry({ path: "/recent", activity: "recent", mtime: 1_000 });
+    expect(buildBranchGroups([idleOld, recent], "demo").map((group) => group.key)).toEqual(["/recent"]);
+  });
+
+  test("the horizon reads its hours from the environment and falls back to two days", () => {
+    const previous = process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS;
+    try {
+      delete process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS;
+      expect(schemeAgeHorizonSeconds()).toBe(48 * HOUR);
+      process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS = "6";
+      expect(schemeAgeHorizonSeconds()).toBe(6 * HOUR);
+      process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS = "nonsense";
+      expect(schemeAgeHorizonSeconds()).toBe(48 * HOUR);
+      process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS = "0";
+      expect(schemeAgeHorizonSeconds()).toBe(48 * HOUR);
+    } finally {
+      if (previous === undefined) delete process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS;
+      else process.env.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS = previous;
+    }
   });
 });
 

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -16,6 +16,23 @@ export const OVERVIEW = "__overview__";
  */
 const tick5 = (t: number) => Math.floor(t / 300);
 
+/** Default age horizon for automatic card placement: a root conversation whose
+    last activity falls inside it keeps an automatic card even while idle; one
+    beyond it leaves the canvas for quiet history / «All conversations». */
+export const DEFAULT_SCHEME_AGE_HORIZON_HOURS = 48;
+
+/**
+ * Operator-tunable placement horizon. `NEXT_PUBLIC_*` is inlined into the
+ * client bundle by Next (the same style `workerCollapseIdleMs` uses), so the
+ * horizon can be retuned without touching this code; a missing or malformed
+ * value falls back to the two-day default.
+ */
+export function schemeAgeHorizonSeconds(): number {
+  const raw = typeof process !== "undefined" ? process.env?.NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS : undefined;
+  const hours = raw ? Number(raw) : Number.NaN;
+  return (Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_SCHEME_AGE_HORIZON_HOURS) * 3_600;
+}
+
 export function activityBand(file: FileEntry): ActivityBand {
   if (file.activity === "live") return 0;
   if (file.activity === "recent") return 1;
@@ -380,16 +397,26 @@ function assembleGroup(
  * they attach to their parent's column as collapsed rows; a parentless one
  * becomes a narrow stub group. Every other descendant of the tree — finished
  * subagents, quiet tasks, compaction-chain predecessor sessions — stays
- * visible as a collapsed chip in the group's `finished` stack. Recent root
- * conversations and recent child conversations (claude subagents, codex
- * job sessions) keep full columns too, because "done between user messages"
- * must not hide active work.
+ * visible as a collapsed chip in the group's `finished` stack. Root
+ * conversations with activity inside the placement age horizon (~48 h,
+ * `NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS`) keep automatic cards even while
+ * idle — the operator's conversation from earlier today belongs on the map —
+ * and roots whose whole tree aged past the horizon leave the canvas for quiet
+ * history. Recent child conversations (claude subagents, codex job sessions)
+ * keep full columns too, because "done between user messages" must not hide
+ * active work.
  */
 export interface BranchGroupOptions {
   /** Quiet conversations promoted into full scheme nodes. */
   expandedConversationPaths?: ReadonlySet<string>;
   /** Engine-native subagent placement from the S2 tray projection (#142). */
   enginePlacement?: EnginePlacement;
+  /** Wall clock in epoch seconds for the placement age horizon. `0` — the
+      server render and the hydration pass — applies no age judgment, so both
+      sides paint the plain activity rule and no hydration skew appears. */
+  now?: number;
+  /** Placement age horizon in seconds; defaults to the env-tunable value. */
+  ageHorizonSeconds?: number;
 }
 
 export function buildBranchGroups(files: FileEntry[], project: string, options: BranchGroupOptions = {}): BranchGroup[] {
@@ -398,20 +425,34 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
   const roots = new Map<string, FileEntry>();
   const orphanTasks = new Map<string, FileEntry>();
   const { expandedConversationPaths, enginePlacement } = options;
+  const now = options.now ?? 0;
+  const ageHorizon = options.ageHorizonSeconds ?? schemeAgeHorizonSeconds();
+  /* The automatic-placement age horizon. Without a clock (`now === 0`, the
+     server/hydration render) age is unknowable, so the test degrades to the
+     plain `recent` activity rule rather than inventing an age. The `recent`
+     clause stays alongside the clock so a sub-15-minute horizon override can
+     never out-tighten the activity the projection already calls recent. */
+  const recentlyActive = (file: FileEntry) =>
+    file.activity === "recent" || (now > 0 && now - file.mtime <= ageHorizon);
   for (const file of files) {
     if (projectKey(file) !== project) continue;
     /* A cross-project child starts an independently owned visual segment. Keep
        its root card after the child becomes quiet while the durable parent
-       pointer continues to support explicit cross-project navigation. */
+       pointer continues to support explicit cross-project navigation. The
+       horizon bounds this card like any other root's: once the segment's
+       activity ages out it leaves the canvas (a live or running one never
+       does), and only an explicit expansion below can still place it. */
     if (beginsProjectSegment(file, byPath)) {
-      roots.set(file.path, file);
-      continue;
+      if (now === 0 || file.activity === "live" || file.proc === "running" || recentlyActive(file)) {
+        roots.set(file.path, file);
+        continue;
+      }
     }
     const expanded = expandedConversationPaths?.has(file.path) === true;
     if (
       file.activity === "live" ||
       file.proc === "running" ||
-      (file.activity === "recent" && isChildConversation(file)) ||
+      (recentlyActive(file) && isChildConversation(file)) ||
       /* A promoted engine child (e.g. an idle child holding a pending question)
          must still open its parent's group so it can render as a full node. */
       enginePlacement?.promotedEnginePaths?.has(file.path) === true ||
@@ -422,7 +463,7 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
       else roots.set(root.path, root);
       continue;
     }
-    if (file.activity === "recent" && isConversation(file)) roots.set(file.path, file);
+    if (recentlyActive(file) && isConversation(file)) roots.set(file.path, file);
   }
   const groups = [...roots.values()].map((root) => assembleGroup(root, kids, expandedConversationPaths, enginePlacement));
   for (const task of orphanTasks.values()) {


### PR DESCRIPTION
## Problem

The identity fix in #942/#943 regrouped weeks of finished `pipeline-*` worker transcripts under their parent repo project; that project's `/api/files` map count went from 56 cards to 328, with 251 older than two days. At the same time the operator could see none of their own conversations from earlier today on the map: `buildBranchGroups` granted an automatic root card only to `activity === "recent"` (a ~15-minute window) or live/running conversations, so an idle conversation from this morning opened no group — and with no groups the canvas fell back to archive history, burying the map in old worker cards.

## Change

Automatic root placement now follows an **age horizon** (default 48 h, tunable via `NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS`, the same inlined-env style as `NEXT_PUBLIC_LLV_WORKER_COLLAPSE_MINUTES`), in both directions:

1. **Admit idle-but-recent.** A root conversation whose last activity is inside the horizon keeps an automatic card even while idle or stalled. The two acceptance conversations in the shuboku-flashcards project (idle, 0 h old; stalled, 13 h old) now open groups.
2. **Evict beyond the horizon.** Roots (including cross-project segment roots) whose whole tree aged past the horizon stop opening groups. They stay reachable in quiet history and «All conversations», and clicking one still works through the existing pin ride-along.

**Recency signal:** wall-clock age of `mtime` (last transcript append — the same signal the projection's activity verdict derives from), with tree recency honored: a recently active child keeps its stale root's card, mirroring the previous rule where a recent child opened its root's group. Turn state stays authoritative for the live/running override.

**Protections, all pinned by tests:**
- Live or `proc === "running"` conversations keep cards whatever their age.
- Expanded/promoted placements (and manual cards, which render on the independent `manualNodes`/`schemeManual` surface this change never touches) are outside the horizon's authority.
- Without a clock (`now === 0`, the server render and hydration pass) placement follows the plain activity rule, per the existing no-hydration-skew convention.
- The 10x80 scheme window (`schemeWindow.ts`) is untouched.

**Sibling gates checked as instructed:** the group-opening child test widens to the horizon (tree recency keeps a root's card); `columnWorthy`'s `recent` clause is left alone — it governs column promotion and quiet classification, and widening it would flood every open group with two days of worker columns, the opposite of the ask.

## Expected effect on the flooded project

With 328 cards of which 251 are older than two days, the default 48 h horizon leaves **at most 77 automatic cards** (plus any live/running or manually placed survivors, which are already within those bounds).

## Verification

- RED-first: the six age-horizon behavior tests failed against the unmodified model (6 fail / 43 pass), then went green after the change — 50/50 in `projectModel.test.ts`.
- Focused suites for every touched file (`projectModel.test.ts`, dashboard selection dom test, scheme composition/minimap/pipeline-region tests): 86 pass / 0 fail, run by path with HOME, XDG_CONFIG_HOME, LLV_STATE_DIR and TMPDIR pointed at a temp dir.
- `tsc --noEmit`, scoped eslint on the three touched source/test files, production `next build`, and the privacy publication gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)