### PR TITLE
fix(board): a flow claim matches its transcript whatever spelling the record kept

### DIFF
--- a/src/components/flows/flowModel.test.ts
+++ b/src/components/flows/flowModel.test.ts
@@ -311,6 +311,58 @@ describe("reviewer folding", () => {
   });
 });
 
+describe("reviewer folding across recorded path spellings (#943 follow-up)", () => {
+  /* Durable flow records keep the spelling that was current when the round ran:
+     a legacy home, or an account-local `projects` that symlinks into the shared
+     store. The projection publishes the shared spelling, so a raw string claim
+     misses and every round of a long-closed flow renders as a free node. */
+  const LEGACY = "/store/legacy/projects/enc-project";
+  const SHARED = "/store/shared/projects/enc-project";
+
+  test("a round recorded under the pre-canonical spelling still claims its reviewer", () => {
+    const implementer = entry({ path: `${SHARED}/impl-3f2a.jsonl` });
+    const reviewer = entry({ path: `${SHARED}/rev-9c41.jsonl`, parent: implementer.path });
+    const subtask = entry({ path: `${SHARED}/sub-1b70.jsonl`, parent: reviewer.path });
+    const closed = flow({
+      implementerPath: `${LEGACY}/impl-3f2a.jsonl`,
+      reviewerPath: `${LEGACY}/rev-9c41.jsonl`,
+      state: "closed",
+      closedAt: "2026-07-06T00:00:00Z",
+    });
+
+    expect(foldClaimedReviewers([implementer, reviewer, subtask], [closed]).map((file) => [file.path, file.parent])).toEqual([
+      [implementer.path, null],
+      [subtask.path, implementer.path],
+    ]);
+  });
+
+  test("a reviewer belonging to no flow keeps its node", () => {
+    const implementer = entry({ path: `${SHARED}/impl-3f2a.jsonl` });
+    const stranger = entry({ path: `${SHARED}/rev-0000.jsonl`, parent: implementer.path });
+    const closed = flow({
+      implementerPath: `${LEGACY}/impl-3f2a.jsonl`,
+      reviewerPath: `${LEGACY}/rev-9c41.jsonl`,
+      state: "closed",
+      closedAt: "2026-07-06T00:00:00Z",
+    });
+
+    expect(foldClaimedReviewers([implementer, stranger], [closed]).map((file) => file.path))
+      .toEqual([implementer.path, stranger.path]);
+  });
+
+  test("a protected pipeline reviewer recorded pre-canonically stays a real card", () => {
+    /* The protection set is built from the same durable records, so resolving
+       only the round would fold away the live stage conversation (#560). */
+    const implementer = entry({ path: `${SHARED}/impl-3f2a.jsonl` });
+    const reviewer = entry({ path: `${SHARED}/rev-9c41.jsonl`, parent: implementer.path, activity: "live" });
+    const active = flow({ implementerPath: `${LEGACY}/impl-3f2a.jsonl`, reviewerPath: `${LEGACY}/rev-9c41.jsonl` });
+    const protectedPaths = new Set([`${LEGACY}/rev-9c41.jsonl`]);
+
+    expect(foldClaimedReviewers([implementer, reviewer], [active], protectedPaths).map((file) => file.path))
+      .toEqual([implementer.path, reviewer.path]);
+  });
+});
+
 test("a quota-blocked flow presents the transient block and suppresses its pending action", () => {
   const limited = flow({
     implementerPath: "/implementer",

--- a/src/components/flows/flowModel.ts
+++ b/src/components/flows/flowModel.ts
@@ -7,6 +7,7 @@ import { currentConversationFile, currentMemberPath, withoutArchivedPredecessors
 
 import { isConversation } from "@/components/projectModel";
 import { formatRateLimitTime } from "@/components/rateLimit";
+import { resolveTranscriptClaims, transcriptClaimResolver } from "@/components/transcriptClaims";
 
 /** Fired after any successful flow PATCH so pollers refresh immediately. */
 export const FLOWS_CHANGED_EVENT = "llv:flows-changed";
@@ -261,29 +262,40 @@ export function claimedReviewerDescendantPaths(files: FileEntry[], flows: Flow[]
  * collapses to a prompt placeholder (task f6c1a774 / Fix #604). Protected
  * reviewers are never anchors either, so their own children keep their real
  * parent.
+ *
+ * Recorded round paths are resolved onto the projected spelling before every
+ * comparison (#943 follow-up): a flow that ran before its account home was cut
+ * over to the shared transcript store holds the old spelling, which matches no
+ * projected file, so its rounds would each hold a free node. `protectedPaths`
+ * comes from the same durable records, so it is resolved too — resolving only
+ * the round would newly fold a live pipeline stage reviewer off the board.
  */
 export function foldClaimedReviewers(
   files: FileEntry[],
   flows: Flow[],
   protectedPaths: ReadonlySet<string> = EMPTY_PROTECTED,
 ): FileEntry[] {
+  const resolveClaim = transcriptClaimResolver(files);
+  const protectedClaims = resolveTranscriptClaims(protectedPaths, resolveClaim);
   const anchorByReviewer = new Map<string, string>();
   for (const flow of flows) {
+    const implementerPath = resolveClaim(flow.implementerPath);
     for (const round of flow.rounds) {
-      if (round.reviewerPath && !protectedPaths.has(round.reviewerPath)) anchorByReviewer.set(round.reviewerPath, flow.implementerPath);
+      const reviewerPath = round.reviewerPath ? resolveClaim(round.reviewerPath) : null;
+      if (reviewerPath && !protectedClaims.has(reviewerPath)) anchorByReviewer.set(reviewerPath, implementerPath);
     }
   }
   const pathByConversationId = new Map(withoutArchivedPredecessors(files).flatMap((file) =>
     file.conversationId ? [[file.conversationId, file.path] as const] : []));
   for (const file of files) {
-    if (protectedPaths.has(file.path)) continue;
+    if (protectedClaims.has(file.path)) continue;
     const membership = file.durableLineage?.memberships.find((candidate) => candidate.kind === "flow" && candidate.role === "reviewer");
     if (!membership) continue;
     const flow = flows.find((candidate) => candidate.id === membership.containerId);
     const reviewedPath = file.durableLineage?.reviewsConversationId
       ? pathByConversationId.get(file.durableLineage.reviewsConversationId)
       : undefined;
-    const anchor = reviewedPath ?? file.parent ?? flow?.implementerPath;
+    const anchor = reviewedPath ?? file.parent ?? (flow ? resolveClaim(flow.implementerPath) : undefined);
     if (anchor) anchorByReviewer.set(file.path, anchor);
   }
   if (!anchorByReviewer.size) return files;

--- a/src/components/scheme/workerCollapse.test.ts
+++ b/src/components/scheme/workerCollapse.test.ts
@@ -4,6 +4,8 @@ import type { Flow, Round } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { FileEntry } from "@/lib/types";
 
+import { transcriptClaimResolver } from "@/components/transcriptClaims";
+
 import {
   classifyWorker,
   collapsibleWorkerFiles,
@@ -357,6 +359,71 @@ describe("pipelineStageAgentPaths", () => {
       },
     ] as unknown as Parameters<typeof pipelineStageAgentPaths>[0];
     expect(pipelineStageAgentPaths(pipelines)).toEqual(new Set(["/a", "/b"]));
+  });
+});
+
+describe("claims across recorded path spellings (#943 follow-up)", () => {
+  /* Flow rounds and pipeline attempts hold whatever spelling was current when
+     they ran; the projection publishes the shared-store one. A raw string claim
+     misses, so a finished reviewer never classifies as worker-class and holds a
+     full node forever. */
+  const LEGACY = "/store/legacy/projects/enc-project";
+  const SHARED = "/store/shared/projects/enc-project";
+  const corpus = (...files: FileEntry[]) => files;
+
+  test("a reviewer round recorded pre-canonically is still flow-reviewer", () => {
+    const reviewer = entry({ path: `${SHARED}/rev-9c41.jsonl` });
+    const flows = [flow({ id: "f1", implementerPath: `${LEGACY}/impl-3f2a.jsonl`, rounds: [round({ reviewerPath: `${LEGACY}/rev-9c41.jsonl` })] })];
+    expect(classifyWorker(reviewer, { ...lineage(flows), resolveClaimPath: transcriptClaimResolver(corpus(reviewer)) })).toBe("flow-reviewer");
+  });
+
+  test("an implementer recorded pre-canonically is still flow-implementer", () => {
+    const impl = entry({ path: `${SHARED}/impl-3f2a.jsonl`, parent: "/orchestrator" });
+    const flows = [flow({ id: "f1", implementerPath: `${LEGACY}/impl-3f2a.jsonl` })];
+    expect(classifyWorker(impl, { ...lineage(flows), resolveClaimPath: transcriptClaimResolver(corpus(impl)) })).toBe("flow-implementer");
+  });
+
+  test("a stage attempt recorded pre-canonically is still pipeline-stage", () => {
+    const stage = entry({ path: `${SHARED}/stage-77bd.jsonl` });
+    const pipelines = [
+      { runs: [{ attempts: [{ agentPath: `${LEGACY}/stage-77bd.jsonl` }] }] },
+    ] as unknown as Parameters<typeof pipelineStageAgentPaths>[0];
+    const paths = pipelineStageAgentPaths(pipelines, transcriptClaimResolver(corpus(stage)));
+    expect(paths.has(stage.path)).toBe(true);
+    expect(classifyWorker(stage, lineage([], paths as Set<string>))).toBe("pipeline-stage");
+  });
+
+  test("a finished round recorded pre-canonically folds, a running one does not", () => {
+    const finished = entry({ path: `${SHARED}/rev-9c41.jsonl` });
+    const running = entry({ path: `${SHARED}/rev-4d10.jsonl`, activity: "live" });
+    const flows = [flow({
+      id: "f1",
+      implementerPath: `${LEGACY}/impl-3f2a.jsonl`,
+      rounds: [
+        round({ n: 1, reviewerPath: `${LEGACY}/rev-9c41.jsonl`, verdict: "APPROVE" }),
+        round({ n: 2, reviewerPath: `${LEGACY}/rev-4d10.jsonl` }),
+      ],
+    })];
+    const files = corpus(finished, running);
+    expect(collapsibleWorkerFiles({ files, project: "demo", flows, pinnedPaths: new Set(), nowMs: NOW }).map((file) => file.path))
+      .toEqual([finished.path]);
+  });
+
+  test("an unresolvable record claims nothing", () => {
+    /* Only a path the corpus actually holds is claimable — a record whose
+       transcript has left the window must not fold an unrelated card. */
+    const other = entry({ path: `${SHARED}/rev-0000.jsonl` });
+    const flows = [flow({ id: "f1", implementerPath: `${LEGACY}/impl-3f2a.jsonl`, rounds: [round({ reviewerPath: `${LEGACY}/rev-9c41.jsonl` })] })];
+    expect(classifyWorker(other, { ...lineage(flows), resolveClaimPath: transcriptClaimResolver(corpus(other)) })).toBeNull();
+  });
+
+  test("an ambiguous tail stays unresolved", () => {
+    /* Two transcripts of the same name under different roots: resolving either
+       way could fold the wrong card, so neither is claimed. */
+    const a = entry({ path: `${SHARED}/rev-9c41.jsonl` });
+    const b = entry({ path: `/store/other/projects/enc-project/rev-9c41.jsonl` });
+    const resolve = transcriptClaimResolver(corpus(a, b));
+    expect(resolve(`${LEGACY}/rev-9c41.jsonl`)).toBe(`${LEGACY}/rev-9c41.jsonl`);
   });
 });
 

--- a/src/components/scheme/workerCollapse.ts
+++ b/src/components/scheme/workerCollapse.ts
@@ -4,6 +4,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { reviewerBindingTargetsForRound } from "@/components/flows/flowModel";
 import { activityBand, isChildConversation, kidsIndex, projectKey, subtree } from "@/components/projectModel";
+import { IDENTITY_CLAIM_RESOLVER, transcriptClaimResolver, type TranscriptClaimResolver } from "@/components/transcriptClaims";
 
 /*
  * Worker-class auto-collapse (issue #112).
@@ -41,13 +42,19 @@ export function workerCollapseIdleMs(): number {
   return Number.isFinite(minutes) && minutes > 0 ? minutes * 60_000 : DEFAULT_WORKER_COLLAPSE_IDLE_MS;
 }
 
-/** Transcript paths owned by a pipeline stage attempt — pipeline-stage workers. */
-export function pipelineStageAgentPaths(pipelines: readonly Pipeline[]): Set<string> {
+/** Transcript paths owned by a pipeline stage attempt — pipeline-stage workers.
+    An attempt records whatever spelling was current when it ran, so `resolve`
+    rewrites it onto the projected corpus before the set is compared against
+    `file.path` (#943 follow-up); the default leaves recorded paths untouched. */
+export function pipelineStageAgentPaths(
+  pipelines: readonly Pipeline[],
+  resolve: TranscriptClaimResolver = IDENTITY_CLAIM_RESOLVER,
+): Set<string> {
   const set = new Set<string>();
   for (const pipeline of pipelines) {
     for (const run of pipeline.runs) {
       for (const attempt of run.attempts) {
-        if (attempt.agentPath) set.add(attempt.agentPath);
+        if (attempt.agentPath) set.add(resolve(attempt.agentPath));
       }
     }
   }
@@ -58,6 +65,11 @@ export interface WorkerLineage {
   flows: readonly Flow[];
   /** Output of {@link pipelineStageAgentPaths} — computed once per render. */
   pipelineStagePaths: ReadonlySet<string>;
+  /** Resolves a flow's recorded member paths onto the projected spelling before
+      they are matched (#943 follow-up). Built once per render from the file set
+      by {@link transcriptClaimResolver}; absent means compare recorded paths raw,
+      which is only correct when records and corpus share one spelling. */
+  resolveClaimPath?: TranscriptClaimResolver;
 }
 
 interface FlowMembership {
@@ -74,8 +86,18 @@ interface FlowMembership {
  * matching `flow.implementerPath` / `round.reviewerPath` is the same resolution
  * the rest of the board already uses (flowByImplementer, claimedReviewerPaths).
  * A reviewer match wins over an implementer match.
+ *
+ * Both sides of that match are canonical (#943 follow-up): a durable record
+ * holds the spelling that was current when the round ran, and the projection
+ * publishes the root discovery walked, so `resolve` rewrites the recorded path
+ * onto the corpus before the comparison. Without it every round of a flow that
+ * predates its account's cut-over misses and renders as a free node.
  */
-function flowMembership(file: FileEntry, flows: readonly Flow[]): FlowMembership | null {
+function flowMembership(
+  file: FileEntry,
+  flows: readonly Flow[],
+  resolve: TranscriptClaimResolver = IDENTITY_CLAIM_RESOLVER,
+): FlowMembership | null {
   const durable = file.durableLineage?.memberships.find((membership) => membership.kind === "flow");
   if (durable) {
     const flow = flows.find((candidate) => candidate.id === durable.containerId);
@@ -87,11 +109,11 @@ function flowMembership(file: FileEntry, flows: readonly Flow[]): FlowMembership
   }
   for (const flow of flows) {
     for (const round of flow.rounds) {
-      if (round.reviewerPath === file.path) return { role: "reviewer", flow, round };
+      if (round.reviewerPath && resolve(round.reviewerPath) === file.path) return { role: "reviewer", flow, round };
     }
   }
   for (const flow of flows) {
-    if (flow.implementerPath === file.path) return { role: "implementer", flow, round: null };
+    if (resolve(flow.implementerPath) === file.path) return { role: "implementer", flow, round: null };
   }
   return null;
 }
@@ -127,7 +149,7 @@ function flowMembership(file: FileEntry, flows: readonly Flow[]): FlowMembership
  */
 export function classifyWorker(file: FileEntry, lineage: WorkerLineage): WorkerClass | null {
   if (file.handoff) return null;
-  const membership = flowMembership(file, lineage.flows);
+  const membership = flowMembership(file, lineage.flows, lineage.resolveClaimPath);
   if (membership?.role === "reviewer") return "flow-reviewer";
   if (membership?.role === "implementer") return file.parent ? "flow-implementer" : null;
   if (lineage.pipelineStagePaths.has(file.path)) return "pipeline-stage";
@@ -194,7 +216,7 @@ export function shouldCollapseWorker(file: FileEntry, context: CollapseContext):
   const klass = classifyWorker(file, context);
   if (!klass) return false;
   if (isCollapseExempt(file, context)) return false;
-  const membership = flowMembership(file, context.flows);
+  const membership = flowMembership(file, context.flows, context.resolveClaimPath);
   if (klass === "flow-reviewer") {
     /* Reviewers collapse exactly on verdict, never on the idle window: a
        still-reviewing round stays put (it is the live loop), and a finished
@@ -227,8 +249,12 @@ export interface WorkerStack {
 /** Flow id owning a transcript, derived from the flows list by path (a flow
     member groups per flow, everything else per worktree). Uses the same
     path-matching as classification — never the absent `file.flow`. */
-export function flowIdForPath(file: FileEntry, flows: readonly Flow[]): string | null {
-  return flowMembership(file, flows)?.flow.id ?? null;
+export function flowIdForPath(
+  file: FileEntry,
+  flows: readonly Flow[],
+  resolve: TranscriptClaimResolver = IDENTITY_CLAIM_RESOLVER,
+): string | null {
+  return flowMembership(file, flows, resolve)?.flow.id ?? null;
 }
 
 /** Transcript path → the id of the pipeline that owns it, so a pipeline's stage
@@ -371,6 +397,7 @@ function stackKeyFor(
   file: FileEntry,
   flows: readonly Flow[],
   resolvers: StackOriginResolvers = {},
+  resolveClaimPath: TranscriptClaimResolver = IDENTITY_CLAIM_RESOLVER,
 ): { key: string; kind: WorkerStack["kind"]; id: string } {
   /* Pipeline ownership wins over the flow bucket (issue #136): a pipeline that
      embeds a review-loop owns that flow's implementer + reviewers, so a whole
@@ -379,7 +406,7 @@ function stackKeyFor(
      resolver covers pipeline-owned paths AND their ancestors. */
   const pipelineId = resolvers.pipelineIdOf?.(file.path) ?? null;
   if (pipelineId) return { key: "wstack::pipeline::" + pipelineId, kind: "pipeline", id: pipelineId };
-  const flowId = flowIdForPath(file, flows);
+  const flowId = flowIdForPath(file, flows, resolveClaimPath);
   if (flowId) return { key: "wstack::flow::" + flowId, kind: "flow", id: flowId };
   const origin = resolvers.originOf?.(file) ?? null;
   if (origin) return { key: "wstack::origin::" + origin, kind: "origin", id: origin };
@@ -409,9 +436,13 @@ export interface CollapsibleInput {
 const EMPTY_PATHS: ReadonlySet<string> = new Set();
 
 function collapseContext(input: CollapsibleInput): CollapseContext {
+  /* One resolver per pass: durable flow/pipeline records are matched against the
+     projected corpus, whatever spelling each side happens to carry (#943). */
+  const resolveClaimPath = transcriptClaimResolver(input.files);
   return {
     flows: input.flows,
-    pipelineStagePaths: pipelineStageAgentPaths(input.pipelines ?? []),
+    resolveClaimPath,
+    pipelineStagePaths: pipelineStageAgentPaths(input.pipelines ?? [], resolveClaimPath),
     nowMs: input.nowMs,
     idleMs: input.idleMs ?? workerCollapseIdleMs(),
     pinnedPaths: input.pinnedPaths,
@@ -459,9 +490,13 @@ export function groupWorkerStacks(
   resolvers: StackOriginResolvers = {},
 ): WorkerStack[] {
   const byKey = new Map<string, WorkerStack>();
+  /* Anchored on the stacked files themselves: a recorded member path resolves to
+     the projected spelling of the very card being placed, so a pre-cut-over flow
+     record still buckets its worker under that flow (#943 follow-up). */
+  const resolveClaimPath = transcriptClaimResolver(files);
   for (const file of files) {
     if (exclude.has(file.path)) continue;
-    const { key, kind, id } = stackKeyFor(file, flows, resolvers);
+    const { key, kind, id } = stackKeyFor(file, flows, resolvers, resolveClaimPath);
     const stack = byKey.get(key) ?? { key, kind, id, items: [] };
     stack.items.push(file);
     byKey.set(key, stack);

--- a/src/components/transcriptClaims.ts
+++ b/src/components/transcriptClaims.ts
@@ -1,0 +1,79 @@
+/*
+ * One physical transcript, one identity — at CLAIM time (issue #943 follow-up).
+ *
+ * Flow rounds and pipeline attempts durably record a member's transcript path in
+ * whatever spelling was current when the record was written: a legacy
+ * `~/.claude/projects/…` home, or an account-local `accounts/claude/<id>/projects/…`
+ * one. The very same file is addressable under all of them, because a cut-over
+ * account home keeps `projects` as a symlink into the shared transcript store —
+ * and discovery reports exactly one of those spellings, the root it walked. Every
+ * claim in the board's fold/collapse path compares those recorded paths against
+ * the projected corpus AS STRINGS, so a record written before the cut-over
+ * silently misses: its reviewer never folds into the flow's round deck and its
+ * stage worker never classifies, and each round renders as a free node instead.
+ *
+ * `src/lib/scanner/transcriptIdentity.ts` solves the same problem for the
+ * scanner's demote and pin sets, but it resolves root aliases through
+ * `fs.realpathSync` — server-only, and blind to an account-local `projects`
+ * symlink, which never appears among the scan roots it rewrites onto. The board
+ * runs in the browser, so the canonical form is derived from the data it already
+ * holds: the projected file corpus IS the set of spellings discovery walked.
+ *
+ * A recorded path is therefore resolved against the corpus by its root-relative
+ * tail — the encoded project directory (Claude) or session day (Codex) plus the
+ * transcript's own UUID-bearing filename. Only a record that is absent from the
+ * corpus verbatim is resolved, only onto a path the corpus actually contains,
+ * and only when that tail names exactly ONE transcript. So the resolution can
+ * never invent a claim on a file that is not there, and an ambiguous tail (two
+ * transcripts of the same name under different roots) stays unresolved rather
+ * than folding the wrong card away.
+ */
+
+/** Rewrites a durably recorded transcript path onto the spelling the projection
+    published, or returns it untouched when there is nothing to resolve. */
+export type TranscriptClaimResolver = (recordedPath: string) => string;
+
+export const IDENTITY_CLAIM_RESOLVER: TranscriptClaimResolver = (recordedPath) => recordedPath;
+
+/** Root-relative tail identifying a transcript across root spellings: the
+    containing directory plus the file name. Both engines put a UUID in the file
+    name, so the pair is an identity everywhere the corpus is not ambiguous. */
+function claimTail(pathname: string): string {
+  return pathname.split("/").slice(-2).join("/");
+}
+
+/**
+ * A resolver anchored on the projected corpus. Pure, allocation-bounded by the
+ * file set, and safe to rebuild per render.
+ */
+export function transcriptClaimResolver(files: readonly { path: string }[]): TranscriptClaimResolver {
+  const corpus = new Set<string>();
+  for (const file of files) corpus.add(file.path);
+  /* A tail claimed by more than one transcript resolves to nothing: `null` marks
+     it ambiguous so a later lookup falls through to the recorded path. */
+  const byTail = new Map<string, string | null>();
+  for (const path of corpus) {
+    const tail = claimTail(path);
+    if (!byTail.has(tail)) byTail.set(tail, path);
+    else if (byTail.get(tail) !== path) byTail.set(tail, null);
+  }
+  return (recordedPath) => {
+    if (!recordedPath || corpus.has(recordedPath)) return recordedPath;
+    return byTail.get(claimTail(recordedPath)) ?? recordedPath;
+  };
+}
+
+/** Resolves a whole claim set, keeping both spellings so either still matches —
+    the set may be compared against recorded paths as well as corpus ones. */
+export function resolveTranscriptClaims(
+  paths: ReadonlySet<string>,
+  resolve: TranscriptClaimResolver,
+): ReadonlySet<string> {
+  if (!paths.size || resolve === IDENTITY_CLAIM_RESOLVER) return paths;
+  const resolved = new Set<string>();
+  for (const path of paths) {
+    resolved.add(path);
+    resolved.add(resolve(path));
+  }
+  return resolved.size === paths.size ? paths : resolved;
+}


### PR DESCRIPTION
## What this fixes

Flow rounds, flow implementers and pipeline stage attempts durably record a member's transcript path in the spelling that was current when they ran — a legacy home, or an account-local `projects` directory that later became a symlink into the shared transcript store. The projection publishes the root discovery actually walked.

`foldClaimedReviewers` (`src/components/flows/flowModel.ts`), `flowMembership` and `pipelineStageAgentPaths` (`src/components/scheme/workerCollapse.ts`) compared the two as raw strings. A record written before its account was cut over claimed nothing: the reviewer never folded into its round deck, the stage worker never classified, and each round held a free node on the canvas.

Both sides of every one of those comparisons are now resolved first.

## How the resolution works, and why not the scanner's helper

`src/lib/scanner/transcriptIdentity.ts` (#943, used at `discover.ts:414`) resolves root aliases through `fs.realpathSync`. That is server-only, and it is also blind to the case that actually diverges here: an account-local `projects` symlink resolves to the shared store, so `claudeProjectRoots()` reports the shared spelling and the account-local one never appears among the aliases it rewrites onto. The fold/claim path runs in the browser.

So the canonical form is derived from the data the board already holds — the projected corpus **is** the set of spellings discovery walked. `src/components/transcriptClaims.ts` resolves a recorded path that is absent from the corpus onto the corpus entry sharing its root-relative tail (encoded project directory or session day, plus the UUID-bearing file name), and only when exactly one entry claims that tail.

Two safety properties fall out and are covered by tests:

- a claim can never land on a transcript the corpus does not hold, so a record whose transcript has left the scan window folds nothing;
- an ambiguous tail stays unresolved rather than folding the wrong card away. The live corpus currently contains two such pairs — the same physical file published under both `~/.claude/projects/…` and the shared root — and both resolve verbatim anyway.

`protectedPaths` comes from the same durable records and is resolved alongside the rounds, so a running pipeline stage reviewer (#560/#604) keeps its real card instead of being newly folded by the more permissive match.

## Verification

- RED first, read out of `git show HEAD:…` in a throwaway worktree — no stash. 5 new focused tests failed before the change; the 3 guard tests (a reviewer belonging to no flow keeps its node, a protected reviewer stays a card, an unresolvable record claims nothing) passed before and after.
- `bun test src/components/flows/flowModel.test.ts src/components/scheme/workerCollapse.test.ts` — 64 pass.
- Consumers of the changed functions: `bun test src/components/ProjectDashboard.test.ts src/components/flows/directReviewGroups.test.ts src/components/scheme/directReviewBoardComposition.test.ts src/components/pipelines/pipelineModel.test.ts` — 146 pass.
- `tsc --noEmit`, scoped `eslint`, `bun run build`, privacy gate: all clean. Every run used an isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR` / `TMPDIR`.

## Measured effect — this is not what fills the canvas

The lane was opened on a diagnosis that pre-canonical spellings explain a wall of ~140 July codex-rollout nodes. The mechanism is real and is fixed here. Its size is not.

Replaying the board's own fold/collapse pipeline over the live projection, pre-fix and post-fix, the flagged project renders **166 nodes both times** (377 across all projects). Exactly one durable record in that projection is recovered by the resolution, and that round was already folded through its `durableLineage` reviewer membership, which is path-independent.

The same replay attributes those 166 nodes:

| holding it on the canvas | nodes |
| --- | ---: |
| authorship exemption alone (`userAuthored` / `authorshipUnverified` in `isCollapseExempt`), all worker-class | 81 |
| parentless roots the classifier leaves out of scope by design | 71 |
| live / running / protected pipeline stage, or inside its idle window | 14 |
| a claim missed on a pre-canonical spelling | 0 |

The July series the report describes are closed-flow builder rounds that classify correctly as `flow-implementer` and are then pinned by the authorship exemption, which fires before the "closed flow, past the idle window" rule ever runs. Reviewer folding is doing its job: it removes 195 of the project's 363 files before collapse is even consulted.

Loosening that exemption is #112's core safety invariant and a separate product decision, so it is out of this lane and not touched here. Also untouched: scanner discovery and pin ride-along (#950), the launch-history claim path (#949), the scheme age horizon (#946).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
