### PR TITLE
fix(search): collapse resume replay duplicates

### DIFF
--- a/src/app/api/search/transcripts/route.test.ts
+++ b/src/app/api/search/transcripts/route.test.ts
@@ -72,6 +72,32 @@ test("returns indexed snippets without reopening the transcript", async () => {
   })]);
 });
 
+test("returns one newest row with duplicateCount for replayed messages", async () => {
+  const older = path.join(sandbox, "route-replay-older.jsonl");
+  const newer = path.join(sandbox, "route-replay-newer.jsonl");
+  const body = (message: string) => JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-08-20T14:05:00.000Z",
+    payload: { type: "user_message", message },
+  }) + "\n";
+  fs.writeFileSync(older, body("replayed   saffron message"));
+  fs.writeFileSync(newer, body(" replayed saffron\nmessage "));
+  await indexTranscriptSources([
+    { path: older, project: "reports", engine: "codex", size: fs.statSync(older).size, mtimeMs: 1_000 },
+    { path: newer, project: "reports", engine: "codex", size: fs.statSync(newer).size, mtimeMs: 2_000 },
+  ], { complete: true });
+
+  const response = await GET(new Request("http://127.0.0.1/api/search/transcripts?q=saffron"));
+  const page = await response.json() as Page;
+
+  expect(response.status).toBe(200);
+  expect(page.total).toBe(1);
+  expect(page.items).toEqual([
+    expect.objectContaining({ transcriptPath: newer, speaker: "user", duplicateCount: 2 }),
+  ]);
+  expect(page.stats).toMatchObject({ conversationsIndexed: 2, messagesIndexed: 2 });
+});
+
 test("rejects a missing query instead of returning an ambiguous empty page", async () => {
   const response = await GET(new Request("http://127.0.0.1/api/search/transcripts"));
   expect(response.status).toBe(400);

--- a/src/app/api/search/transcripts/route.ts
+++ b/src/app/api/search/transcripts/route.ts
@@ -13,7 +13,9 @@ export const dynamic = "force-dynamic";
 /** A search result carries the conversation's own title so a row can name the
     conversation it will open, not just the file it was cut from. Null when the
     catalog knows no title for that transcript. */
-export interface TranscriptSearchRow extends TranscriptSearchItem {
+export interface TranscriptSearchRow extends Omit<TranscriptSearchItem, "duplicateCount"> {
+  /** Added in schema v2; current responses always include it. */
+  duplicateCount?: number;
   title: string | null;
 }
 

--- a/src/lib/scanner/transcriptSearchFeed.test.ts
+++ b/src/lib/scanner/transcriptSearchFeed.test.ts
@@ -83,6 +83,30 @@ test("feeds every configured Codex and Claude transcript store into one backgrou
   expect(feed?.sources.filter((entry) => entry.engine === "claude")).toHaveLength(2);
 });
 
+test("feeds a dual-root Codex rollout once and keeps the account-root copy", async () => {
+  const workspace = path.join(sandbox, "dual-root-workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  const codexNative = path.join(sandbox, "dual-root-native");
+  const codexAccount = path.join(sandbox, "dual-root-account");
+  const rollout = "rollout-dual-root-fixture.jsonl";
+  const nativePath = writeCodex(codexNative, rollout, workspace);
+  const accountPath = writeCodex(codexAccount, rollout, workspace);
+  let feed: TranscriptIndexFeed | undefined;
+
+  await discoverFilesWithProjectCatalog([
+    ["codex-sessions", codexNative],
+    ["codex-sessions", codexAccount],
+  ], undefined, {
+    persist: false,
+    transcriptIndexScheduler: (next) => { feed = next; },
+  });
+
+  expect(feed?.complete).toBeTrue();
+  expect(feed?.sources).toHaveLength(1);
+  expect(feed?.sources[0]?.path).toBe(accountPath);
+  expect(feed?.sources[0]?.path).not.toBe(nativePath);
+});
+
 test("a direct scan invalidated by a newer generation does not publish its stale inventory", async () => {
   const workspace = path.join(sandbox, "overlap-workspace");
   fs.mkdirSync(workspace, { recursive: true });

--- a/src/lib/search/transcriptSearch.test.ts
+++ b/src/lib/search/transcriptSearch.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeEach, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { statePath } from "@/lib/configDir";
 import { snippetSegments } from "./snippet";
 import {
   indexTranscriptSources,
@@ -146,6 +148,119 @@ test("returns bounded non-overlapping result pages", async () => {
   expect(second.items).toHaveLength(1);
   expect(second.nextCursor).toBeNull();
   expect(new Set([...first.items, ...second.items].map((item) => item.byteOffset)).size).toBe(3);
+});
+
+test("collapses resume-replayed bodies after whitespace normalization and keeps the newest rollout", async () => {
+  const oldest = path.join(sandbox, "rollout-oldest.jsonl");
+  const middle = path.join(sandbox, "rollout-middle.jsonl");
+  const newest = path.join(sandbox, "rollout-newest.jsonl");
+  fs.writeFileSync(oldest, JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-08-20T08:00:00.000Z",
+    payload: { type: "user_message", message: "  resume   cobalt\nrequest  " },
+  }) + "\n");
+  fs.writeFileSync(middle, [
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T08:00:00.000Z",
+      payload: { type: "user_message", message: "resume cobalt\trequest" },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T08:01:00.000Z",
+      payload: { type: "agent_message", message: "resume cobalt request" },
+    }),
+  ].join("\n") + "\n");
+  fs.writeFileSync(newest, [
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T08:00:00.000Z",
+      payload: { type: "user_message", message: "resume cobalt request" },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T08:02:00.000Z",
+      payload: { type: "user_message", message: "Resume cobalt request" },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-08-20T08:03:00.000Z",
+      payload: { type: "user_message", message: "cobalt follow-up" },
+    }),
+  ].join("\n") + "\n");
+  const sources = [
+    { ...source(oldest, "codex", "resume"), mtimeMs: 1_000 },
+    { ...source(middle, "codex", "resume"), mtimeMs: 2_000 },
+    { ...source(newest, "codex", "resume"), mtimeMs: 3_000 },
+  ];
+  await indexTranscriptSources(sources, { complete: true });
+
+  const first = searchTranscripts({ query: "cobalt", limit: 2 });
+  const second = searchTranscripts({ query: "cobalt", limit: 2, cursor: first.nextCursor });
+  const items = [...first.items, ...second.items];
+  const replay = items.find((item) => item.duplicateCount === 3);
+
+  expect(first.total).toBe(4);
+  expect(second.total).toBe(4);
+  expect(first.items).toHaveLength(2);
+  expect(second.items).toHaveLength(2);
+  expect(second.nextCursor).toBeNull();
+  expect(replay).toMatchObject({
+    speaker: "user",
+    transcriptPath: newest,
+    duplicateCount: 3,
+  });
+  expect(items.filter((item) => item.duplicateCount === 1)).toHaveLength(3);
+  expect(new Set(items.map((item) => `${item.speaker}:${item.transcriptPath}:${item.lineNumber}`)).size).toBe(4);
+  expect(first.stats).toMatchObject({ conversationsIndexed: 3, messagesIndexed: 6 });
+});
+
+test("migrates a version-one on-disk index before serving collapsed rows", () => {
+  const filename = statePath("transcript-search.sqlite");
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  const db = new Database(filename, { create: true, strict: true });
+  db.exec(`
+    CREATE TABLE transcript_files (
+      path TEXT PRIMARY KEY,
+      size INTEGER NOT NULL,
+      mtime_ms REAL NOT NULL,
+      project TEXT NOT NULL,
+      engine TEXT NOT NULL CHECK(engine IN ('claude', 'codex')),
+      messages_count INTEGER NOT NULL,
+      indexed_at INTEGER NOT NULL
+    );
+    CREATE TABLE transcript_messages (
+      id INTEGER PRIMARY KEY,
+      transcript_path TEXT NOT NULL,
+      message_index INTEGER NOT NULL,
+      speaker TEXT NOT NULL CHECK(speaker IN ('user', 'assistant')),
+      timestamp INTEGER,
+      byte_offset INTEGER NOT NULL,
+      line_number INTEGER NOT NULL,
+      body TEXT NOT NULL,
+      UNIQUE(transcript_path, message_index),
+      FOREIGN KEY(transcript_path) REFERENCES transcript_files(path) ON DELETE CASCADE
+    );
+    CREATE VIRTUAL TABLE transcript_messages_fts USING fts5(
+      body,
+      tokenize = "unicode61 remove_diacritics 0 tokenchars '#_'"
+    );
+    INSERT INTO transcript_files VALUES ('/fixtures/legacy.jsonl', 10, 1000, 'legacy', 'codex', 1, 1);
+    INSERT INTO transcript_messages VALUES (1, '/fixtures/legacy.jsonl', 0, 'user', 1, 0, 1, 'legacy cobalt body');
+    INSERT INTO transcript_messages_fts(rowid, body) VALUES (1, 'legacy cobalt body');
+    PRAGMA user_version = 1;
+  `);
+  db.close();
+
+  expect(searchTranscripts({ query: "cobalt" }).items).toEqual([
+    expect.objectContaining({ transcriptPath: "/fixtures/legacy.jsonl", duplicateCount: 1 }),
+  ]);
+
+  const migrated = new Database(filename, { readonly: true, strict: true });
+  expect(migrated.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(2);
+  expect(migrated.query<{ body_hash: string }, []>("SELECT body_hash FROM transcript_messages").get()?.body_hash)
+    .toMatch(/^[0-9a-f]{64}$/);
+  migrated.close();
 });
 
 test("searches all projects by default and explains a scoped empty result", async () => {

--- a/src/lib/search/transcriptSearch.test.ts
+++ b/src/lib/search/transcriptSearch.test.ts
@@ -215,8 +215,11 @@ test("collapses resume-replayed bodies after whitespace normalization and keeps 
   expect(first.stats).toMatchObject({ conversationsIndexed: 3, messagesIndexed: 6 });
 });
 
-test("migrates a version-one on-disk index before serving collapsed rows", () => {
+test("migrates a version-one index in bounded batches without reopening unchanged files", async () => {
   const filename = statePath("transcript-search.sqlite");
+  const transcript = path.join(sandbox, "legacy-migration.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "legacy cobalt body" } }) + "\n");
+  const legacySource = source(transcript, "codex", "legacy");
   fs.mkdirSync(path.dirname(filename), { recursive: true });
   const db = new Database(filename, { create: true, strict: true });
   db.exec(`
@@ -245,22 +248,64 @@ test("migrates a version-one on-disk index before serving collapsed rows", () =>
       body,
       tokenize = "unicode61 remove_diacritics 0 tokenchars '#_'"
     );
-    INSERT INTO transcript_files VALUES ('/fixtures/legacy.jsonl', 10, 1000, 'legacy', 'codex', 1, 1);
-    INSERT INTO transcript_messages VALUES (1, '/fixtures/legacy.jsonl', 0, 'user', 1, 0, 1, 'legacy cobalt body');
-    INSERT INTO transcript_messages_fts(rowid, body) VALUES (1, 'legacy cobalt body');
     PRAGMA user_version = 1;
   `);
+  db.query("INSERT INTO transcript_files VALUES (?, ?, ?, ?, ?, ?, ?)").run(
+    legacySource.path,
+    legacySource.size,
+    legacySource.mtimeMs,
+    legacySource.project,
+    legacySource.engine,
+    513,
+    1,
+  );
+  const insertMessage = db.query(
+    "INSERT INTO transcript_messages VALUES (?, ?, ?, 'user', ?, ?, ?, ?)",
+  );
+  const insertFts = db.query("INSERT INTO transcript_messages_fts(rowid, body) VALUES (?, ?)");
+  for (let index = 0; index < 513; index += 1) {
+    const body = `legacy cobalt body ${index}`;
+    insertMessage.run(index + 1, legacySource.path, index, index + 1, index, index + 1, body);
+    insertFts.run(index + 1, body);
+  }
   db.close();
 
-  expect(searchTranscripts({ query: "cobalt" }).items).toEqual([
-    expect.objectContaining({ transcriptPath: "/fixtures/legacy.jsonl", duplicateCount: 1 }),
-  ]);
+  const migrationReadSizes: number[] = [];
+  const originalQuery = Database.prototype.query;
+  Database.prototype.query = function query(this: Database, sql: string) {
+    const statement = originalQuery.call(this, sql);
+    if (!sql.includes("SELECT id, body FROM transcript_messages WHERE body_hash IS NULL")) return statement;
+    const originalAll = statement.all.bind(statement);
+    statement.all = ((...bindings: Parameters<typeof statement.all>) => {
+      const rows = originalAll(...bindings);
+      migrationReadSizes.push(rows.length);
+      return rows;
+    }) as typeof statement.all;
+    return statement;
+  } as typeof Database.prototype.query;
+  try {
+    expect(searchTranscripts({ query: "cobalt" }).total).toBe(513);
+  } finally {
+    Database.prototype.query = originalQuery;
+  }
 
   const migrated = new Database(filename, { readonly: true, strict: true });
   expect(migrated.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(2);
-  expect(migrated.query<{ body_hash: string }, []>("SELECT body_hash FROM transcript_messages").get()?.body_hash)
-    .toMatch(/^[0-9a-f]{64}$/);
+  expect(migrated.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM transcript_messages WHERE body_hash IS NULL OR length(body_hash) != 64",
+  ).get()?.count).toBe(0);
   migrated.close();
+
+  let opens = 0;
+  const readMessages = async function* () {
+    opens += 1;
+    yield { body: "unexpected", speaker: "user" as const, timestamp: null, byteOffset: 0, lineNumber: 1 };
+  };
+  const indexed = await indexTranscriptSources([legacySource], { complete: true, readMessages });
+
+  expect(migrationReadSizes).toEqual([256, 256, 1]);
+  expect(indexed).toMatchObject({ filesRead: 0, filesSkipped: 1, failures: [] });
+  expect(opens).toBe(0);
 });
 
 test("searches all projects by default and explains a scoped empty result", async () => {

--- a/src/lib/search/transcriptSearch.ts
+++ b/src/lib/search/transcriptSearch.ts
@@ -108,6 +108,7 @@ function sqliteDatabase(): typeof import("bun:sqlite").Database {
 }
 
 const TRANSCRIPT_SEARCH_SCHEMA_VERSION = 2;
+const TRANSCRIPT_SEARCH_MIGRATION_BATCH_SIZE = 256;
 
 function normalizedBodyHash(body: string): string {
   const normalized = body.trim().replace(/\s+/gu, " ");
@@ -129,11 +130,19 @@ function migrateSearchSchema(db: Database): void {
   db.exec("BEGIN IMMEDIATE");
   try {
     if (!hasBodyHashColumn(db)) db.exec("ALTER TABLE transcript_messages ADD COLUMN body_hash TEXT");
-    const messages = db.query<{ id: number; body: string }, []>(
-      "SELECT id, body FROM transcript_messages WHERE body_hash IS NULL",
-    ).all();
+    const pendingMessages = db.query<{ id: number; body: string }, [number, number]>(`
+      SELECT id, body FROM transcript_messages WHERE body_hash IS NULL AND id > ?
+      ORDER BY id
+      LIMIT ?
+    `);
     const update = db.query("UPDATE transcript_messages SET body_hash = ? WHERE id = ?");
-    for (const message of messages) update.run(normalizedBodyHash(message.body), message.id);
+    let lastId = 0;
+    while (true) {
+      const messages = pendingMessages.all(lastId, TRANSCRIPT_SEARCH_MIGRATION_BATCH_SIZE);
+      for (const message of messages) update.run(normalizedBodyHash(message.body), message.id);
+      if (messages.length < TRANSCRIPT_SEARCH_MIGRATION_BATCH_SIZE) break;
+      lastId = messages.at(-1)!.id;
+    }
     db.exec(`
       CREATE INDEX IF NOT EXISTS transcript_messages_body_hash
         ON transcript_messages(speaker, body_hash);

--- a/src/lib/search/transcriptSearch.ts
+++ b/src/lib/search/transcriptSearch.ts
@@ -24,6 +24,8 @@ export type TranscriptSpeaker = "user" | "assistant";
 export interface TranscriptSearchItem {
   snippet: string;
   speaker: TranscriptSpeaker;
+  /** Number of indexed occurrences collapsed into this result. */
+  duplicateCount: number;
   /** Unix seconds, or null when the transcript record carried no valid timestamp. */
   timestamp: number | null;
   transcriptPath: string;
@@ -90,6 +92,7 @@ type FileIdentityRow = {
 type SearchRow = {
   snippet: string;
   speaker: TranscriptSpeaker;
+  duplicate_count: number;
   timestamp: number | null;
   transcript_path: string;
   byte_offset: number;
@@ -102,6 +105,45 @@ function sqliteDatabase(): typeof import("bun:sqlite").Database {
   const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
   if (!sqlite) throw new Error("Transcript search requires the Bun runtime");
   return sqlite.Database;
+}
+
+const TRANSCRIPT_SEARCH_SCHEMA_VERSION = 2;
+
+function normalizedBodyHash(body: string): string {
+  const normalized = body.trim().replace(/\s+/gu, " ");
+  return crypto.createHash("sha256").update(normalized).digest("hex");
+}
+
+function schemaVersion(db: Database): number {
+  return db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version ?? 0;
+}
+
+function hasBodyHashColumn(db: Database): boolean {
+  return db.query<{ name: string }, []>("PRAGMA table_info(transcript_messages)").all()
+    .some((column) => column.name === "body_hash");
+}
+
+function migrateSearchSchema(db: Database): void {
+  const currentVersion = schemaVersion(db);
+  if (currentVersion >= TRANSCRIPT_SEARCH_SCHEMA_VERSION && hasBodyHashColumn(db)) return;
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    if (!hasBodyHashColumn(db)) db.exec("ALTER TABLE transcript_messages ADD COLUMN body_hash TEXT");
+    const messages = db.query<{ id: number; body: string }, []>(
+      "SELECT id, body FROM transcript_messages WHERE body_hash IS NULL",
+    ).all();
+    const update = db.query("UPDATE transcript_messages SET body_hash = ? WHERE id = ?");
+    for (const message of messages) update.run(normalizedBodyHash(message.body), message.id);
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS transcript_messages_body_hash
+        ON transcript_messages(speaker, body_hash);
+      PRAGMA user_version = ${Math.max(currentVersion, TRANSCRIPT_SEARCH_SCHEMA_VERSION)};
+      COMMIT;
+    `);
+  } catch (error) {
+    try { db.exec("ROLLBACK"); } catch { /* transaction did not open */ }
+    throw error;
+  }
 }
 
 function openWriterDatabase(): Database {
@@ -130,6 +172,7 @@ function openWriterDatabase(): Database {
         byte_offset INTEGER NOT NULL,
         line_number INTEGER NOT NULL,
         body TEXT NOT NULL,
+        body_hash TEXT NOT NULL,
         UNIQUE(transcript_path, message_index),
         FOREIGN KEY(transcript_path) REFERENCES transcript_files(path) ON DELETE CASCADE
       );
@@ -139,8 +182,8 @@ function openWriterDatabase(): Database {
         body,
         tokenize = "unicode61 remove_diacritics 0 tokenchars '#_'"
       );
-      PRAGMA user_version = 1;
     `);
+    migrateSearchSchema(db);
     secureDatabaseFiles(filename);
     return db;
   } catch (error) {
@@ -153,6 +196,14 @@ function openQueryDatabase(): Database {
   const filename = statePath("transcript-search.sqlite");
   if (!fs.existsSync(filename)) return openWriterDatabase();
   const Database = sqliteDatabase();
+  const probe = new Database(filename, { readonly: true, strict: true });
+  let needsMigration: boolean;
+  try {
+    needsMigration = schemaVersion(probe) < TRANSCRIPT_SEARCH_SCHEMA_VERSION || !hasBodyHashColumn(probe);
+  } finally {
+    probe.close();
+  }
+  if (needsMigration) openWriterDatabase().close();
   const db = new Database(filename, { readonly: true, strict: true });
   try {
     db.exec("PRAGMA busy_timeout = 250; PRAGMA query_only = ON; PRAGMA foreign_keys = ON;");
@@ -366,7 +417,7 @@ export async function indexTranscriptSources(
         let messageIndex = 0;
         for await (const message of readMessages(source)) {
           const inserted = db.query(
-            "INSERT INTO transcript_messages(transcript_path, message_index, speaker, timestamp, byte_offset, line_number, body) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id",
+            "INSERT INTO transcript_messages(transcript_path, message_index, speaker, timestamp, byte_offset, line_number, body, body_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
           ).get(
             source.path,
             messageIndex,
@@ -375,6 +426,7 @@ export async function indexTranscriptSources(
             message.byteOffset,
             message.lineNumber,
             message.body,
+            normalizedBodyHash(message.body),
           ) as { id: number };
           db.query("INSERT INTO transcript_messages_fts(rowid, body) VALUES (?, ?)").run(inserted.id, message.body);
           messageIndex += 1;
@@ -491,33 +543,62 @@ export function searchTranscripts(options: {
     const bindings = [query, ...filters.map((filter) => filter.binding)];
     const total = (db.query(`
       SELECT COUNT(*) AS count
-      FROM transcript_messages_fts
-      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
-      JOIN transcript_files AS f ON f.path = m.transcript_path
-      WHERE transcript_messages_fts MATCH ?${where}
+      FROM (
+        SELECT m.speaker, m.body_hash
+        FROM transcript_messages_fts
+        JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+        JOIN transcript_files AS f ON f.path = m.transcript_path
+        WHERE transcript_messages_fts MATCH ?${where}
+        GROUP BY m.speaker, m.body_hash
+      ) AS collapsed
     `).get(...bindings) as { count: number } | null)?.count ?? 0;
     const rows = db.query(`
+      WITH ranked AS (
+        SELECT
+          m.id,
+          m.speaker,
+          m.timestamp,
+          m.transcript_path,
+          m.byte_offset,
+          m.line_number,
+          f.project,
+          f.engine,
+          f.mtime_ms,
+          COUNT(*) OVER (PARTITION BY m.speaker, m.body_hash) AS duplicate_count,
+          ROW_NUMBER() OVER (
+            PARTITION BY m.speaker, m.body_hash
+            /* Replayed records retain their original message timestamp. The
+               transcript mtime identifies the newest rollout generation. */
+            ORDER BY f.mtime_ms DESC, COALESCE(m.timestamp, 0) DESC, m.id DESC
+          ) AS duplicate_rank
+        FROM transcript_messages_fts
+        JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+        JOIN transcript_files AS f ON f.path = m.transcript_path
+        WHERE transcript_messages_fts MATCH ?${where}
+      )
       SELECT
         snippet(transcript_messages_fts, 0, '${SNIPPET_MATCH_OPEN}', '${SNIPPET_MATCH_CLOSE}', '…', 24) AS snippet,
-        m.speaker,
-        m.timestamp,
-        m.transcript_path,
-        m.byte_offset,
-        m.line_number,
-        f.project,
-        f.engine
-      FROM transcript_messages_fts
-      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
-      JOIN transcript_files AS f ON f.path = m.transcript_path
-      WHERE transcript_messages_fts MATCH ?${where}
-      ORDER BY bm25(transcript_messages_fts), COALESCE(m.timestamp, 0) DESC, m.id DESC
+        ranked.speaker,
+        ranked.duplicate_count,
+        ranked.timestamp,
+        ranked.transcript_path,
+        ranked.byte_offset,
+        ranked.line_number,
+        ranked.project,
+        ranked.engine
+      FROM ranked
+      JOIN transcript_messages_fts ON transcript_messages_fts.rowid = ranked.id
+      WHERE ranked.duplicate_rank = 1 AND transcript_messages_fts MATCH ?
+      ORDER BY bm25(transcript_messages_fts), ranked.mtime_ms DESC,
+        COALESCE(ranked.timestamp, 0) DESC, ranked.id DESC
       LIMIT ? OFFSET ?
-    `).all(...bindings, limit, offset) as SearchRow[];
+    `).all(...bindings, query, limit, offset) as SearchRow[];
     const nextOffset = offset + rows.length;
     return {
       items: rows.map((row) => ({
         snippet: row.snippet,
         speaker: row.speaker,
+        duplicateCount: row.duplicate_count,
         timestamp: row.timestamp,
         transcriptPath: row.transcript_path,
         byteOffset: row.byte_offset,


### PR DESCRIPTION
Fixes #1057

## Summary

- collapse matching transcript occurrences in SQLite by speaker and a SHA-256 hash of trim-plus-whitespace-folded body text
- keep the newest rollout occurrence, expose duplicateCount, and keep totals and pagination aligned with collapsed rows
- migrate version-one search indexes in place and verify dual-root Codex rollouts enter the search feed once

## Verification

- bunx tsc --noEmit
- 24 focused tests across 4 files with isolated state roots
- bun run build
- bun scripts/privacy-publication-gate.ts --base 9e6e73c9be7666064328e4748ca4b49c680853be