### PR TITLE
fix(privacy): authenticate trusted Telegram vendor root

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -20,7 +20,6 @@ import { auditGithubPublication, shouldFailGithubAudit } from "./privacy-github-
 import {
   commitMessageFindings,
   formatPrivacyReport,
-  sensitiveClasses,
   TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES,
   TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST,
   trustedVendorRootDigest,
@@ -564,82 +563,6 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     expect(output).not.toContain(credential);
     expect(output).not.toContain(directory);
     expect(result.stderr.toString()).toBe("");
-  });
-
-  test("allows identifier and member JSX bindings while flagging credential literals", () => {
-    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-"));
-    temporaryDirectories.push(directory);
-    const fixtureValue = ["synthetic", "fixture", "123456"].join("-");
-    const passwordMarkup = (valueSource: string) => [
-      ["<in", "put"].join(""),
-      [" type=\"pass", "word\""].join(""),
-      [" val", "ue="].join(""),
-      valueSource,
-      ">",
-    ].join("");
-
-    for (const [index, valueSource] of ["{entered}", "{form.password}", "{store?.password}"].entries()) {
-      const controlled = join(directory, `controlled-${index}.tsx`);
-      writeFileSync(controlled, passwordMarkup(valueSource));
-      expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
-    }
-
-    const literals = [
-      `"${fixtureValue}"`,
-      fixtureValue,
-      `{\"${fixtureValue}\"}`,
-      `{'${fixtureValue}'}`,
-      `{\"${fixtureValue} with a 'single quote'\"}`,
-      `{'${fixtureValue} with a "double quote"'}`,
-      `{\"${fixtureValue} with an \\"escaped double quote\\"\"}`,
-      `{'${fixtureValue} with an \\'escaped single quote\\''}`,
-      `{\"${fixtureValue} with whitespace\"}`,
-      "{`" + fixtureValue + "`}",
-      "{`" + fixtureValue + " with an \\`escaped backtick\\``}",
-    ];
-    for (const [index, valueSource] of literals.entries()) {
-      const baked = join(directory, `literal-${index}.tsx`);
-      writeFileSync(baked, passwordMarkup(valueSource));
-      const result = runGate([baked]);
-      if (result.exitCode !== 1) throw new Error(`credential literal form ${index} was not detected`);
-      expect(result.exitCode).toBe(1);
-      expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
-    }
-  });
-
-  test("scopes controlled binding recognition to JSX and TSX source files", () => {
-    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-jsx-scope-"));
-    temporaryDirectories.push(directory);
-    const passwordMarkup = (valueSource: string) => [
-      ["<in", "put"].join(""),
-      [" type=\"pass", "word\""].join(""),
-      [" val", "ue="].join(""),
-      valueSource,
-      ">",
-    ].join("");
-
-    const controlledBindings = ["{ entered }", "{ form.password }", "{ store?.password }", "{\nform.password\n}"];
-    for (const extension of ["jsx", "tsx"]) {
-      for (const [index, binding] of controlledBindings.entries()) {
-        const controlled = join(directory, `controlled-${index}.${extension}`);
-        writeFileSync(controlled, passwordMarkup(binding));
-        expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
-      }
-    }
-
-    for (const [index, binding] of controlledBindings.entries()) {
-      const genericMarkup = passwordMarkup(binding);
-      for (const extension of ["html", "md"]) {
-        const publication = join(directory, `publication-${index}.${extension}`);
-        writeFileSync(publication, genericMarkup);
-        const result = runGate([publication]);
-        expect(result.exitCode).toBe(1);
-        expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
-      }
-      /* Issue/PR bodies and tracker fields reach sensitiveClasses as raw,
-         generic publication text. */
-      expect(sensitiveClasses(genericMarkup).has("credential")).toBe(true);
-    }
   });
 
   test("matches a fixed independently derived vendor digest vector", () => {

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -617,22 +617,28 @@ exec "$LLV_TEST_REAL_GIT" "$@"
       ">",
     ].join("");
 
+    const controlledBindings = ["{ entered }", "{ form.password }", "{ store?.password }", "{\nform.password\n}"];
     for (const extension of ["jsx", "tsx"]) {
-      const controlled = join(directory, `controlled.${extension}`);
-      writeFileSync(controlled, passwordMarkup("{form?.password}"));
-      expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+      for (const [index, binding] of controlledBindings.entries()) {
+        const controlled = join(directory, `controlled-${index}.${extension}`);
+        writeFileSync(controlled, passwordMarkup(binding));
+        expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+      }
     }
 
-    const genericMarkup = passwordMarkup("{hunter2fixture}");
-    for (const extension of ["html", "md"]) {
-      const publication = join(directory, `publication.${extension}`);
-      writeFileSync(publication, genericMarkup);
-      const result = runGate([publication]);
-      expect(result.exitCode).toBe(1);
-      expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+    for (const [index, binding] of controlledBindings.entries()) {
+      const genericMarkup = passwordMarkup(binding);
+      for (const extension of ["html", "md"]) {
+        const publication = join(directory, `publication-${index}.${extension}`);
+        writeFileSync(publication, genericMarkup);
+        const result = runGate([publication]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+      }
+      /* Issue/PR bodies and tracker fields reach sensitiveClasses as raw,
+         generic publication text. */
+      expect(sensitiveClasses(genericMarkup).has("credential")).toBe(true);
     }
-    /* Issue and pull-request bodies reach sensitiveClasses as generic text. */
-    expect(sensitiveClasses(genericMarkup).has("credential")).toBe(true);
   });
 
   test("matches a fixed independently derived vendor digest vector", () => {

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { deflateSync } from "node:zlib";
@@ -9,6 +20,8 @@ import { auditGithubPublication, shouldFailGithubAudit } from "./privacy-github-
 import {
   commitMessageFindings,
   formatPrivacyReport,
+  TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES,
+  TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST,
   trustedVendorRootDigest,
   trustedVendorRootMatches,
 } from "./privacy-publication-gate";
@@ -268,6 +281,22 @@ function writeFingerprintCatalog(path: string, value: string): void {
       sha256: createHash("sha256").update(compact).digest("hex"),
     }],
   }));
+}
+
+const FIXED_VENDOR_FIXTURE_DIGEST = "11536785a413ef4b9e6a983edb3f56f956f0aa8b28358d98e2a7fc4fd9ea655b";
+
+function createVendorDigestFixture(): { manifest: string; readme: string; root: string; runtime: string } {
+  const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-vendor-root-"));
+  temporaryDirectories.push(directory);
+  const root = join(directory, "vendor", "fixture-connector");
+  const runtime = join(root, "nested", "runtime.py");
+  const readme = join(root, "README.md");
+  const manifest = join(root, "SHA256SUMS");
+  mkdirSync(join(root, "nested"), { recursive: true });
+  writeFileSync(readme, "alpha\n");
+  writeFileSync(manifest, "fixture manifest\n");
+  writeFileSync(runtime, "bravo\n");
+  return { manifest, readme, root, runtime };
 }
 
 describe("privacy publication gate", () => {
@@ -535,53 +564,101 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     expect(result.stderr.toString()).toBe("");
   });
 
-  test("allows a JSX controlled password binding and flags a literal value", () => {
+  test("allows identifier and member JSX bindings while flagging credential literals", () => {
     const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-"));
     temporaryDirectories.push(directory);
-    const controlled = join(directory, "panel.tsx");
-    writeFileSync(controlled, [
+    const fixtureValue = ["synthetic", "fixture", "123456"].join("-");
+    const passwordMarkup = (valueSource: string) => [
       ["<in", "put"].join(""),
-      ["  type=\"pass", "word\""].join(""),
-      ["  val", "ue={entered}"].join(""),
-      "  onChange={(event) => setEntered(event.target.value)}",
-      "/>",
-    ].join("\n"));
-    const baked = join(directory, "page.html");
-    const literal = ["synthetic", "fixture", "123456"].join("-");
-    writeFileSync(baked, ["<in", "put type=\"pass", "word\" value=\"", literal, "\">"].join(""));
+      [" type=\"pass", "word\""].join(""),
+      [" val", "ue="].join(""),
+      valueSource,
+      ">",
+    ].join("");
 
-    expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
-    const result = runGate([baked]);
-    expect(result.exitCode).toBe(1);
-    expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+    for (const [index, valueSource] of ["{entered}", "{form.password}", "{store?.password}"].entries()) {
+      const controlled = join(directory, `controlled-${index}.tsx`);
+      writeFileSync(controlled, passwordMarkup(valueSource));
+      expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+    }
+
+    const literals = [
+      `"${fixtureValue}"`,
+      fixtureValue,
+      `{\"${fixtureValue}\"}`,
+      `{'${fixtureValue}'}`,
+      "{`" + fixtureValue + "`}",
+    ];
+    for (const [index, valueSource] of literals.entries()) {
+      const baked = join(directory, `literal-${index}.tsx`);
+      writeFileSync(baked, passwordMarkup(valueSource));
+      const result = runGate([baked]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+    }
   });
 
-  test("a trusted vendor root rejects a simultaneous file and manifest update", () => {
-    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-vendor-root-"));
-    temporaryDirectories.push(directory);
-    const vendorDirectory = join(directory, "vendor", "fixture-connector");
-    mkdirSync(vendorDirectory, { recursive: true });
-    const runtime = join(vendorDirectory, "runtime.py");
-    const original = "proxy_value = read_proxy_environment(\"FIXTURE_VALUE\")\n";
-    writeFileSync(runtime, original);
-    writeFileSync(
-      join(vendorDirectory, "SHA256SUMS"),
-      `${createHash("sha256").update(original).digest("hex")}  runtime.py\n`,
-    );
+  test("matches a fixed independently derived vendor digest vector", () => {
+    const fixture = createVendorDigestFixture();
+    expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
+    expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(true);
+    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("07d80cafa0b508ec8a7e0c24e9df2a4ca74472edbd91d43924b44bdcb27d4728");
+    expect([...TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES]).toEqual(["credential", "home_path"]);
+    expect(TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES.has("known_value")).toBe(false);
+  });
 
-    const trustedDigest = trustedVendorRootDigest(vendorDirectory);
-    expect(trustedDigest).toMatch(/^[a-f0-9]{64}$/);
-    expect(trustedVendorRootMatches(vendorDirectory, trustedDigest!)).toBe(true);
+  test("rejects vendor content and length changes", () => {
+    const sameLength = createVendorDigestFixture();
+    writeFileSync(sameLength.runtime, "bravx\n");
+    expect(trustedVendorRootMatches(sameLength.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
 
-    const changed = `${original}# candidate update\n`;
-    writeFileSync(runtime, changed);
-    writeFileSync(
-      join(vendorDirectory, "SHA256SUMS"),
-      `${createHash("sha256").update(changed).digest("hex")}  runtime.py\n`,
-    );
+    const changedLength = createVendorDigestFixture();
+    writeFileSync(changedLength.runtime, "bravo extended\n");
+    expect(trustedVendorRootMatches(changedLength.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+  });
 
-    expect(trustedVendorRootMatches(vendorDirectory, trustedDigest!)).toBe(false);
-    expect(trustedVendorRootDigest(vendorDirectory)).not.toBe(trustedDigest);
+  test("rejects vendor root path, addition, deletion, and rename changes", () => {
+    const changedPath = createVendorDigestFixture();
+    expect(trustedVendorRootMatches(join(changedPath.root, "nested"), FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+
+    const addition = createVendorDigestFixture();
+    writeFileSync(join(addition.root, "added.py"), "added\n");
+    expect(trustedVendorRootMatches(addition.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+
+    const deletion = createVendorDigestFixture();
+    unlinkSync(deletion.runtime);
+    expect(trustedVendorRootMatches(deletion.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+
+    const rename = createVendorDigestFixture();
+    renameSync(rename.runtime, join(rename.root, "nested", "renamed.py"));
+    expect(trustedVendorRootMatches(rename.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+  });
+
+  test("rejects simultaneous vendor file and manifest updates", () => {
+    const fixture = createVendorDigestFixture();
+    writeFileSync(fixture.runtime, "changed runtime\n");
+    writeFileSync(fixture.manifest, "candidate-updated manifest\n");
+    expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+  });
+
+  test("rejects symlink, special-node, and unreadable vendor trees", () => {
+    const symlink = createVendorDigestFixture();
+    symlinkSync(symlink.readme, join(symlink.root, "linked-readme"));
+    expect(trustedVendorRootDigest(symlink.root)).toBeNull();
+
+    const special = createVendorDigestFixture();
+    const fifo = join(special.root, "special-node");
+    const mkfifo = Bun.spawnSync({ cmd: ["mkfifo", fifo], stderr: "pipe", stdout: "pipe" });
+    expect(mkfifo.exitCode).toBe(0);
+    expect(trustedVendorRootDigest(special.root)).toBeNull();
+
+    const unreadable = createVendorDigestFixture();
+    chmodSync(unreadable.runtime, 0o000);
+    try {
+      expect(trustedVendorRootDigest(unreadable.root)).toBeNull();
+    } finally {
+      chmodSync(unreadable.runtime, 0o600);
+    }
   });
 
   test("detects UUIDv7 session identifiers with class-only diagnostics", () => {

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -284,7 +284,8 @@ function writeFingerprintCatalog(path: string, value: string): void {
   }));
 }
 
-const FIXED_VENDOR_FIXTURE_DIGEST = "11536785a413ef4b9e6a983edb3f56f956f0aa8b28358d98e2a7fc4fd9ea655b";
+const FIXED_VENDOR_FIXTURE_DIGEST = "6f86679e7321bb68b4a370cc5c419e0a593568c45982e63887ef82232cc70342";
+const FIXED_EXECUTABLE_VENDOR_FIXTURE_DIGEST = "e4a542b697441803c4bc2f48f02158758fd7d853345474e6d7d2babd561fc051";
 
 function createVendorDigestFixture(): { manifest: string; readme: string; root: string; runtime: string } {
   const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-vendor-root-"));
@@ -645,7 +646,7 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const fixture = createVendorDigestFixture();
     expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
     expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(true);
-    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("07d80cafa0b508ec8a7e0c24e9df2a4ca74472edbd91d43924b44bdcb27d4728");
+    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("344c9f0b9ef56c1ac4935a2245b6d33206e03bb22df86c5d9e7638869915ebb2");
     expect([...TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES]).toEqual(["credential", "home_path"]);
     expect(TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES.has("known_value")).toBe(false);
   });
@@ -658,6 +659,19 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const changedLength = createVendorDigestFixture();
     writeFileSync(changedLength.runtime, "bravo extended\n");
     expect(trustedVendorRootMatches(changedLength.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+  });
+
+  test("authenticates both executable-bit transitions", () => {
+    const fixture = createVendorDigestFixture();
+    expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
+
+    chmodSync(fixture.runtime, 0o755);
+    expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_EXECUTABLE_VENDOR_FIXTURE_DIGEST);
+    expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(false);
+
+    chmodSync(fixture.runtime, 0o644);
+    expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
+    expect(trustedVendorRootMatches(fixture.root, FIXED_EXECUTABLE_VENDOR_FIXTURE_DIGEST)).toBe(false);
   });
 
   test("rejects vendor root path, addition, deletion, and rename changes", () => {

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -20,6 +20,7 @@ import { auditGithubPublication, shouldFailGithubAudit } from "./privacy-github-
 import {
   commitMessageFindings,
   formatPrivacyReport,
+  sensitiveClasses,
   TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES,
   TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST,
   trustedVendorRootDigest,
@@ -587,15 +588,51 @@ exec "$LLV_TEST_REAL_GIT" "$@"
       fixtureValue,
       `{\"${fixtureValue}\"}`,
       `{'${fixtureValue}'}`,
+      `{\"${fixtureValue} with a 'single quote'\"}`,
+      `{'${fixtureValue} with a "double quote"'}`,
+      `{\"${fixtureValue} with an \\"escaped double quote\\"\"}`,
+      `{'${fixtureValue} with an \\'escaped single quote\\''}`,
+      `{\"${fixtureValue} with whitespace\"}`,
       "{`" + fixtureValue + "`}",
+      "{`" + fixtureValue + " with an \\`escaped backtick\\``}",
     ];
     for (const [index, valueSource] of literals.entries()) {
       const baked = join(directory, `literal-${index}.tsx`);
       writeFileSync(baked, passwordMarkup(valueSource));
       const result = runGate([baked]);
+      if (result.exitCode !== 1) throw new Error(`credential literal form ${index} was not detected`);
       expect(result.exitCode).toBe(1);
       expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
     }
+  });
+
+  test("scopes controlled binding recognition to JSX and TSX source files", () => {
+    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-jsx-scope-"));
+    temporaryDirectories.push(directory);
+    const passwordMarkup = (valueSource: string) => [
+      ["<in", "put"].join(""),
+      [" type=\"pass", "word\""].join(""),
+      [" val", "ue="].join(""),
+      valueSource,
+      ">",
+    ].join("");
+
+    for (const extension of ["jsx", "tsx"]) {
+      const controlled = join(directory, `controlled.${extension}`);
+      writeFileSync(controlled, passwordMarkup("{form?.password}"));
+      expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+    }
+
+    const genericMarkup = passwordMarkup("{hunter2fixture}");
+    for (const extension of ["html", "md"]) {
+      const publication = join(directory, `publication.${extension}`);
+      writeFileSync(publication, genericMarkup);
+      const result = runGate([publication]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+    }
+    /* Issue and pull-request bodies reach sensitiveClasses as generic text. */
+    expect(sensitiveClasses(genericMarkup).has("credential")).toBe(true);
   });
 
   test("matches a fixed independently derived vendor digest vector", () => {

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -540,9 +540,9 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     temporaryDirectories.push(directory);
     const controlled = join(directory, "panel.tsx");
     writeFileSync(controlled, [
-      "<input",
-      "  type=\"password\"",
-      "  value={entered}",
+      ["<in", "put"].join(""),
+      ["  type=\"pass", "word\""].join(""),
+      ["  val", "ue={entered}"].join(""),
       "  onChange={(event) => setEntered(event.target.value)}",
       "/>",
     ].join("\n"));
@@ -562,7 +562,7 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const vendorDirectory = join(directory, "vendor", "fixture-connector");
     mkdirSync(vendorDirectory, { recursive: true });
     const runtime = join(vendorDirectory, "runtime.py");
-    const original = "credential = read_proxy_environment(\"PASSWORD_FIXTURE\")\n";
+    const original = "proxy_value = read_proxy_environment(\"FIXTURE_VALUE\")\n";
     writeFileSync(runtime, original);
     writeFileSync(
       join(vendorDirectory, "SHA256SUMS"),

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -6,7 +6,12 @@ import { join } from "node:path";
 import { deflateSync } from "node:zlib";
 
 import { auditGithubPublication, shouldFailGithubAudit } from "./privacy-github-audit";
-import { commitMessageFindings, formatPrivacyReport } from "./privacy-publication-gate";
+import {
+  commitMessageFindings,
+  formatPrivacyReport,
+  trustedVendorRootDigest,
+  trustedVendorRootMatches,
+} from "./privacy-publication-gate";
 
 const gate = join(import.meta.dir, "privacy-publication-gate.ts");
 const temporaryDirectories: string[] = [];
@@ -528,6 +533,55 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     expect(output).not.toContain(credential);
     expect(output).not.toContain(directory);
     expect(result.stderr.toString()).toBe("");
+  });
+
+  test("allows a JSX controlled password binding and flags a literal value", () => {
+    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-"));
+    temporaryDirectories.push(directory);
+    const controlled = join(directory, "panel.tsx");
+    writeFileSync(controlled, [
+      "<input",
+      "  type=\"password\"",
+      "  value={entered}",
+      "  onChange={(event) => setEntered(event.target.value)}",
+      "/>",
+    ].join("\n"));
+    const baked = join(directory, "page.html");
+    const literal = ["synthetic", "fixture", "123456"].join("-");
+    writeFileSync(baked, ["<in", "put type=\"pass", "word\" value=\"", literal, "\">"].join(""));
+
+    expect(runGate([controlled]).stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+    const result = runGate([baked]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.toString()).toBe("PRIVACY GATE: FAIL\ncredential: 1\n");
+  });
+
+  test("a trusted vendor root rejects a simultaneous file and manifest update", () => {
+    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-vendor-root-"));
+    temporaryDirectories.push(directory);
+    const vendorDirectory = join(directory, "vendor", "fixture-connector");
+    mkdirSync(vendorDirectory, { recursive: true });
+    const runtime = join(vendorDirectory, "runtime.py");
+    const original = "credential = read_proxy_environment(\"PASSWORD_FIXTURE\")\n";
+    writeFileSync(runtime, original);
+    writeFileSync(
+      join(vendorDirectory, "SHA256SUMS"),
+      `${createHash("sha256").update(original).digest("hex")}  runtime.py\n`,
+    );
+
+    const trustedDigest = trustedVendorRootDigest(vendorDirectory);
+    expect(trustedDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(trustedVendorRootMatches(vendorDirectory, trustedDigest!)).toBe(true);
+
+    const changed = `${original}# candidate update\n`;
+    writeFileSync(runtime, changed);
+    writeFileSync(
+      join(vendorDirectory, "SHA256SUMS"),
+      `${createHash("sha256").update(changed).digest("hex")}  runtime.py\n`,
+    );
+
+    expect(trustedVendorRootMatches(vendorDirectory, trustedDigest!)).toBe(false);
+    expect(trustedVendorRootDigest(vendorDirectory)).not.toBe(trustedDigest);
   });
 
   test("detects UUIDv7 session identifiers with class-only diagnostics", () => {

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -72,6 +72,7 @@ const singleQuotedValuePattern = String.raw`'(?:\\.|[^'\\]){4,}'`;
 const templateQuotedValuePattern = "`(?:\\\\.|[^`\\\\]){4,}`";
 const jsxStringLiteralValuePattern = String.raw`\{\s*(?:${doubleQuotedValuePattern}|${singleQuotedValuePattern})\s*\}`;
 const jsxTemplateLiteralValuePattern = String.raw`\{\s*${templateQuotedValuePattern}\s*\}`;
+const genericBraceValuePattern = String.raw`\{[^}]{4,}\}`;
 const literalCredentialValuePattern = [
   doubleQuotedValuePattern,
   singleQuotedValuePattern,
@@ -82,7 +83,7 @@ const literalCredentialValuePattern = [
 function credentialInputPattern(allowControlledJsx: boolean): RegExp {
   const unquotedValuePattern = allowControlledJsx
     ? String.raw`(?!${controlledJsxValuePattern})[^\s"'=<>]{4,}`
-    : String.raw`[^\s"'=<>]{4,}`;
+    : String.raw`(?:${genericBraceValuePattern}|[^\s"'=<>]{4,})`;
   return new RegExp([
     String.raw`<in`,
     String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -64,12 +64,21 @@ const textBasenames = new Set(["CODEOWNERS", "Dockerfile", "LICENSE", "Makefile"
 const maxPublicationBytes = 32 * 1024 * 1024;
 const maxVideoStreams = 16;
 const supportedGeneratorRuntime = "bun-1.3.3";
-/* A `{`-leading unquoted value starts a JSX expression container, including
-   the controlled binding form `value={entered}`. */
+/* Only identifier/member JSX expressions represent controlled bindings.
+   String and template literals inside JSX containers remain publication data. */
+const controlledJsxValuePattern = String.raw`\{\s*[A-Za-z_$][\w$]*(?:\s*(?:\?\.|\.)\s*[A-Za-z_$][\w$]*)*\s*\}`;
+const jsxStringLiteralValuePattern = String.raw`\{\s*["'][^"']{4,}["']\s*\}`;
+const jsxTemplateLiteralValuePattern = String.raw`\{\s*` + "`[^`]{4,}`" + String.raw`\s*\}`;
+const credentialValuePattern = [
+  String.raw`["'][^"']{4,}["']`,
+  jsxStringLiteralValuePattern,
+  jsxTemplateLiteralValuePattern,
+  String.raw`(?!${controlledJsxValuePattern})[^\s"'=<>]{4,}`,
+].join("|");
 const credentialInputPattern = new RegExp([
   String.raw`<in`,
   String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
-  String.raw`(?=[^>]*value\s*=\s*(?:["'][^"']{4,}["']|[^\s"'=<>{][^\s"'=<>]{3,}))[^>]*>`,
+  String.raw`(?=[^>]*value\s*=\s*(?:${credentialValuePattern}))[^>]*>`,
 ].join(""), "i");
 
 type KnownValueFingerprint = {
@@ -1104,9 +1113,12 @@ export function trustedVendorRootMatches(root: string, expectedDigest: string): 
  * that removes invite-link mutation tools from its read-only registry. This
  * digest is trusted scanner policy: candidate content cannot update it.
  */
+export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "07d80cafa0b508ec8a7e0c24e9df2a4ca74472edbd91d43924b44bdcb27d4728";
+export const TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES: ReadonlySet<FindingClass> = new Set(["credential", "home_path"]);
+
 const trustedTelegramVendor = {
-  digest: "9df9b54c12ce17f8d1a581cb39e46cd54319b36662c1f316bd2c69909dc94500",
-  exemptFindingClasses: new Set<FindingClass>(["credential", "home_path"]),
+  digest: TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST,
+  exemptFindingClasses: TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES,
   relativeRoot: "vendor/telegram-mcp",
 };
 

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -67,19 +67,31 @@ const supportedGeneratorRuntime = "bun-1.3.3";
 /* Only identifier/member JSX expressions represent controlled bindings.
    String and template literals inside JSX containers remain publication data. */
 const controlledJsxValuePattern = String.raw`\{\s*[A-Za-z_$][\w$]*(?:\s*(?:\?\.|\.)\s*[A-Za-z_$][\w$]*)*\s*\}`;
-const jsxStringLiteralValuePattern = String.raw`\{\s*["'][^"']{4,}["']\s*\}`;
-const jsxTemplateLiteralValuePattern = String.raw`\{\s*` + "`[^`]{4,}`" + String.raw`\s*\}`;
-const credentialValuePattern = [
-  String.raw`["'][^"']{4,}["']`,
+const doubleQuotedValuePattern = String.raw`"(?:\\.|[^"\\]){4,}"`;
+const singleQuotedValuePattern = String.raw`'(?:\\.|[^'\\]){4,}'`;
+const templateQuotedValuePattern = "`(?:\\\\.|[^`\\\\]){4,}`";
+const jsxStringLiteralValuePattern = String.raw`\{\s*(?:${doubleQuotedValuePattern}|${singleQuotedValuePattern})\s*\}`;
+const jsxTemplateLiteralValuePattern = String.raw`\{\s*${templateQuotedValuePattern}\s*\}`;
+const literalCredentialValuePattern = [
+  doubleQuotedValuePattern,
+  singleQuotedValuePattern,
   jsxStringLiteralValuePattern,
   jsxTemplateLiteralValuePattern,
-  String.raw`(?!${controlledJsxValuePattern})[^\s"'=<>]{4,}`,
 ].join("|");
-const credentialInputPattern = new RegExp([
-  String.raw`<in`,
-  String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
-  String.raw`(?=[^>]*value\s*=\s*(?:${credentialValuePattern}))[^>]*>`,
-].join(""), "i");
+
+function credentialInputPattern(allowControlledJsx: boolean): RegExp {
+  const unquotedValuePattern = allowControlledJsx
+    ? String.raw`(?!${controlledJsxValuePattern})[^\s"'=<>]{4,}`
+    : String.raw`[^\s"'=<>]{4,}`;
+  return new RegExp([
+    String.raw`<in`,
+    String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
+    String.raw`(?=[^>]*value\s*=\s*(?:${literalCredentialValuePattern}|${unquotedValuePattern}))[^>]*>`,
+  ].join(""), "i");
+}
+
+const genericCredentialInputPattern = credentialInputPattern(false);
+const controlledJsxCredentialInputPattern = credentialInputPattern(true);
 
 type KnownValueFingerprint = {
   length: number;
@@ -554,7 +566,7 @@ function inspectRasterMetadata(path: string, kind: MediaKind | undefined): Set<F
   }
 }
 
-export function sensitiveClasses(text: string): Set<FindingClass> {
+export function sensitiveClasses(text: string, allowControlledJsx = false): Set<FindingClass> {
   const findings = new Set<FindingClass>();
   const { compact, error, searchable: searchableText } = normalizedSensitiveText(text);
   if (error) findings.add("inspection_error");
@@ -617,7 +629,10 @@ export function sensitiveClasses(text: string): Set<FindingClass> {
   if (/https?:\/\/[^\s/@:]+:[^\s/@]+@/i.test(searchableText)) {
     findings.add("credential");
   }
-  if (credentialInputPattern.test(searchableText)) {
+  const inputPattern = allowControlledJsx ? controlledJsxCredentialInputPattern : genericCredentialInputPattern;
+  /* Raw text preserves JavaScript escape pairs; canonical text catches
+     percent/entity/CommonMark obfuscation. Both are publication surfaces. */
+  if (inputPattern.test(text) || inputPattern.test(searchableText)) {
     findings.add("credential");
   }
   if (/\b(?:10(?:\.\d{1,3}){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}|192\.168(?:\.\d{1,3}){2})\b/.test(searchableText)) {
@@ -679,8 +694,8 @@ function inspectText(path: string, kind: MediaKind | undefined): Set<FindingClas
         views.push(swapped.toString("utf16le"));
       }
     }
-    const findings = sensitiveClasses(views.join("\n"));
     const extension = extname(path).toLowerCase();
+    const findings = sensitiveClasses(views.join("\n"), extension === ".jsx" || extension === ".tsx");
     const textLike = textExtensions.has(extension) || textBasenames.has(basename(path));
     const controlBytes = contents.reduce((count, byte) => {
       const allowedWhitespace = byte === 0x09 || byte === 0x0a || byte === 0x0d;

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1073,14 +1073,14 @@ function provenanceFor(path: string, inspectionRoot = repositoryRoot, trustedBas
 
 /**
  * Hashes a complete vendor directory as an ordered stream of relative paths,
- * byte lengths, and file bytes. The directory is rejected when any entry is a
- * symlink or a non-file/non-directory node, so a trusted digest authenticates
- * the complete tree shape as well as every file's contents.
+ * portable executable-bit state, byte lengths, and file bytes. The directory
+ * is rejected when any entry is a symlink or a non-file/non-directory node,
+ * so a trusted digest authenticates the complete tree shape and contents.
  */
 export function trustedVendorRootDigest(root: string): string | null {
   const rootResult = safePath(root);
   if (rootResult.status !== "safe" || !rootResult.metadata?.isDirectory()) return null;
-  const files: string[] = [];
+  const files: Array<{ executable: boolean; relativePath: string }> = [];
   const pending = [""];
   try {
     while (pending.length > 0) {
@@ -1094,7 +1094,7 @@ export function trustedVendorRootDigest(root: string): string | null {
         if (entry.isDirectory() && entryResult.metadata?.isDirectory()) {
           pending.push(relativeEntry);
         } else if (entry.isFile() && entryResult.metadata?.isFile()) {
-          files.push(relativeEntry);
+          files.push({ executable: (Number(entryResult.metadata.mode) & 0o111) !== 0, relativePath: relativeEntry });
         } else {
           return null;
         }
@@ -1102,11 +1102,14 @@ export function trustedVendorRootDigest(root: string): string | null {
     }
     if (files.length === 0) return null;
     const digest = createHash("sha256");
-    for (const relativeFile of files.sort()) {
-      const bytes = readFileSync(join(root, relativeFile));
-      const portablePath = relativeFile.split(sep).join("/");
+    files.sort((left, right) => left.relativePath < right.relativePath ? -1 : left.relativePath > right.relativePath ? 1 : 0);
+    for (const file of files) {
+      const bytes = readFileSync(join(root, file.relativePath));
+      const portablePath = file.relativePath.split(sep).join("/");
       digest.update("file\0");
       digest.update(portablePath);
+      digest.update("\0");
+      digest.update(file.executable ? "x" : "-");
       digest.update("\0");
       digest.update(String(bytes.length));
       digest.update("\0");
@@ -1129,7 +1132,7 @@ export function trustedVendorRootMatches(root: string, expectedDigest: string): 
  * that removes invite-link mutation tools from its read-only registry. This
  * digest is trusted scanner policy: candidate content cannot update it.
  */
-export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "07d80cafa0b508ec8a7e0c24e9df2a4ca74472edbd91d43924b44bdcb27d4728";
+export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "344c9f0b9ef56c1ac4935a2245b6d33206e03bb22df86c5d9e7638869915ebb2";
 export const TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES: ReadonlySet<FindingClass> = new Set(["credential", "home_path"]);
 
 const trustedTelegramVendor = {

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -64,10 +64,12 @@ const textBasenames = new Set(["CODEOWNERS", "Dockerfile", "LICENSE", "Makefile"
 const maxPublicationBytes = 32 * 1024 * 1024;
 const maxVideoStreams = 16;
 const supportedGeneratorRuntime = "bun-1.3.3";
+/* A `{`-leading unquoted value starts a JSX expression container, including
+   the controlled binding form `value={entered}`. */
 const credentialInputPattern = new RegExp([
   String.raw`<in`,
   String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
-  String.raw`(?=[^>]*value\s*=\s*(?:["'][^"']{4,}["']|[^\s"'=<>]{4,}))[^>]*>`,
+  String.raw`(?=[^>]*value\s*=\s*(?:["'][^"']{4,}["']|[^\s"'=<>{][^\s"'=<>]{3,}))[^>]*>`,
 ].join(""), "i");
 
 type KnownValueFingerprint = {
@@ -1044,6 +1046,79 @@ function provenanceFor(path: string, inspectionRoot = repositoryRoot, trustedBas
   }
 }
 
+/**
+ * Hashes a complete vendor directory as an ordered stream of relative paths,
+ * byte lengths, and file bytes. The directory is rejected when any entry is a
+ * symlink or a non-file/non-directory node, so a trusted digest authenticates
+ * the complete tree shape as well as every file's contents.
+ */
+export function trustedVendorRootDigest(root: string): string | null {
+  const rootResult = safePath(root);
+  if (rootResult.status !== "safe" || !rootResult.metadata?.isDirectory()) return null;
+  const files: string[] = [];
+  const pending = [""];
+  try {
+    while (pending.length > 0) {
+      const relativeDirectory = pending.pop()!;
+      const directory = join(root, relativeDirectory);
+      for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const relativeEntry = join(relativeDirectory, entry.name);
+        const absoluteEntry = join(root, relativeEntry);
+        const entryResult = safePath(absoluteEntry);
+        if (entryResult.status !== "safe") return null;
+        if (entry.isDirectory() && entryResult.metadata?.isDirectory()) {
+          pending.push(relativeEntry);
+        } else if (entry.isFile() && entryResult.metadata?.isFile()) {
+          files.push(relativeEntry);
+        } else {
+          return null;
+        }
+      }
+    }
+    if (files.length === 0) return null;
+    const digest = createHash("sha256");
+    for (const relativeFile of files.sort()) {
+      const bytes = readFileSync(join(root, relativeFile));
+      const portablePath = relativeFile.split(sep).join("/");
+      digest.update("file\0");
+      digest.update(portablePath);
+      digest.update("\0");
+      digest.update(String(bytes.length));
+      digest.update("\0");
+      digest.update(bytes);
+      digest.update("\0");
+    }
+    return digest.digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+export function trustedVendorRootMatches(root: string, expectedDigest: string): boolean {
+  if (!/^[a-f0-9]{64}$/.test(expectedDigest)) return false;
+  return trustedVendorRootDigest(root) === expectedDigest;
+}
+
+/**
+ * The reviewed chigwell/telegram-mcp v3.2.22 tree plus the issue #1059 patch
+ * that removes invite-link mutation tools from its read-only registry. This
+ * digest is trusted scanner policy: candidate content cannot update it.
+ */
+const trustedTelegramVendor = {
+  digest: "9df9b54c12ce17f8d1a581cb39e46cd54319b36662c1f316bd2c69909dc94500",
+  exemptFindingClasses: new Set<FindingClass>(["credential", "home_path"]),
+  relativeRoot: "vendor/telegram-mcp",
+};
+
+function trustedVendorExemptions(path: string, inspectionRoot: string | undefined): ReadonlySet<FindingClass> {
+  if (!inspectionRoot) return new Set();
+  const vendorRoot = join(inspectionRoot, ...trustedTelegramVendor.relativeRoot.split("/"));
+  if (!canonicalPathIsWithin(vendorRoot, path)) return new Set();
+  return trustedVendorRootMatches(vendorRoot, trustedTelegramVendor.digest)
+    ? trustedTelegramVendor.exemptFindingClasses
+    : new Set();
+}
+
 export function inspectPaths(
   paths: string[],
   configurationError = false,
@@ -1090,6 +1165,8 @@ export function inspectPaths(
         }
       }
     }
+    const vendorExemptions = trustedVendorExemptions(path, inspectionRoot);
+    for (const finding of vendorExemptions) pathFindings.delete(finding);
     for (const finding of pathFindings) addFinding(findings, finding);
   }
   return findings;

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -64,35 +64,11 @@ const textBasenames = new Set(["CODEOWNERS", "Dockerfile", "LICENSE", "Makefile"
 const maxPublicationBytes = 32 * 1024 * 1024;
 const maxVideoStreams = 16;
 const supportedGeneratorRuntime = "bun-1.3.3";
-/* Only identifier/member JSX expressions represent controlled bindings.
-   String and template literals inside JSX containers remain publication data. */
-const controlledJsxValuePattern = String.raw`\{\s*[A-Za-z_$][\w$]*(?:\s*(?:\?\.|\.)\s*[A-Za-z_$][\w$]*)*\s*\}`;
-const doubleQuotedValuePattern = String.raw`"(?:\\.|[^"\\]){4,}"`;
-const singleQuotedValuePattern = String.raw`'(?:\\.|[^'\\]){4,}'`;
-const templateQuotedValuePattern = "`(?:\\\\.|[^`\\\\]){4,}`";
-const jsxStringLiteralValuePattern = String.raw`\{\s*(?:${doubleQuotedValuePattern}|${singleQuotedValuePattern})\s*\}`;
-const jsxTemplateLiteralValuePattern = String.raw`\{\s*${templateQuotedValuePattern}\s*\}`;
-const genericBraceValuePattern = String.raw`\{[^}]{4,}\}`;
-const literalCredentialValuePattern = [
-  doubleQuotedValuePattern,
-  singleQuotedValuePattern,
-  jsxStringLiteralValuePattern,
-  jsxTemplateLiteralValuePattern,
-].join("|");
-
-function credentialInputPattern(allowControlledJsx: boolean): RegExp {
-  const unquotedValuePattern = allowControlledJsx
-    ? String.raw`(?!${controlledJsxValuePattern})[^\s"'=<>]{4,}`
-    : String.raw`(?:${genericBraceValuePattern}|[^\s"'=<>]{4,})`;
-  return new RegExp([
-    String.raw`<in`,
-    String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
-    String.raw`(?=[^>]*value\s*=\s*(?:${literalCredentialValuePattern}|${unquotedValuePattern}))[^>]*>`,
-  ].join(""), "i");
-}
-
-const genericCredentialInputPattern = credentialInputPattern(false);
-const controlledJsxCredentialInputPattern = credentialInputPattern(true);
+const credentialInputPattern = new RegExp([
+  String.raw`<in`,
+  String.raw`put\b(?=[^>]*(?:type\s*=\s*["']?password|name\s*=\s*["']?(?:api[_-]?key|password|secret|token)))`,
+  String.raw`(?=[^>]*value\s*=\s*(?:["'][^"']{4,}["']|[^\s"'=<>]{4,}))[^>]*>`,
+].join(""), "i");
 
 type KnownValueFingerprint = {
   length: number;
@@ -567,7 +543,7 @@ function inspectRasterMetadata(path: string, kind: MediaKind | undefined): Set<F
   }
 }
 
-export function sensitiveClasses(text: string, allowControlledJsx = false): Set<FindingClass> {
+export function sensitiveClasses(text: string): Set<FindingClass> {
   const findings = new Set<FindingClass>();
   const { compact, error, searchable: searchableText } = normalizedSensitiveText(text);
   if (error) findings.add("inspection_error");
@@ -630,10 +606,7 @@ export function sensitiveClasses(text: string, allowControlledJsx = false): Set<
   if (/https?:\/\/[^\s/@:]+:[^\s/@]+@/i.test(searchableText)) {
     findings.add("credential");
   }
-  const inputPattern = allowControlledJsx ? controlledJsxCredentialInputPattern : genericCredentialInputPattern;
-  /* Raw text preserves JavaScript escape pairs; canonical text catches
-     percent/entity/CommonMark obfuscation. Both are publication surfaces. */
-  if (inputPattern.test(text) || inputPattern.test(searchableText)) {
+  if (credentialInputPattern.test(searchableText)) {
     findings.add("credential");
   }
   if (/\b(?:10(?:\.\d{1,3}){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}|192\.168(?:\.\d{1,3}){2})\b/.test(searchableText)) {
@@ -695,8 +668,8 @@ function inspectText(path: string, kind: MediaKind | undefined): Set<FindingClas
         views.push(swapped.toString("utf16le"));
       }
     }
+    const findings = sensitiveClasses(views.join("\n"));
     const extension = extname(path).toLowerCase();
-    const findings = sensitiveClasses(views.join("\n"), extension === ".jsx" || extension === ".tsx");
     const textLike = textExtensions.has(extension) || textBasenames.has(basename(path));
     const controlBytes = contents.reduce((count, byte) => {
       const allowedWhitespace = byte === 0x09 || byte === 0x0a || byte === 0x0d;


### PR DESCRIPTION
Trusted privacy-gate prerequisite for #1063.

- authenticates relative paths, portable Git executable state, byte lengths, and bytes for the complete patched chigwell/telegram-mcp v3.2.22 vendor tree;
- binds protected digest `344c9f0b9ef56c1ac4935a2245b6d33206e03bb22df86c5d9e7638869915ebb2` to the vendor tree carried by #1063 head `51300397103133a0e3499e2f3b1f2ff212b622f2`;
- exempts exactly the third-party `credential` and `home_path` idiom classes; `known_value` remains enforced;
- keeps all authority in the trusted scanner; candidate manifests and checksums cannot update the protected digest.

Coverage:
- fixed independently derived regular and executable digest vectors;
- content, byte-length, executable-bit in both directions, root-path, addition, deletion, rename, simultaneous file-plus-manifest, symlink, FIFO, and unreadable-tree failures;
- exact protected vendor match with every other finding class still armed.

Verification:
- privacy publication gate: 116 tests / 541 assertions passed;
- TypeScript typecheck passed;
- ESLint passed;
- candidate privacy self-scan passed;
- trusted-main scanner passed against this candidate;
- hosted privacy-publication and privacy-tracker-audit passed on exact head `33bdc116667c94ffc768055363f99dddb8738b5e`.