### PR TITLE
perf(deploy): persist the Next compiler cache across image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 RUN npm install -g bun@1.3.3
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN env -u __NEXT_PRIVATE_STANDALONE_CONFIG \
+# The compiler cache lives in a BuildKit cache mount: it survives between
+# image builds (a fresh `COPY . .` layer otherwise discards it), so an
+# incremental diff recompiles incrementally, and it never bloats the image.
+# Deploys serialize at the runtime host, so no two builds share it at once.
+RUN --mount=type=cache,target=/app/.next/cache \
+    env -u __NEXT_PRIVATE_STANDALONE_CONFIG \
         -u __NEXT_PRIVATE_PREBUNDLED_REACT \
         -u __NEXT_PRIVATE_BUILD_WORKER \
         bun run build


### PR DESCRIPTION
Merge-to-image today measured 6-8 minutes per deploy, dominated by `next build` recompiling from zero: the build stage's fresh `COPY . .` layer always starts with an empty `.next/cache`.

A BuildKit cache mount on `/app/.next/cache` keeps the webpack compiler cache between image builds, so a small diff compiles incrementally. The mount is never part of the image (no size change), and deploys serialize at the runtime host, so the cache never has concurrent writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)