### PR TITLE
fix: trust bounded Telegram vendor root

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -569,7 +569,7 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const fixture = createVendorDigestFixture();
     expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
     expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(true);
-    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("344c9f0b9ef56c1ac4935a2245b6d33206e03bb22df86c5d9e7638869915ebb2");
+    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("8b88c1afc68afa5811f1d46139e2e39acb6af434d5be74788bf1128197f8a6ae");
     expect([...TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES]).toEqual(["credential", "home_path"]);
     expect(TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES.has("known_value")).toBe(false);
   });

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -569,7 +569,7 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const fixture = createVendorDigestFixture();
     expect(trustedVendorRootDigest(fixture.root)).toBe(FIXED_VENDOR_FIXTURE_DIGEST);
     expect(trustedVendorRootMatches(fixture.root, FIXED_VENDOR_FIXTURE_DIGEST)).toBe(true);
-    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("8b88c1afc68afa5811f1d46139e2e39acb6af434d5be74788bf1128197f8a6ae");
+    expect(TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST).toBe("8f3238a84139bff7ef88f522c60affc5880183f9f23048a39e124191c5e6619d");
     expect([...TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES]).toEqual(["credential", "home_path"]);
     expect(TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES.has("known_value")).toBe(false);
   });

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1106,7 +1106,7 @@ export function trustedVendorRootMatches(root: string, expectedDigest: string): 
  * dialog pagination. This digest is trusted scanner policy: candidate content
  * cannot update it.
  */
-export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "8b88c1afc68afa5811f1d46139e2e39acb6af434d5be74788bf1128197f8a6ae";
+export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "8f3238a84139bff7ef88f522c60affc5880183f9f23048a39e124191c5e6619d";
 export const TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES: ReadonlySet<FindingClass> = new Set(["credential", "home_path"]);
 
 const trustedTelegramVendor = {

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1101,11 +1101,12 @@ export function trustedVendorRootMatches(root: string, expectedDigest: string): 
 }
 
 /**
- * The reviewed chigwell/telegram-mcp v3.2.22 tree plus the issue #1059 patch
- * that removes invite-link mutation tools from its read-only registry. This
- * digest is trusted scanner policy: candidate content cannot update it.
+ * The reviewed chigwell/telegram-mcp v3.2.22 tree plus the issue #1059 patches
+ * that remove invite-link mutation tools from the read-only registry and cap
+ * dialog pagination. This digest is trusted scanner policy: candidate content
+ * cannot update it.
  */
-export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "344c9f0b9ef56c1ac4935a2245b6d33206e03bb22df86c5d9e7638869915ebb2";
+export const TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST = "8b88c1afc68afa5811f1d46139e2e39acb6af434d5be74788bf1128197f8a6ae";
 export const TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES: ReadonlySet<FindingClass> = new Set(["credential", "home_path"]);
 
 const trustedTelegramVendor = {


### PR DESCRIPTION
## Summary

- pin the trusted Telegram vendor-root digest to the independently derived tree used by #1063
- document the reviewed dialog-pagination patch in scanner policy
- preserve the existing mode, path, content, length, add/delete/rename, symlink, special-node, unreadable-tree, and known-value fail-closed tests

## Verification

- 116 focused privacy tests pass
- scoped ESLint passes
- privacy publication gate passes
- independent digest implementation matches the policy value