### PR TITLE
fix(scheme): a settled child conversation rests as a chip, not a full column

### DIFF
--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -359,16 +359,19 @@ function assembleGroup(
      cannot leak through that foreign branch and appear twice. */
   const descendants = projectSubtree(root, kids);
   const liveRank = (file: FileEntry) => (file.activity === "live" ? 0 : 1);
-  /* Every child conversation in an active group renders as a connected node
-     below its parent — a claude subagent, a codex child session, a reviewer
-     subtask is real tree structure, not a detached right-side chip. Live and
-     running non-conversation work keeps a column too. This mirrors the
-     structural rule buildArchiveBranchGroups already uses; the "opens an active
-     group" decision stays activity-based in buildBranchGroups, but once a group
-     is open its child conversations are always wired in as nodes. */
+  /* A child conversation is wired in as a connected node while the ROOT is
+     actively working (its quiet children are live-relevant context) or while
+     the child itself is worth a column: live, running, recent, promoted, or
+     explicitly expanded (columnWorthy). The previous unconditional child
+     column made every conveyor tree erupt — one settled root touched inside
+     the age horizon dragged its whole history of finished workers onto the
+     canvas as full nodes. Under a quiet root a settled child now rests as a
+     chip in the group's under-deck, one expand-click away, exactly like every
+     other finished technical item. */
+  const rootActive = root.activity === "live" || root.proc === "running";
   const branches = descendants
-    .filter((file) => !placement?.foldedEnginePaths?.has(file.path)
-      && (isChildConversation(file) || columnWorthy(file, expandedConversationPaths, placement)))
+    .filter((file) => (rootActive && isChildConversation(file) && !placement?.foldedEnginePaths?.has(file.path))
+      || columnWorthy(file, expandedConversationPaths, placement))
     .sort((a, b) => liveRank(a) - liveRank(b) || tick5(b.mtime) - tick5(a.mtime) || a.path.localeCompare(b.path));
   const liveTasks = descendants
     .filter((file) => isAuxTask(file) && file.activity === "live")
@@ -380,9 +383,9 @@ function assembleGroup(
     owner.tasks.push(task);
   }
   const taken = new Set([...columnByPath.keys(), ...liveTasks.map((task) => task.path)]);
-  /* Child conversations are all columns now; the leftovers are technical items
-     (bash tasks, codex job logs, compaction-chain predecessor sessions) that
-     stay as quiet chips in the group's under-deck. */
+  /* The leftovers — settled child conversations, bash tasks, codex job logs,
+     compaction-chain predecessor sessions — stay as quiet chips in the
+     group's under-deck. */
   const finished = descendants.filter((file) => !taken.has(file.path)).sort((a, b) => b.mtime - a.mtime);
   const returnable: FileEntry[] = [];
   const smt = Math.max(...columns.map((column) => column.file.mtime), ...liveTasks.map((task) => task.mtime));


### PR DESCRIPTION
The map wall (operator report, follow-up to #946): `assembleGroup` wired **every** child conversation of an open group in as a full node ("child conversations are all columns"). Pre-identity-fix this was invisible — conveyor workers lived in `pipeline-*` worktree projects outside the window. After #943 canonicalized identity, those workers now file under the repo project, so one settled root touched inside the 48h age horizon dragged its whole worker history onto the canvas as full nodes. Measured live: one root contributed **45 columns**; the project map rendered 168 scheme nodes.

A child conversation now earns a full column while the root is actively working (live/running — its quiet children are live-relevant context, preserving the existing promoted-subagent tests) or while the child itself is `columnWorthy` (live / running / recent / promoted / explicitly expanded). A settled child under a quiet root rests as a chip in the group's under-deck, one expand-click away.

Measured on the live board payload (`/api/files` of the flooded project): **76 columns → 24**, 53 under-deck chips, groups unchanged at 24.

Tests: projectModel suite 50/50 (two tests asserting live-root child promotion still pass); scheme suite matches the clean-main baseline (its 1-2 fails reproduce on `origin/main` and in suite-order isolation checks are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)