### PR TITLE
fix(scheme): the placement age horizon bounds every automatic card, not just roots

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -66,6 +66,8 @@ import {
   quietHistoryRows,
   quietRootsWithActiveDescendants,
   residualItems,
+  schemeAgeHorizonSeconds,
+  withinPlacementHorizon,
 } from "./projectModel";
 import { ArchiveRestore } from "./icons";
 import { KeepAwakeMenuRow } from "./KeepAwakeControl";
@@ -586,8 +588,20 @@ function ProjectDashboardView({
       if (isDirectReviewFlow(flow) && flow.state !== "reviewing") continue;
       paths.add(flow.implementerPath);
     }
+    /* This expansion is automatic — the board opens it, not the operator — so it
+       follows the placement age horizon like every other automatic card. A flow
+       that has sat in an approved state for weeks must not keep dragging its
+       implementer (and, through it, an ancient root) onto the canvas; live and
+       running work stays regardless of age, and the operator's own expansions
+       (`prefs.expanded`, merged below) are never bounded. */
+    const horizon = schemeAgeHorizonSeconds();
+    const byPath = new Map(files.map((file) => [file.path, file] as const));
+    for (const path of [...paths]) {
+      const file = byPath.get(path);
+      if (file && !withinPlacementHorizon(file, nowSeconds, horizon)) paths.delete(path);
+    }
     return paths;
-  }, [files, deckFlows]);
+  }, [files, deckFlows, nowSeconds]);
   /* Flow-driven expansions plus the ones the user opened by hand from a
      collapsed view: a connected conversation the user expanded renders as a
      node wired below its parent, just like an active-group child. */
@@ -1396,7 +1410,7 @@ function ProjectDashboardView({
      exists only for an implementer placed as a board node — the same layout the
      scheme draws. Derive availability from that layout's nodes, so a scanned but
      unplaced (hidden/tombstoned) implementer disables the action (#93 finding). */
-  const pipelineLayout = buildSchemeLayout(hasNodes ? schemeGroups : archiveGroups, hasNodes ? schemeManual : [], files, compactLayoutFlows, hasNodes ? visibleDrafts : [], pipelines, [], new Set(), isolatedCompactHistoryPaths);
+  const pipelineLayout = buildSchemeLayout(hasNodes ? schemeGroups : archiveGroups, hasNodes ? schemeManual : [], files, compactLayoutFlows, hasNodes ? visibleDrafts : [], pipelines, [], new Set(), isolatedCompactHistoryPaths, [], new Set(), { now: nowSeconds });
   /* Worker rows the scheme still draws in a retained form — an active flow's
      reviewer round deck keeps its finished rounds as deck tabs. Those are
      re-admitted here so a folded reviewer is never listed twice (its deck AND a
@@ -1804,6 +1818,7 @@ function ProjectDashboardView({
                 reviewGroups={directReviewGroups}
                 pipelines={pipelines}
                 surfacePipelines={activePipelines}
+                now={nowSeconds}
                 tasks={hasNodes ? boardTasks : []}
                 allTasks={projectTasks}
                 workerStacks={workerStacks}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -847,11 +847,11 @@ function ProjectDashboardView({
       ...manualPaths,
       ...extra.map((file) => file.path),
     ]);
-    const protectedNodes = protectedReviewerNodes({ files, flows: deckFlows, renderedNodePaths: placedNodePaths, hiddenPaths: hiddenSet, pinnedPaths })
+    const protectedNodes = protectedReviewerNodes({ files, flows: deckFlows, renderedNodePaths: placedNodePaths, hiddenPaths: hiddenSet, pinnedPaths, now: nowSeconds })
       .filter((file) => projectKey(file) === project && !compactPipelinePaths.has(file.path));
     const extras = [...extra, ...protectedNodes];
     return extras.length ? [...manualNodes, ...extras] : manualNodes;
-  }, [ephemeral, groupFiles, files, compactPipelinePaths, deckFlows, project, autoPaths, hiddenSet, manualNodes, pinnedPaths]);
+  }, [ephemeral, groupFiles, files, compactPipelinePaths, deckFlows, project, autoPaths, hiddenSet, manualNodes, pinnedPaths, nowSeconds]);
   const liveCount = useMemo(
     () =>
       groups.reduce(

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -67,8 +67,8 @@ import {
   quietRootsWithActiveDescendants,
   residualItems,
   schemeAgeHorizonSeconds,
-  withinPlacementHorizon,
 } from "./projectModel";
+import { boundFlowExpansions } from "./scheme/placementHorizon";
 import { ArchiveRestore } from "./icons";
 import { KeepAwakeMenuRow } from "./KeepAwakeControl";
 import { ArchiveProjectButton, DeleteProjectButton } from "./ProjectTrash";
@@ -588,19 +588,10 @@ function ProjectDashboardView({
       if (isDirectReviewFlow(flow) && flow.state !== "reviewing") continue;
       paths.add(flow.implementerPath);
     }
-    /* This expansion is automatic — the board opens it, not the operator — so it
-       follows the placement age horizon like every other automatic card. A flow
-       that has sat in an approved state for weeks must not keep dragging its
-       implementer (and, through it, an ancient root) onto the canvas; live and
-       running work stays regardless of age, and the operator's own expansions
-       (`prefs.expanded`, merged below) are never bounded. */
-    const horizon = schemeAgeHorizonSeconds();
-    const byPath = new Map(files.map((file) => [file.path, file] as const));
-    for (const path of [...paths]) {
-      const file = byPath.get(path);
-      if (file && !withinPlacementHorizon(file, nowSeconds, horizon)) paths.delete(path);
-    }
-    return paths;
+    /* These expansions are the board's, not the operator's, so they follow the
+       placement age horizon like every other automatic card (the operator's own
+       `prefs.expanded` are merged below and never bounded). */
+    return boundFlowExpansions(paths, { flows: activeFlows, files, now: nowSeconds, ageHorizonSeconds: schemeAgeHorizonSeconds() });
   }, [files, deckFlows, nowSeconds]);
   /* Flow-driven expansions plus the ones the user opened by hand from a
      collapsed view: a connected conversation the user expanded renders as a

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -434,6 +434,51 @@ describe("automatic placement age horizon", () => {
     expect(groups[0]!.finished.map((file) => file.path)).toContain("/old-root/mid/leaf");
   });
 
+  test("an aged root placed by another rule owns its live descendant instead of doubling it", () => {
+    /* Two rules meet on one tree: the operator expanded the aged root, and the
+       child is live. The root is on the canvas, so lifting the child to the
+       "topmost PLACEABLE ancestor" stopped at the child itself and opened a
+       second group for a card the root's group already renders as a column. */
+    const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 200 * HOUR });
+    const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "live", mtime: NOW - 200 * HOUR });
+    const groups = buildBranchGroups([root, child], "demo", { now: NOW, expandedConversationPaths: new Set(["/old-root"]) });
+    expect(groups.map((group) => group.key)).toEqual(["/old-root"]);
+    expect(groups[0]!.columns.map((column) => column.file.path)).toEqual(["/old-root", "/old-root/agent"]);
+    // Every path the groups render, exactly once.
+    const rendered = groups.flatMap((group) => group.columns.map((column) => column.file.path));
+    expect(rendered).toEqual([...new Set(rendered)]);
+  });
+
+  test("a promoted engine child of an aged root is not emitted twice", () => {
+    const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 200 * HOUR });
+    const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "idle", mtime: NOW - 200 * HOUR });
+    const groups = buildBranchGroups([root, child], "demo", {
+      now: NOW,
+      expandedConversationPaths: new Set(["/old-root"]),
+      enginePlacement: { promotedEnginePaths: new Set(["/old-root/agent"]) },
+    });
+    const rendered = groups.flatMap((group) => group.columns.map((column) => column.file.path));
+    expect(rendered).toEqual([...new Set(rendered)]);
+    expect(rendered).toContain("/old-root/agent");
+  });
+
+  test("a card below two group roots hangs under the nearer one, once", () => {
+    /* A `recent` conversation mid-chain becomes a root with no lift at all, so
+       it and the tree root above it both assembled over the same subtree and
+       emitted the leaf twice under one key (React: "two children with the same
+       key"). Nearest drawn ancestor wins, matching how the arrows already read. */
+    const spawned = { kind: "spawn", role: null, depth: 0, parentConversationId: "c", reviewsConversationId: null, memberships: [] } as FileEntry["durableLineage"];
+    const top = entry({ path: "/top", root: "codex-sessions", engine: "codex", activity: "live", mtime: NOW - HOUR });
+    const mid = entry({ path: "/mid", parent: "/top", durableLineage: spawned, activity: "recent", mtime: NOW - HOUR });
+    const leaf = entry({ path: "/leaf", parent: "/mid", durableLineage: spawned, activity: "live", mtime: NOW - HOUR });
+    const groups = buildBranchGroups([top, mid, leaf], "demo", { now: NOW });
+    const rendered = groups.flatMap((group) => group.columns.map((column) => column.file.path));
+    expect(rendered).toEqual([...new Set(rendered)]);
+    expect(rendered).toContain("/leaf");
+    const owner = groups.find((group) => group.columns.some((column) => column.file.path === "/leaf"))!;
+    expect(owner.key).toBe("/mid");
+  });
+
   test("a stale child under a live root rests as a chip instead of taking a column", () => {
     const root = entry({ path: "/live-root", activity: "live", mtime: NOW - HOUR });
     const stale = entry({ path: "/live-root/ancient", parent: "/live-root", kind: "subagent", activity: "idle", mtime: NOW - 400 * HOUR });

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -18,6 +18,7 @@ import {
   resolveProjectView,
   schemeAgeHorizonSeconds,
   subtree,
+  withinPlacementHorizon,
 } from "./projectModel";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
@@ -410,10 +411,75 @@ describe("automatic placement age horizon", () => {
     expect(groups.map((group) => group.key)).toEqual(["/stale-expanded"]);
   });
 
-  test("a recently active child keeps its stale root's card on the canvas", () => {
+  test("a recently active child never resurrects its stale root's card", () => {
     const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 200 * HOUR });
     const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "idle", mtime: NOW - 13 * HOUR });
-    expect(buildBranchGroups([root, child], "demo", { now: NOW }).map((group) => group.key)).toEqual(["/old-root"]);
+    const groups = buildBranchGroups([root, child], "demo", { now: NOW });
+    // The fresh child opens its own group; the root it hangs under stays in
+    // quiet history instead of returning to the canvas after weeks of silence.
+    expect(groups.map((group) => group.key)).toEqual(["/old-root/agent"]);
+    expect(quietHistoryRows([root, child], "demo").map((file) => file.path)).toContain("/old-root");
+  });
+
+  test("two fresh children of one stale root share a single group", () => {
+    const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 200 * HOUR });
+    const mid = entry({ path: "/old-root/mid", parent: "/old-root", kind: "subagent", activity: "idle", mtime: NOW - 13 * HOUR });
+    const leaf = entry({ path: "/old-root/mid/leaf", parent: "/old-root/mid", kind: "subagent", activity: "idle", mtime: NOW - 12 * HOUR });
+    const groups = buildBranchGroups([root, mid, leaf], "demo", { now: NOW });
+    // One group, not two: the deeper placed descendant joins the topmost
+    // placeable ancestor's group (as a settled chip, per the quiet-child rule)
+    // instead of opening a duplicate node for the same tree.
+    expect(groups.map((group) => group.key)).toEqual(["/old-root/mid"]);
+    expect(groups[0]!.columns.map((column) => column.file.path)).toEqual(["/old-root/mid"]);
+    expect(groups[0]!.finished.map((file) => file.path)).toContain("/old-root/mid/leaf");
+  });
+
+  test("a stale child under a live root rests as a chip instead of taking a column", () => {
+    const root = entry({ path: "/live-root", activity: "live", mtime: NOW - HOUR });
+    const stale = entry({ path: "/live-root/ancient", parent: "/live-root", kind: "subagent", activity: "idle", mtime: NOW - 400 * HOUR });
+    const fresh = entry({ path: "/live-root/today", parent: "/live-root", kind: "subagent", activity: "idle", mtime: NOW - 3 * HOUR });
+    const group = buildBranchGroups([root, stale, fresh], "demo", { now: NOW })[0]!;
+    expect(group.columns.map((column) => column.file.path)).toEqual(["/live-root", "/live-root/today"]);
+    // Bounded off the canvas, never lost: it stays a chip in the under-deck.
+    expect(group.finished.map((file) => file.path)).toContain("/live-root/ancient");
+  });
+
+  test("a stale child that is live or running keeps its column under a live root", () => {
+    const root = entry({ path: "/live-root", activity: "live", mtime: NOW - HOUR });
+    const running = entry({ path: "/live-root/long", parent: "/live-root", kind: "subagent", activity: "idle", proc: "running", mtime: NOW - 400 * HOUR });
+    const group = buildBranchGroups([root, running], "demo", { now: NOW })[0]!;
+    expect(group.columns.map((column) => column.file.path)).toEqual(["/live-root", "/live-root/long"]);
+  });
+
+  test("an explicitly expanded stale child places without its stale root", () => {
+    const root = entry({ path: "/old-root", activity: "idle", mtime: NOW - 300 * HOUR });
+    const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "idle", mtime: NOW - 300 * HOUR });
+    const groups = buildBranchGroups([root, child], "demo", {
+      now: NOW,
+      expandedConversationPaths: new Set(["/old-root/agent"]),
+    });
+    expect(groups.map((group) => group.key)).toEqual(["/old-root/agent"]);
+    expect(groups[0]!.columns.map((column) => column.file.path)).toEqual(["/old-root/agent"]);
+  });
+
+  test("without a clock a stale child still opens its root's group", () => {
+    const root = entry({ path: "/old-root", activity: "idle", mtime: 1_000 });
+    const child = entry({ path: "/old-root/agent", parent: "/old-root", kind: "subagent", activity: "recent", mtime: 1_000 });
+    expect(buildBranchGroups([root, child], "demo").map((group) => group.key)).toEqual(["/old-root"]);
+  });
+
+  test("the placement horizon exempts live and running work and bounds the rest", () => {
+    const live = entry({ path: "/live", activity: "live", mtime: NOW - 400 * HOUR });
+    const running = entry({ path: "/running", activity: "idle", proc: "running", mtime: NOW - 400 * HOUR });
+    const recent = entry({ path: "/recent", activity: "recent", mtime: NOW - 400 * HOUR });
+    const stale = entry({ path: "/stale", activity: "idle", mtime: NOW - 400 * HOUR });
+    const fresh = entry({ path: "/fresh", activity: "idle", mtime: NOW - HOUR });
+    for (const file of [live, running, recent, fresh]) {
+      expect(withinPlacementHorizon(file, NOW, 48 * HOUR)).toBe(true);
+    }
+    expect(withinPlacementHorizon(stale, NOW, 48 * HOUR)).toBe(false);
+    // No clock: age is unknowable, so nothing is bounded.
+    expect(withinPlacementHorizon(stale, 0, 48 * HOUR)).toBe(true);
   });
 
   test("a cross-project segment follows the horizon once its child is quiet", () => {

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -33,6 +33,26 @@ export function schemeAgeHorizonSeconds(): number {
   return (Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_SCHEME_AGE_HORIZON_HOURS) * 3_600;
 }
 
+/**
+ * May this entry occupy the canvas automatically, given its age? The one age
+ * judgment every automatic placement path shares — root cards, child columns,
+ * engine-tray promotions and pipeline slots alike — so a conversation cannot
+ * enter the map through a rule that consults no clock.
+ *
+ * Live and running work is never bounded: a long-running session with an old
+ * transcript keeps its node. Without a clock (`now <= 0` — the server render and
+ * the hydration pass) age is unknowable, so nothing is bounded and both sides
+ * paint the plain activity rule. Bounded entries are never lost: they stay in
+ * «All conversations», quiet history, worker stacks and parent trays.
+ */
+export function withinPlacementHorizon(file: FileEntry, now: number, ageHorizonSeconds: number): boolean {
+  if (file.activity === "live" || file.proc === "running") return true;
+  /* The activity rule stays alongside the clock so a sub-15-minute horizon
+     override can never out-tighten the activity the projection calls recent. */
+  if (file.activity === "recent") return true;
+  return now <= 0 || now - file.mtime <= ageHorizonSeconds;
+}
+
 export function activityBand(file: FileEntry): ActivityBand {
   if (file.activity === "live") return 0;
   if (file.activity === "recent") return 1;
@@ -354,6 +374,7 @@ function assembleGroup(
   kids: Map<string, FileEntry[]>,
   expandedConversationPaths?: ReadonlySet<string>,
   placement?: EnginePlacement,
+  placeableByAge: (file: FileEntry) => boolean = () => true,
 ): BranchGroup {
   /* Stop traversal at the first foreign owner so a later same-project node
      cannot leak through that foreign branch and appear twice. */
@@ -368,9 +389,13 @@ function assembleGroup(
      canvas as full nodes. Under a quiet root a settled child now rests as a
      chip in the group's under-deck, one expand-click away, exactly like every
      other finished technical item. */
+  /* The working root's quiet children are live-relevant context only while they
+     are inside the placement age horizon: an active root touched today must not
+     drag a worker it finished three weeks ago back onto the canvas as a full
+     column. The aged one rests in the under-deck like any other finished item. */
   const rootActive = root.activity === "live" || root.proc === "running";
   const branches = descendants
-    .filter((file) => (rootActive && isChildConversation(file) && !placement?.foldedEnginePaths?.has(file.path))
+    .filter((file) => (rootActive && isChildConversation(file) && placeableByAge(file) && !placement?.foldedEnginePaths?.has(file.path))
       || columnWorthy(file, expandedConversationPaths, placement))
     .sort((a, b) => liveRank(a) - liveRank(b) || tick5(b.mtime) - tick5(a.mtime) || a.path.localeCompare(b.path));
   const liveTasks = descendants
@@ -408,6 +433,13 @@ function assembleGroup(
  * history. Recent child conversations (claude subagents, codex job sessions)
  * keep full columns too, because "done between user messages" must not hide
  * active work.
+ *
+ * The horizon bounds EVERY automatic placement here, whatever the entry's role
+ * in the tree (`withinPlacementHorizon`): a root card, a child column under a
+ * working root, and the root a placed descendant opens its group at. Live and
+ * running work is exempt at any age, an explicit expansion still places, and
+ * everything bounded off the canvas keeps its chip in the group's under-deck,
+ * its row in quiet history and its entry in «All conversations».
  */
 export interface BranchGroupOptions {
   /** Quiet conversations promoted into full scheme nodes. */
@@ -437,6 +469,30 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
      never out-tighten the activity the projection already calls recent. */
   const recentlyActive = (file: FileEntry) =>
     file.activity === "recent" || (now > 0 && now - file.mtime <= ageHorizon);
+  /* The same horizon, asked of any entry a rule wants to place. */
+  const placeableByAge = (file: FileEntry) => withinPlacementHorizon(file, now, ageHorizon);
+  /* Which card opens the group a placed descendant belongs to. Its tree root
+     normally does — but a root beyond the horizon is never resurrected by fresh
+     work below it: a worker answering today must not drag a conversation from
+     three weeks ago back onto the canvas. The placed descendant then opens its
+     own group and its aged root stays in quiet history, one click away through
+     the arrow's unresolved parent and «All conversations». */
+  const groupRootFor = (file: FileEntry): FileEntry => {
+    /* The TOPMOST placeable ancestor inside the project, so two placed
+       descendants of one aged root still share a single group instead of
+       rendering the same conversation under two keys. */
+    let best = file;
+    let cursor = file;
+    const seen = new Set<string>([file.path]);
+    while (cursor.parent && !seen.has(cursor.parent)) {
+      const parent = byPath.get(cursor.parent);
+      if (!parent || projectKey(parent) !== projectKey(file)) break;
+      seen.add(parent.path);
+      cursor = parent;
+      if (placeableByAge(parent)) best = parent;
+    }
+    return best;
+  };
   for (const file of files) {
     if (projectKey(file) !== project) continue;
     /* A cross-project child starts an independently owned visual segment. Keep
@@ -461,14 +517,14 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
       enginePlacement?.promotedEnginePaths?.has(file.path) === true ||
       (expanded && (isConversation(file) || isChildConversation(file)))
     ) {
-      const root = rootOf(file, byPath);
+      const root = groupRootFor(file);
       if (isAuxTask(root)) orphanTasks.set(root.path, root);
       else roots.set(root.path, root);
       continue;
     }
     if (recentlyActive(file) && isConversation(file)) roots.set(file.path, file);
   }
-  const groups = [...roots.values()].map((root) => assembleGroup(root, kids, expandedConversationPaths, enginePlacement));
+  const groups = [...roots.values()].map((root) => assembleGroup(root, kids, expandedConversationPaths, enginePlacement, placeableByAge));
   for (const task of orphanTasks.values()) {
     groups.push({
       key: task.path,

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -419,6 +419,60 @@ function assembleGroup(
 
 
 /**
+ * One conversation, one node.
+ *
+ * Two group roots can sit on a single lineage: `groupRootFor` lifts a placed
+ * descendant to the topmost ancestor the HORIZON allows, but an ancestor past
+ * the horizon can still be on the canvas through a rule that consults no clock
+ * (an operator expansion, an engine promotion), and a `recent` conversation
+ * mid-chain becomes a root without any lift at all. Each root then assembles
+ * over its WHOLE subtree, so a card below both was emitted twice under one key
+ * — React's "two children with the same key", and a duplicated card on the
+ * board.
+ *
+ * Ownership is resolved the way the drawn hierarchy already reads: a card
+ * belongs to the group whose root is its NEAREST ancestor, so it hangs under
+ * the closest generation still drawn and never under a further one as well. A
+ * group root another group already renders as a column is redundant in full and
+ * drops out; nothing leaves the canvas, because the column that displaced it is
+ * the same card.
+ */
+function singleOwnership(groups: BranchGroup[], byPath: Map<string, FileEntry>): BranchGroup[] {
+  /* Steps from `file` up to `rootPath`, or Infinity when it is no ancestor. */
+  const distanceTo = (file: FileEntry, rootPath: string): number => {
+    let cursor: FileEntry | undefined = file;
+    const seen = new Set<string>();
+    for (let steps = 0; cursor && !seen.has(cursor.path); steps += 1) {
+      if (cursor.path === rootPath) return steps;
+      seen.add(cursor.path);
+      cursor = cursor.parent ? byPath.get(cursor.parent) : undefined;
+    }
+    return Number.POSITIVE_INFINITY;
+  };
+  const columnedElsewhere = new Set<string>();
+  for (const group of groups) {
+    for (const column of group.columns) {
+      if (column.file.path !== group.key) columnedElsewhere.add(column.file.path);
+    }
+  }
+  const kept = groups.filter((group) => !columnedElsewhere.has(group.key));
+  const owner = new Map<string, BranchGroup>();
+  for (const group of kept) {
+    for (const column of group.columns) {
+      const held = owner.get(column.file.path);
+      if (!held || distanceTo(column.file, group.key) < distanceTo(column.file, held.key)) owner.set(column.file.path, group);
+    }
+  }
+  return kept.map((group) => {
+    const columns = group.columns.filter((column) => owner.get(column.file.path) === group);
+    if (columns.length === group.columns.length) return group;
+    /* The freshness sort key follows the columns that stayed. */
+    const smt = Math.max(...columns.map((column) => column.file.mtime), ...columns.flatMap((column) => column.tasks.map((task) => task.mtime)));
+    return { ...group, columns, smt };
+  });
+}
+
+/**
  * One group per active branch tree: the root conversation opens the group,
  * live descendant agents (subagents, codex rollouts) get their own columns.
  * Live background tasks (bash, codex job logs) never take a full column —
@@ -524,7 +578,10 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
     }
     if (recentlyActive(file) && isConversation(file)) roots.set(file.path, file);
   }
-  const groups = [...roots.values()].map((root) => assembleGroup(root, kids, expandedConversationPaths, enginePlacement, placeableByAge));
+  const groups = singleOwnership(
+    [...roots.values()].map((root) => assembleGroup(root, kids, expandedConversationPaths, enginePlacement, placeableByAge)),
+    byPath,
+  );
   for (const task of orphanTasks.values()) {
     groups.push({
       key: task.path,

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -93,6 +93,10 @@ interface Props {
   workerStacks?: WorkerStack[];
   /** Active project pipelines rendered as world-space desktop containers. */
   surfacePipelines?: Pipeline[];
+  /** The board's wall clock in epoch seconds, shared with the grouping model so
+      one clock bounds every automatic placement. `0` — the server render and the
+      hydration pass — bounds nothing. */
+  now?: number;
   /** Ids of not-yet-spawned conversation drafts drawn as full panes. */
   drafts: string[];
   /** Durable identities the user has crowned (issue #224): their roots lift into
@@ -194,6 +198,7 @@ export function SchemeBoard({
   allTasks = tasks,
   workerStacks = [],
   surfacePipelines = [],
+  now = 0,
   drafts,
   favorites,
   isolatedManualPaths = EMPTY_PATHS,
@@ -301,8 +306,8 @@ export function SchemeBoard({
      task cards (#531), so the pipeline reads as a single region — never a
      detached control card with a duplicate stage graph. */
   const layout = useMemo(
-    () => buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds),
-    [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds],
+    () => buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, { now }),
+    [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, now],
   );
 
   /* NO PRUNING HERE (#771). The selection outlives this view, so dropping a path

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -22,7 +22,7 @@ import {
 } from "./agentLinks";
 import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts, stageRowCollapsible } from "@/components/pipelines/pipelineModel";
 import { buildSchemeLineage } from "./lineageModel";
-import { pipelineWithinPlacementHorizon } from "./placementHorizon";
+import { buildTranscriptLookup, pipelineWithinPlacementHorizon, transcriptIdentity } from "./placementHorizon";
 import { linkedPipelineTasks } from "./pipelineAnchor";
 import { TASK_W, isPlacedTask, taskBoxHeight } from "./taskGeometry";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf, schemeAgeHorizonSeconds } from "@/components/projectModel";
@@ -513,13 +513,20 @@ export function buildSchemeLayout(
        stay drawn around that card rather than leaving it to float. */
     const placementNow = placement.now ?? 0;
     const placementHorizon = placement.ageHorizonSeconds ?? schemeAgeHorizonSeconds();
+    /* Both reads below resolve through the transcript identity. An attempt
+       records whichever root its spawn ran under, which is routinely a
+       different spelling from the one the scan published; a raw-string lookup
+       then silently answers "no such file" and the pipeline loses its liveness
+       exemption and its pin escape at once. */
+    const fileAt = buildTranscriptLookup(files);
+    const prePlacedIdentities = new Set([...prePlacedNodePaths].map(transcriptIdentity));
     const agedOut = (pipeline: Pipeline): boolean => {
-      if (pipelineWithinPlacementHorizon(pipeline, { now: placementNow, ageHorizonSeconds: placementHorizon, fileAt: (path) => byAll.get(path) })) return false;
+      if (pipelineWithinPlacementHorizon(pipeline, { now: placementNow, ageHorizonSeconds: placementHorizon, fileAt })) return false;
       for (const run of pipeline.runs) {
         for (const attempt of run.attempts) {
-          if (attempt.agentPath && prePlacedNodePaths.has(attempt.agentPath)) return false;
+          if (attempt.agentPath && prePlacedIdentities.has(transcriptIdentity(attempt.agentPath))) return false;
           const impl = attempt.flowId ? implOfFlow(attempt.flowId) : null;
-          if (impl && prePlacedNodePaths.has(impl)) return false;
+          if (impl && prePlacedIdentities.has(transcriptIdentity(impl))) return false;
         }
       }
       return true;

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -22,9 +22,10 @@ import {
 } from "./agentLinks";
 import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts, stageRowCollapsible } from "@/components/pipelines/pipelineModel";
 import { buildSchemeLineage } from "./lineageModel";
+import { pipelineWithinPlacementHorizon } from "./placementHorizon";
 import { linkedPipelineTasks } from "./pipelineAnchor";
 import { TASK_W, isPlacedTask, taskBoxHeight } from "./taskGeometry";
-import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf } from "@/components/projectModel";
+import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf, schemeAgeHorizonSeconds } from "@/components/projectModel";
 import { cleanTitle, engineColor } from "@/components/utils";
 import { conversationIdentity } from "@/lib/accounts/identity";
 
@@ -339,6 +340,12 @@ export function buildSchemeLayout(
   /** Session-only expanded-text task ids — an expanded card grows taller, and
       the region reserves that footprint so containment holds live. */
   taskTextExpanded: ReadonlySet<string> = new Set(),
+  /** The board clock in epoch seconds and the automatic-placement age horizon.
+      A pipeline past the horizon with no live or running stage grows no stage
+      surfaces. `now` defaults to `0` — no clock, so nothing is bounded, which
+      is what the server render, the hydration pass and every caller that has no
+      clock of its own must keep painting. */
+  placement: { now?: number; ageHorizonSeconds?: number } = {},
 ): SchemeLayout {
   const byAll = new Map(files.map((file) => [file.path, file]));
   /* The board's single parentage authority (issue #828). Resolved once per
@@ -498,6 +505,25 @@ export function buildSchemeLayout(
       seen.add(pipeline.id);
       return true;
     });
+    /* Stage surfaces follow the board's automatic-placement age horizon: a
+       pipeline that finished or stranded weeks ago keeps no slots, no completed
+       stage cards and no region. A pipeline with any live or running stage is
+       exempt at any age, and so is one whose stage transcript the board still
+       places for its own reasons (a manual pin, an expansion) — its chain must
+       stay drawn around that card rather than leaving it to float. */
+    const placementNow = placement.now ?? 0;
+    const placementHorizon = placement.ageHorizonSeconds ?? schemeAgeHorizonSeconds();
+    const agedOut = (pipeline: Pipeline): boolean => {
+      if (pipelineWithinPlacementHorizon(pipeline, { now: placementNow, ageHorizonSeconds: placementHorizon, fileAt: (path) => byAll.get(path) })) return false;
+      for (const run of pipeline.runs) {
+        for (const attempt of run.attempts) {
+          if (attempt.agentPath && prePlacedNodePaths.has(attempt.agentPath)) return false;
+          const impl = attempt.flowId ? implOfFlow(attempt.flowId) : null;
+          if (impl && prePlacedNodePaths.has(impl)) return false;
+        }
+      }
+      return true;
+    };
     /* Each placed task card belongs to at most one pipeline region. */
     const claimedTaskIds = new Set<string>();
     for (const [pipelineIndex, pipeline] of pool.entries()) {
@@ -511,6 +537,9 @@ export function buildSchemeLayout(
           if (path && !stageRankByPath.has(path)) stageRankByPath.set(path, pipelineIndex * 10_000 + stageIndex);
         }
       });
+      /* Ranks first (they place nothing), then the horizon: an aged-out pipeline
+         still orders whatever the board places for other reasons. */
+      if (agedOut(pipeline)) continue;
       const placeholderIds = new Set(pipelinePlaceholderStages(pipeline, prePlacedNodePaths, prePlacedDeckFlowIds).map((stage) => stage.id));
       /* Completed cards only grow on an active pipeline, and never for the cursor
          stage itself: a cursor stage whose only transcript is quiet history

--- a/src/components/scheme/placementHorizon.test.ts
+++ b/src/components/scheme/placementHorizon.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "bun:test";
 
+import type { Flow } from "@/lib/flows/types";
 import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
 import type { FileEntry } from "@/lib/types";
 import type { BranchGroup } from "@/components/projectModel";
 
 import { buildSchemeLayout } from "./layout";
-import { pipelineWithinPlacementHorizon } from "./placementHorizon";
+import { boundFlowExpansions, buildTranscriptLookup, pipelineWithinPlacementHorizon, transcriptIdentity } from "./placementHorizon";
 
 const HOUR = 3_600;
 const NOW = 1_786_000_000;
@@ -84,6 +85,100 @@ test("without a clock nothing is bounded", () => {
   expect(pipelineWithinPlacementHorizon(pipeline("p"), { now: 0, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(true);
 });
 
+// ── the record's path spelling is not the scanner's ─────────────────────────
+
+/* The exact spellings the live board disagrees on: a durable attempt records
+   the account-shared root a spawn ran under, while the scan that produced the
+   FileEntry walked the operator's own root (or the reverse). Both name one
+   transcript. A resolver keyed on the raw string answers `undefined`, which is
+   why the tests above — every one of which hands back a file for ANY path —
+   cannot see the miss. */
+const RECORD_SPELLING = "/roots/own/claude/projects/-w-pipe/stage-one-session.jsonl";
+const SCANNED_SPELLING = "/roots/shared/claude/projects/-w-pipe/stage-one-session.jsonl";
+
+test("one transcript under two root spellings shares an identity, two transcripts never do", () => {
+  expect(transcriptIdentity(RECORD_SPELLING)).toBe(transcriptIdentity(SCANNED_SPELLING));
+  expect(transcriptIdentity("/a/rollout-2026-08-02T08-22-36-019fc0ec.jsonl")).not.toBe(transcriptIdentity("/a/rollout-2026-08-02T08-22-37-019fc0ed.jsonl"));
+  /* A non-transcript path is never aliased down to its basename. */
+  expect(transcriptIdentity("/one/output")).not.toBe(transcriptIdentity("/two/output"));
+});
+
+test("a running stage exempts its pipeline even when the scan spells the transcript differently", () => {
+  const running = file(SCANNED_SPELLING, { proc: "running" });
+  const aged = pipeline("aged", { agentPath: RECORD_SPELLING });
+  const byPathOnly = new Map([[running.path, running]]);
+  // The raw-string resolver misses the record's spelling — the defect itself.
+  expect(byPathOnly.get(RECORD_SPELLING)).toBeUndefined();
+  const lookup = buildTranscriptLookup([running]);
+  expect(lookup(RECORD_SPELLING)).toBe(running);
+  expect(pipelineWithinPlacementHorizon(aged, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: lookup })).toBe(true);
+});
+
+test("a recently touched transcript dates its pipeline through the other spelling too", () => {
+  const touched = file(SCANNED_SPELLING, { mtime: NOW - 2 * HOUR });
+  const aged = pipeline("aged", { agentPath: RECORD_SPELLING });
+  expect(pipelineWithinPlacementHorizon(aged, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: buildTranscriptLookup([touched]) })).toBe(true);
+});
+
+test("an ambiguous identity never resolves — only an unambiguous one crosses roots", () => {
+  const twinA = file("/root-a/dup.jsonl", { proc: "running" });
+  const twinB = file("/root-b/dup.jsonl");
+  const lookup = buildTranscriptLookup([twinA, twinB]);
+  expect(lookup("/root-a/dup.jsonl")).toBe(twinA);
+  expect(lookup("/somewhere-else/dup.jsonl")).toBeUndefined();
+});
+
+test("a pipeline the record cannot date at all is left alone rather than dated to the epoch", () => {
+  const undatable = { ...pipeline("p"), createdAt: null, runs: [] } as unknown as Pipeline;
+  expect(pipelineWithinPlacementHorizon(undatable, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(true);
+});
+
+test("a stage the projection still calls recent holds its pipeline against a tightened horizon", () => {
+  const recent = file("/stage/one", { activity: "recent", mtime: NOW - 20 * 60 });
+  const aged = pipeline("p", { agentPath: "/stage/one" });
+  // A sub-15-minute override must not out-tighten the activity band itself.
+  expect(pipelineWithinPlacementHorizon(aged, { now: NOW, ageHorizonSeconds: 300, fileAt: () => recent })).toBe(true);
+});
+
+// ── flow-driven expansions ──────────────────────────────────────────────────
+
+function flow(overrides: Partial<Flow> = {}): Flow {
+  return {
+    id: "f1", template: "review", project: "demo", cwd: "/w", implementerPath: "/impl",
+    roles: {}, baseRef: "a", baseMode: "head", mode: "auto", reviewerMode: "headless",
+    roundLimit: 5, state: "reviewing", stateDetail: null, rounds: [], createdAt: iso(400 * HOUR), closedAt: null,
+    ...overrides,
+  } as unknown as Flow;
+}
+
+function round(reviewerPath: string): Flow["rounds"][number] {
+  return { n: 1, reviewerPath, verdict: null, findingsCount: null, startedAt: iso(HOUR), findingsPath: null, triggeredBy: "button", readyNote: null, reviewedAt: null, relayedAt: null, error: null } as unknown as Flow["rounds"][number];
+}
+
+test("an aged implementer keeps its expansion while a reviewer of its flow is live", () => {
+  const impl = file("/impl", { mtime: NOW - 400 * HOUR });
+  const reviewer = file("/impl/reviewer", { parent: "/impl", mtime: NOW - 400 * HOUR, activity: "live" });
+  const reviewing = flow({ rounds: [round(reviewer.path)] });
+  const kept = boundFlowExpansions(new Set(["/impl"]), { flows: [reviewing], files: [impl, reviewer], now: NOW, ageHorizonSeconds: 48 * HOUR });
+  // The implementer is the card the round deck hangs on: bounding it would
+  // strand the live reviewer as a bare node with no deck to fold into.
+  expect([...kept]).toEqual(["/impl"]);
+});
+
+test("a running reviewer holds its implementer too, and a settled flow loses it", () => {
+  const impl = file("/impl", { mtime: NOW - 400 * HOUR });
+  const running = file("/impl/reviewer", { parent: "/impl", mtime: NOW - 400 * HOUR, proc: "running" });
+  const quiet = file("/impl/reviewer", { parent: "/impl", mtime: NOW - 400 * HOUR });
+  const input = { now: NOW, ageHorizonSeconds: 48 * HOUR };
+  expect([...boundFlowExpansions(new Set(["/impl"]), { ...input, flows: [flow({ rounds: [round(running.path)] })], files: [impl, running] })]).toEqual(["/impl"]);
+  expect([...boundFlowExpansions(new Set(["/impl"]), { ...input, flows: [flow({ state: "approved", rounds: [round(quiet.path)] })], files: [impl, quiet] })]).toEqual([]);
+});
+
+test("a fresh implementer keeps its expansion with no reviewer at all", () => {
+  const impl = file("/impl", { mtime: NOW - 2 * HOUR });
+  expect([...boundFlowExpansions(new Set(["/impl"]), { flows: [flow()], files: [impl], now: NOW, ageHorizonSeconds: 48 * HOUR })]).toEqual(["/impl"]);
+});
+
 // ── layout integration ──────────────────────────────────────────────────────
 
 test("a terminal pipeline past the horizon grows no slots while a live one keeps its own", () => {
@@ -121,4 +216,18 @@ test("an aged pipeline with a live stage transcript keeps its slots", () => {
   const runningFile = file(livePath, { proc: "running" });
   const layout = buildSchemeLayout([], [], [runningFile], [], [], [aged], [aged], new Set(), new Set(), [], new Set(), { now: NOW });
   expect(new Set(layout.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["aged"]));
+});
+
+test("the layout reads a running stage and a pinned stage through the scanner's spelling", () => {
+  const running = file(SCANNED_SPELLING, { proc: "running" });
+  const live = pipeline("live", { agentPath: RECORD_SPELLING, state: "running" });
+  const byLiveness = buildSchemeLayout([], [], [running], [], [], [live], [live], new Set(), new Set(), [], new Set(), { now: NOW });
+  expect(new Set(byLiveness.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["live"]));
+
+  /* And the pin escape: an aged, stranded pipeline whose stage card the board
+     places anyway keeps the chain drawn around it. */
+  const pinned = file(SCANNED_SPELLING);
+  const stranded = pipeline("stranded", { agentPath: RECORD_SPELLING, state: "needs_decision" });
+  const byPin = buildSchemeLayout([group(pinned)], [], [pinned], [], [], [stranded], [stranded], new Set(), new Set(), [], new Set(), { now: NOW });
+  expect(new Set(byPin.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["stranded"]));
 });

--- a/src/components/scheme/placementHorizon.test.ts
+++ b/src/components/scheme/placementHorizon.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+
+import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+import type { BranchGroup } from "@/components/projectModel";
+
+import { buildSchemeLayout } from "./layout";
+import { pipelineWithinPlacementHorizon } from "./placementHorizon";
+
+const HOUR = 3_600;
+const NOW = 1_786_000_000;
+const iso = (secondsAgo: number) => new Date((NOW - secondsAgo) * 1_000).toISOString();
+
+function file(path: string, overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path, root: "claude-projects", name: path, project: "demo", title: path, engine: "claude", kind: "session",
+    fmt: "claude", parent: null, mtime: NOW - 400 * HOUR, size: 10, activity: "idle", proc: null, pid: null,
+    model: null, pendingQuestion: null, waitingInput: null, ...overrides,
+  } as FileEntry;
+}
+
+function group(entry: FileEntry): BranchGroup {
+  return { key: entry.path, columns: [{ file: entry, tasks: [] }], returnable: [], finished: [], smt: entry.mtime, orphanTask: false };
+}
+
+function stage(id: string, next: string | null): PipelineStage {
+  return {
+    id, kind: "run", prompt: "{{prev.output}}", next,
+    effectiveRole: { roleId: null, engine: "claude", model: "", effort: "", access: "read-write", promptScaffold: null },
+  } as PipelineStage;
+}
+
+/** A three-stage pipeline: stage one ran at `attemptAgo`, the rest are queued. */
+function pipeline(id: string, options: {
+  agentPath?: string | null;
+  attemptAgo?: number;
+  createdAgo?: number;
+  state?: Pipeline["state"];
+} = {}): Pipeline {
+  const { agentPath = null, attemptAgo = 400 * HOUR, createdAgo = 400 * HOUR, state = "running" } = options;
+  return {
+    id, task: "t", taskIds: [], project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b", baseBranch: "main",
+    baseRef: "a", lastPassedCommit: "a",
+    stages: [stage("one", "two"), stage("two", "three"), stage("three", null)],
+    runs: agentPath
+      ? [{ stageId: "one", attempts: [{ n: 1, state: "passed", agentPath, flowId: null, startedAt: iso(attemptAgo), completedAt: iso(attemptAgo) }] }]
+      : [],
+    state, pausedState: null, stateDetail: null, srcPath: null, srcConversationId: null,
+    createdAt: iso(createdAgo), closedAt: null,
+    cursor: { stageId: "two", state: "pending", input: null, activatedBy: null },
+  } as unknown as Pipeline;
+}
+
+const noFiles = () => undefined;
+
+test("a pipeline whose whole record predates the horizon is bounded off the canvas", () => {
+  expect(pipelineWithinPlacementHorizon(pipeline("p"), { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(false);
+});
+
+test("a pipeline that moved inside the horizon keeps its surfaces", () => {
+  const fresh = pipeline("p", { agentPath: "/stage/one", attemptAgo: 3 * HOUR });
+  expect(pipelineWithinPlacementHorizon(fresh, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(true);
+  const justCreated = pipeline("p", { createdAgo: HOUR });
+  expect(pipelineWithinPlacementHorizon(justCreated, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(true);
+});
+
+test("a live or running stage exempts an old pipeline at any age", () => {
+  const old = pipeline("p", { agentPath: "/stage/one" });
+  const live = file("/stage/one", { activity: "live" });
+  const running = file("/stage/one", { proc: "running" });
+  const idle = file("/stage/one");
+  expect(pipelineWithinPlacementHorizon(old, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: () => live })).toBe(true);
+  expect(pipelineWithinPlacementHorizon(old, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: () => running })).toBe(true);
+  expect(pipelineWithinPlacementHorizon(old, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: () => idle })).toBe(false);
+});
+
+test("a stage transcript written recently dates the pipeline, whatever its stamps say", () => {
+  const old = pipeline("p", { agentPath: "/stage/one" });
+  const touched = file("/stage/one", { mtime: NOW - 2 * HOUR });
+  expect(pipelineWithinPlacementHorizon(old, { now: NOW, ageHorizonSeconds: 48 * HOUR, fileAt: () => touched })).toBe(true);
+});
+
+test("without a clock nothing is bounded", () => {
+  expect(pipelineWithinPlacementHorizon(pipeline("p"), { now: 0, ageHorizonSeconds: 48 * HOUR, fileAt: noFiles })).toBe(true);
+});
+
+// ── layout integration ──────────────────────────────────────────────────────
+
+test("a terminal pipeline past the horizon grows no slots while a live one keeps its own", () => {
+  const stalePath = "/stale/one";
+  const livePath = "/live/one";
+  /* Stranded, not closed: the state still declares work ahead, which is exactly
+     the pipeline that keeps drawing slots forever after its host died. */
+  const stale = pipeline("stale", { agentPath: stalePath, state: "needs_decision" });
+  const alive = pipeline("alive", { agentPath: livePath, attemptAgo: HOUR });
+  const staleFile = file(stalePath);
+  const liveFile = file(livePath, { mtime: NOW - HOUR, activity: "live" });
+  const files = [staleFile, liveFile];
+  const groups = [group(liveFile)];
+
+  const bounded = buildSchemeLayout(groups, [], files, [], [], [stale, alive], [stale, alive], new Set(), new Set(), [], new Set(), { now: NOW });
+  const pipelinesWithSlots = new Set(bounded.slots.map((slot) => slot.pipeline.id));
+  expect(pipelinesWithSlots).toEqual(new Set(["alive"]));
+
+  // Without a clock the layout is unchanged: both pipelines keep their slots.
+  const unbounded = buildSchemeLayout(groups, [], files, [], [], [stale, alive], [stale, alive]);
+  expect(new Set(unbounded.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["stale", "alive"]));
+});
+
+test("an aged pipeline whose stage the board still places keeps its chain", () => {
+  const stalePath = "/stale/one";
+  const stale = pipeline("stale", { agentPath: stalePath, state: "needs_decision" });
+  const pinned = file(stalePath);
+  const layout = buildSchemeLayout([group(pinned)], [], [pinned], [], [], [stale], [stale], new Set(), new Set(), [], new Set(), { now: NOW });
+  expect(new Set(layout.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["stale"]));
+});
+
+test("an aged pipeline with a live stage transcript keeps its slots", () => {
+  const livePath = "/aged/one";
+  const aged = pipeline("aged", { agentPath: livePath, state: "running" });
+  const runningFile = file(livePath, { proc: "running" });
+  const layout = buildSchemeLayout([], [], [runningFile], [], [], [aged], [aged], new Set(), new Set(), [], new Set(), { now: NOW });
+  expect(new Set(layout.slots.map((slot) => slot.pipeline.id))).toEqual(new Set(["aged"]));
+});

--- a/src/components/scheme/placementHorizon.ts
+++ b/src/components/scheme/placementHorizon.ts
@@ -1,5 +1,55 @@
+import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { FileEntry } from "@/lib/types";
+
+import { reviewerFileForRound } from "../flows/flowModel";
+import { withinPlacementHorizon } from "../projectModel";
+
+/**
+ * The identity a durable record and a scanned entry always agree on for a
+ * single transcript — its file name.
+ *
+ * A pipeline attempt stores whichever absolute path the spawn ran under —
+ * `$HOME/.claude/projects/…` or the account-shared
+ * `$XDG_CONFIG_HOME/agent-log-viewer/shared/claude/projects/…` (and the same
+ * pair for codex, `~/.codex/sessions/…` against
+ * `…/agent-log-viewer/accounts/codex/<account>/sessions/…`). The scan that
+ * produced the FileEntry may have walked the other one. Measured on the live
+ * board: 20 of 78 recorded attempt paths, across 15 pipelines including running
+ * ones, miss a raw-string lookup while the same session resolves under the
+ * other spelling.
+ *
+ * Only a transcript file name is an identity — every other path stays itself,
+ * so two unrelated `output` files can never be read as one conversation.
+ */
+export function transcriptIdentity(path: string): string {
+  if (!path.endsWith(".jsonl")) return path;
+  const cut = path.lastIndexOf("/");
+  return cut < 0 ? path : path.slice(cut + 1);
+}
+
+/**
+ * Resolve a path a durable record names against the entries the scanner
+ * actually published: the exact string first, then the transcript identity.
+ *
+ * An identity shared by two scanned entries resolves to neither — a genuine
+ * ambiguity must not silently pick one. Callers that hold a raw
+ * `Map<path, FileEntry>` see none of this, which is exactly how the liveness
+ * exemption below came to miss every cross-spelling attempt.
+ */
+export function buildTranscriptLookup(files: readonly FileEntry[]): (path: string) => FileEntry | undefined {
+  const byPath = new Map<string, FileEntry>();
+  const byIdentity = new Map<string, FileEntry | null>();
+  for (const file of files) {
+    byPath.set(file.path, file);
+    const identity = transcriptIdentity(file.path);
+    if (identity === file.path) continue;
+    const seen = byIdentity.get(identity);
+    if (seen === undefined) byIdentity.set(identity, file);
+    else if (seen && seen.path !== file.path) byIdentity.set(identity, null);
+  }
+  return (path: string) => byPath.get(path) ?? byIdentity.get(transcriptIdentity(path)) ?? undefined;
+}
 
 /**
  * The board's automatic-placement age horizon, asked of a whole pipeline.
@@ -25,8 +75,11 @@ export function pipelineWithinPlacementHorizon(
 ): boolean {
   const { now, ageHorizonSeconds, fileAt } = input;
   if (now <= 0) return true;
-  let newest = epochOf(pipeline.createdAt);
-  for (const stamp of [pipeline.closedAt, pipeline.pausedAt, pipeline.resumedAt]) {
+  /* 0 means "this stamp dates nothing", so it must never win a Math.max against
+     a real time and never stand in as one. A pipeline the record cannot date at
+     all stays put rather than being judged epoch-old. */
+  let newest = 0;
+  for (const stamp of [pipeline.createdAt, pipeline.closedAt, pipeline.pausedAt, pipeline.resumedAt]) {
     newest = Math.max(newest, epochOf(stamp));
   }
   for (const run of pipeline.runs) {
@@ -35,10 +88,52 @@ export function pipelineWithinPlacementHorizon(
       const file = attempt.agentPath ? fileAt(attempt.agentPath) : undefined;
       if (!file) continue;
       if (file.activity === "live" || file.proc === "running") return true;
+      /* The same `recent` guard its twin keeps (withinPlacementHorizon in
+         projectModel.ts): a sub-15-minute horizon override can never
+         out-tighten the activity band the projection already calls recent. */
+      if (file.activity === "recent") return true;
       newest = Math.max(newest, file.mtime);
     }
   }
-  return now - newest <= ageHorizonSeconds;
+  return newest === 0 || now - newest <= ageHorizonSeconds;
+}
+
+/**
+ * The board's own flow-driven expansions, bounded by the same horizon.
+ *
+ * These are automatic — the board opens them, not the operator — so a flow that
+ * has sat approved for weeks must not keep dragging its implementer (and,
+ * through it, an ancient root) onto the canvas. The operator's own expansions
+ * are merged in by the caller afterwards and are never bounded.
+ *
+ * One exemption, and it is the horizon's own rule rather than a hole in it: an
+ * implementer is the card a round deck hangs on, so while a reviewer of that
+ * flow is live or running, bounding the implementer would strand a live
+ * reviewer as a bare node with no deck to fold into. Live work is exempt at any
+ * age; so is the single surface that hosts it. Once every reviewer has gone
+ * quiet the implementer is bounded like anything else.
+ */
+export function boundFlowExpansions(
+  paths: ReadonlySet<string>,
+  input: { flows: readonly Flow[]; files: readonly FileEntry[]; now: number; ageHorizonSeconds: number },
+): Set<string> {
+  const { flows, files, now, ageHorizonSeconds } = input;
+  const kept = new Set(paths);
+  const hostsLiveReviewer = new Set<string>();
+  for (const flow of flows) {
+    const live = flow.rounds.some((round) => {
+      const reviewer = reviewerFileForRound(flow, round, files);
+      return reviewer ? reviewer.activity === "live" || reviewer.proc === "running" : false;
+    });
+    if (live) hostsLiveReviewer.add(flow.implementerPath);
+  }
+  const byPath = new Map(files.map((file) => [file.path, file] as const));
+  for (const path of paths) {
+    if (hostsLiveReviewer.has(path)) continue;
+    const file = byPath.get(path);
+    if (file && !withinPlacementHorizon(file, now, ageHorizonSeconds)) kept.delete(path);
+  }
+  return kept;
 }
 
 /** Epoch seconds of an ISO stamp; an absent or unparseable one dates nothing. */

--- a/src/components/scheme/placementHorizon.ts
+++ b/src/components/scheme/placementHorizon.ts
@@ -1,0 +1,49 @@
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+/**
+ * The board's automatic-placement age horizon, asked of a whole pipeline.
+ *
+ * A pipeline's stage surfaces — `slot::` placeholders, completed stage cards and
+ * the region that frames them — are automatic placements like any card, so they
+ * follow the same clock (issue: the project map filled with slots of pipelines
+ * that finished, or stranded, weeks ago).
+ *
+ * A pipeline stays on the canvas while any stage transcript is live or its host
+ * is running, at any age — a long run with an old transcript never loses its
+ * slots. Otherwise the pipeline's own record dates it: the newest of its
+ * lifecycle stamps and its stage transcripts. Only a fully terminal or stranded
+ * pipeline past the horizon leaves; it keeps its rail entry, its stage history
+ * and every transcript in «All conversations».
+ *
+ * `now <= 0` — the server render and the hydration pass — bounds nothing, so
+ * both sides paint the same markup.
+ */
+export function pipelineWithinPlacementHorizon(
+  pipeline: Pipeline,
+  input: { now: number; ageHorizonSeconds: number; fileAt: (path: string) => FileEntry | undefined },
+): boolean {
+  const { now, ageHorizonSeconds, fileAt } = input;
+  if (now <= 0) return true;
+  let newest = epochOf(pipeline.createdAt);
+  for (const stamp of [pipeline.closedAt, pipeline.pausedAt, pipeline.resumedAt]) {
+    newest = Math.max(newest, epochOf(stamp));
+  }
+  for (const run of pipeline.runs) {
+    for (const attempt of run.attempts) {
+      newest = Math.max(newest, epochOf(attempt.startedAt), epochOf(attempt.completedAt));
+      const file = attempt.agentPath ? fileAt(attempt.agentPath) : undefined;
+      if (!file) continue;
+      if (file.activity === "live" || file.proc === "running") return true;
+      newest = Math.max(newest, file.mtime);
+    }
+  }
+  return now - newest <= ageHorizonSeconds;
+}
+
+/** Epoch seconds of an ISO stamp; an absent or unparseable one dates nothing. */
+function epochOf(stamp: string | null | undefined): number {
+  if (!stamp) return 0;
+  const ms = Date.parse(stamp);
+  return Number.isFinite(ms) ? ms / 1_000 : 0;
+}

--- a/src/components/scheme/subagentTray.test.ts
+++ b/src/components/scheme/subagentTray.test.ts
@@ -353,11 +353,69 @@ test("buildSubagentTrays folds quiet engine children and promotes working ones u
 
 test("buildSubagentTrays keeps a child visible when its parent cannot host a tray", () => {
   const parent = entry({ path: "/parent", conversationId: "parent" });
-  const quiet = child({ path: "/quiet", conversationId: "quiet", parentId: "parent", parent: parent.path, activity: "idle" });
+  const quiet = child({ path: "/quiet", conversationId: "quiet", parentId: "parent", parent: parent.path, activity: "idle", mtime: NOW - 3_600 });
   const projection = buildSubagentTrays(baseInput([parent, quiet], /* no eligible host */ []));
   expect(projection.promotedPaths).toEqual(new Set(["/quiet"]));
   expect(projection.foldedPaths.size).toBe(0);
   expect(projection.traysByParent.size).toBe(0);
+});
+
+// ── automatic-placement age horizon ─────────────────────────────────────────
+
+test("an aged child folds instead of holding a full node on never-expiring evidence", () => {
+  /* A failed spawn and incomplete evidence promote at any age by rule; past the
+     horizon that promotion is exactly what fills the map with weeks-old cards. */
+  const failedSpawn = entry({
+    path: "/a",
+    conversationId: "a",
+    activity: "stalled",
+    mtime: NOW - 100 * 3_600,
+    spawn: { launchId: "l", clientAttemptId: null, accountId: null, state: "failed", initialMessage: "failed", retrySafe: true, error: "boom" },
+  });
+  expect(classifyEngineChild(failedSpawn, ctx)).toEqual({ presence: "folded", reason: "aged" });
+  const incomplete = entry({ path: "/b", conversationId: "b", activity: "stalled", mtime: NOW - 100 * 3_600 });
+  expect(classifyEngineChild(incomplete, ctx)).toEqual({ presence: "folded", reason: "aged" });
+  // Inside the horizon both still promote.
+  expect(classifyEngineChild({ ...incomplete, mtime: NOW - 3_600 }, ctx)).toEqual({ presence: "promoted", reason: "fail-visible" });
+});
+
+test("age never folds live, running, owned or pinned children", () => {
+  const ancient = { activity: "idle" as const, mtime: NOW - 100 * 3_600 };
+  const live = entry({ path: "/a", conversationId: "a", ...ancient, activity: "live" });
+  expect(classifyEngineChild(live, ctx)).toEqual({ presence: "promoted", reason: "busy" });
+  const running = entry({ path: "/b", conversationId: "b", ...ancient, proc: "running" });
+  expect(classifyEngineChild(running, ctx)).toEqual({ presence: "promoted", reason: "busy" });
+  const owned = entry({ path: "/c", conversationId: "c", ...ancient, userAuthored: true });
+  expect(classifyEngineChild(owned, ctx)).toEqual({ presence: "promoted", reason: "owner" });
+  const pinned = entry({ path: "/d", conversationId: "d", ...ancient, proc: "killed" });
+  expect(classifyEngineChild(pinned, { ...ctx, pinned: true })).toEqual({ presence: "promoted", reason: "owner" });
+});
+
+test("without a clock the age rule bounds nothing", () => {
+  const killed = entry({ path: "/a", conversationId: "a", activity: "stalled", proc: "killed", mtime: 1 });
+  expect(classifyEngineChild(killed, { ...ctx, now: epochSeconds(0) })).toEqual({ presence: "promoted", reason: "attention" });
+});
+
+test("an aged child whose parent cannot host a tray claims no board surface", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const aged = child({ path: "/aged", conversationId: "aged", parentId: "parent", parent: parent.path, activity: "idle", proc: "killed", mtime: NOW - 100 * 3_600 });
+  const projection = buildSubagentTrays(baseInput([parent, aged], /* no eligible host */ []));
+  // No host card means no tray to fold into, so the projection claims nothing
+  // and the board's own age rule decides — it stays in «All conversations».
+  expect(projection.promotedPaths.size).toBe(0);
+  expect(projection.foldedPaths.size).toBe(0);
+  // A pin is owner intent: it survives at any age.
+  const pinned = buildSubagentTrays(baseInput([parent, aged], [], { pinnedPaths: new Set(["/aged"]) }));
+  expect(pinned.promotedPaths).toEqual(new Set(["/aged"]));
+});
+
+test("an aged attention child folds into its parent's tray and stays reachable there", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
+  const aged = child({ path: "/aged", conversationId: "aged", parentId: "parent", parent: parent.path, activity: "idle", proc: "killed", mtime: NOW - 100 * 3_600 });
+  const projection = buildSubagentTrays(baseInput([parent, aged], ["parent"]));
+  expect(projection.promotedPaths.size).toBe(0);
+  expect(projection.foldedPaths).toEqual(new Set(["/aged"]));
+  expect(projection.traysByParent.get("parent")!.members.map((member) => member.id)).toEqual(["aged"]);
 });
 
 test("buildSubagentTrays leaves viewer, hidden and claimed children to their own surfaces", () => {

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -1,4 +1,5 @@
 import { attentionId } from "@/components/attention";
+import { schemeAgeHorizonSeconds, withinPlacementHorizon } from "@/components/projectModel";
 import { conversationIdentity, isArchivedPredecessor } from "@/lib/accounts/identity";
 import type { EpochSeconds, Engine, FileEntry } from "@/lib/types";
 
@@ -60,6 +61,7 @@ export type PresenceReason =
   | "owner"
   | "busy"
   | "quiet"
+  | "aged"
   | "fail-visible";
 
 /** A process of this conversation's own, or a launch still binding one. A
@@ -267,6 +269,9 @@ export interface EngineChildContext {
   pinned: boolean;
   /** The same clock `mtime` and `attentionId` are measured on. */
   now: EpochSeconds;
+  /** Automatic-placement age horizon in seconds; defaults to the env-tunable
+      board value. `now === 0` (server render / hydration) bounds nothing. */
+  ageHorizonSeconds?: number;
 }
 
 export interface EngineChildClassification {
@@ -287,13 +292,22 @@ export interface EngineChildClassification {
  * 5. authoritative terminal or idle → folded P1 immediately (no idle wait,
  *    independent of transcript age).
  * 6. conflicting or incomplete evidence → fail-visible promoted P2.
+ *
+ * Rules 1 and 6 promote on evidence that never expires — a killed host, a
+ * failed spawn, an unanswered question, incomplete evidence — so past the
+ * board's placement age horizon they fold instead (reason `aged`): a stage
+ * killed three weeks ago belongs in its parent's tray, not in a full node held
+ * forever. Owner intent (3) and live/running work (4) are exempt at any age,
+ * and the tray row keeps the folded child one click away.
  */
 export function classifyEngineChild(entry: FileEntry, ctx: EngineChildContext): EngineChildClassification {
-  if (engineChildNeedsAttention(entry, ctx.now)) return { presence: "promoted", reason: "attention" };
+  const aged = !withinPlacementHorizon(entry, ctx.now, ctx.ageHorizonSeconds ?? schemeAgeHorizonSeconds());
+  if (!aged && engineChildNeedsAttention(entry, ctx.now)) return { presence: "promoted", reason: "attention" };
   if (ctx.folded) return { presence: "folded", reason: "hand-fold" };
   if (entry.userAuthored || entry.authorshipUnverified || ctx.pinned) return { presence: "promoted", reason: "owner" };
   if (isBusy(entry)) return { presence: "promoted", reason: "busy" };
   if (isTerminalOrIdle(entry)) return { presence: "folded", reason: "quiet" };
+  if (aged) return { presence: "folded", reason: "aged" };
   return { presence: "promoted", reason: "fail-visible" };
 }
 
@@ -339,6 +353,8 @@ export interface SubagentTrayInput {
   /** Transcript freshness and attention TTLs share this clock with `mtime`;
       the branded type keeps a millisecond clock from landing here silently. */
   now: EpochSeconds;
+  /** Automatic-placement age horizon in seconds; defaults to the board value. */
+  ageHorizonSeconds?: number;
 }
 
 export interface SubagentTrayProjection {
@@ -391,6 +407,7 @@ function memberOrder(left: TrayMember, right: TrayMember, timeById: ReadonlyMap<
  * the minimap, and mobile.
  */
 export function buildSubagentTrays(input: SubagentTrayInput): SubagentTrayProjection {
+  const horizon = input.ageHorizonSeconds ?? schemeAgeHorizonSeconds();
   const byPath = new Map(input.entries.map((entry) => [entry.path, entry]));
   const byId = new Map<string, FileEntry>();
   for (const entry of input.entries) {
@@ -419,15 +436,20 @@ export function buildSubagentTrays(input: SubagentTrayInput): SubagentTrayProjec
     if (!parentId) continue;
     const id = conversationIdentity(entry);
     /* Host ineligible (hidden/deleted/cross-project/deck-claimed/compacted
-       parent): the child stays visible through the existing full-node path. */
+       parent): the child stays visible through the existing full-node path —
+       but only inside the placement age horizon. Past it the projection claims
+       nothing: with no host card there is no tray to fold into, so the child is
+       left to the board's own age rule (which keeps live/running work placed)
+       and otherwise rests in quiet history and «All conversations». */
     if (!input.hostEligibleParentIds.has(parentId)) {
-      promotedPaths.add(entry.path);
+      if (input.pinnedPaths.has(entry.path) || withinPlacementHorizon(entry, input.now, horizon)) promotedPaths.add(entry.path);
       continue;
     }
     const classification = classifyEngineChild(entry, {
       folded: input.foldedEngineChildIds.has(id),
       pinned: input.pinnedPaths.has(entry.path),
       now: input.now,
+      ageHorizonSeconds: horizon,
     });
     if (classification.presence === "promoted") {
       promotedPaths.add(entry.path);

--- a/src/components/scheme/workerCollapse.test.ts
+++ b/src/components/scheme/workerCollapse.test.ts
@@ -600,6 +600,28 @@ describe("protectedReviewerNodes", () => {
     expect(nodes({ files: [authored], flows, renderedNodePaths: new Set(["/impl"]) })).toEqual([]);
   });
 
+  test("the placement age horizon bounds an authorship-protected reviewer", () => {
+    /* Authorship protection never expires, so without the horizon a reviewer of
+       a flow closed weeks ago keeps a standalone card forever. */
+    const aged = entry({ path: "/rev-aged", userAuthored: true, mtime: NOW_SEC - 400 * 3_600 });
+    const fresh = entry({ path: "/rev-fresh", userAuthored: true, mtime: NOW_SEC - 3_600 });
+    const flows = [
+      closed({ id: "f1", implementerPath: "/i1", rounds: [round({ reviewerPath: "/rev-aged" })] }),
+      closed({ id: "f2", implementerPath: "/i2", rounds: [round({ reviewerPath: "/rev-fresh" })] }),
+    ];
+    expect(nodes({ files: [aged, fresh], flows, now: NOW_SEC })).toEqual(["/rev-fresh"]);
+    // No clock: nothing is bounded.
+    expect(new Set(nodes({ files: [aged, fresh], flows }))).toEqual(new Set(["/rev-aged", "/rev-fresh"]));
+  });
+
+  test("age never bounds a pinned, live or running reviewer", () => {
+    const aged = entry({ path: "/rev", userAuthored: true, mtime: NOW_SEC - 400 * 3_600 });
+    const flows = [closed({ id: "f1", implementerPath: "/i1", rounds: [round({ reviewerPath: "/rev" })] })];
+    expect(nodes({ files: [aged], flows, now: NOW_SEC, pinnedPaths: new Set(["/rev"]) })).toEqual(["/rev"]);
+    expect(nodes({ files: [{ ...aged, activity: "live" }], flows, now: NOW_SEC })).toEqual(["/rev"]);
+    expect(nodes({ files: [{ ...aged, proc: "running" }], flows, now: NOW_SEC })).toEqual(["/rev"]);
+  });
+
   test("skips a reviewer already drawn as a node, or manually closed", () => {
     const authored = entry({ path: "/rev", userAuthored: true });
     const flows = [closed({ id: "f1", implementerPath: "/impl", rounds: [round({ reviewerPath: "/rev" })] })];

--- a/src/components/scheme/workerCollapse.ts
+++ b/src/components/scheme/workerCollapse.ts
@@ -3,7 +3,7 @@ import type { Pipeline } from "@/lib/pipelines/types";
 import type { FileEntry } from "@/lib/types";
 
 import { reviewerBindingTargetsForRound } from "@/components/flows/flowModel";
-import { activityBand, isChildConversation, kidsIndex, projectKey, subtree } from "@/components/projectModel";
+import { activityBand, isChildConversation, kidsIndex, projectKey, schemeAgeHorizonSeconds, subtree, withinPlacementHorizon } from "@/components/projectModel";
 
 /*
  * Worker-class auto-collapse (issue #112).
@@ -312,6 +312,11 @@ export interface ProtectedReviewerNodesInput {
   /** Durable manual placements/expansions — a reviewer the owner opened out of a
       worker stack must render even though it carries no authorship protection. */
   pinnedPaths: ReadonlySet<string>;
+  /** Board clock in epoch seconds for the automatic-placement age horizon.
+      `0` (the default, and the server render) bounds nothing. */
+  now?: number;
+  /** Placement age horizon in seconds; defaults to the env-tunable board value. */
+  ageHorizonSeconds?: number;
 }
 
 /**
@@ -358,7 +363,15 @@ export function protectedReviewerNodes(input: ProtectedReviewerNodesInput): File
       if (!path || seen.has(path) || decked.has(path)) continue;
       if (input.renderedNodePaths.has(path) || input.hiddenPaths.has(path)) continue;
       const file = byPath.get(path);
-      if (file && (file.userAuthored || file.authorshipUnverified || input.pinnedPaths.has(path))) {
+      if (!file) continue;
+      /* Authorship protection never expires, so past the placement age horizon
+         it would keep a reviewer of a long-closed flow on the canvas forever.
+         An owner PIN is explicit intent and stays unbounded; live and running
+         work is exempt through the horizon itself. A bounded reviewer keeps its
+         row in «All conversations» and quiet history. */
+      const owned = input.pinnedPaths.has(path);
+      if (!owned && !withinPlacementHorizon(file, input.now ?? 0, input.ageHorizonSeconds ?? schemeAgeHorizonSeconds())) continue;
+      if (owned || file.userAuthored || file.authorshipUnverified) {
         out.push(file);
         seen.add(path);
       }


### PR DESCRIPTION
## The problem

The project map for one repo rendered **171 scheme nodes** — 140 codex rollouts dated three weeks back, 25 `slot::` nodes of eight pipelines (several long finished or stranded), a `deck::`, 5 more transcripts. Two theories were already disproved by measurement: a 512 KiB size cut (the real driver was the project cap, #950) and missing flow claims on pre-canonical path spellings (real, fixed in #951, but a fold/collapse replay yields the same node count before and after it).

The #946 age horizon works — it just gates **roots**. Every other way onto the canvas consults no clock:

- a child column under a working root;
- the root a fresh descendant resurrects (`rootOf`, which reaches an arbitrarily old ancestor);
- an engine child promoted on never-expiring attention evidence (a killed host, a failed spawn, incomplete evidence);
- the board's own flow-driven expansion of an implementer;
- a reviewer materialized on authorship protection when its flow has no deck;
- the `slot::`/`deck::` surfaces of a pipeline that finished or stranded weeks ago.

## The change

One predicate answers "may this occupy the canvas automatically" everywhere: `withinPlacementHorizon` for conversations, `pipelineWithinPlacementHorizon` for a pipeline's stage surfaces. Both read the existing env-tunable horizon (`NEXT_PUBLIC_LLV_SCHEME_AGE_HORIZON_HOURS`, 48 h default).

- a child column under a live root must itself be inside the horizon;
- a placed descendant opens its group at the topmost **placeable** ancestor, so an aged root is never resurrected — and two placed descendants of one aged root still share a single group instead of duplicating it;
- an engine child past the horizon folds into its parent's tray (reason `aged`) instead of holding a full node;
- the board's flow-driven expansion follows the horizon; the operator's own expansions do not;
- a protected reviewer of a long-closed flow follows it too, unless pinned;
- a pipeline with no live or running stage and no placed member grows no slots, no completed stage cards and no region.

### Invariants held

Live and running work is exempt **at any age**. Manual placement (`prefs.manual` / `explicitManual`) and explicit expansion are untouched. Nothing becomes unreachable: bounded entries keep their under-deck chip, their tray row, their quiet-history row and their entry in «All conversations». `now === 0` — the server render and the hydration pass — bounds nothing, so both sides still paint the plain activity rule and no hydration skew appears.

## Verification — a measured render, not an argument

Headless probe (playwright-core, `[data-scheme-node]` census) against a dev server on **8899** with an isolated state dir, never prod:

| render | nodes | composition |
| --- | --- | --- |
| base commit, 48 h horizon | 42 | 20 slots, 22 cards |
| this branch, 48 h horizon | 42 | 20 slots, 22 cards — every card ≤ 48 h or manual |
| base commit, horizon narrowed to **2 h** | 40 | 29 slots, 11 cards |
| this branch, horizon narrowed to **2 h** | **18** | 8 slots, 10 cards |

Today's live data holds nothing older than 48 h that the board places, so the two builds agree at the default horizon — the guard is what keeps it that way. Narrowing the horizon to 2 h makes most of the data "aged" and measures the guard directly: **40 → 18**. The 22 removed nodes are all `slot::` surfaces of pipelines with no live or running stage; the survivors are 8 slots of pipelines that are actually running, 2 live/running conversations and 8 manual placements. **Zero** survivors are past the horizon without being live, running, manual or expanded.

The deployed build predates #946/#948, which is where the 171-node census was taken; a base-commit render of the same board today is 42.

Checks: `tsc --noEmit` clean, scoped ESLint clean, production build green, privacy gate PASS, and the focused suites below (run with `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR` pointed at a sandbox).

## Tests

`projectModel.test.ts`, `scheme/placementHorizon.test.ts` (new), `scheme/subagentTray.test.ts`, `scheme/workerCollapse.test.ts` — an old child does not place; an old root is not resurrected by a recent child; a terminal/stranded pipeline's slots do not place while a live pipeline's do; live, running, manual, pinned and expanded survive at any age; `now === 0` degrades to the activity rule.

One existing expectation changed on purpose: "a recently active child keeps its stale root's card" is now "a recently active child never resurrects its stale root's card".

🤖 Generated with [Claude Code](https://claude.com/claude-code)