### PR TITLE
feat(mcp): discoverable request_attention + attention-steering in the orchestrator mandate (#1016)

### DIFF
--- a/src/lib/attention/targets.ts
+++ b/src/lib/attention/targets.ts
@@ -133,3 +133,113 @@ export function isFocusTarget(value: unknown): value is FocusTarget {
 export function targetAcceptsIntent(target: FocusTarget, intent: FocusIntent): boolean {
   return intent === "show" || !isGeometricTarget(target);
 }
+
+/**
+ * The per-kind input contract, PUBLISHED rather than discovered (#1016).
+ *
+ * `FocusTarget` is a discriminated union, and until this table existed the
+ * discriminator lived only in the type: the MCP schema declared a free-form
+ * object and every rejection said "target must be a typed focus target", so a
+ * caller could only guess at `kind` and its fields. Five reasonable guesses in
+ * a row lost, and the handoff was abandoned mid-deploy.
+ *
+ * One table, read by both surfaces that have to speak this contract — the tool
+ * definition the caller reads BEFORE calling, and the error it reads after —
+ * so the published shape and the refused shape can never drift apart.
+ */
+export interface FocusTargetShape {
+  kind: FocusTarget["kind"];
+  /** The fields this kind needs, spelled exactly as a caller must send them. */
+  fields: string;
+  /** A call that works, verbatim. */
+  example: string;
+}
+
+export const FOCUS_TARGET_SHAPES: readonly FocusTargetShape[] = [
+  {
+    kind: "conversation",
+    /* Both forms, because the durable id is what the rest of the MCP surface
+       speaks and the path is what the record stores (#1016). */
+    fields: 'conversationId (the durable "conversation_…" id, resolved to its current transcript) or path (that transcript\'s .jsonl path) — at least one',
+    example: '{"kind":"conversation","conversationId":"conversation_9f2c"}',
+  },
+  {
+    kind: "pipeline",
+    fields: "pipelineId (non-empty string)",
+    example: '{"kind":"pipeline","pipelineId":"pipeline_9f2c"}',
+  },
+  {
+    kind: "stage",
+    fields: "pipelineId and stageId (non-empty strings)",
+    example: '{"kind":"stage","pipelineId":"pipeline_9f2c","stageId":"review"}',
+  },
+  {
+    kind: "flowRound",
+    fields: "flowId (non-empty string) and round (integer, 0 or more)",
+    example: '{"kind":"flowRound","flowId":"flow_9f2c","round":2}',
+  },
+  {
+    kind: "task",
+    fields: "taskId (non-empty string)",
+    example: '{"kind":"task","taskId":"task_9f2c"}',
+  },
+  {
+    kind: "draft",
+    fields: "draftId (non-empty string), and a top-level project alongside target — a draft exists only on the operator's canvas, so the server cannot attribute it",
+    example: '{"kind":"draft","draftId":"draft_9f2c"}',
+  },
+  {
+    kind: "region",
+    fields: "project (non-empty string) and rect {x, y, w, h} (finite numbers; w and h 0 or more)",
+    example: '{"kind":"region","project":"live-log-viewer-next","rect":{"x":0,"y":0,"w":800,"h":600}}',
+  },
+  {
+    kind: "point",
+    fields: "project (non-empty string), x and y (finite numbers), and an optional zoom (greater than 0)",
+    example: '{"kind":"point","project":"live-log-viewer-next","x":1200,"y":480}',
+  },
+];
+
+export const FOCUS_TARGET_KINDS: readonly FocusTarget["kind"][] = FOCUS_TARGET_SHAPES.map((shape) => shape.kind);
+
+/** The second accepted conversation form, for the errors that have to name both
+    of them: an id that resolves to nothing is indistinguishable, to the caller,
+    from an id form that was never supported. */
+export const CONVERSATION_PATH_EXAMPLE = '{"kind":"conversation","path":"/…/transcript.jsonl"}';
+
+function shapeFor(kind: unknown): FocusTargetShape | undefined {
+  return FOCUS_TARGET_SHAPES.find((shape) => shape.kind === kind);
+}
+
+/** One call that works, for the kind asked about. */
+export function focusTargetExample(kind: FocusTarget["kind"]): string {
+  return shapeFor(kind)!.example;
+}
+
+/** Keys only, never values: the message is read by whoever mis-shaped the call,
+    and a target's contents are the operator's, not the error's. */
+function receivedKeys(value: object): string {
+  const keys = Object.keys(value).slice(0, 10);
+  return keys.length > 0 ? ` (received keys: ${keys.join(", ")})` : " (received no keys)";
+}
+
+/**
+ * Why a value is not a focus target, in words that name the way through: the
+ * discriminator, the fields the ATTEMPTED kind expects, and one example that
+ * works. Nothing here judges intent — a caller that guessed `type` instead of
+ * `kind` reads the same sentence as one that guessed nothing.
+ */
+export function describeFocusTargetRejection(value: unknown): string {
+  const kinds = FOCUS_TARGET_KINDS.join(" | ");
+  const conversation = focusTargetExample("conversation");
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return `target must be an object discriminated by "kind": one of ${kinds} — e.g. ${conversation}`;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  const shape = shapeFor(kind);
+  if (!shape) {
+    const read = typeof kind === "string" && kind.length > 0 ? `read kind "${kind}"` : 'read no "kind"';
+    return `target.kind must be one of ${kinds}; ${read}${receivedKeys(value)} — e.g. ${conversation}`;
+  }
+  return `target kind "${shape.kind}" expects ${shape.fields}${receivedKeys(value)} — e.g. ${shape.example}`;
+}

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -17,7 +17,14 @@ import {
   resolveDirectedAttentionView,
 } from "@/lib/attention/service";
 import { readAttentionFile } from "@/lib/attention/store";
-import { geometricFrameRect, isFocusTarget, isGeometricTarget } from "@/lib/attention/targets";
+import {
+  CONVERSATION_PATH_EXAMPLE,
+  describeFocusTargetRejection,
+  focusTargetExample,
+  geometricFrameRect,
+  isFocusTarget,
+  isGeometricTarget,
+} from "@/lib/attention/targets";
 import type { AttentionRequestV1, FocusIntent, FocusTarget, ZoomIntent } from "@/lib/attention/types";
 import { boardFor } from "@/lib/board/store";
 import { applyConversationAction } from "@/lib/conversation/actions";
@@ -1989,6 +1996,44 @@ async function lifecycleEvents(
 }
 
 /**
+ * The caller's target, read into the ONE shape the record stores (#1016).
+ *
+ * Two things happen here and nothing else does. A conversation named by its
+ * durable `conversationId` — the name the rest of this MCP surface speaks, and
+ * the only one that survives a resume or a migration — is resolved to that
+ * conversation's CURRENT generation transcript, which is exactly what a caller
+ * who already knew the path would have sent. And a value that is no target at
+ * all is refused in words that name the discriminator, the fields its kind
+ * expects and an example that works, instead of the bare "target must be a
+ * typed focus target" that cost the reported caller five guesses.
+ *
+ * A usable `path` is honoured untouched, so every call that works today writes
+ * byte-identical records: the id is the way in for callers that have no path,
+ * never a second interpretation of calls that have one.
+ */
+function focusTargetFromArgs(value: unknown, dependencies: ViewerMcpDomainDependencies): FocusTarget {
+  const named = value && typeof value === "object" && !Array.isArray(value)
+    ? value as { kind?: unknown; path?: unknown; conversationId?: unknown }
+    : null;
+  const conversationId = named?.kind === "conversation" && !text(named.path) ? text(named.conversationId) : "";
+  if (conversationId) {
+    /* The registry's own keyed lookup, alias walk included, so an id that was
+       chained through a rollover still names its newest transcript. */
+    const lookup = readOnlyConversationLookupFromSnapshot(dependencies.registrySnapshot());
+    const path = lookup.conversation(conversationId as `conversation_${string}`)?.generations.at(-1)?.path;
+    if (!path) {
+      throw new Error(
+        `no registered conversation has id "${conversationId}" — a conversation target accepts `
+        + `${focusTargetExample("conversation")} or ${CONVERSATION_PATH_EXAMPLE}`,
+      );
+    }
+    return { kind: "conversation", path };
+  }
+  if (!isFocusTarget(value)) throw new Error(describeFocusTargetRejection(value));
+  return value;
+}
+
+/**
  * Which project a target lives in, so the request can record one.
  *
  * Only the project is derived here — never a rect. The server has no board
@@ -2074,8 +2119,7 @@ async function requestAttention(
   }
   const raisedBy = attributionOf(dependencies);
 
-  const target = args.target;
-  if (!isFocusTarget(target)) throw new Error("target must be a typed focus target");
+  const target = focusTargetFromArgs(args.target, dependencies);
   const intent = (text(args.intent) || "show") as FocusIntent;
   if (intent !== "show" && intent !== "open") throw new Error("intent must be show or open");
   const zoom = text(args.zoom) as ZoomIntent | "";

--- a/src/lib/mcp/requestAttention.targets.test.ts
+++ b/src/lib/mcp/requestAttention.targets.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { AttentionCallerAuthority } from "@/lib/attention/callerAuthority";
+import { answerAttentionRequest, awaitAttentionArrival, raiseAttentionRequest } from "@/lib/attention/service";
+import { readAttentionFile } from "@/lib/attention/store";
+import { FOCUS_TARGET_SHAPES } from "@/lib/attention/targets";
+import type { BoardTask } from "@/lib/tasks/types";
+import type { FileEntry } from "@/lib/types";
+import { resetPresenceForTest, upsertPresence } from "@/lib/view/presenceStore";
+import type { PresencePayloadV1 } from "@/lib/view/types";
+
+import { viewerMcpBindings } from "./bindings";
+import { createMcpToolService, MemoryMcpReceiptStore, type McpToolResult } from "./server";
+
+/*
+ * #1016 — the target contract, exercised as a caller meets it.
+ *
+ * The reported failure was not a bug in any single check: `target` published no
+ * structure, so a caller composing one from the tool definition had nothing to
+ * compose from, and every rejection answered "target must be a typed focus
+ * target" whatever was wrong. This file pins the three things that closed it:
+ * every PUBLISHED example is a call that actually works, a conversation can be
+ * named by the durable id the rest of the MCP surface speaks, and a mis-shaped
+ * target is refused in words that name the way through.
+ */
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-attention-targets-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  resetPresenceForTest();
+});
+afterEach(() => {
+  resetPresenceForTest();
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+/** The board the published examples name, entity for entity. */
+const WORKER_PATH = "/tmp/worker-9f2c.jsonl";
+const WORKER_ID = "conversation_9f2c";
+const DEVICE = "device-desktop";
+const PROJECT = "live-log-viewer-next";
+
+const workerFile = {
+  path: WORKER_PATH,
+  project: PROJECT,
+  title: "Builder — attention DX",
+  engine: "claude",
+  activity: "live",
+} as unknown as FileEntry;
+
+const boardTask = {
+  id: "task_9f2c",
+  project: PROJECT,
+  status: "inbox",
+  text: "Ship the handoff",
+  placement: "unplaced",
+  assignments: [],
+  createdAt: "2026-08-19T10:00:00.000Z",
+  updatedAt: "2026-08-19T10:00:00.000Z",
+} as unknown as BoardTask;
+
+const ROOT_CALLER: AttentionCallerAuthority = { kind: "root", conversationId: "conversation_root" };
+
+const fastArrival: typeof awaitAttentionArrival = (id, options = {}) =>
+  awaitAttentionArrival(id, { pollMs: 5, timeoutMs: 1_500, ...options });
+
+function service() {
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    completedFileScan: async () => ({ snapshot: { files: [], projectCatalog: [], complete: true } }),
+    listFiles: async () => [workerFile],
+    loadTasks: () => [boardTask],
+    getPipelines: () => ({ pipelines: [{ id: "pipeline_9f2c", project: PROJECT }] }),
+    getFlowsWithPresets: () => ({ flows: [{ id: "flow_9f2c", project: PROJECT }] }),
+    /* The durable id the published conversation example names, holding the
+       transcript its CURRENT generation is written to. */
+    registrySnapshot: () => ({
+      conversations: {
+        [WORKER_ID]: {
+          id: WORKER_ID,
+          generations: [{ path: "/tmp/worker-9f2c.superseded.jsonl" }, { path: WORKER_PATH }],
+          continuityPaths: [],
+        },
+      },
+      conversationAliases: {},
+    }),
+    adoptRootSession: () => {},
+    attentionAuthority: () => ROOT_CALLER,
+    raiseAttentionRequest,
+    awaitAttentionArrival: fastArrival,
+  } as never);
+  return createMcpToolService(bindings, new MemoryMcpReceiptStore());
+}
+
+function openView(): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "view-1",
+    deviceId: DEVICE,
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: PROJECT,
+    mode: "scheme",
+    viewport: { width: 1_600, height: 900, dpr: 2 },
+    camera: { x: 10, y: 20, zoom: 0.6, worldRect: { x: 0, y: 0, width: 100, height: 80 } },
+    focusedPath: null,
+    selectedPaths: [],
+    visiblePaths: [],
+    board: { renderedRevision: 4, durableRevision: 4, sync: "current" },
+  };
+}
+
+/** An open desk and its browser, so a directed handoff can land. */
+function desk() {
+  upsertPresence(openView());
+  const timer = setInterval(() => {
+    try {
+      for (const request of readAttentionFile().requests) {
+        if (request.state !== "accepted" || request.acknowledgedBy !== DEVICE) continue;
+        answerAttentionRequest(request.id, {
+          kind: "arrive",
+          deviceId: DEVICE,
+          returnPoint: {
+            deviceId: DEVICE,
+            mode: "scheme",
+            camera: { x: 120, y: 340, zoom: 0.55 },
+            focusedPath: "/tmp/what-i-was-reading.jsonl",
+            capturedAt: new Date().toISOString(),
+          },
+          resolution: "exact",
+        });
+      }
+    } catch { /* mid-write read; the next tick sees the settled file */ }
+  }, 10);
+  return { stop: () => clearInterval(timer) };
+}
+
+const ask = (overrides: Record<string, unknown> = {}) => ({
+  clientRequestId: "raise-1",
+  target: { kind: "conversation", path: WORKER_PATH },
+  reason: "The builder just opened the PR.",
+  ...overrides,
+});
+
+/* The published examples ARE the contract: if one of them cannot be pasted into
+   a call, the tool definition is teaching a shape the server refuses. */
+test("every published per-kind example is a call that works", async () => {
+  const browser = desk();
+  try {
+    const tools = service();
+
+    for (const shape of FOCUS_TARGET_SHAPES) {
+      const target = JSON.parse(shape.example) as Record<string, unknown>;
+      const result = await tools.callTool("request_attention", ask({
+        clientRequestId: `raise-${shape.kind}`,
+        target,
+        /* The one kind the server cannot attribute on its own, exactly as the
+           published fields say. */
+        ...(shape.kind === "draft" ? { project: PROJECT } : {}),
+      })) as McpToolResult;
+
+      expect([shape.kind, result.ok, result.error ?? null]).toEqual([shape.kind, true, null]);
+      const stored = readAttentionFile().requests.at(-1)!;
+      /* The durable id resolves to the CURRENT generation's transcript, so the
+         record stores the same target a path-bearing caller would have written
+         — the id is an input form, never a second kind of record. */
+      expect(stored.target).toEqual(
+        shape.kind === "conversation" ? { kind: "conversation", path: WORKER_PATH } : target as never,
+      );
+    }
+    expect(readAttentionFile().requests).toHaveLength(FOCUS_TARGET_SHAPES.length);
+  } finally {
+    browser.stop();
+  }
+});
+
+/* The five shapes the report tried, reconstructed from it: an id with no kind,
+   a `type` discriminator, the kind + durable id, a plausibly-named path field,
+   and the bare id as a string. Exactly one of them was ever going to be the
+   contract; what the report proves is that the other four taught nothing. */
+test("the five shapes from the report either land or say what was expected", async () => {
+  const browser = desk();
+  try {
+    const tools = service();
+
+    const byId = await tools.callTool("request_attention", ask({
+      clientRequestId: "shape-3",
+      target: { kind: "conversation", conversationId: WORKER_ID },
+    })) as McpToolResult;
+    expect(byId.ok).toBe(true);
+    expect(readAttentionFile().requests.at(-1)!.target).toEqual({ kind: "conversation", path: WORKER_PATH });
+
+    for (const [key, target, expected] of [
+      ["no-kind", { conversationId: WORKER_ID }, [
+        'target.kind must be one of conversation | pipeline | stage | flowRound | task | draft | region | point; read no "kind"',
+        "received keys: conversationId",
+        '{"kind":"conversation","conversationId":"conversation_9f2c"}',
+      ]],
+      ["type-discriminator", { type: "conversation", conversationId: WORKER_ID }, [
+        'read no "kind"',
+        "received keys: type, conversationId",
+      ]],
+      ["wrong-field", { kind: "conversation", transcriptPath: WORKER_PATH }, [
+        'target kind "conversation" expects conversationId',
+        "or path (that transcript's .jsonl path) — at least one",
+        "received keys: kind, transcriptPath",
+      ]],
+      ["bare-string", WORKER_ID, [
+        'target must be an object discriminated by "kind": one of conversation | pipeline | stage | flowRound | task | draft | region | point',
+      ]],
+    ] as const) {
+      const refused = await tools.callTool("request_attention", ask({ clientRequestId: `shape-${key}`, target })) as McpToolResult;
+      expect(refused.ok).toBe(false);
+      for (const fragment of expected) expect(refused.error).toContain(fragment);
+      /* Whatever it says, it never says the sentence that started this. */
+      expect(refused.error).not.toBe("target must be a typed focus target");
+    }
+
+    /* One landed move, four refusals that filed nothing. */
+    expect(readAttentionFile().requests).toHaveLength(1);
+  } finally {
+    browser.stop();
+  }
+});
+
+test("a wrong shape names the kind it read and the fields that kind expects", async () => {
+  const tools = service();
+
+  for (const [key, target, expected] of [
+    ["unknown-kind", { kind: "elsewhere", id: "x" }, [
+      'target.kind must be one of conversation | pipeline | stage | flowRound | task | draft | region | point; read kind "elsewhere"',
+      "received keys: kind, id",
+    ]],
+    ["task-wrong-field", { kind: "task", id: "task_9f2c" }, [
+      'target kind "task" expects taskId (non-empty string)',
+      'e.g. {"kind":"task","taskId":"task_9f2c"}',
+    ]],
+    ["stage-missing-half", { kind: "stage", pipelineId: "pipeline_9f2c" }, [
+      'target kind "stage" expects pipelineId and stageId (non-empty strings)',
+      '{"kind":"stage","pipelineId":"pipeline_9f2c","stageId":"review"}',
+    ]],
+    ["round-not-an-integer", { kind: "flowRound", flowId: "flow_9f2c", round: "2" }, [
+      'target kind "flowRound" expects flowId (non-empty string) and round (integer, 0 or more)',
+    ]],
+    ["point-without-project", { kind: "point", x: 1, y: 2 }, [
+      'target kind "point" expects project (non-empty string), x and y (finite numbers)',
+    ]],
+    ["conversation-empty", { kind: "conversation" }, [
+      'target kind "conversation" expects conversationId (the durable "conversation_…" id, resolved to its current transcript)',
+      "received keys: kind",
+    ]],
+  ] as const) {
+    const refused = await tools.callTool("request_attention", ask({ clientRequestId: `bad-${key}`, target })) as McpToolResult;
+
+    expect(refused.ok).toBe(false);
+    for (const fragment of expected) expect(refused.error).toContain(fragment);
+  }
+  expect(readAttentionFile().requests).toEqual([]);
+});
+
+/* A conversationId nothing on the board answers to is the one miss a caller
+   cannot tell from "the id form is unsupported" — so the refusal names both
+   accepted forms rather than only the one that failed. */
+test("an unresolvable conversationId names both accepted conversation forms", async () => {
+  const refused = await service().callTool("request_attention", ask({
+    clientRequestId: "missing-id",
+    target: { kind: "conversation", conversationId: "conversation_gone" },
+  })) as McpToolResult;
+
+  expect(refused.ok).toBe(false);
+  expect(refused.error).toContain('no registered conversation has id "conversation_gone"');
+  expect(refused.error).toContain('{"kind":"conversation","conversationId":"conversation_9f2c"}');
+  expect(refused.error).toContain('{"kind":"conversation","path":"/…/transcript.jsonl"}');
+  expect(readAttentionFile().requests).toEqual([]);
+});
+
+/* The id is a way IN for callers that have no path, never a reinterpretation of
+   calls that already work: a target carrying a usable path is recorded exactly
+   as it arrived, down to whatever else it carries. */
+test("a target that already names a path is recorded untouched", async () => {
+  const browser = desk();
+  try {
+    const result = await service().callTool("request_attention", ask({
+      target: { kind: "conversation", path: WORKER_PATH, conversationId: "conversation_gone" },
+    })) as McpToolResult;
+
+    expect(result.ok).toBe(true);
+    expect(readAttentionFile().requests.at(-1)!.target).toEqual({
+      kind: "conversation", path: WORKER_PATH, conversationId: "conversation_gone",
+    } as never);
+  } finally {
+    browser.stop();
+  }
+});

--- a/src/lib/mcp/requestAttention.test.ts
+++ b/src/lib/mcp/requestAttention.test.ts
@@ -286,7 +286,12 @@ test("a target the server cannot attribute is refused rather than filed under a 
 
     expect(draft).toMatchObject({ ok: false, error: "a draft target needs an explicit project" });
     expect(missing).toMatchObject({ ok: false, error: "no conversation on the board has that transcript path" });
-    expect(nonsense).toMatchObject({ ok: false, error: "target must be a typed focus target" });
+    /* #1016: the rejection names the discriminator and its kinds rather than
+       restating that the value was not a target. The per-kind wording is pinned
+       in `requestAttention.targets.test.ts`. */
+    expect(nonsense.ok).toBe(false);
+    expect(nonsense.error).toContain('target.kind must be one of conversation | pipeline | stage | flowRound | task | draft | region | point');
+    expect(nonsense.error).toContain('read kind "elsewhere"');
     expect(readAttentionFile().requests).toEqual([]);
 
     /* Naming the project explicitly is the way through for a board draft. */

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
+import { FOCUS_TARGET_SHAPES } from "@/lib/attention/targets";
 import { listRoles, resolveRole } from "@/lib/roles/registry";
 import { ROLE_IDS } from "@/lib/roles/types";
 import {
@@ -549,4 +550,74 @@ test("create_pipeline admits the stage shapes the engine accepts", () => {
     clientRequestId: "stage-shape-role-override", task: "t", repoDir: "/repo",
     stages: [{ id: "build", kind: "run", "prompt": "Implement.", role: { roleId: "builder", engine: "codex" } }],
   }).success).toBe(false);
+});
+
+/* #1016 — `target` was a free-form record with a prose list of kind names, so
+   the discriminator and every per-kind field lived only in the TypeScript type:
+   five plausible guesses in a row were rejected by one undifferentiated
+   sentence. The tool definition now publishes the union itself. */
+test("request_attention publishes the per-kind target schema in its tool definition", async () => {
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    const tool = listed.tools.find((candidate) => candidate.name === "request_attention");
+    const target = tool?.inputSchema.properties?.target as {
+      oneOf?: { properties?: Record<string, { const?: string; description?: string }>; required?: string[] }[];
+    } | undefined;
+    const branches = new Map((target?.oneOf ?? []).map(
+      (branch) => [branch.properties?.kind?.const, branch] as const,
+    ));
+
+    /* One branch per kind, in the table's own order — a real oneOf, not a hint. */
+    expect([...branches.keys()]).toEqual(FOCUS_TARGET_SHAPES.map((shape) => shape.kind));
+    for (const [kind, required] of [
+      ["conversation", ["kind"]],
+      ["pipeline", ["kind", "pipelineId"]],
+      ["stage", ["kind", "pipelineId", "stageId"]],
+      ["flowRound", ["kind", "flowId", "round"]],
+      ["task", ["kind", "taskId"]],
+      ["draft", ["kind", "draftId"]],
+      ["region", ["kind", "project", "rect"]],
+      ["point", ["kind", "project", "x", "y"]],
+    ] as const) {
+      expect([kind, branches.get(kind)?.required?.slice().sort()]).toEqual([kind, [...required].sort()]);
+    }
+    /* The conversation branch carries BOTH accepted input forms: the durable id
+       the rest of this surface speaks, and the transcript path the record
+       stores. Neither is required alone, which is why the binding — not the
+       protocol boundary — answers a conversation target naming neither. */
+    const conversation = branches.get("conversation")?.properties;
+    expect(conversation?.conversationId?.description).toContain("survives resume and migration");
+    expect(conversation?.path?.description).toContain("supply at least one");
+
+    /* One pasteable example per kind, on the definition a caller reads first. */
+    for (const shape of FOCUS_TARGET_SHAPES) expect(tool?.description).toContain(shape.example);
+    expect(tool?.description).toContain("A rejected target names the kind it read and the fields that kind expects");
+  });
+});
+
+/* The published union must never be stricter than the record's own validator,
+   or a target the server would have accepted dies at the protocol boundary
+   without ever reaching the error that explains targets. */
+test("request_attention admits every target shape the attention record accepts", () => {
+  const schema = TOOL_INPUT_SCHEMAS.request_attention;
+  const accepted = [
+    ...FOCUS_TARGET_SHAPES.map((shape) => JSON.parse(shape.example) as Record<string, unknown>),
+    { kind: "conversation", path: "/tmp/session.jsonl" },
+    /* Both forms together, and the extra keys `isFocusTarget` has always
+       tolerated: every call that works today keeps working. */
+    { kind: "conversation", path: "/tmp/session.jsonl", conversationId: "conversation_9f2c", note: "kept" },
+    { kind: "flowRound", flowId: "flow_9f2c", round: 0 },
+    { kind: "region", project: "demo", rect: { x: -10, y: -10, w: 0, h: 0 } },
+    { kind: "point", project: "demo", x: -1.5, y: 2.5, zoom: 0.25 },
+  ];
+  for (const target of accepted) {
+    const parsed = schema.safeParse({ clientRequestId: "target-shape", target, reason: "Look at this." });
+    expect([target.kind, parsed.success]).toEqual([target.kind, true]);
+    expect((parsed.data as { target: unknown } | undefined)?.target).toEqual(target);
+  }
+  /* An unknown kind never resolves to a branch, so the discriminator is the one
+     thing the boundary does refuse — naming the kinds it knows. */
+  const refused = schema.safeParse({ clientRequestId: "target-shape", target: { kind: "elsewhere" }, reason: "Look." });
+  expect(refused.success).toBe(false);
+  expect(JSON.stringify(refused.error?.issues)).toContain("conversation");
 });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -8,6 +8,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
+import { FOCUS_TARGET_SHAPES } from "@/lib/attention/targets";
 import { statePath } from "@/lib/configDir";
 import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { DEFAULT_STALL_AFTER_MS } from "@/lib/lifecycle/liveness";
@@ -1637,7 +1638,12 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   conversation_migration: "Reseat, retry, or roll back a conversation account migration.",
   agent_activity: "Read agent liveness: last transcript record, turn state, whether the host is alive or gone, and how long a stalled conversation has been silent.",
   lifecycle_events: "Query the durable lifecycle event journal by lineage and cursor, or poll a bounded relay digest of what changed since the last one.",
-  request_attention: "Move the operator's one active Viewer to a typed target immediately and verify the arrival — no confirmation prompt, no pending offer. Execution is gated on server-derived authority: only the operator's root/gateway session or the target project's designated orchestrator seat may direct it; workers and unidentified callers are refused (ATTENTION_NOT_PERMITTED) with nothing recorded. The latest-interaction active view is chosen deterministically (down to the one executing browser tab); success is returned only after that view's camera/focus actually landed, and a missing view, lost target, or timeout is an explicit bounded failure. Durably attributed to the calling session, idempotent by clientRequestId across restarts, and the operator keeps a one-action Return control that restores exactly where they were.",
+  request_attention: [
+    "Move the operator's one active Viewer to a typed target immediately and verify the arrival — no confirmation prompt, no pending offer. Execution is gated on server-derived authority: only the operator's root/gateway session or the target project's designated orchestrator seat may direct it; workers and unidentified callers are refused (ATTENTION_NOT_PERMITTED) with nothing recorded. The latest-interaction active view is chosen deterministically (down to the one executing browser tab); success is returned only after that view's camera/focus actually landed, and a missing view, lost target, or timeout is an explicit bounded failure. Durably attributed to the calling session, idempotent by clientRequestId across restarts, and the operator keeps a one-action Return control that restores exactly where they were.",
+    `Targets are typed and discriminated by \`kind\`, one shape per kind: ${FOCUS_TARGET_SHAPES.map((shape) => `${shape.kind} — ${shape.example}`).join("; ")}.`,
+    "A conversation target takes either its durable conversationId (resolved server-side to that conversation's current transcript, and the form to prefer because it survives resume and migration) or that transcript's path.",
+    "A draft target also needs the top-level project argument; region and point accept intent \"show\" only. A rejected target names the kind it read and the fields that kind expects.",
+  ].join(" "),
   bridge_report: "Append one bounded report to the durable bridge log for the voice gateway to relay. Callable from any session; the origin is labeled server-side and a non-orchestrator report is visibly attributed to its own session.",
   bridge_directive: "Relay the user's intent to the designated manager. The recipient and the delivery id are derived server-side, so a retry of the same root turn is one instruction, never two.",
   get_orchestrator: "Read a project's designated orchestrator: designation, health and activity, model and prompt version, transcript size, message/tool/compaction counts, context usage against its model's configured window (clearly labelled when estimated), predecessor lineage, and a bounded rotation recommendation — STRONGLY_RECOMMEND_ROTATION once usage reaches the configured threshold. Words only: it never rotates, creates, or interrupts anything itself.",
@@ -1713,6 +1719,63 @@ const pipelineStageSchema = z.object({
   access: z.enum(["read-only", "read-write"]).optional()
     .describe("Stage-level access override. A review-loop stage is always read-only."),
 }).passthrough();
+
+/* #1016: the typed target contract, published rather than guessed. `target` was
+   declared as a free-form record with a prose list of kind names, so the
+   discriminator and every per-kind field lived only in `FocusTarget` — five
+   plausible guesses in a row were rejected with one undifferentiated sentence.
+   Each branch here is exactly as wide as `isFocusTarget`, and each stays open
+   (`passthrough`) so the binding, not the protocol boundary, answers a
+   mis-shaped target with the sentence that names the way through. The
+   conversation branch is the one that carries two accepted forms, so both its
+   fields are optional here and the binding requires one of them. */
+const focusTargetSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("conversation"),
+    conversationId: z.string().min(1).optional()
+      .describe('Durable "conversation_…" id, resolved server-side to that conversation\'s current transcript. The form to prefer: it survives resume and migration, which a path does not.'),
+    path: z.string().min(1).optional()
+      .describe("Transcript .jsonl path of the conversation. Accepted alongside conversationId; supply at least one."),
+  }).passthrough().describe("A conversation card, named by durable id or by transcript path."),
+  z.object({
+    kind: z.literal("pipeline"),
+    pipelineId: z.string().min(1).describe("Pipeline id; the request frames that pipeline's group on the board."),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("stage"),
+    pipelineId: z.string().min(1).describe("Pipeline the stage belongs to."),
+    stageId: z.string().min(1).describe("Stage id within that pipeline. Resolves to the stage slot before it materializes and to the running agent's conversation afterwards."),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("flowRound"),
+    flowId: z.string().min(1).describe("Review flow id; the request frames that flow's deck."),
+    round: z.number().int().min(0).describe("Round number within the flow, from 0."),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("task"),
+    taskId: z.string().min(1).describe("Board task id."),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("draft"),
+    draftId: z.string().min(1).describe("Board draft id. A draft exists only on the operator's canvas, so this target also needs the top-level project argument."),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("region"),
+    project: z.string().min(1).describe("Project whose board the rect is in."),
+    rect: z.object({
+      x: z.number(), y: z.number(),
+      w: z.number().min(0), h: z.number().min(0),
+    }).passthrough().describe("World-space box, in the board's own geometry."),
+  }).passthrough().describe("A board area. Geometric targets accept intent \"show\" only."),
+  z.object({
+    kind: z.literal("point"),
+    project: z.string().min(1).describe("Project whose board the point is in."),
+    x: z.number(), y: z.number(),
+    zoom: z.number().gt(0).optional().describe("Optional explicit zoom; otherwise the point frames a card's worth of context around itself."),
+  }).passthrough().describe("A board coordinate. Geometric targets accept intent \"show\" only."),
+]).describe(
+  `Typed focus target, discriminated by "kind": ${FOCUS_TARGET_SHAPES.map((shape) => `${shape.kind} — ${shape.example}`).join("; ")}.`,
+);
 
 function boundedNumericInput(toolName: McpToolName, fieldPath: string): z.ZodType {
   const spec = MCP_BOUNDED_NUMERIC_ARGS[toolName]?.find((candidate) => candidate.path.join(".") === fieldPath);
@@ -1938,7 +2001,7 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   }).passthrough(),
   request_attention: z.object({
     clientRequestId: clientRequestIdSchema,
-    target: z.record(z.string(), z.unknown()).describe("Typed focus target: conversation | pipeline | stage | flowRound | task | draft | region | point."),
+    target: focusTargetSchema,
     reason: z.string().min(1).describe("One operator-safe sentence saying why it is worth looking at. Never the target's contents."),
     intent: z.enum(["show", "open"]).optional().describe("show frames and highlights; open also opens the target's own surface. Default show."),
     zoom: z.enum(["inspect", "situate"]).optional(),

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import { FOCUS_TARGET_KINDS } from "@/lib/attention/targets";
 import { BRIDGE_REPORT_CLASSES } from "@/lib/bridge/types";
 
 import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "./prompt";
@@ -69,8 +70,48 @@ test("bridge reports survive as the second channel, for the operator away from t
 
 /* Seats record the mandate version they were spawned on; `get_orchestrator` reports
    this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
-test("the default mandate is at version 5", () => {
-  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(5);
+test("the default mandate is at version 6", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(6);
+});
+
+/* #1016 — the seat had the attention tool and never used it: nothing it read said
+   when moving the operator was the right thing to do, and the tool published no
+   target shape, so the one seat that tried gave up after five guesses. The mandate
+   now carries both halves — the occasions, and the shapes to call them with. */
+test("the mandate teaches proactive attention steering with the occasions for it", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Steering the operator's attention (request_attention)");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("you just spawned or resumed a worker for something they asked for");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("a review verdict, merge or deploy lands");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("a lane blocks on THEM");
+  /* Sparingly and tied to concrete work — the failure mode on the other side is a
+     seat that yanks the view on every poll. */
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Do not move them for polling, routine status");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("One move per real outcome");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("NO_ACTIVE_VIEW");
+});
+
+/* Verbatim shapes, so a seat following only the mandate reaches the operator's
+   screen on its FIRST call. Each is parsed here as the tool would receive it. */
+test("the mandate carries working target shapes for every surface it names", () => {
+  for (const shape of [
+    '{"kind":"conversation","conversationId":"conversation_..."}',
+    '{"kind":"conversation","path":"/.../transcript.jsonl"}',
+    '{"kind":"stage","pipelineId":"pipeline_...","stageId":"review"}',
+    '{"kind":"pipeline","pipelineId":"pipeline_..."}',
+    '{"kind":"flowRound","flowId":"flow_...","round":2}',
+    '{"kind":"task","taskId":"task_..."}',
+    '{"kind":"draft","draftId":"draft_..."}',
+  ]) {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain(shape);
+    const target = JSON.parse(shape) as { kind: string };
+    /* Each printed shape is a real target of a real kind, discriminated the way
+       the tool discriminates it. */
+    expect(FOCUS_TARGET_KINDS).toContain(target.kind as never);
+  }
+  /* The two facts a first call also needs: the draft's extra argument, and that
+     intent decides framing versus opening. */
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("plus a top-level project");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('intent "show" frames and highlights the card; intent "open" also opens it');
 });
 
 /* #1026 — a fresh seat composed its first pipeline through seven sequential

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -10,7 +10,9 @@
  * Codex voice gateway drains for everything that must reach the operator when they
  * are not in that chat. v5 (#1026) carries the pipeline stage contract, so a fresh
  * seat composes a valid multi-stage pipeline without discovering the shape through
- * a walk of validation errors. */
+ * a walk of validation errors. v6 (#1016) adds the third way of reaching the
+ * operator — their screen: when to move it, and the target shapes to move it with,
+ * so a seat steers attention to the work instead of describing where to look. */
 
 /** Initial draft values. The operator may choose any engine, model, account, and
     effort the shared launch controls support before creating the project seat. */
@@ -26,7 +28,7 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 5;
+export const ORCHESTRATOR_PROMPT_VERSION = 6;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
 
@@ -45,6 +47,17 @@ Bodies are short prose, at most 2 KB, no transcript payloads, no raw tool output
 
 ## Directives (gateway -> you)
 The gateway relays the user's intent to you with send_message. A directive may carry one trailer line, "[bridge ref=<seq>]", naming the report with that seq it answers. Treat only a trailer as an answer — never read one into unrelated prose.
+
+## Steering the operator's attention (request_attention)
+The two channels above carry words; this one carries their screen. request_attention moves the operator's one active Viewer to a card and verifies it landed; they keep a one-action Return. Use it when you do something concrete they care about right now, and pair it with the words that explain it (chat reply or bridge report) — a move nobody explained is a jump.
+Move them when: you just spawned or resumed a worker for something they asked for (focus that conversation as you say it is running); a review verdict, merge or deploy lands (focus the card it landed on); a lane blocks on THEM (focus the surface that is blocking, and ask in the same breath).
+Do not move them for polling, routine status, your own bookkeeping, or twice for the same event. One move per real outcome; reason is one operator-safe sentence about why to look, never the card's contents. NO_ACTIVE_VIEW means nobody is at the desk — that is normal, not a failure to retry in a loop.
+Targets are typed and discriminated by kind. The shapes, verbatim:
+- conversation — {"kind":"conversation","conversationId":"conversation_..."} (the durable id spawn and list_conversations return; {"kind":"conversation","path":"/.../transcript.jsonl"} works too)
+- stage — {"kind":"stage","pipelineId":"pipeline_...","stageId":"review"}; pipeline — {"kind":"pipeline","pipelineId":"pipeline_..."}
+- flow round — {"kind":"flowRound","flowId":"flow_...","round":2}; task — {"kind":"task","taskId":"task_..."}
+- draft — {"kind":"draft","draftId":"draft_..."} plus a top-level project; board coordinates — region and point, which accept intent "show" only.
+intent "show" frames and highlights the card; intent "open" also opens it. A rejected target names the kind it read and the fields that kind expects — read it rather than guessing another shape.
 
 ## Conveyor rules
 Drive every accepted piece of work through: GitHub issue -> worktree lane -> implementer agent -> review flow -> merge bar -> batched deploy -> cleanup.


### PR DESCRIPTION
Closes #1016 (report + scope-expansion comment).

## The failure this closes

An orchestrator seat tried to move the operator to a card during a live deploy. Five plausible `target` shapes, five identical rejections — `{"error":"target must be a typed focus target"}` — and the seat fell back to typing navigation instructions. The contract lived only in `FocusTarget`: the tool declared `target` as a free-form object with a prose list of kind names, and nothing in the rejection named a field. The seat also had no reason to reach for the tool in the first place: its mandate never mentioned attention.

## Part 1 — the tool

- **Published, not guessed.** `request_attention.target` is now a real `oneOf` over the eight kinds, each branch declaring its own fields with descriptions, and the tool description carries one pasteable example per kind. Every branch is exactly as wide as `isFocusTarget` and stays open (`passthrough`), so no call that works today is refused at the protocol boundary — and a mis-shaped target still reaches the binding, which is where the sentence that explains it lives.
- **Rejections name the way through.** A bad value gets the discriminator and its kinds; a known kind gets the fields *that* kind expects, the keys actually received (keys only, never values) and an example that works. One table in `src/lib/attention/targets.ts` feeds both the published schema and the error text, so the two cannot drift.
- **conversationId accepted.** `{"kind":"conversation","conversationId":"conversation_…"}` resolves server-side to that conversation's current generation transcript — the durable name the rest of the MCP surface already speaks, and the one that survives resume and migration. A target that already names a usable `path` is honoured untouched, so every call that works today writes a byte-identical record; the id is a way in for callers with no path, never a reinterpretation of calls that have one. An id nothing answers to is refused naming **both** accepted forms.

Attention semantics are unchanged: same targets, same camera behaviour, same authority gate, same durable record.

## Part 2 — the mandate (v5 → v6)

A compact `## Steering the operator's attention (request_attention)` section: the occasions that earn a move (a worker just spawned for something the operator asked for, a review verdict / merge / deploy landing, a lane blocking on **them**), the restraint that keeps it usable (never for polling or routine status; one move per real outcome; `NO_ACTIVE_VIEW` is a quiet desk, not a retry loop), and the verbatim target shapes — so a seat following only its mandate lands the first call.

## Verification

```
bun test src/lib/mcp/requestAttention.targets.test.ts   # 5 pass  (new)
bun test src/lib/mcp/requestAttention.test.ts           # 14 pass
bun test src/lib/mcp/schemaParity.test.ts               # 15 pass
bun test src/lib/orchestrator/prompt.test.ts            # 17 pass
bun test src/lib/mcp/requestAttention.immediate.test.ts src/lib/mcp/presentation.test.ts  # 22 pass
bun test src/lib/mcp/server.test.ts                     # 32 pass
bun test src/lib/mcp/bindings.test.ts                   # 23 pass
bun test src/lib/mcp/orchestratorTools.test.ts          # 15 pass
bun test src/lib/attention/store.test.ts src/lib/attention/service.test.ts  # 58 pass
bunx tsc --noEmit                                       # clean
bun scripts/privacy-publication-gate.ts --base <merge-base>  # PASS
```

New coverage worth naming: every **published** example is executed through the MCP binding as a real call (if an example cannot be pasted into a call, the definition is teaching a shape the server refuses); the five reported shapes are replayed — the `kind` + `conversationId` one lands, the other four are asserted to say what was expected; and the published union is checked to admit every target the record accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)