### PR TITLE
feat(deploy): resolve refs machine-to-machine — no hand-carried SHAs (#1033)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,9 +8,15 @@ Production application releases are admitted by the durable runtime host:
 scripts/rebuild.sh
 ```
 
-The default request resolves `origin/main` in the adapter's canonical mirror. A full lowercase commit SHA can be selected with `LLV_DEPLOY_REVISION`. Reuse `LLV_DEPLOY_IDEMPOTENCY_KEY` after a client timeout to receive the original receipt.
+The default invocation carries no revision at all. `scripts/rebuild.sh` reads the canonical `refs/heads/main` tip itself with `git ls-remote` against the canonical remote and posts that exact commit, so no SHA is ever retyped between a note and a deploy — a mangled tail deployed a revision that never existed for six hours (#1032, #1033). It prints the resolved SHA before requesting admission.
 
-The canonical mirror defaults to `https://github.com/Latand/live-log-viewer-next.git`. Set `LLV_VIEWER_CANONICAL_REMOTE` when a different public or private mirror is required.
+A pinned redeploy or rollback still names its commit: `scripts/rebuild.sh <full lowercase commit SHA>`, or `LLV_DEPLOY_REVISION`. A revision the canonical repository does not carry is refused at admission with `revision <sha> not found in the canonical repository (fetched from <remote>)`.
+
+Reuse `LLV_DEPLOY_IDEMPOTENCY_KEY` after a client timeout to receive the original receipt.
+
+`POST /api/runtime/deployments` takes the same target two ways: `{"revision": "<full commit SHA>", "idempotencyKey": "..."}` pins a commit, and `{"ref": "refs/heads/<branch>", "idempotencyKey": "..."}` names a branch of the canonical repository, which the host adapter resolves in the canonical mirror. A request carrying both is refused. Only `refs/heads/*` of the canonical repository is accepted — no tags, no remote-tracking refs, no revision expressions. Whichever way the request named its target, the deployment ledger records the requested target and the exact resolved SHA that was built and promoted.
+
+The canonical remote defaults to `https://github.com/Latand/live-log-viewer-next.git` for both the adapter's mirror and `scripts/rebuild.sh`. Set `LLV_VIEWER_CANONICAL_REMOTE` when a different public or private mirror is required.
 
 The runtime host serializes deployment requests and journals every phase before invoking the host adapter. Its stable listener reads `state/viewer-release.json` for each new connection, so promotion and rollback use an atomic target-file rename. Candidate and previous Viewer containers stay under Docker ownership on alternate loopback ports.
 
@@ -27,7 +33,7 @@ the Docker socket GID as a supplementary group. `LLV_UID`, `LLV_GID`,
 candidate containers preserve supported host overrides. The Docker namespace
 shim restores the complete credential set before invoking the host CLI.
 
-The built-in host adapter lives at `/app/scripts/runtime-host-viewer-adapter.ts`. It maintains a clean canonical Git mirror under the durable state directory, resolves a commit SHA, creates a detached source worktree, builds a versioned Docker image, starts a distinct candidate container with the runtime-host socket configured, checks process readiness plus remote authorized/unauthorized behavior and every referenced CSS/JavaScript asset, and atomically changes the listener target. Post-promotion failure restores the journaled previous target. Successful cleanup retains the serving and immediate rollback containers; failed and superseded managed candidates are retired.
+The built-in host adapter lives at `/app/scripts/runtime-host-viewer-adapter.ts`. It maintains a clean canonical Git mirror under the durable state directory, resolves the requested branch ref or SHA to an exact commit (peeling `^{commit}`, which is what proves the object is actually present), creates a detached source worktree, builds a versioned Docker image, starts a distinct candidate container with the runtime-host socket configured, checks process readiness plus remote authorized/unauthorized behavior and every referenced CSS/JavaScript asset, and atomically changes the listener target. Post-promotion failure restores the journaled previous target. Successful cleanup retains the serving and immediate rollback containers; failed and superseded managed candidates are retired.
 
 Each adapter action has a fixed deadline. Runtime-host records the adapter PID
 and process-start identity durably, launches it with a parent-death signal, and
@@ -49,7 +55,7 @@ recovery can replay it.
 
 | Action | JSON input |
 | --- | --- |
-| `resolve-revision` | `{ "revision": string }` |
+| `resolve-revision` | `{ "revision": string }` — `origin/main`, `refs/heads/<branch>`, or a full commit SHA |
 | `build-candidate` | `{ "deploymentId": string, "revision": string }` |
 | `start-candidate` | `{ "candidate": ViewerReleaseIdentity }` |
 | `current-release` | `{}` |

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 PORT="${PORT:-8898}"
+CANONICAL_REMOTE="${LLV_VIEWER_CANONICAL_REMOTE:-https://github.com/Latand/live-log-viewer-next.git}"
 if [ "$#" -gt 1 ]; then
   echo "usage: rebuild.sh [origin/main|full-commit-sha]" >&2
   exit 1
@@ -24,6 +25,22 @@ esac
 if [ "${#IDEMPOTENCY_KEY}" -gt 200 ]; then
   echo "invalid deployment idempotency key" >&2
   exit 1
+fi
+
+# No SHA is ever carried by hand into a deploy (#1033): the default request
+# reads the canonical main tip machine-to-machine and posts the exact commit it
+# read. An explicit SHA argument stays a pinned redeploy or rollback.
+if [ "$REVISION" = "origin/main" ]; then
+  if ! ls_remote="$(GIT_TERMINAL_PROMPT=0 git ls-remote "$CANONICAL_REMOTE" refs/heads/main)"; then
+    echo "could not read refs/heads/main from $CANONICAL_REMOTE" >&2
+    exit 1
+  fi
+  REVISION="$(printf '%s\n' "$ls_remote" | head -n 1 | cut -f1)"
+  if [[ ! "$REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "could not resolve refs/heads/main at $CANONICAL_REMOTE" >&2
+    exit 1
+  fi
+  echo "resolved refs/heads/main at $CANONICAL_REMOTE: $REVISION"
 fi
 
 BASE="http://127.0.0.1:${PORT}"

--- a/scripts/rebuild.test.ts
+++ b/scripts/rebuild.test.ts
@@ -17,9 +17,19 @@ function fixture() {
   const home = path.join(root, "home");
   const capture = path.join(root, "request.json");
   const args = path.join(root, "request.args");
+  const gitArgs = path.join(root, "git.args");
   fs.mkdirSync(bin);
   fs.mkdirSync(path.join(home, ".config", "agent-log-viewer"), { recursive: true });
   fs.writeFileSync(path.join(home, ".config", "agent-log-viewer", "service.env"), "");
+  /* The canonical main tip is read machine-to-machine (#1033); the stub stands
+     in for the network so the test asserts what the script posts. */
+  const git = path.join(bin, "git");
+  fs.writeFileSync(git, `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >> "$LLV_TEST_GIT_ARGS"
+if [ -n "\${LLV_TEST_LS_REMOTE_FAILS:-}" ]; then exit 128; fi
+printf '%s' "\${LLV_TEST_LS_REMOTE:-}"
+`, { mode: 0o755 });
   const curl = path.join(bin, "curl");
   fs.writeFileSync(curl, `#!/usr/bin/env bash
 set -euo pipefail
@@ -42,10 +52,19 @@ else
   printf '{"phase":"succeeded","terminal":true}'
 fi
 `, { mode: 0o755 });
-  return { root, bin, home, capture, args };
+  return { root, bin, home, capture, args, gitArgs };
 }
 
-function runRebuild(idempotencyKey: string, setup: ReturnType<typeof fixture>, revision?: string) {
+const CANONICAL_REMOTE = "https://canonical.invalid/live-log-viewer-next.git";
+const MAIN_TIP = "b".repeat(40);
+
+function runRebuild(
+  idempotencyKey: string,
+  setup: ReturnType<typeof fixture>,
+  revision?: string,
+  options: { lsRemote?: string | null } = {},
+) {
+  const lsRemote = options.lsRemote === undefined ? `${MAIN_TIP}\trefs/heads/main\n` : options.lsRemote;
   return Bun.spawnSync(["bash", rebuildScript, ...(revision ? [revision] : [])], {
     cwd: setup.root,
     env: {
@@ -56,6 +75,9 @@ function runRebuild(idempotencyKey: string, setup: ReturnType<typeof fixture>, r
       LLV_DEPLOY_IDEMPOTENCY_KEY: idempotencyKey,
       LLV_TEST_CAPTURE: setup.capture,
       LLV_TEST_ARGS: setup.args,
+      LLV_TEST_GIT_ARGS: setup.gitArgs,
+      LLV_VIEWER_CANONICAL_REMOTE: CANONICAL_REMOTE,
+      ...(lsRemote === null ? { LLV_TEST_LS_REMOTE_FAILS: "1" } : { LLV_TEST_LS_REMOTE: lsRemote }),
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -101,10 +123,63 @@ test("rebuild serializes a quoted 200-character idempotency key as JSON", () => 
 
   expect(result.exitCode).toBe(0);
   expect(JSON.parse(fs.readFileSync(setup.capture, "utf8"))).toEqual({
-    revision: "origin/main",
+    revision: MAIN_TIP,
     idempotencyKey,
   });
 });
+
+test("a bare rebuild reads the canonical main tip itself and posts the resolved SHA", () => {
+  const setup = fixture();
+  const result = runRebuild("refless-deploy", setup);
+
+  expect(result.exitCode).toBe(0);
+  expect(fs.readFileSync(setup.gitArgs, "utf8").split("\n").filter(Boolean)).toEqual([
+    "ls-remote",
+    CANONICAL_REMOTE,
+    "refs/heads/main",
+  ]);
+  expect(JSON.parse(fs.readFileSync(setup.capture, "utf8"))).toEqual({
+    revision: MAIN_TIP,
+    idempotencyKey: "refless-deploy",
+  });
+  expect(result.stdout.toString()).toContain(`resolved refs/heads/main at ${CANONICAL_REMOTE}: ${MAIN_TIP}`);
+});
+
+test("an explicit origin/main argument resolves the same way as a bare invocation", () => {
+  const setup = fixture();
+  const result = runRebuild("explicit-origin-main", setup, "origin/main");
+
+  expect(result.exitCode).toBe(0);
+  expect(JSON.parse(fs.readFileSync(setup.capture, "utf8"))).toEqual({
+    revision: MAIN_TIP,
+    idempotencyKey: "explicit-origin-main",
+  });
+});
+
+test("a pinned SHA deploy never consults the remote", () => {
+  const setup = fixture();
+  const revision = "c".repeat(40);
+  const result = runRebuild("pinned-sha", setup, revision);
+
+  expect(result.exitCode).toBe(0);
+  expect(fs.existsSync(setup.gitArgs)).toBe(false);
+  expect(JSON.parse(fs.readFileSync(setup.capture, "utf8"))).toEqual({ revision, idempotencyKey: "pinned-sha" });
+});
+
+for (const [name, lsRemote] of [
+  ["the remote is unreachable", null],
+  ["the branch is absent", ""],
+  ["the tip is not a full SHA", "not-a-sha\trefs/heads/main\n"],
+] as const) {
+  test(`rebuild refuses to deploy when ${name}`, () => {
+    const setup = fixture();
+    const result = runRebuild("unresolvable-main", setup, undefined, { lsRemote });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(CANONICAL_REMOTE);
+    expect(fs.existsSync(setup.capture)).toBe(false);
+  });
+}
 
 test("rebuild rejects an idempotency key above the coordinator limit", () => {
   const setup = fixture();

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -31,7 +31,7 @@ import {
   viewerComposeServiceUid,
   viewerRegistryBackendMode,
 } from "../src/runtime-host/candidateContainer";
-import { ensureCanonicalMirror } from "../src/runtime-host/canonicalMirror";
+import { ensureCanonicalMirror, resolveCanonicalRevision } from "../src/runtime-host/canonicalMirror";
 import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandidatePortAvailable } from "../src/runtime-host/candidatePort";
 import { withBootstrapMcpHealthProbeAdmission } from "../src/runtime-host/bootstrapMcpHealthProbeAdmission";
 import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
@@ -125,11 +125,7 @@ async function ensureMirror(): Promise<void> {
 }
 
 async function resolveRevision(requested: string): Promise<string> {
-  await ensureMirror();
-  const value = requested === "origin/main" ? "refs/heads/main^{commit}" : `${requested}^{commit}`;
-  const revision = await command(["git", "--git-dir", mirrorDir, "rev-parse", "--verify", value]);
-  if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("canonical repository returned an invalid revision");
-  return revision;
+  return resolveCanonicalRevision(requested, { mirrorDir, remote: canonicalRemote }, { run: command, ensureMirror });
 }
 
 function composeConfigFile(container: string): string {

--- a/src/app/api/runtime/deployments/route.test.ts
+++ b/src/app/api/runtime/deployments/route.test.ts
@@ -24,7 +24,7 @@ const originalStateDir = process.env.LLV_STATE_DIR;
 const originalSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
 const originalRollback = process.env.LLV_RUNTIME_EVENTS;
 
-let requested: { revision?: string; idempotencyKey: string }[] = [];
+let requested: { revision?: string; ref?: string; idempotencyKey: string }[] = [];
 
 beforeEach(() => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-deployments-route-"));
@@ -37,7 +37,7 @@ beforeEach(() => {
   requested = [];
   setDeploymentRuntimeForTests(async (request) => {
     requested.push(request);
-    return { deploymentId: "deployment_1", revision: request.revision!, state: "accepted", replayed: false };
+    return { deploymentId: "deployment_1", revision: request.revision ?? "a".repeat(40), state: "accepted", replayed: false };
   });
 });
 
@@ -72,6 +72,35 @@ test("an uppercase revision is normalized to the lowercase exact SHA", async () 
   const response = await POST(deployRequest({ revision: SHA.toUpperCase(), idempotencyKey: "k1" }));
   expect(response.status).toBe(202);
   expect(requested).toEqual([{ revision: SHA, idempotencyKey: "k1" }]);
+});
+
+test("a canonical branch ref is forwarded for server-side resolution (#1033)", async () => {
+  const response = await POST(deployRequest({ ref: "refs/heads/main", idempotencyKey: "k1" }));
+  expect(response.status).toBe(202);
+  expect(requested).toEqual([{ ref: "refs/heads/main", idempotencyKey: "k1" }]);
+});
+
+for (const [name, ref] of [
+  ["a tag", "refs/tags/v1"],
+  ["a remote-tracking ref", "refs/remotes/origin/main"],
+  ["a bare branch name", "main"],
+  ["parent traversal", "refs/heads/../../tags/v1"],
+  ["an option-looking branch", "refs/heads/-upload-pack=touch"],
+  ["a revision expression", "refs/heads/main~1"],
+] as const) {
+  test(`a ref outside the canonical repository's branches is refused: ${name}`, async () => {
+    const response = await POST(deployRequest({ ref, idempotencyKey: "k1" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).reason).toBe("ref_invalid");
+    expect(requested).toEqual([]);
+  });
+}
+
+test("a request naming both a revision and a ref is refused rather than silently preferring one", async () => {
+  const response = await POST(deployRequest({ revision: SHA, ref: "refs/heads/main", idempotencyKey: "k1" }));
+  expect(response.status).toBe(400);
+  expect((await response.json()).reason).toBe("target_ambiguous");
+  expect(requested).toEqual([]);
 });
 
 test("a revision-less or abbreviated deploy is refused: exact-SHA means one immutable commit", async () => {

--- a/src/app/api/runtime/deployments/route.ts
+++ b/src/app/api/runtime/deployments/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { isCanonicalBranchRef } from "@/lib/runtime/canonicalRevision";
 import { RuntimeHostUnavailableError, runtimeHostClient } from "@/lib/runtime/client";
 import { DeploymentRuntimeUnavailableError, requestViewerDeployment } from "@/lib/runtime/deploymentRuntime";
 import { runtimeEventsRolledBack, RUNTIME_PLANE_ABSENT } from "@/lib/runtime/flags";
@@ -49,7 +50,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 /**
  * #795 — the deploy door for HTTP callers, at parity with the MCP binding and
- * the raw runtime-host socket: the same request shape (an exact revision and an
+ * the raw runtime-host socket: the same request shape (a deploy target and an
  * idempotency key), the same admission, the same serialized coordinator.
  *
  * The deploy DECISION belongs to the designated agent and is enforced where
@@ -57,8 +58,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  * server-attributed designated-seat identity. No confirmation proof exists
  * anywhere anymore, so nothing here forwards or verifies one.
  *
- * `revision` is required as a full commit SHA: an exact-SHA deployment ships
- * one immutable commit, and "deploy whatever the host picks" is not a request.
+ * A request names its target one of two ways. `revision` is a full commit SHA:
+ * an exact-SHA deployment ships one immutable commit, and "deploy whatever the
+ * host picks" is not a request. `ref` names a branch of the canonical
+ * repository (#1033) and the host resolves it to a commit machine-to-machine,
+ * so no caller has to carry a SHA through its own notes — the mangled tail in
+ * #1032 deployed a revision that never existed for six hours. Either way the
+ * ledger records the exact resolved SHA.
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const rejection = rejectCrossOrigin(request);
@@ -69,22 +75,37 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 503 },
     );
   }
-  let body: { revision?: unknown; idempotencyKey?: unknown };
+  let body: { revision?: unknown; ref?: unknown; idempotencyKey?: unknown };
   try { body = await request.json() as typeof body; }
   catch { return NextResponse.json({ error: "invalid JSON" }, { status: 400 }); }
   if (typeof body.idempotencyKey !== "string") return NextResponse.json({ error: "idempotencyKey is required" }, { status: 400 });
-  if (typeof body.revision !== "string" || !/^[0-9a-f]{40}$/i.test(body.revision)) {
+  if (body.ref !== undefined && body.revision !== undefined) {
     return NextResponse.json(
-      { error: "revision must be a full 40-character commit SHA", reason: "revision_invalid" },
+      { error: "a deployment names either revision or ref, not both", reason: "target_ambiguous" },
       { status: 400 },
     );
   }
+  let target: { revision: string } | { ref: string };
+  if (body.ref !== undefined) {
+    if (typeof body.ref !== "string" || !isCanonicalBranchRef(body.ref)) {
+      return NextResponse.json(
+        { error: "ref must name a canonical repository branch as refs/heads/<branch>", reason: "ref_invalid" },
+        { status: 400 },
+      );
+    }
+    target = { ref: body.ref };
+  } else {
+    if (typeof body.revision !== "string" || !/^[0-9a-f]{40}$/i.test(body.revision)) {
+      return NextResponse.json(
+        { error: "revision must be a full 40-character commit SHA", reason: "revision_invalid" },
+        { status: 400 },
+      );
+    }
+    target = { revision: body.revision.toLowerCase() };
+  }
 
   try {
-    const receipt = await requestViewerDeployment({
-      revision: body.revision.toLowerCase(),
-      idempotencyKey: body.idempotencyKey,
-    });
+    const receipt = await requestViewerDeployment({ ...target, idempotencyKey: body.idempotencyKey });
     return NextResponse.json(receipt, { status: receipt.state === "busy" ? 409 : 202 });
   } catch (error) {
     if (error instanceof DeploymentRuntimeUnavailableError) {

--- a/src/lib/runtime/canonicalRevision.ts
+++ b/src/lib/runtime/canonicalRevision.ts
@@ -1,0 +1,41 @@
+/**
+ * What a deploy request may name, in one place (#1033).
+ *
+ * A SHA that travels through a human's or an agent's notes is a SHA that can be
+ * mangled: #1032 burned six hours redeploying `0afe3c29238ac2d2…` — a revision
+ * that never existed, one retyped tail away from the real main tip. Callers may
+ * therefore name a branch of the canonical repository instead, and the exact
+ * commit is resolved machine-to-machine against the canonical mirror.
+ *
+ * An explicit SHA stays accepted for pinned redeploys and rollbacks; what
+ * changes is that carrying one is no longer the only way to deploy.
+ */
+
+export const CANONICAL_MAIN_REF = "refs/heads/main";
+
+/** Branch refs of the canonical repository, and nothing else: no tags, no
+    remote-tracking refs, no `..` traversal, and no leading `-` that git would
+    read as an option. */
+export function isCanonicalBranchRef(value: string): boolean {
+  return value.length <= 200 && /^refs\/heads\/[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/.test(value);
+}
+
+export function isExactRevision(value: string): boolean {
+  return /^[0-9a-f]{40}$/.test(value);
+}
+
+/** The `git rev-parse` query for a requested revision, or `null` when the
+    request names something this deploy path refuses to resolve. */
+export function canonicalRevisionQuery(requested: string): string | null {
+  if (requested === "origin/main") return `${CANONICAL_MAIN_REF}^{commit}`;
+  if (isExactRevision(requested) || isCanonicalBranchRef(requested)) return `${requested}^{commit}`;
+  return null;
+}
+
+export const REQUESTED_REVISION_REFUSAL = "deployment revision must be origin/main, a canonical branch ref, or a full commit SHA";
+
+/** #1032: the admission failure named neither the revision nor where it looked,
+    so a mangled SHA read as broken infrastructure for five hours. */
+export function revisionNotFoundMessage(requested: string, remote: string): string {
+  return `revision ${requested} not found in the canonical repository (fetched from ${remote})`;
+}

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -532,6 +532,10 @@ export interface ViewerDeploymentStatus {
 
 export interface ViewerDeploymentRequest {
   revision?: string;
+  /** A branch of the canonical repository (`refs/heads/<branch>`), resolved to
+      its exact commit by the host adapter (#1033). Takes precedence over
+      `revision` when both are present. */
+  ref?: string;
   idempotencyKey: string;
 }
 

--- a/src/runtime-host/canonicalMirror.test.ts
+++ b/src/runtime-host/canonicalMirror.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { ensureCanonicalMirror } from "./canonicalMirror";
+import { ensureCanonicalMirror, resolveCanonicalRevision } from "./canonicalMirror";
 
 const sandboxes: string[] = [];
 
@@ -49,4 +49,49 @@ test("restart replaces an interrupted initial clone with a validated mirror", as
   expect(fs.existsSync(incomingDir)).toBe(false);
   expect(calls.some((argv) => argv.includes("set-url"))).toBe(true);
   expect(calls.some((argv) => argv.includes("fetch"))).toBe(true);
+});
+
+function resolver(objects: Record<string, string>) {
+  const queries: string[] = [];
+  let ensured = 0;
+  const run = async (argv: string[]): Promise<string> => {
+    const query = argv.at(-1)!;
+    queries.push(query);
+    const resolved = objects[query];
+    if (resolved === undefined) throw new Error("fatal: Needed a single revision");
+    return resolved;
+  };
+  return { queries, run, ensureMirror: async () => { ensured += 1; }, ensuredCount: () => ensured };
+}
+
+test("a canonical branch ref resolves to the tip commit the mirror holds", async () => {
+  const tip = "a".repeat(40);
+  const fixture = resolver({ "refs/heads/main^{commit}": tip, "refs/heads/agent/lane^{commit}": "b".repeat(40) });
+
+  await expect(resolveCanonicalRevision("origin/main", { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture)).resolves.toBe(tip);
+  await expect(resolveCanonicalRevision("refs/heads/main", { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture)).resolves.toBe(tip);
+  await expect(resolveCanonicalRevision("refs/heads/agent/lane", { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture)).resolves.toBe("b".repeat(40));
+  expect(fixture.ensuredCount()).toBe(3);
+});
+
+test("an exact revision is peeled to a commit, so a well-formed SHA the mirror lacks is a miss (#1032)", async () => {
+  const present = "c".repeat(40);
+  const absent = "d".repeat(40);
+  const fixture = resolver({ [`${present}^{commit}`]: present });
+
+  await expect(resolveCanonicalRevision(present, { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture)).resolves.toBe(present);
+  await expect(resolveCanonicalRevision(absent, { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture))
+    .rejects.toThrow(`revision ${absent} not found in the canonical repository (fetched from ssh://canonical)`);
+  expect(fixture.queries).toEqual([`${present}^{commit}`, `${absent}^{commit}`]);
+});
+
+test("a request that names neither a branch of the canonical repository nor a SHA never reaches git", async () => {
+  const fixture = resolver({});
+
+  for (const requested of ["refs/tags/v1", "main", "HEAD", "refs/heads/main~1", "--upload-pack=touch"]) {
+    await expect(resolveCanonicalRevision(requested, { mirrorDir: "/mirror", remote: "ssh://canonical" }, fixture))
+      .rejects.toThrow("deployment revision must be origin/main, a canonical branch ref, or a full commit SHA");
+  }
+  expect(fixture.queries).toEqual([]);
+  expect(fixture.ensuredCount()).toBe(0);
 });

--- a/src/runtime-host/canonicalMirror.ts
+++ b/src/runtime-host/canonicalMirror.ts
@@ -1,5 +1,12 @@
 import fs from "node:fs";
 
+import {
+  canonicalRevisionQuery,
+  isExactRevision,
+  REQUESTED_REVISION_REFUSAL,
+  revisionNotFoundMessage,
+} from "@/lib/runtime/canonicalRevision";
+
 export interface CanonicalMirrorOptions {
   deploymentDir: string;
   mirrorDir: string;
@@ -41,4 +48,30 @@ export async function ensureCanonicalMirror(
   }
   await dependencies.run(["git", "--git-dir", options.mirrorDir, "remote", "set-url", "origin", options.remote]);
   await dependencies.run(["git", "--git-dir", options.mirrorDir, "fetch", "--prune", "origin", "+refs/heads/*:refs/heads/*"]);
+}
+
+/**
+ * Resolves a requested deploy revision to the immutable commit it names, in the
+ * canonical mirror (#1033). A branch ref resolves to the tip the canonical
+ * repository holds right now; an explicit SHA resolves to itself when the
+ * mirror actually carries that object — `rev-parse --verify <40-hex>` alone
+ * echoes any well-formed hex string back, which is why the `^{commit}` peel is
+ * the check that matters.
+ */
+export async function resolveCanonicalRevision(
+  requested: string,
+  options: Pick<CanonicalMirrorOptions, "mirrorDir" | "remote">,
+  dependencies: CanonicalMirrorDependencies & { ensureMirror(): Promise<void> },
+): Promise<string> {
+  const query = canonicalRevisionQuery(requested);
+  if (!query) throw new Error(REQUESTED_REVISION_REFUSAL);
+  await dependencies.ensureMirror();
+  let revision: string;
+  try {
+    revision = await dependencies.run(["git", "--git-dir", options.mirrorDir, "rev-parse", "--verify", query]);
+  } catch {
+    throw new Error(revisionNotFoundMessage(requested, options.remote));
+  }
+  if (!isExactRevision(revision)) throw new Error("canonical repository returned an invalid revision");
+  return revision;
 }

--- a/src/runtime-host/deployment.test.ts
+++ b/src/runtime-host/deployment.test.ts
@@ -79,7 +79,7 @@ class FakeDeploymentAdapter implements ViewerDeploymentAdapter {
     this.calls.push(`resolve:${revision}`);
     await this.resolveGate;
     if (this.resolveFailures > 0) { this.resolveFailures -= 1; throw new Error("revision resolution timed out"); }
-    return revision === "origin/main" ? "a".repeat(40) : revision;
+    return revision === "origin/main" || revision.startsWith("refs/heads/") ? "a".repeat(40) : revision;
   }
   async buildCandidate(deploymentId: string, revision: string): Promise<ViewerReleaseIdentity> {
     this.calls.push(`build:${revision}`);
@@ -181,6 +181,40 @@ test("deployment admission is serialized and idempotent", async () => {
   releaseBuild();
   await coordinator.waitForDeployment(first.deploymentId);
   expect(adapter.calls.some((call) => call.startsWith("retain-only:"))).toBe(true);
+  store.close();
+});
+
+test("issue 1033: a branch ref is resolved by the host and the ledger records the exact commit", async () => {
+  const store = journal("ref-admission");
+  const adapter = new FakeDeploymentAdapter();
+  const coordinator = new ViewerDeploymentCoordinator(store, adapter, { pid: 10, startIdentity: "10:1" });
+
+  const receipt = await coordinator.requestViewerDeployment({ ref: "refs/heads/main", idempotencyKey: "deploy-ref" });
+
+  expect(receipt).toMatchObject({ state: "accepted", revision: "a".repeat(40) });
+  if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
+  expect(adapter.calls.filter((call) => call.startsWith("resolve:"))).toEqual(["resolve:refs/heads/main"]);
+  await coordinator.waitForDeployment(receipt.deploymentId);
+  /* The exactness the ledger keeps is the RESOLVED commit; the ref is kept
+     beside it as what the caller asked for. */
+  expect(coordinator.readViewerDeployment(receipt.deploymentId)).toMatchObject({
+    requestedRevision: "refs/heads/main",
+    revision: "a".repeat(40),
+    phase: "succeeded",
+    candidate: { revision: "a".repeat(40) },
+  });
+  store.close();
+});
+
+test("issue 1033: a ref outside the canonical repository's branches is refused before resolution", async () => {
+  const store = journal("ref-refusal");
+  const adapter = new FakeDeploymentAdapter();
+  const coordinator = new ViewerDeploymentCoordinator(store, adapter, { pid: 10, startIdentity: "10:1" });
+
+  await expect(coordinator.requestViewerDeployment({ ref: "refs/tags/v1", idempotencyKey: "deploy-tag" }))
+    .rejects.toThrow("deployment revision must be origin/main, a canonical branch ref, or a full commit SHA");
+
+  expect(adapter.calls).toEqual([]);
   store.close();
 });
 

--- a/src/runtime-host/deployment.ts
+++ b/src/runtime-host/deployment.ts
@@ -1,4 +1,9 @@
 import { procBackend } from "@/lib/proc";
+import {
+  isCanonicalBranchRef,
+  isExactRevision,
+  REQUESTED_REVISION_REFUSAL,
+} from "@/lib/runtime/canonicalRevision";
 import type {
   ViewerDeploymentOwner,
   ViewerDeploymentReceipt,
@@ -73,7 +78,7 @@ export interface ViewerDeploymentCoordinatorOptions {
 }
 
 function validRequestedRevision(revision: string): boolean {
-  return revision === "origin/main" || /^[0-9a-f]{40}$/.test(revision);
+  return revision === "origin/main" || isExactRevision(revision) || isCanonicalBranchRef(revision);
 }
 
 function safeError(error: unknown): string {
@@ -137,8 +142,11 @@ export class ViewerDeploymentCoordinator {
     if (!request.idempotencyKey || request.idempotencyKey.length > 200 || /[\r\n]/.test(request.idempotencyKey)) {
       throw new Error("deployment idempotencyKey is invalid");
     }
-    const requestedRevision = request.revision?.trim() || this.defaultRevision;
-    if (!validRequestedRevision(requestedRevision)) throw new Error("deployment revision must be origin/main or a full commit SHA");
+    /* #1033: a caller may name a canonical branch instead of carrying a SHA.
+       Either way the adapter resolves it, and the journal below records the
+       exact commit that was resolved. */
+    const requestedRevision = request.ref?.trim() || request.revision?.trim() || this.defaultRevision;
+    if (!validRequestedRevision(requestedRevision)) throw new Error(REQUESTED_REVISION_REFUSAL);
     /* Replay first: a retry after a lost response presents the same idempotency
        key, and the original receipt is the record that this key was admitted
        once. */

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -173,6 +173,7 @@ export class RuntimeHost {
         if (!this.deployments) throw new Error("viewer deployments are disabled");
         result = await this.deployments.requestViewerDeployment({
           revision: typeof request.params?.revision === "string" ? request.params.revision : undefined,
+          ref: typeof request.params?.ref === "string" ? request.params.ref : undefined,
           idempotencyKey: String(request.params?.idempotencyKey ?? ""),
         });
       } else if (request.method === "viewer-deployment-read") {


### PR DESCRIPTION
Closes #1033. Absorbs the rescoped #1032 (error ergonomics).

## Why

A SHA that travels through a human's or an agent's notes can be mangled. #1032 burned six hours redeploying `0afe3c29238ac2d2…`, a revision that never existed, because every deploy door demanded an exact SHA as *caller input* and the admission failure named neither the revision nor where it looked.

## What changed

**1. `scripts/rebuild.sh` resolves the tip itself.** Bare (or with `origin/main`) it reads `refs/heads/main` from the canonical remote with `git ls-remote` and posts the resolved 40-hex; it prints the resolved SHA before requesting admission. `GIT_TERMINAL_PROMPT=0` keeps a credential prompt from hanging the deploy. An unreachable remote, an absent branch, or a non-SHA tip refuses before any deployment request is made. A pinned SHA argument is byte-identical to today and never consults the remote. The idempotency-key derivation, request body shape, admission handling, and polling loop are untouched.

**2. `POST /api/runtime/deployments` accepts a ref.** `{"ref": "refs/heads/<branch>", "idempotencyKey": "…"}` is allowlisted to canonical repository branches — no tags, no remote-tracking refs, no revision expressions, no `..` traversal, no option-looking names — and is resolved server-side by the adapter's existing `resolve-revision` against the canonical mirror. A request carrying both `revision` and `ref` is refused rather than silently preferring one. `ViewerDeploymentRequest`, the runtime-host socket, and the coordinator carry `ref` end to end; the ledger records the requested target beside the exact resolved SHA exactly as today.

**3. Error ergonomics (#1032).** A miss now answers `revision <sha> not found in the canonical repository (fetched from <remote>)` instead of raw `fatal: Needed a single revision`. Resolution moved out of the adapter script into `resolveCanonicalRevision` in `src/runtime-host/canonicalMirror.ts`, so the peel-to-`^{commit}` check (the one that actually proves the object exists) and the message are testable.

**4. Docs.** `docs/RELEASING.md`: the default invocation carries no revision, the pinned form is documented as the redeploy/rollback path, and the API's two target shapes plus the ledger's exactness guarantee are spelled out.

## Verification

```
bun test scripts/rebuild.test.ts src/runtime-host/canonicalMirror.test.ts \
         src/runtime-host/deployment.test.ts src/app/api/runtime/deployments/route.test.ts
  56 pass, 0 fail (187 expect() calls)
bunx tsc --noEmit          clean
bunx eslint <touched files> clean
bun scripts/privacy-publication-gate.ts --base <merge-base>   PASS
```

New coverage: `ls-remote` resolution with a stubbed `git` (bare, explicit `origin/main`, pinned SHA never touching the remote, and the three unresolvable-tip refusals); API ref acceptance and the allowlist rejections; coordinator admission of a ref with the resolved SHA recorded in the ledger; the miss message and the "well-formed SHA the mirror lacks" case that fooled the #1032 investigation.

Not run: `scripts/runtime-host-viewer-adapter.test.ts`, which exercises host lifecycle paths — this repo's suites are not swept against the live runtime state on the operator's machine. The adapter change there is a two-line delegation covered by `tsc` and by the extracted function's own tests.

## Known window

A new Viewer talking to a not-yet-replaced runtime-host generation would have its `ref` field ignored by the old coordinator, which falls back to `origin/main`. The default deploy path is unaffected because `rebuild.sh` sends a resolved SHA, and the ref path becomes usable once the host generation running this revision is in place.

No deploys or container restarts were performed for this work.