### PR TITLE
feat(orchestrator): mandate v4 — direct operator chat is a first-class channel (#982)

### DIFF
--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import { BRIDGE_REPORT_CLASSES } from "@/lib/bridge/types";
 
-import { ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "./prompt";
+import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "./prompt";
 
 test("the manager spawns as Claude Opus 5 on low effort through the role preset", () => {
   expect(ORCHESTRATOR_SPAWN_CONFIG).toMatchObject({ engine: "claude", model: "opus", effort: "low", role: "orchestrator" });
@@ -22,13 +22,43 @@ test("system prompt encodes the conveyor loop and its bars", () => {
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("src = YOUR transcript path");
 });
 
-/* #691 — the half of the load-bearing constraint that only a prompt can carry: the
-   manager has no user-facing channel, so it must not try to use one. */
+/* #982 / PRD #976 decision 7 — the operator talks to whoever they want, the manager
+   included. Mandate v4 replaced #691's "You do not talk to the user" section with two
+   channels: direct chat in the manager's own conversation, and bridge reports for the
+   voice gateway. The tests below pin both halves of that contract so the prohibition
+   cannot creep back in silently — in the replaced section or anywhere else. */
 
-test("the manager is told it does not talk to the user", () => {
-  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("You do not talk to the user");
-  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Never address the user");
+test("direct operator chat is sanctioned as a first-class channel", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Two channels to the operator");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("The operator talks to whoever they want, you included");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("answer them there");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("That channel is sanctioned and first-class");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("gateway");
+});
+
+test("no prohibition on addressing the operator survives anywhere in the mandate", () => {
+  for (const prohibition of [
+    "You do not talk to the user",
+    "Never address the user",
+    "never ask them a question directly",
+    "you have no user-facing channel",
+    "not as chat",
+    "only through your reports",
+  ]) {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain(prohibition);
+  }
+});
+
+test("bridge reports survive as the second channel, for the operator away from the chat", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Bridge reports — the second channel (manager -> gateway)");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("carries what must reach the operator while they are elsewhere");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Append one report per meaningful outcome, with a stable key");
+});
+
+/* Seats record the mandate version they were spawned on; `get_orchestrator` reports
+   this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
+test("the default mandate is at version 4", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(4);
 });
 
 test("the prompt names every bridge report class and no others", () => {

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -15,6 +15,17 @@ test("system prompt carries the draft-only pipeline contract", () => {
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("explicitly asked to start it in the same request");
 });
 
+/* #982 — the auto-start exception used to require the request to arrive "relayed
+   through the gateway", which made an explicit start asked in the manager's own
+   conversation carry less authority than the same words spoken to the gateway. Under
+   PRD #976 decision 7 both channels are equal; the draft-by-default rule above is
+   untouched, only the channel qualifier is gone. */
+test("the auto-start exception treats direct chat and the gateway as equal channels", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("asked in your own conversation or relayed through the gateway");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("both channels carry the same authority");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain("same request, relayed through the gateway");
+});
+
 test("system prompt encodes the conveyor loop and its bars", () => {
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("GitHub issue -> worktree lane -> implementer agent -> review flow -> merge bar");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("merge only on an APPROVE verdict");

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -56,7 +56,7 @@ Drive every accepted piece of work through: GitHub issue -> worktree lane -> imp
 - Keep task cards updated via /api/tasks. Report state changes as bridge reports.
 
 ## Draft-only pipeline contract
-You NEVER auto-start pipelines. When asked to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and report the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request, relayed through the gateway.
+You NEVER auto-start pipelines. When asked to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and report the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request — asked in your own conversation or relayed through the gateway; both channels carry the same authority.
 
 ## Deploys
 YOU decide when to deploy, and you execute it yourself. Your authority is your designated seat, attributed server-side — a session that is not the designated orchestrator is refused, and a seat acts only for its own project. Nobody — you included — ever asks the user to confirm, approve, repeat, or say a commit hash. There is no confirmation step for the user, anywhere; deploys reach the user through your reports.

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -5,10 +5,11 @@
  * built-in system directive. Shared by the client button and the API layer, so it must
  * stay a pure-constant module.
  *
- * #691 changed what this agent is, not what it can do. It keeps the full Viewer MCP
- * surface; what it loses is the user. The Codex voice root is the sole user-facing
- * gateway, so everything this agent wants the operator to know goes into the bridge
- * report log and reaches them in the gateway's voice. */
+ * #691 reshaped this agent's role while leaving its tool surface whole: it keeps the
+ * full Viewer MCP surface. Mandate v4 (#982, PRD #976) gives it two channels to the
+ * operator — direct replies in its own conversation, and the bridge report log the
+ * Codex voice gateway drains for everything that must reach the operator when they
+ * are not in that chat. */
 
 /** Fixed spawn identity: the resident brain runs on the latest Opus alias (`opus` is
     Claude Opus 5 — see `src/lib/agent/models.ts`) and escalates by spawning
@@ -26,15 +27,15 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 3;
+export const ORCHESTRATOR_PROMPT_VERSION = 4;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
 
-## You do not talk to the user
-The user talks to ONE agent: the Codex realtime voice root, which is the gateway. You are not it, and you have no user-facing channel. Never address the user, never ask them a question directly, never assume they read anything you write in your own transcript.
-Everything the user should hear leaves you as a BRIDGE REPORT. The gateway drains those reports and decides what to say aloud. A thought you did not put in a report did not reach anyone.
+## Two channels to the operator
+The operator talks to whoever they want, you included. When they write in your own conversation, answer them there — directly, plainly, helpfully, in your own voice, at whatever length the question deserves. That channel is sanctioned and first-class: what you write in it reaches them, and a question they put to you is yours to answer.
+The second channel is the bridge report log below. It carries what must reach the operator while they are elsewhere, spoken in the Codex realtime voice gateway's voice once the gateway drains it. An outcome you neither answered in chat nor put in a report reached nobody.
 
-## Bridge reports (manager -> gateway)
+## Bridge reports — the second channel (manager -> gateway)
 Append one report per meaningful outcome, with a stable key so a retry after a host death is a no-op rather than a duplicate. Classes, and nothing outside this list:
 - status — brief progress worth surfacing; keep these rare.
 - completed / failed — a stage, review, merge or deploy settled.
@@ -52,13 +53,13 @@ Drive every accepted piece of work through: GitHub issue -> worktree lane -> imp
 - Spawn implementers via POST /api/spawn with src = YOUR transcript path (lineage draws the diagram edges) and role per the role table; workers end with "REVIEW_READY: <PR url>".
 - Reviews run as flows (POST /api/flows) or fresh reviewer spawns (role: "reviewer", reviews: <implementer ref>) — a fresh reviewer every round, verdict contract "VERDICT: APPROVE|REQUEST_CHANGES".
 - Merge bar: merge only on an APPROVE verdict with green gates (tsc + tests). Never merge red.
-- Keep task cards updated via /api/tasks. Report state changes as bridge reports, not as chat.
+- Keep task cards updated via /api/tasks. Report state changes as bridge reports.
 
 ## Draft-only pipeline contract
 You NEVER auto-start pipelines. When asked to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and report the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request, relayed through the gateway.
 
 ## Deploys
-YOU decide when to deploy, and you execute it yourself. Your authority is your designated seat, attributed server-side — a session that is not the designated orchestrator is refused, and a seat acts only for its own project. Nobody — you included — ever asks the user to confirm, approve, repeat, or say a commit hash. There is no confirmation step for the user, anywhere; the user hears about deploys only through your reports.
+YOU decide when to deploy, and you execute it yourself. Your authority is your designated seat, attributed server-side — a session that is not the designated orchestrator is refused, and a seat acts only for its own project. Nobody — you included — ever asks the user to confirm, approve, repeat, or say a commit hash. There is no confirmation step for the user, anywhere; deploys reach the user through your reports.
 1. Prepare: merges landed on origin/main, gates green. Never deploy red.
 2. Resolve origin/main to a full 40-hex commit SHA yourself and verify it contains what you shipped. The SHA is machine evidence — never route it through the user.
 3. Call deploy_exact_sha with revision=<sha>. Deployments serialize (a busy receipt means one is already running); a retry reuses the same clientRequestId and replays the original receipt.


### PR DESCRIPTION
Closes #982 (slice F of PRD #976).

## Why

PRD #976 decision 7, operator verbatim (translated): *"The prompt is wrong. I can talk to whoever I want — the orchestrator, the voice coordinator, individual agents. Whoever I want to talk to, I talk to."* The default mandate said the opposite — it told the manager it had no user-facing channel and must never address the operator.

## What changed

`src/lib/orchestrator/prompt.ts` only, plus its test.

**The section swap.** `## You do not talk to the user` becomes `## Two channels to the operator`:

- **Direct chat** — when the operator writes in the manager's own conversation, it answers them there, directly and plainly, in its own voice. Sanctioned and first-class.
- **Bridge reports** — the second channel, for the voice gateway and for what must reach the operator while they are elsewhere. Report classes, the 2 KB / no-raw-output body bounds and the `[bridge ref=<seq>]` directive trailer contract are byte-identical; only the heading gains "— the second channel".

**Two residual prohibitions elsewhere.** Acceptance criterion 1 is "no prohibition on addressing the user survives *anywhere* in the default mandate", and two exclusivity clauses outside the replaced section still forbade it. Each loses only the clause, keeping the rule's substance:

- Conveyor: `Report state changes as bridge reports, not as chat.` → `Report state changes as bridge reports.`
- Deploys: `the user hears about deploys only through your reports` → `deploys reach the user through your reports`. The deploy contract is otherwise untouched — no confirmation step, no SHA and no question ever route through the user.

**Nothing tightens.** No new prohibition, gate, confirmation or ceremony anywhere; conveyor rules, the draft-only pipeline contract and the deploy procedure are otherwise unchanged.

**Version.** `ORCHESTRATOR_PROMPT_VERSION` 3 → 4. Seats store the version they were spawned on, so existing v3 seats now read as stale against `get_orchestrator`'s `defaultPromptVersion: 4` — a reporting difference with no behaviour change. No consumer hardcodes the literal (`bindings.ts` and `orchestratorTools.test.ts` both reference the constant).

## Tests

`prompt.test.ts` retires the "the manager is told it does not talk to the user" test and pins the new contract with four:

- direct operator chat is sanctioned as a first-class channel
- **no prohibition on addressing the operator survives anywhere in the mandate** — asserts the absence of all six retired phrasings, so the ban cannot silently return
- bridge reports survive as the second channel
- the default mandate is at version 4

## Verification

- `bun test src/lib/orchestrator/prompt.test.ts` — 13 pass
- consumers: `orchestratorTools.test.ts` + `seats.test.ts` — 44 pass; `seatCommand.test.ts` + `authority.test.ts` + `managerAuthority.test.ts` — 43 pass
- all runs used an isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR` / `TMPDIR`; no broad suites, no sweep of the shared state dir
- `bunx tsc --noEmit` clean; `eslint` on both files clean; `bun run build` green (incl. MCP bundle); privacy publication gate PASS

Not deployed — per the PRD delivery policy this batch merges only, and the operator deploys it together later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)