### PR TITLE
fix(composer): release switch-held messages level-wise once the switch is over

### DIFF
--- a/src/components/BranchPane.render.test.tsx
+++ b/src/components/BranchPane.render.test.tsx
@@ -72,3 +72,31 @@ test("the full-window overlay (expanded) mounts the strip the same way", () => {
   expect(strip(html)).toBe(true);
   expect(surface(html)).toBe("live-root");
 });
+
+test("the pending migration ribbon clears once the card already runs under the hold's target account", () => {
+  // The live P1: "Account switch pending — after current turn" stayed up while
+  // the switch had ALREADY completed and the card ran under the target account.
+  // The banner must obey the level, not wait for a clearing event.
+  const migration = {
+    intentId: "i1", trigger: "manual", phase: "waiting-turn",
+    targetAccountId: "account-b", targetLabel: "account-b", failure: null,
+  } as FileEntry["migration"];
+  const staleHtml = renderToStaticMarkup(
+    <BranchPane
+      file={file({ path: "/data/accounts/claude/account-b/root.jsonl", migration })}
+      tasks={[]}
+      isRoot
+    />,
+  );
+  expect(staleHtml).not.toContain("Account switch pending");
+
+  // A genuinely live hold (card still on the source account) keeps the ribbon.
+  const liveHtml = renderToStaticMarkup(
+    <BranchPane
+      file={file({ path: "/data/accounts/claude/account-a/root.jsonl", migration })}
+      tasks={[]}
+      isRoot
+    />,
+  );
+  expect(liveHtml).toContain("Account switch pending");
+});

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -10,7 +10,7 @@ import { type TFunction, useLocale } from "@/lib/i18n";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
-import { cardMigrationState, migrationTargetName, postConversationMigration } from "@/lib/accounts/migration";
+import { activeCardMigration, cardMigrationState, migrationTargetName, postConversationMigration } from "@/lib/accounts/migration";
 import { conversationIdentity } from "@/lib/accounts/identity";
 import { accountIdFromPath } from "@/lib/accounts/badge";
 
@@ -162,7 +162,11 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
   const badge = engineBadge(file);
   const state = paneState(file);
   const tone = PANE_TONES[state];
-  const migState = cardMigrationState(file.migration);
+  /* Level rule (P1 held-release): a hold annotation whose target the card
+     ALREADY runs under is a completed switch's leftover — the ribbon must
+     clear on the next snapshot, never wait for a clearing event. */
+  const liveMigration = activeCardMigration(file.migration, accountIdFromPath(file.path));
+  const migState = cardMigrationState(liveMigration);
   /* The phone metadata row scrolls horizontally to stay one line (issue #177
      item 4); this tracks whether more is clipped to the right so a fade
      affordance can show, and the row swallows its own touch gestures so a scroll
@@ -476,9 +480,9 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
         {migState ? (
           <MigrationRibbon
             state={migState}
-            targetLabel={migrationTargetName(file.migration) ?? ""}
-            currentLabel={file.migration?.sourceLabel}
-            error={file.migration?.failure ?? null}
+            targetLabel={migrationTargetName(liveMigration) ?? ""}
+            currentLabel={liveMigration?.sourceLabel}
+            error={liveMigration?.failure ?? null}
             actionError={recoveryError}
             onRetry={recover ? () => void recover("retry") : undefined}
             onKeep={recover ? () => void recover("rollback") : undefined}

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -7,8 +7,9 @@ import { ArrowDown, ChevronUp, Sparkle } from "@/components/icons";
 import { useLogTail } from "@/hooks/useLogTail";
 import { useRuntimeSessionForConversation } from "@/hooks/useRuntime";
 import { useToolActivityCues } from "@/hooks/useToolActivityCues";
+import { accountIdFromPath } from "@/lib/accounts/badge";
 import { conversationIdentity } from "@/lib/accounts/identity";
-import { cardMigrationState, migrationHoldsDelivery, migrationTargetName } from "@/lib/accounts/migration";
+import { activeCardMigration, cardMigrationState, migrationHoldsDelivery, migrationTargetName } from "@/lib/accounts/migration";
 import { getLocale, translate, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -752,9 +753,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
               if (section === "outbox") {
                 /* While this card is switching accounts the server holds every
                    delivery it admits, so the bubble — the message's ONE delivery
-                   state — is what says the message waits for the switch. */
-                const switchHold = migrationHoldsDelivery(cardMigrationState(file.migration))
-                  ? { label: migrationTargetName(file.migration) }
+                   state — is what says the message waits for the switch. A hold
+                   annotation the card has already satisfied (its target IS the
+                   active account) says nothing: the switch is over. */
+                const liveMigration = activeCardMigration(file.migration, accountIdFromPath(file.path));
+                const switchHold = migrationHoldsDelivery(cardMigrationState(liveMigration))
+                  ? { label: migrationTargetName(liveMigration) }
                   : null;
                 return <OutboxBubbles key="outbox" cardId={memoryKey!} entries={pendingOutbox} switchHold={switchHold} />;
               }

--- a/src/components/TmuxComposer.heldRelease.dom.test.tsx
+++ b/src/components/TmuxComposer.heldRelease.dom.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * P1 — composer messages held for an account switch must RELEASE once the
+ * switch is over, level-triggered, never only on a live event.
+ *
+ * Reproduced live: two messages on one card read "Held for «B» — delivers
+ * after the switch" while the switch had ALREADY completed server-side (the
+ * conversation ran under the target account and a fresh send delivered within
+ * seconds). The held texts existed in no server-side store — the hold lived in
+ * the client outbox, whose only release signals were events (a receipt, the
+ * delivered text's transcript echo) that never arrived once the server-side
+ * hold record was gone. The entries sat "delivering" forever and, because the
+ * dispatcher is serial, everything queued behind them was stranded too.
+ *
+ * The rule asserted here: whenever the card's account state no longer holds
+ * deliveries — the migration annotation vanished, or its target already IS the
+ * account the card runs under — every switch-held entry returns to the queue
+ * and redelivers under its ORIGINAL idempotency key. On the next snapshot, not
+ * only on the event that was missed.
+ */
+import { afterAll, afterEach, expect, mock, test } from "bun:test";
+import { act } from "react";
+import { installActEnv } from "@/test-helpers/actEnv";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { ConversationMigration, FileEntry } from "@/lib/types";
+import { setLocale } from "@/lib/i18n";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+/* The legacy pane route is the subject: `file.proc` is the host authority and
+   the composer sends through /api/tmux. The runtime plane stays OFF. */
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntime: () => ({
+    enabled: false,
+    structuredHostsEnabled: false,
+    connection: "offline",
+    resyncedAt: null,
+    store: {},
+  }),
+  useRuntimeEnabled: () => false,
+  useRuntimeSession: () => null,
+  useRuntimeSessionByArtifact: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+}));
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+});
+
+const { TmuxComposer } = await import("./TmuxComposer");
+const { enqueueOutbox, readOutbox, resetOutboxForTests } = await import("./conversation/outbox");
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  setLocale("en");
+  globalThis.fetch = realFetch;
+  document.body.replaceChildren();
+  localStorage.clear();
+  sessionStorage.clear();
+  resetOutboxForTests();
+});
+
+const CARD = "conversation_held-release";
+const SOURCE_PATH = "/data/accounts/codex/account-a/sessions/hold.jsonl";
+const TARGET_PATH = "/data/accounts/codex/account-b/sessions/hold.jsonl";
+
+/** The stale annotation exactly as the incident showed it: still `waiting-turn`
+    toward account B while the card already runs under account B. */
+const switchingToB: ConversationMigration = {
+  intentId: "intent-1",
+  trigger: "manual",
+  phase: "waiting-turn",
+  targetAccountId: "account-b",
+  targetLabel: "account-b",
+  failure: null,
+};
+
+function fileWith(path: string, migration: ConversationMigration | undefined): FileEntry {
+  return {
+    path,
+    root: "codex-sessions",
+    name: "hold.jsonl",
+    project: "viewer",
+    title: "Codex",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "live",
+    proc: "running",
+    pid: null,
+    conversationId: CARD,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...(migration ? { migration } : {}),
+  } as FileEntry;
+}
+
+/** The pane route, scripted: answers `held` while `state.outcome` says so, and
+    records every send body so replays can be asserted key-exact. */
+function stubWire(): { calls: { clientMessageId?: string; text?: string }[]; outcome: "held" | "delivered" } {
+  const state = { calls: [] as { clientMessageId?: string; text?: string }[], outcome: "held" as "held" | "delivered" };
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "/api/tmux/targets") return { ok: true, json: async () => ({ targets: { "0": "%1" } }) } as Response;
+    if (url === "/api/tmux") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { clientMessageId?: string; text?: string };
+      state.calls.push(body);
+      return {
+        ok: true,
+        json: async () => (state.outcome === "held" ? { ok: true, outcome: "held" } : { ok: true }),
+      } as Response;
+    }
+    return { ok: true, json: async () => ({ ok: true }) } as Response;
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+async function renderInto(node: React.ReactElement): Promise<{ host: HTMLElement; root: Root }> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  return { host, root };
+}
+
+const settle = async (rounds = 1) => {
+  for (let i = 0; i < rounds; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+};
+
+/** Queue two messages and let the first settle as held-for-the-switch: the
+    incident's starting position — one entry parked `delivering`, the second
+    stranded `queued` behind the serial dispatcher. */
+async function holdTwoMessages(wire: ReturnType<typeof stubWire>, root: Root) {
+  enqueueOutbox(CARD, { id: "key-held-1", text: "first held message", images: 0, at: Date.now() });
+  enqueueOutbox(CARD, { id: "key-held-2", text: "second held message", images: 0, at: Date.now() + 1 });
+  await act(async () => {
+    root.render(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle();
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-held-1"]);
+  expect(readOutbox(CARD).map((entry) => entry.state)).toEqual(["delivering", "queued"]);
+}
+
+test("held entries deliver once the hold's target IS the active account, even under a stale annotation", async () => {
+  const wire = stubWire();
+  const { root } = await renderInto(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+  await holdTwoMessages(wire, root);
+
+  /* The switch completes: the transcript now lives under account B. The
+     annotation is STALE — still `waiting-turn` toward the very account the
+     card already runs under — and no release event ever fires. */
+  wire.outcome = "delivered";
+  await act(async () => {
+    root.render(<TmuxComposer file={fileWith(TARGET_PATH, switchingToB)} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(6);
+
+  /* Both messages redelivered, in order, under their ORIGINAL idempotency
+     keys — an idempotent replay, never a second distinct message. */
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-held-1", "key-held-1", "key-held-2"]);
+  expect(readOutbox(CARD).map((entry) => entry.state)).toEqual(["delivered", "delivered"]);
+  await act(async () => root.unmount());
+});
+
+test("held entries deliver when the migration annotation vanishes (registry already reads migration=null)", async () => {
+  const wire = stubWire();
+  const { root } = await renderInto(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+  await holdTwoMessages(wire, root);
+
+  wire.outcome = "delivered";
+  await act(async () => {
+    root.render(<TmuxComposer file={fileWith(TARGET_PATH, undefined)} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(6);
+
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-held-1", "key-held-1", "key-held-2"]);
+  expect(readOutbox(CARD).map((entry) => entry.state)).toEqual(["delivered", "delivered"]);
+  await act(async () => root.unmount());
+});
+
+test("a live hold toward a DIFFERENT account keeps holding — no premature replay", async () => {
+  const wire = stubWire();
+  const { root } = await renderInto(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+  await holdTwoMessages(wire, root);
+
+  /* Another poll of the same switching card: nothing may re-fire. */
+  await act(async () => {
+    root.render(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle();
+
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-held-1"]);
+  expect(readOutbox(CARD).map((entry) => entry.state)).toEqual(["delivering", "queued"]);
+  await act(async () => root.unmount());
+});
+
+test("a replay the server holds AGAIN does not loop: one replay per hold-level change", async () => {
+  const wire = stubWire();
+  const { root } = await renderInto(<TmuxComposer file={fileWith(SOURCE_PATH, switchingToB)} />);
+  await holdTwoMessages(wire, root);
+
+  /* The annotation drops but the server still answers `held` (e.g. the fence
+     outlived the annotation by one poll). The release replays ONCE, re-parks
+     the entry as held, and does not hammer the wire. */
+  await act(async () => {
+    root.render(<TmuxComposer file={fileWith(TARGET_PATH, undefined)} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(6);
+
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-held-1", "key-held-1"]);
+  expect(readOutbox(CARD)[0]!.state).toBe("delivering");
+  await act(async () => root.unmount());
+});
+
+test("a held entry survives reload and still delivers once the hold is over", async () => {
+  /* What a refresh restores after the incident: the persisted queue holds the
+     stranded entry. It must deliver — never be silently lost or stuck. */
+  sessionStorage.setItem(`llvOutbox:${CARD}`, JSON.stringify([
+    { id: "key-reloaded", text: "held before the refresh", images: 0, at: Date.now(), state: "delivering", heldForSwitch: true },
+  ]));
+  const wire = stubWire();
+  wire.outcome = "delivered";
+  const { root } = await renderInto(<TmuxComposer file={fileWith(TARGET_PATH, undefined)} />);
+  await settle(6);
+
+  expect(wire.calls.map((call) => call.clientMessageId)).toEqual(["key-reloaded"]);
+  expect(readOutbox(CARD).map((entry) => entry.state)).toEqual(["delivered"]);
+  await act(async () => root.unmount());
+});

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -16,8 +16,9 @@ import { refreshRuntime, sendRuntimeMessage, useRuntimeReceiptsForArtifact, type
 import type { SelectedContextRef } from "@/lib/selection/selectedContext";
 import { useViewerSelectedContext, viewerSelectedContext } from "@/lib/selection/viewerSelectedContext";
 import { useTmuxTarget } from "@/hooks/useTmuxTarget";
+import { accountIdFromPath } from "@/lib/accounts/badge";
 import { conversationIdentity } from "@/lib/accounts/identity";
-import { cardMigrationState, migrationHoldsDelivery, migrationHoldsSends, migrationTargetName } from "@/lib/accounts/migration";
+import { activeCardMigration, cardMigrationState, migrationHoldsDelivery, migrationHoldsSends, migrationTargetName } from "@/lib/accounts/migration";
 import { getLocale, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
@@ -33,6 +34,7 @@ import {
   outboxHistory,
   outboxStateForReceiptStatus,
   rebindOutboxEchoText,
+  releaseHeldOutbox,
   transcriptEchoCount,
   updateOutbox,
   useOutbox,
@@ -1091,8 +1093,13 @@ export function TmuxComposerCore({
     : undefined;
   /* While a card is switching accounts its next send is held for the successor
      (Sol delivery fence): the composer shows the held affordance instead of
-     pretending the text reached the live predecessor pane. */
-  const holdsSends = migrationHoldsSends(cardMigrationState(file.migration));
+     pretending the text reached the live predecessor pane. Every migration
+     read below goes through `activeCardMigration`, which collapses a hold
+     annotation whose target the card ALREADY runs under — a completed switch's
+     leftover must neither promise a hold nor keep one held. */
+  const liveMigration = activeCardMigration(file.migration, accountIdFromPath(file.path));
+  const holdsSends = migrationHoldsSends(cardMigrationState(liveMigration));
+  const holdsDelivery = migrationHoldsDelivery(cardMigrationState(liveMigration));
   /* An off-screen or far-zoom pane skips the pane-resolution poll; the last
      known target keeps the composer usable the moment it comes back. */
   const target = useTmuxTarget(file.pid, canMessageWithoutPane(file) ? file.path : undefined, !pollPaused);
@@ -1506,6 +1513,32 @@ export function TmuxComposerCore({
     }
   }, [displayedRuntimeReceipts, outbox, cardId]);
 
+  /* Level-triggered release of switch-held submissions (P1: messages held for
+     an account switch were never released after the switch completed). A held
+     entry's event-shaped release signals — the successor's receipt, the
+     delivered text's transcript echo — can simply never arrive once the
+     server-side hold record is gone, so the release is re-derived from the
+     LEVEL on every snapshot: whenever this card no longer holds deliveries,
+     every parked entry returns to the queue and the serial dispatcher replays
+     it under its original idempotency key. The per-hold-cycle set damps the
+     level to one replay per transition, so a fence that momentarily outlives
+     the annotation re-parks the entry as held instead of looping the wire. */
+  const releasedHolds = useRef<{ card: string; ids: Set<string> }>({ card: cardId, ids: new Set() });
+  useEffect(() => {
+    if (releasedHolds.current.card !== cardId) releasedHolds.current = { card: cardId, ids: new Set() };
+    if (holdsDelivery) {
+      releasedHolds.current.ids.clear();
+      return;
+    }
+    for (const id of releaseHeldOutbox(cardId, releasedHolds.current.ids)) {
+      releasedHolds.current.ids.add(id);
+      /* The held attempt already settled this generation once (that is what
+         parked it). The replay is a NEW attempt under the same key: its
+         settlement record resets so the redelivery can settle the bubble. */
+      settledSendKeys.current.delete(id);
+    }
+  }, [holdsDelivery, cardId, outbox]);
+
   /* A link-arrow drop appended to the stored draft; reload it and put the
      caret at the end so the ask can be typed straight away. Goes through the
      stable ref/setter pair rather than setText — the draft is already
@@ -1654,16 +1687,26 @@ export function TmuxComposerCore({
         direct (non-queued) send, which reports through the status line. The
         bubble takes the state the receipt PROVES: a bare admission stays
         `delivering`, only a delivered receipt reads `delivered` (round-1 P1#4). */
-    const settleOutbox = (state: OutboxState, error?: string) => {
+    const settleOutbox = (state: OutboxState, error?: string, held?: boolean) => {
       if (!outboxId) return;
-      updateOutbox(cardId, outboxId, { state, settledAt: nowMs(), ...(error ? { error } : {}) });
+      /* A held settlement stamps the entry so `releaseHeldOutbox` can requeue
+         it level-wise once the switch is over — a parked hold looks exactly
+         like an in-flight delivery otherwise. */
+      updateOutbox(cardId, outboxId, {
+        state,
+        settledAt: nowMs(),
+        ...(error ? { error } : {}),
+        ...(held ? { heldForSwitch: true as const } : {}),
+      });
       if (state === "delivered") outboxImages.current.delete(outboxId);
     };
       const settleOutboxFromReceipt = (receipt: RuntimeReceipt) => {
       /* The late admission: a send that answered `pending` and settled on the receipt
          stream. This is the moment its bridge batch became durable. */
       if (receiptIsAdmitted(receipt.status)) commitBridgeFor(clientMessageId);
-      return settleOutbox(outboxStateForReceiptStatus(receipt.status));
+      /* `queued` is the admitted-and-held state on the structured plane: the
+         server parked the message (the account-switch delivery fence). */
+      return settleOutbox(outboxStateForReceiptStatus(receipt.status), undefined, receipt.status === "queued");
     };
     /* Resolve the key before selecting the payload. A generation retained after
        uncertain admission owns an immutable text/image snapshot; later edits
@@ -1841,7 +1884,7 @@ export function TmuxComposerCore({
       settleGeneration(payloadText, attempt?.images ?? sentImages);
       /* A legacy pane send that reached the pane is delivered; a migration
          hold/queue is still in flight to the successor (round-1 P1#4). */
-      settleOutbox(held ? "delivering" : "delivered");
+      settleOutbox(held ? "delivering" : "delivered", undefined, held);
       if (ownsDeliveryState) {
         /* A `held` outcome does NOT imply an account switch: the registry fence
            also holds a delivery whose generation claim did not land. Only a card
@@ -1851,8 +1894,8 @@ export function TmuxComposerCore({
            annotation is published before the target identity reaches the card.
            The hold is still true, so it is said without a name rather than held
            for «» (an account the operator cannot recognize). */
-        const heldForSwitch = migrationHoldsDelivery(cardMigrationState(file.migration));
-        const heldFor = migrationTargetName(file.migration);
+        const heldForSwitch = migrationHoldsDelivery(cardMigrationState(liveMigration));
+        const heldFor = migrationTargetName(liveMigration);
         setStatus({
           kind: held ? "info" : "ok",
           text: held

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -83,6 +83,13 @@ export interface OutboxEntry {
       already scoped to the pane. Legacy launch rows with a missing/string owner
       fail closed on production render until the server projection upgrades them. */
   owner?: OutboxOwner;
+  /** The server admitted this submission but HELD it (the account-switch
+      delivery fence) instead of delivering: the entry is parked `delivering`
+      with nothing on the wire. Its release is level-triggered — see
+      {@link releaseHeldOutbox} — because the event-shaped signals (a successor
+      receipt, the delivered text's transcript echo) can simply never arrive
+      once the server-side hold record is gone. Cleared on requeue. */
+  heldForSwitch?: true;
 }
 
 function isOutboxOwner(value: unknown): value is OutboxOwner {
@@ -807,6 +814,36 @@ export function settleLaunchOutboxFailed(
   };
   recordCurrentLaunchEntry(cardId, updated);
   write(cardId, queue.map((item) => (item.id === launch.id ? updated : item)));
+}
+
+/**
+ * Level-triggered release of switch-held submissions (P1: held messages never
+ * released after the switch completed). Whenever the card's account state no
+ * longer holds deliveries — the migration annotation vanished, or its target
+ * already IS the active account — every entry still parked as held returns to
+ * `queued` under its ORIGINAL id, which is its idempotency key, so the serial
+ * dispatcher replays it: the server dedupes a message that WAS delivered to
+ * the successor and delivers one that never was. Entries with delivery proof
+ * of their own (a transcript echo, a started response) are left to their
+ * normal retirement, and the requeued entry keeps its cancel affordance.
+ * `except` lets the caller damp the level to one replay per hold transition,
+ * so a fence that outlives the annotation cannot start a replay loop.
+ * Returns the ids it requeued.
+ */
+export function releaseHeldOutbox(cardId: string, except?: ReadonlySet<string>): string[] {
+  const queue = readOutbox(cardId);
+  const released: string[] = [];
+  const next = queue.map((entry) => {
+    if (!entry.heldForSwitch || entry.state !== "delivering") return entry;
+    if (entry.retiredEchoId || entry.responseStartedAt !== undefined) return entry;
+    if (except?.has(entry.id)) return entry;
+    released.push(entry.id);
+    const requeued: OutboxEntry = { ...entry, state: "queued" };
+    delete requeued.heldForSwitch;
+    return requeued;
+  });
+  if (released.length) write(cardId, next);
+  return released;
 }
 
 /** Remove an entry outright — the operator cancelled a message that never left. */

--- a/src/lib/accounts/migration.test.ts
+++ b/src/lib/accounts/migration.test.ts
@@ -4,6 +4,7 @@ import type { ConversationMigration } from "@/lib/types";
 
 import {
   accountSelectOutcome,
+  activeCardMigration,
   autoBalanceLine,
   bannerModel,
   cardMigrationState,
@@ -65,6 +66,37 @@ describe("cardMigrationState", () => {
     expect(migrationHoldsDelivery("done")).toBeFalse();
     expect(migrationHoldsDelivery("rolled-back")).toBeFalse();
     expect(migrationHoldsDelivery(null)).toBeFalse();
+  });
+});
+
+describe("activeCardMigration (level rule: a completed switch's leftover annotation is dead)", () => {
+  test("a hold annotation whose target IS the active account collapses to null", () => {
+    expect(activeCardMigration(migration("waiting-turn"), "work")).toBeNull();
+    expect(activeCardMigration(migration("preparing"), "work")).toBeNull();
+    expect(activeCardMigration(migration("verifying"), "work")).toBeNull();
+  });
+
+  test("a hold toward a DIFFERENT account stays live", () => {
+    const pending = migration("waiting-turn");
+    expect(activeCardMigration(pending, "personal")).toBe(pending);
+  });
+
+  test("a failed annotation keeps its ribbon even under the target account (retry/keep are real)", () => {
+    const failed = migration("failed-recoverable");
+    expect(activeCardMigration(failed, "work")).toBe(failed);
+  });
+
+  test("an unknown active account or a target-less annotation changes nothing", () => {
+    const pending = migration("waiting-turn");
+    expect(activeCardMigration(pending, null)).toBe(pending);
+    expect(activeCardMigration(pending, "")).toBe(pending);
+    const nameless = { ...pending, targetAccountId: "" };
+    expect(activeCardMigration(nameless, "work")).toBe(nameless);
+  });
+
+  test("no annotation is simply null", () => {
+    expect(activeCardMigration(null, "work")).toBeNull();
+    expect(activeCardMigration(undefined, "work")).toBeNull();
   });
 });
 

--- a/src/lib/accounts/migration.ts
+++ b/src/lib/accounts/migration.ts
@@ -160,6 +160,33 @@ export function migrationTargetName(migration: ConversationMigration | null | un
   return accountId ? accountId : null;
 }
 
+/**
+ * The migration annotation that is still LIVE for a card, or `null` when the
+ * annotation describes a switch the card has already completed.
+ *
+ * A hold annotation (`pending`/`switching`) whose target IS the account the
+ * card currently runs under is a dead record: the switch committed, the
+ * transcript already rotated onto the target account, and the annotation
+ * simply outlived it. Every surface that keys a hold or a banner on the
+ * annotation must ask HERE first, level-wise, instead of trusting a clearing
+ * event that may never re-fire — the live incident kept a card reading
+ * "Account switch pending" and its messages "Held for «B»" forever while the
+ * registry already said the switch was done. A `failed` annotation always
+ * stays live (its retry/keep affordances are real), and `done`/`rolled-back`
+ * render nothing anyway.
+ */
+export function activeCardMigration(
+  migration: ConversationMigration | null | undefined,
+  activeAccountId: string | null | undefined,
+): ConversationMigration | null {
+  if (!migration) return null;
+  const state = cardMigrationState(migration);
+  if (state !== "pending" && state !== "switching") return migration;
+  const target = migration.targetAccountId?.trim();
+  if (!target || !activeAccountId || target !== activeAccountId) return migration;
+  return null;
+}
+
 /** A card in `pending` still delivers to the live predecessor pane, but its
     interrupt/kill controls must survive; `switching` freezes them (a signal
     would race the coordinator). Held-send only applies during `switching`. */


### PR DESCRIPTION
## P1 — composer messages held for an account switch are never released after the switch completes

Reproduced live on the operator's phone: two composer messages showed **"Held for «B» — delivers after the switch"** and the card banner **"Account switch pending — after current turn"** stayed up — while the switch had ALREADY completed server-side (registry: target account, `status=live`, `migration=null`, `pendingAction=null`; a fresh `send_message` delivered within seconds). The held texts existed in **no** server-side store: the hold lived client-side in the composer outbox.

## Root cause

`src/components/TmuxComposer.tsx` — a queued submission whose send settles as `held` is parked `state:"delivering"` (`settleOutbox(held ? "delivering" : "delivered")`) and its only release signals were **events**: a runtime receipt progressing the bubble, or the delivered text's transcript echo retiring it. Once the server-side hold record is gone (the exact incident), neither event can ever arrive, nothing re-checks, the entry is stranded forever — and `nextDispatch` (`src/components/conversation/outbox.ts`) refuses to drain anything queued behind a `delivering` entry, so the whole queue stalls. The pending banner keyed the same stale `file.migration` annotation, which still read `waiting-turn` toward the very account the card already ran under, with no surface cross-checking it against the card's active account.

## Fix — level-triggered release, client-side only

- **Stamp the hold**: a held settlement marks the outbox entry (`heldForSwitch`), on both the legacy pane path and the structured `queued` admission, so a parked hold is distinguishable from an in-flight delivery.
- **`releaseHeldOutbox`** (outbox.ts): whenever the card no longer holds deliveries, every stamped entry returns to `queued` under its ORIGINAL idempotency key and the serial dispatcher replays it — the server dedupes a message that WAS delivered to the successor and delivers one that never was. Damped to one replay per hold transition so a fence that momentarily outlives the annotation cannot loop the wire. Entries with their own delivery proof (transcript echo, started response) are left to normal retirement; requeued entries keep the X-cancel.
- **`activeCardMigration`** (`src/lib/accounts/migration.ts`): a `pending`/`switching` annotation whose target IS the account the card already runs under is a completed switch's leftover — it collapses to "no migration" for the pending ribbon (`BranchPane`), the held-send hint and held status line (`TmuxComposer`), and the bubbles' held label (`LogFeed`). A `failed` annotation stays live (its retry/keep actions are real).
- The release condition is re-derived from the card state on every snapshot, reload, and reconnect — never only on a live event. Reload restore already requeued unsettled entries and continues to.

No server-side migration mechanics touched.

## Tests

- `src/components/TmuxComposer.heldRelease.dom.test.tsx` (new, RED before the fix): held entries deliver once the hold's target is the active account under a **stale** annotation; deliver when the annotation **vanishes**; a live hold toward a different account keeps holding; a replay the server holds again does **not** loop; a reloaded held entry still delivers. Replays asserted key-exact (idempotent, never a second message), and the queue behind the hold drains.
- `src/lib/accounts/migration.test.ts`: `activeCardMigration` level-rule unit tests.
- `src/components/BranchPane.render.test.tsx`: the pending ribbon clears under the hold's target account and stays for a genuinely live hold.

## Verification

- Focused suites by path with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: all new tests green; every touched neighboring suite matches its pre-existing pass/fail set at the merge base exactly (the known cross-file `mock.module` leakage failures are byte-identical at HEAD, verified in a scratch worktree).
- `tsc --noEmit` clean, scoped eslint clean, production build green, `privacy-publication-gate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)