### PR TITLE
fix(runtime): silent healthy connection pill — footer rows stay readable (#1069)

### DIFF
--- a/src/components/ConnectionPill.tsx
+++ b/src/components/ConnectionPill.tsx
@@ -79,17 +79,27 @@ export interface ConnectionPillProps {
 }
 
 /**
- * #1069: the floating pill sits over the left-rail footer (Telegram row,
- * account controls). A healthy connection is the steady state and needs no
- * visual — only the trouble states earn the overlay, and the transient
- * resynced note still shows. Compact placements are inside their own header
- * and never overlap the footer, so they keep the steady badge.
+ * The positioned pill, decided entirely from props so tests exercise the real
+ * render. #1069: the floating pill sits over the left-rail footer (Telegram
+ * row, account controls). A healthy connection is the steady state and needs
+ * no visual — only the trouble states and the transient resynced note earn
+ * the overlay, and the polite announcer stays mounted so recovery back to
+ * live is still spoken. Compact placements are inside their own header and
+ * never overlap the footer, so they keep the steady badge.
  */
-export function connectionPillSilent(
-  connection: ConnectionState,
-  { compact, resynced }: { compact?: boolean; resynced: boolean },
-): boolean {
-  return !compact && connection === "live" && !resynced;
+export function ConnectionPillBody({ connection, resynced, legacy, compact, announce, t }: ConnectionPillViewProps) {
+  if (!compact && connection === "live" && !resynced) {
+    return (
+      <span role="status" aria-live="polite" className="sr-only">
+        {announce}
+      </span>
+    );
+  }
+  return (
+    <div className={compact ? "pointer-events-auto absolute right-2 top-1.5 z-30" : "pointer-events-auto fixed bottom-3 left-3 z-20"}>
+      <ConnectionPillView connection={connection} resynced={resynced} legacy={legacy} compact={compact} announce={announce} t={t} />
+    </div>
+  );
 }
 
 /**
@@ -103,16 +113,5 @@ export function ConnectionPill({ legacy, compact }: ConnectionPillProps) {
   const resynced = resyncedAt !== null;
   const announce = useThrottledAnnounce(resynced ? t("runtime.announce.resynced") : t(ANNOUNCE_KEY[connection]));
   if (!enabled) return null;
-  if (connectionPillSilent(connection, { compact, resynced })) {
-    return (
-      <span role="status" aria-live="polite" className="sr-only">
-        {announce}
-      </span>
-    );
-  }
-  return (
-    <div className={compact ? "pointer-events-auto absolute right-2 top-1.5 z-30" : "pointer-events-auto fixed bottom-3 left-3 z-20"}>
-      <ConnectionPillView connection={connection} resynced={resynced} legacy={legacy} compact={compact} announce={announce} t={t} />
-    </div>
-  );
+  return <ConnectionPillBody connection={connection} resynced={resynced} legacy={legacy} compact={compact} announce={announce} t={t} />;
 }

--- a/src/components/ConnectionPill.tsx
+++ b/src/components/ConnectionPill.tsx
@@ -79,6 +79,20 @@ export interface ConnectionPillProps {
 }
 
 /**
+ * #1069: the floating pill sits over the left-rail footer (Telegram row,
+ * account controls). A healthy connection is the steady state and needs no
+ * visual — only the trouble states earn the overlay, and the transient
+ * resynced note still shows. Compact placements are inside their own header
+ * and never overlap the footer, so they keep the steady badge.
+ */
+export function connectionPillSilent(
+  connection: ConnectionState,
+  { compact, resynced }: { compact?: boolean; resynced: boolean },
+): boolean {
+  return !compact && connection === "live" && !resynced;
+}
+
+/**
  * The tab's runtime connection pill. Renders nothing while slice-one is
  * disabled (the flag is off), so it is inert on the landing page until the
  * backend routes exist and the flag flips on.
@@ -89,6 +103,13 @@ export function ConnectionPill({ legacy, compact }: ConnectionPillProps) {
   const resynced = resyncedAt !== null;
   const announce = useThrottledAnnounce(resynced ? t("runtime.announce.resynced") : t(ANNOUNCE_KEY[connection]));
   if (!enabled) return null;
+  if (connectionPillSilent(connection, { compact, resynced })) {
+    return (
+      <span role="status" aria-live="polite" className="sr-only">
+        {announce}
+      </span>
+    );
+  }
   return (
     <div className={compact ? "pointer-events-auto absolute right-2 top-1.5 z-30" : "pointer-events-auto fixed bottom-3 left-3 z-20"}>
       <ConnectionPillView connection={connection} resynced={resynced} legacy={legacy} compact={compact} announce={announce} t={t} />

--- a/src/components/runtime/runtimeComponents.render.test.tsx
+++ b/src/components/runtime/runtimeComponents.render.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { translate } from "@/lib/i18n";
 
-import { ConnectionPillView, connectionPillSilent } from "@/components/ConnectionPill";
+import { ConnectionPillBody, ConnectionPillView } from "@/components/ConnectionPill";
 import { AttentionCard } from "./AttentionCard";
 import { ReceiptChip } from "./ReceiptChip";
 import type { RuntimeAttention, RuntimeReceipt } from "./runtimeModel";
@@ -39,16 +39,35 @@ test("live pill pulses but honors reduced motion", () => {
   expect(html).toContain("motion-reduce:animate-none");
 });
 
-test("#1069: the floating pill is silent while healthy and visible in every trouble state", () => {
-  // Steady live state: no overlay covering the footer's Telegram row.
-  expect(connectionPillSilent("live", { resynced: false })).toBe(true);
-  // Trouble states and the transient resynced note still earn the pill.
+test("#1069: the healthy floating pill renders no overlay, only the polite announcer", () => {
+  const html = renderToStaticMarkup(
+    <ConnectionPillBody connection="live" resynced={false} announce="announce-live" t={t} />,
+  );
+  // No fixed overlay covering the footer's Telegram row, no visible badge.
+  expect(html).not.toContain("fixed bottom-3 left-3");
+  expect(html).not.toContain("data-connection");
+  // Recovery back to live is still spoken.
+  expect(html).toContain('role="status"');
+  expect(html).toContain('aria-live="polite"');
+  expect(html).toContain("announce-live");
+});
+
+test("#1069: trouble states, the resynced note, and compact placement keep the real pill", () => {
   for (const connection of ["reconnecting", "degraded", "offline"] as const) {
-    expect(connectionPillSilent(connection, { resynced: false })).toBe(false);
+    const html = renderToStaticMarkup(
+      <ConnectionPillBody connection={connection} resynced={false} announce="x" t={t} />,
+    );
+    expect(html).toContain("fixed bottom-3 left-3");
+    expect(html).toContain(`data-connection="${connection}"`);
+    expect(html).toContain(translate("en", `runtime.${connection}`));
   }
-  expect(connectionPillSilent("live", { resynced: true })).toBe(false);
+  const resynced = renderToStaticMarkup(<ConnectionPillBody connection="live" resynced announce="x" t={t} />);
+  expect(resynced).toContain('data-connection="live"');
+  expect(resynced).toContain(translate("en", "runtime.resynced"));
   // Compact placements live inside their own header, never over the footer.
-  expect(connectionPillSilent("live", { compact: true, resynced: false })).toBe(false);
+  const compact = renderToStaticMarkup(<ConnectionPillBody connection="live" resynced={false} compact announce="x" t={t} />);
+  expect(compact).toContain('data-connection="live"');
+  expect(compact).toContain("absolute right-2 top-1.5");
 });
 
 /* ------------------------------ ReceiptChip ------------------------------ */

--- a/src/components/runtime/runtimeComponents.render.test.tsx
+++ b/src/components/runtime/runtimeComponents.render.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { translate } from "@/lib/i18n";
 
-import { ConnectionPillView } from "@/components/ConnectionPill";
+import { ConnectionPillView, connectionPillSilent } from "@/components/ConnectionPill";
 import { AttentionCard } from "./AttentionCard";
 import { ReceiptChip } from "./ReceiptChip";
 import type { RuntimeAttention, RuntimeReceipt } from "./runtimeModel";
@@ -37,6 +37,18 @@ test("live pill pulses but honors reduced motion", () => {
   const html = renderToStaticMarkup(<ConnectionPillView connection="live" resynced={false} announce="x" t={t} />);
   expect(html).toContain("animate-pulse");
   expect(html).toContain("motion-reduce:animate-none");
+});
+
+test("#1069: the floating pill is silent while healthy and visible in every trouble state", () => {
+  // Steady live state: no overlay covering the footer's Telegram row.
+  expect(connectionPillSilent("live", { resynced: false })).toBe(true);
+  // Trouble states and the transient resynced note still earn the pill.
+  for (const connection of ["reconnecting", "degraded", "offline"] as const) {
+    expect(connectionPillSilent(connection, { resynced: false })).toBe(false);
+  }
+  expect(connectionPillSilent("live", { resynced: true })).toBe(false);
+  // Compact placements live inside their own header, never over the footer.
+  expect(connectionPillSilent("live", { compact: true, resynced: false })).toBe(false);
 });
 
 /* ------------------------------ ReceiptChip ------------------------------ */


### PR DESCRIPTION
Fixes #1069.

The floating runtime connection pill (fixed bottom-left) sat on top of the left-rail footer, covering the new Telegram row's status text. A healthy connection is the steady state and earns no overlay:

- `connectionPillSilent()` decides visibility: non-compact + `live` + no resynced note → only the sr-only polite announcer renders, so recovery transitions are still spoken.
- `reconnecting`, `degraded`, `offline`, and the transient resynced note keep the pill exactly as before — those are the states worth an overlay.
- Compact placements (inside a pane header, never over the footer) are unchanged.

Gates: tsc clean, targeted render tests 15 pass (new case covers silent-live, all trouble states, resynced, compact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)