### PR TITLE
fix(runtime): reconcile dead stage-host ownership so completed pipeline conversations stay messageable (#1006)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,25 +1,30 @@
-# Issue #151: Route the delivery queue through structured hosts
+# Issue #1006: Recover conversations owned by dead stage hosts
 
-Persist structured-session composer messages in the runtime journal before actuation and deliver them through `EngineHost.send`.
+Restore messaging for a pipeline-stage Codex conversation after its structured host exits without releasing ownership. Reconcile ownership only when the recorded host process is provably gone, then let the existing send and resume path claim a fresh viewer-owned structured host and deliver the queued message.
 
 ## Acceptance criteria
 
-AC1: Structured Codex and Claude messages enter the durable runtime journal before engine actuation.
+AC1: Send admission detects a stale structured-host claim whose recorded process identity is provably dead and releases that claim before recovery.
 
-AC2: Each conversation drains in FIFO order while independent conversations can progress concurrently.
+AC2: A send to a completed pipeline-stage conversation with a dead host proceeds through a fresh structured-host claim and reaches the delivery queue.
 
-AC3: Codex delivery uses the queue entry ID as its client message ID and preserves idle and active turn fences across races and retries.
+AC3: Startup reconciliation releases stale dead-host ownership for terminal or superseded structured conversations.
 
-AC4: Claude delivery uses its durable replay ledger so recovery cannot duplicate engine writes.
+AC4: Periodic runtime reconciliation releases the same stale ownership when the viewer remains running after the stage host disappears.
 
-AC5: Migration-held structured messages drain through the runtime journal and remain fenced until durable structured completion.
+AC5: Live owners and unverifiable process identities remain fenced from takeover.
 
-AC6: Explicit `tmux-legacy` sessions retain the existing tmux delivery path.
+AC6: Recovery uses the existing structured send and resume path without adding a new UI surface or changing explicit legacy delivery.
 
-AC7: Queued, delivering, delivered, and failed receipt states remain observable and recoverable after process loss.
+AC7: Runtime-state tests use isolated temporary state and cover stage completion, unclean host loss, retained ownership, fresh claiming, and successful message enqueueing.
+
+AC8: Focused tests, TypeScript type checking, scoped linting, diff checks, and publication privacy checks pass.
 
 ## Validation gates
 
+- `bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/startup.test.ts src/lib/reaperRuntime.test.ts src/lib/runtime/structuredRecovery.test.ts`
 - `bunx tsc --noEmit`
-- `bun test`
+- Scoped ESLint over changed TypeScript files
 - `git diff --check`
+- `bun scripts/privacy-publication-gate.ts --base origin/main`
+- `bun run privacy:check`

--- a/spec.md
+++ b/spec.md
@@ -23,6 +23,7 @@ AC8: Focused tests, TypeScript type checking, scoped linting, diff checks, and p
 ## Validation gates
 
 - `bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/startup.test.ts src/lib/reaperRuntime.test.ts src/lib/runtime/structuredRecovery.test.ts`
+- `LLV_AGENT_REGISTRY_SQLITE=sqlite bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/startup.test.ts src/lib/reaperRuntime.test.ts src/lib/runtime/structuredRecovery.test.ts`
 - `bunx tsc --noEmit`
 - Scoped ESLint over changed TypeScript files
 - `git diff --check`

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -4530,7 +4530,8 @@ export class AgentRegistry {
         || !conversation.generations.some((generation) => generation.id === key.sessionId)
         || !entry
         || (expected && (!structuredProcess
-          || !isDeepStrictEqual(structuredProcess, expected.process)
+          || structuredProcess.pid !== expected.process.pid
+          || structuredProcess.startIdentity !== expected.process.startIdentity
           || entry.claimEpoch !== expected.claimEpoch
           || entry.structuredHost?.writerClaimEpoch !== expected.claimEpoch))
         || entry.host

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -4511,9 +4511,13 @@ export class AgentRegistry {
     });
   }
 
+  /** Clears an inactive structured row. Reconciliation callers supply their
+      observed process and claim epoch so replacement rows fail the comparison
+      inside the same registry mutation. */
   terminateInactiveStructuredHost(
     conversationId: ViewerConversationId,
     key: SessionKey,
+    expected?: Readonly<{ process: ProcessIdentity; claimEpoch: number }>,
   ): false | "current" | "predecessor" {
     return this.mutate((file) => {
       const conversation = file.conversations[conversationId];
@@ -4525,6 +4529,10 @@ export class AgentRegistry {
         || conversation.engine !== key.engine
         || !conversation.generations.some((generation) => generation.id === key.sessionId)
         || !entry
+        || (expected && (!structuredProcess
+          || !isDeepStrictEqual(structuredProcess, expected.process)
+          || entry.claimEpoch !== expected.claimEpoch
+          || entry.structuredHost?.writerClaimEpoch !== expected.claimEpoch))
         || entry.host
         || (structuredProcess !== null && !staleStructuredWrapper)
         || (entry.claimOwner && !staleStructuredWrapper)

--- a/src/lib/reaperRuntime.test.ts
+++ b/src/lib/reaperRuntime.test.ts
@@ -61,6 +61,66 @@ test("runtime cycle enters active mode only for the exact opt-in flag", async ()
   }
 });
 
+test("the periodic reaper releases a completed conversation's dead structured-host claim", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reaper-dead-structured-owner-"));
+  process.env.LLV_STATE_DIR = directory;
+  delete process.env.LLV_REAPER_ENABLED;
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "bbbbbbbb-2222-0222-0222-bbbbbbbbbbbb";
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "pipeline-account",
+    launchProfile: profile,
+    turn: { state: "terminal", source: "assistant", terminalAt: "2026-08-14T08:00:00.000Z" },
+    observedAt: "2026-08-14T08:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "pipeline-account",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:dead-stage-host",
+      process: { pid: 2_000_000_000, startIdentity: "dead-stage-host" },
+      eventCursor: 19,
+      protocolVersion: "v2",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 5,
+    claimOwner: `structured-host:${JSON.stringify({ pid: process.pid, startIdentity: null })}`,
+    pendingAction: null,
+  });
+
+  try {
+    await runReaperCycle({
+      registry,
+      hosts: [],
+      files: [],
+      actuation: { runtimeClient: () => null },
+    });
+
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+    expect(registry.readOnlySnapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      status: "dead",
+      structuredHost: null,
+      claimOwner: null,
+    });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("the issue 652 convergence pass stops a no-progress intent and terminalizes its held delivery", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reaper-stale-migration-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/accounts/migration/intentLiveness";
 import { procBackend } from "@/lib/proc";
 import { runtimeHostClient } from "@/lib/runtime/client";
+import { reconcileDeadStructuredRegistryHosts } from "@/lib/runtime/registry";
 import { reconcileStaleSpawnsHeldByLiveOwners } from "@/lib/runtime/staleSpawnOwner";
 import { terminalizeStaleStructuredSpawns } from "@/lib/runtime/structuredSpawn";
 import { listFiles } from "@/lib/scanner";
@@ -957,6 +958,15 @@ export async function runReaperCycle(options: {
     registry.terminalizeFailedSpawnDeliveries();
   } catch (error) {
     console.error("[reaper] failed-spawn held-delivery convergence failed", error);
+  }
+  /* Completed structured conversations can retain a live Viewer writer claim
+     after their recorded engine child exits without cleanup. Revalidate only
+     those recorded PIDs and available start identities, then clear dead rows
+     without signalling any process so ordinary recovery can claim them again. */
+  try {
+    reconcileDeadStructuredRegistryHosts(registry);
+  } catch (error) {
+    console.error("[reaper] dead structured-host ownership convergence failed", error);
   }
   /* Stale structured launch convergence (#334): the reaper cycle is the
      while-running seam that turns dead-evidence pending receipts terminal, so

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -321,11 +321,15 @@ export function reconcileDeadStructuredRegistryHost(
   key: SessionKey,
 ): boolean {
   const entry = registry.readOnlySnapshot().entries[sessionKeyId(key)];
-  if (!entry?.structuredHost?.process) return false;
-  return Boolean(registry.terminateInactiveStructuredHost(conversationId, key));
+  const structuredProcess = entry?.structuredHost?.process;
+  if (!entry || !structuredProcess) return false;
+  return Boolean(registry.terminateInactiveStructuredHost(conversationId, key, {
+    process: structuredProcess,
+    claimEpoch: entry.claimEpoch,
+  }));
 }
 
-/** Periodic bounded pass for completed conversation rows. Active conversation
+/** Bounded reconciliation pass for completed conversation rows. Active conversation
     recovery stays demand-driven, while terminal rows cannot retain a dead
     engine process and its writer claim indefinitely. */
 export function reconcileDeadStructuredRegistryHosts(registry: AgentRegistry): void {

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -3,6 +3,7 @@ import type {
   AgentRegistry,
   AgentRegistryEntry,
   ProcessIdentity,
+  RegistryConversation,
   StructuredHostColumns,
 } from "@/lib/agent/registry";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
@@ -311,6 +312,34 @@ function verifiedProcessAlive(processIdentity: ProcessIdentity): boolean {
     && procBackend.processIdentity(processIdentity.pid) === processIdentity.startIdentity;
 }
 
+/** Clears one structured ownership claim only when its recorded engine process
+    exists and the registry revalidates its PID plus start identity, when one
+    was captured, as gone. */
+export function reconcileDeadStructuredRegistryHost(
+  registry: AgentRegistry,
+  conversationId: RegistryConversation["id"],
+  key: SessionKey,
+): boolean {
+  const entry = registry.readOnlySnapshot().entries[sessionKeyId(key)];
+  if (!entry?.structuredHost?.process) return false;
+  return Boolean(registry.terminateInactiveStructuredHost(conversationId, key));
+}
+
+/** Periodic bounded pass for completed conversation rows. Active conversation
+    recovery stays demand-driven, while terminal rows cannot retain a dead
+    engine process and its writer claim indefinitely. */
+export function reconcileDeadStructuredRegistryHosts(registry: AgentRegistry): void {
+  const snapshot = registry.readOnlySnapshot();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    if (conversation.turn.state !== "terminal" && !conversation.supersededBy) continue;
+    const generation = conversation.generations.at(-1);
+    if (!generation) continue;
+    const key = { engine: conversation.engine, sessionId: generation.id } as const;
+    if (!snapshot.entries[sessionKeyId(key)]?.structuredHost?.process) continue;
+    reconcileDeadStructuredRegistryHost(registry, conversation.id, key);
+  }
+}
+
 async function waitForVerifiedProcessExit(processIdentity: ProcessIdentity, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (verifiedProcessAlive(processIdentity) && Date.now() < deadline) {
@@ -349,6 +378,9 @@ export async function demoteSkippedStructuredRegistryHosts(
       && host.pendingAttention.length === 0
       && host.activeFlags.length === 0;
     if (alreadyDead) continue;
+    const conversation = registry.conversationForPath(entry.artifactPath);
+    if (conversation
+      && reconcileDeadStructuredRegistryHost(registry, conversation.id, entry.key)) continue;
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1044,7 +1044,9 @@ async function startupAdoptionAttempts(
     shouldAdopt: StructuredHostAdoptionFilter,
   ) => {
     for (const entry of Object.values(received.snapshot().entries)) {
-      if (entry.key.engine === engine && shouldAdopt(entry)) attempts.push(`${entry.key.engine}:${entry.key.sessionId}`);
+      if (entry.key.engine === engine
+        && entry.structuredHost
+        && shouldAdopt(entry)) attempts.push(`${entry.key.engine}:${entry.key.sessionId}`);
     }
   };
   await adoptStructuredHostsAtStartup({
@@ -1062,11 +1064,11 @@ async function startupAdoptionAttempts(
   return attempts;
 }
 
-test("startup releases a completed stage host claim after its recorded process dies", async () => {
+test("startup releases a completed stage host claim with pending delivery after its recorded process dies", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-dead-stage-owner-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const sessionId = "aaaaaaaa-2222-0222-0222-aaaaaaaaaaaa";
-  addStructuredRestartConversation(registry, directory, {
+  const { conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "idle",
     turn: "terminal",
@@ -1089,6 +1091,7 @@ test("startup releases a completed stage host claim after its recorded process d
     claimOwner: `structured-host:${JSON.stringify({ pid: process.pid, startIdentity: null })}`,
     pendingAction: stored.pendingAction,
   });
+  const delivery = registry.holdDelivery(conversation.id, "deliver after dead stage recovery", "dead-stage-pending");
 
   expect(await startupAdoptionAttempts(registry)).toEqual([]);
   expect(registry.readOnlySnapshot().entries[`codex:${sessionId}`]).toMatchObject({
@@ -1096,6 +1099,7 @@ test("startup releases a completed stage host claim after its recorded process d
     structuredHost: null,
     claimOwner: null,
   });
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{ id: delivery.id, state: "assigned" }]);
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   fs.rmSync(directory, { recursive: true, force: true });

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1064,9 +1064,11 @@ async function startupAdoptionAttempts(
   return attempts;
 }
 
-test("startup releases a completed stage host claim with pending delivery after its recorded process dies", async () => {
+test("SQLite startup releases a completed stage host claim with pending delivery after its recorded process dies", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-dead-stage-owner-"));
-  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, {
+    sqliteMode: "sqlite",
+  });
   const sessionId = "aaaaaaaa-2222-0222-0222-aaaaaaaaaaaa";
   const { conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1062,6 +1062,45 @@ async function startupAdoptionAttempts(
   return attempts;
 }
 
+test("startup releases a completed stage host claim after its recorded process dies", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-dead-stage-owner-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "aaaaaaaa-2222-0222-0222-aaaaaaaaaaaa";
+  addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "idle",
+    turn: "terminal",
+  });
+  const stored = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    key: stored.key,
+    artifactPath: stored.artifactPath,
+    cwd: stored.cwd,
+    accountId: stored.accountId,
+    launchProfile: stored.launchProfile,
+    status: stored.status,
+    host: stored.host,
+    structuredHost: {
+      ...stored.structuredHost!,
+      endpoint: "stdio:dead-stage-host",
+      process: { pid: 2_000_000_000, startIdentity: "dead-stage-host" },
+    },
+    claimEpoch: stored.claimEpoch,
+    claimOwner: `structured-host:${JSON.stringify({ pid: process.pid, startIdentity: null })}`,
+    pendingAction: stored.pendingAction,
+  });
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([]);
+  expect(registry.readOnlySnapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    structuredHost: null,
+    claimOwner: null,
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test("startup publishes per-host progress across the serial provider adoption loops", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-progress-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -16,6 +16,7 @@ import {
   adoptClaudeRegistryHosts,
   adoptCodexRegistryHosts,
   demoteSkippedStructuredRegistryHosts,
+  reconcileDeadStructuredRegistryHosts,
   type AdoptedClaudeHost,
   type AdoptedCodexHost,
   type StructuredHostAdoptionFilter,
@@ -392,6 +393,10 @@ export async function adoptStructuredHostsAtStartup(
   await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry);
   let nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, retryAdoptedHosts);
   retryAdoptedHosts = nextAdoptedHosts;
+  /* Pending work makes a terminal conversation adoption-eligible. Clear any
+     provably dead wrapper before that decision so its stale writer fence
+     cannot block the startup recovery path. */
+  reconcileDeadStructuredRegistryHosts(registry);
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
   const adoptionCandidates = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -959,6 +959,13 @@ test("a reopened synchronization hold rejects changed payload and command reuse"
     outcome: "held",
   });
   const firstReservation = registry.pendingDeliveries(conversation.id)[0]!;
+  const hydratedFirstReservation = {
+    ...firstReservation,
+    contentDigest: structuredContentDigest({
+      text: firstReservation.text,
+      images: firstReservation.runtimeImages,
+    }),
+  };
   const reopened = new AgentRegistry(registry.filename);
   const reopenedDependencies = { ...dependencies, registry: () => reopened };
 
@@ -998,7 +1005,7 @@ test("a reopened synchronization hold rejects changed payload and command reuse"
     outcome: "failed",
     status: 409,
   });
-  expect(reopened.pendingDeliveries(conversation.id)).toEqual([firstReservation]);
+  expect(reopened.pendingDeliveries(conversation.id)).toEqual([hydratedFirstReservation]);
 
   expect(await enqueueStructuredMessage({
     ...original,

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -12,6 +12,7 @@ import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, RuntimeImageStore, runtimeImageCapa
 import { structuredContentDigest, type StructuredImageRef } from "./structuredContent";
 
 import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { recoverDeadStructuredConversation } from "./structuredRecovery";
 
 const artifactPath = "/sessions/11111111-1111-\x34111-8111-111111111111.jsonl";
 const conversationId = "conversation_11111111-1111-\x34111-8111-111111111111";
@@ -1428,6 +1429,185 @@ test("dead structured composer send is durable before recovery and delivers afte
     spawned: true,
     outcome: "queued",
     receipt: { idempotencyKey: "recovered-message-one", status: "queued" },
+  });
+});
+
+test("a completed pipeline-stage send replaces dead host ownership and reaches a fresh claim", async () => {
+  const { registry, conversation } = registryWithConversation("pipeline-account");
+  const generation = conversation.generations.at(-1)!;
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: generation.path,
+    accountId: generation.accountId,
+    launchProfile: generation.launchProfile,
+    turn: { state: "terminal", source: "assistant", terminalAt: "2026-08-14T08:00:00.000Z" },
+    observedAt: "2026-08-14T08:00:00.000Z",
+  }]);
+  const key = { engine: "codex" as const, sessionId: generation.id };
+  const staleClaimOwner = `structured-host:${JSON.stringify({ pid: process.pid, startIdentity: null })}`;
+  registry.upsert({
+    key,
+    artifactPath: generation.path,
+    cwd: generation.launchProfile.cwd,
+    accountId: generation.accountId,
+    launchProfile: generation.launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:dead-stage-host",
+      process: { pid: 2_000_000_000, startIdentity: "dead-stage-host" },
+      eventCursor: 12,
+      protocolVersion: "v2",
+      writerClaimEpoch: 7,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 7,
+    claimOwner: staleClaimOwner,
+    pendingAction: null,
+  });
+  const deadSnapshot = snapshot(conversation.id);
+  deadSnapshot.sessions[0] = {
+    ...deadSnapshot.sessions[0]!,
+    sessionKey: key,
+    host: "dead",
+    turn: "unknown",
+  };
+  const hostedSnapshot = snapshot(conversation.id);
+  hostedSnapshot.sessions[0] = { ...hostedSnapshot.sessions[0]!, sessionKey: key };
+  let currentSnapshot = deadSnapshot;
+  let recoveryCalls = 0;
+  const commands: unknown[] = [];
+  const client = {
+    snapshot: async () => currentSnapshot,
+    command: async (command: {
+      kind: "send";
+      operationId?: string;
+      idempotencyKey: string;
+      conversationId: string;
+    }) => {
+      commands.push(command);
+      return {
+        operationId: command.operationId ?? "pipeline-stage-recovery-send",
+        replayed: false,
+        receipt: {
+          operationId: command.operationId ?? "pipeline-stage-recovery-send",
+          idempotencyKey: command.idempotencyKey,
+          conversationId: command.conversationId,
+          kind: command.kind,
+          status: "queued" as const,
+          queuePosition: 1,
+          at: "2026-08-14T09:00:00.000Z",
+          revision: 1,
+        },
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage({
+    path: generation.path,
+    conversationId: conversation.id,
+    clientMessageId: "pipeline-stage-recovery-message",
+    text: "continue after the completed stage host exited",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    republish: async () => true,
+    recover: async (request) => {
+      recoveryCalls += 1;
+      return recoverDeadStructuredConversation(request, {
+        registry,
+        client,
+        transport: () => "structured",
+        resolveAccount: () => ({
+          engine: "codex",
+          accountId: "pipeline-account",
+          kind: "managed",
+          home: path.join(sandbox, "pipeline-account"),
+          transcriptRoot: sandbox,
+          env: { NODE_ENV: "test" },
+        }),
+        spawn: async (input) => {
+          const resumeEntry = registry.readOnlySnapshot().entries[`codex:${generation.id}`];
+          if (resumeEntry?.structuredHost) {
+            const adopted = registry.claimStructuredHost(key, {
+              pid: process.pid,
+              startIdentity: "fresh-viewer-owner",
+            }, { allowUnhosted: true });
+            if (!adopted?.claimOwner) throw new Error("structured resume host claim is unavailable");
+          }
+          const staged = registry.stageStructuredSpawn(input.receipt.launchId, {
+            key,
+            artifactPath: generation.path,
+            cwd: generation.launchProfile.cwd,
+            accountId: generation.accountId,
+            launchProfile: generation.launchProfile,
+            status: "unhosted",
+            host: null,
+            structuredHost: {
+              kind: "codex-app-server",
+              endpoint: "stdio:staged-successor",
+              process: null,
+              eventCursor: 12,
+              protocolVersion: "v2",
+              writerClaimEpoch: 0,
+              activeTurnRef: null,
+              pendingAttention: [],
+              activeFlags: [],
+            },
+            claimEpoch: 0,
+            claimOwner: null,
+            pendingAction: "spawn",
+          });
+          if (staged.kind !== "settled") throw new Error("successor staging failed");
+          const claimed = registry.claimStructuredHost(key, {
+            pid: process.pid,
+            startIdentity: "fresh-viewer-owner",
+          }, { allowUnhosted: true });
+          if (!claimed?.claimOwner || !claimed.structuredHost) {
+            throw new Error("structured spawn host claim is unavailable");
+          }
+          registry.setStructuredHostClaimed(key, {
+            ...claimed.structuredHost,
+            endpoint: `stdio:${process.pid}`,
+            process: { pid: process.pid, startIdentity: null },
+            writerClaimEpoch: claimed.claimEpoch,
+          }, "idle", claimed.claimOwner, claimed.claimEpoch);
+          registry.finalizeStructuredSpawn(input.receipt.launchId);
+          currentSnapshot = hostedSnapshot;
+          return {
+            ok: true,
+            target: null,
+            path: generation.path,
+            launchId: input.receipt.launchId,
+            conversationId: conversation.id,
+            launched: true,
+            retrySafe: false,
+            initialMessage: "delivered" as const,
+            state: "settled" as const,
+          };
+        },
+      });
+    },
+    kick: () => {},
+  });
+
+  expect(result).toMatchObject({
+    ok: true,
+    structured: true,
+    spawned: true,
+    outcome: "queued",
+  });
+  expect(recoveryCalls).toBe(1);
+  expect(commands).toHaveLength(1);
+  expect(registry.readOnlySnapshot().entries[`codex:${generation.id}`]).toMatchObject({
+    status: "idle",
+    claimOwner: `structured-host:${JSON.stringify({ pid: process.pid, startIdentity: "fresh-viewer-owner" })}`,
+    structuredHost: { process: { pid: process.pid, startIdentity: null } },
   });
 });
 

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -607,7 +607,6 @@ export async function enqueueStructuredMessage(
         dependencies.republish ?? republishStructuredDeliveryHost,
       );
       session = refreshed.session;
-      if (refreshed.republished && (session.host === "dead" || session.host === "unhosted")) return ownershipUnavailable();
     } catch (error) {
       return deliveryFailure(error);
     }

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -11,11 +11,78 @@ import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
+import { reconcileDeadStructuredRegistryHost } from "./registry";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { structuredResumeSessionId } from "./structuredSpawn";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-recovery-"));
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+
+test("dead-host reconciliation preserves a replacement spawn staged after observation", () => {
+  const sessionId = crypto.randomUUID();
+  const directory = path.join(sandbox, `dead-host-reconciliation-race-${sessionId}`);
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(directory, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "default");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:dead-wrapper",
+      process: { pid: 2_000_000_000, startIdentity: "dead-wrapper" },
+      eventCursor: 17,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: "structured-host:stale-viewer",
+    pendingAction: null,
+  });
+
+  const terminate = registry.terminateInactiveStructuredHost.bind(registry);
+  registry.terminateInactiveStructuredHost = ((...args: Parameters<AgentRegistry["terminateInactiveStructuredHost"]>) => {
+    const observed = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+    registry.upsert({
+      ...observed,
+      status: "unhosted",
+      structuredHost: {
+        ...observed.structuredHost!,
+        endpoint: "stdio:replacement-staging",
+        process: null,
+        writerClaimEpoch: 5,
+      },
+      claimEpoch: 5,
+      claimOwner: null,
+      pendingAction: "spawn",
+    });
+    return terminate(...args);
+  }) as AgentRegistry["terminateInactiveStructuredHost"];
+
+  expect(reconcileDeadStructuredRegistryHost(registry, conversation.id, key)).toBeFalse();
+  expect(registry.readOnlySnapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "unhosted",
+    claimEpoch: 5,
+    claimOwner: null,
+    pendingAction: "spawn",
+    structuredHost: {
+      endpoint: "stdio:replacement-staging",
+      process: null,
+      writerClaimEpoch: 5,
+    },
+  });
+});
 
 test("the recovery reservation converges repeated calls onto one successor spawn", async () => {
   const sessionId = crypto.randomUUID();

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -8,6 +8,7 @@ import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import { reconcileDeadStructuredRegistryHost } from "./registry";
 import { spawnStructuredConversation } from "./structuredSpawn";
 import { spawnTransport } from "./spawnTransport";
 
@@ -142,6 +143,14 @@ async function recoverCandidate(
     await assertOwnership();
     let current = candidateFor(registry, request, Boolean(ownership));
     if (!current) return null;
+    /* A host wrapper can disappear before its live Viewer writer releases the
+       claim. Retire that claim only through the registry's PID/start-identity
+       check; a live or unverifiable host remains fenced. */
+    if (!current.publishReady) {
+      reconcileDeadStructuredRegistryHost(registry, current.conversationId, current.key);
+      current = candidateFor(registry, request, Boolean(ownership));
+      if (!current) return null;
+    }
     if (current.publishReady) {
       if (!ownership) {
         return {


### PR DESCRIPTION
## Summary

- Reconcile stale structured-host claims during send recovery, startup admission, and the periodic reaper.
- Preserve the ownership fence for live or unverifiable hosts.
- Let the existing send and resume paths start a fresh pane-less structured host after a completed stage host is provably gone.

## Diagnosis

A pipeline attempt retains its Viewer conversation id and transcript path. The agent registry binds the current native generation to `structuredHost` process evidence plus a `claimOwner` writer fence.

When terminal stage cleanup loses the engine child before persistence releases the writer fence, the runtime journal can project the session as dead while the registry still records the claim. Send admission then republishes the registered host. Republish returns success even when the refreshed health remains dead, and admission returned `structured host ownership is unavailable; retry after runtime synchronization` before recovery ran.

At startup, pending delivery makes a terminal conversation eligible for adoption. The earlier stale-owner pass covered only rows excluded from adoption, so this row kept its dead engine process and surviving Viewer writer claim. Adoption could not acquire that claim. Repeated startup and retry passes therefore preserved the same stale ownership until a later periodic pass.

The compare-and-clear fence originally used deep object equality across a read snapshot and a mutation transaction. Authoritative SQLite materializes these process identities through separate adapters, so logically identical values could fail that comparison. Reconciliation now compares the durable scalar fields.

The related scopes remain separate: #282 covers ambiguous spawn admission, #852 covers input parked behind a live structured host, and #988 covers pipeline close teardown. This change addresses post-completion recovery after the owning engine process has exited.

## Fix

- Continue from dead republish into ordinary dead-conversation recovery.
- Reconcile terminal dead-host ownership before startup calculates adoption candidates.
- Compare the observed PID, start identity, and claim epoch inside the registry mutation, preserving any replacement recovery row staged after observation.
- Reuse the identity-fenced reconciliation in startup demotion and on-demand recovery.
- Run a terminal-conversation-only reconciliation during the existing periodic reaper cycle. This pass changes registry state only and sends no process signals.

## Verification

- Pre-fix send repro: completed stage, dead engine PID, retained live Viewer claim, send arrives; observed the permanent 503 and zero recovery calls.
- Pre-fix startup repro: terminal stage with pending delivery retained stale ownership and entered adoption with an unavailable claim.
- Race repro: a replacement unhosted spawn row staged after observation survived the atomic compare-and-clear fence.
- Authoritative SQLite repro: the startup recovery test failed before scalar comparison and passes afterward.
- Default focused matrix: 171 tests passed across the message-delivery, startup, recovery, and periodic-reaper files.
- Authoritative SQLite focused matrix: 171 tests passed across the same four files.
- `bunx tsc --noEmit`
- Scoped ESLint on all changed TypeScript files
- Local publication privacy gate, including committed-value checks

Closes #1006