### PR TITLE
fix(pipelines): preserve pass across GitHub outages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,12 @@ RUN --mount=type=cache,target=/app/.next/cache \
 RUN chmod -R u=rwX,go=rX /app
 
 FROM node:22.16.0-bookworm-slim AS runtime
+ARG LLV_RUNTIME_HOME=/home/user
 WORKDIR /app
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     NEXT_PUBLIC_RUNTIME_UI=1 \
+    HOME=${LLV_RUNTIME_HOME} \
     HOSTNAME=127.0.0.1 \
     PORT=8898 \
     LLV_WHISPER_VENV=/opt/llv-whisper-venv \
@@ -47,6 +49,7 @@ ENV NODE_ENV=production \
 
 RUN <<'EOF'
 set -eu
+/usr/sbin/usermod --home "$LLV_RUNTIME_HOME" node
 apt-get update
 apt-get install -y --no-install-recommends \
   ca-certificates \
@@ -75,14 +78,6 @@ cat > /usr/local/bin/python <<'WRAPPER'
 exec /opt/llv-whisper-venv/bin/python "$@"
 WRAPPER
 chmod +x /usr/local/bin/python
-cat > /usr/local/bin/llv-git-ssh <<'WRAPPER'
-#!/bin/sh
-exec ssh -F "$HOME/.ssh/config" \
-  -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
-  -o IdentityFile="$HOME/.ssh/id_ed25519" \
-  "$@"
-WRAPPER
-chmod +x /usr/local/bin/llv-git-ssh
 mkdir -p /usr/local/host-bin
 make_nsenter_shim() {
   name=$1

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,14 @@ cat > /usr/local/bin/python <<'WRAPPER'
 exec /opt/llv-whisper-venv/bin/python "$@"
 WRAPPER
 chmod +x /usr/local/bin/python
+cat > /usr/local/bin/llv-git-ssh <<'WRAPPER'
+#!/bin/sh
+exec ssh -F "$HOME/.ssh/config" \
+  -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+  -o IdentityFile="$HOME/.ssh/id_ed25519" \
+  "$@"
+WRAPPER
+chmod +x /usr/local/bin/llv-git-ssh
 mkdir -p /usr/local/host-bin
 make_nsenter_shim() {
   name=$1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ x-viewer-common: &viewer-common
   build:
     context: .
     dockerfile: Dockerfile
+    args:
+      LLV_RUNTIME_HOME: ${HOME:-/home/user}
   image: agent-log-viewer:node22
   network_mode: host
   pid: host
@@ -11,24 +13,23 @@ x-viewer-common: &viewer-common
   "user": "${LLV_UID:-1000}:${LLV_GID:-1000}"
   working_dir: /app
   env_file:
-    - ${LLV_ENV_FILE:-${HOME}/.config/agent-log-viewer/service.env}
+    - ${LLV_ENV_FILE:-${HOME:-/home/user}/.config/agent-log-viewer/service.env}
   environment:
-    HOME: ${HOME}
+    HOME: ${HOME:-/home/user}
     HOSTNAME: 127.0.0.1
-    PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
-    XDG_CONFIG_HOME: ${HOME}/.config
-    XDG_CACHE_HOME: ${HOME}/.cache
+    PATH: /usr/local/bin:${HOME:-/home/user}/.bun/bin:${HOME:-/home/user}/.npm-global/bin:${HOME:-/home/user}/.local/bin:/usr/bin:/bin
+    XDG_CONFIG_HOME: ${HOME:-/home/user}/.config
+    XDG_CACHE_HOME: ${HOME:-/home/user}/.cache
     # Keep /tmp until the explicit migration flag is enabled. The supervisor
     # endpoint lives outside the disposable Viewer container.
     TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
     LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-    HF_HOME: ${HOME}/.cache/huggingface
+    HF_HOME: ${HOME:-/home/user}/.cache/huggingface
     LLV_WHISPER_VENV: /opt/llv-whisper-venv
     LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
     LLV_DOCKER_NSENTER_SHIMS: "1"
-    GIT_SSH_COMMAND: &git-ssh-command /usr/local/bin/llv-git-ssh
   volumes:
-    - ${HOME}:${HOME}
+    - ${HOME:-/home/user}:${HOME:-/home/user}
     - /tmp/tmux-${LLV_UID:-1000}:/tmp/tmux-${LLV_UID:-1000}
     - /tmp/claude-${LLV_UID:-1000}:/tmp/claude-${LLV_UID:-1000}
 
@@ -46,14 +47,14 @@ services:
     # to the host and remaps /app to $HOME, so the module is never found.
     command: ["bun-container", "run", "src/runtime-host/main.ts"]
     environment:
-      HOME: ${HOME}
-      XDG_CONFIG_HOME: ${HOME}/.config
-      XDG_CACHE_HOME: ${HOME}/.cache
+      HOME: ${HOME:-/home/user}
+      XDG_CONFIG_HOME: ${HOME:-/home/user}/.config
+      XDG_CACHE_HOME: ${HOME:-/home/user}/.cache
       # Nested `docker compose config` must see the same interpolation inputs
       # that produced this runtime-host container.
       LLV_UID: ${LLV_UID:-1000}
       LLV_GID: ${LLV_GID:-1000}
-      LLV_ENV_FILE: ${LLV_ENV_FILE:-${HOME}/.config/agent-log-viewer/service.env}
+      LLV_ENV_FILE: ${LLV_ENV_FILE:-${HOME:-/home/user}/.config/agent-log-viewer/service.env}
       LLV_TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
@@ -62,13 +63,12 @@ services:
       # always an events host (main.ts refuses to boot without the flag).
       LLV_RUNTIME_EVENTS: ${LLV_RUNTIME_EVENTS:-1}
       LLV_RUNTIME_LEGACY_SCHEDULER: ${LLV_RUNTIME_LEGACY_SCHEDULER:-0}
-      LLV_RUNTIME_HOST_SOCKET: ${LLV_RUNTIME_HOST_SOCKET:-${HOME}/.config/agent-log-viewer/state/runtime-host.sock}
-      LLV_RUNTIME_JOURNAL: ${LLV_RUNTIME_JOURNAL:-${HOME}/.config/agent-log-viewer/state/runtime-events.sqlite}
+      LLV_RUNTIME_HOST_SOCKET: ${LLV_RUNTIME_HOST_SOCKET:-${HOME:-/home/user}/.config/agent-log-viewer/state/runtime-host.sock}
+      LLV_RUNTIME_JOURNAL: ${LLV_RUNTIME_JOURNAL:-${HOME:-/home/user}/.config/agent-log-viewer/state/runtime-events.sqlite}
       LLV_VIEWER_DEPLOYMENTS: ${LLV_VIEWER_DEPLOYMENTS:-0}
       LLV_VIEWER_DEPLOY_ADAPTER: ${LLV_VIEWER_DEPLOY_ADAPTER:-/app/scripts/runtime-host-viewer-adapter.ts}
-      LLV_VIEWER_DEPLOY_TARGET: ${LLV_VIEWER_DEPLOY_TARGET:-${HOME}/.config/agent-log-viewer/state/viewer-release.json}
+      LLV_VIEWER_DEPLOY_TARGET: ${LLV_VIEWER_DEPLOY_TARGET:-${HOME:-/home/user}/.config/agent-log-viewer/state/viewer-release.json}
       LLV_VIEWER_PORT: ${LLV_VIEWER_PORT:-8898}
-      GIT_SSH_COMMAND: *git-ssh-command
 
   viewer:
     <<: *viewer-common
@@ -87,36 +87,34 @@ services:
         fi
         exec bun-container --bun node_modules/.bin/next start --port "$${PORT:-8898}" --hostname "$${HOSTNAME:-127.0.0.1}"
     environment:
-      HOME: ${HOME}
+      HOME: ${HOME:-/home/user}
       HOSTNAME: 127.0.0.1
       PORT: 8898
-      PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
-      XDG_CONFIG_HOME: ${HOME}/.config
-      XDG_CACHE_HOME: ${HOME}/.cache
+      PATH: /usr/local/bin:${HOME:-/home/user}/.bun/bin:${HOME:-/home/user}/.npm-global/bin:${HOME:-/home/user}/.local/bin:/usr/bin:/bin
+      XDG_CONFIG_HOME: ${HOME:-/home/user}/.config
+      XDG_CACHE_HOME: ${HOME:-/home/user}/.cache
       TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-      HF_HOME: ${HOME}/.cache/huggingface
+      HF_HOME: ${HOME:-/home/user}/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
       LLV_ALLOW_LEGACY_VIEWER: ${LLV_ALLOW_LEGACY_VIEWER:-0}
       LLV_DOCKER_NSENTER_SHIMS: "1"
-      GIT_SSH_COMMAND: *git-ssh-command
 
   viewer-test:
     <<: *viewer-common
     profiles:
       - test
     environment:
-      HOME: ${HOME}
+      HOME: ${HOME:-/home/user}
       HOSTNAME: 127.0.0.1
       PORT: ${LLV_TEST_PORT:-8901}
-      PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
-      XDG_CONFIG_HOME: ${HOME}/.config
-      XDG_CACHE_HOME: ${HOME}/.cache
+      PATH: /usr/local/bin:${HOME:-/home/user}/.bun/bin:${HOME:-/home/user}/.npm-global/bin:${HOME:-/home/user}/.local/bin:/usr/bin:/bin
+      XDG_CONFIG_HOME: ${HOME:-/home/user}/.config
+      XDG_CACHE_HOME: ${HOME:-/home/user}/.cache
       TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-      HF_HOME: ${HOME}/.cache/huggingface
+      HF_HOME: ${HOME:-/home/user}/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
       LLV_DOCKER_NSENTER_SHIMS: "1"
-      GIT_SSH_COMMAND: *git-ssh-command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,27 +8,27 @@ x-viewer-common: &viewer-common
   network_mode: host
   pid: host
   privileged: true
-  user: "${LLV_UID:-1000}:${LLV_GID:-1000}"
+  "user": "${LLV_UID:-1000}:${LLV_GID:-1000}"
   working_dir: /app
   env_file:
-    - ${LLV_ENV_FILE:-/home/latand/.config/agent-log-viewer/service.env}
+    - ${LLV_ENV_FILE:-${HOME}/.config/agent-log-viewer/service.env}
   environment:
-    HOME: /home/latand
+    HOME: ${HOME}
     HOSTNAME: 127.0.0.1
-    PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
-    XDG_CONFIG_HOME: /home/latand/.config
-    XDG_CACHE_HOME: /home/latand/.cache
+    PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
+    XDG_CONFIG_HOME: ${HOME}/.config
+    XDG_CACHE_HOME: ${HOME}/.cache
     # Keep /tmp until the explicit migration flag is enabled. The supervisor
     # endpoint lives outside the disposable Viewer container.
     TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
     LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-    HF_HOME: /home/latand/.cache/huggingface
+    HF_HOME: ${HOME}/.cache/huggingface
     LLV_WHISPER_VENV: /opt/llv-whisper-venv
     LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
     LLV_DOCKER_NSENTER_SHIMS: "1"
-    GIT_SSH_COMMAND: ssh -F /home/latand/.ssh/config -o UserKnownHostsFile=/home/latand/.ssh/known_hosts -o IdentityFile=/home/latand/.ssh/id_ed25519
+    GIT_SSH_COMMAND: &git-ssh-command /usr/local/bin/llv-git-ssh
   volumes:
-    - /home/latand:/home/latand
+    - ${HOME}:${HOME}
     - /tmp/tmux-${LLV_UID:-1000}:/tmp/tmux-${LLV_UID:-1000}
     - /tmp/claude-${LLV_UID:-1000}:/tmp/claude-${LLV_UID:-1000}
 
@@ -46,14 +46,14 @@ services:
     # to the host and remaps /app to $HOME, so the module is never found.
     command: ["bun-container", "run", "src/runtime-host/main.ts"]
     environment:
-      HOME: /home/latand
-      XDG_CONFIG_HOME: /home/latand/.config
-      XDG_CACHE_HOME: /home/latand/.cache
+      HOME: ${HOME}
+      XDG_CONFIG_HOME: ${HOME}/.config
+      XDG_CACHE_HOME: ${HOME}/.cache
       # Nested `docker compose config` must see the same interpolation inputs
       # that produced this runtime-host container.
       LLV_UID: ${LLV_UID:-1000}
       LLV_GID: ${LLV_GID:-1000}
-      LLV_ENV_FILE: ${LLV_ENV_FILE:-/home/latand/.config/agent-log-viewer/service.env}
+      LLV_ENV_FILE: ${LLV_ENV_FILE:-${HOME}/.config/agent-log-viewer/service.env}
       LLV_TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
@@ -62,12 +62,13 @@ services:
       # always an events host (main.ts refuses to boot without the flag).
       LLV_RUNTIME_EVENTS: ${LLV_RUNTIME_EVENTS:-1}
       LLV_RUNTIME_LEGACY_SCHEDULER: ${LLV_RUNTIME_LEGACY_SCHEDULER:-0}
-      LLV_RUNTIME_HOST_SOCKET: ${LLV_RUNTIME_HOST_SOCKET:-/home/latand/.config/agent-log-viewer/state/runtime-host.sock}
-      LLV_RUNTIME_JOURNAL: ${LLV_RUNTIME_JOURNAL:-/home/latand/.config/agent-log-viewer/state/runtime-events.sqlite}
+      LLV_RUNTIME_HOST_SOCKET: ${LLV_RUNTIME_HOST_SOCKET:-${HOME}/.config/agent-log-viewer/state/runtime-host.sock}
+      LLV_RUNTIME_JOURNAL: ${LLV_RUNTIME_JOURNAL:-${HOME}/.config/agent-log-viewer/state/runtime-events.sqlite}
       LLV_VIEWER_DEPLOYMENTS: ${LLV_VIEWER_DEPLOYMENTS:-0}
       LLV_VIEWER_DEPLOY_ADAPTER: ${LLV_VIEWER_DEPLOY_ADAPTER:-/app/scripts/runtime-host-viewer-adapter.ts}
-      LLV_VIEWER_DEPLOY_TARGET: ${LLV_VIEWER_DEPLOY_TARGET:-/home/latand/.config/agent-log-viewer/state/viewer-release.json}
+      LLV_VIEWER_DEPLOY_TARGET: ${LLV_VIEWER_DEPLOY_TARGET:-${HOME}/.config/agent-log-viewer/state/viewer-release.json}
       LLV_VIEWER_PORT: ${LLV_VIEWER_PORT:-8898}
+      GIT_SSH_COMMAND: *git-ssh-command
 
   viewer:
     <<: *viewer-common
@@ -86,36 +87,36 @@ services:
         fi
         exec bun-container --bun node_modules/.bin/next start --port "$${PORT:-8898}" --hostname "$${HOSTNAME:-127.0.0.1}"
     environment:
-      HOME: /home/latand
+      HOME: ${HOME}
       HOSTNAME: 127.0.0.1
       PORT: 8898
-      PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
-      XDG_CONFIG_HOME: /home/latand/.config
-      XDG_CACHE_HOME: /home/latand/.cache
+      PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
+      XDG_CONFIG_HOME: ${HOME}/.config
+      XDG_CACHE_HOME: ${HOME}/.cache
       TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-      HF_HOME: /home/latand/.cache/huggingface
+      HF_HOME: ${HOME}/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
       LLV_ALLOW_LEGACY_VIEWER: ${LLV_ALLOW_LEGACY_VIEWER:-0}
       LLV_DOCKER_NSENTER_SHIMS: "1"
-      GIT_SSH_COMMAND: ssh -F /home/latand/.ssh/config -o UserKnownHostsFile=/home/latand/.ssh/known_hosts -o IdentityFile=/home/latand/.ssh/id_ed25519
+      GIT_SSH_COMMAND: *git-ssh-command
 
   viewer-test:
     <<: *viewer-common
     profiles:
       - test
     environment:
-      HOME: /home/latand
+      HOME: ${HOME}
       HOSTNAME: 127.0.0.1
       PORT: ${LLV_TEST_PORT:-8901}
-      PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
-      XDG_CONFIG_HOME: /home/latand/.config
-      XDG_CACHE_HOME: /home/latand/.cache
+      PATH: /usr/local/bin:${HOME}/.bun/bin:${HOME}/.npm-global/bin:${HOME}/.local/bin:/usr/bin:/bin
+      XDG_CONFIG_HOME: ${HOME}/.config
+      XDG_CACHE_HOME: ${HOME}/.cache
       TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
-      HF_HOME: /home/latand/.cache/huggingface
+      HF_HOME: ${HOME}/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
       LLV_DOCKER_NSENTER_SHIMS: "1"
-      GIT_SSH_COMMAND: ssh -F /home/latand/.ssh/config -o UserKnownHostsFile=/home/latand/.ssh/known_hosts -o IdentityFile=/home/latand/.ssh/id_ed25519
+      GIT_SSH_COMMAND: *git-ssh-command

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -90,15 +90,15 @@ describe("runtime-host Docker credentials (#102)", () => {
     expect(wrapper).not.toContain("--setuid");
   });
 
-  test("every engine container resolves git SSH credentials from its runtime HOME (#999)", () => {
-    const wrapper = dockerfile.match(/cat > \/usr\/local\/bin\/llv-git-ssh <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
-    expect(wrapper).toBeDefined();
-    expect(wrapper).toContain('exec ssh -F "$HOME/.ssh/config"');
-    expect(wrapper).toContain('-o UserKnownHostsFile="$HOME/.ssh/known_hosts"');
-    expect(wrapper).toContain('-o IdentityFile="$HOME/.ssh/id_ed25519"');
-    expect(compose.match(/GIT_SSH_COMMAND:/g)).toHaveLength(4);
-    expect(compose).toContain("GIT_SSH_COMMAND: &git-ssh-command /usr/local/bin/llv-git-ssh");
-    expect(compose.match(/GIT_SSH_COMMAND: \*git-ssh-command/g)).toHaveLength(3);
+  test("the runtime passwd home follows the portable Compose HOME for every git caller (#999)", () => {
+    expect(dockerfile).toContain("ARG LLV_RUNTIME_HOME=/home/user");
+    expect(dockerfile).toContain("HOME=${LLV_RUNTIME_HOME}");
+    expect(dockerfile).toContain('/usr/sbin/usermod --home "$LLV_RUNTIME_HOME" node');
+    expect(compose).toContain("LLV_RUNTIME_HOME: ${HOME:-/home/user}");
+    expect(compose.match(/^\s+HOME: \${HOME:-\/home\/user}/gm)).toHaveLength(4);
+    expect(compose).not.toContain("GIT_SSH_COMMAND");
+    expect(dockerfile).not.toContain("llv-git-ssh");
+    expect(dockerfile).not.toContain("IdentityFile");
   });
 });
 
@@ -114,7 +114,6 @@ describe("SQLite registry Viewer runtime (#187)", () => {
   });
 
   test("host CLI shims derive the mounted home from the runtime environment", () => {
-    expect(dockerfile).not.toContain("/home/latand");
     expect(dockerfile).toContain("make_nsenter_shim claude '$HOME/.bun/bin/claude'");
     expect(dockerfile).toContain('"$HOME"|"$HOME"/*');
   });

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -80,7 +80,7 @@ describe("runtime image permission determinism (#76)", () => {
 
 describe("runtime-host Docker credentials (#102)", () => {
   test("runtime UID 1000 retains the host Docker socket group through nsenter", () => {
-    expect(compose).toContain('user: "${LLV_UID:-1000}:${LLV_GID:-1000}"');
+    expect(compose).toContain('"user": "${LLV_UID:-1000}:${LLV_GID:-1000}"');
     expect(compose).toContain('group_add:\n      - "${LLV_DOCKER_GID:-957}"');
     const wrapper = dockerfile.match(/cat > \/usr\/local\/bin\/docker <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
     expect(wrapper).toBeDefined();
@@ -88,6 +88,17 @@ describe("runtime-host Docker credentials (#102)", () => {
     expect(wrapper).toContain('/usr/bin/setpriv --reuid="$uid" --regid="$gid" --groups="$groups" --');
     expect(wrapper).not.toContain("--setgid");
     expect(wrapper).not.toContain("--setuid");
+  });
+
+  test("every engine container resolves git SSH credentials from its runtime HOME (#999)", () => {
+    const wrapper = dockerfile.match(/cat > \/usr\/local\/bin\/llv-git-ssh <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toContain('exec ssh -F "$HOME/.ssh/config"');
+    expect(wrapper).toContain('-o UserKnownHostsFile="$HOME/.ssh/known_hosts"');
+    expect(wrapper).toContain('-o IdentityFile="$HOME/.ssh/id_ed25519"');
+    expect(compose.match(/GIT_SSH_COMMAND:/g)).toHaveLength(4);
+    expect(compose).toContain("GIT_SSH_COMMAND: &git-ssh-command /usr/local/bin/llv-git-ssh");
+    expect(compose.match(/GIT_SSH_COMMAND: \*git-ssh-command/g)).toHaveLength(3);
   });
 });
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -196,8 +196,9 @@ function harness() {
   let residentHosts = false;
   let monotonic: () => number = () => Date.now();
   const ports: PipelinePorts = {
-    exec: (command, args) => {
-      calls.push(`${command} ${args.join(" ")}`);
+    exec: (rawCommand, rawArgs) => {
+      calls.push(`${rawCommand} ${rawArgs.join(" ")}`);
+      const args = rawCommand === "timeout" ? rawArgs.slice(rawArgs.indexOf("git") + 1) : rawArgs;
       if (args[0] === "rev-parse" && args[1] === "--git-dir") return { code: 0, stdout: ".git\n", stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--verify") return { code: 0, stdout: `${ORIGIN_MAIN_SHA}\n`, stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { code: 0, stdout: "main\n", stderr: "" };
@@ -1604,7 +1605,8 @@ function countDurableReads(h: ReturnType<typeof harness>): () => number {
 
 function pinStageHead(h: ReturnType<typeof harness>) {
   const baseExec = h.ports.exec;
-  h.ports.exec = (command, args, cwd) => {
+  h.ports.exec = (rawCommand, rawArgs, cwd) => {
+    const args = rawCommand === "timeout" ? rawArgs.slice(rawArgs.indexOf("git") + 1) : rawArgs;
     if (args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${STAGE_HEAD}\n`, stderr: "" };
     /* The remote carries the same stage commit: these tests are about durable
        turn evidence, not publication, so origin is modelled as already current
@@ -1612,7 +1614,7 @@ function pinStageHead(h: ReturnType<typeof harness>) {
     if (args[0] === "ls-remote") {
       return { code: 0, stdout: `${STAGE_HEAD}\trefs/heads/${loadPipelines()[0]?.branch ?? "pipeline/test"}\n`, stderr: "" };
     }
-    return baseExec(command, args, cwd);
+    return baseExec(rawCommand, rawArgs, cwd);
   };
 }
 
@@ -2404,7 +2406,9 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
   let remoteHead = ORIGIN_MAIN_SHA;
   let fastForwarded = false;
   const baseExec = h.ports.exec;
-  h.ports.exec = (command, args, cwd) => {
+  h.ports.exec = (rawCommand, rawArgs, cwd) => {
+    const command = rawCommand === "timeout" ? "git" : rawCommand;
+    const args = rawCommand === "timeout" ? rawArgs.slice(rawArgs.indexOf("git") + 1) : rawArgs;
     if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
     if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${remoteHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
@@ -2417,7 +2421,7 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
       fastForwarded = true;
       return { code: 0, stdout: "", stderr: "" };
     }
-    return baseExec(command, args, cwd);
+    return baseExec(rawCommand, rawArgs, cwd);
   };
 
   const pipeline = await create(h.ports, stages as never);
@@ -2472,10 +2476,12 @@ test("issue 533: an in-loop repair advances expectedReviewHeadSha with reviewHea
      review ingress publishes the exact accepted head, so a fixture whose
      worktree disagreed with its own accepted commit would park instead. */
   const baseExec = h.ports.exec;
-  h.ports.exec = (command, args, cwd) => {
+  h.ports.exec = (rawCommand, rawArgs, cwd) => {
+    const command = rawCommand === "timeout" ? "git" : rawCommand;
+    const args = rawCommand === "timeout" ? rawArgs.slice(rawArgs.indexOf("git") + 1) : rawArgs;
     if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${beforeRepair}\n`, stderr: "" };
     if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${beforeRepair}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
-    return baseExec(command, args, cwd);
+    return baseExec(rawCommand, rawArgs, cwd);
   };
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
@@ -5136,13 +5142,12 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
   let remoteBranch: string | null = null;
   let dirty = true;
   let pushFails = false;
+  let remoteReadFails = options.remoteReadFails ?? false;
   let remoteReadAttempts = 0;
   const baseExec = h.ports.exec;
-  h.ports.exec = (command, args, cwd) => {
-    if (command === "sleep") {
-      order.push(`backoff:${args[0]}`);
-      return { code: 0, stdout: "", stderr: "" };
-    }
+  h.ports.exec = (rawCommand, rawArgs, cwd) => {
+    const command = rawCommand === "timeout" ? "git" : rawCommand;
+    const args = rawCommand === "timeout" ? rawArgs.slice(rawArgs.indexOf("git") + 1) : rawArgs;
     if (command !== "git") return baseExec(command, args, cwd);
     const branch = loadPipelines()[0]?.branch ?? "pipeline/test";
     if (args[0] === "status") return { code: 0, stdout: dirty ? " M src/lib/thing.ts\n" : "", stderr: "" };
@@ -5161,7 +5166,7 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
     }
     if (args[0] === "ls-remote") {
       remoteReadAttempts += 1;
-      if (options.remoteReadFails) {
+      if (remoteReadFails) {
         return { code: 128, stdout: "", stderr: "fatal: remote authentication unavailable" };
       }
       return { code: 0, stdout: remoteBranch ? `${remoteBranch}\trefs/heads/${branch}\n` : "", stderr: "" };
@@ -5210,6 +5215,7 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
     setRemote: (sha: string | null) => { remoteBranch = sha; },
     setDirty: (value: boolean) => { dirty = value; },
     setPushFails: (value: boolean) => { pushFails = value; },
+    setRemoteReadFails: (value: boolean) => { remoteReadFails = value; },
     remoteReadAttempts: () => remoteReadAttempts,
     setLocalHead: (sha: string) => { localHead = sha; if (!history.includes(sha)) history.push(sha); },
     /* Records a revision nobody's local checkout contains — a repair pushed
@@ -5265,8 +5271,8 @@ test("an unreachable remote leaves the stage passed and records it as unpublishe
     verdict: { status: "pass" },
     error: expect.stringContaining("passed but unpublished"),
   });
-  expect(box.remoteReadAttempts()).toBe(3);
-  expect(box.order).toEqual(["commit", "backoff:0.25", "backoff:0.5"]);
+  expect(box.remoteReadAttempts()).toBe(1);
+  expect(box.order).toEqual(["commit"]);
   expect(h.flows.size).toBe(0);
 
   /* Review ingress still cannot fence a flow while GitHub is unreachable. It
@@ -5281,8 +5287,54 @@ test("an unreachable remote leaves the stage passed and records it as unpublishe
     state: "passed",
     verdict: { status: "pass" },
   });
-  expect(box.remoteReadAttempts()).toBe(6);
+  expect(box.remoteReadAttempts()).toBe(2);
   expect(h.flows.size).toBe(0);
+});
+
+test("a final passing stage stays open until its accepted head is published (#999)", async () => {
+  const h = harness();
+  const box = publishHarness(h, { remoteReadFails: true });
+  await create(h.ports, [
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  const waiting = loadPipelines()[0]!;
+  expect(waiting).toMatchObject({
+    state: "running",
+    closedAt: null,
+    lastPassedCommit: box.passedSha,
+    publishedCommit: null,
+    stateDetail: expect.stringContaining("passed but unpublished"),
+  });
+  expect(waiting.runs[0]!.attempts[0]).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass" },
+    error: expect.stringContaining("passed but unpublished"),
+  });
+  expect(box.remoteReadAttempts()).toBe(1);
+
+  box.setRemoteReadFails(false);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const completed = loadPipelines()[0]!;
+  expect(completed).toMatchObject({
+    state: "completed",
+    cursor: null,
+    lastPassedCommit: box.passedSha,
+    publishedCommit: box.passedSha,
+    stateDetail: null,
+  });
+  expect(completed.closedAt).not.toBeNull();
+  expect(completed.runs[0]!.attempts[0]).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass" },
+    error: null,
+  });
+  expect(box.order).toEqual(["commit", `push:${box.passedSha}`]);
+  expect(box.remoteReadAttempts()).toBe(3);
 });
 
 test("a publication that cannot land parks the pass without losing the commit", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -5126,7 +5126,7 @@ test("closing a fail-edge target with an older terminal attempt records a fresh 
 
 /* --- #729: the orchestrator publishes the head the review layer fences on --- */
 
-function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boolean; pushFails?: boolean } = {}) {
+function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boolean; pushFails?: boolean; remoteReadFails?: boolean } = {}) {
   const passedSha = "7".repeat(40);
   const order: string[] = [];
   /* Oldest first. `merge-base --is-ancestor` is answered from this, so the
@@ -5136,8 +5136,13 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
   let remoteBranch: string | null = null;
   let dirty = true;
   let pushFails = false;
+  let remoteReadAttempts = 0;
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => {
+    if (command === "sleep") {
+      order.push(`backoff:${args[0]}`);
+      return { code: 0, stdout: "", stderr: "" };
+    }
     if (command !== "git") return baseExec(command, args, cwd);
     const branch = loadPipelines()[0]?.branch ?? "pipeline/test";
     if (args[0] === "status") return { code: 0, stdout: dirty ? " M src/lib/thing.ts\n" : "", stderr: "" };
@@ -5155,6 +5160,10 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
         : { code: 0, stdout: "git@example.invalid:owner/repo.git\n", stderr: "" };
     }
     if (args[0] === "ls-remote") {
+      remoteReadAttempts += 1;
+      if (options.remoteReadFails) {
+        return { code: 128, stdout: "", stderr: "fatal: remote authentication unavailable" };
+      }
       return { code: 0, stdout: remoteBranch ? `${remoteBranch}\trefs/heads/${branch}\n` : "", stderr: "" };
     }
     if (args[0] === "push") {
@@ -5201,6 +5210,7 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
     setRemote: (sha: string | null) => { remoteBranch = sha; },
     setDirty: (value: boolean) => { dirty = value; },
     setPushFails: (value: boolean) => { pushFails = value; },
+    remoteReadAttempts: () => remoteReadAttempts,
     setLocalHead: (sha: string) => { localHead = sha; if (!history.includes(sha)) history.push(sha); },
     /* Records a revision nobody's local checkout contains — a repair pushed
        from another clone, which must never be fast-forwarded away. */
@@ -5232,6 +5242,47 @@ test("a passed run stage publishes its committed head before the review stage cr
   expect(box.order).toEqual(["commit", `push:${box.passedSha}`, "createFlow"]);
   expect(h.flows.get("flow-1")).toMatchObject({ headRef: loadPipelines()[0]!.branch, targetSha: box.passedSha });
   expect(loadPipelines()[0]!.state).toBe("running");
+});
+
+test("an unreachable remote leaves the stage passed and records it as unpublished (#999)", async () => {
+  const h = harness();
+  const box = publishHarness(h, { remoteReadFails: true });
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  const current = loadPipelines()[0]!;
+  const attempt = current.runs.find((run) => run.stageId === "build")!.attempts[0]!;
+  expect(current).toMatchObject({
+    state: "running",
+    lastPassedCommit: box.passedSha,
+    publishedCommit: null,
+    stateDetail: expect.stringContaining("passed but unpublished"),
+  });
+  expect(attempt).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass" },
+    error: expect.stringContaining("passed but unpublished"),
+  });
+  expect(box.remoteReadAttempts()).toBe(3);
+  expect(box.order).toEqual(["commit", "backoff:0.25", "backoff:0.5"]);
+  expect(h.flows.size).toBe(0);
+
+  /* Review ingress still cannot fence a flow while GitHub is unreachable. It
+     keeps the lane retryable in place instead of turning infrastructure into
+     a second operator decision. */
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  const waiting = loadPipelines()[0]!;
+  expect(waiting.state).toBe("running");
+  expect(waiting.cursor?.stageId).toBe("review");
+  expect(waiting.stateDetail).toContain("passed but unpublished");
+  expect(waiting.runs.find((run) => run.stageId === "build")!.attempts[0]).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass" },
+  });
+  expect(box.remoteReadAttempts()).toBe(6);
+  expect(h.flows.size).toBe(0);
 });
 
 test("a publication that cannot land parks the pass without losing the commit", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1280,6 +1280,11 @@ function commitPassedStage(
   attempt.state = "passed";
   attempt.completedAt = ports.now();
   advancePipeline(pipeline, stage, ports, attempt);
+  if (published.remote === "unreachable") {
+    const detail = `passed but unpublished: ${published.detail}`;
+    attempt.error = detail;
+    pipeline.stateDetail = detail;
+  }
 }
 
 /** One-shot settlement of a completed stage turn. Semantic contradictions park
@@ -1646,25 +1651,44 @@ export function reviewNote(pipeline: Pipeline, stage: PipelineStage, role: Effec
  * null so the remote is genuinely probed, which is what makes a stale or
  * migrated record safe. Publication itself stays fast-forward-only.
  */
-function publishReviewIngressHead(pipeline: Pipeline, attempt: PipelineStageAttempt, ports: PipelinePorts): string | null {
+function publishReviewIngressHead(
+  pipeline: Pipeline,
+  attempt: PipelineStageAttempt,
+  ports: PipelinePorts,
+): { ok: true } | { ok: false; retryable: boolean; detail: string } {
   const expected = attempt.expectedReviewHeadSha;
-  if (!expected) return "review-loop stage requires a verified pipeline commit";
+  if (!expected) return { ok: false, retryable: false, detail: "review-loop stage requires a verified pipeline commit" };
 
   const local = currentPipelineBranchHead(pipeline, ports.exec);
-  if (!local.ok) return `review stage could not verify the pipeline head before publishing: ${local.error}`;
+  if (!local.ok) {
+    return { ok: false, retryable: false, detail: `review stage could not verify the pipeline head before publishing: ${local.error}` };
+  }
   if (local.sha !== expected) {
-    return `review stage head mismatch: the accepted review head is ${expected}, but the pipeline worktree is at ${local.sha}; nothing was published`;
+    return {
+      ok: false,
+      retryable: false,
+      detail: `review stage head mismatch: the accepted review head is ${expected}, but the pipeline worktree is at ${local.sha}; nothing was published`,
+    };
   }
 
   /* `publishedSha` is deliberately omitted: ingress probes the remote for real
      rather than trusting a durable record that may be stale or migrated. */
   const published = publishPipelineBranch(pipeline, ports.exec, { acceptedSha: expected });
-  if (!published.ok) return `review stage could not publish the accepted head ${expected}: ${published.error}`;
+  if (!published.ok) {
+    return { ok: false, retryable: false, detail: `review stage could not publish the accepted head ${expected}: ${published.error}` };
+  }
+  if (published.remote === "unreachable") {
+    return { ok: false, retryable: true, detail: `passed but unpublished: ${published.detail}` };
+  }
   if (published.remote === "unavailable") {
-    return `review stage requires a published pipeline branch, but this repository has no origin remote to publish ${expected} to`;
+    return {
+      ok: false,
+      retryable: false,
+      detail: `review stage requires a published pipeline branch, but this repository has no origin remote to publish ${expected} to`,
+    };
   }
   pipeline.publishedCommit = published.sha;
-  return null;
+  return { ok: true };
 }
 
 async function tickReviewStage(
@@ -1707,11 +1731,19 @@ async function tickReviewStage(
   }
 
   if (!attempt.flowId) {
-    const ingressError = publishReviewIngressHead(pipeline, attempt, ports);
-    if (ingressError) {
-      park(pipeline, ingressError, attempt);
+    const ingress = publishReviewIngressHead(pipeline, attempt, ports);
+    if (!ingress.ok) {
+      if (ingress.retryable) {
+        attempt.error = ingress.detail;
+        pipeline.state = "running";
+        pipeline.stateDetail = ingress.detail;
+        return;
+      }
+      park(pipeline, ingress.detail, attempt);
       return;
     }
+    attempt.error = null;
+    pipeline.stateDetail = null;
     persist();
     const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, pipeline.baseRef, attempt.expectedReviewHeadSha);
     if (existing) {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1219,6 +1219,43 @@ function advancePipeline(pipeline: Pipeline, stage: PipelineStage, ports: Pipeli
   pipeline.pausedState = null;
 }
 
+function keepPassedStageUnpublished(
+  pipeline: Pipeline,
+  attempt: PipelineStageAttempt,
+  detail: string,
+): void {
+  const message = `passed but unpublished: ${detail}`;
+  attempt.error = message;
+  pipeline.state = "running";
+  pipeline.stateDetail = message;
+}
+
+/** A terminal pass cannot close until its accepted revision is remotely
+    durable. The pass receipt stays terminal and the committing cursor becomes
+    a publication retry seam, so later ticks never rerun or reset stage work. */
+function retryTerminalStagePublication(
+  pipeline: Pipeline,
+  stage: PipelineStage,
+  attempt: PipelineStageAttempt,
+  ports: PipelinePorts,
+): void {
+  const published = publishPipelineBranch(pipeline, ports.exec, {
+    acceptedSha: pipeline.lastPassedCommit,
+    publishedSha: pipeline.publishedCommit ?? null,
+  });
+  if (!published.ok) {
+    park(pipeline, `publishing the passed stage: ${published.error}`, attempt);
+    return;
+  }
+  if (published.remote === "unreachable") {
+    keepPassedStageUnpublished(pipeline, attempt, published.detail);
+    return;
+  }
+  pipeline.publishedCommit = published.remote === "published" ? published.sha : null;
+  attempt.error = null;
+  advancePipeline(pipeline, stage, ports, attempt);
+}
+
 /** Attempts of the fail edge's target that this stage's fail edge activated —
     the derived (never stored) loop budget, so counts cannot drift from the
     durable evidence. */
@@ -1279,11 +1316,13 @@ function commitPassedStage(
   pipeline.publishedCommit = published.remote === "published" ? published.sha : null;
   attempt.state = "passed";
   attempt.completedAt = ports.now();
+  if (published.remote === "unreachable" && stage.next === null) {
+    keepPassedStageUnpublished(pipeline, attempt, published.detail);
+    return;
+  }
   advancePipeline(pipeline, stage, ports, attempt);
   if (published.remote === "unreachable") {
-    const detail = `passed but unpublished: ${published.detail}`;
-    attempt.error = detail;
-    pipeline.stateDetail = detail;
+    keepPassedStageUnpublished(pipeline, attempt, published.detail);
   }
 }
 
@@ -1390,6 +1429,11 @@ async function tickRunStage(
     ? newAttempt(pipeline, stage)
     : prior ?? newAttempt(pipeline, stage);
   if (!attempt || pipeline.state === "needs_decision") return;
+
+  if (attempt.state === "passed" && pipeline.cursor?.state === "committing") {
+    retryTerminalStagePublication(pipeline, stage, attempt, ports);
+    return;
+  }
 
   if (attempt.state === "committing") {
     commitPassedStage(pipeline, stage, attempt, ports);
@@ -1703,6 +1747,10 @@ async function tickReviewStage(
     ? newAttempt(pipeline, stage)
     : prior ?? newAttempt(pipeline, stage);
   if (!attempt || pipeline.state === "needs_decision") return;
+  if (attempt.state === "passed" && pipeline.cursor?.state === "committing") {
+    retryTerminalStagePublication(pipeline, stage, attempt, ports);
+    return;
+  }
   if (attempt.state === "committing") {
     const fenceError = reviewHeadFenceError(pipeline, attempt, ports);
     if (fenceError) {

--- a/src/lib/pipelines/git.test.ts
+++ b/src/lib/pipelines/git.test.ts
@@ -425,6 +425,31 @@ test("a head already recorded as published costs no remote probe at all", () => 
   expect(calls.some((call) => call.includes("remote get-url"))).toBe(false);
 });
 
+test("an unreachable remote gets one time-bounded read per publication call (#999)", () => {
+  const head = "a".repeat(40);
+  const calls: string[] = [];
+  const exec: ExecPort = (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "branch") return { code: 0, stdout: `${pipeline().branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse") return { code: 0, stdout: `${head}\n`, stderr: "" };
+    if (command === "git" && args[0] === "remote") return { code: 0, stdout: "git@example.invalid:owner/repo.git\n", stderr: "" };
+    if (command === "timeout") return { code: 124, stdout: "", stderr: "" };
+    return { code: 128, stdout: "", stderr: "remote read must be bounded" };
+  };
+
+  expect(publishPipelineBranch(pipeline(), exec, { acceptedSha: head })).toEqual({
+    ok: true,
+    sha: head,
+    remote: "unreachable",
+    detail: "checking the remote pipeline branch: git remote read timed out after 5s",
+  });
+  expect(calls.filter((call) => call.includes("ls-remote"))).toEqual([
+    `timeout --signal=KILL 5s git ls-remote --heads origin refs/heads/${pipeline().branch}`,
+  ]);
+  expect(calls.some((call) => call.startsWith("sleep "))).toBe(false);
+});
+
 test("publication pushes only the immutable accepted revision when the branch advances mid-publish", () => {
   const box = publishSandbox();
   try {
@@ -437,7 +462,7 @@ test("publication pushes only the immutable accepted revision when the branch ad
        this unaccepted commit to origin and leave review fenced on a target that
        never passed; pushing the accepted object cannot. */
     const racing: ExecPort = (command, args, cwd) => {
-      if (command === "git" && args[0] === "ls-remote" && racy === null) {
+      if (command === "timeout" && args.includes("ls-remote") && racy === null) {
         racy = box.commit("racy.txt", "never accepted\n");
       }
       return realExec(command, args, cwd);

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -145,25 +145,27 @@ export type PipelinePublishResult =
   | { ok: true; sha: string; remote: "unreachable"; detail: string }
   | { ok: false; error: string };
 
-const REMOTE_READ_BACKOFF_SECONDS = ["0.25", "0.5"] as const;
+const REMOTE_READ_TIMEOUT = "5s";
 
-/** A remote read gets three bounded attempts. The synchronous git adapter
-    already blocks for each git process; keeping the two short delays behind
-    that same adapter also keeps tests deterministic and the retry local to the
-    publication module. */
+/** A publication tick gets one bounded remote read. The engine tick is already
+    the retry loop, so retrying or sleeping inside this synchronous adapter only
+    multiplies event-loop stalls. `timeout` exists in both the runtime image and
+    the Linux host namespace used by agent shims. */
 function readRemotePipelineBranch(
   pipeline: Pipeline,
   exec: ExecPort,
   step: string,
 ): { ok: true; sha: string } | { ok: false; error: string } {
-  let last: ExecResult = { code: null, stdout: "", stderr: "remote read was not attempted" };
-  for (let attempt = 0; attempt <= REMOTE_READ_BACKOFF_SECONDS.length; attempt += 1) {
-    last = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
-    if (last.code === 0) return { ok: true, sha: last.stdout.trim().split(/\s+/)[0] ?? "" };
-    const delay = REMOTE_READ_BACKOFF_SECONDS[attempt];
-    if (delay) exec("sleep", [delay], pipeline.worktreeDir);
+  const result = exec(
+    "timeout",
+    ["--signal=KILL", REMOTE_READ_TIMEOUT, "git", "ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`],
+    pipeline.worktreeDir,
+  );
+  if (result.code === 0) return { ok: true, sha: result.stdout.trim().split(/\s+/)[0] ?? "" };
+  if (result.code === 124 || result.code === 137) {
+    return { ok: false, error: `${step}: git remote read timed out after ${REMOTE_READ_TIMEOUT}` };
   }
-  return failure(step, last);
+  return failure(step, result);
 }
 
 export interface PipelinePublishRequest {

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -142,7 +142,29 @@ export function currentPipelineRemoteBranchHead(pipeline: Pipeline, exec: ExecPo
 
 export type PipelinePublishResult =
   | { ok: true; sha: string; remote: "published" | "unavailable" }
+  | { ok: true; sha: string; remote: "unreachable"; detail: string }
   | { ok: false; error: string };
+
+const REMOTE_READ_BACKOFF_SECONDS = ["0.25", "0.5"] as const;
+
+/** A remote read gets three bounded attempts. The synchronous git adapter
+    already blocks for each git process; keeping the two short delays behind
+    that same adapter also keeps tests deterministic and the retry local to the
+    publication module. */
+function readRemotePipelineBranch(
+  pipeline: Pipeline,
+  exec: ExecPort,
+  step: string,
+): { ok: true; sha: string } | { ok: false; error: string } {
+  let last: ExecResult = { code: null, stdout: "", stderr: "remote read was not attempted" };
+  for (let attempt = 0; attempt <= REMOTE_READ_BACKOFF_SECONDS.length; attempt += 1) {
+    last = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+    if (last.code === 0) return { ok: true, sha: last.stdout.trim().split(/\s+/)[0] ?? "" };
+    const delay = REMOTE_READ_BACKOFF_SECONDS[attempt];
+    if (delay) exec("sleep", [delay], pipeline.worktreeDir);
+  }
+  return failure(step, last);
+}
 
 export interface PipelinePublishRequest {
   /** The immutable revision the pipeline accepted. This exact object is what
@@ -191,9 +213,9 @@ export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, reques
   const origin = exec("git", ["remote", "get-url", "origin"], pipeline.worktreeDir);
   if (origin.code !== 0 || !origin.stdout.trim()) return { ok: true, sha: acceptedSha, remote: "unavailable" };
 
-  const probe = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
-  if (probe.code !== 0) return failure("checking the remote pipeline branch", probe);
-  const remoteSha = probe.stdout.trim().split(/\s+/)[0] ?? "";
+  const probe = readRemotePipelineBranch(pipeline, exec, "checking the remote pipeline branch");
+  if (!probe.ok) return { ok: true, sha: acceptedSha, remote: "unreachable", detail: probe.error };
+  const remoteSha = probe.sha;
   if (remoteSha === acceptedSha) return { ok: true, sha: acceptedSha, remote: "published" };
   if (remoteSha) {
     if (!/^[0-9a-f]{40}$/i.test(remoteSha)) return { ok: false, error: "the remote pipeline branch has no exact commit SHA" };
@@ -223,9 +245,9 @@ export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, reques
 
   const push = exec("git", ["push", "origin", `${acceptedSha}:refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
   if (push.code !== 0) return failure("publishing the pipeline branch", push);
-  const confirm = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
-  if (confirm.code !== 0) return failure("confirming the published pipeline branch", confirm);
-  const publishedHead = confirm.stdout.trim().split(/\s+/)[0] ?? "";
+  const confirm = readRemotePipelineBranch(pipeline, exec, "confirming the published pipeline branch");
+  if (!confirm.ok) return { ok: true, sha: acceptedSha, remote: "unreachable", detail: confirm.error };
+  const publishedHead = confirm.sha;
   if (publishedHead !== acceptedSha) {
     return { ok: false, error: `publishing the pipeline branch did not land: origin/${pipeline.branch} is ${publishedHead || "absent"}, expected ${acceptedSha}` };
   }


### PR DESCRIPTION
Closes #999

## Summary
- route container git SSH through one runtime-HOME-aware wrapper and propagate it to every engine-capable Compose service
- retry authoritative remote branch reads with bounded 250 ms and 500 ms backoff
- retain a stage pass verdict when GitHub remains unreachable, record passed-but-unpublished, and keep review ingress retryable

## Verification
- 212 focused tests across the pipeline engine, git publication, container credential contract, and promoted-container propagation
- bunx tsc --noEmit
- scoped ESLint on changed TypeScript files
- bun run build
- privacy publication gate against the merge base
