### PR TITLE
fix(viewer): the canonical #c= deep link opens its conversation instead of silently bouncing

### DIFF
--- a/src/components/Viewer.catalogFailure.dom.test.tsx
+++ b/src/components/Viewer.catalogFailure.dom.test.tsx
@@ -63,8 +63,13 @@ const matchMedia = (query: string) => ({
 Object.assign(globalThis, { matchMedia });
 Object.assign(dom, { matchMedia });
 
-/* The runtime bus is a separate plane; this test is about the catalog fetch. */
+/* The runtime bus is a separate plane; this test is about the catalog fetch.
+   The constants ride along because other modules in the Viewer's import graph
+   read them from the mocked module. */
 mock.module("@/hooks/runtimeBus", () => ({
+  SNAPSHOT_URL: "/api/runtime/snapshot",
+  STREAM_URL: "/api/runtime/stream",
+  STREAM_RECONNECTED_EVENT: "llv:stream-reconnected",
   isRuntimeUiEnabled: () => false,
   getRuntimeBus: () => ({
     getState: () => ({ connection: "offline" }),

--- a/src/components/Viewer.deepLink.dom.test.tsx
+++ b/src/components/Viewer.deepLink.dom.test.tsx
@@ -231,6 +231,22 @@ async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<boolean
   return check();
 }
 
+/** The navigation-loop oracle, applied to EVERY ordering: once the run under
+    test settles, resolution must not have pushed a single history entry (a
+    push loop grows the stack and breaks Back), must write nothing further,
+    and must leave the tab on the same URL. Valid only alongside an assertion
+    about the outcome itself — a quiescence check over a failed open says
+    nothing, which is exactly how the first version of the loop test passed
+    on the defective base. */
+async function expectNavigationQuiescence(): Promise<void> {
+  const settled = historyWrites.length;
+  const hashAtSettle = dom.location.hash;
+  await act(async () => { await Bun.sleep(300); });
+  expect(historyWrites.every((write) => write.startsWith("replace:"))).toBe(true);
+  expect(historyWrites.length).toBe(settled);
+  expect(dom.location.hash).toBe(hashAtSettle);
+}
+
 test("#c= to a conversation whose only present generation is an archived predecessor opens it", async () => {
   dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
   /* The global scope is capped past the conversation; the pinned scope (by id
@@ -246,21 +262,37 @@ test("#c= to a conversation whose only present generation is an archived predece
   expect(dom.location.hash).toBe(`#c=${encodeURIComponent(CONVERSATION_ID)}`);
   /* No visible failure state: this link RESOLVED. */
   expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+  await expectNavigationQuiescence();
 });
 
-test("#c= resolution never navigates in a loop: no pushes, only bounded same-URL retypes", async () => {
+test("#c= resolution OPENS the conversation and never navigates in a loop", async () => {
   dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
   stubFetch((pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, predecessorRow] : [otherRow]));
 
   const host = await mountViewer();
-  await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null);
-  const settled = historyWrites.length;
-  await act(async () => { await Bun.sleep(300); });
-
-  /* A resolver-driven open only ever replaces the entry it stands on. */
-  expect(historyWrites.every((write) => write.startsWith("replace:"))).toBe(true);
-  expect(historyWrites.length).toBe(settled);
+  /* The loop oracle is conditioned on a SUCCESSFUL open: on the defective base
+     the card never materializes and this assertion REDs. The first version of
+     this test ignored the waitFor result and green-lit the base. */
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
+  /* The canonical link survives resolution untouched — the observed prod
+     symptom retyped the same URL four times; here the resolver may retype the
+     entry it stands on at most a bounded number of times, all replaces. */
+  expect(dom.location.hash).toBe(`#c=${encodeURIComponent(CONVERSATION_ID)}`);
   expect(historyWrites.length).toBeLessThanOrEqual(3);
+  await expectNavigationQuiescence();
+});
+
+test("#c= from a tab standing on another project switches to the target's project and opens", async () => {
+  dom.localStorage.setItem("llvProject", "other-project");
+  dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
+  stubFetch((pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, targetRow] : [otherRow]));
+
+  const host = await mountViewer();
+
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
+  expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+  await expectNavigationQuiescence();
 });
 
 test("#c= whose row arrives only via the pinned fetch keeps its pin after resolving", async () => {
@@ -280,6 +312,7 @@ test("#c= whose row arrives only via the pinned fetch keeps its pin after resolv
   expect(filesRequests.length).toBeGreaterThan(0);
   expect(filesRequests[filesRequests.length - 1]).toContain("path=");
   expect(host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`)).not.toBeNull();
+  await expectNavigationQuiescence();
 });
 
 test("legacy #f= to an archived predecessor transcript opens it the same way", async () => {
@@ -293,6 +326,7 @@ test("legacy #f= to an archived predecessor transcript opens it the same way", a
 
   expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
   expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+  await expectNavigationQuiescence();
 });
 
 test("an id no payload can resolve gets a visible notice, never a silent landing", async () => {
@@ -304,4 +338,35 @@ test("an id no payload can resolve gets a visible notice, never a silent landing
   /* Bounded by the same deadline a Back/Forward replay uses (8s). */
   expect(await waitFor(() => host.querySelector("[data-stale-focus-notice]") !== null, 10_000)).toBe(true);
   expect(host.textContent).toContain(en["viewer.staleFocusEntry"]);
+  /* Failing must not navigate either: the hash the operator pasted stays. */
+  await expectNavigationQuiescence();
 }, 15_000);
+
+test("a true-miss notice is DURABLE: it outlives the old self-dismiss window and clears on navigation", async () => {
+  dom.location.hash = "#c=conversation_nowhere-to-be-found";
+  stubFetch(() => [otherRow]);
+
+  const host = await mountViewer();
+
+  expect(await waitFor(() => host.querySelector("[data-stale-focus-notice]") !== null, 10_000)).toBe(true);
+  /* Pre-fix the notice evaporated 6s after appearing while the dead #c= hash
+     stayed put — the operator was back on the silent default view. */
+  await act(async () => { await Bun.sleep(6_500); });
+  expect(host.querySelector("[data-stale-focus-notice]")).not.toBeNull();
+  /* Navigation is a legitimate exit: moving to a project retires the claim. */
+  await act(async () => { dom.location.hash = "#p=other-project"; });
+  expect(await waitFor(() => host.querySelector("[data-stale-focus-notice]") === null)).toBe(true);
+}, 30_000);
+
+test("the durable not-found notice has an explicit dismiss", async () => {
+  dom.location.hash = "#c=conversation_nowhere-to-be-found";
+  stubFetch(() => [otherRow]);
+
+  const host = await mountViewer();
+
+  expect(await waitFor(() => host.querySelector("[data-stale-focus-notice]") !== null, 10_000)).toBe(true);
+  const dismiss = host.querySelector("[data-stale-focus-dismiss]") as HTMLElement | null;
+  expect(dismiss).not.toBeNull();
+  await act(async () => { dismiss!.click(); });
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+}, 20_000);

--- a/src/components/Viewer.deepLink.dom.test.tsx
+++ b/src/components/Viewer.deepLink.dom.test.tsx
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
+import { en } from "@/lib/i18n/en";
+import type { FileEntry } from "@/lib/types";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+/*
+ * P1 — the canonical `#c=<conversationId>` deep link silently bounced instead
+ * of opening the conversation. Two client-side defects, both against the same
+ * invariant (resolution is level-triggered against arriving data, and failure
+ * is VISIBLE, never a silent landing on the default view):
+ *
+ * 1. When the only generation of the conversation in the payload is an
+ *    archived predecessor (`migratedTo` set; the successor transcript sits
+ *    beyond the capped feed — 44 of 52 migrated rows on the machine that
+ *    reproduced this), the resolver correctly picked that row, but
+ *    `withoutArchivedPredecessors` then folded it out of every rendering
+ *    surface: the board had no node for the focused path, nothing opened, no
+ *    error anywhere.
+ *
+ * 2. The catalog-pin release effect read the EMPTY scope-transition
+ *    placeholder (`loaded: false`) as evidence the pinned transcript was gone
+ *    and released a freshly hydrated pin, so even a healthy beyond-cap deep
+ *    link lost its pinned row and its focus request right after resolving.
+ *
+ * These mount the real Viewer with the hash pre-set — the row arriving only
+ * via the pinned fetch, exactly like a pasted deep link on a fresh tab.
+ */
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const dom = new Window({ url: "http://localhost/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  location: dom.location,
+  history: dom.history,
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Element: dom.Element,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+  MutationObserver: dom.MutationObserver,
+  ResizeObserver: dom.ResizeObserver ?? class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  requestAnimationFrame: (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+});
+
+const matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+Object.assign(globalThis, { matchMedia });
+Object.assign(dom, { matchMedia });
+
+/* happy-dom has no Web Animations API; useFlip animates board children. */
+(dom.HTMLElement.prototype as unknown as { animate: () => unknown }).animate = () => ({
+  cancel() {},
+  addEventListener() {},
+});
+
+mock.module("@/hooks/runtimeBus", () => ({
+  SNAPSHOT_URL: "/api/runtime/snapshot",
+  STREAM_URL: "/api/runtime/stream",
+  STREAM_RECONNECTED_EVENT: "llv:stream-reconnected",
+  isRuntimeUiEnabled: () => false,
+  getRuntimeBus: () => ({
+    getState: () => ({ connection: "offline" }),
+    subscribe: () => () => {},
+    subscribeFilesRevision: () => () => {},
+  }),
+}));
+
+const { Viewer } = await import("./Viewer");
+const { resetFilesClientCacheForTests } = await import("@/hooks/useFiles");
+
+const CONVERSATION_ID = "conversation_deeplink-target";
+const TARGET_PATH = "/sessions/deep-link-target.jsonl";
+const TARGET_PROJECT = "deep-link-project";
+
+function fileEntry(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/sessions/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "other-project",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+const otherRow = fileEntry({ path: "/sessions/other.jsonl", title: "Other" });
+const targetRow = fileEntry({
+  path: TARGET_PATH,
+  name: "deep-link-target.jsonl",
+  project: TARGET_PROJECT,
+  title: "The deep-linked conversation",
+  conversationId: CONVERSATION_ID,
+});
+/* The production shape of the P1: the conversation's ONLY row in the payload is
+   an archived predecessor — its account migration recorded a successor path the
+   capped feed does not carry. */
+const predecessorRow = fileEntry({
+  ...targetRow,
+  migratedTo: "/beyond-cap/successor-generation.jsonl",
+});
+
+const originalFetch = globalThis.fetch;
+const requestLog: string[] = [];
+let historyWrites: string[] = [];
+let boards: Record<string, BoardProjectStateV1> = {};
+
+const emptyBoard = (): BoardProjectStateV1 => ({
+  schemaVersion: 1,
+  revision: 0,
+  updatedAt: new Date(0).toISOString(),
+  pathAliases: {},
+  prefs: { manual: [], hidden: [], expanded: [], favorites: [], foldedEngineChildIds: [], expandedEngineTrayParentIds: [], viewMode: null, taskPanelOpen: false },
+});
+
+/* Wrapped ONCE at module scope: re-wrapping per test would stack the loggers
+   and double-count every write in later tests. */
+const origPush = dom.history.pushState.bind(dom.history);
+const origReplace = dom.history.replaceState.bind(dom.history);
+dom.history.pushState = (s: unknown, t: string, u?: string | URL) => { historyWrites.push(`push:${u}`); return origPush(s, t, u); };
+dom.history.replaceState = (s: unknown, t: string, u?: string | URL) => { historyWrites.push(`replace:${u}`); return origReplace(s, t, u); };
+
+beforeEach(() => {
+  resetFilesClientCacheForTests();
+  dom.localStorage.clear();
+  dom.sessionStorage.clear();
+  document.body.replaceChildren();
+  requestLog.length = 0;
+  historyWrites = [];
+  boards = {};
+});
+
+afterEach(() => {
+  unmountViewer();
+  globalThis.fetch = originalFetch;
+  document.body.replaceChildren();
+  dom.location.hash = "";
+});
+
+/** `/api/files` serves `filesByPin` keyed by the request's `path` param
+    (`""` = the unpinned global scope); `/api/board` is a real in-memory board
+    so the focus request can actually place its card. Everything else 404s. */
+function stubFetch(filesByPin: (pin: string) => FileEntry[]) {
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    requestLog.push(url);
+    if (url.startsWith("/api/files")) {
+      const pin = new URL(url, "http://localhost").searchParams.get("path") ?? "";
+      return new Response(
+        JSON.stringify({ files: filesByPin(pin), projectCatalog: [] }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/board")) {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET") {
+        const project = new URL(url, "http://localhost").searchParams.get("project") ?? "";
+        return Response.json({ ok: true, board: boards[project] ?? emptyBoard() });
+      }
+      const body = JSON.parse(String(init?.body)) as { project: string; mutations?: BoardMutationV1[] };
+      const current = boards[body.project] ?? emptyBoard();
+      const reduced = applyBoardMutations(current, body.mutations ?? []);
+      const next = { ...reduced, schemaVersion: 1 as const, revision: current.revision + 1, updatedAt: new Date(0).toISOString(), pathAliases: reduced.pathAliases ?? {} };
+      boards[body.project] = next;
+      return Response.json({ ok: true, applied: true, board: next });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+let mounted: { unmount: () => void } | null = null;
+
+async function mountViewer(): Promise<HTMLElement> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted = root;
+  await act(async () => { root.render(<Viewer />); });
+  await act(async () => { await Bun.sleep(50); });
+  return host as unknown as HTMLElement;
+}
+
+function unmountViewer() {
+  if (!mounted) return;
+  const root = mounted;
+  mounted = null;
+  act(() => { root.unmount(); });
+}
+
+/** Level-triggered settling: polls until the condition holds or the bounded
+    window elapses, driving timers/microtasks through `act` between checks. */
+async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return true;
+    await act(async () => { await Bun.sleep(40); });
+  }
+  return check();
+}
+
+test("#c= to a conversation whose only present generation is an archived predecessor opens it", async () => {
+  dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
+  /* The global scope is capped past the conversation; the pinned scope (by id
+     or by the resolved transcript path) serves the archived predecessor row. */
+  stubFetch((pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, predecessorRow] : [otherRow]));
+
+  const host = await mountViewer();
+
+  /* The conversation's project is selected and its card materializes. */
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
+  expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+  /* The canonical link survives resolution. */
+  expect(dom.location.hash).toBe(`#c=${encodeURIComponent(CONVERSATION_ID)}`);
+  /* No visible failure state: this link RESOLVED. */
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+});
+
+test("#c= resolution never navigates in a loop: no pushes, only bounded same-URL retypes", async () => {
+  dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
+  stubFetch((pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, predecessorRow] : [otherRow]));
+
+  const host = await mountViewer();
+  await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null);
+  const settled = historyWrites.length;
+  await act(async () => { await Bun.sleep(300); });
+
+  /* A resolver-driven open only ever replaces the entry it stands on. */
+  expect(historyWrites.every((write) => write.startsWith("replace:"))).toBe(true);
+  expect(historyWrites.length).toBe(settled);
+  expect(historyWrites.length).toBeLessThanOrEqual(3);
+});
+
+test("#c= whose row arrives only via the pinned fetch keeps its pin after resolving", async () => {
+  dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`;
+  stubFetch((pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, targetRow] : [otherRow]));
+
+  const host = await mountViewer();
+
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
+  expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+  await act(async () => { await Bun.sleep(200); });
+  /* The scope transition after resolution serves an EMPTY placeholder before
+     its own fetch lands; that placeholder must not release the hydrated pin.
+     A released pin shows up here as a trailing UNPINNED /api/files request —
+     and as the card evaporating from the board. */
+  const filesRequests = requestLog.filter((url) => url.startsWith("/api/files"));
+  expect(filesRequests.length).toBeGreaterThan(0);
+  expect(filesRequests[filesRequests.length - 1]).toContain("path=");
+  expect(host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`)).not.toBeNull();
+});
+
+test("legacy #f= to an archived predecessor transcript opens it the same way", async () => {
+  dom.location.hash = `#f=${encodeURIComponent(TARGET_PATH)}`;
+  /* Resolution retypes the entry to the canonical `#c=` form, so the follow-up
+     intent pins by conversation id — the server answers both, and so does this
+     stub. */
+  stubFetch((pin) => (pin === TARGET_PATH || pin === CONVERSATION_ID ? [otherRow, predecessorRow] : [otherRow]));
+
+  const host = await mountViewer();
+
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null)).toBe(true);
+  expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+});
+
+test("an id no payload can resolve gets a visible notice, never a silent landing", async () => {
+  dom.location.hash = "#c=conversation_nowhere-to-be-found";
+  stubFetch(() => [otherRow]);
+
+  const host = await mountViewer();
+
+  /* Bounded by the same deadline a Back/Forward replay uses (8s). */
+  expect(await waitFor(() => host.querySelector("[data-stale-focus-notice]") !== null, 10_000)).toBe(true);
+  expect(host.textContent).toContain(en["viewer.staleFocusEntry"]);
+}, 15_000);

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -98,8 +98,12 @@ function projectUrl(project: string): string {
     stay usable. */
 const STALE_FOCUS_REPLAY_MS = 8_000;
 
-/** How long the stale-entry notice stays up before it dismisses itself. */
-const STALE_FOCUS_NOTICE_MS = 6_000;
+/** How long the unknown-fragment notice stays up before it dismisses itself.
+    The stale-conversation notice never self-dismisses: an unresolved deep link
+    keeps its visible not-found state until the operator navigates, resolves a
+    new target, or dismisses it — a notice that evaporates while the hash stays
+    put lands the tab back on the silent default view this fix exists to kill. */
+const UNKNOWN_FRAGMENT_NOTICE_MS = 6_000;
 
 /** One-line reason a queue item waits: question header, screen tail, or the stalled wording. */
 function attentionSnippet(t: TFunction, item: AttentionItem): string {
@@ -262,6 +266,9 @@ export function Viewer() {
          focus entry with its full stored identity; deriving a second, weaker
          intent from the bare hash would drop the project and path support. */
       if (traversalFenceRef.current.swallows(location.hash)) return;
+      /* Navigation is one of the two exits a durable not-found notice has
+         (the other is its dismiss button): a new attempt starts clean. */
+      setStaleFocusNotice(false);
       const next = readHash();
       if (next.filePath || next.conversationId) {
         dispatchCatalogPin({ kind: "release" });
@@ -298,6 +305,7 @@ export function Viewer() {
       /* The browser has already applied this traversal's URL, so the fragment
          read here is exactly the hash whose follow-up hashchange must skip. */
       traversalFenceRef.current.arm(location.hash);
+      setStaleFocusNotice(false);
       dispatchCatalogPin({ kind: "release" });
       setFocusRequest(null);
       /* Cross-project entries select the stored project first, then resolve. */
@@ -328,14 +336,8 @@ export function Viewer() {
   }, []);
 
   useEffect(() => {
-    if (!staleFocusNotice) return;
-    const timer = window.setTimeout(() => setStaleFocusNotice(false), STALE_FOCUS_NOTICE_MS);
-    return () => window.clearTimeout(timer);
-  }, [staleFocusNotice]);
-
-  useEffect(() => {
     if (!unknownFragmentNotice) return;
-    const timer = window.setTimeout(() => setUnknownFragmentNotice(false), STALE_FOCUS_NOTICE_MS);
+    const timer = window.setTimeout(() => setUnknownFragmentNotice(false), UNKNOWN_FRAGMENT_NOTICE_MS);
     return () => window.clearTimeout(timer);
   }, [unknownFragmentNotice]);
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -346,7 +348,9 @@ export function Viewer() {
   const applyProject = useCallback((nextProject: string) => {
     setProject(nextProject);
     /* Explicit project navigation replaces the hash without a hashchange
-       event, so any unresolved conversation intent is cancelled here. */
+       event, so any unresolved conversation intent is cancelled here — and a
+       deliberate navigation retires the durable not-found notice. */
+    setStaleFocusNotice(false);
     setPendingHash(null);
     dispatchCatalogPin({ kind: "release" });
     setFocusRequest(null);
@@ -404,6 +408,9 @@ export function Viewer() {
      the node after the transient hash intent resolves. */
   const openPinnedFile = useCallback((file: FileEntry, hydrated = false) => {
     const key = projectKey(file);
+    /* A resolution landing is the third exit for the not-found notice: the
+       viewer is now showing a conversation, so the failure claim is over. */
+    setStaleFocusNotice(false);
     queueColumnOpen(key, file.path, isChildConversation(file));
     dispatchCatalogPin({ kind: hydrated ? "resolve" : "open", path: file.path, conversationId: file.conversationId });
     setProject(key);
@@ -972,13 +979,25 @@ export function Viewer() {
       {/* Staging instances (#659) announce themselves on every device; prod
           renders nothing. Top-center, clear of both corner anchors. */}
       <StagingBadge />
-      {/* A Back/Forward entry whose conversation no longer resolves (issue
-          #866): says so and self-dismisses; the surrounding history keeps
-          working. Below the staging badge's anchor so the two never overlap. */}
+      {/* A Back/Forward entry or pasted deep link whose conversation never
+          resolves (issues #866, P1 #c= bounce): says so and STAYS — the notice
+          survives until a navigation, a successful resolution, or its dismiss
+          button, because a self-dismissing notice left the unchanged hash
+          sitting silently on the default view. Below the staging badge's
+          anchor so the two never overlap. */}
       {staleFocusNotice ? (
         <div className="pointer-events-none fixed left-1/2 top-10 z-40 -translate-x-1/2" role="status" data-stale-focus-notice>
-          <div className="rounded-full border border-warning/45 bg-warning-soft px-3.5 py-1.5 text-[12px] font-semibold text-warning shadow-1 backdrop-blur">
+          <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-warning/45 bg-warning-soft py-1.5 pl-3.5 pr-2 text-[12px] font-semibold text-warning shadow-1 backdrop-blur">
             {t("viewer.staleFocusEntry")}
+            <button
+              type="button"
+              onClick={() => setStaleFocusNotice(false)}
+              aria-label={t("viewer.closeNotification")}
+              className="rounded-full p-0.5 hover:bg-warning/15"
+              data-stale-focus-dismiss
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
           </div>
         </div>
       ) : null}

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -3,7 +3,7 @@
 import { Crown, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 
-import { formatConversationHash, parseConversationHash, resolveConversationTarget, withoutArchivedPredecessors, type ConversationHash } from "@/lib/accounts/identity";
+import { formatConversationHash, isArchivedPredecessor, parseConversationHash, resolveConversationTarget, withoutArchivedPredecessors, type ConversationHash } from "@/lib/accounts/identity";
 import { createTraversalFence, parseFocusHistoryState, recordFocusNavigation, recordProjectNavigation, retargetRecordedProject } from "@/lib/navigation/focusHistory";
 import { onAccountPanelRequest } from "@/lib/accounts/openPanel";
 import { useAgentChimes } from "@/hooks/useAgentChimes";
@@ -91,9 +91,11 @@ function projectUrl(project: string): string {
   return project !== OVERVIEW ? "#p=" + encodeURIComponent(project) : location.pathname;
 }
 
-/** How long a Back/Forward replay waits for its pinned poll to resolve the
-    target before it reports the entry stale (issue #866): a few poll rounds,
-    then the intent clears so later history actions stay usable. */
+/** How long an unresolved conversation intent — a Back/Forward replay (issue
+    #866) or a pasted `#c=`/`#f=` deep link — waits for its pinned poll to
+    resolve the target before it reports the entry stale: a few poll rounds,
+    then the intent clears so the failure is visible and later history actions
+    stay usable. */
 const STALE_FOCUS_REPLAY_MS = 8_000;
 
 /** How long the stale-entry notice stays up before it dismisses itself. */
@@ -149,8 +151,26 @@ export function Viewer() {
   /* A committed account migration keeps the archived predecessor entry in the
      payload (for chain history) but it must never render as a second standalone
      card — every surface below sees only current generations. A no-op (same
-     array identity) until something actually migrates. */
-  const files = useMemo(() => withoutArchivedPredecessors(allFiles), [allFiles]);
+     array identity) until something actually migrates.
+
+     One carve-out: a `#c=`/`#f=` deep link can resolve to an archived
+     predecessor that is the ONLY generation of its conversation in the payload
+     (the successor transcript sits beyond the capped feed). Folding that row
+     out left the pinned open with nothing to render — the board had no node
+     for the focused path and the link silently opened nothing. Keeping the one
+     pinned row cannot duplicate a card, and the moment a current generation
+     arrives the pin retargets to it (see the catalog-pin files effect) and the
+     predecessor folds away again. */
+  const files = useMemo(() => {
+    const folded = withoutArchivedPredecessors(allFiles);
+    const pinnedPath = catalogPin?.path;
+    if (!pinnedPath || folded.some((file) => file.path === pinnedPath)) return folded;
+    const pinned = allFiles.find((file) => file.path === pinnedPath);
+    if (!pinned || !isArchivedPredecessor(pinned)) return folded;
+    const currentGenerationPresent = Boolean(pinned.conversationId)
+      && folded.some((file) => file.conversationId === pinned.conversationId);
+    return currentGenerationPresent ? folded : [...folded, pinned];
+  }, [allFiles, catalogPin]);
   const dashboardFilesRef = useRef<{ project: string; files: FileEntry[] } | null>(null);
   const dashboardFiles = useMemo(() => {
     if (project === OVERVIEW) return [];
@@ -424,6 +444,23 @@ export function Viewer() {
   }, [pendingHash, allFiles, conversationAliases, launchRoutes, openPinnedFile]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
+  /* A deep-link intent no payload resolves (the id is absent from the corpus
+     and from its own pinned request) must FAIL VISIBLY: sitting silently on the
+     default view read as "the page just reloads and nothing opens". Same
+     bounded deadline the Back/Forward replay uses; the countdown starts only
+     once a certified payload exists, and a resolution clearing `pendingHash`
+     cancels it. The popstate path arms its own identity-checked timer — for a
+     replayed entry both reach the same notice. */
+  useEffect(() => {
+    if (!pendingHash || !loaded) return;
+    const timer = window.setTimeout(() => {
+      setPendingHash(null);
+      dispatchCatalogPin({ kind: "release" });
+      setStaleFocusNotice(true);
+    }, STALE_FOCUS_REPLAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [pendingHash, loaded]);
+
   const releaseCatalogFile = useCallback((path: string) => {
     dispatchCatalogPin({ kind: "release", path });
     setFocusRequest((current) => current?.path === path ? null : current);
@@ -432,6 +469,12 @@ export function Viewer() {
 
   useEffect(() => {
     if (!catalogPin?.hydrated || pendingHash) return;
+    /* A scope transition (the pin just moved to a new request URL) serves the
+       EMPTY placeholder until its own fetch lands. That placeholder is not
+       evidence the transcript disappeared — releasing the hydrated pin on it
+       dropped every freshly resolved beyond-cap deep link right after it
+       opened. Only a certified payload may retire the pin. */
+    if (!loaded) return;
     const currentPath = catalogPin.conversationId
       ? files.find((file) => file.conversationId === catalogPin.conversationId)?.path
       : undefined;
@@ -441,7 +484,7 @@ export function Viewer() {
       pending: false,
       currentPath,
     });
-  }, [catalogPin, pendingHash, allFiles, files]);
+  }, [catalogPin, pendingHash, allFiles, files, loaded]);
 
   /* The one queue every counter shows: badge, popover and the tab title all
      read the same list, stalled tail included (D10). The clock advances when


### PR DESCRIPTION
## P1 — the canonical `#c=<conversationId>` deep link silently bounced

Opening the viewer at `/#c=<id>` performed a handful of same-URL history writes and landed on a board with no conversation pane, no scheme node for the target, the hash intact, and zero console errors. Reproduced headlessly against the deployed head with a fresh browser context before the fix.

### Root cause (client-side; the server pin ride-along is fine)

The target conversation's ONLY row in the `/api/files` payload is an **archived predecessor** — its account migration recorded a `migratedTo` successor transcript that sits beyond the capped feed. On the machine that reproduced this, 44 of 52 migrated rows are in that state, so this covers a whole class of deep links (including the earlier "large conversation won't open" report).

1. `src/components/Viewer.tsx` resolution effect → `resolveConversationTarget` → `currentConversationFile` (`src/lib/accounts/identity.ts:108`) correctly falls back to the archived predecessor when no current generation is present, and `openPinnedFile` selects the project and requests focus on that row's path.
2. But the render corpus is `withoutArchivedPredecessors(allFiles)` (`src/components/Viewer.tsx:153` pre-fix), which folds that very row out of every surface — the board never materializes the node, the focus request dangles forever, and the failure is silent.
3. Secondary race: the catalog-pin release effect treated the EMPTY scope-transition placeholder (`loaded: false`, served while the pin's new request URL has no representation yet) as evidence the pinned transcript disappeared, and released a freshly hydrated pin — so even a healthy beyond-cap deep link lost its pinned row and focus request right after resolving.

The "four navigations" are the initial load plus benign same-URL `replaceState` retypes (hydration + the resolver's `restore` record); there was never a real reload loop — it just looked like one because nothing opened.

### Fix (all in the Viewer shell; producers untouched)

- **Keep the resolved predecessor renderable**: the `files` memo keeps the pinned archived-predecessor row while it is the only generation of its conversation in the payload. The moment a current generation arrives, the existing catalog-pin retarget hands the pin to it and the predecessor folds away again — no duplicate card is possible.
- **Pin release requires certified evidence**: the release effect skips the `loaded: false` scope-transition placeholder; only a fetched payload may retire a hydrated pin.
- **Unresolvable links fail visibly**: a pending deep-link intent now clears after the same bounded deadline a Back/Forward replay uses (8s from the first certified payload) and shows the existing stale-conversation notice instead of sitting silently on the default view.

The legacy `#f=` route shares the same resolver path (checked, not assumed): a `#f=` link to a predecessor transcript resolves, retypes to canonical `#c=`, and opens through the same carve-out. Covered by a dedicated test.

### Tests

`src/components/Viewer.deepLink.dom.test.tsx` mounts the real `Viewer` with the hash pre-set and the row arriving only via the pinned fetch (all five were RED before the fix):

- `#c=` to a conversation whose only present generation is an archived predecessor opens it
- resolution never navigates in a loop: no pushes, only bounded same-URL retypes
- `#c=` whose row arrives only via the pinned fetch keeps its pin after resolving
- legacy `#f=` to an archived predecessor transcript opens it the same way
- an id no payload can resolve gets a visible notice, never a silent landing

Ride-along: `Viewer.catalogFailure.dom.test.tsx`'s runtimeBus mock gains the module's exported constants — it failed standalone at HEAD (`STREAM_RECONNECTED_EVENT` missing from the mocked module).

### Verification

- Focused test files by path (isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`): the new file 5/5, plus `Viewer.test.ts` 9/9, `Viewer.catalogFailure.dom.test.tsx` 4/4, `Viewer.attentionMount.test.ts` 3/3, `identity.test.ts` 22/22, `focusHistory.test.ts` 23/23, `focusHistory.dom.test.ts` 14/14
- `tsc --noEmit` clean; scoped eslint adds no new findings (8 `react-hooks/refs` errors in untouched `dashboardFiles` code pre-exist at HEAD, verified on a clean HEAD worktree)
- `next build` + MCP bundle green
- `bun scripts/privacy-publication-gate.ts --base <merge-base>`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)