### PR TITLE
fix(telegram): connector runs from a kept staged source copy; provisioning verified by import probe (#1084)

### DIFF
--- a/bin/provision-telegram-connector.mjs
+++ b/bin/provision-telegram-connector.mjs
@@ -135,28 +135,53 @@ export async function provisionTelegramConnector(env = process.env) {
   ownerOnlyDirectory(telegramStateDir);
 
   const uvCommand = await installPinnedUv(join(telegramStateDir, "tools"));
-  /* The packaged vendor tree can live on a read-only filesystem (the deploy
-     image, #1081), while setuptools writes build metadata into the project
-     directory. Sync from a writable owner-only staging copy under state, and
-     install non-editable so the venv is self-contained — nothing references
-     the staging copy or the packaged tree afterwards. */
-  const stagingDir = join(telegramStateDir, `vendor-src-${process.pid}-${randomUUID()}`);
-  let result;
+  /* The packaged tree can sit on a read-only filesystem (#1081), while the
+     vendored runtime's supply-chain guard requires running from a source
+     checkout and setuptools writes build metadata into the project dir. So:
+     stage a writable owner-only copy at a STABLE path, editable-install from
+     it, and keep it — the connector runs from this copy (#1084). */
+  const sourceDir = join(telegramStateDir, "vendor-src");
+  const incoming = join(telegramStateDir, `.vendor-src-${process.pid}-${randomUUID()}`);
   try {
-    cpSync(vendorDir, stagingDir, { recursive: true });
-    chmodSync(stagingDir, 0o700);
-    result = spawnSync(uvCommand, ["sync", "--frozen", "--no-dev", "--no-editable", "--project", stagingDir], {
-      cwd: stagingDir,
-      env: { ...env, UV_PROJECT_ENVIRONMENT: venvDir },
-      stdio: "inherit",
-      timeout: CONNECTOR_PROVISION_TIMEOUT_MS,
-      killSignal: "SIGKILL",
-    });
+    cpSync(vendorDir, incoming, { recursive: true });
+    chmodSync(incoming, 0o700);
+    rmSync(sourceDir, { recursive: true, force: true });
+    renameSync(incoming, sourceDir);
   } finally {
-    rmSync(stagingDir, { recursive: true, force: true });
+    rmSync(incoming, { recursive: true, force: true });
   }
-  if (result.error || result.status !== 0) throw new Error("connector dependency provisioning failed");
-  if (!existsSync(venvPython)) throw new Error("provisioning completed without a Python executable");
+
+  const result = spawnSync(uvCommand, ["sync", "--frozen", "--no-dev", "--project", sourceDir], {
+    cwd: sourceDir,
+    env: { ...env, UV_PROJECT_ENVIRONMENT: venvDir },
+    stdio: "inherit",
+    timeout: CONNECTOR_PROVISION_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+  });
+  const failed = () => {
+    /* A partial venv must never pass a later provisioned check (#1084). */
+    rmSync(venvDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  };
+  if (result.error || result.status !== 0) {
+    failed();
+    throw new Error("connector dependency provisioning failed");
+  }
+  if (!existsSync(venvPython)) {
+    failed();
+    throw new Error("provisioning completed without a Python executable");
+  }
+  /* Success is a verified import, recorded durably — bare venv existence has
+     already lied once (#1084). */
+  const probe = spawnSync(venvPython, ["-c", "import telethon, telegram_mcp"], {
+    stdio: "ignore",
+    timeout: UV_SELF_CHECK_TIMEOUT_MS * 6,
+  });
+  if (probe.error || probe.status !== 0) {
+    failed();
+    throw new Error("provisioned environment failed its import probe");
+  }
+  writeFileSync(join(venvDir, ".llv-provisioned"), "ok\n", { mode: 0o600 });
 }
 
 const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);

--- a/src/lib/telegram/adapter.test.ts
+++ b/src/lib/telegram/adapter.test.ts
@@ -19,7 +19,7 @@ fs.writeFileSync(fakeUv, [
   "set -eu",
   "if [ \"${1:-}\" = \"--version\" ]; then exit 0; fi",
   "mkdir -p \"$UV_PROJECT_ENVIRONMENT/bin\"",
-  "printf '%s\\n' '#!/bin/sh' \"printf '%s\\n' '{\\\"event\\\":\\\"qr\\\",\\\"url\\\":\\\"tg://login?token=fixture\\\",\\\"expiresAt\\\":\\\"2026-08-20T20:00:00.000Z\\\"}'\" 'sleep 30' > \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
+  "printf '%s\\n' '#!/bin/sh' 'if [ \"${1:-}\" = \"-c\" ]; then exit 0; fi' \"printf '%s\\n' '{\\\"event\\\":\\\"qr\\\",\\\"url\\\":\\\"tg://login?token=fixture\\\",\\\"expiresAt\\\":\\\"2026-08-20T20:00:00.000Z\\\"}'\" 'sleep 30' > \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
   "chmod 700 \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
   "",
 ].join("\n"), { mode: 0o700 });

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -68,6 +68,10 @@ function fakePorts(script: Array<ConnectorProbe | null>, options: { spawnFails?:
 beforeEach(async () => {
   await stopTelegramConnector();
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+  /* #1084: the connector runs from the provisioner's staged source copy;
+     tests provide the directory the way a completed provision would. */
+  fs.mkdirSync(path.join(process.env.LLV_STATE_DIR!, "telegram"), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "vendor-src"), { mode: 0o700 });
 });
 afterAll(() => {
   if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE;

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -199,7 +199,8 @@ test("the published tarball carries and runs the connector provisioner", async (
     "if [ \"${1:-}\" = \"--version\" ]; then exit 0; fi",
     "mkdir -p \"$UV_PROJECT_ENVIRONMENT/bin\"",
     "printf '%s\\n' \"$@\" > \"$UV_PROJECT_ENVIRONMENT/uv-args.txt\"",
-    ": > \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
+    "printf '#!/bin/sh\\nexit 0\\n' > \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
+    "chmod 700 \"$UV_PROJECT_ENVIRONMENT/bin/python\"",
     "",
   ].join("\n"));
   fs.chmodSync(fakeUv, 0o700);
@@ -223,15 +224,14 @@ test("the published tarball carries and runs the connector provisioner", async (
   expect(fs.existsSync(path.join(installedState, "telegram", "venv", "bin", "python"))).toBe(true);
   expect(fs.statSync(path.join(installedState, "telegram")).mode & 0o777).toBe(0o700);
   const uvArgs = fs.readFileSync(path.join(installedState, "telegram", "venv", "uv-args.txt"), "utf8").split("\n").filter(Boolean);
-  /* #1081: provisioning syncs a writable owner-only staging copy under state
-     (the packaged tree can be read-only), installs non-editable, and removes
-     the staging copy afterwards. */
-  expect(uvArgs.slice(0, 4)).toEqual(["sync", "--frozen", "--no-dev", "--no-editable"]);
-  expect(uvArgs[4]).toBe("--project");
-  const stagingPrefix = path.join(installedState, "telegram", "vendor-src-");
-  expect(uvArgs[5]?.startsWith(stagingPrefix)).toBe(true);
-  const leftovers = fs.readdirSync(path.join(installedState, "telegram")).filter((name) => name.startsWith("vendor-src-"));
-  expect(leftovers).toEqual([]);
+  /* #1081/#1084: provisioning editable-syncs a writable owner-only staged
+     copy at a stable path (the vendored runtime's supply-chain guard needs a
+     source checkout), keeps it for the connector to run from, and records
+     success only after the import probe. */
+  const stagedSource = path.join(installedState, "telegram", "vendor-src");
+  expect(uvArgs).toEqual(["sync", "--frozen", "--no-dev", "--project", stagedSource]);
+  expect(fs.existsSync(path.join(stagedSource, "pyproject.toml"))).toBe(true);
+  expect(fs.existsSync(path.join(installedState, "telegram", "venv", ".llv-provisioned"))).toBe(true);
 
   const previousState = process.env.LLV_STATE_DIR;
   process.env.LLV_STATE_DIR = installedState;

--- a/src/lib/telegram/packaging.ts
+++ b/src/lib/telegram/packaging.ts
@@ -67,6 +67,15 @@ export function telegramVenvDir(): string {
   return statePath("telegram", "venv");
 }
 
+/** The provisioner's writable staging copy of the vendored tree (#1084): the
+    packaged tree can sit on a read-only filesystem, while the runtime's
+    supply-chain guard requires a source checkout and the server writes its
+    log beside its cwd. Provisioning keeps this copy; the connector runs from
+    it. */
+export function stagedConnectorSourceDir(): string {
+  return statePath("telegram", "vendor-src");
+}
+
 export function telegramVenvPython(): string {
   return process.env.LLV_TELEGRAM_PYTHON || path.join(telegramVenvDir(), "bin", "python");
 }
@@ -174,7 +183,12 @@ export function provisionLaunchSpec(): ProcessSpec {
 }
 
 export function connectorProvisioned(): boolean {
-  return fs.existsSync(telegramVenvPython());
+  /* #1084: bare venv existence lied once (a failed sync leaves scaffolding).
+     Provisioned means: the provisioner's post-import-probe marker, the venv
+     python, and the staged source the connector runs from all exist. */
+  return fs.existsSync(path.join(telegramVenvDir(), ".llv-provisioned"))
+    && fs.existsSync(telegramVenvPython())
+    && fs.existsSync(path.join(stagedConnectorSourceDir(), "pyproject.toml"));
 }
 
 let provisioningInFlight: Promise<boolean> | null = null;
@@ -219,7 +233,7 @@ export function ensureConnectorProvisioned(): Promise<boolean> {
     contract) — never as an argument, so it cannot surface in process listings,
     transcripts, or the activity journal. */
 export function connectorLaunchSpec(input: { sessionString: string; connectorToken: string; credentials: TelegramApiCredentials }): ProcessSpec {
-  const vendor = vendoredConnectorDir();
+  const vendor = stagedConnectorSourceDir();
   return {
     command: telegramVenvPython(),
     args: [telegramMcpServerPath()],


### PR DESCRIPTION
Fixes #1084, completes the #1081 chain (layers 5-6, found live on prod):

- The vendored runtime's supply-chain guard refuses a wheel install ("telegram-mcp on PyPI is owned by a different project — run from a source checkout"), so #1083's `--no-editable` could never start the connector; and the server writes its log beside its cwd, which is read-only in the image.
- The provisioner now stages the vendored tree at a STABLE owner-only path under state (`telegram/vendor-src`, atomic replace), editable-installs from it, and keeps it. `connectorLaunchSpec` runs the server from that copy: the guard sees a source checkout, logs land on a writable filesystem, and the packaged tree stays read-only.
- Provisioned-ness is no longer "venv python exists" (a failed sync's skeleton passed that forever): success requires an actual `import telethon, telegram_mcp` probe and writes a durable `.llv-provisioned` marker; failure removes the partial venv and staging so the next attempt starts clean. `connectorProvisioned()` checks marker + python + staged source.
- Tests updated across packaging/connector/adapter: fake uv now materializes an executable probe-passing python, connector tests provide the staged dir the way a completed provision would, and the tarball test pins the new uv argv + kept staging + marker.

Gates: tsc clean, 71 targeted telegram tests pass, privacy gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)