### PR TITLE
fix(tts): speak-control tails - alert lifecycle, flip clamp, keyless tooltip (#1030)

### DIFF
--- a/src/components/feed/SpeakButton.dom.test.tsx
+++ b/src/components/feed/SpeakButton.dom.test.tsx
@@ -161,6 +161,30 @@ function alertNode(): HTMLElement | null {
   return document.querySelector("[data-tts-alert]") as HTMLElement | null;
 }
 
+/* Where the trigger sits on screen. happy-dom lays nothing out — every rect is
+   zeros — so the tests that care where the anchored popovers land, and whether
+   their trigger is still on screen at all, say so themselves. */
+function placeTrigger(button: HTMLButtonElement, top: number): void {
+  button.getBoundingClientRect = () =>
+    ({ top, bottom: top + 24, left: 400, right: 500, width: 100, height: 24, x: 400, y: top, toJSON: () => ({}) }) as DOMRect;
+}
+
+/** A scroll anywhere in the page, which every anchored popover re-measures on. */
+async function scrollPage(): Promise<void> {
+  flushSync(() => {
+    document.body.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  await drainUpdates();
+}
+
+/** Escape, from wherever the focus happens to be. */
+async function pressEscape(): Promise<void> {
+  flushSync(() => {
+    document.body.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }) as unknown as Event);
+  });
+  await drainUpdates();
+}
+
 /* The TTS configuration is one module-level singleton shared by every control
    on the page (one fetch, all controls in step), and only a right-click menu
    re-reads it. So the two tests that change the active provider come LAST in
@@ -442,6 +466,100 @@ test("a message past the ceiling refuses out loud instead of being cut short", a
   view.host.remove();
 });
 
+/* #1030: portalling the refusal to `fixed` coordinates took away the only exit
+   it had — scrolling out of sight with its message — and the placement math
+   clamps a scrolled-away anchor back on screen, so the red box parked itself at
+   the top of the viewport for the rest of the session. The only thing that
+   cleared it was clicking Speak again, i.e. buying another synthesis. */
+test("a refusal is dismissed by Escape or a click away, with nothing bought", async () => {
+  let posts = 0;
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    if (!init?.method) return Response.json(backendInfo);
+    posts += 1;
+    return new Response(new Blob(["audio"]));
+  }) as unknown as typeof fetch;
+  useFakeAudio();
+
+  const view = await mount("word ".repeat(MAX_TTS_MESSAGE_LENGTH / 4));
+  await speak(view);
+  expect(alertNode()).not.toBeNull();
+
+  await pressEscape();
+  expect(alertNode()).toBeNull();
+
+  /* Refused again, and this time dismissed by a click elsewhere — but not by a
+     pointerdown inside the alert itself, which is how the key path it names
+     stays selectable. */
+  await speak(view);
+  const alert = alertNode()!;
+  flushSync(() => {
+    alert.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event);
+  });
+  await drainUpdates();
+  expect(alertNode()).not.toBeNull();
+  flushSync(() => {
+    document.body.dispatchEvent(new dom.MouseEvent("pointerdown", { bubbles: true }) as unknown as Event);
+  });
+  await drainUpdates();
+  expect(alertNode()).toBeNull();
+
+  /* Nothing above was a synthesis: a refusal now ends for free. */
+  expect(posts).toBe(0);
+  expect(playing()).toBeUndefined();
+
+  /* And the menu still owns Escape while it is open: the first press closes the
+     menu and hands focus back — the refusal it was carrying as its notice is
+     untouched, and reappears as its own popover — and only the next press
+     dismisses that. */
+  await speak(view);
+  expect(alertNode()).not.toBeNull();
+  await openMenu(view);
+  expect(alertNode()).toBeNull();
+  await pressEscape();
+  expect(menuOpen()).toBe(false);
+  expect(document.activeElement).toBe(view.button);
+  expect(alertNode()!.textContent).toContain("Too long to read aloud");
+  await pressEscape();
+  expect(alertNode()).toBeNull();
+
+  flushSync(() => { view.root.unmount(); });
+  view.host.remove();
+});
+
+/* The other half of #1030: the alert is anchored to the trigger, so it follows
+   the trigger while the feed scrolls and leaves with it — rather than being
+   clamped back onto the viewport edge over whatever the operator scrolls to. */
+test("the refusal alert tracks its trigger on scroll and leaves the screen with it", async () => {
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    if (!init?.method) return Response.json(backendInfo);
+    throw new Error("unexpected synthesis");
+  }) as unknown as typeof fetch;
+  useFakeAudio();
+
+  const view = await mount("word ".repeat(MAX_TTS_MESSAGE_LENGTH / 4));
+  placeTrigger(view.button, 300);
+  await speak(view);
+  await scrollPage();
+  /* Under the trigger, right edges aligned: the same placement as the menu. */
+  expect(alertNode()!.style.top).toBe("332px");
+  expect(alertNode()!.style.left).toBe("276px");
+
+  /* Scrolled 2000px above the fold, the anchor is gone — and so is the alert,
+     instead of clamping to `top: 8`. */
+  placeTrigger(view.button, -2000);
+  await scrollPage();
+  expect(alertNode()).toBeNull();
+
+  /* Scrolled back to it, the refusal is still there to read. */
+  placeTrigger(view.button, 200);
+  await scrollPage();
+  expect(alertNode()!.textContent).toContain("Too long to read aloud");
+  expect(alertNode()!.style.top).toBe("232px");
+
+  flushSync(() => { view.root.unmount(); });
+  view.host.remove();
+});
+
 test("a chunk failure mid-sequence surfaces the provider error and stops cleanly", async () => {
   let posts = 0;
   globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -652,6 +770,10 @@ test("a provider with no key refuses out loud and names the file to drop it into
      the provider changed under it without a round trip on the play path. */
   const menu = await openMenu(view);
   expect(menu.textContent).toContain("Add the elevenlabs API key at /keys/elevenlabs");
+  /* And the tooltip, the surface that has to be right BEFORE the click, names
+     the missing key instead of promising a paid read it cannot perform
+     (#1030). */
+  expect(view.button.getAttribute("title")).toBe("Add the elevenlabs API key at /keys/elevenlabs");
   flushSync(() => {
     document.body.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }) as unknown as Event);
   });

--- a/src/components/feed/SpeakButton.tsx
+++ b/src/components/feed/SpeakButton.tsx
@@ -64,6 +64,15 @@ function stopActive(): void {
   stop?.();
 }
 
+/* The page-wide "only one control speaks at a time" latch. Assigned through a
+   module function like `stopActive` above rather than from the component body,
+   where the React Compiler reads a bare `activeStop = stop` as a global mutated
+   during render — `begin` is only ever called from a click, but nothing in the
+   source says so. */
+function claimActive(stop: () => void): void {
+  activeStop = stop;
+}
+
 function messageKey(info: BackendInfo, text: string): string {
   const option = info.options.find((candidate) => candidate.id === info.backend)!;
   return voiceKey(option, text);
@@ -128,6 +137,12 @@ export function SpeakButton({ text }: { text: string }) {
     setMenuOpen(false);
     if (restoreFocus) queueMicrotask(() => triggerRef.current?.focus());
   }, []);
+
+  /* The refusal alert's way out (#1030): the same click-away and Escape the
+     menu installs, so a refusal that nothing else clears does not have to be
+     bought off with another synthesis. Stable, or the alert would rebind its
+     listeners on every render. */
+  const dismissError = useCallback(() => setError(null), []);
 
   if (!info || !text) return null;
   const option = info.options.find((candidate) => candidate.id === info.backend);
@@ -246,7 +261,7 @@ export function SpeakButton({ text }: { text: string }) {
     });
 
     ownedStop.current = stop;
-    activeStop = stop;
+    claimActive(stop);
     setPhase("loading");
     setAnnouncement(t("tts.generating"));
     setError(null);
@@ -335,12 +350,18 @@ export function SpeakButton({ text }: { text: string }) {
   const active = phase !== "idle";
   const Icon = active ? Square : replayable ? RotateCw : Volume2;
   /* The tooltip is where the paid/free truth lives now, next to the hint that
-     the menu is a right-click away — the same split MicButton uses. */
+     the menu is a right-click away — the same split MicButton uses. It runs the
+     click's own order of refusals, so it says what the click will actually do:
+     a provider with no key cannot read anything, paid or otherwise, and
+     promising a paid read there was the last place this control oversold
+     itself (#1030). */
   const title = active
     ? t("tts.stop")
     : tooLong
       ? t("tts.tooLong", { count: MAX_TTS_MESSAGE_LENGTH.toLocaleString() })
-      : t("tts.triggerTitle", { action: replayable ? t("tts.replayFree") : t("tts.readPaid") });
+      : !option.available
+        ? t("tts.missingKey", { provider: option.id, path: option.keyPath })
+        : t("tts.triggerTitle", { action: replayable ? t("tts.replayFree") : t("tts.readPaid") });
   return (
     <span className="relative">
       <button ref={triggerRef} data-tts-trigger type="button" onClick={toggle} onContextMenu={(event) => { event.preventDefault(); toggleMenu(); }} aria-haspopup="menu" aria-expanded={menuOpen} className={`inline-flex items-center justify-center rounded-md text-muted transition-opacity hover:bg-sunken hover:text-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${isMobile ? "h-11 w-11" : "p-1"} opacity-70 hover:opacity-100 group-hover/msg:opacity-100`} aria-label={active ? t("tts.stop") : replayable ? t("tts.replay") : t("tts.read")} title={title}>
@@ -367,7 +388,7 @@ export function SpeakButton({ text }: { text: string }) {
           onClose={closeMenu}
         />
       ) : null}
-      {error && !menuOpen ? <SpeakAlert anchorRef={triggerRef}>{error}</SpeakAlert> : null}
+      {error && !menuOpen ? <SpeakAlert anchorRef={triggerRef} onDismiss={dismissError}>{error}</SpeakAlert> : null}
     </span>
   );
 }

--- a/src/components/feed/SpeakMenu.placement.test.ts
+++ b/src/components/feed/SpeakMenu.placement.test.ts
@@ -29,6 +29,15 @@ describe("speakMenuPlacement (#1024: the menu is never clipped)", () => {
     expect(place.top + tall.height).toBeLessThanOrEqual(viewport.height - 8);
   });
 
+  /* #1030: the flip branch carried only a lower bound, so a trigger scrolled
+     far below the fold — the `scroll` re-measure keeps an open menu on it —
+     placed the menu below the fold with it, off screen entirely. */
+  test("clamps a flip against the bottom edge when the trigger is below the fold", () => {
+    const place = speakMenuPlacement({ top: 5000, bottom: 5024, right: 900 }, menu, viewport);
+    expect(place.top).toBe(532);
+    expect(place.top + menu.height).toBeLessThanOrEqual(viewport.height - 8);
+  });
+
   test("clamps against the right edge instead of spilling off it", () => {
     const place = speakMenuPlacement({ top: 100, bottom: 124, right: 1198 }, menu, viewport);
     expect(place.left).toBe(892);

--- a/src/components/feed/SpeakMenu.tsx
+++ b/src/components/feed/SpeakMenu.tsx
@@ -53,8 +53,23 @@ export function speakMenuPlacement(
   const roomBelow = viewport.height - anchor.bottom - margin;
   const roomAbove = anchor.top - margin;
   const flip = content.height > roomBelow && roomAbove > roomBelow;
-  if (flip) return { left, top: Math.max(margin, anchor.top - margin - content.height) };
-  return { left, top: Math.max(margin, Math.min(anchor.bottom + margin, viewport.height - margin - content.height)) };
+  /* One clamp for both branches: the flipped side used to carry only the lower
+     bound, so an anchor scrolled far below the fold placed the menu below the
+     fold with it. */
+  const wanted = flip ? anchor.top - margin - content.height : anchor.bottom + margin;
+  return { left, top: Math.max(margin, Math.min(wanted, viewport.height - margin - content.height)) };
+}
+
+/**
+ * Whether the trigger is still on screen at all. A popover anchored to a
+ * scrolled-away trigger has nothing to point at, and `speakMenuPlacement`
+ * clamps rather than following it off the edge — so the caller that must
+ * disappear with its message (the alert) asks this instead of being pinned to
+ * the viewport edge for the rest of the session (#1030). Touching an edge still
+ * counts as on screen, so a degenerate zero rect never hides anything.
+ */
+function anchorOnScreen(rect: { top: number; bottom: number; left: number; right: number }, viewport: { width: number; height: number }): boolean {
+  return rect.bottom >= 0 && rect.top <= viewport.height && rect.right >= 0 && rect.left <= viewport.width;
 }
 
 /**
@@ -70,23 +85,32 @@ export function speakMenuPlacement(
  * to the same trigger: an inline `absolute` alert is clipped by the message row
  * (`.feed-cv` carries `content-visibility: auto`, hence paint containment) and
  * painted over by the next message, which is what #1024 condemned.
+ *
+ * Also reports whether the trigger is still on screen, which is measured even
+ * while the caller renders nothing — a caller that hides itself when the
+ * trigger scrolls away has to be able to come back when it scrolls in again.
  */
 export function useAnchoredBox(
   anchorRef: RefObject<HTMLElement | null>,
   rootRef: RefObject<HTMLElement | null>,
   fallbackWidth = MENU_WIDTH,
-): CSSProperties {
+): { style: CSSProperties; onScreen: boolean } {
   const [box, setBox] = useState<{ left: number; top: number } | null>(null);
+  const [onScreen, setOnScreen] = useState(true);
 
   const measure = useCallback(() => {
     const anchor = anchorRef.current;
-    const root = rootRef.current;
-    if (!anchor || !root) return;
+    if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
+    const viewport = { width: window.innerWidth, height: window.innerHeight };
+    setOnScreen(anchorOnScreen(rect, viewport));
+    /* Nothing rendered to place — the visibility above is what brings it back. */
+    const root = rootRef.current;
+    if (!root) return;
     const next = speakMenuPlacement(
       { top: rect.top, bottom: rect.bottom, right: rect.right },
       { width: root.offsetWidth || fallbackWidth, height: root.offsetHeight },
-      { width: window.innerWidth, height: window.innerHeight },
+      viewport,
     );
     /* Replaced only when it actually moved, so a re-measure that agrees with
        the current placement does not schedule another render. */
@@ -104,7 +128,7 @@ export function useAnchoredBox(
     };
   }, [measure]);
 
-  return box ? { left: box.left, top: box.top } : { left: -9999, top: 0, opacity: 0 };
+  return { style: box ? { left: box.left, top: box.top } : { left: -9999, top: 0, opacity: 0 }, onScreen };
 }
 
 /**
@@ -117,11 +141,50 @@ export function useAnchoredBox(
  * Only ever shown while the menu is CLOSED — both hang off the same trigger at
  * the same coordinates, so an open menu carries the same text in its own
  * notice slot rather than being painted over by it.
+ *
+ * It also has to END (#1030). Portalling it to `fixed` coordinates took away
+ * the exit the inline alert had — scrolling out of sight with the message it
+ * belongs to — and the placement math clamps a scrolled-away anchor back onto
+ * the screen, so a refusal that nothing clears parked itself at the viewport
+ * edge over the rest of the session. Two ends, both borrowed from the menu
+ * rather than invented: it goes away with its trigger (`onScreen`), and an
+ * outside pointerdown or Escape dismisses it. Neither can fire while the menu
+ * owns those keys and clicks, because this is unmounted for as long as the menu
+ * is open. Pointerdowns inside the alert are left alone so the key path it
+ * names can be selected and copied, and the trigger keeps its own click.
  */
-export function SpeakAlert({ anchorRef, children }: { anchorRef: RefObject<HTMLElement | null>; children: ReactNode }) {
+export function SpeakAlert({
+  anchorRef,
+  onDismiss,
+  children,
+}: {
+  anchorRef: RefObject<HTMLElement | null>;
+  onDismiss: () => void;
+  children: ReactNode;
+}) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const style = useAnchoredBox(anchorRef, rootRef, ALERT_WIDTH);
-  if (typeof document === "undefined") return null;
+  const { style, onScreen } = useAnchoredBox(anchorRef, rootRef, ALERT_WIDTH);
+
+  useEffect(() => {
+    const away = (event: Event) => {
+      const target = event.target as Node | null;
+      if (rootRef.current?.contains(target ?? null) || anchorRef.current?.contains(target ?? null)) return;
+      onDismiss();
+    };
+    const key = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onDismiss();
+    };
+    window.addEventListener("pointerdown", away);
+    window.addEventListener("keydown", key);
+    return () => {
+      window.removeEventListener("pointerdown", away);
+      window.removeEventListener("keydown", key);
+    };
+  }, [anchorRef, onDismiss]);
+
+  if (typeof document === "undefined" || !onScreen) return null;
   return createPortal(
     <div
       ref={rootRef}
@@ -173,7 +236,7 @@ export function SpeakMenu({ anchorRef, info, option, chars, notice, freeReplay, 
   const { t } = useLocale();
   const isMobile = useIsMobile();
   const rootRef = useRef<HTMLDivElement>(null);
-  const style = useAnchoredBox(anchorRef, rootRef);
+  const { style } = useAnchoredBox(anchorRef, rootRef);
   const [saving, setSaving] = useState<BackendId | null>(null);
   const [error, setError] = useState<string | null>(null);
   /* Only a re-render trigger: the cost line is answered by the tts cache, and


### PR DESCRIPTION
Closes #1030 — the three leftovers from PR 1025's round-2 review, all inside the read-aloud control #1024 reworked. Scope held to `SpeakButton.tsx`, `SpeakMenu.tsx` and their tests; `/api/tts`, `ttsSession`/chunker and karaoke are untouched.

## MEDIUM — the refusal alert had no end, and pinned itself to the viewport

`error` is set by `refuse()` and every failure path and cleared only on the left-click play path, so once #1024 portalled the alert to `fixed` coordinates it lost the exit the inline `absolute` version had — scrolling out of sight with its message — and `speakMenuPlacement` clamped a scrolled-away anchor back onto the screen. A refused too-long click parked a red box at the top of the viewport for the rest of the session, over whatever the operator scrolled to; clicking Speak again re-entered the same refusal and re-set the identical text, so the only thing that actually cleared it was buying another synthesis.

It now ends two ways, both borrowed from the menu rather than invented:

- `useAnchoredBox` also reports whether the trigger is still on screen (measured even while its caller renders nothing, so the alert can come back when the trigger scrolls in again), and `SpeakAlert` renders nothing while the anchor is gone. It scrolls off with its message, the way it used to.
- An outside `pointerdown` or Escape dismisses it — the same two listeners the menu installs. Pointerdowns inside the alert and on the trigger are left alone, so the key path it names stays selectable and the trigger keeps its own click.

Neither can fire while the menu owns those keys and clicks, because the alert is unmounted for as long as the menu is open: a refusal carried as the menu's `notice` survives the Escape that closes the menu, reappears as its own popover, and takes one more press to dismiss. The portal, the `fixed` placement, `break-all` and `setError(null)` in `begin` are unchanged; no close button, no modal, no auto-timeout.

## LOW — `speakMenuPlacement`'s flip branch had no bottom clamp

The docstring promised both axes clamped; the flip return applied only `Math.max(margin, …)`, so an anchor at `top: 5000` in an 800px viewport returned `top: 4732`. Both branches now go through one clamp expression. The five existing cases keep their exact expected values.

## LOW — the tooltip advertised "Read aloud (paid)" for a provider with no key

`title` consulted `active`/`tooLong`/`replayable` only, while the click refuses on `option.available` two branches later. It now runs the click's own order of refusals and names the missing key with the existing `tts.missingKey` message (no new strings, `uk` already carries it). Billing honesty is otherwise untouched: partial playback still never advertises a free replay, and the provider still comes from the response.

## One incidental

The honest tooltip made the React Compiler start reporting the pre-existing bare `activeStop = stop` in the component body as a global mutated during render (`react-hooks/globals`, clean before and after on every other shape). The latch is now assigned through a module function beside `stopActive`, which is where the other write to it already lives. Behavior identical.

## Verification

- `bun test src/components/feed/SpeakButton.dom.test.tsx src/components/feed/SpeakMenu.placement.test.ts` — 23 pass, 0 fail.
  - New: the alert is dismissed by Escape and by a click away, not by a pointerdown inside itself, with `posts` at 0 and no playback; the menu still owns Escape while open and hands focus back before the alert can be dismissed.
  - New: the alert lands under its trigger, disappears when the trigger is scrolled 2000px above the fold instead of clamping to `top: 8`, and returns with its text when it is scrolled back.
  - New: a flip below the fold satisfies `top + height <= viewport.height - margin`.
  - Extended: the keyless-provider test asserts the trigger's `title` names the missing key before the click.
- RED verified against `origin/main` in a throwaway worktree: the two new DOM tests and the flip case fail there (`Expected: 532, Received: 4732`), the rest pass.
- `bunx tsc --noEmit` clean; `eslint` clean on all four touched files.
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` — PASS.

No runtime/agent suites were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
