### PR TITLE
fix(orchestrator): derive context-window policy from the model registry (#1005)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,25 +1,30 @@
-# Issue #151: Route the delivery queue through structured hosts
+# Issue #1005: Orchestrator context policy registry alignment
 
-Persist structured-session composer messages in the runtime journal before actuation and deliver them through `EngineHost.send`.
+## Task statement
+
+Derive Claude orchestrator context-window policy from the scanner model registry through `normalizeModelKey` and `registryWindow`. Keep the 50% rotation threshold and an operator-readable policy audit name. Models without a registry entry must retain an unknown threshold.
 
 ## Acceptance criteria
 
-AC1: Structured Codex and Claude messages enter the durable runtime journal before engine actuation.
+AC1: `fable-5` resolves to a 1,000,000-token window, and 129,000 reported tokens render as 13% with no rotation recommendation.
 
-AC2: Each conversation drains in FIFO order while independent conversations can progress concurrently.
+AC2: `sonnet-5` resolves to a 1,000,000-token window.
 
-AC3: Codex delivery uses the queue entry ID as its client message ID and preserves idle and active turn fences across races and retries.
+AC3: registered Opus models retain a 1,000,000-token window and a 500,000-token rotation threshold.
 
-AC4: Claude delivery uses its durable replay ledger so recovery cannot duplicate engine writes.
+AC4: `haiku-4-5` resolves to a 200,000-token window and a 100,000-token rotation threshold.
 
-AC5: Migration-held structured messages drain through the runtime journal and remain fenced until durable structured completion.
+AC5: a model absent from the registry resolves to a null policy, and callers report that its threshold is unknown.
 
-AC6: Explicit `tmux-legacy` sessions retain the existing tmux delivery path.
+AC6: the policy audit name identifies the normalized registry key and resolved window so rotation banner wording remains meaningful.
 
-AC7: Queued, delivering, delivered, and failed receipt states remain observable and recoverable after process loss.
+AC7: `ROTATION_THRESHOLD_FRACTION` remains `0.5`.
+
+AC8: the focused orchestrator health tests and TypeScript compilation pass.
 
 ## Validation gates
 
+- `bun test src/lib/orchestrator/health.test.ts`
 - `bunx tsc --noEmit`
-- `bun test`
 - `git diff --check`
+- `bun scripts/privacy-publication-gate.ts --base <captured-base>`

--- a/spec.md
+++ b/spec.md
@@ -10,7 +10,7 @@ AC1: `fable-5` resolves to a 1,000,000-token window, and 129,000 reported tokens
 
 AC2: `sonnet-5` resolves to a 1,000,000-token window.
 
-AC3: registered Opus models retain a 1,000,000-token window and a 500,000-token rotation threshold.
+AC3: the persisted `opus` launch alias resolves through the current Opus registry entry and retains a 1,000,000-token window, a 500,000-token rotation threshold, and its established audit label.
 
 AC4: `haiku-4-5` resolves to a 200,000-token window and a 100,000-token rotation threshold.
 

--- a/src/lib/orchestrator/contextPolicy.ts
+++ b/src/lib/orchestrator/contextPolicy.ts
@@ -13,7 +13,7 @@
  * nothing else — see `./health`, whose recommendation carries no action.
  */
 
-import { normalizeModelKey, registryWindow } from "../scanner/modelRegistry";
+import { normalizeModelKey, registryWindow, resolveRegistryKey } from "../scanner/modelRegistry";
 
 export const ROTATION_THRESHOLD_FRACTION = 0.5;
 
@@ -38,11 +38,15 @@ export function contextWindowPolicyFor(engine: string | null, model: string | nu
   if (engine !== "claude" || !model) return null;
   const normalized = normalizeModelKey(model);
   if (!normalized) return null;
-  const windowTokens = registryWindow(normalized.key, normalized.mode);
+  const registryKey = resolveRegistryKey(normalized.key);
+  const windowTokens = registryWindow(registryKey, normalized.mode);
   if (windowTokens === null) return null;
+  const windowName = policyWindowName(windowTokens);
   return {
     windowTokens,
     rotationThresholdTokens: Math.round(windowTokens * ROTATION_THRESHOLD_FRACTION),
-    policy: `registry:${normalized.key}:${policyWindowName(windowTokens)}`,
+    policy: normalized.key === registryKey
+      ? `registry:${registryKey}:${windowName}`
+      : `claude-${normalized.key}-${windowName}`,
   };
 }

--- a/src/lib/orchestrator/contextPolicy.ts
+++ b/src/lib/orchestrator/contextPolicy.ts
@@ -1,12 +1,10 @@
 /* Context-window rotation policy (operator decision, two-axis contract).
  *
- * THE one place window sizes and rotation thresholds live — product
- * configuration, not scattered literals. The threshold is expressed as a
- * FRACTION of the model's window: it stays meaningful across window sizes, so
- * adding a model needs only its window, while every absolute number below is
- * explicit and reviewable. Reference case, operator-stated: the Claude Opus
- * orchestrator has a nominal 1,000,000-token window and rotates at
- * 500,000 tokens — exactly the fraction applied to its window.
+ * Window sizes come from the scanner's model registry. The rotation threshold
+ * is expressed here as a FRACTION of the registered window, so adding a model
+ * window does not create a second orchestrator configuration seam. Reference
+ * case, operator-stated: a registered 1,000,000-token Claude Opus window
+ * rotates at 500,000 tokens — exactly the fraction applied to its window.
  *
  * A model with no entry has NO window invented for it: callers report the
  * usage they can prove and say plainly that the threshold is unknown.
@@ -14,6 +12,8 @@
  * Crossing a threshold changes WORDS in get_orchestrator's payload and
  * nothing else — see `./health`, whose recommendation carries no action.
  */
+
+import { normalizeModelKey, registryWindow } from "../scanner/modelRegistry";
 
 export const ROTATION_THRESHOLD_FRACTION = 0.5;
 
@@ -26,41 +26,23 @@ export interface ContextWindowPolicy {
   policy: string;
 }
 
-interface ContextWindowRule {
-  policy: string;
-  matches(engine: string, model: string): boolean;
-  windowTokens: number;
+function policyWindowName(windowTokens: number): string {
+  if (windowTokens % 1_000_000 === 0) return `${windowTokens / 1_000_000}m`;
+  if (windowTokens % 1_000 === 0) return `${windowTokens / 1_000}k`;
+  return `${windowTokens}-tokens`;
 }
-
-/** First match wins; more specific rows come first. */
-const CONTEXT_WINDOW_RULES: readonly ContextWindowRule[] = [
-  {
-    /* The operator's reference case: Opus-class orchestrators. `opus` is this
-       repo's latest-Opus alias (see `@/lib/agent/models`), and dated Opus model
-       ids carry the substring too. */
-    policy: "claude-opus-1m",
-    matches: (engine, model) => engine === "claude" && model.toLowerCase().includes("opus"),
-    windowTokens: 1_000_000,
-  },
-  {
-    /* Every other managed Claude model: the standard published window. */
-    policy: "claude-standard-200k",
-    matches: (engine) => engine === "claude",
-    windowTokens: 200_000,
-  },
-  /* No Codex row on purpose: Codex windows vary by account tier and are not
-     knowable here. Absent means unknown, never a guess. */
-];
 
 /** The window policy for a model, or null when none is configured — in which
     case NO window may be assumed anywhere downstream. */
 export function contextWindowPolicyFor(engine: string | null, model: string | null): ContextWindowPolicy | null {
-  if (!engine) return null;
-  const rule = CONTEXT_WINDOW_RULES.find((candidate) => candidate.matches(engine, model ?? ""));
-  if (!rule) return null;
+  if (engine !== "claude" || !model) return null;
+  const normalized = normalizeModelKey(model);
+  if (!normalized) return null;
+  const windowTokens = registryWindow(normalized.key, normalized.mode);
+  if (windowTokens === null) return null;
   return {
-    windowTokens: rule.windowTokens,
-    rotationThresholdTokens: Math.round(rule.windowTokens * ROTATION_THRESHOLD_FRACTION),
-    policy: rule.policy,
+    windowTokens,
+    rotationThresholdTokens: Math.round(windowTokens * ROTATION_THRESHOLD_FRACTION),
+    policy: `registry:${normalized.key}:${policyWindowName(windowTokens)}`,
   };
 }

--- a/src/lib/orchestrator/health.test.ts
+++ b/src/lib/orchestrator/health.test.ts
@@ -32,23 +32,50 @@ const facts = (overrides: Partial<OrchestratorTranscriptFacts> = {}): Orchestrat
   ...overrides,
 });
 
-const OPUS = contextWindowPolicyFor("claude", "opus");
+const OPUS = contextWindowPolicyFor("claude", "claude-opus-4-8");
+
+test("Fable at 129k tokens uses 13% of its registry window and needs no rotation", () => {
+  const policy = contextWindowPolicyFor("claude", "fable-5");
+  const currentFacts = facts({ reportedContextTokens: 129_000 });
+  const context = contextReading({ policy, facts: currentFacts });
+  const recommendation = rotationRecommendation({ context, facts: currentFacts, activity: "live", policy });
+
+  expect(policy).toEqual({
+    windowTokens: 1_000_000,
+    rotationThresholdTokens: 500_000,
+    policy: "registry:fable-5:1m",
+  });
+  expect(context.percent).toBe(13);
+  expect(recommendation).toMatchObject({ recommended: false, level: "none", advisory: null });
+});
 
 /* ── The named policy: explicit, configurable, one place ─────────────────── */
 
 test("the reference case is explicit policy: Opus-class window 1,000,000 tokens, threshold 500,000", () => {
-  expect(OPUS).toEqual({ windowTokens: 1_000_000, rotationThresholdTokens: 500_000, policy: "claude-opus-1m" });
+  expect(OPUS).toEqual({ windowTokens: 1_000_000, rotationThresholdTokens: 500_000, policy: "registry:opus-4-8:1m" });
   /* The threshold is the fraction applied to the window, so a new model entry
      needs only its window and inherits a meaningful threshold. */
   expect(OPUS!.rotationThresholdTokens).toBe(OPUS!.windowTokens * ROTATION_THRESHOLD_FRACTION);
 });
 
-test("a model with a DIFFERENT window uses ITS OWN threshold — 1M is not hard-coded", () => {
-  const sonnetLike = contextWindowPolicyFor("claude", "sonnet");
-  expect(sonnetLike).toEqual({ windowTokens: 200_000, rotationThresholdTokens: 100_000, policy: "claude-standard-200k" });
+test("Sonnet 5 keeps its 1M registry window", () => {
+  expect(contextWindowPolicyFor("claude", "sonnet-5")).toEqual({
+    windowTokens: 1_000_000,
+    rotationThresholdTokens: 500_000,
+    policy: "registry:sonnet-5:1m",
+  });
+});
+
+test("Haiku 4.5 keeps its 200k registry window", () => {
+  expect(contextWindowPolicyFor("claude", "haiku-4-5")).toEqual({
+    windowTokens: 200_000,
+    rotationThresholdTokens: 100_000,
+    policy: "registry:haiku-4-5:200k",
+  });
 });
 
 test("an unconfigured model gets NO invented window", () => {
+  expect(contextWindowPolicyFor("claude", "claude-newthing-9")).toBeNull();
   expect(contextWindowPolicyFor("codex", "gpt-5.6-sol")).toBeNull();
   expect(contextWindowPolicyFor(null, null)).toBeNull();
 });
@@ -71,7 +98,7 @@ test("provider-reported usage wins and is NOT labelled an estimate, even with a 
     percent: 14,
     estimated: false,
     basis: "provider-reported usage from the transcript's newest turn",
-    policy: "claude-opus-1m",
+    policy: "registry:opus-4-8:1m",
   });
 });
 
@@ -114,7 +141,7 @@ test("a missing transcript reports absence, never a fabricated number", () => {
 
 /* ── The threshold changes WORDS and nothing else ────────────────────────── */
 
-const recommendationFor = (tokens: number, policyModel = "opus") => {
+const recommendationFor = (tokens: number, policyModel = "opus-4-8") => {
   const policy = contextWindowPolicyFor("claude", policyModel);
   const context = contextReading({ policy, facts: facts({ reportedContextTokens: tokens }) });
   return rotationRecommendation({ context, facts: facts({ reportedContextTokens: tokens }), activity: "live", policy });
@@ -135,25 +162,28 @@ test("usage at EXACTLY the threshold, and above it, is a prominent STRONGLY_RECO
     expect(recommendation.level).toBe("strongly_recommend");
     expect(recommendation.advisory).toBe(STRONGLY_RECOMMEND_ROTATION);
     expect(recommendation.reasons[0]).toContain("500,000");
+    expect(recommendation.reasons[0]).toContain("registry:opus-4-8:1m: 50% of a 1,000,000-token window");
     expect(recommendation.threshold).toEqual({
       windowTokens: 1_000_000,
       thresholdTokens: 500_000,
       fraction: ROTATION_THRESHOLD_FRACTION,
-      policy: "claude-opus-1m",
+      policy: "registry:opus-4-8:1m",
     });
   }
 });
 
 test("the SAME usage that is safe on Opus strongly recommends on a 200k-window model — per-model thresholds", () => {
-  expect(recommendationFor(150_000, "opus").level).toBe("none");
-  const smaller = recommendationFor(150_000, "sonnet");
+  expect(recommendationFor(150_000, "opus-4-8").level).toBe("none");
+  const smaller = recommendationFor(150_000, "haiku-4-5");
   expect(smaller.level).toBe("strongly_recommend");
   expect(smaller.threshold).toMatchObject({ windowTokens: 200_000, thresholdTokens: 100_000 });
 });
 
 test("an unknown window withholds the threshold recommendation and says the threshold is unknown", () => {
-  const context = contextReading({ policy: null, facts: facts({ reportedContextTokens: 900_000 }) });
-  const recommendation = rotationRecommendation({ context, facts: facts({ reportedContextTokens: 900_000 }), activity: "live", policy: null });
+  const policy = contextWindowPolicyFor("claude", "claude-newthing-9");
+  const context = contextReading({ policy, facts: facts({ reportedContextTokens: 900_000 }) });
+  const recommendation = rotationRecommendation({ context, facts: facts({ reportedContextTokens: 900_000 }), activity: "live", policy });
+  expect(policy).toBeNull();
   expect(recommendation.level).toBe("none");
   expect(recommendation.advisory).toBeNull();
   expect(recommendation.threshold).toBeNull();
@@ -161,7 +191,7 @@ test("an unknown window withholds the threshold recommendation and says the thre
 });
 
 test("an ESTIMATED usage over the threshold still recommends, and the reason says it is an estimate", () => {
-  const policy = contextWindowPolicyFor("claude", "opus");
+  const policy = contextWindowPolicyFor("claude", "opus-4-8");
   /* 2.4 MB of transcript ≈ 600k estimated tokens — over the 500k threshold. */
   const estimated = facts({ transcriptBytes: 2_400_000 });
   const context = contextReading({ policy, facts: estimated });
@@ -179,7 +209,7 @@ test("the recommendation is structurally incapable of acting: plain data, bounde
 });
 
 test("secondary wear signals still produce an ordinary (non-strong) recommendation", () => {
-  const policy = contextWindowPolicyFor("claude", "opus");
+  const policy = contextWindowPolicyFor("claude", "opus-4-8");
   const worn = facts({ compactionCount: 3, reportedContextTokens: 10_000 });
   const context = contextReading({ policy, facts: worn });
   const recommendation = rotationRecommendation({ context, facts: worn, activity: "live", policy });
@@ -189,7 +219,7 @@ test("secondary wear signals still produce an ordinary (non-strong) recommendati
 });
 
 test("a healthy incumbent gets no recommendation at all", () => {
-  const policy = contextWindowPolicyFor("claude", "opus");
+  const policy = contextWindowPolicyFor("claude", "opus-4-8");
   const healthy = facts({ transcriptBytes: 100_000 });
   const context = contextReading({ policy, facts: healthy });
   expect(rotationRecommendation({ context, facts: healthy, activity: "live", policy }))

--- a/src/lib/orchestrator/health.test.ts
+++ b/src/lib/orchestrator/health.test.ts
@@ -32,7 +32,7 @@ const facts = (overrides: Partial<OrchestratorTranscriptFacts> = {}): Orchestrat
   ...overrides,
 });
 
-const OPUS = contextWindowPolicyFor("claude", "claude-opus-4-8");
+const OPUS = contextWindowPolicyFor("claude", "opus");
 
 test("Fable at 129k tokens uses 13% of its registry window and needs no rotation", () => {
   const policy = contextWindowPolicyFor("claude", "fable-5");
@@ -52,10 +52,16 @@ test("Fable at 129k tokens uses 13% of its registry window and needs no rotation
 /* ── The named policy: explicit, configurable, one place ─────────────────── */
 
 test("the reference case is explicit policy: Opus-class window 1,000,000 tokens, threshold 500,000", () => {
-  expect(OPUS).toEqual({ windowTokens: 1_000_000, rotationThresholdTokens: 500_000, policy: "registry:opus-4-8:1m" });
+  expect(OPUS).toEqual({ windowTokens: 1_000_000, rotationThresholdTokens: 500_000, policy: "claude-opus-1m" });
   /* The threshold is the fraction applied to the window, so a new model entry
      needs only its window and inherits a meaningful threshold. */
   expect(OPUS!.rotationThresholdTokens).toBe(OPUS!.windowTokens * ROTATION_THRESHOLD_FRACTION);
+});
+
+test("supported Claude launch aliases resolve to their current registry windows", () => {
+  expect(contextWindowPolicyFor("claude", "fable")).toMatchObject({ windowTokens: 1_000_000, policy: "claude-fable-1m" });
+  expect(contextWindowPolicyFor("claude", "sonnet")).toMatchObject({ windowTokens: 1_000_000, policy: "claude-sonnet-1m" });
+  expect(contextWindowPolicyFor("claude", "haiku")).toMatchObject({ windowTokens: 200_000, policy: "claude-haiku-200k" });
 });
 
 test("Sonnet 5 keeps its 1M registry window", () => {
@@ -98,7 +104,7 @@ test("provider-reported usage wins and is NOT labelled an estimate, even with a 
     percent: 14,
     estimated: false,
     basis: "provider-reported usage from the transcript's newest turn",
-    policy: "registry:opus-4-8:1m",
+    policy: "claude-opus-1m",
   });
 });
 

--- a/src/lib/scanner/modelRegistry.ts
+++ b/src/lib/scanner/modelRegistry.ts
@@ -26,7 +26,19 @@ const MODEL_REGISTRY: Readonly<Record<string, RegistryEntry>> = {
   "sonnet-4-0": { standard: TWO_HUNDRED_THOUSAND, extended: ONE_MILLION },
 };
 
+const MODEL_REGISTRY_ALIASES: Readonly<Record<string, string>> = {
+  fable: "fable-5",
+  opus: "opus-4-8",
+  sonnet: "sonnet-5",
+  haiku: "haiku-4-5",
+};
+
 export type ModelContextMode = "standard" | "1m";
+
+/** Resolve a supported launch-family alias to the exact current registry key. */
+export function resolveRegistryKey(key: string): string {
+  return MODEL_REGISTRY_ALIASES[key] ?? key;
+}
 
 export function normalizeModelKey(raw: string): { key: string; mode: ModelContextMode } | null {
   let value = raw.toLowerCase().trim();


### PR DESCRIPTION
Fixes #1005

## Summary
- derive Claude orchestrator context windows from the scanner model registry
- retain the 50% rotation threshold and expose registry key plus window in the policy audit name
- keep unregistered models at threshold unknown

## Verification
- bun test src/lib/orchestrator/health.test.ts
- bunx tsc --noEmit
- bun scripts/privacy-publication-gate.ts --base 4df326322c2e49242b7ff758936daf4f92f22550