### PR TITLE
fix(docker): workers keep supplementary groups across nsenter, every viewer container gets the docker GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,10 @@ case "\$wd" in
   "\$HOME"|"\$HOME"/*) ;;
   *) wd=\$HOME ;;
 esac
-exec nsenter -t 1 -m -p --setgid="\$(id -g)" --setuid="\$(id -u)" -- /bin/sh -c 'cd "\$1" || exit; shift; exec "\$@"' sh "\$wd" "$host_path" "\$@"
+uid=\$(id -u)
+gid=\$(id -g)
+groups=\$(id -G | tr ' ' ',')
+exec nsenter -t 1 -m -p -- /usr/bin/setpriv --reuid="\$uid" --regid="\$gid" --groups="\$groups" -- /bin/sh -c 'cd "\$1" || exit; shift; exec "\$@"' sh "\$wd" "$host_path" "\$@"
 WRAPPER
   chmod +x "/usr/local/bin/$name"
 }
@@ -128,11 +131,14 @@ host_wd() {
 
 run_host_tmux() {
   wd=$(host_wd)
+  uid=$(id -u)
+  gid=$(id -g)
+  groups=$(id -G | tr ' ' ',')
   # LC_ALL: without a UTF-8 locale tmux sanitizes control bytes in `-F` output,
   # turning the TAB field separators panePidMap relies on into "_" — which left
   # the viewer unable to see (or kill) any tmux session. Force UTF-8 so tabs
   # survive regardless of whether the container env propagates through nsenter.
-  nsenter -t 1 -m -p --setgid="$(id -g)" --setuid="$(id -u)" -- /bin/sh -c 'cd "$1" || exit; shift; exec "$@"' sh "$wd" env LC_ALL=C.UTF-8 /usr/bin/tmux "$@"
+  nsenter -t 1 -m -p -- /usr/bin/setpriv --reuid="$uid" --regid="$gid" --groups="$groups" -- /bin/sh -c 'cd "$1" || exit; shift; exec "$@"' sh "$wd" env LC_ALL=C.UTF-8 /usr/bin/tmux "$@"
 }
 
 target_key() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ x-viewer-common: &viewer-common
   pid: host
   privileged: true
   "user": "${LLV_UID:-1000}:${LLV_GID:-1000}"
+  group_add:
+    - "${LLV_DOCKER_GID:-957}"
   working_dir: /app
   env_file:
     - ${LLV_ENV_FILE:-${HOME:-/home/user}/.config/agent-log-viewer/service.env}
@@ -38,8 +40,6 @@ services:
   # lifecycle after the listener migration.
   runtime-host:
     <<: *viewer-common
-    group_add:
-      - "${LLV_DOCKER_GID:-957}"
     restart: unless-stopped
     profiles:
       - runtime-host
@@ -54,6 +54,7 @@ services:
       # that produced this runtime-host container.
       LLV_UID: ${LLV_UID:-1000}
       LLV_GID: ${LLV_GID:-1000}
+      LLV_DOCKER_GID: ${LLV_DOCKER_GID:-957}
       LLV_ENV_FILE: ${LLV_ENV_FILE:-${HOME:-/home/user}/.config/agent-log-viewer/service.env}
       LLV_TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
       LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -81,13 +81,29 @@ describe("runtime image permission determinism (#76)", () => {
 describe("runtime-host Docker credentials (#102)", () => {
   test("runtime UID 1000 retains the host Docker socket group through nsenter", () => {
     expect(compose).toContain('"user": "${LLV_UID:-1000}:${LLV_GID:-1000}"');
-    expect(compose).toContain('group_add:\n      - "${LLV_DOCKER_GID:-957}"');
+    expect(compose).toContain('group_add:\n    - "${LLV_DOCKER_GID:-957}"');
     const wrapper = dockerfile.match(/cat > \/usr\/local\/bin\/docker <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
     expect(wrapper).toBeDefined();
     expect(wrapper).toContain("nsenter -t 1 -m -p --");
     expect(wrapper).toContain('/usr/bin/setpriv --reuid="$uid" --regid="$gid" --groups="$groups" --');
     expect(wrapper).not.toContain("--setgid");
     expect(wrapper).not.toContain("--setuid");
+  });
+
+  test("host CLI and tmux shims retain every supplementary group", () => {
+    const cliShim = dockerfile.match(/make_nsenter_shim\(\) \{([\s\S]*?)\n\}/)?.[1];
+    expect(cliShim).toBeDefined();
+    expect(cliShim).toContain("groups=\\$(id -G | tr ' ' ',')");
+    expect(cliShim).toContain('/usr/bin/setpriv --reuid="\\$uid" --regid="\\$gid" --groups="\\$groups" --');
+    expect(cliShim).not.toContain("--setgid");
+    expect(cliShim).not.toContain("--setuid");
+
+    const tmuxWrapper = dockerfile.match(/cat > \/usr\/local\/bin\/tmux <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
+    expect(tmuxWrapper).toBeDefined();
+    expect(tmuxWrapper).toContain("groups=$(id -G | tr ' ' ',')");
+    expect(tmuxWrapper).toContain('/usr/bin/setpriv --reuid="$uid" --regid="$gid" --groups="$groups" --');
+    expect(tmuxWrapper).not.toContain("--setgid");
+    expect(tmuxWrapper).not.toContain("--setuid");
   });
 
   test("the runtime passwd home follows the portable Compose HOME for every git caller (#999)", () => {

--- a/src/runtime-host/candidateContainer.test.ts
+++ b/src/runtime-host/candidateContainer.test.ts
@@ -41,6 +41,7 @@ const composeService = {
     HF_HOME: "/home/user/.cache/huggingface",
     GIT_SSH_COMMAND: "ssh compose-config",
   },
+  group_add: ["957"],
   image: "agent-log-viewer:node22",
   labels: { "compose.viewer": "production" },
   network_mode: "host",
@@ -70,6 +71,7 @@ function environmentFromArgs(args: string[]): Record<string, string> {
 interface ResolvedComposeService {
   command: string[] | null;
   environment: Record<string, string>;
+  group_add?: string[];
   profiles?: string[];
   "user": string;
   volumes: Array<{ source: string; target: string }>;
@@ -127,9 +129,24 @@ test("promoted candidate derives its runtime contract from Compose", () => {
   expect(args[args.indexOf("--restart") + 1]).toBe("unless-stopped");
   expect(args[args.indexOf("--network") + 1]).toBe("host");
   expect(args[args.indexOf("--pid") + 1]).toBe("host");
+  expect(valuesAfter(args, "--group-add")).toEqual(["957"]);
   expect(args[args.indexOf("--user") + 1]).toBe("1000:1000");
   expect(args[args.indexOf("--workdir") + 1]).toBe("/app");
   expect(args).toContain("--privileged");
+});
+
+test("candidate accepts an older Compose snapshot without supplementary groups", () => {
+  const legacyViewer = JSON.parse(JSON.stringify(composeService)) as Record<string, unknown>;
+  delete legacyViewer.group_add;
+  const service = viewerComposeServiceFromConfig(JSON.stringify({ services: { viewer: legacyViewer } }));
+  const args = viewerCandidateDockerArgs(candidate, service, {
+    runtimeSocket: "/state/runtime-host.sock",
+    legacyTmuxExternal: "1",
+    tmuxTmpdir: "/run/user/1000/agent-log-viewer",
+  });
+
+  expect(service.group_add).toEqual([]);
+  expect(valuesAfter(args, "--group-add")).toEqual([]);
 });
 
 test("promoted candidate validates and pins the operator registry backend mode", () => {
@@ -206,6 +223,8 @@ test("actual Viewer Compose keys remain covered by the candidate generator", () 
     tmuxTmpdir: "/run/user/1000/agent-log-viewer",
   });
   const environment = environmentFromArgs(args);
+  expect(service.group_add).toEqual(["957"]);
+  expect(valuesAfter(args, "--group-add")).toEqual(service.group_add);
   expect(Object.keys(environment).sort()).toEqual([
     ...new Set([
       ...Object.keys(service.environment),
@@ -235,15 +254,18 @@ test("runtime-host propagates every Viewer Compose interpolation input", () => {
   const config = resolvedCompose({
     LLV_UID: "1201",
     LLV_GID: "1202",
+    LLV_DOCKER_GID: "1203",
     LLV_TMUX_TMPDIR: "/run/user/1201/agent-log-viewer",
   });
   expect(config.services["runtime-host"].environment).toMatchObject({
     LLV_UID: "1201",
     LLV_GID: "1202",
+    LLV_DOCKER_GID: "1203",
     LLV_TMUX_TMPDIR: "/run/user/1201/agent-log-viewer",
     LLV_ENV_FILE: expect.any(String),
   });
   expect(config.services.viewer.user).toBe("1201:1202");
+  expect(config.services.viewer.group_add).toEqual(["1203"]);
   expect(config.services.viewer.environment.TMUX_TMPDIR).toBe("/run/user/1201/agent-log-viewer");
   expect(config.services.viewer.volumes.map((volume) => volume.source)).toContain("/tmp/tmux-1201");
 });

--- a/src/runtime-host/candidateContainer.ts
+++ b/src/runtime-host/candidateContainer.ts
@@ -17,6 +17,7 @@ export interface ViewerComposeService {
   command: string[] | null;
   entrypoint: null;
   environment: Record<string, string>;
+  group_add: string[];
   image: string;
   labels: Record<string, string>;
   network_mode: string;
@@ -47,7 +48,7 @@ export function viewerRegistryBackendMode(service: Pick<ViewerComposeService, "e
 }
 
 const SERVICE_KEYS = new Set([
-  "build", "command", "entrypoint", "environment", "image", "labels", "network_mode",
+  "build", "command", "entrypoint", "environment", "group_add", "image", "labels", "network_mode",
   "pid", "privileged", "profiles", "restart", "user", "volumes", "working_dir",
 ]);
 const VOLUME_KEYS = new Set(["bind", "read_only", "source", "target", "type"]);
@@ -121,6 +122,7 @@ export function viewerComposeServiceFromConfig(configJson: string): ViewerCompos
     command: viewer.command === null ? null : stringArray(viewer.command, "Viewer Compose command"),
     entrypoint: null,
     environment: stringRecord(viewer.environment, "Viewer Compose environment"),
+    group_add: viewer.group_add === undefined ? [] : stringArray(viewer.group_add, "Viewer Compose group_add"),
     image: stringValue(viewer.image, "Viewer Compose image"),
     labels: viewer.labels === undefined ? {} : stringRecord(viewer.labels, "Viewer Compose labels"),
     network_mode: stringValue(viewer.network_mode, "Viewer Compose network_mode"),
@@ -215,6 +217,7 @@ export function viewerCandidateDockerArgs(
     "--network", service.network_mode,
     "--pid", service.pid,
     ...(service.privileged ? ["--privileged"] : []),
+    ...service.group_add.flatMap((group) => ["--group-add", group]),
     "--user", service.user,
     "--workdir", service.working_dir,
     ...Object.entries(environment).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, value]) => ["-e", `${key}=${value}`]),

--- a/src/runtime-host/stagingContainer.test.ts
+++ b/src/runtime-host/stagingContainer.test.ts
@@ -34,6 +34,7 @@ const composeService = {
     LLV_DOCKER_NSENTER_SHIMS: "1",
     GIT_SSH_COMMAND: "ssh compose-config",
   },
+  group_add: ["957"],
   image: "agent-log-viewer:node22",
   labels: { "compose.viewer": "production" },
   network_mode: "host",
@@ -101,6 +102,15 @@ test("staging containers are never labelled as prod-managed releases", () => {
     expect(labels).toContain(`${STAGING_LABEL}=1`);
     expect(labels).toContain(`dev.live-log-viewer.revision=${revision}`);
     expect(labels.some((label) => label.startsWith("dev.live-log-viewer.managed="))).toBe(false);
+  }
+});
+
+test("staging containers retain the configured supplementary groups", () => {
+  for (const args of [
+    stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+    stagingRuntimeHostDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+  ]) {
+    expect(valuesAfter(args, "--group-add")).toEqual(["957"]);
   }
 });
 

--- a/src/runtime-host/stagingContainer.ts
+++ b/src/runtime-host/stagingContainer.ts
@@ -122,6 +122,7 @@ function stagingDockerArgs(
     "--network", context.service.network_mode,
     "--pid", context.service.pid,
     ...(context.service.privileged ? ["--privileged"] : []),
+    ...context.service.group_add.flatMap((group) => ["--group-add", group]),
     "--user", context.service.user,
     "--workdir", context.service.working_dir,
     ...Object.entries(environment).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, value]) => ["-e", `${key}=${value}`]),


### PR DESCRIPTION
Closes #1042.

Workers launched from viewer containers lost the docker supplementary group twice over: the nsenter wrappers re-entered the host namespace with `--setuid/--setgid` only (supplementary groups discarded), and `group_add: ${LLV_DOCKER_GID}` existed only on the runtime-host service, so viewer/candidate/staging containers never received the docker GID at all. A host package update removing `sg` (newer shadow) took away the last fallback and made this user-blocking.

- Dockerfile: codex/claude/tmux wrappers re-enter via `setpriv --reuid --regid --groups $(id -G)` — full group list survives.
- docker-compose.yml: `group_add` moves to the shared viewer-common anchor; `LLV_DOCKER_GID` is forwarded into the nested compose environment.
- candidateContainer/stagingContainer: promoted and staged `docker run` args carry `--group-add`.

Verification: 74 relevant tests green (isolated state), tsc/eslint/production build green, privacy gate PASS, real container probe (`groups=957,1000`, Docker server reachable), real tmux pane shows both groups. Temporary probe container/image removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
