### PR TITLE
fix(docker): runtime image carries vendor/ — Telegram sign-in can provision (#1081)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,6 +221,10 @@ COPY --from=build /app/next.config.ts ./next.config.ts
 COPY --from=build /app/tsconfig.json ./tsconfig.json
 COPY --from=build /app/src ./src
 COPY --from=build /app/scripts/whisper_transcribe.py ./scripts/whisper_transcribe.py
+# The pinned Telegram connector (#1059) is resolved at runtime from
+# /app/vendor — without this line the image ships without it and sign-in
+# dies with start_failed (#1081).
+COPY --from=build /app/vendor ./vendor
 COPY --from=build /app/scripts/runtime-host-viewer-adapter.ts ./scripts/runtime-host-viewer-adapter.ts
 COPY --from=build /app/node_modules ./node_modules
 


### PR DESCRIPTION
Fixes #1081. The runtime stage's COPY whitelist never included vendor/, so the deployed image lacked the pinned telegram-mcp tree and every sign-in failed with start_failed. One line: copy /app/vendor from the build stage; the UID-1000 permission gate now covers it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)