### PR TITLE
feat(orchestrator): per-project dock width (#1011)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,33 +1,31 @@
-# Issue #1004: Keep the focused mandate field above the fold in the mobile create-orchestrator sheet
+# Issue #1011: Per-project orchestrator dock width
 
-On the phone's create-orchestrator sheet, with the keyboard open, the focused Mandate field can sit entirely below the fold: in the intent-error state the error card plus the engine/account/reasoning controls fill the sheet's visible scroller, the "Mandate" label lands at the fold, and the focused textarea starts past it — the operator types into an invisible field. The #979 capture script's geometry gate measures only the confirm button, so the state passes green.
+Each project's orchestrator dock should remember its own width. Today the width is one global preference: `OrchestratorDock` reads it from `localStorage` under a single `WIDTH_KEY` on mount and the pointer-up handler writes that same key, so dragging the dock wide for one mandate-heavy project resizes the dock in every other project. Projects are isolated surfaces and their dock width should be too.
 
-The fix is the one designed by the 2026-08 UX audit (`docs/design/ux-audit-2026-08.md`, finding 5): reveal the field inside the sheet's own scroller on focus while the keyboard inset is > 0, and extend the capture gate to require the focused field above the fold. No alternative design.
+The fix is the one the issue specifies, no alternative: key the stored width by project (`WIDTH_KEY:<project>`), fall back to the legacy global key and then `DEFAULT_WIDTH` when the scoped key is absent so existing operators keep their current width as the seed everywhere, write only the scoped key, and re-read on a project switch. The component already receives `project` as a prop, so the change is contained to it.
 
 ## Acceptance criteria
 
-AC1: With the keyboard inset > 0 and the mandate field focused, the sheet scrolls the mandate block — the element carrying the label, not the bare textarea — into view inside its own body scroller with `scrollIntoView({ block: "start" })`.
+AC1: The width the drag lands on is written under the project's own key, `llvOrchestratorPanelWidth:<project>`, and nowhere else — the legacy global key is left exactly as the operator had it.
 
-AC2: Both arrival orders reveal the field: focus first with the keyboard opening after (a tap), and focus moving in while the keyboard is already open.
+AC2: A project that has never been sized opens at the legacy global width when one exists, so an operator arriving from the single shared preference keeps that width in every project; with neither key present it opens at `DEFAULT_WIDTH`. The legacy key answers only for **absence** of the scoped one — a scoped value that is unusable (non-numeric, or below `MIN_WIDTH`) falls to `DEFAULT_WIDTH`, which is `storedDockWidth`'s existing contract.
 
-AC3: The reveal fires once per typing session. A later keyboard resize while the field stays focused does not scroll again, so manual scrolling is never fought after the initial reveal. Focus or the keyboard leaving and returning re-arms it.
+AC3: Two projects hold independent widths: resizing project A leaves project B's stored width untouched, and each reload restores its own.
 
-AC4: Focus with the keyboard closed (inset 0) scrolls nothing.
+AC4: Switching projects while the dock is open re-reads the new project's width, and the `shellLayout` row the preview sheet budgets around follows the switch. Switching back finds the first project's width unchanged.
 
-AC5: The #979 capture geometry gate additionally requires, in every keyboard-open sheet state it already visits (draft, edited, intent-error) and both schemes, that the focused field's first line sits above whichever fold comes first — the sheet scroller's bottom edge or the keyboard's top — and that the field's top is not above the scroller's own top edge.
+AC5: Every clamp is unchanged — `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor — and the dock still publishes `RAIL_WIDTH + width` through `setLeftShellInset`, giving the row back on unmount. The board keeps `MIN_BOARD` with the preview sheet open, exactly as before.
 
-AC6: The extended gate fails on the pre-fix component in the state that violates it, and the whole capture run passes with the fix: exit 0, every state × scheme, all frames written.
+AC6: The DOM test file covers the scoped write, the legacy-key fallback seed, independence across two projects, and the project-switch re-read.
 
-AC7: Every gate the script already enforced stays green: 44px tap target, pin before the first conversation chip, chat-budget strip height, no horizontal document scroll, confirm above the keyboard, no window scroll to reach the field, sheet body is the one scroller.
+AC7: Scope holds — only `src/components/orchestrator/OrchestratorDock.tsx` and its DOM test file change (plus this spec). No `src/lib/{flows,agent,runtime}`, no API routes, no mobile surfaces, no new dependency, no new setting, no refactor beyond the fix.
 
-AC8: Scope holds — only the mobile create-orchestrator sheet component, the capture script's gates, and the sheet's own DOM test file change. No `src/lib/{flows,agent,runtime}`, no API routes, no desktop surfaces, no new dependency, no new setting, no refactor beyond the fix.
-
-AC9: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
+AC8: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
 
 ## Validation gates
 
-- `bun test src/components/mobile/mobileOrchestratorRow.dom.test.tsx`
-- `bun run build && bun scripts/capture-issue-979-mobile-orchestrator.ts` (the capture is the acceptance test: it must exit 0)
+- `bun test src/components/orchestrator/OrchestratorDock.dom.test.tsx`
+- `bun test src/components/Viewer.orchestratorDock.dom.test.tsx src/components/orchestrator/OrchestratorPanel.dom.test.tsx` (the changed module's consumers)
 - `bunx tsc --noEmit`
 - `bunx eslint` over the changed TypeScript files
 - `bun scripts/privacy-publication-gate.ts --base origin/main`

--- a/spec.md
+++ b/spec.md
@@ -14,13 +14,15 @@ AC3: Two projects hold independent widths: resizing project A leaves project B's
 
 AC4: Switching projects while the dock is open re-reads the new project's width, and the `shellLayout` row the preview sheet budgets around follows the switch. Switching back finds the first project's width unchanged.
 
-AC5: Every clamp is unchanged — `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor — and the dock still publishes `RAIL_WIDTH + width` through `setLeftShellInset`, giving the row back on unmount. The board keeps `MIN_BOARD` with the preview sheet open, exactly as before.
+AC5: A drag owns the project it started on and the width it produced. If the project switches while a drag is still armed — a pointerup released outside the window never reaches the dock's listeners — the dragged width settles on the project the operator sized, the new project's stored width is untouched, and the dead drag stops moving the dock the operator is now looking at. A drag started afterwards on the new project works normally.
 
-AC6: The DOM test file covers the scoped write, the legacy-key fallback seed, independence across two projects, and the project-switch re-read.
+AC6: Every clamp is unchanged — `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor — and the dock still publishes `RAIL_WIDTH + width` through `setLeftShellInset`, giving the row back on unmount. The board keeps `MIN_BOARD` with the preview sheet open, exactly as before.
 
-AC7: Scope holds — only `src/components/orchestrator/OrchestratorDock.tsx` and its DOM test file change (plus this spec). No `src/lib/{flows,agent,runtime}`, no API routes, no mobile surfaces, no new dependency, no new setting, no refactor beyond the fix.
+AC7: The DOM test file covers the scoped write, the legacy-key fallback seed, independence across two projects, the project-switch re-read, and the project switch under an unfinished drag.
 
-AC8: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
+AC8: Scope holds — only `src/components/orchestrator/OrchestratorDock.tsx` and its DOM test file change (plus this spec). No `src/lib/{flows,agent,runtime}`, no API routes, no mobile surfaces, no new dependency, no new setting, no refactor beyond the fix.
+
+AC9: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
 
 ## Validation gates
 

--- a/spec.md
+++ b/spec.md
@@ -16,13 +16,15 @@ AC4: Switching projects while the dock is open re-reads the new project's width,
 
 AC5: A drag owns the project it started on and the width it produced. If the project switches while a drag is still armed — a pointerup released outside the window never reaches the dock's listeners — the dragged width settles on the project the operator sized, the new project's stored width is untouched, and the dead drag stops moving the dock the operator is now looking at. A drag started afterwards on the new project works normally.
 
-AC6: Every clamp is unchanged — `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor — and the dock still publishes `RAIL_WIDTH + width` through `setLeftShellInset`, giving the row back on unmount. The board keeps `MIN_BOARD` with the preview sheet open, exactly as before.
+AC6: The drag's listeners are detached inside the commit that switches the project, so a pointermove arriving before the browser paints cannot drag the newly opened project's dock. A passive cleanup leaves that gap open; the fix ends the drag in the layout phase.
 
-AC7: The DOM test file covers the scoped write, the legacy-key fallback seed, independence across two projects, the project-switch re-read, and the project switch under an unfinished drag.
+AC7: Every clamp is unchanged — `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor — and the dock still publishes `RAIL_WIDTH + width` through `setLeftShellInset`, giving the row back on unmount. The published row and the committed width change in the SAME frame, at mount and through a project switch, so no painted frame shows a wide dock against a row the sheet budgeted for a narrower one. The board keeps `MIN_BOARD` with the preview sheet open, exactly as before.
 
-AC8: Scope holds — only `src/components/orchestrator/OrchestratorDock.tsx` and its DOM test file change (plus this spec). No `src/lib/{flows,agent,runtime}`, no API routes, no mobile surfaces, no new dependency, no new setting, no refactor beyond the fix.
+AC8: The DOM test file covers the scoped write, the legacy-key fallback seed, independence across two projects, the project-switch re-read, the project switch under an unfinished drag, and the two commit-boundary invariants (detached listeners, published row) observed from inside the commit.
 
-AC9: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
+AC9: Scope holds — only `src/components/orchestrator/OrchestratorDock.tsx` and its DOM test file change (plus this spec). No `src/lib/{flows,agent,runtime}`, no API routes, no mobile surfaces, no new dependency, no new setting, no refactor beyond the fix.
+
+AC10: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
 
 ## Validation gates
 

--- a/src/components/orchestrator/OrchestratorDock.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorDock.dom.test.tsx
@@ -106,17 +106,28 @@ function mountDock(project: string) {
     <OrchestratorDock project={on} projectName={on} files={[]} onClose={() => undefined} />,
   ));
   render(project);
+  /* The gesture in three parts, because a switch can land between them. */
+  const pointerDown = () => {
+    const handle = host.querySelector("[data-orchestrator-dock-resize]") as unknown as HTMLElement;
+    flushSync(() => handle.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event));
+  };
+  /** Move the pointer to where the dock lands on `target` px, on a 2000px
+      desktop wide enough that the pointer clamp does not bite. */
+  const pointerMoveTo = (target: number) => {
+    Object.defineProperty(dom, "innerWidth", { value: 2_000, configurable: true });
+    flushSync(() => dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: RAIL_WIDTH + target })));
+  };
+  const pointerUp = () => flushSync(() => dom.dispatchEvent(new dom.Event("pointerup")));
   return {
     render,
     width: () => host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width"),
-    /** Drag the right edge to land the dock on `target` px, on a 2000px desktop
-        wide enough that the pointer clamp does not bite. */
+    pointerDown,
+    pointerMoveTo,
+    pointerUp,
     dragTo: (target: number) => {
-      const handle = host.querySelector("[data-orchestrator-dock-resize]") as unknown as HTMLElement;
-      flushSync(() => handle.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event));
-      Object.defineProperty(dom, "innerWidth", { value: 2_000, configurable: true });
-      flushSync(() => dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: RAIL_WIDTH + target })));
-      flushSync(() => dom.dispatchEvent(new dom.Event("pointerup")));
+      pointerDown();
+      pointerMoveTo(target);
+      pointerUp();
     },
     unmount: () => {
       flushSync(() => root.unmount());
@@ -226,8 +237,8 @@ test("dragging the dock's edge persists the width under the project's own key, a
   expect(dock.width()).toBe(String(DEFAULT_WIDTH));
   dock.dragTo(600);
 
-  /* Scoped to the project (#1011). The legacy global key is left exactly as the
-     operator had it — the drag claims one project's width, not everyone's. */
+  /* Scoped to the project (#1011). The drag claims one project's width and
+     leaves the legacy global key exactly as the operator had it. */
   expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
   expect(dom.localStorage.getItem("llvOrchestratorPanelWidth")).toBeNull();
   expect(dock.width()).toBe("600");
@@ -248,8 +259,8 @@ test("a project with no width of its own seeds from the legacy global one", () =
   /* A width of its own outranks the seed... */
   dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "500");
   expect(mountDock("borealis").width()).toBe("500");
-  /* ...and an unusable one falls to the default rather than to the seed: the
-     legacy key answers only for a project that has never been sized. */
+  /* ...and an unusable one falls to the default: the legacy key answers only
+     for a project that has never been sized. */
   dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "12");
   expect(mountDock("borealis").width()).toBe(String(DEFAULT_WIDTH));
 });
@@ -286,5 +297,39 @@ test("switching projects while the dock is open re-reads the new project's width
   /* And back: the visit changed nothing about atlas's own width. */
   dock.render("atlas");
   expect(dock.width()).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+});
+
+test("a project switch under an unfinished drag settles the width on the project it started on", () => {
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "500");
+
+  const dock = mountDock("atlas");
+  dock.pointerDown();
+  dock.pointerMoveTo(600);
+  expect(dock.width()).toBe("600");
+
+  /* The operator switches projects with the drag still armed — a pointerup
+     released outside the window never reaches the dock's listeners, so this is
+     reachable in the real app. */
+  dock.render("borealis");
+  expect(dock.width()).toBe("500");
+
+  /* Atlas keeps the width the operator dragged IT to, and borealis keeps its
+     own: neither project's key holds the other's number. */
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("500");
+
+  /* The dead drag is over: the pointer no longer drags borealis's dock, and
+     its pointerup writes nothing. */
+  dock.pointerMoveTo(720);
+  expect(dock.width()).toBe("500");
+  dock.pointerUp();
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("500");
+
+  /* Borealis is still resizable by a drag of its own. */
+  dock.dragTo(700);
+  expect(dock.width()).toBe("700");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("700");
   expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
 });

--- a/src/components/orchestrator/OrchestratorDock.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorDock.dom.test.tsx
@@ -8,7 +8,9 @@ import { emptyStore } from "@/components/runtime/runtimeModel";
 /*
  * The dock's geometry contract (issue #977 acceptance): the width is the
  * operator's and survives reload, and the board keeps at least 320px even with
- * the document preview sheet open on the other side.
+ * the document preview sheet open on the other side. Since #1011 that width is
+ * remembered PER PROJECT, so a mandate-heavy dock in one project leaves every
+ * other project's dock the size the operator left it.
  */
 
 const dom = new HappyWindow();
@@ -91,6 +93,38 @@ afterEach(() => {
 afterAll(() => {
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
 });
+
+/** One dock on a project, as a page load gives it: its own host, its own root,
+    and the two gestures the width contract is made of — drag the edge, switch
+    the project underneath it. */
+function mountDock(project: string) {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  const render = (on: string) => flushSync(() => root.render(
+    <OrchestratorDock project={on} projectName={on} files={[]} onClose={() => undefined} />,
+  ));
+  render(project);
+  return {
+    render,
+    width: () => host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width"),
+    /** Drag the right edge to land the dock on `target` px, on a 2000px desktop
+        wide enough that the pointer clamp does not bite. */
+    dragTo: (target: number) => {
+      const handle = host.querySelector("[data-orchestrator-dock-resize]") as unknown as HTMLElement;
+      flushSync(() => handle.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event));
+      Object.defineProperty(dom, "innerWidth", { value: 2_000, configurable: true });
+      flushSync(() => dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: RAIL_WIDTH + target })));
+      flushSync(() => dom.dispatchEvent(new dom.Event("pointerup")));
+    },
+    unmount: () => {
+      flushSync(() => root.unmount());
+      roots.delete(root);
+      host.remove();
+    },
+  };
+}
 
 test("dock and preview sheet share ONE budget: the board keeps 320px at every desktop width", () => {
   /* The reviewer's own case: 1440px, both surfaces at their remembered
@@ -182,29 +216,75 @@ test("switching projects re-seats the panel on the new project's own draft, keep
 
   expect(host.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe("borealis");
   expect((host.querySelector("[data-orchestrator-mandate]") as unknown as HTMLTextAreaElement).value).not.toBe("Atlas only");
-  /* Width is the operator's preference, not the project's — it rides across. */
+  /* Neither project has a width of its own here, so both open on the default;
+     the width that DOES follow a switch is the case below. */
   expect(host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width")).toBe(String(DEFAULT_WIDTH));
 });
 
-test("dragging the dock's edge persists the width, and the next mount opens on it", () => {
-  const host = dom.document.createElement("div");
-  dom.document.body.append(host);
-  const root = createRoot(host as unknown as HTMLElement);
-  roots.add(root);
-  flushSync(() => root.render(
-    <OrchestratorDock project="atlas" projectName="Atlas" files={[]} onClose={() => undefined} />,
-  ));
+test("dragging the dock's edge persists the width under the project's own key, and the next mount opens on it", () => {
+  const dock = mountDock("atlas");
+  expect(dock.width()).toBe(String(DEFAULT_WIDTH));
+  dock.dragTo(600);
 
-  const dock = host.querySelector("[data-orchestrator-dock]") as unknown as HTMLElement;
-  expect(dock.getAttribute("data-orchestrator-dock-width")).toBe(String(DEFAULT_WIDTH));
+  /* Scoped to the project (#1011). The legacy global key is left exactly as the
+     operator had it — the drag claims one project's width, not everyone's. */
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth")).toBeNull();
+  expect(dock.width()).toBe("600");
+  expect(storedDockWidth(() => dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas"))).toBe(600);
 
-  const handle = host.querySelector("[data-orchestrator-dock-resize]") as unknown as HTMLElement;
-  flushSync(() => handle.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event));
-  Object.defineProperty(dom, "innerWidth", { value: 2_000, configurable: true });
-  flushSync(() => dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: 848 })));
-  flushSync(() => dom.dispatchEvent(new dom.Event("pointerup")));
+  /* Reload: the same project opens on the width it was left at. */
+  dock.unmount();
+  expect(mountDock("atlas").width()).toBe("600");
+});
 
-  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth")).toBe("600");
-  expect(host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width")).toBe("600");
-  expect(storedDockWidth(() => dom.localStorage.getItem("llvOrchestratorPanelWidth"))).toBe(600);
+test("a project with no width of its own seeds from the legacy global one", () => {
+  /* What an operator carries in from before #1011: ONE width, shared by every
+     project. It seeds them all, so nobody's dock snaps back to the default. */
+  dom.localStorage.setItem("llvOrchestratorPanelWidth", "620");
+  expect(mountDock("atlas").width()).toBe("620");
+  expect(mountDock("borealis").width()).toBe("620");
+
+  /* A width of its own outranks the seed... */
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "500");
+  expect(mountDock("borealis").width()).toBe("500");
+  /* ...and an unusable one falls to the default rather than to the seed: the
+     legacy key answers only for a project that has never been sized. */
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "12");
+  expect(mountDock("borealis").width()).toBe(String(DEFAULT_WIDTH));
+});
+
+test("two projects hold independent widths: resizing one leaves the other's alone", () => {
+  const atlas = mountDock("atlas");
+  atlas.dragTo(600);
+  atlas.unmount();
+
+  const borealis = mountDock("borealis");
+  /* Untouched by the drag next door — no seed, so its own default. */
+  expect(borealis.width()).toBe(String(DEFAULT_WIDTH));
+  borealis.dragTo(520);
+  borealis.unmount();
+
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("520");
+  expect(mountDock("atlas").width()).toBe("600");
+});
+
+test("switching projects while the dock is open re-reads the new project's width", () => {
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:atlas", "600");
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "500");
+
+  const dock = mountDock("atlas");
+  expect(dock.width()).toBe("600");
+  expect(leftShellInset()).toBe(RAIL_WIDTH + 600);
+
+  dock.render("borealis");
+  expect(dock.width()).toBe("500");
+  /* The row the preview sheet budgets around follows the switch too. */
+  expect(leftShellInset()).toBe(RAIL_WIDTH + 500);
+
+  /* And back: the visit changed nothing about atlas's own width. */
+  dock.render("atlas");
+  expect(dock.width()).toBe("600");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
 });

--- a/src/components/orchestrator/OrchestratorDock.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorDock.dom.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { Window as HappyWindow } from "happy-dom";
+import { useLayoutEffect } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -94,16 +95,36 @@ afterAll(() => {
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
 });
 
+/** A witness at the commit boundary. Its layout effect runs inside the SAME
+    commit as the dock's own — after the dock's subtree, before the browser
+    paints and before any passive effect — so what it observes is the frame the
+    operator would actually see. Timing bugs that a passive effect papers over
+    are visible from here and nowhere else. */
+function CommitProbe({ at }: { at: () => void }) {
+  useLayoutEffect(() => {
+    at();
+  });
+  return null;
+}
+
+/** The dock's committed width, as the observer at a commit boundary reads it. */
+type CommitWatcher = (width: string | null | undefined) => void;
+
 /** One dock on a project, as a page load gives it: its own host, its own root,
     and the two gestures the width contract is made of — drag the edge, switch
     the project underneath it. */
-function mountDock(project: string) {
+function mountDock(project: string, atCommit?: CommitWatcher) {
   const host = dom.document.createElement("div");
   dom.document.body.append(host);
   const root = createRoot(host as unknown as HTMLElement);
   roots.add(root);
+  const readWidth = () => host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width");
+  let commit = atCommit;
   const render = (on: string) => flushSync(() => root.render(
-    <OrchestratorDock project={on} projectName={on} files={[]} onClose={() => undefined} />,
+    <>
+      <OrchestratorDock project={on} projectName={on} files={[]} onClose={() => undefined} />
+      <CommitProbe at={() => commit?.(readWidth())} />
+    </>,
   ));
   render(project);
   /* The gesture in three parts, because a switch can land between them. */
@@ -111,17 +132,24 @@ function mountDock(project: string) {
     const handle = host.querySelector("[data-orchestrator-dock-resize]") as unknown as HTMLElement;
     flushSync(() => handle.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event));
   };
-  /** Move the pointer to where the dock lands on `target` px, on a 2000px
-      desktop wide enough that the pointer clamp does not bite. */
-  const pointerMoveTo = (target: number) => {
+  /** The raw pointer event that lands the dock on `target` px, on a 2000px
+      desktop wide enough that the pointer clamp does not bite. Unflushed, so it
+      can be fired from inside a commit the way a real one arrives. */
+  const dispatchMove = (target: number) => {
     Object.defineProperty(dom, "innerWidth", { value: 2_000, configurable: true });
-    flushSync(() => dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: RAIL_WIDTH + target })));
+    dom.dispatchEvent(Object.assign(new dom.Event("pointermove"), { clientX: RAIL_WIDTH + target }));
   };
+  const pointerMoveTo = (target: number) => flushSync(() => dispatchMove(target));
   const pointerUp = () => flushSync(() => dom.dispatchEvent(new dom.Event("pointerup")));
   return {
     render,
-    width: () => host.querySelector("[data-orchestrator-dock]")?.getAttribute("data-orchestrator-dock-width"),
+    width: readWidth,
+    /** What to run at each commit boundary from here on. */
+    onCommit: (fn?: CommitWatcher) => {
+      commit = fn;
+    },
     pointerDown,
+    dispatchMove,
     pointerMoveTo,
     pointerUp,
     dragTo: (target: number) => {
@@ -332,4 +360,52 @@ test("a project switch under an unfinished drag settles the width on the project
   expect(dock.width()).toBe("700");
   expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("700");
   expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+});
+
+test("the old drag's listeners are gone before the new project is on screen", () => {
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "500");
+
+  const dock = mountDock("atlas");
+  dock.pointerDown();
+  dock.pointerMoveTo(600);
+
+  /* A pointermove fired at the commit boundary: the switch to borealis is
+     committed and nothing has been painted yet. This is the window a passive
+     cleanup leaves open, and a real pointer sits in it whenever the drag was
+     left armed — so a listener still attached here would drag BOREALIS's dock
+     with the gesture the operator aimed at atlas. */
+  let fired = false;
+  dock.onCommit(() => {
+    if (fired) return;
+    fired = true;
+    dock.dispatchMove(720);
+  });
+  dock.render("borealis");
+  dock.onCommit(undefined);
+  expect(fired).toBe(true);
+
+  expect(dock.width()).toBe("500");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:borealis")).toBe("500");
+  expect(dom.localStorage.getItem("llvOrchestratorPanelWidth:atlas")).toBe("600");
+});
+
+test("the published row and the committed width change in the same frame", () => {
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:atlas", "400");
+  dom.localStorage.setItem("llvOrchestratorPanelWidth:borealis", "900");
+
+  const seen: Array<{ width: string | null | undefined; inset: number }> = [];
+  const dock = mountDock("atlas", (width) => seen.push({ width, inset: leftShellInset() }));
+
+  /* Mount: the sheet's budget is right from the first frame. */
+  expect(seen.at(-1)).toEqual({ width: "400", inset: RAIL_WIDTH + 400 });
+
+  dock.render("borealis");
+
+  /* And through the switch that widens the dock by 500px, the two move
+     together. Publishing a frame late would paint 900px of dock against a row
+     reserved for 400 — the sheet takes its full 560 and the board is left with
+     212px, well under its floor. */
+  expect(seen.at(-1)).toEqual({ width: "900", inset: RAIL_WIDTH + 900 });
+  expect(visibleBoard(1_920, 900)).toBeGreaterThanOrEqual(MIN_BOARD);
+  expect(1_920 - RAIL_WIDTH - 900 - sheetWidth(1_920, RAIL_WIDTH + 400)).toBeLessThan(MIN_BOARD);
 });

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
@@ -112,8 +112,13 @@ export function OrchestratorDock({
   }
 
   /* The row this dock occupies, for the preview sheet to budget around —
-     published live through the resize drag, and given back on close. */
-  useEffect(() => {
+     published live through the resize drag, and given back on close.
+
+     LAYOUT phase, so the published row and the committed width are one atomic
+     change: a passive effect publishes a frame late, and a project switch that
+     widens the dock would paint that frame with the sheet still budgeting for
+     the narrower one, taking the board under {@link MIN_BOARD}. */
+  useLayoutEffect(() => {
     setLeftShellInset(RAIL_WIDTH + width);
     return () => setLeftShellInset(0);
   }, [width]);
@@ -154,8 +159,14 @@ export function OrchestratorDock({
 
   /* End an unfinished drag when the project changes under it, or when the dock
      closes: the width it produced is settled on its owner, and the dock the
-     operator is now looking at stops following the pointer. */
-  useEffect(() => () => endDrag.current?.(), [project]);
+     operator is now looking at stops following the pointer.
+
+     LAYOUT phase again, and for the sharper reason: this cleanup runs inside
+     the commit, so the listeners are gone before the switch is observable. A
+     passive cleanup leaves them live until after paint, and any pointermove in
+     that gap — a drag whose pointerup was released outside the window stays
+     armed indefinitely — drags the dock of the project just opened. */
+  useLayoutEffect(() => () => endDrag.current?.(), [project]);
 
   return (
     <aside

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
@@ -8,9 +8,10 @@ import type { FileEntry } from "@/lib/types";
 import { setLeftShellInset } from "../shellLayout";
 import { OrchestratorPanel } from "./OrchestratorPanel";
 
-/** The width every project shared before #1011. Still READ, never written: it
-    is the seed a project that has never been sized falls back to, so operators
-    coming from the single global preference keep their width everywhere. */
+/** The width every project shared before #1011. Since the split it serves as a
+    seed: a project that has never been sized falls back to it, so operators
+    coming from the single global preference keep their width everywhere.
+    Nothing writes it. */
 const LEGACY_WIDTH_KEY = "llvOrchestratorPanelWidth";
 /** One project's own width (#1011). Projects are isolated surfaces — a dock
     dragged wide for a mandate-heavy project must not resize every other one. */
@@ -100,9 +101,9 @@ export function OrchestratorDock({
   const [width, setWidth] = useState(() => projectDockWidth(project));
 
   /* A project switch re-reads the width, because the width now BELONGS to the
-     project (#1011). Adjusted during render rather than from an effect, so the
-     dock never paints — nor publishes to `../shellLayout` — one frame of the
-     project the operator just left. */
+     project (#1011). The adjustment happens during render, so the dock never
+     paints — nor publishes to `../shellLayout` — a frame of the project the
+     operator just left. */
   const [sizedProject, setSizedProject] = useState(project);
   if (sizedProject !== project) {
     setSizedProject(project);
@@ -116,23 +117,44 @@ export function OrchestratorDock({
     return () => setLeftShellInset(0);
   }, [width]);
 
+  /* The drag in flight, so a project switch can end it. A pointerup released
+     outside the window never reaches these listeners, so a drag can still be
+     armed when the operator moves to another project. */
+  const endDrag = useRef<(() => void) | null>(null);
+
   const resizeFrom = useCallback(() => {
-    const move = (event: PointerEvent) => setWidth(dockWidthForPointer(event.clientX, window.innerWidth));
-    const up = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
-      setWidth((value) => {
-        try {
-          window.localStorage.setItem(widthKey(project), String(value));
-        } catch {
-          /* private mode */
-        }
-        return value;
-      });
+    /* A drag belongs to the project it started on, and carries its own width:
+       both are captured here so a switch mid-drag lands the dragged width on
+       the project the operator sized, leaving the new project's own width
+       alone. Reading the width back out of state at pointerup would write
+       whatever the switch loaded into the wrong project's key. */
+    const owner = project;
+    let dragged: number | null = null;
+    const move = (event: PointerEvent) => {
+      dragged = dockWidthForPointer(event.clientX, window.innerWidth);
+      setWidth(dragged);
     };
+    const end = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", end);
+      endDrag.current = null;
+      if (dragged === null) return;
+      try {
+        window.localStorage.setItem(widthKey(owner), String(dragged));
+      } catch {
+        /* private mode */
+      }
+    };
+    endDrag.current?.();
+    endDrag.current = end;
     window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
+    window.addEventListener("pointerup", end);
   }, [project]);
+
+  /* End an unfinished drag when the project changes under it, or when the dock
+     closes: the width it produced is settled on its owner, and the dock the
+     operator is now looking at stops following the pointer. */
+  useEffect(() => () => endDrag.current?.(), [project]);
 
   return (
     <aside

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -8,7 +8,13 @@ import type { FileEntry } from "@/lib/types";
 import { setLeftShellInset } from "../shellLayout";
 import { OrchestratorPanel } from "./OrchestratorPanel";
 
-const WIDTH_KEY = "llvOrchestratorPanelWidth";
+/** The width every project shared before #1011. Still READ, never written: it
+    is the seed a project that has never been sized falls back to, so operators
+    coming from the single global preference keep their width everywhere. */
+const LEGACY_WIDTH_KEY = "llvOrchestratorPanelWidth";
+/** One project's own width (#1011). Projects are isolated surfaces — a dock
+    dragged wide for a mandate-heavy project must not resize every other one. */
+const widthKey = (project: string) => `${LEGACY_WIDTH_KEY}:${project}`;
 export const OPEN_KEY = "llvOrchestratorPanelOpen";
 
 export const MIN_WIDTH = 360;
@@ -38,6 +44,21 @@ export function storedDockWidth(read: () => string | null): number {
   return DEFAULT_WIDTH;
 }
 
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** The width to open `project` at: its own, else the pre-#1011 global one as a
+    seed, else the default. Only ABSENCE falls through to the seed — a project
+    that has been sized answers for itself, nonsense included. */
+function projectDockWidth(project: string): number {
+  return storedDockWidth(() => readStorage(widthKey(project)) ?? readStorage(LEGACY_WIDTH_KEY));
+}
+
 /** Width the drag lands on for a pointer at `clientX`, given the viewport. */
 export function dockWidthForPointer(clientX: number, viewportWidth: number): number {
   const room = Math.max(MIN_WIDTH, viewportWidth - RESERVED_BESIDE_DOCK);
@@ -50,8 +71,9 @@ export function dockWidthForPointer(clientX: number, viewportWidth: number): num
  * a flex sibling, so the board simply gets the rest of the row.
  *
  * Width is the operator's, persisted like the document preview's
- * (`ArtifactPreviewHost`): drag the right edge, and the next session opens at
- * the same width. The CSS `min()` is the hard floor that the pointer clamp
+ * (`ArtifactPreviewHost`) but PER PROJECT (#1011): drag the right edge, and
+ * that project opens at the same width next session while the others keep
+ * theirs. The CSS `min()` is the hard floor that the pointer clamp
  * cannot express — a window resized after the drag must not let a remembered
  * width squeeze the board below {@link MIN_BOARD} with the preview sheet also
  * open, and `max()` keeps the dock itself usable on a genuinely small desktop.
@@ -75,13 +97,17 @@ export function OrchestratorDock({
   onClose: () => void;
 }) {
   const { t } = useLocale();
-  const [width, setWidth] = useState(() => storedDockWidth(() => {
-    try {
-      return window.localStorage.getItem(WIDTH_KEY);
-    } catch {
-      return null;
-    }
-  }));
+  const [width, setWidth] = useState(() => projectDockWidth(project));
+
+  /* A project switch re-reads the width, because the width now BELONGS to the
+     project (#1011). Adjusted during render rather than from an effect, so the
+     dock never paints — nor publishes to `../shellLayout` — one frame of the
+     project the operator just left. */
+  const [sizedProject, setSizedProject] = useState(project);
+  if (sizedProject !== project) {
+    setSizedProject(project);
+    setWidth(projectDockWidth(project));
+  }
 
   /* The row this dock occupies, for the preview sheet to budget around —
      published live through the resize drag, and given back on close. */
@@ -97,7 +123,7 @@ export function OrchestratorDock({
       window.removeEventListener("pointerup", up);
       setWidth((value) => {
         try {
-          window.localStorage.setItem(WIDTH_KEY, String(value));
+          window.localStorage.setItem(widthKey(project), String(value));
         } catch {
           /* private mode */
         }
@@ -106,7 +132,7 @@ export function OrchestratorDock({
     };
     window.addEventListener("pointermove", move);
     window.addEventListener("pointerup", up);
-  }, []);
+  }, [project]);
 
   return (
     <aside
@@ -119,9 +145,9 @@ export function OrchestratorDock({
     >
       {/* Keyed by project: the panel's draft — mandate, engine, model, account,
           and the idempotency key of an unsettled confirm — belongs to ONE
-          project. The dock survives the switch (its width is the operator's,
-          not the project's); the panel is re-seated on the new one and reads
-          that project's own stored draft. */}
+          project. The dock survives the switch, resized to the new project's
+          own remembered width; the panel is re-seated on it and reads that
+          project's own stored draft. */}
       <OrchestratorPanel
         key={project}
         project={project}

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -71,13 +71,14 @@ export function dockWidthForPointer(clientX: number, viewportWidth: number): num
  * the project rail and the board — not an overlay (PRD #976 decision 1). It is
  * a flex sibling, so the board simply gets the rest of the row.
  *
- * Width is the operator's, persisted like the document preview's
- * (`ArtifactPreviewHost`) but PER PROJECT (#1011): drag the right edge, and
- * that project opens at the same width next session while the others keep
- * theirs. The CSS `min()` is the hard floor that the pointer clamp
- * cannot express — a window resized after the drag must not let a remembered
- * width squeeze the board below {@link MIN_BOARD} with the preview sheet also
- * open, and `max()` keeps the dock itself usable on a genuinely small desktop.
+ * Width is the operator's, persisted PER PROJECT (#1011) the way the document
+ * preview persists its own (`ArtifactPreviewHost`): drag the right edge, and
+ * that project opens at the same width next session while every other project
+ * keeps the width it was left at. The CSS `min()` is the hard floor that the
+ * pointer clamp cannot express — a window resized after the drag must not let
+ * a remembered width squeeze the board below {@link MIN_BOARD} with the preview
+ * sheet also open, and `max()` keeps the dock itself usable on a genuinely
+ * small desktop.
  *
  * The other half of that guarantee lives in the sheet: this dock publishes the
  * row it occupies (`../shellLayout`) and the sheet budgets around it, so a


### PR DESCRIPTION
Closes #1011.

## What

The orchestrator dock persisted its dragged width under one global `localStorage` key, so widening it for a mandate-heavy project widened it in every other project. The width is now scoped to the project the dock is showing.

- Key: `llvOrchestratorPanelWidth:<project>` — the repo's existing per-project key shape (`llvOrchestrator<Flow>:<project>:<name>`).
- Read order: the project's own key → the legacy global key → `DEFAULT_WIDTH`. Only **absence** falls through to the legacy seed, so an operator arriving with the old single preference keeps that width in every project, and a project that has been sized answers for itself.
- Write: the scoped key only. The legacy key is read-only now, so a rollback still finds the width every project shared before this change.
- Switching projects while the dock is open re-reads the new project's width. The adjustment happens during render (React's "adjust state when props change" pattern) rather than in an effect, so the dock never paints — nor publishes to `shellLayout` — one frame of the project just left.

Every clamp is untouched: `MIN_WIDTH`, `RESERVED_BESIDE_DOCK`, `dockWidthForPointer`, and the CSS `max()/min()` floor. `setLeftShellInset(RAIL_WIDTH + width)` still publishes the dock's row for the preview sheet to budget around — it now simply follows a project switch too.

## Tests

`OrchestratorDock.dom.test.tsx`, four cases (written RED first, each failing on the global key before the change):

- the dragged width lands under the project's own key and leaves the legacy global one untouched, and the next mount opens on it;
- a project with no width of its own seeds from the legacy global one, a scoped width outranks that seed, and an unusable scoped value falls to the default rather than back to the seed;
- two projects hold independent widths — resizing one leaves the other's stored width alone;
- switching projects while the dock is open re-reads the new project's width, `leftShellInset()` follows, and switching back finds the first project's width unchanged.

The existing geometry/budget cases are unchanged; the one comment claiming the width "rides across" a switch is corrected.

## Verification

- `bun test src/components/orchestrator/OrchestratorDock.dom.test.tsx` — 8 pass, 0 fail (4 before).
- `bunx tsc --noEmit` — clean.
- `bunx eslint` on both touched files — clean.
- Regression on the consumers of the changed module: `bun test src/components/Viewer.orchestratorDock.dom.test.tsx src/components/orchestrator/OrchestratorPanel.dom.test.tsx` — 33 pass, 0 fail. The `act(...)` warning those two print is pre-existing; verified identical output at `HEAD` in a throwaway worktree.
- `bun scripts/privacy-publication-gate.ts --base origin/main` — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)