### PR TITLE
fix(files): an explicit path pin answers with the record, whatever the window published

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { NextResponse } from "next/server";
 
 import { listFilesWithProjectCatalog, pinnedPathsFor } from "@/lib/scanner";
+import { pinnedIdentityEntries } from "@/lib/scanner/pinRideAlong";
 import { agentRegistry, readOnlyConversationLookupFromSnapshot, supersedenceChainTail } from "@/lib/agent/registry";
 import { projectLaunchConversations } from "@/lib/agent/spawnProjection";
 import { conversationCatalogSnapshot } from "@/lib/scanner/conversationCatalog";
@@ -258,6 +259,18 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     const launch = launchProjection.facts.get(file.path);
     if (launch) file.launch = launch;
   }
+  /* Ride-along identity for an explicit pin (issue #950). The scheme window is
+     a board budget, so a conversation outside it — an older project, whatever
+     the transcript's size — has no scanned row, and the «All conversations»
+     click that asked for it BY PATH would find no card and report nothing. The
+     pin sheds payload detail, never identity: these rows carry path, project,
+     title, engine and activity, and the conversation id is attached with every
+     other row's below. The pinned scan still runs and replaces them. */
+  for (const entry of pinnedIdentityEntries(visibilityPinnedPaths, new Set(files.map((file) => file.path)))) {
+    files.push(entry);
+    responsePinOverlayPaths.add(entry.path);
+  }
+  traceStep("pin-ride-along");
   const conversationLookup = readOnlyConversationLookupFromSnapshot(registrySnapshot);
   traceStep("conversation-lookup");
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -249,6 +249,23 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   const registry = agentRegistry();
   const registrySnapshot = registry.readOnlySnapshot();
   traceStep("registry-snapshot");
+  /* Ride-along identity for an explicit pin (#950). The scheme window is
+     a board budget, so a conversation outside it — an older project, whatever
+     the transcript's size — has no scanned row, and the «All conversations»
+     click that asked for it BY PATH would find no card and report nothing. The
+     pin sheds payload detail, never identity: these rows carry path, project,
+     title, engine and activity, and the conversation id is attached with every
+     other row's below. The pinned scan still runs and replaces them.
+
+     This runs BEFORE the launch read-model below, so a pinned conversation
+     that also carries a launch receipt is a materialized row by the time the
+     projection asks: the launch folds into it as chips, exactly as it would
+     for a scanned row, instead of projecting a second `spawn:` card beside it. */
+  for (const entry of pinnedIdentityEntries(visibilityPinnedPaths, new Set(files.map((file) => file.path)))) {
+    files.push(entry);
+    responsePinOverlayPaths.add(entry.path);
+  }
+  traceStep("pin-ride-along");
   /* One launch read-model (issue #569): a launch either projects the
      conversation window itself (nothing materialized yet) or folds into the
      live conversation as transient chips — never both. */
@@ -259,18 +276,6 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     const launch = launchProjection.facts.get(file.path);
     if (launch) file.launch = launch;
   }
-  /* Ride-along identity for an explicit pin (#950). The scheme window is
-     a board budget, so a conversation outside it — an older project, whatever
-     the transcript's size — has no scanned row, and the «All conversations»
-     click that asked for it BY PATH would find no card and report nothing. The
-     pin sheds payload detail, never identity: these rows carry path, project,
-     title, engine and activity, and the conversation id is attached with every
-     other row's below. The pinned scan still runs and replaces them. */
-  for (const entry of pinnedIdentityEntries(visibilityPinnedPaths, new Set(files.map((file) => file.path)))) {
-    files.push(entry);
-    responsePinOverlayPaths.add(entry.path);
-  }
-  traceStep("pin-ride-along");
   const conversationLookup = readOnlyConversationLookupFromSnapshot(registrySnapshot);
   traceStep("conversation-lookup");
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -259,7 +259,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     const launch = launchProjection.facts.get(file.path);
     if (launch) file.launch = launch;
   }
-  /* Ride-along identity for an explicit pin (issue #950). The scheme window is
+  /* Ride-along identity for an explicit pin (#950). The scheme window is
      a board budget, so a conversation outside it — an older project, whatever
      the transcript's size — has no scanned row, and the «All conversations»
      click that asked for it BY PATH would find no card and report nothing. The

--- a/src/app/api/files/route.pin.rideAlong.test.ts
+++ b/src/app/api/files/route.pin.rideAlong.test.ts
@@ -24,14 +24,24 @@ const previous = {
   codex: process.env.LLV_CODEX_HOME,
   claude: process.env.LLV_CLAUDE_HOME,
   tmp: process.env.TMPDIR,
+  home: process.env.HOME,
 };
 process.env.LLV_STATE_DIR = path.join(sandbox, "state");
 process.env.LLV_CODEX_HOME = path.join(sandbox, "codex");
 process.env.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
 process.env.TMPDIR = fs.mkdtempSync(path.join(sandbox, "tmp-"));
+/* The Claude background-task root is the one root no LLV_* variable redirects:
+   `claudeTasksRoot()` takes `<tmpdir>/claude-<uid>` only when it EXISTS and
+   otherwise falls back to the literal `/tmp/claude-<uid>`, which on a real
+   machine is the operator's own live task tree. Creating it inside the
+   redirected TMPDIR — and pinning HOME, which `ROOTS` reads at import — keeps
+   the corpus this file declares the only corpus it scans. */
+process.env.HOME = fs.mkdtempSync(path.join(sandbox, "home-"));
+fs.mkdirSync(path.join(process.env.TMPDIR, `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
 
 const { GET } = await import("./route");
 const { DEFAULT_SCHEME_PROJECT_CAP } = await import("@/lib/scanner/schemeWindow");
+const { agentRegistry } = await import("@/lib/agent/registry");
 
 const day = path.join(process.env.LLV_CODEX_HOME, "sessions", "2026", "07", "16");
 fs.mkdirSync(day, { recursive: true });
@@ -67,7 +77,7 @@ for (let index = 0; index < DEFAULT_SCHEME_PROJECT_CAP + 2; index += 1) {
 rollout("recent", "/repo/recent", 5_600_000, 0.001);
 
 afterAll(() => {
-  for (const [key, value] of [["LLV_STATE_DIR", previous.state], ["LLV_CODEX_HOME", previous.codex], ["LLV_CLAUDE_HOME", previous.claude], ["TMPDIR", previous.tmp]] as const) {
+  for (const [key, value] of [["LLV_STATE_DIR", previous.state], ["LLV_CODEX_HOME", previous.codex], ["LLV_CLAUDE_HOME", previous.claude], ["TMPDIR", previous.tmp], ["HOME", previous.home]] as const) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
@@ -98,6 +108,36 @@ test("an explicit ?path= pin answers with the record on the first request, whate
   expect(pinned!.size).toBe(fs.statSync(target).size);
   expect(pinned!.activity).toBeTruthy();
   expect(pinned!.engine).toBe("codex");
+});
+
+test("the unpinned baseline carries the generated corpus and nothing of the host", async () => {
+  const published = await files();
+  expect(published.length).toBeGreaterThan(0);
+  for (const file of published) {
+    expect(file.root).toBe("codex-sessions");
+    expect(path.dirname(file.path)).toBe(day);
+  }
+});
+
+test("a pinned conversation with a launch receipt folds it into one card", async () => {
+  const published = new Set((await files()).map((file) => file.path));
+  const target = corpus.filter((pathname) => !published.has(pathname)).at(-1)!;
+  /* The launch read-model folds into a MATERIALIZED row and projects its own
+     `spawn:` card only when none is present. A ride-along row that arrives
+     after that decision leaves the operator with two cards for one
+     conversation — the pinned row without its chips, and a spawn placeholder. */
+  agentRegistry().beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo/project-11",
+    transport: "structured",
+    expectedArtifactPath: target,
+    launchProfile: { cwd: "/repo/project-11" },
+  });
+
+  const rows = await files(target);
+
+  expect(rows.find((file) => file.path === target)?.launch).toBeDefined();
+  expect(rows.filter((file) => file.path.startsWith("spawn:"))).toEqual([]);
 });
 
 test("the oversized elided transcript rides along by identity, not by being small enough to read", async () => {

--- a/src/app/api/files/route.pin.rideAlong.test.ts
+++ b/src/app/api/files/route.pin.rideAlong.test.ts
@@ -11,7 +11,7 @@ import type { FileEntry } from "@/lib/types";
  * the scheme cap publishes the newest projects only — so most catalog rows have
  * no scan entry, and the pin is the ONLY thing that puts the record in the
  * payload. When the pin answers with the unpinned corpus, the click produces no
- * card and no feedback at all (issue #950).
+ * card and no feedback at all (#950).
  *
  * The fixture is generated, never copied from a real session: a synthetic Codex
  * corpus with more projects than the scheme project cap, whose oldest projects

--- a/src/app/api/files/route.pin.rideAlong.test.ts
+++ b/src/app/api/files/route.pin.rideAlong.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * Clicking a row in «All conversations» runs `board.restore(path)`, which asks
+ * `/api/files?path=<pin>` for that one record. The board is a bounded window —
+ * the scheme cap publishes the newest projects only — so most catalog rows have
+ * no scan entry, and the pin is the ONLY thing that puts the record in the
+ * payload. When the pin answers with the unpinned corpus, the click produces no
+ * card and no feedback at all (issue #950).
+ *
+ * The fixture is generated, never copied from a real session: a synthetic Codex
+ * corpus with more projects than the scheme project cap, whose oldest projects
+ * hold oversized transcripts.
+ */
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pin-ride-along-"));
+const previous = {
+  state: process.env.LLV_STATE_DIR,
+  codex: process.env.LLV_CODEX_HOME,
+  claude: process.env.LLV_CLAUDE_HOME,
+  tmp: process.env.TMPDIR,
+};
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.LLV_CODEX_HOME = path.join(sandbox, "codex");
+process.env.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+process.env.TMPDIR = fs.mkdtempSync(path.join(sandbox, "tmp-"));
+
+const { GET } = await import("./route");
+const { DEFAULT_SCHEME_PROJECT_CAP } = await import("@/lib/scanner/schemeWindow");
+
+const day = path.join(process.env.LLV_CODEX_HOME, "sessions", "2026", "07", "16");
+fs.mkdirSync(day, { recursive: true });
+
+/** A synthetic Codex rollout of the requested size, aged the requested days. */
+function rollout(name: string, cwd: string, bytes: number, ageDays: number): string {
+  const pathname = path.join(day, `rollout-${name}.jsonl`);
+  const head = [
+    JSON.stringify({ type: "session_meta", payload: { id: name, cwd, timestamp: "2026-07-16T00:00:00.000Z" } }),
+    JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: `title ${name}` }] } }),
+  ].join("\n") + "\n";
+  const filler = JSON.stringify({
+    type: "response_item",
+    payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "x".repeat(900) }] },
+  }) + "\n";
+  let body = head;
+  while (Buffer.byteLength(body) < bytes) body += filler;
+  fs.writeFileSync(pathname, body);
+  const when = new Date(Date.now() - ageDays * 86_400_000);
+  fs.utimesSync(pathname, when, when);
+  return pathname;
+}
+
+/* One project per rollout, two more than the scheme project cap, oldest last:
+   the tail projects fall outside the published window. */
+const corpus: string[] = [];
+for (let index = 0; index < DEFAULT_SCHEME_PROJECT_CAP + 2; index += 1) {
+  const slug = String(index).padStart(2, "0");
+  corpus.push(rollout(`session-${slug}`, `/repo/project-${slug}`, index % 2 === 0 ? 700_000 : 200_000, 21 + index / 100));
+}
+/* Larger than every dropped transcript and newer than all of them: size never
+   decides membership, recency does. */
+rollout("recent", "/repo/recent", 5_600_000, 0.001);
+
+afterAll(() => {
+  for (const [key, value] of [["LLV_STATE_DIR", previous.state], ["LLV_CODEX_HOME", previous.codex], ["LLV_CLAUDE_HOME", previous.claude], ["TMPDIR", previous.tmp]] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+async function files(pin?: string): Promise<FileEntry[]> {
+  const url = "http://127.0.0.1/api/files" + (pin ? `?path=${encodeURIComponent(pin)}` : "");
+  const response = await GET(new Request(url, { headers: { host: "127.0.0.1" } }));
+  expect(response.status).toBe(200);
+  return ((await response.json()) as { files: FileEntry[] }).files;
+}
+
+test("an explicit ?path= pin answers with the record on the first request, whatever the window published", async () => {
+  const published = new Set((await files()).map((file) => file.path));
+  const elided = corpus.filter((pathname) => !published.has(pathname));
+  /* The window really does shed whole projects — otherwise this test proves
+     nothing about the pin. */
+  expect(elided.length).toBeGreaterThan(0);
+
+  const target = elided[0]!;
+  const pinned = (await files(target)).find((file) => file.path === target);
+
+  /* Identity, not payload detail: enough to create the card and click it. */
+  expect(pinned).toBeDefined();
+  expect(pinned!.project).toBeTruthy();
+  expect(pinned!.project).not.toBe("other");
+  expect(pinned!.size).toBe(fs.statSync(target).size);
+  expect(pinned!.activity).toBeTruthy();
+  expect(pinned!.engine).toBe("codex");
+});
+
+test("the oversized elided transcript rides along by identity, not by being small enough to read", async () => {
+  const published = new Set((await files()).map((file) => file.path));
+  const oversized = corpus.find((pathname) => !published.has(pathname) && fs.statSync(pathname).size > 512 * 1024);
+  expect(oversized).toBeDefined();
+
+  const pinned = (await files(oversized!)).find((file) => file.path === oversized);
+  expect(pinned).toBeDefined();
+  expect(pinned!.title).toBeTruthy();
+});

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -671,7 +671,7 @@ test("runtime callbacks advance while a large lineage projection is linking", as
 /* The chain-head window bounds how many bytes of a successor are read looking
    for its compact_boundary marker. A transcript whose head outgrew that window
    must degrade to «parent unknown» — it must never lose its entry, because the
-   entry is the conversation's only route onto the board (issue #950). */
+   entry is the conversation's only route onto the board (#950). */
 test("a compact marker beyond the chain-head window leaves the parent unknown, never the conversation absent", async () => {
   const slug = "-repo-chain-head-window";
   const predecessorPath = path.join(SANDBOX, "beyond-window-predecessor.jsonl");

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -667,3 +667,30 @@ test("runtime callbacks advance while a large lineage projection is linking", as
   expect(runtimeCallbackAdvanced).toBe(true);
   await callback;
 });
+
+/* The chain-head window bounds how many bytes of a successor are read looking
+   for its compact_boundary marker. A transcript whose head outgrew that window
+   must degrade to «parent unknown» — it must never lose its entry, because the
+   entry is the conversation's only route onto the board (issue #950). */
+test("a compact marker beyond the chain-head window leaves the parent unknown, never the conversation absent", async () => {
+  const slug = "-repo-chain-head-window";
+  const predecessorPath = path.join(SANDBOX, "beyond-window-predecessor.jsonl");
+  const successorPath = path.join(SANDBOX, "beyond-window-successor.jsonl");
+  const logicalParentUuid = "99999999-8888-0777-0666-555555555555";
+  fs.writeFileSync(predecessorPath, `${JSON.stringify({ type: "assistant", uuid: logicalParentUuid })}\n`);
+  /* CHAIN_HEAD_BYTES is 512 KiB; the marker sits a megabyte in. */
+  fs.writeFileSync(successorPath, Buffer.concat([
+    Buffer.from(`${JSON.stringify({ type: "user", uuid: "head" })}\n`),
+    Buffer.alloc(1024 * 1024, 0x20),
+    Buffer.from(`\n${JSON.stringify({ type: "system", subtype: "compact_boundary", logicalParentUuid })}\n`),
+  ]));
+  const predecessor = entry(predecessorPath, `${slug}/predecessor.jsonl`, 1);
+  const successor = entry(successorPath, `${slug}/successor.jsonl`, 2);
+  const entries = [predecessor, successor];
+
+  await linkEntries(entries, { persist: false });
+
+  expect(entries).toHaveLength(2);
+  expect(entries.map((item) => item.path)).toContain(successorPath);
+  expect(predecessor.parent).toBeNull();
+});

--- a/src/lib/scanner/pinRideAlong.test.ts
+++ b/src/lib/scanner/pinRideAlong.test.ts
@@ -34,6 +34,22 @@ fs.writeFileSync(empty, "");
 const foreign = path.join(sandbox, "outside-every-root.jsonl");
 fs.writeFileSync(foreign, `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo" } })}\n`);
 
+/** The same physical rollout addressed through a symlinked session tree — the
+    second absolute form a registry-recorded pin can carry (issue #942). */
+const aliasTree = path.join(sandbox, "codex-alias");
+fs.symlinkSync(path.join(process.env.LLV_CODEX_HOME, "sessions"), aliasTree);
+const aliased = path.join(aliasTree, "2026", "07", "16", "rollout-oversized.jsonl");
+
+/* Two directories discovery never descends into: any `.git*` tree, and the
+   `tool-results` blobs beside a Claude project's transcripts. */
+const claudeProject = path.join(process.env.LLV_CLAUDE_HOME, "projects", "-repo-p");
+fs.mkdirSync(path.join(claudeProject, "tool-results"), { recursive: true });
+const toolResult = path.join(claudeProject, "tool-results", "blob.jsonl");
+fs.writeFileSync(toolResult, `${JSON.stringify({ type: "user", message: { role: "user", content: "blob" } })}\n`);
+fs.mkdirSync(path.join(claudeProject, ".git", "objects"), { recursive: true });
+const gitBlob = path.join(claudeProject, ".git", "objects", "packed.jsonl");
+fs.writeFileSync(gitBlob, `${JSON.stringify({ type: "user", message: { role: "user", content: "packed" } })}\n`);
+
 afterAll(() => {
   for (const [key, value] of [["LLV_STATE_DIR", previous.state], ["LLV_CODEX_HOME", previous.codex], ["LLV_CLAUDE_HOME", previous.claude]] as const) {
     if (value === undefined) delete process.env[key];
@@ -68,4 +84,22 @@ test("the ride-along refuses what discovery itself refuses", () => {
   /* Empty transcripts and paths that are simply gone are not conversations. */
   expect(pinnedIdentityEntries([empty], new Set())).toEqual([]);
   expect(pinnedIdentityEntries([path.join(sessions, "rollout-deleted.jsonl")], new Set())).toEqual([]);
+  /* Directories the walk refuses whole: a pin must not turn a tool-result blob
+     or anything inside a `.git` tree into a clickable phantom card. */
+  expect(pinnedIdentityEntries([toolResult], new Set())).toEqual([]);
+  expect(pinnedIdentityEntries([gitBlob], new Set())).toEqual([]);
+});
+
+test("one physical transcript is one row, whichever path form the pin carries", () => {
+  /* The scan walked the real form; the pin names the symlinked one. Comparing
+     those raw yields a second card for the one conversation (issue #942). */
+  expect(pinnedIdentityEntries([aliased], new Set([oversized]))).toEqual([]);
+
+  const [row] = pinnedIdentityEntries([aliased], new Set());
+  expect(row).toBeDefined();
+  /* The form discovery itself would have published, so every downstream join
+     keys on the same path — and the name stays inside its own root. */
+  expect(row!.path).toBe(oversized);
+  expect(row!.name.split(path.sep)).not.toContain("..");
+  expect(pinnedIdentityEntries([aliased, oversized], new Set())).toHaveLength(1);
 });

--- a/src/lib/scanner/pinRideAlong.test.ts
+++ b/src/lib/scanner/pinRideAlong.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pin-ride-along-unit-"));
+const previous = {
+  state: process.env.LLV_STATE_DIR,
+  codex: process.env.LLV_CODEX_HOME,
+  claude: process.env.LLV_CLAUDE_HOME,
+};
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.LLV_CODEX_HOME = path.join(sandbox, "codex");
+process.env.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+
+const { pinnedIdentityEntries } = await import("./pinRideAlong");
+
+const sessions = path.join(process.env.LLV_CODEX_HOME, "sessions", "2026", "07", "16");
+fs.mkdirSync(sessions, { recursive: true });
+
+/** An oversized synthetic rollout — larger than every read window the scanner
+    applies, so nothing about it can be derived from a single head read alone. */
+const oversized = path.join(sessions, "rollout-oversized.jsonl");
+fs.writeFileSync(oversized, [
+  JSON.stringify({ type: "session_meta", payload: { id: "oversized", cwd: "/repo/quiet-project", timestamp: "2026-07-16T00:00:00.000Z" } }),
+  JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "the first prompt" }] } }),
+].join("\n") + "\n" + "x".repeat(2 * 1024 * 1024) + "\n");
+const aged = new Date(Date.now() - 21 * 86_400_000);
+fs.utimesSync(oversized, aged, aged);
+
+const empty = path.join(sessions, "rollout-empty.jsonl");
+fs.writeFileSync(empty, "");
+
+const foreign = path.join(sandbox, "outside-every-root.jsonl");
+fs.writeFileSync(foreign, `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo" } })}\n`);
+
+afterAll(() => {
+  for (const [key, value] of [["LLV_STATE_DIR", previous.state], ["LLV_CODEX_HOME", previous.codex], ["LLV_CLAUDE_HOME", previous.claude]] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("an oversized, weeks-old transcript still yields identity", () => {
+  const [row] = pinnedIdentityEntries([oversized], new Set());
+
+  expect(row).toBeDefined();
+  expect(row!.path).toBe(oversized);
+  expect(row!.engine).toBe("codex");
+  expect(row!.root).toBe("codex-sessions");
+  expect(row!.size).toBe(fs.statSync(oversized).size);
+  expect(row!.project).not.toBe("other");
+  expect(row!.title).toBeTruthy();
+  expect(row!.activity).toBe("idle");
+  expect(row!.parent).toBeNull();
+});
+
+test("a path already carried by the scan is never duplicated", () => {
+  expect(pinnedIdentityEntries([oversized], new Set([oversized]))).toEqual([]);
+  expect(pinnedIdentityEntries([oversized, oversized], new Set())).toHaveLength(1);
+});
+
+test("the ride-along refuses what discovery itself refuses", () => {
+  /* Outside every scan root — the same containment gate `pathAllowed` applies,
+     so a pin can never name an arbitrary file on the host. */
+  expect(pinnedIdentityEntries([foreign], new Set())).toEqual([]);
+  /* Empty transcripts and paths that are simply gone are not conversations. */
+  expect(pinnedIdentityEntries([empty], new Set())).toEqual([]);
+  expect(pinnedIdentityEntries([path.join(sessions, "rollout-deleted.jsonl")], new Set())).toEqual([]);
+});

--- a/src/lib/scanner/pinRideAlong.ts
+++ b/src/lib/scanner/pinRideAlong.ts
@@ -9,19 +9,31 @@ import { taskParts } from "./discover";
 import { projectResolutionStateKey } from "./projectState";
 import { EXTS, ROOTS, scanRootEntries } from "./roots";
 
+type ScanRoot = { rootName: RootKey; root: string; bases: string[] };
+
+/** Every scan root with the path forms it can be addressed by. An account home
+    that symlinks into the shared transcript store gives one root two absolute
+    forms, and a pin may name either. */
+function scanRoots(): ScanRoot[] {
+  return scanRootEntries().map(([rootName, root]) => ({
+    rootName,
+    root,
+    bases: [...new Set([root, realpath(root)].filter((value): value is string => value !== null))],
+  }));
+}
+
 /**
  * Which scan root owns a path, with its root key — the same containment gate
  * `pathAllowed` applies, so a pin can only ever name a transcript the scanner
  * itself would have walked. The longest matching root wins: account homes nest
  * inside one another, and the relative name must be taken from the innermost.
  */
-function rootFor(pathname: string): [RootKey, string] | null {
-  let match: [RootKey, string] | null = null;
-  const candidates = [pathname, realpath(pathname)].filter((value): value is string => value !== null);
-  for (const [rootName, root] of scanRootEntries()) {
-    const roots = [root, realpath(root)].filter((value): value is string => value !== null);
-    const contained = roots.some((base) => candidates.some((candidate) => candidate.startsWith(base + path.sep)));
-    if (contained && (match === null || root.length > match[1].length)) match = [rootName, root];
+function rootFor(pathname: string, roots: readonly ScanRoot[]): ScanRoot | null {
+  let match: ScanRoot | null = null;
+  const candidates = [...new Set([pathname, realpath(pathname)].filter((value): value is string => value !== null))];
+  for (const scanRoot of roots) {
+    const contained = scanRoot.bases.some((base) => candidates.some((candidate) => candidate.startsWith(base + path.sep)));
+    if (contained && (match === null || scanRoot.root.length > match.root.length)) match = scanRoot;
   }
   return match;
 }
@@ -70,13 +82,16 @@ export function pinnedIdentityEntries(
   pinnedPaths: Iterable<string>,
   knownPaths: ReadonlySet<string>,
 ): FileEntry[] {
+  const missing = [...pinnedPaths].filter((pathname) => !knownPaths.has(pathname));
+  if (!missing.length) return [];
+  const roots = scanRoots();
   const stateKey = projectResolutionStateKey();
   const entries: FileEntry[] = [];
   const seen = new Set<string>();
-  for (const pathname of pinnedPaths) {
-    if (knownPaths.has(pathname) || seen.has(pathname)) continue;
+  for (const pathname of missing) {
+    if (seen.has(pathname)) continue;
     seen.add(pathname);
-    const owner = rootFor(pathname);
+    const owner = rootFor(pathname, roots);
     if (!owner) continue;
     let st: fs.Stats;
     try {
@@ -84,7 +99,7 @@ export function pinnedIdentityEntries(
     } catch {
       continue;
     }
-    const [rootName, root] = owner;
+    const { rootName, root } = owner;
     if (!discoverable(rootName, pathname, st)) continue;
     const meta = describe(rootName, root, pathname, st, stateKey);
     const mtime = st.mtimeMs / 1000;

--- a/src/lib/scanner/pinRideAlong.ts
+++ b/src/lib/scanner/pinRideAlong.ts
@@ -10,6 +10,8 @@ import { projectResolutionStateKey } from "./projectState";
 import { EXTS, ROOTS, scanRootEntries } from "./roots";
 
 type ScanRoot = { rootName: RootKey; root: string; bases: string[] };
+/** A pinned path resolved onto the root — and the path form — discovery walks. */
+type Owner = { rootName: RootKey; root: string; name: string; path: string };
 
 /** Every scan root with the path forms it can be addressed by. An account home
     that symlinks into the shared transcript store gives one root two absolute
@@ -27,13 +29,29 @@ function scanRoots(): ScanRoot[] {
  * `pathAllowed` applies, so a pin can only ever name a transcript the scanner
  * itself would have walked. The longest matching root wins: account homes nest
  * inside one another, and the relative name must be taken from the innermost.
+ *
+ * The answer carries the path REBASED onto that root, because one physical
+ * transcript has as many absolute forms as there are symlinks reaching it
+ * (issue #942): a registry-recorded pin can name the account-home form while
+ * discovery walked the shared store. Rebasing onto the walked root is what
+ * makes the two comparable — otherwise the pin rides along beside the scanned
+ * row as a second card for one conversation, under a relative name that
+ * escapes its own root.
  */
-function rootFor(pathname: string, roots: readonly ScanRoot[]): ScanRoot | null {
-  let match: ScanRoot | null = null;
+function rootFor(pathname: string, roots: readonly ScanRoot[]): Owner | null {
+  let match: Owner | null = null;
+  let matched = -1;
   const candidates = [...new Set([pathname, realpath(pathname)].filter((value): value is string => value !== null))];
   for (const scanRoot of roots) {
-    const contained = scanRoot.bases.some((base) => candidates.some((candidate) => candidate.startsWith(base + path.sep)));
-    if (contained && (match === null || scanRoot.root.length > match.root.length)) match = scanRoot;
+    if (scanRoot.root.length <= matched) continue;
+    for (const base of scanRoot.bases) {
+      const candidate = candidates.find((value) => value.startsWith(base + path.sep));
+      if (!candidate) continue;
+      const name = path.relative(base, candidate);
+      match = { rootName: scanRoot.rootName, root: scanRoot.root, name, path: path.join(scanRoot.root, name) };
+      matched = scanRoot.root.length;
+      break;
+    }
   }
   return match;
 }
@@ -47,13 +65,19 @@ function realpath(pathname: string): string | null {
 }
 
 /** Discovery's own refusals, so a pin can never surface a row discovery would
-    have dropped: bookkeeping sidecars, empty transcripts, task outputs that are
-    not `<slug>/<sid>/tasks/<tid>.output`, and outputs mirrored by a subagent
+    have dropped: the directories the walk never descends into (`.git*`
+    anywhere, `tool-results` beside a Claude project's transcripts), bookkeeping
+    sidecars, empty transcripts, task outputs that are not
+    `<slug>/<sid>/tasks/<tid>.output`, and outputs mirrored by a subagent
     transcript. */
-function discoverable(rootName: RootKey, pathname: string, st: fs.Stats): boolean {
+function discoverable(owner: Owner, st: fs.Stats): boolean {
+  const { rootName, name, path: pathname } = owner;
   if (!st.isFile()) return false;
   if (!EXTS.some((ext) => pathname.endsWith(ext))) return false;
-  if (rootName === "claude-projects" && isClaudeWorkflowBookkeeping(path.relative(ROOTS["claude-projects"], pathname))) return false;
+  const dirs = name.split(path.sep).slice(0, -1);
+  if (dirs.some((dir) => dir.startsWith(".git"))) return false;
+  if (rootName === "claude-projects" && dirs.includes("tool-results")) return false;
+  if (rootName === "claude-projects" && isClaudeWorkflowBookkeeping(name)) return false;
   if (rootName !== "claude-tasks") return st.size > 0;
   const parts = taskParts(ROOTS["claude-tasks"], pathname);
   if (!parts) return false;
@@ -88,26 +112,28 @@ export function pinnedIdentityEntries(
   const stateKey = projectResolutionStateKey();
   const entries: FileEntry[] = [];
   const seen = new Set<string>();
-  for (const pathname of missing) {
-    if (seen.has(pathname)) continue;
-    seen.add(pathname);
-    const owner = rootFor(pathname, roots);
+  for (const pinned of missing) {
+    const owner = rootFor(pinned, roots);
     if (!owner) continue;
+    /* Dedupe and the against-the-scan comparison both happen on the walked
+       form, so two path forms of one transcript can never yield two cards. */
+    const { rootName, root, name, path: pathname } = owner;
+    if (seen.has(pathname) || knownPaths.has(pathname)) continue;
+    seen.add(pathname);
     let st: fs.Stats;
     try {
       st = fs.statSync(pathname);
     } catch {
       continue;
     }
-    const { rootName, root } = owner;
-    if (!discoverable(rootName, pathname, st)) continue;
+    if (!discoverable(owner, st)) continue;
     const meta = describe(rootName, root, pathname, st, stateKey);
     const mtime = st.mtimeMs / 1000;
     const verdict = activityVerdict(rootName, pathname, mtime, st.size);
     entries.push({
       path: pathname,
       root: rootName,
-      name: path.relative(root, pathname),
+      name,
       project: meta.project,
       projectName: meta.projectName,
       projectUnresolved: meta.projectUnresolved,

--- a/src/lib/scanner/pinRideAlong.ts
+++ b/src/lib/scanner/pinRideAlong.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { FileEntry, RootKey } from "../types";
+import { activityVerdict } from "./activity";
+import { isClaudeWorkflowBookkeeping } from "./claudeNative";
+import { describe } from "./describe";
+import { taskParts } from "./discover";
+import { projectResolutionStateKey } from "./projectState";
+import { EXTS, ROOTS, scanRootEntries } from "./roots";
+
+/**
+ * Which scan root owns a path, with its root key — the same containment gate
+ * `pathAllowed` applies, so a pin can only ever name a transcript the scanner
+ * itself would have walked. The longest matching root wins: account homes nest
+ * inside one another, and the relative name must be taken from the innermost.
+ */
+function rootFor(pathname: string): [RootKey, string] | null {
+  let match: [RootKey, string] | null = null;
+  const candidates = [pathname, realpath(pathname)].filter((value): value is string => value !== null);
+  for (const [rootName, root] of scanRootEntries()) {
+    const roots = [root, realpath(root)].filter((value): value is string => value !== null);
+    const contained = roots.some((base) => candidates.some((candidate) => candidate.startsWith(base + path.sep)));
+    if (contained && (match === null || root.length > match[1].length)) match = [rootName, root];
+  }
+  return match;
+}
+
+function realpath(pathname: string): string | null {
+  try {
+    return fs.realpathSync(pathname);
+  } catch {
+    return null;
+  }
+}
+
+/** Discovery's own refusals, so a pin can never surface a row discovery would
+    have dropped: bookkeeping sidecars, empty transcripts, task outputs that are
+    not `<slug>/<sid>/tasks/<tid>.output`, and outputs mirrored by a subagent
+    transcript. */
+function discoverable(rootName: RootKey, pathname: string, st: fs.Stats): boolean {
+  if (!st.isFile()) return false;
+  if (!EXTS.some((ext) => pathname.endsWith(ext))) return false;
+  if (rootName === "claude-projects" && isClaudeWorkflowBookkeeping(path.relative(ROOTS["claude-projects"], pathname))) return false;
+  if (rootName !== "claude-tasks") return st.size > 0;
+  const parts = taskParts(ROOTS["claude-tasks"], pathname);
+  if (!parts) return false;
+  const [slug, sid, tid] = parts;
+  return !fs.existsSync(path.join(ROOTS["claude-projects"], slug, sid, "subagents", `agent-${tid}.jsonl`));
+}
+
+/**
+ * Identity rows for pinned transcripts the published scan left out (issue #950).
+ *
+ * The scheme window is a BOARD budget: it bounds how many conversations the
+ * unpinned feed carries, ranked by recency, so whole projects sit outside it
+ * once the corpus outgrows the project cap. Everything in «All conversations»
+ * is clickable, though, and that click asks `/api/files?path=<pin>` for exactly
+ * one record. Waiting for the pinned full-corpus scan generation to publish it
+ * means the click does nothing at all for as long as that scan takes.
+ *
+ * So the budget sheds payload detail, never identity: one `stat` plus the
+ * scanner's cached summary give path, project, title, engine and activity —
+ * everything the client needs to create the card and open it — while the pinned
+ * scan continues in the background and replaces these rows with fully derived
+ * ones. Size only ever bounds how many bytes the summary reads; it never
+ * decides whether the conversation exists.
+ */
+export function pinnedIdentityEntries(
+  pinnedPaths: Iterable<string>,
+  knownPaths: ReadonlySet<string>,
+): FileEntry[] {
+  const stateKey = projectResolutionStateKey();
+  const entries: FileEntry[] = [];
+  const seen = new Set<string>();
+  for (const pathname of pinnedPaths) {
+    if (knownPaths.has(pathname) || seen.has(pathname)) continue;
+    seen.add(pathname);
+    const owner = rootFor(pathname);
+    if (!owner) continue;
+    let st: fs.Stats;
+    try {
+      st = fs.statSync(pathname);
+    } catch {
+      continue;
+    }
+    const [rootName, root] = owner;
+    if (!discoverable(rootName, pathname, st)) continue;
+    const meta = describe(rootName, root, pathname, st, stateKey);
+    const mtime = st.mtimeMs / 1000;
+    const verdict = activityVerdict(rootName, pathname, mtime, st.size);
+    entries.push({
+      path: pathname,
+      root: rootName,
+      name: path.relative(root, pathname),
+      project: meta.project,
+      projectName: meta.projectName,
+      projectUnresolved: meta.projectUnresolved,
+      worktree: meta.worktree,
+      cwd: meta.cwd,
+      sessionStartedAt: meta.sessionStartedAt,
+      nativeParentThreadId: meta.nativeParentThreadId,
+      nativeForkSourceThreadId: meta.nativeForkSourceThreadId,
+      projectRoot: meta.projectRoot,
+      title: meta.title,
+      engine: meta.engine,
+      kind: meta.kind,
+      fmt: meta.fmt,
+      parent: null,
+      mtime,
+      size: st.size,
+      activity: verdict.state,
+      activityReason: verdict.reason,
+      proc: null,
+      pid: null,
+      model: null,
+      pendingQuestion: null,
+      waitingInput: null,
+    });
+  }
+  return entries;
+}

--- a/src/lib/scanner/pinRideAlong.ts
+++ b/src/lib/scanner/pinRideAlong.ts
@@ -62,7 +62,7 @@ function discoverable(rootName: RootKey, pathname: string, st: fs.Stats): boolea
 }
 
 /**
- * Identity rows for pinned transcripts the published scan left out (issue #950).
+ * Identity rows for pinned transcripts the published scan left out (#950).
  *
  * The scheme window is a BOARD budget: it bounds how many conversations the
  * unpinned feed carries, ranked by recency, so whole projects sit outside it


### PR DESCRIPTION
## The click

Clicking a row in «All conversations» runs `board.restore(path)`, which asks
`GET /api/files?path=<pin>` for that one record. The record was absent, so no
card was created and the click reported nothing at all.

## What the evidence actually says

The reported shape — a 512 KiB per-file gate — is **not** the mechanism. A
generated corpus of twelve one-conversation projects reproduces the drop
exactly, and the split follows the **project cap**, not bytes:

| corpus | published |
| --- | --- |
| 12 projects × 1 rollout, aged ~3 weeks, sizes 200 KB / 700 KB alternating | the 10 newest projects, whatever their transcripts weigh |
| 1 project, 5.6 MB rollout, minutes old | published |
| the 2 oldest projects | **dropped whole**, both their 700 KB and their 200 KB transcripts |

`selectSchemeWindow` (`src/lib/scanner/schemeWindow.ts:6`, `DEFAULT_SCHEME_PROJECT_CAP = 10`)
is applied by `cappedEntries` at `src/lib/scanner/discover.ts:429`. The 512 KiB
coincidence in the day directory that was measured is exactly that — a
coincidence; recency is the only variable that decides membership.

Two leads killed with evidence:

- `CHAIN_HEAD_BYTES` (`src/lib/scanner/links.ts:50`) cannot cause absence.
  `compactParentUuid` only ever returns a uuid or `null`, and `linkEntries`
  assigns `parent` — it never removes an entry. A marker beyond the window
  already degrades to «parent unknown». A regression test now pins that.
- `FALLBACK_BYTES_CAP` is unrelated, as previously noted.

## Why the pin did not save it

The ride-along in `entriesFromRaw` works — but only from a **completed pinned
scan**, and that scan is `exclusive`, so it queues behind the running
full-corpus generation. On a real corpus the first pinned responses come back
carrying the unpinned snapshot. Reproduced end to end: pinned requests 1 and 2
lack the record, request 3 has it.

## The fix

`src/lib/scanner/pinRideAlong.ts` — the budget now sheds payload detail and
never identity. A pinned path the published scan omitted gets one `stat` plus
the scanner's cached summary: path, project, title, engine, activity, and the
conversation id every other row receives in the same projection. `/api/files`
attaches those rows as pin overlay before lineage closure, so the card exists on
the **first** pinned request, while the pinned scan keeps running behind it and
replaces them with fully derived rows.

The ride-along applies discovery's own refusals (bookkeeping sidecars, empty
transcripts, task outputs mirrored by a subagent transcript) and the same root
containment gate as `pathAllowed`, so it can never surface a row discovery
would have dropped, and a pin can never name an arbitrary file on the host.

## Verification

- RED first: the new route test fails on a pristine `HEAD` checkout (scratch
  worktree, no stash) and passes here.
- Focused runs, isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`,
  fixtures generated, never copied:
  `src/app/api/files/route.pin.rideAlong.test.ts`,
  `src/lib/scanner/pinRideAlong.test.ts`,
  `src/lib/scanner/links.performance.test.ts`,
  `src/lib/scanner/index.pin.test.ts` — 17 pass.
  `src/app/api/files/route.test.ts` — 85/86, the one failure
  («a staged structured card stays binding…») reproduces unchanged on `HEAD`
  and is untouched by this change.
- `tsc --noEmit`, scoped `eslint`, `next build`, privacy gate: all clean.
- The five worktree projects still reported missing all resolve through the
  ride-along, including the 5.3 MB and 3.7 MB transcripts, and every one groups
  under its parent repo project with its worktree name intact — the canonical
  worktree grouping, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
