### PR TITLE
design(board): operator-first status vocabulary and motion budget

### DIFF
--- a/evidence/issue-961/status-vocabulary.json
+++ b/evidence/issue-961/status-vocabulary.json
@@ -80,7 +80,7 @@
     }
   ],
   "stack": {
-    "key": "/tmp/llv-issue-961/home/.claude/projects/-tmp-llv-issue-961-home-Projects-atlas/10101010.jsonl::stack",
+    "key": "$HOME/.claude/projects/$HOME-Projects-atlas/10101010.jsonl::stack",
     "badges": [
       "queued"
     ]

--- a/evidence/issue-961/status-vocabulary.json
+++ b/evidence/issue-961/status-vocabulary.json
@@ -1,0 +1,124 @@
+{
+  "board": [
+    {
+      "card": "10101010.jsonl::stack",
+      "status": "queued",
+      "word": "queued",
+      "fontPx": 10
+    },
+    {
+      "card": "10101010.jsonl",
+      "status": null,
+      "word": null,
+      "fontPx": null
+    },
+    {
+      "card": "11111111.jsonl",
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 10
+    },
+    {
+      "card": "11111111.jsonl",
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 26.364
+    },
+    {
+      "card": "22222222.jsonl",
+      "status": "held",
+      "word": "held×3",
+      "fontPx": 10
+    },
+    {
+      "card": "22222222.jsonl",
+      "status": "held",
+      "word": "held×3",
+      "fontPx": 26.364
+    },
+    {
+      "card": "33333333.jsonl",
+      "status": "running",
+      "word": "working12m 34s",
+      "fontPx": 10
+    },
+    {
+      "card": "33333333.jsonl",
+      "status": "running",
+      "word": "working12m 34s",
+      "fontPx": 26.364
+    },
+    {
+      "card": "44444444.jsonl",
+      "status": "queued",
+      "word": "queued",
+      "fontPx": 10
+    },
+    {
+      "card": "44444444.jsonl",
+      "status": "queued",
+      "word": "queued",
+      "fontPx": 26.364
+    },
+    {
+      "card": "55555555.jsonl",
+      "status": null,
+      "word": null,
+      "fontPx": null
+    },
+    {
+      "card": "99999999.jsonl",
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 10
+    },
+    {
+      "card": "99999999.jsonl",
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 26.364
+    }
+  ],
+  "stack": {
+    "key": "/tmp/llv-issue-961/home/.claude/projects/-tmp-llv-issue-961-home-Projects-atlas/10101010.jsonl::stack",
+    "badges": [
+      "queued"
+    ]
+  },
+  "switchboard": [
+    {
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 10
+    },
+    {
+      "status": "needs-you",
+      "word": "needs you",
+      "fontPx": 10
+    },
+    {
+      "status": "running",
+      "word": "working12m 34s",
+      "fontPx": 10
+    },
+    {
+      "status": "held",
+      "word": "held×3",
+      "fontPx": 10
+    },
+    {
+      "status": "queued",
+      "word": "queued",
+      "fontPx": 10
+    }
+  ],
+  "mobileFocus": {
+    "status": "needs-you",
+    "word": "needs you",
+    "fontPx": 10
+  },
+  "mobileMap": {
+    "markers": 8,
+    "surface": "marker map (#418), unchanged by #961"
+  }
+}

--- a/scripts/capture-issue-961-evidence.test.ts
+++ b/scripts/capture-issue-961-evidence.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Publication hygiene (#961 review): the committed capture summary is a public
+ * surface, so every path in it must be $HOME-relative — the synthetic capture
+ * home must never leak in raw or slug-encoded form.
+ */
+test("the committed #961 evidence carries no absolute home paths", () => {
+  const evidence = fs.readFileSync(
+    path.resolve(import.meta.dir, "../evidence/issue-961/status-vocabulary.json"),
+    "utf8",
+  );
+  expect(evidence).not.toMatch(/(?:^|["\s])\/(?:home|tmp|Users)\//m);
+  expect(evidence).not.toContain("-tmp-llv-");
+  /* The scrub keeps the payload useful: the stack key survives, rebased. */
+  expect(evidence).toContain("$HOME/");
+});

--- a/scripts/capture-issue-961-status.ts
+++ b/scripts/capture-issue-961-status.ts
@@ -449,8 +449,13 @@ async function main(): Promise<void> {
     const evidenceDir = path.join(repoRoot, "evidence", "issue-961");
     fs.mkdirSync(evidenceDir, { recursive: true });
     /* The committed summary names cards by their 8-char seed only: a full
-       fixture UUID would trip the privacy gate's resource-identifier class. */
-    const scrubbed = JSON.stringify(summary, null, 2).replaceAll("-1111-4111-8111-111111111111", "");
+       fixture UUID would trip the privacy gate's resource-identifier class.
+       The synthetic capture home is likewise scrubbed — a publication surface
+       carries only $HOME-relative paths, in raw and slug-encoded form. */
+    const scrubbed = JSON.stringify(summary, null, 2)
+      .replaceAll("-1111-4111-8111-111111111111", "")
+      .replaceAll(projectSlug(HOME), "$HOME")
+      .replaceAll(HOME, "$HOME");
     fs.writeFileSync(path.join(evidenceDir, "status-vocabulary.json"), scrubbed + "\n", "utf8");
     console.log(`screenshots: ${OUT_DIR}`);
   } finally {

--- a/scripts/capture-issue-961-status.ts
+++ b/scripts/capture-issue-961-status.ts
@@ -1,0 +1,462 @@
+/**
+ * Rendered verification of the #961 board status vocabulary, in a real browser:
+ *
+ *   bun scripts/capture-issue-961-status.ts
+ *
+ * Serves the production build against a purpose-built synthetic home under
+ * /tmp (never the operator's live state, and no real home path anywhere in the
+ * frames), then drives the real board with a locally available Chromium.
+ *
+ * The scanner reads real seeded transcripts; the browser then patches the
+ * `/api/files` payload in flight to place each card into exactly one authority
+ * state — a pending question (NEEDS YOU), a draining account switch holding
+ * three deliveries (HELD ×3), an open turn on a live agent (RUNNING · elapsed),
+ * a scheduled wakeup (QUEUED), and untouched quiet cards. Everything the
+ * frames show — projection, badge, tones, translations, layout, zoom — is the
+ * production render path; only the authority facts are seeded, the same way
+ * the launch receipt is fulfilled synthetically in the #887 capture.
+ *
+ * Shots land outside the repository for direct inspection:
+ *
+ *   <out>/961-desktop-dense.png        — the dense board, one word per card, quiet cards bare
+ *   <out>/961-card-needs-you.png       — NEEDS YOU, warning tone, question card
+ *   <out>/961-card-held.png            — HELD ×3 during the account switch, ribbon intact
+ *   <out>/961-card-running.png         — RUNNING with the elapsed run time
+ *   <out>/961-card-queued.png          — QUEUED beside the existing ⏰ wakeup chip
+ *   <out>/961-card-quiet.png           — a quiet card carries no status badge
+ *   <out>/961-stack-collapsed.png      — the collapsed branch stack keeps the words
+ *   <out>/961-far-zoom.png             — far-zoom labels carry the word at map distance
+ *   <out>/961-switchboard.png          — switch cards share the same vocabulary
+ *   <out>/961-mobile-390-focus.png     — 390 px conversation, word in the header
+ *   <out>/961-mobile-390-map.png       — 390 px lite map cards
+ *
+ * A DOM summary (badge words, computed font sizes, per-card status attributes)
+ * is written to evidence/issue-961/status-vocabulary.json for the repository.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { chromium, type Page, type Route } from "playwright-core";
+
+import { demoPort } from "./demo-capture";
+
+const BASE = process.env.STATUS_CAPTURE_DIR ?? "/tmp/llv-issue-961";
+const HOME = path.join(BASE, "home");
+const OUT_DIR = path.join(BASE, "out");
+const REPO_DIR = path.join(HOME, "Projects", "atlas");
+
+/** Frozen browser clock, so every elapsed/countdown in the frames is stable. */
+const CAPTURE_MS = Date.parse("2100-01-02T12:00:00.000Z");
+
+type SeededSession = {
+  id: string;
+  title: string;
+  /** Minutes before the capture moment the transcript last grew. */
+  agoMinutes: number;
+  status: "needs-you" | "held" | "running" | "queued" | "rate-limited" | "quiet";
+  /** Child of this session id — becomes a quiet subagent branch in a stack. */
+  childOf?: string;
+};
+
+const SESSIONS: SeededSession[] = [
+  { id: "11111111", title: "Gate the release on the review verdict", agoMinutes: 6, status: "needs-you" },
+  { id: "22222222", title: "Move the delivery fence into the registry", agoMinutes: 9, status: "held" },
+  { id: "33333333", title: "Rebuild the board status projection", agoMinutes: 1, status: "running" },
+  { id: "44444444", title: "Poll the nightly integration run", agoMinutes: 25, status: "queued" },
+  { id: "55555555", title: "Write the migration retrospective", agoMinutes: 200, status: "quiet" },
+  { id: "66666666", title: "Audit the tone tokens", agoMinutes: 300, status: "quiet", childOf: "10101010" },
+  { id: "77777777", title: "Sweep the caption floor", agoMinutes: 320, status: "queued", childOf: "10101010" },
+  { id: "88888888", title: "Collect switch-card fixtures", agoMinutes: 340, status: "quiet", childOf: "10101010" },
+  { id: "99999999", title: "Compare account quotas", agoMinutes: 12, status: "rate-limited" },
+  { id: "10101010", title: "Draft the deployment notes", agoMinutes: 500, status: "quiet" },
+];
+
+function must(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+const sessionUuid = (id: string) => `${id}-1111-4111-8111-111111111111`;
+const sessionPathSuffix = (id: string) => `${sessionUuid(id)}.jsonl`;
+
+function seedHome(): void {
+  fs.rmSync(BASE, { recursive: true, force: true });
+  fs.mkdirSync(REPO_DIR, { recursive: true });
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(path.join(BASE, "tmp", `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".config/agent-log-viewer/state"), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".codex/sessions"), { recursive: true });
+  const folder = path.join(HOME, ".claude/projects", projectSlug(REPO_DIR));
+  fs.mkdirSync(folder, { recursive: true });
+  SESSIONS.forEach((session) => {
+    const uuid = sessionUuid(session.id);
+    const at = new Date(CAPTURE_MS - session.agoMinutes * 60_000);
+    const stamp = at.toISOString();
+    const lines = [
+      { type: "user", uuid: `${uuid}-u`, timestamp: stamp, cwd: REPO_DIR, message: { role: "user", content: `${session.title}.` } },
+      { type: "assistant", uuid: `${uuid}-a`, timestamp: stamp, cwd: REPO_DIR, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: `${session.title} — on it.` }] } },
+    ];
+    const file = path.join(folder, `${uuid}.jsonl`);
+    fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
+    fs.utimesSync(file, at, at);
+  });
+}
+
+function buildEnvironment(port: number): NodeJS.ProcessEnv {
+  const config = path.join(HOME, ".config");
+  return {
+    NODE_ENV: "production",
+    PATH: process.env.PATH,
+    HOME,
+    TMPDIR: path.join(BASE, "tmp"),
+    TMUX_TMPDIR: path.join(BASE, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(BASE, "cache"),
+    XDG_RUNTIME_DIR: path.join(BASE, "runtime"),
+    LLV_STATE_DIR: path.join(config, "agent-log-viewer", "state"),
+    LLV_CLAUDE_HOME: path.join(HOME, ".claude"),
+    LLV_CODEX_HOME: path.join(HOME, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    PORT: String(port),
+    TZ: "UTC", LANG: "C.UTF-8", LC_ALL: "C.UTF-8", USER: "demo", LOGNAME: "demo", SHELL: "/bin/sh",
+  };
+}
+
+const seedInit = () => {
+  const captureTime = Date.parse("2100-01-02T12:00:00.000Z");
+  const NativeDate = Date;
+  class CaptureDate extends NativeDate {
+    constructor(...args: unknown[]) {
+      super(...((args.length ? args : [captureTime]) as []));
+    }
+    static now() { return captureTime; }
+  }
+  Object.defineProperty(globalThis, "Date", { configurable: true, value: CaptureDate });
+  Object.defineProperty(globalThis, "EventSource", { configurable: true, value: undefined });
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("llv_lang", "en");
+  localStorage.setItem("llvSound", "0");
+};
+
+/** When set, the payload narrows to these session ids — the close-up frames
+    center one card (or one root + its stacked branches) at a readable zoom. */
+let onlyIds: string[] | null = null;
+
+/** Place each scanned card into exactly one authority state, in flight. */
+function patchFilesPayload(payload: { files?: Array<Record<string, unknown>> }): typeof payload {
+  if (onlyIds) {
+    const keep = new Set(onlyIds.map(sessionPathSuffix));
+    payload.files = (payload.files ?? []).filter((file) => keep.has(String(file.path).split("/").at(-1) ?? ""));
+  }
+  const bySuffix = new Map(SESSIONS.map((session) => [sessionPathSuffix(session.id), session]));
+  const pathOf = (id: string) =>
+    (payload.files ?? []).find((file) => String(file.path).endsWith(sessionPathSuffix(id)))?.path as string | undefined;
+  const stackRoot = pathOf("10101010");
+  for (const file of payload.files ?? []) {
+    const seed = bySuffix.get(String(file.path).split("/").at(-1) ?? "");
+    if (!seed) continue;
+    /* The fixture clock is pinned to 2100 in the browser while the server
+       scans with the real clock, so scanner-derived liveness is meaningless
+       here. Normalize every seeded card to a settled baseline, then apply the
+       ONE authority state this card demonstrates. */
+    file.activity = "idle";
+    file.lastTurn = null;
+    file.pendingWakeup = null;
+    file.proc = null;
+    file.pid = null;
+    file.mtime = (CAPTURE_MS - seed.agoMinutes * 60_000) / 1000;
+    if (seed.childOf && stackRoot) {
+      file.parent = stackRoot;
+      file.kind = "subagent";
+    }
+    if (seed.status === "needs-you") {
+      file.activity = "recent";
+      file.pendingQuestion = {
+        kind: "question",
+        toolUseId: `toolu_${seed.id}`,
+        transcriptPath: file.path,
+        pid: 4242,
+        paneTarget: null,
+        askedAt: new Date(CAPTURE_MS - 4 * 60_000).toISOString(),
+        questions: [{ question: "Ship behind the flag or wait for the verdict?", options: [] }],
+      };
+    }
+    if (seed.status === "rate-limited") {
+      file.activity = "recent";
+      file.rateLimit = { source: "account", accountId: "default", window: "session", resetAt: (CAPTURE_MS + 90 * 60_000) / 1000 };
+    }
+    if (seed.status === "held") {
+      file.migration = {
+        intentId: "intent-961",
+        trigger: "quota",
+        phase: "waiting-turn",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        heldDeliveries: 3,
+        failure: null,
+      };
+    }
+    if (seed.status === "running") {
+      file.activity = "live";
+      file.lastTurn = { startedAt: CAPTURE_MS - (12 * 60 + 34) * 1000, endedAt: null };
+    }
+    if (seed.status === "queued") {
+      file.pendingWakeup = { fireAt: CAPTURE_MS + 12 * 60_000, reason: "poll the nightly integration run" };
+    }
+  }
+  return payload;
+}
+
+async function routeFiles(page: Page): Promise<void> {
+  await page.route("**/api/files*", async (route: Route) => {
+    try {
+      const response = await route.fetch();
+      const payload = patchFilesPayload(await response.json());
+      await route.fulfill({ response, contentType: "application/json", body: JSON.stringify(payload) });
+    } catch {
+      /* A poll aborted by page teardown: let it fail as it would unrouted. */
+      await route.abort().catch(() => undefined);
+    }
+  });
+}
+
+async function waitForServer(url: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}`);
+    try {
+      const response = await fetch(`${url}/api/files`);
+      if (response.ok) return;
+    } catch {
+      // still booting
+    }
+    await Bun.sleep(300);
+  }
+  throw new Error("production server did not become ready");
+}
+
+/** A card's on-screen rect, padded, for a framed close-up. */
+async function nodeClip(page: Page, suffix: string, pad = 28) {
+  const box = await page.evaluate(({ suffix: tail, pad: margin }) => {
+    const node = Array.from(document.querySelectorAll("[data-scheme-node]"))
+      .find((el) => el.getAttribute("data-scheme-node")?.endsWith(tail));
+    if (!node) return null;
+    const rect = node.getBoundingClientRect();
+    return { x: Math.max(rect.x - margin, 0), y: Math.max(rect.y - margin - 40, 0), width: rect.width + margin * 2, height: rect.height + margin * 2 + 40 };
+  }, { suffix, pad });
+  if (!box) return undefined;
+  const viewport = page.viewportSize()!;
+  const x = Math.max(0, Math.min(box.x, viewport.width - 1));
+  const y = Math.max(0, Math.min(box.y, viewport.height - 1));
+  const width = Math.min(box.width, viewport.width - x);
+  const height = Math.min(box.height, viewport.height - y);
+  /* A card partly outside the viewport cannot be framed; fall back to the
+     full page rather than hanging the screenshot on a degenerate clip. */
+  if (width < 40 || height < 40) return undefined;
+  return { x, y, width, height };
+}
+
+type BadgeFact = { card: string; status: string | null; word: string | null; fontPx: number | null };
+
+/** Every rendered badge with the card it sits on and its computed font size. */
+async function badgeFacts(page: Page): Promise<BadgeFact[]> {
+  return page.evaluate(() => {
+    const facts: Array<{ card: string; status: string | null; word: string | null; fontPx: number | null }> = [];
+    for (const node of Array.from(document.querySelectorAll("[data-scheme-node]"))) {
+      const card = node.getAttribute("data-scheme-node") ?? "";
+      const badges = Array.from(node.querySelectorAll("[data-card-status]"));
+      if (!badges.length) {
+        facts.push({ card: card.split("/").at(-1) ?? card, status: null, word: null, fontPx: null });
+        continue;
+      }
+      for (const badge of badges) {
+        facts.push({
+          card: card.split("/").at(-1) ?? card,
+          status: badge.getAttribute("data-card-status"),
+          word: badge.textContent?.trim() ?? null,
+          fontPx: Number.parseFloat(getComputedStyle(badge).fontSize) || null,
+        });
+      }
+    }
+    return facts;
+  });
+}
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(import.meta.dir, "..");
+  const port = demoPort(process.env.STATUS_CAPTURE_PORT, 3049, "STATUS_CAPTURE_PORT");
+  const baseUrl = `http://127.0.0.1:${port}`;
+  seedHome();
+
+  const server = spawn("bunx", ["next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: repoRoot,
+    env: buildEnvironment(port),
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  const executablePath = process.env.CHROME_BIN
+    ?? ["/usr/bin/chromium", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find((candidate) => fs.existsSync(candidate));
+  const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+  const summary: Record<string, unknown> = {};
+  try {
+    await waitForServer(baseUrl, server);
+    const scanned = await (await fetch(`${baseUrl}/api/files`)).json() as { files?: Array<{ project?: string; cwd?: string }> };
+    const projectId = scanned.files?.find((file) => file.cwd === REPO_DIR)?.project ?? "";
+    must(Boolean(projectId), `no scanned project owns the seeded repository`);
+
+    /* ── Desktop board ──────────────────────────────────────────────────── */
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 }, deviceScaleFactor: 2 });
+    await page.addInitScript(seedInit);
+    await routeFiles(page);
+    await page.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "networkidle", timeout: 90_000 });
+    await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+    await page.waitForTimeout(1200);
+    /* Frame the WHOLE board — the dense-board evidence must show every card. */
+    await page.locator('button[title^="Fit all content"]').first().click();
+    await page.waitForTimeout(900);
+
+    const facts = await badgeFacts(page);
+    summary.board = facts;
+    if (process.env.STATUS_CAPTURE_DEBUG) console.log(JSON.stringify(facts, null, 2));
+    const wordOf = (id: string) => facts.find((fact) => fact.card.startsWith(sessionUuid(id)) && fact.status);
+    must(wordOf("11111111")?.status === "needs-you", "the question card does not read NEEDS YOU");
+    must(wordOf("22222222")?.status === "held", "the switching card does not read HELD");
+    must((wordOf("22222222")?.word ?? "").includes("×3"), "HELD does not carry the unsettled count");
+    must(wordOf("33333333")?.status === "running", "the live card does not read RUNNING");
+    must((wordOf("33333333")?.word ?? "").includes("12m"), "RUNNING does not carry the elapsed time");
+    must(wordOf("44444444")?.status === "queued", "the wakeup card does not read QUEUED");
+    must(wordOf("99999999")?.status === "needs-you", "the rate-limited card does not read NEEDS YOU");
+    const quiet = facts.filter((fact) => fact.card.startsWith(sessionUuid("55555555")));
+    must(quiet.length === 1 && quiet[0]!.status === null, "a quiet card grew a status badge");
+    for (const fact of facts) {
+      if (fact.fontPx !== null) must(fact.fontPx >= 10, `badge under the 10px caption floor: ${fact.card} at ${fact.fontPx}px`);
+    }
+    await page.screenshot({ path: path.join(OUT_DIR, "961-desktop-dense.png") });
+
+    /* Close-ups: narrow the payload to the one card and reload — the default
+       framing then centers it alone at a readable zoom. */
+    const closeups: Array<[string, string]> = [
+      ["11111111", "961-card-needs-you.png"],
+      ["22222222", "961-card-held.png"],
+      ["33333333", "961-card-running.png"],
+      ["44444444", "961-card-queued.png"],
+      ["55555555", "961-card-quiet.png"],
+    ];
+    for (const [id, name] of closeups) {
+      onlyIds = [id];
+      await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+      await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+      await page.waitForTimeout(1200);
+      await page.screenshot({ path: path.join(OUT_DIR, name), clip: await nodeClip(page, sessionPathSuffix(id)) });
+    }
+    onlyIds = null;
+
+    /* The collapsed branch stack under its quiet root. */
+    onlyIds = ["10101010", "66666666", "77777777", "88888888"];
+    await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+    await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+    await page.waitForTimeout(1200);
+    const stackFacts = await page.evaluate(() => {
+      const stack = Array.from(document.querySelectorAll("[data-scheme-node]"))
+        .find((el) => (el.getAttribute("data-scheme-node") ?? "").endsWith("::stack"));
+      if (!stack) return null;
+      return {
+        key: stack.getAttribute("data-scheme-node"),
+        badges: Array.from(stack.querySelectorAll("[data-card-status]")).map((badge) => badge.getAttribute("data-card-status")),
+      };
+    });
+    must(Boolean(stackFacts), "no collapsed branch stack rendered");
+    must((stackFacts!.badges ?? []).includes("queued"), "the stack rows dropped the queued branch's word");
+    summary.stack = stackFacts;
+    await page.screenshot({ path: path.join(OUT_DIR, "961-stack-collapsed.png"), clip: await nodeClip(page, "::stack") });
+    onlyIds = null;
+
+    /* Far zoom on the full board: the identity labels take over the word. */
+    await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+    await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+    await page.waitForTimeout(1200);
+    for (let step = 0; step < 10; step += 1) await page.locator('button[title^="Zoom out"]').first().click();
+    await page.waitForTimeout(600);
+    const farBadges = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("[data-scheme-node] [data-card-status]"))
+        .filter((badge) => {
+          let el: Element | null = badge;
+          while (el && !(el instanceof HTMLElement && el.style.opacity !== "")) el = el.parentElement;
+          return true;
+        }).length,
+    );
+    must(farBadges > 0, "no badges survive at far zoom");
+    await page.screenshot({ path: path.join(OUT_DIR, "961-far-zoom.png") });
+
+    /* Switchboard: same words on the switch cards. The far-zoom minimap rect
+       overlays the corner trigger's hit point, so activate it via the DOM. */
+    await page.evaluate(() => {
+      (document.querySelector('[aria-label="Open the agent switchboard"]') as HTMLButtonElement | null)?.click();
+    });
+    await page.waitForTimeout(800);
+    const switchFacts = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("article [data-card-status]")).map((badge) => ({
+        status: badge.getAttribute("data-card-status"),
+        word: badge.textContent?.trim() ?? "",
+        fontPx: Number.parseFloat(getComputedStyle(badge).fontSize) || null,
+      })),
+    );
+    must(switchFacts.some((fact) => fact.status === "needs-you"), "no switch card reads NEEDS YOU");
+    must(switchFacts.some((fact) => fact.status === "running"), "no switch card reads RUNNING");
+    for (const fact of switchFacts) must((fact.fontPx ?? 0) >= 10, "a switch-card badge sits under the caption floor");
+    summary.switchboard = switchFacts;
+    await page.screenshot({ path: path.join(OUT_DIR, "961-switchboard.png") });
+    await page.close();
+
+    /* ── 390 px phone ───────────────────────────────────────────────────── */
+    const phone = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 3, hasTouch: true, isMobile: true });
+    await phone.addInitScript(seedInit);
+    await routeFiles(phone);
+    await phone.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+    await phone.waitForTimeout(2500);
+    /* Open the blocked conversation the way an operator would: by its row. */
+    const focusTarget = phone.locator("text=Gate the release on the review verdict").first();
+    if (await focusTarget.count()) {
+      await focusTarget.click({ force: true });
+      await phone.waitForTimeout(1500);
+    }
+    const mobileHeader = await phone.evaluate(() => {
+      const badge = document.querySelector("header [data-card-status], [data-card-status]");
+      return badge ? { status: badge.getAttribute("data-card-status"), word: badge.textContent?.trim(), fontPx: Number.parseFloat(getComputedStyle(badge).fontSize) } : null;
+    });
+    must(mobileHeader?.status === "needs-you", "the 390px conversation header does not carry the word");
+    must((mobileHeader?.fontPx ?? 0) >= 10, "the 390px badge sits under the caption floor");
+    summary.mobileFocus = mobileHeader;
+    await phone.screenshot({ path: path.join(OUT_DIR, "961-mobile-390-focus.png") });
+
+    /* Context shot only: the phone map is MobileMapLite's bounded MARKER
+       projection (#418), not the lite scheme cards, and it is deliberately
+       outside this lane's surfaces — the words live on the focus view above
+       and on the lite/far-zoom scheme labels captured on desktop. */
+    const mapButton = phone.locator('[aria-label="Open the project map"]');
+    if (await mapButton.count()) {
+      await mapButton.first().click();
+      await phone.waitForSelector('[data-testid="mobile-map"]', { timeout: 30_000 });
+      await phone.waitForTimeout(1500);
+      summary.mobileMap = { markers: await phone.locator('[data-testid="mobile-map"] button').count(), surface: "marker map (#418), unchanged by #961" };
+      await phone.screenshot({ path: path.join(OUT_DIR, "961-mobile-390-map.png") });
+    }
+    await phone.close();
+
+    const evidenceDir = path.join(repoRoot, "evidence", "issue-961");
+    fs.mkdirSync(evidenceDir, { recursive: true });
+    /* The committed summary names cards by their 8-char seed only: a full
+       fixture UUID would trip the privacy gate's resource-identifier class. */
+    const scrubbed = JSON.stringify(summary, null, 2).replaceAll("-1111-4111-8111-111111111111", "");
+    fs.writeFileSync(path.join(evidenceDir, "status-vocabulary.json"), scrubbed + "\n", "utf8");
+    console.log(`screenshots: ${OUT_DIR}`);
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+  }
+}
+
+await main();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,26 @@ body {
   }
 }
 
+/* The status vocabulary's ONE motion treatment (issue #961): a card whose word
+   is "needs you" breathes a soft warning halo. Every other word is static, and
+   reduced-motion stills this one too — the word plus colour already carry the
+   full meaning. */
+@keyframes card-status-breathe {
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-warning) 22%, transparent);
+  }
+}
+
+.card-status-attention {
+  animation: card-status-breathe 2.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-status-attention {
+    animation: none;
+  }
+}
+
 /* Syntax highlighting palette (issue #9 §7): highlight.js emits .hljs-* class
    names. The app's light-theme tokens supply their colors and keep every color
    in a single source of truth. */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,7 +109,9 @@ body {
 /* The status vocabulary's ONE motion treatment (issue #961): a card whose word
    is "needs you" breathes a soft warning halo. Every other word is static, and
    reduced-motion stills this one too — the word plus colour already carry the
-   full meaning. */
+   full meaning. The cadence is the board's own: it beats in the 3.4s period of
+   the pane-attention orbit above, so the two attention treatments share one
+   pulse instead of introducing a second rhythm. */
 @keyframes card-status-breathe {
   50% {
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-warning) 22%, transparent);
@@ -117,7 +119,7 @@ body {
 }
 
 .card-status-attention {
-  animation: card-status-breathe 2.6s ease-in-out infinite;
+  animation: card-status-breathe 3.4s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -16,6 +16,7 @@ import { accountIdFromPath } from "@/lib/accounts/badge";
 
 import { AccountBadge } from "./AccountBadge";
 import { registerLinkTarget } from "./AgentLink";
+import { CardStatusBadge } from "./CardStatusBadge";
 import { DeleteFileButton } from "./DeleteFileButton";
 import { FavoriteCrown, FavoriteCrownMarker } from "./FavoriteCrown";
 import { MigrationDivider, MigrationRibbon } from "./MigrationRibbon";
@@ -293,6 +294,9 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
         >
           <div className="flex min-w-0 items-center gap-1.5">
             <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} title={t(`branch.${state}`)} />
+            {/* The operator-facing status word (issue #961): at most one per
+                card, projected from the authorities the card already trusts. */}
+            <CardStatusBadge file={file} />
             {titleOverride ? (
               /* The owner names this pane (#658). The transcript's own title —
                  the first line of the prompt it opened with — stays in the

--- a/src/components/CardStatusBadge.render.test.tsx
+++ b/src/components/CardStatusBadge.render.test.tsx
@@ -17,7 +17,7 @@ const NOW_S = NOW_MS / 1000;
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
-    path: "/home/op/.claude/projects/demo/a.jsonl",
+    path: "/home/user/.claude/projects/demo/a.jsonl",
     root: "claude-projects",
     name: "a.jsonl",
     project: "demo",

--- a/src/components/CardStatusBadge.render.test.tsx
+++ b/src/components/CardStatusBadge.render.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ConversationMigration, FileEntry } from "@/lib/types";
+
+import { CardStatusBadge } from "./CardStatusBadge";
+
+/**
+ * Issue #961: one word plus colour per card, never colour alone. Each kind
+ * carries its word as text, its semantic tone token, and a data hook; text
+ * sits on the 10px caption floor; the only animated treatment is the
+ * needs-you breath (a CSS class the reduced-motion media query stills).
+ */
+
+const NOW_MS = Date.now();
+const NOW_S = NOW_MS / 1000;
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/home/op/.claude/projects/demo/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "demo",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW_S - 30,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+const badge = (entry: FileEntry) => renderToStaticMarkup(<CardStatusBadge file={entry} />);
+
+test("a quiet card renders no badge at all", () => {
+  expect(badge(file())).toBe("");
+});
+
+test("needs-you: warning tone, the word as text, and the one motion class", () => {
+  const html = badge(file({ waitingInput: { since: NOW_S - 40 } as FileEntry["waitingInput"] }));
+  expect(html).toContain('data-card-status="needs-you"');
+  expect(html).toContain("needs you");
+  expect(html).toContain("text-warning");
+  expect(html).toContain("card-status-attention");
+  /* Caption floor: the badge face never drops below the 10px token. */
+  expect(html).toContain("text-caption");
+});
+
+test("held: shows the unsettled registry count next to the word", () => {
+  const migration: ConversationMigration = {
+    intentId: "intent-1",
+    trigger: "quota",
+    phase: "waiting-turn",
+    targetAccountId: "acct-b",
+    heldDeliveries: 3,
+    failure: null,
+  };
+  const html = badge(file({ migration }));
+  expect(html).toContain('data-card-status="held"');
+  expect(html).toContain("held");
+  expect(html).toContain("×3");
+  expect(html).toContain("text-accent");
+  expect(html).not.toContain("card-status-attention");
+});
+
+test("running: success tone with the elapsed run time", () => {
+  const html = badge(file({ activity: "live", lastTurn: { startedAt: NOW_MS - 12 * 60_000 - 30_000, endedAt: null } }));
+  expect(html).toContain('data-card-status="running"');
+  expect(html).toContain("working");
+  expect(html).toContain("12m");
+  expect(html).toContain("text-success");
+});
+
+test("queued: muted word from the wakeup authority", () => {
+  const html = badge(file({ pendingWakeup: { fireAt: NOW_MS + 600_000, reason: "poll CI" } }));
+  expect(html).toContain('data-card-status="queued"');
+  expect(html).toContain("queued");
+  expect(html).toContain("text-muted");
+});

--- a/src/components/CardStatusBadge.render.test.tsx
+++ b/src/components/CardStatusBadge.render.test.tsx
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { ConversationMigration, FileEntry } from "@/lib/types";
@@ -17,7 +19,7 @@ const NOW_S = NOW_MS / 1000;
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
-    path: "/home/user/.claude/projects/demo/a.jsonl",
+    path: "$HOME/.claude/projects/demo/a.jsonl",
     root: "claude-projects",
     name: "a.jsonl",
     project: "demo",
@@ -77,6 +79,17 @@ test("running: success tone with the elapsed run time", () => {
   expect(html).toContain("working");
   expect(html).toContain("12m");
   expect(html).toContain("text-success");
+});
+
+test("the needs-you breath beats in the board's own attention cadence", () => {
+  /* BUSL fence (#961 review): the breath's timing is derived from LLV's own
+     pane-attention orbit, never lifted from nodeterm's stylesheet. */
+  const css = fs.readFileSync(path.resolve(import.meta.dir, "../app/globals.css"), "utf8");
+  const breathe = /animation:\s*card-status-breathe\s+([\d.]+s)\s+\S+\s+infinite/.exec(css);
+  const orbit = /animation:\s*pane-orbit\s+([\d.]+s)/.exec(css);
+  expect(breathe?.[1]).toBeDefined();
+  expect(breathe?.[1]).toBe(orbit?.[1] ?? "");
+  expect(css).not.toContain("2.6s ease-in-out infinite");
 });
 
 test("queued: muted word from the wakeup authority", () => {

--- a/src/components/CardStatusBadge.tsx
+++ b/src/components/CardStatusBadge.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useLocale, type TFunction } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { cardStatus, type CardStatus } from "./cardStatus";
+import { humanizeDuration } from "./turnDuration";
+
+/**
+ * The board's one textual status word (issue #961): word plus colour, never
+ * colour alone. One badge per card at most; a quiet card renders nothing.
+ *
+ * Tones reuse the existing semantic tokens: attention keeps the warning tone
+ * the waiting cards already wear, held keeps the accent of the account-switch
+ * surfaces, running keeps the success of the live treatments, and queued stays
+ * muted. The only motion is the restrained attention breath on `needs-you`
+ * (`card-status-attention`), disabled under prefers-reduced-motion. Text sits
+ * at the 10px caption floor; a scaled host (the far-zoom label) passes its own
+ * em-based size instead.
+ */
+const TONE: Record<CardStatus["kind"], string> = {
+  "needs-you": "card-status-attention border-warning/50 bg-warning-soft text-warning",
+  held: "border-accent/45 bg-accent-soft text-accent",
+  running: "border-success/45 bg-success-soft text-success",
+  queued: "border-border bg-canvas text-muted",
+};
+
+/** The status word (uppercased by the badge) and its detail, per kind. */
+export function cardStatusText(t: TFunction, status: CardStatus): { word: string; detail: string | null } {
+  if (status.kind === "needs-you") return { word: t("cardStatus.needsYou"), detail: null };
+  if (status.kind === "held") return { word: t("cardStatus.held"), detail: `×${status.count}` };
+  if (status.kind === "running") {
+    return {
+      word: t("cardStatus.running"),
+      detail: status.elapsedSeconds === null ? null : humanizeDuration(status.elapsedSeconds),
+    };
+  }
+  return { word: t("cardStatus.queued"), detail: null };
+}
+
+export function CardStatusBadge({ file, fontClassName = "text-caption" }: {
+  file: FileEntry;
+  /** Overrides the caption-floor font for hosts that scale in em (far label). */
+  fontClassName?: string;
+}) {
+  const { t } = useLocale();
+  const status = cardStatus(file);
+  if (!status) return null;
+  const { word, detail } = cardStatusText(t, status);
+  const label = detail ? `${word} ${detail}` : word;
+  return (
+    <span
+      data-card-status={status.kind}
+      title={label}
+      className={`inline-flex min-w-0 shrink-0 items-center gap-[0.35em] rounded-full border px-[0.6em] py-[0.15em] font-bold ${fontClassName} ${TONE[status.kind]}`}
+    >
+      <span className="truncate uppercase tracking-wide">{word}</span>
+      {detail ? <span className="shrink-0 tabular-nums opacity-90">{detail}</span> : null}
+    </span>
+  );
+}

--- a/src/components/SwitchCard.status.render.test.tsx
+++ b/src/components/SwitchCard.status.render.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { SwitchCard } from "./SwitchCard";
+
+/**
+ * Issue #961: the switch card carries the same status vocabulary as the board
+ * cards — one projected word, quiet cards none — beside its existing free-text
+ * status line, which stays untouched.
+ */
+
+const NOW_S = Date.now() / 1000;
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/sessions/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "demo",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW_S - 30,
+    size: 1,
+    activity: "recent",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+function card(entry: FileEntry): string {
+  return renderToStaticMarkup(
+    <SwitchCard
+      file={entry}
+      title="Session"
+      project="demo"
+      currentProject="demo"
+      descendants={0}
+      statusLine="working on the release"
+      size="large"
+      tone="working"
+      onOpen={() => {}}
+      onArchive={() => {}}
+    />,
+  );
+}
+
+test("a blocked switch card carries the needs-you word; a quiet one carries none", () => {
+  const blocked = card(file({ waitingInput: { since: NOW_S - 40 } as FileEntry["waitingInput"] }));
+  expect(blocked).toContain('data-card-status="needs-you"');
+  expect(blocked).toContain("needs you");
+  expect(card(file())).not.toContain("data-card-status");
+});
+
+test("the existing status line survives beside the projected word", () => {
+  const blocked = card(file({ waitingInput: { since: NOW_S - 40 } as FileEntry["waitingInput"] }));
+  expect(blocked).toContain("working on the release");
+});

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -7,6 +7,7 @@ import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
+import { CardStatusBadge } from "./CardStatusBadge";
 import { EffortPills } from "./EffortPills";
 import { CtxChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
@@ -102,6 +103,9 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
         <EffortPills file={file} />
         <RateLimitBadge file={file} />
         <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />
+        {/* The operator-facing status word (issue #961): same vocabulary and
+            tones as the board cards, so a switch column reads identically. */}
+        <CardStatusBadge file={file} />
         <span
           className={`ml-auto min-w-0 truncate rounded-full border border-border bg-canvas px-1.5 py-0.5 text-[9.5px] font-semibold ${
             project === currentProject ? "text-muted" : "text-primary"

--- a/src/components/cardStatus.test.ts
+++ b/src/components/cardStatus.test.ts
@@ -16,7 +16,7 @@ const NOW_S = NOW_MS / 1000;
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
-    path: "/home/user/.claude/projects/demo/a.jsonl",
+    path: "$HOME/.claude/projects/demo/a.jsonl",
     root: "claude-projects",
     name: "a.jsonl",
     project: "demo",
@@ -90,7 +90,7 @@ test("held reads the registry count level-wise: a committed switch's leftover an
   /* The annotation targets the account the transcript ALREADY runs under —
      the activeCardMigration level rule says the switch completed. */
   const leftover = file({
-    path: "/home/user/.config/agent-log-viewer/accounts/claude/acct-b/projects/demo/a.jsonl",
+    path: "$HOME/.config/agent-log-viewer/accounts/claude/acct-b/projects/demo/a.jsonl",
     migration: holdingMigration(3, "acct-b"),
   });
   expect(cardStatus(leftover, NOW_MS)).toBeNull();

--- a/src/components/cardStatus.test.ts
+++ b/src/components/cardStatus.test.ts
@@ -16,7 +16,7 @@ const NOW_S = NOW_MS / 1000;
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
-    path: "/home/op/.claude/projects/demo/a.jsonl",
+    path: "/home/user/.claude/projects/demo/a.jsonl",
     root: "claude-projects",
     name: "a.jsonl",
     project: "demo",
@@ -90,7 +90,7 @@ test("held reads the registry count level-wise: a committed switch's leftover an
   /* The annotation targets the account the transcript ALREADY runs under —
      the activeCardMigration level rule says the switch completed. */
   const leftover = file({
-    path: "/home/op/.config/agent-log-viewer/accounts/claude/acct-b/projects/demo/a.jsonl",
+    path: "/home/user/.config/agent-log-viewer/accounts/claude/acct-b/projects/demo/a.jsonl",
     migration: holdingMigration(3, "acct-b"),
   });
   expect(cardStatus(leftover, NOW_MS)).toBeNull();

--- a/src/components/cardStatus.test.ts
+++ b/src/components/cardStatus.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+
+import type { ConversationMigration, FileEntry } from "@/lib/types";
+
+import { cardStatus } from "./cardStatus";
+
+/**
+ * Issue #961: the shared status projection is pure and its mixed-state
+ * precedence is deterministic — NEEDS YOU over HELD over RUNNING over QUEUED,
+ * quiet cards project nothing. Every input is one of the authorities the board
+ * already trusts; no fixture invents a parallel lifecycle.
+ */
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_S = NOW_MS / 1000;
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/home/op/.claude/projects/demo/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "demo",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW_S - 30,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+const holdingMigration = (held: number, targetAccountId = "acct-b"): ConversationMigration => ({
+  intentId: "intent-1",
+  trigger: "manual",
+  phase: "waiting-turn",
+  targetAccountId,
+  heldDeliveries: held,
+  failure: null,
+});
+
+const openTurn = { startedAt: NOW_MS - 754_000, endedAt: null };
+const futureWakeup = { fireAt: NOW_MS + 12 * 60_000, reason: "poll CI" };
+
+const everything = (): FileEntry =>
+  file({
+    pendingQuestion: { toolUseId: "tool-1", askedAt: new Date(NOW_MS - 5_000).toISOString() } as FileEntry["pendingQuestion"],
+    migration: holdingMigration(2),
+    activity: "live",
+    lastTurn: openTurn,
+    pendingWakeup: futureWakeup,
+  });
+
+test("quiet card projects nothing", () => {
+  expect(cardStatus(file(), NOW_MS)).toBeNull();
+  expect(cardStatus(file({ activity: "recent" }), NOW_MS)).toBeNull();
+});
+
+test("mixed state resolves by precedence: needs-you beats held beats running beats queued", () => {
+  const all = everything();
+  expect(cardStatus(all, NOW_MS)).toEqual({ kind: "needs-you" });
+
+  const noQuestion = { ...all, pendingQuestion: null };
+  expect(cardStatus(noQuestion, NOW_MS)).toEqual({ kind: "held", count: 2 });
+
+  const noHold = { ...noQuestion, migration: undefined };
+  expect(cardStatus(noHold, NOW_MS)).toEqual({ kind: "running", elapsedSeconds: 754 });
+
+  const idle = { ...noHold, activity: "idle" as const, lastTurn: { startedAt: NOW_MS - 900_000, endedAt: NOW_MS - 60_000 } };
+  expect(cardStatus(idle, NOW_MS)).toEqual({ kind: "queued" });
+});
+
+test("needs-you derives from the frozen attention authority, including its stalled TTL", () => {
+  expect(cardStatus(file({ rateLimit: { resetAt: null } as FileEntry["rateLimit"] }), NOW_MS)).toEqual({ kind: "needs-you" });
+  expect(cardStatus(file({ waitingInput: { since: NOW_S - 40 } as FileEntry["waitingInput"] }), NOW_MS)).toEqual({ kind: "needs-you" });
+  /* Stalled counts only while a live process still waits, within the TTL. */
+  expect(cardStatus(file({ activity: "stalled", proc: "running", mtime: NOW_S - 600 }), NOW_MS)).toEqual({ kind: "needs-you" });
+  expect(cardStatus(file({ activity: "stalled", proc: null, mtime: NOW_S - 600 }), NOW_MS)).toBeNull();
+  expect(cardStatus(file({ activity: "stalled", proc: "running", mtime: NOW_S - 3 * 3600 }), NOW_MS)).toBeNull();
+});
+
+test("held reads the registry count level-wise: a committed switch's leftover annotation never shows", () => {
+  /* The annotation targets the account the transcript ALREADY runs under —
+     the activeCardMigration level rule says the switch completed. */
+  const leftover = file({
+    path: "/home/op/.config/agent-log-viewer/accounts/claude/acct-b/projects/demo/a.jsonl",
+    migration: holdingMigration(3, "acct-b"),
+  });
+  expect(cardStatus(leftover, NOW_MS)).toBeNull();
+  /* Zero held deliveries is not a HELD card, whatever the phase. */
+  expect(cardStatus(file({ migration: holdingMigration(0) }), NOW_MS)).toBeNull();
+});
+
+test("running requires the open-turn condition; elapsed is null without a turn boundary", () => {
+  expect(cardStatus(file({ activity: "live", lastTurn: openTurn }), NOW_MS)).toEqual({ kind: "running", elapsedSeconds: 754 });
+  expect(cardStatus(file({ activity: "live", lastTurn: null }), NOW_MS)).toEqual({ kind: "running", elapsedSeconds: null });
+  /* A closed turn on a live-looking card is not running. */
+  expect(cardStatus(file({ activity: "live", lastTurn: { startedAt: NOW_MS - 900_000, endedAt: NOW_MS - 60_000 } }), NOW_MS)).toBeNull();
+});
+
+test("queued follows the wakeup authority and clears once the fire time passes", () => {
+  expect(cardStatus(file({ pendingWakeup: futureWakeup }), NOW_MS)).toEqual({ kind: "queued" });
+  expect(cardStatus(file({ pendingWakeup: { fireAt: NOW_MS - 1_000, reason: "done" } }), NOW_MS)).toBeNull();
+});

--- a/src/components/cardStatus.ts
+++ b/src/components/cardStatus.ts
@@ -1,0 +1,49 @@
+import { accountIdFromPath } from "@/lib/accounts/badge";
+import { activeCardMigration } from "@/lib/accounts/migration";
+import type { FileEntry } from "@/lib/types";
+
+import { attentionId } from "./attention";
+import { turnIsRunning } from "./turnDuration";
+
+/**
+ * The one operator-facing textual status of a board card (issue #961).
+ *
+ * A pure projection over the authorities the board already trusts — it owns no
+ * state and invents no lifecycle. Each word names the authority it reads:
+ *
+ * 1. `needs-you` — the attention queue ({@link attentionId}), the same identity
+ *    every badge/toast/push surface derives from. Frozen semantics.
+ * 2. `held` — the account-switch delivery fence, read level-wise through
+ *    {@link activeCardMigration} exactly like the composer's held ribbon and the
+ *    outgoing message bubbles, with the registry's unsettled count.
+ * 3. `running` — the open-turn condition the pinned working spinner paints from
+ *    ({@link turnIsRunning}), plus the elapsed run time when the turn boundary
+ *    is known.
+ * 4. `queued` — a scheduled self-wake still in the future (the wakeup authority
+ *    behind the ⏰ chip).
+ *
+ * Precedence is exactly that order; a quiet card projects `null`. A word never
+ * deletes the information below it — the chips that carry the lower-priority
+ * facts (wakeup, rate limit, recency, outbox bubbles) keep rendering beside it.
+ */
+export type CardStatus =
+  | { kind: "needs-you" }
+  | { kind: "held"; count: number }
+  | { kind: "running"; elapsedSeconds: number | null }
+  | { kind: "queued" };
+
+export function cardStatus(file: FileEntry, nowMs: number = Date.now()): CardStatus | null {
+  if (attentionId(file, nowMs / 1000) !== null) return { kind: "needs-you" };
+  const migration = activeCardMigration(file.migration, accountIdFromPath(file.path));
+  const held = migration?.heldDeliveries ?? 0;
+  if (held > 0) return { kind: "held", count: held };
+  if (turnIsRunning(file)) {
+    const startedAt = file.lastTurn && file.lastTurn.endedAt === null ? file.lastTurn.startedAt : null;
+    return {
+      kind: "running",
+      elapsedSeconds: startedAt === null ? null : Math.max(0, (nowMs - startedAt) / 1000),
+    };
+  }
+  if (file.pendingWakeup && file.pendingWakeup.fireAt > nowMs) return { kind: "queued" };
+  return null;
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -38,6 +38,7 @@ import { RoundStateIcon } from "@/components/flows/RoundIcons";
 import { canHandoff, HandoffHandle } from "@/components/HandoffHandle";
 import { isWorkflowDraftId } from "@/components/workflows/workflowModel";
 import { WorkflowDraftPane } from "@/components/workflows/WorkflowDraftPane";
+import { CardStatusBadge } from "@/components/CardStatusBadge";
 import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/components/utils";
 import { recencyTurnInfo } from "@/components/turnDuration";
 
@@ -633,6 +634,10 @@ function FarLabel({ file }: { file: FileEntry }) {
         <span className="shrink-0 rounded-full px-[0.45em] font-bold" style={{ ...badge.style, fontSize: "0.72em" }}>
           {badge.label}
         </span>
+        {/* The status word survives far zoom: sized in em off the label's own
+            counter-scaled font, so it holds ≥10px on screen until the label's
+            2.6× cap — the same floor the rest of the label obeys (#961). */}
+        <CardStatusBadge file={file} fontClassName="text-[0.78em]" />
         <RateLimitBadge rateLimit={file.rateLimit} />
         <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} interactive={false} />
         <span className="line-clamp-2 min-w-0 font-bold">{cleanTitle(file.title, 70)}</span>
@@ -694,6 +699,9 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
               map's pointer-events-none layer, so its reason disclosure works at
               390px; the chip's own guard keeps the tap from opening the pane. */}
           <WakeupChip key={wakeupChipKey(node.file.pendingWakeup)} wakeup={node.file.pendingWakeup} className="pointer-events-auto" />
+          {/* The operator-facing status word (issue #961), same vocabulary as
+              the full card's header. */}
+          <CardStatusBadge file={node.file} />
           <RecencyChip file={node.file} className="ml-auto text-[11px]" />
         </div>
         <div className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">
@@ -810,6 +818,9 @@ function MiniStackShell({ stack, dimmed, onSelect }: { stack: MiniStack; dimmed:
                 <span className="min-w-0 flex-1 truncate text-[11.5px] font-semibold">{cleanTitle(file.title, 70)}</span>
               </span>
               <span className="flex items-center gap-2 pl-3 text-[10.5px] text-muted">
+                {/* A collapsed branch keeps the same status word as its full
+                    card, so a held or blocked branch cannot hide in the stack. */}
+                <CardStatusBadge file={file} />
                 <span>{kindLabel(t, file.kind)}</span>
                 <span>{fmtAge(file.mtime)}</span>
                 {branches ? <span>⤷ {branches}</span> : null}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -52,6 +52,13 @@ export const en = {
   "turn.lastRun": "last run: {d}",
   "turn.timer": "elapsed work time",
 
+  // Board status vocabulary (issue #961) — wording reused from the existing
+  // attention/receipt/turn surfaces, one word per card.
+  "cardStatus.needsYou": "needs you",
+  "cardStatus.held": "held",
+  "cardStatus.running": "working",
+  "cardStatus.queued": "queued",
+
   // Conversation kind labels (display of file.kind discriminant)
   "kind.session": "session",
   "kind.subagent": "subagent",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -49,6 +49,13 @@ export const uk: Record<keyof typeof en, Message> = {
   "turn.lastRun": "останній прогін: {d}",
   "turn.timer": "час роботи",
 
+  // Словник статусів дошки (issue #961) — формулювання з наявних поверхонь
+  // уваги/квитанцій/ходу, одне слово на картку.
+  "cardStatus.needsYou": "потребує вас",
+  "cardStatus.held": "притримано",
+  "cardStatus.running": "працює",
+  "cardStatus.queued": "у черзі",
+
   "kind.session": "сесія",
   "kind.subagent": "субагент",
   "kind.job": "джоба",


### PR DESCRIPTION
Closes #961.

On a dense board the operator could not tell at a glance which card needs intervention, which delivery is held mid-switch, which agent works, and which work is queued — those truths lived scattered across activity dots, attention UI, wakeup chips, and the outbox. Every board card now carries at most ONE operator-facing textual status word, projected by a shared pure function with deterministic precedence:

1. **NEEDS YOU** — from the frozen attention authority (`attentionId`), warning tone.
2. **HELD ×N** — from the account-switch delivery fence, read level-wise through `activeCardMigration` exactly like the outgoing message bubbles, with the registry's unsettled count; accent tone.
3. **RUNNING · elapsed** — from the open-turn condition the working spinner already paints from (`turnIsRunning`), success tone, wording reused from `turn.running` ("working {d}" / «працює {d}»).
4. **QUEUED** — from the pending-wakeup authority, muted tone.

Quiet cards render nothing. A word never deletes the information below it: the ⏰ wakeup chip, rate-limit badge, model/account chips, recency slot, migration ribbon, and outbox bubbles (with their retry/cancel affordances, #264/#648 untouched) all keep rendering beside it.

**Where the word appears** (`CardStatusBadge`, word + semantic tone token, never colour alone): full-card headers (`BranchPane`), switch cards, collapsed branch-stack rows, the lite scheme cards, and the far-zoom identity labels (em-scaled off the label's counter-scaled font). Text sits on the 10px `--text-caption` floor everywhere. Wording is reused from the existing attention/receipt/turn surfaces in both locales; no new status framework and no parallel lifecycle store.

**Motion budget**: exactly one restrained treatment — a soft warning breath on NEEDS YOU (`card-status-attention`), stilled under `prefers-reduced-motion`. Every other word is static.

**Tests** (isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, by path; no broad sweeps): 6 pure precedence tests (`cardStatus.test.ts`, incl. mixed-state precedence, the held level rule, the stalled-attention TTL), 5 badge render tests, 2 switch-card render tests; plus the adjacent existing suites — `SwitchCard.attention.render`, `EffortPills.slot.dom`, `scheme/nodes.dom|stageRow|strip`, `i18n` — 50/50 pass. The two `BranchPane.mobileChrome.dom` failures reproduce byte-identically at the base commit in a throwaway worktree (pre-existing, unrelated).

**Rendered evidence** — production build served on a scratch port against a synthetic `/tmp` home with a frozen clock (`scripts/capture-issue-961-status.ts`); the real scanner feeds the board and the browser pins each card to exactly one authority state in the `/api/files` payload. The extracted DOM facts (word, `data-card-status`, computed font size per card) are committed at `evidence/issue-961/status-vocabulary.json`; the frames were inspected at: dense desktop board (one word per card, quiet cards bare — no wall of chips), per-state close-ups (NEEDS YOU question card; HELD ×3 with the "Account switch pending" ribbon intact; RUNNING 12m 34s; QUEUED beside the ⏰ chip; quiet card bare), collapsed stack keeping the queued branch's word, far zoom, switchboard, and 390px focus view + marker map. The DOM assertions in the capture double as the gate: precedence, ×3 count, elapsed time, quiet-card absence, and the ≥10px floor are all `must(...)`ed before any frame is written.

**Scope**: card anatomy untouched (#964), tokens/canvas/region styling untouched (#962), attention control untouched (#963), attention semantics frozen. The phone marker map (#418) stays a bounded marker projection by design. Independent reimplementation only — nothing taken from nodeterm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)