### PR TITLE
fix(state): a local client is not fenced out of settled hot state

### DIFF
--- a/src/lib/state/hotStateAuthority.ts
+++ b/src/lib/state/hotStateAuthority.ts
@@ -143,9 +143,20 @@ export function hotStateSqliteWriterReady(
 ): boolean {
   const target = readHotStateReleaseTarget(directory, env);
   if (!target) return true;
+  const authority = readHotStateAuthority(directory);
+  /* Fencing covers the handoff window, when a retiring and an arriving release
+     could both write. Once the authority has activated sqlite FOR THE RELEASE
+     CURRENTLY PROMOTED, that window is closed and there is no second writer to
+     protect against. Every local client — the MCP runtime, a CLI, a script —
+     writes through this same store and carries neither PORT nor the revision
+     env, so proving a revision is something only the release server can do.
+     Demanding it after activation fences those clients out of settled state
+     permanently rather than transiently (issue #907 follow-up). */
+  if (authority?.mode === "sqlite"
+    && authority.releaseRevision === target.revision
+    && typeof authority.activationReadyAt === "string") return true;
   const revision = hotStateWriterRevision(directory, env);
   if (!revision) return false;
-  const authority = readHotStateAuthority(directory);
   return authority?.mode === "sqlite"
     && authority.releaseRevision === revision
     && target.revision === revision;

--- a/src/lib/state/hotStateStores.sqlite.test.ts
+++ b/src/lib/state/hotStateStores.sqlite.test.ts
@@ -21,6 +21,7 @@ import {
   acknowledgeHotStateFence,
   HOT_STATE_BACKEND,
   HOT_STATE_RELEASE_REVISION_ENV,
+  hotStateSqliteWriterReady,
   markHotStateActivationReady,
   publishHotStateAuthority,
   readHotStateAuthority,
@@ -961,6 +962,45 @@ test("first boot imports every store once and folds in the pipeline archive", ()
   } finally {
     if (previous === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previous;
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("a client that cannot prove a revision still writes once the promoted release has activated", () => {
+  /* The MCP runtime, a CLI and any script write through this same store and
+     carry neither PORT nor the revision env — only the release server can prove
+     a revision. Before this, they were fenced permanently after activation
+     rather than only during the handoff window. */
+  const previousDir = process.env.LLV_STATE_DIR;
+  const previousPort = process.env.PORT;
+  const previousRevisionEnv = process.env[HOT_STATE_RELEASE_REVISION_ENV];
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-state-unfenced-client-"));
+  const revision = "c".repeat(40);
+  try {
+    process.env.LLV_STATE_DIR = sandbox;
+    delete process.env.PORT;
+    delete process.env[HOT_STATE_RELEASE_REVISION_ENV];
+    fs.writeFileSync(path.join(sandbox, "viewer-release.json"), JSON.stringify({
+      endpoint: "http://127.0.0.1:19101", revision, hotStateBackend: HOT_STATE_BACKEND,
+    }));
+
+    const published = publishHotStateAuthority(sandbox, "sqlite", revision);
+    expect(hotStateSqliteWriterReady(sandbox)).toBe(false);
+
+    markHotStateActivationReady(sandbox, published);
+    expect(hotStateSqliteWriterReady(sandbox)).toBe(true);
+
+    /* An activation belonging to a DIFFERENT release than the promoted one is
+       still a live handoff, so the fence must hold. */
+    fs.writeFileSync(path.join(sandbox, "viewer-release.json"), JSON.stringify({
+      endpoint: "http://127.0.0.1:19101", revision: "d".repeat(40), hotStateBackend: HOT_STATE_BACKEND,
+    }));
+    expect(hotStateSqliteWriterReady(sandbox)).toBe(false);
+  } finally {
+    if (previousDir === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = previousDir;
+    if (previousPort === undefined) delete process.env.PORT; else process.env.PORT = previousPort;
+    if (previousRevisionEnv === undefined) delete process.env[HOT_STATE_RELEASE_REVISION_ENV];
+    else process.env[HOT_STATE_RELEASE_REVISION_ENV] = previousRevisionEnv;
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
`hotStateSqliteWriterReady` demanded a provable release revision on every write. Only the release server can prove one — it comes from `PORT` matching the promoted endpoint, or from `LLV_HOT_STATE_RELEASE_REVISION`. Every other local writer (the MCP runtime, a CLI, a script) carries neither, so once #907 activated SQLite they were fenced **permanently** instead of only across the handoff.

Observed on the live instance right after promoting `dfa7447e`: every `create_pipeline` call failed with `hot state migration is waiting for release promotion`, and all five running `mcp-server.mjs` processes had empty `PORT`, `LLV_HOT_STATE_RELEASE_REVISION` and `LLV_VIEWER_DEPLOY_TARGET`. The authority itself was healthy (`mode: sqlite`, matching `releaseRevision`, `activationReadyAt` set) — the gate simply refused clients that structurally cannot answer it.

Fencing exists for the window where a retiring and an arriving release could both write. Once the authority has activated sqlite **for the release currently promoted**, that window is closed and there is no second writer to guard against. An activation belonging to a *different* release than the promoted one is still a live handoff and stays fenced — covered by the test.

Verified RED first against `origin/main` in a throwaway worktree, then green: 22/22 in `src/lib/state/hotStateStores.sqlite.test.ts` under isolated HOME/XDG_CONFIG_HOME/LLV_STATE_DIR/TMPDIR. Privacy gate PASS.