### PR TITLE
fix(mobile): keep the focused mandate field above the fold in the create-orchestrator sheet (#1004)

### DIFF
--- a/scripts/capture-issue-979-mobile-orchestrator.ts
+++ b/scripts/capture-issue-979-mobile-orchestrator.ts
@@ -223,6 +223,14 @@ async function checkSheetReach(page: Page, state: string): Promise<void> {
  *
  * A sheet that ignored the signal reads bottom 844 against a visible 508 and
  * fails here; so does one that reached its confirm by scrolling the window.
+ *
+ * Reaching the confirm was never the whole claim, though (#1004): the field
+ * being typed INTO has to be on screen too. The body scroller keeps its own
+ * fold — an intent error's card plus engine/account/reasoning can fill it
+ * entirely and clip the mandate away below — so the focused field is measured
+ * against the nearer of the two edges that can hide it, the scroller's bottom
+ * and the keyboard's top, and against the scroller's top edge that a reveal
+ * could overshoot past.
  */
 async function checkSheetKeyboardReach(page: Page, state: string): Promise<void> {
   await page.focus("[data-orchestrator-mandate]");
@@ -238,7 +246,11 @@ async function checkSheetKeyboardReach(page: Page, state: string): Promise<void>
     const sheet = document.querySelector('[data-testid="mobile-orchestrator-sheet"]')!;
     const confirm = document.querySelector("[data-orchestrator-confirm]")!;
     const body = sheet.querySelector(".overflow-y-auto")!;
+    const field = document.querySelector("[data-orchestrator-mandate]")!;
     const rect = confirm.getBoundingClientRect();
+    const fieldRect = field.getBoundingClientRect();
+    const bodyRect = body.getBoundingClientRect();
+    const fieldStyle = getComputedStyle(field);
     return {
       focused: document.activeElement?.hasAttribute("data-orchestrator-mandate") ?? false,
       inset: Math.round(parseFloat(getComputedStyle(sheet.parentElement!).paddingBottom) || 0),
@@ -248,12 +260,26 @@ async function checkSheetKeyboardReach(page: Page, state: string): Promise<void>
       windowScroll: Math.round(window.scrollY),
       documentHeight: document.documentElement.scrollHeight,
       bodyScrolls: getComputedStyle(body).overflowY,
+      fieldTop: Math.round(fieldRect.top),
+      /* Chrome resolves a unitless line-height to px here; the font size is the
+         fallback for a `normal` that does not parse, and still measures a line. */
+      fieldLine: Math.round(parseFloat(fieldStyle.lineHeight) || parseFloat(fieldStyle.fontSize)),
+      scrollerTop: Math.round(bodyRect.top),
+      scrollerBottom: Math.round(bodyRect.bottom),
     };
   });
   if (!reach.focused) throw new Error(`${state}: the mandate field never took focus, so the keyboard case was not exercised`);
   if (reach.inset < KEYBOARD_PX - 1) throw new Error(`${state}: the sheet reserved ${reach.inset}px for a ${KEYBOARD_PX}px keyboard`);
   if (reach.bottom > reach.visibleBottom) {
     throw new Error(`${state}: with the keyboard open the confirm ends at ${reach.bottom}px, under the keyboard — only ${reach.visibleBottom}px of the ${reach.layout}px viewport is visible`);
+  }
+  /* #1004: the focused field's first line, above whichever fold comes first. */
+  const fold = Math.min(reach.scrollerBottom, reach.visibleBottom);
+  if (reach.fieldTop + reach.fieldLine > fold) {
+    throw new Error(`${state}: with the keyboard open the focused mandate field starts at ${reach.fieldTop}px and its first line ends past the ${fold}px fold (scroller ${reach.scrollerBottom}px, keyboard ${reach.visibleBottom}px) — the operator types into a field they cannot see`);
+  }
+  if (reach.fieldTop < reach.scrollerTop) {
+    throw new Error(`${state}: the focused mandate field starts at ${reach.fieldTop}px, above the scroller's own top edge at ${reach.scrollerTop}px, so its first line is clipped`);
   }
   /* #983's other half: the browser must never have to scroll the WINDOW to
      reach the focused field — the sheet's own body is the one scroller. */

--- a/spec.md
+++ b/spec.md
@@ -1,31 +1,33 @@
-# Issue #1006: Recover conversations owned by dead stage hosts
+# Issue #1004: Keep the focused mandate field above the fold in the mobile create-orchestrator sheet
 
-Restore messaging for a pipeline-stage Codex conversation after its structured host exits without releasing ownership. Reconcile ownership only when the recorded host process is provably gone, then let the existing send and resume path claim a fresh viewer-owned structured host and deliver the queued message.
+On the phone's create-orchestrator sheet, with the keyboard open, the focused Mandate field can sit entirely below the fold: in the intent-error state the error card plus the engine/account/reasoning controls fill the sheet's visible scroller, the "Mandate" label lands at the fold, and the focused textarea starts past it — the operator types into an invisible field. The #979 capture script's geometry gate measures only the confirm button, so the state passes green.
+
+The fix is the one designed by the 2026-08 UX audit (`docs/design/ux-audit-2026-08.md`, finding 5): reveal the field inside the sheet's own scroller on focus while the keyboard inset is > 0, and extend the capture gate to require the focused field above the fold. No alternative design.
 
 ## Acceptance criteria
 
-AC1: Send admission detects a stale structured-host claim whose recorded process identity is provably dead and releases that claim before recovery.
+AC1: With the keyboard inset > 0 and the mandate field focused, the sheet scrolls the mandate block — the element carrying the label, not the bare textarea — into view inside its own body scroller with `scrollIntoView({ block: "start" })`.
 
-AC2: A send to a completed pipeline-stage conversation with a dead host proceeds through a fresh structured-host claim and reaches the delivery queue.
+AC2: Both arrival orders reveal the field: focus first with the keyboard opening after (a tap), and focus moving in while the keyboard is already open.
 
-AC3: Startup reconciliation releases stale dead-host ownership for terminal or superseded structured conversations.
+AC3: The reveal fires once per typing session. A later keyboard resize while the field stays focused does not scroll again, so manual scrolling is never fought after the initial reveal. Focus or the keyboard leaving and returning re-arms it.
 
-AC4: Periodic runtime reconciliation releases the same stale ownership when the viewer remains running after the stage host disappears.
+AC4: Focus with the keyboard closed (inset 0) scrolls nothing.
 
-AC5: Live owners and unverifiable process identities remain fenced from takeover.
+AC5: The #979 capture geometry gate additionally requires, in every keyboard-open sheet state it already visits (draft, edited, intent-error) and both schemes, that the focused field's first line sits above whichever fold comes first — the sheet scroller's bottom edge or the keyboard's top — and that the field's top is not above the scroller's own top edge.
 
-AC6: Recovery uses the existing structured send and resume path without adding a new UI surface or changing explicit legacy delivery.
+AC6: The extended gate fails on the pre-fix component in the state that violates it, and the whole capture run passes with the fix: exit 0, every state × scheme, all frames written.
 
-AC7: Runtime-state tests use isolated temporary state and cover stage completion, unclean host loss, retained ownership, fresh claiming, and successful message enqueueing.
+AC7: Every gate the script already enforced stays green: 44px tap target, pin before the first conversation chip, chat-budget strip height, no horizontal document scroll, confirm above the keyboard, no window scroll to reach the field, sheet body is the one scroller.
 
-AC8: Focused tests, TypeScript type checking, scoped linting, diff checks, and publication privacy checks pass.
+AC8: Scope holds — only the mobile create-orchestrator sheet component, the capture script's gates, and the sheet's own DOM test file change. No `src/lib/{flows,agent,runtime}`, no API routes, no desktop surfaces, no new dependency, no new setting, no refactor beyond the fix.
+
+AC9: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
 
 ## Validation gates
 
-- `bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/startup.test.ts src/lib/reaperRuntime.test.ts src/lib/runtime/structuredRecovery.test.ts`
-- `LLV_AGENT_REGISTRY_SQLITE=sqlite bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/startup.test.ts src/lib/reaperRuntime.test.ts src/lib/runtime/structuredRecovery.test.ts`
+- `bun test src/components/mobile/mobileOrchestratorRow.dom.test.tsx`
+- `bun run build && bun scripts/capture-issue-979-mobile-orchestrator.ts` (the capture is the acceptance test: it must exit 0)
 - `bunx tsc --noEmit`
-- Scoped ESLint over changed TypeScript files
-- `git diff --check`
+- `bunx eslint` over the changed TypeScript files
 - `bun scripts/privacy-publication-gate.ts --base origin/main`
-- `bun run privacy:check`

--- a/src/components/mobile/MobileOrchestratorSheet.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Bot, LoaderCircle, RotateCcw, TriangleAlert } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { X } from "@/components/icons";
 import { AgentLaunchControls, useAgentLaunchDraft, type LaunchEngine, type SpeedChoice } from "@/components/draft/AgentLaunchControls";
@@ -85,6 +85,9 @@ export function MobileOrchestratorSheet({
   const { t } = useLocale();
   const kbInset = useKeyboardInset();
   const sheetRef = useRef<HTMLFormElement>(null);
+  const mandateBlockRef = useRef<HTMLDivElement>(null);
+  const revealedRef = useRef(false);
+  const [mandateFocused, setMandateFocused] = useState(false);
   const [mandate, setMandateState] = useState(() => readSeatDraftField(project, "mandate") || ORCHESTRATOR_SYSTEM_PROMPT);
   const [formError, setFormError] = useState<string | null>(null);
   const launch = useAgentLaunchDraft({
@@ -100,6 +103,27 @@ export function MobileOrchestratorSheet({
   /* Full modal semantics through the shared layer stack: focus in on open, Tab
      trapped, Escape closes, body scroll locked, focus back to the row. */
   useModalLayer({ containerRef: sheetRef, onClose });
+
+  /* The keyboard costs the body scroller most of its height, and everything
+     above the mandate — an intent error's card, then engine/account/reasoning —
+     can fill what is left, leaving the operator typing into a field below the
+     scroller's own fold (#1004). So the field is brought to the top of the
+     scroller once the keyboard is actually up: the block, not the textarea, so
+     its label comes along.
+     Both orders arrive here — focus first and the keyboard after (a tap), or
+     the keyboard already up (focus moving in from another field) — because the
+     condition is the state, not either event. It fires ONCE per typing session:
+     after that the scroller is the operator's, and a keyboard that resizes
+     under them never yanks it back. */
+  useEffect(() => {
+    if (!mandateFocused || kbInset <= 0) {
+      revealedRef.current = false;
+      return;
+    }
+    if (revealedRef.current) return;
+    revealedRef.current = true;
+    mandateBlockRef.current?.scrollIntoView({ block: "start" });
+  }, [mandateFocused, kbInset]);
 
   const setMandate = (value: string) => {
     setMandateState(value);
@@ -254,7 +278,7 @@ export function MobileOrchestratorSheet({
                 <AgentLaunchControls draft={launch} disabled={submitting} stacked />
               </div>
 
-              <div className="flex min-h-[180px] flex-1 flex-col gap-1">
+              <div ref={mandateBlockRef} className="flex min-h-[180px] flex-1 flex-col gap-1">
                 <div className="flex min-h-11 items-center gap-2">
                   <label className="text-label font-semibold text-muted" htmlFor="mobile-orchestrator-mandate">
                     {t("orchPanel.mandate")}
@@ -277,6 +301,8 @@ export function MobileOrchestratorSheet({
                   value={mandate}
                   disabled={submitting}
                   onChange={(event) => setMandate(event.target.value)}
+                  onFocus={() => setMandateFocused(true)}
+                  onBlur={() => setMandateFocused(false)}
                   spellCheck={false}
                   /* Prose the agent reads, so sans (design system §1.1); the
                      only mono here is the cwd caption, which is a path. */

--- a/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
@@ -441,6 +441,62 @@ test("a designation failing ALONGSIDE a live incumbent gets its own control, and
   expect(sheet(host)).not.toBeNull();
 });
 
+/* A minimal visualViewport stand-in — happy-dom has none, and the keyboard is
+   the only thing that shrinks it (#983's signal, `useKeyboardInset`). */
+function makeVisualViewport(height: number) {
+  const listeners = new Set<() => void>();
+  return {
+    height, scale: 1, offsetTop: 0,
+    addEventListener(type: string, cb: () => void) { if (type === "resize") listeners.add(cb); },
+    removeEventListener(type: string, cb: () => void) { if (type === "resize") listeners.delete(cb); },
+    resizeTo(next: number) {
+      this.height = next;
+      for (const cb of [...listeners]) cb();
+    },
+  };
+}
+
+test("the keyboard opening on the focused mandate brings the field into the scroller — once (#1004)", async () => {
+  const vv = makeVisualViewport(844);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  (globalThis as Record<string, unknown>).visualViewport = vv;
+  try {
+    const files = [conversation({})];
+    const { host, root } = await mount(files);
+    flushSync(() => openButton(host).click());
+    await settle(root, view(files), 2);
+
+    const field = sheet(host)!.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement;
+    /* The block that carries the label, not the bare textarea: happy-dom does
+       no layout, so what is asserted is WHICH element is revealed and how
+       often — the geometry itself is the capture script's gate. */
+    const block = field.parentElement as HTMLElement & { scrollIntoView: (options?: unknown) => void };
+    const reveals: unknown[] = [];
+    block.scrollIntoView = (options?: unknown) => { reveals.push(options); };
+
+    /* Focus alone, keyboard still closed: nothing moves. */
+    flushSync(() => field.focus());
+    await settle(root, view(files), 2);
+    expect(reveals).toHaveLength(0);
+
+    /* The keyboard opens under the already-focused field — the tap order a
+       phone actually produces. */
+    flushSync(() => vv.resizeTo(508));
+    await settle(root, view(files), 2);
+    expect(reveals).toEqual([{ block: "start" }]);
+
+    /* And it stays revealed exactly once: a keyboard that resizes again (an
+       autocorrect bar, a rotation) must not yank a scroller the operator has
+       since moved themselves. */
+    flushSync(() => vv.resizeTo(468));
+    await settle(root, view(files), 2);
+    expect(reveals).toHaveLength(1);
+  } finally {
+    delete (dom as unknown as Record<string, unknown>).visualViewport;
+    delete (globalThis as Record<string, unknown>).visualViewport;
+  }
+});
+
 test("an unreadable seat offers a re-read that recovers the row without a page reload", async () => {
   const failing = new Response("", { status: 500 });
   void failing;


### PR DESCRIPTION
Closes #1004. Implements finding 5 of the 2026-08 UX audit (`docs/design/ux-audit-2026-08.md`) as designed there — no alternative was invented.

## What was wrong

With the keyboard open on a 390×844 phone, the create sheet reserves the keyboard's 336px, so its body scroller keeps ~390px. In the intent-error state the error card plus the engine/account/reasoning controls fill that entirely: the "Mandate" label lands at the scroller's fold and the focused textarea starts past it. The operator types into a field they cannot see. The #979 geometry gate measured only the confirm button, so the state passed green.

## The fix

`MobileOrchestratorSheet` brings the mandate **block** (label included, so the field is not revealed anonymously) to the top of its own scroller with `scrollIntoView({ block: "start" })`, once the keyboard is actually up.

- Both arrival orders are covered, because the effect keys on state rather than on either event: a tap that focuses first and opens the keyboard after, and focus moving in while the keyboard is already open.
- It fires **once per typing session**. After the reveal the scroller belongs to the operator — a keyboard that resizes again (autocorrect bar, rotation) never yanks it back. A new reveal only happens after focus or the keyboard has left and returned.
- Nothing else moves: no layout change, no new state, no dependency, and the explainer header is left alone (in the state that hurts most, the tall block is an error `role="alert"` that should not be collapsed away).

## The gate (capture-as-acceptance-test, kept)

`checkSheetKeyboardReach` in `scripts/capture-issue-979-mobile-orchestrator.ts` now also measures the focused field, in every keyboard-open state it already visits — draft, edited, intent-error, both schemes:

- the field's first line must sit above whichever fold comes first, the **scroller's bottom edge** or the **keyboard's top** (`Math.min` of the two — the scroller clips before the keyboard does, which is exactly why the old confirm-only check missed this);
- the field's top must not be above the scroller's own top edge, so a reveal that overshoots and clips the first line upward fails too.

All previous gates are untouched: 44px target, pin-before-first-chip, chat-budget strip height, no horizontal document scroll, confirm above the keyboard, no window scroll, sheet body is the one scroller.

## Verification

**Red baseline** — same new gate, `origin/main`'s component, production build:

```
error: sheet-intent-error/dark: with the keyboard open the focused mandate field
starts at 450px and its first line ends past the 443px fold
(scroller 443px, keyboard 508px) — the operator types into a field they cannot see
```

The field's top (450px) is below the scroller's bottom (443px): entirely clipped, which is the reported defect. Script exits 1. In that same run `sheet-draft-keyboard` and `sheet-draft-edited-keyboard` pass — their top is above the fold already (the audit's "one visible line") — so the gate fails precisely on the state that violates the acceptance rather than on everything nearby.

**Green** — with the fix, full run, production build: exit 0, all 12 states × 2 schemes, 30 frames, every gate green including the new one. In the three keyboard frames per scheme the mandate label plus ~5 lines of the field now sit above the fold (before: the intent-error field was fully clipped, the edited one showed a single line).

```
bun run build
bun scripts/capture-issue-979-mobile-orchestrator.ts   # exit 0, 30 frames
```

Raw frames are not committed — `evidence/**/*.png` is gitignored by repo convention and this script writes outside the repository by design (`<tmp>/llv-issue-979-<run>/out/979-sheet-*-keyboard-*.png`).

**Also run**

- `bun test src/components/mobile/mobileOrchestratorRow.dom.test.tsx` — 13 pass / 0 fail. One case added: focus alone with the keyboard closed reveals nothing; the keyboard opening under the focused field reveals the block once with `{ block: "start" }`; a second keyboard resize does not reveal again. Both new assertions were confirmed red against a deliberately broken version of the fix (call removed → first fails; once-guard removed → second fails).
- `bunx tsc --noEmit` — clean. `bunx eslint <changed files>` — clean. `bun scripts/privacy-publication-gate.ts --base origin/main` — PASS.

Scope stayed inside the sheet component, the capture script's gates, and that one DOM test file; no runtime, flow, agent, API-route or desktop surface was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
