### PR TITLE
fix(telegram): provisioner stages a writable vendor copy and installs non-editable (#1081)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,6 +221,10 @@ COPY --from=build /app/next.config.ts ./next.config.ts
 COPY --from=build /app/tsconfig.json ./tsconfig.json
 COPY --from=build /app/src ./src
 COPY --from=build /app/scripts/whisper_transcribe.py ./scripts/whisper_transcribe.py
+# The pinned Telegram connector (#1059) is resolved at runtime from
+# /app/vendor — without this line the image ships without it and sign-in
+# dies with start_failed (#1081).
+COPY --from=build /app/vendor ./vendor
 COPY --from=build /app/scripts/runtime-host-viewer-adapter.ts ./scripts/runtime-host-viewer-adapter.ts
 COPY --from=build /app/node_modules ./node_modules
 

--- a/bin/provision-telegram-connector.mjs
+++ b/bin/provision-telegram-connector.mjs
@@ -21,6 +21,7 @@ import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -134,13 +135,26 @@ export async function provisionTelegramConnector(env = process.env) {
   ownerOnlyDirectory(telegramStateDir);
 
   const uvCommand = await installPinnedUv(join(telegramStateDir, "tools"));
-  const result = spawnSync(uvCommand, ["sync", "--frozen", "--no-dev", "--project", vendorDir], {
-    cwd: vendorDir,
-    env: { ...env, UV_PROJECT_ENVIRONMENT: venvDir },
-    stdio: "inherit",
-    timeout: CONNECTOR_PROVISION_TIMEOUT_MS,
-    killSignal: "SIGKILL",
-  });
+  /* The packaged vendor tree can live on a read-only filesystem (the deploy
+     image, #1081), while setuptools writes build metadata into the project
+     directory. Sync from a writable owner-only staging copy under state, and
+     install non-editable so the venv is self-contained — nothing references
+     the staging copy or the packaged tree afterwards. */
+  const stagingDir = join(telegramStateDir, `vendor-src-${process.pid}-${randomUUID()}`);
+  let result;
+  try {
+    cpSync(vendorDir, stagingDir, { recursive: true });
+    chmodSync(stagingDir, 0o700);
+    result = spawnSync(uvCommand, ["sync", "--frozen", "--no-dev", "--no-editable", "--project", stagingDir], {
+      cwd: stagingDir,
+      env: { ...env, UV_PROJECT_ENVIRONMENT: venvDir },
+      stdio: "inherit",
+      timeout: CONNECTOR_PROVISION_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
   if (result.error || result.status !== 0) throw new Error("connector dependency provisioning failed");
   if (!existsSync(venvPython)) throw new Error("provisioning completed without a Python executable");
 }

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -223,13 +223,15 @@ test("the published tarball carries and runs the connector provisioner", async (
   expect(fs.existsSync(path.join(installedState, "telegram", "venv", "bin", "python"))).toBe(true);
   expect(fs.statSync(path.join(installedState, "telegram")).mode & 0o777).toBe(0o700);
   const uvArgs = fs.readFileSync(path.join(installedState, "telegram", "venv", "uv-args.txt"), "utf8").split("\n").filter(Boolean);
-  expect(uvArgs).toEqual([
-    "sync",
-    "--frozen",
-    "--no-dev",
-    "--project",
-    path.join(packageRoot, "vendor", "telegram-mcp"),
-  ]);
+  /* #1081: provisioning syncs a writable owner-only staging copy under state
+     (the packaged tree can be read-only), installs non-editable, and removes
+     the staging copy afterwards. */
+  expect(uvArgs.slice(0, 4)).toEqual(["sync", "--frozen", "--no-dev", "--no-editable"]);
+  expect(uvArgs[4]).toBe("--project");
+  const stagingPrefix = path.join(installedState, "telegram", "vendor-src-");
+  expect(uvArgs[5]?.startsWith(stagingPrefix)).toBe(true);
+  const leftovers = fs.readdirSync(path.join(installedState, "telegram")).filter((name) => name.startsWith("vendor-src-"));
+  expect(leftovers).toEqual([]);
 
   const previousState = process.env.LLV_STATE_DIR;
   process.env.LLV_STATE_DIR = installedState;


### PR DESCRIPTION
Second half of #1081. With vendor/ back in the image (#1082), provisioning still failed on prod: the default editable install writes build metadata (egg-info) into the project directory, and the deployed vendor tree is read-only for the runtime user. The provisioner now copies the vendored tree to an owner-only staging dir under state, runs the pinned uv with `sync --frozen --no-dev --no-editable --project <staging>`, and removes the staging copy — the venv ends up self-contained, so runtime needs neither the staging copy nor a writable packaged tree. Tarball test updated to pin the new contract (staging path, no-editable, no leftovers). 10 tests pass, tsc clean, privacy gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)