### PR TITLE
fix(docker): bootstrap #1042 phase 2 — restore group_add on the shared viewer anchor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ x-viewer-common: &viewer-common
   pid: host
   privileged: true
   "user": "${LLV_UID:-1000}:${LLV_GID:-1000}"
+  group_add:
+    - "${LLV_DOCKER_GID:-957}"
   working_dir: /app
   env_file:
     - ${LLV_ENV_FILE:-${HOME:-/home/user}/.config/agent-log-viewer/service.env}
@@ -38,10 +40,6 @@ services:
   # lifecycle after the listener migration.
   runtime-host:
     <<: *viewer-common
-    # BOOTSTRAP (#1042 phase 1): group_add stays runtime-host-only until a
-    # deployer that knows the key is live; phase 2 moves it back to the anchor.
-    group_add:
-      - "${LLV_DOCKER_GID:-957}"
     restart: unless-stopped
     profiles:
       - runtime-host

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -81,7 +81,7 @@ describe("runtime image permission determinism (#76)", () => {
 describe("runtime-host Docker credentials (#102)", () => {
   test("runtime UID 1000 retains the host Docker socket group through nsenter", () => {
     expect(compose).toContain('"user": "${LLV_UID:-1000}:${LLV_GID:-1000}"');
-    expect(compose).toContain('group_add:\n      - "${LLV_DOCKER_GID:-957}"');
+    expect(compose).toContain('group_add:\n    - "${LLV_DOCKER_GID:-957}"');
     const wrapper = dockerfile.match(/cat > \/usr\/local\/bin\/docker <<'WRAPPER'([\s\S]*?)WRAPPER/)?.[1];
     expect(wrapper).toBeDefined();
     expect(wrapper).toContain("nsenter -t 1 -m -p --");

--- a/src/runtime-host/candidateContainer.test.ts
+++ b/src/runtime-host/candidateContainer.test.ts
@@ -223,9 +223,7 @@ test("actual Viewer Compose keys remain covered by the candidate generator", () 
     tmuxTmpdir: "/run/user/1000/agent-log-viewer",
   });
   const environment = environmentFromArgs(args);
-  // BOOTSTRAP (#1042 phase 1): the viewer service carries no group_add until
-  // a deployer that covers the key is live; phase 2 restores ["957"] here.
-  expect(service.group_add).toEqual([]);
+  expect(service.group_add).toEqual(["957"]);
   expect(valuesAfter(args, "--group-add")).toEqual(service.group_add);
   expect(Object.keys(environment).sort()).toEqual([
     ...new Set([
@@ -267,9 +265,7 @@ test("runtime-host propagates every Viewer Compose interpolation input", () => {
     LLV_ENV_FILE: expect.any(String),
   });
   expect(config.services.viewer.user).toBe("1201:1202");
-  // BOOTSTRAP (#1042 phase 1): group_add is runtime-host-only; phase 2
-  // restores ["1203"] on the viewer service.
-  expect(config.services["runtime-host"].group_add).toEqual(["1203"]);
+  expect(config.services.viewer.group_add).toEqual(["1203"]);
   expect(config.services.viewer.environment.TMUX_TMPDIR).toBe("/run/user/1201/agent-log-viewer");
   expect(config.services.viewer.volumes.map((volume) => volume.source)).toContain("/tmp/tmux-1201");
 });


### PR DESCRIPTION
Closes #1042. Phase 2 of the two-phase bootstrap started in #1044 (constraint documented in #1045).

Restores the #1043 compose shape now that a deployer covering the `group_add` key is live: the key returns to the shared viewer anchor (every viewer container gets the docker GID), and the BOOTSTRAP markers in the tests flip back to the anchor expectations.

MERGE ONLY AFTER the phase-1 deployment is COMPLETE — merging earlier re-breaks deployments on the incumbent deployer with `uncovered fields: group_add`.

30 focused tests green (isolated state), tsc clean, privacy gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)