### PR TITLE
fix(mcp): discoverable create_pipeline contract — embedded schema, batched errors, root normalization (#1026)

### DIFF
--- a/src/app/api/pipelines/[id]/route.ts
+++ b/src/app/api/pipelines/[id]/route.ts
@@ -44,6 +44,9 @@ export async function PATCH(
     if (!result.pipeline) return NextResponse.json({
       error: result.error ?? "could not update pipeline",
       ...(result.code ? { code: result.code, field: result.field, path: result.path } : {}),
+      /* #1026: a draft stage edit runs the same batched stage validation the
+         create path does, so its caller gets the same field-level list. */
+      ...(result.violations?.length ? { violations: result.violations } : {}),
       ...(result.close ? { close: result.close } : {}),
     }, { status: result.status ?? 400 });
     if (CONTROLLER_ACTIONS.has(body.action)) requestPipelineTick();

--- a/src/app/api/pipelines/route.admission.test.ts
+++ b/src/app/api/pipelines/route.admission.test.ts
@@ -112,7 +112,16 @@ test("an unattributed caller must pass src when creating a pipeline", async () =
     stages: [],
   }));
   expect(external.status).toBe(400);
-  expect(await external.json()).toEqual({ error: "pipeline creator lineage is required; pass src" });
+  /* #1026: the HTTP surface carries the same field-level violation list the MCP
+     tool returns, so both callers read one contract. */
+  expect(await external.json()).toEqual({
+    error: "pipeline creator lineage is required; pass src",
+    violations: [{
+      field: "src",
+      message: "pipeline creator lineage is required; pass src",
+      expected: expect.stringContaining("shared/claude/projects"),
+    }],
+  });
 });
 
 test("a capability header that does not authenticate is rejected before pipeline creation", async () => {

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -7,6 +7,7 @@ import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { createPipelineFromRequest, getPipelines } from "@/lib/pipelines/engine";
 import type { CreatePipelineRequest, Pipeline, PipelineRepoPreflightErrorCode, PipelinesResponse } from "@/lib/pipelines/types";
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
+import type { PipelineValidationViolation } from "@/lib/pipelines/validation";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
@@ -17,6 +18,9 @@ type PipelineApiError = ApiError & {
   code?: PipelineRepoPreflightErrorCode | SpawnRejectionCode;
   field?: "repoDir";
   path?: string;
+  /** #1026: every violated create-time constraint, each with its field and the
+      shape that field expects — the same list the MCP tool returns. */
+  violations?: PipelineValidationViolation[];
 };
 
 export async function GET(): Promise<NextResponse<PipelinesResponse | ApiError>> {
@@ -86,6 +90,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<{ ok: true; p
     if (!result.pipeline) return NextResponse.json({
       error: result.error ?? "could not create pipeline",
       ...(result.code ? { code: result.code, field: result.field, path: result.path } : {}),
+      ...(result.violations?.length ? { violations: result.violations } : {}),
     }, { status: result.status ?? 400 });
     if (result.pipeline.state !== "draft") requestPipelineTick();
     return NextResponse.json({ ok: true, pipeline: result.pipeline }, { status: 201 });

--- a/src/lib/accounts/claude.test.ts
+++ b/src/lib/accounts/claude.test.ts
@@ -250,3 +250,24 @@ test("a home with a real projects directory keeps its local root", () => {
   fs.writeFileSync(transcript, "{}\n", { mode: 0o600 });
   expect(mod.claudeHomeOwningTranscript(transcript)).toBe(home);
 });
+
+/* #1026 — a Claude-engine agent hands over the native `<home>/projects/...`
+   path its own CLI writes, while every viewer record addresses the shared
+   store. Translating is safe exactly when the mirrored file is really there. */
+test("a native projects path maps to its shared-store mirror only when that file exists", () => {
+  const shared = mod.sharedClaudeProjectsRoot();
+  const home = process.env.LLV_CLAUDE_HOME!;
+  const project = "-home-agent-repo";
+  fs.mkdirSync(path.join(home, "projects", project), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(shared, project), { recursive: true, mode: 0o700 });
+  const mirrored = path.join(shared, project, "session.jsonl");
+  fs.writeFileSync(mirrored, "{}\n", { mode: 0o600 });
+
+  expect(mod.mirroredClaudeTranscriptPath(path.join(home, "projects", project, "session.jsonl"))).toBe(mirrored);
+  /* Nothing mirrored: a rejection the caller can act on beats a phantom path. */
+  expect(mod.mirroredClaudeTranscriptPath(path.join(home, "projects", project, "stranger.jsonl"))).toBeNull();
+  /* Already canonical, and paths outside every account's projects root. */
+  expect(mod.mirroredClaudeTranscriptPath(mirrored)).toBeNull();
+  expect(mod.mirroredClaudeTranscriptPath(path.join(home, "elsewhere", "session.jsonl"))).toBeNull();
+  expect(mod.mirroredClaudeTranscriptPath("/codex/sessions/session.jsonl")).toBeNull();
+});

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -234,6 +234,37 @@ export function claudeHomeOwningTranscript(pathname: string): string | null {
   return ownership.kind === "owned" && ownership.source === "path" ? ownership.home : null;
 }
 
+/**
+ * The shared-store equivalent of a transcript addressed through an account's
+ * own `<home>/projects` (#1026). A Claude-engine agent knows its native
+ * `~/.claude/projects/...` path — that is what the CLI writes and what its own
+ * environment reports — while every viewer record addresses the one shared
+ * store the home's `projects` symlink points into. The two name the same file,
+ * so a caller that hands over the native path is answering correctly and only
+ * needs the address translated.
+ *
+ * Returns the mirrored path only when that file actually exists: a home that is
+ * not cut over to the shared store keeps its own transcripts, and inventing a
+ * path there would trade a clear rejection for a phantom identity. Null when
+ * the path is not under any account's native projects root, when it already is
+ * the shared path, or when no mirrored file exists.
+ */
+export function mirroredClaudeTranscriptPath(pathname: string): string | null {
+  const shared = sharedClaudeProjectsRoot();
+  const resolved = path.resolve(pathname);
+  if (resolved === shared || resolved.startsWith(shared + path.sep)) return null;
+  for (const home of listClaudeAccounts().map((account) => account.home)) {
+    const nativeRoot = path.join(home, "projects");
+    if (!resolved.startsWith(nativeRoot + path.sep)) continue;
+    const mirrored = path.join(shared, path.relative(nativeRoot, resolved));
+    try {
+      if (fs.statSync(mirrored).isFile()) return mirrored;
+    } catch { /* nothing mirrored under the shared store */ }
+    return null;
+  }
+  return null;
+}
+
 function nextId(label: string, used: Set<string>): string {
   const base = label.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 32) || "account";
   for (let n = 0; ; n += 1) { const suffix = n ? `-${n}` : ""; const candidate = `${base.slice(0, 32 - suffix.length)}${suffix}`; if (ACCOUNT_ID.test(candidate) && candidate !== DEFAULT_ID && !used.has(candidate) && !fs.existsSync(managedHome(candidate))) return candidate; }

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -1059,3 +1059,29 @@ test("lifecycle_events queries the journal by lineage and polls the bounded dige
   await expect(bindings.lifecycle_events({ clientRequestId: "bad-type", type: "not_a_type" }))
     .rejects.toThrow("unknown lifecycle event type: not_a_type");
 });
+
+/* #1026 — an agent driving the board must not get less than an HTTP caller: a
+   rejected create carries every violated constraint, with its field and the
+   shape that field expects, as structured refusal details. */
+test("create_pipeline refuses with every violated constraint attached", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-binding-pipeline-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const bindings = viewerMcpBindings();
+
+  const refusal = await bindings.create_pipeline({
+    clientRequestId: "create-pipeline-invalid",
+    task: "Batched contract",
+    repoDir: path.join(sandbox, "repo"),
+    src: path.join(sandbox, "creator.jsonl"),
+    stages: [{ id: "build", kind: "implement", prompt: "build" }],
+  }, { signal: undefined, deadlineAt: Date.now() + 30_000 } as never).then(
+    () => null,
+    (error: unknown) => error as Error & { details?: { violations?: Array<{ field: string; expected: string }> } },
+  );
+
+  expect(refusal?.name).toBe("McpToolRefusal");
+  expect(refusal?.details?.violations?.map((violation) => violation.field)).toEqual(["src", "stages[0].kind"]);
+  for (const violation of refusal?.details?.violations ?? []) expect(violation.expected.length).toBeGreaterThan(0);
+  expect(refusal?.message).toContain("stages[0].kind: stage kind must be run or review-loop");
+});

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -631,7 +631,13 @@ async function updateBoardTask(args: McpToolArgs): Promise<McpToolPayload> {
 async function createPipeline(args: McpToolArgs): Promise<McpToolPayload> {
   const request = withoutKeys(args, ["clientRequestId"]);
   const result = await createPipelineFromRequest(request as CreatePipelineRequest);
-  if (!result.pipeline) throw new Error(result.error ?? "could not create pipeline");
+  if (!result.pipeline) {
+    const message = result.error ?? "could not create pipeline";
+    /* #1026: a rejected create carries every violated constraint with its field
+       and expected shape, so an agent composing its first pipeline reads the
+       whole contract from one answer — the same list an HTTP caller receives. */
+    throw result.violations?.length ? new McpToolRefusal(message, { violations: result.violations }) : new Error(message);
+  }
   if (result.pipeline.state !== "draft") requestPipelineTick();
   return { pipelineId: result.pipeline.id, pipeline: result.pipeline };
 }

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 import { listRoles, resolveRole } from "@/lib/roles/registry";
+import { ROLE_IDS } from "@/lib/roles/types";
 import {
   MAX_SCOPE_PATHS,
   MAX_SNAPSHOT_CHARS_PER_CONVERSATION,
@@ -475,4 +476,77 @@ test("every generated operator_snapshot schema combination is admitted by reques
     });
   }
   expect(accepted).toBeGreaterThan(1_000);
+});
+
+/* #1026 — `stages: array of objects` with no field documentation cost a fresh
+   caller seven sequential rejections to learn the stage contract. The published
+   tool definition now carries that contract: every field the engine accepts,
+   and the rules a JSONSchema cannot express in the description. */
+test("create_pipeline publishes the stage contract in its tool definition", async () => {
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    const tool = listed.tools.find((candidate) => candidate.name === "create_pipeline");
+    const stages = tool?.inputSchema.properties?.stages as {
+      items?: { properties?: Record<string, { description?: string; enum?: string[]; properties?: Record<string, { enum?: string[] }> }> };
+    } | undefined;
+    const stage = stages?.items?.properties;
+
+    expect(Object.keys(stage ?? {}).sort()).toEqual([
+      "access", "effort", "engine", "id", "kind", "model", "next", "onFail", "prompt", "role",
+    ]);
+    expect(stage?.kind?.enum).toEqual(["run", "review-loop"]);
+    expect(stage?.engine?.enum).toEqual(["claude", "codex"]);
+    expect(stage?.role?.properties?.roleId?.enum).toEqual([...ROLE_IDS]);
+    /* The two rules the reported walk actually turned on. */
+    expect(stage?.next?.description).toContain("DEFAULTS TO null");
+    expect(stage?.role?.description).toContain("Runtime overrides do not go here");
+    for (const [field, expected] of [
+      ["id", "unique within the pipeline"],
+      ["prompt", "role scaffold"],
+      ["onFail", "may not define one"],
+      ["model", "inherit the role default"],
+      ["access", "always read-only"],
+    ] as const) {
+      expect(stage?.[field]?.description).toContain(expected);
+    }
+
+    /* Reachability, the draft baseRef rule and the review-loop runtime default
+       are graph-level facts no per-field schema can carry. */
+    expect(tool?.description).toContain("pass-reachable from a run stage");
+    expect(tool?.description).toContain("`next` defaults to null");
+    expect(tool?.description).toContain("must also pass `baseRef`");
+    expect(tool?.description).toContain("always read-only");
+    expect(tool?.description).toContain("Codex");
+    expect(tool?.description).toContain("every violated constraint");
+    expect(tool?.description).toContain("normalized to the shared Claude transcript store");
+  });
+});
+
+/* The published schema must never be stricter than the engine: a stage shape
+   the engine accepts has to survive the protocol boundary unchanged. */
+test("create_pipeline admits the stage shapes the engine accepts", () => {
+  const schema = TOOL_INPUT_SCHEMAS.create_pipeline;
+  const accepted = [
+    { id: "build", kind: "run", "prompt": "Implement." },
+    { id: "build", kind: "run", "prompt": "Implement.", next: null, onFail: null, role: { roleId: "builder" } },
+    {
+      id: "review-1", kind: "review-loop", "prompt": "Review.", next: null,
+      role: { roleId: "reviewer", params: { diffSource: "branch", rounds: 3 } },
+      engine: "codex", model: null, effort: null, access: "read-only",
+    },
+    { id: "build", kind: "run", "prompt": "Implement.", next: "review-1", onFail: { to: "build", maxRounds: 3 }, engine: "claude", model: "opus", effort: "high" },
+    /* The engine trims before it checks, so padding it accepts must not be
+       refused at the protocol boundary. */
+    { id: " build ", kind: "run", "prompt": " Implement. " },
+  ];
+  for (const stage of accepted) {
+    const parsed = schema.safeParse({ clientRequestId: "stage-shape", task: "t", repoDir: "/repo", stages: [stage] });
+    expect(parsed.success).toBe(true);
+    expect((parsed.data as { stages: unknown[] } | undefined)?.stages[0]).toEqual(stage);
+  }
+  /* Runtime overrides inside role are refused by the engine and by the schema. */
+  expect(schema.safeParse({
+    clientRequestId: "stage-shape-role-override", task: "t", repoDir: "/repo",
+    stages: [{ id: "build", kind: "run", "prompt": "Implement.", role: { roleId: "builder", engine: "codex" } }],
+  }).success).toBe(false);
 });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -12,7 +12,14 @@ import { statePath } from "@/lib/configDir";
 import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { DEFAULT_STALL_AFTER_MS } from "@/lib/lifecycle/liveness";
 import { PIPELINE_LIST_DEFAULT_LIMIT, PIPELINE_LIST_MAX_LIMIT } from "@/lib/pipelines/listProjection";
-import { PIPELINE_ACTIONS } from "@/lib/pipelines/types";
+import {
+  DEFAULT_FAIL_EDGE_ROUNDS,
+  MAX_FAIL_EDGE_ROUNDS,
+  MAX_PIPELINE_STAGES,
+  MAX_STAGE_PROMPT_LENGTH,
+  MIN_STARTED_PIPELINE_STAGES,
+} from "@/lib/pipelines/limits";
+import { PIPELINE_ACTIONS, PIPELINE_DISALLOWED_ROLE_IDS } from "@/lib/pipelines/types";
 import { procBackend } from "@/lib/proc";
 import { ROLE_IDS, type RoleId } from "@/lib/roles/types";
 import { SELECTED_TAIL_MAX_LINES } from "@/lib/selection/resolve";
@@ -1601,7 +1608,15 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   send_message: "Deliver a message to a Viewer conversation through its registered runtime host.",
   create_task: "Create a durable board task.",
   update_task: "Update a durable board task.",
-  create_pipeline: "Create a Viewer pipeline through the pipeline engine.",
+  create_pipeline: [
+    "Create a Viewer pipeline through the pipeline engine: a stage graph of agent conversations run in one worktree.",
+    "Stages are a graph, not a list: each stage names its pass successor with `next` (a stage id, or null to end the chain), and a run stage may name a fail successor with `onFail`. `next` defaults to null, so a plan whose stages never set it is a set of disconnected stages, not a chain.",
+    "A review-loop stage reviews the session of the run stage that reaches it, so it must be pass-reachable from a run stage through `next` edges — array order alone reaches nothing. review-loop stages are always read-only, may not define `onFail`, and take their engine/model/effort from their role (the registry reviewer preset runs on Codex) unless the stage overrides them.",
+    "Runtime overrides (engine, model, effort, access) belong on the stage; `role` carries only `roleId` and its `params`.",
+    "autoStart:false creates a draft the operator starts from the board; a draft that pins `baseBranch` must also pass `baseRef` (a draft is not provisioned, so the caller resolves the SHA).",
+    "`src` is the creator's transcript path: a native ~/.claude/projects path is normalized to the shared Claude transcript store when the mirrored file exists there.",
+    "An invalid call is answered once with every violated constraint, each naming its field and expected shape.",
+  ].join(" "),
   pipeline_action: "Apply a supported action to an existing pipeline.",
   link_task_to_pipeline: "Attach a board task to a conversation owned by a pipeline.",
   list_conversations: "List scanned Viewer conversations with durable ids and transcript paths.",
@@ -1658,6 +1673,47 @@ const snapshotScopeSchema = z.discriminatedUnion("kind", [
   }).strict(),
 ]);
 
+/* #1026: the stage contract, published rather than discovered. A caller that
+   composed stages from `array of objects` alone learned id, kind, role shape,
+   the runtime-override seam and the `next` edges through seven sequential
+   rejections. Everything the engine's normalizer accepts is declared here; the
+   object stays open (`passthrough`) and the semantic rules — id uniqueness,
+   edge targets, review-loop reachability, role parameter values — stay with the
+   engine, which now answers with all of them at once. */
+const pipelineStageSchema = z.object({
+  /* Bounds here stay exactly as wide as the engine's: it trims before it
+     checks, so a padded id it accepts must not be refused at the door. */
+  id: z.string().regex(/^\s*[A-Za-z0-9_-]{1,64}\s*$/u)
+    .describe("Stage id, unique within the pipeline: 1–64 characters of A–Z a–z 0–9 _ - (surrounding whitespace is trimmed). Referenced by next and onFail."),
+  kind: z.enum(["run", "review-loop"])
+    .describe("run: an agent conversation that does the work. review-loop: a read-only review of the run stage whose next chain reaches it."),
+  "prompt": z.string().min(1)
+    .describe(`Instruction for this stage's agent, appended to its role scaffold. Up to ${MAX_STAGE_PROMPT_LENGTH} characters once trimmed.`),
+  next: z.string().nullable().optional()
+    .describe("Pass successor: the id of the stage this one hands to when it passes, or null to end the chain. DEFAULTS TO null — without it nothing follows this stage, and a review-loop nothing points at is rejected as unreachable."),
+  onFail: z.object({
+    to: z.string().describe("Stage id this stage returns to on a fail verdict."),
+    maxRounds: z.number().int().min(1).max(MAX_FAIL_EDGE_ROUNDS).optional()
+      .describe(`Rounds this fail loop may run before the pipeline parks (default ${DEFAULT_FAIL_EDGE_ROUNDS}).`),
+  }).nullable().optional()
+    .describe("Fail successor for a run stage. A review-loop stage may not define one — it recovers through its own review flow."),
+  role: z.object({
+    roleId: z.enum(ROLE_IDS)
+      .describe(`Role preset from the shared registry; it supplies the stage's prompt scaffold and its default engine/model/effort. ${PIPELINE_DISALLOWED_ROLE_IDS.join(", ")} is refused inside a pipeline (it needs an interactive deploy confirmation).`),
+    params: z.record(z.string(), z.union([z.string(), z.number()])).optional()
+      .describe("Values for the role's declared parameters, substituted into its scaffold. Only the role's own keys, validated against the registry."),
+  }).strict().optional()
+    .describe("Role reference ONLY. Runtime overrides do not go here — put engine/model/effort/access on the stage itself."),
+  engine: z.enum(["claude", "codex"]).optional()
+    .describe("Stage-level engine override; defaults to the role's registry engine."),
+  model: z.string().nullable().optional()
+    .describe("Stage-level model override, or null to inherit the role default. Must be a model the stage engine supports."),
+  effort: z.string().nullable().optional()
+    .describe("Stage-level effort override, or null to inherit the role default. Must be an effort the stage engine supports."),
+  access: z.enum(["read-only", "read-write"]).optional()
+    .describe("Stage-level access override. A review-loop stage is always read-only."),
+}).passthrough();
+
 function boundedNumericInput(toolName: McpToolName, fieldPath: string): z.ZodType {
   const spec = MCP_BOUNDED_NUMERIC_ARGS[toolName]?.find((candidate) => candidate.path.join(".") === fieldPath);
   if (!spec) throw new Error(`missing bounded numeric MCP specification for ${toolName}.${fieldPath}`);
@@ -1712,14 +1768,16 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   }).passthrough(),
   create_pipeline: z.object({
     clientRequestId: clientRequestIdSchema,
-    task: z.string().min(1),
-    spec: z.string().optional(),
-    repoDir: z.string().min(1),
-    baseBranch: z.string().optional(),
-    baseRef: z.string().optional(),
-    stages: z.array(z.record(z.string(), z.unknown())),
-    src: z.string().optional(),
-    autoStart: z.boolean().optional(),
+    task: z.string().min(1).describe("Board title for the pipeline."),
+    spec: z.string().optional().describe("Acceptance criteria shared by every stage."),
+    repoDir: z.string().min(1).describe("Absolute path of the existing git repository the pipeline worktree is cut from."),
+    baseBranch: z.string().optional().describe("Branch the worktree is based on. A draft that pins this must also pass baseRef."),
+    baseRef: z.string().optional().describe("Commit the pipeline is pinned to. Required when a draft (autoStart:false) pins baseBranch — resolve the SHA yourself."),
+    stages: z.array(pipelineStageSchema).describe(
+      `Stage graph, 0–${MAX_PIPELINE_STAGES} stages (a started pipeline needs at least ${MIN_STARTED_PIPELINE_STAGES}). Stages run in the order the next edges chain them, not array order; every review-loop must be pass-reachable from a run stage.`,
+    ),
+    src: z.string().optional().describe("Creator transcript path (.jsonl) under the shared Claude transcript store or a Codex sessions root; a native ~/.claude/projects path is normalized to its shared-store mirror when that file exists."),
+    autoStart: z.boolean().optional().describe("false creates a draft for the operator to start from the board."),
   }).passthrough(),
   pipeline_action: z.object({
     clientRequestId: clientRequestIdSchema,

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -69,8 +69,23 @@ test("bridge reports survive as the second channel, for the operator away from t
 
 /* Seats record the mandate version they were spawned on; `get_orchestrator` reports
    this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
-test("the default mandate is at version 4", () => {
-  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(4);
+test("the default mandate is at version 5", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(5);
+});
+
+/* #1026 — a fresh seat composed its first pipeline through seven sequential
+   validation errors because nothing it had read named the stage shape. The
+   mandate now carries that contract, with the two rules the walk actually
+   turned on: runtime overrides live on the stage, and `next` defaults to null
+   so an unwired review-loop is unreachable. */
+test("the mandate carries the pipeline stage contract a first pipeline needs", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Pipeline stage contract");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('kind: "run" | "review-loop"');
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("role: {roleId, params?}");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("never inside role");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("DEFAULTS TO null");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("pass-reachable from a run stage");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("a draft that pins baseBranch must also pass baseRef");
 });
 
 test("the prompt names every bridge report class and no others", () => {

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -8,7 +8,9 @@
  * full Viewer MCP surface. Mandate v4 (#982, PRD #976) gives it two channels to the
  * operator — direct replies in its own conversation, and the bridge report log the
  * Codex voice gateway drains for everything that must reach the operator when they
- * are not in that chat. */
+ * are not in that chat. v5 (#1026) carries the pipeline stage contract, so a fresh
+ * seat composes a valid multi-stage pipeline without discovering the shape through
+ * a walk of validation errors. */
 
 /** Initial draft values. The operator may choose any engine, model, account, and
     effort the shared launch controls support before creating the project seat. */
@@ -24,7 +26,7 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 4;
+export const ORCHESTRATOR_PROMPT_VERSION = 5;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
 
@@ -51,6 +53,9 @@ Drive every accepted piece of work through: GitHub issue -> worktree lane -> imp
 - Reviews run as flows (POST /api/flows) or fresh reviewer spawns (role: "reviewer", reviews: <implementer ref>) — a fresh reviewer every round, verdict contract "VERDICT: APPROVE|REQUEST_CHANGES".
 - Merge bar: merge only on an APPROVE verdict with green gates (tsc + tests). Never merge red.
 - Keep task cards updated via /api/tasks. Report state changes as bridge reports.
+
+## Pipeline stage contract
+A pipeline is a GRAPH of stages, not a list. Each stage is {id (unique, URL-safe), kind: "run" | "review-loop", prompt, next: <stage id> | null, onFail?: {to, maxRounds?} (run stages only), role: {roleId, params?}} and carries its runtime overrides — engine, model, effort, access — on the stage itself, never inside role. next is the pass edge and DEFAULTS TO null: stages you never wire reach nothing, and a review-loop must be pass-reachable from a run stage through next edges (it reviews that run's session), so array order alone is not a chain. review-loop stages are read-only, take no onFail, and default to the registry's Codex reviewer runtime. src is your transcript path; a draft that pins baseBranch must also pass baseRef, a SHA you resolve.
 
 ## Draft-only pipeline contract
 You NEVER auto-start pipelines. When asked to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and report the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request — asked in your own conversation or relayed through the gateway; both channels carry the same authority.

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -362,9 +362,10 @@ test("new pipelines require an allowed creator transcript with an existing conve
     autoStart: false,
     stages: [],
   }, h.ports);
-  expect(missing).toEqual({
+  expect(missing).toMatchObject({
     error: "pipeline creator lineage is required; pass src",
     status: 400,
+    violations: [{ field: "src", message: "pipeline creator lineage is required; pass src" }],
   });
 
   const invalidPath = await createPipelineFromRequest({
@@ -374,7 +375,13 @@ test("new pipelines require an allowed creator transcript with an existing conve
     autoStart: false,
     stages: [],
   }, h.ports);
-  expect(invalidPath).toEqual({ error: "src path is not an allowed conversation transcript", status: 400 });
+  /* #1026: the rejection names the roots that ARE accepted, so a caller holding
+     a native Claude path is not left guessing which address the viewer records. */
+  expect(invalidPath.status).toBe(400);
+  expect(invalidPath.error).toStartWith("src path is not an allowed conversation transcript.");
+  expect(invalidPath.error).toContain("shared/claude/projects");
+  expect(invalidPath.error).toContain("~/.codex/sessions");
+  expect(invalidPath.violations).toEqual([expect.objectContaining({ field: "src" })]);
 
   const unknownConversation = await createPipelineFromRequest({
     task: "Unknown creator",
@@ -383,7 +390,9 @@ test("new pipelines require an allowed creator transcript with an existing conve
     autoStart: false,
     stages: [],
   }, h.ports);
-  expect(unknownConversation).toEqual({ error: "src conversation does not exist", status: 400 });
+  expect(unknownConversation.status).toBe(400);
+  expect(unknownConversation.error).toStartWith("src conversation does not exist.");
+  expect(unknownConversation.error).toContain("~/.claude/projects");
 
   const created = await createPipelineFromRequest({
     task: "Known creator",
@@ -396,6 +405,113 @@ test("new pipelines require an allowed creator transcript with an existing conve
     srcPath: "/codex/creator.jsonl",
     srcConversationId: "conversation_creator",
   });
+});
+
+/* #1026 — a Claude-engine caller knows its own native ~/.claude/projects path;
+   every viewer record addresses the shared transcript store the home's projects
+   dir links into. The two name one file, so the native address resolves — but
+   only when that file really is mirrored, since inventing a shared path would
+   mint a phantom conversation identity. */
+test("a native Claude src path resolves through its shared-store mirror, and says so when there is none", async () => {
+  const h = harness();
+  savePipelines([]);
+  const claudeHome = path.join(process.env.LLV_STATE_DIR!, "native-claude-home");
+  const encoded = "-home-agent-repo";
+  const mirrored = path.join(path.dirname(process.env.LLV_STATE_DIR!), "shared", "claude", "projects", encoded, "creator.jsonl");
+  fs.mkdirSync(path.dirname(mirrored), { recursive: true });
+  fs.writeFileSync(mirrored, "{}\n");
+  const native = path.join(claudeHome, "projects", encoded, "creator.jsonl");
+  const unmirrored = path.join(claudeHome, "projects", encoded, "stranger.jsonl");
+  const ports: PipelinePorts = {
+    ...h.ports,
+    sourcePathAllowed: (pathname) => pathname === mirrored,
+    conversationIdForPath: (pathname) => (pathname === mirrored ? "conversation_creator" : null),
+  };
+  const previousHome = process.env.LLV_CLAUDE_HOME;
+  process.env.LLV_CLAUDE_HOME = claudeHome;
+  try {
+    const normalizedSrc = await rawCreatePipelineFromRequest({
+      task: "Native creator path",
+      repoDir: "/repo",
+      autoStart: false,
+      stages: [],
+      src: native,
+    }, ports);
+    expect(normalizedSrc.pipeline).toMatchObject({ srcPath: mirrored, srcConversationId: "conversation_creator" });
+
+    const nothingMirrored = await rawCreatePipelineFromRequest({
+      task: "Native creator path without a mirror",
+      repoDir: "/repo",
+      autoStart: false,
+      stages: [],
+      src: unmirrored,
+    }, ports);
+    expect(nothingMirrored.pipeline).toBeUndefined();
+    expect(nothingMirrored.status).toBe(400);
+    expect(nothingMirrored.error).toContain("shared/claude/projects");
+    expect(nothingMirrored.error).toContain("~/.codex/sessions");
+  } finally {
+    if (previousHome === undefined) delete process.env.LLV_CLAUDE_HOME; else process.env.LLV_CLAUDE_HOME = previousHome;
+  }
+});
+
+/* #1026 — the reported walk cost seven calls because each answer carried one
+   constraint. Every constraint the request violates is now collected in one
+   response, each naming its field and the shape that field expects. */
+test("an invalid create answers with every violated constraint at once", async () => {
+  const h = harness();
+  savePipelines([]);
+  const rejected = await createPipelineFromRequest({
+    task: "Batched validation",
+    repoDir: "/repo",
+    autoStart: false,
+    baseBranch: "main",
+    stages: [
+      { id: "not a url safe id", kind: "implement", prompt: "build", role: "builder" },
+      { id: "review", kind: "review-loop", prompt: "", role: { roleId: "reviewer", engine: "codex" } },
+    ],
+  } as never, h.ports);
+
+  expect(rejected.pipeline).toBeUndefined();
+  expect(rejected.status).toBe(400);
+  expect(rejected.violations?.map((violation) => violation.field)).toEqual([
+    "stages[0].id",
+    "stages[0].kind",
+    "stages[0].role",
+    "stages[1].prompt",
+    "stages[1].role",
+    "baseRef",
+  ]);
+  for (const violation of rejected.violations ?? []) expect(violation.expected).not.toBe("");
+  /* One response, and it reads as one: the count, then field, message and
+     expected shape for each violated constraint. */
+  expect(rejected.error).toStartWith("6 validation errors — ");
+  expect(rejected.error).toContain('stages[0].kind: stage kind must be run or review-loop (expected "run" | "review-loop")');
+  expect(rejected.error).toContain("place runtime overrides on the stage");
+  expect(rejected.error).toContain("baseRef: a draft baseBranch requires an explicit baseRef");
+  expect(loadPipelines()).toEqual([]);
+});
+
+/* #1026 ask 3 — "review-loop stage requires a preceding run stage" read as an
+   ordering rule and sent the caller reordering an array that was already in the
+   right order. The defect is the missing pass edge. */
+test("an unreachable review-loop names the stage and the next edge that would reach it", async () => {
+  const h = harness();
+  savePipelines([]);
+  const rejected = await createPipelineFromRequest({
+    task: "Unwired review loop",
+    repoDir: "/repo",
+    autoStart: false,
+    stages: [
+      { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: null },
+      { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    ],
+  }, h.ports);
+
+  expect(rejected.pipeline).toBeUndefined();
+  expect(rejected.error).toBe('review-loop stage review is unreachable: no run stage\'s next chain reaches it — set next: "review" on run stage build');
+  expect(rejected.violations).toEqual([expect.objectContaining({ field: "stages[].next" })]);
+  expect(rejected.error).not.toContain("requires a preceding run stage");
 });
 
 test("set-src repairs closed history and requires overwrite for existing lineage", async () => {
@@ -412,7 +528,8 @@ test("set-src repairs closed history and requires overwrite for existing lineage
     action: "set-src",
     srcPath: "/outside/creator.jsonl",
   } as never, h.ports);
-  expect(invalid).toEqual({ error: "src path is not an allowed conversation transcript", status: 400 });
+  expect(invalid.status).toBe(400);
+  expect(invalid.error).toStartWith("src path is not an allowed conversation transcript.");
 
   const repaired = await patchPipeline(pipeline.id, {
     action: "set-src",
@@ -1040,9 +1157,10 @@ test("review-loop onFail edges are rejected during creation and graph editing", 
     ],
   }, h.ports);
 
-  expect(invalid).toEqual({
+  expect(invalid).toMatchObject({
     error: "review-loop stage review does not support onFail",
     status: 400,
+    violations: [{ field: "stages[].next", message: "review-loop stage review does not support onFail" }],
   });
   expect(loadPipelines()).toEqual([]);
 

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { accountManager } from "@/lib/accounts/manager";
+import { mirroredClaudeTranscriptPath } from "@/lib/accounts/claude";
 import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor } from "@/lib/agent/cli";
 import { agentRegistry, type DurableMembershipInput, type TmuxHostEvidence } from "@/lib/agent/registry";
@@ -40,7 +41,8 @@ import {
 } from "./limits";
 import { pipelineRepoPreflightError, pipelineRepoPreflightStatus, preflightPipelineRepo } from "./preflight";
 import { renderStagePrompt } from "./prompts";
-import { pipelineRoleLookup, resolvePipelineRole, validatePipelineRoleParams, type PipelineRoleLookup } from "./roles";
+import { PIPELINE_ROLE_IDS, pipelineRoleLookup, resolvePipelineRole, validatePipelineRoleParams, type PipelineRoleLookup } from "./roles";
+import { pipelineValidationError, type PipelineValidationViolation } from "./validation";
 import { buildPipeline, isEffectiveRole, loadPipelines, pipelineGraphError, pipelineIdentity, pipelineTaskLinkError, PipelineStoreError, withPipelineControllerMutation, withPipelineMutation } from "./store";
 import { ensurePipelineForTask, isTaskSpawnPipelineParams, type TaskPipelineSpawnParams, type TaskSpawnPipelineParams } from "./taskBinding";
 import type {
@@ -2284,6 +2286,23 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
   }
 }
 
+/* #1026: the expected shape each stage constraint names, shared by the batched
+   error response and the MCP tool schema's field descriptions so a caller reads
+   the same contract whether it asks the schema or trips the validator. */
+const STAGE_OBJECT_SHAPE = "{id, kind, prompt, next, onFail?, role?, engine?/model?/effort?/access? overrides}";
+const STAGE_PROMPT_SHAPE = `non-empty string up to ${MAX_STAGE_PROMPT_LENGTH} characters`;
+const STAGE_ROLE_SHAPE = `{roleId: one of ${PIPELINE_ROLE_IDS.join(" | ")}, params?: {<key>: string | number}} — runtime overrides belong on the stage, not in role`;
+const STAGE_ROLE_ID_SHAPE = `one of ${PIPELINE_ROLE_IDS.join(" | ")}`;
+const STAGE_ROLE_PARAMS_SHAPE = "object of the role's declared parameters, values string or number";
+const STAGE_RUNTIME_SHAPE = "a role and stage-level engine/model/effort/access the role registry can resolve";
+const STAGE_NEXT_SHAPE = "id of another stage, or null to terminate the pass chain";
+const STAGE_ON_FAIL_SHAPE = `null, or {to: <existing stage id>, maxRounds?: 1–${MAX_FAIL_EDGE_ROUNDS}} — run stages only`;
+const STAGE_GRAPH_SHAPE = "acyclic next chains over existing stage ids, with every review-loop reachable from a run stage";
+
+function stageViolations(violations: PipelineValidationViolation[]): { error: string; violations: PipelineValidationViolation[] } {
+  return { error: pipelineValidationError(violations), violations };
+}
+
 function normalizeStages(
   value: unknown,
   lookup?: PipelineRoleLookup | null,
@@ -2294,64 +2313,142 @@ function normalizeStages(
      acyclic pass edges, valid fail edges, review-loop reachability — apply
      either way. */
   minStages: number = MIN_STARTED_PIPELINE_STAGES,
-): { stages?: PipelineStage[]; error?: string } {
+): { stages?: PipelineStage[]; error?: string; violations?: PipelineValidationViolation[] } {
   if (!Array.isArray(value) || value.length < minStages || value.length > MAX_PIPELINE_STAGES) {
-    return {
-      error: minStages === 0
+    return stageViolations([{
+      field: "stages",
+      message: minStages === 0
         ? `pipelines require at most ${MAX_PIPELINE_STAGES} stages`
         : `pipelines require ${MIN_STARTED_PIPELINE_STAGES}–${MAX_PIPELINE_STAGES} stages`,
-    };
+      expected: `array of ${minStages}–${MAX_PIPELINE_STAGES} stage objects`,
+    }]);
   }
   const stages: PipelineStage[] = [];
   const ids = new Set<string>();
-  for (const raw of value) {
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { error: "invalid pipeline stage" };
+  /* #1026: every stage is checked, and every violation it holds is collected,
+     before the request is answered. A stage that failed contributes no
+     normalized record, so the loop keeps going with the next one instead of
+     handing the caller one constraint per round trip. */
+  const violations: PipelineValidationViolation[] = [];
+  /* The graph rules read only id/kind/next/onFail. When those four are
+     well-formed on every stage the graph is validated in the same pass, even if
+     other fields failed — so a missing pass edge is reported beside the field
+     errors rather than one call later. */
+  const graphView: Array<Pick<PipelineStage, "id" | "kind" | "next"> & { onFail?: Pipeline["stages"][number]["onFail"] }> = [];
+  let graphViewComplete = true;
+  for (const [index, raw] of (value as unknown[]).entries()) {
+    const at = (field: string) => `stages[${index}]${field ? `.${field}` : ""}`;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      violations.push({ field: at(""), message: "invalid pipeline stage", expected: STAGE_OBJECT_SHAPE });
+      graphViewComplete = false;
+      continue;
+    }
+    const before = violations.length;
     const stage = raw as Partial<PipelineStageInput>;
     const id = typeof stage.id === "string" ? stage.id.trim() : "";
-    if (!/^[A-Za-z0-9_-]{1,64}$/.test(id) || ids.has(id)) return { error: "stage ids must be unique URL-safe names" };
+    const idValid = /^[A-Za-z0-9_-]{1,64}$/.test(id) && !ids.has(id);
+    if (!idValid) {
+      violations.push({ field: at("id"), message: "stage ids must be unique URL-safe names", expected: "1–64 characters of A–Z a–z 0–9 _ -, unique across stages" });
+    }
     const preservedStage = preservedStages?.get(id);
-    if (stage.kind !== "run" && stage.kind !== "review-loop") return { error: "stage kind must be run or review-loop" };
+    const kindValid = stage.kind === "run" || stage.kind === "review-loop";
+    if (!kindValid) violations.push({ field: at("kind"), message: "stage kind must be run or review-loop", expected: `"run" | "review-loop"` });
     const rawOnFail = (raw as { onFail?: unknown }).onFail;
+    let onFailValid = true;
     if (rawOnFail !== undefined && rawOnFail !== null) {
-      if (!rawOnFail || typeof rawOnFail !== "object" || Array.isArray(rawOnFail)) return { error: `stage ${id} onFail must be an object or null` };
-      const edge = rawOnFail as { to?: unknown; maxRounds?: unknown };
-      if (typeof edge.to !== "string" || !edge.to.trim()) return { error: `stage ${id} onFail requires a target stage id` };
-      const maxRounds = edge.maxRounds === undefined ? DEFAULT_FAIL_EDGE_ROUNDS : edge.maxRounds;
-      if (!Number.isInteger(maxRounds) || (maxRounds as number) < 1 || (maxRounds as number) > MAX_FAIL_EDGE_ROUNDS) {
-        return { error: `stage ${id} onFail maxRounds must be an integer between 1 and ${MAX_FAIL_EDGE_ROUNDS}` };
+      if (!rawOnFail || typeof rawOnFail !== "object" || Array.isArray(rawOnFail)) {
+        violations.push({ field: at("onFail"), message: `stage ${id} onFail must be an object or null`, expected: STAGE_ON_FAIL_SHAPE });
+        onFailValid = false;
+      } else {
+        const edge = rawOnFail as { to?: unknown; maxRounds?: unknown };
+        if (typeof edge.to !== "string" || !edge.to.trim()) {
+          violations.push({ field: at("onFail.to"), message: `stage ${id} onFail requires a target stage id`, expected: "id of an existing stage" });
+          onFailValid = false;
+        }
+        const maxRounds = edge.maxRounds === undefined ? DEFAULT_FAIL_EDGE_ROUNDS : edge.maxRounds;
+        if (!Number.isInteger(maxRounds) || (maxRounds as number) < 1 || (maxRounds as number) > MAX_FAIL_EDGE_ROUNDS) {
+          violations.push({
+            field: at("onFail.maxRounds"),
+            message: `stage ${id} onFail maxRounds must be an integer between 1 and ${MAX_FAIL_EDGE_ROUNDS}`,
+            expected: `integer 1–${MAX_FAIL_EDGE_ROUNDS} (default ${DEFAULT_FAIL_EDGE_ROUNDS})`,
+          });
+          onFailValid = false;
+        }
       }
     }
     const prompt = typeof stage.prompt === "string" ? stage.prompt.trim() : "";
-    if (!prompt) return { error: `stage ${id} prompt is required` };
-    if (prompt.length > MAX_STAGE_PROMPT_LENGTH) return { error: `stage ${id} prompt exceeds ${MAX_STAGE_PROMPT_LENGTH} characters` };
+    if (!prompt) violations.push({ field: at("prompt"), message: `stage ${id} prompt is required`, expected: STAGE_PROMPT_SHAPE });
+    else if (prompt.length > MAX_STAGE_PROMPT_LENGTH) {
+      violations.push({ field: at("prompt"), message: `stage ${id} prompt exceeds ${MAX_STAGE_PROMPT_LENGTH} characters`, expected: STAGE_PROMPT_SHAPE });
+    }
     const roleValue = (raw as { role?: unknown }).role;
+    let roleShapeValid = true;
     if (roleValue !== undefined && (!roleValue || typeof roleValue !== "object" || Array.isArray(roleValue))) {
-      return { error: `stage ${id} role must be an object` };
+      violations.push({ field: at("role"), message: `stage ${id} role must be an object`, expected: STAGE_ROLE_SHAPE });
+      roleShapeValid = false;
     }
-    if (roleValue && Object.keys(roleValue).some((key) => key !== "roleId" && key !== "params")) {
-      return { error: `stage ${id} role only accepts roleId and params; place runtime overrides on the stage` };
+    if (roleShapeValid && roleValue && Object.keys(roleValue).some((key) => key !== "roleId" && key !== "params")) {
+      violations.push({
+        field: at("role"),
+        message: `stage ${id} role only accepts roleId and params; place runtime overrides on the stage`,
+        expected: STAGE_ROLE_SHAPE,
+      });
+      roleShapeValid = false;
     }
-    const roleId = roleValue && typeof (roleValue as { roleId?: unknown }).roleId === "string"
+    const roleId = roleShapeValid && roleValue && typeof (roleValue as { roleId?: unknown }).roleId === "string"
       ? (roleValue as { roleId: string }).roleId.trim()
       : "";
-    if (roleValue && !roleId) return { error: `stage ${id} roleId is required when role is present` };
-    const rawParams = (roleValue as { params?: unknown } | undefined)?.params;
+    if (roleShapeValid && roleValue && !roleId) {
+      violations.push({ field: at("role.roleId"), message: `stage ${id} roleId is required when role is present`, expected: STAGE_ROLE_ID_SHAPE });
+      roleShapeValid = false;
+    }
+    const rawParams = roleShapeValid ? (roleValue as { params?: unknown } | undefined)?.params : undefined;
     if (rawParams !== undefined && (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams))) {
-      return { error: `stage ${id} role params must be an object` };
+      violations.push({ field: at("role.params"), message: `stage ${id} role params must be an object`, expected: STAGE_ROLE_PARAMS_SHAPE });
+      roleShapeValid = false;
     }
-    const roleParams = rawParams as Record<string, unknown> | undefined;
+    const roleParams = roleShapeValid ? rawParams as Record<string, unknown> | undefined : undefined;
     if (roleParams && Object.values(roleParams).some((value) => typeof value !== "string" && typeof value !== "number")) {
-      return { error: `stage ${id} role params must be strings or numbers` };
+      violations.push({ field: at("role.params"), message: `stage ${id} role params must be strings or numbers`, expected: STAGE_ROLE_PARAMS_SHAPE });
+      roleShapeValid = false;
     }
-    if (roleParams && !roleId) return { error: `stage ${id} role params require a roleId` };
-    if (roleId && roleParams && !preservedStage) {
+    if (roleShapeValid && roleParams && !roleId) {
+      violations.push({ field: at("role.roleId"), message: `stage ${id} role params require a roleId`, expected: STAGE_ROLE_ID_SHAPE });
+      roleShapeValid = false;
+    }
+    if (roleShapeValid && roleId && roleParams && !preservedStage) {
       /* Canonical value checks (options, integer bounds, text length, unknown
          keys) so an invalid param can't freeze into the stored scaffold. */
       const paramError = validatePipelineRoleParams(roleId, roleParams as Record<string, string | number>);
-      if (paramError) return { error: `stage ${id} ${paramError}` };
+      if (paramError) {
+        violations.push({ field: at("role.params"), message: `stage ${id} ${paramError}`, expected: STAGE_ROLE_PARAMS_SHAPE });
+        roleShapeValid = false;
+      }
     }
-    if (stage.model !== undefined && stage.model !== null && typeof stage.model !== "string") return { error: `stage ${id} model must be a string or null` };
-    if (stage.effort !== undefined && stage.effort !== null && typeof stage.effort !== "string") return { error: `stage ${id} effort must be a string or null` };
+    if (stage.model !== undefined && stage.model !== null && typeof stage.model !== "string") {
+      violations.push({ field: at("model"), message: `stage ${id} model must be a string or null`, expected: "model id string, or null to inherit the role default" });
+    }
+    if (stage.effort !== undefined && stage.effort !== null && typeof stage.effort !== "string") {
+      violations.push({ field: at("effort"), message: `stage ${id} effort must be a string or null`, expected: "effort string supported by the stage engine, or null to inherit the role default" });
+    }
+    const nextValid = stage.next === undefined || stage.next === null || typeof stage.next === "string";
+    if (!nextValid) {
+      violations.push({ field: at("next"), message: `stage ${id} next must be a stage id or null`, expected: STAGE_NEXT_SHAPE });
+    }
+    if (idValid && kindValid && onFailValid && nextValid) {
+      graphView.push({
+        id,
+        kind: stage.kind as PipelineStage["kind"],
+        next: stage.next ?? null,
+        onFail: rawOnFail
+          ? { to: (rawOnFail as { to: string }).to.trim(), maxRounds: ((rawOnFail as { maxRounds?: number }).maxRounds ?? DEFAULT_FAIL_EDGE_ROUNDS) }
+          : null,
+      });
+    } else {
+      graphViewComplete = false;
+    }
+    if (idValid) ids.add(id);
+    if (violations.length > before) continue;
     const onFailEdge = rawOnFail
       ? {
           to: (rawOnFail as { to: string }).to.trim(),
@@ -2360,7 +2457,7 @@ function normalizeStages(
       : null;
     const input: PipelineStageInput = {
       id,
-      kind: stage.kind,
+      kind: stage.kind as PipelineStage["kind"],
       ...(roleId ? { role: { roleId: roleId as PipelineRoleId, ...(roleParams && Object.keys(roleParams).length ? { params: roleParams as Record<string, string | number> } : {}) } } : {}),
       ...(stage.engine !== undefined ? { engine: stage.engine } : {}),
       ...(stage.model !== undefined ? { model: typeof stage.model === "string" ? stage.model.trim() || null : null } : {}),
@@ -2370,16 +2467,23 @@ function normalizeStages(
       next: stage.next ?? null,
       onFail: onFailEdge,
     };
-    const resolved = preservedStage ? { role: preservedStage.effectiveRole } : resolvePipelineRole(input, stage.kind, lookup);
-    if (!resolved.role) return { error: "error" in resolved ? resolved.error : "invalid stage role" };
+    const resolved = preservedStage ? { role: preservedStage.effectiveRole } : resolvePipelineRole(input, stage.kind as PipelineStage["kind"], lookup);
+    if (!resolved.role) {
+      violations.push({
+        field: at("role"),
+        message: "error" in resolved && resolved.error ? resolved.error : "invalid stage role",
+        expected: STAGE_RUNTIME_SHAPE,
+      });
+      continue;
+    }
     const normalizedStage: PipelineStage = { ...input, effectiveRole: structuredClone(resolved.role) };
-    ids.add(id);
     stages.push(normalizedStage);
   }
   /* v3 graph contract: acyclic pass edges over valid targets, bounded fail
      edges, review-loop pass-reachability — shared with the store validator. */
-  const graphError = pipelineGraphError(stages);
-  if (graphError) return { error: graphError };
+  const graphError = graphViewComplete ? pipelineGraphError(graphView) : null;
+  if (graphError) violations.push({ field: "stages[].next", message: graphError, expected: STAGE_GRAPH_SHAPE });
+  if (violations.length) return stageViolations(violations);
   return { stages };
 }
 
@@ -2406,7 +2510,7 @@ function replaceDraftStages(
   pipeline: Pipeline,
   inputs: PipelineStageInput[],
   lookup?: PipelineRoleLookup | null,
-): { error?: string } {
+): { error?: string; violations?: PipelineValidationViolation[] } {
   /* Custom edges survive structural edits (#353): each kept stage's intentional
      pass and fail edge is preserved as-is, and the add/remove handlers rewire
      only the edit's own seam. This safety net clears an edge whose target left
@@ -2422,14 +2526,16 @@ function replaceDraftStages(
   /* Draft edits may empty the plan entirely (remove down to zero); the 1-stage
      floor is enforced only at Start (#136, #353). */
   const normalized = normalizeStages(relinked, lookup, preserved, 0);
-  if (!normalized.stages) return { error: normalized.error ?? "invalid stages" };
+  if (!normalized.stages) return { error: normalized.error ?? "invalid stages", ...(normalized.violations ? { violations: normalized.violations } : {}) };
   /* The entry stage (the draft cursor rests on stages[0]) must be a run: a
      review-loop entry has no preceding run to review and would park on Start.
      Preserved edges let a fronted review stay graph-reachable from a later run,
      so the array-position guard runs explicitly here (matching the client's
      reviewLoopChainValid). */
   if (normalized.stages[0] && normalized.stages[0].kind !== "run") {
-    return { error: "review-loop stage requires a preceding run stage" };
+    /* #1026: name the stage and the rule it breaks, not an ordering the caller
+       is left to guess at. */
+    return { error: `review-loop stage ${normalized.stages[0].id} may not be the entry stage: the plan starts on its first stage, which must be a run stage whose session a review-loop then reviews` };
   }
   pipeline.stages = normalized.stages;
   pipeline.runs = normalized.stages.map((stage) => ({ stageId: stage.id, attempts: [] }));
@@ -2446,6 +2552,10 @@ export type PipelineMutationResult = {
   code?: PipelineRepoPreflightErrorCode;
   field?: "repoDir";
   path?: string;
+  /** #1026: every request-shape constraint the call violated, each naming its
+      field and the shape that field expects. Present on a batched validation
+      rejection; `error` renders the same list. */
+  violations?: PipelineValidationViolation[];
   /** Set by the close action: what its host teardown stopped and preserved. */
   close?: PipelineCloseReport;
 };
@@ -2455,16 +2565,31 @@ type PipelineCreatorLineage = {
   srcConversationId: string | null;
 };
 
+/** #1026: the roots a creator transcript may live under, named in every `src`
+    rejection. A Claude-engine caller knows only its native path, so the message
+    has to say which address the viewer records — and that the native one is
+    accepted whenever the shared mirror holds the same file. */
+export const PIPELINE_SRC_ROOT_GUIDANCE =
+  "src must be a .jsonl transcript under an accepted root: the shared Claude transcript store (<viewer config dir>/shared/claude/projects), a Claude account's own projects root, or a Codex sessions root (~/.codex/sessions). A native ~/.claude/projects path is accepted and normalized to the shared store when the mirrored file exists there.";
+
 function resolvePipelineCreatorLineage(
   value: unknown,
   ports: Pick<PipelinePorts, "sourcePathAllowed" | "conversationIdForPath">,
 ): { lineage?: PipelineCreatorLineage; error?: string; status?: number } {
-  const srcPath = typeof value === "string" ? value.trim() : "";
-  if (!srcPath) return { error: "pipeline creator lineage is required; pass src", status: 400 };
-  if (!ports.sourcePathAllowed(srcPath)) return { error: "src path is not an allowed conversation transcript", status: 400 };
-  const srcConversationId = ports.conversationIdForPath(srcPath);
-  if (!srcConversationId) return { error: "src conversation does not exist", status: 400 };
-  return { lineage: { srcPath, srcConversationId } };
+  const requested = typeof value === "string" ? value.trim() : "";
+  if (!requested) return { error: "pipeline creator lineage is required; pass src", status: 400 };
+  /* The native `<claude home>/projects/...` path and its shared-store mirror
+     name the same file; viewer records address the shared one. Try what the
+     caller passed first, so nothing about an already-canonical path changes. */
+  for (const srcPath of [requested, mirroredClaudeTranscriptPath(requested)]) {
+    if (!srcPath || !ports.sourcePathAllowed(srcPath)) continue;
+    const srcConversationId = ports.conversationIdForPath(srcPath);
+    if (srcConversationId) return { lineage: { srcPath, srcConversationId } };
+  }
+  if (!ports.sourcePathAllowed(requested)) {
+    return { error: `src path is not an allowed conversation transcript. ${PIPELINE_SRC_ROOT_GUIDANCE}`, status: 400 };
+  }
+  return { error: `src conversation does not exist. ${PIPELINE_SRC_ROOT_GUIDANCE}`, status: 400 };
 }
 
 type CreatePipelineOptions = {
@@ -2542,17 +2667,23 @@ export async function createPipelineFromRequest(
   ports: PipelinePorts = defaultPipelinePorts(),
   options: CreatePipelineOptions = {},
 ): Promise<PipelineMutationResult> {
+  /* #1026: every request-shape constraint is evaluated before the request is
+     answered, and the response carries all of them. The checks and their
+     verdicts are the ones that were here before, only their reporting is
+     batched; the repo preflight and base resolution below still answer alone,
+     because each carries its own code, field and status. */
+  const violations: PipelineValidationViolation[] = [];
   const task = typeof req.task === "string" ? req.task.trim() : "";
-  if (!task) return { error: "task is required", status: 400 };
-  if (task.length > MAX_TASK_LENGTH) return { error: `task exceeds ${MAX_TASK_LENGTH} characters`, status: 400 };
+  if (!task) violations.push({ field: "task", message: "task is required", expected: `non-empty string up to ${MAX_TASK_LENGTH} characters` });
+  else if (task.length > MAX_TASK_LENGTH) violations.push({ field: "task", message: `task exceeds ${MAX_TASK_LENGTH} characters`, expected: `non-empty string up to ${MAX_TASK_LENGTH} characters` });
   const spec = typeof req.spec === "string" && req.spec.trim() ? req.spec.trim() : undefined;
-  if (req.spec !== undefined && typeof req.spec !== "string") return { error: "spec must be a string", status: 400 };
-  if (spec && spec.length > MAX_SPEC_LENGTH) return { error: `spec exceeds ${MAX_SPEC_LENGTH} characters`, status: 400 };
-  if (req.autoStart !== undefined && typeof req.autoStart !== "boolean") return { error: "autoStart must be a boolean", status: 400 };
-  if (req.baseBranch !== undefined && typeof req.baseBranch !== "string") return { error: "baseBranch must be a string", status: 400 };
-  if (req.baseRef !== undefined && typeof req.baseRef !== "string") return { error: "baseRef must be a string", status: 400 };
+  if (req.spec !== undefined && typeof req.spec !== "string") violations.push({ field: "spec", message: "spec must be a string", expected: `string up to ${MAX_SPEC_LENGTH} characters` });
+  if (spec && spec.length > MAX_SPEC_LENGTH) violations.push({ field: "spec", message: `spec exceeds ${MAX_SPEC_LENGTH} characters`, expected: `string up to ${MAX_SPEC_LENGTH} characters` });
+  if (req.autoStart !== undefined && typeof req.autoStart !== "boolean") violations.push({ field: "autoStart", message: "autoStart must be a boolean", expected: "boolean (false creates a draft the operator starts)" });
+  if (req.baseBranch !== undefined && typeof req.baseBranch !== "string") violations.push({ field: "baseBranch", message: "baseBranch must be a string", expected: "branch name string" });
+  if (req.baseRef !== undefined && typeof req.baseRef !== "string") violations.push({ field: "baseRef", message: "baseRef must be a string", expected: "commit-ish string resolved against repoDir" });
   if (req.taskIds !== undefined && (!Array.isArray(req.taskIds) || req.taskIds.some((taskId) => typeof taskId !== "string" || !taskId.trim()))) {
-    return { error: "taskIds must be an array of non-empty strings", status: 400 };
+    violations.push({ field: "taskIds", message: "taskIds must be an array of non-empty strings", expected: "array of board task ids" });
   }
   const taskSpawn = options.ensureTask && options.spawnParams && isTaskSpawnPipelineParams(options.spawnParams)
     ? { task: options.ensureTask, params: options.spawnParams }
@@ -2565,22 +2696,37 @@ export async function createPipelineFromRequest(
     : operatorDraftWithoutLineage
       ? { lineage: { srcPath: null, srcConversationId: null } }
     : resolvePipelineCreatorLineage(req.src, ports);
-  if (!creator.lineage) return { error: creator.error, status: creator.status };
+  /* A task-spawn lineage failure is a launch-identity conflict, not a request
+     the caller can fix by editing fields, so it answers alone as it always did. */
+  if (!creator.lineage && taskSpawn) return { error: creator.error, status: creator.status };
+  if (!creator.lineage) violations.push({ field: "src", message: creator.error ?? "pipeline creator lineage is required; pass src", expected: PIPELINE_SRC_ROOT_GUIDANCE });
   const taskIds = [...new Set((req.taskIds ?? []).map((taskId) => taskId.trim()))];
   const requestedRepoDir = typeof req.repoDir === "string" ? req.repoDir.trim() : "";
-  if (!requestedRepoDir) return { error: "repoDir is required", status: 400 };
-  const admission = ports.preflightRepo(requestedRepoDir);
-  if (!admission.ok) return preflightFailure(admission);
-  const repoDir = admission.repoDir;
+  if (!requestedRepoDir) violations.push({ field: "repoDir", message: "repoDir is required", expected: "absolute path of an existing git repository" });
   /* A draft (autoStart:false) may be created empty and assembled on the canvas
      (#136); an immediately-started pipeline needs at least its one implement
      conversation (#353). */
   const normalized = normalizeStages(req.stages, ports.roleLookup, undefined, req.autoStart === false ? 0 : MIN_STARTED_PIPELINE_STAGES);
-  if (!normalized.stages) return { error: normalized.error ?? "invalid stages", status: 400 };
-  const explicitBaseRef = req.baseRef?.trim();
-  if (req.autoStart === false && req.baseBranch?.trim() && !explicitBaseRef) {
-    return { error: "a draft baseBranch requires an explicit baseRef", status: 400 };
+  if (!normalized.stages) {
+    violations.push(...(normalized.violations ?? [{ field: "stages", message: normalized.error ?? "invalid stages", expected: STAGE_OBJECT_SHAPE }]));
   }
+  /* Read after the type checks above recorded their verdicts: with batching a
+     non-string baseRef reaches here, so the trims must not assume a string. */
+  const explicitBaseRef = typeof req.baseRef === "string" ? req.baseRef.trim() : undefined;
+  const requestedBaseBranch = typeof req.baseBranch === "string" ? req.baseBranch.trim() : "";
+  if (req.autoStart === false && requestedBaseBranch && !explicitBaseRef) {
+    violations.push({
+      field: "baseRef",
+      message: "a draft baseBranch requires an explicit baseRef",
+      expected: "commit SHA the draft is pinned to, resolved by the caller (a draft is not provisioned, so the viewer cannot resolve the branch itself)",
+    });
+  }
+  if (violations.length || !normalized.stages || !creator.lineage) {
+    return { error: pipelineValidationError(violations), violations, status: 400 };
+  }
+  const admission = ports.preflightRepo(requestedRepoDir);
+  if (!admission.ok) return preflightFailure(admission);
+  const repoDir = admission.repoDir;
   const base = req.autoStart === false && !explicitBaseRef
     ? null
     : resolvePipelineBase(repoDir, { baseBranch: req.baseBranch, baseRef: explicitBaseRef }, ports.exec);
@@ -2893,7 +3039,7 @@ export async function patchPipeline(
       inputs.splice(index, 0, inserted);
       if (predecessor) predecessor.next = inserted.id;
       const replaced = replaceDraftStages(pipeline, inputs, ports.roleLookup);
-      if (replaced.error) return { error: replaced.error, status: 400 };
+      if (replaced.error) return { error: replaced.error, status: 400, ...(replaced.violations ? { violations: replaced.violations } : {}) };
     } else if (req.action === "remove-stage") {
       if (pipeline.state !== "draft") return { error: "pipeline is not a draft", status: 409 };
       /* A draft can be emptied entirely on the canvas (#136); the 2-stage floor is
@@ -2918,7 +3064,7 @@ export async function patchPipeline(
         if (input.onFail?.to === removed.id) input.onFail = null;
       }
       const replaced = replaceDraftStages(pipeline, inputs, ports.roleLookup);
-      if (replaced.error) return { error: replaced.error, status: 400 };
+      if (replaced.error) return { error: replaced.error, status: 400, ...(replaced.violations ? { violations: replaced.violations } : {}) };
     } else if (req.action === "reorder-stage") {
       if (pipeline.state !== "draft") return { error: "pipeline is not a draft", status: 409 };
       const inputs = draftStageInputs(pipeline.stages);
@@ -2940,7 +3086,7 @@ export async function patchPipeline(
         ordered.splice(toIndex!, 0, moved!);
       }
       const replaced = replaceDraftStages(pipeline, ordered, ports.roleLookup);
-      if (replaced.error) return { error: replaced.error, status: 400 };
+      if (replaced.error) return { error: replaced.error, status: 400, ...(replaced.violations ? { violations: replaced.violations } : {}) };
     } else if (req.action === "set-edge") {
       /* Conversation-graph editing (#353): rewires a stage's pass or fail edge.
          Edits always shape the future, never rewrite evidence: a stage that has

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -275,7 +275,19 @@ export function pipelineGraphError(
       }
       return false;
     });
-    if (!reachable) return "review-loop stage requires a preceding run stage";
+    /* #1026: this used to say "review-loop stage requires a preceding run
+       stage", which reads as an ordering rule and sent a caller reordering an
+       array that was already in the right order. The defect is a missing pass
+       edge: stages default to `next: null`, so nothing reaches the review-loop.
+       Name the unreachable stage and the edge that would reach it. */
+    if (!reachable) {
+      const runStages = stages.filter((candidate) => candidate.kind === "run");
+      if (runStages.length === 0) {
+        return `review-loop stage ${stage.id} is unreachable: the pipeline has no run stage, and a review-loop reviews the session of a run stage that reaches it`;
+      }
+      const source = runStages.findLast((candidate) => candidate.next === null) ?? runStages.at(-1)!;
+      return `review-loop stage ${stage.id} is unreachable: no run stage's next chain reaches it — set next: "${stage.id}" on run stage ${source.id}`;
+    }
   }
   return null;
 }

--- a/src/lib/pipelines/validation.ts
+++ b/src/lib/pipelines/validation.ts
@@ -1,0 +1,31 @@
+/**
+ * Batched create-time validation reporting (#1026).
+ *
+ * The constraints themselves live where they always did — `normalizeStages`,
+ * `createPipelineFromRequest`, `pipelineGraphError`. What changed is that a
+ * rejected request no longer stops at the first violated one: every violation
+ * is collected, each naming the field it belongs to and the shape that field
+ * expects, so a caller composing its first pipeline learns the whole contract
+ * from one response instead of one constraint per round trip.
+ *
+ * A single violation renders to exactly the message it rendered to before, so
+ * existing callers, the builder dialog and their tests keep reading the text
+ * they already know; the structured list always carries field and expected.
+ */
+export type PipelineValidationViolation = {
+  /** Path of the offending field in the request, e.g. `stages[1].next`. */
+  field: string;
+  /** The violated constraint, in the same words the single-error path used. */
+  message: string;
+  /** What a valid value for `field` looks like. */
+  expected: string;
+};
+
+/** The `error` string for a batch: one violation keeps its own message; several
+    are listed with their field and expected shape, in request order. */
+export function pipelineValidationError(violations: readonly PipelineValidationViolation[]): string {
+  if (violations.length === 0) return "invalid pipeline request";
+  if (violations.length === 1) return violations[0]!.message;
+  const listed = violations.map((violation) => `${violation.field}: ${violation.message} (expected ${violation.expected})`);
+  return `${violations.length} validation errors — ${listed.join("; ")}`;
+}


### PR DESCRIPTION
Fixes #1026.

A fresh seat's first `create_pipeline` call cost seven sequential validation errors. Three causes: the tool schema said `stages: array of objects` and nothing else; each rejection carried exactly one constraint; and the constraint that took longest to decode named an ordering rule when the defect was a missing `next` edge.

## What changed

**1. The stage contract is published, not discovered.** `create_pipeline` now declares a real JSONSchema for stage objects — `id`, `kind`, `prompt`, `next`, `onFail{to,maxRounds}`, `role{roleId,params}` and the stage-level `engine`/`model`/`effort`/`access` overrides — each field describing what it is and how it defaults. The tool description carries what no per-field schema can: stages are a graph whose `next` defaults to null, a review-loop must be pass-reachable from a run stage, a draft that pins `baseBranch` must also pass `baseRef`, and review-loops are read-only on their role's registry runtime.

Every published bound is exactly as wide as the engine's (the engine trims before it checks, so the schema tolerates the same padding). A test asserts the schema admits the stage shapes the engine accepts.

**2. Validation batches.** A rejected create collects every violated constraint and answers once, each violation naming its `field` (`stages[1].role`, `baseRef`, …) and the `expected` shape. MCP callers get the list as structured refusal details; HTTP callers get it as `violations` alongside the existing `error`. The rendered `error` for a single violation is byte-identical to what it was, so nothing downstream reads a new string for a case it already handled.

Semantics are untouched: same constraints, same accept/reject verdicts, same statuses. The repo preflight and base resolution still answer alone, because each carries its own `code`/`field`/`path`. Stage-graph rules are evaluated in the same pass as the field rules whenever `id`/`kind`/`next`/`onFail` are well-formed, so a missing edge is reported beside the field errors rather than one call later.

**3. The unreachable-review-loop error names the defect.** `review-loop stage requires a preceding run stage` becomes `review-loop stage review is unreachable: no run stage's next chain reaches it — set next: "review" on run stage build`.

**4. `src` accepts both transcript roots.** A native `~/.claude/projects/...` path is normalized to its shared-store mirror when that file exists — the two address one file, and a Claude-engine caller only knows the native one. When nothing is mirrored the call still fails, now with an error naming the accepted roots.

**5. Mandate v5.** The default orchestrator mandate carries one compact stage-contract paragraph, so a fresh seat never re-runs the discovery walk. Version bumped 4 → 5 per the file's convention.

## Verification

`bunx tsc --noEmit` clean; `bunx eslint` clean on every touched file; local privacy gate passes.

Tests run by path (247 pass, 0 fail):

| file | covers |
| --- | --- |
| `src/lib/mcp/schemaParity.test.ts` | published stage fields, enums, the two rules the walk turned on; schema admits what the engine accepts |
| `src/lib/pipelines/engine.test.ts` | batched response listing six violations in request order; unreachable-review-loop message; native `src` with and without a mirror |
| `src/lib/mcp/bindings.test.ts` | MCP refusal carries `violations` with field and expected |
| `src/lib/accounts/claude.test.ts` | native → shared-store mirror only when the mirrored file exists |
| `src/lib/orchestrator/prompt.test.ts` | mandate carries the stage contract, version 5 |
| `src/app/api/pipelines/route.admission.test.ts` | HTTP surface returns the same violation list |

Also re-ran, unchanged: `src/lib/pipelines/store.test.ts`, `src/app/api/pipelines/route.test.ts`, `src/app/api/pipelines/[id]/route.test.ts`, `src/lib/mcp/server.test.ts`, `src/lib/mcp/presentation.test.ts`, `src/lib/mcp/orchestratorTools.test.ts`, `src/components/pipelines/createDraftPipeline.dom.test.tsx`, `src/components/pipelines/pipelineModel.test.ts`, `src/components/orchestrator/OrchestratorPanel.dom.test.tsx`, `src/lib/pipelines/roles.test.ts`, `src/lib/pipelines/controllerSignal.test.ts`, `src/lib/accounts/claudeTranscriptOwnership.test.ts`.

## Note

Where the published schema is strict (a `role` object carrying a runtime override, a `kind` outside the enum), the protocol boundary rejects before the engine's batched validator runs. That answer still lists every schema issue at once and names each path, so a caller never walks constraints one at a time either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
