### PR TITLE
fix(spawn): validate model ids at launch admission

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -80,12 +80,25 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
 test("spawn admission rejects malformed MCP allowlists", async () => {
   const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
     method: "POST",
-    headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+    headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
     body: JSON.stringify({ engine: "codex", cwd: routeSandbox, prompt: "inspect", mcpServers: "viewer" }),
   }), structuredRouteDependencies(routeSandbox));
 
   expect(response.status).toBe(400);
   expect(await response.json()).toEqual({ error: "mcpServers must be an array of non-empty server names" });
+});
+
+test("spawn admission rejects an explicit model outside the selected engine catalog", async () => {
+  const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+    method: "POST",
+    headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
+    body: JSON.stringify({ engine: "codex", model: "gpt-5.6-codex", cwd: routeSandbox, prompt: "inspect" }),
+  }), structuredRouteDependencies(routeSandbox));
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({
+    error: "invalid codex model id \"gpt-5.6-codex\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna",
+  });
 });
 
 test("an explicit spawn account is durably pinned while an omitted account uses the selected fallback", async () => {
@@ -118,7 +131,7 @@ test("an explicit spawn account is durably pinned while an omitted account uses 
     const post = async (clientAttemptId: string, accountId?: string) => await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
       method: "POST",
       headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
-      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", clientAttemptId, ...(accountId ? { accountId } : {}) }),
+      body: JSON.stringify({ engine: "claude", model: "sonnet", cwd, prompt: "inspect", clientAttemptId, ...(accountId ? { accountId } : {}) }),
     }), dependencies);
 
     const pinnedResponses = await Promise.all([
@@ -185,7 +198,7 @@ test("an unusable explicit account creates a terminal retryable pinned receipt a
     const capability = rotateOperatorSpawnCapability();
     const baseRequest = {
       engine: "claude",
-      model: "claude-sonnet-4-6",
+      model: "sonnet",
       cwd,
       ["prompt"]: "inspect",
       accountId: "unusable-pin",
@@ -414,7 +427,7 @@ test("spawn admission grants MCP servers by session origin and refuses ungranted
            parent and no preset is the operator-root session class. */
         ...(role ? {} : { "sec-fetch-site": "same-origin" }),
       },
-      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", ...(role ? { role } : {}), clientAttemptId, ...(mcpServers === undefined ? {} : { mcpServers }) }),
+      body: JSON.stringify({ engine: "claude", model: "sonnet", cwd, prompt: "inspect", ...(role ? { role } : {}), clientAttemptId, ...(mcpServers === undefined ? {} : { mcpServers }) }),
     }), dependencies);
 
     const defaultResponse = await post("mcp_default_20260723");
@@ -601,7 +614,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
     const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
       method: "POST",
       headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "x-llv-spawn-capability": capability },
-      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "fallback", src: sourcePath, role: "builder", clientAttemptId: "pipeline_adoption_20260719" }),
+      body: JSON.stringify({ engine: "claude", model: "sonnet", cwd, prompt: "fallback", src: sourcePath, role: "builder", clientAttemptId: "pipeline_adoption_20260719" }),
     }), dependencies);
 
     expect({ status: response.status, body: await response.clone().json() }).toMatchObject({ status: 202 });
@@ -616,7 +629,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
         round: null,
         runtime: {
           engine: "claude",
-          model: "claude-sonnet-4-6",
+          model: "sonnet",
           effort: expect.any(String),
         },
       }),
@@ -625,7 +638,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
       expect.objectContaining({
         runtime: {
           engine: "claude",
-          model: "claude-sonnet-4-6",
+          model: "sonnet",
           effort: expect.any(String),
         },
       }),
@@ -634,7 +647,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
     const replay = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
       method: "POST",
       headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "x-llv-spawn-capability": capability },
-      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "fallback", src: sourcePath, role: "builder", clientAttemptId: "pipeline_adoption_20260719" }),
+      body: JSON.stringify({ engine: "claude", model: "sonnet", cwd, prompt: "fallback", src: sourcePath, role: "builder", clientAttemptId: "pipeline_adoption_20260719" }),
     }), dependencies);
     expect(replay.status).toBe(200);
     expect(structuredLaunches).toBe(1);
@@ -646,7 +659,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
         agentPath: childPath,
         runtime: {
           engine: "claude",
-          model: "claude-sonnet-4-6",
+          model: "sonnet",
           effort: expect.any(String),
         },
       }),
@@ -658,7 +671,7 @@ test("a materialized structured child is offered for pipeline attempt adoption",
         agentPath: childPath,
         runtime: {
           engine: "claude",
-          model: "claude-sonnet-4-6",
+          model: "sonnet",
           effort: expect.any(String),
         },
       }),
@@ -1508,7 +1521,7 @@ test("operator and agent structured Claude role launches both retain bypass perm
   const request = (capability: string, clientAttemptId = attemptId) => new NextRequest("http://127.0.0.1:8898/api/spawn", {
     method: "POST",
     headers: { host: "127.0.0.1:8898", "content-type": "application/json", "x-llv-spawn-capability": capability },
-    body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "build", src: callerPath, role: "builder", clientAttemptId }),
+    body: JSON.stringify({ engine: "claude", model: "sonnet", cwd, prompt: "build", src: callerPath, role: "builder", clientAttemptId }),
   });
   const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
   const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
@@ -1741,7 +1754,7 @@ async function runDeferred(work: (() => Promise<void>) | null): Promise<void> {
   if (work) await work();
 }
 
-test("text-only Codex models reject images before blob and receipt mutation", async () => {
+test("unknown Codex models reject before image blob and receipt mutation", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "codex-text-only-image-"));
   const previous = {
     transport: process.env.LLV_SPAWN_TRANSPORT,
@@ -1782,9 +1795,9 @@ test("text-only Codex models reject images before blob and receipt mutation", as
         images: [{ base64: png, mime: "image/png" }],
       }),
     }), dependencies);
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: "The selected Codex model does not advertise image input through app-server.",
+      error: "invalid codex model id \"gpt-5.3-codex-spark\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna",
     });
     expect(storageCalled).toBeFalse();
     expect(Object.keys(agentRegistry().snapshot().receipts).sort()).toEqual(beforeReceipts);

--- a/src/app/api/tasks/[id]/spawn/route.test.ts
+++ b/src/app/api/tasks/[id]/spawn/route.test.ts
@@ -5,11 +5,139 @@ import path from "node:path";
 import { expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { ENGINE_MODELS } from "@/lib/agent/models";
 import { AgentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { BoardTask } from "@/lib/tasks/types";
 
 import { POST } from "./route";
+
+test("task spawn rejects an explicit unknown model before receipt or assignment mutation", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-model-admission-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const tasks: BoardTask[] = [{
+    id: "10410000-89c5-0064-9118-51661c4f1041",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Reject an unknown task-spawn model",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [],
+    createdAt: "2026-08-19T12:00:00.000Z",
+    updatedAt: "2026-08-19T12:00:00.000Z",
+  }];
+  let writes = 0;
+  let spawnCalls = 0;
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: () => {
+      writes += 1;
+      throw new Error("assignment mutation must stay unreachable");
+    },
+    resolveSpawnAccount: () => ({
+      engine: "codex" as const,
+      accountId: "codex-test",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => null,
+    spawnAgentWithPrompt: async () => {
+      spawnCalls += 1;
+      throw new Error("spawn must stay unreachable");
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const response = await POST.withDependencies(new NextRequest(
+    `http://127.0.0.1/api/tasks/${tasks[0]!.id}/spawn`,
+    {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({ engine: "codex", model: "gpt-5.6-codex", cwd }),
+    },
+  ), { params: Promise.resolve({ id: tasks[0]!.id }) }, dependencies);
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({
+    error: `invalid codex model id "gpt-5.6-codex"; valid codex model ids: ${ENGINE_MODELS.codex.map((option) => option.id).join(", ")}`,
+  });
+  expect(Object.keys(registry.snapshot().receipts)).toHaveLength(0);
+  expect(writes).toBe(0);
+  expect(spawnCalls).toBe(0);
+});
+
+test("task retry preserves a failed receipt's historical model without fresh-launch validation", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-model-retry-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const historicalModel = "claude-opus-4-8-20260630";
+  const begun = registry.beginSpawnRequest({
+    engine: "claude",
+    cwd,
+    accountId: "claude-test",
+    origin: { kind: "operator" },
+    launchProfile: emptyLaunchProfile({ cwd, model: historicalModel, effort: "high" }),
+  });
+  if (begun.kind !== "created") throw new Error("expected historical task launch receipt");
+  registry.failSpawn(begun.receipt.launchId, "historical launch failed before pane creation");
+  let tasks: BoardTask[] = [{
+    id: "10410001-89c5-0064-9118-51661c4f1041",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Retry a historical task-spawn model",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [{
+      launchId: begun.receipt.launchId,
+      clientAttemptId: begun.receipt.clientAttemptId,
+      conversationId: begun.receipt.conversationId,
+      path: null,
+      panePid: null,
+      state: "failed",
+      error: "historical launch failed before pane creation",
+      at: "2026-08-19T12:00:00.000Z",
+      accountId: "claude-test",
+      engine: "claude",
+    }],
+    createdAt: "2026-08-19T12:00:00.000Z",
+    updatedAt: "2026-08-19T12:00:00.000Z",
+  }];
+  let launchedModel: string | null | undefined;
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: (mutator: (current: BoardTask[]) => { tasks?: BoardTask[]; result: unknown }) => {
+      const mutation = mutator(tasks);
+      if (mutation.tasks) tasks = mutation.tasks;
+      return mutation.result;
+    },
+    resolveSpawnAccount: () => ({
+      engine: "claude" as const,
+      accountId: "claude-test",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => null,
+    spawnAgentWithPrompt: async (spec: { launchProfile?: { model?: string | null } }) => {
+      launchedModel = spec.launchProfile?.model;
+      throw new Error("retry reached the launch seam");
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const response = await POST.withDependencies(new NextRequest(
+    `http://127.0.0.1/api/tasks/${tasks[0]!.id}/spawn`,
+    {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({ retryOfLaunchId: begun.receipt.launchId }),
+    },
+  ), { params: Promise.resolve({ id: tasks[0]!.id }) }, dependencies);
+
+  expect(response.status).toBe(500);
+  expect(launchedModel).toBe(historicalModel);
+});
 
 test("task attribution failure replays one launched pane into one durable assignment", async () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-spawn-282-"));

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -10,7 +10,7 @@ import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import type { AccountContext } from "@/lib/accounts/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { reasoningFromBody } from "@/lib/agent/efforts";
-import { modelFromBody } from "@/lib/agent/models";
+import { modelFromBody, validateLaunchModel } from "@/lib/agent/models";
 import { agentRegistry, type AgentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { spawnResponseForReceipt, type SpawnResponse as AgentSpawnResponse } from "@/lib/agent/spawnResponse";
@@ -231,6 +231,12 @@ async function postTaskSpawn(
     ? { ...(retryOf.launchProfile.model != null ? { model: retryOf.launchProfile.model } : {}) }
     : body);
   if (selectedModel.error) return NextResponse.json({ error: selectedModel.error }, { status: 400 });
+  let launchModel = selectedModel.model;
+  if (!retryOf && launchModel) {
+    const validation = validateLaunchModel(engine, launchModel);
+    if ("error" in validation) return NextResponse.json({ error: validation.error }, { status: 400 });
+    launchModel = validation.model;
+  }
   const cwdResult = cwdFromBody(retryOf ? retryOf.cwd : body.cwd);
   if (!cwdResult.cwd) return NextResponse.json({ error: cwdResult.error ?? "invalid working directory" }, { status: cwdResult.status ?? 400 });
 
@@ -244,7 +250,7 @@ async function postTaskSpawn(
   const shape = {
     engine,
     cwd: cwdResult.cwd,
-    model: selectedModel.model,
+    model: launchModel,
     effort: reasoning.effort,
     fast: reasoning.fast,
     accountId: account.accountId,
@@ -255,7 +261,7 @@ async function postTaskSpawn(
   const accountPin = registry.spawnReceiptForClientAttempt(clientAttemptId)?.accountPin
     ?? (previous !== null);
   const specBase = freshSpecFor(engine, cwdResult.cwd, {
-    model: selectedModel.model,
+    model: launchModel,
     effort: reasoning.effort,
     fast: reasoning.fast,
     codexHome: engine === "codex" ? account.home : null,
@@ -292,7 +298,7 @@ async function postTaskSpawn(
   const pipelineSpawnParams = (srcPath: string | null) => ({
     repoDir: cwdResult.cwd!,
     engine,
-    model: selectedModel.model,
+    model: launchModel,
     effort: reasoning.effort,
     launchId: launchReceipt.launchId,
     conversationId: launchReceipt.conversationId,

--- a/src/lib/agent/models.test.ts
+++ b/src/lib/agent/models.test.ts
@@ -3,10 +3,12 @@ import { expect, test } from "bun:test";
 import {
   CODEX_SOL_MODEL,
   CODEX_TERRA_MODEL,
+  CODEX_LUNA_MODEL,
   defaultModelFor,
   ENGINE_MODELS,
   modelFromBody,
   normalizeClaudeLaunchModel,
+  validateLaunchModel,
 } from "./models";
 
 test("the model catalog exposes Opus 5 as the Claude default", () => {
@@ -14,6 +16,7 @@ test("the model catalog exposes Opus 5 as the Claude default", () => {
   expect(ENGINE_MODELS.codex).toEqual([
     { id: CODEX_SOL_MODEL, label: "GPT-5.6-Sol", shortLabel: "5.6-Sol", use: "review" },
     { id: CODEX_TERRA_MODEL, label: "GPT-5.6-Terra", shortLabel: "5.6-Terra", use: "implement" },
+    { id: CODEX_LUNA_MODEL, label: "GPT-5.6-Luna", shortLabel: "5.6-Luna", use: "general" },
   ]);
   expect(defaultModelFor("codex")).toBe(CODEX_SOL_MODEL);
   expect(defaultModelFor("claude")).toBe("opus");
@@ -23,6 +26,16 @@ test("spawn model validation accepts CLI ids and rejects control characters", ()
   expect(modelFromBody({ model: " gpt-5.6-terra " })).toEqual({ model: CODEX_TERRA_MODEL });
   expect(modelFromBody({})).toEqual({ model: null });
   expect(modelFromBody({ model: "terra\n--help" }).error).toBeDefined();
+});
+
+test("explicit launch models are admitted only from the selected engine catalog", () => {
+  expect(validateLaunchModel("codex", CODEX_TERRA_MODEL)).toEqual({ model: CODEX_TERRA_MODEL });
+  expect(validateLaunchModel("codex", "gpt-5.6-codex")).toEqual({
+    error: `invalid codex model id "gpt-5.6-codex"; valid codex model ids: ${ENGINE_MODELS.codex.map((option) => option.id).join(", ")}`,
+  });
+  expect(validateLaunchModel("claude", "claude-fable-5")).toEqual({
+    error: `invalid claude model id "claude-fable-5"; valid claude model ids: ${ENGINE_MODELS.claude.map((option) => option.id).join(", ")}`,
+  });
 });
 
 test("Claude transcript model families normalize to stable launch aliases", () => {

--- a/src/lib/agent/models.ts
+++ b/src/lib/agent/models.ts
@@ -41,6 +41,19 @@ export const ENGINE_MODELS: Record<"claude" | "codex", readonly AgentModelOption
   ],
 };
 
+export type LaunchModelValidation = { model: string } | { error: string };
+
+/** Validate a fresh-launch model against the catalog rendered by the Viewer.
+    Resume and migration paths deliberately do not call this helper. */
+export function validateLaunchModel(engine: "claude" | "codex", model: string): LaunchModelValidation {
+  const requested = model.trim();
+  const validIds = ENGINE_MODELS[engine].map((option) => option.id);
+  if (validIds.includes(requested)) return { model: requested };
+  return {
+    error: `invalid ${engine} model id ${JSON.stringify(requested)}; valid ${engine} model ids: ${validIds.join(", ")}`,
+  };
+}
+
 /** A fresh Codex conversation starts on the architecture/review profile. */
 export function defaultModelFor(engine: "claude" | "codex"): string {
   return engine === "codex" ? CODEX_SOL_MODEL : "opus";

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -13,7 +13,7 @@ import { agentRegistry, SpawnChildLimitError, type SpawnRequest } from "@/lib/ag
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { mcpServersForSession, normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 import { normalizeSpawnPlugins, pluginAllowlistForSession, sessionOriginFor } from "@/lib/agent/pluginAllowlist";
-import { codexModelSupportsImages, modelFromBody } from "@/lib/agent/models";
+import { codexModelSupportsImages, modelFromBody, validateLaunchModel } from "@/lib/agent/models";
 import { resolveSpawnRole } from "@/lib/roles/registry";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { spawnContentDigest, spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
@@ -196,6 +196,10 @@ export async function executeSpawnRequest(
   if (reasoning.error) return NextResponse.json({ error: reasoning.error }, { status: 400 });
   const selectedModel = modelFromBody({ model: body.model === undefined ? role.value?.config.model : body.model });
   if (selectedModel.error) return NextResponse.json({ error: selectedModel.error }, { status: 400 });
+  if (body.model !== undefined && body.model !== null && selectedModel.model) {
+    const validation = validateLaunchModel(engine, selectedModel.model);
+    if ("error" in validation) return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
 
   const userPrompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
   const prompt = role.value ? [role.value.scaffold, userPrompt].filter(Boolean).join("\n\n") : userPrompt;

--- a/src/lib/flows/commands.durable.test.ts
+++ b/src/lib/flows/commands.durable.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { ENGINE_MODELS } from "@/lib/agent/models";
+
 const previousStateDir = process.env.LLV_STATE_DIR;
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-durable-create-"));
 process.env.LLV_STATE_DIR = sandbox;
@@ -53,6 +55,33 @@ test("durable implementer identity creates a flow without scanner or live-host e
     targetSha: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
     state: "waiting_ready",
   });
+});
+
+test("flow creation returns the catalog error before persisting an unknown reviewer model", async () => {
+  saveFlows([]);
+  const transcript = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
+  const implementer = registry.ensureConversation("codex", transcript, null);
+
+  const result = await createFlowFromRequest({
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    deliverKickoff: false,
+    roles: {
+      implementer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+      reviewer: { engine: "codex", model: "gpt-fabricated", effort: "high" },
+    },
+    baseMode: "head",
+    baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+  }, []);
+
+  expect(result).toEqual({
+    error: `invalid codex model id "gpt-fabricated"; valid codex model ids: ${ENGINE_MODELS.codex.map((option) => option.id).join(", ")}`,
+    status: 400,
+  });
+  expect(loadFlows()).toEqual([]);
 });
 
 test("closeFlow rejects a replacement reviewer binding while preserving concurrent flows", async () => {

--- a/src/lib/flows/commands.set-roles.test.ts
+++ b/src/lib/flows/commands.set-roles.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { CODEX_SOL_MODEL, ENGINE_MODELS } from "@/lib/agent/models";
+
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-set-roles-"));
 const { patchFlow } = await import("./commands");
 const { reviewerRoleFor, flowTickBase, persistTickFlows } = await import("./engine");
@@ -39,12 +41,12 @@ function seed(overrides: Partial<Flow> = {}): Flow {
 
 test("set-roles re-configures the reviewer for the next round and persists", () => {
   seed();
-  const result = patchFlow("f1", { action: "set-roles", roles: { reviewer: { model: "gpt-5-codex", effort: "" } } });
+  const result = patchFlow("f1", { action: "set-roles", roles: { reviewer: { model: CODEX_SOL_MODEL, effort: "" } } });
   expect(result.error).toBeUndefined();
-  expect(result.flow!.roles.reviewer).toEqual({ engine: "codex", model: "gpt-5-codex", effort: null });
+  expect(result.flow!.roles.reviewer).toEqual({ engine: "codex", model: CODEX_SOL_MODEL, effort: null });
   /* Implementer is untouched, and the change is written to the store. */
   expect(result.flow!.roles.implementer).toEqual({ engine: "codex", model: "gpt-5.6", effort: "medium" });
-  expect(loadFlows()[0]!.roles.reviewer.model).toBe("gpt-5-codex");
+  expect(loadFlows()[0]!.roles.reviewer.model).toBe(CODEX_SOL_MODEL);
 });
 
 test("resuming a known legacy pre-actuation relay failure clears its stale checkpoint", () => {
@@ -85,8 +87,11 @@ test("resuming a known legacy pre-actuation relay failure clears its stale check
 
 test("set-roles rejects a reviewer config the CLI cannot launch (issue #118 Finding 3)", () => {
   seed();
-  /* codex + a claude model must not persist and fail later at spawn. */
-  expect(patchFlow("f1", { action: "set-roles", roles: { reviewer: { model: "fable" } } }).status).toBe(400);
+  const rejected = patchFlow("f1", { action: "set-roles", roles: { reviewer: { model: "gpt-fabricated" } } });
+  expect(rejected).toEqual({
+    error: `invalid codex model id "gpt-fabricated"; valid codex model ids: ${ENGINE_MODELS.codex.map((option) => option.id).join(", ")}`,
+    status: 400,
+  });
   expect(patchFlow("f1", { action: "set-roles", roles: { reviewer: { engine: "claude" } } }).status).toBe(400);
   expect(loadFlows()[0]!.roles.reviewer).toEqual({ engine: "codex", model: "gpt-5.6", effort: "high" });
 });
@@ -203,6 +208,28 @@ test("set-roles leaves a spawning round's frozen snapshot untouched (issue #118 
   const result = patchFlow("f1", { action: "set-roles", roles: { reviewer: { engine: "claude", model: "fable" } } });
   expect(result.flow!.rounds[0]!.reviewerRole).toEqual({ engine: "codex", model: "gpt-5.6", effort: "high" });
   expect(result.flow!.roles.reviewer).toMatchObject({ engine: "claude", model: "fable" });
+});
+
+test("set-roles leaves a dated Claude model on an in-flight round untouched", () => {
+  const historicalModel = "claude-opus-4-8-20260630";
+  seed({
+    state: "reviewing",
+    roles: {
+      implementer: { engine: "codex", model: "gpt-5.6", effort: "medium" },
+      reviewer: { engine: "claude", model: historicalModel, effort: "high" },
+    },
+    rounds: [{
+      n: 1, reviewerPath: "/rev", reviewerRole: { engine: "claude", model: historicalModel, effort: "high" },
+      accountId: null, sessionId: null, reviewerPane: null, findingsPath: null, triggeredBy: "button",
+      readyNote: null, verdict: null, findingsCount: null, startedAt: "2026-07-05T00:00:00Z",
+      spawnStartedAt: "2026-07-05T00:00:01Z", relayStartedAt: null, reviewedAt: null, relayedAt: null, error: null,
+    }] as never,
+  });
+
+  const result = patchFlow("f1", { action: "set-roles", roles: { reviewer: { model: "opus" } } });
+
+  expect(result.flow!.roles.reviewer.model).toBe("opus");
+  expect(result.flow!.rounds[0]!.reviewerRole?.model).toBe(historicalModel);
 });
 
 test("set-roles rejects an invalid override and an empty payload", () => {

--- a/src/lib/flows/commands.test.ts
+++ b/src/lib/flows/commands.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
 
+import { CODEX_SOL_MODEL } from "@/lib/agent/models";
+
 import { applyRoleOverride, normalizeFlowSpec } from "./commands";
 import type { RoleConfig } from "./types";
 
@@ -16,7 +18,7 @@ const base: RoleConfig = { engine: "codex", model: "gpt-5.6", effort: "high" };
 
 test("applyRoleOverride merges only the provided fields and blanks to null (issue #118)", () => {
   /* A partial override touches just the reviewer model, keeping engine/effort. */
-  expect(applyRoleOverride(base, { model: "gpt-5-codex" })).toEqual({ engine: "codex", model: "gpt-5-codex", effort: "high" });
+  expect(applyRoleOverride(base, { model: CODEX_SOL_MODEL })).toEqual({ engine: "codex", model: CODEX_SOL_MODEL, effort: "high" });
   /* An explicit blank model/effort resolves to the engine default (null). */
   expect(applyRoleOverride(base, { model: "  ", effort: "" })).toEqual({ engine: "codex", model: null, effort: null });
   /* Reseating the engine with a compatible model is allowed. */

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 
 import { isEngineEffort } from "@/lib/agent/efforts";
-import { isCodexLaunchModel, normalizeClaudeLaunchModel } from "@/lib/agent/models";
+import { validateLaunchModel } from "@/lib/agent/models";
 import { agentRegistry } from "@/lib/agent/registry";
 import { headCwd } from "@/lib/agent/transcript";
 import { livePaneTarget } from "@/lib/delivery";
@@ -41,32 +41,39 @@ function validateRole(value: unknown): RoleConfig | null {
  * model/effort blank out to the engine default. Returns null on an invalid
  * engine so the caller can 400 instead of silently keeping the old value.
  */
-export function applyRoleOverride(current: RoleConfig, patch: unknown): RoleConfig | null {
-  if (!patch || typeof patch !== "object" || Array.isArray(patch)) return null;
+function roleOverrideFromRequest(
+  current: RoleConfig,
+  patch: unknown,
+): { role: RoleConfig } | { error: string } {
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) return { error: "invalid reviewer role override" };
   const p = patch as Partial<RoleConfig>;
   const next: RoleConfig = { ...current };
   if (p.engine !== undefined) {
-    if (p.engine !== "claude" && p.engine !== "codex") return null;
+    if (p.engine !== "claude" && p.engine !== "codex") return { error: "invalid reviewer role override" };
     next.engine = p.engine;
   }
   if (p.model !== undefined) {
-    if (p.model !== null && typeof p.model !== "string") return null;
+    if (p.model !== null && typeof p.model !== "string") return { error: "invalid reviewer role override" };
     next.model = typeof p.model === "string" && p.model.trim() ? p.model.trim() : null;
   }
   if (p.effort !== undefined) {
-    if (p.effort !== null && typeof p.effort !== "string") return null;
+    if (p.effort !== null && typeof p.effort !== "string") return { error: "invalid reviewer role override" };
     next.effort = typeof p.effort === "string" && p.effort.trim() ? p.effort.trim() : null;
   }
-  /* Validate the MERGED config through the canonical launch validators, not just
-     primitive shapes (issue #118 Finding 3): a claude+gpt / codex+fable / bad
-     effort combination must be rejected here rather than persisting and failing at
-     the next reviewer launch. */
+  /* This override controls a future reviewer launch. Frozen round snapshots do
+     not pass through here when they resume or replay. */
   if (next.model) {
-    if (next.engine === "claude" && !normalizeClaudeLaunchModel(next.model)) return null;
-    if (next.engine === "codex" && !isCodexLaunchModel(next.model)) return null;
+    const validation = validateLaunchModel(next.engine, next.model);
+    if ("error" in validation) return validation;
+    next.model = validation.model;
   }
-  if (next.effort && !isEngineEffort(next.engine, next.effort)) return null;
-  return next;
+  if (next.effort && !isEngineEffort(next.engine, next.effort)) return { error: "invalid reviewer role override" };
+  return { role: next };
+}
+
+export function applyRoleOverride(current: RoleConfig, patch: unknown): RoleConfig | null {
+  const result = roleOverrideFromRequest(current, patch);
+  return "role" in result ? result.role : null;
 }
 
 export function rolesFromRequest(req: CreateFlowRequest): Record<"implementer" | "reviewer", RoleConfig> | null {
@@ -128,6 +135,11 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
   }
   const roles = rolesFromRequest(req);
   if (!roles) return { error: "invalid flow roles or preset", status: 400 };
+  if (roles.reviewer.model) {
+    const validation = validateLaunchModel(roles.reviewer.engine, roles.reviewer.model);
+    if ("error" in validation) return { error: validation.error, status: 400 };
+    roles.reviewer.model = validation.model;
+  }
   const registry = agentRegistry();
   const requestedConversationId = req.implementerConversationId?.startsWith("conversation_")
     ? req.implementerConversationId as `conversation_${string}`
@@ -489,8 +501,9 @@ export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; err
        reseated in place, so it is not overridable here (see PatchFlowRequest). */
     const patch = req.roles && typeof req.roles === "object" && !Array.isArray(req.roles) ? req.roles.reviewer : undefined;
     if (patch === undefined) return { error: "reviewer role override is required", status: 400 };
-    const merged = applyRoleOverride(flow.roles.reviewer, patch);
-    if (!merged) return { error: "invalid reviewer role override", status: 400 };
+    const override = roleOverrideFromRequest(flow.roles.reviewer, patch);
+    if ("error" in override) return { error: override.error, status: 400 };
+    const merged = override.role;
     flow.roles = { ...flow.roles, reviewer: merged };
     /* Manual mode parks a created-but-unspawned round at spawn_pending with its
        role already frozen (newRound/retry snapshot it). The override must reach

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -52,6 +52,37 @@ test("spawn_agent reaches spawn validation through the operator admission lane",
   expect(fs.readFileSync(path.join(sandbox, "operator-spawn-capability"), "utf8").trim()).toMatch(/^[A-Za-z0-9_-]{43}$/);
 });
 
+test("spawn_agent rejects an explicit model outside the engine catalog before control-plane admission", async () => {
+  const requests: Record<string, unknown>[] = [];
+  const spawnAgent = viewerMcpBindings(undefined, {
+    post: async (_pathname, body) => {
+      requests.push(body);
+      return {};
+    },
+  }).spawn_agent;
+
+  const refusal = await spawnAgent({
+    clientRequestId: "mcp-invalid-model",
+    engine: "codex",
+    model: "gpt-5.6-codex",
+    cwd: "/repo",
+    ["prompt"]: "probe",
+  }).then(
+    () => null,
+    (error: unknown) => error as Error & { details?: { violations?: Array<{ field: string; message: string; expected: string }> } },
+  );
+
+  const message = "invalid codex model id \"gpt-5.6-codex\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna";
+  expect(refusal?.name).toBe("McpToolRefusal");
+  expect(refusal?.message).toBe(message);
+  expect(refusal?.details?.violations).toEqual([{
+    field: "model",
+    message,
+    expected: "one of: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna",
+  }]);
+  expect(requests).toEqual([]);
+});
+
 test("spawn_agent derives required role params from the prompt and preserves supplied params", async () => {
   const bodies: Record<string, unknown>[] = [];
   const spawn = viewerMcpBindings(undefined, {
@@ -1084,4 +1115,34 @@ test("create_pipeline refuses with every violated constraint attached", async ()
   expect(refusal?.details?.violations?.map((violation) => violation.field)).toEqual(["src", "stages[0].kind"]);
   for (const violation of refusal?.details?.violations ?? []) expect(violation.expected.length).toBeGreaterThan(0);
   expect(refusal?.message).toContain("stages[0].kind: stage kind must be run or review-loop");
+});
+
+test("create_pipeline batches every invalid stage model with each engine catalog", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-binding-pipeline-models-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const bindings = viewerMcpBindings();
+
+  const refusal = await bindings.create_pipeline({
+    clientRequestId: "create-pipeline-invalid-models",
+    task: "Validate model catalog",
+    repoDir: path.join(sandbox, "repo"),
+    src: path.join(sandbox, "creator.jsonl"),
+    stages: [
+      { id: "build", kind: "run", engine: "codex", model: "gpt-5.6-codex", prompt: "build", next: "review" },
+      { id: "review", kind: "review-loop", engine: "claude", model: "claude-fable-5", prompt: "review", next: null },
+    ],
+  }, { signal: undefined, deadlineAt: Date.now() + 30_000 } as never).then(
+    () => null,
+    (error: unknown) => error as Error & { details?: { violations?: Array<{ field: string; message: string }> } },
+  );
+
+  expect(refusal?.name).toBe("McpToolRefusal");
+  expect(refusal?.details?.violations?.map((violation) => violation.field)).toEqual([
+    "src",
+    "stages[0].model",
+    "stages[1].model",
+  ]);
+  expect(refusal?.message).toContain("valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna");
+  expect(refusal?.message).toContain("valid claude model ids: opus, fable, sonnet, haiku");
 });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { agentRegistry, readOnlyConversationLookupFromSnapshot } from "@/lib/agent/registry";
+import { ENGINE_MODELS, validateLaunchModel } from "@/lib/agent/models";
 import { procBackend } from "@/lib/proc";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_ENV, VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
@@ -58,7 +59,7 @@ import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
-import { listRoles } from "@/lib/roles/registry";
+import { listRoles, resolveSpawnRole } from "@/lib/roles/registry";
 import type { RoleDefinition, RoleParameter } from "@/lib/roles/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
@@ -448,6 +449,27 @@ function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function validateExplicitMcpLaunchModel(args: McpToolArgs, fallbackRole?: string): void {
+  const model = text(args.model);
+  if (!model) return;
+  if (args.engine !== undefined && args.engine !== "claude" && args.engine !== "codex") return;
+  const roleId = text(args.role) || fallbackRole;
+  const role = roleId ? resolveSpawnRole({ role: roleId, roleParams: args.roleParams }) : null;
+  let engine: "claude" | "codex" | null = null;
+  if (args.engine === "claude" || args.engine === "codex") engine = args.engine;
+  else if (role?.ok && role.value) engine = role.value.config.engine;
+  if (!engine) return;
+  const validation = validateLaunchModel(engine, model);
+  if (!("error" in validation)) return;
+  throw new McpToolRefusal(validation.error, {
+    violations: [{
+      field: "model",
+      message: validation.error,
+      expected: `one of: ${ENGINE_MODELS[engine].map((option) => option.id).join(", ")}`,
+    }],
+  });
+}
+
 function objectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -557,6 +579,7 @@ export function requestAttentionOperationKey(clientRequestId: string): string {
 }
 
 async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
+  validateExplicitMcpLaunchModel(args);
   const clientAttemptId = spawnAttemptId(requestId(args));
   const body = withoutKeys(args, ["clientRequestId"]);
   const roleParams = defaultMcpSpawnRoleParams(args);
@@ -1486,6 +1509,7 @@ async function getOrchestrator(args: McpToolArgs, dependencies: ViewerMcpDomainD
     approved versioned default mandate (or the caller's edited text based on
     it). The seat route owns the durable intent, so a retry replays. */
 async function createOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
+  if (!text(args.conversationId)) validateExplicitMcpLaunchModel(args, "orchestrator");
   const project = canonicalOrchestratorProject(required(args, "project"));
   const result = await control.post("/api/orchestrator/seat", {
     project,

--- a/src/lib/mcp/orchestratorTools.test.ts
+++ b/src/lib/mcp/orchestratorTools.test.ts
@@ -196,6 +196,19 @@ test("create_orchestrator posts the versioned approved default mandate through t
   expect(result).toMatchObject({ conversationId: SEATED_ID, transcriptPath: "/tmp/o.jsonl" });
 });
 
+test("create_orchestrator rejects an explicit fresh-launch model outside the engine catalog before posting", async () => {
+  const { posts, control } = controlStub();
+
+  await expect(bindingsWith(control).create_orchestrator({
+    clientRequestId: "create-invalid-model",
+    project: "proj-a",
+    engine: "claude",
+    model: "claude-fable-5",
+  })).rejects.toThrow("invalid claude model id \"claude-fable-5\"; valid claude model ids: opus, fable, sonnet, haiku");
+
+  expect(posts).toEqual([]);
+});
+
 test("create_orchestrator adopts an eligible existing conversation through the seat route", async () => {
   const { posts, control } = controlStub({
     "/api/orchestrator/seat": { ok: true, conversationId: SEATED_ID, path: "/tmp/o.jsonl", seat: { conversationId: SEATED_ID }, state: "settled" },
@@ -205,6 +218,7 @@ test("create_orchestrator adopts an eligible existing conversation through the s
     clientRequestId: "adopt-01",
     project: "proj-a",
     conversationId: SEATED_ID,
+    model: "historical-provider-model",
   });
 
   expect(posts).toHaveLength(1);
@@ -212,6 +226,7 @@ test("create_orchestrator adopts an eligible existing conversation through the s
   expect(posts[0]!.body).toMatchObject({
     project: "proj-a",
     conversationId: SEATED_ID,
+    model: "historical-provider-model",
     clientRequestId: "adopt-01",
   });
   expect(result).toMatchObject({ conversationId: SEATED_ID, transcriptPath: "/tmp/o.jsonl" });

--- a/src/lib/orchestrator/seatCommand.test.ts
+++ b/src/lib/orchestrator/seatCommand.test.ts
@@ -624,6 +624,22 @@ test("validation refuses a missing project, empty mandate, and malformed request
   expect((await executeOrchestratorSeatRequest({ project: "proj-a", mandate: "m", clientRequestId: "no" }, deps)).status).toBe(400);
 });
 
+test("spawn-mode seat creation rejects an explicit model outside the engine catalog before intent or spawn", async () => {
+  const { deps, recorded } = dependencies();
+  const result = await executeOrchestratorSeatRequest({
+    ...spawnRequest(),
+    engine: "codex",
+    model: "gpt-5.6-codex",
+  }, deps);
+
+  expect(result).toEqual({
+    status: 400,
+    body: { error: "invalid codex model id \"gpt-5.6-codex\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna" },
+  });
+  expect(recorded.spawns).toEqual([]);
+  expect(orchestratorSeatFor("proj-a")).toMatchObject({ active: null, pending: null });
+});
+
 /* Issue #903: a spawn falling back to the server's own working directory
    minted seats in /app — outside every scanner root — that held authority
    while permanently inert. */
@@ -679,4 +695,21 @@ test("rotation without a cwd continues in the predecessor's checkout", async () 
     if (previous === undefined) delete process.env.LLV_ORCHESTRATOR_CWD;
     else process.env.LLV_ORCHESTRATOR_CWD = previous;
   }
+});
+
+test("rotation rejects an explicit successor model outside the engine catalog before spawning", async () => {
+  const { deps, recorded } = dependencies();
+  expect((await executeOrchestratorSeatRequest(spawnRequest("req_00000205"), deps)).status).toBe(200);
+
+  const rotated = await executeOrchestratorRotation({
+    project: "proj-a",
+    clientRequestId: "req_00000206",
+    engine: "claude",
+    model: "claude-fable-5",
+  }, deps);
+
+  expect(rotated.status).toBe(400);
+  expect(rotated.body.error).toBe("invalid claude model id \"claude-fable-5\"; valid claude model ids: opus, fable, sonnet, haiku");
+  expect(recorded.spawns).toHaveLength(1);
+  expect(orchestratorSeatFor("proj-a")).toMatchObject({ active: { conversationId: NEW_ID }, pending: null });
 });

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -3,11 +3,13 @@ import fs from "node:fs";
 
 import { validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { agentRegistry } from "@/lib/agent/registry";
+import { validateLaunchModel } from "@/lib/agent/models";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { deliverConversationMessage } from "@/lib/delivery";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
 import { projectForCwd } from "@/lib/scanner/describe";
+import { resolveSpawnRole } from "@/lib/roles/registry";
 
 import { loadTasks } from "@/lib/tasks/store";
 import {
@@ -213,6 +215,18 @@ export interface SeatCommandResult {
 
 function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function explicitSeatModelError(rawBody: Record<string, unknown>): string | null {
+  const model = text(rawBody.model);
+  if (!model) return null;
+  const role = resolveSpawnRole({ role: "orchestrator", roleParams: rawBody.roleParams ?? { mode: "standard" } });
+  let engine: "claude" | "codex" | null = null;
+  if (rawBody.engine === "claude" || rawBody.engine === "codex") engine = rawBody.engine;
+  else if (role.ok && role.value) engine = role.value.config.engine;
+  if (!engine) return null;
+  const validation = validateLaunchModel(engine, model);
+  return "error" in validation ? validation.error : null;
 }
 
 function replayedSeatResponse(seat: OrchestratorSeat): SeatCommandResult {
@@ -430,6 +444,8 @@ export async function executeOrchestratorSeatRequest(
       },
     };
   }
+  const modelError = explicitSeatModelError(rawBody);
+  if (modelError) return { status: 400, body: { error: modelError } };
   const begun = beginOrchestratorSeatIntent({ project, mandate, clientRequestId, mode: "spawn", promptVersion, now: dependencies.now() });
   if (begun.kind === "completed") return replayedSeatResponse(begun.seat);
   if (begun.kind === "in_progress") return inProgressSeatResponse(begun.seat);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -4753,6 +4753,11 @@ test("override-stage rejects an unknown/disallowed role and an incompatible role
   /* architect resolves to claude; a codex-only model must fail canonical bounds. */
   const bad = await patchPipeline(created.id, { action: "override-stage", stageId: "build", role: { roleId: "architect" }, model: "gpt-5.6-sol" }, ports);
   expect(bad.status).toBe(400);
+  const unknown = await patchPipeline(created.id, { action: "override-stage", stageId: "build", engine: "codex", model: "gpt-5.6-codex" }, ports);
+  expect(unknown).toMatchObject({
+    status: 400,
+    error: "invalid codex model id \"gpt-5.6-codex\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna",
+  });
 });
 
 test("override-stage rejects non-string model/effort instead of silently ignoring them (issue #118 review F3)", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -2469,10 +2469,11 @@ function normalizeStages(
     };
     const resolved = preservedStage ? { role: preservedStage.effectiveRole } : resolvePipelineRole(input, stage.kind as PipelineStage["kind"], lookup);
     if (!resolved.role) {
+      const field = "field" in resolved && resolved.field === "model" ? "model" : "role";
       violations.push({
-        field: at("role"),
+        field: at(field),
         message: "error" in resolved && resolved.error ? resolved.error : "invalid stage role",
-        expected: STAGE_RUNTIME_SHAPE,
+        expected: field === "model" ? "model id from the selected engine's curated catalog" : STAGE_RUNTIME_SHAPE,
       });
       continue;
     }

--- a/src/lib/pipelines/roles.test.ts
+++ b/src/lib/pipelines/roles.test.ts
@@ -87,11 +87,18 @@ test("stage runtime fields override registry and global defaults", () => {
 
 test("cross-engine overrides require a compatible model", () => {
   expect(resolvePipelineRole({ role: { roleId: "reviewer" }, engine: "claude" }, "review-loop", REGISTRY_LOOKUP).error)
-    .toContain("model is not supported by claude");
+    .toContain("valid claude model ids: opus, fable, sonnet, haiku");
   expect(resolvePipelineRole({ engine: "claude" }, "run", REGISTRY_LOOKUP).error)
-    .toContain("model is not supported by claude");
+    .toContain("valid claude model ids: opus, fable, sonnet, haiku");
   expect(resolvePipelineRole({ engine: "claude", model: "opus", effort: "high" }, "run", REGISTRY_LOOKUP).role)
     .toMatchObject({ engine: "claude", model: "opus", effort: "high" });
+});
+
+test("stage model overrides enumerate the selected engine catalog when invalid", () => {
+  expect(resolvePipelineRole({ engine: "codex", model: "gpt-5.6-codex" }, "run", REGISTRY_LOOKUP).error)
+    .toBe("invalid codex model id \"gpt-5.6-codex\"; valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna");
+  expect(resolvePipelineRole({ engine: "claude", model: "claude-fable-5" }, "run", REGISTRY_LOOKUP).error)
+    .toBe("invalid claude model id \"claude-fable-5\"; valid claude model ids: opus, fable, sonnet, haiku");
 });
 
 test("review-loop roles default to read-only access", () => {
@@ -191,9 +198,9 @@ test("Builder domain=frontend keeps the canonical frontend scaffold guidance (pa
   expect(pipelineRoleLookup("builder", {})?.promptScaffold).not.toContain("UI/frontend implementation guidance");
 });
 
-test("codex model overrides mirror the store bounds at create time", () => {
+test("codex model overrides use the curated launch catalog at create time", () => {
   expect(resolvePipelineRole({ model: `gpt-${"x".repeat(200)}` }, "run", REGISTRY_LOOKUP).error)
-    .toContain("not supported by codex");
+    .toContain("valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna");
   expect(resolvePipelineRole({ model: "gpt-5.6\u0000sol" }, "run", REGISTRY_LOOKUP).error)
-    .toContain("not supported by codex");
+    .toContain("valid codex model ids: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna");
 });

--- a/src/lib/pipelines/roles.ts
+++ b/src/lib/pipelines/roles.ts
@@ -1,7 +1,7 @@
 import { configForParams, listRoles, roleFenceBlock, roleScaffoldBody, validateRoleParams } from "@/lib/roles/registry";
 import { MAX_SCAFFOLD_LENGTH } from "@/lib/roles/store";
 import { isEngineEffort } from "@/lib/agent/efforts";
-import { isCodexLaunchModel, normalizeClaudeLaunchModel } from "@/lib/agent/models";
+import { validateLaunchModel } from "@/lib/agent/models";
 import { defaultRoleParameterValue } from "@/lib/roles/parameters";
 
 import { PIPELINE_DISALLOWED_ROLE_IDS, type EffectivePipelineRole, type PipelineRoleId, type PipelineStage, type PipelineStageKind } from "./types";
@@ -87,7 +87,7 @@ export function resolvePipelineRole(
   stage: Pick<PipelineStage, "role" | "engine" | "model" | "effort" | "access">,
   kind: PipelineStageKind,
   lookup?: PipelineRoleLookup | null,
-): { role?: EffectivePipelineRole; error?: string } {
+): { role?: EffectivePipelineRole; error?: string; field?: "model" } {
   const ref = stage.role;
   if (ref !== undefined && (!ref || typeof ref !== "object" || Array.isArray(ref))) {
     return { error: "stage role must be an object" };
@@ -121,13 +121,9 @@ export function resolvePipelineRole(
   const engine = stage.engine ?? registered?.engine ?? builder.engine;
   const model = value(stage.model, registered?.model ?? builder.model);
   const effort = value(stage.effort, registered?.effort ?? builder.effort);
-  if (model && engine === "claude" && !normalizeClaudeLaunchModel(model)) {
-    return { error: "stage model is not supported by claude; provide a compatible model override" };
-  }
-  /* Mirrors the store's isEffectiveRole bounds so a bad override fails the
-     create with a 400 instead of surfacing as a persist-time 500. */
-  if (model && engine === "codex" && !isCodexLaunchModel(model)) {
-    return { error: "stage model is not supported by codex; provide a compatible model override" };
+  if (model) {
+    const validation = validateLaunchModel(engine, model);
+    if ("error" in validation) return { error: validation.error, field: "model" };
   }
   if (effort && !isEngineEffort(engine, effort)) {
     return { error: `stage effort is not supported by ${engine}` };

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -116,6 +116,18 @@ test("spawn role resolution injects the scaffold and requires deploy confirmatio
   expect(spawn.value.scaffold).toContain("Builder in tdd mode");
 });
 
+test("spawn role resolution enumerates the selected engine catalog for an invalid explicit model", () => {
+  expect(resolveSpawnRole({
+    role: "builder",
+    roleParams: { mode: "plain" },
+    engine: "claude",
+    model: "mythos-1",
+  })).toEqual({
+    ok: false,
+    error: "invalid claude model id \"mythos-1\"; valid claude model ids: opus, fable, sonnet, haiku",
+  });
+});
+
 test("orchestrator spawn defaults omitted maxWorkers to three and preserves explicit one", () => {
   const omitted = resolveSpawnRole({ role: "orchestrator" });
   if (!omitted.ok || !omitted.value) throw new Error("expected resolved orchestrator role");

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -1,5 +1,5 @@
 import { isEngineEffort } from "@/lib/agent/efforts";
-import { normalizeClaudeLaunchModel } from "@/lib/agent/models";
+import { validateLaunchModel } from "@/lib/agent/models";
 
 import { BUILDER_APPLY_FIXES_CONFIG, BUILDER_FRONTEND_CONFIG } from "./paramConfig";
 import { defaultRoleParameterValue } from "./parameters";
@@ -99,9 +99,9 @@ export function configForParams(definition: RoleDefinition, params: RoleParamVal
 function resolveConfig(definition: RoleDefinition, params: RoleParamValues, explicit: ExplicitRoleConfig): { ok: true; value: RoleConfig } | { ok: false; error: string } {
   const config = { ...configForParams(definition, params), ...explicit };
   if (config.engine !== "claude" && config.engine !== "codex") return { ok: false, error: "engine must be claude or codex" };
-  if (!config.model || config.model.length > 128) return { ok: false, error: "model must be a printable id up to 128 characters" };
-  if (config.engine === "claude" && !normalizeClaudeLaunchModel(config.model)) return { ok: false, error: "model is not supported by claude" };
-  if (config.engine === "codex" && !config.model.startsWith("gpt-")) return { ok: false, error: "model is not supported by codex" };
+  const model = validateLaunchModel(config.engine, config.model);
+  if ("error" in model) return { ok: false, error: model.error };
+  config.model = model.model;
   if (!isEngineEffort(config.engine, config.effort)) return { ok: false, error: `effort for ${config.engine} must be one of: ${config.engine === "codex" ? "low, medium, high, xhigh" : "low, medium, high, xhigh, max"}` };
   return { ok: true, value: config };
 }

--- a/src/lib/workflows/engine.test.ts
+++ b/src/lib/workflows/engine.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { ENGINE_MODELS } from "@/lib/agent/models";
 import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
@@ -173,6 +174,37 @@ test("createWorkflowFromRequest validates task, repo and stages", () => {
   const { ports: failing, state } = makeHarness();
   state.execFail = "--git-dir";
   expect(createWorkflowFromRequest({ task: "t", repoDir: "/r", stages: STAGES as never }, failing).status).toBe(400);
+});
+
+test("createWorkflowFromRequest rejects unknown implementer, reviewer, and fixer models before persistence", () => {
+  const { ports } = makeHarness();
+  const expected = `invalid codex model id "gpt-fabricated"; valid codex model ids: ${ENGINE_MODELS.codex.map((option) => option.id).join(", ")}`;
+  const cases = [
+    [
+      { ...STAGES[0], agent: { ...STAGES[0].agent, model: "gpt-fabricated" } },
+      STAGES[1],
+      STAGES[2],
+    ],
+    [
+      STAGES[0],
+      STAGES[1],
+      { ...STAGES[2], reviewer: { ...STAGES[2].reviewer, model: "gpt-fabricated" } },
+    ],
+    [
+      STAGES[0],
+      STAGES[1],
+      { ...STAGES[2], fixer: { ...STAGES[2].fixer, model: "gpt-fabricated" } },
+    ],
+  ];
+
+  for (const stages of cases) {
+    saveWorkflows([]);
+    expect(createWorkflowFromRequest({ task: "t", repoDir: "/r", stages: stages as never }, ports)).toEqual({
+      error: expected,
+      status: 400,
+    });
+    expect(loadWorkflows()).toEqual([]);
+  }
 });
 
 test("createWorkflowFromRequest stamps the scanner project key, basename as fallback", () => {

--- a/src/lib/workflows/engine.ts
+++ b/src/lib/workflows/engine.ts
@@ -20,7 +20,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { realExec, provisionWorktree, runFinish, setupStatus, startSetup, type ExecPort, type SetupStatus } from "./provision";
 import { fixerKickoff, prBody, stageKickoff } from "./prompts";
-import { buildWorkflow, loadTemplates, loadWorkflows, normalizeStages, saveWorkflows, setupExitPath } from "./store";
+import { buildWorkflow, loadTemplates, loadWorkflows, normalizeStages, saveWorkflows, setupExitPath, validateWorkflowLaunchModels } from "./store";
 import type {
   CreateWorkflowRequest,
   PatchWorkflowRequest,
@@ -610,6 +610,8 @@ export function createWorkflowFromRequest(
       ...(typeof req.verify === "string" && req.verify.trim() ? { verify: req.verify.trim() } : {}),
     };
   }
+  const modelValidation = validateWorkflowLaunchModels(template.stages);
+  if ("error" in modelValidation) return { error: modelValidation.error, status: 400 };
 
   const wf = buildWorkflow({
     id: crypto.randomUUID().slice(0, 8),

--- a/src/lib/workflows/store.ts
+++ b/src/lib/workflows/store.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { validateLaunchModel } from "@/lib/agent/models";
 import { statePath } from "@/lib/configDir";
 import { canonicalProject } from "@/lib/projects/aliases";
 import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
@@ -276,6 +277,24 @@ export function normalizeStages(value: unknown): { stages: WorkflowStage[] } | {
   const reviewCount = stages.filter((stage) => stage.kind === "review-loop").length;
   if (reviewCount !== 1 || stages.at(-1)?.kind !== "review-loop") {
     return { error: "stages must be implement+ followed by exactly one review-loop last" };
+  }
+  return { stages };
+}
+
+/** Validate only a workflow being admitted for a new run. Persisted workflow
+    snapshots keep bypassing this helper so restart/replay can retain historical
+    provider model ids. */
+export function validateWorkflowLaunchModels(stages: WorkflowStage[]): { stages: WorkflowStage[] } | { error: string } {
+  for (const stage of stages) {
+    const roles = stage.kind === "implement"
+      ? [stage.agent]
+      : [stage.reviewer, stage.fixer];
+    for (const role of roles) {
+      if (!role.model) continue;
+      const validation = validateLaunchModel(role.engine, role.model);
+      if ("error" in validation) return validation;
+      role.model = validation.model;
+    }
   }
   return { stages };
 }


### PR DESCRIPTION
## Summary

- validate fresh-launch model ids from `ENGINE_MODELS` across spawn, pipeline, and orchestrator admission
- return actionable errors that name the rejected id and enumerate the selected engine's valid ids
- preserve historical Claude resume and orchestrator adoption behavior
- expose batched model violations through MCP pipeline creation

## Verification

- 325 focused tests across 8 exact test files with isolated runtime state
- `bunx tsc --noEmit`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base eca8000475045a8e4795903750bc6ed46d9fb16b`

Fixes #1041
