### PR TITLE
chore(search): neutral placeholder tokens in search fixtures

### DIFF
--- a/src/app/api/search/transcripts/route.test.ts
+++ b/src/app/api/search/transcripts/route.test.ts
@@ -37,7 +37,7 @@ test("returns indexed snippets without reopening the transcript", async () => {
   fs.writeFileSync(transcript, JSON.stringify({
     type: "user",
     timestamp: "2026-08-20T14:00:00.000Z",
-    message: { content: "HTTP finds #звіт in the persisted body index" },
+    message: { content: "HTTP finds #тег in the persisted body index" },
   }) + "\n");
   const stat = fs.statSync(transcript);
   await indexTranscriptSources([{
@@ -49,7 +49,7 @@ test("returns indexed snippets without reopening the transcript", async () => {
   }], { complete: true });
   fs.rmSync(transcript);
 
-  const response = await GET(new Request("http://127.0.0.1/api/search/transcripts?q=%23%D0%B7%D0%B2%D1%96%D1%82&limit=5"));
+  const response = await GET(new Request("http://127.0.0.1/api/search/transcripts?q=%23%D1%82%D0%B5%D0%B3&limit=5"));
   const body = await response.json() as {
     items: Array<{ transcriptPath: string; speaker: string; snippet: string }>;
     total: number;
@@ -60,7 +60,7 @@ test("returns indexed snippets without reopening the transcript", async () => {
   expect(body.items).toEqual([expect.objectContaining({
     transcriptPath: transcript,
     speaker: "user",
-    snippet: expect.stringContaining("звіт"),
+    snippet: expect.stringContaining("тег"),
   })]);
 });
 

--- a/src/lib/mcp/searchTranscripts.test.ts
+++ b/src/lib/mcp/searchTranscripts.test.ts
@@ -6,7 +6,7 @@ test("search_transcripts reads the HTTP body index with cross-project pagination
   const reads: string[] = [];
   const indexedPage = {
     items: [{
-      snippet: "matched #звіт body",
+      snippet: "matched #тег body",
       speaker: "user",
       timestamp: 1_780_000_000,
       transcriptPath: "/sessions/report.jsonl",
@@ -35,14 +35,14 @@ test("search_transcripts reads the HTTP body index with cross-project pagination
 
   const result = await bindings.search_transcripts({
     clientRequestId: "search-body-1",
-    query: "#звіт",
+    query: "#тег",
     project: "reports",
     cursor: "cursor-a",
     limit: 25,
   });
 
   expect(reads).toEqual([
-    "/api/search/transcripts?q=%23%D0%B7%D0%B2%D1%96%D1%82&project=reports&cursor=cursor-a&limit=25",
+    "/api/search/transcripts?q=%23%D1%82%D0%B5%D0%B3&project=reports&cursor=cursor-a&limit=25",
   ]);
   expect(result).toEqual(indexedPage);
 });

--- a/src/lib/search/transcriptSearch.test.ts
+++ b/src/lib/search/transcriptSearch.test.ts
@@ -107,18 +107,18 @@ test("matches Cyrillic hashtags and underscore tags as exact FTS tokens", async 
     JSON.stringify({
       type: "user",
       timestamp: "2026-08-20T11:00:00.000Z",
-      message: { role: "user", content: "Підготуй #звіт за правилом cron_work_daily" },
+      message: { role: "user", content: "Підготуй #тег за правилом cron_tag_sample" },
     }),
     JSON.stringify({
       type: "assistant",
       timestamp: "2026-08-20T11:00:01.000Z",
-      message: { role: "assistant", content: "Окрема #звітність використовує cron_work_daily_extra" },
+      message: { role: "assistant", content: "Окрема #тегування використовує cron_tag_sample_extra" },
     }),
   ].join("\n") + "\n");
   await indexTranscriptSources([source(transcript, "claude", "reports")], { complete: true });
 
-  const hashtag = searchTranscripts({ query: "#звіт" });
-  const underscore = searchTranscripts({ query: "cron_work_daily" });
+  const hashtag = searchTranscripts({ query: "#тег" });
+  const underscore = searchTranscripts({ query: "cron_tag_sample" });
 
   expect(hashtag.items).toHaveLength(1);
   expect(hashtag.items[0]).toMatchObject({ speaker: "user", transcriptPath: transcript });
@@ -213,7 +213,7 @@ test("indexes Codex event messages while collapsing their response-item mirrors"
     JSON.stringify({
       type: "event_msg",
       timestamp: "2026-08-20T13:00:01.000Z",
-      payload: { type: "agent_message", message: "event-only answer with #звіт" },
+      payload: { type: "agent_message", message: "event-only answer with #тег" },
     }),
     JSON.stringify({
       type: "response_item",
@@ -231,7 +231,7 @@ test("indexes Codex event messages while collapsing their response-item mirrors"
 
   expect(searchTranscripts({ query: "duplicate" }).items).toHaveLength(1);
   expect(searchTranscripts({ query: "duplicated" }).items).toHaveLength(1);
-  expect(searchTranscripts({ query: "#звіт" }).items)
+  expect(searchTranscripts({ query: "#тег" }).items)
     .toEqual([expect.objectContaining({ speaker: "assistant", lineNumber: 3 })]);
   expect(searchTranscripts({ query: "body" }).stats.messagesIndexed).toBe(3);
 });


### PR DESCRIPTION
Replaces fixture tokens that were lifted from a live investigation with invented placeholders, preserving every tokenizer semantic the tests pin (hashtag exactness, Cyrillic, prefix distinction, underscore tokens). Fixture policy: invented placeholders only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)