### PR TITLE
fix(board): a failed-delivery launch record never hides a real conversation

### DIFF
--- a/src/components/ProjectDashboard.launchClaim.dom.test.tsx
+++ b/src/components/ProjectDashboard.launchClaim.dom.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * A failed delivery must never hide a transcript that actually exists.
+ *
+ * A structured launch can fail its initial delivery (e.g. cancelled while the
+ * owning account migration stalled) while the agent still materializes a real
+ * conversation. When that terminal launch record rides on the SAME path that
+ * identifies the scanned transcript, the launch-history shelf used to claim
+ * the path off the scene: `sceneFiles` dropped the conversation, `claimedPaths`
+ * fenced it from the tray, and the archive fallback and worker stacks inherited
+ * the same hole — the operator's finished conversation vanished from the map,
+ * with only a "Launch history · 1" failure row left.
+ *
+ * This mounts the REAL ProjectDashboard with that exact shape and proves the
+ * conversation keeps its board card while the shelf still reports the failed
+ * delivery. A pathless `spawn:<launchId>` receipt keeps today's behavior: it is
+ * shelved and claimed, because it has no transcript to hide.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualConversationCatalogHooks = await import("@/hooks/useConversationCatalog");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useConversationCatalog", () => ({
+  useConversationCatalog: () => ({ items: [], nextCursor: null, total: 0, loading: false, error: false, loadMore: () => {}, retry: () => {} }),
+}));
+
+const { ProjectDashboard } = await import("@/components/ProjectDashboard");
+
+const dom = new Window({ url: "http://localhost/" });
+const G = globalThis as Record<string, unknown>;
+
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: (query: string) => ({
+    matches: false, media: String(query), onchange: null,
+    addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; },
+  }),
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  fetch: (async (input: string | URL | Request) => {
+    const url = String(input);
+    const body = url.startsWith("/api/conversations") ? { items: [], nextCursor: null } : {};
+    return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+  }) as unknown as typeof fetch,
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+  (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+  (dom as unknown as { matchMedia: unknown }).matchMedia = OVERRIDES.matchMedia;
+});
+afterAll(async () => {
+  for (let index = 0; index < 8; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useConversationCatalog", () => actualConversationCatalogHooks);
+});
+
+let roots: Root[] = [];
+let projectCounter = 0;
+let PROJECT = "launch-claim-0";
+beforeEach(() => {
+  roots = [];
+  projectCounter += 1;
+  PROJECT = `launch-claim-${projectCounter}`;
+  dom.document.body.replaceChildren();
+});
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  dom.document.body.replaceChildren();
+});
+
+const settle = async () => {
+  for (let index = 0; index < 6; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+const waitFor = async (predicate: () => boolean, timeoutMs = 4000): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  }
+  return predicate();
+};
+
+/* One hour old: past the 15-minute launch-history horizon, inside the ~48 h
+   automatic-placement age horizon — the exact incident window. */
+const AGE_SECONDS = 3_600;
+
+const failedDelivery = (launchId: string): StructuredSpawnCardState => ({
+  launchId,
+  clientAttemptId: null,
+  accountId: null,
+  conversationId: `conversation-${launchId}`,
+  state: "failed",
+  initialMessage: "failed",
+  retrySafe: true,
+  error: "delivery cancelled because its owning account migration made no progress",
+});
+
+function conversationWithFailedLaunchRecord(path: string): FileEntry {
+  return {
+    path,
+    root: "claude-projects",
+    name: "conversation-claim.jsonl",
+    project: PROJECT,
+    title: "Finished conversation",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: Date.now() / 1000 - AGE_SECONDS,
+    size: 2048,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: "conversation-launch-claim-1",
+    spawn: failedDelivery("launch-claim-1"),
+  };
+}
+
+function pathlessReceipt(launchId: string): FileEntry {
+  return {
+    ...conversationWithFailedLaunchRecord(`spawn:${launchId}`),
+    name: `spawn:${launchId}`,
+    title: "Claude",
+    size: 0,
+    conversationId: `conversation-${launchId}`,
+    spawn: failedDelivery(launchId),
+  };
+}
+
+function mount(files: FileEntry[]): HTMLElement {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() =>
+    root.render(
+      <ProjectDashboard
+        files={files}
+        flows={[]}
+        pipelines={[]}
+        workflows={[]}
+        tasks={[]}
+        project={PROJECT}
+        loaded
+        openNonce={0}
+        archived={false}
+        catalogKnown
+        catalogConversationCount={files.length}
+        onArchive={() => {}}
+        onUnarchive={() => {}}
+      />,
+    ),
+  );
+  roots.push(root);
+  return host as unknown as HTMLElement;
+}
+
+test("a failed-delivery launch record on a scanned transcript path never hides the conversation", async () => {
+  const path = "/claude-projects/repo-fixture/conversation-claim.jsonl";
+  const host = mount([conversationWithFailedLaunchRecord(path)]);
+
+  /* The conversation is real board content: it must keep its scheme card. */
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${path}"]`) !== null)).toBe(true);
+
+  /* The failed delivery stays visible: the shelf still lists the record. */
+  await settle();
+  expect(host.querySelector('[data-testid="launch-history"]')).not.toBeNull();
+});
+
+test("a pathless terminal receipt is still shelved and never becomes a board card", async () => {
+  const host = mount([pathlessReceipt("launch-claim-2")]);
+  await settle();
+
+  expect(host.querySelector('[data-scheme-node="spawn:launch-claim-2"]')).toBeNull();
+  expect(host.querySelector('[data-testid="launch-history"]')).not.toBeNull();
+});

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -37,7 +37,7 @@ import type { SubagentTrayApi } from "./scheme/SubagentTrayView";
 import { conversationIdentity, formatConversationHash } from "@/lib/accounts/identity";
 import { recordFocusNavigation } from "@/lib/navigation/focusHistory";
 import { collapsibleWorkerFiles, groupWorkerStacks, pipelineOriginOf, pipelineStagePipelineIds, protectedReviewerNodes } from "./scheme/workerCollapse";
-import { launchHistoryFor, pipelineRetryTarget, retryPipelineLaunch } from "./launchHistoryModel";
+import { launchHistoryClaimPaths, launchHistoryFor, pipelineRetryTarget, retryPipelineLaunch } from "./launchHistoryModel";
 import { LaunchHistory } from "./LaunchHistory";
 import { isPlacedTask } from "./scheme/taskGeometry";
 import { loadExpandedTasks, partitionTaskStacks, persistExpandedTasks } from "./scheme/taskStacks";
@@ -677,11 +677,14 @@ function ProjectDashboardView({
     [filesByPath],
   );
   /* Terminal spawn receipts past the recent horizon (compact launch history):
-     they leave the board layout and minimap entirely and render in the
-     launch-history strip instead — a pathless receipt has no transcript to
-     mount as a pane. */
+     a pathless `spawn:` receipt has no transcript to mount as a pane, so it
+     leaves the board layout and minimap entirely and renders in the
+     launch-history strip instead. The strip lists every terminal record, but
+     only placeholder paths are CLAIMED off the scene: a failed launch whose
+     record rides on a real scanned transcript path must never hide that
+     conversation — the shelf row stays, the card renders. */
   const launchHistory = useMemo(() => launchHistoryFor(files, project, nowMs), [files, project, nowMs]);
-  const launchHistoryPaths = useMemo(() => new Set(launchHistory.map((file) => file.path)), [launchHistory]);
+  const launchHistoryPaths = useMemo(() => launchHistoryClaimPaths(launchHistory), [launchHistory]);
   /* The board layout's file set with collapsed workers removed. Kept separate
      from `groupFiles` so board-membership reconciliation still sees the full
      catalog and never retires a collapsed worker's durable placement. */

--- a/src/components/launchHistoryModel.test.ts
+++ b/src/components/launchHistoryModel.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
 
-import { isHistoricalLaunchReceipt, LAUNCH_HISTORY_HORIZON_MS, launchHistoryFor, pipelineRetryTarget, retryPipelineLaunch } from "./launchHistoryModel";
+import { isHistoricalLaunchReceipt, LAUNCH_HISTORY_HORIZON_MS, launchHistoryClaimPaths, launchHistoryFor, pipelineRetryTarget, retryPipelineLaunch } from "./launchHistoryModel";
 
 const NOW = Date.parse("2026-07-17T12:00:00.000Z");
 
@@ -71,6 +71,17 @@ test("launchHistoryFor scopes to the project and orders freshest first", () => {
   ];
   const rows = launchHistoryFor(files, "-agents-tools-live-log-viewer-next", NOW);
   expect(rows.map((row) => row.spawn!.launchId)).toEqual(["bbbb", "aaaa"]);
+});
+
+test("only pathless spawn placeholders are claimed off the scene", () => {
+  const rows = [
+    receipt(3_600_000, {}, { launchId: "eeee" }),
+    /* A failed delivery whose record rides on a real scanned transcript path:
+       it stays a shelf row, but claiming the path would hide the conversation. */
+    receipt(3_600_000, { path: "/claude-projects/repo-fixture/conversation.jsonl" }, { launchId: "ffff" }),
+  ];
+  expect(launchHistoryFor(rows, "-agents-tools-live-log-viewer-next", NOW)).toHaveLength(2);
+  expect(launchHistoryClaimPaths(rows)).toEqual(new Set(["spawn:eeee"]));
 });
 
 test("issue 533: a pipeline-owned failed launch retries its durable stage", () => {

--- a/src/components/launchHistoryModel.ts
+++ b/src/components/launchHistoryModel.ts
@@ -15,8 +15,13 @@ import { projectKey } from "@/components/projectModel";
  * available when the history group is expanded.
  *
  * Receipts whose artifact transcript IS scanned never become synthetic cards
- * at all (spawnProjection suppresses them), so every history row here is a
- * pathless terminal receipt by construction.
+ * at all (spawnProjection suppresses them), so a history row is normally a
+ * pathless terminal receipt. That suppression is not a guarantee this module
+ * may lean on: a terminal launch record can surface on an entry whose path IS
+ * a real scanned transcript (the launch failed its delivery but the
+ * conversation materialized anyway). Such a row may still appear on the shelf,
+ * but it must never CLAIM its path off the scene — that would erase a live
+ * conversation from the board ({@link launchHistoryClaimPaths}).
  */
 
 /** Mirror of spawnProjection's TERMINAL_SPAWN_RECENT_MS (a server-only module
@@ -47,6 +52,25 @@ export function launchHistoryFor(files: readonly FileEntry[], project: string, n
   return files
     .filter((file) => projectKey(file) === project && isHistoricalLaunchReceipt(file, nowMs))
     .sort((a, b) => b.mtime - a.mtime);
+}
+
+/** Mirror of spawnProjection's `isSpawnPlaceholderPath` (a server-only module
+    this client bundle cannot import): the projected placeholder path of a
+    launch that has no transcript. */
+export function isLaunchPlaceholderPath(pathname: string): boolean {
+  return pathname.startsWith("spawn:");
+}
+
+/** The paths launch history CLAIMS off the board scene. Only the pathless
+    `spawn:<launchId>` placeholder qualifies — it has no transcript to mount, so
+    shelving it hides nothing. A terminal launch record keyed on a real scanned
+    transcript path is delivery evidence ON a live conversation: it keeps its
+    shelf row (the failure stays visible and retryable), but claiming the path
+    would erase the conversation itself from the canvas. */
+export function launchHistoryClaimPaths(rows: readonly FileEntry[]): Set<string> {
+  const claims = new Set<string>();
+  for (const row of rows) if (isLaunchPlaceholderPath(row.path)) claims.add(row.path);
+  return claims;
 }
 
 /** Routes retry back through the owning pipeline, whose durable attempt keeps


### PR DESCRIPTION
## Problem

Operator-blocking P1: a finished, ~1-hour-old conversation with a real transcript on disk did not render on the project map. `buildBranchGroups` run directly against the live payload opened a group for it, but the board showed only **"Launch history · 1"** with *"Claude failed — delivery cancelled because its owning account migration made no progress for 300000ms"*.

## Mechanism

`launchHistoryFor` (`src/components/launchHistoryModel.ts`) returns every project file whose `spawn.state` is `failed`/`recovered` and whose `mtime` is older than the 15-minute horizon. Its doc comment claimed "every history row here is a pathless terminal receipt by construction" — but nothing enforced that. When a terminal launch record rides on an entry whose path **is** a real scanned transcript (the launch failed its initial delivery during a stalled account migration, yet the agent materialized a real conversation), the record qualified as a history row.

`ProjectDashboard` then turned every history row's path into a claim: `sceneFiles` filtered the path out of the board layout, `claimedPaths` fenced it from the subagent tray (`scheme/subagentTray.ts`), and the archive fallback and worker-stack derivations repeated the same exclusion. The claim was keyed on a path that also identified the live transcript, so the failed delivery erased the real conversation from the canvas.

On canonicalisation: the claim here hits by plain path identity on a single merged entry — the record and the transcript share one path — so the pre/post-#943 spelling divergence is not what makes this claim hit. Spelling mismatches sit on the other side of the incident (why the record was never retired once the conversation materialized in the projection); that retirement path belongs to the queued reviewer-canonicalisation lane and is untouched here.

## Fix

One derivation point, `launchHistoryClaimPaths`: only a pathless `spawn:<launchId>` placeholder — which has no transcript to mount — can be claimed off the scene. `ProjectDashboard` consumes it where `launchHistoryPaths` is built, so `sceneFiles`, `claimedPaths`, the archive fallback, and the worker stacks all inherit the rule with no per-site patches.

The shelf row deliberately stays visible for a record on a real transcript path: the failed initial delivery is real operational news (the transcript can exist with the launch prompt never delivered), and the row keeps the retry affordance for pipeline-owned launches. Only the *claim* is withheld — the conversation renders regardless.

## Tests (RED-first)

- `ProjectDashboard.launchClaim.dom.test.tsx` mounts the **real** `ProjectDashboard` with the incident shape: one scanned idle conversation (1 h old) carrying a failed-delivery launch record on its own path. Asserts the scheme card renders and the launch-history strip is present. Confirmed RED before the dashboard change (the fix was staged as new, unused exports first, so no source stashing was needed): the card was absent while the shelf showed the failure. A control case proves a pathless `spawn:` receipt is still shelved and never becomes a board card.
- `launchHistoryModel.test.ts`: a real-path terminal record stays a shelf row via `launchHistoryFor` but is excluded from `launchHistoryClaimPaths`; placeholder rows remain claimable.

## Verification

- `bun test src/components/ProjectDashboard.launchClaim.dom.test.tsx src/components/launchHistoryModel.test.ts` — 10 pass (isolated HOME/XDG_CONFIG_HOME/LLV_STATE_DIR/TMPDIR)
- `bun test` on the five pre-existing ProjectDashboard test files — 22 pass
- `tsc --noEmit` clean, scoped `eslint` clean, `bun run build` (production) passes
- `bun scripts/privacy-publication-gate.ts --base 1aeb3942` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)