### PR TITLE
fix(orchestrator): start requested pipelines by default

### DIFF
--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -10,19 +10,20 @@ test("the manager draft defaults to Claude Opus 5 on low effort through the role
   expect(ORCHESTRATOR_SPAWN_CONFIG).toMatchObject({ engine: "claude", model: "opus", effort: "low", role: "orchestrator" });
 });
 
-test("system prompt carries the draft-only pipeline contract", () => {
-  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("NEVER auto-start pipelines");
+test("system prompt carries the start-by-default pipeline contract", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Start-by-default pipeline contract");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("autoStart: true");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("put the work in motion without a confirmation step or draft");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("autoStart: false");
-  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("presses Start himself");
-  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("explicitly asked to start it in the same request");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("explicitly asks for a draft or to review the plan first in that request");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("press Start on the board");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain("NEVER auto-start");
 });
 
-/* #982 — the auto-start exception used to require the request to arrive "relayed
-   through the gateway", which made an explicit start asked in the manager's own
-   conversation carry less authority than the same words spoken to the gateway. Under
-   PRD #976 decision 7 both channels are equal; the draft-by-default rule above is
-   untouched, only the channel qualifier is gone. */
-test("the auto-start exception treats direct chat and the gateway as equal channels", () => {
+/* #982 — pipeline requests used to carry different authority depending on whether
+   they arrived in the manager's own conversation or through the gateway. Under PRD
+   #976 decision 7 both channels are equal, including an explicit request for a draft. */
+test("the explicit draft request treats direct chat and the gateway as equal channels", () => {
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("asked in your own conversation or relayed through the gateway");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("both channels carry the same authority");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain("same request, relayed through the gateway");
@@ -70,8 +71,8 @@ test("bridge reports survive as the second channel, for the operator away from t
 
 /* Seats record the mandate version they were spawned on; `get_orchestrator` reports
    this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
-test("the default mandate is at version 6", () => {
-  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(6);
+test("the default mandate is at version 7", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(7);
 });
 
 /* #1016 — the seat had the attention tool and never used it: nothing it read said

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -12,7 +12,8 @@
  * seat composes a valid multi-stage pipeline without discovering the shape through
  * a walk of validation errors. v6 (#1016) adds the third way of reaching the
  * operator — their screen: when to move it, and the target shapes to move it with,
- * so a seat steers attention to the work instead of describing where to look. */
+ * so a seat steers attention to the work instead of describing where to look. v7
+ * starts requested pipelines by default and reserves drafts for explicit requests. */
 
 /** Initial draft values. The operator may choose any engine, model, account, and
     effort the shared launch controls support before creating the project seat. */
@@ -28,7 +29,7 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 6;
+export const ORCHESTRATOR_PROMPT_VERSION = 7;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
 
@@ -70,8 +71,8 @@ Drive every accepted piece of work through: GitHub issue -> worktree lane -> imp
 ## Pipeline stage contract
 A pipeline is a GRAPH of stages, not a list. Each stage is {id (unique, URL-safe), kind: "run" | "review-loop", prompt, next: <stage id> | null, onFail?: {to, maxRounds?} (run stages only), role: {roleId, params?}} and carries its runtime overrides — engine, model, effort, access — on the stage itself, never inside role. next is the pass edge and DEFAULTS TO null: stages you never wire reach nothing, and a review-loop must be pass-reachable from a run stage through next edges (it reviews that run's session), so array order alone is not a chain. review-loop stages are read-only, take no onFail, and default to the registry's Codex reviewer runtime. src is your transcript path; a draft that pins baseBranch must also pass baseRef, a SHA you resolve.
 
-## Draft-only pipeline contract
-You NEVER auto-start pipelines. When asked to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and report the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request — asked in your own conversation or relayed through the gateway; both channels carry the same authority.
+## Start-by-default pipeline contract
+When the operator asks for work, assess complexity, compose stages/roles, POST /api/pipelines with autoStart: true (or start it immediately after creation), and put the work in motion without a confirmation step or draft. Create a draft only when the operator explicitly asks for a draft or to review the plan first in that request: POST /api/pipelines with autoStart: false, report the draft id/link, and wait for the operator to press Start on the board. The explicit draft request may be asked in your own conversation or relayed through the gateway; both channels carry the same authority.
 
 ## Deploys
 YOU decide when to deploy, and you execute it yourself. Your authority is your designated seat, attributed server-side — a session that is not the designated orchestrator is refused, and a seat acts only for its own project. Nobody — you included — ever asks the user to confirm, approve, repeat, or say a commit hash. There is no confirmation step for the user, anywhere; deploys reach the user through your reports.


### PR DESCRIPTION
Fixes #1037

## Summary
- start composed pipelines by default with `autoStart: true`
- create a draft only when the request explicitly asks for one or asks to review the plan first
- preserve equal authority for direct orchestrator requests and gateway-relayed requests
- bump the orchestrator mandate version to 7

## Verification
- `bun test src/lib/orchestrator/prompt.test.ts` — 17 pass
- `bunx tsc --noEmit`
- `bun scripts/privacy-publication-gate.ts --base <merge-base>`

Deployment is outside this issue's scope.
