### PR TITLE
feat(search): full-text transcript body index

### DIFF
--- a/src/app/api/search/transcripts/route.test.ts
+++ b/src/app/api/search/transcripts/route.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { indexTranscriptSources } from "@/lib/search/transcriptSearch";
+
+import { GET } from "./route";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-transcript-route-"));
+const previousEnvironment = {
+  HOME: process.env.HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  TMPDIR: process.env.TMPDIR,
+};
+
+beforeEach(() => {
+  process.env.HOME = path.join(sandbox, "home");
+  process.env.XDG_CONFIG_HOME = path.join(sandbox, "config");
+  process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+  process.env.TMPDIR = path.join(sandbox, "tmp");
+  fs.rmSync(process.env.LLV_STATE_DIR, { recursive: true, force: true });
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+});
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(previousEnvironment)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("returns indexed snippets without reopening the transcript", async () => {
+  const transcript = path.join(sandbox, "route-session.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({
+    type: "user",
+    timestamp: "2026-08-20T14:00:00.000Z",
+    message: { content: "HTTP finds #звіт in the persisted body index" },
+  }) + "\n");
+  const stat = fs.statSync(transcript);
+  await indexTranscriptSources([{
+    path: transcript,
+    project: "reports",
+    engine: "claude",
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+  }], { complete: true });
+  fs.rmSync(transcript);
+
+  const response = await GET(new Request("http://127.0.0.1/api/search/transcripts?q=%23%D0%B7%D0%B2%D1%96%D1%82&limit=5"));
+  const body = await response.json() as {
+    items: Array<{ transcriptPath: string; speaker: string; snippet: string }>;
+    total: number;
+  };
+
+  expect(response.status).toBe(200);
+  expect(body.total).toBe(1);
+  expect(body.items).toEqual([expect.objectContaining({
+    transcriptPath: transcript,
+    speaker: "user",
+    snippet: expect.stringContaining("звіт"),
+  })]);
+});
+
+test("rejects a missing query instead of returning an ambiguous empty page", async () => {
+  const response = await GET(new Request("http://127.0.0.1/api/search/transcripts"));
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({ error: "q is required" });
+});

--- a/src/app/api/search/transcripts/route.ts
+++ b/src/app/api/search/transcripts/route.ts
@@ -1,0 +1,32 @@
+import {
+  InvalidTranscriptSearchCursorError,
+  searchTranscripts,
+} from "@/lib/search/transcriptSearch";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function pageLimit(value: string | null): number | undefined {
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? Math.max(1, Math.min(100, parsed)) : undefined;
+}
+
+export function GET(request: Request): Response {
+  const url = new URL(request.url);
+  const query = url.searchParams.get("q")?.trim() ?? "";
+  if (!query) return Response.json({ error: "q is required" }, { status: 400 });
+  try {
+    return Response.json(searchTranscripts({
+      query,
+      project: url.searchParams.get("project")?.trim() || undefined,
+      cursor: url.searchParams.get("cursor"),
+      limit: pageLimit(url.searchParams.get("limit")),
+    }));
+  } catch (error) {
+    if (error instanceof InvalidTranscriptSearchCursorError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+}

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1079,6 +1079,34 @@ async function listConversations(
   return redactPayload({ count: rows.length, conversations: rows });
 }
 
+async function searchTranscripts(
+  args: McpToolArgs,
+  control: ViewerControlDependencies,
+): Promise<McpToolPayload> {
+  const query = text(args.query).trim();
+  if (!query) throw new Error("query is required");
+  const project = text(args.project).trim();
+  const cursor = text(args.cursor).trim();
+  const limit = Math.max(1, Math.min(100, integer(args.limit, 20)));
+  const params = new URLSearchParams({ q: query });
+  if (project) params.set("project", project);
+  if (cursor) params.set("cursor", cursor);
+  params.set("limit", String(limit));
+  const source = await readViewerControl(control, `/api/search/transcripts?${params}`);
+  const stats = objectRecord(source.stats) ? source.stats : null;
+  if (!Array.isArray(source.items)
+    || typeof source.total !== "number"
+    || (source.nextCursor !== null && typeof source.nextCursor !== "string")
+    || !stats
+    || typeof stats.conversationsIndexed !== "number"
+    || typeof stats.messagesIndexed !== "number"
+    || !Array.isArray(stats.fieldsSearched)
+    || typeof stats.tokenizer !== "string") {
+    throw new ViewerControlResponseError("Viewer control returned a malformed transcript search page");
+  }
+  return redactPayload(source);
+}
+
 async function getConversation(
   args: McpToolArgs,
   dependencies: Pick<ViewerMcpDomainDependencies, "listFiles" | "completedFileScan" | "targetedFileEntry" | "selectedContext">,
@@ -2367,6 +2395,7 @@ export function viewerMcpBindings(
     pipeline_action: (args) => pipelineAction(args, domainDependencies),
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
     list_conversations: (args) => listConversations(args, controlDependencies),
+    search_transcripts: (args) => searchTranscripts(args, controlDependencies),
     get_conversation: (args, context) => getConversation(args, domainDependencies, context),
     deploy_exact_sha: (args) => deployExactSha(args, controlDependencies, domainDependencies),
     get_pipeline: getPipeline,

--- a/src/lib/mcp/presentation.test.ts
+++ b/src/lib/mcp/presentation.test.ts
@@ -36,6 +36,7 @@ describe("describeMcpCall", () => {
       ["pipeline_action", { pipelineId: "pipe-a", action: "resume" }, "pipeline", "Resuming pipeline"],
       ["link_task_to_pipeline", { taskId: "task-a", pipelineId: "pipe-a" }, "link", "Linking task to pipeline"],
       ["list_conversations", { project: "viewer" }, "conversation", "Listing conversations"],
+      ["search_transcripts", { query: "report" }, "conversation", "Searching transcripts"],
       ["get_conversation", { conversationId: "conversation_a" }, "conversation", "Opening conversation"],
       ["deploy_exact_sha", { revision: "abcdef1234567890", confirm: "deploy" }, "deploy", "Deploying release"],
       ["get_pipeline", { pipelineId: "pipe-a" }, "pipeline", "Opening pipeline"],

--- a/src/lib/mcp/presentation.ts
+++ b/src/lib/mcp/presentation.ts
@@ -178,6 +178,18 @@ export function describeMcpCall(
     };
   }
 
+  if (toolName === "search_transcripts") {
+    const query = compact(string(args.query));
+    const total = typeof result.total === "number" ? `${result.total} matches` : "";
+    return {
+      icon: "conversation",
+      verb: "Searching",
+      title: `Searching transcripts${query ? `: ${query}` : ""}`,
+      subtitle: replaySubtitle(result, total),
+      links: [],
+    };
+  }
+
   if (toolName === "get_conversation") {
     const conversationId = string(result.conversationId) || string(args.conversationId);
     const transcriptPath = string(result.transcriptPath) || string(args.transcriptPath);

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -86,6 +86,7 @@ function boundedArgs(
       roleParams: {},
     });
   }
+  if (toolName === "search_transcripts") args.query = "fixture";
   return args;
 }
 
@@ -251,6 +252,26 @@ test("get_conversation listTools publishes every bounded tail target", async () 
     }
     expect(tool?.description).toContain("validated pinned reader");
     expect(tailSchema?.description).toContain("validated pinned reader");
+  });
+});
+
+test("search_transcripts publishes its body-query, project, cursor, and bounded page schema", async () => {
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    const tool = listed.tools.find((candidate) => candidate.name === "search_transcripts");
+
+    expect(tool?.description).toContain("message bodies");
+    expect(tool?.inputSchema.required).toEqual(expect.arrayContaining(["clientRequestId", "query"]));
+    expect(Object.keys(tool?.inputSchema.properties ?? {})).toEqual(expect.arrayContaining([
+      "clientRequestId",
+      "query",
+      "project",
+      "cursor",
+      "limit",
+    ]));
+    expect(tool?.inputSchema.properties?.limit).toMatchObject({
+      description: expect.stringContaining("Integer 1..100"),
+    });
   });
 });
 

--- a/src/lib/mcp/searchTranscripts.test.ts
+++ b/src/lib/mcp/searchTranscripts.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+
+import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
+
+test("search_transcripts reads the HTTP body index with cross-project pagination arguments", async () => {
+  const reads: string[] = [];
+  const indexedPage = {
+    items: [{
+      snippet: "matched #звіт body",
+      speaker: "user",
+      timestamp: 1_780_000_000,
+      transcriptPath: "/sessions/report.jsonl",
+      byteOffset: 42,
+      lineNumber: 3,
+      project: "reports",
+      engine: "codex",
+    }],
+    nextCursor: "cursor-b",
+    total: 2,
+    stats: {
+      conversationsIndexed: 12,
+      messagesIndexed: 34,
+      fieldsSearched: ["message.body"],
+      tokenizer: "FTS5 unicode61, remove_diacritics=0, tokenchars=#_",
+    },
+  };
+  const control: ViewerControlDependencies = {
+    get: async (pathname) => {
+      reads.push(pathname);
+      return indexedPage;
+    },
+    post: async () => ({}),
+  };
+  const bindings = viewerMcpBindings(undefined, control);
+
+  const result = await bindings.search_transcripts({
+    clientRequestId: "search-body-1",
+    query: "#звіт",
+    project: "reports",
+    cursor: "cursor-a",
+    limit: 25,
+  });
+
+  expect(reads).toEqual([
+    "/api/search/transcripts?q=%23%D0%B7%D0%B2%D1%96%D1%82&project=reports&cursor=cursor-a&limit=25",
+  ]);
+  expect(result).toEqual(indexedPage);
+});

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1543,6 +1543,7 @@ describe("MCP tool service", () => {
         "pipeline_action",
         "link_task_to_pipeline",
         "list_conversations",
+        "search_transcripts",
         "get_conversation",
         "deploy_exact_sha",
         "get_pipeline",

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -42,6 +42,7 @@ export const MCP_TOOL_NAMES = [
   "pipeline_action",
   "link_task_to_pipeline",
   "list_conversations",
+  "search_transcripts",
   "get_conversation",
   "deploy_exact_sha",
   "get_pipeline",
@@ -156,6 +157,9 @@ export const MCP_BOUNDED_NUMERIC_ARGS: Partial<Record<McpToolName, readonly McpB
   ],
   list_conversations: [
     { path: ["limit"], min: 1, max: 100, fallback: 50 },
+  ],
+  search_transcripts: [
+    { path: ["limit"], min: 1, max: 100, fallback: 20 },
   ],
   get_conversation: [
     { path: ["maxRecords"], min: 1, max: 500, fallback: 100 },
@@ -1621,6 +1625,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   pipeline_action: "Apply a supported action to an existing pipeline.",
   link_task_to_pipeline: "Attach a board task to a conversation owned by a pipeline.",
   list_conversations: "List scanned Viewer conversations with durable ids and transcript paths.",
+  search_transcripts: "Search indexed user and assistant message bodies across every scanned transcript store. Returns match snippets with speaker, timestamp, transcript path and byte offset; project is optional, and empty pages include corpus statistics. Queries never read transcript files.",
   get_conversation: "Read a conversation summary and its recent messages and tools. With tailLines, conversationId or selectedContext uses the bounded identity path, while transcriptPath uses the validated pinned reader; both return a bounded raw tail without a corpus scan.",
   deploy_exact_sha: "Deploy one full commit SHA. The designated orchestrator decides when to deploy and calls this directly; authority is the server-attributed designated seat, and nobody asks the operator for a confirmation, a phrase, or a SHA. Idempotent by clientRequestId; deployments serialize at the runtime host.",
   get_pipeline: "Read one pipeline by durable id.",
@@ -1858,6 +1863,13 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     project: z.string().optional(),
     query: z.string().optional(),
     limit: boundedNumericInput("list_conversations", "limit"),
+  }).passthrough(),
+  search_transcripts: z.object({
+    clientRequestId: clientRequestIdSchema,
+    query: z.string().trim().min(1).describe("Terms to match in indexed user and assistant message bodies."),
+    project: z.string().trim().min(1).optional().describe("Canonical project key. Omit to search every indexed project."),
+    cursor: z.string().min(1).optional().describe("Opaque cursor returned by the preceding page for this query and project."),
+    limit: boundedNumericInput("search_transcripts", "limit"),
   }).passthrough(),
   get_conversation: z.object({
     clientRequestId: clientRequestIdSchema,

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -10,7 +10,13 @@ import { isClaudeWorkflowBookkeeping } from "./claudeNative";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { describe } from "./describe";
 import type { ConversationCatalogEntry } from "./conversationCatalog";
-import { beginProjectCatalogScan, projectCatalogSnapshotFromRaw, type ParsedFileSummary } from "./projectCatalog";
+import {
+  beginProjectCatalogScan,
+  isProjectCatalogScanCurrent,
+  projectCatalogSnapshotFromRaw,
+  type ParsedFileSummary,
+  type ProjectCatalogScanToken,
+} from "./projectCatalog";
 import { projectResolutionStateKey } from "./projectState";
 import { EXTS, ROOTS, scanRootEntries } from "./roots";
 import { selectSchemeWindow } from "./schemeWindow";
@@ -191,9 +197,11 @@ function transcriptIndexFeed(
 function publishTranscriptIndexFeed(
   catalog: readonly ConversationCatalogEntry[],
   complete: boolean,
+  scanToken: ProjectCatalogScanToken,
   projectByPath?: ReadonlyMap<string, string>,
   scheduler?: TranscriptIndexScheduler,
 ): void {
+  if (!isProjectCatalogScanCurrent(scanToken)) return;
   const publish = scheduler
     ?? (process.env.LLV_FILE_SCANNER_WORKER === "1" ? undefined : scheduleTranscriptIndex);
   publish?.(transcriptIndexFeed(catalog, complete, projectByPath));
@@ -589,6 +597,7 @@ export async function discoverFilesWithProjectCatalog(
   publishTranscriptIndexFeed(
     snapshot.conversationCatalog,
     snapshot.complete,
+    scanToken,
     projectByPath,
     options.transcriptIndexScheduler,
   );
@@ -634,7 +643,7 @@ export async function discoverFiles(
     canonicalizePath,
     canonicalizeTranscriptPaths(hosted, canonicalizePath),
   );
-  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, projectByPath);
+  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, scanToken, projectByPath);
   return entries.files;
 }
 
@@ -644,5 +653,5 @@ export async function refreshConversationCatalog(roots: Roots | RootEntries = sc
   const scanToken = beginProjectCatalogScan(false);
   const discovery = await discoverRaw(roots, createLimiter(48));
   const snapshot = await projectCatalogSnapshotFromRaw(discovery.raw, { persist: false, scanToken, complete: discovery.complete });
-  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, snapshot.projectByPath);
+  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, scanToken, snapshot.projectByPath);
 }

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { FileEntry, ProjectCatalogEntry, RootKey } from "../types";
 import { forEachCooperatively, mapCooperatively } from "../cooperative";
 import { sessionProjectProjection } from "../session/titleProjection";
+import { scheduleTranscriptIndex, type TranscriptIndexFeed } from "../search/transcriptFeed";
 import { isClaudeWorkflowBookkeeping } from "./claudeNative";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { describe } from "./describe";
@@ -47,6 +48,7 @@ type ResourceScopeSnapshot = {
   projectCatalog: ProjectCatalogEntry[];
   complete: boolean;
 };
+type TranscriptIndexScheduler = (feed: TranscriptIndexFeed) => void;
 const DISCOVERY_DIAGNOSTIC_MS = 60_000;
 let lastDiscoveryDiagnosticAt = Number.NEGATIVE_INFINITY;
 
@@ -167,6 +169,34 @@ function rootEntries(roots: Roots | RootEntries): RootEntries {
 /** Rewrites foreign root forms of a transcript onto the roots this scan walked. */
 function canonicalizerFor(roots: Roots | RootEntries): TranscriptPathCanonicalizer {
   return createTranscriptPathCanonicalizer(rootEntries(roots).map(([, root]) => root));
+}
+
+function transcriptIndexFeed(
+  catalog: readonly ConversationCatalogEntry[],
+  complete: boolean,
+  projectByPath?: ReadonlyMap<string, string>,
+): TranscriptIndexFeed {
+  return {
+    complete,
+    sources: catalog.map((entry) => ({
+      path: entry.path,
+      project: projectByPath?.get(entry.path) ?? entry.project,
+      engine: entry.engine,
+      size: entry.size,
+      mtimeMs: entry.mtime * 1_000,
+    })),
+  };
+}
+
+function publishTranscriptIndexFeed(
+  catalog: readonly ConversationCatalogEntry[],
+  complete: boolean,
+  projectByPath?: ReadonlyMap<string, string>,
+  scheduler?: TranscriptIndexScheduler,
+): void {
+  const publish = scheduler
+    ?? (process.env.LLV_FILE_SCANNER_WORKER === "1" ? undefined : scheduleTranscriptIndex);
+  publish?.(transcriptIndexFeed(catalog, complete, projectByPath));
 }
 
 async function discoverRaw(
@@ -512,6 +542,8 @@ export async function discoverFilesWithProjectCatalog(
     onResourceSnapshot?: (snapshot: ResourceScopeSnapshot) => void;
     /** Carries the uncapped catalog across the file-scanner process boundary. */
     transportConversationCatalog?: boolean;
+    /** Focused-test seam for observing the non-awaited transcript index feed. */
+    transcriptIndexScheduler?: TranscriptIndexScheduler;
   } = {},
 ): Promise<{
   files: FileEntry[];
@@ -554,10 +586,23 @@ export async function discoverFilesWithProjectCatalog(
     canonicalizePath,
     canonicalizeTranscriptPaths(options.hosted, canonicalizePath),
   );
+  publishTranscriptIndexFeed(
+    snapshot.conversationCatalog,
+    snapshot.complete,
+    projectByPath,
+    options.transcriptIndexScheduler,
+  );
   return {
     ...entries,
     projectCatalog,
-    ...(options.transportConversationCatalog ? { conversationCatalog: snapshot.conversationCatalog } : {}),
+    ...(options.transportConversationCatalog
+      ? {
+          conversationCatalog: snapshot.conversationCatalog.map((entry) => ({
+            ...entry,
+            project: projectByPath.get(entry.path) ?? entry.project,
+          })),
+        }
+      : {}),
     complete: snapshot.complete,
   };
 }
@@ -580,7 +625,7 @@ export async function discoverFiles(
     snapshot.projectCatalog,
     canonicalizePath,
   );
-  return (await entriesFromRaw(
+  const entries = await entriesFromRaw(
     discovery.raw,
     projectByPath,
     demote,
@@ -588,7 +633,9 @@ export async function discoverFiles(
     snapshot.summaryByPath,
     canonicalizePath,
     canonicalizeTranscriptPaths(hosted, canonicalizePath),
-  )).files;
+  );
+  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, projectByPath);
+  return entries.files;
 }
 
 /** Cold-start fallback for the list/search route. It builds only lightweight
@@ -596,5 +643,6 @@ export async function discoverFiles(
 export async function refreshConversationCatalog(roots: Roots | RootEntries = scanRootEntries()): Promise<void> {
   const scanToken = beginProjectCatalogScan(false);
   const discovery = await discoverRaw(roots, createLimiter(48));
-  await projectCatalogSnapshotFromRaw(discovery.raw, { persist: false, scanToken, complete: discovery.complete });
+  const snapshot = await projectCatalogSnapshotFromRaw(discovery.raw, { persist: false, scanToken, complete: discovery.complete });
+  publishTranscriptIndexFeed(snapshot.conversationCatalog, snapshot.complete, snapshot.projectByPath);
 }

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { scheduleTranscriptIndex, waitForTranscriptIndexIdleForTests } from "@/lib/search/transcriptFeed";
+import { searchTranscripts } from "@/lib/search/transcriptSearch";
+
 import { conversationCatalogSnapshot, replaceConversationCatalog } from "./conversationCatalog";
 import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
 
@@ -66,7 +69,7 @@ test("worker scan streams the resource scope, keeps the caller event loop live, 
   }
 });
 
-test("a successful worker exit schedules the transported transcript catalog in the parent", async () => {
+test("a current incomplete worker scan schedules a non-deleting transcript feed", async () => {
   const transcript = {
     path: "/sessions/indexed.jsonl",
     root: "codex-sessions",
@@ -82,7 +85,7 @@ test("a successful worker exit schedules the transported transcript catalog in t
   };
   const completion = JSON.stringify({
     type: "complete",
-    snapshot: { files: [], projectCatalog: [], conversationCatalog: [transcript], complete: true },
+    snapshot: { files: [], projectCatalog: [], conversationCatalog: [transcript], complete: false },
   });
   const { directory, workerPath } = fixtureWorker(`
     process.stdin.resume();
@@ -102,7 +105,7 @@ test("a successful worker exit schedules the transported transcript catalog in t
   );
 
   expect(feeds).toEqual([{
-    complete: true,
+    complete: false,
     sources: [{
       path: transcript.path,
       project: transcript.project,
@@ -111,6 +114,103 @@ test("a successful worker exit schedules the transported transcript catalog in t
       mtimeMs: transcript.mtime * 1_000,
     }],
   }]);
+});
+
+test("an obsolete worker scan finishing last cannot delete newer transcript index results", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-worker-overlap-"));
+  directories.push(directory);
+  const previousEnvironment = {
+    HOME: process.env.HOME,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+    TMPDIR: process.env.TMPDIR,
+  };
+  process.env.HOME = path.join(directory, "home");
+  process.env.XDG_CONFIG_HOME = path.join(directory, "config");
+  process.env.LLV_STATE_DIR = path.join(directory, "state");
+  process.env.TMPDIR = path.join(directory, "tmp");
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+
+  const transcript = (name: string, body: string) => {
+    const pathname = path.join(directory, `${name}.jsonl`);
+    fs.writeFileSync(pathname, `${JSON.stringify({
+      type: "user",
+      timestamp: "2026-08-20T09:00:00.000Z",
+      message: { content: body },
+    })}\n`);
+    const stat = fs.statSync(pathname);
+    return {
+      path: pathname,
+      root: "claude-projects",
+      name: path.basename(pathname),
+      project: "repo-overlap",
+      title: name,
+      firstPrompt: "",
+      engine: "claude",
+      kind: "session",
+      fmt: "claude",
+      mtime: stat.mtimeMs / 1_000,
+      size: stat.size,
+    };
+  };
+  const older = transcript("older", "obsoleteinventorymarker");
+  const newer = transcript("newer", "newerinventorymarker");
+  const completion = (entry: ReturnType<typeof transcript>) => `${JSON.stringify({
+    type: "complete",
+    snapshot: { files: [], projectCatalog: [], conversationCatalog: [entry], complete: true },
+  })}\n`;
+  const worker = (entry: ReturnType<typeof transcript>, delayMs: number) => fixtureWorker(`
+    process.stdin.resume();
+    process.stdin.on("end", () => setTimeout(() => {
+      process.stdout.write(${JSON.stringify(completion(entry))});
+    }, ${delayMs}));
+  `);
+  const olderWorker = worker(older, 250);
+  const newerWorker = worker(newer, 0);
+  const scheduledPaths: string[][] = [];
+  const schedule = (feed: Parameters<typeof scheduleTranscriptIndex>[0]) => {
+    scheduledPaths.push(feed.sources.map((entry) => entry.path));
+    scheduleTranscriptIndex(feed, { force: true });
+  };
+
+  try {
+    await waitForTranscriptIndexIdleForTests();
+    const olderScan = collectFileScanInWorker(
+      { persist: false, persistIndex: false },
+      undefined,
+      {
+        launch: { executable: process.execPath, workerPath: olderWorker.workerPath },
+        cwd: olderWorker.directory,
+        timeoutMs: 2_000,
+        transcriptIndexScheduler: schedule,
+      },
+    );
+    const newerScan = collectFileScanInWorker(
+      { persist: false, persistIndex: false },
+      undefined,
+      {
+        launch: { executable: process.execPath, workerPath: newerWorker.workerPath },
+        cwd: newerWorker.directory,
+        timeoutMs: 2_000,
+        transcriptIndexScheduler: schedule,
+      },
+    );
+
+    await newerScan;
+    await waitForTranscriptIndexIdleForTests();
+    expect(searchTranscripts({ query: "newerinventorymarker" }).items).toHaveLength(1);
+
+    await olderScan;
+    await waitForTranscriptIndexIdleForTests();
+    expect(scheduledPaths).toEqual([[newer.path]]);
+    expect(searchTranscripts({ query: "newerinventorymarker" }).items).toHaveLength(1);
+  } finally {
+    await waitForTranscriptIndexIdleForTests();
+    for (const [key, value] of Object.entries(previousEnvironment)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 });
 
 test("worker scans publish a Claude transcript that appears in a previously sessionless project directory", async () => {

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -66,6 +66,53 @@ test("worker scan streams the resource scope, keeps the caller event loop live, 
   }
 });
 
+test("a successful worker exit schedules the transported transcript catalog in the parent", async () => {
+  const transcript = {
+    path: "/sessions/indexed.jsonl",
+    root: "codex-sessions",
+    name: "indexed.jsonl",
+    project: "repo-indexed",
+    title: "indexed",
+    firstPrompt: "",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    mtime: 1_780_000_000,
+    size: 100,
+  };
+  const completion = JSON.stringify({
+    type: "complete",
+    snapshot: { files: [], projectCatalog: [], conversationCatalog: [transcript], complete: true },
+  });
+  const { directory, workerPath } = fixtureWorker(`
+    process.stdin.resume();
+    process.stdin.on("end", () => process.stdout.write(${JSON.stringify(`${completion}\n`)}));
+  `);
+  const feeds: unknown[] = [];
+
+  await collectFileScanInWorker(
+    { persist: false, persistIndex: false },
+    undefined,
+    {
+      launch: { executable: process.execPath, workerPath },
+      cwd: directory,
+      timeoutMs: 2_000,
+      transcriptIndexScheduler: (feed) => { feeds.push(feed); },
+    },
+  );
+
+  expect(feeds).toEqual([{
+    complete: true,
+    sources: [{
+      path: transcript.path,
+      project: transcript.project,
+      engine: transcript.engine,
+      size: transcript.size,
+      mtimeMs: transcript.mtime * 1_000,
+    }],
+  }]);
+});
+
 test("worker scans publish a Claude transcript that appears in a previously sessionless project directory", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-worker-late-session-"));
   directories.push(directory);
@@ -147,6 +194,7 @@ test("a completion frame followed by worker failure preserves the published conv
     });
   `);
   replaceConversationCatalog([retained]);
+  let transcriptIndexFeeds = 0;
 
   await expect(collectFileScanInWorker(
     { persist: false, persistIndex: false },
@@ -155,10 +203,12 @@ test("a completion frame followed by worker failure preserves the published conv
       launch: { executable: process.execPath, workerPath },
       cwd: directory,
       timeoutMs: 2_000,
+      transcriptIndexScheduler: () => { transcriptIndexFeeds += 1; },
     },
   )).rejects.toThrow("file scanner worker exited before completion");
 
   expect(conversationCatalogSnapshot()).toEqual([retained]);
+  expect(transcriptIndexFeeds).toBe(0);
 });
 
 test("aborting a worker scan kills the child and releases its timer and listener", async () => {

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -7,7 +7,11 @@ import { scheduleTranscriptIndex, type TranscriptIndexFeed } from "@/lib/search/
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { FileCatalogScan, FileScanOptions } from "./index";
-import { beginProjectCatalogScan, publishConversationCatalogForScan } from "./projectCatalog";
+import {
+  beginProjectCatalogScan,
+  isProjectCatalogScanCurrent,
+  publishConversationCatalogForScan,
+} from "./projectCatalog";
 
 const FILE_SCAN_WORKER_TIMEOUT_MS = 5 * 60_000;
 const FILE_SCAN_WORKER_OUTPUT_MAX_BYTES = 32 * 1024 * 1024;
@@ -196,17 +200,20 @@ export function collectFileScanInWorker(
         return;
       }
       if (completedConversationCatalog) {
+        const currentScan = isProjectCatalogScanCurrent(catalogScanToken);
         publishConversationCatalogForScan(completedConversationCatalog, catalogScanToken, completed.complete);
-        (runtime.transcriptIndexScheduler ?? scheduleTranscriptIndex)({
-          complete: completed.complete,
-          sources: completedConversationCatalog.map((entry) => ({
-            path: entry.path,
-            project: entry.project,
-            engine: entry.engine,
-            size: entry.size,
-            mtimeMs: entry.mtime * 1_000,
-          })),
-        });
+        if (currentScan) {
+          (runtime.transcriptIndexScheduler ?? scheduleTranscriptIndex)({
+            complete: completed.complete,
+            sources: completedConversationCatalog.map((entry) => ({
+              path: entry.path,
+              project: entry.project,
+              engine: entry.engine,
+              size: entry.size,
+              mtimeMs: entry.mtime * 1_000,
+            })),
+          });
+        }
       }
       finish(undefined, completed);
     });

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { systemScheduler, type DeadlineScheduler } from "@/lib/deadline";
+import { scheduleTranscriptIndex, type TranscriptIndexFeed } from "@/lib/search/transcriptFeed";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { FileCatalogScan, FileScanOptions } from "./index";
@@ -25,6 +26,7 @@ export interface FileScanWorkerRuntime {
   timeoutMs?: number;
   signal?: AbortSignal | null;
   scheduler?: DeadlineScheduler;
+  transcriptIndexScheduler?: (feed: TranscriptIndexFeed) => void;
 }
 
 function abortError(): Error {
@@ -195,6 +197,16 @@ export function collectFileScanInWorker(
       }
       if (completedConversationCatalog) {
         publishConversationCatalogForScan(completedConversationCatalog, catalogScanToken, completed.complete);
+        (runtime.transcriptIndexScheduler ?? scheduleTranscriptIndex)({
+          complete: completed.complete,
+          sources: completedConversationCatalog.map((entry) => ({
+            path: entry.path,
+            project: entry.project,
+            engine: entry.engine,
+            size: entry.size,
+            mtimeMs: entry.mtime * 1_000,
+          })),
+        });
       }
       finish(undefined, completed);
     });

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -92,13 +92,16 @@ export function beginProjectCatalogScan(persist: boolean): ProjectCatalogScanTok
   return { publication, persistence };
 }
 
+export function isProjectCatalogScanCurrent(scanToken: ProjectCatalogScanToken): boolean {
+  return projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
+}
+
 export function publishConversationCatalogForScan(
   entries: ConversationCatalogEntry[],
   scanToken: ProjectCatalogScanToken,
   complete: boolean,
 ): boolean {
-  const current = projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
-  if (!current || !complete) return false;
+  if (!isProjectCatalogScanCurrent(scanToken) || !complete) return false;
   replaceConversationCatalog(entries);
   return true;
 }

--- a/src/lib/scanner/transcriptSearchFeed.test.ts
+++ b/src/lib/scanner/transcriptSearchFeed.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { TranscriptIndexFeed } from "@/lib/search/transcriptFeed";
+
+import { discoverFilesWithProjectCatalog } from "./discover";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-search-feed-scan-"));
+const previousEnvironment = {
+  HOME: process.env.HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  TMPDIR: process.env.TMPDIR,
+};
+
+process.env.HOME = path.join(sandbox, "home");
+process.env.XDG_CONFIG_HOME = path.join(sandbox, "config");
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.TMPDIR = path.join(sandbox, "tmp");
+fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(previousEnvironment)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function writeCodex(root: string, name: string, cwd: string): string {
+  const transcript = path.join(root, "2026", "08", "20", name);
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, [
+    JSON.stringify({ type: "session_meta", payload: { cwd, timestamp: "2026-08-20T09:00:00.000Z" } }),
+    JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: `prompt ${name}` } }),
+  ].join("\n") + "\n");
+  return transcript;
+}
+
+function writeClaude(root: string, slug: string, name: string, cwd: string): string {
+  const transcript = path.join(root, slug, name);
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, JSON.stringify({
+    type: "user",
+    cwd,
+    timestamp: "2026-08-20T09:00:00.000Z",
+    message: { content: `prompt ${name}` },
+  }) + "\n");
+  return transcript;
+}
+
+test("feeds every configured Codex and Claude transcript store into one background inventory", async () => {
+  const workspace = path.join(sandbox, "workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  const codexShared = path.join(sandbox, "codex-shared");
+  const codexAccount = path.join(sandbox, "codex-account");
+  const claudeShared = path.join(sandbox, "claude-shared");
+  const claudeNative = path.join(sandbox, "claude-native");
+  const paths = [
+    writeCodex(codexShared, "rollout-shared.jsonl", workspace),
+    writeCodex(codexAccount, "rollout-account.jsonl", workspace),
+    writeClaude(claudeShared, "workspace-a", "shared.jsonl", workspace),
+    writeClaude(claudeNative, "workspace-b", "native.jsonl", workspace),
+  ];
+  let feed: TranscriptIndexFeed | undefined;
+
+  const scan = await discoverFilesWithProjectCatalog([
+    ["codex-sessions", codexShared],
+    ["codex-sessions", codexAccount],
+    ["claude-projects", claudeShared],
+    ["claude-projects", claudeNative],
+  ], undefined, {
+    persist: false,
+    transcriptIndexScheduler: (next) => { feed = next; },
+  });
+
+  expect(scan.complete).toBeTrue();
+  expect(feed?.complete).toBeTrue();
+  expect(feed?.sources.map((entry) => entry.path).sort()).toEqual(paths.sort());
+  expect(feed?.sources.filter((entry) => entry.engine === "codex")).toHaveLength(2);
+  expect(feed?.sources.filter((entry) => entry.engine === "claude")).toHaveLength(2);
+});

--- a/src/lib/scanner/transcriptSearchFeed.test.ts
+++ b/src/lib/scanner/transcriptSearchFeed.test.ts
@@ -82,3 +82,44 @@ test("feeds every configured Codex and Claude transcript store into one backgrou
   expect(feed?.sources.filter((entry) => entry.engine === "codex")).toHaveLength(2);
   expect(feed?.sources.filter((entry) => entry.engine === "claude")).toHaveLength(2);
 });
+
+test("a direct scan invalidated by a newer generation does not publish its stale inventory", async () => {
+  const workspace = path.join(sandbox, "overlap-workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  const olderRoot = path.join(sandbox, "overlap-older");
+  const newerRoot = path.join(sandbox, "overlap-newer");
+  const olderPath = writeCodex(olderRoot, "rollout-older.jsonl", workspace);
+  const newerPath = writeCodex(newerRoot, "rollout-newer.jsonl", workspace);
+  let olderFeed: TranscriptIndexFeed | undefined;
+  let newerFeed: TranscriptIndexFeed | undefined;
+  let newerScan: ReturnType<typeof discoverFilesWithProjectCatalog> | undefined;
+  let markNewerStarted: (() => void) | undefined;
+  const newerStarted = new Promise<void>((resolve) => { markNewerStarted = resolve; });
+
+  const olderScan = discoverFilesWithProjectCatalog(
+    [["codex-sessions", olderRoot]],
+    undefined,
+    {
+      persist: false,
+      onResourceSnapshot: () => {
+        newerScan = discoverFilesWithProjectCatalog(
+          [["codex-sessions", newerRoot]],
+          undefined,
+          {
+            persist: false,
+            transcriptIndexScheduler: (feed) => { newerFeed = feed; },
+          },
+        );
+        markNewerStarted?.();
+      },
+      transcriptIndexScheduler: (feed) => { olderFeed = feed; },
+    },
+  );
+
+  await newerStarted;
+  await Promise.all([olderScan, newerScan!]);
+
+  expect(olderFeed).toBeUndefined();
+  expect(newerFeed?.sources.map((entry) => entry.path)).toEqual([newerPath]);
+  expect(newerFeed?.sources.map((entry) => entry.path)).not.toContain(olderPath);
+});

--- a/src/lib/search/transcriptFeed.test.ts
+++ b/src/lib/search/transcriptFeed.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { scheduleTranscriptIndex, waitForTranscriptIndexIdleForTests } from "./transcriptFeed";
+import { indexTranscriptSources, searchTranscripts, type TranscriptIndexSource } from "./transcriptSearch";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-transcript-feed-"));
+const previousEnvironment = {
+  HOME: process.env.HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  TMPDIR: process.env.TMPDIR,
+};
+
+beforeEach(async () => {
+  await waitForTranscriptIndexIdleForTests();
+  process.env.HOME = path.join(sandbox, "home");
+  process.env.XDG_CONFIG_HOME = path.join(sandbox, "config");
+  process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+  process.env.TMPDIR = path.join(sandbox, "tmp");
+  fs.rmSync(process.env.LLV_STATE_DIR, { recursive: true, force: true });
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+});
+
+afterAll(async () => {
+  await waitForTranscriptIndexIdleForTests();
+  for (const [key, value] of Object.entries(previousEnvironment)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("starts initial indexing after the caller returns and completes it in the background", async () => {
+  const transcript = path.join(sandbox, "background-session.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "background saffron body" } }) + "\n");
+  const stat = fs.statSync(transcript);
+  const sources: TranscriptIndexSource[] = [{
+    path: transcript,
+    project: "background",
+    engine: "claude",
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+  }];
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => { markStarted = resolve; });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const run = async (nextSources: readonly TranscriptIndexSource[], complete: boolean) => {
+    markStarted();
+    await gate;
+    await indexTranscriptSources(nextSources, { complete });
+  };
+
+  const returned = scheduleTranscriptIndex({ sources, complete: true }, { force: true, run });
+
+  expect(returned).toBeUndefined();
+  await started;
+  expect(fs.existsSync(path.join(process.env.LLV_STATE_DIR!, "transcript-search.sqlite"))).toBeFalse();
+  release();
+  await waitForTranscriptIndexIdleForTests();
+  expect(searchTranscripts({ query: "saffron" }).items).toHaveLength(1);
+});

--- a/src/lib/search/transcriptFeed.ts
+++ b/src/lib/search/transcriptFeed.ts
@@ -1,0 +1,102 @@
+import {
+  indexTranscriptSources,
+  type TranscriptIndexSource,
+} from "./transcriptSearch";
+
+export interface TranscriptIndexFeed {
+  sources: readonly TranscriptIndexSource[];
+  complete: boolean;
+}
+
+type TranscriptIndexRun = (
+  sources: readonly TranscriptIndexSource[],
+  complete: boolean,
+) => Promise<void>;
+
+interface ScheduledFeed {
+  feed: TranscriptIndexFeed;
+  run: TranscriptIndexRun;
+}
+
+interface TranscriptFeedState {
+  pending?: ScheduledFeed;
+  active?: Promise<void>;
+  scheduled: boolean;
+  idleWaiters: Array<() => void>;
+}
+
+const host = globalThis as typeof globalThis & {
+  __llvTranscriptFeed?: TranscriptFeedState;
+};
+
+function state(): TranscriptFeedState {
+  return host.__llvTranscriptFeed ??= { scheduled: false, idleWaiters: [] };
+}
+
+async function productionRun(
+  sources: readonly TranscriptIndexSource[],
+  complete: boolean,
+): Promise<void> {
+  const indexed = await indexTranscriptSources(sources, { complete });
+  if (indexed.failures.length) {
+    throw new Error(`${indexed.failures.length} transcript file(s) could not be indexed`);
+  }
+}
+
+function settleIdle(current: TranscriptFeedState): void {
+  if (current.scheduled || current.active || current.pending) return;
+  for (const resolve of current.idleWaiters.splice(0)) resolve();
+}
+
+async function drain(current: TranscriptFeedState): Promise<void> {
+  while (current.pending) {
+    const scheduled = current.pending;
+    delete current.pending;
+    try {
+      await scheduled.run(scheduled.feed.sources, scheduled.feed.complete);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`[transcript search] background indexing failed: ${detail}; a later scan will retry`);
+    }
+  }
+}
+
+function start(current: TranscriptFeedState): void {
+  current.scheduled = false;
+  if (current.active) return;
+  const active = drain(current);
+  current.active = active;
+  void active.finally(() => {
+    if (current.active === active) delete current.active;
+    if (current.pending && !current.scheduled) {
+      current.scheduled = true;
+      setImmediate(() => start(current));
+    } else {
+      settleIdle(current);
+    }
+  });
+}
+
+/**
+ * Publishes the latest complete scanner inventory to the durable body index.
+ * Scheduling is synchronous and performs no transcript or SQLite reads; the
+ * first file is opened on a later event-loop turn.
+ */
+export function scheduleTranscriptIndex(
+  feed: TranscriptIndexFeed,
+  options: { force?: boolean; run?: TranscriptIndexRun } = {},
+): void {
+  if (process.env.NODE_ENV === "test" && !options.force) return;
+  const current = state();
+  current.pending = { feed, run: options.run ?? productionRun };
+  if (current.active || current.scheduled) return;
+  current.scheduled = true;
+  setImmediate(() => start(current));
+}
+
+/** Test-only observation seam for focused fixture runs. */
+export function waitForTranscriptIndexIdleForTests(): Promise<void> {
+  const current = state();
+  if (!current.scheduled && !current.active && !current.pending) return Promise.resolve();
+  return new Promise((resolve) => current.idleWaiters.push(resolve));
+}

--- a/src/lib/search/transcriptSearch.test.ts
+++ b/src/lib/search/transcriptSearch.test.ts
@@ -1,0 +1,300 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  indexTranscriptSources,
+  searchTranscripts,
+  type TranscriptIndexSource,
+} from "./transcriptSearch";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-transcript-search-"));
+const previousEnvironment = {
+  HOME: process.env.HOME,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  TMPDIR: process.env.TMPDIR,
+};
+
+function source(pathname: string, engine: "claude" | "codex", project: string): TranscriptIndexSource {
+  const stat = fs.statSync(pathname);
+  return { path: pathname, engine, project, size: stat.size, mtimeMs: stat.mtimeMs };
+}
+
+beforeEach(() => {
+  process.env.HOME = path.join(sandbox, "home");
+  process.env.XDG_CONFIG_HOME = path.join(sandbox, "config");
+  process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+  process.env.TMPDIR = path.join(sandbox, "tmp");
+  fs.rmSync(process.env.LLV_STATE_DIR, { recursive: true, force: true });
+  fs.mkdirSync(process.env.TMPDIR, { recursive: true });
+});
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(previousEnvironment)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("indexes Claude and Codex message bodies with jump metadata", async () => {
+  const claude = path.join(sandbox, "claude-session.jsonl");
+  const codex = path.join(sandbox, "codex-session.jsonl");
+  fs.writeFileSync(claude, [
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-08-20T09:00:00.000Z",
+      message: { role: "user", content: [{ type: "text", text: "Prepare the cobalt daily report" }] },
+    }),
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-08-20T09:00:03.000Z",
+      message: { role: "assistant", content: [{ type: "text", text: "The cobalt report is ready" }] },
+    }),
+  ].join("\n") + "\n");
+  fs.writeFileSync(codex, [
+    JSON.stringify({ type: "session_meta", payload: { cwd: "/workspace/fixture" } }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-20T10:00:00.000Z",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Cobalt appears inside the Codex answer" }],
+      },
+    }),
+  ].join("\n") + "\n");
+
+  await indexTranscriptSources([
+    source(claude, "claude", "project-a"),
+    source(codex, "codex", "project-b"),
+  ], { complete: true });
+  const result = searchTranscripts({ query: "cobalt", limit: 10 });
+
+  expect(result.items).toHaveLength(3);
+  expect(result.items).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      speaker: "user",
+      timestamp: Date.parse("2026-08-20T09:00:00.000Z") / 1_000,
+      transcriptPath: claude,
+      byteOffset: 0,
+      lineNumber: 1,
+      project: "project-a",
+      engine: "claude",
+      snippet: expect.stringContaining("cobalt"),
+    }),
+    expect.objectContaining({
+      speaker: "assistant",
+      transcriptPath: codex,
+      lineNumber: 2,
+      project: "project-b",
+      engine: "codex",
+    }),
+  ]));
+  expect(result.stats).toEqual({
+    conversationsIndexed: 2,
+    messagesIndexed: 3,
+    fieldsSearched: ["message.body"],
+    tokenizer: "FTS5 unicode61, remove_diacritics=0, tokenchars=#_",
+  });
+});
+
+test("matches Cyrillic hashtags and underscore tags as exact FTS tokens", async () => {
+  const transcript = path.join(sandbox, "tagged-session.jsonl");
+  fs.writeFileSync(transcript, [
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-08-20T11:00:00.000Z",
+      message: { role: "user", content: "Підготуй #звіт за правилом cron_work_daily" },
+    }),
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-08-20T11:00:01.000Z",
+      message: { role: "assistant", content: "Окрема #звітність використовує cron_work_daily_extra" },
+    }),
+  ].join("\n") + "\n");
+  await indexTranscriptSources([source(transcript, "claude", "reports")], { complete: true });
+
+  const hashtag = searchTranscripts({ query: "#звіт" });
+  const underscore = searchTranscripts({ query: "cron_work_daily" });
+
+  expect(hashtag.items).toHaveLength(1);
+  expect(hashtag.items[0]).toMatchObject({ speaker: "user", transcriptPath: transcript });
+  expect(underscore.items).toHaveLength(1);
+  expect(underscore.items[0]).toMatchObject({ speaker: "user", transcriptPath: transcript });
+});
+
+test("returns bounded non-overlapping result pages", async () => {
+  const transcript = path.join(sandbox, "paged-session.jsonl");
+  fs.writeFileSync(transcript, Array.from({ length: 3 }, (_value, index) => JSON.stringify({
+    type: index % 2 ? "assistant" : "user",
+    timestamp: `2026-08-20T12:00:0${index}.000Z`,
+    message: { content: `paginated cobalt message ${index}` },
+  })).join("\n") + "\n");
+  await indexTranscriptSources([source(transcript, "claude", "pages")], { complete: true });
+
+  const first = searchTranscripts({ query: "cobalt", limit: 2 });
+  const second = searchTranscripts({ query: "cobalt", limit: 2, cursor: first.nextCursor });
+
+  expect(first.items).toHaveLength(2);
+  expect(first.nextCursor).not.toBeNull();
+  expect(first.total).toBe(3);
+  expect(second.items).toHaveLength(1);
+  expect(second.nextCursor).toBeNull();
+  expect(new Set([...first.items, ...second.items].map((item) => item.byteOffset)).size).toBe(3);
+});
+
+test("searches all projects by default and explains a scoped empty result", async () => {
+  const firstPath = path.join(sandbox, "first-project.jsonl");
+  const secondPath = path.join(sandbox, "second-project.jsonl");
+  fs.writeFileSync(firstPath, JSON.stringify({ type: "user", message: { content: "shared heliotrope term" } }) + "\n");
+  fs.writeFileSync(secondPath, JSON.stringify({ type: "assistant", message: { content: "shared heliotrope term" } }) + "\n");
+  await indexTranscriptSources([
+    source(firstPath, "claude", "project-a"),
+    source(secondPath, "claude", "project-b"),
+  ], { complete: true });
+
+  expect(searchTranscripts({ query: "heliotrope" }).items).toHaveLength(2);
+  expect(searchTranscripts({ query: "heliotrope", project: "project-a" }).items)
+    .toEqual([expect.objectContaining({ project: "project-a" })]);
+
+  const empty = searchTranscripts({ query: "missing", project: "project-a" });
+  expect(empty.items).toEqual([]);
+  expect(empty.stats).toEqual({
+    conversationsIndexed: 2,
+    messagesIndexed: 2,
+    fieldsSearched: ["message.body"],
+    tokenizer: "FTS5 unicode61, remove_diacritics=0, tokenchars=#_",
+  });
+});
+
+test("does not reopen an unchanged transcript on the next index pass", async () => {
+  const transcript = path.join(sandbox, "unchanged-session.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "fixture" } }) + "\n");
+  const indexedSource = source(transcript, "claude", "performance");
+  let opens = 0;
+  const readMessages = async function* () {
+    opens += 1;
+    yield {
+      body: "incremental heliotrope fixture",
+      speaker: "user" as const,
+      timestamp: null,
+      byteOffset: 0,
+      lineNumber: 1,
+    };
+  };
+
+  const first = await indexTranscriptSources([indexedSource], { complete: true, readMessages });
+  const second = await indexTranscriptSources([indexedSource], { complete: true, readMessages });
+  await indexTranscriptSources([{ ...indexedSource, project: "performance-renamed" }], { complete: true, readMessages });
+
+  expect(first).toMatchObject({ filesRead: 1, filesSkipped: 0 });
+  expect(second).toMatchObject({ filesRead: 0, filesSkipped: 1 });
+  expect(opens).toBe(1);
+  expect(searchTranscripts({ query: "heliotrope", project: "performance" }).items).toEqual([]);
+  expect(searchTranscripts({ query: "heliotrope", project: "performance-renamed" }).items).toHaveLength(1);
+});
+
+test("indexes Codex event messages while collapsing their response-item mirrors", async () => {
+  const transcript = path.join(sandbox, "codex-event-session.jsonl");
+  fs.writeFileSync(transcript, [
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-20T13:00:00.000Z",
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text: "duplicate user body" }] },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T13:00:00.001Z",
+      payload: { type: "user_message", message: "duplicate user body" },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T13:00:01.000Z",
+      payload: { type: "agent_message", message: "event-only answer with #звіт" },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-08-20T13:00:02.000Z",
+      payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "duplicated assistant body" }] },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T13:00:02.001Z",
+      payload: { type: "agent_message", message: "duplicated assistant body" },
+    }),
+  ].join("\n") + "\n");
+
+  await indexTranscriptSources([source(transcript, "codex", "events")], { complete: true });
+
+  expect(searchTranscripts({ query: "duplicate" }).items).toHaveLength(1);
+  expect(searchTranscripts({ query: "duplicated" }).items).toHaveLength(1);
+  expect(searchTranscripts({ query: "#звіт" }).items)
+    .toEqual([expect.objectContaining({ speaker: "assistant", lineNumber: 3 })]);
+  expect(searchTranscripts({ query: "body" }).stats.messagesIndexed).toBe(3);
+});
+
+test("serves the committed index while a changed transcript is rebuilding", async () => {
+  const transcript = path.join(sandbox, "rebuilding-session.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "old marigold body" } }) + "\n");
+  await indexTranscriptSources([source(transcript, "claude", "rebuild")], { complete: true });
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "new marigold body" } }) + "\n");
+  const changed = source(transcript, "claude", "rebuild");
+  changed.mtimeMs += 1_000;
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => { markStarted = resolve; });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const readMessages = async function* () {
+    markStarted();
+    await gate;
+    yield {
+      body: "new marigold body",
+      speaker: "user" as const,
+      timestamp: null,
+      byteOffset: 0,
+      lineNumber: 1,
+    };
+  };
+  const rebuilding = indexTranscriptSources([changed], { complete: true, readMessages });
+  await started;
+
+  const queryStartedAt = performance.now();
+  const during = searchTranscripts({ query: "old" });
+
+  expect(performance.now() - queryStartedAt).toBeLessThan(250);
+  expect(during.items).toHaveLength(1);
+  release();
+  await rebuilding;
+  expect(searchTranscripts({ query: "old" }).items).toEqual([]);
+  expect(searchTranscripts({ query: "new" }).items).toHaveLength(1);
+});
+
+test("continues the backfill when one discovered transcript becomes unreadable", async () => {
+  const vanished = path.join(sandbox, "vanished-session.jsonl");
+  const readable = path.join(sandbox, "readable-session.jsonl");
+  fs.writeFileSync(vanished, "fixture\n");
+  fs.writeFileSync(readable, "fixture\n");
+  const sources = [
+    source(vanished, "claude", "resilient"),
+    source(readable, "claude", "resilient"),
+  ];
+  const readMessages = async function* (indexed: TranscriptIndexSource) {
+    if (indexed.path === vanished) throw new Error("transcript disappeared");
+    yield {
+      body: "resilient periwinkle body",
+      speaker: "assistant" as const,
+      timestamp: null,
+      byteOffset: 0,
+      lineNumber: 1,
+    };
+  };
+
+  const indexed = await indexTranscriptSources(sources, { complete: true, readMessages });
+
+  expect(indexed.failures).toEqual([{ path: vanished, error: "transcript disappeared" }]);
+  expect(searchTranscripts({ query: "periwinkle" }).items)
+    .toEqual([expect.objectContaining({ transcriptPath: readable })]);
+});

--- a/src/lib/search/transcriptSearch.ts
+++ b/src/lib/search/transcriptSearch.ts
@@ -1,0 +1,512 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { Database as BunDatabase } from "bun:sqlite";
+
+import { statePath } from "@/lib/configDir";
+
+export const TRANSCRIPT_SEARCH_TOKENIZER = "FTS5 unicode61, remove_diacritics=0, tokenchars=#_";
+export const TRANSCRIPT_SEARCH_FIELDS = ["message.body"] as const;
+
+export interface TranscriptIndexSource {
+  path: string;
+  project: string;
+  engine: "claude" | "codex";
+  size: number;
+  mtimeMs: number;
+}
+
+export interface TranscriptSearchItem {
+  snippet: string;
+  speaker: "user" | "assistant";
+  /** Unix seconds, or null when the transcript record carried no valid timestamp. */
+  timestamp: number | null;
+  transcriptPath: string;
+  byteOffset: number;
+  lineNumber: number;
+  project: string;
+  engine: "claude" | "codex";
+}
+
+export interface TranscriptCorpusStats {
+  conversationsIndexed: number;
+  messagesIndexed: number;
+  fieldsSearched: readonly string[];
+  tokenizer: string;
+}
+
+export interface TranscriptSearchResult {
+  items: TranscriptSearchItem[];
+  nextCursor: string | null;
+  total: number;
+  stats: TranscriptCorpusStats;
+}
+
+export interface ParsedTranscriptMessage {
+  body: string;
+  speaker: "user" | "assistant";
+  timestamp: number | null;
+  byteOffset: number;
+  lineNumber: number;
+}
+
+export type TranscriptMessageReader = (
+  source: TranscriptIndexSource,
+) => AsyncIterable<ParsedTranscriptMessage>;
+
+export interface TranscriptIndexOptions {
+  complete?: boolean;
+  readMessages?: TranscriptMessageReader;
+}
+
+export interface TranscriptIndexResult {
+  filesRead: number;
+  filesSkipped: number;
+  messagesIndexed: number;
+  failures: Array<{ path: string; error: string }>;
+}
+
+export class InvalidTranscriptSearchCursorError extends Error {
+  constructor() {
+    super("transcript search cursor is invalid or belongs to another query");
+    this.name = "InvalidTranscriptSearchCursorError";
+  }
+}
+
+type Database = BunDatabase;
+
+type FileIdentityRow = {
+  size: number;
+  mtime_ms: number;
+  project: string;
+  engine: string;
+};
+
+type SearchRow = {
+  snippet: string;
+  speaker: "user" | "assistant";
+  timestamp: number | null;
+  transcript_path: string;
+  byte_offset: number;
+  line_number: number;
+  project: string;
+  engine: "claude" | "codex";
+};
+
+function sqliteDatabase(): typeof import("bun:sqlite").Database {
+  const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
+  if (!sqlite) throw new Error("Transcript search requires the Bun runtime");
+  return sqlite.Database;
+}
+
+function openWriterDatabase(): Database {
+  const filename = statePath("transcript-search.sqlite");
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const Database = sqliteDatabase();
+  const db = new Database(filename, { create: true, strict: true });
+  try {
+    db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA foreign_keys = ON;");
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS transcript_files (
+        path TEXT PRIMARY KEY,
+        size INTEGER NOT NULL,
+        mtime_ms REAL NOT NULL,
+        project TEXT NOT NULL,
+        engine TEXT NOT NULL CHECK(engine IN ('claude', 'codex')),
+        messages_count INTEGER NOT NULL,
+        indexed_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS transcript_messages (
+        id INTEGER PRIMARY KEY,
+        transcript_path TEXT NOT NULL,
+        message_index INTEGER NOT NULL,
+        speaker TEXT NOT NULL CHECK(speaker IN ('user', 'assistant')),
+        timestamp INTEGER,
+        byte_offset INTEGER NOT NULL,
+        line_number INTEGER NOT NULL,
+        body TEXT NOT NULL,
+        UNIQUE(transcript_path, message_index),
+        FOREIGN KEY(transcript_path) REFERENCES transcript_files(path) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS transcript_messages_path
+        ON transcript_messages(transcript_path, message_index);
+      CREATE VIRTUAL TABLE IF NOT EXISTS transcript_messages_fts USING fts5(
+        body,
+        tokenize = "unicode61 remove_diacritics 0 tokenchars '#_'"
+      );
+      PRAGMA user_version = 1;
+    `);
+    secureDatabaseFiles(filename);
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}
+
+function openQueryDatabase(): Database {
+  const filename = statePath("transcript-search.sqlite");
+  if (!fs.existsSync(filename)) return openWriterDatabase();
+  const Database = sqliteDatabase();
+  const db = new Database(filename, { readonly: true, strict: true });
+  try {
+    db.exec("PRAGMA busy_timeout = 250; PRAGMA query_only = ON; PRAGMA foreign_keys = ON;");
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}
+
+function secureDatabaseFiles(filename: string): void {
+  for (const candidate of [filename, `${filename}-wal`, `${filename}-shm`]) {
+    try {
+      fs.chmodSync(candidate, 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => record(item) !== null)
+    : [];
+}
+
+function textContent(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  return records(value)
+    .filter((part) => part.type === "text" || part.type === "input_text" || part.type === "output_text")
+    .map((part) => typeof part.text === "string" ? part.text : "")
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function unixTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? Math.floor(millis / 1_000) : null;
+}
+
+function messageFromRecord(
+  parsed: Record<string, unknown>,
+  source: TranscriptIndexSource,
+  byteOffset: number,
+  lineNumber: number,
+): (ParsedTranscriptMessage & { representation: "claude" | "response" | "event" }) | null {
+  let speaker: "user" | "assistant" | null = null;
+  let body = "";
+  let representation: "claude" | "response" | "event" = "claude";
+  if (source.engine === "claude" && (parsed.type === "user" || parsed.type === "assistant")) {
+    speaker = parsed.type;
+    body = textContent(record(parsed.message)?.content);
+  } else if (source.engine === "codex" && parsed.type === "response_item") {
+    representation = "response";
+    const payload = record(parsed.payload);
+    if (payload?.type === "message" && (payload.role === "user" || payload.role === "assistant")) {
+      speaker = payload.role;
+      body = textContent(payload.content);
+    } else if (payload?.type === "agent_message") {
+      speaker = "assistant";
+      body = textContent(payload.content);
+    }
+  } else if (source.engine === "codex" && parsed.type === "event_msg") {
+    representation = "event";
+    const payload = record(parsed.payload);
+    if (payload?.type === "user_message") {
+      speaker = "user";
+      body = typeof payload.message === "string" ? payload.message.trim() : "";
+    } else if (payload?.type === "agent_message") {
+      speaker = "assistant";
+      body = typeof payload.message === "string" ? payload.message.trim() : "";
+    }
+  }
+  if (!speaker || !body) return null;
+  return {
+    body,
+    speaker,
+    timestamp: unixTimestamp(parsed.timestamp ?? parsed.created_at),
+    byteOffset,
+    lineNumber,
+    representation,
+  };
+}
+
+async function* transcriptLines(pathname: string): AsyncGenerator<{ bytes: Buffer; byteOffset: number; lineNumber: number }> {
+  let fragments: Buffer[] = [];
+  let fragmentBytes = 0;
+  let lineOffset = 0;
+  let lineNumber = 1;
+  let streamOffset = 0;
+  for await (const chunk of fs.createReadStream(pathname)) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    let start = 0;
+    while (true) {
+      const newline = bytes.indexOf(0x0a, start);
+      if (newline < 0) break;
+      const tail = bytes.subarray(start, newline);
+      const totalBytes = fragmentBytes + tail.length;
+      const combined = fragments.length
+        ? Buffer.concat(tail.length ? [...fragments, tail] : fragments, totalBytes)
+        : tail;
+      const line = combined.at(-1) === 0x0d ? combined.subarray(0, -1) : combined;
+      yield { bytes: line, byteOffset: lineOffset, lineNumber };
+      lineNumber += 1;
+      fragments = [];
+      fragmentBytes = 0;
+      start = newline + 1;
+      lineOffset = streamOffset + start;
+    }
+    if (start < bytes.length) {
+      const remainder = bytes.subarray(start);
+      fragments.push(remainder);
+      fragmentBytes += remainder.length;
+    }
+    streamOffset += bytes.length;
+  }
+  if (fragmentBytes) {
+    const combined = fragments.length === 1 ? fragments[0]! : Buffer.concat(fragments, fragmentBytes);
+    const line = combined.at(-1) === 0x0d ? combined.subarray(0, -1) : combined;
+    yield { bytes: line, byteOffset: lineOffset, lineNumber };
+  }
+}
+
+async function* readTranscriptMessages(source: TranscriptIndexSource): AsyncGenerator<ParsedTranscriptMessage> {
+  type RecentMessage = { representation: "response" | "event"; timestamp: number | null; lineNumber: number };
+  const recent = new Map<string, RecentMessage>();
+  const recentOrder: Array<{ key: string; message: RecentMessage }> = [];
+  for await (const line of transcriptLines(source.path)) {
+    if (!line.bytes.length) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line.bytes.toString("utf8"));
+    } catch {
+      continue;
+    }
+    const message = messageFromRecord(record(parsed) ?? {}, source, line.byteOffset, line.lineNumber);
+    if (!message) continue;
+    if (message.representation !== "claude") {
+      const key = `${message.speaker}\0${message.body}`;
+      const previous = recent.get(key);
+      const closeInTime = previous
+        && (message.timestamp !== null && previous.timestamp !== null
+          ? Math.abs(message.timestamp - previous.timestamp) <= 2
+          : message.lineNumber - previous.lineNumber <= 2);
+      if (previous && previous.representation !== message.representation && closeInTime) continue;
+      const remembered = {
+        representation: message.representation,
+        timestamp: message.timestamp,
+        lineNumber: message.lineNumber,
+      };
+      recent.set(key, remembered);
+      recentOrder.push({ key, message: remembered });
+      while (recentOrder.length > 8) {
+        const expired = recentOrder.shift()!;
+        if (recent.get(expired.key) === expired.message) recent.delete(expired.key);
+      }
+    }
+    const { representation: _representation, ...indexed } = message;
+    yield indexed;
+  }
+}
+
+function removeTranscript(db: Database, pathname: string): void {
+  db.query("DELETE FROM transcript_messages_fts WHERE rowid IN (SELECT id FROM transcript_messages WHERE transcript_path = ?)")
+    .run(pathname);
+  db.query("DELETE FROM transcript_messages WHERE transcript_path = ?").run(pathname);
+  db.query("DELETE FROM transcript_files WHERE path = ?").run(pathname);
+}
+
+export async function indexTranscriptSources(
+  sources: readonly TranscriptIndexSource[],
+  options: TranscriptIndexOptions = {},
+): Promise<TranscriptIndexResult> {
+  const db = openWriterDatabase();
+  const readMessages = options.readMessages ?? readTranscriptMessages;
+  let filesRead = 0;
+  let filesSkipped = 0;
+  let messagesIndexed = 0;
+  const failures: TranscriptIndexResult["failures"] = [];
+  try {
+    const identity = db.query<FileIdentityRow, [string]>(
+      "SELECT size, mtime_ms, project, engine FROM transcript_files WHERE path = ?",
+    );
+    const updateMetadata = db.query(
+      "UPDATE transcript_files SET project = ?, engine = ? WHERE path = ?",
+    );
+    for (const source of sources) {
+      const current = identity.get(source.path);
+      if (current?.size === source.size && current.mtime_ms === source.mtimeMs) {
+        if (current.project !== source.project || current.engine !== source.engine) {
+          updateMetadata.run(source.project, source.engine, source.path);
+        }
+        filesSkipped += 1;
+        continue;
+      }
+      filesRead += 1;
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        removeTranscript(db, source.path);
+        db.query(
+          "INSERT INTO transcript_files(path, size, mtime_ms, project, engine, messages_count, indexed_at) VALUES (?, ?, ?, ?, ?, 0, ?)",
+        ).run(source.path, source.size, source.mtimeMs, source.project, source.engine, Math.floor(Date.now() / 1_000));
+        let messageIndex = 0;
+        for await (const message of readMessages(source)) {
+          const inserted = db.query(
+            "INSERT INTO transcript_messages(transcript_path, message_index, speaker, timestamp, byte_offset, line_number, body) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id",
+          ).get(
+            source.path,
+            messageIndex,
+            message.speaker,
+            message.timestamp,
+            message.byteOffset,
+            message.lineNumber,
+            message.body,
+          ) as { id: number };
+          db.query("INSERT INTO transcript_messages_fts(rowid, body) VALUES (?, ?)").run(inserted.id, message.body);
+          messageIndex += 1;
+        }
+        db.query("UPDATE transcript_files SET messages_count = ? WHERE path = ?").run(messageIndex, source.path);
+        db.exec("COMMIT");
+        messagesIndexed += messageIndex;
+      } catch (error) {
+        try { db.exec("ROLLBACK"); } catch { /* transaction did not open */ }
+        failures.push({
+          path: source.path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (options.complete) {
+      const currentPaths = new Set(sources.map((source) => source.path));
+      const indexed = db.query<{ path: string }, []>("SELECT path FROM transcript_files").all();
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        for (const row of indexed) {
+          if (!currentPaths.has(row.path)) removeTranscript(db, row.path);
+        }
+        db.exec("COMMIT");
+      } catch (error) {
+        try { db.exec("ROLLBACK"); } catch { /* transaction did not open */ }
+        throw error;
+      }
+    }
+    return { filesRead, filesSkipped, messagesIndexed, failures };
+  } finally {
+    db.close();
+  }
+}
+
+function ftsQuery(query: string): string | null {
+  const terms = query.trim().split(/\s+/).filter(Boolean);
+  if (!terms.length) return null;
+  return terms.map((term) => `"${term.replaceAll('"', '""')}"`).join(" AND ");
+}
+
+function cursorScope(query: string, project: string | undefined): string {
+  return crypto.createHash("sha256").update(query).update("\0").update(project ?? "").digest("base64url").slice(0, 16);
+}
+
+function encodeCursor(offset: number, scope: string): string {
+  return Buffer.from(JSON.stringify({ version: 1, offset, scope })).toString("base64url");
+}
+
+function decodeCursor(value: string | null | undefined, scope: string): number {
+  if (!value) return 0;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as {
+      version?: unknown;
+      offset?: unknown;
+      scope?: unknown;
+    };
+    if (parsed.version !== 1
+      || !Number.isSafeInteger(parsed.offset)
+      || (parsed.offset as number) < 1
+      || parsed.scope !== scope) throw new InvalidTranscriptSearchCursorError();
+    return parsed.offset as number;
+  } catch (error) {
+    if (error instanceof InvalidTranscriptSearchCursorError) throw error;
+    throw new InvalidTranscriptSearchCursorError();
+  }
+}
+
+function corpusStats(db: Database): TranscriptCorpusStats {
+  const conversations = db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM transcript_files").get()?.count ?? 0;
+  const messages = db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM transcript_messages").get()?.count ?? 0;
+  return {
+    conversationsIndexed: conversations,
+    messagesIndexed: messages,
+    fieldsSearched: TRANSCRIPT_SEARCH_FIELDS,
+    tokenizer: TRANSCRIPT_SEARCH_TOKENIZER,
+  };
+}
+
+export function searchTranscripts(options: {
+  query: string;
+  project?: string;
+  limit?: number;
+  cursor?: string | null;
+}): TranscriptSearchResult {
+  const db = openQueryDatabase();
+  try {
+    const query = ftsQuery(options.query);
+    const stats = corpusStats(db);
+    if (!query) return { items: [], nextCursor: null, total: 0, stats };
+    const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 20)));
+    const scope = cursorScope(query, options.project);
+    const offset = decodeCursor(options.cursor, scope);
+    const whereProject = options.project ? " AND f.project = ?" : "";
+    const bindings = options.project ? [query, options.project] : [query];
+    const total = (db.query(`
+      SELECT COUNT(*) AS count
+      FROM transcript_messages_fts
+      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+      JOIN transcript_files AS f ON f.path = m.transcript_path
+      WHERE transcript_messages_fts MATCH ?${whereProject}
+    `).get(...bindings) as { count: number } | null)?.count ?? 0;
+    const rows = db.query(`
+      SELECT
+        snippet(transcript_messages_fts, 0, '[', ']', '…', 24) AS snippet,
+        m.speaker,
+        m.timestamp,
+        m.transcript_path,
+        m.byte_offset,
+        m.line_number,
+        f.project,
+        f.engine
+      FROM transcript_messages_fts
+      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+      JOIN transcript_files AS f ON f.path = m.transcript_path
+      WHERE transcript_messages_fts MATCH ?${whereProject}
+      ORDER BY bm25(transcript_messages_fts), COALESCE(m.timestamp, 0) DESC, m.id DESC
+      LIMIT ? OFFSET ?
+    `).all(...bindings, limit, offset) as SearchRow[];
+    const nextOffset = offset + rows.length;
+    return {
+      items: rows.map((row) => ({
+        snippet: row.snippet,
+        speaker: row.speaker,
+        timestamp: row.timestamp,
+        transcriptPath: row.transcript_path,
+        byteOffset: row.byte_offset,
+        lineNumber: row.line_number,
+        project: row.project,
+        engine: row.engine,
+      })),
+      nextCursor: nextOffset < total ? encodeCursor(nextOffset, scope) : null,
+      total,
+      stats,
+    };
+  } finally {
+    db.close();
+  }
+}


### PR DESCRIPTION
## Summary

- add a durable SQLite FTS5 index for Claude and Codex user/assistant message bodies, with exact Cyrillic hashtag and underscore-token matching
- feed every configured transcript store from successful scanner generations, using size+mtime fencing and background backfill
- return bounded snippet pages with jump metadata, project scoping, cursors, and corpus statistics
- expose `/api/search/transcripts` and the `search_transcripts` MCP tool while preserving `list_conversations`

## Verification

- 135 focused tests passed with isolated HOME, XDG_CONFIG_HOME, LLV_STATE_DIR, and TMPDIR
- `bunx tsc --noEmit`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base <merge-base>`

## MVP notes

Speaker and Unix timestamp are stored per message. Date-range and speaker query filters remain deferred under the issue acceptance criteria.

Closes #1050
