### PR TITLE
fix(conversations): publish worker catalogs and signal unknown projects

### DIFF
--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -229,3 +229,29 @@ test("a primitive JSON line in one transcript does not break global search", asy
   expect(response.status).toBe(200);
   expect(body.items.map((item) => item.path)).toEqual([target]);
 });
+
+test("a just-written transcript surfaces as recent, not idle, in the route rows (#1038 review)", async () => {
+  const transcript = path.join(sandbox, "live-row.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "still talking" } }) + "\n");
+  const stat = fs.statSync(transcript);
+  replaceConversationCatalog([{
+    path: transcript,
+    root: "claude-projects",
+    name: "live-row.jsonl",
+    project: "quiet-project",
+    title: "Live row",
+    firstPrompt: "",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    mtime: stat.mtimeMs / 1000,
+    size: stat.size,
+  }]);
+
+  const response = await GET(new Request("http://127.0.0.1/api/conversations?project=quiet-project"));
+  const body = await response.json() as { items: Array<{ path: string; activity: string }> };
+
+  expect(response.status).toBe(200);
+  expect(body.items[0]?.path).toBe(transcript);
+  expect(body.items[0]?.activity).toBe("recent");
+});

--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -255,3 +255,41 @@ test("a just-written transcript surfaces as recent, not idle, in the route rows 
   expect(body.items[0]?.path).toBe(transcript);
   expect(body.items[0]?.activity).toBe("recent");
 });
+
+test("query results keep the registry-overlaid durable conversation id (#1040 review)", async () => {
+  const transcript = path.join(sandbox, "durable-id.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "durable cinnabar quay" } }) + "\n");
+  const stat = fs.statSync(transcript);
+  replaceConversationCatalog([{
+    path: transcript,
+    root: "claude-projects",
+    name: "durable-id.jsonl",
+    project: "quiet-project",
+    title: "Durable id row",
+    firstPrompt: "durable cinnabar quay",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    mtime: stat.mtimeMs / 1000,
+    size: stat.size,
+  }]);
+  registry.reconcileConversations([{
+    engine: "claude",
+    path: transcript,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: sandbox, title: "Durable id row", project: "launch-project" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-13T00:00:00.000Z",
+  }]);
+
+  const unfiltered = await GET(new Request("http://127.0.0.1/api/conversations?project=" + encodeURIComponent(projectForCwd(sandbox))));
+  const unfilteredBody = await unfiltered.json() as { items: Array<{ path: string; conversationId: string | null }> };
+  const filtered = await GET(new Request("http://127.0.0.1/api/conversations?q=cinnabar%20quay"));
+  const filteredBody = await filtered.json() as { items: Array<{ path: string; conversationId: string | null }> };
+
+  expect(filtered.status).toBe(200);
+  const unfilteredRow = unfilteredBody.items.find((item) => item.path === transcript);
+  const filteredRow = filteredBody.items.find((item) => item.path === transcript);
+  expect(unfilteredRow?.conversationId).toStartWith("conversation_");
+  expect(filteredRow?.conversationId).toBe(unfilteredRow?.conversationId ?? null);
+});

--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -282,7 +282,7 @@ test("query results keep the registry-overlaid durable conversation id (#1040 re
     observedAt: "2026-07-13T00:00:00.000Z",
   }]);
 
-  const unfiltered = await GET(new Request("http://127.0.0.1/api/conversations?project=" + encodeURIComponent(projectForCwd(sandbox))));
+  const unfiltered = await GET(new Request("http://127.0.0.1/api/conversations?project=" + encodeURIComponent(projectForCwd(sandbox) ?? "")));
   const unfilteredBody = await unfiltered.json() as { items: Array<{ path: string; conversationId: string | null }> };
   const filtered = await GET(new Request("http://127.0.0.1/api/conversations?q=cinnabar%20quay"));
   const filteredBody = await filtered.json() as { items: Array<{ path: string; conversationId: string | null }> };
@@ -291,5 +291,5 @@ test("query results keep the registry-overlaid durable conversation id (#1040 re
   const unfilteredRow = unfilteredBody.items.find((item) => item.path === transcript);
   const filteredRow = filteredBody.items.find((item) => item.path === transcript);
   expect(unfilteredRow?.conversationId).toStartWith("conversation_");
-  expect(filteredRow?.conversationId).toBe(unfilteredRow?.conversationId ?? null);
+  expect(filteredRow?.conversationId ?? null).toEqual(unfilteredRow?.conversationId ?? null);
 });

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -45,6 +45,10 @@ export async function GET(request: Request): Promise<Response> {
         return display ? { ...entry, title: display.title, project: display.project } : entry;
       });
       page = await loadConversationCatalogPage(projected, options);
+      // The bounded final page re-runs the registry overlay: search projection
+      // above carried only title/project, so without this the query branch
+      // ships conversationId: null for registry-owned rows (#1040 review).
+      overlaySessionTitles(page.items);
     } else {
       const projectEntries = source.map(catalogEntryToFileEntry);
       overlaySessionProjects(projectEntries);

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -999,36 +999,44 @@ async function listConversations(
   control: ViewerControlDependencies,
 ): Promise<McpToolPayload> {
   const project = text(args.project);
-  const query = text(args.query).toLocaleLowerCase();
+  const query = text(args.query).trim();
   const limit = Math.max(1, Math.min(100, integer(args.limit, 50)));
-  /* MCP servers are caller processes, so their module-local completed scan can
-     differ by launch time. Read the Viewer's one completed generation instead:
-     /api/files is centrally cached and does not start a caller-local corpus
-     walk, while the project hint keeps its bounded scheme window relevant. */
-  const source = await readViewerControl(
-    control,
-    project ? `/api/files?project=${encodeURIComponent(project)}` : "/api/files",
-  );
-  if (!Array.isArray(source.files) || !Array.isArray(source.projectCatalog)) {
-    throw new ViewerControlResponseError("Viewer control returned a malformed completed file generation");
+  const params = new URLSearchParams();
+  if (project) params.set("project", project);
+  if (query) params.set("q", query);
+  params.set("limit", String(limit));
+  /* The Viewer's conversation endpoint projects the uncapped catalog published
+     by the scanner worker. Its scheme feed can omit projects beyond the board's
+     recent-project window even while their catalog rows remain current. */
+  const source = await readViewerControl(control, `/api/conversations?${params}`);
+  if (!Array.isArray(source.items) || typeof source.total !== "number") {
+    throw new ViewerControlResponseError("Viewer control returned a malformed conversation catalog page");
   }
-  const files = source.files.filter(objectRecord) as unknown as FileEntry[];
-  if (project) {
-    const knownProject = source.projectCatalog.some((entry) => objectRecord(entry) && text(entry.project) === project)
-      || files.some((entry) => entry.project === project);
+  if (project && source.total === 0) {
+    let knownProject = false;
+    if (query) {
+      const validation = await readViewerControl(
+        control,
+        `/api/conversations?project=${encodeURIComponent(project)}&limit=1`,
+      );
+      if (!Array.isArray(validation.items) || typeof validation.total !== "number") {
+        throw new ViewerControlResponseError("Viewer control returned a malformed conversation catalog page");
+      }
+      knownProject = validation.total > 0;
+    }
     if (!knownProject) {
       return redactPayload({
         count: 0,
         conversations: [],
         code: "UNKNOWN_PROJECT",
-        hint: "The requested project does not match a canonical project key in the completed scan.",
+        hint: "The requested project does not match a canonical project key in the conversation catalog.",
       });
     }
   }
-  const conversations = files
+  const conversations = source.items
+    .filter(objectRecord) as unknown as FileEntry[];
+  const rows = conversations
     .filter((entry) => entry.engine === "claude" || entry.engine === "codex")
-    .filter((entry) => !project || entry.project === project)
-    .filter((entry) => !query || `${entry.title}\n${entry.project}\n${entry.path}`.toLocaleLowerCase().includes(query))
     .slice(0, limit)
     .map((entry) => ({
       conversationId: entry.conversationId ?? null,
@@ -1038,7 +1046,7 @@ async function listConversations(
       engine: entry.engine,
       activity: entry.activity,
     }));
-  return redactPayload({ count: conversations.length, conversations });
+  return redactPayload({ count: rows.length, conversations: rows });
 }
 
 async function getConversation(

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1001,7 +1001,20 @@ async function listConversations(
      it reads what the process already knows, the same corpus `board_snapshot`
      reads. Forcing a full fresh scan per call meant every agent asking "what is
      running" started another full-corpus walk beside the coordinator's own. */
-  const files = (await dependencies.completedFileScan()).snapshot.files;
+  const snapshot = (await dependencies.completedFileScan()).snapshot;
+  const files = snapshot.files;
+  if (project) {
+    const knownProject = snapshot.projectCatalog.some((entry) => entry.project === project)
+      || files.some((entry) => entry.project === project);
+    if (!knownProject) {
+      return redactPayload({
+        count: 0,
+        conversations: [],
+        code: "UNKNOWN_PROJECT",
+        hint: "The requested project does not match a canonical project key in the completed scan.",
+      });
+    }
+  }
   const conversations = files
     .filter((entry) => entry.engine === "claude" || entry.engine === "codex")
     .filter((entry) => !project || entry.project === project)

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -441,6 +441,10 @@ function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function objectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function integer(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) ? value : fallback;
 }
@@ -992,19 +996,25 @@ async function entryForPath(
 
 async function listConversations(
   args: McpToolArgs,
-  dependencies: Pick<ViewerMcpDomainDependencies, "completedFileScan">,
+  control: ViewerControlDependencies,
 ): Promise<McpToolPayload> {
   const project = text(args.project);
   const query = text(args.query).toLocaleLowerCase();
   const limit = Math.max(1, Math.min(100, integer(args.limit, 50)));
-  /* The COMPLETED generation, not a private fresh scan (#845). This is a listing:
-     it reads what the process already knows, the same corpus `board_snapshot`
-     reads. Forcing a full fresh scan per call meant every agent asking "what is
-     running" started another full-corpus walk beside the coordinator's own. */
-  const snapshot = (await dependencies.completedFileScan()).snapshot;
-  const files = snapshot.files;
+  /* MCP servers are caller processes, so their module-local completed scan can
+     differ by launch time. Read the Viewer's one completed generation instead:
+     /api/files is centrally cached and does not start a caller-local corpus
+     walk, while the project hint keeps its bounded scheme window relevant. */
+  const source = await readViewerControl(
+    control,
+    project ? `/api/files?project=${encodeURIComponent(project)}` : "/api/files",
+  );
+  if (!Array.isArray(source.files) || !Array.isArray(source.projectCatalog)) {
+    throw new ViewerControlResponseError("Viewer control returned a malformed completed file generation");
+  }
+  const files = source.files.filter(objectRecord) as unknown as FileEntry[];
   if (project) {
-    const knownProject = snapshot.projectCatalog.some((entry) => entry.project === project)
+    const knownProject = source.projectCatalog.some((entry) => objectRecord(entry) && text(entry.project) === project)
       || files.some((entry) => entry.project === project);
     if (!knownProject) {
       return redactPayload({
@@ -2280,7 +2290,7 @@ export function viewerMcpBindings(
     create_pipeline: createPipeline,
     pipeline_action: (args) => pipelineAction(args, domainDependencies),
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
-    list_conversations: (args) => listConversations(args, domainDependencies),
+    list_conversations: (args) => listConversations(args, controlDependencies),
     get_conversation: (args, context) => getConversation(args, domainDependencies, context),
     deploy_exact_sha: (args) => deployExactSha(args, controlDependencies, domainDependencies),
     get_pipeline: getPipeline,

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -173,58 +173,71 @@ function dependencies(options: { scans?: number; projections?: number; completed
   };
 }
 
-function filesControl(
-  snapshot: { files: unknown[]; projectCatalog: unknown[] },
+function viewerControl(
+  response: Record<string, unknown>,
   onRead: (pathname: string) => void | Promise<void> = () => {},
 ): ViewerControlDependencies {
   return {
     get: async (pathname) => {
       await onRead(pathname);
-      return snapshot;
+      return response;
     },
     post: async () => ({}),
   };
 }
 
-test("list_conversations reads the Viewer's completed generation and starts no caller-local scan", async () => {
+test("list_conversations reads the Viewer's uncapped catalog and starts no caller-local scan", async () => {
   const { counts, injected, snapshot } = dependencies();
   const controlReads: string[] = [];
-  const bindings = viewerMcpBindings(undefined, filesControl(snapshot, (pathname) => { controlReads.push(pathname); }), injected);
+  const page = { items: snapshot.files, nextCursor: null, total: snapshot.files.length };
+  const bindings = viewerMcpBindings(undefined, viewerControl(page, (pathname) => { controlReads.push(pathname); }), injected);
 
   const result = await bindings.list_conversations({ clientRequestId: "list-1", limit: 50 }) as { count: number };
 
   expect(result.count).toBe(50);
-  expect(controlReads).toEqual(["/api/files"]);
+  expect(controlReads).toEqual(["/api/conversations?limit=50"]);
   expect(counts.scanCalls).toBe(0);
   expect(counts.scans).toBe(0);
   expect(counts.rawScans).toBe(0);
 });
 
-test("list_conversations returns the same Viewer rows when the caller-local completed generations disagree", async () => {
-  const viewerSnapshot = {
-    files: [{
-      ...scanRow(1),
-      path: "/sessions/project-worker.jsonl",
-      project: "repo-fixture",
-      conversationId: "conversation_project_worker",
-    }],
-    projectCatalog: [{
-      project: "repo-fixture",
-      displayName: "fixture",
-      conversations: 1,
-      smt: 1_780_000_001,
-    }],
+test("list_conversations reaches a project outside the scheme cap for an unattributed own seat", async () => {
+  const target = {
+    ...scanRow(100),
+    path: "/sessions/project-worker.jsonl",
+    project: "repo-fixture",
+    conversationId: "conversation_project_worker",
+  };
+  const schemeFiles = Array.from({ length: 10 }, (_value, index) => ({
+    ...scanRow(index + 1),
+    project: `repo-visible-${index}`,
+  }));
+  const schemeSnapshot = {
+    files: schemeFiles,
+    projectCatalog: [
+      ...schemeFiles.map((entry) => ({ project: entry.project, displayName: entry.project, conversations: 1, smt: entry.mtime })),
+      { project: "repo-fixture", displayName: "fixture", conversations: 1, smt: target.mtime },
+    ],
     complete: true,
+  };
+  const catalogPage = { items: [target], nextCursor: null, total: 1 };
+  const controlReads: string[] = [];
+  const control: ViewerControlDependencies = {
+    get: async (pathname) => {
+      controlReads.push(pathname);
+      return pathname.startsWith("/api/conversations") ? catalogPage : schemeSnapshot;
+    },
+    post: async () => ({}),
   };
   let callerLocalReads = 0;
   const bindingsFor = (
     conversationId: string,
     callerProject: string,
-    localFiles: typeof viewerSnapshot.files,
-  ) => viewerMcpBindings(undefined, filesControl(viewerSnapshot), {
+    localFiles: typeof schemeFiles,
+  ) => viewerMcpBindings(undefined, control, {
     completedFileScan: async () => {
       callerLocalReads += 1;
-      return { snapshot: { ...viewerSnapshot, files: localFiles } };
+      return { snapshot: { ...schemeSnapshot, files: localFiles } };
     },
     callerAttribution: () => ({ kind: "manager", conversationId, role: null }),
     callerProject: () => callerProject,
@@ -232,27 +245,22 @@ test("list_conversations returns the same Viewer rows when the caller-local comp
 
   const ownSeat = await bindingsFor("conversation_missing_own_transcript", "repo-fixture", [])
     .list_conversations({ clientRequestId: "list-own-seat", project: "repo-fixture" });
-  const foreignSeat = await bindingsFor("conversation_foreign_seat", "repo-foreign", viewerSnapshot.files)
+  const foreignSeat = await bindingsFor("conversation_foreign_seat", "repo-foreign", schemeFiles)
     .list_conversations({ clientRequestId: "list-foreign-seat", project: "repo-fixture" });
 
   expect(ownSeat).toEqual(foreignSeat);
   expect(ownSeat).toMatchObject({ count: 1, conversations: [{ project: "repo-fixture" }] });
+  expect(controlReads).toEqual([
+    "/api/conversations?project=repo-fixture&limit=50",
+    "/api/conversations?project=repo-fixture&limit=50",
+  ]);
   expect(callerLocalReads).toBe(0);
 });
 
 test("list_conversations identifies an unknown project instead of returning a silent zero", async () => {
-  const snapshot = {
-    files: [{ ...scanRow(1), project: "repo-fixture" }],
-    projectCatalog: [{
-      project: "repo-fixture",
-      displayName: "fixture",
-      conversations: 1,
-      smt: 1_780_000_001,
-    }],
-    complete: true,
-  };
-  const bindings = viewerMcpBindings(undefined, filesControl(snapshot), {
-    completedFileScan: async () => ({ snapshot }),
+  const page = { items: [], nextCursor: null, total: 0 };
+  const bindings = viewerMcpBindings(undefined, viewerControl(page), {
+    completedFileScan: async () => ({ snapshot: { files: [], projectCatalog: [], complete: true } }),
   } as never);
 
   const result = await bindings.list_conversations({
@@ -266,6 +274,31 @@ test("list_conversations identifies an unknown project instead of returning a si
     code: "UNKNOWN_PROJECT",
     hint: expect.stringContaining("canonical project key"),
   });
+});
+
+test("list_conversations keeps an empty query result distinct from an unknown project", async () => {
+  const controlReads: string[] = [];
+  const bindings = viewerMcpBindings(undefined, {
+    get: async (pathname) => {
+      controlReads.push(pathname);
+      return pathname.includes("q=missing")
+        ? { items: [], nextCursor: null, total: 0 }
+        : { items: [scanRow(1)], nextCursor: null, total: 1 };
+    },
+    post: async () => ({}),
+  });
+
+  const result = await bindings.list_conversations({
+    clientRequestId: "list-known-project-empty-query",
+    project: "repo-fixture",
+    query: "missing",
+  });
+
+  expect(result).toEqual({ count: 0, conversations: [] });
+  expect(controlReads).toEqual([
+    "/api/conversations?project=repo-fixture&q=missing&limit=50",
+    "/api/conversations?project=repo-fixture&limit=1",
+  ]);
 });
 
 test("get_conversation reads the completed generation when it already carries the transcript", async () => {
@@ -725,11 +758,11 @@ test("twenty concurrent control reads join one scan and one projection", async (
   /* A single-flight completed scan, as the real one is: the assertion is that the
      READS join it rather than each reserving their own generation. */
   const { counts, completedFileScan, injected } = dependencies({ scans: 1, projections: 1 });
-  const controlSnapshot: { files: unknown[]; projectCatalog: unknown[] } = { files: [], projectCatalog: [] };
-  const control = filesControl(controlSnapshot, async () => {
+  const controlPage: { items: unknown[]; nextCursor: null; total: number } = { items: [], nextCursor: null, total: 0 };
+  const control = viewerControl(controlPage, async () => {
     const completed = await completedFileScan();
-    controlSnapshot.files = completed.snapshot.files;
-    controlSnapshot.projectCatalog = completed.snapshot.projectCatalog;
+    controlPage.items = completed.snapshot.files;
+    controlPage.total = completed.snapshot.files.length;
   });
   const bindings = viewerMcpBindings(undefined, control, injected);
 

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { targetedConversationAtPath, viewerMcpBindings, type TargetedConversationDependencies } from "./bindings";
+import { targetedConversationAtPath, viewerMcpBindings, type TargetedConversationDependencies, type ViewerControlDependencies } from "./bindings";
 import { createMcpToolService, MemoryMcpReceiptStore } from "./server";
 
 /**
@@ -122,20 +122,23 @@ function dependencies(options: { scans?: number; projections?: number; completed
   const targetedCalls: Array<{ pathname: string; signal: AbortSignal | undefined; deadlineAt: number | undefined }> = [];
   let inflight: Promise<{ snapshot: typeof snapshot }> | null = null;
   let materialised: ReturnType<typeof projection> | null = null;
+  const completedFileScan = () => {
+    counts.scanCalls += 1;
+    if (inflight) return inflight;
+    counts.scans += 1;
+    if (counts.scans > allowedScans) throw new Error(`a second completed scan generation was started (${counts.scans})`);
+    inflight = Promise.resolve({ snapshot });
+    /* Released a turn later, so genuinely concurrent callers join and a LATER
+       read still gets a fresh generation — exactly the real cache's shape. */
+    void inflight.then(() => { queueMicrotask(() => { inflight = null; }); });
+    return inflight;
+  };
   return {
     counts,
+    snapshot,
+    completedFileScan,
     injected: {
-      completedFileScan: () => {
-        counts.scanCalls += 1;
-        if (inflight) return inflight;
-        counts.scans += 1;
-        if (counts.scans > allowedScans) throw new Error(`a second completed scan generation was started (${counts.scans})`);
-        inflight = Promise.resolve({ snapshot });
-        /* Released a turn later, so genuinely concurrent callers join and a LATER
-           read still gets a fresh generation — exactly the real cache's shape. */
-        void inflight.then(() => { queueMicrotask(() => { inflight = null; }); });
-        return inflight;
-      },
+      completedFileScan,
       registrySnapshot: () => {
         counts.projectionCalls += 1;
         if (materialised) return materialised;
@@ -170,19 +173,35 @@ function dependencies(options: { scans?: number; projections?: number; completed
   };
 }
 
-test("list_conversations reads the completed generation and starts no raw scan", async () => {
-  const { counts, injected } = dependencies();
-  const bindings = viewerMcpBindings(undefined, undefined, injected);
+function filesControl(
+  snapshot: { files: unknown[]; projectCatalog: unknown[] },
+  onRead: (pathname: string) => void | Promise<void> = () => {},
+): ViewerControlDependencies {
+  return {
+    get: async (pathname) => {
+      await onRead(pathname);
+      return snapshot;
+    },
+    post: async () => ({}),
+  };
+}
+
+test("list_conversations reads the Viewer's completed generation and starts no caller-local scan", async () => {
+  const { counts, injected, snapshot } = dependencies();
+  const controlReads: string[] = [];
+  const bindings = viewerMcpBindings(undefined, filesControl(snapshot, (pathname) => { controlReads.push(pathname); }), injected);
 
   const result = await bindings.list_conversations({ clientRequestId: "list-1", limit: 50 }) as { count: number };
 
   expect(result.count).toBe(50);
-  expect(counts.scans).toBe(1);
+  expect(controlReads).toEqual(["/api/files"]);
+  expect(counts.scanCalls).toBe(0);
+  expect(counts.scans).toBe(0);
   expect(counts.rawScans).toBe(0);
 });
 
-test("list_conversations returns the same project rows when the caller's own transcript is absent", async () => {
-  const snapshot = {
+test("list_conversations returns the same Viewer rows when the caller-local completed generations disagree", async () => {
+  const viewerSnapshot = {
     files: [{
       ...scanRow(1),
       path: "/sessions/project-worker.jsonl",
@@ -197,19 +216,28 @@ test("list_conversations returns the same project rows when the caller's own tra
     }],
     complete: true,
   };
-  const bindingsFor = (conversationId: string, callerProject: string) => viewerMcpBindings(undefined, undefined, {
-    completedFileScan: async () => ({ snapshot }),
+  let callerLocalReads = 0;
+  const bindingsFor = (
+    conversationId: string,
+    callerProject: string,
+    localFiles: typeof viewerSnapshot.files,
+  ) => viewerMcpBindings(undefined, filesControl(viewerSnapshot), {
+    completedFileScan: async () => {
+      callerLocalReads += 1;
+      return { snapshot: { ...viewerSnapshot, files: localFiles } };
+    },
     callerAttribution: () => ({ kind: "manager", conversationId, role: null }),
     callerProject: () => callerProject,
   } as never);
 
-  const ownSeat = await bindingsFor("conversation_missing_own_transcript", "repo-fixture")
+  const ownSeat = await bindingsFor("conversation_missing_own_transcript", "repo-fixture", [])
     .list_conversations({ clientRequestId: "list-own-seat", project: "repo-fixture" });
-  const foreignSeat = await bindingsFor("conversation_foreign_seat", "repo-foreign")
+  const foreignSeat = await bindingsFor("conversation_foreign_seat", "repo-foreign", viewerSnapshot.files)
     .list_conversations({ clientRequestId: "list-foreign-seat", project: "repo-fixture" });
 
   expect(ownSeat).toEqual(foreignSeat);
   expect(ownSeat).toMatchObject({ count: 1, conversations: [{ project: "repo-fixture" }] });
+  expect(callerLocalReads).toBe(0);
 });
 
 test("list_conversations identifies an unknown project instead of returning a silent zero", async () => {
@@ -223,7 +251,7 @@ test("list_conversations identifies an unknown project instead of returning a si
     }],
     complete: true,
   };
-  const bindings = viewerMcpBindings(undefined, undefined, {
+  const bindings = viewerMcpBindings(undefined, filesControl(snapshot), {
     completedFileScan: async () => ({ snapshot }),
   } as never);
 
@@ -696,8 +724,14 @@ test("operator_snapshot keeps the transcript-only registry projection lazy", asy
 test("twenty concurrent control reads join one scan and one projection", async () => {
   /* A single-flight completed scan, as the real one is: the assertion is that the
      READS join it rather than each reserving their own generation. */
-  const { counts, injected } = dependencies({ scans: 1, projections: 1 });
-  const bindings = viewerMcpBindings(undefined, undefined, injected);
+  const { counts, completedFileScan, injected } = dependencies({ scans: 1, projections: 1 });
+  const controlSnapshot: { files: unknown[]; projectCatalog: unknown[] } = { files: [], projectCatalog: [] };
+  const control = filesControl(controlSnapshot, async () => {
+    const completed = await completedFileScan();
+    controlSnapshot.files = completed.snapshot.files;
+    controlSnapshot.projectCatalog = completed.snapshot.projectCatalog;
+  });
+  const bindings = viewerMcpBindings(undefined, control, injected);
 
   const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_value, index) => {
     const read = index % 3 === 0

--- a/src/lib/mcp/controlPlaneReads.test.ts
+++ b/src/lib/mcp/controlPlaneReads.test.ts
@@ -181,6 +181,65 @@ test("list_conversations reads the completed generation and starts no raw scan",
   expect(counts.rawScans).toBe(0);
 });
 
+test("list_conversations returns the same project rows when the caller's own transcript is absent", async () => {
+  const snapshot = {
+    files: [{
+      ...scanRow(1),
+      path: "/sessions/project-worker.jsonl",
+      project: "repo-fixture",
+      conversationId: "conversation_project_worker",
+    }],
+    projectCatalog: [{
+      project: "repo-fixture",
+      displayName: "fixture",
+      conversations: 1,
+      smt: 1_780_000_001,
+    }],
+    complete: true,
+  };
+  const bindingsFor = (conversationId: string, callerProject: string) => viewerMcpBindings(undefined, undefined, {
+    completedFileScan: async () => ({ snapshot }),
+    callerAttribution: () => ({ kind: "manager", conversationId, role: null }),
+    callerProject: () => callerProject,
+  } as never);
+
+  const ownSeat = await bindingsFor("conversation_missing_own_transcript", "repo-fixture")
+    .list_conversations({ clientRequestId: "list-own-seat", project: "repo-fixture" });
+  const foreignSeat = await bindingsFor("conversation_foreign_seat", "repo-foreign")
+    .list_conversations({ clientRequestId: "list-foreign-seat", project: "repo-fixture" });
+
+  expect(ownSeat).toEqual(foreignSeat);
+  expect(ownSeat).toMatchObject({ count: 1, conversations: [{ project: "repo-fixture" }] });
+});
+
+test("list_conversations identifies an unknown project instead of returning a silent zero", async () => {
+  const snapshot = {
+    files: [{ ...scanRow(1), project: "repo-fixture" }],
+    projectCatalog: [{
+      project: "repo-fixture",
+      displayName: "fixture",
+      conversations: 1,
+      smt: 1_780_000_001,
+    }],
+    complete: true,
+  };
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    completedFileScan: async () => ({ snapshot }),
+  } as never);
+
+  const result = await bindings.list_conversations({
+    clientRequestId: "list-unknown-project",
+    project: "fixture",
+  });
+
+  expect(result).toMatchObject({
+    count: 0,
+    conversations: [],
+    code: "UNKNOWN_PROJECT",
+    hint: expect.stringContaining("canonical project key"),
+  });
+});
+
 test("get_conversation reads the completed generation when it already carries the transcript", async () => {
   const { counts, injected } = dependencies();
   const bindings = viewerMcpBindings(undefined, undefined, injected);

--- a/src/lib/scanner/conversationCatalog.test.ts
+++ b/src/lib/scanner/conversationCatalog.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 
 import type { ConversationCatalogEntry } from "./conversationCatalog";
-import { ExpiredConversationCatalogCursorError, loadConversationCatalogPage, paginateConversationCatalog } from "./conversationCatalog";
+import { catalogEntryToFileEntry, ExpiredConversationCatalogCursorError, loadConversationCatalogPage, paginateConversationCatalog } from "./conversationCatalog";
 import { schemeWindowConfig, selectSchemeWindow } from "./schemeWindow";
 
 function entry(index: number, project = "viewer"): ConversationCatalogEntry {
@@ -122,4 +122,12 @@ test("scheme project and card caps are independently configurable", () => {
     projectCap: 3,
     cardsPerProject: 7,
   });
+});
+
+test("a fresh transcript never reads idle in list rows — activity carries the scanner's mtime tier (#1038 review)", () => {
+  const nowMs = 1_780_000_000_000;
+  const fresh = catalogEntryToFileEntry({ ...entry(1), mtime: nowMs / 1000 - 60 }, nowMs);
+  const aged = catalogEntryToFileEntry({ ...entry(2), mtime: nowMs / 1000 - 3_600 }, nowMs);
+  expect(fresh.activity).toBe("recent");
+  expect(aged.activity).toBe("idle");
 });

--- a/src/lib/scanner/conversationCatalog.ts
+++ b/src/lib/scanner/conversationCatalog.ts
@@ -167,9 +167,12 @@ export function paginateConversationCatalog(
   };
 }
 
-/** Minimal inactive FileEntry used by list/search results before a pin hydrates
- * the conversation through the full scheme scanner. */
-export function catalogEntryToFileEntry(entry: ConversationCatalogEntry): FileEntry {
+/** Minimal FileEntry used by list/search results before a pin hydrates the
+ * conversation through the full scheme scanner. Activity carries only the
+ * scanner's own no-process-evidence tier (mtime_recent, activity.ts): a fresh
+ * transcript reads "recent", never a false "idle"; "live"/"stalled" need
+ * process and tail evidence the lightweight catalog deliberately skips. */
+export function catalogEntryToFileEntry(entry: ConversationCatalogEntry, nowMs: number = Date.now()): FileEntry {
   return {
     path: entry.path,
     root: entry.root,
@@ -183,7 +186,7 @@ export function catalogEntryToFileEntry(entry: ConversationCatalogEntry): FileEn
     parent: null,
     mtime: entry.mtime,
     size: entry.size,
-    activity: "idle",
+    activity: nowMs / 1000 - entry.mtime < 900 ? "recent" : "idle",
     proc: null,
     pid: null,
     model: null,

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -24,6 +24,7 @@ async function writeFixture(pathname: string, content: string, mtimeSeconds: num
 
 async function createRepository(root: string, name: string): Promise<string> {
   await mkdir(path.join(root, ".git"), { recursive: true });
+  await writeFile(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
   await writeFile(path.join(root, ".git", "config"), [
     '[remote "origin"]',
     `\turl = ssh://git@example.invalid/team/${name}.git`,
@@ -1167,6 +1168,47 @@ test("project catalog omits task-only residue from a clean state", async () => {
     expect(scan.projectCatalog).toEqual([]);
     const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
     expect(persisted.files[taskPath]).toBeDefined();
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a Claude transcript appearing in a previously sessionless project directory enters the conversation catalog", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-late-claude-session-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const repository = path.join(base, "late-session-repository");
+    const project = await createRepository(repository, "late-session-repository");
+    const encodedCwd = repository.replaceAll(path.sep, "-");
+    const projectDirectory = path.join(roots["claude-projects"], encodedCwd);
+    await writeFixture(
+      path.join(projectDirectory, "historical.jsonl.wakatime"),
+      "{}\n",
+      1_700_000_000,
+    );
+
+    const before = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(before.projectCatalog.some((entry) => entry.project === project)).toBe(false);
+
+    const transcript = path.join(projectDirectory, "late-session.jsonl");
+    await writeFixture(
+      transcript,
+      `${JSON.stringify({ type: "user", cwd: repository, message: { content: "late session" } })}\n`,
+      1_700_000_010,
+    );
+
+    const after = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(after.files.some((entry) => entry.path === transcript)).toBe(true);
+    expect(conversationCatalogSnapshot()).toContainEqual(expect.objectContaining({ path: transcript, project }));
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -510,10 +510,13 @@ export async function discoverFilesWithProjectCatalog(
     hosted?: ReadonlySet<string>;
     resourceBaseline?: ResourceScopeSnapshot;
     onResourceSnapshot?: (snapshot: ResourceScopeSnapshot) => void;
+    /** Carries the uncapped catalog across the file-scanner process boundary. */
+    transportConversationCatalog?: boolean;
   } = {},
 ): Promise<{
   files: FileEntry[];
   projectCatalog: ProjectCatalogEntry[];
+  conversationCatalog?: ConversationCatalogEntry[];
   pinOverlayPaths?: string[];
   complete: boolean;
 }> {
@@ -551,7 +554,12 @@ export async function discoverFilesWithProjectCatalog(
     canonicalizePath,
     canonicalizeTranscriptPaths(options.hosted, canonicalizePath),
   );
-  return { ...entries, projectCatalog, complete: snapshot.complete };
+  return {
+    ...entries,
+    projectCatalog,
+    ...(options.transportConversationCatalog ? { conversationCatalog: snapshot.conversationCatalog } : {}),
+    complete: snapshot.complete,
+  };
 }
 
 export async function discoverFiles(

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { conversationCatalogSnapshot, replaceConversationCatalog } from "./conversationCatalog";
 import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
 
 const directories: string[] = [];
@@ -63,6 +64,63 @@ test("worker scan streams the resource scope, keeps the caller event loop live, 
   } finally {
     clearInterval(timer);
   }
+});
+
+test("worker scans publish a Claude transcript that appears in a previously sessionless project directory", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-worker-late-session-"));
+  directories.push(directory);
+  const home = path.join(directory, "home");
+  const stateDir = path.join(directory, "state");
+  const temporaryDir = path.join(directory, "tmp");
+  const repository = path.join(directory, "late-session-repository");
+  const encodedCwd = repository.replaceAll(path.sep, "-");
+  const projectDirectory = path.join(home, ".claude", "projects", encodedCwd);
+  fs.mkdirSync(path.join(repository, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(repository, ".git", "HEAD"), "ref: refs/heads/main\n");
+  fs.writeFileSync(path.join(repository, ".git", "config"), [
+    '[remote "origin"]',
+    "\turl = https://example.invalid/team/late-session-repository.git",
+    "",
+  ].join("\n"));
+  fs.mkdirSync(projectDirectory, { recursive: true });
+  fs.mkdirSync(temporaryDir, { recursive: true });
+  fs.mkdirSync(path.join(temporaryDir, `claude-${process.getuid?.() ?? 1000}`));
+  fs.writeFileSync(path.join(projectDirectory, "historical.jsonl.wakatime"), "{}\n");
+  replaceConversationCatalog([]);
+  const runtime = {
+    launch: {
+      executable: process.execPath,
+      workerPath: path.resolve(import.meta.dir, "../fileScanner.worker.ts"),
+    },
+    cwd: path.resolve(import.meta.dir, "../../.."),
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: path.join(directory, "config"),
+      LLV_STATE_DIR: stateDir,
+      TMPDIR: temporaryDir,
+      NODE_ENV: "production" as const,
+      LLV_AGENT_REGISTRY_SQLITE: "off",
+    },
+    timeoutMs: 10_000,
+  };
+
+  const before = await collectFileScanInWorker({ persist: false, persistIndex: true }, undefined, runtime);
+  expect(before.files).toEqual([]);
+
+  const transcript = path.join(projectDirectory, "late-session.jsonl");
+  fs.writeFileSync(
+    transcript,
+    `${JSON.stringify({ type: "user", cwd: repository, message: { content: "late session" } })}\n`,
+  );
+  const after = await collectFileScanInWorker({ persist: false, persistIndex: true }, undefined, runtime);
+
+  expect(after.complete).toBe(true);
+  expect(after.files.some((entry) => entry.path === transcript)).toBe(true);
+  expect(conversationCatalogSnapshot()).toContainEqual(expect.objectContaining({
+    path: transcript,
+    project: expect.stringMatching(/^repo-[0-9a-f]{32}$/),
+  }));
 });
 
 test("aborting a worker scan kills the child and releases its timer and listener", async () => {

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -88,10 +88,6 @@ test("worker scans publish a Claude transcript that appears in a previously sess
   fs.writeFileSync(path.join(projectDirectory, "historical.jsonl.wakatime"), "{}\n");
   replaceConversationCatalog([]);
   const runtime = {
-    launch: {
-      executable: process.execPath,
-      workerPath: path.resolve(import.meta.dir, "../fileScanner.worker.ts"),
-    },
     cwd: path.resolve(import.meta.dir, "../../.."),
     env: {
       ...process.env,
@@ -121,6 +117,48 @@ test("worker scans publish a Claude transcript that appears in a previously sess
     path: transcript,
     project: expect.stringMatching(/^repo-[0-9a-f]{32}$/),
   }));
+});
+
+test("a completion frame followed by worker failure preserves the published conversation catalog", async () => {
+  const retained = {
+    path: "/sessions/retained.jsonl",
+    root: "codex-sessions" as const,
+    name: "retained.jsonl",
+    project: "repo-retained",
+    title: "retained",
+    firstPrompt: "",
+    engine: "codex" as const,
+    kind: "session",
+    fmt: "codex" as const,
+    mtime: 1_780_000_000,
+    size: 100,
+  };
+  const replacement = { ...retained, path: "/sessions/replacement.jsonl", name: "replacement.jsonl", title: "replacement" };
+  const completion = JSON.stringify({
+    type: "complete",
+    snapshot: { files: [], projectCatalog: [], conversationCatalog: [replacement], complete: true },
+  });
+  const { directory, workerPath } = fixtureWorker(`
+    process.stdin.resume();
+    process.stdin.on("end", () => {
+      process.stdout.write(${JSON.stringify(`${completion}\n`)}, () => {
+        process.exitCode = 1;
+      });
+    });
+  `);
+  replaceConversationCatalog([retained]);
+
+  await expect(collectFileScanInWorker(
+    { persist: false, persistIndex: false },
+    undefined,
+    {
+      launch: { executable: process.execPath, workerPath },
+      cwd: directory,
+      timeoutMs: 2_000,
+    },
+  )).rejects.toThrow("file scanner worker exited before completion");
+
+  expect(conversationCatalogSnapshot()).toEqual([retained]);
 });
 
 test("aborting a worker scan kills the child and releases its timer and listener", async () => {

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -100,6 +100,7 @@ export function collectFileScanInWorker(
     let stderr = "";
     let outputBytes = 0;
     let completed: FileCatalogScan | null = null;
+    let completedConversationCatalog: FileCatalogScan["conversationCatalog"];
     let terminationError: Error | null = null;
     let timer: unknown;
     const finish = (error?: Error, snapshot?: FileCatalogScan) => {
@@ -152,8 +153,8 @@ export function collectFileScanInWorker(
           /* The full scanner runs in a child process. Its process-global
              publication cannot update the parent that serves /api/conversations,
              so carry the completed uncapped catalog over the existing worker
-             response and publish it here. */
-          if (conversationCatalog) publishConversationCatalogForScan(conversationCatalog, catalogScanToken, snapshot.complete);
+             response. Publication waits for successful worker exit below. */
+          completedConversationCatalog = conversationCatalog;
           completed = snapshot;
         }
       }
@@ -191,6 +192,9 @@ export function collectFileScanInWorker(
         const detail = stderr.trim();
         finish(new Error(`file scanner worker exited before completion (${signal ?? code ?? "unknown"})${detail ? `: ${detail}` : ""}`));
         return;
+      }
+      if (completedConversationCatalog) {
+        publishConversationCatalogForScan(completedConversationCatalog, catalogScanToken, completed.complete);
       }
       finish(undefined, completed);
     });

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -6,6 +6,7 @@ import { systemScheduler, type DeadlineScheduler } from "@/lib/deadline";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { FileCatalogScan, FileScanOptions } from "./index";
+import { beginProjectCatalogScan, publishConversationCatalogForScan } from "./projectCatalog";
 
 const FILE_SCAN_WORKER_TIMEOUT_MS = 5 * 60_000;
 const FILE_SCAN_WORKER_OUTPUT_MAX_BYTES = 32 * 1024 * 1024;
@@ -39,6 +40,7 @@ function fileCatalogScan(value: unknown): value is FileCatalogScan {
     && Array.isArray(value.files)
     && Array.isArray(value.projectCatalog)
     && typeof value.complete === "boolean"
+    && (value.conversationCatalog === undefined || Array.isArray(value.conversationCatalog))
     && (value.pinOverlayPaths === undefined || Array.isArray(value.pinOverlayPaths));
 }
 
@@ -73,6 +75,7 @@ export function collectFileScanInWorker(
   runtime: FileScanWorkerRuntime = {},
 ): Promise<FileCatalogScan> {
   if (runtime.signal?.aborted) return Promise.reject(abortError());
+  const catalogScanToken = beginProjectCatalogScan(false);
   const launch = runtime.launch ?? workerLaunch(runtime.cwd);
   /* Full-corpus scans are background freshness work. Keep the interactive
      Next process ahead of their CPU demand on a busy operator host. Explicit
@@ -142,8 +145,17 @@ export function collectFileScanInWorker(
           fail("file scanner worker emitted an invalid message");
           return;
         }
-        if (message.type === "resource") onResourceSnapshot?.(message.snapshot);
-        else completed = message.snapshot;
+        if (message.type === "resource") {
+          onResourceSnapshot?.(message.snapshot);
+        } else {
+          const { conversationCatalog, ...snapshot } = message.snapshot;
+          /* The full scanner runs in a child process. Its process-global
+             publication cannot update the parent that serves /api/conversations,
+             so carry the completed uncapped catalog over the existing worker
+             response and publish it here. */
+          if (conversationCatalog) publishConversationCatalogForScan(conversationCatalog, catalogScanToken, snapshot.complete);
+          completed = snapshot;
+        }
       }
     };
     timer = scheduler.setTimeout(() => {

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -11,6 +11,7 @@ import { tickTaskInbox } from "../tasks/inboxScanner";
 import { panePidMap, resolveTarget } from "../tmux";
 import { tickWorkflows } from "../workflows/engine";
 import { activityVerdict, transcriptTurnResult } from "./activity";
+import type { ConversationCatalogEntry } from "./conversationCatalog";
 import { ctxFor } from "./context";
 import { lastTurnFor } from "./turnDuration";
 import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
@@ -102,6 +103,8 @@ export interface FileScanOptions {
 export interface FileCatalogScan {
   files: FileEntry[];
   projectCatalog: ProjectCatalogEntry[];
+  /** Worker-only transport; the parent publishes and removes it on receipt. */
+  conversationCatalog?: ConversationCatalogEntry[];
   pinOverlayPaths?: string[];
   complete: boolean;
 }
@@ -274,6 +277,7 @@ async function listFilesInternal(
         hosted,
         resourceBaseline: options.resourceBaseline,
         onResourceSnapshot: options.onResourceSnapshot,
+        transportConversationCatalog: process.env.LLV_FILE_SCANNER_WORKER === "1",
       })
     : { files: await discoverFiles(undefined, demote ?? archivedTranscriptPaths(), pin, hosted), projectCatalog: [], complete: true };
   if (options.signal?.aborted) throw new DOMException("file scan cancelled", "AbortError");
@@ -341,6 +345,9 @@ async function listFilesInternal(
   return {
     files: entries,
     projectCatalog: scan.projectCatalog,
+    ...("conversationCatalog" in scan && scan.conversationCatalog
+      ? { conversationCatalog: scan.conversationCatalog }
+      : {}),
     ...(pinOverlayPaths?.length ? { pinOverlayPaths } : {}),
     complete: scan.complete && entries.every((entry) => entry.derivationComplete !== false),
   };

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -92,6 +92,17 @@ export function beginProjectCatalogScan(persist: boolean): ProjectCatalogScanTok
   return { publication, persistence };
 }
 
+export function publishConversationCatalogForScan(
+  entries: ConversationCatalogEntry[],
+  scanToken: ProjectCatalogScanToken,
+  complete: boolean,
+): boolean {
+  const current = projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
+  if (!current || !complete) return false;
+  replaceConversationCatalog(entries);
+  return true;
+}
+
 function catalogPath(): string {
   return statePath(CATALOG_FILE);
 }
@@ -583,10 +594,9 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
       size: file.size,
     });
   });
-  const isCurrentPublication = projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
   const isCurrentPersistence = scanToken.persistence !== null
     && projectCatalogRuntime.__llvProjectCatalogPersistenceGeneration === scanToken.persistence;
-  if (isCurrentPublication && complete) replaceConversationCatalog(conversationCatalog);
+  publishConversationCatalogForScan(conversationCatalog, scanToken, complete);
   if (isCurrentPersistence && persistIndex && complete) {
     let boardHealed = true;
     if (options.persist !== false) {


### PR DESCRIPTION
Fixes #1038
Fixes #1039

## Summary

- transport the uncapped conversation catalog from the scanner worker to the Viewer with generation fencing and successful-exit publication
- read MCP list_conversations from the Viewer uncapped conversation catalog so caller-local state and the board recent-project cap cannot hide project rows
- return UNKNOWN_PROJECT with a canonical-key hint for unknown project filters
- cover late Claude transcript admission, own-seat parity beyond the scheme cap, worker failure retention, and isolated production-worker execution

## Verification

- focused scanner and MCP tests: 71 passed with isolated HOME, XDG_CONFIG_HOME, LLV_STATE_DIR, and TMPDIR
- bunx tsc --noEmit
- production build
- privacy publication gate