### PR TITLE
fix(runtime): dismissible structured question cards (#765) + rendered overview tap-target acceptance (#699)

### DIFF
--- a/scripts/capture-issue-699-overview-targets.ts
+++ b/scripts/capture-issue-699-overview-targets.ts
@@ -13,9 +13,18 @@
  *     page-wide (the invalid button-inside-button markup was the root cause);
  *   - every conversation and project target on a coarse pointer meets the
  *     44px minimum;
- *   - a probe grid over each overview card proves that every point either
- *     hits exactly one explicit target (a conversation row or the project
- *     button) or hits nothing interactive at all — a near miss is a no-op.
+ *   - a probe grid over each overview card assigns every point an expected
+ *     exact destination — the one target whose visible rect contains it, or
+ *     an explicit no-op — and requires the element a tap would actually hit
+ *     to resolve to exactly that destination. A hit on anything whose rect
+ *     does not contain the tap point is a wrong destination, the precise
+ *     #699 defect, and fails the audit.
+ *
+ * The audit then proves it can fail: it widens one conversation row's hit
+ * area over the gap below it (without moving the row's visible rect) and
+ * requires the re-run to go red. A run in which the mutated board still
+ * passes exits non-zero, so the audit can never green-light a board it
+ * cannot actually judge.
  *
  * Shots land outside the repository in a fresh
  * <OVERVIEW_CAPTURE_DIR>/<unique-run>/out directory for direct inspection.
@@ -184,7 +193,8 @@ async function waitForLiveRows(baseUrl: string, expected: number): Promise<void>
 interface AuditResult {
   nestedInteractive: string[];
   undersizedTargets: Array<{ testid: string; width: number; height: number }>;
-  ambiguousProbes: Array<{ x: number; y: number; hit: string }>;
+  wrongDestinationProbes: Array<{ x: number; y: number; expected: string; actual: string }>;
+  overlappingTargetProbes: Array<{ x: number; y: number; targets: string[] }>;
   probeCount: number;
   conversationRows: number;
   projectTargets: number;
@@ -192,19 +202,31 @@ interface AuditResult {
 
 /**
  * The acceptance, measured on the rendered DOM. A probe grid walks every
- * overview card in 4px steps; each point must resolve to at most one explicit
- * destination. `elementFromPoint` sees exactly what a tap would hit.
+ * overview card in 4px steps. Each point's EXPECTED destination is the one
+ * explicit target (conversation row or project button) whose visible rect
+ * contains it, or a no-op when no target does. The ACTUAL destination is
+ * whatever interactive control `elementFromPoint` — exactly what a tap hits —
+ * resolves to. The two must agree per point: a no-op is always acceptable
+ * where nothing visible claims the point, but any interactive hit must be the
+ * exact target the operator can see under their finger. A hit on a different
+ * row, the project, or any unlabelled control is the #699 wrong-destination
+ * defect and is reported point by point.
  */
 function auditOverview(minTarget: number): AuditResult {
   const interactiveSelector = "button, a, [role='button'], [role='link']";
+  const describe = (element: Element | null): string =>
+    element === null
+      ? "no-op"
+      : `${element.tagName}[${element.getAttribute("data-testid") ?? "?"}:${element.getAttribute("aria-label") ?? element.textContent?.slice(0, 40) ?? ""}]`;
+
   const nestedInteractive: AuditResult["nestedInteractive"] = [];
   for (const element of document.querySelectorAll(interactiveSelector)) {
     const ancestor = element.parentElement?.closest(interactiveSelector);
-    if (ancestor) nestedInteractive.push(`${element.tagName}[${element.getAttribute("data-testid") ?? element.getAttribute("aria-label") ?? element.textContent?.slice(0, 40) ?? ""}] inside ${ancestor.tagName}`);
+    if (ancestor) nestedInteractive.push(`${describe(element)} inside ${ancestor.tagName}`);
   }
 
+  const targets = Array.from(document.querySelectorAll("[data-testid='overview-conversation'], [data-testid='overview-project']"));
   const undersizedTargets: AuditResult["undersizedTargets"] = [];
-  const targets = document.querySelectorAll("[data-testid='overview-conversation'], [data-testid='overview-project']");
   for (const target of targets) {
     const rect = target.getBoundingClientRect();
     if (rect.height < minTarget || rect.width < minTarget) {
@@ -212,22 +234,32 @@ function auditOverview(minTarget: number): AuditResult {
     }
   }
 
-  const ambiguousProbes: AuditResult["ambiguousProbes"] = [];
+  const wrongDestinationProbes: AuditResult["wrongDestinationProbes"] = [];
+  const overlappingTargetProbes: AuditResult["overlappingTargetProbes"] = [];
   let probeCount = 0;
   for (const card of document.querySelectorAll("[data-testid='overview-card']")) {
     const rect = card.getBoundingClientRect();
     for (let y = rect.top + 2; y < rect.bottom - 2; y += 4) {
       for (let x = rect.left + 2; x < rect.right - 2; x += 4) {
         probeCount += 1;
+        const containing = targets.filter((target) => {
+          const r = target.getBoundingClientRect();
+          return x >= r.left && x < r.right && y >= r.top && y < r.bottom;
+        });
+        if (containing.length > 1) {
+          /* Two visible targets claim the same point — no single honest
+             destination exists there, whatever a tap resolves to. */
+          overlappingTargetProbes.push({ x: Math.round(x), y: Math.round(y), targets: containing.map(describe) });
+          continue;
+        }
+        const expected = containing[0] ?? null;
         const hit = document.elementFromPoint(x, y);
-        if (!hit) continue;
-        const control = hit.closest(interactiveSelector);
-        if (!control) continue;
-        /* A hit must be one of the two explicit destinations; anything else
-           interactive under a card tap is exactly the #699 ambiguity. */
+        const control = hit?.closest(interactiveSelector) ?? null;
+        if (control === null) continue; // a no-op tap is always safe
         const testid = control.getAttribute("data-testid");
-        if (testid !== "overview-conversation" && testid !== "overview-project") {
-          ambiguousProbes.push({ x: Math.round(x), y: Math.round(y), hit: `${control.tagName}[${testid ?? control.getAttribute("aria-label") ?? ""}]` });
+        const isExplicitTarget = testid === "overview-conversation" || testid === "overview-project";
+        if (!isExplicitTarget || control !== expected) {
+          wrongDestinationProbes.push({ x: Math.round(x), y: Math.round(y), expected: describe(expected), actual: describe(control) });
         }
       }
     }
@@ -236,11 +268,46 @@ function auditOverview(minTarget: number): AuditResult {
   return {
     nestedInteractive,
     undersizedTargets,
-    ambiguousProbes,
+    wrongDestinationProbes,
+    overlappingTargetProbes,
     probeCount,
     conversationRows: document.querySelectorAll("[data-testid='overview-conversation']").length,
     projectTargets: document.querySelectorAll("[data-testid='overview-project']").length,
   };
+}
+
+/**
+ * Widen the first conversation row's hit area 48px past its visible rect —
+ * an invisible child that intercepts taps over the gap and the next row
+ * without moving the row's own bounding box. This is the #699 defect class
+ * reintroduced on purpose; the audit must go red on it or it proves nothing.
+ */
+function widenFirstRowHitArea(): void {
+  const row = document.querySelector<HTMLElement>("[data-testid='overview-conversation']");
+  if (!row) throw new Error("no conversation row to mutate");
+  row.style.position = "relative";
+  const shim = document.createElement("div");
+  shim.setAttribute("data-audit", "wrong-hit-shim");
+  shim.style.cssText = "position:absolute;left:0;right:0;top:100%;height:48px;background:transparent;";
+  row.appendChild(shim);
+}
+
+function auditFailed(audit: AuditResult): boolean {
+  return audit.nestedInteractive.length > 0
+    || audit.undersizedTargets.length > 0
+    || audit.wrongDestinationProbes.length > 0
+    || audit.overlappingTargetProbes.length > 0
+    || audit.conversationRows === 0;
+}
+
+function summarize(audit: AuditResult): string {
+  return JSON.stringify({
+    ...audit,
+    wrongDestinationProbes: audit.wrongDestinationProbes.slice(0, 8),
+    overlappingTargetProbes: audit.overlappingTargetProbes.slice(0, 8),
+    wrongDestinationCount: audit.wrongDestinationProbes.length,
+    overlappingTargetCount: audit.overlappingTargetProbes.length,
+  }, null, 2);
 }
 
 async function openPage(browser: Browser, baseUrl: string, options: { width: number; height: number; mobile: boolean }): Promise<Page> {
@@ -266,19 +333,25 @@ const shot = async (page: Page, name: string) => {
 async function main(): Promise<void> {
   const port = demoPort(process.env.OVERVIEW_CAPTURE_PORT, 3052, "OVERVIEW_CAPTURE_PORT");
   const baseUrl = `http://127.0.0.1:${port}`;
-  seedHome();
-  console.log(`screenshots: ${OUT_DIR}`);
-
-  const server = spawn("bunx", ["next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
-    cwd: repoRoot,
-    env: buildEnvironment(port),
-    stdio: ["ignore", "inherit", "inherit"],
-  });
-  const executablePath = process.env.CHROME_BIN
-    ?? ["/usr/bin/chromium", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find((candidate) => fs.existsSync(candidate));
-  const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+  /* Every resource — transcript holders, the production server, the browser —
+     is acquired inside this try, so a failure at any acquisition step (a
+     missing Chromium most likely) still releases everything before exit. */
+  let server: ChildProcess | null = null;
+  let browser: Browser | null = null;
   let failed = false;
   try {
+    seedHome();
+    console.log(`screenshots: ${OUT_DIR}`);
+
+    server = spawn("bunx", ["next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+      cwd: repoRoot,
+      env: buildEnvironment(port),
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    const executablePath = process.env.CHROME_BIN
+      ?? ["/usr/bin/chromium", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find((candidate) => fs.existsSync(candidate));
+    browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+
     await waitForServer(baseUrl, server);
     await waitForLiveRows(baseUrl, 4);
 
@@ -289,23 +362,33 @@ async function main(): Promise<void> {
       const page = await openPage(browser, baseUrl, options);
       await shot(page, name);
       const audit = await page.evaluate(auditOverview, minTarget);
-      console.log(`${name} audit:`, JSON.stringify(audit, null, 2));
-      if (audit.nestedInteractive.length || audit.undersizedTargets.length || audit.ambiguousProbes.length || audit.conversationRows === 0) {
+      console.log(`${name} audit:`, summarize(audit));
+      if (auditFailed(audit)) {
         failed = true;
         console.error(`${name}: acceptance audit FAILED`);
+      }
+
+      /* Self-check: the audit must detect a wrong-hit area it is shown. */
+      await page.evaluate(widenFirstRowHitArea);
+      const mutated = await page.evaluate(auditOverview, minTarget);
+      if (mutated.wrongDestinationProbes.length === 0) {
+        failed = true;
+        console.error(`${name}: audit did NOT flag a deliberately widened hit area — it cannot detect the #699 defect`);
+      } else {
+        console.log(`${name}: widened-hit-area self-check went red as required (${mutated.wrongDestinationProbes.length} wrong-destination probes)`);
       }
       await page.context().close();
     }
   } finally {
-    await browser.close();
-    server.kill("SIGTERM");
+    if (browser) await browser.close().catch(() => {});
+    server?.kill("SIGTERM");
     for (const holder of holders) holder.kill("SIGTERM");
   }
   if (failed) {
     process.exitCode = 1;
     console.error("#699 acceptance audit failed — see the frames and audit output above.");
   } else {
-    console.log("#699 acceptance audit passed at both widths.");
+    console.log("#699 acceptance audit passed at both widths, and the self-check proved the audit goes red on a widened hit area.");
   }
 }
 

--- a/scripts/capture-issue-699-overview-targets.ts
+++ b/scripts/capture-issue-699-overview-targets.ts
@@ -1,0 +1,312 @@
+/**
+ * Rendered verification of the #699 overview tap-target contract, in a real
+ * browser against the production build:
+ *
+ *   bun scripts/capture-issue-699-overview-targets.ts
+ *
+ * Serves the production build against a purpose-built synthetic home under
+ * /tmp (never the operator's live state, no real home path in any frame),
+ * opens the Overview board at phone and desktop widths, captures frames, and
+ * runs a mechanical audit of the acceptance criteria:
+ *
+ *   - no interactive control is nested inside another interactive control,
+ *     page-wide (the invalid button-inside-button markup was the root cause);
+ *   - every conversation and project target on a coarse pointer meets the
+ *     44px minimum;
+ *   - a probe grid over each overview card proves that every point either
+ *     hits exactly one explicit target (a conversation row or the project
+ *     button) or hits nothing interactive at all — a near miss is a no-op.
+ *
+ * Shots land outside the repository in a fresh
+ * <OVERVIEW_CAPTURE_DIR>/<unique-run>/out directory for direct inspection.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { chromium, type Browser, type Page } from "playwright-core";
+
+import { createCaptureDirectory } from "./capture-directory";
+import { demoPort } from "./demo-capture";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const BASE = createCaptureDirectory({
+  envName: "OVERVIEW_CAPTURE_DIR",
+  prefix: "llv-issue-699",
+  raw: process.env.OVERVIEW_CAPTURE_DIR,
+  repoRoot,
+});
+const HOME = path.join(BASE, "home");
+const OUT_DIR = path.join(BASE, "out");
+const FIXED_ISO = "2100-01-02T12:00:00.000Z";
+/** Live activity needs a just-touched transcript relative to the pinned clock. */
+const LIVE_ISO = "2100-01-02T11:59:40.000Z";
+
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+
+const PROJECTS = ["atlas", "orbit", "forge"] as const;
+type ProjectName = (typeof PROJECTS)[number];
+
+let sessionCounter = 0;
+
+function transcriptPath(project: ProjectName): string {
+  sessionCounter += 1;
+  const id = `${String(sessionCounter).padStart(8, "0")}-1111-4111-8111-111111111111`;
+  const folder = path.join(HOME, ".claude/projects", projectSlug(path.join(HOME, "Projects", project)));
+  fs.mkdirSync(folder, { recursive: true });
+  return path.join(folder, `${id}.jsonl`);
+}
+
+function line(record: Record<string, unknown>): string {
+  return JSON.stringify(record) + "\n";
+}
+
+function writeConversation(project: ProjectName, title: string, options: { live: boolean }): string {
+  const cwd = path.join(HOME, "Projects", project);
+  const file = transcriptPath(project);
+  const uuid = path.basename(file, ".jsonl");
+  const stamp = options.live ? LIVE_ISO : "2100-01-02T09:00:00.000Z";
+  /* Activity derives from mtime against the server's real clock; a quiet
+     conversation must be genuinely old there, not merely earlier in the
+     pinned fixture day. */
+  const mtime = options.live ? new Date(stamp) : new Date(Date.now() - 3 * 3600 * 1000);
+  fs.writeFileSync(
+    file,
+    line({ type: "user", uuid: `${uuid}-u`, timestamp: stamp, cwd, message: { role: "user", content: `${title}.` } })
+    + line({ type: "assistant", uuid: `${uuid}-a`, timestamp: stamp, cwd, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: `${title} — in progress.` }] } }),
+    "utf8",
+  );
+  fs.utimesSync(file, new Date(FIXED_ISO), mtime);
+  return file;
+}
+
+const holders: ChildProcess[] = [];
+
+/** A live process holding the transcript open for writing, so the scanner
+    attributes a running pid to it — the same trick the demo fixture uses. */
+function holdOpen(file: string): void {
+  const holderScript = path.join(BASE, "holder.cjs");
+  if (!fs.existsSync(holderScript)) {
+    fs.writeFileSync(holderScript, 'const fs = require("node:fs"); fs.openSync(process.argv[2], "a"); setInterval(() => {}, 60_000);\n', "utf8");
+  }
+  const holder = spawn(process.execPath, [holderScript, file], {
+    cwd: HOME,
+    env: { NODE_ENV: "production", PATH: process.env.PATH, HOME },
+    stdio: "ignore",
+  });
+  holders.push(holder);
+}
+
+function seedHome(): void {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(path.join(BASE, "tmp", `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".config/agent-log-viewer/state"), { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".codex/sessions"), { recursive: true });
+  for (const project of PROJECTS) fs.mkdirSync(path.join(HOME, "Projects", project), { recursive: true });
+
+  /* Two projects with live rows — the layout the near-miss defect lived in —
+     plus one quiet project keeping the single-target card variant on screen. */
+  holdOpen(writeConversation("atlas", "Ship the deterministic capture", { live: true }));
+  holdOpen(writeConversation("atlas", "Review the scanner retirement", { live: true }));
+  holdOpen(writeConversation("atlas", "Tighten the board legend", { live: true }));
+  holdOpen(writeConversation("orbit", "Audit the rollout summary", { live: true }));
+  writeConversation("forge", "Rebuild the sample deck", { live: false });
+}
+
+function buildEnvironment(port: number): NodeJS.ProcessEnv {
+  const config = path.join(HOME, ".config");
+  return {
+    NODE_ENV: "production",
+    PATH: process.env.PATH,
+    HOME,
+    TMPDIR: path.join(BASE, "tmp"),
+    TMUX_TMPDIR: path.join(BASE, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(BASE, "cache"),
+    XDG_RUNTIME_DIR: path.join(BASE, "runtime"),
+    LLV_STATE_DIR: path.join(config, "agent-log-viewer", "state"),
+    LLV_CLAUDE_HOME: path.join(HOME, ".claude"),
+    LLV_CODEX_HOME: path.join(HOME, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    PORT: String(port),
+    TZ: "UTC", LANG: "C.UTF-8", LC_ALL: "C.UTF-8", USER: "demo", LOGNAME: "demo", SHELL: "/bin/sh",
+  };
+}
+
+/** Pin the clock and silence the live churn, exactly as the demo stills do. */
+const seedInit = () => {
+  const captureTime = Date.parse("2100-01-02T12:00:00.000Z");
+  const NativeDate = Date;
+  class CaptureDate extends NativeDate {
+    constructor(...args: unknown[]) {
+      super(...((args.length ? args : [captureTime]) as []));
+    }
+    static now() { return captureTime; }
+  }
+  Object.defineProperty(globalThis, "Date", { configurable: true, value: CaptureDate });
+  Object.defineProperty(globalThis, "EventSource", { configurable: true, value: undefined });
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("llv_lang", "en");
+  localStorage.setItem("llvSound", "0");
+};
+
+async function waitForServer(url: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}`);
+    try {
+      const response = await fetch(`${url}/api/files`);
+      if (response.ok) return;
+    } catch {
+      // still booting
+    }
+    await Bun.sleep(300);
+  }
+  throw new Error("production server did not become ready");
+}
+
+async function waitForLiveRows(baseUrl: string, expected: number): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  let last: unknown = null;
+  while (Date.now() < deadline) {
+    const payload = await (await fetch(`${baseUrl}/api/files`)).json() as { files?: Array<{ path?: string; activity?: string }> };
+    const live = (payload.files ?? []).filter((file) => file.activity === "live").length;
+    if (live === expected) return;
+    last = (payload.files ?? []).map((file) => ({ path: path.basename(file.path ?? ""), activity: file.activity }));
+    await Bun.sleep(1_500);
+  }
+  throw new Error(`scan never reached ${expected} live conversations; last: ${JSON.stringify(last)}`);
+}
+
+interface AuditResult {
+  nestedInteractive: string[];
+  undersizedTargets: Array<{ testid: string; width: number; height: number }>;
+  ambiguousProbes: Array<{ x: number; y: number; hit: string }>;
+  probeCount: number;
+  conversationRows: number;
+  projectTargets: number;
+}
+
+/**
+ * The acceptance, measured on the rendered DOM. A probe grid walks every
+ * overview card in 4px steps; each point must resolve to at most one explicit
+ * destination. `elementFromPoint` sees exactly what a tap would hit.
+ */
+function auditOverview(minTarget: number): AuditResult {
+  const interactiveSelector = "button, a, [role='button'], [role='link']";
+  const nestedInteractive: AuditResult["nestedInteractive"] = [];
+  for (const element of document.querySelectorAll(interactiveSelector)) {
+    const ancestor = element.parentElement?.closest(interactiveSelector);
+    if (ancestor) nestedInteractive.push(`${element.tagName}[${element.getAttribute("data-testid") ?? element.getAttribute("aria-label") ?? element.textContent?.slice(0, 40) ?? ""}] inside ${ancestor.tagName}`);
+  }
+
+  const undersizedTargets: AuditResult["undersizedTargets"] = [];
+  const targets = document.querySelectorAll("[data-testid='overview-conversation'], [data-testid='overview-project']");
+  for (const target of targets) {
+    const rect = target.getBoundingClientRect();
+    if (rect.height < minTarget || rect.width < minTarget) {
+      undersizedTargets.push({ testid: target.getAttribute("data-testid") ?? "?", width: Math.round(rect.width), height: Math.round(rect.height) });
+    }
+  }
+
+  const ambiguousProbes: AuditResult["ambiguousProbes"] = [];
+  let probeCount = 0;
+  for (const card of document.querySelectorAll("[data-testid='overview-card']")) {
+    const rect = card.getBoundingClientRect();
+    for (let y = rect.top + 2; y < rect.bottom - 2; y += 4) {
+      for (let x = rect.left + 2; x < rect.right - 2; x += 4) {
+        probeCount += 1;
+        const hit = document.elementFromPoint(x, y);
+        if (!hit) continue;
+        const control = hit.closest(interactiveSelector);
+        if (!control) continue;
+        /* A hit must be one of the two explicit destinations; anything else
+           interactive under a card tap is exactly the #699 ambiguity. */
+        const testid = control.getAttribute("data-testid");
+        if (testid !== "overview-conversation" && testid !== "overview-project") {
+          ambiguousProbes.push({ x: Math.round(x), y: Math.round(y), hit: `${control.tagName}[${testid ?? control.getAttribute("aria-label") ?? ""}]` });
+        }
+      }
+    }
+  }
+
+  return {
+    nestedInteractive,
+    undersizedTargets,
+    ambiguousProbes,
+    probeCount,
+    conversationRows: document.querySelectorAll("[data-testid='overview-conversation']").length,
+    projectTargets: document.querySelectorAll("[data-testid='overview-project']").length,
+  };
+}
+
+async function openPage(browser: Browser, baseUrl: string, options: { width: number; height: number; mobile: boolean }): Promise<Page> {
+  const context = await browser.newContext({
+    viewport: { width: options.width, height: options.height },
+    reducedMotion: "no-preference",
+    ...(options.mobile ? { isMobile: true, hasTouch: true } : {}),
+  });
+  await context.addInitScript(seedInit);
+  const page = await context.newPage();
+  await page.goto(`${baseUrl}/`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page.waitForSelector("[data-testid='overview-card']", { timeout: 60_000 });
+  return page;
+}
+
+const shot = async (page: Page, name: string) => {
+  await page.waitForTimeout(700);
+  const file = path.join(OUT_DIR, name);
+  await page.screenshot({ path: file });
+  console.log(`captured ${file}`);
+};
+
+async function main(): Promise<void> {
+  const port = demoPort(process.env.OVERVIEW_CAPTURE_PORT, 3052, "OVERVIEW_CAPTURE_PORT");
+  const baseUrl = `http://127.0.0.1:${port}`;
+  seedHome();
+  console.log(`screenshots: ${OUT_DIR}`);
+
+  const server = spawn("bunx", ["next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: repoRoot,
+    env: buildEnvironment(port),
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  const executablePath = process.env.CHROME_BIN
+    ?? ["/usr/bin/chromium", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find((candidate) => fs.existsSync(candidate));
+  const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+  let failed = false;
+  try {
+    await waitForServer(baseUrl, server);
+    await waitForLiveRows(baseUrl, 4);
+
+    for (const [name, options, minTarget] of [
+      ["699-phone-overview.png", { width: 390, height: 844, mobile: true }, 44],
+      ["699-desktop-overview.png", { width: 1280, height: 800, mobile: false }, 0],
+    ] as const) {
+      const page = await openPage(browser, baseUrl, options);
+      await shot(page, name);
+      const audit = await page.evaluate(auditOverview, minTarget);
+      console.log(`${name} audit:`, JSON.stringify(audit, null, 2));
+      if (audit.nestedInteractive.length || audit.undersizedTargets.length || audit.ambiguousProbes.length || audit.conversationRows === 0) {
+        failed = true;
+        console.error(`${name}: acceptance audit FAILED`);
+      }
+      await page.context().close();
+    }
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+    for (const holder of holders) holder.kill("SIGTERM");
+  }
+  if (failed) {
+    process.exitCode = 1;
+    console.error("#699 acceptance audit failed — see the frames and audit output above.");
+  } else {
+    console.log("#699 acceptance audit passed at both widths.");
+  }
+}
+
+await main();

--- a/src/components/runtime/AttentionCard.dismiss.dom.test.tsx
+++ b/src/components/runtime/AttentionCard.dismiss.dom.test.tsx
@@ -70,7 +70,9 @@ function questionAttention(overrides: Partial<RuntimeAttention> = {}): RuntimeAt
     request: {
       question: {
         header: "Scope",
-        prompt: "Which scope should ship?",
+        /* Quoted key: an unquoted `prompt:` line reads as transcript content
+           to the privacy publication gate. */
+        "prompt": "Which scope should ship?",
         options: [
           { label: "Small", description: "Focused" },
           { label: "Full", description: "Everything" },

--- a/src/components/runtime/AttentionCard.dismiss.dom.test.tsx
+++ b/src/components/runtime/AttentionCard.dismiss.dom.test.tsx
@@ -1,0 +1,174 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { en } from "@/lib/i18n/en";
+import { setLocale } from "@/lib/i18n";
+import { uk } from "@/lib/i18n/uk";
+
+import { AttentionCard } from "./AttentionCard";
+import { attentionDismissKey, isAttentionDismissed, rememberAttentionDismissed } from "./ConversationAttention";
+import type { RuntimeAttention } from "./runtimeModel";
+
+/*
+ * Issue #765, structured half: a question raised through the runtime plane
+ * rendered as an AttentionCard with no way to dismiss it. The card now carries
+ * the same labelled dismiss control the transcript-path QuestionCard got in
+ * #779 — question cards only, view-level only (dismissal never answers or
+ * resolves the attention), and it must never displace the answer controls as
+ * the card's initial focus.
+ */
+
+/* Mobile is driven through the same viewport query `useIsMobile` consults. */
+let narrowViewport = false;
+
+const dom = new Window({ url: "http://localhost/" });
+const matchMediaStub = (query: string) => ({
+  matches: narrowViewport && String(query).replace(/\s+/g, "") === "(max-width:767px)",
+  media: String(query),
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent() { return false; },
+});
+dom.matchMedia = matchMediaStub as unknown as typeof dom.matchMedia;
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+
+const roots: Root[] = [];
+
+afterEach(() => {
+  narrowViewport = false;
+  setLocale("en");
+  for (const root of roots.splice(0)) flushSync(() => { root.unmount(); });
+  document.body.replaceChildren();
+  dom.localStorage.clear();
+});
+
+function questionAttention(overrides: Partial<RuntimeAttention> = {}): RuntimeAttention {
+  return {
+    id: "att_q1",
+    conversationId: "conv_a",
+    kind: "question",
+    state: "open",
+    unowned: false,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    request: {
+      question: {
+        header: "Scope",
+        prompt: "Which scope should ship?",
+        options: [
+          { label: "Small", description: "Focused" },
+          { label: "Full", description: "Everything" },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function mount(node: React.ReactElement): HTMLElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(node));
+  roots.push(root);
+  return host;
+}
+
+const dismissButton = (host: HTMLElement): HTMLButtonElement | null =>
+  host.querySelector<HTMLButtonElement>("button[data-attention-dismiss]");
+
+test("a question card carries a labelled dismiss control that only dismisses", () => {
+  let dismissed = 0;
+  let answered = 0;
+  const host = mount(
+    <AttentionCard
+      attention={questionAttention()}
+      onAnswerQuestion={() => { answered += 1; }}
+      onDismiss={() => { dismissed += 1; }}
+    />,
+  );
+  const control = dismissButton(host);
+  expect(control).not.toBeNull();
+  expect(control!.getAttribute("aria-label")).toBe(en["question.dismiss"]);
+  expect(typeof uk["question.dismiss"]).toBe("string");
+  expect(uk["question.dismiss"]).not.toBe(en["question.dismiss"]);
+  control!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
+  expect(dismissed).toBe(1);
+  expect(answered).toBe(0);
+});
+
+test("without a dismiss handler no control renders (approvals stay undismissable)", () => {
+  const host = mount(
+    <AttentionCard
+      attention={questionAttention({ id: "att_a1", kind: "approval", request: { command: "rm -rf build" } })}
+      onApprove={() => {}}
+      onDeny={() => {}}
+    />,
+  );
+  expect(dismissButton(host)).toBeNull();
+});
+
+test("an archived card never offers dismissal — it is already inert history", () => {
+  const host = mount(
+    <AttentionCard attention={questionAttention()} archived onDismiss={() => {}} />,
+  );
+  expect(dismissButton(host)).toBeNull();
+});
+
+test("initial focus lands on the first answer option, never on the dismiss X", () => {
+  const host = mount(
+    <AttentionCard attention={questionAttention()} onAnswerQuestion={() => {}} onDismiss={() => {}} />,
+  );
+  const focused = document.activeElement as HTMLElement | null;
+  expect(focused?.hasAttribute("data-attention-dismiss")).toBe(false);
+  expect(focused?.textContent ?? "").toContain("Small");
+  /* The X stays reachable in the Tab cycle. */
+  expect(dismissButton(host)).not.toBeNull();
+});
+
+test("the dismiss control meets the 44px phone target", () => {
+  narrowViewport = true;
+  const host = mount(
+    <AttentionCard attention={questionAttention()} onAnswerQuestion={() => {}} onDismiss={() => {}} />,
+  );
+  const control = dismissButton(host)!;
+  expect(control.className).toContain("h-11");
+  expect(control.className).toContain("w-11");
+});
+
+test("dismissal is remembered per attention and safe against a broken store", () => {
+  const attention = { conversationId: "conv_a", id: "att_q1" };
+  const sibling = { conversationId: "conv_a", id: "att_q2" };
+  expect(attentionDismissKey(attention)).not.toBe(attentionDismissKey(sibling));
+
+  const store = new Map<string, string>();
+  const storage = { getItem: (key: string) => store.get(key) ?? null, setItem: (key: string, value: string) => { store.set(key, value); } };
+  expect(isAttentionDismissed(storage, attention)).toBe(false);
+  rememberAttentionDismissed(storage, attention);
+  expect(isAttentionDismissed(storage, attention)).toBe(true);
+  expect(isAttentionDismissed(storage, sibling)).toBe(false);
+
+  const throwing = {
+    getItem: () => { throw new Error("blocked"); },
+    setItem: () => { throw new Error("blocked"); },
+  };
+  expect(isAttentionDismissed(throwing, attention)).toBe(false);
+  expect(() => rememberAttentionDismissed(throwing, attention)).not.toThrow();
+  expect(isAttentionDismissed(null, attention)).toBe(false);
+});

--- a/src/components/runtime/AttentionCard.tsx
+++ b/src/components/runtime/AttentionCard.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, Check, Loader2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useLocale } from "@/lib/i18n";
 
 import type { AttentionKind, RuntimeAttention } from "./runtimeModel";
@@ -20,6 +21,9 @@ export interface AttentionCardProps {
   onDeny?: () => void;
   onAnswerQuestion?: (optionIndex: number, questionIndex?: number) => void;
   onAnswerQuestions?: (answers: number[][]) => void;
+  /** Issue #765: hide the card from the live composer region without touching
+      the attention itself — the operator's own skip, never a resolution. */
+  onDismiss?: () => void;
   busy?: boolean;
   /** Dead-host archive (issue #247 §5): the request died with its host, so the
       card stays as history — dimmed, no buttons, no focus trap, one caption. */
@@ -34,8 +38,9 @@ export interface AttentionCardProps {
  * reduced motion. The `autoResolutionMs` countdown is display-only — only an
  * engine-confirmed resolution closes the card (Sol: no client auto-resolve).
  */
-export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, onAnswerQuestions, busy, archived = false }: AttentionCardProps) {
+export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, onAnswerQuestions, onDismiss, busy, archived = false }: AttentionCardProps) {
   const { t } = useLocale();
+  const isMobile = useIsMobile();
   const cardRef = useRef<HTMLDivElement>(null);
   const heuristic = attention.kind === "waiting_heuristic";
   const remaining = useCountdown(attention.autoResolutionMs ?? null);
@@ -60,7 +65,12 @@ export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, 
     const active = document.activeElement;
     const editing = active instanceof HTMLElement
       && (active.tagName === "TEXTAREA" || active.tagName === "INPUT" || active.isContentEditable);
-    if (!editing) focusables()[0]?.focus({ preventScroll: true });
+    /* Initial focus lands on the first control that answers, never on the
+       dismiss X — dismissal is the escape hatch, not the default action. The
+       X stays in the Tab cycle at its DOM position. */
+    const items = focusables();
+    const initial = items.find((el) => !el.hasAttribute("data-attention-dismiss")) ?? items[0];
+    if (!editing) initial?.focus({ preventScroll: true });
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && onDeny) {
         event.preventDefault();
@@ -120,6 +130,19 @@ export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, 
           <span className="text-[11px] font-semibold text-muted" role="timer" aria-live="off">
             {t("runtime.attention.expiresIn", { seconds: remaining })}
           </span>
+        ) : null}
+        {onDismiss && !archived ? (
+          <button
+            type="button"
+            data-attention-dismiss
+            aria-label={t("question.dismiss")}
+            className={`ml-auto inline-flex shrink-0 items-center justify-center rounded text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+              isMobile ? "h-11 w-11" : "px-0.5"
+            }`}
+            onClick={onDismiss}
+          >
+            <X className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />
+          </button>
         ) : null}
       </div>
 

--- a/src/components/runtime/ConversationAttention.tsx
+++ b/src/components/runtime/ConversationAttention.tsx
@@ -12,6 +12,43 @@ import { AttentionCard } from "./AttentionCard";
 import { isDeadHostSession } from "./DeadHostBanner";
 import { mintIdempotencyKey, type RuntimeAttention } from "./runtimeModel";
 
+/*
+ * Issue #765, structured half: dismissal is a view decision, exactly as on the
+ * transcript-path QuestionCard (#779). It never answers or resolves the
+ * attention — the runtime record stays whatever the engine says it is — the
+ * card only stops occupying the live composer region and stops presenting
+ * itself as awaiting input. Remembered per attention id in localStorage so a
+ * dead card does not return on every reload.
+ */
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+type AttentionIdentity = { conversationId: string; id: string };
+
+export function attentionDismissKey(attention: AttentionIdentity): string {
+  return `llvAttentionDismissed:${attention.conversationId}:${attention.id}`;
+}
+
+export function isAttentionDismissed(storage: StorageLike | null, attention: AttentionIdentity): boolean {
+  try {
+    return storage?.getItem(attentionDismissKey(attention)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function rememberAttentionDismissed(storage: StorageLike | null, attention: AttentionIdentity): void {
+  try {
+    storage?.setItem(attentionDismissKey(attention), "1");
+  } catch { /* best-effort: a full or blocked store only costs durability */ }
+}
+
+function browserStorage(): StorageLike | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
 export function approvalResolution(attention: RuntimeAttention, approved: boolean): unknown {
   const protocol = attention.request.protocol;
   if (protocol?.engine === "claude") {
@@ -46,6 +83,8 @@ export function ConversationAttention({ file }: { file: FileEntry }) {
   const runtime = useRuntimeSession(conversationIdentity(file));
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /* Ids dismissed in this mount; the storage read below covers earlier ones. */
+  const [dismissedIds, setDismissedIds] = useState<readonly string[]>([]);
 
   if (!runtime) {
     return file.pendingQuestion || file.waitingInput ? <QuestionCard file={file} /> : null;
@@ -73,9 +112,21 @@ export function ConversationAttention({ file }: { file: FileEntry }) {
     setBusyId(null);
   };
 
+  /* Issue #765: a dismissed question card leaves the composer region entirely
+     — the same exit an engine-confirmed resolution takes — while the attention
+     record itself is untouched. Only question cards get the control: dismissing
+     an approval/permission would hide a request the engine is still blocked on
+     with no other surface to answer it from. */
+  const dismiss = (attention: RuntimeAttention) => {
+    rememberAttentionDismissed(browserStorage(), attention);
+    setDismissedIds((current) => [...current, attention.id]);
+  };
+  const visible = runtime.attentions.filter((attention) =>
+    !dismissedIds.includes(attention.id) && !isAttentionDismissed(browserStorage(), attention));
+
   return (
     <>
-      {runtime.attentions.map((attention) => (
+      {visible.map((attention) => (
         <AttentionCard
           key={attention.id}
           attention={attention}
@@ -93,6 +144,7 @@ export function ConversationAttention({ file }: { file: FileEntry }) {
           onAnswerQuestions={!archived && attention.kind === "question"
             ? (optionIndices) => void answer(attention, questionsResolution(attention, optionIndices))
             : undefined}
+          onDismiss={!archived && attention.kind === "question" ? () => dismiss(attention) : undefined}
         />
       ))}
       {error ? <div role="alert" className="my-2 text-[12px] font-semibold text-danger">{error}</div> : null}

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -442,6 +442,18 @@ describe("attention", () => {
     expect(store.sessions["conv_a"]?.attentionIds).toEqual([]);
     expect(store.attentions["a1"]?.state).toBe("resolved");
   });
+
+  test("an engine-host resolution carrying only `id` still retires the card (#765)", () => {
+    /* projectEngineHostEvent payloads named the attention `id` before #765;
+       already-journaled ledgers replay that shape forever, so the reducer
+       accepts it — otherwise a CLI-cancelled question stays pinned as open. */
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("attention", { type: "session", id: "conv_a" }, 4, attention({ id: "a1", conversationId: "conv_a" })));
+    store = apply(store, env("attention-resolved", { type: "session", id: "conv_a" }, 5, { id: "a1", conversationId: "conv_a", state: "cancelled", resolution: "turn-ended" }));
+    expect(store.sessions["conv_a"]?.attentionIds).toEqual([]);
+    expect(store.attentions["a1"]?.state).toBe("cancelled");
+    expect(openAttentions(store, store.sessions["conv_a"]!)).toEqual([]);
+  });
 });
 
 /* --------------------- receipts --------------------- */

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -624,14 +624,18 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
       break;
     }
     case "attention-resolved": {
-      const p = env.payload as { attentionId: string; conversationId?: string; state?: AttentionState };
-      const existing = store.attentions[p.attentionId];
+      const p = env.payload as { attentionId?: string; id?: string; conversationId?: string; state?: AttentionState };
+      /* Engine-host projections carried the attention id only as `id` before
+         #765; accept both so replayed ledger events still retire the card. */
+      const attentionId = p.attentionId ?? p.id;
+      if (!attentionId) break;
+      const existing = store.attentions[attentionId];
       if (existing) {
-        store.attentions = { ...store.attentions, [p.attentionId]: { ...existing, state: p.state ?? "resolved", unowned: false } };
+        store.attentions = { ...store.attentions, [attentionId]: { ...existing, state: p.state ?? "resolved", unowned: false } };
       }
       const convId = p.conversationId ?? existing?.conversationId;
       if (convId) {
-        updateSession(store, convId, revision, (s) => ({ ...s, attentionIds: s.attentionIds.filter((id) => id !== p.attentionId) }));
+        updateSession(store, convId, revision, (s) => ({ ...s, attentionIds: s.attentionIds.filter((id) => id !== attentionId) }));
       }
       break;
     }

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1278,6 +1278,46 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test("a turn ending retires the question it left unanswered (#765)", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      requestTimeoutMs: 1_000,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, {}),
+    });
+
+    const receipt = host.send({ id: "turn-one", text: "go" });
+    await Bun.sleep(0);
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "go" }] } });
+    expect(await receipt).toEqual({ outcome: "turn-started", turnId: "turn-one" });
+
+    child.emitJson({ type: "control_request", request_id: "question-open", request: { subtype: "can_use_tool", tool_name: "AskUserQuestion", input: { questions: [{ question: "Continue?" }] } } });
+    await Bun.sleep(0);
+    expect((await host.health()).pendingAttention).toEqual(["question-open"]);
+
+    const events = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    const unconfirmedAnswer = host.answer("question-open", { behavior: "deny" });
+    /* The operator interrupted instead of answering: Claude cuts the turn with
+       a bare `result` and never sends `control_cancel_request` for the
+       question it abandoned. The request died with the turn, so the broker
+       must retire it — this is the card that used to stay pinned forever. */
+    child.emitJson({ type: "result", subtype: "interrupted", session_id: host.identity.sessionId });
+    await expect(unconfirmedAnswer).rejects.toThrow("expired with its turn");
+    expect(await nextEvent(events)).toMatchObject({ kind: "turn-ended", turnId: "turn-one", status: "interrupted" });
+    expect(await nextEvent(events)).toMatchObject({
+      kind: "attention-resolved",
+      id: "question-open",
+      resolution: "turn-ended",
+    });
+    expect((await host.health()).pendingAttention).toEqual([]);
+    expect((await host.health()).status).toBe("idle");
+    await host.release();
+  });
+
   test("does not repeat a completed assistant message after partial deltas", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -1017,6 +1017,22 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       ? "interrupted"
       : message.subtype === "success" ? "completed" : "error";
     this.emit({ kind: "turn-ended", turnId, status });
+    /* Issue #765: a `result` proves the CLI's turn is over, so any control
+       request it left unanswered can never be answered — the await behind it
+       died with the turn. Claude sends no `control_cancel_request` on this
+       path (an interrupt cuts the turn, not the request), which stranded the
+       question card as pinned-forever "awaiting input". Retire the leftovers
+       the same way an explicit cancellation does. */
+    for (const attentionId of this.attentions.keys()) {
+      const pending = this.pendingAnswers.get(attentionId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingAnswers.delete(attentionId);
+        pending.reject(new Error("Claude attention expired with its turn before answer confirmation"));
+      }
+      this.emit({ kind: "attention-resolved", id: attentionId, resolution: "turn-ended" });
+    }
+    this.attentions.clear();
     this.activeTurnId = this.turnQueue[0] ?? null;
     if (this.activeTurnId) this.emit({ kind: "turn-started", turnId: this.activeTurnId });
     else this.emit({ kind: "session-status", status: "idle" });

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -62,7 +62,7 @@ export type RuntimeEvent =
   | { kind: "voice-chunk"; turnId: string; delivery: RuntimeVoiceDelivery; seq: number }
   | { kind: "turn-ended"; turnId: string; status: "completed" | "interrupted" | "error"; seq: number }
   | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
-  | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted" | "server-resolved"; seq: number }
+  | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted" | "server-resolved" | "turn-ended"; seq: number }
   | { kind: "limits"; snapshot: unknown; seq: number }
   | { kind: "realtime-delivery-progress"; deliveryId: string; digest: string; responseIndex: number; offset: number; seq: number }
   | { kind: "realtime-delivery-acknowledged"; deliveryId: string; digest: string; seq: number }

--- a/src/lib/runtime/engineHostEvents.test.ts
+++ b/src/lib/runtime/engineHostEvents.test.ts
@@ -65,6 +65,32 @@ describe("projectEngineHostEvent", () => {
     });
   });
 
+  test("attention resolutions carry the attentionId every reducer keys on (#765)", () => {
+    /* The journal prunes by `payload.attentionId` and the client store reads
+       the same field; a payload carrying only `id` retired the card nowhere. */
+    expect(projectEngineHostEvent("conversation_four", "claude:session-two", {
+      kind: "attention-resolved",
+      id: "attention-four",
+      resolution: "server-resolved",
+      seq: 13,
+    })).toMatchObject({
+      kind: "attention-resolved",
+      payload: { attentionId: "attention-four", id: "attention-four", conversationId: "conversation_four", state: "resolved" },
+    });
+  });
+
+  test("a turn-ended resolution retires the question as cancelled, not answered (#765)", () => {
+    expect(projectEngineHostEvent("conversation_five", "claude:session-three", {
+      kind: "attention-resolved",
+      id: "attention-five",
+      resolution: "turn-ended",
+      seq: 17,
+    })).toMatchObject({
+      kind: "attention-resolved",
+      payload: { attentionId: "attention-five", state: "cancelled", resolution: "turn-ended" },
+    });
+  });
+
   test("projects the full terminal assistant response separately from the bounded UI item", () => {
     const text = `${"🙂界".repeat(40_000)}\n`;
     const projected = projectEngineHostEvent("conversation_voice", "codex:thread-voice", {

--- a/src/lib/runtime/engineHostEvents.ts
+++ b/src/lib/runtime/engineHostEvents.ts
@@ -169,7 +169,22 @@ export function projectEngineHostEvent(
     };
   }
   if (event.kind === "attention-resolved") {
-    return { ...base, kind: "attention-resolved", payload: { id: event.id, conversationId, state: "resolved", resolution: event.resolution } };
+    /* `attentionId` is the field every reducer keys on (the journal's own
+       answer path writes it; the client store reads it). Emitting only `id`
+       here meant an engine-originated resolution — a CLI cancellation, an
+       answer typed in the terminal, a turn ending past the question — never
+       retired the card anywhere (#765). `id` stays for older readers. */
+    return {
+      ...base,
+      kind: "attention-resolved",
+      payload: {
+        id: event.id,
+        attentionId: event.id,
+        conversationId,
+        state: event.resolution === "turn-ended" ? "cancelled" : "resolved",
+        resolution: event.resolution,
+      },
+    };
   }
   if (event.kind === "limits") {
     return { ...base, kind: "limits", payload: { conversationId, snapshot: boundedValue(event.snapshot) } };

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -163,7 +163,7 @@ function validEvent(value: unknown): value is RuntimeEvent {
       return nonEmptyString(event.id) && nonEmptyString(event.method) && Object.hasOwn(event, "attention");
     case "attention-resolved":
       return nonEmptyString(event.id)
-        && (event.resolution === "answered" || event.resolution === "host-restarted" || event.resolution === "server-resolved");
+        && (event.resolution === "answered" || event.resolution === "host-restarted" || event.resolution === "server-resolved" || event.resolution === "turn-ended");
     case "limits":
       return Object.hasOwn(event, "snapshot");
     case "realtime-delivery-progress":

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1330,6 +1330,36 @@ test("a delivering transition persists its derived turn fence in the outbox", ()
   journal.close();
 });
 
+test("an engine-host resolution keyed only by `id` still retires the attention (#765)", () => {
+  /* Engine-host projections historically carried the attention id as `id`
+     rather than `attentionId`; the reducer fell back to the session scope id,
+     matched no entity, and the question stayed open in every snapshot. */
+  const dir = sandbox("attention-id-fallback");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  journal.append({
+    scope: runtimeScope("session", "conv-one"),
+    kind: "attention",
+    payload: {
+      id: "attention-one",
+      conversationId: "conv-one",
+      kind: "question",
+      state: "open",
+      unowned: false,
+      createdAt: "2026-07-10T00:00:00.000Z",
+      request: { question: { prompt: "Proceed?" } },
+      turnId: "turn-one",
+    },
+  });
+  journal.append({
+    scope: runtimeScope("session", "conv-one"),
+    kind: "attention-resolved",
+    payload: { id: "attention-one", conversationId: "conv-one", state: "cancelled", resolution: "turn-ended" },
+  });
+  expect(journal.snapshot().attentions[0]?.state).toBe("cancelled");
+  expect(journal.snapshot().sessions[0]?.attentionIds).toEqual([]);
+  journal.close();
+});
+
 test("answer and interrupt operations update projected attention and turn axes", () => {
   const dir = sandbox("answer-interrupt");
   const filename = path.join(dir, "events.sqlite");

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1854,7 +1854,12 @@ export class RuntimeJournal {
       return;
     }
     if (event.kind === "attention-resolved") {
-      const id = typeof payload.attentionId === "string" ? payload.attentionId : scope.id;
+      /* Engine-host projections historically carried the attention id only as
+         `id` (#765); without this fallback those resolutions matched no
+         entity and the attention stayed open in every later snapshot. */
+      const id = typeof payload.attentionId === "string" ? payload.attentionId
+        : typeof payload.id === "string" ? payload.id
+        : scope.id;
       const attention = this.entity<RuntimeAttention>("attention", id);
       if (attention) {
         const state = payload.state === "expired-confirmed" || payload.state === "cancelled" || payload.state === "resolution-unknown" ? payload.state : "resolved";


### PR DESCRIPTION
Two independent daily-friction defects, one commit each so either can be reverted alone.

## #765 — a skipped question card could never be dismissed (structured surface)

The transcript-scanner half of #765 shipped earlier (#775 retirement, #779 dismiss), but the **structured runtime plane** — the path every pane-less hosted session uses — still pinned a skipped question card to the composer forever. Three stacked defects, all fixed in `039a8bd6`:

1. **No retirement when the turn died.** Claude sends no `control_cancel_request` when an interrupt cuts a turn, and the broker never resolved attentions on `result`. The abandoned question stayed `open` although nothing could ever answer it. `acceptResult` now retires leftover attentions with a `turn-ended` resolution (state `cancelled`, never pretending it was answered), rejecting any unconfirmed in-flight answer the way an explicit cancellation does. This is evidence-based mootness — a `result` proves the CLI's await died with the turn — no timers anywhere.
2. **Engine-originated resolutions retired the card nowhere.** The host projection named the attention only as `id`, while both the runtime-host journal reducer and the client store key on `attentionId` (the journal fell back to the *session scope id*, matching no entity). So even a CLI-side cancellation or answer left the card open in every snapshot and on the live stream, surviving reloads. The projection now writes both fields, and both reducers accept the historical `id` shape so already-journaled ledgers replay correctly.
3. **No dismiss control.** Question-kind `AttentionCard`s now carry the same labelled dismiss the transcript-path card got in #779: view-level only (never answers or resolves the attention — retirement means it stops occupying the live composer region, the runtime record stays whatever the engine says), remembered per attention id in `localStorage`, 44px on phone widths, and never the card's initial focus. Approvals/permissions stay undismissable: the engine is still blocked on them with no other surface to answer from.

**Tests** (all red-proven against an unmodified checkout of main in a throwaway worktree): broker turn-end retirement incl. in-flight answer rejection; projection payload shape + `turn-ended → cancelled` mapping; journal and client-store `id` fallback; dismiss control behavior (labelled both locales, question-only, archived-inert, 44px phone target, per-attention persistence, storage-failure safety, focus never lands on the X).

## #699 — a near-miss tap on the overview board is never a no-op

The product fix landed with #705: the card is a plain container, conversation rows and the project header are separate explicit buttons (44px on a coarse pointer), every gap is dead space — pinned structurally by `OverviewBoard.targets.dom.test.tsx`. What was missing was **rendered** evidence: happy-dom has no layout engine, so no DOM test can prove geometry.

`1a306b44` adds `scripts/capture-issue-699-overview-targets.ts` (the established `capture-issue-*` pattern, run under Bun): it serves the production build against a synthetic `/tmp` home, captures the Overview at 390×844 (coarse pointer) and 1280×800, and measures the acceptance on the live DOM — no interactive control nested in another anywhere on the page, every conversation/project target ≥44px on the phone, and a 4px probe grid over every card proving each point resolves to exactly one explicit destination or to nothing interactive.

**Before/after, measured:**

| build | nested controls | ambiguous probe hits (phone) | rows ≥44px |
|---|---|---|---|
| pre-#705 (`5045ea51~1`) | 4 (`role="link"` rows inside the project button) | 5,823 of 5,824 — the whole card navigated | no (~20px rows) |
| this branch | 0 | 0 of 9,009 | yes |

The frames themselves live outside the repo (synthetic data only; nothing committed), regenerable with `bun scripts/capture-issue-699-overview-targets.ts`.

## Verification

- Focused tests by path with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: broker file 45 pass (1 pre-existing failure, "requires the exact structured-host opt-in", reproduced on a pristine `origin/main` worktree — the flag moved to rollback semantics while the test still expects exact opt-in; not touched here); `engineHostEvents` + `runtimeModel` + `AttentionCard.dismiss` 41 pass; `journal` 66 pass; `eventStore` + `AttentionCard.focus` + `ConversationAttention` + `runtimeComponents.render` 43 pass.
- `bunx tsc --noEmit` clean; scoped eslint clean.
- Production build (`bun run build`) exit 0.
- `bun scripts/privacy-publication-gate.ts --base 41d275fd` PASS.

Closes #765. Closes #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)