### PR TITLE
fix(files): projectCwds must not leak one project's cwd into another (#1012)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,33 +1,28 @@
-# Issue #1004: Keep the focused mandate field above the fold in the mobile create-orchestrator sheet
+# Issue #1012: Keep each project cwd within its own project
 
-On the phone's create-orchestrator sheet, with the keyboard open, the focused Mandate field can sit entirely below the fold: in the intent-error state the error card plus the engine/account/reasoning controls fill the sheet's visible scroller, the "Mandate" label lands at the fold, and the focused textarea starts past it — the operator types into an invisible field. The #979 capture script's geometry gate measures only the confirm button, so the state passes green.
-
-The fix is the one designed by the 2026-08 UX audit (`docs/design/ux-audit-2026-08.md`, finding 5): reveal the field inside the sheet's own scroller on focus while the keyboard inset is > 0, and extend the capture gate to require the focused field above the fold. No alternative design.
+The files response currently allows session-derived cwd evidence from one project to populate another project's `projectCwds` entry. The create-orchestrator sheet consumes this projection, so poisoned evidence can launch an orchestrator in an unrelated repository. The scanner/files projection must validate cwd ownership through the existing project resolver and recover repository-less directory projects to their own directory.
 
 ## Acceptance criteria
 
-AC1: With the keyboard inset > 0 and the mandate field focused, the sheet scrolls the mandate block — the element carrying the label, not the bare textarea — into view inside its own body scroller with `scrollIntoView({ block: "start" })`.
+AC1: A canonical `dir-` project's `projectCwds` value is the directory from which that project identity is derived.
 
-AC2: Both arrival orders reveal the field: focus first with the keyboard opening after (a tap), and focus moving in while the keyboard is already open.
+AC2: A canonical `repo-` project's cwd candidate is accepted only when `projectInfoFromCwd(candidate)` resolves to that same project.
 
-AC3: The reveal fires once per typing session. A later keyboard resize while the field stays focused does not scroll again, so manual scrolling is never fought after the initial reveal. Focus or the keyboard leaving and returning re-arms it.
+AC3: Session evidence whose cwd resolves to another project is excluded from the candidate set and cannot collapse distinct projects onto one repository checkout.
 
-AC4: Focus with the keyboard closed (inset 0) scrolls nothing.
+AC4: Cwd ownership uses the scanner's existing `projectInfoFromCwd` and worktree-grouping resolution. No additional project naming or grouping scheme is introduced.
 
-AC5: The #979 capture geometry gate additionally requires, in every keyboard-open sheet state it already visits (draft, edited, intent-error) and both schemes, that the focused field's first line sits above whichever fold comes first — the sheet scroller's bottom edge or the keyboard's top — and that the field's top is not above the scroller's own top edge.
+AC5: A focused poisoned-evidence regression covers distinct directory and repository projects and proves that their `projectCwds` values remain distinct.
 
-AC6: The extended gate fails on the pre-fix component in the state that violates it, and the whole capture run passes with the fix: exit 0, every state × scheme, all frames written.
+AC6: Product source changes stay within the scanner/files projection that derives `projectCwds`; no flow, agent, runtime, or UI source changes are made.
 
-AC7: Every gate the script already enforced stays green: 44px tap target, pin before the first conversation chip, chat-budget strip height, no horizontal document scroll, confirm above the keyboard, no window scroll to reach the field, sheet body is the one scroller.
+AC7: The focused files-route and project-directory tests pass, `bunx tsc --noEmit` passes, and the publication privacy gate passes without running broad runtime or registry suites.
 
-AC8: Scope holds — only the mobile create-orchestrator sheet component, the capture script's gates, and the sheet's own DOM test file change. No `src/lib/{flows,agent,runtime}`, no API routes, no desktop surfaces, no new dependency, no new setting, no refactor beyond the fix.
-
-AC9: Focused tests, TypeScript type checking, scoped linting and the publication privacy gate pass; no repo suite that sweeps the operator's live runtime/registry state is run.
+AC8: The fix is delivered in a non-draft pull request titled `fix(files): projectCwds must not leak one project's cwd into another (#1012)` with an identity-free diagnosis.
 
 ## Validation gates
 
-- `bun test src/components/mobile/mobileOrchestratorRow.dom.test.tsx`
-- `bun run build && bun scripts/capture-issue-979-mobile-orchestrator.ts` (the capture is the acceptance test: it must exit 0)
+- `bun test src/app/api/files/route.test.ts`
+- `bun test src/lib/scanner/projectDirectories.test.ts`
 - `bunx tsc --noEmit`
-- `bunx eslint` over the changed TypeScript files
 - `bun scripts/privacy-publication-gate.ts --base origin/main`

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -755,9 +755,12 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     ...workflows.map((workflow) => workflow.project),
     ...tasks.tasks.map((task) => task.project),
   ];
+  /* Explicit project attribution can leave a foreign repository root on a
+     catalog row. Keep roots the scanner resolves back into that project. */
   const projectCwds = Object.fromEntries(
     effectiveProjectCatalog
-      .filter((entry): entry is ProjectCatalogEntry & { projectRoot: string } => Boolean(entry.projectRoot))
+      .filter((entry): entry is ProjectCatalogEntry & { projectRoot: string } =>
+        typeof entry.projectRoot === "string" && projectInfoFromCwd(entry.projectRoot)?.project === entry.project)
       .map((entry) => [entry.project, entry.projectRoot]),
   );
   const missingProjectCwds = [...new Set(visibleProjects)].filter((project) => !projectCwds[project]);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -11,7 +11,7 @@ import { replaceConversationCatalog } from "@/lib/scanner/conversationCatalog";
 import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
 import { readStateCollectionRows } from "@/lib/state/sqliteStateStore";
 import { writeSessionTitle } from "@/lib/session/titleStore";
-import type { FileEntry } from "@/lib/types";
+import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { createFilesClientCache } from "@/hooks/useFiles";
 
@@ -19,6 +19,7 @@ let scans = 0;
 let scanOptions: unknown;
 let scanProjects: Array<string | undefined> = [];
 let scannedFiles: FileEntry[] = [];
+let scannedProjectCatalog: ProjectCatalogEntry[] = [];
 let scanFileResults: FileEntry[][] = [];
 let scanPinOverlayResults: Array<string[] | undefined> = [];
 let scanCompleteResults: Array<boolean | undefined> = [];
@@ -55,6 +56,7 @@ beforeEach(() => {
   scans = 0;
   scanProjects = [];
   scannedFiles = [];
+  scannedProjectCatalog = [];
   scanFileResults = [];
   scanPinOverlayResults = [];
   scanCompleteResults = [];
@@ -104,7 +106,7 @@ mock.module("@/lib/scanner", () => ({
     scanProjects.push(project);
     scanOptions = options;
     const files = hydrateScannedFiles(scanFileResults.shift() ?? scannedFiles, options);
-    const resourceSnapshot = { files, projectCatalog: [], complete: true };
+    const resourceSnapshot = { files, projectCatalog: scannedProjectCatalog, complete: true };
     (options as { onResourceSnapshot?: (snapshot: typeof resourceSnapshot) => void }).onResourceSnapshot?.(resourceSnapshot);
     const gate = scanGates.shift();
     const signal = (options as { signal?: AbortSignal }).signal;
@@ -123,7 +125,7 @@ mock.module("@/lib/scanner", () => ({
     }
     const pinOverlayPaths = scanPinOverlayResults.shift();
     const complete = scanCompleteResults.shift();
-    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}), complete: complete ?? true };
+    return { files, projectCatalog: scannedProjectCatalog, ...(pinOverlayPaths ? { pinOverlayPaths } : {}), complete: complete ?? true };
   },
 }));
 let pipelinesStore: () => unknown[] = () => [];
@@ -250,6 +252,59 @@ test("a repository checkout recorded as a folder group's projectRoot never renam
   expect(result.projectRemap.get("dir-33333333333333333333333333333333")).toBe("dir-33333333333333333333333333333333");
   const folder = result.projectCatalog.find((entry) => entry.project.startsWith("dir-"))!;
   expect(folder.displayName).toBe("home-operator");
+});
+
+test("project cwd projection rejects repository evidence poisoned into a directory project", async () => {
+  const directoryCwd = path.join(stateDir, "plain-workspace");
+  const repositoryCwd = process.cwd();
+  fs.mkdirSync(directoryCwd, { recursive: true });
+  const directory = projectInfoFromCwd(directoryCwd)!;
+  const repository = projectInfoFromCwd(repositoryCwd)!;
+
+  scannedProjectCatalog = [
+    {
+      project: directory.project,
+      displayName: directory.displayName,
+      projectRoot: repositoryCwd,
+      smt: 20,
+      conversations: 1,
+    },
+    {
+      project: repository.project,
+      displayName: repository.displayName,
+      projectRoot: repositoryCwd,
+      smt: 10,
+      conversations: 1,
+    },
+  ];
+  replaceConversationCatalog(scannedProjectCatalog.map((entry, index) => ({
+    path: path.join(stateDir, `project-cwd-${index}.jsonl`),
+    root: "codex-sessions",
+    name: `project-cwd-${index}.jsonl`,
+    project: entry.project,
+    projectName: entry.displayName,
+    title: "Project cwd fixture",
+    firstPrompt: "",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    mtime: entry.smt,
+    size: 1,
+  })));
+  fs.writeFileSync(path.join(stateDir, "project-catalog.json"), JSON.stringify({
+    version: 2,
+    files: {
+      directory: { cwd: directoryCwd, projectRoot: repositoryCwd },
+      repository: { cwd: repositoryCwd, projectRoot: repositoryCwd },
+    },
+  }));
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { projectCwds?: Record<string, string> };
+
+  expect(body.projectCwds?.[directory.project]).toBe(directoryCwd);
+  expect(body.projectCwds?.[repository.project]).toBe(repositoryCwd);
+  expect(body.projectCwds?.[directory.project]).not.toBe(body.projectCwds?.[repository.project]);
 });
 
 test("catalog aliases collapse a legacy dashed-path variant before grouping", () => {

--- a/src/lib/scanner/projectDirectories.ts
+++ b/src/lib/scanner/projectDirectories.ts
@@ -117,7 +117,9 @@ function localProjectDirectories(): ProjectDirectory[] {
       continue;
     }
     const project = projectForCwd(cwd);
-    const projectRoot = projectRootForCwd(cwd);
+    /* A directory identity is minted from this cwd, which is also its launch
+       root when no repository contains it. */
+    const projectRoot = projectRootForCwd(cwd) ?? (project?.startsWith("dir-") ? cwd : undefined);
     const key = project ? `${project}\0${cwd}` : "";
     if (!project || !projectRoot || seen.has(key)) continue;
     seen.add(key);


### PR DESCRIPTION
## Diagnosis

The files response built `projectCwds` by copying every consolidated catalog `projectRoot` directly. Explicit project attribution can leave a session-derived foreign repository root on another project catalog row, so the foreign root became the launch cwd without an ownership check.

The recovery path also discarded repository-less directory evidence because it required `projectRootForCwd(cwd)` to succeed. Once a poisoned root is rejected, a directory project therefore had no way to recover its own directory.

## Fix

- accept a catalog root only when the existing scanner `projectInfoFromCwd` resolver maps it back into the projected project
- treat a resolver-confirmed `dir-` cwd as its own launch root in project-directory fallbacks
- add a response-level poisoned-evidence regression covering distinct directory and repository projects

## Verification

- `bun test src/app/api/files/route.test.ts` — 87 passed
- `bun test src/lib/scanner/projectDirectories.test.ts` — 3 passed
- `bunx tsc --noEmit` — passed
- `bun scripts/privacy-publication-gate.ts --base origin/main` — passed
- fresh full-diff review — no findings

Closes https://github.com/Latand/live-log-viewer-next/issues/1012