### PR TITLE
design(board): depth ladder with filled wells, deeper canvas, sparse grid, and quiet-card tone

### DIFF
--- a/docs/design/viewer-design-system.md
+++ b/docs/design/viewer-design-system.md
@@ -138,6 +138,19 @@ Four surface levels; the shadow belongs to the level, never applied à la carte.
 | `--surface-sunken` | `#f7f7fa` | `#121216` | code blocks, raw output, collapsed strips, canvas-docked bands |
 | `--surface-raised` | `#ffffff` | `#1d1d24` | menus, popovers, sheets, toasts |
 
+The scheme board adds a three-level depth ladder (issue #962): board canvas →
+container well → card. Dark mode dips the board below the app canvas so wells
+and cards climb from it; light mode keeps the board at the canvas value and
+recesses wells slightly instead. Quiet is the surface of an inactive card with
+no attention state. All three carry the same 4.5:1 small-text floor as the
+surfaces above (pinned by `tokens.contrast.test.ts`).
+
+| token | light | dark | use |
+| --- | --- | --- | --- |
+| `--surface-board` | `#f3f3f6` | `#0d0d11` | scheme canvas behind the dot grid |
+| `--surface-well` | `#f0f0f4` | `#131318` | faint filled interior of a pipeline/branch container |
+| `--surface-quiet` | `#fafafb` | `#141419` | inactive card, no attention: recedes from the card white |
+
 ```css
 --shadow-1: 0 1px 2px rgb(20 20 30 / 0.05);                      /* card   */
 --shadow-2: 0 8px 32px rgb(20 20 30 / 0.16), 0 1px 2px rgb(20 20 30 / 0.06);  /* raised */

--- a/evidence/issue-962/depth-ladder.json
+++ b/evidence/issue-962/depth-ladder.json
@@ -1,7 +1,7 @@
 {
   "issue": 962,
-  "capturedAt": "2026-08-09T21:34:41.553Z",
-  "buildHead": "019a7b83727c0db7655af4451714c6a4ce8bb6e8",
+  "capturedAt": "2026-08-09T21:51:22.314Z",
+  "buildHead": "f299c4d1698a2f3c40e7dbcd6a0f6a8eeafdcf30",
   "runner": "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated pipeline/board fixtures; headless host Chrome over raw CDP",
   "screenshots": [
     "desktop-light-beacon-wells.png",

--- a/evidence/issue-962/depth-ladder.json
+++ b/evidence/issue-962/depth-ladder.json
@@ -1,0 +1,136 @@
+{
+  "issue": 962,
+  "capturedAt": "2026-08-09T21:34:41.553Z",
+  "buildHead": "019a7b83727c0db7655af4451714c6a4ce8bb6e8",
+  "runner": "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated pipeline/board fixtures; headless host Chrome over raw CDP",
+  "screenshots": [
+    "desktop-light-beacon-wells.png",
+    "desktop-light-beacon-zoomed-out.png",
+    "desktop-light-beacon-selected.png",
+    "desktop-light-forge-branch-group.png",
+    "desktop-light-atlas-needs-you.png",
+    "desktop-light-empty-project.png",
+    "desktop-dark-beacon-wells.png",
+    "desktop-dark-forge-branch-group.png",
+    "desktop-dark-atlas-needs-you.png",
+    "mobile-light-beacon.png",
+    "mobile-dark-beacon.png"
+  ],
+  "checks": [
+    {
+      "name": "light: a settled pipeline container is a filled well — 1px solid hairline + well-surface fill",
+      "pass": true,
+      "detail": {
+        "borderStyle": "solid",
+        "borderWidth": "1px",
+        "background": "color(srgb 0.921363 0.92553 0.909027)",
+        "inlineStyle": "border-color: color-mix(in srgb, hsl(68 62% 42%) 32%, var(--border-default)); background-color: color-mix(in srgb, hsl(68 62% 42%) 6%, var(--surface-well));"
+      }
+    },
+    {
+      "name": "light: a draft pipeline keeps the dashed 2px halo — dashed stays a draft/drop affordance",
+      "pass": true,
+      "detail": {
+        "borderStyle": "dashed",
+        "borderWidth": "2px",
+        "background": "rgb(255, 244, 221)",
+        "inlineStyle": "border-color: var(--color-warning); background-color: var(--color-warning-soft); background-image: repeating-linear-gradient(135deg, transparent 0 12px, color-mix(in srgb, var(--color-warning) 7%, transparent) 12px 14px);"
+      }
+    },
+    {
+      "name": "light: the dot grid lives on the scheme canvas and the board matches the app canvas (rgb(243, 243, 246))",
+      "pass": true,
+      "detail": {
+        "tile": 20.5137,
+        "boardBg": "rgb(243, 243, 246)",
+        "bodyBg": "rgb(243, 243, 246)"
+      }
+    },
+    {
+      "name": "light: an inactive card takes the quiet surface (rgb(250, 250, 251))",
+      "pass": true,
+      "detail": {
+        "background": "rgb(250, 250, 251)"
+      }
+    },
+    {
+      "name": "the dot grid stays sparse across zoom-out steps (every on-screen tile ≥ 18px)",
+      "pass": true,
+      "detail": [
+        20.5137,
+        32.8219,
+        26.2575,
+        21.006,
+        33.6096,
+        26.8877,
+        23.04
+      ]
+    },
+    {
+      "name": "a selected card keeps its full selection treatment on the dense board",
+      "pass": true,
+      "detail": null
+    },
+    {
+      "name": "light: the branch/flow container renders as the same filled hairline well",
+      "pass": true,
+      "detail": {
+        "borderStyle": "solid",
+        "borderWidth": "1px",
+        "background": "color(srgb 0.92553 0.894282 0.92413)",
+        "inlineStyle": "border-color: color-mix(in srgb, hsl(331 62% 42%) 32%, var(--border-default)); background-color: color-mix(in srgb, hsl(331 62% 42%) 6%, var(--surface-well));"
+      }
+    },
+    {
+      "name": "the NEEDS-YOU card keeps its full attention treatment and never takes the quiet tone",
+      "pass": true,
+      "detail": {
+        "glow": true,
+        "quiet": false
+      }
+    },
+    {
+      "name": "the near-empty project renders the bare scheme canvas + sparse dot grid around a single card",
+      "pass": true,
+      "detail": {
+        "nodes": 1,
+        "grid": true
+      }
+    },
+    {
+      "name": "dark: the scheme canvas (rgb(13, 13, 17)) dips deeper than the app canvas (rgb(16, 16, 20))",
+      "pass": true,
+      "detail": {
+        "tile": 20.5137,
+        "boardBg": "rgb(13, 13, 17)",
+        "bodyBg": "rgb(16, 16, 20)"
+      }
+    },
+    {
+      "name": "dark: the settled pipeline well keeps the 1px hairline + filled treatment",
+      "pass": true,
+      "detail": {
+        "borderStyle": "solid",
+        "borderWidth": "1px",
+        "background": "color(srgb 0.106697 0.110863 0.0980466)",
+        "inlineStyle": "border-color: color-mix(in srgb, hsl(68 62% 42%) 32%, var(--border-default)); background-color: color-mix(in srgb, hsl(68 62% 42%) 6%, var(--surface-well));"
+      }
+    },
+    {
+      "name": "dark: the inactive card takes the dark quiet surface (rgb(20, 20, 25))",
+      "pass": true,
+      "detail": {
+        "background": "rgb(20, 20, 25)"
+      }
+    },
+    {
+      "name": "390px: the mobile shell renders its panes over the new tokens",
+      "pass": true,
+      "detail": {
+        "panes": 1,
+        "body": true
+      }
+    }
+  ],
+  "verdict": "PASS"
+}

--- a/evidence/issue-962/drive.ts
+++ b/evidence/issue-962/drive.ts
@@ -4,6 +4,10 @@
  *
  *   bun evidence/issue-962/drive.ts
  *
+ * Deep checkouts overflow the ~108-byte unix-socket path limit for the fixture
+ * tmux socket ("tmux exited with 1" at boot); point LLV_DEMO_TMUX_TMPDIR at a
+ * short dir (e.g. /tmp/e962-tmux), exactly like the issue-866/873 drivers.
+ *
  * PRODUCTION-SHAPED, exactly like the issue-884 driver it extends: builds the
  * EXACT current head (`next build --webpack`), serves it with `next start`
  * over the ISOLATED demo runtime (fixtures/demo-home + its own LLV_STATE_DIR;

--- a/evidence/issue-962/drive.ts
+++ b/evidence/issue-962/drive.ts
@@ -21,7 +21,9 @@
  *  - the scheme canvas is deeper than the app canvas in dark mode only;
  *  - an inactive card takes the quiet surface; the NEEDS-YOU (waiting) card
  *    and a selected card keep their full treatments;
- *  - an empty project renders the bare canvas + grid with zero cards.
+ *  - the near-empty project renders the bare canvas + sparse grid around a
+ *    single card (zero visible conversations render the dashboard's empty
+ *    state, not a canvas, so one card is the sparsest board the app draws).
  *
  * Output: evidence/issue-962/depth-ladder.json (booleans + colors only) and
  * screenshots of the rendered states. No absolute paths, no identities.
@@ -146,6 +148,8 @@ const quietProbe = `(() => {
 async function openProject(tab: Cdp, baseUrl: string, project: string, ready: string, label: string): Promise<void> {
   await tab.send("Page.navigate", { url: `${baseUrl}/#p=${encodeURIComponent(project)}` });
   await poll(tab, ready, label, 120_000);
+  /* Frame everything: shots must show the whole board, not a remembered camera. */
+  await tab.eval(`(() => { const b = document.querySelector('button[title^="Fit all content"]'); b && b.click(); return true; })()`);
   /* Let the camera glide + entry fades settle so shots are stable. */
   await sleep(1_200);
 }
@@ -186,6 +190,27 @@ async function main(): Promise<void> {
        registries migrate into the fresh capture-state SQLite on first read. */
     seedPipelines(home);
     seedEmptyProject(home);
+    /* The 2100-dated fixture clock renders negative "-…s ago" ages against the
+       real clock this run serves under; restamp every transcript a few minutes
+       back so ages read naturally in the shots. Activity states that matter
+       here are content-driven (open turns, the pending question), not
+       mtime-driven, so the board keeps its mixed live/waiting states. */
+    const recent = new Date(Date.now() - 4 * 60 * 1000);
+    const stampTree = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const child = path.join(dir, entry.name);
+        if (entry.isDirectory()) stampTree(child);
+        else fs.utimesSync(child, recent, recent);
+      }
+    };
+    stampTree(path.join(home, ".claude", "projects"));
+    stampTree(path.join(home, ".codex", "sessions"));
+    /* The resources footer renders the fixture's 2100 capture stamp as a
+       negative age; restamp it to the same recent past. */
+    const resourcesFile = path.join(home, ".config", "agent-log-viewer", "state", "resources.json");
+    const resources = JSON.parse(fs.readFileSync(resourcesFile, "utf8")) as { system?: { capturedAt?: string } };
+    if (resources.system) resources.system.capturedAt = recent.toISOString();
+    fs.writeFileSync(resourcesFile, JSON.stringify(resources, null, 2) + "\n");
     /* One inactive beacon conversation: an mtime hours in the past (relative
        to the REAL clock the server runs on) reads as done — the quiet card. */
     const quietPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.spare), home);
@@ -211,6 +236,22 @@ async function main(): Promise<void> {
     }
     console.log("production server ready");
     const baseUrl = `http://${devHost}:${prodPort}`;
+
+    /* Resolve each fixture project's ACTUAL viewer key from the scan (the
+       directory-identity `dir-…` keys; flow-bound fixture conversations land
+       under the unresolved-project board on current main) so navigation never
+       hardcodes an identity derivation. */
+    const scanned = (await fetch(`http://127.0.0.1:${prodPort}/api/files`).then((r) => r.json())) as Array<{ project?: string; path?: string }> | { files?: Array<{ project?: string; path?: string }> };
+    const scannedFiles = Array.isArray(scanned) ? scanned : scanned.files ?? [];
+    const keyFor = (marker: string): string => {
+      const hit = scannedFiles.find((file) => typeof file.path === "string" && file.path.includes(marker) && typeof file.project === "string");
+      if (!hit) throw new Error(`no scanned file matches ${marker}`);
+      return hit.project!;
+    };
+    const beaconKey = keyFor("-Projects-beacon/");
+    const emberKey = keyFor("-Projects-ember/");
+    const flowKey = keyFor("-Projects-forge/");
+    const attentionKey = keyFor("-Projects-atlas/");
 
     /* ── Headless host Chrome ─────────────────────────────────────────── */
     const profile = path.join(runtime.root, "chrome-profile");
@@ -256,11 +297,14 @@ async function main(): Promise<void> {
     await setScheme(tab, "light");
 
     /* Beacon: dense board — settled pipeline well + dashed draft halo. */
-    await openProject(tab, baseUrl, "beacon", `!!document.querySelector('${PIPELINE_WELL}') && !!document.querySelector('${DRAFT_HALO}')`, "beacon board with both pipeline halos");
+    await openProject(tab, baseUrl, beaconKey, `!!document.querySelector('${PIPELINE_WELL}') && !!document.querySelector('${DRAFT_HALO}')`, "beacon board with both pipeline halos");
+    /* Chrome serializes a computed color-mix as `color(srgb …)`; an unset fill
+       computes to the transparent `rgba(0, 0, 0, 0)` — filled means neither. */
+    const filled = (background: string) => background !== "" && background !== "rgba(0, 0, 0, 0)";
     const wellLight = await tab.eval<{ borderStyle: string; borderWidth: string; background: string; inlineStyle: string } | null>(regionProbe(PIPELINE_WELL));
     expect("light: a settled pipeline container is a filled well — 1px solid hairline + well-surface fill",
       !!wellLight && wellLight.borderStyle === "solid" && wellLight.borderWidth === "1px"
-        && wellLight.inlineStyle.includes("var(--surface-well)") && wellLight.background.startsWith("rgb"),
+        && wellLight.inlineStyle.includes("var(--surface-well)") && filled(wellLight.background),
       wellLight);
     const draftLight = await tab.eval<{ borderStyle: string; borderWidth: string } | null>(regionProbe(DRAFT_HALO));
     expect("light: a draft pipeline keeps the dashed 2px halo — dashed stays a draft/drop affordance",
@@ -303,7 +347,7 @@ async function main(): Promise<void> {
     await tab.eval(`(() => { const check = document.querySelector('[data-lasso-selected="true"] .scheme-select-check'); check && check.click(); return true; })()`);
 
     /* Forge: the flow (branch-group) container takes the same well. */
-    await openProject(tab, baseUrl, "forge", `!!document.querySelector('${FLOW_WELL}')`, "forge flow group");
+    await openProject(tab, baseUrl, flowKey, `!!document.querySelector('${FLOW_WELL}')`, "flow-group board");
     const flowLight = await tab.eval<{ borderStyle: string; borderWidth: string; inlineStyle: string } | null>(regionProbe(FLOW_WELL));
     expect("light: the branch/flow container renders as the same filled hairline well",
       !!flowLight && flowLight.borderStyle === "solid" && flowLight.borderWidth === "1px" && flowLight.inlineStyle.includes("var(--surface-well)"),
@@ -311,7 +355,7 @@ async function main(): Promise<void> {
     await tab.screenshot("desktop-light-forge-branch-group.png");
 
     /* Atlas: the NEEDS-YOU card (pending question) keeps its attention glow. */
-    await openProject(tab, baseUrl, "atlas", `!!document.querySelector('.pane-attention')`, "atlas NEEDS-YOU card");
+    await openProject(tab, baseUrl, attentionKey, `!!document.querySelector('.pane-attention')`, "NEEDS-YOU card");
     const needsYou = await tab.eval<{ glow: boolean; quiet: boolean }>(`(() => {
       const pane = document.querySelector('.pane-attention');
       return { glow: !!pane, quiet: !!pane.querySelector('section[class*="bg-quiet"]') };
@@ -320,51 +364,60 @@ async function main(): Promise<void> {
       needsYou.glow && !needsYou.quiet, needsYou);
     await tab.screenshot("desktop-light-atlas-needs-you.png");
 
-    /* Ember: an empty project — bare canvas, dot grid, zero cards. */
-    await openProject(tab, baseUrl, "ember", `!!${GRID}`, "ember empty project");
+    /* Ember: the minimal project — one card on the bare canvas. (A project
+       with zero visible conversations renders the dashboard's empty state,
+       not a scheme canvas, so this is the sparsest board the app draws.) */
+    await openProject(tab, baseUrl, emberKey, `!!${GRID}`, "ember empty project");
     const empty = await tab.eval<{ nodes: number; grid: boolean }>(`({
       nodes: document.querySelectorAll('[data-scheme-node]').length,
       grid: !!${GRID},
     })`);
-    expect("an empty project renders the bare scheme canvas with the dot grid and zero cards",
-      empty.nodes === 0 && empty.grid, empty);
+    expect("the near-empty project renders the bare scheme canvas + sparse dot grid around a single card",
+      empty.nodes === 1 && empty.grid, empty);
     await tab.screenshot("desktop-light-empty-project.png");
 
-    /* ── Desktop, DARK ────────────────────────────────────────────────── */
-    await setScheme(tab, "dark");
-    await openProject(tab, baseUrl, "beacon", `!!document.querySelector('${PIPELINE_WELL}')`, "beacon dark");
-    const gridDark = await tab.eval<{ tile: number; boardBg: string; bodyBg: string } | null>(gridProbe);
+    tab.close();
+
+    /* ── Desktop, DARK — a fresh tab, so no remembered camera or session
+       state from the light pass leaks into the framing ─────────────────── */
+    const dark = await newTarget();
+    await dark.send("Emulation.setDeviceMetricsOverride", { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false });
+    await setScheme(dark, "dark");
+    await openProject(dark, baseUrl, beaconKey, `!!document.querySelector('${PIPELINE_WELL}')`, "beacon dark");
+    const gridDark = await dark.eval<{ tile: number; boardBg: string; bodyBg: string } | null>(gridProbe);
     expect("dark: the scheme canvas (rgb(13, 13, 17)) dips deeper than the app canvas (rgb(16, 16, 20))",
       !!gridDark && gridDark.boardBg === "rgb(13, 13, 17)" && gridDark.bodyBg === "rgb(16, 16, 20)",
       gridDark);
-    const wellDark = await tab.eval<{ borderStyle: string; borderWidth: string; background: string } | null>(regionProbe(PIPELINE_WELL));
+    const wellDark = await dark.eval<{ borderStyle: string; borderWidth: string; background: string } | null>(regionProbe(PIPELINE_WELL));
     expect("dark: the settled pipeline well keeps the 1px hairline + filled treatment",
-      !!wellDark && wellDark.borderStyle === "solid" && wellDark.borderWidth === "1px" && wellDark.background.startsWith("rgb"),
+      !!wellDark && wellDark.borderStyle === "solid" && wellDark.borderWidth === "1px" && filled(wellDark.background),
       wellDark);
-    const quietDark = await tab.eval<{ background: string } | null>(quietProbe);
+    const quietDark = await dark.eval<{ background: string } | null>(quietProbe);
     expect("dark: the inactive card takes the dark quiet surface (rgb(20, 20, 25))",
       !!quietDark && quietDark.background === "rgb(20, 20, 25)",
       quietDark);
-    await tab.screenshot("desktop-dark-beacon-wells.png");
+    await dark.screenshot("desktop-dark-beacon-wells.png");
 
-    await openProject(tab, baseUrl, "forge", `!!document.querySelector('${FLOW_WELL}')`, "forge dark");
-    await tab.screenshot("desktop-dark-forge-branch-group.png");
-    await openProject(tab, baseUrl, "atlas", `!!document.querySelector('.pane-attention')`, "atlas dark");
-    await tab.screenshot("desktop-dark-atlas-needs-you.png");
-    tab.close();
+    await openProject(dark, baseUrl, flowKey, `!!document.querySelector('${FLOW_WELL}')`, "flow-group dark");
+    await dark.screenshot("desktop-dark-forge-branch-group.png");
+    await openProject(dark, baseUrl, attentionKey, `!!document.querySelector('.pane-attention')`, "NEEDS-YOU dark");
+    await dark.screenshot("desktop-dark-atlas-needs-you.png");
+    dark.close();
 
     /* ── 390 px mobile, light + dark ──────────────────────────────────── */
     const mob = await newTarget();
     await mob.send("Emulation.setDeviceMetricsOverride", { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
     await mob.send("Emulation.setTouchEmulationEnabled", { enabled: true });
     await setScheme(mob, "light");
-    await openProject(mob, baseUrl, "beacon", `!!${GRID}`, "beacon 390px light");
-    const mobile = await mob.eval<{ grid: boolean; tile: number }>(`(() => {
-      const grid = ${GRID};
-      const size = grid ? parseFloat((getComputedStyle(grid).backgroundSize.split(" ")[0] || "0").replace("px", "")) : 0;
-      return { grid: !!grid, tile: size };
-    })()`);
-    expect("390px: the scheme canvas keeps the sparse grid", mobile.grid && mobile.tile >= 18, mobile);
+    /* 390px renders the mobile focus view (compact panes), not the desktop
+       canvas — the evidence here is that the depth-ladder token changes leave
+       the mobile shell fully rendered and legible in both themes. */
+    await openProject(mob, baseUrl, beaconKey, `!!document.querySelector('section[data-link-path], [data-scheme-node]')`, "beacon 390px light");
+    const mobile = await mob.eval<{ panes: number; body: boolean }>(`({
+      panes: document.querySelectorAll('section[data-link-path], [data-scheme-node]').length,
+      body: document.querySelectorAll('body *').length > 50,
+    })`);
+    expect("390px: the mobile shell renders its panes over the new tokens", mobile.panes > 0 && mobile.body, mobile);
     await mob.screenshot("mobile-light-beacon.png");
     await setScheme(mob, "dark");
     await sleep(600);

--- a/evidence/issue-962/drive.ts
+++ b/evidence/issue-962/drive.ts
@@ -166,6 +166,17 @@ async function main(): Promise<void> {
 
   /* ── The exact-head PRODUCTION build the server below serves ─────────── */
   const buildHead = execSync("git rev-parse HEAD", { cwd: repoRoot }).toString().trim();
+  /* Attestation guard (#962 review): the stamped buildHead must BE the code
+     this run renders. Anything dirty besides this driver's own regenerated
+     outputs means the stamp would lie about the rendered tree — refuse. */
+  const REGENERATED = /^evidence\/issue-962\/(depth-ladder\.json|[\w-]+\.png)$/;
+  const dirty = execSync("git status --porcelain", { cwd: repoRoot })
+    .toString()
+    .split("\n")
+    .filter((line) => line.trim() !== "" && !REGENERATED.test(line.slice(3)));
+  if (dirty.length > 0) {
+    throw new Error(`worktree differs from ${buildHead.slice(0, 12)} beyond regenerated evidence outputs — commit first so the attestation SHA matches the rendered code:\n${dirty.join("\n")}`);
+  }
   if (process.env.LLV_EVIDENCE_SKIP_BUILD !== "1") {
     console.log(`building production head ${buildHead.slice(0, 12)}…`);
     const buildEnv = { ...process.env, NODE_ENV: "production" as const };

--- a/evidence/issue-962/drive.ts
+++ b/evidence/issue-962/drive.ts
@@ -1,0 +1,407 @@
+/**
+ * Real-browser evidence for issue #962 — the depth ladder: filled container
+ * wells, deeper dark scheme canvas, zoom-sparse dot grid, quiet-card tone.
+ *
+ *   bun evidence/issue-962/drive.ts
+ *
+ * PRODUCTION-SHAPED, exactly like the issue-884 driver it extends: builds the
+ * EXACT current head (`next build --webpack`), serves it with `next start`
+ * over the ISOLATED demo runtime (fixtures/demo-home + its own LLV_STATE_DIR;
+ * never the operator's viewer state, never ports 8898/8899), and drives real
+ * headless host Chrome over raw CDP. Every pipeline/board fixture is SYNTHETIC
+ * and generated at runtime into the disposable capture home (seeds.ts).
+ *
+ * What the checks prove (issue #962 acceptance):
+ *  - a settled pipeline container renders as a faint FILLED well: solid
+ *    hairline (1px) border + well-surface fill, in light AND dark;
+ *  - the flow (branch-group) container takes the same well treatment;
+ *  - a draft pipeline keeps its DASHED halo — dashed stays a draft affordance;
+ *  - the dot grid is confined to the scheme canvas and its on-screen spacing
+ *    never collapses below the sparse floor while zooming out;
+ *  - the scheme canvas is deeper than the app canvas in dark mode only;
+ *  - an inactive card takes the quiet surface; the NEEDS-YOU (waiting) card
+ *    and a selected card keep their full treatments;
+ *  - an empty project renders the bare canvas + grid with zero cards.
+ *
+ * Output: evidence/issue-962/depth-ladder.json (booleans + colors only) and
+ * screenshots of the rendered states. No absolute paths, no identities.
+ */
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { bootstrapDemoRuntime, claudePath, demoPort, renderFixtureTemplate } from "../../scripts/demo-capture";
+import { BEACON_SESSIONS, seedEmptyProject, seedPipelines } from "./seeds";
+
+const CHROME = process.env.LLV_EVIDENCE_CHROME || "/usr/bin/google-chrome-stable";
+const CDP_PORT = 9347;
+
+interface Check {
+  name: string;
+  pass: boolean;
+  detail: unknown;
+}
+
+class Cdp {
+  #ws: WebSocket;
+  #id = 0;
+  #pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+  private constructor(ws: WebSocket) {
+    this.#ws = ws;
+    ws.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (message.id !== undefined && this.#pending.has(message.id)) {
+        const waiter = this.#pending.get(message.id)!;
+        this.#pending.delete(message.id);
+        if (message.error) waiter.reject(new Error(`${message.error.message} (${message.error.code})`));
+        else waiter.resolve(message.result);
+      }
+    });
+  }
+
+  static async connect(url: string): Promise<Cdp> {
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", () => reject(new Error("CDP connect failed")));
+    });
+    return new Cdp(ws);
+  }
+
+  send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const id = ++this.#id;
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+      this.#ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  async eval<T>(expression: string): Promise<T> {
+    const result = (await this.send("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    })) as { result: { value: T }; exceptionDetails?: { text: string; exception?: { description?: string } } };
+    if (result.exceptionDetails) {
+      throw new Error(`page eval failed: ${result.exceptionDetails.exception?.description ?? result.exceptionDetails.text}\n${expression.slice(0, 200)}`);
+    }
+    return result.result.value;
+  }
+
+  async screenshot(file: string): Promise<void> {
+    const shot = (await this.send("Page.captureScreenshot", { format: "png" })) as { data: string };
+    fs.writeFileSync(path.join(import.meta.dir, file), Buffer.from(shot.data, "base64"));
+  }
+
+  close(): void {
+    this.#ws.close();
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function poll(cdp: Cdp, expression: string, label: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await cdp.eval<boolean>(expression)) return;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for: ${label}`);
+    await sleep(250);
+  }
+}
+
+/* ── Page probes (self-contained expressions, evaluated in the app) ─────── */
+
+/** Region fill/border of the FIRST matching group's halo region div. */
+const regionProbe = (selector: string) => `(() => {
+  const wrap = document.querySelector('${selector}');
+  if (!wrap) return null;
+  const region = wrap.firstElementChild;
+  const cs = getComputedStyle(region);
+  return {
+    borderStyle: cs.borderTopStyle,
+    borderWidth: cs.borderTopWidth,
+    background: cs.backgroundColor,
+    inlineStyle: region.getAttribute("style") || "",
+  };
+})()`;
+
+const GRID = `document.querySelector('[data-scheme-grid]')`;
+
+const gridProbe = `(() => {
+  const grid = ${GRID};
+  if (!grid) return null;
+  const board = grid.parentElement;
+  const size = parseFloat((getComputedStyle(grid).backgroundSize.split(" ")[0] || "0").replace("px", ""));
+  return { tile: size, boardBg: getComputedStyle(board).backgroundColor, bodyBg: getComputedStyle(document.body).backgroundColor };
+})()`;
+
+/** The quiet card's computed body fill, if any inactive card is on the board. */
+const quietProbe = `(() => {
+  const section = document.querySelector('section[data-link-path][class*="bg-quiet"]');
+  if (!section) return null;
+  return { background: getComputedStyle(section).backgroundColor };
+})()`;
+
+async function openProject(tab: Cdp, baseUrl: string, project: string, ready: string, label: string): Promise<void> {
+  await tab.send("Page.navigate", { url: `${baseUrl}/#p=${encodeURIComponent(project)}` });
+  await poll(tab, ready, label, 120_000);
+  /* Let the camera glide + entry fades settle so shots are stable. */
+  await sleep(1_200);
+}
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(import.meta.dir, "../..");
+  const port = demoPort(process.env.LLV_EVIDENCE_PORT, 3071, "LLV_EVIDENCE_PORT");
+  const devHost = [172, 17, 0, 1].join(".");
+  const checks: Check[] = [];
+  const expect = (name: string, pass: boolean, detail: unknown = null) => {
+    checks.push({ name, pass, detail });
+    console.log(`${pass ? "PASS" : "FAIL"} ${name}${pass ? "" : " — " + JSON.stringify(detail)}`);
+  };
+
+  /* ── The exact-head PRODUCTION build the server below serves ─────────── */
+  const buildHead = execSync("git rev-parse HEAD", { cwd: repoRoot }).toString().trim();
+  if (process.env.LLV_EVIDENCE_SKIP_BUILD !== "1") {
+    console.log(`building production head ${buildHead.slice(0, 12)}…`);
+    const buildEnv = { ...process.env, NODE_ENV: "production" as const };
+    delete (buildEnv as Record<string, unknown>).__NEXT_PRIVATE_STANDALONE_CONFIG;
+    execSync("bunx next build --webpack", { cwd: repoRoot, env: buildEnv, stdio: "inherit" });
+  }
+
+  console.log("booting isolated demo runtime…");
+  const prodPort = port + 1;
+  /* An orphaned server from a crashed run would silently serve a STALE build
+     to every check below. Refuse to start over an occupied port. */
+  for (const candidate of [port, prodPort]) {
+    const occupied = await fetch(`http://127.0.0.1:${candidate}/`, { signal: AbortSignal.timeout(1_000) }).then(() => true).catch(() => false);
+    if (occupied) throw new Error(`port ${candidate} is already serving something — kill the stale server first`);
+  }
+  const runtime = await bootstrapDemoRuntime(repoRoot, port);
+  let chrome: ChildProcess | null = null;
+  let prodServer: ChildProcess | null = null;
+  try {
+    const home = runtime.env.HOME!;
+    /* Seed BEFORE any server request touches the pipeline store, so the JSON
+       registries migrate into the fresh capture-state SQLite on first read. */
+    seedPipelines(home);
+    seedEmptyProject(home);
+    /* One inactive beacon conversation: an mtime hours in the past (relative
+       to the REAL clock the server runs on) reads as done — the quiet card. */
+    const quietPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.spare), home);
+    const stale = new Date(Date.now() - 6 * 3600 * 1000);
+    fs.utimesSync(quietPath, stale, stale);
+
+    prodServer = spawn(
+      "bunx",
+      ["next", "start", "--hostname", "0.0.0.0", "--port", String(prodPort)],
+      { cwd: repoRoot, env: { ...runtime.env, NODE_ENV: "production" }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const prodDeadline = Date.now() + 60_000;
+    for (;;) {
+      if (prodServer.exitCode !== null) throw new Error(`production server exited with ${prodServer.exitCode}`);
+      try {
+        const response = await fetch(`http://127.0.0.1:${prodPort}/api/files`);
+        if (response.ok) break;
+      } catch {
+        /* still booting */
+      }
+      if (Date.now() > prodDeadline) throw new Error("production server never became ready");
+      await sleep(400);
+    }
+    console.log("production server ready");
+    const baseUrl = `http://${devHost}:${prodPort}`;
+
+    /* ── Headless host Chrome ─────────────────────────────────────────── */
+    const profile = path.join(runtime.root, "chrome-profile");
+    fs.mkdirSync(profile, { recursive: true });
+    chrome = spawn(CHROME, [
+      "--headless=new",
+      `--remote-debugging-port=${CDP_PORT}`,
+      `--user-data-dir=${profile}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-extensions",
+      "--window-size=1440,900",
+      "about:blank",
+    ], { stdio: "ignore" });
+    const cdpDeadline = Date.now() + 20_000;
+    for (;;) {
+      try {
+        await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`);
+        break;
+      } catch {
+        if (Date.now() > cdpDeadline) throw new Error("Chrome CDP endpoint never came up");
+        await sleep(300);
+      }
+    }
+    const newTarget = async (): Promise<Cdp> => {
+      const created = await fetch(`http://127.0.0.1:${CDP_PORT}/json/new?about:blank`, { method: "PUT" });
+      const target = (await created.json()) as { webSocketDebuggerUrl: string };
+      const cdp = await Cdp.connect(target.webSocketDebuggerUrl);
+      await cdp.send("Page.enable");
+      await cdp.send("Runtime.enable");
+      return cdp;
+    };
+    const setScheme = (tab: Cdp, value: "light" | "dark") =>
+      tab.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-color-scheme", value }] });
+
+    const PIPELINE_WELL = `[data-scheme-group="pipeline"]:not([data-pipeline-draft])`;
+    const DRAFT_HALO = `[data-scheme-group="pipeline"][data-pipeline-draft]`;
+    const FLOW_WELL = `[data-scheme-group="flow"]`;
+
+    /* ── Desktop, LIGHT ───────────────────────────────────────────────── */
+    const tab = await newTarget();
+    await tab.send("Emulation.setDeviceMetricsOverride", { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false });
+    await setScheme(tab, "light");
+
+    /* Beacon: dense board — settled pipeline well + dashed draft halo. */
+    await openProject(tab, baseUrl, "beacon", `!!document.querySelector('${PIPELINE_WELL}') && !!document.querySelector('${DRAFT_HALO}')`, "beacon board with both pipeline halos");
+    const wellLight = await tab.eval<{ borderStyle: string; borderWidth: string; background: string; inlineStyle: string } | null>(regionProbe(PIPELINE_WELL));
+    expect("light: a settled pipeline container is a filled well — 1px solid hairline + well-surface fill",
+      !!wellLight && wellLight.borderStyle === "solid" && wellLight.borderWidth === "1px"
+        && wellLight.inlineStyle.includes("var(--surface-well)") && wellLight.background.startsWith("rgb"),
+      wellLight);
+    const draftLight = await tab.eval<{ borderStyle: string; borderWidth: string } | null>(regionProbe(DRAFT_HALO));
+    expect("light: a draft pipeline keeps the dashed 2px halo — dashed stays a draft/drop affordance",
+      !!draftLight && draftLight.borderStyle === "dashed" && draftLight.borderWidth === "2px",
+      draftLight);
+    const gridLight = await tab.eval<{ tile: number; boardBg: string; bodyBg: string } | null>(gridProbe);
+    expect("light: the dot grid lives on the scheme canvas and the board matches the app canvas (rgb(243, 243, 246))",
+      !!gridLight && gridLight.tile >= 18 && gridLight.boardBg === "rgb(243, 243, 246)" && gridLight.bodyBg === "rgb(243, 243, 246)",
+      gridLight);
+    const quietLight = await tab.eval<{ background: string } | null>(quietProbe);
+    expect("light: an inactive card takes the quiet surface (rgb(250, 250, 251))",
+      !!quietLight && quietLight.background === "rgb(250, 250, 251)",
+      quietLight);
+    await tab.screenshot("desktop-light-beacon-wells.png");
+
+    /* Zoom out: the grid's on-screen spacing never drops below the floor. */
+    const tiles: number[] = [gridLight?.tile ?? 0];
+    for (let i = 0; i < 6; i += 1) {
+      await tab.eval(`(() => { const b = document.querySelector('button[title^="Zoom out"]'); b && b.click(); return true; })()`);
+      await sleep(150);
+      const probe = await tab.eval<{ tile: number } | null>(gridProbe);
+      tiles.push(probe?.tile ?? 0);
+    }
+    expect("the dot grid stays sparse across zoom-out steps (every on-screen tile ≥ 18px)",
+      tiles.every((tile) => tile >= 18), tiles);
+    await tab.screenshot("desktop-light-beacon-zoomed-out.png");
+    await tab.eval(`(() => { const b = document.querySelector('button[title^="Zoom 100"]'); b && b.click(); return true; })()`);
+    await sleep(600);
+
+    /* Selected card: the member tint + check, over the new well. */
+    const marked = await tab.eval<boolean>(`(() => {
+      const check = document.querySelector('[data-scheme-node] .scheme-select-check');
+      if (!check) return false;
+      check.click();
+      return true;
+    })()`);
+    await poll(tab, `!!document.querySelector('[data-lasso-selected="true"]')`, "selection session engaged", 10_000);
+    expect("a selected card keeps its full selection treatment on the dense board", marked);
+    await tab.screenshot("desktop-light-beacon-selected.png");
+    await tab.eval(`(() => { const check = document.querySelector('[data-lasso-selected="true"] .scheme-select-check'); check && check.click(); return true; })()`);
+
+    /* Forge: the flow (branch-group) container takes the same well. */
+    await openProject(tab, baseUrl, "forge", `!!document.querySelector('${FLOW_WELL}')`, "forge flow group");
+    const flowLight = await tab.eval<{ borderStyle: string; borderWidth: string; inlineStyle: string } | null>(regionProbe(FLOW_WELL));
+    expect("light: the branch/flow container renders as the same filled hairline well",
+      !!flowLight && flowLight.borderStyle === "solid" && flowLight.borderWidth === "1px" && flowLight.inlineStyle.includes("var(--surface-well)"),
+      flowLight);
+    await tab.screenshot("desktop-light-forge-branch-group.png");
+
+    /* Atlas: the NEEDS-YOU card (pending question) keeps its attention glow. */
+    await openProject(tab, baseUrl, "atlas", `!!document.querySelector('.pane-attention')`, "atlas NEEDS-YOU card");
+    const needsYou = await tab.eval<{ glow: boolean; quiet: boolean }>(`(() => {
+      const pane = document.querySelector('.pane-attention');
+      return { glow: !!pane, quiet: !!pane.querySelector('section[class*="bg-quiet"]') };
+    })()`);
+    expect("the NEEDS-YOU card keeps its full attention treatment and never takes the quiet tone",
+      needsYou.glow && !needsYou.quiet, needsYou);
+    await tab.screenshot("desktop-light-atlas-needs-you.png");
+
+    /* Ember: an empty project — bare canvas, dot grid, zero cards. */
+    await openProject(tab, baseUrl, "ember", `!!${GRID}`, "ember empty project");
+    const empty = await tab.eval<{ nodes: number; grid: boolean }>(`({
+      nodes: document.querySelectorAll('[data-scheme-node]').length,
+      grid: !!${GRID},
+    })`);
+    expect("an empty project renders the bare scheme canvas with the dot grid and zero cards",
+      empty.nodes === 0 && empty.grid, empty);
+    await tab.screenshot("desktop-light-empty-project.png");
+
+    /* ── Desktop, DARK ────────────────────────────────────────────────── */
+    await setScheme(tab, "dark");
+    await openProject(tab, baseUrl, "beacon", `!!document.querySelector('${PIPELINE_WELL}')`, "beacon dark");
+    const gridDark = await tab.eval<{ tile: number; boardBg: string; bodyBg: string } | null>(gridProbe);
+    expect("dark: the scheme canvas (rgb(13, 13, 17)) dips deeper than the app canvas (rgb(16, 16, 20))",
+      !!gridDark && gridDark.boardBg === "rgb(13, 13, 17)" && gridDark.bodyBg === "rgb(16, 16, 20)",
+      gridDark);
+    const wellDark = await tab.eval<{ borderStyle: string; borderWidth: string; background: string } | null>(regionProbe(PIPELINE_WELL));
+    expect("dark: the settled pipeline well keeps the 1px hairline + filled treatment",
+      !!wellDark && wellDark.borderStyle === "solid" && wellDark.borderWidth === "1px" && wellDark.background.startsWith("rgb"),
+      wellDark);
+    const quietDark = await tab.eval<{ background: string } | null>(quietProbe);
+    expect("dark: the inactive card takes the dark quiet surface (rgb(20, 20, 25))",
+      !!quietDark && quietDark.background === "rgb(20, 20, 25)",
+      quietDark);
+    await tab.screenshot("desktop-dark-beacon-wells.png");
+
+    await openProject(tab, baseUrl, "forge", `!!document.querySelector('${FLOW_WELL}')`, "forge dark");
+    await tab.screenshot("desktop-dark-forge-branch-group.png");
+    await openProject(tab, baseUrl, "atlas", `!!document.querySelector('.pane-attention')`, "atlas dark");
+    await tab.screenshot("desktop-dark-atlas-needs-you.png");
+    tab.close();
+
+    /* ── 390 px mobile, light + dark ──────────────────────────────────── */
+    const mob = await newTarget();
+    await mob.send("Emulation.setDeviceMetricsOverride", { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+    await mob.send("Emulation.setTouchEmulationEnabled", { enabled: true });
+    await setScheme(mob, "light");
+    await openProject(mob, baseUrl, "beacon", `!!${GRID}`, "beacon 390px light");
+    const mobile = await mob.eval<{ grid: boolean; tile: number }>(`(() => {
+      const grid = ${GRID};
+      const size = grid ? parseFloat((getComputedStyle(grid).backgroundSize.split(" ")[0] || "0").replace("px", "")) : 0;
+      return { grid: !!grid, tile: size };
+    })()`);
+    expect("390px: the scheme canvas keeps the sparse grid", mobile.grid && mobile.tile >= 18, mobile);
+    await mob.screenshot("mobile-light-beacon.png");
+    await setScheme(mob, "dark");
+    await sleep(600);
+    await mob.screenshot("mobile-dark-beacon.png");
+    mob.close();
+
+    const failed = checks.filter((check) => !check.pass);
+    const output = {
+      issue: 962,
+      capturedAt: new Date().toISOString(),
+      buildHead,
+      runner: "exact-head production build served by `next start` over the isolated demo runtime (fixtures/demo-home); synthetic runtime-generated pipeline/board fixtures; headless host Chrome over raw CDP",
+      screenshots: [
+        "desktop-light-beacon-wells.png", "desktop-light-beacon-zoomed-out.png",
+        "desktop-light-beacon-selected.png", "desktop-light-forge-branch-group.png",
+        "desktop-light-atlas-needs-you.png", "desktop-light-empty-project.png",
+        "desktop-dark-beacon-wells.png", "desktop-dark-forge-branch-group.png",
+        "desktop-dark-atlas-needs-you.png",
+        "mobile-light-beacon.png", "mobile-dark-beacon.png",
+      ],
+      checks,
+      verdict: failed.length === 0 ? "PASS" : "FAIL",
+    };
+    fs.writeFileSync(
+      path.join(import.meta.dir, "depth-ladder.json"),
+      (JSON.stringify(output, null, 2) + "\n")
+        .replaceAll(repoRoot, "<repo>")
+        .replaceAll(runtime.root, "<capture>")
+        .replace(/\b([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "$1-x"),
+    );
+    console.log(`\n${output.verdict}: ${checks.length - failed.length}/${checks.length} checks`);
+    if (failed.length) process.exitCode = 1;
+  } finally {
+    chrome?.kill("SIGKILL");
+    prodServer?.kill("SIGTERM");
+    await runtime.shutdown();
+  }
+}
+
+await main();

--- a/evidence/issue-962/seeds.ts
+++ b/evidence/issue-962/seeds.ts
@@ -37,8 +37,8 @@ export const DRAFT_PIPELINE_ID = "well962drf";
 
 /* The fixture session ids, assembled at runtime so no UUID shape lands in
    published sources (privacy gate resource_identifier class). The demo-home
-   fixtures repeat one byte: aa-bb-4ab-8ab-aa… for byte "a1" reads
-   a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1. */
+   fixtures repeat one byte per id, with a "4"/"8" version/variant prefix on
+   the third and fourth segments. */
 const sessionId = (byte: string) =>
   [byte.repeat(4), byte.repeat(2), `4${byte}${byte[0]}`, `8${byte}${byte[0]}`, byte.repeat(6)].join("-");
 

--- a/evidence/issue-962/seeds.ts
+++ b/evidence/issue-962/seeds.ts
@@ -1,0 +1,195 @@
+/**
+ * Synthetic board seeds for the issue #962 depth-ladder evidence run. All data
+ * is generated at runtime into the DISPOSABLE demo capture home — nothing here
+ * touches the operator's viewer state and no identities land in sources.
+ *
+ * Seeded surfaces:
+ *  - a PARKED (needs_decision) two-stage pipeline over two existing beacon
+ *    conversations — renders the settled pipeline region as a filled well;
+ *  - a DRAFT pipeline in the same project — renders the dashed draft halo,
+ *    proving dashed stays reserved for draft/drop affordances;
+ *  - an extra "ember" project whose only conversation is hidden by board
+ *    prefs — renders the empty-project canvas (dot grid over the board
+ *    surface, no cards).
+ *
+ * Both pipelines are parked states (draft / needs_decision), so the pipeline
+ * engine never acts on them: no spawns, no worktrees, no tmux — they are pure
+ * board projections.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { claudePath, renderFixtureTemplate } from "../../scripts/demo-capture";
+
+const ROLE = {
+  roleId: null,
+  engine: "claude",
+  model: null,
+  effort: null,
+  access: "read-write",
+  promptScaffold: null,
+} as const;
+
+/** IDs kept UUID-free so no identifier shape lands in published evidence. */
+export const RUN_PIPELINE_ID = "well962run";
+export const DRAFT_PIPELINE_ID = "well962drf";
+
+/* The fixture session ids, assembled at runtime so no UUID shape lands in
+   published sources (privacy gate resource_identifier class). The demo-home
+   fixtures repeat one byte: aa-bb-4ab-8ab-aa… for byte "a1" reads
+   a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1. */
+const sessionId = (byte: string) =>
+  [byte.repeat(4), byte.repeat(2), `4${byte}${byte[0]}`, `8${byte}${byte[0]}`, byte.repeat(6)].join("-");
+
+export const BEACON_SESSIONS = {
+  implement: `${sessionId("a1")}.jsonl`,
+  verify: `${sessionId("b2")}.jsonl`,
+  spare: `${sessionId("c3")}.jsonl`,
+} as const;
+
+export const EMBER_SESSION = sessionId("e5");
+
+/** worktreeDir/branch must satisfy the store's identity invariant. */
+function identity(id: string, task: string, repoDir: string) {
+  const slug = task.toLowerCase().replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").slice(0, 40).replace(/-+$/, "");
+  return {
+    worktreeDir: path.join(path.dirname(repoDir), `${path.basename(repoDir)}-pipeline-${id}`),
+    branch: `pipeline/${slug}-${id}`,
+  };
+}
+
+export function seedPipelines(home: string): void {
+  const repoDir = "/demo/Projects/beacon";
+  const at = "2100-01-02T11:40:00.000Z";
+  const implementPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.implement), home);
+  const verifyPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.verify), home);
+
+  const runTask = "Harden the demo capture pipeline";
+  const run = {
+    id: RUN_PIPELINE_ID,
+    task: runTask,
+    taskIds: [],
+    project: "beacon",
+    repoDir,
+    ...identity(RUN_PIPELINE_ID, runTask, repoDir),
+    baseBranch: "main",
+    baseRef: "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0",
+    lastPassedCommit: "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0",
+    stages: [
+      { id: "implement", kind: "run", prompt: "Implement the capture hardening.", next: "verify", onFail: null, effectiveRole: ROLE },
+      { id: "verify", kind: "run", prompt: "Verify the capture output.", next: null, onFail: null, effectiveRole: ROLE },
+    ],
+    runs: [
+      {
+        stageId: "implement",
+        attempts: [{
+          n: 1,
+          state: "passed",
+          effectiveRole: ROLE,
+          launchId: null,
+          conversationId: "demo-beacon-implement",
+          sessionId: null,
+          agentPath: implementPath,
+          paneId: null,
+          flowId: null,
+          startedAt: at,
+          completedAt: at,
+          input: null,
+          activatedBy: null,
+          output: null,
+          verdict: null,
+          error: null,
+        }],
+      },
+      {
+        stageId: "verify",
+        attempts: [{
+          n: 1,
+          state: "needs_decision",
+          effectiveRole: ROLE,
+          launchId: null,
+          conversationId: "demo-beacon-verify",
+          sessionId: null,
+          agentPath: verifyPath,
+          paneId: null,
+          flowId: null,
+          startedAt: at,
+          completedAt: at,
+          input: null,
+          activatedBy: { stageId: "implement", attempt: 1, edge: "pass" },
+          output: null,
+          verdict: null,
+          error: null,
+        }],
+      },
+    ],
+    cursor: null,
+    state: "needs_decision",
+    pausedState: null,
+    stateDetail: "Verifier parked for the operator",
+    srcPath: null,
+    srcConversationId: null,
+    createdAt: at,
+    closedAt: null,
+  };
+
+  const draftTask = "Draft the depth ladder rollout";
+  const draft = {
+    id: DRAFT_PIPELINE_ID,
+    task: draftTask,
+    taskIds: [],
+    project: "beacon",
+    repoDir,
+    ...identity(DRAFT_PIPELINE_ID, draftTask, repoDir),
+    baseBranch: "",
+    baseRef: "",
+    lastPassedCommit: "",
+    stages: [
+      { id: "implement", kind: "run", prompt: "{{task}}", next: null, onFail: null, effectiveRole: ROLE },
+    ],
+    runs: [{ stageId: "implement", attempts: [] }],
+    cursor: { stageId: "implement", state: "pending", input: null, activatedBy: null },
+    state: "draft",
+    pausedState: null,
+    stateDetail: null,
+    srcPath: null,
+    srcConversationId: null,
+    createdAt: at,
+    closedAt: null,
+  };
+
+  const stateDir = path.join(home, ".config", "agent-log-viewer", "state");
+  fs.writeFileSync(
+    path.join(stateDir, "pipelines.json"),
+    JSON.stringify({ schemaVersion: 5, pipelines: [run, draft] }, null, 2) + "\n",
+  );
+}
+
+/** An "ember" project whose single conversation is hidden by board prefs: the
+    project exists, its scheme canvas renders empty. Cloned from a beacon
+    fixture transcript with project name and session id rewritten. */
+export function seedEmptyProject(home: string): string {
+  const sourcePath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.spare), home);
+  const emberPath = renderFixtureTemplate(claudePath("ember", `${EMBER_SESSION}.jsonl`), home);
+  fs.mkdirSync(path.dirname(emberPath), { recursive: true });
+  const content = fs.readFileSync(sourcePath, "utf8")
+    .replaceAll("beacon", "ember")
+    .replaceAll(BEACON_SESSIONS.spare.replace(".jsonl", ""), EMBER_SESSION);
+  fs.writeFileSync(emberPath, content);
+  /* Keep the clone inside the fixture's stable clock (set before boot). */
+  const sourceStat = fs.statSync(sourcePath);
+  fs.utimesSync(emberPath, sourceStat.atime, sourceStat.mtime);
+
+  const boardFile = path.join(home, ".config", "agent-log-viewer", "state", "board.json");
+  const board = JSON.parse(fs.readFileSync(boardFile, "utf8")) as { projects: Record<string, unknown> };
+  board.projects.ember = {
+    schemaVersion: 1,
+    revision: 1,
+    updatedAt: "2100-01-02T11:45:00.000Z",
+    pathAliases: {},
+    explicitManual: [],
+    prefs: { manual: [], hidden: [emberPath], expanded: [], viewMode: "scheme", taskPanelOpen: false },
+  };
+  fs.writeFileSync(boardFile, JSON.stringify(board, null, 2) + "\n");
+  return emberPath;
+}

--- a/evidence/issue-962/seeds.ts
+++ b/evidence/issue-962/seeds.ts
@@ -16,6 +16,7 @@
  * engine never acts on them: no spawns, no worktrees, no tmux — they are pure
  * board projections.
  */
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -49,6 +50,14 @@ export const BEACON_SESSIONS = {
 
 export const EMBER_SESSION = sessionId("e5");
 
+/** The viewer's directory-identity project key for a fixture cwd (identity.ts:
+    no repository claims `/demo/Projects/<name>`, so the directory itself is
+    the project). Keys the seeded pipelines and board prefs to the same project
+    the scanner will derive. */
+export function directoryProjectKey(cwd: string): string {
+  return `dir-${crypto.createHash("sha256").update(`dir:${path.resolve(cwd)}`).digest("hex").slice(0, 32)}`;
+}
+
 /** worktreeDir/branch must satisfy the store's identity invariant. */
 function identity(id: string, task: string, repoDir: string) {
   const slug = task.toLowerCase().replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").slice(0, 40).replace(/-+$/, "");
@@ -59,8 +68,18 @@ function identity(id: string, task: string, repoDir: string) {
 }
 
 export function seedPipelines(home: string): void {
-  const repoDir = "/demo/Projects/beacon";
-  const at = "2100-01-02T11:40:00.000Z";
+  /* The board projection (filterPipelinesForFileScan) keeps a pipeline only if
+     its repoDir/worktreeDir exists on disk or an attempt transcript is in the
+     scan. The draft has no attempts, so its repoDir must be a real directory —
+     materialized inside the disposable capture home. The PROJECT key still
+     binds both pipelines to the beacon board (the fixture cwd's directory
+     identity), independent of where repoDir lives. */
+  const repoDir = path.join(home, "Projects", "beacon");
+  fs.mkdirSync(repoDir, { recursive: true });
+  const beaconProject = directoryProjectKey("/demo/Projects/beacon");
+  /* Recent-past stamps: the fixture's fixed 2100 clock reads as a negative age
+     against the real clock this evidence run serves under. */
+  const at = new Date(Date.now() - 20 * 60 * 1000).toISOString();
   const implementPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.implement), home);
   const verifyPath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.verify), home);
 
@@ -69,7 +88,7 @@ export function seedPipelines(home: string): void {
     id: RUN_PIPELINE_ID,
     task: runTask,
     taskIds: [],
-    project: "beacon",
+    project: beaconProject,
     repoDir,
     ...identity(RUN_PIPELINE_ID, runTask, repoDir),
     baseBranch: "main",
@@ -138,7 +157,7 @@ export function seedPipelines(home: string): void {
     id: DRAFT_PIPELINE_ID,
     task: draftTask,
     taskIds: [],
-    project: "beacon",
+    project: beaconProject,
     repoDir,
     ...identity(DRAFT_PIPELINE_ID, draftTask, repoDir),
     baseBranch: "",
@@ -165,8 +184,9 @@ export function seedPipelines(home: string): void {
   );
 }
 
-/** An "ember" project whose single conversation is hidden by board prefs: the
-    project exists, its scheme canvas renders empty. Cloned from a beacon
+/** An "ember" project holding a single conversation: the minimal scheme canvas
+    (a truly empty project renders the dashboard's empty state, not a canvas,
+    so one card is the sparsest board the app draws). Cloned from a beacon
     fixture transcript with project name and session id rewritten. */
 export function seedEmptyProject(home: string): string {
   const sourcePath = renderFixtureTemplate(claudePath("beacon", BEACON_SESSIONS.spare), home);
@@ -182,13 +202,13 @@ export function seedEmptyProject(home: string): string {
 
   const boardFile = path.join(home, ".config", "agent-log-viewer", "state", "board.json");
   const board = JSON.parse(fs.readFileSync(boardFile, "utf8")) as { projects: Record<string, unknown> };
-  board.projects.ember = {
+  board.projects[directoryProjectKey("/demo/Projects/ember")] = {
     schemaVersion: 1,
     revision: 1,
     updatedAt: "2100-01-02T11:45:00.000Z",
     pathAliases: {},
     explicitManual: [],
-    prefs: { manual: [], hidden: [emberPath], expanded: [], viewMode: "scheme", taskPanelOpen: false },
+    prefs: { manual: [], hidden: [], expanded: [], viewMode: "scheme", taskPanelOpen: false },
   };
   fs.writeFileSync(boardFile, JSON.stringify(board, null, 2) + "\n");
   return emberPath;

--- a/src/components/BranchPane.paneTones.test.ts
+++ b/src/components/BranchPane.paneTones.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 
 import { paneToneSurface } from "./BranchPane";
 import type { PaneState } from "./paneState";
+
+const STATES: PaneState[] = ["live", "waiting", "returned", "stalled", "done"];
 
 /*
  * Issue #962 quiet-card tone: only an INACTIVE pane — `done`, i.e. finished
@@ -12,7 +16,20 @@ import type { PaneState } from "./paneState";
  */
 test("quiet surface applies only to the inactive done state", () => {
   expect(paneToneSurface("done")).toBe("bg-quiet");
-  for (const state of ["live", "waiting", "returned", "stalled"] as PaneState[]) {
+  for (const state of STATES.filter((s) => s !== "done")) {
     expect(paneToneSurface(state)).toBe("bg-card");
   }
+});
+
+/*
+ * Ownership fence (#962 review): the body-surface choice lives in its own
+ * PANE_SURFACES map. PANE_TONES — the shared header/status tone table — is
+ * #961's territory and must carry no `surface` entries from this lane.
+ */
+test("PANE_TONES stays free of body-surface entries (fence to #961)", () => {
+  const source = fs.readFileSync(path.join(import.meta.dir, "BranchPane.tsx"), "utf8");
+  const tones = source.match(/const PANE_TONES[^=]*=\s*\{[\s\S]*?\n\};/);
+  expect(tones).not.toBeNull();
+  expect(tones![0]).not.toContain("surface");
+  expect(source).toContain("const PANE_SURFACES: Record<PaneState, string>");
 });

--- a/src/components/BranchPane.paneTones.test.ts
+++ b/src/components/BranchPane.paneTones.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { paneToneSurface } from "./BranchPane";
+import type { PaneState } from "./paneState";
+
+/*
+ * Issue #962 quiet-card tone: only an INACTIVE pane — `done`, i.e. finished
+ * with nothing pending and no attention state — recedes onto the quiet
+ * surface. Every state that asks for the operator's eye (live, waiting,
+ * returned, stalled — NEEDS YOU, active, rate-limited flows resolve to these)
+ * keeps the full card surface so its legibility is untouched.
+ */
+test("quiet surface applies only to the inactive done state", () => {
+  expect(paneToneSurface("done")).toBe("bg-quiet");
+  for (const state of ["live", "waiting", "returned", "stalled"] as PaneState[]) {
+    expect(paneToneSurface(state)).toBe("bg-card");
+  }
+});

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -39,22 +39,31 @@ import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, engineEd
 
 const noop = () => undefined;
 
-/* Card treatment per lifecycle state; `glow` also feeds the orbiting border.
-   `surface` is the card body fill: every state with something to say keeps the
-   full card white; only `done` — inactive, no attention — takes the quiet
-   surface so it recedes on the #962 depth ladder. */
-const PANE_TONES: Record<PaneState, { section: string; header: string; surface: string; glow?: string }> = {
-  live: { section: "border-success/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-success)_20%,transparent)]", header: "bg-success-soft", surface: "bg-card" },
-  waiting: { section: "border-warning/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-warning)_26%,transparent)]", header: "bg-warning-soft", surface: "bg-card", glow: "var(--color-warning)" },
-  returned: { section: "border-accent/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_20%,transparent)]", header: "bg-accent-soft", surface: "bg-card", glow: "var(--color-accent)" },
-  stalled: { section: "border-danger/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-danger)_18%,transparent)]", header: "bg-danger-soft", surface: "bg-card", glow: "var(--color-danger)" },
-  done: { section: "border-border", header: "bg-sunken text-muted opacity-80 saturate-50", surface: "bg-quiet" },
+/* Card treatment per lifecycle state; `glow` also feeds the orbiting border. */
+const PANE_TONES: Record<PaneState, { section: string; header: string; glow?: string }> = {
+  live: { section: "border-success/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-success)_20%,transparent)]", header: "bg-success-soft" },
+  waiting: { section: "border-warning/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-warning)_26%,transparent)]", header: "bg-warning-soft", glow: "var(--color-warning)" },
+  returned: { section: "border-accent/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_20%,transparent)]", header: "bg-accent-soft", glow: "var(--color-accent)" },
+  stalled: { section: "border-danger/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-danger)_18%,transparent)]", header: "bg-danger-soft", glow: "var(--color-danger)" },
+  done: { section: "border-border", header: "bg-sunken text-muted opacity-80 saturate-50" },
+};
+
+/* #962 quiet-card tone: the card BODY fill only, kept OUTSIDE PANE_TONES —
+   that table's header/status treatments belong to the #961 lane. Every state
+   with something to say keeps the full card surface; only `done` — inactive,
+   no attention — recedes onto the quiet surface of the depth ladder. */
+const PANE_SURFACES: Record<PaneState, string> = {
+  live: "bg-card",
+  waiting: "bg-card",
+  returned: "bg-card",
+  stalled: "bg-card",
+  done: "bg-quiet",
 };
 
 /** The pane body surface for a lifecycle state (issue #962 quiet tone).
     Exported for the focused test: quiet applies ONLY to `done`. */
 export function paneToneSurface(state: PaneState): string {
-  return PANE_TONES[state].surface;
+  return PANE_SURFACES[state];
 }
 
 /** Maps the internal (Cyrillic) file.kind discriminant to a localized label. */
@@ -278,7 +287,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
            presses that start here (wheel pan still covers scrolling). */
         data-pan-ignore
         data-link-path={file.path}
-        className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[10px] border ${tone.surface} shadow-1 ${tone.section}`}
+        className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[10px] border ${paneToneSurface(state)} shadow-1 ${tone.section}`}
       >
         <span
           aria-hidden

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -39,14 +39,23 @@ import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, engineEd
 
 const noop = () => undefined;
 
-/* Card treatment per lifecycle state; `glow` also feeds the orbiting border. */
-const PANE_TONES: Record<PaneState, { section: string; header: string; glow?: string }> = {
-  live: { section: "border-success/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-success)_20%,transparent)]", header: "bg-success-soft" },
-  waiting: { section: "border-warning/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-warning)_26%,transparent)]", header: "bg-warning-soft", glow: "var(--color-warning)" },
-  returned: { section: "border-accent/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_20%,transparent)]", header: "bg-accent-soft", glow: "var(--color-accent)" },
-  stalled: { section: "border-danger/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-danger)_18%,transparent)]", header: "bg-danger-soft", glow: "var(--color-danger)" },
-  done: { section: "border-border", header: "bg-sunken text-muted opacity-80 saturate-50" },
+/* Card treatment per lifecycle state; `glow` also feeds the orbiting border.
+   `surface` is the card body fill: every state with something to say keeps the
+   full card white; only `done` — inactive, no attention — takes the quiet
+   surface so it recedes on the #962 depth ladder. */
+const PANE_TONES: Record<PaneState, { section: string; header: string; surface: string; glow?: string }> = {
+  live: { section: "border-success/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-success)_20%,transparent)]", header: "bg-success-soft", surface: "bg-card" },
+  waiting: { section: "border-warning/60 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-warning)_26%,transparent)]", header: "bg-warning-soft", surface: "bg-card", glow: "var(--color-warning)" },
+  returned: { section: "border-accent/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_20%,transparent)]", header: "bg-accent-soft", surface: "bg-card", glow: "var(--color-accent)" },
+  stalled: { section: "border-danger/50 shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-danger)_18%,transparent)]", header: "bg-danger-soft", surface: "bg-card", glow: "var(--color-danger)" },
+  done: { section: "border-border", header: "bg-sunken text-muted opacity-80 saturate-50", surface: "bg-quiet" },
 };
+
+/** The pane body surface for a lifecycle state (issue #962 quiet tone).
+    Exported for the focused test: quiet applies ONLY to `done`. */
+export function paneToneSurface(state: PaneState): string {
+  return PANE_TONES[state].surface;
+}
 
 /** Maps the internal (Cyrillic) file.kind discriminant to a localized label. */
 export function kindLabel(t: TFunction, kind: string): string {
@@ -269,7 +278,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
            presses that start here (wheel pan still covers scrolling). */
         data-pan-ignore
         data-link-path={file.path}
-        className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[10px] border bg-card shadow-1 ${tone.section}`}
+        className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[10px] border ${tone.surface} shadow-1 ${tone.section}`}
       >
         <span
           aria-hidden

--- a/src/components/scheme/GroupsLayer.render.test.tsx
+++ b/src/components/scheme/GroupsLayer.render.test.tsx
@@ -61,6 +61,35 @@ test("each group draws a named, hue-tinted halo region (issue #118)", () => {
   expect(html).toContain('data-scheme-group="pipeline"');
 });
 
+/* Issue #962 depth ladder: a settled container is a faint FILLED well with a
+   hairline border, so grouping reads by depth instead of by outline. */
+test("a settled flow/pipeline container renders as a filled well with a hairline border, not a dashed outline", () => {
+  const html = render([flowGroup, pipelineGroup], true);
+  /* The well fill sits on the shared well surface, washed with the group hue. */
+  expect(html).toContain("var(--surface-well)");
+  expect(html).toContain("background-color:color-mix(in srgb, hsl(210 62% 42%) 6%, var(--surface-well))");
+  /* Hairline: the region border derives from the default hairline role. */
+  expect(html).toContain("border-color:color-mix(in srgb, hsl(210 62% 42%) 32%, var(--border-default))");
+  /* No dashed region and no 2px outline anywhere in a settled board. */
+  expect(html).not.toContain("border-dashed");
+});
+
+/* Dashed treatment stays reserved for drafts (and drop targets elsewhere). */
+test("a draft pipeline keeps its dashed warning halo (issue #962: dashed = draft/drop affordance)", () => {
+  const draft = {
+    ...pipelineGroup,
+    key: "group::pipeline::d1",
+    id: "d1",
+    pipeline: { ...planPipeline, id: "d1", state: "draft" } as unknown as Pipeline,
+  };
+  const html = render([draft], true);
+  expect(html).toContain("border-dashed");
+  expect(html).toContain("data-pipeline-draft");
+  expect(html).toContain("var(--color-warning)");
+  /* The draft halo does NOT take the settled well fill. */
+  expect(html).not.toContain("var(--surface-well)");
+});
+
 test("the label chip fully counter-scales so it stays readable at minimum zoom (issue #118 review)", () => {
   const html = render([flowGroup], true);
   /* Uncapped inverse-zoom scaling: constant on-screen size, no min(…) ceiling

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -1161,6 +1161,7 @@ export function SchemeBoard({
           background every frame. */}
       <div
         aria-hidden
+        data-scheme-grid
         className="pointer-events-none absolute"
         style={{
           inset: -tile,

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -28,6 +28,7 @@ import { compactPipelineLayoutFlows, compactPipelineOpenTarget, pipelineAnnounce
 import { focusHandoffBus } from "@/components/attention/focusHandoffBus";
 import { INSPECT_ZOOM } from "@/components/attention/navigate";
 import { BulkActionBar } from "./BulkActionBar";
+import { gridTilePx } from "./canvasGrid";
 import { buildFocusFrameIndex, stageAnchorAliases } from "./focusFrames";
 import { EdgeChips } from "./EdgeChips";
 import { nodesInRect, selectionBBox } from "./lasso";
@@ -1117,7 +1118,7 @@ export function SchemeBoard({
     setDormant((prev) => (prev ? cam.z < DORMANT_EXIT_Z : cam.z < DORMANT_ENTER_Z));
   }, [cam.z]);
 
-  const tile = 24 * cam.z;
+  const tile = gridTilePx(cam.z);
 
   return (
     <>
@@ -1126,8 +1127,9 @@ export function SchemeBoard({
       /* select-none is scoped to a gesture, never to the transcripts: it covers
          the pan and the live marquee, so a rect crossing cards cannot leave
          highlighted text behind, and lifts the moment the drag commits or
-         cancels (issue #771). */
-      className={`relative min-h-0 flex-1 overflow-clip ${
+         cancels (issue #771). bg-board is the scheme canvas — the depth
+         ladder's base (#962), a notch deeper than the app canvas in dark. */
+      className={`relative min-h-0 flex-1 overflow-clip bg-board ${
         panning ? "cursor-grabbing" : taskTool ? "cursor-crosshair" : handLike ? "cursor-grab" : ""
       } ${panning || marquee ? "select-none" : ""} ${handLike ? "touch-none" : ""}`}
       tabIndex={mapMode ? undefined : 0}

--- a/src/components/scheme/canvasGrid.test.ts
+++ b/src/components/scheme/canvasGrid.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+import { GRID_BASE_TILE, GRID_MIN_SCREEN_PX, gridTilePx } from "./canvasGrid";
+
+test("the dot grid stays sparse across the whole zoom range (issue #962)", () => {
+  /* Sweep the camera's practical range (lite-map minimum ~0.12 up to 3×):
+     the on-screen spacing never collapses below the sparse floor. */
+  for (let zoom = 0.05; zoom <= 3; zoom += 0.01) {
+    expect(gridTilePx(zoom)).toBeGreaterThanOrEqual(GRID_MIN_SCREEN_PX);
+  }
+});
+
+test("spacing doubles in power-of-two steps of the world base, so dots thin in place", () => {
+  for (const zoom of [0.12, 0.3, 0.5, 0.75, 1, 1.5, 2]) {
+    const ratio = gridTilePx(zoom) / (GRID_BASE_TILE * zoom);
+    expect(Math.log2(ratio) % 1).toBeCloseTo(0, 9);
+  }
+});
+
+test("at zoom 1 and above the native spacing is already sparse and unchanged", () => {
+  expect(gridTilePx(1)).toBe(GRID_BASE_TILE);
+  expect(gridTilePx(2)).toBe(GRID_BASE_TILE * 2);
+});
+
+test("a degenerate zoom falls back to the base tile instead of looping", () => {
+  expect(gridTilePx(0)).toBe(GRID_BASE_TILE);
+  expect(gridTilePx(-1)).toBe(GRID_BASE_TILE);
+  expect(gridTilePx(Number.NaN)).toBe(GRID_BASE_TILE);
+});

--- a/src/components/scheme/canvasGrid.ts
+++ b/src/components/scheme/canvasGrid.ts
@@ -1,0 +1,24 @@
+/**
+ * The scheme canvas dot grid (issue #962): one world-space lattice that stays
+ * visually SPARSE at every zoom. A fixed world spacing turns into noise when
+ * the camera zooms out (24px of world reads as 3px on screen), so the spacing
+ * doubles in power-of-two steps until the on-screen tile clears a floor —
+ * every second dot survives a step, so the lattice thins in place instead of
+ * re-randomizing while the operator zooms.
+ */
+
+/** World-space spacing between dots at zoom 1. */
+export const GRID_BASE_TILE = 24;
+
+/** Minimum on-screen spacing; below it the grid reads as texture, not anchors. */
+export const GRID_MIN_SCREEN_PX = 18;
+
+/** On-screen dot spacing for a zoom level: base × zoom, doubled until sparse.
+    Screen-space result always lands in [GRID_MIN_SCREEN_PX, 2·GRID_MIN_SCREEN_PX)
+    for zooms below 1; above 1 the native spacing simply grows. */
+export function gridTilePx(zoom: number): number {
+  if (!Number.isFinite(zoom) || zoom <= 0) return GRID_BASE_TILE;
+  let tile = GRID_BASE_TILE * zoom;
+  while (tile < GRID_MIN_SCREEN_PX) tile *= 2;
+  return tile;
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -458,14 +458,25 @@ export const GroupsLayer = memo(function GroupsLayer({
             className="pointer-events-none absolute"
             style={{ left: group.x, top: group.y, width: group.w, height: group.h, transition: GROUP_MOVE_TRANSITION }}
           >
+            {/* Depth ladder (issue #962): a settled container is a faint FILLED
+                well — hue-washed fill over the well surface, hairline border —
+                so grouping reads by depth. Dashed stays reserved for drafts
+                (and drop targets elsewhere), which keep the warning halo. */}
             <div
               aria-hidden
-              className="absolute inset-0 rounded-[20px] border-2 border-dashed"
-              style={{
-                borderColor: color,
-                backgroundColor: soft,
-                ...(draft ? { backgroundImage: "repeating-linear-gradient(135deg, transparent 0 12px, color-mix(in srgb, var(--color-warning) 7%, transparent) 12px 14px)" } : {}),
-              }}
+              className={`absolute inset-0 rounded-[20px] ${draft ? "border-2 border-dashed" : "border"}`}
+              style={
+                draft
+                  ? {
+                      borderColor: color,
+                      backgroundColor: soft,
+                      backgroundImage: "repeating-linear-gradient(135deg, transparent 0 12px, color-mix(in srgb, var(--color-warning) 7%, transparent) 12px 14px)",
+                    }
+                  : {
+                      borderColor: `color-mix(in srgb, ${color} 32%, var(--border-default))`,
+                      backgroundColor: `color-mix(in srgb, ${color} 6%, var(--surface-well))`,
+                    }
+              }
             />
             {/* One compact header attached to the halo (#353): title, progress,
                 lifecycle, and the disclosure control — no second stage graph and

--- a/src/styles/tokens.contrast.test.ts
+++ b/src/styles/tokens.contrast.test.ts
@@ -36,6 +36,12 @@ test("state text roles clear the small-text contrast floor on every surface they
   const canvas = values("surface-canvas");
   const card = values("surface-card");
   const sunken = values("surface-sunken");
+  /* The #962 depth ladder: board canvas, container well, quiet card. State
+     text renders over all three (far labels, well-docked chips, quiet-card
+     meta rows), so they carry the same floor. */
+  const board = values("surface-board");
+  const well = values("surface-well");
+  const quiet = values("surface-quiet");
   const muted = values("color-muted");
   const success = values("color-success");
   const successSoft = values("color-success-soft");
@@ -43,8 +49,8 @@ test("state text roles clear the small-text contrast floor on every surface they
   const warningSoft = values("color-warning-soft");
 
   for (const scheme of [0, 1]) {
-    const surfaces = [canvas[scheme], card[scheme], sunken[scheme]].filter(Boolean);
-    expect(surfaces.length).toBe(3);
+    const surfaces = [canvas[scheme], card[scheme], sunken[scheme], board[scheme], well[scheme], quiet[scheme]].filter(Boolean);
+    expect(surfaces.length).toBe(6);
     for (const surface of surfaces) {
       expect(contrast(muted[scheme], surface)).toBeGreaterThanOrEqual(AA_SMALL_TEXT);
       expect(contrast(success[scheme], surface)).toBeGreaterThanOrEqual(AA_SMALL_TEXT);
@@ -53,6 +59,33 @@ test("state text roles clear the small-text contrast floor on every surface they
     /* Both roles are also used as text on their own -soft fill (chips, cards). */
     expect(contrast(success[scheme], successSoft[scheme])).toBeGreaterThanOrEqual(AA_SMALL_TEXT);
     expect(contrast(warning[scheme], warningSoft[scheme])).toBeGreaterThanOrEqual(AA_SMALL_TEXT);
+  }
+});
+
+/* The depth ladder only works while its three levels stay ordered: a palette
+   tweak that lands the well on the card (or the board on the well) silently
+   flattens every container back into an outline-only group. */
+test("the #962 depth ladder keeps board, well, and card strictly ordered in both schemes", () => {
+  const board = values("surface-board");
+  const well = values("surface-well");
+  const quiet = values("surface-quiet");
+  const card = values("surface-card");
+
+  /* Light: card floats brightest; quiet recedes toward the well; the well sits
+     below the board so a container reads as a recess in the canvas. */
+  expect(relativeLuminance(card[0])).toBeGreaterThan(relativeLuminance(quiet[0]));
+  expect(relativeLuminance(quiet[0])).toBeGreaterThan(relativeLuminance(well[0]));
+  expect(relativeLuminance(board[0])).toBeGreaterThan(relativeLuminance(well[0]));
+
+  /* Dark: the board dips deepest; well and quiet climb toward the card. */
+  expect(relativeLuminance(board[1])).toBeLessThan(relativeLuminance(well[1]));
+  expect(relativeLuminance(well[1])).toBeLessThan(relativeLuminance(card[1]));
+  expect(relativeLuminance(quiet[1])).toBeLessThan(relativeLuminance(card[1]));
+
+  /* Both dark override blocks (media query + data-theme) stay in sync. */
+  for (const token of [board, well, quiet]) {
+    expect(token.length).toBe(3);
+    expect(token[1]).toBe(token[2]);
   }
 });
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -48,10 +48,23 @@
   --surface-sunken: #f7f7fa; /* code blocks, collapsed strips, canvas bands     */
   --surface-raised: #ffffff; /* menus, popovers, sheets, toasts                 */
 
+  /* ── Depth ladder (issue #962): scheme canvas → container well → card ──────
+     Three fixed levels so a dense board reads by depth, not by outline. The
+     board surface matches the canvas in light mode and dips slightly deeper in
+     dark; a well is the faint filled interior of a pipeline/branch container;
+     quiet is the receded surface of an inactive card. Each value clears the
+     4.5:1 small-text floor for muted/success/warning (tokens.contrast.test). */
+  --surface-board: #f3f3f6; /* scheme canvas behind the dot grid              */
+  --surface-well: #f0f0f4; /*  container-well fill under grouped cards        */
+  --surface-quiet: #fafafb; /* inactive card, no attention: recedes off white */
+
   --color-canvas: var(--surface-canvas);
   --color-card: var(--surface-card);
   --color-sunken: var(--surface-sunken);
   --color-raised: var(--surface-raised);
+  --color-board: var(--surface-board);
+  --color-well: var(--surface-well);
+  --color-quiet: var(--surface-quiet);
 
   --shadow-1: 0 1px 2px rgb(20 20 30 / 0.05); /* card  */
   --shadow-2: 0 8px 32px rgb(20 20 30 / 0.16), 0 1px 2px rgb(20 20 30 / 0.06); /* raised */
@@ -142,6 +155,12 @@
     --surface-sunken: #121216;
     --surface-raised: #1d1d24;
 
+    /* Dark depth ladder: the board dips below the canvas so cards and wells
+       climb from it — board < well < card. */
+    --surface-board: #0d0d11;
+    --surface-well: #131318;
+    --surface-quiet: #141419;
+
     --shadow-1: 0 1px 2px rgb(0 0 0 / 0.4);
     --shadow-2: 0 8px 32px rgb(0 0 0 / 0.55), 0 1px 2px rgb(0 0 0 / 0.4);
 
@@ -190,6 +209,12 @@
   --surface-card: #17171c;
   --surface-sunken: #121216;
   --surface-raised: #1d1d24;
+
+  /* Dark depth ladder: the board dips below the canvas so cards and wells
+     climb from it — board < well < card. */
+  --surface-board: #0d0d11;
+  --surface-well: #131318;
+  --surface-quiet: #141419;
 
   --shadow-1: 0 1px 2px rgb(0 0 0 / 0.4);
   --shadow-2: 0 8px 32px rgb(0 0 0 / 0.55), 0 1px 2px rgb(0 0 0 / 0.4);


### PR DESCRIPTION
Closes #962.

## What this ships

The nodeterm-inspired depth ladder, independently reimagined for LLV (no code, CSS values, icons, sprites, or assets taken from nodeterm — BUSL-1.1):

1. **scheme canvas** — new `--surface-board` token on the board viewport; light stays at the app canvas value, dark dips a notch deeper (`#0d0d11` under the `#101014` app canvas) so wells and cards climb from it. The dot grid now keeps a sparse on-screen spacing at every zoom: the world tile doubles in power-of-two steps whenever the screen tile would fall under 18px (`canvasGrid.ts`), so zooming out thins the lattice in place instead of collapsing it into noise.
2. **container well** — settled pipeline and branch (flow) group halos switch from a 2px dashed outline to a faint FILLED well: hue-washed `--surface-well` fill + a 1px hairline mixed from the group hue and `--border-default`. Dashed stays reserved for affordances: draft pipelines keep their dashed warning halo (hatch included), and the task drop target keeps its dashed frame.
3. **card** — unchanged for every state with something to say. Only an inactive card (`done`: finished, nothing pending, no attention) recedes onto the new `--surface-quiet`; live/waiting/returned/stalled keep the full card surface, so NEEDS YOU, active, selected, focused, rate-limited, and delivery-held treatments are untouched.

Attention semantics are frozen — no new status framework; the quiet tone derives purely from the existing `paneState` lifecycle.

## Tokens

`--surface-board` / `--surface-well` / `--surface-quiet` (+ `--color-*` aliases for Tailwind utilities), documented in design-system §1.4 with a dedicated ladder table. All three carry the same 4.5:1 small-text floor as the existing surfaces, pinned at the token level, plus a new ladder-ordering test so a palette tweak cannot silently flatten the depth (`tokens.contrast.test.ts`).

## Tests (focused, isolated state via bunfig preload; no broad suites)

- `src/styles/tokens.contrast.test.ts` — floors extended to board/well/quiet; ladder ordering pinned in both schemes; both dark blocks kept in sync.
- `src/components/scheme/canvasGrid.test.ts` — sparse floor across the zoom sweep, power-of-two stepping, degenerate zoom fallback.
- `src/components/scheme/GroupsLayer.render.test.tsx` — settled containers are filled hairline wells; drafts keep the dashed halo.
- `src/components/BranchPane.paneTones.test.ts` — quiet surface applies only to `done`.
- Touched-area DOM suites (pipelineRegions, selection, nodes, camera, builderReveal, GroupOverridePanel) all green: 51 pass / 0 fail.

## Rendered evidence (`evidence/issue-962/`)

Production-shaped run at the exact branch head: `next build --webpack` + `next start` over the isolated demo runtime (`fixtures/demo-home` capture home, own `LLV_STATE_DIR`, dev ports — never 8898/8899), synthetic runtime-generated pipeline/board seeds, real headless host Chrome over raw CDP. **13/13 checks PASS** (`depth-ladder.json`, colors and booleans only, scrubbed of absolute paths and id shapes).

Screenshots cover: dense board, pipeline region (filled well), branch/flow group (same well), draft halo (dashed), selected card, NEEDS YOU card, near-empty project (a project with zero visible conversations renders the dashboard's empty state, not a canvas, so the sparsest board the app draws is one card), zoomed-out sparse grid, dark + light, and 390px light + dark.

## Gates

- `tsc --noEmit` clean; scoped eslint clean.
- Production `next build --webpack` clean (the evidence run's build).
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` PASS.

## Scope fences honored

Card-header/status hunks (#961), the attention control (#963), and card anatomy (#964) untouched — the one BranchPane change adds a `surface` field beside the existing tone map and swaps the section's hardcoded `bg-card` for it. #223 structural scope (titles, zones, reviewer tuck-in, hub edges) untouched; its future zones can consume `--surface-well` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
