### PR TITLE
fix(deploy): decouple host adoption from promotion readiness

### DIFF
--- a/docs/state-hot-stores-sqlite.md
+++ b/docs/state-hot-stores-sqlite.md
@@ -164,10 +164,13 @@ moving the stable target. The promoted process waits for three stable
 legacy-file observations, completes the dry run and atomic import, and changes
 the same authority epoch to `sqlite`. It adds `activationReadyAt` after the hot
 stores are initialized, then starts structured-host adoption and controllers
-before adding `releaseReadyAt`. The deployment adapter uses the first timestamp
-to complete target promotion; the capability route remains 503 until the
-second timestamp records full release startup. Slow recoverable adoption stays
-inside the longer post-promotion health gate. The release monitor starts before
+in parallel before adding `releaseReadyAt` once serving controllers have
+started. The deployment adapter uses the first timestamp to complete target
+promotion and the second timestamp to verify serving readiness, referenced
+assets, and the promoted MCP runtime. Structured-host adoption continues as a
+recoverable background task. The deployment capability publishes its current
+phase and completed/total host counts, while the runtime startup axis exposes
+pending, failed, and recovered states. The release monitor starts before
 activation work, so rollback fencing remains available during a failed or
 stalled startup.
 

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -52,8 +52,10 @@ import {
 import { completeRuntimeHostHandoff, stageRuntimeHostSuccessorContainer } from "../src/runtime-host/hostSuccessor";
 import {
   hasViewerDeploymentCapability,
+  promotedViewerReadinessPhase,
   viewerDeploymentRegistryBackendMode,
   viewerDeploymentReleaseReady,
+  viewerDeploymentStructuredHostStartup,
   viewerHealthRequestPlan,
   waitForViewerReadiness,
   type ViewerCandidateContainerState,
@@ -348,7 +350,12 @@ async function containerState(container: string): Promise<ViewerCandidateContain
   return await command(["docker", "inspect", "--format", "{{.State.Status}}", container]) === "running" ? "running" : "exited";
 }
 
-async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, expectedAssetsEndpoint?: string): Promise<ViewerHealthEvidence> {
+async function probeRoutes(
+  candidate: ViewerReleaseIdentity,
+  endpoint: string,
+  expectedAssetsEndpoint?: string,
+  reportPhase?: (phase: string) => void,
+): Promise<ViewerHealthEvidence> {
   const token = serviceToken(candidate);
   const requests = viewerHealthRequestPlan(endpoint, token);
   const root = await fetchStatus(requests.root.url, requests.root.headers);
@@ -363,6 +370,11 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
   const registryBackendMatches = observedRegistryBackendMode === expectedRegistryBackendMode;
   const releaseReady = expectedAssetsEndpoint === undefined
     || viewerDeploymentReleaseReady(capability.status, capability.text);
+  if (expectedAssetsEndpoint !== undefined) {
+    reportPhase?.(promotedViewerReadinessPhase(
+      viewerDeploymentStructuredHostStartup(capability.status, capability.text),
+    ));
+  }
   const html = authenticated?.status === 200 ? authenticated.text : root.text;
   const paths = referencedAssets(html);
   const assets = await Promise.all(paths.map(async (asset) => ({ path: asset, status: (await fetchStatus(`${endpoint}${asset}`)).status })));
@@ -400,11 +412,16 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
   };
 }
 
-async function verifyViewer(candidate: ViewerReleaseIdentity, endpoint: string, expectedAssetsEndpoint?: string): Promise<ViewerHealthEvidence> {
+async function verifyViewer(
+  candidate: ViewerReleaseIdentity,
+  endpoint: string,
+  expectedAssetsEndpoint?: string,
+  reportPhase?: (phase: string) => void,
+): Promise<ViewerHealthEvidence> {
   return waitForViewerReadiness({
     endpoint,
     inspect: () => containerState(candidate.container),
-    probe: () => probeRoutes(candidate, endpoint, expectedAssetsEndpoint),
+    probe: () => probeRoutes(candidate, endpoint, expectedAssetsEndpoint, reportPhase),
     ...(expectedAssetsEndpoint ? { maxAttempts: 90 } : {}),
   });
 }
@@ -431,9 +448,10 @@ async function verify(
     expectedAssetsEndpoint?: string;
     healthProbeCapability?: string;
     healthProbeAdmissions?: McpHealthProbeAdmissionConsumer;
+    reportPhase?: (phase: string) => void;
   } = {},
 ): Promise<ViewerHealthEvidence> {
-  const viewer = await verifyViewer(candidate, endpoint, options.expectedAssetsEndpoint);
+  const viewer = await verifyViewer(candidate, endpoint, options.expectedAssetsEndpoint, options.reportPhase);
   if (!viewer.ok) return viewer;
   if (!candidate.mcpRuntime || candidate.mcpRuntime.source !== "managed") {
     return { ...viewer, ok: false, detail: "candidate MCP runtime identity is missing" };
@@ -994,11 +1012,12 @@ async function main(): Promise<unknown> {
     return promoteTarget(candidate, (phase) => reportAdapterPhase(action, phase));
   }
   if (action === "verify-promoted") {
-    reportAdapterPhase(action, "waiting for full promoted Viewer readiness");
+    reportAdapterPhase(action, promotedViewerReadinessPhase(null));
     const candidate = release(input.candidate);
     const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
     return verify(candidate, stableEndpoint, {
       expectedAssetsEndpoint: candidate.endpoint,
+      reportPhase: (phase) => reportAdapterPhase(action, phase),
       ...(healthProbe ?? {}),
     });
   }

--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -1,5 +1,6 @@
 import { sqliteModeFromEnvironment } from "@/lib/agent/registry";
 import { statePath } from "@/lib/configDir";
+import { structuredStartupStatus } from "@/lib/runtime/startupStatus";
 import { HOT_STATE_BACKEND, readHotStateAuthority, readHotStateReleaseTarget } from "@/lib/state/hotStateAuthority";
 
 export const runtime = "nodejs";
@@ -27,8 +28,9 @@ function viewerReleaseStartupState(
 /* The deployment readiness gate probes this route with a 5s budget. It reads
    two small handoff records and still avoids instantiating the agent registry,
    whose first probe would otherwise pay a multi-MB parse. The activation gate
-   remains compatible with the deployed predecessor adapter; newer adapters
-   also consume releaseReady while structured-host startup finishes. */
+   remains compatible with the deployed predecessor adapter. Structured-host
+   recovery is reported independently because it may continue after serving
+   readiness. */
 export function GET(): Response {
   const startup = viewerReleaseStartupState();
   if (!startup.activationReady) {
@@ -43,6 +45,7 @@ export function GET(): Response {
       version: 1,
       registryBackendMode: sqliteModeFromEnvironment(),
       releaseReady: startup.releaseReady,
+      structuredHostStartup: structuredStartupStatus(),
     },
     { headers: { "cache-control": "no-store" } },
   );

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -256,6 +256,39 @@ test("hot-state activation beats a slow structured-host startup and the promote 
   expect(outcome).toBe("activated");
 });
 
+test("promoted serving readiness beats a legitimately slow structured-host adoption window", async () => {
+  let finishStructuredStartup!: () => void;
+  let publishReleaseReady!: () => void;
+  let structuredStartupFinished = false;
+  const structuredStartup = new Promise<void>((resolve) => {
+    finishStructuredStartup = () => {
+      structuredStartupFinished = true;
+      resolve();
+    };
+  });
+  const releaseReady = new Promise<void>((resolve) => { publishReleaseReady = resolve; });
+  const activation = completeViewerRuntimeActivation({
+    initializeOperatorCapability: async () => undefined,
+    startWakatime: async () => undefined,
+    startStructuredHosts: () => structuredStartup,
+    startControllers: async () => undefined,
+    publishHotStateActivation: () => undefined,
+    publishViewerReleaseReady: publishReleaseReady,
+  });
+
+  const outcome = await Promise.race([
+    releaseReady.then(() => "release-ready"),
+    Bun.sleep(25).then(() => "verify-promoted-timeout"),
+  ]);
+  expect({ outcome, structuredStartupFinished }).toEqual({
+    outcome: "release-ready",
+    structuredStartupFinished: false,
+  });
+
+  finishStructuredStartup();
+  await activation;
+});
+
 test("cutover import faults roll back all four collection markers and retry cleanly", async () => {
   const previousState = process.env.LLV_STATE_DIR;
   const previousPort = process.env.PORT;

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -288,6 +288,7 @@ export interface AdoptedClaudeHost {
 }
 
 export type StructuredHostAdoptionFilter = (entry: AgentRegistryEntry) => boolean;
+export type StructuredHostAdoptionProgress = (entry: AgentRegistryEntry) => void;
 
 const STRUCTURED_CLAIM_PREFIX = "structured-host:";
 const ORPHAN_TERM_GRACE_MS = 250;
@@ -396,6 +397,7 @@ export async function adoptCodexRegistryHosts(
   optionsFor: (entry: AgentRegistryEntry) => CodexAppServerHostOptions,
   env: NodeJS.ProcessEnv = process.env,
   shouldAdopt: StructuredHostAdoptionFilter = () => true,
+  processed?: StructuredHostAdoptionProgress,
 ): Promise<AdoptedCodexHost[]> {
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
@@ -444,6 +446,8 @@ export async function adoptCodexRegistryHosts(
       });
     } catch (error) {
       if (!(error instanceof Error) || error.message !== "agent registry is busy") throw error;
+    } finally {
+      processed?.(entry);
     }
   }
   return adopted;
@@ -456,6 +460,7 @@ export async function adoptClaudeRegistryHosts(
   optionsFor: (entry: AgentRegistryEntry) => ClaudeStreamBrokerHostOptions,
   env: NodeJS.ProcessEnv = process.env,
   shouldAdopt: StructuredHostAdoptionFilter = () => true,
+  processed?: StructuredHostAdoptionProgress,
 ): Promise<AdoptedClaudeHost[]> {
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
@@ -513,6 +518,8 @@ export async function adoptClaudeRegistryHosts(
       });
     } catch (error) {
       if (!(error instanceof Error) || error.message !== "agent registry is busy") throw error;
+    } finally {
+      processed?.(entry);
     }
   }
   return adopted;

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -15,7 +15,7 @@ import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost, publishStructur
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import { demoteSkippedStructuredRegistryHosts, type StructuredHostAdoptionFilter } from "./registry";
 import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { didStructuredHostStartupFail } from "./startupStatus";
+import { didStructuredHostStartupFail, structuredStartupStatus } from "./startupStatus";
 import { adoptStructuredHostsAtStartup, structuredStartupHosts, type StructuredStartupDependencies } from "./startup";
 
 function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
@@ -1061,6 +1061,73 @@ async function startupAdoptionAttempts(
   });
   return attempts;
 }
+
+test("startup publishes per-host progress across the serial provider adoption loops", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-progress-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  addStructuredRestartConversation(registry, directory, {
+    engine: "codex",
+    sessionId: crypto.randomUUID(),
+    status: "live",
+    turn: "busy",
+  });
+  addStructuredRestartConversation(registry, directory, {
+    engine: "claude",
+    sessionId: crypto.randomUUID(),
+    status: "live",
+    turn: "busy",
+  });
+  const progress: unknown[] = [];
+  const capture = () => {
+    progress.push(structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" }));
+  };
+  try {
+    await adoptStructuredHostsAtStartup({
+      registry,
+      client: null,
+      refreshTranscriptState: async () => undefined,
+      adopt: async (received, _optionsFor, _env, shouldAdopt = () => true, processed) => {
+        for (const entry of Object.values(received.snapshot().entries)) {
+          if (entry.key.engine !== "codex" || !shouldAdopt(entry)) continue;
+          processed?.(entry);
+          capture();
+        }
+        return [];
+      },
+      adoptClaude: async (received, _optionsFor, _env, shouldAdopt = () => true, processed) => {
+        for (const entry of Object.values(received.snapshot().entries)) {
+          if (entry.key.engine !== "claude" || !shouldAdopt(entry)) continue;
+          processed?.(entry);
+          capture();
+        }
+        return [];
+      },
+    });
+
+    expect(progress).toEqual([
+      expect.objectContaining({
+        state: "pending",
+        phase: "adopting Codex hosts",
+        completedHosts: 1,
+        totalHosts: 2,
+      }),
+      expect.objectContaining({
+        state: "pending",
+        phase: "adopting Claude hosts",
+        completedHosts: 2,
+        totalHosts: 2,
+      }),
+    ]);
+    expect(structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
+      phase: "finalizing structured delivery",
+      completedHosts: 2,
+      totalHosts: 2,
+    });
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 function claudeTerminalRecord() {
   return {

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -29,6 +29,7 @@ import {
 } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverPendingStructuredSpawns } from "./structuredSpawn";
+import { markStructuredHostStartupProgress, type StructuredHostStartupPhase } from "./startupStatus";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
 let adoptedHosts: AdoptedStructuredHost[] = [];
@@ -383,11 +384,26 @@ export async function adoptStructuredHostsAtStartup(
       deferStartupWork: true,
     });
   }
+  markStructuredHostStartupProgress({
+    phase: "refreshing transcripts",
+    completedHosts: 0,
+    totalHosts: null,
+  });
   await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry);
   let nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, retryAdoptedHosts);
   retryAdoptedHosts = nextAdoptedHosts;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
+  const adoptionCandidates = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
+    entry.structuredHost && shouldAdopt(entry));
+  const codexCandidateCount = adoptionCandidates.filter((entry) => entry.key.engine === "codex").length;
+  const claudeCandidateCount = adoptionCandidates.length - codexCandidateCount;
+  let totalHosts = adoptionCandidates.length;
+  let completedHosts = 0;
+  const reportProgress = (phase: StructuredHostStartupPhase) => {
+    markStructuredHostStartupProgress({ phase, completedHosts, totalHosts });
+  };
+  reportProgress("adopting Codex hosts");
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -417,9 +433,16 @@ export async function adoptStructuredHostsAtStartup(
     },
     startupEnvironment,
     shouldAdopt,
+    () => {
+      completedHosts += 1;
+      totalHosts = Math.max(totalHosts, completedHosts);
+      reportProgress("adopting Codex hosts");
+    },
   );
+  completedHosts = Math.max(completedHosts, codexCandidateCount);
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, codex);
   retryAdoptedHosts = nextAdoptedHosts;
+  reportProgress("adopting Claude hosts");
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     registry,
     (entry) => {
@@ -446,9 +469,16 @@ export async function adoptStructuredHostsAtStartup(
     },
     startupEnvironment,
     shouldAdopt,
+    () => {
+      completedHosts += 1;
+      totalHosts = Math.max(totalHosts, completedHosts);
+      reportProgress("adopting Claude hosts");
+    },
   );
+  completedHosts = Math.max(completedHosts, codexCandidateCount + claudeCandidateCount);
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
   retryAdoptedHosts = nextAdoptedHosts;
+  reportProgress("reconciling structured hosts");
   const candidateHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
   const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) =>
     candidateHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
@@ -475,6 +505,7 @@ export async function adoptStructuredHostsAtStartup(
   const finalCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex",
   );
+  reportProgress("finalizing structured delivery");
   if (controllerBoundEarly) {
     await completeStructuredDeliveryQueueStartup(nextAdoptedHosts);
   } else {

--- a/src/lib/runtime/startupStatus.test.ts
+++ b/src/lib/runtime/startupStatus.test.ts
@@ -34,3 +34,61 @@ test("issue 367: the structured startup axis never reports ready before adoption
     else store.__llvStructuredHostStartupFailed = previous;
   }
 });
+
+test("structured startup status retains host adoption progress through failure and recovery", async () => {
+  const status = await import(`./startupStatus?${"progress-copy"}`);
+  const store = process as typeof process & {
+    __llvStructuredHostStartupFailed?: boolean;
+    __llvStructuredHostStartupProgress?: unknown;
+  };
+  const previousFailed = store.__llvStructuredHostStartupFailed;
+  const previousProgress = store.__llvStructuredHostStartupProgress;
+  try {
+    delete store.__llvStructuredHostStartupFailed;
+    delete store.__llvStructuredHostStartupProgress;
+    status.markStructuredHostStartupProgress({
+      phase: "adopting Claude hosts",
+      completedHosts: 7,
+      totalHosts: 19,
+    });
+    expect(status.structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
+      state: "pending",
+      phase: "adopting Claude hosts",
+      completedHosts: 7,
+      totalHosts: 19,
+      updatedAt: expect.any(String),
+    });
+
+    status.markStructuredHostStartupFailed();
+    expect(status.structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
+      state: "failed",
+      phase: "adopting Claude hosts",
+      completedHosts: 7,
+      totalHosts: 19,
+    });
+
+    status.markStructuredHostStartupProgress({
+      phase: "finalizing structured delivery",
+      completedHosts: 19,
+      totalHosts: 19,
+    });
+    expect(status.structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
+      state: "failed",
+      phase: "finalizing structured delivery",
+      completedHosts: 19,
+      totalHosts: 19,
+    });
+    status.markStructuredHostStartupReady();
+    expect(status.structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
+      state: "ready",
+      phase: "ready",
+      completedHosts: 19,
+      totalHosts: 19,
+    });
+  } finally {
+    if (previousFailed === undefined) delete store.__llvStructuredHostStartupFailed;
+    else store.__llvStructuredHostStartupFailed = previousFailed;
+    if (previousProgress === undefined) delete store.__llvStructuredHostStartupProgress;
+    else store.__llvStructuredHostStartupProgress = previousProgress;
+  }
+});

--- a/src/lib/runtime/startupStatus.ts
+++ b/src/lib/runtime/startupStatus.ts
@@ -2,14 +2,72 @@ import { structuredHostsEnabled } from "./flags";
 
 const startupStore = process as typeof process & {
   __llvStructuredHostStartupFailed?: boolean;
+  __llvStructuredHostStartupProgress?: StructuredHostStartupStatus;
 };
+
+export type StructuredHostStartupPhase =
+  | "waiting for structured startup"
+  | "refreshing transcripts"
+  | "adopting Codex hosts"
+  | "adopting Claude hosts"
+  | "reconciling structured hosts"
+  | "finalizing structured delivery"
+  | "ready";
+
+export interface StructuredHostStartupProgress {
+  phase: StructuredHostStartupPhase;
+  completedHosts: number;
+  totalHosts: number | null;
+}
+
+export interface StructuredHostStartupStatus extends StructuredHostStartupProgress {
+  state: "pending" | "failed" | "ready";
+  updatedAt: string;
+}
+
+function pendingStatus(): StructuredHostStartupStatus {
+  return {
+    state: "pending",
+    phase: "waiting for structured startup",
+    completedHosts: 0,
+    totalHosts: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function setStatus(
+  state: StructuredHostStartupStatus["state"],
+  progress: StructuredHostStartupProgress,
+): void {
+  if (!Number.isSafeInteger(progress.completedHosts) || progress.completedHosts < 0) {
+    throw new Error("structured host startup completed count is invalid");
+  }
+  if (progress.totalHosts !== null
+    && (!Number.isSafeInteger(progress.totalHosts)
+      || progress.totalHosts < progress.completedHosts)) {
+    throw new Error("structured host startup total count is invalid");
+  }
+  startupStore.__llvStructuredHostStartupProgress = {
+    ...progress,
+    state,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function markStructuredHostStartupProgress(progress: StructuredHostStartupProgress): void {
+  setStatus(startupStore.__llvStructuredHostStartupFailed === true ? "failed" : "pending", progress);
+}
 
 export function markStructuredHostStartupFailed(): void {
   startupStore.__llvStructuredHostStartupFailed = true;
+  const current = startupStore.__llvStructuredHostStartupProgress ?? pendingStatus();
+  setStatus("failed", current);
 }
 
 export function markStructuredHostStartupReady(): void {
   startupStore.__llvStructuredHostStartupFailed = false;
+  const current = startupStore.__llvStructuredHostStartupProgress ?? pendingStatus();
+  setStatus("ready", { ...current, phase: "ready" });
 }
 
 export function didStructuredHostStartupFail(): boolean {
@@ -27,4 +85,11 @@ export function structuredStartupAxis(
   const failed = startupStore.__llvStructuredHostStartupFailed;
   if (failed === undefined) return "pending";
   return failed ? "failed" : "ready";
+}
+
+export function structuredStartupStatus(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): StructuredHostStartupStatus | null {
+  if (!structuredHostsEnabled(env)) return null;
+  return { ...(startupStore.__llvStructuredHostStartupProgress ?? pendingStatus()) };
 }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -85,7 +85,7 @@ interface CurrentReleaseControllerLoaders {
 interface ViewerRuntimeActivationSteps {
   initializeOperatorCapability: () => Promise<void>;
   startWakatime: () => Promise<void>;
-  startStructuredHosts: (() => Promise<void>) | null;
+  startStructuredHosts: (() => void) | null;
   startControllers: () => Promise<void>;
   publishHotStateActivation: () => void;
   publishViewerReleaseReady: () => void;
@@ -464,7 +464,7 @@ export async function completeViewerRuntimeActivation(
   await steps.initializeOperatorCapability();
   await steps.startWakatime();
   steps.publishHotStateActivation();
-  if (steps.startStructuredHosts) await steps.startStructuredHosts();
+  steps.startStructuredHosts?.();
   await steps.startControllers();
   steps.publishViewerReleaseReady();
 }
@@ -485,9 +485,12 @@ export async function registerViewerRuntime(): Promise<void> {
       initializeOperatorCapability: initializeOperatorSpawnCapabilityAtStartup,
       startWakatime: startWakatimeIntegrationIfEnabled,
       startStructuredHosts: structuredHostsEnabled()
-        ? async () => {
-            const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-            await runStructuredHostStartup(adoptStructuredHostsAtStartup, console.error, { waitUntilReady: true });
+        ? () => {
+            void (async () => {
+              const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
+              await runStructuredHostStartup(adoptStructuredHostsAtStartup, console.error, { waitUntilReady: true });
+            })()
+              .catch((error) => console.error("[structured hosts] background startup aborted", error));
           }
         : null,
       startControllers: startCurrentReleaseControllers,

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { HostCommandViewerDeploymentAdapter } from "./deploymentAdapter";
+import { promotedViewerReadinessPhase } from "./deploymentHealth";
 
 const sandboxes: string[] = [];
 afterEach(() => {
@@ -220,4 +221,28 @@ test("promotion deadline reports the active handoff phase", async () => {
     );
     expect(fs.existsSync(`${fixture.stateFile}.phase`)).toBe(false);
   }
+});
+
+test("post-promotion deadline reports serving readiness and host adoption progress", async () => {
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:18001",
+    revision: "a".repeat(40),
+  };
+  const phase = promotedViewerReadinessPhase({
+    state: "pending",
+    phase: "adopting Claude hosts",
+    completedHosts: 7,
+    totalHosts: 19,
+  });
+  const fixture = sleepingAdapter(phase);
+  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, {
+    stateFile: fixture.stateFile,
+    timeouts: { "verify-promoted": 20 },
+  });
+
+  await expect(adapter.verifyPromoted(candidate)).rejects.toThrow(
+    "deployment adapter verify-promoted timed out while waiting for promoted Viewer serving readiness - adoption 7 of 19 - adopting Claude hosts",
+  );
 });

--- a/src/runtime-host/deploymentHealth.test.ts
+++ b/src/runtime-host/deploymentHealth.test.ts
@@ -4,11 +4,13 @@ import { NextRequest } from "next/server";
 import type { ViewerHealthEvidence } from "@/lib/runtime/contracts";
 import { proxy } from "@/proxy";
 import { GET as deploymentCapability } from "@/app/api/runtime/deployments/capabilities/v1/route";
+import { markStructuredHostStartupProgress, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 
 import {
   hasViewerDeploymentCapability,
   viewerDeploymentRegistryBackendMode,
   viewerDeploymentReleaseReady,
+  viewerDeploymentStructuredHostStartup,
   viewerHealthRequestPlan,
   waitForViewerReadiness,
 } from "./deploymentHealth";
@@ -104,4 +106,35 @@ test("deployment capability requires the candidate-owned versioned endpoint", as
     version: 1,
     releaseReady: false,
   }))).toBe(false);
+});
+
+test("deployment capability publishes bounded structured-host adoption progress", async () => {
+  try {
+    markStructuredHostStartupProgress({
+      phase: "adopting Claude hosts",
+      completedHosts: 7,
+      totalHosts: 19,
+    });
+    const response = deploymentCapability();
+    const body = await response.text();
+
+    expect(viewerDeploymentStructuredHostStartup(response.status, body)).toMatchObject({
+      state: "pending",
+      phase: "adopting Claude hosts",
+      completedHosts: 7,
+      totalHosts: 19,
+    });
+    expect(viewerDeploymentStructuredHostStartup(200, JSON.stringify({
+      capability: "viewer-deployments",
+      version: 1,
+      structuredHostStartup: {
+        state: "pending",
+        phase: "invalid/control/phase",
+        completedHosts: 20,
+        totalHosts: 19,
+      },
+    }))).toBeNull();
+  } finally {
+    markStructuredHostStartupReady();
+  }
 });

--- a/src/runtime-host/deploymentHealth.ts
+++ b/src/runtime-host/deploymentHealth.ts
@@ -54,8 +54,8 @@ export function viewerDeploymentRegistryBackendMode(
 }
 
 /** Older release capabilities omit this field and already represent complete
- * startup. SQLite-wave releases expose an explicit false value while their
- * post-activation controllers and structured hosts are still starting. */
+ * startup. SQLite-wave releases expose an explicit false value until their
+ * post-activation serving controllers have started. */
 export function viewerDeploymentReleaseReady(status: number, body: string): boolean {
   if (!hasViewerDeploymentCapability(status, body)) return false;
   try {
@@ -63,6 +63,56 @@ export function viewerDeploymentReleaseReady(status: number, body: string): bool
   } catch {
     return false;
   }
+}
+
+export interface ViewerStructuredHostStartupProgress {
+  state: "pending" | "failed" | "ready";
+  phase: string;
+  completedHosts: number;
+  totalHosts: number | null;
+}
+
+export function viewerDeploymentStructuredHostStartup(
+  status: number,
+  body: string,
+): ViewerStructuredHostStartupProgress | null {
+  if (!hasViewerDeploymentCapability(status, body)) return null;
+  try {
+    const progress = (JSON.parse(body) as { structuredHostStartup?: unknown }).structuredHostStartup;
+    if (!progress || typeof progress !== "object" || Array.isArray(progress)) return null;
+    const candidate = progress as Record<string, unknown>;
+    const state = candidate.state;
+    const phase = candidate.phase;
+    const completedHosts = candidate.completedHosts;
+    const totalHosts = candidate.totalHosts;
+    if ((state !== "pending" && state !== "failed" && state !== "ready")
+      || typeof phase !== "string"
+      || !/^[A-Za-z0-9 -]{1,80}$/.test(phase)
+      || !Number.isSafeInteger(completedHosts)
+      || (completedHosts as number) < 0
+      || (totalHosts !== null
+        && (!Number.isSafeInteger(totalHosts)
+          || (totalHosts as number) < (completedHosts as number)))) return null;
+    return {
+      state,
+      phase,
+      completedHosts: completedHosts as number,
+      totalHosts: totalHosts as number | null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function promotedViewerReadinessPhase(
+  progress: ViewerStructuredHostStartupProgress | null,
+): string {
+  if (!progress) {
+    return "waiting for promoted Viewer serving readiness - adoption progress unavailable";
+  }
+  const total = progress.totalHosts === null ? "unknown" : String(progress.totalHosts);
+  const prefix = `waiting for promoted Viewer serving readiness - adoption ${progress.completedHosts} of ${total} - `;
+  return `${prefix}${progress.phase.slice(0, Math.max(0, 160 - prefix.length)).trimEnd()}`;
 }
 
 export interface ViewerReadinessProbe {


### PR DESCRIPTION
## Summary

- publish `releaseReadyAt` after hot-state activation and serving-controller startup while structured-host recovery continues in its existing bounded retry loop
- expose bounded structured-host phase and completed/total counts through the deployment capability and adapter timeout phase
- retain the promoted HTTP, authentication, referenced-asset, registry-backend, release identity, and managed MCP runtime gates

## Root cause

Read-only runtime-journal evidence from two consecutive failed releases showed a durable candidate activation followed roughly 122 seconds later by restore. Both candidates had already passed the route, asset, authentication, registry-backend, revision, and managed MCP runtime probes.

The production snapshot contained 20 eligible startup-adoption rows: 19 Claude rows and one Codex row. The [Claude registry adoption loop](https://github.com/Latand/live-log-viewer-next/blob/e774820bbd92edfc24dba379e5a95ed373890897/src/lib/runtime/registry.ts#L458-L525) processes those rows serially. `releaseReadyAt` remained downstream of `runStructuredHostStartup(..., { waitUntilReady: true })`, so this loop dominated the deployed adapter's [120-second verify-promoted deadline](https://github.com/Latand/live-log-viewer-next/blob/e774820bbd92edfc24dba379e5a95ed373890897/src/runtime-host/deploymentAdapter.ts#L28-L43).

The revised [activation sequence](https://github.com/Latand/live-log-viewer-next/blob/e774820bbd92edfc24dba379e5a95ed373890897/src/lib/viewerInstrumentation.ts#L461-L503) starts adoption in the background, awaits serving-controller startup, and then publishes `releaseReadyAt`. Adoption failures and recovery remain visible through the existing runtime startup axis, with phase/count detail added for deployment diagnostics.

## Bootstrap under the deployed adapter

The deployed predecessor adapter continues to poll `releaseReadyAt` within its existing 120-second window. This candidate publishes that timestamp after serving-controller startup, independently of the longer adoption loop, so it can pass the predecessor's gate directly. No operational bootstrap step is required. The progress field improves diagnostics once this adapter revision is active.

## Verification

- 145 focused tests across 7 exact test files with isolated `HOME`, `XDG_CONFIG_HOME`, `LLV_STATE_DIR`, and `TMPDIR`
- `bunx tsc --noEmit`
- scoped ESLint for changed TypeScript files
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base origin/main`

No deployment, restart, merge, or live-state mutation was performed.
