### PR TITLE
fix(deploy): complete SQLite promotion before slow runtime startup

### DIFF
--- a/docs/state-hot-stores-sqlite.md
+++ b/docs/state-hot-stores-sqlite.md
@@ -162,14 +162,14 @@ handoff.
 For the first SQLite release, the adapter durably publishes `preparing` before
 moving the stable target. The promoted process waits for three stable
 legacy-file observations, completes the dry run and atomic import, and changes
-the same authority epoch to `sqlite`. It starts operator services, optional
-integrations, structured-host adoption, and controllers before adding
-`activationReadyAt`. Recoverable structured-host startup keeps activation
-pending until adoption succeeds. The capability route returns 503 for the
-promoted endpoint until that timestamp exists, and the deployment adapter
-waits for it before reporting promotion success. The release monitor starts
-before activation work, so rollback fencing remains available during a failed
-or stalled startup.
+the same authority epoch to `sqlite`. It adds `activationReadyAt` after the hot
+stores are initialized, then starts structured-host adoption and controllers
+before adding `releaseReadyAt`. The deployment adapter uses the first timestamp
+to complete target promotion; the capability route remains 503 until the
+second timestamp records full release startup. Slow recoverable adoption stays
+inside the longer post-promotion health gate. The release monitor starts before
+activation work, so rollback fencing remains available during a failed or
+stalled startup.
 
 Every writer proves that its Viewer port or MCP release revision matches both
 the durable target and SQLite authority. Passive candidates, portless MCP

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -23,7 +23,9 @@ import {
   completeHotStatePreparation,
   HOT_STATE_BACKEND,
   HOT_STATE_RELEASE_REVISION_ENV,
+  hotStateSqliteWriterReady,
   markHotStateActivationReady,
+  markViewerReleaseReady,
   publishHotStateAuthority,
   readHotStateAuthority,
 } from "../src/lib/state/hotStateAuthority";
@@ -313,8 +315,10 @@ async function runAction(options: {
   environment?: Record<string, string>;
   setupState?: (state: string) => void;
   observe?: (state: string, child: { exited: Promise<number> }) => Promise<void>;
+  sandbox?: string;
+  preserveSandbox?: boolean;
 }) {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-release-lifecycle-adapter-"));
+  const sandbox = options.sandbox ?? fs.mkdtempSync(path.join(os.tmpdir(), "llv-release-lifecycle-adapter-"));
   const state = path.join(sandbox, "state");
   const bin = path.join(sandbox, "bin");
   const dockerLog = path.join(sandbox, "docker.log");
@@ -358,8 +362,20 @@ async function runAction(options: {
   const target = fs.existsSync(targetFile) ? JSON.parse(fs.readFileSync(targetFile, "utf8")) as unknown : null;
   const authority = readHotStateAuthority(state);
   const handoffIntentExists = fs.existsSync(path.join(state, "runtime-host-handoff-intent.json"));
-  fs.rmSync(sandbox, { recursive: true, force: true });
-  return { code, stdout, stderr, dockerCalls, target, authority, handoffIntentExists };
+  const releaseSwitchIntentExists = fs.existsSync(path.join(state, "viewer-release-switch-intent.json"));
+  if (!options.preserveSandbox) fs.rmSync(sandbox, { recursive: true, force: true });
+  return {
+    code,
+    stdout,
+    stderr,
+    dockerCalls,
+    target,
+    authority,
+    handoffIntentExists,
+    releaseSwitchIntentExists,
+    sandbox,
+    state,
+  };
 }
 
 function initializeHotStateFixture(
@@ -1083,6 +1099,119 @@ exit 1
     expect(result.authority).toMatchObject({ mode: "legacy", releaseRevision: previous.revision });
   } finally {
     server.stop(true);
+  }
+});
+
+test("SQLite rollback recovers an interrupted promotion before health and keeps the candidate fenced", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-sqlite-promotion-recovery-"));
+  const state = path.join(sandbox, "state");
+  const targetFile = path.join(state, "viewer-release.json");
+  let previousWriterReady = () => false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const pathname = new URL(request.url).pathname;
+      if (pathname === "/api/runtime/deployments/capabilities/v1") {
+        return Response.json(
+          { capability: "viewer-deployments", version: 1, registryBackendMode: "off" },
+          { status: previousWriterReady() ? 200 : 503 },
+        );
+      }
+      if (pathname === "/_next/static/app.js") return new Response("self.__viewer=true");
+      return new Response('<script src="/_next/static/app.js"></script>', {
+        headers: { "content-type": "text/html" },
+      });
+    },
+  });
+  const previous = {
+    ...release,
+    endpoint: server.url.origin,
+    hotStateBackend: HOT_STATE_BACKEND,
+    revision: "2".repeat(40),
+  };
+  const candidate = {
+    ...release,
+    container: "viewer-interrupted-candidate",
+    endpoint: "http://127.0.0.1:19991",
+    image: "viewer:interrupted-candidate",
+    hotStateBackend: HOT_STATE_BACKEND,
+    revision: "3".repeat(40),
+    mcpRuntime: {
+      source: "managed" as const,
+      revision: "3".repeat(40),
+      releaseId: "deploy-interrupted-candidate",
+      artifactDigest: "3".repeat(64),
+      stagedAt: "2026-08-09T00:00:00.000Z",
+    },
+  };
+  const previousMcpRuntime = {
+    source: "managed" as const,
+    revision: previous.revision,
+    releaseId: "deploy-previous",
+    artifactDigest: "2".repeat(64),
+    stagedAt: "2026-08-08T00:00:00.000Z",
+  };
+  const writerReady = (revision: string) => hotStateSqliteWriterReady(state, {
+    LLV_VIEWER_DEPLOY_TARGET: targetFile,
+    [HOT_STATE_RELEASE_REVISION_ENV]: revision,
+  });
+  previousWriterReady = () => writerReady(previous.revision);
+  const dockerScript = `#!/bin/sh
+set -eu
+if [ "$1 $2" = "container inspect" ]; then exit 0; fi
+if [ "$1" = "inspect" ]; then printf 'running\n'; exit 0; fi
+if [ "$1" = "start" ]; then exit 0; fi
+exit 1
+`;
+  try {
+    let originalAuthority: ReturnType<typeof readHotStateAuthority> = null;
+    const crashed = await runAction({
+      action: "promote",
+      input: { candidate },
+      sandbox,
+      preserveSandbox: true,
+      snapshots: [previous.container],
+      environment: { NODE_ENV: "test", LLV_TEST_EXIT_AFTER_HOT_STATE_AUTHORITY: "1" },
+      setupState: (directory) => {
+        initializeHotStateFixture(directory, previous);
+        const authority = readHotStateAuthority(directory)!;
+        originalAuthority = markViewerReleaseReady(
+          directory,
+          markHotStateActivationReady(directory, authority),
+        );
+      },
+      dockerScript,
+    });
+    expect(crashed.code).toBe(86);
+    expect(crashed.target).toEqual(previous);
+    expect(crashed.authority).toMatchObject({ mode: "sqlite", releaseRevision: candidate.revision });
+    expect(crashed.releaseSwitchIntentExists).toBe(true);
+    expect(writerReady(previous.revision)).toBe(false);
+    expect(writerReady(candidate.revision)).toBe(false);
+
+    expect(previousWriterReady()).toBe(false);
+    const recovered = await runAction({
+      action: "rollback",
+      input: { previous, candidate, previousMcpRuntime },
+      sandbox,
+      preserveSandbox: true,
+      dockerScript,
+    });
+    expect({ code: recovered.code, stderr: recovered.stderr }).toEqual({ code: 0, stderr: "" });
+    expect(recovered.target).toEqual(previous);
+    expect(recovered.releaseSwitchIntentExists).toBe(false);
+    expect(recovered.authority).toMatchObject({
+      mode: "sqlite",
+      releaseRevision: previous.revision,
+      activationReadyAt: originalAuthority!.activationReadyAt,
+      releaseReadyAt: originalAuthority!.releaseReadyAt,
+    });
+    expect(previousWriterReady()).toBe(true);
+    expect(writerReady(candidate.revision)).toBe(false);
+  } finally {
+    server.stop(true);
+    fs.rmSync(sandbox, { recursive: true, force: true });
   }
 });
 

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -53,6 +53,7 @@ import { completeRuntimeHostHandoff, stageRuntimeHostSuccessorContainer } from "
 import {
   hasViewerDeploymentCapability,
   viewerDeploymentRegistryBackendMode,
+  viewerDeploymentReleaseReady,
   viewerHealthRequestPlan,
   waitForViewerReadiness,
   type ViewerCandidateContainerState,
@@ -71,6 +72,36 @@ const runtimeHostImageTag = process.env.LLV_RUNTIME_HOST_IMAGE_TAG || "agent-log
 const mcpRuntimeRoot = process.env.LLV_MCP_RUNTIME_ROOT || path.join(process.env.HOME || "/home/user", ".agents", "tools", "llv-mcp-runtime");
 const mcpRuntimeStore = new McpRuntimeReleaseStore({ stateDir, stableRuntimeRoot: mcpRuntimeRoot });
 const deploymentPackageRoot = process.env.LLV_DEPLOYMENT_PACKAGE_ROOT || path.resolve(import.meta.dir, "..");
+const releaseSwitchIntentFile = path.join(stateDir, "viewer-release-switch-intent.json");
+const adapterPhaseFile = process.env.LLV_DEPLOYMENT_ADAPTER_PHASE_FILE?.trim() || null;
+
+function writeDurableJson(filename: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = `${filename}.${process.pid}.${randomUUID()}.tmp`;
+  const descriptor = fs.openSync(temporary, "wx", 0o600);
+  try {
+    fs.writeFileSync(descriptor, JSON.stringify(value));
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  fs.renameSync(temporary, filename);
+  const directory = fs.openSync(path.dirname(filename), "r");
+  try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+}
+
+function removeDurableFile(filename: string): void {
+  fs.rmSync(filename, { force: true });
+  let directory: number;
+  try { directory = fs.openSync(path.dirname(filename), "r"); }
+  catch { return; }
+  try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+}
+
+function reportAdapterPhase(action: string, phase: string): void {
+  if (!adapterPhaseFile) return;
+  writeDurableJson(adapterPhaseFile, { action, phase, updatedAt: new Date().toISOString() });
+}
 
 async function command(argv: string[], options: { cwd?: string } = {}): Promise<string> {
   const child = Bun.spawn(["/usr/bin/setpriv", "--pdeathsig", "KILL", "--", ...argv], {
@@ -330,6 +361,8 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
   );
   const observedRegistryBackendMode = viewerDeploymentRegistryBackendMode(capability.status, capability.text);
   const registryBackendMatches = observedRegistryBackendMode === expectedRegistryBackendMode;
+  const releaseReady = expectedAssetsEndpoint === undefined
+    || viewerDeploymentReleaseReady(capability.status, capability.text);
   const html = authenticated?.status === 200 ? authenticated.text : root.text;
   const paths = referencedAssets(html);
   const assets = await Promise.all(paths.map(async (asset) => ({ path: asset, status: (await fetchStatus(`${endpoint}${asset}`)).status })));
@@ -348,6 +381,7 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
     && assets.every((asset) => asset.status === 200)
     && deploymentCapable
     && registryBackendMatches
+    && releaseReady
     && expectedAssetsMatch;
   return {
     checkedAt: new Date().toISOString(), endpoint, processReady, rootStatus: root.status,
@@ -357,9 +391,11 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
         ? "Viewer deployment capability gate failed"
         : !registryBackendMatches
           ? `Viewer registry backend mode mismatch: expected ${expectedRegistryBackendMode}, observed ${observedRegistryBackendMode ?? "unavailable"}`
-        : expectedAssetsMatch
-          ? "Viewer health or referenced asset gate failed"
-          : "stable listener does not serve the candidate asset set",
+          : !releaseReady
+            ? "Viewer release startup is incomplete"
+            : expectedAssetsMatch
+              ? "Viewer health or referenced asset gate failed"
+              : "stable listener does not serve the candidate asset set",
     }),
   };
 }
@@ -369,6 +405,7 @@ async function verifyViewer(candidate: ViewerReleaseIdentity, endpoint: string, 
     endpoint,
     inspect: () => containerState(candidate.container),
     probe: () => probeRoutes(candidate, endpoint, expectedAssetsEndpoint),
+    ...(expectedAssetsEndpoint ? { maxAttempts: 90 } : {}),
   });
 }
 
@@ -455,6 +492,130 @@ function readCurrentRelease(): ViewerReleaseIdentity | null {
   }
 }
 
+interface ViewerReleaseSwitchIntent {
+  schemaVersion: 1;
+  action: "activate" | "restore";
+  previousTarget: ViewerReleaseIdentity | null;
+  previousAuthority: HotStateAuthority | null;
+  target: ViewerReleaseIdentity;
+  recordedAt: string;
+}
+
+function checkpointFromIntent(value: unknown): HotStateAuthority["checkpoint"] | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Viewer release switch intent is invalid");
+  const checkpoint = value as { acknowledgedAt?: unknown; revisions?: Record<string, unknown> };
+  const revisions = checkpoint.revisions;
+  const numbers = revisions
+    ? [revisions.flows, revisions.pipelines, revisions.pipelinesArchive, revisions.workflows]
+    : [];
+  if (typeof checkpoint.acknowledgedAt !== "string"
+    || numbers.length !== 4
+    || numbers.some((revision) => !Number.isInteger(revision) || (revision as number) < 0)) {
+    throw new Error("Viewer release switch intent is invalid");
+  }
+  return value as HotStateAuthority["checkpoint"];
+}
+
+function authorityFromIntent(value: unknown): HotStateAuthority | null {
+  if (value === null) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Viewer release switch intent is invalid");
+  const authority = value as Partial<HotStateAuthority>;
+  if (authority.schemaVersion !== 1
+    || !Number.isInteger(authority.epoch)
+    || (authority.epoch ?? 0) < 1
+    || !["legacy", "preparing", "sqlite", "fencing"].includes(String(authority.mode))
+    || (authority.releaseRevision !== null
+      && (typeof authority.releaseRevision !== "string" || !/^[0-9a-f]{40}$/.test(authority.releaseRevision)))
+    || typeof authority.updatedAt !== "string"
+    || (authority.activationReadyAt !== undefined && typeof authority.activationReadyAt !== "string")
+    || (authority.releaseReadyAt !== undefined && typeof authority.releaseReadyAt !== "string")
+    || (authority.releaseReadyAt !== undefined && authority.activationReadyAt === undefined)) {
+    throw new Error("Viewer release switch intent is invalid");
+  }
+  return {
+    ...(authority as HotStateAuthority),
+    ...(checkpointFromIntent(authority.checkpoint) ? { checkpoint: checkpointFromIntent(authority.checkpoint) } : {}),
+  };
+}
+
+function readReleaseSwitchIntent(): ViewerReleaseSwitchIntent | null {
+  let value: unknown;
+  try { value = JSON.parse(fs.readFileSync(releaseSwitchIntentFile, "utf8")) as unknown; }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error("Viewer release switch intent is unreadable", { cause: error });
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Viewer release switch intent is invalid");
+  const intent = value as Record<string, unknown>;
+  if (intent.schemaVersion !== 1
+    || (intent.action !== "activate" && intent.action !== "restore")
+    || typeof intent.recordedAt !== "string") throw new Error("Viewer release switch intent is invalid");
+  return {
+    schemaVersion: 1,
+    action: intent.action,
+    previousTarget: intent.previousTarget === null ? null : release(intent.previousTarget),
+    previousAuthority: authorityFromIntent(intent.previousAuthority),
+    target: release(intent.target),
+    recordedAt: intent.recordedAt,
+  };
+}
+
+function sameAuthority(left: HotStateAuthority | null, right: HotStateAuthority | null): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function targetMatches(left: ViewerReleaseIdentity | null, right: ViewerReleaseIdentity | null): boolean {
+  if (left === null || right === null) return left === right;
+  return releasesEqual(left, right);
+}
+
+function expectedTransitionAuthority(intent: ViewerReleaseSwitchIntent, authority: HotStateAuthority | null): boolean {
+  if (!authority) return false;
+  const expectedMode = intent.action === "restore"
+    ? intent.target.hotStateBackend === HOT_STATE_BACKEND ? "sqlite" : "legacy"
+    : intent.target.hotStateBackend === HOT_STATE_BACKEND
+      ? intent.previousAuthority?.mode === "sqlite" ? "sqlite" : "preparing"
+      : "legacy";
+  return authority.epoch === (intent.previousAuthority?.epoch ?? 0) + 1
+    && authority.mode === expectedMode
+    && authority.releaseRevision === intent.target.revision;
+}
+
+function authorityServesTarget(authority: HotStateAuthority | null, target: ViewerReleaseIdentity): boolean {
+  return authority?.releaseRevision === target.revision
+    && (target.hotStateBackend === HOT_STATE_BACKEND
+      ? authority.mode === "preparing" || authority.mode === "sqlite"
+      : authority.mode === "legacy");
+}
+
+function recoverInterruptedReleaseSwitch(): void {
+  const intent = readReleaseSwitchIntent();
+  if (!intent) return;
+  const currentTarget = readCurrentRelease();
+  const currentAuthority = readHotStateAuthority(stateDir);
+  if (targetMatches(currentTarget, intent.target)) {
+    if (!authorityServesTarget(currentAuthority, intent.target)) {
+      throw new Error("interrupted Viewer release switch target has mismatched hot-state authority");
+    }
+    removeDurableFile(releaseSwitchIntentFile);
+    return;
+  }
+  if (!targetMatches(currentTarget, intent.previousTarget)) {
+    throw new Error("interrupted Viewer release switch conflicts with the durable target");
+  }
+  if (sameAuthority(currentAuthority, intent.previousAuthority)) {
+    removeDurableFile(releaseSwitchIntentFile);
+    return;
+  }
+  if (!expectedTransitionAuthority(intent, currentAuthority)) {
+    throw new Error("interrupted Viewer release switch has unexpected hot-state authority");
+  }
+  const restored = restoreHotStateAuthority(stateDir, intent.previousAuthority, currentAuthority!);
+  if (!restored) throw new Error("interrupted Viewer release switch authority changed during recovery");
+  removeDurableFile(releaseSwitchIntentFile);
+}
+
 function writeReleaseTarget(filename: string, target: ViewerReleaseIdentity): void {
   mcpRuntimeStore.publishReleaseTarget(filename, target);
 }
@@ -474,6 +635,7 @@ function switchTarget(
   action: ViewerMcpRuntimePublicationEvidence["action"],
   fallbackRuntime?: ViewerMcpRuntimeIdentity,
   fence?: HotStateAuthority | null,
+  phase?: (value: string) => void,
 ): ViewerMcpRuntimePublicationEvidence {
   const runtime = target.mcpRuntime ?? fallbackRuntime;
   if (!runtime) throw new Error("release MCP runtime identity is missing");
@@ -485,8 +647,23 @@ function switchTarget(
     && currentTarget.endpoint === target.endpoint;
   const previousAuthority = readHotStateAuthority(stateDir);
   let transitionAuthority: HotStateAuthority | null = null;
+  const intent: ViewerReleaseSwitchIntent | null = sameRelease
+    ? null
+    : {
+        schemaVersion: 1,
+        action,
+        previousTarget: currentTarget,
+        previousAuthority,
+        target,
+        recordedAt: new Date().toISOString(),
+      };
+  if (intent) {
+    phase?.("recording the Viewer release switch intent");
+    writeDurableJson(releaseSwitchIntentFile, intent);
+  }
   try {
     if (!sameRelease) {
+      phase?.("publishing hot-state authority");
       if (action === "restore") {
         transitionAuthority = publishHotStateAuthority(
           stateDir,
@@ -510,7 +687,9 @@ function switchTarget(
     if (transitionAuthority
       && process.env.NODE_ENV === "test"
       && process.env.LLV_TEST_EXIT_AFTER_HOT_STATE_AUTHORITY === "1") process.exit(86);
+    phase?.("publishing the Viewer release target");
     writeReleaseTarget(targetFile, target);
+    if (intent) removeDurableFile(releaseSwitchIntentFile);
   } catch (error) {
     let restoreError: unknown = null;
     try {
@@ -520,9 +699,16 @@ function switchTarget(
       restoreError = failure;
     }
     try {
-      if (transitionAuthority) restoreHotStateAuthority(stateDir, previousAuthority, transitionAuthority);
+      if (transitionAuthority) {
+        const restored = restoreHotStateAuthority(stateDir, previousAuthority, transitionAuthority);
+        if (!restored) throw new Error("hot-state authority changed before target restore");
+      }
     } catch (failure) {
       restoreError ??= failure;
+    }
+    if (!restoreError && intent) {
+      try { removeDurableFile(releaseSwitchIntentFile); }
+      catch (failure) { restoreError = failure; }
     }
     if (restoreError) {
       const message = error instanceof Error ? error.message : "release target publication failed";
@@ -612,13 +798,18 @@ async function waitForHotStateActivation(candidate: ViewerReleaseIdentity): Prom
   throw new Error("timed out waiting for the promoted Viewer to activate hot state");
 }
 
-async function promoteTarget(candidate: ViewerReleaseIdentity): Promise<ViewerMcpRuntimePublicationEvidence> {
+async function promoteTarget(
+  candidate: ViewerReleaseIdentity,
+  phase: (value: string) => void = () => {},
+): Promise<ViewerMcpRuntimePublicationEvidence> {
   const current = readCurrentRelease();
+  phase("fencing the current SQLite release");
   const fence = current?.hotStateBackend === HOT_STATE_BACKEND
     && candidate.hotStateBackend !== HOT_STATE_BACKEND
     ? await fenceCurrentSqliteRelease(current.revision, candidate)
     : null;
-  const publication = switchTarget(candidate, "activate", undefined, fence);
+  const publication = switchTarget(candidate, "activate", undefined, fence, phase);
+  phase("waiting for hot-state activation");
   await waitForHotStateActivation(candidate);
   return publication;
 }
@@ -766,6 +957,8 @@ async function main(): Promise<unknown> {
   if (process.env.LLV_DEPLOYMENT_ADAPTER_PROTOCOL !== "1") throw new Error("deployment adapter protocol is required");
   const action = process.argv[2];
   const input = JSON.parse(await Bun.stdin.text()) as Record<string, unknown>;
+  reportAdapterPhase(String(action ?? "unknown"), "recovering an interrupted Viewer release switch");
+  recoverInterruptedReleaseSwitch();
   if (action === "bootstrap-release") return runBootstrapRelease(input);
   const healthProbeCapability = typeof input.healthProbeCapability === "string"
     ? input.healthProbeCapability
@@ -798,9 +991,10 @@ async function main(): Promise<unknown> {
   if (action === "promote") {
     const candidate = release(input.candidate);
     if (candidate.mcpRuntime?.source !== "managed") throw new Error("candidate MCP runtime identity is missing");
-    return promoteTarget(candidate);
+    return promoteTarget(candidate, (phase) => reportAdapterPhase(action, phase));
   }
   if (action === "verify-promoted") {
+    reportAdapterPhase(action, "waiting for full promoted Viewer readiness");
     const candidate = release(input.candidate);
     const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
     return verify(candidate, stableEndpoint, {
@@ -810,13 +1004,22 @@ async function main(): Promise<unknown> {
   }
   if (action === "rollback") {
     const previous = release(input.previous);
+    reportAdapterPhase(action, "starting the rollback Viewer release");
     await startCandidate(previous);
+    reportAdapterPhase(action, "verifying the rollback Viewer release");
     const evidence = await verifyViewer(previous, previous.endpoint);
     if (!evidence.ok) throw new Error(evidence.detail ?? "rollback release health gate failed");
     const previousMcpRuntime = mcpRuntime(input.previousMcpRuntime);
     const candidate = release(input.candidate);
+    reportAdapterPhase(action, "fencing the promoted SQLite release");
     const fence = await fenceCurrentSqliteRelease(candidate.revision, previous);
-    return switchTarget(previous, "restore", previousMcpRuntime, fence);
+    return switchTarget(
+      previous,
+      "restore",
+      previousMcpRuntime,
+      fence,
+      (phase) => reportAdapterPhase(action, phase),
+    );
   }
   if (action === "stage-host-successor") {
     const candidate = release(input.candidate);

--- a/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
@@ -10,10 +10,14 @@ import {
   markViewerReleaseReady,
   publishHotStateAuthority,
 } from "@/lib/state/hotStateAuthority";
+import {
+  hasViewerDeploymentCapability,
+  viewerDeploymentReleaseReady,
+} from "@/runtime-host/deploymentHealth";
 
 import { GET } from "./route";
 
-test("the promoted capability stays closed until release startup completes", () => {
+test("the deployed predecessor adapter can pass after activation while a new adapter waits for full startup", async () => {
   const previous = process.env.LLV_STATE_DIR;
   const previousPort = process.env.PORT;
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-hot-state-capability-"));
@@ -39,9 +43,16 @@ test("the promoted capability stays closed until release startup completes", () 
     const authority = publishHotStateAuthority(sandbox, "sqlite", revision);
     expect(GET().status).toBe(503);
     const activated = markHotStateActivationReady(sandbox, authority);
-    expect(GET().status).toBe(503);
+    for (let startupPoll = 0; startupPoll < 31; startupPoll += 1) {
+      const predecessorResponse = GET();
+      const predecessorBody = await predecessorResponse.text();
+      expect(predecessorResponse.status).toBe(200);
+      expect(hasViewerDeploymentCapability(predecessorResponse.status, predecessorBody)).toBe(true);
+      expect(viewerDeploymentReleaseReady(predecessorResponse.status, predecessorBody)).toBe(false);
+    }
     markViewerReleaseReady(sandbox, activated);
-    expect(GET().status).toBe(200);
+    const completeResponse = GET();
+    expect(viewerDeploymentReleaseReady(completeResponse.status, await completeResponse.text())).toBe(true);
   } finally {
     if (previousPort === undefined) delete process.env.PORT;
     else process.env.PORT = previousPort;

--- a/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
@@ -7,12 +7,13 @@ import { expect, test } from "bun:test";
 import {
   HOT_STATE_BACKEND,
   markHotStateActivationReady,
+  markViewerReleaseReady,
   publishHotStateAuthority,
 } from "@/lib/state/hotStateAuthority";
 
 import { GET } from "./route";
 
-test("the promoted capability stays closed until hot-state activation completes", () => {
+test("the promoted capability stays closed until release startup completes", () => {
   const previous = process.env.LLV_STATE_DIR;
   const previousPort = process.env.PORT;
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-hot-state-capability-"));
@@ -37,7 +38,9 @@ test("the promoted capability stays closed until hot-state activation completes"
     expect(GET().status).toBe(503);
     const authority = publishHotStateAuthority(sandbox, "sqlite", revision);
     expect(GET().status).toBe(503);
-    markHotStateActivationReady(sandbox, authority);
+    const activated = markHotStateActivationReady(sandbox, authority);
+    expect(GET().status).toBe(503);
+    markViewerReleaseReady(sandbox, activated);
     expect(GET().status).toBe(200);
   } finally {
     if (previousPort === undefined) delete process.env.PORT;

--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -5,7 +5,7 @@ import { HOT_STATE_BACKEND, readHotStateAuthority, readHotStateReleaseTarget } f
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function hotStateActivationReady(
+function viewerReleaseStartupReady(
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): boolean {
   const directory = env.LLV_STATE_DIR?.trim() || statePath(".");
@@ -17,17 +17,17 @@ function hotStateActivationReady(
   const authority = readHotStateAuthority(directory);
   return authority?.mode === "sqlite"
     && authority.releaseRevision === target.revision
-    && typeof authority.activationReadyAt === "string";
+    && typeof authority.releaseReadyAt === "string";
 }
 
 /* The deployment readiness gate probes this route with a 5s budget. It reads
    two small handoff records and still avoids instantiating the agent registry,
    whose first probe would otherwise pay a multi-MB parse. Passive candidates
-   stay probeable; the promoted endpoint waits for completed activation. */
+   stay probeable; the promoted endpoint waits for complete release startup. */
 export function GET(): Response {
-  if (!hotStateActivationReady()) {
+  if (!viewerReleaseStartupReady()) {
     return Response.json(
-      { error: "Viewer hot-state activation is incomplete" },
+      { error: "Viewer release startup is incomplete" },
       { status: 503, headers: { "cache-control": "no-store" } },
     );
   }

--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -5,34 +5,45 @@ import { HOT_STATE_BACKEND, readHotStateAuthority, readHotStateReleaseTarget } f
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function viewerReleaseStartupReady(
+function viewerReleaseStartupState(
   env: Readonly<Record<string, string | undefined>> = process.env,
-): boolean {
+): { activationReady: boolean; releaseReady: boolean } {
   const directory = env.LLV_STATE_DIR?.trim() || statePath(".");
   const target = readHotStateReleaseTarget(directory, env);
-  if (!target) return true;
-  if (target.hotStateBackend !== HOT_STATE_BACKEND) return true;
+  if (!target) return { activationReady: true, releaseReady: true };
+  if (target.hotStateBackend !== HOT_STATE_BACKEND) return { activationReady: true, releaseReady: true };
   const port = env.PORT?.trim();
-  if (!port || new URL(target.endpoint).port !== port) return true;
+  if (!port || new URL(target.endpoint).port !== port) return { activationReady: true, releaseReady: true };
   const authority = readHotStateAuthority(directory);
-  return authority?.mode === "sqlite"
+  const ownsActivatedState = authority?.mode === "sqlite"
     && authority.releaseRevision === target.revision
-    && typeof authority.releaseReadyAt === "string";
+    && typeof authority.activationReadyAt === "string";
+  return {
+    activationReady: ownsActivatedState,
+    releaseReady: ownsActivatedState && typeof authority.releaseReadyAt === "string",
+  };
 }
 
 /* The deployment readiness gate probes this route with a 5s budget. It reads
    two small handoff records and still avoids instantiating the agent registry,
-   whose first probe would otherwise pay a multi-MB parse. Passive candidates
-   stay probeable; the promoted endpoint waits for complete release startup. */
+   whose first probe would otherwise pay a multi-MB parse. The activation gate
+   remains compatible with the deployed predecessor adapter; newer adapters
+   also consume releaseReady while structured-host startup finishes. */
 export function GET(): Response {
-  if (!viewerReleaseStartupReady()) {
+  const startup = viewerReleaseStartupState();
+  if (!startup.activationReady) {
     return Response.json(
-      { error: "Viewer release startup is incomplete" },
+      { error: "Viewer hot-state activation is incomplete" },
       { status: 503, headers: { "cache-control": "no-store" } },
     );
   }
   return Response.json(
-    { capability: "viewer-deployments", version: 1, registryBackendMode: sqliteModeFromEnvironment() },
+    {
+      capability: "viewer-deployments",
+      version: 1,
+      registryBackendMode: sqliteModeFromEnvironment(),
+      releaseReady: startup.releaseReady,
+    },
     { headers: { "cache-control": "no-store" } },
   );
 }

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -8,6 +8,7 @@ import { Database } from "bun:sqlite";
 import {
   accountControllerDelayMs,
   activateViewerRuntimeWhenCurrent,
+  completeViewerRuntimeActivation,
   completeViewerReleaseDemotion,
   establishHotStateCutoverBoundary,
   initializeHotStateStoresAtStartup,
@@ -229,6 +230,30 @@ test("a current release monitors rollback fences while activation is still pendi
   expect(checkpoints).toBe(1);
   rejectActivation(new Error("injected activation failure"));
   await expect(activation).rejects.toThrow("injected activation failure");
+});
+
+test("hot-state activation beats a slow structured-host startup and the promote deadline", async () => {
+  let finishStructuredStartup!: () => void;
+  let publishActivation!: () => void;
+  const structuredStartup = new Promise<void>((resolve) => { finishStructuredStartup = resolve; });
+  const published = new Promise<void>((resolve) => { publishActivation = resolve; });
+  const activation = completeViewerRuntimeActivation({
+    initializeOperatorCapability: async () => undefined,
+    startWakatime: async () => undefined,
+    startStructuredHosts: () => structuredStartup,
+    startControllers: async () => undefined,
+    publishHotStateActivation: publishActivation,
+    publishViewerReleaseReady: () => undefined,
+  });
+
+  const outcome = await Promise.race([
+    published.then(() => "activated"),
+    Bun.sleep(25).then(() => "deployment adapter promote timed out while waiting for hot-state activation"),
+  ]);
+  finishStructuredStartup();
+  await activation;
+
+  expect(outcome).toBe("activated");
 });
 
 test("cutover import faults roll back all four collection markers and retry cleanly", async () => {

--- a/src/lib/state/hotStateAuthority.ts
+++ b/src/lib/state/hotStateAuthority.ts
@@ -27,6 +27,7 @@ export interface HotStateAuthority {
   releaseRevision: string | null;
   updatedAt: string;
   activationReadyAt?: string;
+  releaseReadyAt?: string;
   checkpoint?: HotStateCheckpoint;
 }
 
@@ -66,6 +67,8 @@ function parseAuthority(value: unknown): HotStateAuthority | null {
     || (authority.releaseRevision !== null && !validRevision(authority.releaseRevision))
     || typeof authority.updatedAt !== "string"
     || (authority.activationReadyAt !== undefined && typeof authority.activationReadyAt !== "string")
+    || (authority.releaseReadyAt !== undefined && typeof authority.releaseReadyAt !== "string")
+    || (authority.releaseReadyAt !== undefined && authority.activationReadyAt === undefined)
     || (authority.checkpoint !== undefined && !validCheckpoint(authority.checkpoint))) return null;
   return authority as HotStateAuthority;
 }
@@ -145,18 +148,20 @@ export function hotStateSqliteWriterReady(
   if (!target) return true;
   const authority = readHotStateAuthority(directory);
   /* Fencing covers the handoff window, when a retiring and an arriving release
-     could both write. Once the authority has activated sqlite FOR THE RELEASE
-     CURRENTLY PROMOTED, that window is closed and there is no second writer to
-     protect against. Every local client — the MCP runtime, a CLI, a script —
-     writes through this same store and carries neither PORT nor the revision
-     env, so proving a revision is something only the release server can do.
-     Demanding it after activation fences those clients out of settled state
-     permanently rather than transiently (issue #907 follow-up). */
-  if (authority?.mode === "sqlite"
-    && authority.releaseRevision === target.revision
-    && typeof authority.activationReadyAt === "string") return true;
+     could both write. Unidentified local clients may write after the promoted
+     release activates settled SQLite state. A client carrying PORT or an
+     explicit revision remains bound to that identity, so a retiring server or
+     MCP process stays fenced after the target changes (issue #907 follow-up). */
   const revision = hotStateWriterRevision(directory, env);
-  if (!revision) return false;
+  if (!revision) {
+    const carriesReleaseIdentity = Boolean(
+      env[HOT_STATE_RELEASE_REVISION_ENV]?.trim() || env.PORT?.trim(),
+    );
+    return !carriesReleaseIdentity
+      && authority?.mode === "sqlite"
+      && authority.releaseRevision === target.revision
+      && typeof authority.activationReadyAt === "string";
+  }
   return authority?.mode === "sqlite"
     && authority.releaseRevision === revision
     && target.revision === revision;
@@ -189,8 +194,12 @@ function writeHotStateAuthority(
     checkpoint?: HotStateCheckpoint;
     epoch?: number;
     activationReadyAt?: string;
+    releaseReadyAt?: string;
   } = {},
 ): HotStateAuthority {
+  if (options.releaseReadyAt && !options.activationReadyAt) {
+    throw new Error("Viewer release readiness requires completed hot-state activation");
+  }
   const authority: HotStateAuthority = {
     schemaVersion: 1,
     epoch: options.epoch ?? ((previous?.epoch ?? 0) + 1),
@@ -198,6 +207,7 @@ function writeHotStateAuthority(
     releaseRevision,
     updatedAt: new Date().toISOString(),
     ...(options.activationReadyAt ? { activationReadyAt: options.activationReadyAt } : {}),
+    ...(options.releaseReadyAt ? { releaseReadyAt: options.releaseReadyAt } : {}),
     ...(options.checkpoint ? { checkpoint: options.checkpoint } : {}),
   };
   if (!Number.isInteger(authority.epoch) || authority.epoch < 1) throw new Error("hot-state authority epoch is invalid");
@@ -210,7 +220,7 @@ export function publishHotStateAuthority(
   directory: string,
   mode: HotStateAuthorityMode,
   releaseRevision: string | null,
-  options: { checkpoint?: HotStateCheckpoint; epoch?: number; activationReadyAt?: string } = {},
+  options: { checkpoint?: HotStateCheckpoint; epoch?: number; activationReadyAt?: string; releaseReadyAt?: string } = {},
 ): HotStateAuthority {
   if (releaseRevision !== null && !validRevision(releaseRevision)) throw new Error("hot-state release revision is invalid");
   return withFileTransactionSync(authorityFile(directory), "hot-state authority is busy", () =>
@@ -236,6 +246,7 @@ export function restoreHotStateAuthority(
       {
         ...(authority?.checkpoint ? { checkpoint: authority.checkpoint } : {}),
         ...(authority?.activationReadyAt ? { activationReadyAt: authority.activationReadyAt } : {}),
+        ...(authority?.releaseReadyAt ? { releaseReadyAt: authority.releaseReadyAt } : {}),
         epoch: current!.epoch + 1,
       },
     );
@@ -290,6 +301,26 @@ export function markHotStateActivationReady(
     return writeHotStateAuthority(directory, current, "sqlite", current.releaseRevision, {
       epoch: current.epoch,
       activationReadyAt: new Date().toISOString(),
+    });
+  });
+}
+
+export function markViewerReleaseReady(
+  directory: string,
+  request: HotStateAuthority,
+): HotStateAuthority {
+  return withFileTransactionSync(authorityFile(directory), "hot-state authority is busy", () => {
+    const current = readHotStateAuthority(directory);
+    if (!current
+      || !sameAuthority(current, request)
+      || current.mode !== "sqlite"
+      || typeof current.activationReadyAt !== "string") {
+      throw new Error("hot-state authority changed before Viewer release startup completed");
+    }
+    return writeHotStateAuthority(directory, current, "sqlite", current.releaseRevision, {
+      epoch: current.epoch,
+      activationReadyAt: current.activationReadyAt,
+      releaseReadyAt: new Date().toISOString(),
     });
   });
 }

--- a/src/lib/state/hotStateStores.sqlite.test.ts
+++ b/src/lib/state/hotStateStores.sqlite.test.ts
@@ -23,6 +23,7 @@ import {
   HOT_STATE_RELEASE_REVISION_ENV,
   hotStateSqliteWriterReady,
   markHotStateActivationReady,
+  markViewerReleaseReady,
   publishHotStateAuthority,
   readHotStateAuthority,
   restoreHotStateAuthority,
@@ -542,12 +543,13 @@ test("authority rollback uses a monotonic compare-and-set and rejects delayed fe
   }
 });
 
-test("authority rollback preserves the previous SQLite activation readiness", () => {
+test("authority rollback preserves the previous SQLite release readiness", () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-hot-state-authority-ready-"));
   const revision = "9".repeat(40);
   try {
     const initial = publishHotStateAuthority(sandbox, "sqlite", revision);
-    const ready = markHotStateActivationReady(sandbox, initial);
+    const activated = markHotStateActivationReady(sandbox, initial);
+    const ready = markViewerReleaseReady(sandbox, activated);
     const transition = publishHotStateAuthority(sandbox, "fencing", revision);
 
     const restored = restoreHotStateAuthority(sandbox, ready, transition);
@@ -555,8 +557,20 @@ test("authority rollback preserves the previous SQLite activation readiness", ()
       mode: "sqlite",
       releaseRevision: revision,
       activationReadyAt: ready.activationReadyAt,
+      releaseReadyAt: ready.releaseReadyAt,
     });
     expect(restored!.epoch).toBeGreaterThan(transition.epoch);
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("release readiness cannot precede hot-state activation", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-hot-state-authority-order-"));
+  try {
+    expect(() => publishHotStateAuthority(sandbox, "sqlite", "7".repeat(40), {
+      releaseReadyAt: "2026-08-09T00:00:00.000Z",
+    })).toThrow("requires completed hot-state activation");
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
@@ -966,11 +980,10 @@ test("first boot imports every store once and folds in the pipeline archive", ()
   }
 });
 
-test("a client that cannot prove a revision still writes once the promoted release has activated", () => {
-  /* The MCP runtime, a CLI and any script write through this same store and
-     carry neither PORT nor the revision env — only the release server can prove
-     a revision. Before this, they were fenced permanently after activation
-     rather than only during the handoff window. */
+test("an unidentified client writes after activation while retired release identities stay fenced", () => {
+  /* A CLI or script may carry no release identity. Servers and managed MCP
+     processes retain PORT or an explicit revision, which keeps the retired
+     generation outside the promoted writer set. */
   const previousDir = process.env.LLV_STATE_DIR;
   const previousPort = process.env.PORT;
   const previousRevisionEnv = process.env[HOT_STATE_RELEASE_REVISION_ENV];
@@ -989,6 +1002,14 @@ test("a client that cannot prove a revision still writes once the promoted relea
 
     markHotStateActivationReady(sandbox, published);
     expect(hotStateSqliteWriterReady(sandbox)).toBe(true);
+    expect(hotStateSqliteWriterReady(sandbox, {
+      [HOT_STATE_RELEASE_REVISION_ENV]: "d".repeat(40),
+    })).toBe(false);
+    expect(hotStateSqliteWriterReady(sandbox, { PORT: "19102" })).toBe(false);
+    expect(hotStateSqliteWriterReady(sandbox, {
+      [HOT_STATE_RELEASE_REVISION_ENV]: revision,
+    })).toBe(true);
+    expect(hotStateSqliteWriterReady(sandbox, { PORT: "19101" })).toBe(true);
 
     /* An activation belonging to a DIFFERENT release than the promoted one is
        still a live handoff, so the fence must hold. */

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -9,6 +9,7 @@ import {
   completeHotStatePreparation,
   hotStateWriterRevision,
   markHotStateActivationReady,
+  markViewerReleaseReady,
   publishHotStateAuthority,
   readHotStateAuthority,
   type HotStateAuthority,
@@ -79,6 +80,15 @@ export interface HotStateCutoverBoundary {
 interface CurrentReleaseControllerLoaders {
   loadFlowPipelineController: () => Promise<{ startFlowPipelineController: () => void }>;
   loadAccountMigrationController: () => Promise<{ startAccountMigrationController: () => Promise<void> }>;
+}
+
+interface ViewerRuntimeActivationSteps {
+  initializeOperatorCapability: () => Promise<void>;
+  startWakatime: () => Promise<void>;
+  startStructuredHosts: (() => Promise<void>) | null;
+  startControllers: () => Promise<void>;
+  publishHotStateActivation: () => void;
+  publishViewerReleaseReady: () => void;
 }
 
 /** Candidate containers share production state while their health gate runs.
@@ -448,6 +458,17 @@ export async function runStructuredHostStartup(
   await ready;
 }
 
+export async function completeViewerRuntimeActivation(
+  steps: ViewerRuntimeActivationSteps,
+): Promise<void> {
+  await steps.initializeOperatorCapability();
+  await steps.startWakatime();
+  steps.publishHotStateActivation();
+  if (steps.startStructuredHosts) await steps.startStructuredHosts();
+  await steps.startControllers();
+  steps.publishViewerReleaseReady();
+}
+
 /** The full node-runtime startup sequence `src/instrumentation.ts` defers to. */
 export async function registerViewerRuntime(): Promise<void> {
   discardWakatimeEnvironmentCredential();
@@ -459,14 +480,24 @@ export async function registerViewerRuntime(): Promise<void> {
     const boundary = await establishHotStateCutoverBoundary(isCurrent);
     activatedReleaseRevision = boundary.authority?.releaseRevision ?? null;
     const authority = await initializeHotStateStoresAtStartup(boundary);
-    await initializeOperatorSpawnCapabilityAtStartup();
-    await startWakatimeIntegrationIfEnabled();
-    if (structuredHostsEnabled()) {
-      const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-      await runStructuredHostStartup(adoptStructuredHostsAtStartup, console.error, { waitUntilReady: true });
-    }
-    await startCurrentReleaseControllers();
-    if (authority) markHotStateActivationReady(hotStateDirectory, authority);
+    let activatedAuthority: HotStateAuthority | null = null;
+    await completeViewerRuntimeActivation({
+      initializeOperatorCapability: initializeOperatorSpawnCapabilityAtStartup,
+      startWakatime: startWakatimeIntegrationIfEnabled,
+      startStructuredHosts: structuredHostsEnabled()
+        ? async () => {
+            const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
+            await runStructuredHostStartup(adoptStructuredHostsAtStartup, console.error, { waitUntilReady: true });
+          }
+        : null,
+      startControllers: startCurrentReleaseControllers,
+      publishHotStateActivation: () => {
+        if (authority) activatedAuthority = markHotStateActivationReady(hotStateDirectory, authority);
+      },
+      publishViewerReleaseReady: () => {
+        if (activatedAuthority) markViewerReleaseReady(hotStateDirectory, activatedAuthority);
+      },
+    });
   }, isCurrent, {
     fenceRequest: () => {
       const revision = releaseRevision();

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -11,11 +11,14 @@ afterEach(() => {
   for (const dir of sandboxes.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
-function sleepingAdapter(): { executable: string; stateFile: string } {
+function sleepingAdapter(phase?: string): { executable: string; stateFile: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-adapter-process-"));
   sandboxes.push(dir);
   const executable = path.join(dir, "adapter.sh");
-  fs.writeFileSync(executable, "#!/bin/sh\nsleep 60\nprintf '{\"revision\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\\n'\n", { mode: 0o700 });
+  const phaseWrite = phase
+    ? `printf '{"action":"%s","phase":"${phase}"}' "$1" > "$LLV_DEPLOYMENT_ADAPTER_PHASE_FILE"\n`
+    : "";
+  fs.writeFileSync(executable, `#!/bin/sh\n${phaseWrite}sleep 60\nprintf '{"revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}\\n'\n`, { mode: 0o700 });
   return { executable, stateFile: path.join(dir, "adapter-process.json") };
 }
 
@@ -198,12 +201,7 @@ test("adapter action deadline terminates the process tree and clears durable own
   expect(fs.existsSync(fixture.stateFile)).toBe(false);
 });
 
-test("promotion deadline names the hot-state activation wait", async () => {
-  const fixture = sleepingAdapter();
-  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, {
-    stateFile: fixture.stateFile,
-    timeouts: { promote: 20 },
-  });
+test("promotion deadline reports the active handoff phase", async () => {
   const candidate = {
     image: "viewer:test",
     container: "viewer-candidate",
@@ -211,7 +209,15 @@ test("promotion deadline names the hot-state activation wait", async () => {
     revision: "a".repeat(40),
   };
 
-  await expect(adapter.promote(candidate)).rejects.toThrow(
-    "deployment adapter promote timed out while waiting for hot-state activation",
-  );
+  for (const phase of ["fencing the current SQLite release", "publishing the Viewer release target"]) {
+    const fixture = sleepingAdapter(phase);
+    const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, {
+      stateFile: fixture.stateFile,
+      timeouts: { promote: 20 },
+    });
+    await expect(adapter.promote(candidate)).rejects.toThrow(
+      `deployment adapter promote timed out while ${phase}`,
+    );
+    expect(fs.existsSync(`${fixture.stateFile}.phase`)).toBe(false);
+  }
 });

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -197,3 +197,21 @@ test("adapter action deadline terminates the process tree and clears durable own
   expect(processGroupAlive(timedOutPid)).toBe(false);
   expect(fs.existsSync(fixture.stateFile)).toBe(false);
 });
+
+test("promotion deadline names the hot-state activation wait", async () => {
+  const fixture = sleepingAdapter();
+  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, {
+    stateFile: fixture.stateFile,
+    timeouts: { promote: 20 },
+  });
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:18001",
+    revision: "a".repeat(40),
+  };
+
+  await expect(adapter.promote(candidate)).rejects.toThrow(
+    "deployment adapter promote timed out while waiting for hot-state activation",
+  );
+});

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -34,17 +34,12 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
   "reconcile-mcp-runtime": 10 * 60_000,
   "verify-candidate": 90_000,
   promote: 30_000,
-  "verify-promoted": 90_000,
+  "verify-promoted": 120_000,
   rollback: 90_000,
   retire: 60_000,
   "retain-only": 60_000,
   "stage-host-successor": 60_000,
   "complete-host-handoff": 60_000,
-};
-
-const ACTION_TIMEOUT_WAITS: Partial<Record<AdapterAction, string>> = {
-  promote: "hot-state activation",
-  "verify-promoted": "full promoted Viewer readiness",
 };
 
 const MCP_HEALTH_PROBE_ACTIONS: ReadonlySet<AdapterAction> = new Set([
@@ -57,6 +52,11 @@ interface AdapterProcessRecord {
   pid: number;
   startIdentity: string;
   action: AdapterAction;
+}
+
+interface AdapterPhaseRecord {
+  action: AdapterAction;
+  phase: string;
 }
 
 export interface HostCommandViewerDeploymentAdapterOptions {
@@ -97,6 +97,19 @@ function clearProcessRecord(filename: string, expected?: AdapterProcessRecord): 
     if (current && (current.pid !== expected.pid || current.startIdentity !== expected.startIdentity)) return;
   }
   fs.rmSync(filename, { force: true });
+}
+
+function readAdapterPhase(filename: string, action: AdapterAction): string | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<AdapterPhaseRecord>;
+    return value.action === action
+      && typeof value.phase === "string"
+      && /^[A-Za-z0-9 -]{1,160}$/.test(value.phase)
+      ? value.phase
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
@@ -275,13 +288,19 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
   static fromExecutable(executable: string, options: HostCommandViewerDeploymentAdapterOptions = {}): HostCommandViewerDeploymentAdapter {
     if (!executable.startsWith("/")) throw new Error("viewer deployment adapter path must be absolute");
     const stateFile = options.stateFile ?? statePath("viewer-deployment-adapter-process.json");
+    const phaseFile = `${stateFile}.phase`;
     const proc = options.proc ?? procBackend;
     const timeouts = { ...ACTION_TIMEOUTS, ...options.timeouts };
     const reconcile = async () => {
       const previous = readProcessRecord(stateFile);
-      if (!previous) { clearProcessRecord(stateFile); return; }
+      if (!previous) {
+        clearProcessRecord(stateFile);
+        fs.rmSync(phaseFile, { force: true });
+        return;
+      }
       await terminateAdapterProcess(previous, proc);
       clearProcessRecord(stateFile, previous);
+      fs.rmSync(phaseFile, { force: true });
     };
     const runAction = async (
       action: AdapterAction,
@@ -296,9 +315,14 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
         : ["pipe", "pipe", "pipe"];
       let child: ReturnType<typeof spawn>;
       try {
+        fs.rmSync(phaseFile, { force: true });
         child = spawn("/usr/bin/setpriv", ["--pdeathsig", "KILL", "--", executable, action], {
           stdio,
-          env: { ...withoutWakatimeCredential(process.env), LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1" },
+          env: {
+            ...withoutWakatimeCredential(process.env),
+            LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1",
+            LLV_DEPLOYMENT_ADAPTER_PHASE_FILE: phaseFile,
+          },
           detached: true,
         });
       } catch (error) {
@@ -358,8 +382,8 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
           await terminateAdapterProcess(record, proc);
           await exitPromise;
           await Promise.all([stdoutPromise, stderrPromise]);
-          const waitedOn = ACTION_TIMEOUT_WAITS[action] ?? "the adapter process";
-          throw new Error(`deployment adapter ${action} timed out while waiting for ${waitedOn}`);
+          const phase = readAdapterPhase(phaseFile, action) ?? "waiting for the adapter process";
+          throw new Error(`deployment adapter ${action} timed out while ${phase}`);
         }
         const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
         if (outcome.exitCode !== 0) throw new Error((stderr.trim() || `deployment adapter ${action} failed`).slice(0, 500));
@@ -369,6 +393,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
         if (timer) clearTimeout(timer);
         closeHealthAdmission?.();
         clearProcessRecord(stateFile, record);
+        fs.rmSync(phaseFile, { force: true });
       }
     };
     const run: CommandRunner = async (rawAction, input) => {

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -42,6 +42,11 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
   "complete-host-handoff": 60_000,
 };
 
+const ACTION_TIMEOUT_WAITS: Partial<Record<AdapterAction, string>> = {
+  promote: "hot-state activation",
+  "verify-promoted": "full promoted Viewer readiness",
+};
+
 const MCP_HEALTH_PROBE_ACTIONS: ReadonlySet<AdapterAction> = new Set([
   "reconcile-mcp-runtime",
   "verify-candidate",
@@ -353,7 +358,8 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
           await terminateAdapterProcess(record, proc);
           await exitPromise;
           await Promise.all([stdoutPromise, stderrPromise]);
-          throw new Error(`deployment adapter ${action} timed out`);
+          const waitedOn = ACTION_TIMEOUT_WAITS[action] ?? "the adapter process";
+          throw new Error(`deployment adapter ${action} timed out while waiting for ${waitedOn}`);
         }
         const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
         if (outcome.exitCode !== 0) throw new Error((stderr.trim() || `deployment adapter ${action} failed`).slice(0, 500));

--- a/src/runtime-host/deploymentHealth.test.ts
+++ b/src/runtime-host/deploymentHealth.test.ts
@@ -8,6 +8,7 @@ import { GET as deploymentCapability } from "@/app/api/runtime/deployments/capab
 import {
   hasViewerDeploymentCapability,
   viewerDeploymentRegistryBackendMode,
+  viewerDeploymentReleaseReady,
   viewerHealthRequestPlan,
   waitForViewerReadiness,
 } from "./deploymentHealth";
@@ -94,4 +95,13 @@ test("deployment capability requires the candidate-owned versioned endpoint", as
     version: 1,
     registryBackendMode: "invalid",
   }))).toBeNull();
+  expect(viewerDeploymentReleaseReady(200, JSON.stringify({
+    capability: "viewer-deployments",
+    version: 1,
+  }))).toBe(true);
+  expect(viewerDeploymentReleaseReady(200, JSON.stringify({
+    capability: "viewer-deployments",
+    version: 1,
+    releaseReady: false,
+  }))).toBe(false);
 });

--- a/src/runtime-host/deploymentHealth.ts
+++ b/src/runtime-host/deploymentHealth.ts
@@ -53,6 +53,18 @@ export function viewerDeploymentRegistryBackendMode(
   }
 }
 
+/** Older release capabilities omit this field and already represent complete
+ * startup. SQLite-wave releases expose an explicit false value while their
+ * post-activation controllers and structured hosts are still starting. */
+export function viewerDeploymentReleaseReady(status: number, body: string): boolean {
+  if (!hasViewerDeploymentCapability(status, body)) return false;
+  try {
+    return (JSON.parse(body) as { releaseReady?: unknown }).releaseReady !== false;
+  } catch {
+    return false;
+  }
+}
+
 export interface ViewerReadinessProbe {
   endpoint: string;
   inspect(): Promise<ViewerCandidateContainerState>;


### PR DESCRIPTION
## Summary

- publish SQLite activation before slow structured-host startup so the deployed predecessor adapter can complete promotion
- expose `releaseReady` for successor adapters to keep full-startup verification bounded at 90 polls under a 120-second action deadline
- journal every authority-to-target switch and recover an interrupted switch before rollback health checks
- report the live fencing, authority-publication, target-publication, activation, or full-readiness phase when an adapter deadline expires

## Root cause and bootstrap

`promoteTarget()` waited for `activationReadyAt` after runtime startup had already entered structured-host adoption. Production adoption exceeded the 30-second `promote` deadline, so the runtime host killed the adapter child first.

The candidate now publishes activation immediately after hot-store initialization. Its capability endpoint then returns the versioned deployment capability with `releaseReady: false`. The deployed `dfa7447e` adapter understands the capability/version fields and completes its 30-attempt post-promotion gate. A successor adapter also reads `releaseReady` and keeps polling until structured hosts and controllers publish full readiness. The regression holds full startup incomplete across 31 probes while proving the predecessor gate remains successful.

## Handoff recovery

The adapter durably records the previous target, previous authority, destination, and action before authority publication. A process crash in the authority-to-target gap leaves that intent in place. The next target-dependent action compares the durable target and authority to the intent, restores the exact previous authority through a newer epoch when the target stayed previous, and clears the intent only after the repair is durable.

The SQLite-to-SQLite crash regression exits immediately after candidate authority publication. Both release identities are fenced in that state. Rollback recovers the previous activation and full-readiness markers before its health probe, then proves the previous writer is enabled and the candidate remains fenced.

## Timeout diagnostics

The host supplies a per-action phase record to the adapter child. Parent deadlines report the phase last durably published by that child, including fencing and Viewer target publication, and clear the record during normal completion and orphan reconciliation.

## Verification

- 83 focused tests across 6 exact files with isolated `HOME`, `XDG_CONFIG_HOME`, `LLV_STATE_DIR`, and `TMPDIR`
- `bunx tsc --noEmit`
- ESLint over the 8 changed TypeScript files
- `bun run build` including the MCP bundle
- `bun scripts/privacy-publication-gate.ts --base origin/main`
