### PR TITLE
fix(mobile): focusing a long composer message keeps the controls visible — budget against the keyboard-shrunk viewport (#983)

### DIFF
--- a/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
+++ b/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
@@ -1,0 +1,180 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { BranchGroup } from "@/components/projectModel";
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * Issue #983 — the focus root must fit the KEYBOARD-SHRUNK viewport. iOS Safari
+ * ignores interactive-widget=resizes-content, so with the keyboard open the
+ * layout viewport (h-dvh body, this root's max-h-[100dvh]) keeps the full
+ * screen height and the keyboard covers its bottom — composer controls
+ * included. The browser then scrolls the WINDOW to reach the focused field and
+ * re-asserts that scroll against any manual gesture (the reported snap-back).
+ * Padding the keyboard's overlap away keeps everything inside the visible area
+ * so the browser never has a reason to scroll the window at all.
+ */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+
+const { MobileFocusView } = await import("@/components/mobile/MobileFocusView");
+
+/* A minimal visualViewport stand-in — happy-dom does not provide one. */
+function makeVisualViewport(height: number) {
+  const listeners = new Set<() => void>();
+  return {
+    height,
+    scale: 1,
+    offsetTop: 0,
+    addEventListener(type: string, cb: () => void) { if (type === "resize") listeners.add(cb); },
+    removeEventListener(type: string, cb: () => void) { if (type === "resize") listeners.delete(cb); },
+    resizeTo(next: number) {
+      this.height = next;
+      for (const cb of [...listeners]) cb();
+    },
+  };
+}
+
+const dom = new Window({ url: "http://localhost/", width: 390, height: 800 });
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: (q: string) => ({ matches: /max-width/.test(String(q)), media: String(q), onchange: null, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; } }),
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  fetch: (async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" })) as unknown as typeof fetch,
+};
+(dom as unknown as { matchMedia: unknown }).matchMedia = OVERRIDES.matchMedia;
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)); };
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+  (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+});
+
+let roots: Root[] = [];
+beforeEach(() => { dom.document.body.replaceChildren(); roots = []; });
+afterEach(async () => {
+  for (const r of roots) flushSync(() => r.unmount());
+  roots = [];
+  await settle();
+  dom.sessionStorage.clear();
+  delete (dom as unknown as Record<string, unknown>).visualViewport;
+  delete G.visualViewport;
+});
+
+function mount(node: React.ReactElement): Root {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  return root;
+}
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects", name: overrides.path, project: "demo", title: overrides.path,
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1_000, size: 10,
+    activity: "idle", proc: null, pid: null, model: null, pendingQuestion: null, waitingInput: null,
+    ...overrides,
+  };
+}
+
+function view() {
+  const conversation = entry({ path: "/session", title: "Main session", activity: "live", mtime: 9_000 });
+  const group: BranchGroup = { key: conversation.path, columns: [{ file: conversation, tasks: [] }], returnable: [], finished: [], smt: conversation.mtime, orphanTask: false };
+  return (
+    <MobileFocusView
+      project="demo" groups={[group]} manual={[]} files={[conversation]} flows={[]}
+      pipelines={[]} surfacePipelines={[]} tasks={[]} drafts={[]}
+      loaded focus={null} onSelect={() => {}} onClose={() => {}} onDraftClose={() => {}} onDraftSpawned={() => {}}
+    />
+  );
+}
+
+function shell(): HTMLElement {
+  return dom.document.querySelector('[data-testid="mobile-chat-shell"]') as unknown as HTMLElement;
+}
+
+test("keyboard open: the focus root pads the keyboard's overlap out of its height (#983)", async () => {
+  /* Layout viewport 800px, visible area 448px: the keyboard covers 352px of
+     the layout the root would otherwise fill. That overlap becomes bottom
+     padding, so the composer's controls land above the keyboard and the
+     browser has nothing to scroll the window for. */
+  const vv = makeVisualViewport(448);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  roots.push(mount(view()));
+  await settle();
+
+  expect(shell()).not.toBeNull();
+  expect(shell().style.paddingBottom).toBe("352px");
+  /* The window-scroll prevention contract stays: a fixed-height root that
+     clips its own overflow, never a scrollable document. */
+  expect(shell().className).toContain("max-h-[100dvh]");
+  expect(shell().className).toContain("overflow-hidden");
+});
+
+test("keyboard closes: the visualViewport resize returns the full-height root (#983)", async () => {
+  const vv = makeVisualViewport(448);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  roots.push(mount(view()));
+  await settle();
+  expect(shell().style.paddingBottom).toBe("352px");
+
+  flushSync(() => vv.resizeTo(800));
+  expect(shell().style.paddingBottom).toBe("");
+});
+
+test("no visualViewport: the root keeps today's exact layout (#983 fallback)", async () => {
+  roots.push(mount(view()));
+  await settle();
+
+  expect(shell()).not.toBeNull();
+  expect(shell().style.paddingBottom).toBe("");
+  expect(shell().className).toContain("h-full");
+  expect(shell().className).toContain("max-h-[100dvh]");
+});
+
+test("a layout-resizing keyboard (resizes-content honored) needs no inset (#983)", async () => {
+  /* Android Chrome honors the app's interactive-widget=resizes-content: the
+     layout viewport itself shrinks, both viewports agree, and double-shrinking
+     the root would waste half the screen. */
+  const vv = makeVisualViewport(800);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  roots.push(mount(view()));
+  await settle();
+
+  expect(shell().style.paddingBottom).toBe("");
+});

--- a/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
+++ b/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from "react-dom";
 
 import { emptyStore } from "@/components/runtime/runtimeModel";
 import type { BranchGroup } from "@/components/projectModel";
+import { MOBILE_COMPOSER_CHROME_PX } from "@/lib/composerScroll";
 import type { FileEntry } from "@/lib/types";
 
 /*
@@ -74,9 +75,13 @@ const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await n
 beforeAll(() => {
   for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
   (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+  /* Text always overflows, so the composer textarea lands exactly on its grow
+     ceiling — the number the integrated geometry tests assert on. */
+  Object.defineProperty(dom.HTMLElement.prototype, "scrollHeight", { configurable: true, get: () => 2000 });
 });
 afterAll(async () => {
   await settle();
+  delete (dom.HTMLElement.prototype as unknown as { scrollHeight?: unknown }).scrollHeight;
   for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
 });
@@ -164,6 +169,56 @@ test("no visualViewport: the root keeps today's exact layout (#983 fallback)", a
   expect(shell().style.paddingBottom).toBe("");
   expect(shell().className).toContain("h-full");
   expect(shell().className).toContain("max-h-[100dvh]");
+});
+
+/* The reported conditions COMBINED (#983 round 2): a long draft, inside the
+   overflow-clipped shell, with the picker row present, at keyboard-open
+   heights. happy-dom has no layout engine — getBoundingClientRect is all
+   zeros — so rendered control bounds cannot be asserted here; what CAN be is
+   the arithmetic that decides them: the textarea's ceiling plus the mandatory
+   chrome fits the visible height, and the root's height is driven by the
+   visual viewport, so the clipped shell has everything inside it. */
+const LONG_DRAFT = "line\n".repeat(60);
+
+function composerTextarea(): HTMLTextAreaElement {
+  return dom.document.querySelector("textarea") as unknown as HTMLTextAreaElement;
+}
+
+test("integrated, portrait keyboard: long draft caps at 160px and the chrome fits (#983 round 2)", async () => {
+  dom.sessionStorage.setItem("llvDraft:/session", LONG_DRAFT);
+  const vv = makeVisualViewport(400);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  roots.push(mount(view()));
+  await settle();
+
+  /* The root yields the keyboard's 400px overlap, so its content box IS the
+     visible area. */
+  expect(shell().style.paddingBottom).toBe("400px");
+  const textarea = composerTextarea();
+  expect(textarea).not.toBeNull();
+  expect(textarea.value).toBe(LONG_DRAFT);
+  expect(textarea.style.height).toBe("160px");
+  expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(400);
+});
+
+test("integrated, rotated keyboard: the field yields below 160px so picker and send fit (#983 round 2)", async () => {
+  dom.sessionStorage.setItem("llvDraft:/session", LONG_DRAFT);
+  const vv = makeVisualViewport(280);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  roots.push(mount(view()));
+  await settle();
+
+  expect(shell().style.paddingBottom).toBe("520px");
+  const textarea = composerTextarea();
+  expect(textarea).not.toBeNull();
+  expect(textarea.value).toBe(LONG_DRAFT);
+  expect(textarea.style.height).toBe("124px");
+  expect(124 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
+  /* Past the shrunken ceiling the field scrolls internally (issue #177 item 3
+     preserved), never the window. */
+  expect(textarea.className).toContain("overflow-y-auto");
 });
 
 test("a layout-resizing keyboard (resizes-content honored) needs no inset (#983)", async () => {

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -7,6 +7,7 @@ import { Loader2, X } from "@/components/icons";
 import { TaskSheet, type TaskSheetView } from "@/components/tasks/TaskSheet";
 import { taskRelationsByPath } from "@/components/tasks/taskRelations";
 import { useBoardState } from "@/hooks/useBoardState";
+import { useKeyboardInset } from "@/hooks/useComposer";
 import { selectionInOrder, viewBus } from "@/hooks/viewPresenceBus";
 import { projectDisplayName } from "@/lib/displayNames";
 import type { Flow } from "@/lib/flows/types";
@@ -139,6 +140,17 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
      (#771). Same store the desktop board and the dashboard bind — stores are
      refcounted per project, so this is the same instance, never a copy. */
   const board = useBoardState(project);
+  /* The on-screen keyboard's overlap with this full-height root (#983). iOS
+     Safari ignores interactive-widget=resizes-content, so with the keyboard up
+     this 100dvh column kept its full height and the keyboard covered its
+     bottom — the composer's picker/send controls included. The browser then
+     scrolled the WINDOW to reach the focused field, hiding the header, and
+     re-asserted that scroll against every manual gesture (the snap-back:
+     an overflow-hidden root gives a gesture nothing else to move). Padding
+     the overlap away keeps the whole column inside the visible area, so the
+     browser has no reason to touch the window scroll at all. Zero whenever
+     the layout viewport already matches the visible one. */
+  const kbInset = useKeyboardInset();
   const [focusPath, setFocusPath] = useState<string | null>(null);
   const [mapOpen, setMapOpen] = useState(false);
   const [pipelineSheetOpen, setPipelineSheetOpen] = useState(false);
@@ -427,6 +439,7 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
          least this share of the usable viewport before the keyboard opens. */
       data-chat-min-share={MIN_TRANSCRIPT_SHARE}
       className="relative flex h-full max-h-[100dvh] min-h-0 min-w-0 max-w-[100dvw] flex-1 flex-col overflow-hidden overflow-x-clip"
+      style={kbInset > 0 ? { paddingBottom: kbInset } : undefined}
     >
       {/* Same runtime connection pill as desktop, compact, one thumb away.
           Renders nothing while slice-one is disabled. */}

--- a/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
+++ b/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
@@ -4,6 +4,7 @@ import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
 import { useComposer } from "@/hooks/useComposer";
+import { MOBILE_COMPOSER_CHROME_PX } from "@/lib/composerScroll";
 
 import { ComposerBar } from "@/components/ComposerBar";
 
@@ -81,7 +82,9 @@ function Harness() {
       placeholder="Prompt"
       textareaAriaLabel="Prompt"
       imageAriaLabel="Add images"
-      leftSlot={null}
+      /* The model-picker stand-in: on the phone ComposerBar renders leftSlot in
+         its always-visible 44px runtime row — the control the operator lost. */
+      leftSlot={<button type="button">model picker</button>}
       sendLabelIdle="Send"
       sendLabelRecording="Stop"
       sendIdleClassName="bg-accent"
@@ -130,6 +133,51 @@ test("pinch zoom is not a keyboard: the scale factor cancels out of the budget (
   G.visualViewport = vv;
   const textarea = mountComposer();
   expect(textarea.style.height).toBe("320px");
+});
+
+test("rotated keyboard: the ceiling shrinks below 160px so the chrome fits the visible area (#983 round 2)", () => {
+  /* Landscape phone, keyboard up: 280px visible. The old 160px floor plus the
+     mandatory chrome (focus strip, conversation header, 44px picker row —
+     MOBILE_COMPOSER_CHROME_PX) needs ~316px, and the overflow-clipped shell
+     hides the overflow — the picker was unreachable. The ceiling must yield
+     the chrome's share first: 280 − 156 = 124px. */
+  const vv = makeVisualViewport(280);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("124px");
+  /* The arithmetic that decides visibility inside the clipped shell. */
+  expect(124 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
+  /* The picker row is present with its 44px row contract, and the field still
+     scrolls internally past the shrunken ceiling. */
+  const row = dom.document.querySelector('[data-testid="composer-runtime-row"]') as unknown as HTMLElement;
+  expect(row).not.toBeNull();
+  expect(row.className).toContain("min-h-11");
+  expect(textarea.className).toContain("overflow-y-auto");
+});
+
+test("smaller rotated viewport: send stays visible because the field yields further (#983 round 2)", () => {
+  /* At 240px visible the budget after chrome is 84px — still above the 44px
+     one-row floor, so the field shrinks rather than pushing Send out. */
+  const vv = makeVisualViewport(240);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("84px");
+  const send = dom.document.querySelector('button[aria-label="Send"]') as unknown as HTMLElement;
+  expect(send).not.toBeNull();
+  /* The 44px tap-target contract: 32px visual control + the -inset-1.5
+     pseudo-element hit area (design doc §3.5). */
+  expect(send.className).toContain("h-8");
+  expect(send.className).toContain("before:-inset-1.5");
+});
+
+test("an absurdly small visible viewport floors the field at one tap-target row (#983 round 2)", () => {
+  const vv = makeVisualViewport(150);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("44px");
 });
 
 test("without visualViewport the layout viewport still drives the ceiling (#177 item 3)", () => {

--- a/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
+++ b/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
@@ -1,0 +1,140 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { useComposer } from "@/hooks/useComposer";
+
+import { ComposerBar } from "@/components/ComposerBar";
+
+/*
+ * Issue #983 — the phone grow ceiling must budget against the VISIBLE viewport.
+ * iOS Safari ignores interactive-widget=resizes-content: with the on-screen
+ * keyboard open, window.innerHeight keeps the full screen height and only
+ * window.visualViewport reports the shrunken visible area. Sizing the field at
+ * 40% of innerHeight then overflows the visible half-screen, pushing the model
+ * picker and send/mic controls under the keyboard.
+ */
+
+/* A minimal visualViewport stand-in — happy-dom does not provide one. Resize
+   listeners are collected so a test can play the keyboard opening/closing. */
+function makeVisualViewport(height: number) {
+  const listeners = new Set<() => void>();
+  return {
+    height,
+    scale: 1,
+    offsetTop: 0,
+    addEventListener(type: string, cb: () => void) { if (type === "resize") listeners.add(cb); },
+    removeEventListener(type: string, cb: () => void) { if (type === "resize") listeners.delete(cb); },
+    resizeTo(next: number) {
+      this.height = next;
+      for (const cb of [...listeners]) cb();
+    },
+  };
+}
+
+const dom = new Window({ width: 390, height: 800 });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+/* Phone layout: the width-based media query matches. */
+(dom as unknown as { matchMedia(query: string): unknown }).matchMedia = (query: string) => ({
+  matches: query.includes("max-width"),
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+/* Text always overflows: every measurement hits the grow ceiling exactly. */
+const proto = dom.HTMLElement.prototype as unknown as Record<string, unknown>;
+Object.defineProperty(proto, "scrollHeight", { configurable: true, get: () => 2000 });
+
+const G = globalThis as { visualViewport?: unknown } & Record<string, unknown>;
+
+let roots: Root[] = [];
+afterEach(() => {
+  for (const r of roots) flushSync(() => r.unmount());
+  roots = [];
+  dom.document.body.replaceChildren();
+  delete (dom as unknown as Record<string, unknown>).visualViewport;
+  delete G.visualViewport;
+});
+afterAll(() => {
+  delete (proto as { scrollHeight?: unknown }).scrollHeight;
+});
+
+function Harness() {
+  const composer = useComposer({
+    initialText: () => "line\n".repeat(40),
+    persistText: () => {},
+    submit: () => {},
+  });
+  return (
+    <ComposerBar
+      composer={composer}
+      placeholder="Prompt"
+      textareaAriaLabel="Prompt"
+      imageAriaLabel="Add images"
+      leftSlot={null}
+      sendLabelIdle="Send"
+      sendLabelRecording="Stop"
+      sendIdleClassName="bg-accent"
+    />
+  );
+}
+
+function mountComposer(): HTMLTextAreaElement {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  roots.push(root);
+  flushSync(() => root.render(<Harness />));
+  return host.querySelector("textarea") as unknown as HTMLTextAreaElement;
+}
+
+test("keyboard open: the ceiling tracks the visual viewport, not the layout viewport (#983)", () => {
+  /* Layout viewport 800px, keyboard eating half: visible 400px. The field may
+     take 40% of what the user can SEE — max(160, 0.4·400) = 160px — never 40%
+     of the full screen (320px), which would not fit above the keyboard. */
+  const vv = makeVisualViewport(400);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(dom.innerHeight).toBe(800);
+  expect(textarea.style.height).toBe("160px");
+});
+
+test("keyboard closes: a visualViewport resize re-opens the tall ceiling (#983)", () => {
+  const vv = makeVisualViewport(400);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("160px");
+  /* The keyboard folds away — only visualViewport says so on iOS. */
+  flushSync(() => vv.resizeTo(800));
+  expect(textarea.style.height).toBe("320px");
+});
+
+test("pinch zoom is not a keyboard: the scale factor cancels out of the budget (#983)", () => {
+  /* Zoomed 2×, no keyboard: the visual viewport halves in CSS px but the
+     layout budget is unchanged — the field keeps its full 40% ceiling. */
+  const vv = makeVisualViewport(400);
+  vv.scale = 2;
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  G.visualViewport = vv;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("320px");
+});
+
+test("without visualViewport the layout viewport still drives the ceiling (#177 item 3)", () => {
+  /* Older browsers / SSR hydration: no visualViewport at all. Today's
+     behaviour is preserved — 40% of window.innerHeight. */
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("320px");
+});

--- a/src/hooks/useComposer.ts
+++ b/src/hooks/useComposer.ts
@@ -7,16 +7,8 @@ import { performVoiceSend } from "@/hooks/composerVoiceSend";
 import { useAutosizePinned } from "@/hooks/useAutosizePinned";
 import { useDictation } from "@/hooks/useDictation";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { keyboardInset, visibleViewportHeight } from "@/lib/composerScroll";
+import { COMPOSER_MAX_PX, keyboardInset, mobileComposerCeiling, visibleViewportHeight } from "@/lib/composerScroll";
 import type { RuntimeImageCapability } from "@/lib/runtime/structuredContent";
-
-/* The pane / draft / bulk / task-create composers grow to ~6 rows, then scroll
-   internally pinned to the newest text. */
-const COMPOSER_MAX_PX = 160;
-/* On the phone the field grows further — up to ~40% of the viewport (issue #177
-   item 3) — so a multi-line prompt is comfortable to read while typing, past
-   which it scrolls internally. The send/mic controls keep their 44px targets. */
-const COMPOSER_MAX_VH = 0.4;
 
 /* Live VISIBLE viewport height, tracked the same way as `useIsMobile`
    (external store, no setState-in-effect) so the phone grow ceiling
@@ -157,16 +149,17 @@ export function useComposer({ initialText, persistText, submit, disabled = false
     };
   }, []);
 
-  /* Grow ceiling: the desktop keeps its ~6-row cap; the phone tracks 40% of the
-     live VISIBLE viewport height so the field can open into a tall multi-line
-     input and re-measures on rotation/resize (issue #177 item 3). With the
-     on-screen keyboard up the visible viewport is roughly half the screen —
-     budgeting against the full layout height there grew the field past what
-     fits above the keyboard and pushed the picker/send controls out of view
-     (#983). */
+  /* Grow ceiling: the desktop keeps its fixed ~6-row cap; the phone budgets
+     against the live VISIBLE viewport height so the field can open into a tall
+     multi-line input and re-measures on rotation/resize (issue #177 item 3).
+     With the on-screen keyboard up the visible viewport is roughly half the
+     screen — budgeting against the full layout height there grew the field
+     past what fits above the keyboard and pushed the picker/send controls out
+     of view (#983); on a short rotated viewport even the 160px cap overflows,
+     so the ceiling yields the chrome's share first and shrinks below it. */
   const isMobile = useIsMobile();
   const viewportH = useViewportHeight();
-  const maxPx = isMobile ? Math.max(COMPOSER_MAX_PX, Math.round(viewportH * COMPOSER_MAX_VH)) : COMPOSER_MAX_PX;
+  const maxPx = isMobile ? mobileComposerCeiling(viewportH) : COMPOSER_MAX_PX;
 
   const attachments = useImageAttachments({
     onError: (message) => setStatus({ kind: "err", text: message }),

--- a/src/hooks/useComposer.ts
+++ b/src/hooks/useComposer.ts
@@ -7,6 +7,7 @@ import { performVoiceSend } from "@/hooks/composerVoiceSend";
 import { useAutosizePinned } from "@/hooks/useAutosizePinned";
 import { useDictation } from "@/hooks/useDictation";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { keyboardInset, visibleViewportHeight } from "@/lib/composerScroll";
 import type { RuntimeImageCapability } from "@/lib/runtime/structuredContent";
 
 /* The pane / draft / bulk / task-create composers grow to ~6 rows, then scroll
@@ -17,15 +18,38 @@ const COMPOSER_MAX_PX = 160;
    which it scrolls internally. The send/mic controls keep their 44px targets. */
 const COMPOSER_MAX_VH = 0.4;
 
-/* Live viewport height, tracked the same way as `useIsMobile` (external store,
-   no setState-in-effect) so the phone grow ceiling re-measures on rotation and
-   the server render stays stable. */
+/* Live VISIBLE viewport height, tracked the same way as `useIsMobile`
+   (external store, no setState-in-effect) so the phone grow ceiling
+   re-measures on rotation and the server render stays stable. The on-screen
+   keyboard is the reason both event sources matter (#983): browsers honoring
+   the app's interactive-widget=resizes-content shrink the layout viewport and
+   fire window `resize`, but iOS Safari ignores that meta — there the keyboard
+   shrinks only `window.visualViewport`, whose own `resize` is the one signal
+   that the visible area halved. */
 function subscribeViewport(onChange: () => void) {
   window.addEventListener("resize", onChange);
-  return () => window.removeEventListener("resize", onChange);
+  const visual = window.visualViewport;
+  visual?.addEventListener("resize", onChange);
+  return () => {
+    window.removeEventListener("resize", onChange);
+    visual?.removeEventListener("resize", onChange);
+  };
 }
 function useViewportHeight(): number {
-  return useSyncExternalStore(subscribeViewport, () => window.innerHeight, () => 800);
+  return useSyncExternalStore(subscribeViewport, () => visibleViewportHeight(window.innerHeight, window.visualViewport), () => 800);
+}
+
+/**
+ * The on-screen keyboard's overlap with the layout viewport (#983): how much of
+ * a full-height (100dvh) surface the keyboard covers when the browser refuses
+ * to shrink the layout viewport (iOS Safari). The mobile focus root pads this
+ * away so the composer's controls stay above the keyboard and the browser
+ * never scrolls the window to reach the focused field. Zero whenever the two
+ * viewports agree — keyboard closed, resizes-content honored, no
+ * visualViewport, desktop — so every other layout is byte-identical.
+ */
+export function useKeyboardInset(): number {
+  return useSyncExternalStore(subscribeViewport, () => keyboardInset(window.innerHeight, window.visualViewport), () => 0);
 }
 
 export interface ComposerStatus {
@@ -134,8 +158,12 @@ export function useComposer({ initialText, persistText, submit, disabled = false
   }, []);
 
   /* Grow ceiling: the desktop keeps its ~6-row cap; the phone tracks 40% of the
-     live viewport height so the field can open into a tall multi-line input and
-     re-measures on rotation/resize (issue #177 item 3). */
+     live VISIBLE viewport height so the field can open into a tall multi-line
+     input and re-measures on rotation/resize (issue #177 item 3). With the
+     on-screen keyboard up the visible viewport is roughly half the screen —
+     budgeting against the full layout height there grew the field past what
+     fits above the keyboard and pushed the picker/send controls out of view
+     (#983). */
   const isMobile = useIsMobile();
   const viewportH = useViewportHeight();
   const maxPx = isMobile ? Math.max(COMPOSER_MAX_PX, Math.round(viewportH * COMPOSER_MAX_VH)) : COMPOSER_MAX_PX;

--- a/src/lib/composerScroll.test.ts
+++ b/src/lib/composerScroll.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { caretAtEnd, clampHeight, keyboardInset, shouldPin, visibleViewportHeight } from "./composerScroll";
+import { caretAtEnd, clampHeight, keyboardInset, MOBILE_COMPOSER_CHROME_PX, mobileComposerCeiling, shouldPin, visibleViewportHeight } from "./composerScroll";
 
 describe("clampHeight grows to fit then caps", () => {
   test("adds the 2px border allowance below the cap", () => {
@@ -64,6 +64,27 @@ describe("visibleViewportHeight — the keyboard-aware layout budget (#983)", ()
 
   test("rounding noise never exceeds the layout viewport", () => {
     expect(visibleViewportHeight(800, { height: 400.4, scale: 2 })).toBe(800);
+  });
+});
+
+describe("mobileComposerCeiling — the phone grow ceiling against the visible viewport (#983)", () => {
+  test("a full portrait viewport grows to 40%", () => {
+    expect(mobileComposerCeiling(800)).toBe(320);
+  });
+
+  test("a portrait keyboard-open viewport holds the 160px cap — the chrome still fits", () => {
+    expect(mobileComposerCeiling(400)).toBe(160);
+    expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(400);
+  });
+
+  test("a rotated keyboard-open viewport yields below 160px to keep the chrome visible (round 2)", () => {
+    expect(mobileComposerCeiling(280)).toBe(280 - MOBILE_COMPOSER_CHROME_PX);
+    expect(mobileComposerCeiling(240)).toBe(240 - MOBILE_COMPOSER_CHROME_PX);
+  });
+
+  test("never collapses below one 44px tap-target row", () => {
+    expect(mobileComposerCeiling(150)).toBe(44);
+    expect(mobileComposerCeiling(0)).toBe(44);
   });
 });
 

--- a/src/lib/composerScroll.test.ts
+++ b/src/lib/composerScroll.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { caretAtEnd, clampHeight, shouldPin } from "./composerScroll";
+import { caretAtEnd, clampHeight, keyboardInset, shouldPin, visibleViewportHeight } from "./composerScroll";
 
 describe("clampHeight grows to fit then caps", () => {
   test("adds the 2px border allowance below the cap", () => {
@@ -45,5 +45,40 @@ describe("shouldPin — keep the newest text visible only when appending", () =>
   test("typing pins only when the caret is at the end", () => {
     expect(shouldPin({ pinned: false, caretAtEnd: true })).toBe(true);
     expect(shouldPin({ pinned: false, caretAtEnd: false })).toBe(false);
+  });
+});
+
+describe("visibleViewportHeight — the keyboard-aware layout budget (#983)", () => {
+  test("no visualViewport falls back to the layout viewport", () => {
+    expect(visibleViewportHeight(800, null)).toBe(800);
+    expect(visibleViewportHeight(800, undefined)).toBe(800);
+  });
+
+  test("an open keyboard (iOS: layout viewport unchanged) shrinks the budget", () => {
+    expect(visibleViewportHeight(800, { height: 400, scale: 1 })).toBe(400);
+  });
+
+  test("pinch zoom cancels out: scale restores the layout-px measure", () => {
+    expect(visibleViewportHeight(800, { height: 400, scale: 2 })).toBe(800);
+  });
+
+  test("rounding noise never exceeds the layout viewport", () => {
+    expect(visibleViewportHeight(800, { height: 400.4, scale: 2 })).toBe(800);
+  });
+});
+
+describe("keyboardInset — the keyboard's overlap with a 100dvh surface (#983)", () => {
+  test("the iOS keyboard's slice of the layout viewport", () => {
+    expect(keyboardInset(800, { height: 448, scale: 1 })).toBe(352);
+  });
+
+  test("zero when the viewports agree (keyboard closed, or resizes-content honored)", () => {
+    expect(keyboardInset(800, { height: 800, scale: 1 })).toBe(0);
+    expect(keyboardInset(391, { height: 391, scale: 1 })).toBe(0);
+  });
+
+  test("zero without visualViewport and never negative", () => {
+    expect(keyboardInset(800, null)).toBe(0);
+    expect(keyboardInset(800, { height: 801, scale: 1 })).toBe(0);
   });
 });

--- a/src/lib/composerScroll.ts
+++ b/src/lib/composerScroll.ts
@@ -26,3 +26,31 @@ export function caretAtEnd(selectionStart: number, selectionEnd: number, length:
 export function shouldPin({ pinned, caretAtEnd }: { pinned: boolean; caretAtEnd: boolean }): boolean {
   return pinned || caretAtEnd;
 }
+
+/** The slice of `window.visualViewport` the viewport budget reads. */
+export interface VisualViewportSize {
+  height: number;
+  scale: number;
+}
+
+/** The height actually visible to the user, in layout px (#983). iOS Safari
+    ignores interactive-widget=resizes-content: the on-screen keyboard leaves
+    `window.innerHeight` at the full screen height and shrinks only the visual
+    viewport, so the visible budget must come from there when the browser
+    reports one. Multiplying by `scale` cancels pinch zoom — zoomed in, the
+    visual viewport narrows without any keyboard, and the layout budget must
+    not shrink with it. Clamped to the layout height so rounding noise can
+    never claim MORE than the layout viewport. */
+export function visibleViewportHeight(layoutHeight: number, visual: VisualViewportSize | null | undefined): number {
+  if (!visual) return layoutHeight;
+  return Math.min(layoutHeight, Math.round(visual.height * visual.scale));
+}
+
+/** The on-screen keyboard's overlap with the layout viewport, in px — the
+    bottom slice of a full-height (h-dvh / 100dvh) surface the keyboard covers.
+    Zero with the keyboard closed, when the browser shrinks the layout viewport
+    itself (interactive-widget=resizes-content honored), or with no
+    visualViewport at all. */
+export function keyboardInset(layoutHeight: number, visual: VisualViewportSize | null | undefined): number {
+  return Math.max(0, layoutHeight - visibleViewportHeight(layoutHeight, visual));
+}

--- a/src/lib/composerScroll.ts
+++ b/src/lib/composerScroll.ts
@@ -54,3 +54,34 @@ export function visibleViewportHeight(layoutHeight: number, visual: VisualViewpo
 export function keyboardInset(layoutHeight: number, visual: VisualViewportSize | null | undefined): number {
   return Math.max(0, layoutHeight - visibleViewportHeight(layoutHeight, visual));
 }
+
+/* The composer surfaces' shared grow cap (~6 rows): the fixed desktop ceiling,
+   and the phone ceiling's grow floor while the visible viewport has room for
+   it alongside the chrome below. */
+export const COMPOSER_MAX_PX = 160;
+/* On the phone the field grows further — up to ~40% of the visible viewport
+   (issue #177 item 3) — so a multi-line prompt is comfortable to read while
+   typing, past which it scrolls internally. */
+const COMPOSER_MAX_VH = 0.4;
+/* The mobile chrome that must share the keyboard-open visible area with the
+   textarea (#983 round 2): the docked focus strip (~52px), the conversation
+   header (~52px), and the always-visible 44px runtime-picker row under the
+   input, with the row gaps and field border riding in the strips' slack. The
+   focus root clips its overflow, so whatever this chrome cannot fit is not
+   scrolled to — it is gone. */
+export const MOBILE_COMPOSER_CHROME_PX = 156;
+/* One comfortable row at the 44px tap-target height: on a visible viewport too
+   small for chrome plus field, the field stays usable rather than collapsing
+   to zero. */
+const COMPOSER_CEILING_FLOOR_PX = 44;
+
+/** The phone grow ceiling for a given VISIBLE viewport height (#983): 40% of
+    what the user can see, floored at the shared cap while there is room — but
+    never more than what leaves the mandatory chrome visible. A short rotated
+    viewport with the keyboard open drops the budget below the 160px cap; the
+    field then scrolls internally sooner instead of pushing the picker and send
+    controls out of the clipped focus root. */
+export function mobileComposerCeiling(visibleHeight: number): number {
+  const grown = Math.max(COMPOSER_MAX_PX, Math.round(visibleHeight * COMPOSER_MAX_VH));
+  return Math.max(COMPOSER_CEILING_FLOOR_PX, Math.min(grown, visibleHeight - MOBILE_COMPOSER_CHROME_PX));
+}


### PR DESCRIPTION
Fixes #983 (operator-reported, 2026-08-13).

## Symptom

On a phone, tapping into a composer that already holds a long multi-line message auto-scrolled the window so the model picker and send/mic controls vanished; the field did not fit by height, and a manual scroll down snapped back within a frame — editing a long message was close to impossible.

## Mechanism — verified, with one correction to the issue

All three suspected legs are confirmed in the pre-fix source, with one refinement:

1. **The grow ceiling budgeted against the layout viewport.** `src/hooks/useComposer.ts` computed `maxPx = max(160, round(window.innerHeight * 0.4))`, subscribed only to window `resize`. Correction to the issue's parenthetical: the app already ships `interactive-widget=resizes-content` (`src/app/layout.tsx`), so **Android Chrome does shrink the layout viewport** and was largely fine. The broken path is iOS Safari, which ignores that meta entirely: `innerHeight` (and `100dvh`) keep the full screen height with the keyboard open, so the field was allowed 40% of the full screen while only ~half was visible — textarea + picker + buttons no longer fit above the keyboard.
2. **Nothing read `window.visualViewport`** — zero non-test hits in `src/`, so no layout knew the keyboard inset.
3. **The focus root is a full-height `overflow-hidden` column** (`MobileFocusView.tsx`), nested under the `h-dvh overflow-hidden` body and the ~52px project header. With the layout viewport unchanged, the browser's scroll-focused-element-into-view moved the **window** (on iOS, a visual-viewport pan — it happens regardless of `overflow: hidden`), hiding the header and controls; a manual gesture had no scrollable overflow of its own to move, and the browser re-scrolled to the focused field — the snap-back.

## Fix

One viewport subscription, two consumers — no new files, no context/store:

- `src/lib/composerScroll.ts`: pure `visibleViewportHeight(layoutHeight, visual)` (visual height × scale, clamped to layout — the scale factor cancels pinch zoom so zooming never shrinks the budget) and `keyboardInset(layoutHeight, visual)` (the keyboard's overlap with a 100dvh surface).
- `src/hooks/useComposer.ts`: the existing viewport external store now also subscribes to `visualViewport` `resize` and snapshots the **visible** height, so the phone grow ceiling is 40% of what the user can actually see. Desktop cap, tall multi-line growth, internal scroll past the ceiling, and rotation re-measure (#177 item 3) are unchanged. Exports `useKeyboardInset()` for the second consumer.
- `src/components/mobile/MobileFocusView.tsx`: the focus root pads `keyboardInset` out of its height (inline `paddingBottom`, only when > 0). The header strip, transcript and composer controls then all fit inside the visible area, the focused field is never under the keyboard, and the browser has no reason to scroll the window — nothing to snap back from. Manual gestures are never written to: the fix adds **no** scroll listeners and no `scrollTo` calls. The inset is measured as an overlap rather than an absolute root height, so the ~52px project header above the root cannot skew the budget.

Fallback: with no `visualViewport` (older browsers, SSR snapshot) the inset is 0 and the ceiling reads `innerHeight` — byte-identical to today's behaviour, proven by tests. When the browser honors `resizes-content` (Android), both viewports agree and the inset is 0, so nothing double-shrinks. The list rendering inside `MobileFocusView` is untouched (parallel lane #979). The 44px tap-target contract lives in the untouched control classes; the mobileOptions/EffortPills suites still pass.

## Tests — RED-first

New keyboard-open DOM tests (visual viewport stubbed explicitly — happy-dom has none) were written before the fix and failed against the pre-fix working tree exactly as predicted (ceiling `320px` instead of `160px`; no root inset), then went green after:

- `src/hooks/useComposer.keyboardCeiling.dom.test.tsx` — keyboard-open ceiling tracks the visual viewport; keyboard-close resize re-opens the tall ceiling; pinch zoom does not shrink the budget; no-`visualViewport` fallback keeps #177 behaviour.
- `src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx` — keyboard-open root pads the exact overlap; keyboard-close clears it; no-`visualViewport` keeps today's layout; a layout-resizing keyboard (resizes-content honored) needs no inset.
- `src/lib/composerScroll.test.ts` — unit coverage for both pure helpers.

## Verification

- 23 new tests + 64 existing tests across the touched surfaces (ComposerBar, MobileFocusView, MobileBottomShelf, TmuxComposer, mobile header/dock suites), all green, run by path with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`.
- `bunx tsc --noEmit` clean; scoped eslint clean; production `bun run build` clean.
- `bun scripts/privacy-publication-gate.ts --base <merge-base>`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)