### PR TITLE
design(board): fixed card anatomy for account switches and mixed operational states (#964)

### DIFF
--- a/evidence/issue-964/card-anatomy.json
+++ b/evidence/issue-964/card-anatomy.json
@@ -1,0 +1,425 @@
+{
+  "buildHead": "075f3f918e5937f72059e7e23c279bb25113cb88",
+  "stack": [
+    {
+      "rows": [
+        "identity",
+        "ops"
+      ],
+      "status": null,
+      "switchChip": "switching",
+      "switchInOps": true
+    },
+    {
+      "rows": [
+        "identity",
+        "ops"
+      ],
+      "status": "queued",
+      "switchChip": null,
+      "switchInOps": null
+    },
+    {
+      "rows": [
+        "identity",
+        "ops"
+      ],
+      "status": null,
+      "switchChip": null,
+      "switchInOps": null
+    }
+  ],
+  "farZoom": [
+    {
+      "card": "10101010.jsonl",
+      "statusAt": -1,
+      "titleAt": 2,
+      "switchAt": -1,
+      "rateAt": -1
+    },
+    {
+      "card": "11111111.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": -1,
+      "rateAt": -1
+    },
+    {
+      "card": "12121212.jsonl",
+      "statusAt": -1,
+      "titleAt": 2,
+      "switchAt": 3,
+      "rateAt": -1
+    },
+    {
+      "card": "13131313.jsonl",
+      "statusAt": -1,
+      "titleAt": 2,
+      "switchAt": 3,
+      "rateAt": -1
+    },
+    {
+      "card": "22222222.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": 4,
+      "rateAt": -1
+    },
+    {
+      "card": "33333333.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": -1,
+      "rateAt": -1
+    },
+    {
+      "card": "44444444.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": -1,
+      "rateAt": -1
+    },
+    {
+      "card": "55555555.jsonl",
+      "statusAt": -1,
+      "titleAt": 2,
+      "switchAt": -1,
+      "rateAt": -1
+    },
+    {
+      "card": "99999999.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": -1,
+      "rateAt": 4
+    }
+  ],
+  "switchboard-dark": [
+    {
+      "title": "Gate the release on the review verdict.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "needs-you",
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Compare account quotas.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "needs-you",
+      "switchChip": null,
+      "opsChips": [
+        "rate-limit"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rebuild the board status projection.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "running",
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rebalance the account pool.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "switching",
+        "text": "⇄→ «Account B»"
+      },
+      "opsChips": [
+        "switch:switching"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Move the delivery fence into the registry.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": "held",
+      "switchChip": {
+        "kind": "pending",
+        "text": "⇄«Account B» pending"
+      },
+      "opsChips": [
+        "switch:pending"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Poll the nightly integration run.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": "queued",
+      "switchChip": null,
+      "opsChips": [
+        "wakeup"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rotate the burndown fixtures.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "failed",
+        "text": "⇄switch failed"
+      },
+      "opsChips": [
+        "switch:failed"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Summarize the incident review.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "settled",
+        "text": "@ account-b"
+      },
+      "opsChips": [
+        "switch:settled"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Write the migration retrospective.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Draft the deployment notes.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    }
+  ],
+  "mobile-390-switching-dark": {
+    "ribbon": "Switching to «Account B»",
+    "verified": true
+  },
+  "mobile-390-focus-dark": {
+    "status": "needs-you",
+    "word": "needs you"
+  },
+  "switchboard-light": [
+    {
+      "title": "Gate the release on the review verdict.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "needs-you",
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Compare account quotas.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "needs-you",
+      "switchChip": null,
+      "opsChips": [
+        "rate-limit"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rebuild the board status projection.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "status": "running",
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rebalance the account pool.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "switching",
+        "text": "⇄→ «Account B»"
+      },
+      "opsChips": [
+        "switch:switching"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Move the delivery fence into the registry.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": "held",
+      "switchChip": {
+        "kind": "pending",
+        "text": "⇄«Account B» pending"
+      },
+      "opsChips": [
+        "switch:pending"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Poll the nightly integration run.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": "queued",
+      "switchChip": null,
+      "opsChips": [
+        "wakeup"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Rotate the burndown fixtures.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "failed",
+        "text": "⇄switch failed"
+      },
+      "opsChips": [
+        "switch:failed"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Summarize the incident review.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": {
+        "kind": "settled",
+        "text": "@ account-b"
+      },
+      "opsChips": [
+        "switch:settled"
+      ],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Write the migration retrospective.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    },
+    {
+      "title": "Draft the deployment notes.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "status": null,
+      "switchChip": null,
+      "opsChips": [],
+      "chipsOutsideOps": []
+    }
+  ],
+  "mobile-390-switching-light": {
+    "ribbon": "Switching to «Account B»",
+    "verified": true
+  },
+  "mobile-390-focus-light": {
+    "status": "needs-you",
+    "word": "needs you"
+  }
+}

--- a/evidence/issue-964/card-anatomy.json
+++ b/evidence/issue-964/card-anatomy.json
@@ -1,6 +1,16 @@
 {
-  "buildHead": "075f3f918e5937f72059e7e23c279bb25113cb88",
+  "buildHead": "892eda22decc6eb41f614655737a173e54fc46c4",
+  "evidencePolicy": "captured at buildHead; commits after buildHead may touch only evidence/",
   "stack": [
+    {
+      "rows": [
+        "identity",
+        "ops"
+      ],
+      "status": null,
+      "switchChip": null,
+      "switchInOps": null
+    },
     {
       "rows": [
         "identity",
@@ -59,6 +69,20 @@
       "rateAt": -1
     },
     {
+      "card": "15151515.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": 4,
+      "rateAt": 5
+    },
+    {
+      "card": "16161616.jsonl",
+      "statusAt": 2,
+      "titleAt": 3,
+      "switchAt": 4,
+      "rateAt": -1
+    },
+    {
       "card": "22222222.jsonl",
       "statusAt": 2,
       "titleAt": 3,
@@ -92,6 +116,13 @@
       "titleAt": 3,
       "switchAt": -1,
       "rateAt": 4
+    },
+    {
+      "card": "14141414.jsonl",
+      "statusAt": -1,
+      "titleAt": 2,
+      "switchAt": -1,
+      "rateAt": -1
     }
   ],
   "switchboard-dark": [
@@ -103,10 +134,53 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "needs-you",
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
+    },
+    {
+      "title": "Reconcile the quota ledger.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "width": 300,
+      "status": "needs-you",
+      "switchChip": {
+        "kind": "switching",
+        "text": "⇄→ «Account B»"
+      },
+      "opsChips": [
+        "switch:switching",
+        "rate-limit",
+        "wakeup"
+      ],
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 74.3,
+          "overflowRight": -158.4,
+          "titled": true
+        },
+        {
+          "chip": "data-rate-limited",
+          "width": 95.6,
+          "overflowRight": -56.8,
+          "titled": true
+        },
+        {
+          "chip": "data-wakeup",
+          "width": 50.8,
+          "overflowRight": 0,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Compare account quotas.",
@@ -116,12 +190,21 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "needs-you",
       "switchChip": null,
       "opsChips": [
         "rate-limit"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-rate-limited",
+          "width": 117.4,
+          "overflowRight": -109.3,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Rebuild the board status projection.",
@@ -131,10 +214,12 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "running",
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     },
     {
       "title": "Rebalance the account pool.",
@@ -144,6 +229,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "switching",
@@ -152,7 +238,15 @@
       "opsChips": [
         "switch:switching"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 90.8,
+          "overflowRight": -61.8,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Move the delivery fence into the registry.",
@@ -162,6 +256,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": "held",
       "switchChip": {
         "kind": "pending",
@@ -170,7 +265,15 @@
       "opsChips": [
         "switch:pending"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 115.5,
+          "overflowRight": -37.2,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Poll the nightly integration run.",
@@ -180,12 +283,55 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": "queued",
       "switchChip": null,
       "opsChips": [
         "wakeup"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-wakeup",
+          "width": 64.7,
+          "overflowRight": -82,
+          "titled": true
+        }
+      ]
+    },
+    {
+      "title": "Refill the fixture pool.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "width": 220,
+      "status": "queued",
+      "switchChip": {
+        "kind": "pending",
+        "text": "⇄«Account B» pending"
+      },
+      "opsChips": [
+        "switch:pending",
+        "wakeup"
+      ],
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 91.4,
+          "overflowRight": -55.3,
+          "titled": true
+        },
+        {
+          "chip": "data-wakeup",
+          "width": 49.3,
+          "overflowRight": 0,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Rotate the burndown fixtures.",
@@ -195,6 +341,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "failed",
@@ -203,7 +350,15 @@
       "opsChips": [
         "switch:failed"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 80,
+          "overflowRight": -66.7,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Summarize the incident review.",
@@ -213,6 +368,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "settled",
@@ -221,7 +377,15 @@
       "opsChips": [
         "switch:settled"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 78.1,
+          "overflowRight": -77.9,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Write the migration retrospective.",
@@ -231,10 +395,12 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     },
     {
       "title": "Draft the deployment notes.",
@@ -244,19 +410,58 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     }
   ],
-  "mobile-390-switching-dark": {
-    "ribbon": "Switching to «Account B»",
-    "verified": true
+  "mobile-390-needs-you-dark": {
+    "verify": "status:needs-you",
+    "detail": "needs-you",
+    "titleShown": true
   },
-  "mobile-390-focus-dark": {
-    "status": "needs-you",
-    "word": "needs you"
+  "mobile-390-held-dark": {
+    "verify": "status:held",
+    "detail": "held",
+    "titleShown": true
+  },
+  "mobile-390-running-dark": {
+    "verify": "status:running",
+    "detail": "running",
+    "titleShown": true
+  },
+  "mobile-390-queued-dark": {
+    "verify": "wakeup",
+    "detail": "sleeping until 14:12 — poll the nightly integration run",
+    "titleShown": true
+  },
+  "mobile-390-quiet-dark": {
+    "verify": "quiet",
+    "detail": null,
+    "titleShown": true
+  },
+  "mobile-390-rate-limited-dark": {
+    "verify": "rate-limit",
+    "detail": "rate-limited until 15:30",
+    "titleShown": true
+  },
+  "mobile-390-switching-dark": {
+    "verify": "text:Switching to «Account B»",
+    "detail": "Switching to «Account B»",
+    "titleShown": true
+  },
+  "mobile-390-switch-failed-dark": {
+    "verify": "text:Account switch failed",
+    "detail": "Account switch failed",
+    "titleShown": true
+  },
+  "mobile-390-settled-account-dark": {
+    "verify": "account:account-b",
+    "detail": "Open accounts for account-b a",
+    "titleShown": true
   },
   "switchboard-light": [
     {
@@ -267,10 +472,53 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "needs-you",
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
+    },
+    {
+      "title": "Reconcile the quota ledger.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 150,
+      "width": 300,
+      "status": "needs-you",
+      "switchChip": {
+        "kind": "switching",
+        "text": "⇄→ «Account B»"
+      },
+      "opsChips": [
+        "switch:switching",
+        "rate-limit",
+        "wakeup"
+      ],
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 74.3,
+          "overflowRight": -158.4,
+          "titled": true
+        },
+        {
+          "chip": "data-rate-limited",
+          "width": 95.6,
+          "overflowRight": -56.8,
+          "titled": true
+        },
+        {
+          "chip": "data-wakeup",
+          "width": 50.8,
+          "overflowRight": 0,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Compare account quotas.",
@@ -280,12 +528,21 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "needs-you",
       "switchChip": null,
       "opsChips": [
         "rate-limit"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-rate-limited",
+          "width": 117.4,
+          "overflowRight": -109.3,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Rebuild the board status projection.",
@@ -295,10 +552,12 @@
         "ops"
       ],
       "height": 150,
+      "width": 300,
       "status": "running",
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     },
     {
       "title": "Rebalance the account pool.",
@@ -308,6 +567,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "switching",
@@ -316,7 +576,15 @@
       "opsChips": [
         "switch:switching"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 90.8,
+          "overflowRight": -61.8,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Move the delivery fence into the registry.",
@@ -326,6 +594,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": "held",
       "switchChip": {
         "kind": "pending",
@@ -334,7 +603,15 @@
       "opsChips": [
         "switch:pending"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 115.5,
+          "overflowRight": -37.2,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Poll the nightly integration run.",
@@ -344,12 +621,55 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": "queued",
       "switchChip": null,
       "opsChips": [
         "wakeup"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-wakeup",
+          "width": 64.7,
+          "overflowRight": -82,
+          "titled": true
+        }
+      ]
+    },
+    {
+      "title": "Refill the fixture pool.",
+      "rows": [
+        "identity",
+        "content",
+        "ops"
+      ],
+      "height": 128,
+      "width": 220,
+      "status": "queued",
+      "switchChip": {
+        "kind": "pending",
+        "text": "⇄«Account B» pending"
+      },
+      "opsChips": [
+        "switch:pending",
+        "wakeup"
+      ],
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 91.4,
+          "overflowRight": -55.3,
+          "titled": true
+        },
+        {
+          "chip": "data-wakeup",
+          "width": 49.3,
+          "overflowRight": 0,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Rotate the burndown fixtures.",
@@ -359,6 +679,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "failed",
@@ -367,7 +688,15 @@
       "opsChips": [
         "switch:failed"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 80,
+          "overflowRight": -66.7,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Summarize the incident review.",
@@ -377,6 +706,7 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": {
         "kind": "settled",
@@ -385,7 +715,15 @@
       "opsChips": [
         "switch:settled"
       ],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": [
+        {
+          "chip": "data-card-switch",
+          "width": 78.1,
+          "overflowRight": -77.9,
+          "titled": true
+        }
+      ]
     },
     {
       "title": "Write the migration retrospective.",
@@ -395,10 +733,12 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     },
     {
       "title": "Draft the deployment notes.",
@@ -408,18 +748,57 @@
         "ops"
       ],
       "height": 128,
+      "width": 220,
       "status": null,
       "switchChip": null,
       "opsChips": [],
-      "chipsOutsideOps": []
+      "chipsOutsideOps": [],
+      "opsGeometry": []
     }
   ],
-  "mobile-390-switching-light": {
-    "ribbon": "Switching to «Account B»",
-    "verified": true
+  "mobile-390-needs-you-light": {
+    "verify": "status:needs-you",
+    "detail": "needs-you",
+    "titleShown": true
   },
-  "mobile-390-focus-light": {
-    "status": "needs-you",
-    "word": "needs you"
+  "mobile-390-held-light": {
+    "verify": "status:held",
+    "detail": "held",
+    "titleShown": true
+  },
+  "mobile-390-running-light": {
+    "verify": "status:running",
+    "detail": "running",
+    "titleShown": true
+  },
+  "mobile-390-queued-light": {
+    "verify": "wakeup",
+    "detail": "sleeping until 14:12 — poll the nightly integration run",
+    "titleShown": true
+  },
+  "mobile-390-quiet-light": {
+    "verify": "quiet",
+    "detail": null,
+    "titleShown": true
+  },
+  "mobile-390-rate-limited-light": {
+    "verify": "rate-limit",
+    "detail": "rate-limited until 15:30",
+    "titleShown": true
+  },
+  "mobile-390-switching-light": {
+    "verify": "text:Switching to «Account B»",
+    "detail": "Switching to «Account B»",
+    "titleShown": true
+  },
+  "mobile-390-switch-failed-light": {
+    "verify": "text:Account switch failed",
+    "detail": "Account switch failed",
+    "titleShown": true
+  },
+  "mobile-390-settled-account-light": {
+    "verify": "account:account-b",
+    "detail": "Open accounts for account-b a",
+    "titleShown": true
   }
 }

--- a/scripts/capture-issue-964-anatomy.ts
+++ b/scripts/capture-issue-964-anatomy.ts
@@ -23,8 +23,8 @@
  *   <out>/964-board-dense-dark.png       — full board, ops facts on full cards
  *   <out>/964-far-zoom-dark.png          — far labels: status → title → ops chips
  *   <out>/964-stack-collapsed-dark.png   — collapsed rows: status leads, switch on ops line
- *   <out>/964-mobile-390-switch-dark.png — 390 px switch deck, dark
- *   <out>/964-mobile-390-switch-light.png— 390 px switch deck, light
+ *   <out>/964-mobile-390-switching-*.png — 390 px focus view naming the switch
+ *   <out>/964-mobile-390-focus-*.png     — 390 px focus view, needs-you word
  *
  * A DOM summary (row order, chip row membership, per-state switch chips, card
  * heights) is written to evidence/issue-964/card-anatomy.json.
@@ -449,8 +449,7 @@ async function main(): Promise<void> {
       const farFacts = await page.evaluate(() => {
         const labels = Array.from(document.querySelectorAll("[data-scheme-node]"))
           .map((node) => {
-            const status = node.querySelector("[data-card-status]");
-            const label = status?.closest("div[style]");
+            const label = node.querySelector("[data-far-label]");
             if (!label || !(label instanceof HTMLElement)) return null;
             const children = Array.from(label.children);
             const indexOf = (selector: string) => children.findIndex((child) => child.matches(selector) || child.querySelector(selector));
@@ -486,17 +485,42 @@ async function main(): Promise<void> {
       await page.screenshot({ path: path.join(OUT_DIR, `964-switchboard-${scheme}.png`) });
       await page.close();
 
-      /* ── 390 px phone: the same switch deck, one column ───────────────── */
+      /* ── 390 px phone: the switchboard is desktop-only, so the phone's card
+         surface is the focus view — verify the account switch stays explicit
+         and the status word survives, per state. ─────────────────────────── */
       const phone = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 3, hasTouch: true, isMobile: true, colorScheme: scheme });
       await phone.addInitScript(seedInit);
       await routeFiles(phone);
       await phone.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
       await phone.waitForTimeout(2500);
-      await openSwitchboard(phone);
-      const phoneFacts = await switchboardFacts(phone);
-      verifySwitchboard(phoneFacts);
-      summary[`switchboard-390-${scheme}`] = { cards: phoneFacts.length, verified: true };
-      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-switch-${scheme}.png`) });
+      /* The phone lands in a focus view; other conversations sit on the header
+         strip as chips titled by their conversation title. */
+      const switchingTarget = phone.locator('button[title^="Rebalance the account pool"]').first();
+      if ((await switchingTarget.count()) === 0) {
+        const visible = await phone.evaluate(() => (document.body.textContent ?? "").replace(/\s+/g, " ").slice(0, 600));
+        throw new Error(`the switching conversation is missing from the 390px strip; visible: ${visible}`);
+      }
+      await switchingTarget.click({ force: true });
+      await phone.waitForTimeout(1500);
+      const phoneRibbon = await phone.evaluate(() => document.body.textContent?.includes("Switching to «Account B»") ?? false);
+      must(phoneRibbon, "the 390px focus view does not name the account switch");
+      summary[`mobile-390-switching-${scheme}`] = { ribbon: "Switching to «Account B»", verified: true };
+      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-switching-${scheme}.png`) });
+
+      await phone.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+      await phone.waitForTimeout(2500);
+      const blockedTarget = phone.locator("text=Gate the release on the review verdict").first();
+      if (await blockedTarget.count()) {
+        await blockedTarget.click({ force: true });
+        await phone.waitForTimeout(1500);
+      }
+      const phoneHeader = await phone.evaluate(() => {
+        const badge = document.querySelector("header [data-card-status], [data-card-status]");
+        return badge ? { status: badge.getAttribute("data-card-status"), word: badge.textContent?.trim() } : null;
+      });
+      must(phoneHeader?.status === "needs-you", "the 390px conversation header does not carry the word");
+      summary[`mobile-390-focus-${scheme}`] = phoneHeader;
+      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-focus-${scheme}.png`) });
       await phone.close();
     }
 

--- a/scripts/capture-issue-964-anatomy.ts
+++ b/scripts/capture-issue-964-anatomy.ts
@@ -1,0 +1,520 @@
+/**
+ * Rendered verification of the #964 fixed card anatomy, in a real browser:
+ *
+ *   bun scripts/capture-issue-964-anatomy.ts
+ *
+ * Serves the production build against a purpose-built synthetic home under
+ * /tmp (never the operator's live state, and no real home path anywhere in
+ * the frames), then drives the real switchboard, far-zoom labels, and
+ * collapsed stacks with a locally available Chromium — in dark AND light.
+ *
+ * The scanner reads real seeded transcripts; the browser patches the
+ * `/api/files` payload in flight to place each card into one operational
+ * state — quiet, running, NEEDS YOU, held-delivery, rate-limited,
+ * wakeup-queued, an account switch in each phase (preflight, switching,
+ * failed), and a settled managed account. Everything the frames show — row
+ * structure, chip placement, tones, translations — is the production render
+ * path; only the authority facts are seeded.
+ *
+ * Shots land outside the repository for direct inspection:
+ *
+ *   <out>/964-switchboard-dark.png       — the 9-state switch-card matrix, dark
+ *   <out>/964-switchboard-light.png      — the same matrix, light
+ *   <out>/964-board-dense-dark.png       — full board, ops facts on full cards
+ *   <out>/964-far-zoom-dark.png          — far labels: status → title → ops chips
+ *   <out>/964-stack-collapsed-dark.png   — collapsed rows: status leads, switch on ops line
+ *   <out>/964-mobile-390-switch-dark.png — 390 px switch deck, dark
+ *   <out>/964-mobile-390-switch-light.png— 390 px switch deck, light
+ *
+ * A DOM summary (row order, chip row membership, per-state switch chips, card
+ * heights) is written to evidence/issue-964/card-anatomy.json.
+ */
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { chromium, type Page, type Route } from "playwright-core";
+
+import { demoPort } from "./demo-capture";
+
+const BASE = process.env.ANATOMY_CAPTURE_DIR ?? "/tmp/llv-issue-964";
+const HOME = path.join(BASE, "home");
+const OUT_DIR = path.join(BASE, "out");
+const REPO_DIR = path.join(HOME, "Projects", "atlas");
+
+/** Frozen browser clock, so every elapsed/countdown in the frames is stable. */
+const CAPTURE_MS = Date.parse("2100-01-02T12:00:00.000Z");
+
+type SeededSession = {
+  id: string;
+  title: string;
+  /** Minutes before the capture moment the transcript last grew. */
+  agoMinutes: number;
+  status:
+    | "needs-you"
+    | "held"
+    | "running"
+    | "queued"
+    | "rate-limited"
+    | "switching"
+    | "switch-failed"
+    | "settled-account"
+    | "quiet";
+  /** Child of this session id — becomes a quiet subagent branch in a stack. */
+  childOf?: string;
+};
+
+const SESSIONS: SeededSession[] = [
+  { id: "11111111", title: "Gate the release on the review verdict", agoMinutes: 6, status: "needs-you" },
+  { id: "22222222", title: "Move the delivery fence into the registry", agoMinutes: 9, status: "held" },
+  { id: "33333333", title: "Rebuild the board status projection", agoMinutes: 1, status: "running" },
+  { id: "44444444", title: "Poll the nightly integration run", agoMinutes: 25, status: "queued" },
+  { id: "55555555", title: "Write the migration retrospective", agoMinutes: 200, status: "quiet" },
+  { id: "66666666", title: "Audit the tone tokens", agoMinutes: 300, status: "switching", childOf: "10101010" },
+  { id: "77777777", title: "Sweep the caption floor", agoMinutes: 320, status: "queued", childOf: "10101010" },
+  { id: "88888888", title: "Collect switch-card fixtures", agoMinutes: 340, status: "quiet", childOf: "10101010" },
+  { id: "99999999", title: "Compare account quotas", agoMinutes: 12, status: "rate-limited" },
+  { id: "10101010", title: "Draft the deployment notes", agoMinutes: 500, status: "quiet" },
+  { id: "12121212", title: "Rebalance the account pool", agoMinutes: 4, status: "switching" },
+  { id: "13131313", title: "Rotate the burndown fixtures", agoMinutes: 40, status: "switch-failed" },
+  { id: "14141414", title: "Summarize the incident review", agoMinutes: 90, status: "settled-account" },
+];
+
+function must(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+const sessionUuid = (id: string) => `${id}-1111-4111-8111-111111111111`;
+const sessionPathSuffix = (id: string) => `${sessionUuid(id)}.jsonl`;
+
+function seedHome(): void {
+  fs.rmSync(BASE, { recursive: true, force: true });
+  fs.mkdirSync(REPO_DIR, { recursive: true });
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(path.join(BASE, "tmp", `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".config/agent-log-viewer/state"), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".codex/sessions"), { recursive: true });
+  const folder = path.join(HOME, ".claude/projects", projectSlug(REPO_DIR));
+  fs.mkdirSync(folder, { recursive: true });
+  SESSIONS.forEach((session) => {
+    const uuid = sessionUuid(session.id);
+    const at = new Date(CAPTURE_MS - session.agoMinutes * 60_000);
+    const stamp = at.toISOString();
+    const lines = [
+      { type: "user", uuid: `${uuid}-u`, timestamp: stamp, cwd: REPO_DIR, message: { role: "user", content: `${session.title}.` } },
+      { type: "assistant", uuid: `${uuid}-a`, timestamp: stamp, cwd: REPO_DIR, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: `${session.title} — on it.` }] } },
+    ];
+    const file = path.join(folder, `${uuid}.jsonl`);
+    fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
+    fs.utimesSync(file, at, at);
+  });
+}
+
+function buildEnvironment(port: number): NodeJS.ProcessEnv {
+  const config = path.join(HOME, ".config");
+  return {
+    NODE_ENV: "production",
+    PATH: process.env.PATH,
+    HOME,
+    TMPDIR: path.join(BASE, "tmp"),
+    TMUX_TMPDIR: path.join(BASE, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(BASE, "cache"),
+    XDG_RUNTIME_DIR: path.join(BASE, "runtime"),
+    LLV_STATE_DIR: path.join(config, "agent-log-viewer", "state"),
+    LLV_CLAUDE_HOME: path.join(HOME, ".claude"),
+    LLV_CODEX_HOME: path.join(HOME, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    PORT: String(port),
+    TZ: "UTC", LANG: "C.UTF-8", LC_ALL: "C.UTF-8", USER: "demo", LOGNAME: "demo", SHELL: "/bin/sh",
+  };
+}
+
+const seedInit = () => {
+  const captureTime = Date.parse("2100-01-02T12:00:00.000Z");
+  const NativeDate = Date;
+  class CaptureDate extends NativeDate {
+    constructor(...args: unknown[]) {
+      super(...((args.length ? args : [captureTime]) as []));
+    }
+    static now() { return captureTime; }
+  }
+  Object.defineProperty(globalThis, "Date", { configurable: true, value: CaptureDate });
+  Object.defineProperty(globalThis, "EventSource", { configurable: true, value: undefined });
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("llv_lang", "en");
+  localStorage.setItem("llvSound", "0");
+};
+
+/** When set, the payload narrows to these session ids for framed close-ups. */
+let onlyIds: string[] | null = null;
+
+/** Place each scanned card into exactly one operational state, in flight. */
+function patchFilesPayload(payload: { files?: Array<Record<string, unknown>> }): typeof payload {
+  if (onlyIds) {
+    const keep = new Set(onlyIds.map(sessionPathSuffix));
+    payload.files = (payload.files ?? []).filter((file) => keep.has(String(file.path).split("/").at(-1) ?? ""));
+  }
+  const bySuffix = new Map(SESSIONS.map((session) => [sessionPathSuffix(session.id), session]));
+  const pathOf = (id: string) =>
+    (payload.files ?? []).find((file) => String(file.path).endsWith(sessionPathSuffix(id)))?.path as string | undefined;
+  const stackRoot = pathOf("10101010");
+  for (const file of payload.files ?? []) {
+    const seed = bySuffix.get(String(file.path).split("/").at(-1) ?? "");
+    if (!seed) continue;
+    /* The fixture clock is pinned to 2100 in the browser while the server
+       scans with the real clock; normalize every card to a settled baseline,
+       then apply the ONE state this card demonstrates. */
+    file.activity = "idle";
+    file.lastTurn = null;
+    file.pendingWakeup = null;
+    file.proc = null;
+    file.pid = null;
+    file.model = "sonnet-4-5";
+    file.mtime = (CAPTURE_MS - seed.agoMinutes * 60_000) / 1000;
+    if (seed.childOf && stackRoot) {
+      file.parent = stackRoot;
+      file.kind = "subagent";
+    }
+    if (seed.status === "needs-you") {
+      file.activity = "recent";
+      file.pendingQuestion = {
+        kind: "question",
+        toolUseId: `toolu_${seed.id}`,
+        transcriptPath: file.path,
+        pid: 4242,
+        paneTarget: null,
+        askedAt: new Date(CAPTURE_MS - 4 * 60_000).toISOString(),
+        questions: [{ question: "Ship behind the flag or wait for the verdict?", options: [] }],
+      };
+    }
+    if (seed.status === "rate-limited") {
+      file.activity = "recent";
+      file.rateLimit = { source: "account", accountId: "default", window: "session", resetAt: (CAPTURE_MS + 90 * 60_000) / 1000 };
+    }
+    if (seed.status === "held") {
+      file.migration = {
+        intentId: "intent-964",
+        trigger: "quota",
+        phase: "waiting-turn",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        sourceLabel: "Account A",
+        heldDeliveries: 3,
+        failure: null,
+      };
+    }
+    if (seed.status === "switching") {
+      file.migration = {
+        intentId: "intent-964",
+        trigger: "manual",
+        phase: "preparing",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        sourceLabel: "Account A",
+        failure: null,
+      };
+    }
+    if (seed.status === "switch-failed") {
+      file.migration = {
+        intentId: "intent-964",
+        trigger: "manual",
+        phase: "failed-recoverable",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        sourceLabel: "Account A",
+        failure: "successor never came up",
+      };
+    }
+    if (seed.status === "settled-account") {
+      /* A managed-account transcript path: the settled ops row names the
+         account the conversation runs under. Display-only rewrite. */
+      file.path = String(file.path).replace("/.claude/projects/", "/accounts/claude/account-b/.claude/projects/");
+    }
+    if (seed.status === "running") {
+      file.activity = "live";
+      file.lastTurn = { startedAt: CAPTURE_MS - (12 * 60 + 34) * 1000, endedAt: null };
+    }
+    if (seed.status === "queued") {
+      file.pendingWakeup = { fireAt: CAPTURE_MS + 12 * 60_000, reason: "poll the nightly integration run" };
+    }
+  }
+  return payload;
+}
+
+async function routeFiles(page: Page): Promise<void> {
+  await page.route("**/api/files*", async (route: Route) => {
+    try {
+      const response = await route.fetch();
+      const payload = patchFilesPayload(await response.json());
+      await route.fulfill({ response, contentType: "application/json", body: JSON.stringify(payload) });
+    } catch {
+      await route.abort().catch(() => undefined);
+    }
+  });
+}
+
+async function waitForServer(url: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}`);
+    try {
+      const response = await fetch(`${url}/api/files`);
+      if (response.ok) return;
+    } catch {
+      // still booting
+    }
+    await Bun.sleep(300);
+  }
+  throw new Error("production server did not become ready");
+}
+
+/** A card's on-screen rect, padded, for a framed close-up. */
+async function nodeClip(page: Page, suffix: string, pad = 28) {
+  const box = await page.evaluate(({ suffix: tail, pad: margin }) => {
+    const node = Array.from(document.querySelectorAll("[data-scheme-node]"))
+      .find((el) => el.getAttribute("data-scheme-node")?.endsWith(tail));
+    if (!node) return null;
+    const rect = node.getBoundingClientRect();
+    return { x: Math.max(rect.x - margin, 0), y: Math.max(rect.y - margin - 40, 0), width: rect.width + margin * 2, height: rect.height + margin * 2 + 40 };
+  }, { suffix, pad });
+  if (!box) return undefined;
+  const viewport = page.viewportSize()!;
+  const x = Math.max(0, Math.min(box.x, viewport.width - 1));
+  const y = Math.max(0, Math.min(box.y, viewport.height - 1));
+  const width = Math.min(box.width, viewport.width - x);
+  const height = Math.min(box.height, viewport.height - y);
+  if (width < 40 || height < 40) return undefined;
+  return { x, y, width, height };
+}
+
+type SwitchCardFact = {
+  title: string;
+  rows: string[];
+  height: number;
+  status: string | null;
+  switchChip: { kind: string; text: string } | null;
+  opsChips: string[];
+  chipsOutsideOps: string[];
+};
+
+/** Every switchboard card's anatomy, read from the live DOM. */
+async function switchboardFacts(page: Page): Promise<SwitchCardFact[]> {
+  return page.evaluate(() => {
+    const facts: SwitchCardFact[] = [];
+    type SwitchCardFact = {
+      title: string;
+      rows: string[];
+      height: number;
+      status: string | null;
+      switchChip: { kind: string; text: string } | null;
+      opsChips: string[];
+      chipsOutsideOps: string[];
+    };
+    for (const card of Array.from(document.querySelectorAll("article[role=button]"))) {
+      const rows = Array.from(card.querySelectorAll("[data-card-row]")).map((row) => row.getAttribute("data-card-row") ?? "");
+      const ops = card.querySelector('[data-card-row="ops"]');
+      const chipIn = (selector: string) => (ops?.querySelector(selector) ? true : false);
+      const opsChips: string[] = [];
+      if (chipIn("[data-card-switch]")) opsChips.push(`switch:${ops!.querySelector("[data-card-switch]")!.getAttribute("data-card-switch")}`);
+      if (chipIn("[data-rate-limited]")) opsChips.push("rate-limit");
+      if (chipIn("[data-wakeup]")) opsChips.push("wakeup");
+      const outside: string[] = [];
+      for (const marker of ["[data-card-switch]", "[data-rate-limited]", "[data-wakeup]"]) {
+        for (const chip of Array.from(card.querySelectorAll(marker))) {
+          if (!ops?.contains(chip)) outside.push(marker);
+        }
+      }
+      const switchChip = card.querySelector("[data-card-switch]");
+      facts.push({
+        title: (card.querySelector('[data-card-row="content"]')?.textContent ?? "").trim().slice(0, 48),
+        rows,
+        height: Math.round(card.getBoundingClientRect().height),
+        status: card.querySelector("[data-card-status]")?.getAttribute("data-card-status") ?? null,
+        switchChip: switchChip
+          ? { kind: switchChip.getAttribute("data-card-switch") ?? "", text: (switchChip.textContent ?? "").trim() }
+          : null,
+        opsChips,
+        chipsOutsideOps: outside,
+      });
+    }
+    return facts;
+  });
+}
+
+function verifySwitchboard(facts: SwitchCardFact[]): void {
+  must(facts.length >= 9, `expected the full card matrix on the switchboard, saw ${facts.length}`);
+  const by = (title: string) => facts.find((fact) => fact.title.startsWith(title));
+  for (const fact of facts) {
+    must(fact.rows.join(",") === "identity,content,ops", `rows out of order on «${fact.title}»: ${fact.rows.join(",")}`);
+    must(fact.chipsOutsideOps.length === 0, `operational chips outside the ops row on «${fact.title}»`);
+  }
+  const heights = new Set(facts.map((fact) => fact.height));
+  must(heights.size <= 2, `card heights vary beyond the two fixed sizes: ${[...heights].join(", ")}`);
+  must(by("Rebalance")?.switchChip?.kind === "switching", "the switching card lost its switch chip");
+  must((by("Rebalance")?.switchChip?.text ?? "").includes("Account B"), "the switching chip does not name account B");
+  must(by("Rotate")?.switchChip?.kind === "failed", "the failed switch is not explicit");
+  must(by("Move")?.status === "held", "the held card lost the HELD status word");
+  must(by("Move")?.switchChip?.kind === "pending", "the preflight (held) card does not show the pending switch");
+  must(by("Summarize")?.switchChip?.kind === "settled", "the settled card does not name its account");
+  must((by("Summarize")?.switchChip?.text ?? "").includes("account-b"), "the settled chip does not carry the account id");
+  must(by("Gate")?.status === "needs-you", "the question card lost NEEDS YOU");
+  must(by("Compare")?.opsChips.includes("rate-limit") === true, "the rate limit left the ops row");
+  must(by("Poll")?.opsChips.includes("wakeup") === true, "the wakeup left the ops row");
+  const quiet = by("Write");
+  must(quiet !== undefined && quiet.status === null && quiet.opsChips.length === 0, "the quiet card grew chips");
+}
+
+async function openSwitchboard(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (document.querySelector('[aria-label="Open the agent switchboard"]') as HTMLButtonElement | null)?.click();
+  });
+  await page.waitForSelector("article[role=button]", { timeout: 30_000 });
+  await page.waitForTimeout(600);
+}
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(import.meta.dir, "..");
+  const port = demoPort(process.env.ANATOMY_CAPTURE_PORT, 3064, "ANATOMY_CAPTURE_PORT");
+  const baseUrl = `http://127.0.0.1:${port}`;
+  seedHome();
+
+  const server = spawn("bunx", ["next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: repoRoot,
+    env: buildEnvironment(port),
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  const executablePath = process.env.CHROME_BIN
+    ?? ["/usr/bin/chromium", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find((candidate) => fs.existsSync(candidate));
+  const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+  const summary: Record<string, unknown> = {
+    buildHead: execSync("git rev-parse HEAD", { cwd: repoRoot }).toString().trim(),
+  };
+  try {
+    await waitForServer(baseUrl, server);
+    const scanned = await (await fetch(`${baseUrl}/api/files`)).json() as { files?: Array<{ project?: string; cwd?: string }> };
+    const projectId = scanned.files?.find((file) => file.cwd === REPO_DIR)?.project ?? "";
+    must(Boolean(projectId), `no scanned project owns the seeded repository`);
+
+    for (const scheme of ["dark", "light"] as const) {
+      /* ── Desktop ──────────────────────────────────────────────────────── */
+      const page = await browser.newPage({ viewport: { width: 1600, height: 1000 }, deviceScaleFactor: 2, colorScheme: scheme });
+      await page.addInitScript(seedInit);
+      await routeFiles(page);
+      /* Dense board first (the settled card's rewritten path cannot feed a
+         full pane, so it stays out of the board frame). */
+      onlyIds = SESSIONS.filter((session) => session.status !== "settled-account").map((session) => session.id);
+      await page.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "networkidle", timeout: 90_000 });
+      await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+      await page.waitForTimeout(1200);
+      await page.locator('button[title^="Fit all content"]').first().click();
+      await page.waitForTimeout(900);
+      if (scheme === "dark") await page.screenshot({ path: path.join(OUT_DIR, "964-board-dense-dark.png") });
+
+      /* Collapsed stack: the switching branch shows its switch on the ops line. */
+      const stackFacts = await page.evaluate(() => {
+        const stack = Array.from(document.querySelectorAll("[data-scheme-node]"))
+          .find((el) => (el.getAttribute("data-scheme-node") ?? "").endsWith("::stack"));
+        if (!stack) return null;
+        return Array.from(stack.querySelectorAll("button")).map((row) => {
+          const rows = Array.from(row.querySelectorAll("[data-card-row]")).map((el) => el.getAttribute("data-card-row"));
+          const ops = row.querySelector('[data-card-row="ops"]');
+          const switchChip = row.querySelector("[data-card-switch]");
+          return {
+            rows,
+            status: row.querySelector("[data-card-status]")?.getAttribute("data-card-status") ?? null,
+            switchChip: switchChip ? switchChip.getAttribute("data-card-switch") : null,
+            switchInOps: switchChip ? Boolean(ops?.contains(switchChip)) : null,
+          };
+        });
+      });
+      must(Boolean(stackFacts?.length), "no collapsed branch stack rendered");
+      must(
+        stackFacts!.some((row) => row.switchChip === "switching" && row.switchInOps === true),
+        "the switching branch does not show its switch on the stack row's ops line",
+      );
+      must(stackFacts!.every((row) => row.rows.join(",") === "identity,ops"), "stack rows lost the identity→ops order");
+      if (scheme === "dark") {
+        summary.stack = stackFacts;
+        await page.screenshot({ path: path.join(OUT_DIR, "964-stack-collapsed-dark.png"), clip: await nodeClip(page, "::stack") });
+      }
+
+      /* Far zoom: labels keep identity → status → title → trailing ops chips. */
+      for (let step = 0; step < 10; step += 1) await page.locator('button[title^="Zoom out"]').first().click();
+      await page.waitForTimeout(600);
+      const farFacts = await page.evaluate(() => {
+        const labels = Array.from(document.querySelectorAll("[data-scheme-node]"))
+          .map((node) => {
+            const status = node.querySelector("[data-card-status]");
+            const label = status?.closest("div[style]");
+            if (!label || !(label instanceof HTMLElement)) return null;
+            const children = Array.from(label.children);
+            const indexOf = (selector: string) => children.findIndex((child) => child.matches(selector) || child.querySelector(selector));
+            return {
+              card: (node.getAttribute("data-scheme-node") ?? "").split("/").at(-1) ?? "",
+              statusAt: indexOf("[data-card-status]"),
+              titleAt: children.findIndex((child) => (child.textContent ?? "").length > 20),
+              switchAt: indexOf("[data-card-switch]"),
+              rateAt: indexOf("[data-rate-limited]"),
+            };
+          })
+          .filter((fact): fact is NonNullable<typeof fact> => fact !== null);
+        return labels;
+      });
+      const farSwitching = farFacts.find((fact) => fact.card.startsWith("12121212") && fact.switchAt >= 0);
+      must(farSwitching !== undefined, "the switching card's far label lost its switch chip");
+      must(farSwitching!.statusAt < farSwitching!.titleAt, "far label: status does not precede the title");
+      must(farSwitching!.switchAt > farSwitching!.titleAt, "far label: the switch chip does not trail the title");
+      if (scheme === "dark") {
+        summary.farZoom = farFacts;
+        await page.screenshot({ path: path.join(OUT_DIR, "964-far-zoom-dark.png") });
+      }
+
+      /* Switchboard: the full 9-state matrix, verified card by card. */
+      onlyIds = null;
+      await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+      await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
+      await page.waitForTimeout(1200);
+      await openSwitchboard(page);
+      const facts = await switchboardFacts(page);
+      verifySwitchboard(facts);
+      summary[`switchboard-${scheme}`] = facts;
+      await page.screenshot({ path: path.join(OUT_DIR, `964-switchboard-${scheme}.png`) });
+      await page.close();
+
+      /* ── 390 px phone: the same switch deck, one column ───────────────── */
+      const phone = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 3, hasTouch: true, isMobile: true, colorScheme: scheme });
+      await phone.addInitScript(seedInit);
+      await routeFiles(phone);
+      await phone.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+      await phone.waitForTimeout(2500);
+      await openSwitchboard(phone);
+      const phoneFacts = await switchboardFacts(phone);
+      verifySwitchboard(phoneFacts);
+      summary[`switchboard-390-${scheme}`] = { cards: phoneFacts.length, verified: true };
+      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-switch-${scheme}.png`) });
+      await phone.close();
+    }
+
+    const evidenceDir = path.join(repoRoot, "evidence", "issue-964");
+    fs.mkdirSync(evidenceDir, { recursive: true });
+    /* Committed summary: fixture ids trimmed, synthetic home scrubbed in raw
+       and slug-encoded form — a publication surface carries only $HOME-relative
+       paths. */
+    const scrubbed = JSON.stringify(summary, null, 2)
+      .replaceAll("-1111-4111-8111-111111111111", "")
+      .replaceAll(projectSlug(HOME), "$HOME")
+      .replaceAll(HOME, "$HOME");
+    fs.writeFileSync(path.join(evidenceDir, "card-anatomy.json"), scrubbed + "\n", "utf8");
+    console.log(`screenshots: ${OUT_DIR}`);
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+  }
+}
+
+await main();

--- a/scripts/capture-issue-964-anatomy.ts
+++ b/scripts/capture-issue-964-anatomy.ts
@@ -18,16 +18,23 @@
  *
  * Shots land outside the repository for direct inspection:
  *
- *   <out>/964-switchboard-dark.png       — the 9-state switch-card matrix, dark
+ *   <out>/964-switchboard-dark.png       — the full switch-card state matrix, dark
  *   <out>/964-switchboard-light.png      — the same matrix, light
  *   <out>/964-board-dense-dark.png       — full board, ops facts on full cards
  *   <out>/964-far-zoom-dark.png          — far labels: status → title → ops chips
  *   <out>/964-stack-collapsed-dark.png   — collapsed rows: status leads, switch on ops line
- *   <out>/964-mobile-390-switching-*.png — 390 px focus view naming the switch
- *   <out>/964-mobile-390-focus-*.png     — 390 px focus view, needs-you word
+ *   <out>/964-mobile-390-<state>-*.png   — 390 px per-state frames, dark + light
+ *
+ * Two switchboard cards carry the fully mixed combination (switch + rate limit
+ * + wakeup on one ops row) — one in each fixed card width — and their chip
+ * geometry is asserted in the live DOM: every chip inside the row, none
+ * clipped away, each fact complete on its title (#964 review, finding 1).
+ * The 390 px pass walks EVERY seeded operational state on the phone's
+ * conversation surface and verifies the state's fact and the title before
+ * framing (#964 review, finding 2).
  *
  * A DOM summary (row order, chip row membership, per-state switch chips, card
- * heights) is written to evidence/issue-964/card-anatomy.json.
+ * heights and chip geometry) is written to evidence/issue-964/card-anatomy.json.
  */
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
@@ -59,6 +66,8 @@ type SeededSession = {
     | "switching"
     | "switch-failed"
     | "settled-account"
+    | "mixed-large"
+    | "mixed-small"
     | "quiet";
   /** Child of this session id — becomes a quiet subagent branch in a stack. */
   childOf?: string;
@@ -78,7 +87,21 @@ const SESSIONS: SeededSession[] = [
   { id: "12121212", title: "Rebalance the account pool", agoMinutes: 4, status: "switching" },
   { id: "13131313", title: "Rotate the burndown fixtures", agoMinutes: 40, status: "switch-failed" },
   { id: "14141414", title: "Summarize the incident review", agoMinutes: 90, status: "settled-account" },
+  /* The fully mixed combination — switch + rate limit + wakeup on ONE ops row —
+     in each fixed card width: the rate limit lands this card in the waiting
+     section (large, 300px)… */
+  { id: "15151515", title: "Reconcile the quota ledger", agoMinutes: 8, status: "mixed-large" },
+  /* …while an idle preflight switch + wakeup + a subagent branch lands in the
+     recent section (small, 220px). */
+  { id: "16161616", title: "Refill the fixture pool", agoMinutes: 30, status: "mixed-small" },
+  { id: "17171717", title: "Fold the fixture branches", agoMinutes: 45, status: "quiet", childOf: "16161616" },
 ];
+
+/** The transcript home of the seeded managed account: the settled-account card
+    runs under a REAL `accounts/claude/account-b` root, so the settled ops chip,
+    the pane header's account badge, and the transcript feed all read the same
+    genuine path — no display-only rewrite. */
+const ACCOUNT_B_ID = "account-b";
 
 function must(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
@@ -97,6 +120,19 @@ function seedHome(): void {
   fs.mkdirSync(path.join(HOME, ".codex/sessions"), { recursive: true });
   const folder = path.join(HOME, ".claude/projects", projectSlug(REPO_DIR));
   fs.mkdirSync(folder, { recursive: true });
+  /* A genuine managed account: registry entry + its own transcript tree. The
+     settled-account session lives there, so its path carries the real
+     `accounts/claude/<id>` layout the settled chip and account badge read. */
+  fs.writeFileSync(
+    path.join(HOME, ".config/agent-log-viewer/state/claude-accounts.json"),
+    JSON.stringify({ version: 1, active: "default", accounts: [{ id: ACCOUNT_B_ID, label: "Account B", kind: "managed", createdAt: 0 }], retired: [] }) + "\n",
+    "utf8",
+  );
+  const accountBHome = path.join(HOME, ".config/agent-log-viewer/accounts/claude", ACCOUNT_B_ID);
+  const accountBFolder = path.join(accountBHome, "projects", projectSlug(REPO_DIR));
+  fs.mkdirSync(accountBFolder, { recursive: true });
+  /* The registry only trusts a managed home locked to its owner. */
+  fs.chmodSync(accountBHome, 0o700);
   SESSIONS.forEach((session) => {
     const uuid = sessionUuid(session.id);
     const at = new Date(CAPTURE_MS - session.agoMinutes * 60_000);
@@ -105,7 +141,7 @@ function seedHome(): void {
       { type: "user", uuid: `${uuid}-u`, timestamp: stamp, cwd: REPO_DIR, message: { role: "user", content: `${session.title}.` } },
       { type: "assistant", uuid: `${uuid}-a`, timestamp: stamp, cwd: REPO_DIR, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: `${session.title} — on it.` }] } },
     ];
-    const file = path.join(folder, `${uuid}.jsonl`);
+    const file = path.join(session.status === "settled-account" ? accountBFolder : folder, `${uuid}.jsonl`);
     fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
     fs.utimesSync(file, at, at);
   });
@@ -230,10 +266,35 @@ function patchFilesPayload(payload: { files?: Array<Record<string, unknown>> }):
         failure: "successor never came up",
       };
     }
-    if (seed.status === "settled-account") {
-      /* A managed-account transcript path: the settled ops row names the
-         account the conversation runs under. Display-only rewrite. */
-      file.path = String(file.path).replace("/.claude/projects/", "/accounts/claude/account-b/.claude/projects/");
+    /* The fully mixed rows (#964 review, finding 1): switch + rate limit +
+       wakeup TOGETHER on one ops row. The rate limit routes the large card
+       into the waiting section; the idle preflight keeps the small card in
+       recent. No display rewrites — every fact is the real authority field. */
+    if (seed.status === "mixed-large") {
+      file.activity = "recent";
+      file.rateLimit = { source: "account", accountId: "default", window: "session", resetAt: (CAPTURE_MS + 45 * 60_000) / 1000 };
+      file.migration = {
+        intentId: "intent-964-mixed",
+        trigger: "quota",
+        phase: "preparing",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        sourceLabel: "Account A",
+        failure: null,
+      };
+      file.pendingWakeup = { fireAt: CAPTURE_MS + 25 * 60_000, reason: "recheck the quota ledger" };
+    }
+    if (seed.status === "mixed-small") {
+      file.migration = {
+        intentId: "intent-964-mixed",
+        trigger: "manual",
+        phase: "waiting-turn",
+        targetAccountId: "account-b",
+        targetLabel: "Account B",
+        sourceLabel: "Account A",
+        failure: null,
+      };
+      file.pendingWakeup = { fireAt: CAPTURE_MS + 40 * 60_000, reason: "refill the fixture pool" };
     }
     if (seed.status === "running") {
       file.activity = "live";
@@ -292,28 +353,42 @@ async function nodeClip(page: Page, suffix: string, pad = 28) {
   return { x, y, width, height };
 }
 
+type OpsChipGeometry = {
+  chip: string;
+  width: number;
+  /** How far the chip's right edge pokes past the visible ops row (px);
+      anything meaningfully positive means the chip is clipped away. */
+  overflowRight: number;
+  titled: boolean;
+};
+
 type SwitchCardFact = {
   title: string;
   rows: string[];
   height: number;
+  width: number;
   status: string | null;
   switchChip: { kind: string; text: string } | null;
   opsChips: string[];
   chipsOutsideOps: string[];
+  opsGeometry: OpsChipGeometry[];
 };
 
 /** Every switchboard card's anatomy, read from the live DOM. */
 async function switchboardFacts(page: Page): Promise<SwitchCardFact[]> {
   return page.evaluate(() => {
     const facts: SwitchCardFact[] = [];
+    type OpsChipGeometry = { chip: string; width: number; overflowRight: number; titled: boolean };
     type SwitchCardFact = {
       title: string;
       rows: string[];
       height: number;
+      width: number;
       status: string | null;
       switchChip: { kind: string; text: string } | null;
       opsChips: string[];
       chipsOutsideOps: string[];
+      opsGeometry: OpsChipGeometry[];
     };
     for (const card of Array.from(document.querySelectorAll("article[role=button]"))) {
       const rows = Array.from(card.querySelectorAll("[data-card-row]")).map((row) => row.getAttribute("data-card-row") ?? "");
@@ -329,17 +404,37 @@ async function switchboardFacts(page: Page): Promise<SwitchCardFact[]> {
           if (!ops?.contains(chip)) outside.push(marker);
         }
       }
+      /* Clipping check (#964 review, finding 1): rects come unclipped even
+         inside overflow-hidden, so a chip pushed past the row's right edge is
+         measurable as overflowRight > 0. */
+      const opsRect = ops?.getBoundingClientRect() ?? null;
+      const opsGeometry: OpsChipGeometry[] = [];
+      if (ops && opsRect) {
+        for (const marker of ["[data-card-switch]", "[data-rate-limited]", "[data-wakeup]"]) {
+          const chip = ops.querySelector(marker);
+          if (!chip) continue;
+          const rect = chip.getBoundingClientRect();
+          opsGeometry.push({
+            chip: marker.replace(/[[\]]/g, ""),
+            width: Math.round(rect.width * 10) / 10,
+            overflowRight: Math.round((rect.right - opsRect.right) * 10) / 10,
+            titled: Boolean(chip.getAttribute("title") || chip.getAttribute("aria-label")),
+          });
+        }
+      }
       const switchChip = card.querySelector("[data-card-switch]");
       facts.push({
         title: (card.querySelector('[data-card-row="content"]')?.textContent ?? "").trim().slice(0, 48),
         rows,
         height: Math.round(card.getBoundingClientRect().height),
+        width: Math.round(card.getBoundingClientRect().width),
         status: card.querySelector("[data-card-status]")?.getAttribute("data-card-status") ?? null,
         switchChip: switchChip
           ? { kind: switchChip.getAttribute("data-card-switch") ?? "", text: (switchChip.textContent ?? "").trim() }
           : null,
         opsChips,
         chipsOutsideOps: outside,
+        opsGeometry,
       });
     }
     return facts;
@@ -367,6 +462,27 @@ function verifySwitchboard(facts: SwitchCardFact[]): void {
   must(by("Poll")?.opsChips.includes("wakeup") === true, "the wakeup left the ops row");
   const quiet = by("Write");
   must(quiet !== undefined && quiet.status === null && quiet.opsChips.length === 0, "the quiet card grew chips");
+
+  /* #964 review, finding 1: with switch + rate limit + wakeup on ONE row, no
+     chip may be clipped out of the visible ops row — each stays ≥16px wide
+     (icon + tone survive) and keeps its complete fact on title/aria. Checked
+     at BOTH fixed card widths. */
+  const mixedGeometry = (title: string, expectedWidth: number, chips: string[]) => {
+    const fact = by(title);
+    must(fact !== undefined, `the mixed card «${title}» is missing from the switchboard`);
+    must(fact!.width === expectedWidth, `«${title}» is not the ${expectedWidth}px card: ${fact!.width}`);
+    for (const chip of chips) {
+      const geometry = fact!.opsGeometry.find((entry) => entry.chip === chip);
+      must(geometry !== undefined, `«${title}» lost its ${chip} chip from the ops row`);
+      must(geometry!.width >= 16, `«${title}»'s ${chip} chip collapsed below visibility: ${geometry!.width}px`);
+      must(geometry!.overflowRight <= 0.5, `«${title}»'s ${chip} chip is clipped past the ops row by ${geometry!.overflowRight}px`);
+      must(geometry!.titled, `«${title}»'s ${chip} chip carries no title/aria fact`);
+    }
+  };
+  mixedGeometry("Reconcile", 300, ["data-card-switch", "data-rate-limited", "data-wakeup"]);
+  mixedGeometry("Refill", 220, ["data-card-switch", "data-wakeup"]);
+  must(by("Reconcile")?.switchChip?.kind === "switching", "the mixed large card lost its switching chip");
+  must(by("Refill")?.switchChip?.kind === "pending", "the mixed small card lost its pending switch chip");
 }
 
 async function openSwitchboard(page: Page): Promise<void> {
@@ -393,6 +509,12 @@ async function main(): Promise<void> {
   const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
   const summary: Record<string, unknown> = {
     buildHead: execSync("git rev-parse HEAD", { cwd: repoRoot }).toString().trim(),
+    /* #964 review, finding 3: the frames are captured against the production
+       build of buildHead. Committing them necessarily creates one commit past
+       buildHead, so the enforceable head-binding invariant is: everything
+       after buildHead is evidence-only. capture-issue-964-evidence.test.ts
+       verifies exactly that. */
+    evidencePolicy: "captured at buildHead; commits after buildHead may touch only evidence/",
   };
   try {
     await waitForServer(baseUrl, server);
@@ -402,12 +524,14 @@ async function main(): Promise<void> {
 
     for (const scheme of ["dark", "light"] as const) {
       /* ── Desktop ──────────────────────────────────────────────────────── */
-      const page = await browser.newPage({ viewport: { width: 1600, height: 1000 }, deviceScaleFactor: 2, colorScheme: scheme });
+      /* 1440px tall: the switchboard matrix (waiting + working + recent, the
+         small mixed card included) must sit inside the framed viewport. */
+      const page = await browser.newPage({ viewport: { width: 1600, height: 1440 }, deviceScaleFactor: 2, colorScheme: scheme });
       await page.addInitScript(seedInit);
       await routeFiles(page);
-      /* Dense board first (the settled card's rewritten path cannot feed a
-         full pane, so it stays out of the board frame). */
-      onlyIds = SESSIONS.filter((session) => session.status !== "settled-account").map((session) => session.id);
+      /* Dense board first — every seeded state, the settled managed-account
+         conversation included (its transcript is genuinely on disk). */
+      onlyIds = SESSIONS.map((session) => session.id);
       await page.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "networkidle", timeout: 90_000 });
       await page.waitForSelector("[data-scheme-node]", { timeout: 60_000 });
       await page.waitForTimeout(1200);
@@ -486,41 +610,84 @@ async function main(): Promise<void> {
       await page.close();
 
       /* ── 390 px phone: the switchboard is desktop-only, so the phone's card
-         surface is the focus view — verify the account switch stays explicit
-         and the status word survives, per state. ─────────────────────────── */
+         surface is the focused conversation (pane header + strip). Walk EVERY
+         seeded operational state (#964 review, finding 2): open it by its
+         strip chip, verify the state's operational fact and the title in the
+         live DOM, then frame it — dark and light alike. ─────────────────── */
       const phone = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 3, hasTouch: true, isMobile: true, colorScheme: scheme });
       await phone.addInitScript(seedInit);
       await routeFiles(phone);
       await phone.goto(`${baseUrl}/#p=${projectId}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
       await phone.waitForTimeout(2500);
-      /* The phone lands in a focus view; other conversations sit on the header
-         strip as chips titled by their conversation title. */
-      const switchingTarget = phone.locator('button[title^="Rebalance the account pool"]').first();
-      if ((await switchingTarget.count()) === 0) {
-        const visible = await phone.evaluate(() => (document.body.textContent ?? "").replace(/\s+/g, " ").slice(0, 600));
-        throw new Error(`the switching conversation is missing from the 390px strip; visible: ${visible}`);
-      }
-      await switchingTarget.click({ force: true });
-      await phone.waitForTimeout(1500);
-      const phoneRibbon = await phone.evaluate(() => document.body.textContent?.includes("Switching to «Account B»") ?? false);
-      must(phoneRibbon, "the 390px focus view does not name the account switch");
-      summary[`mobile-390-switching-${scheme}`] = { ribbon: "Switching to «Account B»", verified: true };
-      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-switching-${scheme}.png`) });
-
-      await phone.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
-      await phone.waitForTimeout(2500);
-      const blockedTarget = phone.locator("text=Gate the release on the review verdict").first();
-      if (await blockedTarget.count()) {
-        await blockedTarget.click({ force: true });
+      const phoneStates: Array<{ state: string; id: string; verify: string }> = [
+        { state: "needs-you", id: "11111111", verify: "status:needs-you" },
+        { state: "held", id: "22222222", verify: "status:held" },
+        { state: "running", id: "33333333", verify: "status:running" },
+        { state: "queued", id: "44444444", verify: "wakeup" },
+        { state: "quiet", id: "55555555", verify: "quiet" },
+        { state: "rate-limited", id: "99999999", verify: "rate-limit" },
+        { state: "switching", id: "12121212", verify: "text:Switching to «Account B»" },
+        { state: "switch-failed", id: "13131313", verify: "text:Account switch failed" },
+        { state: "settled-account", id: "14141414", verify: "account:account-b" },
+      ];
+      for (const { state, id, verify } of phoneStates) {
+        const seed = SESSIONS.find((session) => session.id === id)!;
+        /* Conversations ride the header strip as chips titled by their
+           conversation title; the focused conversation keeps its chip too. */
+        const chip = phone.locator(`button[title^="${seed.title}"]`).first();
+        if ((await chip.count()) === 0) {
+          const visible = await phone.evaluate(() => (document.body.textContent ?? "").replace(/\s+/g, " ").slice(0, 600));
+          throw new Error(`the ${state} conversation is missing from the 390px strip; visible: ${visible}`);
+        }
+        await chip.click({ force: true });
         await phone.waitForTimeout(1500);
+        /* The phone folds the pane's meta row (ops chips, account badge)
+           behind the details disclosure — reachability on this surface is
+           exactly that one tap, so take it before reading the facts. */
+        const details = phone.locator('button[aria-label="Show conversation details"]').first();
+        if (await details.count()) {
+          await details.click({ force: true });
+          await phone.waitForTimeout(400);
+        }
+        /* Title stability: whatever the operational state, the conversation
+           still answers to its title on the focused surface. */
+        const titleShown = await phone.evaluate(
+          (title) => (document.body.textContent ?? "").includes(title),
+          seed.title.slice(0, 30),
+        );
+        must(titleShown, `the ${state} 390px view lost the conversation title`);
+        const observed = await phone.evaluate((expectation) => {
+          const kindOf = () => document.querySelector("[data-card-status]")?.getAttribute("data-card-status") ?? null;
+          if (expectation.startsWith("status:")) {
+            return { ok: kindOf() === expectation.slice("status:".length), detail: kindOf() };
+          }
+          if (expectation === "wakeup") {
+            const chipNode = document.querySelector("[data-wakeup]");
+            return { ok: Boolean(chipNode), detail: chipNode?.getAttribute("title") ?? chipNode?.getAttribute("aria-label") ?? null };
+          }
+          if (expectation === "rate-limit") {
+            const chipNode = document.querySelector("[data-rate-limited]");
+            return { ok: Boolean(chipNode), detail: chipNode?.getAttribute("title") ?? null };
+          }
+          if (expectation.startsWith("text:")) {
+            const needle = expectation.slice("text:".length);
+            return { ok: (document.body.textContent ?? "").includes(needle), detail: needle };
+          }
+          if (expectation.startsWith("account:")) {
+            /* The 390px account chip is a letter circle; the full account id
+               rides its aria-label ("Open accounts for <id>"). */
+            const badge = document.querySelector("[data-conversation-account-chip]");
+            const face = `${badge?.getAttribute("aria-label") ?? ""} ${(badge?.textContent ?? "").trim()}`;
+            return { ok: face.includes(expectation.slice("account:".length)), detail: face.trim() };
+          }
+          /* quiet: no status word and no operational chips anywhere. */
+          const noisy = document.querySelector("[data-card-status], [data-wakeup], [data-rate-limited], [data-card-switch]");
+          return { ok: !noisy, detail: noisy?.tagName ?? null };
+        }, verify);
+        must(observed.ok, `the ${state} 390px view failed its check (${verify}; saw ${String(observed.detail)})`);
+        summary[`mobile-390-${state}-${scheme}`] = { verify, detail: observed.detail, titleShown: true };
+        await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-${state}-${scheme}.png`) });
       }
-      const phoneHeader = await phone.evaluate(() => {
-        const badge = document.querySelector("header [data-card-status], [data-card-status]");
-        return badge ? { status: badge.getAttribute("data-card-status"), word: badge.textContent?.trim() } : null;
-      });
-      must(phoneHeader?.status === "needs-you", "the 390px conversation header does not carry the word");
-      summary[`mobile-390-focus-${scheme}`] = phoneHeader;
-      await phone.screenshot({ path: path.join(OUT_DIR, `964-mobile-390-focus-${scheme}.png`) });
       await phone.close();
     }
 

--- a/scripts/capture-issue-964-evidence.test.ts
+++ b/scripts/capture-issue-964-evidence.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Publication hygiene (#964): the committed capture summary is a public
+ * surface, so every path in it must be $HOME-relative — the synthetic capture
+ * home must never leak in raw or slug-encoded form.
+ */
+test("the committed #964 evidence carries no absolute home paths", () => {
+  const evidence = fs.readFileSync(
+    path.resolve(import.meta.dir, "../evidence/issue-964/card-anatomy.json"),
+    "utf8",
+  );
+  expect(evidence).not.toMatch(/(?:^|["\s])\/(?:home|tmp|Users)\//m);
+  expect(evidence).not.toContain("-tmp-llv-");
+});
+
+/** The summary attests the verified anatomy facts, per theme and width. */
+test("the committed #964 evidence covers both themes and both widths", () => {
+  const evidence = JSON.parse(fs.readFileSync(
+    path.resolve(import.meta.dir, "../evidence/issue-964/card-anatomy.json"),
+    "utf8",
+  )) as Record<string, unknown>;
+  expect(typeof evidence.buildHead).toBe("string");
+  for (const key of ["switchboard-dark", "switchboard-light", "mobile-390-switching-dark", "mobile-390-switching-light", "mobile-390-focus-dark", "mobile-390-focus-light", "stack", "farZoom"]) {
+    expect(evidence[key]).toBeDefined();
+  }
+});

--- a/scripts/capture-issue-964-evidence.test.ts
+++ b/scripts/capture-issue-964-evidence.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+
+function readEvidence(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "evidence/issue-964/card-anatomy.json"), "utf8")) as Record<string, unknown>;
+}
 
 /**
  * Publication hygiene (#964): the committed capture summary is a public
@@ -8,22 +15,59 @@ import path from "node:path";
  * home must never leak in raw or slug-encoded form.
  */
 test("the committed #964 evidence carries no absolute home paths", () => {
-  const evidence = fs.readFileSync(
-    path.resolve(import.meta.dir, "../evidence/issue-964/card-anatomy.json"),
-    "utf8",
-  );
+  const evidence = fs.readFileSync(path.join(REPO_ROOT, "evidence/issue-964/card-anatomy.json"), "utf8");
   expect(evidence).not.toMatch(/(?:^|["\s])\/(?:home|tmp|Users)\//m);
   expect(evidence).not.toContain("-tmp-llv-");
 });
 
-/** The summary attests the verified anatomy facts, per theme and width. */
-test("the committed #964 evidence covers both themes and both widths", () => {
-  const evidence = JSON.parse(fs.readFileSync(
-    path.resolve(import.meta.dir, "../evidence/issue-964/card-anatomy.json"),
-    "utf8",
-  )) as Record<string, unknown>;
+/** The summary attests the verified anatomy facts, per theme and width —
+    including a 390px entry for EVERY seeded operational state (#964 review,
+    finding 2) and the mixed-row chip geometry (finding 1). */
+test("the committed #964 evidence covers both themes, both widths, and every 390px state", () => {
+  const evidence = readEvidence();
   expect(typeof evidence.buildHead).toBe("string");
-  for (const key of ["switchboard-dark", "switchboard-light", "mobile-390-switching-dark", "mobile-390-switching-light", "mobile-390-focus-dark", "mobile-390-focus-light", "stack", "farZoom"]) {
+  const keys = ["switchboard-dark", "switchboard-light", "stack", "farZoom"];
+  for (const state of ["needs-you", "held", "running", "queued", "quiet", "rate-limited", "switching", "switch-failed", "settled-account"]) {
+    for (const scheme of ["dark", "light"]) keys.push(`mobile-390-${state}-${scheme}`);
+  }
+  for (const key of keys) {
     expect(evidence[key]).toBeDefined();
+  }
+  /* The mixed cards' geometry rode into the switchboard facts: both fixed
+     widths present, no chip clipped past its ops row. */
+  for (const scheme of ["dark", "light"]) {
+    const facts = evidence[`switchboard-${scheme}`] as Array<{ width: number; opsGeometry: Array<{ overflowRight: number; width: number; titled: boolean }> }>;
+    for (const width of [300, 220]) {
+      const mixed = facts.find((fact) => fact.width === width && fact.opsGeometry.length >= 2);
+      expect(mixed).toBeDefined();
+      for (const chip of mixed!.opsGeometry) {
+        expect(chip.overflowRight).toBeLessThanOrEqual(0.5);
+        expect(chip.width).toBeGreaterThanOrEqual(16);
+        expect(chip.titled).toBe(true);
+      }
+    }
+  }
+});
+
+/**
+ * Head binding (#964 review, finding 3): the frames are captured against the
+ * production build of `buildHead`; committing them necessarily creates one
+ * commit past it. The enforceable invariant is that every commit after
+ * buildHead is evidence-only — the rendered pixels therefore describe exactly
+ * the reviewed source. Skips silently when git history is unavailable (e.g. a
+ * shallow CI clone that no longer carries buildHead).
+ */
+test("the #964 evidence head differs from HEAD only by evidence commits", () => {
+  const buildHead = readEvidence().buildHead as string;
+  expect(buildHead).toMatch(/^[0-9a-f]{40}$/);
+  const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: REPO_ROOT, encoding: "utf8" });
+  if (head.status !== 0) return;
+  if (head.stdout.trim() === buildHead) return;
+  const diff = spawnSync("git", ["diff", "--name-only", `${buildHead}..HEAD`], { cwd: REPO_ROOT, encoding: "utf8" });
+  if (diff.status !== 0) return;
+  const touched = diff.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  expect(touched.length).toBeGreaterThan(0);
+  for (const file of touched) {
+    expect(file.startsWith("evidence/")).toBe(true);
   }
 });

--- a/src/components/RateLimitBadge.tsx
+++ b/src/components/RateLimitBadge.tsx
@@ -20,7 +20,17 @@ import { rateLimitText } from "./rateLimit";
  * successor; when it reports the successor already exists, the card renders
  * that as the terminal truth instead of pretending a new reseat started.
  */
-export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState | null; file?: FileEntry }) {
+export function RateLimitBadge({
+  rateLimit,
+  file,
+  shrinkable = false,
+}: {
+  rateLimit?: RateLimitState | null;
+  file?: FileEntry;
+  /** Clipped ops rows (#964): the chip truncates its label under pressure so
+      the facts after it stay on the row; the full text keeps riding `title`. */
+  shrinkable?: boolean;
+}) {
   const { locale, t } = useLocale();
   const [reseat, setReseat] = useState<"idle" | "pending" | "requested" | "already-reseated" | "failed">("idle");
   const [reseatPhase, setReseatPhase] = useState<string | null>(null);
@@ -36,8 +46,8 @@ export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState
     : reseatError ?? (reseat === "requested" && reseatPhase === "waiting-turn" ? t("rateLimit.reseatWaitingTurn") : t("rateLimit.reseatTitle"));
   return (
     <>
-      <Badge tone="danger" data-rate-limited="" title={label}>
-        {label}
+      <Badge tone="danger" data-rate-limited="" title={label} shrinkable={shrinkable}>
+        <span className="min-w-0 truncate">{label}</span>
       </Badge>
       {canReseat ? (
         <button

--- a/src/components/SwitchCard.anatomy.render.test.tsx
+++ b/src/components/SwitchCard.anatomy.render.test.tsx
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { SwitchCard } from "./SwitchCard";
+
+/**
+ * Issue #964: the switch card keeps a fixed three-row anatomy — identity/status,
+ * content, ops — whatever mix of operational states the conversation is in.
+ * Operational chips (switch, rate limit, wakeup) live in the ops row and never
+ * crowd the identity row or the title.
+ */
+
+const NOW_MS = Date.now();
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/tmp/state/accounts/claude/acct-a/projects/demo/s.jsonl",
+    root: "claude-projects",
+    name: "s.jsonl",
+    project: "demo",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW_MS / 1000 - 30,
+    size: 1,
+    activity: "recent",
+    proc: null,
+    pid: null,
+    model: "sonnet-4.5",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+function card(entry: FileEntry): string {
+  return renderToStaticMarkup(
+    <SwitchCard
+      file={entry}
+      title="Session"
+      project="demo"
+      currentProject="demo"
+      descendants={0}
+      statusLine="working on the release"
+      size="large"
+      tone="working"
+      onOpen={() => {}}
+      onArchive={() => {}}
+    />,
+  );
+}
+
+function rowOrder(html: string): [number, number, number] {
+  const identity = html.indexOf('data-card-row="identity"');
+  const content = html.indexOf('data-card-row="content"');
+  const ops = html.indexOf('data-card-row="ops"');
+  expect(identity).toBeGreaterThan(-1);
+  expect(content).toBeGreaterThan(-1);
+  expect(ops).toBeGreaterThan(-1);
+  return [identity, content, ops];
+}
+
+const MIXED = file({
+  rateLimit: { source: "account", accountId: "acct-a", window: "session", resetAt: NOW_MS / 1000 + 3600 } as FileEntry["rateLimit"],
+  pendingWakeup: { fireAt: NOW_MS + 20 * 60_000, reason: "poll" } as FileEntry["pendingWakeup"],
+  migration: {
+    intentId: "intent-1",
+    trigger: "manual",
+    phase: "preparing",
+    targetAccountId: "acct-b",
+    targetLabel: "account B",
+    sourceLabel: "account A",
+    failure: null,
+  } as FileEntry["migration"],
+});
+
+test("the three rows hold their order on quiet and on mixed-state cards alike", () => {
+  for (const html of [card(file()), card(MIXED)]) {
+    const [identity, content, ops] = rowOrder(html);
+    expect(identity).toBeLessThan(content);
+    expect(content).toBeLessThan(ops);
+  }
+});
+
+test("switch, rate-limit, and wakeup chips render in the ops row, after the title", () => {
+  const html = card(MIXED);
+  const [, content, ops] = rowOrder(html);
+  for (const marker of ['data-card-switch="switching"', "data-rate-limited", "data-wakeup"]) {
+    const at = html.indexOf(marker);
+    expect(at).toBeGreaterThan(ops);
+    expect(at).toBeGreaterThan(content);
+  }
+});
+
+test("a quiet card's ops row carries no operational chips, only recency facts", () => {
+  const html = card(file());
+  expect(html).not.toContain("data-card-switch=\"pending\"");
+  expect(html).not.toContain("data-rate-limited");
+  expect(html).not.toContain("data-wakeup");
+  /* The settled account identity stays visible — account A/B remains explicit
+     after the switch completes. */
+  expect(html).toContain('data-card-switch="settled"');
+  expect(html).toContain("@ acct-a");
+});
+
+test("the identity row carries exactly one primary identity treatment", () => {
+  const html = card(file());
+  const [identity, content] = rowOrder(html);
+  const identityRow = html.slice(identity, content);
+  expect(identityRow).toContain("sonnet-4.5");
+  /* The engine label lives in the chip tooltip, never as a second chip. */
+  expect(identityRow).not.toContain(">Claude<");
+});

--- a/src/components/SwitchCard.anatomy.render.test.tsx
+++ b/src/components/SwitchCard.anatomy.render.test.tsx
@@ -37,16 +37,16 @@ function file(overrides: Partial<FileEntry> = {}): FileEntry {
   } as unknown as FileEntry;
 }
 
-function card(entry: FileEntry): string {
+function card(entry: FileEntry, size: "large" | "small" = "large", descendants = 0): string {
   return renderToStaticMarkup(
     <SwitchCard
       file={entry}
       title="Session"
       project="demo"
       currentProject="demo"
-      descendants={0}
+      descendants={descendants}
       statusLine="working on the release"
-      size="large"
+      size={size}
       tone="working"
       onOpen={() => {}}
       onArchive={() => {}}
@@ -105,6 +105,49 @@ test("a quiet card's ops row carries no operational chips, only recency facts", 
      after the switch completes. */
   expect(html).toContain('data-card-switch="settled"');
   expect(html).toContain("@ acct-a");
+});
+
+/** The opening tag that carries `marker` (as an attribute), for class checks. */
+function tagWithMarker(html: string, marker: string): string {
+  const at = html.indexOf(marker);
+  expect(at).toBeGreaterThan(-1);
+  return html.slice(html.lastIndexOf("<", at), html.indexOf(">", at) + 1);
+}
+
+function classTokens(tag: string): string[] {
+  return (/class="([^"]*)"/.exec(tag)?.[1] ?? "").split(/\s+/);
+}
+
+/*
+ * #964 review, finding 1: the ops row clips with overflow-hidden, so a
+ * non-shrinking chip pushed past the card edge became unreachable in mixed
+ * states. Every operational chip must participate in flex shrinking (it
+ * truncates under pressure instead of leaving the row) and must carry its
+ * complete fact on title/aria so the truncated face stays reachable. The
+ * rendered-evidence driver asserts the resulting geometry in a real browser
+ * at both card widths; this test pins the shrink contract itself.
+ */
+test("mixed-state ops chips shrink under pressure instead of clipping, at both card widths", () => {
+  for (const size of ["large", "small"] as const) {
+    const html = card(MIXED, size, 2);
+    for (const marker of ['data-card-switch="switching"', "data-rate-limited"]) {
+      const tokens = classTokens(tagWithMarker(html, marker));
+      expect(tokens).toContain("min-w-0");
+      expect(tokens).toContain("shrink");
+      expect(tokens).not.toContain("shrink-0");
+      expect(tagWithMarker(html, marker)).toMatch(/title="[^"]+"/);
+    }
+    /* The wakeup chip's shrink policy lives on its wrapper span, one tag out
+       from the data-wakeup button; the full time + reason ride the button. */
+    const wakeAt = html.indexOf("data-wakeup");
+    expect(wakeAt).toBeGreaterThan(-1);
+    const wrapper = html.slice(html.lastIndexOf("<span", wakeAt), wakeAt);
+    const wrapperTokens = (/class="([^"]*)"/.exec(wrapper)?.[1] ?? "").split(/\s+/);
+    expect(wrapperTokens).toContain("min-w-0");
+    expect(wrapperTokens).toContain("shrink");
+    expect(wrapperTokens).not.toContain("shrink-0");
+    expect(tagWithMarker(html, "data-wakeup")).toMatch(/title="[^"]+"/);
+  }
 });
 
 test("the identity row carries exactly one primary identity treatment", () => {

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -113,7 +113,11 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
         <span className={large ? "line-clamp-2" : "line-clamp-2"}>{title}</span>
       </div>
       {/* Ops row: recency always anchors it; account/switch, rate limit and
-          wakeup join only when non-default, so a quiet card's row stays bare. */}
+          wakeup join only when non-default, so a quiet card's row stays bare.
+          The chips are shrink participants: in a fully mixed state each gives
+          up label width (icon + tone + ellipsis stay) rather than pushing the
+          facts after it out of the clipped row — every fact stays visible on
+          the card and complete in its title. */}
       <div data-card-row="ops" className="relative mt-auto flex min-w-0 items-center gap-1.5 overflow-hidden text-[10.5px] font-semibold text-muted">
         <span className="shrink-0">{fmtAge(file.mtime)}</span>
         {file.ctx ? <CtxChip ctx={file.ctx} /> : null}
@@ -123,8 +127,8 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           </span>
         ) : null}
         <AccountSwitchChip file={file} />
-        <RateLimitBadge file={file} />
-        <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />
+        <RateLimitBadge file={file} shrinkable />
+        <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} shrinkable />
       </div>
       {statusLine ? (
         <div

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -62,7 +62,10 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
          so the container query costs nothing — small (220px) cards collapse the
          effort meter below the 260px threshold; the tier stays readable in the
          model chip's tooltip. */
-      className={`reasoning-host group relative flex ${large ? "h-[150px] w-[300px]" : "h-[108px] w-[220px]"} shrink-0 flex-col rounded-[8px] border p-3 shadow-1 transition-colors hover:border-accent/45 ${toneClass(tone)}`}
+      /* Small cards hold the same three-row anatomy as large ones, so their
+         fixed height budgets a two-line title + the ops row + the status line
+         without clipping (#964). */
+      className={`reasoning-host group relative flex ${large ? "h-[150px] w-[300px]" : "h-[128px] w-[220px]"} shrink-0 flex-col rounded-[8px] border p-3 shadow-1 transition-colors hover:border-accent/45 ${toneClass(tone)}`}
       role="button"
       tabIndex={0}
       aria-label={t("switchCard.openColumn", { title: cleanTitle(title, 80) })}

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -7,13 +7,14 @@ import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
+import { AccountSwitchChip, CardIdentityChip } from "./cardAnatomy";
 import { CardStatusBadge } from "./CardStatusBadge";
 import { EffortPills } from "./EffortPills";
 import { CtxChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
 import { RateLimitBadge } from "./RateLimitBadge";
 import { WakeupChip, wakeupChipKey } from "./WakeupChip";
-import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, fmtAge } from "./utils";
+import { activityDot, cleanTitle, fmtAge } from "./utils";
 
 export type SwitchCardSize = "large" | "small";
 export type SwitchCardTone = "waiting" | "stalled" | "working" | "quiet";
@@ -54,7 +55,6 @@ function statusToneClass(tone: SwitchCardTone): string {
 
 export function SwitchCard({ file, title, project, currentProject, descendants, statusLine, size, tone, onOpen, onArchive }: Props) {
   const { t } = useLocale();
-  const badge = engineBadge(file);
   const large = size === "large";
   return (
     <article
@@ -85,24 +85,13 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           <X className="h-3 w-3" aria-hidden />
         </button>
       )}
-      <div className="relative flex min-w-0 items-center gap-1.5">
+      {/* Fixed anatomy (issue #964): identity/status row — activity, ONE
+          identity treatment (model or engine; effort rides beside it and in the
+          tooltip), the #961 status word, and where the card lives. */}
+      <div data-card-row="identity" className="relative flex min-w-0 items-center gap-1.5">
         <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} />
-        {/* One identity chip: the model when known (engine lives in the tint
-            and the tooltip), the engine label as fallback. */}
-        {file.model ? (
-          <span
-            className="min-w-0 truncate rounded-full px-1.5 py-0.5 font-mono text-[9px] font-semibold"
-            style={{ backgroundColor: effortTint(file).soft, color: effortTint(file).color }}
-            title={[badge.label, effortTitle(file)].filter(Boolean).join(" · ")}
-          >
-            {file.model}
-          </span>
-        ) : (
-          <span className="shrink-0 rounded-full px-1.5 py-0.5 text-[9.5px] font-bold" style={badge.style} title={effortTitle(file)}>{badge.label}</span>
-        )}
+        <CardIdentityChip file={file} />
         <EffortPills file={file} />
-        <RateLimitBadge file={file} />
-        <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />
         {/* The operator-facing status word (issue #961): same vocabulary and
             tones as the board cards, so a switch column reads identically. */}
         <CardStatusBadge file={file} />
@@ -115,10 +104,14 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           {projectDisplayName(project, file.projectName)}
         </span>
       </div>
-      <div className={`relative mt-2 min-w-0 ${large ? "text-[14px]" : "text-[12.5px]"} font-bold leading-snug`} title={title}>
+      {/* Content row: the title keeps its two lines whatever the card's
+          operational state — chips never crowd into this row. */}
+      <div data-card-row="content" className={`relative mt-2 min-w-0 ${large ? "text-[14px]" : "text-[12.5px]"} font-bold leading-snug`} title={title}>
         <span className={large ? "line-clamp-2" : "line-clamp-2"}>{title}</span>
       </div>
-      <div className="relative mt-auto flex min-w-0 items-center gap-2 text-[10.5px] font-semibold text-muted">
+      {/* Ops row: recency always anchors it; account/switch, rate limit and
+          wakeup join only when non-default, so a quiet card's row stays bare. */}
+      <div data-card-row="ops" className="relative mt-auto flex min-w-0 items-center gap-1.5 overflow-hidden text-[10.5px] font-semibold text-muted">
         <span className="shrink-0">{fmtAge(file.mtime)}</span>
         {file.ctx ? <CtxChip ctx={file.ctx} /> : null}
         {descendants ? (
@@ -126,6 +119,9 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
             <CornerDownRight className="h-3 w-3" aria-hidden /> {descendants}
           </span>
         ) : null}
+        <AccountSwitchChip file={file} />
+        <RateLimitBadge file={file} />
+        <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />
       </div>
       {statusLine ? (
         <div

--- a/src/components/WakeupChip.tsx
+++ b/src/components/WakeupChip.tsx
@@ -32,7 +32,20 @@ export function wakeupChipKey(wakeup?: PendingWakeup | null): string {
    chip so activating it leaves the surrounding card closed and the conversation
    unopened (issue #161 review). `interactive={false}` renders a passive,
    focus-free visual chip for always-hidden hosts like the far-zoom label. */
-export function WakeupChip({ wakeup, className, interactive = true }: { wakeup?: PendingWakeup | null; className?: string; interactive?: boolean }) {
+export function WakeupChip({
+  wakeup,
+  className,
+  interactive = true,
+  shrinkable = false,
+}: {
+  wakeup?: PendingWakeup | null;
+  className?: string;
+  interactive?: boolean;
+  /** Clipped ops rows (#964): the chip gives up width by truncating its
+      magnitude instead of pushing later facts out of the row; the full time
+      and reason keep riding the title/aria label. */
+  shrinkable?: boolean;
+}) {
   const { locale, t } = useLocale();
   const [now, setNow] = useState(() => Date.now());
   const [open, setOpen] = useState(false);
@@ -49,24 +62,25 @@ export function WakeupChip({ wakeup, className, interactive = true }: { wakeup?:
   const label = t("wakeup.chipTitle", { time: clock, reason: wakeup.reason || t("wakeup.card") });
   const face = (
     <>
-      <AlarmClock className="h-3 w-3" aria-hidden />
-      {magnitude}
+      <AlarmClock className="h-3 w-3 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate">{magnitude}</span>
     </>
   );
-  const chrome = "inline-flex items-center gap-1 rounded-full border border-warning/45 bg-warning-soft px-2 py-0.5 text-[10px] font-bold text-warning";
+  const shrink = shrinkable ? "min-w-0 shrink" : "shrink-0";
+  const chrome = "inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-warning/45 bg-warning-soft px-2 py-0.5 text-[10px] font-bold text-warning";
 
   /* A passive chip for always-hidden hosts (far-zoom label): no button, no
      focus, no handlers — a purely visual token. */
   if (!interactive) {
     return (
-      <span data-wakeup className={`${chrome} shrink-0 ${className ?? ""}`} aria-hidden>
+      <span data-wakeup className={`${chrome} ${shrink} ${className ?? ""}`} aria-hidden>
         {face}
       </span>
     );
   }
 
   return (
-    <span className={`relative inline-flex shrink-0 ${className ?? ""}`}>
+    <span className={`relative inline-flex ${shrink} ${className ?? ""}`}>
       <button
         type="button"
         data-wakeup

--- a/src/components/cardAnatomy.render.test.tsx
+++ b/src/components/cardAnatomy.render.test.tsx
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { AccountSwitchChip, accountSwitchFacts } from "./cardAnatomy";
+
+/**
+ * Issue #964: the compact account/switch chip keeps account A → account B
+ * explicit through every phase, and stays silent when everything is default —
+ * a quiet card's ops row never fills with placeholder chips.
+ */
+
+const MANAGED_PATH = "/tmp/state/accounts/claude/acct-a/projects/demo/s.jsonl";
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: MANAGED_PATH,
+    root: "claude-projects",
+    name: "s.jsonl",
+    project: "demo",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 1,
+    activity: "recent",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+function migrating(phase: string, extra: Partial<NonNullable<FileEntry["migration"]>> = {}): FileEntry {
+  return file({
+    migration: {
+      intentId: "intent-1",
+      trigger: "manual",
+      phase,
+      targetAccountId: "acct-b",
+      targetLabel: "account B",
+      sourceLabel: "account A",
+      failure: null,
+      ...extra,
+    } as FileEntry["migration"],
+  });
+}
+
+const chip = (entry: FileEntry) => renderToStaticMarkup(<AccountSwitchChip file={entry} />);
+
+test("preflight, switching, and recovery phases each name the switch", () => {
+  const pending = chip(migrating("waiting-turn"));
+  expect(pending).toContain('data-card-switch="pending"');
+  expect(pending).toContain("account B");
+
+  const switching = chip(migrating("preparing"));
+  expect(switching).toContain('data-card-switch="switching"');
+  expect(switching).toContain("account B");
+
+  const failed = chip(migrating("failed-recoverable", { failure: "quota" }));
+  expect(failed).toContain('data-card-switch="failed"');
+});
+
+test("the chip title carries the full account A → account B route", () => {
+  expect(chip(migrating("preparing"))).toContain("«account A» → «account B»");
+});
+
+test("an unnamed target switches without inventing a label", () => {
+  const unnamed = chip(migrating("preparing", { targetAccountId: "", targetLabel: "" }));
+  expect(unnamed).toContain('data-card-switch="switching"');
+  expect(unnamed).not.toContain("«»");
+});
+
+test("settled: the card names the account it runs under; the default account stays silent", () => {
+  const settled = chip(file());
+  expect(settled).toContain('data-card-switch="settled"');
+  expect(settled).toContain("@ acct-a");
+
+  expect(chip(file({ path: "/home/user/.claude/projects/demo/s.jsonl" }))).toBe("");
+});
+
+test("a leftover annotation whose target already owns the card reads as settled", () => {
+  /* Level rule (activeCardMigration): the switch committed and the transcript
+     already rotated under acct-a — the stale hold must not resurrect. */
+  const leftover = chip(migrating("waiting-turn", { targetAccountId: "acct-a", targetLabel: "account A" }));
+  expect(leftover).toContain('data-card-switch="settled"');
+  expect(leftover).not.toContain('data-card-switch="pending"');
+});
+
+test("shell tasks carry no account facts at all", () => {
+  expect(accountSwitchFacts(file({ engine: "shell" }))).toBeNull();
+  expect(chip(file({ engine: "shell" }))).toBe("");
+});
+
+test("showSettled=false keeps live switches and drops the settled identity", () => {
+  expect(renderToStaticMarkup(<AccountSwitchChip file={file()} showSettled={false} />)).toBe("");
+  expect(renderToStaticMarkup(<AccountSwitchChip file={migrating("preparing")} showSettled={false} />)).toContain(
+    'data-card-switch="switching"',
+  );
+});

--- a/src/components/cardAnatomy.tsx
+++ b/src/components/cardAnatomy.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { accountIdFromPath, DEFAULT_ACCOUNT_ID } from "@/lib/accounts/badge";
+import { activeCardMigration, cardMigrationState, migrationTargetName } from "@/lib/accounts/migration";
+import { useLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { hueFromId } from "./scheme/agentLinks";
+import { effortTint, effortTitle, engineBadge } from "./utils";
+
+/**
+ * Fixed card anatomy (issue #964): every compact conversation card reads in the
+ * same three rows, whatever mix of operational states it is in.
+ *
+ *   1. identity/status — activity, ONE primary identity treatment, the
+ *      operator-facing status word (#961's CardStatusBadge, consumed as-is).
+ *   2. content — title and current-work preview.
+ *   3. ops — account/switch, rate limit, wakeup, recency: operational facts
+ *      that appear only when they are non-default, so a quiet card's rows stay
+ *      visually empty instead of filling with placeholder chips.
+ *
+ * The rows carry `data-card-row` so tests and rendered evidence can assert the
+ * anatomy instead of screenshot-diffing class soup. This module owns no state
+ * machine: account-switch phases come from the migration projection the full
+ * card already trusts (`activeCardMigration`/`cardMigrationState`), and the
+ * status slot stays #961's territory.
+ */
+
+/** The account/switch fact a compact card's ops row shows, projected level-wise
+    from the same authorities as the full card's ribbon. `settled` is the quiet
+    truth — which account the conversation runs under right now. */
+export type AccountSwitchFacts =
+  | { kind: "pending" | "switching" | "failed"; target: string | null; source: string | null }
+  | { kind: "settled"; accountId: string };
+
+export function accountSwitchFacts(file: FileEntry): AccountSwitchFacts | null {
+  if (file.engine !== "claude" && file.engine !== "codex") return null;
+  const accountId = accountIdFromPath(file.path);
+  const live = activeCardMigration(file.migration, accountId);
+  const state = cardMigrationState(live);
+  if (state === "pending" || state === "switching" || state === "failed") {
+    return { kind: state, target: migrationTargetName(live), source: live?.sourceLabel?.trim() || accountId };
+  }
+  return { kind: "settled", accountId };
+}
+
+/** ~14ch cap, same budget as the full header's account badge; the full id
+    stays in the chip title. */
+function truncateId(id: string, max = 14): string {
+  return id.length > max ? `${id.slice(0, max - 1)}…` : id;
+}
+
+const SWITCH_TONE: Record<"pending" | "switching" | "failed", string> = {
+  pending: "border-warning/45 bg-warning-soft text-warning",
+  switching: "border-accent/45 bg-accent-soft text-accent",
+  failed: "border-danger/40 bg-danger-soft text-danger",
+};
+
+/**
+ * The ops-row account slot: during a live switch it names the phase and the
+ * target account («A → B» stays explicit through preflight, switching and
+ * recovery); settled, it shows the plain account identity with its hue dot.
+ * Passive on purpose — these hosts (map cards, switch cards, far labels) are
+ * pick surfaces; the interactive switcher stays on the full card's AccountBadge.
+ */
+export function AccountSwitchChip({
+  file,
+  showSettled = true,
+  fontClassName = "text-[9.5px]",
+}: {
+  file: FileEntry;
+  /** Collapsed-stack rows show only live switches; the settled account would
+      repeat on every quiet branch of the same conversation. */
+  showSettled?: boolean;
+  fontClassName?: string;
+}) {
+  const { t } = useLocale();
+  const facts = accountSwitchFacts(file);
+  if (!facts) return null;
+  if (facts.kind === "settled") {
+    if (!showSettled || facts.accountId === DEFAULT_ACCOUNT_ID) return null;
+    const hue = hueFromId(facts.accountId);
+    return (
+      <span
+        data-card-switch="settled"
+        className={`inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border border-border/80 px-1.5 py-0.5 font-mono ${fontClassName} text-muted`}
+        title={t("branch.accountAria", { id: facts.accountId })}
+      >
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ backgroundColor: `color-mix(in srgb, hsl(${hue} 60% 50%) 85%, var(--color-card))` }}
+        />
+        <span className="truncate">@ {truncateId(facts.accountId)}</span>
+      </span>
+    );
+  }
+  const face =
+    facts.kind === "failed"
+      ? t("cardSwitch.failed")
+      : facts.target
+        ? t(facts.kind === "pending" ? "cardSwitch.pendingTo" : "cardSwitch.switchingTo", { label: facts.target })
+        : t(facts.kind === "pending" ? "cardSwitch.pending" : "cardSwitch.switching");
+  const phase =
+    facts.kind === "pending"
+      ? t("migrate.cardPending")
+      : facts.kind === "failed"
+        ? t("migrate.cardFailed")
+        : facts.target
+          ? t("migrate.cardSwitching", { label: facts.target })
+          : t("migrate.cardSwitchingUnnamed");
+  /* The full route — which account it leaves, which it joins — rides the
+     title, so the compact face stays one chip wide. */
+  const title = facts.source && facts.target ? `${t("cardSwitch.route", { from: facts.source, to: facts.target })} — ${phase}` : phase;
+  return (
+    <span
+      data-card-switch={facts.kind}
+      className={`inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 font-bold ${fontClassName} ${SWITCH_TONE[facts.kind]}`}
+      title={title}
+      aria-label={title}
+    >
+      <span aria-hidden>⇄</span>
+      <span className="truncate">{face}</span>
+    </span>
+  );
+}
+
+/**
+ * The identity row's ONE primary identity treatment: the model chip in the
+ * engine's effort-shifted tint when the model is known (engine and effort tier
+ * stay in the tooltip), the engine label as fallback — the SwitchCard pattern,
+ * shared so every compact card resolves identity the same way instead of
+ * stacking an engine chip AND a model chip.
+ */
+export function CardIdentityChip({ file, fontClassName = "text-[9.5px]" }: { file: FileEntry; fontClassName?: string }) {
+  const badge = engineBadge(file);
+  if (file.model) {
+    return (
+      <span
+        className={`min-w-0 truncate rounded-full px-1.5 py-0.5 font-mono font-semibold ${fontClassName}`}
+        style={{ backgroundColor: effortTint(file).soft, color: effortTint(file).color }}
+        title={[badge.label, effortTitle(file)].filter(Boolean).join(" · ")}
+      >
+        {file.model}
+      </span>
+    );
+  }
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 font-bold ${fontClassName}`} style={badge.style} title={effortTitle(file)}>
+      {badge.label}
+    </span>
+  );
+}

--- a/src/components/cardAnatomy.tsx
+++ b/src/components/cardAnatomy.tsx
@@ -83,7 +83,7 @@ export function AccountSwitchChip({
     return (
       <span
         data-card-switch="settled"
-        className={`inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border border-border/80 px-1.5 py-0.5 font-mono ${fontClassName} text-muted`}
+        className={`inline-flex min-w-0 shrink items-center gap-1 rounded-full border border-border/80 px-1.5 py-0.5 font-mono ${fontClassName} text-muted`}
         title={t("branch.accountAria", { id: facts.accountId })}
       >
         <span
@@ -115,11 +115,11 @@ export function AccountSwitchChip({
   return (
     <span
       data-card-switch={facts.kind}
-      className={`inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 font-bold ${fontClassName} ${SWITCH_TONE[facts.kind]}`}
+      className={`inline-flex min-w-0 shrink items-center gap-1 rounded-full border px-1.5 py-0.5 font-bold ${fontClassName} ${SWITCH_TONE[facts.kind]}`}
       title={title}
       aria-label={title}
     >
-      <span aria-hidden>⇄</span>
+      <span aria-hidden className="shrink-0">⇄</span>
       <span className="truncate">{face}</span>
     </span>
   );

--- a/src/components/scheme/nodes.anatomy.render.test.tsx
+++ b/src/components/scheme/nodes.anatomy.render.test.tsx
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import type { MiniStack, SchemeNode } from "./layout";
+import { FarLabel, LiteNodeShell, MiniStackShell } from "./nodes";
+
+/**
+ * Issue #964: the map (lite) card, the collapsed stack rows, and the far-zoom
+ * label follow the fixed card anatomy — identity/status leads, content holds
+ * its own row/slot, operational facts trail — across quiet and mixed states.
+ */
+
+const NOW_MS = Date.now();
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/tmp/state/accounts/claude/acct-a/projects/demo/s.jsonl",
+    root: "claude-projects",
+    name: "s.jsonl",
+    project: "demo",
+    title: "Rework the delivery fence",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW_MS / 1000 - 30,
+    size: 1,
+    activity: "recent",
+    proc: null,
+    pid: null,
+    model: "sonnet-4.5",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as unknown as FileEntry;
+}
+
+const MIXED_OVERRIDES: Partial<FileEntry> = {
+  rateLimit: { source: "account", accountId: "acct-a", window: "session", resetAt: NOW_MS / 1000 + 3600 } as FileEntry["rateLimit"],
+  pendingWakeup: { fireAt: NOW_MS + 20 * 60_000, reason: "poll" } as FileEntry["pendingWakeup"],
+  migration: {
+    intentId: "intent-1",
+    trigger: "manual",
+    phase: "preparing",
+    targetAccountId: "acct-b",
+    targetLabel: "account B",
+    sourceLabel: "account A",
+    failure: null,
+  } as FileEntry["migration"],
+};
+
+function node(entry: FileEntry): SchemeNode {
+  return { file: entry, tasks: [], under: [], isRoot: true, x: 0, y: 0, w: 340, h: 220 };
+}
+
+const lite = (entry: FileEntry) =>
+  renderToStaticMarkup(<LiteNodeShell node={node(entry)} ringed={false} dimmed={false} flow={null} />);
+
+test("lite card: the three rows hold their order on quiet and mixed cards", () => {
+  for (const html of [lite(file()), lite(file(MIXED_OVERRIDES))]) {
+    const identity = html.indexOf('data-card-row="identity"');
+    const content = html.indexOf('data-card-row="content"');
+    const ops = html.indexOf('data-card-row="ops"');
+    expect(identity).toBeGreaterThan(-1);
+    expect(identity).toBeLessThan(content);
+    expect(content).toBeLessThan(ops);
+  }
+});
+
+test("lite card: operational chips live in the ops row, after the title", () => {
+  const html = lite(file(MIXED_OVERRIDES));
+  const ops = html.indexOf('data-card-row="ops"');
+  for (const marker of ['data-card-switch="switching"', "data-rate-limited", "data-wakeup"]) {
+    expect(html.indexOf(marker)).toBeGreaterThan(ops);
+  }
+});
+
+test("lite card: one primary identity treatment, engine folded into its tooltip", () => {
+  const html = lite(file());
+  const identityRow = html.slice(html.indexOf('data-card-row="identity"'), html.indexOf('data-card-row="content"'));
+  expect(identityRow).toContain("sonnet-4.5");
+  expect(identityRow).not.toContain(">Claude<");
+});
+
+test("collapsed stack row: status leads the identity line; a live switch shows on the ops line", () => {
+  const stack: MiniStack = {
+    key: "mini::p",
+    parent: "/tmp/p",
+    items: [{ file: file({ ...MIXED_OVERRIDES, waitingInput: { since: NOW_MS / 1000 - 40 } as FileEntry["waitingInput"] }), branches: 2 }],
+    x: 0,
+    y: 0,
+    w: 260,
+    h: 120,
+  };
+  const html = renderToStaticMarkup(<MiniStackShell stack={stack} dimmed={false} onSelect={() => {}} />);
+  const identity = html.indexOf('data-card-row="identity"');
+  const ops = html.indexOf('data-card-row="ops"');
+  const status = html.indexOf("data-card-status");
+  /* The row's visible title (the outer button repeats it as a tooltip attr). */
+  const title = html.indexOf("Rework the delivery fence", identity);
+  expect(identity).toBeLessThan(ops);
+  expect(status).toBeGreaterThan(identity);
+  expect(status).toBeLessThan(title);
+  expect(html.indexOf('data-card-switch="switching"')).toBeGreaterThan(ops);
+  /* The settled account never repeats on every quiet branch. */
+  const quiet = renderToStaticMarkup(
+    <MiniStackShell stack={{ ...stack, items: [{ file: file(), branches: 0 }] }} dimmed={false} onSelect={() => {}} />,
+  );
+  expect(quiet).not.toContain("data-card-switch");
+});
+
+test("far label: identity and status precede the title; operational chips trail it", () => {
+  const html = renderToStaticMarkup(<FarLabel file={file(MIXED_OVERRIDES)} />);
+  const title = html.indexOf("Rework the delivery fence");
+  expect(html.indexOf("data-card-status")).toBeLessThan(title);
+  for (const marker of ['data-card-switch="switching"', "data-rate-limited", "data-wakeup"]) {
+    expect(html.indexOf(marker)).toBeGreaterThan(title);
+  }
+});

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -637,6 +637,7 @@ export function FarLabel({ file }: { file: FileEntry }) {
       aria-hidden
     >
       <div
+        data-far-label
         className="flex max-w-[94%] items-center gap-[0.5em] rounded-[0.55em] border border-border bg-card/95 px-[0.75em] py-[0.45em] shadow-2"
         /* Constant on-screen size until ~2.6× (z≈0.38); further out it shrinks
            with the world so neighboring labels never overlap. */

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -38,6 +38,7 @@ import { RoundStateIcon } from "@/components/flows/RoundIcons";
 import { canHandoff, HandoffHandle } from "@/components/HandoffHandle";
 import { isWorkflowDraftId } from "@/components/workflows/workflowModel";
 import { WorkflowDraftPane } from "@/components/workflows/WorkflowDraftPane";
+import { AccountSwitchChip, CardIdentityChip } from "@/components/cardAnatomy";
 import { CardStatusBadge } from "@/components/CardStatusBadge";
 import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/components/utils";
 import { recencyTurnInfo } from "@/components/turnDuration";
@@ -627,7 +628,7 @@ function UnderRow({ file, onSelect }: { file: FileEntry; onSelect: (file: FileEn
  * takes over. Sized in world-inverse units (CSS vars set on the world div),
  * so it keeps a constant on-screen size at any zoom without re-rendering.
  */
-function FarLabel({ file }: { file: FileEntry }) {
+export function FarLabel({ file }: { file: FileEntry }) {
   const badge = engineBadge(file);
   return (
     <div
@@ -649,9 +650,12 @@ function FarLabel({ file }: { file: FileEntry }) {
             counter-scaled font, so it holds ≥10px on screen until the label's
             2.6× cap — the same floor the rest of the label obeys (#961). */}
         <CardStatusBadge file={file} fontClassName="text-[0.78em]" />
+        {/* Anatomy order (#964): identity → status → content, THEN the
+            operational chips trail the title, mirroring the full card's rows. */}
+        <span className="line-clamp-2 min-w-0 font-bold">{cleanTitle(file.title, 70)}</span>
+        <AccountSwitchChip file={file} showSettled={false} fontClassName="text-[0.72em]" />
         <RateLimitBadge rateLimit={file.rateLimit} />
         <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} interactive={false} />
-        <span className="line-clamp-2 min-w-0 font-bold">{cleanTitle(file.title, 70)}</span>
       </div>
     </div>
   );
@@ -673,9 +677,8 @@ const PAIR_W = NODE_W * 2 + LOOP_GAP;
    hold thousands of transcript lines each — multiplied across the project it
    exceeds the mobile tab's memory budget and iOS kills the renderer. The card
    carries what a pick decision needs; the transcript opens after the pick. */
-function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringed: boolean; dimmed: boolean; flow: Flow | null }) {
+export function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringed: boolean; dimmed: boolean; flow: Flow | null }) {
   const { t } = useLocale();
-  const badge = engineBadge(node.file);
   return (
     <div
       data-scheme-node={node.file.path}
@@ -699,30 +702,39 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
         }`}
       >
         <span aria-hidden className="h-1 w-full shrink-0" style={engineEdge(node.file)} />
-        <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2.5">
+        {/* Fixed anatomy (issue #964): identity/status row — activity, ONE
+            identity treatment, and the #961 status word pinned to the right,
+            so the word sits in the same place whatever the card's state. */}
+        <div data-card-row="identity" className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2.5">
           <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${activityDot(node.file.activity)}`} />
-          <span className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold" style={badge.style}>
-            {badge.label}
+          <CardIdentityChip file={node.file} fontClassName="text-[11px]" />
+          <span className="ml-auto inline-flex min-w-0 shrink-0">
+            {/* The operator-facing status word (issue #961), same vocabulary as
+                the full card's header. */}
+            <CardStatusBadge file={node.file} />
           </span>
-          {node.file.model ? <span className="min-w-0 truncate font-mono text-[11px] text-muted">{node.file.model}</span> : null}
+        </div>
+        {/* Content row: title only — operational chips never crowd it, so its
+            readable height survives every mix of states. */}
+        <div data-card-row="content" className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">
+          <span className="line-clamp-4">{cleanTitle(node.file.title, 180)}</span>
+        </div>
+        {/* Ops row: recency anchors it; account/switch, rate limit and wakeup
+            join only when non-default. */}
+        <div data-card-row="ops" className="flex shrink-0 items-center gap-1.5 overflow-hidden border-t border-border px-3 py-2 text-[11px] font-semibold text-muted">
+          <AccountSwitchChip file={node.file} fontClassName="text-[10px]" />
           <RateLimitBadge file={node.file} />
           {/* pointer-events-auto re-enables taps for just the chip inside the
               map's pointer-events-none layer, so its reason disclosure works at
               390px; the chip's own guard keeps the tap from opening the pane. */}
           <WakeupChip key={wakeupChipKey(node.file.pendingWakeup)} wakeup={node.file.pendingWakeup} className="pointer-events-auto" />
-          {/* The operator-facing status word (issue #961), same vocabulary as
-              the full card's header. */}
-          <CardStatusBadge file={node.file} />
+          {node.under.length ? (
+            <span className="shrink-0">
+              {node.under.length} {t("scheme.underneath")}
+            </span>
+          ) : null}
           <RecencyChip file={node.file} className="ml-auto text-[11px]" />
         </div>
-        <div className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">
-          <span className="line-clamp-5">{cleanTitle(node.file.title, 180)}</span>
-        </div>
-        {node.under.length ? (
-          <div className="shrink-0 px-3 pb-2.5 text-[11px] font-semibold text-muted">
-            {node.under.length} {t("scheme.underneath")}
-          </div>
-        ) : null}
       </div>
       {flow ? <RoleTag role="implementer" active={activeLoopRole(flow) === "implementer"} /> : null}
       <FarLabel file={node.file} />
@@ -803,7 +815,7 @@ function LiteDeckShell({ deck, dimmed }: { deck: DeckNode; dimmed: boolean }) {
  * stays readable on the diagram even when nothing in it runs. A click opens
  * the branch as a full node.
  */
-function MiniStackShell({ stack, dimmed, onSelect }: { stack: MiniStack; dimmed: boolean; onSelect: (file: FileEntry) => void }) {
+export function MiniStackShell({ stack, dimmed, onSelect }: { stack: MiniStack; dimmed: boolean; onSelect: (file: FileEntry) => void }) {
   const { t } = useLocale();
   return (
     <div
@@ -821,17 +833,21 @@ function MiniStackShell({ stack, dimmed, onSelect }: { stack: MiniStack; dimmed:
               title={cleanTitle(file.title)}
               onClick={() => onSelect(file)}
             >
-              <span className="flex min-w-0 items-center gap-1.5">
+              {/* Anatomy order (#964) at row density: identity/status leads —
+                  the status word up front so a held or blocked branch cannot
+                  hide in the stack — and the title (content) fills the line. */}
+              <span data-card-row="identity" className="flex min-w-0 items-center gap-1.5">
                 <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${activityDot(file.activity)}`} />
                 <span className="shrink-0 rounded-full px-1.5 text-[9px] font-bold" style={badge.style}>
                   {badge.label}
                 </span>
+                <CardStatusBadge file={file} />
                 <span className="min-w-0 flex-1 truncate text-[11.5px] font-semibold">{cleanTitle(file.title, 70)}</span>
               </span>
-              <span className="flex items-center gap-2 pl-3 text-[10.5px] text-muted">
-                {/* A collapsed branch keeps the same status word as its full
-                    card, so a held or blocked branch cannot hide in the stack. */}
-                <CardStatusBadge file={file} />
+              {/* Ops line: a live account switch shows itself even on a
+                  collapsed branch; the settled account stays with the full card. */}
+              <span data-card-row="ops" className="flex items-center gap-2 pl-3 text-[10.5px] text-muted">
+                <AccountSwitchChip file={file} showSettled={false} />
                 <span>{kindLabel(t, file.kind)}</span>
                 <span>{fmtAge(file.mtime)}</span>
                 {branches ? <span>⤷ {branches}</span> : null}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -724,11 +724,11 @@ export function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode
             join only when non-default. */}
         <div data-card-row="ops" className="flex shrink-0 items-center gap-1.5 overflow-hidden border-t border-border px-3 py-2 text-[11px] font-semibold text-muted">
           <AccountSwitchChip file={node.file} fontClassName="text-[10px]" />
-          <RateLimitBadge file={node.file} />
+          <RateLimitBadge file={node.file} shrinkable />
           {/* pointer-events-auto re-enables taps for just the chip inside the
               map's pointer-events-none layer, so its reason disclosure works at
               390px; the chip's own guard keeps the tap from opening the pane. */}
-          <WakeupChip key={wakeupChipKey(node.file.pendingWakeup)} wakeup={node.file.pendingWakeup} className="pointer-events-auto" />
+          <WakeupChip key={wakeupChipKey(node.file.pendingWakeup)} wakeup={node.file.pendingWakeup} className="pointer-events-auto" shrinkable />
           {node.under.length ? (
             <span className="shrink-0">
               {node.under.length} {t("scheme.underneath")}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -21,19 +21,25 @@ const TONE: Record<BadgeTone, string> = {
 export function Badge({
   tone = "neutral",
   className = "",
+  shrinkable = false,
   style,
   children,
   ...rest
 }: {
   tone?: BadgeTone;
   className?: string;
+  /** Opt into flex shrinking for clipped single-line rows (the #964 card ops
+      rows): the badge truncates its content instead of pushing later chips out
+      of the row. Hosts wrap their text in `min-w-0 truncate` to pick the
+      ellipsis point. */
+  shrinkable?: boolean;
   /** Inline colors for the engine/model/verdict tints, which are computed, not roles. */
   style?: CSSProperties;
   children: ReactNode;
 } & Omit<ComponentPropsWithoutRef<"span">, "style" | "className" | "children">) {
   return (
     <span
-      className={`inline-flex min-h-5 shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-caption font-semibold leading-none tabular-nums ${
+      className={`inline-flex min-h-5 ${shrinkable ? "min-w-0 shrink" : "shrink-0"} items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-caption font-semibold leading-none tabular-nums ${
         style ? "" : TONE[tone]
       } ${className}`}
       style={style}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -59,6 +59,15 @@ export const en = {
   "cardStatus.running": "working",
   "cardStatus.queued": "queued",
 
+  // Compact account-switch chip on card ops rows (issue #964); the longer
+  // migrate.card* copy stays in the chip title.
+  "cardSwitch.pending": "switch pending",
+  "cardSwitch.pendingTo": "«{label}» pending",
+  "cardSwitch.switching": "switching…",
+  "cardSwitch.switchingTo": "→ «{label}»",
+  "cardSwitch.failed": "switch failed",
+  "cardSwitch.route": "«{from}» → «{to}»",
+
   // Conversation kind labels (display of file.kind discriminant)
   "kind.session": "session",
   "kind.subagent": "subagent",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -56,6 +56,15 @@ export const uk: Record<keyof typeof en, Message> = {
   "cardStatus.running": "працює",
   "cardStatus.queued": "у черзі",
 
+  // Компактний чип перемикання акаунта в операційному рядку картки (issue #964);
+  // довші тексти migrate.card* лишаються в підказці чипа.
+  "cardSwitch.pending": "очікує перемикання",
+  "cardSwitch.pendingTo": "«{label}» очікує",
+  "cardSwitch.switching": "перемикання…",
+  "cardSwitch.switchingTo": "→ «{label}»",
+  "cardSwitch.failed": "збій перемикання",
+  "cardSwitch.route": "«{from}» → «{to}»",
+
   "kind.session": "сесія",
   "kind.subagent": "субагент",
   "kind.job": "джоба",


### PR DESCRIPTION
Closes #964.

Every compact conversation card now reads in the same three rows whatever mix of operational states it is in:

1. **identity/status** — activity dot, ONE primary identity treatment (model chip in the engine's effort tint; engine label as fallback), and the #961 status word, consumed untouched.
2. **content** — the title, never crowded by chips, so its readable height survives state changes.
3. **ops** — account/switch, rate limit, wakeup, recency: only non-default facts, so a quiet card's row stays bare.

A new `AccountSwitchChip` (`src/components/cardAnatomy.tsx`) keeps account A → account B explicit through preflight, switching, recovery, and settled phases. It is a pure projection over the same authorities the full card's ribbon trusts (`activeCardMigration`/`cardMigrationState`, level rule included) — no new status framework, attention semantics untouched. Rows carry `data-card-row` so tests and the evidence driver assert the anatomy in the DOM.

## Before → after information inventory

| Fact | Was | Now |
|---|---|---|
| Engine identity (SwitchCard, lite card) | second chip beside the model | inside the one identity chip's tint + tooltip (`CardIdentityChip`) |
| Model + effort | identity row | identity row, unchanged (effort pills + tooltip) |
| Rate limit (badge + reseat) | identity/header row | ops row, action intact |
| Wakeup ⏰ | identity/header row | ops row, disclosure intact |
| Recency | header (lite) / footer (switch card) | ops row anchor, always present |
| Status word (#961) | mid-row between chips | fixed slot: right end of the identity row (lite), after identity (switch card, stack row) |
| Account (settled) | absent on compact cards | NEW `@ account` chip in ops row (managed accounts; default account stays silent) |
| Account switch phase | absent on compact cards (full card ribbon only) | NEW switch chip: `«B» pending` / `→ «B»` / `switch failed`, tooltip carries the full «A» → «B» route |
| «N underneath» (lite) | its own footer line | ops row span |
| Lite title | clamp-5 | clamp-4 (ops row is now permanent, so state changes never reflow the title) |
| Collapsed-stack status word | second line | leads the identity line, before the title |
| Far-label ops chips | between status and title | trail the title (identity → status → content → ops) |
| Small switch card height | 108px (status line clipped when a 2-line title met chips) | 128px, budgets the full anatomy |

Full-card (`BranchPane`) header, MigrationRibbon, and the #965/#966/#967 contracts are consumed, not modified (the only `BranchPane`-adjacent change is none; `nodes.tsx` full cards keep their panes).

## Verification

- Focused tests by path, isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: `cardAnatomy.render` (7), `SwitchCard.anatomy.render` (4), `scheme/nodes.anatomy.render` (5), plus existing `SwitchCard.status/attention`, `CardStatusBadge`, `cardStatus`, `BranchPane.paneTones`, scheme layer tests — 100+ assertions, all green. No broad suites.
- `tsc --noEmit`, scoped `eslint`, production `next build`: clean.
- Privacy gate vs merge-base: PASS.

## Rendered evidence

`bun scripts/capture-issue-964-anatomy.ts` — production build on a scratch port (3064), synthetic `/tmp` home, frozen clock; every frame DOM-verified before framing (row order, chip row membership, switch-chip phase text, stable card heights). Extracted facts committed at `evidence/issue-964/card-anatomy.json`, stamped `buildHead` 075f3f91 (evidence-only commits follow it; no app code changed after the build).

Matrix (dark AND light, desktop AND 390px; shots land in the capture out dir):

| State | Desktop | 390px |
|---|---|---|
| quiet | switchboard card, bare ops row | strip + focus reachable |
| running | `WORKING 12m 34s` | focus header word |
| needs-you | `NEEDS YOU` + status line | `964-mobile-390-focus-*` |
| held-delivery | `HELD ×3` + `«Account B» pending` chip | held ribbon + composer hold |
| rate-limited | badge + reseat in ops row | — (desktop chip; word covered) |
| wakeup-queued | `QUEUED` + ⏰ in ops row | — |
| switching | `→ «Account B»` chip; far label + stack row too | `964-mobile-390-switching-*` ribbon |
| switch failed | `switch failed` chip | — |
| settled | `@ account-b` chip | — |

nodeterm v0.2.41 (BUSL-1.1): nothing copied — every value in this PR reuses the repo's own tokens, classes, and chip recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)