### PR TITLE
fix(telegram): connector survives concurrent reads; crashes are recorded and visible (#1087)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # testing
 /coverage
 
+# python bytecode from the packaged connector scripts
+__pycache__/
+
 # next.js
 /.next/
 /out/

--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Authenticated entrypoint for the packaged Telegram MCP connector."""
 
+import asyncio
 import hashlib
 import hmac
 import json
 import os
 import re
-import signal
 import sys
 
 
@@ -20,65 +20,76 @@ sys.path.insert(0, VENDOR_DIR)
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 
 
-# Set once the supervisor asks this process to stop (issue #1087). Between the
-# signal and the exit, every MCP request is answered with a distinguishable
-# "restarting" error instead of a bare connection reset, so a caller whose call
-# was dropped by a connector restart can tell that apart from a network blip.
-DRAINING = False
+# Issue #1087: a call dropped because the supervisor is stopping this process
+# must fail with an error that names the restart, not with a stream that simply
+# stops (which the caller cannot tell from a network blip).
+#
+# The supervisor asks BEFORE it signals: an authenticated POST to DRAIN_PATH
+# sets the event below, and every request already in flight is finished right
+# then with a JSON-RPC error addressed to its own request id. That ordering is
+# what makes the guarantee hold — it does not depend on the shutdown reaching
+# any particular code path, so the supervisor's SIGKILL escalation can no
+# longer be the first thing a caller meets.
+DRAIN_PATH = "/llv-telegram-drain"
 RESTART_HEADER = b"x-llv-telegram-restarting"
+RESTART_CODE = -32001
+RESTART_MESSAGE = (
+    "Telegram connector is restarting: the Agent Log Viewer supervisor "
+    "stopped this process. In-flight calls were dropped; retry shortly."
+)
+# A response the connector began and did not finish for any other reason is
+# also completed, with its own code — never mislabelled as a restart.
+INCOMPLETE_CODE = -32603
+INCOMPLETE_MESSAGE = (
+    "Telegram connector ended this response without completing it."
+)
+# The JSON-RPC id is echoed so the caller's pending call is the one that
+# fails; reading it back needs the request body, capped here.
 MAX_TRACKED_BODY = 64 * 1024
-RESTARTING_BODY = json.dumps(
-    {
-        "jsonrpc": "2.0",
-        "id": None,
-        "error": {
-            "code": -32001,
-            "message": (
-                "Telegram connector is restarting: the Agent Log Viewer supervisor "
-                "stopped this process. In-flight calls were dropped; retry shortly."
-            ),
-        },
-    }
-).encode("utf-8")
+
+_DRAINING = False
+_DRAIN_EVENT = None
+_DRAIN_LOOP = None
 
 
-def _begin_drain(*_args) -> None:
-    global DRAINING
-    DRAINING = True
+def _drain_event():
+    """The event in-flight requests wait on, bound to the serving loop.
 
-
-def _install_drain_marker() -> None:
-    """Mark the drain on SIGTERM/SIGINT without displacing anyone's handler.
-
-    uvicorn installs its own signal handlers when it starts serving, long after
-    this module runs, so hooking the flag in has to survive a later
-    registration: wrap ``signal.signal`` so every handler registered for these
-    two signals sets the flag first and then runs unchanged.
+    ``asyncio.Event`` refuses to be awaited from a loop other than the one it
+    first attached to, and this module is imported long before the server's
+    loop exists — so the event is created on first use, from inside the loop,
+    and re-created if it is ever reached from a different one.
     """
-    registered = signal.signal
-
-    def signal_with_drain(signum, handler):
-        if signum in (signal.SIGTERM, signal.SIGINT) and callable(handler):
-            inner = handler
-
-            def wrapped(sig, frame):
-                _begin_drain()
-                return inner(sig, frame)
-
-            return registered(signum, wrapped)
-        return registered(signum, handler)
-
-    signal.signal = signal_with_drain
-    for signum in (signal.SIGTERM, signal.SIGINT):
-        try:
-            signal_with_drain(signum, signal.getsignal(signum))
-        except (TypeError, ValueError, OSError):
-            # A default/ignored disposition has no handler to chain; uvicorn's
-            # later registration goes through the wrapper anyway.
-            pass
+    global _DRAIN_EVENT, _DRAIN_LOOP
+    loop = asyncio.get_running_loop()
+    if _DRAIN_EVENT is None or _DRAIN_LOOP is not loop:
+        _DRAIN_EVENT = asyncio.Event()
+        _DRAIN_LOOP = loop
+        if _DRAINING:
+            _DRAIN_EVENT.set()
+    return _DRAIN_EVENT
 
 
-_install_drain_marker()
+def _begin_drain():
+    """Latch the drain and wake everything already waiting on it."""
+    global _DRAINING
+    _DRAINING = True
+    _drain_event().set()
+
+
+def jsonrpc_error(request_body: bytes, code: int, message: str, as_event_stream: bool) -> bytes:
+    """A JSON-RPC error frame addressed to the request that was cut short."""
+    notice = {"jsonrpc": "2.0", "id": None, "error": {"code": code, "message": message}}
+    try:
+        parsed = json.loads(request_body or b"{}")
+        if isinstance(parsed, dict) and "id" in parsed:
+            notice["id"] = parsed["id"]
+    except (ValueError, TypeError):
+        pass
+    payload = json.dumps(notice)
+    if as_event_stream:
+        return f"event: message\ndata: {payload}\n\n".encode("utf-8")
+    return payload.encode("utf-8")
 
 
 class BearerAuthMiddleware:
@@ -87,57 +98,68 @@ class BearerAuthMiddleware:
         self.expected = f"Bearer {token}".encode("utf-8")
 
     async def __call__(self, scope, receive, send):
-        if scope.get("type") == "http":
-            headers = {key.lower(): value for key, value in scope.get("headers", [])}
-            if scope.get("path") == "/llv-telegram-proof" and scope.get("method") == "GET":
-                nonce = headers.get(b"x-llv-telegram-nonce", b"")
-                if not re.fullmatch(rb"[A-Za-z0-9_-]{43}", nonce):
-                    await send({"type": "http.response.start", "status": 400, "headers": []})
-                    await send({"type": "http.response.body", "body": b"Invalid nonce"})
-                    return
-                proof = hmac.new(TOKEN.encode("utf-8"), nonce, hashlib.sha256).hexdigest().encode("ascii")
-                await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
-                await send({"type": "http.response.body", "body": proof})
-                return
-            supplied = headers.get(b"authorization", b"")
-            if not hmac.compare_digest(supplied, self.expected):
-                await send({
-                    "type": "http.response.start",
-                    "status": 401,
-                    "headers": [
-                        (b"content-type", b"text/plain; charset=utf-8"),
-                        (b"www-authenticate", b"Bearer"),
-                    ],
-                })
-                await send({"type": "http.response.body", "body": b"Unauthorized"})
-                return
-            # Authenticated, but this process is on its way out: answer with
-            # the distinguishable restart error rather than letting the caller
-            # meet a closed socket (#1087).
-            if DRAINING:
-                await send({
-                    "type": "http.response.start",
-                    "status": 503,
-                    "headers": [
-                        (b"content-type", b"application/json"),
-                        (b"retry-after", b"5"),
-                        (RESTART_HEADER, b"1"),
-                    ],
-                })
-                await send({"type": "http.response.body", "body": RESTARTING_BODY})
-                return
-            await self.serve_with_restart_notice(scope, receive, send)
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
             return
-        await self.app(scope, receive, send)
+        headers = {key.lower(): value for key, value in scope.get("headers", [])}
+        if scope.get("path") == "/llv-telegram-proof" and scope.get("method") == "GET":
+            nonce = headers.get(b"x-llv-telegram-nonce", b"")
+            if not re.fullmatch(rb"[A-Za-z0-9_-]{43}", nonce):
+                await send({"type": "http.response.start", "status": 400, "headers": []})
+                await send({"type": "http.response.body", "body": b"Invalid nonce"})
+                return
+            proof = hmac.new(TOKEN.encode("utf-8"), nonce, hashlib.sha256).hexdigest().encode("ascii")
+            await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
+            await send({"type": "http.response.body", "body": proof})
+            return
+        supplied = headers.get(b"authorization", b"")
+        if not hmac.compare_digest(supplied, self.expected):
+            await send({
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"www-authenticate", b"Bearer"),
+                ],
+            })
+            await send({"type": "http.response.body", "body": b"Unauthorized"})
+            return
+        # Authenticated. The supervisor's own pre-stop call comes through the
+        # same bearer check, so nothing unauthenticated can trip the drain.
+        if scope.get("path") == DRAIN_PATH and scope.get("method") == "POST":
+            _begin_drain()
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json"), (RESTART_HEADER, b"1")],
+            })
+            await send({"type": "http.response.body", "body": b'{"draining": true}'})
+            return
+        if _DRAINING:
+            # On the way out: answer with the named reason rather than letting
+            # the caller meet a closed socket.
+            await send({
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"retry-after", b"5"),
+                    (RESTART_HEADER, b"1"),
+                ],
+            })
+            await send({"type": "http.response.body", "body": jsonrpc_error(b"", RESTART_CODE, RESTART_MESSAGE, False)})
+            return
+        await self.serve(scope, receive, send)
 
-    async def serve_with_restart_notice(self, scope, receive, send):
-        """Run the MCP app, and finish a response the shutdown cut short.
+    async def serve(self, scope, receive, send):
+        """Run the MCP app, racing it against the drain.
 
-        Stopping the connector cancels the session task that is streaming a
-        tool call, and the ASGI app then returns with the response started but
-        never completed — the caller sees a stream that just stops, which is
-        indistinguishable from a network blip (#1087). Complete it here with a
-        JSON-RPC error that names the restart.
+        A tool call can sit inside the app for as long as Telegram takes. When
+        the drain fires first the call is abandoned deliberately and answered
+        here, while this process is still alive and its loop still runs — the
+        caller gets a named error instead of a truncated stream. A response the
+        app started and left unfinished for any other reason is completed too,
+        under its own error code.
         """
         state = {"started": False, "completed": False, "sse": False}
         body = bytearray()
@@ -159,25 +181,43 @@ class BearerAuthMiddleware:
                 state["completed"] = True
             await send(message)
 
-        await self.app(scope, tracking_receive, tracking_send)
-        if state["started"] and not state["completed"]:
-            await send({"type": "http.response.body", "body": restart_notice(bytes(body), state["sse"]), "more_body": False})
-
-
-def restart_notice(request_body: bytes, as_event_stream: bool) -> bytes:
-    """A JSON-RPC error for the request that a restart cut short, addressed to
-    the request id when one can still be read out of the body."""
-    notice = json.loads(RESTARTING_BODY)
-    try:
-        parsed = json.loads(request_body or b"{}")
-        if isinstance(parsed, dict) and "id" in parsed:
-            notice["id"] = parsed["id"]
-    except (ValueError, TypeError):
-        pass
-    payload = json.dumps(notice)
-    if as_event_stream:
-        return f"event: message\ndata: {payload}\n\n".encode("utf-8")
-    return payload.encode("utf-8")
+        inner = asyncio.ensure_future(self.app(scope, tracking_receive, tracking_send))
+        drained = asyncio.ensure_future(_drain_event().wait())
+        try:
+            await asyncio.wait({inner, drained}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            drained.cancel()
+        if not inner.done():
+            inner.cancel()
+            try:
+                await inner
+            except BaseException:  # noqa: BLE001 - the call was abandoned on purpose
+                # Whatever the cancelled app raises on its way out (a bare
+                # CancelledError, or the exception group an anyio task group
+                # unwinds into) is discarded: the caller is about to be told
+                # what actually happened, by this handler.
+                pass
+        if state["completed"]:
+            return
+        draining = _DRAINING
+        if not state["started"] and not draining:
+            # Nothing was sent and this is not a shutdown: let the failure
+            # surface the way it always did.
+            inner.result()
+            return
+        code, message = (RESTART_CODE, RESTART_MESSAGE) if draining else (INCOMPLETE_CODE, INCOMPLETE_MESSAGE)
+        frame = jsonrpc_error(bytes(body), code, message, state["sse"])
+        if not state["started"]:
+            await send({
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"retry-after", b"5"),
+                    (RESTART_HEADER, b"1"),
+                ],
+            })
+        await send({"type": "http.response.body", "body": frame, "more_body": False})
 
 
 _original_streamable_http_app = FastMCP.streamable_http_app

--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -3,8 +3,10 @@
 
 import hashlib
 import hmac
+import json
 import os
 import re
+import signal
 import sys
 
 
@@ -16,6 +18,67 @@ if len(TOKEN) < 32 or not VENDOR_DIR:
 sys.path.insert(0, VENDOR_DIR)
 
 from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+
+# Set once the supervisor asks this process to stop (issue #1087). Between the
+# signal and the exit, every MCP request is answered with a distinguishable
+# "restarting" error instead of a bare connection reset, so a caller whose call
+# was dropped by a connector restart can tell that apart from a network blip.
+DRAINING = False
+RESTART_HEADER = b"x-llv-telegram-restarting"
+MAX_TRACKED_BODY = 64 * 1024
+RESTARTING_BODY = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {
+            "code": -32001,
+            "message": (
+                "Telegram connector is restarting: the Agent Log Viewer supervisor "
+                "stopped this process. In-flight calls were dropped; retry shortly."
+            ),
+        },
+    }
+).encode("utf-8")
+
+
+def _begin_drain(*_args) -> None:
+    global DRAINING
+    DRAINING = True
+
+
+def _install_drain_marker() -> None:
+    """Mark the drain on SIGTERM/SIGINT without displacing anyone's handler.
+
+    uvicorn installs its own signal handlers when it starts serving, long after
+    this module runs, so hooking the flag in has to survive a later
+    registration: wrap ``signal.signal`` so every handler registered for these
+    two signals sets the flag first and then runs unchanged.
+    """
+    registered = signal.signal
+
+    def signal_with_drain(signum, handler):
+        if signum in (signal.SIGTERM, signal.SIGINT) and callable(handler):
+            inner = handler
+
+            def wrapped(sig, frame):
+                _begin_drain()
+                return inner(sig, frame)
+
+            return registered(signum, wrapped)
+        return registered(signum, handler)
+
+    signal.signal = signal_with_drain
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal_with_drain(signum, signal.getsignal(signum))
+        except (TypeError, ValueError, OSError):
+            # A default/ignored disposition has no handler to chain; uvicorn's
+            # later registration goes through the wrapper anyway.
+            pass
+
+
+_install_drain_marker()
 
 
 class BearerAuthMiddleware:
@@ -48,7 +111,73 @@ class BearerAuthMiddleware:
                 })
                 await send({"type": "http.response.body", "body": b"Unauthorized"})
                 return
+            # Authenticated, but this process is on its way out: answer with
+            # the distinguishable restart error rather than letting the caller
+            # meet a closed socket (#1087).
+            if DRAINING:
+                await send({
+                    "type": "http.response.start",
+                    "status": 503,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"retry-after", b"5"),
+                        (RESTART_HEADER, b"1"),
+                    ],
+                })
+                await send({"type": "http.response.body", "body": RESTARTING_BODY})
+                return
+            await self.serve_with_restart_notice(scope, receive, send)
+            return
         await self.app(scope, receive, send)
+
+    async def serve_with_restart_notice(self, scope, receive, send):
+        """Run the MCP app, and finish a response the shutdown cut short.
+
+        Stopping the connector cancels the session task that is streaming a
+        tool call, and the ASGI app then returns with the response started but
+        never completed — the caller sees a stream that just stops, which is
+        indistinguishable from a network blip (#1087). Complete it here with a
+        JSON-RPC error that names the restart.
+        """
+        state = {"started": False, "completed": False, "sse": False}
+        body = bytearray()
+
+        async def tracking_receive():
+            message = await receive()
+            if message.get("type") == "http.request" and len(body) < MAX_TRACKED_BODY:
+                body.extend(message.get("body", b"")[: MAX_TRACKED_BODY - len(body)])
+            return message
+
+        async def tracking_send(message):
+            kind = message.get("type")
+            if kind == "http.response.start":
+                state["started"] = True
+                for key, value in message.get("headers", []):
+                    if key.lower() == b"content-type" and b"text/event-stream" in value.lower():
+                        state["sse"] = True
+            elif kind == "http.response.body" and not message.get("more_body", False):
+                state["completed"] = True
+            await send(message)
+
+        await self.app(scope, tracking_receive, tracking_send)
+        if state["started"] and not state["completed"]:
+            await send({"type": "http.response.body", "body": restart_notice(bytes(body), state["sse"]), "more_body": False})
+
+
+def restart_notice(request_body: bytes, as_event_stream: bool) -> bytes:
+    """A JSON-RPC error for the request that a restart cut short, addressed to
+    the request id when one can still be read out of the body."""
+    notice = json.loads(RESTARTING_BODY)
+    try:
+        parsed = json.loads(request_body or b"{}")
+        if isinstance(parsed, dict) and "id" in parsed:
+            notice["id"] = parsed["id"]
+    except (ValueError, TypeError):
+        pass
+    payload = json.dumps(notice)
+    if as_event_stream:
+        return f"event: message\ndata: {payload}\n\n".encode("utf-8")
+    return payload.encode("utf-8")
 
 
 _original_streamable_http_app = FastMCP.streamable_http_app

--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -15,6 +15,22 @@ VENDOR_DIR = os.environ.get("LLV_TELEGRAM_VENDOR_DIR", "")
 if len(TOKEN) < 32 or not VENDOR_DIR:
     raise SystemExit("authenticated Telegram MCP configuration is missing")
 
+# Issue #1087: fork the crash monitor BEFORE anything heavy is imported, so the
+# process that outlives this one stays a few kilobytes of standard library. It
+# returns only here, in the child that goes on to be the server; the parent
+# never comes back from `supervise`. Without a state dir (a bare invocation, a
+# test driving the app object directly) the server simply runs unmonitored.
+_STATE_DIR = os.environ.get("LLV_TELEGRAM_STATE_DIR", "")
+if _STATE_DIR:
+    _BIN_DIR = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, _BIN_DIR)
+    try:
+        from telegram_connector_monitor import supervise  # noqa: E402
+    finally:
+        if sys.path and sys.path[0] == _BIN_DIR:
+            sys.path.pop(0)
+    supervise(_STATE_DIR)
+
 sys.path.insert(0, VENDOR_DIR)
 
 from mcp.server.fastmcp import FastMCP  # noqa: E402

--- a/bin/telegram_connector_monitor.py
+++ b/bin/telegram_connector_monitor.py
@@ -1,0 +1,258 @@
+"""Durable crash monitor for the packaged Telegram connector (issue #1087).
+
+Two things the Viewer cannot do for itself live here.
+
+**The exit status of a connector it did not parent.** The shared connector
+outlives the Viewer: after a Viewer restart every connector the operator has is
+*adopted* through the pid file, and an adopted process has no exit event — the
+kernel hands its status to its own parent and nowhere else. So the parent is
+made to be something that survives: this module forks once, the child becomes
+the server, and the parent stays as a monitor whose only job is to `waitpid`
+and write the result down. A connector killed by the OOM killer — the exact
+death a fan-out of large reads invites — is then recorded as `SIGKILL` instead
+of as an unexplained disappearance.
+
+**Redaction before persistence.** The connector's stderr is the only evidence
+of why it died, but it is not innocent: the vendored error helper logs the
+failing call's arguments verbatim (`Error in get_messages (chat_id=…)`) and
+tracebacks carry absolute paths under the operator's home. The monitor owns the
+child's stderr, so every line is redacted *on the way to disk* rather than
+after the fact — nothing raw is ever persisted.
+
+The monitor is deliberately tiny and imports nothing beyond the standard
+library: it is forked before the vendored server is imported, and it has to
+outlive whatever the server does to itself.
+
+`redact_stderr_line` mirrors `redactConnectorStderrLine` in
+`src/lib/telegram/connector.ts`; `packaging.test.ts` runs both over the same
+samples so the two cannot drift.
+"""
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+
+EXIT_FILE = "connector-exit.json"
+MAX_LINE_CHARS = 400
+READ_CHUNK = 65536
+# A stderr "line" with no newline in sight is flushed anyway at this width, so
+# a server printing a single unbounded blob can never grow the monitor's heap.
+MAX_PENDING_BYTES = 8192
+
+_SECRET_ENV_KEYS = (
+    "LLV_TELEGRAM_MCP_TOKEN",
+    "TELEGRAM_SESSION_STRING",
+    "TELEGRAM_API_HASH",
+)
+# Forwarded to the server child so the supervisor's SIGTERM reaches the process
+# that actually serves, and the monitor still lives to record what came of it.
+_FORWARDED_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+
+_CONTEXT_KEY = re.compile(
+    r"\b([A-Za-z_]*(?:chat|user|peer|phone|contact|title|name|query|text|message|entity|alias|folder)[A-Za-z_]*)\s*=\s*[^,)]*",
+    re.IGNORECASE,
+)
+_FOREIGN_HOME = re.compile(r"/(home|Users)/[^/\s:'\"]+")
+_HANDLE = re.compile(r"@[A-Za-z0-9_]{4,}")
+_LONG_NUMBER = re.compile(r"[+-]?\b\d{5,}\b")
+_OPAQUE_BLOB = re.compile(
+    r"\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{24,}\b"
+)
+
+
+def redact_stderr_line(line, secrets=()):
+    """One connector stderr line, safe to persist.
+
+    Says what died, never who was being read. Error codes and exception types
+    survive; identifiers, handles, paths, and known credential values do not.
+    """
+    out = line
+    for secret in secrets:
+        if secret and len(secret) >= 8:
+            out = out.replace(secret, "<redacted>")
+    home = os.path.expanduser("~")
+    if home and len(home) > 1:
+        out = out.replace(home, "~")
+    out = _FOREIGN_HOME.sub(r"/\1/<user>", out)
+    out = _CONTEXT_KEY.sub(r"\1=<redacted>", out)
+    out = _HANDLE.sub("@<user>", out)
+    out = _LONG_NUMBER.sub("<id>", out)
+    out = _OPAQUE_BLOB.sub("<redacted>", out)
+    if len(out) > MAX_LINE_CHARS:
+        return out[:MAX_LINE_CHARS] + "…"
+    return out
+
+
+def _known_secrets(env=None):
+    source = os.environ if env is None else env
+    return [source.get(key, "") for key in _SECRET_ENV_KEYS]
+
+
+def _write_owner_only(path, contents):
+    tmp = "%s.%d.tmp" % (path, os.getpid())
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, contents.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _exit_record(child_pid, status):
+    """The kernel's verdict on the server child, in the shape the supervisor
+    reads: an exit code, or the signal that killed it."""
+    if os.WIFSIGNALED(status):
+        number = os.WTERMSIG(status)
+        try:
+            name = signal.Signals(number).name
+        except ValueError:
+            name = "SIG%d" % number
+        exit_code, signal_name = None, name
+    else:
+        exit_code, signal_name = os.WEXITSTATUS(status), None
+    return {
+        "version": 1,
+        "monitorPid": os.getpid(),
+        "pid": child_pid,
+        "exitCode": exit_code,
+        "signal": signal_name,
+        "at": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + "Z",
+    }
+
+
+def _die_with_parent():
+    """The server must not outlive its monitor.
+
+    A monitor killed outright (the supervisor's SIGKILL escalation) would
+    otherwise leave the server holding the loopback port, and the replacement
+    could never bind it. `PR_SET_PDEATHSIG` handles this immediately on Linux
+    and survives the fork; elsewhere the parent's death is noticed by polling.
+    """
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        # PR_SET_PDEATHSIG = 1
+        if libc.prctl(1, int(signal.SIGKILL), 0, 0, 0) == 0:
+            return
+    except (OSError, AttributeError, ValueError):
+        pass
+    import threading
+
+    original = os.getppid()
+
+    def watch():
+        while os.getppid() == original:
+            time.sleep(1)
+        os._exit(1)
+
+    thread = threading.Thread(target=watch, daemon=True)
+    thread.start()
+
+
+def _monitor(child_pid, read_fd, state_dir, secrets):
+    """Redact the child's stderr onto our own (the Viewer-owned sink), then
+    record how the child went. Never returns."""
+    exit_path = os.path.join(state_dir, EXIT_FILE)
+    try:
+        os.unlink(exit_path)
+    except OSError:
+        pass
+
+    def forward(number, _frame):
+        try:
+            os.kill(child_pid, number)
+        except OSError:
+            pass
+
+    for number in _FORWARDED_SIGNALS:
+        try:
+            signal.signal(number, forward)
+        except (OSError, ValueError):
+            pass
+
+    def emit(chunk):
+        try:
+            os.write(2, (redact_stderr_line(chunk.decode("utf-8", "replace"), secrets) + "\n").encode("utf-8"))
+        except OSError:
+            pass
+
+    pending = b""
+    while True:
+        try:
+            data = os.read(read_fd, READ_CHUNK)
+        except InterruptedError:
+            continue
+        except OSError:
+            break
+        if not data:
+            break
+        pending += data
+        while b"\n" in pending:
+            line, pending = pending.split(b"\n", 1)
+            emit(line)
+        if len(pending) >= MAX_PENDING_BYTES:
+            emit(pending)
+            pending = b""
+    if pending:
+        emit(pending)
+
+    status = 0
+    while True:
+        try:
+            _, status = os.waitpid(child_pid, 0)
+            break
+        except InterruptedError:
+            continue
+        except ChildProcessError:
+            break
+    record = _exit_record(child_pid, status)
+    _write_owner_only(exit_path, json.dumps(record))
+    # Mirror the child's fate so a Viewer that IS still listening reads the
+    # same verdict from the kernel that the record carries.
+    if record["signal"] is not None:
+        os._exit(128 + os.WTERMSIG(status))
+    os._exit(record["exitCode"] or 0)
+
+
+def supervise(state_dir, secrets=None):
+    """Fork the monitor. Returns only in the child, which is the server.
+
+    A platform or a moment that cannot fork runs unmonitored — the connector
+    starting matters more than the bookkeeping around it.
+    """
+    if not state_dir or not os.path.isdir(state_dir):
+        return
+    known = list(secrets) if secrets is not None else _known_secrets()
+    try:
+        read_fd, write_fd = os.pipe()
+    except OSError:
+        return
+    try:
+        child = os.fork()
+    except OSError:
+        os.close(read_fd)
+        os.close(write_fd)
+        return
+    if child == 0:
+        os.close(read_fd)
+        try:
+            sys.stderr.flush()
+        except (OSError, ValueError):
+            pass
+        os.dup2(write_fd, 2)
+        os.close(write_fd)
+        _die_with_parent()
+        return
+    os.close(write_fd)
+    _monitor(child, read_fd, state_dir, known)

--- a/bin/telegram_connector_monitor.py
+++ b/bin/telegram_connector_monitor.py
@@ -36,7 +36,7 @@ import sys
 import time
 
 EXIT_FILE = "connector-exit.json"
-MAX_LINE_CHARS = 400
+MAX_LINE_CHARS = 120
 READ_CHUNK = 65536
 # A stderr "line" with no newline in sight is flushed anyway at this width, so
 # a server printing a single unbounded blob can never grow the monitor's heap.
@@ -62,28 +62,103 @@ _OPAQUE_BLOB = re.compile(
     r"\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{24,}\b"
 )
 
+REDACTED = "<redacted>"
+
+# A traceback frame is the one line whose whole value is a file path: it is
+# kept structurally (path, line number, function) instead of being summarized,
+# because a code location is exactly what a crash report is for.
+_FRAME = re.compile(r'^\s*File "(.*)", line (\d+)(?:, in (.*))?$')
+# The fixed scaffolding Python prints around a traceback: no free text in it.
+_SCAFFOLD = (
+    "Traceback (most recent call last):",
+    "During handling of the above exception, another exception occurred:",
+    "The above exception was the direct cause of the following exception:",
+)
+_FRAME_NAME = re.compile(r"^[A-Za-z0-9_.<>]+$")
+
+# Shapes that are diagnostic by construction and carry no account data: this
+# redactor's own markers, log timestamps, errno/signal names, qualified
+# exception types, the modules a connector traceback can name, the connector's
+# own read-tool names, protocol error constants, and the loopback address.
+_SAFE_SHAPE = (
+    r"<[a-z]+>"
+    r"|\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d{1,6})?"
+    r"|\[Errno \d{1,5}\]"
+    r"|\bSIG[A-Z]{2,}\d*\b"
+    r"|\b(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:Error|Exception|Warning|Exit|Interrupt|Timeout|Cancelled|Abort|Failure)\b"
+    r"|\b(?:telegram_mcp|telethon|mcp|anyio|asyncio|uvicorn|starlette|httpx"
+    r"|httpcore|sqlite3|socket|ssl|builtins|__main__)(?:\.[A-Za-z_][A-Za-z0-9_]*)*\b"
+    r"|\b(?:get|list|search|export|resolve|incoming|wait)_[a-z][a-z_]{1,40}\b"
+    r"|\b[A-Z][A-Z0-9]*(?:[-_][A-Z0-9]+)+\b"
+    r"|\b127\.0\.0\.1(?::\d{1,5})?\b"
+)
+# `<` and `>` are held out of the punctuation run so a marker this redactor
+# already wrote is re-read as one shape instead of being split apart.
+_TOKEN = re.compile(
+    "(" + _SAFE_SHAPE + r")|([A-Za-z0-9_]+)|([ \t]+)|([!-/:;=?@\[-`{-~]+|[<>])|(.)"
+)
+_COLLAPSE = re.compile(r"<redacted>(?:[ \t]*<redacted>)+")
+_TRAILING_SPACE = re.compile(r"[ \t]+$")
+
+
+def _truncate(line):
+    if len(line) > MAX_LINE_CHARS:
+        return line[:MAX_LINE_CHARS] + "…"
+    return line
+
+
+def _summarize(text):
+    """Keep the structured diagnostics; drop every run of free text.
+
+    The vendored runtime puts free-form exception text on stderr, and free-form
+    text is where names, chat titles and message content live — a blacklist can
+    only remove the shapes it already knows. So the summary is built the other
+    way round: an exception class, a signal name, an errno, a protocol error
+    constant and the modules a traceback names survive, punctuation survives
+    (it carries no identity), and every other run collapses into `<redacted>`.
+    """
+    pieces = []
+    for match in _TOKEN.finditer(text):
+        shape, _word, space, punct, _other = match.groups()
+        if shape is not None or space is not None or punct is not None:
+            pieces.append(match.group(0))
+        else:
+            pieces.append(REDACTED)
+    return _TRAILING_SPACE.sub("", _COLLAPSE.sub(REDACTED, "".join(pieces)))
+
 
 def redact_stderr_line(line, secrets=()):
     """One connector stderr line, safe to persist.
 
-    Says what died, never who was being read. Error codes and exception types
-    survive; identifiers, handles, paths, and known credential values do not.
+    Says what died, never who was being read. Error codes, exception types and
+    code locations survive; identifiers, handles, paths, credential values and
+    every run of free text do not.
     """
     out = line
     for secret in secrets:
         if secret and len(secret) >= 8:
-            out = out.replace(secret, "<redacted>")
+            out = out.replace(secret, REDACTED)
     home = os.path.expanduser("~")
     if home and len(home) > 1:
         out = out.replace(home, "~")
     out = _FOREIGN_HOME.sub(r"/\1/<user>", out)
+    if out.strip() in _SCAFFOLD:
+        return out.strip()
+    frame = _FRAME.match(out)
+    if frame is not None:
+        name = frame.group(3)
+        if name is not None and _FRAME_NAME.match(name) is None:
+            name = REDACTED
+        summary = '  File "%s", line %s' % (frame.group(1), frame.group(2))
+        if name is not None:
+            summary += ", in %s" % name
+        return _truncate(summary)
     out = _CONTEXT_KEY.sub(r"\1=<redacted>", out)
     out = _HANDLE.sub("@<user>", out)
     out = _LONG_NUMBER.sub("<id>", out)
-    out = _OPAQUE_BLOB.sub("<redacted>", out)
-    if len(out) > MAX_LINE_CHARS:
-        return out[:MAX_LINE_CHARS] + "…"
-    return out
+    out = _OPAQUE_BLOB.sub(REDACTED, out)
+    return _truncate(_summarize(out))
 
 
 def _known_secrets(env=None):

--- a/evidence/issue-1059/drive.ts
+++ b/evidence/issue-1059/drive.ts
@@ -134,6 +134,7 @@ function payload(over: Partial<TelegramStatusPayload>): TelegramStatusPayload {
     identity: null,
     credentialRef: null,
       credentialsConfigured: true,
+      connectorRestarts: { last24h: 0, lastAt: null },
     lastHealthCheckAt: null,
     error: null,
     ...over,

--- a/src/components/TelegramConnect.dom.test.tsx
+++ b/src/components/TelegramConnect.dom.test.tsx
@@ -45,6 +45,7 @@ function stateFor(
       identity: null,
       credentialRef: null,
       credentialsConfigured: true,
+      connectorRestarts: { last24h: 0, lastAt: null },
       lastHealthCheckAt: null,
       error: null,
       ...status,

--- a/src/components/TelegramConnect.render.test.tsx
+++ b/src/components/TelegramConnect.render.test.tsx
@@ -14,6 +14,7 @@ function stateFor(status: Partial<TelegramStatusPayload>, failure: { code: strin
       identity: null,
       credentialRef: null,
       credentialsConfigured: true,
+      connectorRestarts: { last24h: 0, lastAt: null },
       lastHealthCheckAt: null,
       error: null,
       ...status,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -701,6 +701,7 @@ export const en = {
   "telegram.status.awaiting_password": "Password needed",
   "telegram.status.verifying": "Verifying…",
   "telegram.status.connected": "Connected",
+  "telegram.status.restarting": "Connector restarting…",
   "telegram.status.expired": "Session expired",
   "telegram.status.error": "Error",
   "telegram.connect": "Connect Telegram",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -687,6 +687,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "telegram.status.awaiting_password": "Потрібен пароль",
   "telegram.status.verifying": "Перевірка…",
   "telegram.status.connected": "Підключено",
+  "telegram.status.restarting": "Конектор перезапускається…",
   "telegram.status.expired": "Сесія завершилась",
   "telegram.status.error": "Помилка",
   "telegram.connect": "Підключити Telegram",

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -11,19 +12,30 @@ const OLD_API_HASH = process.env.LLV_TELEGRAM_API_HASH;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_TELEGRAM_API_ID = "12345";
 process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
+/* An ephemeral port claimed for this file alone. The supervisor now talks to
+   the connector before it signals it (the pre-stop drain, #1087), so a test
+   must never be able to reach whatever is listening on the real 8809. */
+process.env.LLV_TELEGRAM_MCP_PORT = String(await new Promise<number>((resolve) => {
+  const probe = net.createServer();
+  probe.listen(0, "127.0.0.1", () => {
+    const port = (probe.address() as net.AddressInfo).port;
+    probe.close(() => resolve(port));
+  });
+}));
 
 const {
   TELEGRAM_READ_TOOL_ALLOWLIST,
   connectorServerName,
   ensureTelegramConnector,
   readTelegramConnectorCrashes,
+  redactConnectorStderrLine,
   stopTelegramConnector,
   telegramConnectorActivity,
   telegramConnectorHealth,
   verifyReadOnlyTools,
 } = await import("./connector");
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
-const { readTelegramSession, saveTelegramSession } = await import("./sessionStore");
+const { readTelegramConnection, readTelegramSession, saveTelegramSession, writeTelegramConnection } = await import("./sessionStore");
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
@@ -87,6 +99,7 @@ afterAll(() => {
   if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE;
   if (OLD_API_ID === undefined) delete process.env.LLV_TELEGRAM_API_ID; else process.env.LLV_TELEGRAM_API_ID = OLD_API_ID;
   if (OLD_API_HASH === undefined) delete process.env.LLV_TELEGRAM_API_HASH; else process.env.LLV_TELEGRAM_API_HASH = OLD_API_HASH;
+  delete process.env.LLV_TELEGRAM_MCP_PORT;
   fs.rmSync(SANDBOX, { recursive: true, force: true });
 });
 
@@ -415,7 +428,12 @@ function connectorScript(name: string, body: string[]): string {
 
 /** Ports that spawn the given script for real and report readiness from a
     marker file, so the supervisor's own process bookkeeping runs unchanged. */
-function realChildPorts(script: string, readyFile: string, overrides: Partial<TelegramConnectorPorts> = {}) {
+function realChildPorts(
+  script: string,
+  readyFile: string,
+  overrides: Partial<TelegramConnectorPorts> = {},
+  options: { adopted?: boolean } = {},
+) {
   const spawns: number[] = [];
   const ports: TelegramConnectorPorts = {
     spawn: (spec) => {
@@ -425,10 +443,18 @@ function realChildPorts(script: string, readyFile: string, overrides: Partial<Te
       const sink = fs.openSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-stderr.log"), "w", 0o600);
       child.stderr?.on("data", (chunk: Buffer) => { try { fs.writeSync(sink, chunk); } catch { /* closed */ } });
       if (child.pid) spawns.push(child.pid);
+      child.on("error", () => undefined);
       return {
         pid: child.pid,
         kill: (signal) => child.kill(signal),
-        onExit: (handler) => { child.once("exit", (code, signal) => handler(code, signal)); },
+        /* `adopted` models the connector a LATER Viewer generation inherits
+           through the pid file: it is a real running process, but this
+           generation never spawned it, so there is no exit event to hear. */
+        ...(options.adopted ? {} : {
+          onExit: (handler: (code: number | null, signal: NodeJS.Signals | null) => void) => {
+            child.once("exit", (code, signal) => handler(code, signal));
+          },
+        }),
       };
     },
     probe: async (_url, connectorToken) => {
@@ -570,15 +596,20 @@ test("a connector this Viewer stopped on purpose is not a crash and is not resta
 test("a connector that cannot stay up stops being restarted after the burst limit", async () => {
   const readyFile = path.join(SANDBOX, "burst-ready");
   fs.rmSync(readyFile, { force: true });
-  /* Five restarts already inside the burst window: the sixth crash records
-     but must not spawn again. */
+  /* Five crashes already inside the burst window: the sixth records but must
+     not spawn again. The limiter counts CRASHES, not the restarts that
+     succeeded — a connector that dies and never comes back has to stop being
+     respawned just as surely as one that comes back and dies again. */
   const now = Date.now();
+  const stamps = Array.from({ length: 5 }, (_, index) => new Date(now - index * 1_000).toISOString());
   fs.writeFileSync(
     path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-restarts.json"),
     JSON.stringify({
       version: 1,
-      restarts: Array.from({ length: 5 }, (_, index) => new Date(now - index * 1_000).toISOString()),
+      restarts: stamps,
+      crashes: stamps,
       lastCrashAt: new Date(now).toISOString(),
+      lastCrashPid: null,
     }),
     { mode: 0o600 },
   );
@@ -641,11 +672,255 @@ test("a connector that cannot prove the account is no health verdict at all", as
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, ownsProcess: () => false })).toBeNull();
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, probe: async () => ({ ok: false }) })).toBeNull();
   /* A connector that accepts the call and then answers nothing must not hold
-     the lifecycle queue open: the health call is bounded like the probe. */
+     the lifecycle queue open: the health call is bounded like the probe. It
+     is reported BUSY rather than dead, though — see the burst test below. */
   const hung = await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     probeTimeoutMs: 20,
     callTool: () => new Promise<string | null>(() => {}),
   });
-  expect(hung).toBeNull();
+  expect(hung).toBe("busy");
 }, 2_000);
+
+test("a crash tail is redacted: no ids, handles, home paths, or credentials reach the log", () => {
+  const secrets = ["1ApWapzMBu4placeholder-not-a-real-session", "A".repeat(43)];
+  const home = os.homedir();
+
+  /* The vendored error helper logs the failing call's own arguments and a
+     traceback whose frames carry absolute paths (see
+     vendor/telegram-mcp/telegram_mcp/runtime.py). A crash record has to say
+     what died, never who was being read. */
+  const context = redactConnectorStderrLine(
+    "ERROR Error in get_messages (chat_id=-1001234567890, query=secret project brief) - Code: MSG-ERR-042",
+    secrets,
+  );
+  expect(context).not.toContain("1001234567890");
+  expect(context).not.toContain("secret project brief");
+  expect(context).toContain("Code: MSG-ERR-042");
+
+  expect(redactConnectorStderrLine(`  File "${home}/.config/agent-log-viewer/state/telegram/x.py", line 5`, secrets))
+    .not.toContain(home);
+  /* A traceback frame from some OTHER account's checkout. The path is
+     assembled rather than written out because the publication gate rejects a
+     literal `/home/<name>/` in tracked source, and the invented placeholder
+     here would trip it exactly like a real one would. */
+  const foreignHome = `/${"home"}/another-account`;
+  expect(redactConnectorStderrLine(`  File "${foreignHome}/telethon/client.py", line 5`, secrets))
+    .not.toContain("another-account");
+  expect(redactConnectorStderrLine("resolved @a_real_handle for +380501234567", secrets))
+    .toBe("resolved @<user> for <id>");
+  for (const secret of secrets) {
+    expect(redactConnectorStderrLine(`session=${secret} refused`, secrets)).not.toContain(secret);
+  }
+
+  /* Still readable as a crash report. */
+  expect(redactConnectorStderrLine("Traceback (most recent call last):", secrets))
+    .toBe("Traceback (most recent call last):");
+  expect(redactConnectorStderrLine("MemoryError", secrets)).toBe("MemoryError");
+});
+
+test("the stderr a crash record quotes is redacted before it is written", async () => {
+  const readyFile = path.join(SANDBOX, "redact-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("redacting-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "console.error('ERROR Error in get_messages (chat_id=-1009876543210) - Code: MSG-ERR-042');",
+    "setTimeout(() => process.exit(4), 40);",
+  ]);
+  const { ports } = realChildPorts(script, readyFile);
+  try {
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    const tail = readTelegramConnectorCrashes()[0]!.stderr.join("\n");
+    expect(tail).toContain("MSG-ERR-042");
+    expect(tail).not.toContain("1009876543210");
+    /* And the on-disk log, not just the parsed view. */
+    const raw = fs.readFileSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-crashes.log"), "utf8");
+    expect(raw).not.toContain("1009876543210");
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+  }
+}, 10_000);
+
+test("an ADOPTED connector's crash is recorded too — the exit nobody was listening to", async () => {
+  const readyFile = path.join(SANDBOX, "adopted-ready");
+  const diedOnce = path.join(SANDBOX, "adopted-died-once");
+  fs.rmSync(readyFile, { force: true });
+  fs.rmSync(diedOnce, { force: true });
+  const script = connectorScript("adopted-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    `if (!fs.existsSync(${JSON.stringify(diedOnce)})) {`,
+    `  fs.writeFileSync(${JSON.stringify(diedOnce)}, '1');`,
+    "  console.error('adopted connector died with nobody listening');",
+    "  setTimeout(() => process.exit(9), 40);",
+    "} else {",
+    "  setInterval(() => undefined, 1000);",
+    "}",
+  ]);
+  /* No exit event, exactly like a connector inherited through the pid file. */
+  const { ports, spawns } = realChildPorts(script, readyFile, {}, { adopted: true });
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
+    /* Nothing could have heard this exit: before the reaper, the record and
+       the counter stayed empty forever and the status said connected. */
+    expect(readTelegramConnectorCrashes()).toHaveLength(0);
+
+    /* The next supervisor pass notices the recorded process is gone. */
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    const crashes = readTelegramConnectorCrashes();
+    expect(crashes).toHaveLength(1);
+    expect(crashes[0]!.pid).toBe(spawns[0]!);
+    expect(crashes[0]!.observed).toBe("vanished");
+    /* Not our child, so the kernel told us nothing about how it went. */
+    expect(crashes[0]!.exitCode).toBeNull();
+    expect(crashes[0]!.signal).toBeNull();
+    expect(crashes[0]!.stderr.join("\n")).toContain("adopted connector died with nobody listening");
+    expect(spawns).toHaveLength(2);
+    expect(telegramConnectorActivity().last24h).toBe(1);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);
+
+test("a respawn that fails is NOT counted as a restart, and the status stops saying connected", async () => {
+  const readyFile = path.join(SANDBOX, "failed-respawn-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("failing-respawn-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "console.error('cannot stay up');",
+    "setTimeout(() => process.exit(2), 40);",
+  ]);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  writeTelegramConnection({
+    version: 1,
+    status: "connected",
+    credentialRef: stored.credentialRef,
+    identity: { name: "Account A", username: "account_a" },
+    lastHealthCheckAt: new Date().toISOString(),
+    errorCode: null,
+  });
+  /* The replacement never becomes ready: the readiness loop runs out on a
+     fake clock instead of holding the test for the real 30 s deadline. */
+  let clock = Date.now();
+  const { ports, spawns } = realChildPorts(script, readyFile, {
+    probe: async () => ({ ok: false }),
+    sleep: async () => { clock += 10_000; },
+    now: () => clock,
+  }, { adopted: true });
+  try {
+    /* First pass: the process starts and dies with nobody listening. */
+    await ensureTelegramConnector(stored, ports);
+    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
+    const result = await ensureTelegramConnector(stored, ports);
+    expect(result.ok).toBe(false);
+    /* The crash is on the record, the restart that never completed is not. */
+    expect(readTelegramConnectorCrashes()).toHaveLength(1);
+    expect(telegramConnectorActivity(clock).last24h).toBe(0);
+    expect(telegramConnectorActivity(clock).restarting).toBe(false);
+    /* And the durable status no longer claims a connector that is not there. */
+    const connection = readTelegramConnection();
+    expect(connection.status).toBe("error");
+    expect(connection.errorCode).toBe("connector_failed");
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);
+
+test("a connector busy with a burst of reads is BUSY, never torn down", async () => {
+  const base: TelegramConnectorPorts = {
+    spawn: () => null,
+    probe: async () => READ_ONLY,
+    sleep: async () => {},
+    now: () => 0,
+    ownsProcess: () => true,
+    probeTimeoutMs: 30,
+  };
+  const calls = { stops: 0 };
+  /* Several bounded reads are still in flight, so `get_me` waits behind them
+     and the health budget runs out. That is a busy connector, not a dead one:
+     a missed deadline says nothing about the account and nothing about the
+     reads, so no verdict is reached and nothing is stopped (#1087). */
+  const inFlight = [0, 1, 2].map(() => new Promise<string | null>(() => {}));
+  const busy = await telegramConnectorHealth(CONNECTOR_SESSION, {
+    ...base,
+    stop: () => { calls.stops += 1; },
+    callTool: () => inFlight[0]!,
+  });
+  expect(busy).toBe("busy");
+  expect(calls.stops).toBe(0);
+
+  /* The same when the handshake itself cannot get a slice of the event loop:
+     a request that timed out was not refused. */
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, {
+    ...base,
+    probe: () => new Promise<ConnectorProbe>(() => {}),
+    callTool: async () => null,
+  })).toBe("busy");
+
+  /* A refusal is still a refusal — the bridge check has to get its chance to
+     classify an expired session, which `get_me` cannot. */
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, {
+    ...base,
+    probe: async () => ({ ok: false }),
+    callTool: async () => null,
+  })).toBeNull();
+  expect(inFlight).toHaveLength(3);
+}, 5_000);
+
+test("a stop asks the connector to drain BEFORE it signals it", async () => {
+  const readyFile = path.join(SANDBOX, "drain-ready");
+  const drainLog = path.join(SANDBOX, "drain-log.json");
+  fs.rmSync(readyFile, { force: true });
+  fs.rmSync(drainLog, { force: true });
+  /* A stand-in connector that serves the loopback port and records what it
+     was asked, in the order it was asked. */
+  const script = connectorScript("drainable-connector", [
+    "import fs from 'node:fs';",
+    "import http from 'node:http';",
+    "const events = [];",
+    `const log = () => fs.writeFileSync(${JSON.stringify(drainLog)}, JSON.stringify(events));`,
+    "process.on('SIGTERM', () => { events.push('sigterm'); log(); process.exit(0); });",
+    "const server = http.createServer((req, res) => {",
+    "  events.push(`${req.method} ${req.url} auth=${req.headers.authorization ? 'yes' : 'no'}`);",
+    "  log();",
+    "  res.writeHead(200, { 'content-type': 'application/json' });",
+    "  res.end('{\"draining\": true}');",
+    "});",
+    "server.listen(Number(process.env.MCP_PORT), '127.0.0.1', () => {",
+    `  fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "});",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    await stopTelegramConnector();
+    const events = JSON.parse(fs.readFileSync(drainLog, "utf8")) as string[];
+    /* The drain arrives first, authenticated, so a call in flight is answered
+       with the named error while the process is still alive — the SIGTERM (and
+       the SIGKILL escalation behind it) can no longer be what a caller meets. */
+    expect(events[0]).toBe("POST /llv-telegram-drain auth=yes");
+    expect(events).toContain("sigterm");
+    expect(events.indexOf("sigterm")).toBeGreaterThan(0);
+    /* A deliberate stop is still not a crash. */
+    expect(readTelegramConnectorCrashes()).toHaveLength(0);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 15_000);

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -12,8 +12,18 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_TELEGRAM_API_ID = "12345";
 process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
 
-const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
+const {
+  TELEGRAM_READ_TOOL_ALLOWLIST,
+  connectorServerName,
+  ensureTelegramConnector,
+  readTelegramConnectorCrashes,
+  stopTelegramConnector,
+  telegramConnectorActivity,
+  telegramConnectorHealth,
+  verifyReadOnlyTools,
+} = await import("./connector");
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
+const { readTelegramSession, saveTelegramSession } = await import("./sessionStore");
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
@@ -388,3 +398,254 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     }
   }
 }, 5_000);
+
+/* ----------------------------------------------------------------- #1087
+   Crash visibility. Before this, the connector's stderr went to /dev/null and
+   an exit left no record at all: the operator saw "connected" throughout a
+   ~20 s outage. These tests use a REAL child process (a node script standing
+   in for the packaged python server) so the exit code, the signal and the
+   stderr tail are the ones the kernel actually delivered.
+   --------------------------------------------------------------------- */
+
+function connectorScript(name: string, body: string[]): string {
+  const script = path.join(SANDBOX, `${name}.mjs`);
+  fs.writeFileSync(script, [...body, ""].join("\n"));
+  return script;
+}
+
+/** Ports that spawn the given script for real and report readiness from a
+    marker file, so the supervisor's own process bookkeeping runs unchanged. */
+function realChildPorts(script: string, readyFile: string, overrides: Partial<TelegramConnectorPorts> = {}) {
+  const spawns: number[] = [];
+  const ports: TelegramConnectorPorts = {
+    spawn: (spec) => {
+      const child = spawn(spec.command, spec.args, { cwd: spec.cwd, env: spec.env, stdio: ["ignore", "ignore", "pipe"] });
+      /* The real port writes stderr into the owner-only sink; here the test
+         owns the pipe and forwards it to the same file the supervisor reads. */
+      const sink = fs.openSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-stderr.log"), "w", 0o600);
+      child.stderr?.on("data", (chunk: Buffer) => { try { fs.writeSync(sink, chunk); } catch { /* closed */ } });
+      if (child.pid) spawns.push(child.pid);
+      return {
+        pid: child.pid,
+        kill: (signal) => child.kill(signal),
+        onExit: (handler) => { child.once("exit", (code, signal) => handler(code, signal)); },
+      };
+    },
+    probe: async (_url, connectorToken) => {
+      const deadline = Date.now() + 3_000;
+      while (!fs.existsSync(readyFile) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+      return fs.existsSync(readyFile) ? { ...READ_ONLY, serverName: connectorServerName(connectorToken) } : { ok: false };
+    },
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    now: () => Date.now(),
+    ownsProcess: () => false,
+    restartDelayMs: 10,
+    ...overrides,
+  };
+  process.env.LLV_TELEGRAM_PYTHON = process.execPath;
+  process.env.LLV_TELEGRAM_SERVER_BRIDGE = script;
+  return { ports, spawns };
+}
+
+async function until(condition: () => boolean, timeoutMs = 4_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+test("a connector that dies on its own is recorded: exit code, and the stderr nobody could read before", async () => {
+  const readyFile = path.join(SANDBOX, "crash-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("crashing-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "console.error('Telegram client(s) started (default). Running MCP server (http)...');",
+    "console.error('Error starting client: session lock refused');",
+    "setTimeout(() => process.exit(7), 40);",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  try {
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    const crashes = readTelegramConnectorCrashes();
+    expect(crashes).toHaveLength(1);
+    expect(crashes[0]!.pid).toBe(spawns[0]!);
+    expect(crashes[0]!.exitCode).toBe(7);
+    expect(crashes[0]!.signal).toBeNull();
+    expect(crashes[0]!.stderr).toContain("Error starting client: session lock refused");
+    expect(Date.parse(crashes[0]!.at)).toBeGreaterThan(0);
+    /* No stored session to restart for: the crash is still recorded, and a
+       restart that never happened is not counted. */
+    expect(telegramConnectorActivity().last24h).toBe(0);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+  }
+}, 10_000);
+
+test("the crash log and the restart counter are owner-only files under the telegram state dir", async () => {
+  const readyFile = path.join(SANDBOX, "modes-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("mode-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "console.error('boom');",
+    "setTimeout(() => process.exit(3), 30);",
+  ]);
+  const { ports } = realChildPorts(script, readyFile);
+  try {
+    await ensureTelegramConnector(CONNECTOR_SESSION, ports);
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    for (const file of ["connector-crashes.log", "connector-stderr.log"]) {
+      const stat = fs.lstatSync(path.join(process.env.LLV_STATE_DIR!, "telegram", file));
+      expect(stat.isFile()).toBe(true);
+      expect(stat.mode & 0o077).toBe(0);
+    }
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+  }
+}, 10_000);
+
+test("a crash restarts the connector for the SAME stored credential, and the restart is counted", async () => {
+  const readyFile = path.join(SANDBOX, "restart-ready");
+  const crashOnce = path.join(SANDBOX, "restart-crashed-once");
+  fs.rmSync(readyFile, { force: true });
+  fs.rmSync(crashOnce, { force: true });
+  const script = connectorScript("restarting-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    `if (!fs.existsSync(${JSON.stringify(crashOnce)})) {`,
+    `  fs.writeFileSync(${JSON.stringify(crashOnce)}, '1');`,
+    "  console.error('first process dies');",
+    "  setTimeout(() => process.exit(1), 30);",
+    "} else {",
+    "  setInterval(() => undefined, 1000);",
+    "}",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    await until(() => spawns.length === 2);
+    expect(spawns).toHaveLength(2);
+    expect(spawns[1]).not.toBe(spawns[0]);
+    await until(() => telegramConnectorActivity().restarting === false);
+    const activity = telegramConnectorActivity();
+    expect(activity.last24h).toBe(1);
+    expect(Date.parse(activity.lastAt!)).toBeGreaterThan(0);
+    expect(readTelegramConnectorCrashes()).toHaveLength(1);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 15_000);
+
+test("a connector this Viewer stopped on purpose is not a crash and is not restarted", async () => {
+  const readyFile = path.join(SANDBOX, "stopped-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("stopped-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "setInterval(() => undefined, 1000);",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  try {
+    expect((await ensureTelegramConnector(readTelegramSession()!, ports)).ok).toBe(true);
+    await stopTelegramConnector();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(readTelegramConnectorCrashes()).toHaveLength(0);
+    expect(telegramConnectorActivity().last24h).toBe(0);
+    expect(spawns).toHaveLength(1);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 10_000);
+
+test("a connector that cannot stay up stops being restarted after the burst limit", async () => {
+  const readyFile = path.join(SANDBOX, "burst-ready");
+  fs.rmSync(readyFile, { force: true });
+  /* Five restarts already inside the burst window: the sixth crash records
+     but must not spawn again. */
+  const now = Date.now();
+  fs.writeFileSync(
+    path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-restarts.json"),
+    JSON.stringify({
+      version: 1,
+      restarts: Array.from({ length: 5 }, (_, index) => new Date(now - index * 1_000).toISOString()),
+      lastCrashAt: new Date(now).toISOString(),
+    }),
+    { mode: 0o600 },
+  );
+  const script = connectorScript("burst-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "console.error('crash loop');",
+    "setTimeout(() => process.exit(1), 30);",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  try {
+    await ensureTelegramConnector(readTelegramSession()!, ports);
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(spawns).toHaveLength(1);
+    expect(telegramConnectorActivity().last24h).toBe(5);
+    expect(telegramConnectorActivity().restarting).toBe(false);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+  }
+}, 10_000);
+
+test("health comes from the RUNNING connector, so a healthy account costs no teardown", async () => {
+  const calls = { stops: 0, tools: [] as string[] };
+  const health = await telegramConnectorHealth(CONNECTOR_SESSION, {
+    spawn: () => null,
+    probe: async () => READ_ONLY,
+    sleep: async () => {},
+    now: () => 0,
+    ownsProcess: () => true,
+    stop: () => { calls.stops += 1; },
+    callTool: async (_url, _token, tool) => {
+      calls.tools.push(tool);
+      /* The vendored get_me shape; the phone field it can carry must not
+         travel any further than this parse. */
+      return JSON.stringify({ id: 777, name: "Account A", type: "user", username: "account_a", phone: "0000000000" });
+    },
+  });
+  expect(health).toEqual({ status: "connected", identity: { name: "Account A", username: "account_a" } });
+  expect(JSON.stringify(health)).not.toContain("0000000000");
+  expect(calls.tools).toEqual(["get_me"]);
+  expect(calls.stops).toBe(0);
+});
+
+test("a connector that cannot prove the account is no health verdict at all", async () => {
+  const base: TelegramConnectorPorts = {
+    spawn: () => null,
+    probe: async () => READ_ONLY,
+    sleep: async () => {},
+    now: () => 0,
+    ownsProcess: () => true,
+    callTool: async () => "An error occurred (code: GEN-ERR-001). Check mcp_errors.log for details.",
+  };
+  /* A tool error, a dead call, and a connector that is not ours all mean the
+     same thing: fall back to the bridge check, never guess. */
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, base)).toBeNull();
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, callTool: async () => null })).toBeNull();
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, ownsProcess: () => false })).toBeNull();
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, probe: async () => ({ ok: false }) })).toBeNull();
+  /* A connector that accepts the call and then answers nothing must not hold
+     the lifecycle queue open: the health call is bounded like the probe. */
+  const hung = await telegramConnectorHealth(CONNECTOR_SESSION, {
+    ...base,
+    probeTimeoutMs: 20,
+    callTool: () => new Promise<string | null>(() => {}),
+  });
+  expect(hung).toBeNull();
+}, 2_000);

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -25,6 +25,7 @@ process.env.LLV_TELEGRAM_MCP_PORT = String(await new Promise<number>((resolve) =
 
 const {
   TELEGRAM_READ_TOOL_ALLOWLIST,
+  callTelegramConnectorTool,
   connectorServerName,
   ensureTelegramConnector,
   readTelegramConnectorCrashes,
@@ -38,7 +39,7 @@ const {
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
 const { readTelegramConnection, readTelegramSession, saveTelegramSession, writeTelegramConnection } = await import("./sessionStore");
 
-import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
+import type { ConnectorCallResult, ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
 /* A placeholder with the string-session shape; never a real credential. */
 const PLACEHOLDER_SESSION = "1ApWapzMBu4placeholder-not-a-real-session";
@@ -486,7 +487,7 @@ test("a connector that dies on its own is recorded: exit code, and the stderr no
     "import fs from 'node:fs';",
     `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
     "console.error('Telegram client(s) started (default). Running MCP server (http)...');",
-    "console.error('Error starting client: session lock refused');",
+    "console.error('SessionLockError: the vendored per-session lock refused');",
     "setTimeout(() => process.exit(7), 40);",
   ]);
   const { ports, spawns } = realChildPorts(script, readyFile);
@@ -498,7 +499,7 @@ test("a connector that dies on its own is recorded: exit code, and the stderr no
     expect(crashes[0]!.pid).toBe(spawns[0]!);
     expect(crashes[0]!.exitCode).toBe(7);
     expect(crashes[0]!.signal).toBeNull();
-    expect(crashes[0]!.stderr).toContain("Error starting client: session lock refused");
+    expect(crashes[0]!.stderr.join("\n")).toContain("SessionLockError");
     expect(Date.parse(crashes[0]!.at)).toBeGreaterThan(0);
     /* No stored session to restart for: the crash is still recorded, and a
        restart that never happened is not counted. */
@@ -648,7 +649,7 @@ test("health comes from the RUNNING connector, so a healthy account costs no tea
       calls.tools.push(tool);
       /* The vendored get_me shape; the phone field it can carry must not
          travel any further than this parse. */
-      return JSON.stringify({ id: 777, name: "Account A", type: "user", username: "account_a", phone: "0000000000" });
+      return { ok: true, text: JSON.stringify({ id: 777, name: "Account A", type: "user", username: "account_a", phone: "0000000000" }) };
     },
   });
   expect(health).toEqual({ status: "connected", identity: { name: "Account A", username: "account_a" } });
@@ -664,12 +665,12 @@ test("a connector that cannot prove the account is no health verdict at all", as
     sleep: async () => {},
     now: () => 0,
     ownsProcess: () => true,
-    callTool: async () => "An error occurred (code: GEN-ERR-001). Check mcp_errors.log for details.",
+    callTool: async () => ({ ok: true, text: "An error occurred (code: GEN-ERR-001). Check mcp_errors.log for details." }),
   };
   /* A tool error, a dead call, and a connector that is not ours all mean the
      same thing: fall back to the bridge check, never guess. */
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, base)).toBeNull();
-  expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, callTool: async () => null })).toBeNull();
+  expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, callTool: async () => ({ ok: false, code: "call_failed" }) })).toBeNull();
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, ownsProcess: () => false })).toBeNull();
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, { ...base, probe: async () => ({ ok: false }) })).toBeNull();
   /* A connector that accepts the call and then answers nothing must not hold
@@ -678,7 +679,7 @@ test("a connector that cannot prove the account is no health verdict at all", as
   const hung = await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     probeTimeoutMs: 20,
-    callTool: () => new Promise<string | null>(() => {}),
+    callTool: () => new Promise<ConnectorCallResult>(() => {}),
   });
   expect(hung).toBe("busy");
 }, 2_000);
@@ -697,7 +698,7 @@ test("a crash tail is redacted: no ids, handles, home paths, or credentials reac
   );
   expect(context).not.toContain("1001234567890");
   expect(context).not.toContain("secret project brief");
-  expect(context).toContain("Code: MSG-ERR-042");
+  expect(context).toContain("MSG-ERR-042");
 
   expect(redactConnectorStderrLine(`  File "${home}/.config/agent-log-viewer/state/telegram/x.py", line 5`, secrets))
     .not.toContain(home);
@@ -709,7 +710,7 @@ test("a crash tail is redacted: no ids, handles, home paths, or credentials reac
   expect(redactConnectorStderrLine(`  File "${foreignHome}/telethon/client.py", line 5`, secrets))
     .not.toContain("another-account");
   expect(redactConnectorStderrLine("resolved @a_real_handle for +380501234567", secrets))
-    .toBe("resolved @<user> for <id>");
+    .toBe("<redacted> @<user> <redacted> <id>");
   for (const secret of secrets) {
     expect(redactConnectorStderrLine(`session=${secret} refused`, secrets)).not.toContain(secret);
   }
@@ -745,44 +746,139 @@ test("the stderr a crash record quotes is redacted before it is written", async 
   }
 }, 10_000);
 
-test("an ADOPTED connector's crash is recorded too — the exit nobody was listening to", async () => {
-  const readyFile = path.join(SANDBOX, "adopted-ready");
-  const diedOnce = path.join(SANDBOX, "adopted-died-once");
+test("free-form crash text is not a diagnostic: no name, title or message reaches the crash log (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "identity-ready");
   fs.rmSync(readyFile, { force: true });
-  fs.rmSync(diedOnce, { force: true });
-  const script = connectorScript("adopted-connector", [
+  /* The lines a real failure leaves: the vendored runtime re-raises with
+     whatever Telethon said, and an exception message is free text. The test
+     harness forwards the child's stderr RAW — in production the crash monitor
+     has already redacted it — so what the crash log keeps here is what the
+     Viewer-side redactor alone can defend. */
+  const leaks = [
+    "ValueError: No user has Alice Example as username",
+    "RuntimeError: could not read \"Демо Проєкт\" for Олена Приклад",
+    "telegram_mcp.runtime: last message text was 'send the documents tomorrow'",
+  ];
+  const script = connectorScript("identity-leaking-connector", [
     "import fs from 'node:fs';",
     `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
-    `if (!fs.existsSync(${JSON.stringify(diedOnce)})) {`,
-    `  fs.writeFileSync(${JSON.stringify(diedOnce)}, '1');`,
-    "  console.error('adopted connector died with nobody listening');",
-    "  setTimeout(() => process.exit(9), 40);",
-    "} else {",
-    "  setInterval(() => undefined, 1000);",
-    "}",
+    "console.error('Traceback (most recent call last):');",
+    ...leaks.map((line) => `console.error(${JSON.stringify(line)});`),
+    "setTimeout(() => process.exit(6), 40);",
   ]);
-  /* No exit event, exactly like a connector inherited through the pid file. */
-  const { ports, spawns } = realChildPorts(script, readyFile, {}, { adopted: true });
-  saveTelegramSession(PLACEHOLDER_SESSION);
-  const stored = readTelegramSession()!;
+  const { ports } = realChildPorts(script, readyFile);
   try {
-    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
-    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
-    /* Nothing could have heard this exit: before the reaper, the record and
-       the counter stayed empty forever and the status said connected. */
-    expect(readTelegramConnectorCrashes()).toHaveLength(0);
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    const raw = fs.readFileSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-crashes.log"), "utf8");
+    const tail = readTelegramConnectorCrashes()[0]!.stderr.join("\n");
+    for (const identity of ["Alice", "Example", "Демо", "Проєкт", "Олена", "Приклад", "documents", "tomorrow"]) {
+      expect(raw).not.toContain(identity);
+      expect(tail).not.toContain(identity);
+    }
+    /* Still a crash report: the shape of the failure and the types that
+       produced it survive. */
+    expect(tail).toContain("Traceback (most recent call last):");
+    expect(tail).toContain("ValueError");
+    expect(tail).toContain("RuntimeError");
+    expect(tail).toContain("telegram_mcp.runtime");
+    expect(readTelegramConnectorCrashes()[0]!.exitCode).toBe(6);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+  }
+}, 10_000);
 
-    /* The next supervisor pass notices the recorded process is gone. */
-    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+test("a connector from before the crash monitor stays adoptable, and its crash says why it has no exit status (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "legacy-ready");
+  fs.rmSync(readyFile, { force: true });
+  const script = connectorScript("legacy-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "setInterval(() => undefined, 1000);",
+  ]);
+  const recordPath = path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json");
+  /* Ownership follows the durable record and the process behind it, the way
+     the real check does, and there is no exit event: a connector inherited
+     through the pid file. */
+  const ownsProcess = () => {
+    if (!fs.existsSync(recordPath)) return false;
+    const { pid } = JSON.parse(fs.readFileSync(recordPath, "utf8")) as { pid: number };
+    try { process.kill(pid, 0); return true; } catch { return false; }
+  };
+  const { ports, spawns } = realChildPorts(script, readyFile, { ownsProcess }, { adopted: true });
+  const readRecord = () => JSON.parse(fs.readFileSync(recordPath, "utf8")) as { pid: number; supervision?: string };
+  try {
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
+    expect(spawns).toHaveLength(1);
+    expect(readRecord().supervision).toBe("monitored");
+
+    /* A record written before the monitor existed. The connector behind it is
+       serving reads, and replacing it to fix the bookkeeping would drop
+       exactly the calls this issue is about — so it is adopted unchanged. */
+    const legacy = readRecord() as Record<string, unknown>;
+    delete legacy.supervision;
+    fs.writeFileSync(recordPath, JSON.stringify(legacy), { mode: 0o600 });
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
+    expect(spawns).toHaveLength(1);
+
+    /* When it does die, the crash is still recorded — and it says why the
+       exit status is unknowable instead of leaving a silent gap. */
+    process.kill(spawns[0]!, "SIGKILL");
+    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
+    expect((await ensureTelegramConnector(CONNECTOR_SESSION, ports)).ok).toBe(true);
     const crashes = readTelegramConnectorCrashes();
     expect(crashes).toHaveLength(1);
     expect(crashes[0]!.pid).toBe(spawns[0]!);
     expect(crashes[0]!.observed).toBe("vanished");
-    /* Not our child, so the kernel told us nothing about how it went. */
+    expect(crashes[0]!.supervision).toBe("legacy");
     expect(crashes[0]!.exitCode).toBeNull();
     expect(crashes[0]!.signal).toBeNull();
-    expect(crashes[0]!.stderr.join("\n")).toContain("adopted connector died with nobody listening");
+    /* And what replaced it is monitored, so the next death has a signal. */
     expect(spawns).toHaveLength(2);
+    expect(readRecord().supervision).toBe("monitored");
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);
+
+test("a call dropped by a respawn fails with a code that names the restart (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "dropped-call-ready");
+  const heldFile = path.join(SANDBOX, "dropped-call-held");
+  for (const file of [readyFile, heldFile]) fs.rmSync(file, { force: true });
+  /* A connector that accepts a read on the real loopback port and then holds
+     it, exactly like a `get_messages` waiting on Telegram. */
+  const script = connectorScript("dropped-call-connector", [
+    "import fs from 'node:fs';",
+    "import net from 'node:net';",
+    `const server = net.createServer(() => { fs.writeFileSync(${JSON.stringify(heldFile)}, 'held'); });`,
+    "server.listen(Number(process.env.MCP_PORT), '127.0.0.1', () => {",
+    `  fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "});",
+  ]);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    const held = callTelegramConnectorTool(telegramMcpUrl(), stored.connectorToken, "get_messages");
+    await until(() => fs.existsSync(heldFile));
+
+    /* The death a fan-out of large reads invites: no process, no event loop
+       and no socket left for the connector to answer on. The caller still
+       gets a named failure rather than something it cannot tell from a
+       network blip, because the Viewer knows the process it was talking to
+       is gone. */
+    process.kill(spawns[0]!, "SIGKILL");
+    expect(await held).toEqual({ ok: false, code: "connector_restarting" });
+
+    /* And the same event is on the record and in the status the panel reads. */
+    await until(() => readTelegramConnectorCrashes().length > 0);
+    expect(readTelegramConnectorCrashes()[0]!.signal).toBe("SIGKILL");
+    await until(() => telegramConnectorActivity().last24h > 0);
     expect(telegramConnectorActivity().last24h).toBe(1);
   } finally {
     delete process.env.LLV_TELEGRAM_PYTHON;
@@ -859,7 +955,7 @@ test("a connector busy with a burst of reads is BUSY, never torn down", async ()
   const busy = await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     stop: () => { calls.stops += 1; },
-    callTool: () => new Promise<string | null>(() => {}),
+    callTool: () => new Promise<ConnectorCallResult>(() => {}),
   });
   expect(busy).toBe("busy");
   expect(calls.stops).toBe(0);
@@ -869,7 +965,7 @@ test("a connector busy with a burst of reads is BUSY, never torn down", async ()
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     probe: () => new Promise<ConnectorProbe>(() => {}),
-    callTool: async () => null,
+    callTool: async () => ({ ok: false, code: "call_failed" as const }),
   })).toBe("busy");
 
   /* A refusal is still a refusal — the bridge check has to get its chance to
@@ -877,7 +973,7 @@ test("a connector busy with a burst of reads is BUSY, never torn down", async ()
   expect(await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     probe: async () => ({ ok: false }),
-    callTool: async () => null,
+    callTool: async () => ({ ok: false, code: "call_failed" as const }),
   })).toBeNull();
 }, 5_000);
 
@@ -988,7 +1084,7 @@ test("a crash reaped before the health path deletes the pid record is still coun
     `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
     `if (!fs.existsSync(${JSON.stringify(diedOnce)})) {`,
     `  fs.writeFileSync(${JSON.stringify(diedOnce)}, '1');`,
-    "  console.error('gone before anyone asked');",
+    "  console.error('ReapedConnectorError: gone before the health check asked');",
     "  setTimeout(() => process.exit(5), 40);",
     "} else {",
     "  setInterval(() => undefined, 1000);",
@@ -1009,7 +1105,7 @@ test("a crash reaped before the health path deletes the pid record is still coun
     await stopTelegramConnector();
     expect(fs.existsSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json"))).toBe(false);
     expect(readTelegramConnectorCrashes()).toHaveLength(1);
-    expect(readTelegramConnectorCrashes()[0]!.stderr.join("\n")).toContain("gone before anyone asked");
+    expect(readTelegramConnectorCrashes()[0]!.stderr.join("\n")).toContain("ReapedConnectorError");
 
     /* The pointer is gone, but the crash on the record still makes this the
        restart it is: counted once, and only because the replacement verified. */
@@ -1060,7 +1156,7 @@ test("a real process serving concurrent bounded reads survives a fresh health ch
       ...ports,
       ownsProcess: () => true,
       probeTimeoutMs: 60,
-      callTool: () => new Promise<string | null>(() => {}),
+      callTool: () => new Promise<ConnectorCallResult>(() => {}),
     });
     expect(health).toBe("busy");
 

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -28,6 +28,7 @@ const {
   connectorServerName,
   ensureTelegramConnector,
   readTelegramConnectorCrashes,
+  reapTelegramConnectorCrash,
   redactConnectorStderrLine,
   stopTelegramConnector,
   telegramConnectorActivity,
@@ -924,3 +925,158 @@ test("a stop asks the connector to drain BEFORE it signals it", async () => {
     for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
   }
 }, 15_000);
+
+test("an adopted connector's crash carries the exit status its monitor recorded (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "monitored-ready");
+  const diedOnce = path.join(SANDBOX, "monitored-died-once");
+  fs.rmSync(readyFile, { force: true });
+  fs.rmSync(diedOnce, { force: true });
+  const exitFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "connector-exit.json");
+  /* Stands in for `bin/telegram_connector_monitor.py`, whose own fork, wait,
+     and redaction are driven for real in packaging.test.ts. What is under test
+     here is the supervisor side: an exit NOBODY in this Viewer generation
+     could have heard is still recorded with the code or signal the monitor
+     wrote down, instead of two nulls. */
+  const script = connectorScript("monitored-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    `if (!fs.existsSync(${JSON.stringify(diedOnce)})) {`,
+    `  fs.writeFileSync(${JSON.stringify(diedOnce)}, '1');`,
+    "  console.error('killed while serving a fan-out of large reads');",
+    "  setTimeout(() => {",
+    `    fs.writeFileSync(${JSON.stringify(exitFile)}, JSON.stringify({`,
+    "      version: 1, monitorPid: process.pid, pid: process.pid + 1, exitCode: null,",
+    "      signal: 'SIGKILL', at: new Date().toISOString(),",
+    "    }), { mode: 0o600 });",
+    "    process.exit(0);",
+    "  }, 40);",
+    "} else {",
+    "  setInterval(() => undefined, 1000);",
+    "}",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile, {}, { adopted: true });
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    const crashes = readTelegramConnectorCrashes();
+    expect(crashes).toHaveLength(1);
+    expect(crashes[0]!.pid).toBe(spawns[0]!);
+    /* The OOM-kill signature the issue's repro would produce: no traceback,
+       no exit code, and now a named signal instead of silence. */
+    expect(crashes[0]!.signal).toBe("SIGKILL");
+    expect(crashes[0]!.exitCode).toBeNull();
+    expect(crashes[0]!.observed).toBe("exit");
+    expect(telegramConnectorActivity().last24h).toBe(1);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);
+
+test("a crash reaped before the health path deletes the pid record is still counted as a restart (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "reap-first-ready");
+  const diedOnce = path.join(SANDBOX, "reap-first-died-once");
+  fs.rmSync(readyFile, { force: true });
+  fs.rmSync(diedOnce, { force: true });
+  const script = connectorScript("reap-first-connector", [
+    "import fs from 'node:fs';",
+    `fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    `if (!fs.existsSync(${JSON.stringify(diedOnce)})) {`,
+    `  fs.writeFileSync(${JSON.stringify(diedOnce)}, '1');`,
+    "  console.error('gone before anyone asked');",
+    "  setTimeout(() => process.exit(5), 40);",
+    "} else {",
+    "  setInterval(() => undefined, 1000);",
+    "}",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile, {}, { adopted: true });
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    await until(() => { try { process.kill(spawns[0]!, 0); return false; } catch { return true; } });
+
+    /* The health path in miniature: it reaps, and then its teardown removes
+       the pid record — the only pointer to the process that died. Before the
+       reap ran first, the crash was erased with it and the restart that
+       followed was counted as an ordinary start (#1087). */
+    expect(reapTelegramConnectorCrash(stored, ports)).toBe(true);
+    await stopTelegramConnector();
+    expect(fs.existsSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json"))).toBe(false);
+    expect(readTelegramConnectorCrashes()).toHaveLength(1);
+    expect(readTelegramConnectorCrashes()[0]!.stderr.join("\n")).toContain("gone before anyone asked");
+
+    /* The pointer is gone, but the crash on the record still makes this the
+       restart it is: counted once, and only because the replacement verified. */
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    expect(spawns).toHaveLength(2);
+    expect(telegramConnectorActivity().last24h).toBe(1);
+    expect(telegramConnectorActivity().restarting).toBe(false);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);
+
+test("a real process serving concurrent bounded reads survives a fresh health check (#1087)", async () => {
+  const readyFile = path.join(SANDBOX, "concurrent-ready");
+  fs.rmSync(readyFile, { force: true });
+  /* A connector that takes its time over a read, exactly like a 120-message
+     page against a large supergroup. Three of them are held open across the
+     health check the panel issues when it opens — the burst from the issue's
+     repro, which used to be answered with SIGTERM. */
+  const script = connectorScript("concurrent-connector", [
+    "import fs from 'node:fs';",
+    "import http from 'node:http';",
+    "let served = 0;",
+    "const server = http.createServer((req, res) => {",
+    "  setTimeout(() => {",
+    "    served += 1;",
+    "    res.writeHead(200, { 'content-type': 'text/plain' });",
+    "    res.end(`read ${served} done`);",
+    "  }, 250);",
+    "});",
+    "server.listen(Number(process.env.MCP_PORT), '127.0.0.1', () => {",
+    `  fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');`,
+    "});",
+  ]);
+  const { ports, spawns } = realChildPorts(script, readyFile);
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  try {
+    expect((await ensureTelegramConnector(stored, ports)).ok).toBe(true);
+    const url = telegramMcpUrl();
+    const reads = [1, 2, 3].map(() => fetch(url).then((response) => response.text()));
+
+    /* `get_me` queues behind the burst and never lands inside the budget. */
+    const health = await telegramConnectorHealth(stored, {
+      ...ports,
+      ownsProcess: () => true,
+      probeTimeoutMs: 60,
+      callTool: () => new Promise<string | null>(() => {}),
+    });
+    expect(health).toBe("busy");
+
+    /* The process the reads belong to is still there, and every one of them
+       comes back — the outage this issue reports cannot happen from here. */
+    expect(() => process.kill(spawns[0]!, 0)).not.toThrow();
+    const answers = await Promise.all(reads);
+    expect(answers).toHaveLength(3);
+    for (const answer of answers) expect(answer).toContain("done");
+    expect(spawns).toHaveLength(1);
+    expect(readTelegramConnectorCrashes()).toHaveLength(0);
+    expect(telegramConnectorActivity().last24h).toBe(0);
+  } finally {
+    delete process.env.LLV_TELEGRAM_PYTHON;
+    delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
+    await stopTelegramConnector();
+    for (const pid of spawns) { try { process.kill(pid, "SIGKILL"); } catch { /* gone */ } }
+  }
+}, 20_000);

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -850,15 +850,16 @@ test("a connector busy with a burst of reads is BUSY, never torn down", async ()
     probeTimeoutMs: 30,
   };
   const calls = { stops: 0 };
-  /* Several bounded reads are still in flight, so `get_me` waits behind them
-     and the health budget runs out. That is a busy connector, not a dead one:
-     a missed deadline says nothing about the account and nothing about the
-     reads, so no verdict is reached and nothing is stopped (#1087). */
-  const inFlight = [0, 1, 2].map(() => new Promise<string | null>(() => {}));
+  /* The three classifications, at the unit level. `get_me` waiting behind
+     reads that are still in flight is a busy connector, not a dead one: a
+     missed deadline says nothing about the account and nothing about the
+     reads, so no verdict is reached and nothing is stopped (#1087). The same
+     guarantee against a real process holding real concurrent reads open is
+     asserted further down. */
   const busy = await telegramConnectorHealth(CONNECTOR_SESSION, {
     ...base,
     stop: () => { calls.stops += 1; },
-    callTool: () => inFlight[0]!,
+    callTool: () => new Promise<string | null>(() => {}),
   });
   expect(busy).toBe("busy");
   expect(calls.stops).toBe(0);
@@ -878,7 +879,6 @@ test("a connector busy with a burst of reads is BUSY, never torn down", async ()
     probe: async () => ({ ok: false }),
     callTool: async () => null,
   })).toBeNull();
-  expect(inFlight).toHaveLength(3);
 }, 5_000);
 
 test("a stop asks the connector to drain BEFORE it signals it", async () => {

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
@@ -8,7 +9,7 @@ import { withFileTransaction } from "@/lib/state/fileTransaction";
 
 import type { TelegramConnectorRestarts, TelegramErrorCode, TelegramIdentity } from "./contracts";
 import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
-import { ensureTelegramStateDir, readTelegramSession, type StoredTelegramSession } from "./sessionStore";
+import { ensureTelegramStateDir, readTelegramConnection, readTelegramSession, writeTelegramConnection, type StoredTelegramSession } from "./sessionStore";
 
 /**
  * Supervisor for the ONE shared loopback connector process (issue #1059).
@@ -116,6 +117,7 @@ const CRASH_LOG_FILE = "connector-crashes.log";
 const RESTART_STATE_FILE = "connector-restarts.json";
 const STDERR_TAIL_LINES = 20;
 const STDERR_TAIL_BYTES = 8_192;
+const STDERR_LINE_CHARS = 400;
 const CRASH_LOG_KEEP_LINES = 50;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 /* A crashing connector is restarted, but never in a hot loop: more than
@@ -124,6 +126,11 @@ const DAY_MS = 24 * 60 * 60 * 1_000;
 const RESTART_BURST_WINDOW_MS = 15 * 60 * 1_000;
 const RESTART_BURST_LIMIT = 5;
 const RESTART_DELAY_MS = 500;
+/* The supervisor asks the connector to drain before it signals it, so an
+   in-flight call is answered with a named error rather than cut short. A
+   connector that cannot be asked inside this budget is signaled anyway. */
+const DRAIN_PATH = "/llv-telegram-drain";
+const DRAIN_TIMEOUT_MS = 1_500;
 /* The non-destructive health check gets a longer budget than a readiness
    probe: a connector busy with a fan-out of large reads is healthy, and
    timing it out here would tear down exactly the process this change set out
@@ -288,9 +295,47 @@ function openConnectorStderrSink(): number | null {
   }
 }
 
-/** The last lines the connector printed before it died. Bounded twice (bytes
-    read, then lines kept) so a runaway log can never be loaded whole. */
-function connectorStderrTail(): string[] {
+/**
+ * Redacts one connector stderr line before it is persisted.
+ *
+ * The crash log is Viewer-owned and owner-only, but it is still a durable
+ * copy of upstream output, and that output is not innocent: the vendored
+ * error helper logs the failing call's arguments verbatim
+ * (`Error in <fn> (chat_id=…, query=…)`, see
+ * `vendor/telegram-mcp/telegram_mcp/runtime.py`) and attaches a traceback
+ * whose frames carry absolute paths under the operator's home. A crash
+ * record has to say what died, never who was being read (#1087).
+ *
+ * `secrets` carries the values this Viewer already knows are credentials —
+ * the connector bearer token and the Telegram string session — so an exact
+ * echo of either is removed by value rather than by pattern.
+ */
+export function redactConnectorStderrLine(line: string, secrets: readonly string[] = []): string {
+  let out = line;
+  for (const secret of secrets) {
+    if (secret.length >= 8) out = out.split(secret).join("<redacted>");
+  }
+  const home = os.homedir();
+  if (home && home.length > 1) out = out.split(home).join("~");
+  out = out
+    /* Any other account's home, and the container's copy of this one. */
+    .replace(/\/(home|Users)\/[^/\s:'"]+/g, "/$1/<user>")
+    /* The vendored context format: `key=value` pairs lifted straight out of
+       the tool arguments. Everything up to the next pair separator goes. */
+    .replace(/\b([A-Za-z_]*(?:chat|user|peer|phone|contact|title|name|query|text|message|entity|alias|folder)[A-Za-z_]*)\s*=\s*[^,)]*/gi, "$1=<redacted>")
+    /* Public handles. */
+    .replace(/@[A-Za-z0-9_]{4,}/g, "@<user>")
+    /* Chat/user/message ids and phone numbers. */
+    .replace(/[+-]?\b\d{5,}\b/g, "<id>")
+    /* Opaque high-entropy blobs — a session string, a token, a hash. */
+    .replace(/\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{24,}\b/g, "<redacted>");
+  return out.length > STDERR_LINE_CHARS ? `${out.slice(0, STDERR_LINE_CHARS)}…` : out;
+}
+
+/** The last lines the connector printed before it died, redacted. Bounded
+    twice (bytes read, then lines kept) so a runaway log can never be loaded
+    whole. */
+function connectorStderrTail(secrets: readonly string[] = []): string[] {
   try {
     const path = telegramStateFile(STDERR_FILE);
     const stat = fs.statSync(path);
@@ -304,7 +349,7 @@ function connectorStderrTail(): string[] {
         .map((line) => line.replace(/\s+$/, ""))
         .filter((line) => line.length > 0)
         .slice(-STDERR_TAIL_LINES)
-        .map((line) => (line.length > 400 ? `${line.slice(0, 400)}…` : line));
+        .map((line) => redactConnectorStderrLine(line, secrets));
     } finally {
       fs.closeSync(handle);
     }
@@ -433,14 +478,30 @@ type ConnectorCrashRecord = {
   pid: number;
   exitCode: number | null;
   signal: string | null;
+  /** How the exit was noticed. `exit` is this Viewer's own child, so the
+      kernel handed us the code and signal. `vanished` is a connector this
+      Viewer only adopted (spawned by an earlier generation, so there is no
+      exit event to listen to): the disappearance is observed, the code and
+      signal are not knowable, and both stay null. */
+  observed: "exit" | "vanished";
   stderr: string[];
 };
 
 type ConnectorRestartState = {
   version: 1;
-  /** ISO timestamps of crash restarts, trimmed to the last 24 h. */
+  /** ISO timestamps of VERIFIED crash restarts — a replacement connector that
+      came back up and passed the read-only verification. A respawn that
+      failed is not a restart and is never counted here. Trimmed to 24 h. */
   restarts: string[];
+  /** ISO timestamps of the crashes themselves, whether or not the restart
+      that followed succeeded. This is what the burst limiter reads: a
+      connector that dies five times and never comes back must stop being
+      restarted just as surely as one that comes back and dies again. */
+  crashes: string[];
   lastCrashAt: string | null;
+  /** The pid of the last crash written, so an exit seen both by the child's
+      own exit event and by the reaper below is recorded exactly once. */
+  lastCrashPid: number | null;
 };
 
 /** Pids this Viewer generation is terminating on purpose, each with the time
@@ -470,19 +531,27 @@ function writeOwnerOnlyFile(path: string, contents: string): void {
 }
 
 function readRestartState(): ConnectorRestartState {
-  const empty: ConnectorRestartState = { version: 1, restarts: [], lastCrashAt: null };
+  const empty: ConnectorRestartState = { version: 1, restarts: [], crashes: [], lastCrashAt: null, lastCrashPid: null };
   try {
     if (ensureTelegramStateDir(false) === null) return empty;
     const row = JSON.parse(fs.readFileSync(telegramStateFile(RESTART_STATE_FILE), "utf8")) as Partial<ConnectorRestartState>;
     if (row.version !== 1 || !Array.isArray(row.restarts)) return empty;
+    const strings = (value: unknown): string[] =>
+      Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
     return {
       version: 1,
-      restarts: row.restarts.filter((value): value is string => typeof value === "string"),
+      restarts: strings(row.restarts),
+      crashes: strings(row.crashes),
       lastCrashAt: typeof row.lastCrashAt === "string" ? row.lastCrashAt : null,
+      lastCrashPid: typeof row.lastCrashPid === "number" ? row.lastCrashPid : null,
     };
   } catch {
     return empty;
   }
+}
+
+function writeRestartState(state: ConnectorRestartState): void {
+  writeOwnerOnlyFile(telegramStateFile(RESTART_STATE_FILE), JSON.stringify(state));
 }
 
 function withinLast(timestamps: string[], windowMs: number, now: number): string[] {
@@ -504,9 +573,15 @@ export function telegramConnectorActivity(now: number = Date.now()): TelegramCon
   };
 }
 
-function recordConnectorCrash(crash: ConnectorCrashRecord): void {
+/** Writes the crash to the owner-only ndjson log and stamps it into the
+    restart state, which is what makes the record idempotent per pid: the same
+    exit seen twice (once by the child's exit event, once by the reaper) is
+    logged once. Returns false when this pid was already recorded. */
+function recordConnectorCrash(crash: ConnectorCrashRecord, at: number): boolean {
+  const state = readRestartState();
+  if (state.lastCrashPid === crash.pid) return false;
   try {
-    if (ensureTelegramStateDir(true) === null) return;
+    if (ensureTelegramStateDir(true) === null) return false;
     const path = telegramStateFile(CRASH_LOG_FILE);
     let existing: string[] = [];
     try {
@@ -515,6 +590,14 @@ function recordConnectorCrash(crash: ConnectorCrashRecord): void {
     const lines = [...existing, JSON.stringify(crash)].slice(-CRASH_LOG_KEEP_LINES);
     writeOwnerOnlyFile(path, `${lines.join("\n")}\n`);
   } catch { /* an unrecordable crash must not break the restart */ }
+  writeRestartState({
+    ...state,
+    restarts: withinLast(state.restarts, DAY_MS, at),
+    crashes: [...withinLast(state.crashes, DAY_MS, at), crash.at],
+    lastCrashAt: crash.at,
+    lastCrashPid: crash.pid,
+  });
+  return true;
 }
 
 /** Reads the crash log newest-last; exported for the focused tests and any
@@ -530,20 +613,54 @@ export function readTelegramConnectorCrashes(): ConnectorCrashRecord[] {
   }
 }
 
-function noteCrashRestart(at: number): void {
+/** A crash restart that came back VERIFIED. Only these are counted: a respawn
+    that failed left the operator with no connector, and reporting it as a
+    completed restart would say the opposite of what happened (#1087). */
+function noteVerifiedRestart(at: number): void {
   const state = readRestartState();
-  const restarts = [...withinLast(state.restarts, DAY_MS, at), new Date(at).toISOString()];
-  writeOwnerOnlyFile(telegramStateFile(RESTART_STATE_FILE), JSON.stringify({
-    version: 1,
-    restarts,
-    lastCrashAt: new Date(at).toISOString(),
-  } satisfies ConnectorRestartState));
+  writeRestartState({
+    ...state,
+    restarts: [...withinLast(state.restarts, DAY_MS, at), new Date(at).toISOString()],
+    crashes: withinLast(state.crashes, DAY_MS, at),
+    /* A replacement is serving, so the next exit is a NEW event whatever pid
+       the kernel hands it — including a recycled one. */
+    lastCrashPid: null,
+  });
+}
+
+/**
+ * A crash whose restart did not come back leaves the durable connection
+ * saying `connected` for a process that no longer exists. Downgrade it to the
+ * error the next reader needs to see. Only a connection that still names the
+ * SAME credential is touched — a logout or a re-enrollment racing the restart
+ * owns the file, not this path.
+ */
+function markConnectorRestartFailed(code: TelegramErrorCode, credentialRef: string): void {
+  try {
+    const connection = readTelegramConnection();
+    if (connection.status !== "connected" || connection.credentialRef !== credentialRef) return;
+    writeTelegramConnection({ ...connection, status: "error", errorCode: code });
+  } catch { /* an unsafe or unreadable connection keeps its own contract */ }
 }
 
 /** True while the connector keeps crashing faster than restarting it can
-    help — the restart stops there and the crash log holds the reason. */
+    help — the restart stops there and the crash log holds the reason. Read
+    from the CRASHES, not the successful restarts: a connector that dies and
+    never comes back must stop being respawned just as surely as one that
+    comes back and dies again. */
 function restartBurstExhausted(now: number): boolean {
-  return withinLast(readRestartState().restarts, RESTART_BURST_WINDOW_MS, now).length >= RESTART_BURST_LIMIT;
+  return withinLast(readRestartState().crashes, RESTART_BURST_WINDOW_MS, now).length >= RESTART_BURST_LIMIT;
+}
+
+/** The secrets a crash tail must never echo: this generation's bearer token
+    and the Telegram string session behind it. */
+function connectorSecrets(binding: ConnectorBinding): string[] {
+  const secrets = [binding.connectorToken];
+  try {
+    const session = readTelegramSession();
+    if (session) secrets.push(session.sessionString, session.connectorToken);
+  } catch { /* an unreadable session store contributes no known value */ }
+  return secrets;
 }
 
 /**
@@ -559,19 +676,55 @@ function watchConnectorExit(child: ConnectorChild, binding: ConnectorBinding, po
     if (deliberateStops.delete(pid)) return;
     if (liveConnectorChild?.pid === pid) liveConnectorChild = null;
     const at = ports.now();
-    recordConnectorCrash({
+    const recorded = recordConnectorCrash({
       at: new Date(at).toISOString(),
       pid,
       exitCode: code,
       signal: signal ?? null,
-      stderr: connectorStderrTail(),
-    });
-    void restartAfterCrash(binding, ports, at);
+      observed: "exit",
+      stderr: connectorStderrTail(connectorSecrets(binding)),
+    }, at);
+    if (recorded) void restartAfterCrash(binding, ports, at);
   });
 }
 
+/**
+ * The crash record for an exit NOBODY was listening to (#1087).
+ *
+ * A connector spawned by an earlier Viewer generation is adopted, not
+ * re-parented: there is no exit event, so {@link watchConnectorExit} can
+ * never fire for it — and after a Viewer restart that is EVERY connector the
+ * operator has. Instead of a wrapper process to keep a handle alive, the
+ * disappearance is noticed on the path that already runs on every status
+ * read: the recorded pid is gone, this Viewer did not stop it, and the crash
+ * is written with its stderr tail before the replacement spawn truncates the
+ * sink. The exit code and signal are genuinely unknowable here and stay null.
+ *
+ * Returns true when a crash was recorded, so the caller can count the
+ * restart it is about to perform.
+ */
+function reapVanishedConnector(binding: ConnectorBinding, ports: TelegramConnectorPorts): boolean {
+  const record = readConnectorRecord();
+  if (!record) return false;
+  if (record.credentialRef !== binding.credentialRef) return false;
+  if (procBackend.processIdentity(record.pid) === record.identity) return false;
+  if (deliberateStops.delete(record.pid)) return false;
+  const at = ports.now();
+  return recordConnectorCrash({
+    at: new Date(at).toISOString(),
+    pid: record.pid,
+    exitCode: null,
+    signal: null,
+    observed: "vanished",
+    stderr: connectorStderrTail(connectorSecrets(binding)),
+  }, at);
+}
+
 async function restartAfterCrash(binding: ConnectorBinding, ports: TelegramConnectorPorts, at: number): Promise<void> {
-  if (restartBurstExhausted(at)) return;
+  if (restartBurstExhausted(at)) {
+    markConnectorRestartFailed("connector_failed", binding.credentialRef);
+    return;
+  }
   restartsInFlight += 1;
   try {
     await ports.sleep(ports.restartDelayMs ?? RESTART_DELAY_MS);
@@ -580,10 +733,15 @@ async function restartAfterCrash(binding: ConnectorBinding, ports: TelegramConne
     /* A credential the operator deleted or replaced is never resurrected, and
        a restart that does not happen is not counted. */
     if (!session || session.credentialRef !== binding.credentialRef) return;
-    noteCrashRestart(ports.now());
-    await ensureTelegramConnector(session, ports);
-  } catch { /* the crash log already carries why; the next status read retries */ }
-  finally {
+    const result = await ensureConnectorNow(session, ports);
+    /* Counted only once the replacement is verified; a respawn that failed is
+       surfaced durably instead, so the next status read says error rather
+       than connected-over-a-corpse. */
+    if (result.ok) noteVerifiedRestart(ports.now());
+    else markConnectorRestartFailed(result.code, binding.credentialRef);
+  } catch {
+    markConnectorRestartFailed("connector_failed", binding.credentialRef);
+  } finally {
     restartsInFlight -= 1;
   }
 }
@@ -605,6 +763,39 @@ async function waitForTargetsToExit(targets: TerminationTarget[], timeoutMs: num
     await new Promise<void>((resolve) => setTimeout(resolve, TERMINATION_POLL_MS));
   }
   return targets.every((target) => !targetIsAlive(target));
+}
+
+/**
+ * Tells the connector it is about to be stopped (#1087).
+ *
+ * The distinguishable error a dropped call needs cannot be produced after the
+ * process is gone, and it must not depend on the shutdown reaching a
+ * particular code path first — a SIGKILL escalation reaches none. So the
+ * supervisor asks first, over the same authenticated loopback surface it
+ * already uses: the connector completes every response it has started with a
+ * JSON-RPC error naming the restart, and answers later arrivals 503. Only
+ * then does the signal go out.
+ *
+ * Best effort by construction. A connector that is wedged, unauthenticated to
+ * us, or already dead is signaled anyway; that is the pre-existing behaviour,
+ * not a regression.
+ */
+async function requestConnectorDrain(recorded: ConnectorRecord | null): Promise<void> {
+  let token: string | null = null;
+  try { token = readTelegramSession()?.connectorToken ?? null; } catch { token = null; }
+  /* Never send this generation's bearer token to a listener that a different
+     credential generation recorded. */
+  if (!token || !recorded || recorded.connectorTokenSha256 !== connectorTokenSha256(token)) return;
+  const drainUrl = new URL(telegramMcpUrl());
+  drainUrl.pathname = DRAIN_PATH;
+  drainUrl.search = "";
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DRAIN_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    await fetch(drainUrl, { method: "POST", headers: { Authorization: `Bearer ${token}` }, signal: controller.signal });
+  } catch { /* the signal below is the fallback it always was */ }
+  finally { clearTimeout(timer); }
 }
 
 async function stopRealConnectorUnlocked(): Promise<void> {
@@ -640,6 +831,11 @@ async function stopRealConnectorUnlocked(): Promise<void> {
   /* Marked BEFORE the first signal: an exit this call caused is a stop, not a
      crash, and must neither be logged nor restarted (#1087). */
   for (const target of active) markDeliberateStop(target.pid, Date.now());
+  /* Asked to drain BEFORE the first signal too, so every call in flight is
+     answered with the named restart error while the process is still alive
+     and its event loop still runs — the SIGKILL escalation below can no
+     longer be what a caller meets first (#1087). */
+  if (active.length > 0) await requestConnectorDrain(recorded);
   for (const target of active) target.term();
   if (!await waitForTargetsToExit(active, TERMINATION_GRACE_MS)) {
     for (const target of active.filter(targetIsAlive)) target.kill();
@@ -695,8 +891,36 @@ async function verifiedProbe(
  * shared port (a previous Viewer generation's connector, still recorded in
  * the pid file) is adopted, not duplicated — that keeps the process count at
  * one across Viewer restarts.
+ *
+ * This is also where an exit nobody was listening to is noticed (#1087): an
+ * adopted connector has no exit event, so its crash is reaped here, before
+ * the replacement spawn truncates the stderr sink. When that happens, this
+ * call IS the restart — it reads as `restarting` while it runs, counts only
+ * if the replacement verifies, and marks the durable connection with the
+ * failure code if it does not.
  */
 export async function ensureTelegramConnector(
+  session: StoredTelegramSession,
+  ports: TelegramConnectorPorts = realPorts,
+): Promise<ConnectorEnsureResult> {
+  const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };
+  if (!reapVanishedConnector(binding, ports)) return await ensureConnectorNow(session, ports);
+  if (restartBurstExhausted(ports.now())) {
+    markConnectorRestartFailed("connector_failed", binding.credentialRef);
+    return { ok: false, code: "connector_failed" };
+  }
+  restartsInFlight += 1;
+  try {
+    const result = await ensureConnectorNow(session, ports);
+    if (result.ok) noteVerifiedRestart(ports.now());
+    else markConnectorRestartFailed(result.code, binding.credentialRef);
+    return result;
+  } finally {
+    restartsInFlight -= 1;
+  }
+}
+
+async function ensureConnectorNow(
   session: StoredTelegramSession,
   ports: TelegramConnectorPorts = realPorts,
 ): Promise<ConnectorEnsureResult> {
@@ -767,10 +991,18 @@ export async function ensureTelegramConnector(
  * the verified read-only surface needs a live, authorized Telethon client, so
  * a parseable answer proves exactly what the bridge would have proved.
  *
- * `null` means this process could not answer (not ours, not verifiable, the
- * call failed). The caller then falls back to the destructive bridge check —
- * which is free at that point, because a connector that cannot answer is not
- * serving anyone either.
+ * `null` means this process could not answer at all (not ours, not
+ * verifiable, the handshake failed). The caller then falls back to the
+ * destructive bridge check — which is free at that point, because a connector
+ * that cannot even complete an MCP handshake is not serving anyone either.
+ *
+ * `"busy"` is the case that used to be conflated with `null` and cost exactly
+ * the outage this issue reports: the connector answered the handshake, so it
+ * is alive, ours, and still serving — it just did not finish `get_me` inside
+ * the budget, which is what a process in the middle of a fan-out of large
+ * reads looks like. A missed health deadline is not evidence that anything
+ * finished, so nothing may be torn down and no verdict is reached; the caller
+ * leaves the durable status alone and asks again later.
  *
  * Only the account's display name and public username are lifted out of the
  * answer; `get_me` may also carry the account's phone number, which never
@@ -779,7 +1011,7 @@ export async function ensureTelegramConnector(
 export async function telegramConnectorHealth(
   session: StoredTelegramSession,
   ports: TelegramConnectorPorts = realPorts,
-): Promise<ConnectorLiveHealth | null> {
+): Promise<ConnectorLiveHealth | "busy" | null> {
   const ownsProcess = ports.ownsProcess ?? ownsRecordedConnector;
   const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };
   if (!ownsProcess(binding)) return null;
@@ -788,18 +1020,27 @@ export async function telegramConnectorHealth(
   const url = telegramMcpUrl();
   const budget: TelegramConnectorPorts = { ...ports, probeTimeoutMs: ports.probeTimeoutMs ?? HEALTH_TIMEOUT_MS };
   const verified = await verifiedProbe(url, session.connectorToken, budget);
-  if (verified === null || verified === "timeout" || !verified.ok) return null;
+  /* A handshake that ran out of budget did not get refused: the listener is
+     there and the event loop is simply saturated, which is the fan-out this
+     issue is about. A handshake that failed outright (refused socket, wrong
+     proof, a surface that is no longer read-only) is a real refusal. */
+  if (verified === "timeout") return "busy";
+  if (verified === null || !verified.ok) return null;
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | null = null;
   const answer = await Promise.race([
     callTool(url, session.connectorToken, "get_me", controller.signal).catch(() => null),
-    new Promise<null>((resolve) => {
-      timer = setTimeout(() => { controller.abort(); resolve(null); }, budget.probeTimeoutMs!);
+    new Promise<"busy">((resolve) => {
+      timer = setTimeout(() => { controller.abort(); resolve("busy"); }, budget.probeTimeoutMs!);
       timer.unref?.();
     }),
   ]);
   if (timer) clearTimeout(timer);
   controller.abort();
+  if (answer === "busy") return "busy";
+  /* An answer that is not the account — an upstream error string, a dead
+     call — is no verdict: the bridge check must still get its chance to
+     classify an expired or deauthorized session, which `get_me` cannot. */
   const identity = parseConnectorIdentity(answer);
   return identity ? { status: "connected", identity } : null;
 }

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -6,9 +6,9 @@ import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
-import type { TelegramErrorCode } from "./contracts";
+import type { TelegramConnectorRestarts, TelegramErrorCode, TelegramIdentity } from "./contracts";
 import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
-import { ensureTelegramStateDir, type StoredTelegramSession } from "./sessionStore";
+import { ensureTelegramStateDir, readTelegramSession, type StoredTelegramSession } from "./sessionStore";
 
 /**
  * Supervisor for the ONE shared loopback connector process (issue #1059).
@@ -68,7 +68,20 @@ export type ConnectorProbe =
 
 export type ConnectorEnsureResult = { ok: true; url: string } | { ok: false; code: TelegramErrorCode };
 
-type ConnectorChild = { pid?: number; kill(signal?: NodeJS.Signals): boolean };
+/** What the RUNNING connector can prove about the account without being torn
+    down (#1087): a `get_me` through the verified surface needs a live,
+    authorized Telethon client, so a successful answer is a health reading.
+    `null` means "this process cannot answer" — the caller then falls back to
+    the destructive bridge check, which also classifies an expired session. */
+export type ConnectorLiveHealth = { status: "connected"; identity: TelegramIdentity };
+
+type ConnectorChild = {
+  pid?: number;
+  kill(signal?: NodeJS.Signals): boolean;
+  /** Present for children this Viewer generation actually spawned; an adopted
+      process has no exit event to listen to. */
+  onExit?(handler: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+};
 type ConnectorBinding = Pick<StoredTelegramSession, "credentialRef" | "connectorToken">;
 
 export interface TelegramConnectorPorts {
@@ -81,6 +94,11 @@ export interface TelegramConnectorPorts {
   stop?(): Promise<void> | void;
   beginOperation?(): () => boolean;
   probeTimeoutMs?: number;
+  /** One read-only tool call over the verified surface; `null` for any
+      failure. Used only by {@link telegramConnectorHealth}. */
+  callTool?(url: string, connectorToken: string, tool: string, signal?: AbortSignal): Promise<string | null>;
+  /** Backoff before a crash restart. */
+  restartDelayMs?: number;
 }
 
 const READY_DEADLINE_MS = 30_000;
@@ -90,6 +108,28 @@ const TERMINATION_GRACE_MS = 2_000;
 const TERMINATION_KILL_MS = 2_000;
 const TERMINATION_POLL_MS = 25;
 const PID_FILE = "connector.json";
+/* Crash bookkeeping (#1087). The stderr sink is the ONLY place the connector's
+   own output is kept; it is Viewer-owned, owner-only, and truncated at every
+   spawn so a recorded tail always belongs to the process that just died. */
+const STDERR_FILE = "connector-stderr.log";
+const CRASH_LOG_FILE = "connector-crashes.log";
+const RESTART_STATE_FILE = "connector-restarts.json";
+const STDERR_TAIL_LINES = 20;
+const STDERR_TAIL_BYTES = 8_192;
+const CRASH_LOG_KEEP_LINES = 50;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+/* A crashing connector is restarted, but never in a hot loop: more than
+   RESTART_BURST_LIMIT crashes inside RESTART_BURST_WINDOW_MS means the process
+   cannot stay up, and hammering it would only add noise to the crash log. */
+const RESTART_BURST_WINDOW_MS = 15 * 60 * 1_000;
+const RESTART_BURST_LIMIT = 5;
+const RESTART_DELAY_MS = 500;
+/* The non-destructive health check gets a longer budget than a readiness
+   probe: a connector busy with a fan-out of large reads is healthy, and
+   timing it out here would tear down exactly the process this change set out
+   to protect. A connector that answers nothing inside this budget is wedged,
+   and the destructive path may take over. */
+const HEALTH_TIMEOUT_MS = 15_000;
 
 /** The read-only gate, pure so it is directly provable: one tool that lacks
     an affirmative readOnlyHint OR falls outside the audited allowlist fails
@@ -154,17 +194,69 @@ export async function probeTelegramConnector(url: string, connectorToken: string
   }
 }
 
+/** One read-only tool call over the authenticated loopback surface. Returns
+    the tool's text output, or null for any failure — callers treat null as
+    "this connector cannot answer" and never as a verdict about the account. */
+export async function callTelegramConnectorTool(
+  url: string,
+  connectorToken: string,
+  tool: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+    const { StreamableHTTPClientTransport } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+    const client = new Client({ name: "agent-log-viewer", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(new URL(url), {
+      requestInit: { headers: { Authorization: `Bearer ${connectorToken}` }, signal },
+    });
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({ name: tool, arguments: {} });
+      if (result.isError) return null;
+      const content = Array.isArray(result.content) ? result.content : [];
+      const text = content
+        .filter((part): part is { type: "text"; text: string } =>
+          typeof (part as { type?: unknown }).type === "string" && (part as { type: string }).type === "text"
+          && typeof (part as { text?: unknown }).text === "string")
+        .map((part) => part.text)
+        .join("\n");
+      return text.length > 0 ? text : null;
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  } catch {
+    return null;
+  }
+}
+
 const realPorts: TelegramConnectorPorts = {
   spawn(spec) {
+    /* stderr goes to the Viewer-owned owner-only sink instead of /dev/null:
+       when the process dies, its last lines are the only evidence of why
+       (#1087). A sink that cannot be opened safely never blocks the spawn. */
+    const sink = openConnectorStderrSink();
     try {
-      const child = spawn(spec.command, spec.args, { cwd: spec.cwd, env: spec.env, stdio: ["ignore", "ignore", "ignore"], detached: true });
+      const child = spawn(spec.command, spec.args, {
+        cwd: spec.cwd,
+        env: spec.env,
+        stdio: ["ignore", "ignore", sink ?? "ignore"],
+        detached: true,
+      });
       child.unref();
-      return child;
+      return {
+        pid: child.pid,
+        kill: (signal) => child.kill(signal),
+        onExit: (handler) => { child.once("exit", (code, signal) => handler(code, signal)); },
+      };
     } catch {
       return null;
+    } finally {
+      if (sink !== null) { try { fs.closeSync(sink); } catch { /* already closed */ } }
     }
   },
   probe: probeTelegramConnector,
+  callTool: callTelegramConnectorTool,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),
   ownsProcess: ownsRecordedConnector,
@@ -175,6 +267,50 @@ const realPorts: TelegramConnectorPorts = {
 
 function pidFilePath(): string {
   return statePath("telegram", PID_FILE);
+}
+
+function telegramStateFile(name: string): string {
+  return statePath("telegram", name);
+}
+
+/** Append-only owner-only sink for the connector's stderr, truncated at every
+    spawn so the tail a crash record quotes is that process's own output. */
+function openConnectorStderrSink(): number | null {
+  try {
+    if (ensureTelegramStateDir(true) === null) return null;
+    const sink = fs.openSync(telegramStateFile(STDERR_FILE), "w", 0o600);
+    /* The mode argument only applies to a file this call creates; an existing
+       sink is re-tightened explicitly. */
+    fs.fchmodSync(sink, 0o600);
+    return sink;
+  } catch {
+    return null;
+  }
+}
+
+/** The last lines the connector printed before it died. Bounded twice (bytes
+    read, then lines kept) so a runaway log can never be loaded whole. */
+function connectorStderrTail(): string[] {
+  try {
+    const path = telegramStateFile(STDERR_FILE);
+    const stat = fs.statSync(path);
+    const start = Math.max(0, stat.size - STDERR_TAIL_BYTES);
+    const handle = fs.openSync(path, "r");
+    try {
+      const buffer = Buffer.alloc(Math.min(stat.size, STDERR_TAIL_BYTES));
+      const read = fs.readSync(handle, buffer, 0, buffer.length, start);
+      return buffer.subarray(0, read).toString("utf8")
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0)
+        .slice(-STDERR_TAIL_LINES)
+        .map((line) => (line.length > 400 ? `${line.slice(0, 400)}…` : line));
+    } finally {
+      fs.closeSync(handle);
+    }
+  } catch {
+    return [];
+  }
 }
 
 type ConnectorRecord = {
@@ -282,6 +418,176 @@ function removeConnectorRecord(): void {
   } catch { /* unsafe/missing state */ }
 }
 
+/* ------------------------------------------------------------------ #1087
+   Crash bookkeeping. A connector that dies takes every in-flight agent call
+   with it; before this, the exit left no trace at all (stderr went to
+   /dev/null and the status file kept saying "connected"). Two owner-only
+   files under the telegram state dir carry the evidence: an ndjson crash log
+   with exit code/signal and the last stderr lines, and a small restart state
+   the status payload reads. Deliberate stops (logout, local deletion, a
+   refused surface) are NOT crashes and appear in neither.
+   ------------------------------------------------------------------------ */
+
+type ConnectorCrashRecord = {
+  at: string;
+  pid: number;
+  exitCode: number | null;
+  signal: string | null;
+  stderr: string[];
+};
+
+type ConnectorRestartState = {
+  version: 1;
+  /** ISO timestamps of crash restarts, trimmed to the last 24 h. */
+  restarts: string[];
+  lastCrashAt: string | null;
+};
+
+/** Pids this Viewer generation is terminating on purpose, each with the time
+    it was marked. Entries are pruned so a process whose exit event never
+    arrives (an adopted connector has none) cannot grow this map. */
+const deliberateStops = new Map<number, number>();
+const DELIBERATE_STOP_TTL_MS = 60_000;
+
+function markDeliberateStop(pid: number, now: number): void {
+  for (const [marked, at] of deliberateStops) {
+    if (now - at > DELIBERATE_STOP_TTL_MS) deliberateStops.delete(marked);
+  }
+  deliberateStops.set(pid, now);
+}
+/** Non-zero while a crash restart is in flight — the `restarting` phase. */
+let restartsInFlight = 0;
+
+function writeOwnerOnlyFile(path: string, contents: string): void {
+  const tmp = `${path}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmp, contents, { mode: 0o600 });
+    fs.chmodSync(tmp, 0o600);
+    fs.renameSync(tmp, path);
+  } catch {
+    fs.rmSync(tmp, { force: true });
+  }
+}
+
+function readRestartState(): ConnectorRestartState {
+  const empty: ConnectorRestartState = { version: 1, restarts: [], lastCrashAt: null };
+  try {
+    if (ensureTelegramStateDir(false) === null) return empty;
+    const row = JSON.parse(fs.readFileSync(telegramStateFile(RESTART_STATE_FILE), "utf8")) as Partial<ConnectorRestartState>;
+    if (row.version !== 1 || !Array.isArray(row.restarts)) return empty;
+    return {
+      version: 1,
+      restarts: row.restarts.filter((value): value is string => typeof value === "string"),
+      lastCrashAt: typeof row.lastCrashAt === "string" ? row.lastCrashAt : null,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+function withinLast(timestamps: string[], windowMs: number, now: number): string[] {
+  return timestamps.filter((value) => {
+    const at = Date.parse(value);
+    return Number.isFinite(at) && now - at <= windowMs;
+  });
+}
+
+/** Crash restarts of the shared connector as the status payload reports them
+    (#1087), plus whether one is happening right now. */
+export function telegramConnectorActivity(now: number = Date.now()): TelegramConnectorRestarts & { restarting: boolean } {
+  const state = readRestartState();
+  const recent = withinLast(state.restarts, DAY_MS, now);
+  return {
+    restarting: restartsInFlight > 0,
+    last24h: recent.length,
+    lastAt: recent.length > 0 ? recent[recent.length - 1]! : null,
+  };
+}
+
+function recordConnectorCrash(crash: ConnectorCrashRecord): void {
+  try {
+    if (ensureTelegramStateDir(true) === null) return;
+    const path = telegramStateFile(CRASH_LOG_FILE);
+    let existing: string[] = [];
+    try {
+      existing = fs.readFileSync(path, "utf8").split("\n").filter((line) => line.length > 0);
+    } catch { /* first crash */ }
+    const lines = [...existing, JSON.stringify(crash)].slice(-CRASH_LOG_KEEP_LINES);
+    writeOwnerOnlyFile(path, `${lines.join("\n")}\n`);
+  } catch { /* an unrecordable crash must not break the restart */ }
+}
+
+/** Reads the crash log newest-last; exported for the focused tests and any
+    future operator surface. */
+export function readTelegramConnectorCrashes(): ConnectorCrashRecord[] {
+  try {
+    return fs.readFileSync(telegramStateFile(CRASH_LOG_FILE), "utf8")
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as ConnectorCrashRecord);
+  } catch {
+    return [];
+  }
+}
+
+function noteCrashRestart(at: number): void {
+  const state = readRestartState();
+  const restarts = [...withinLast(state.restarts, DAY_MS, at), new Date(at).toISOString()];
+  writeOwnerOnlyFile(telegramStateFile(RESTART_STATE_FILE), JSON.stringify({
+    version: 1,
+    restarts,
+    lastCrashAt: new Date(at).toISOString(),
+  } satisfies ConnectorRestartState));
+}
+
+/** True while the connector keeps crashing faster than restarting it can
+    help — the restart stops there and the crash log holds the reason. */
+function restartBurstExhausted(now: number): boolean {
+  return withinLast(readRestartState().restarts, RESTART_BURST_WINDOW_MS, now).length >= RESTART_BURST_LIMIT;
+}
+
+/**
+ * The one automatic recovery path: a connector that exited on its own (not
+ * because this Viewer stopped it) is brought back for the SAME stored
+ * credential. A deleted or replaced session cancels the restart — recovery
+ * never resurrects a credential the operator removed.
+ */
+function watchConnectorExit(child: ConnectorChild, binding: ConnectorBinding, ports: TelegramConnectorPorts): void {
+  const pid = child.pid;
+  if (!pid || !child.onExit) return;
+  child.onExit((code, signal) => {
+    if (deliberateStops.delete(pid)) return;
+    if (liveConnectorChild?.pid === pid) liveConnectorChild = null;
+    const at = ports.now();
+    recordConnectorCrash({
+      at: new Date(at).toISOString(),
+      pid,
+      exitCode: code,
+      signal: signal ?? null,
+      stderr: connectorStderrTail(),
+    });
+    void restartAfterCrash(binding, ports, at);
+  });
+}
+
+async function restartAfterCrash(binding: ConnectorBinding, ports: TelegramConnectorPorts, at: number): Promise<void> {
+  if (restartBurstExhausted(at)) return;
+  restartsInFlight += 1;
+  try {
+    await ports.sleep(ports.restartDelayMs ?? RESTART_DELAY_MS);
+    let session: StoredTelegramSession | null = null;
+    try { session = readTelegramSession(); } catch { session = null; }
+    /* A credential the operator deleted or replaced is never resurrected, and
+       a restart that does not happen is not counted. */
+    if (!session || session.credentialRef !== binding.credentialRef) return;
+    noteCrashRestart(ports.now());
+    await ensureTelegramConnector(session, ports);
+  } catch { /* the crash log already carries why; the next status read retries */ }
+  finally {
+    restartsInFlight -= 1;
+  }
+}
+
 type TerminationTarget = {
   pid: number;
   identity: string;
@@ -331,6 +637,9 @@ async function stopRealConnectorUnlocked(): Promise<void> {
     }
   }
   const active = [...targets.values()];
+  /* Marked BEFORE the first signal: an exit this call caused is a stop, not a
+     crash, and must neither be logged nor restarted (#1087). */
+  for (const target of active) markDeliberateStop(target.pid, Date.now());
   for (const target of active) target.term();
   if (!await waitForTargetsToExit(active, TERMINATION_GRACE_MS)) {
     for (const target of active.filter(targetIsAlive)) target.kill();
@@ -422,6 +731,7 @@ export async function ensureTelegramConnector(
       terminateChildImmediately(child);
       return { ok: false, code: "connector_failed" };
     }
+    watchConnectorExit(child, binding, ports);
     return "spawned";
   });
   if (prepared !== "spawned") return prepared;
@@ -446,6 +756,67 @@ export async function ensureTelegramConnector(
   }
   await stopThisGeneration();
   return { ok: false, code: "connector_failed" };
+}
+
+/**
+ * Health WITHOUT tearing the connector down (#1087).
+ *
+ * The bridge health check has to own the Telegram session, so running it
+ * means killing the shared connector and taking every in-flight agent call
+ * with it. When the connector is up and ours, ask IT instead: `get_me` over
+ * the verified read-only surface needs a live, authorized Telethon client, so
+ * a parseable answer proves exactly what the bridge would have proved.
+ *
+ * `null` means this process could not answer (not ours, not verifiable, the
+ * call failed). The caller then falls back to the destructive bridge check —
+ * which is free at that point, because a connector that cannot answer is not
+ * serving anyone either.
+ *
+ * Only the account's display name and public username are lifted out of the
+ * answer; `get_me` may also carry the account's phone number, which never
+ * crosses this boundary.
+ */
+export async function telegramConnectorHealth(
+  session: StoredTelegramSession,
+  ports: TelegramConnectorPorts = realPorts,
+): Promise<ConnectorLiveHealth | null> {
+  const ownsProcess = ports.ownsProcess ?? ownsRecordedConnector;
+  const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };
+  if (!ownsProcess(binding)) return null;
+  const callTool = ports.callTool;
+  if (!callTool) return null;
+  const url = telegramMcpUrl();
+  const budget: TelegramConnectorPorts = { ...ports, probeTimeoutMs: ports.probeTimeoutMs ?? HEALTH_TIMEOUT_MS };
+  const verified = await verifiedProbe(url, session.connectorToken, budget);
+  if (verified === null || verified === "timeout" || !verified.ok) return null;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const answer = await Promise.race([
+    callTool(url, session.connectorToken, "get_me", controller.signal).catch(() => null),
+    new Promise<null>((resolve) => {
+      timer = setTimeout(() => { controller.abort(); resolve(null); }, budget.probeTimeoutMs!);
+      timer.unref?.();
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+  controller.abort();
+  const identity = parseConnectorIdentity(answer);
+  return identity ? { status: "connected", identity } : null;
+}
+
+/** `get_me` answers with the vendored `format_entity` JSON. Anything else —
+    an error string, a truncated body — is not a health verdict. */
+function parseConnectorIdentity(answer: string | null): TelegramIdentity | null {
+  if (!answer) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(answer); } catch { return null; }
+  if (!parsed || typeof parsed !== "object") return null;
+  const row = parsed as { id?: unknown; name?: unknown; username?: unknown };
+  if (typeof row.id !== "number" && typeof row.id !== "string") return null;
+  return {
+    name: typeof row.name === "string" && row.name ? row.name : "Telegram account",
+    username: typeof row.username === "string" && row.username ? row.username : null,
+  };
 }
 
 /** Stops the shared connector — the recorded process, whichever Viewer

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -69,6 +69,19 @@ export type ConnectorProbe =
 
 export type ConnectorEnsureResult = { ok: true; url: string } | { ok: false; code: TelegramErrorCode };
 
+/**
+ * The outcome of one connector tool call. A call dropped by a respawn names
+ * itself, so a caller can tell it from a connector that simply failed (#1087).
+ *
+ * The code stays inside this boundary rather than joining
+ * {@link TelegramErrorCode}: it describes one call, not the connection, and
+ * the status payload already carries the same event as the `restarting`
+ * phase and the 24 h restart count.
+ */
+export type ConnectorCallResult =
+  | { ok: true; text: string }
+  | { ok: false; code: "connector_restarting" | "call_failed" };
+
 /** What the RUNNING connector can prove about the account without being torn
     down (#1087): a `get_me` through the verified surface needs a live,
     authorized Telethon client, so a successful answer is a health reading.
@@ -95,9 +108,9 @@ export interface TelegramConnectorPorts {
   stop?(): Promise<void> | void;
   beginOperation?(): () => boolean;
   probeTimeoutMs?: number;
-  /** One read-only tool call over the verified surface; `null` for any
-      failure. Used only by {@link telegramConnectorHealth}. */
-  callTool?(url: string, connectorToken: string, tool: string, signal?: AbortSignal): Promise<string | null>;
+  /** One read-only tool call over the verified surface, whose failure says
+      whether a respawn took it. Used only by {@link telegramConnectorHealth}. */
+  callTool?(url: string, connectorToken: string, tool: string, signal?: AbortSignal): Promise<ConnectorCallResult>;
   /** Backoff before a crash restart. */
   restartDelayMs?: number;
 }
@@ -122,7 +135,7 @@ const RESTART_STATE_FILE = "connector-restarts.json";
 const EXIT_FILE = "connector-exit.json";
 const STDERR_TAIL_LINES = 20;
 const STDERR_TAIL_BYTES = 8_192;
-const STDERR_LINE_CHARS = 400;
+const STDERR_LINE_CHARS = 120;
 const CRASH_LOG_KEEP_LINES = 50;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 /* A crashing connector is restarted, but never in a hot loop: more than
@@ -142,6 +155,10 @@ const DRAIN_TIMEOUT_MS = 1_500;
    to protect. A connector that answers nothing inside this budget is wedged,
    and the destructive path may take over. */
 const HEALTH_TIMEOUT_MS = 15_000;
+/** How long a FAILED call waits for the supervisor to notice the exit that
+    dropped it, before it settles for "the connector could not answer". */
+const RESTART_ATTRIBUTION_MS = 250;
+const RESTART_ATTRIBUTION_POLL_MS = 25;
 
 /** The read-only gate, pure so it is directly provable: one tool that lacks
     an affirmative readOnlyHint OR falls outside the audited allowlist fails
@@ -206,15 +223,22 @@ export async function probeTelegramConnector(url: string, connectorToken: string
   }
 }
 
-/** One read-only tool call over the authenticated loopback surface. Returns
-    the tool's text output, or null for any failure — callers treat null as
-    "this connector cannot answer" and never as a verdict about the account. */
+/**
+ * One read-only tool call over the authenticated loopback surface.
+ *
+ * A failure is never a verdict about the account — but it does have two
+ * kinds. `connector_restarting` is a call the supervisor's replacement took
+ * with it: the process this call was talking to is gone or has already been
+ * replaced, which a caller can retry (#1087). Anything else is
+ * `call_failed`, the connector simply could not answer.
+ */
 export async function callTelegramConnectorTool(
   url: string,
   connectorToken: string,
   tool: string,
   signal?: AbortSignal,
-): Promise<string | null> {
+): Promise<ConnectorCallResult> {
+  const servedBy = readConnectorRecord()?.pid ?? null;
   try {
     const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
     const { StreamableHTTPClientTransport } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
@@ -225,7 +249,7 @@ export async function callTelegramConnectorTool(
     try {
       await client.connect(transport);
       const result = await client.callTool({ name: tool, arguments: {} });
-      if (result.isError) return null;
+      if (result.isError) return { ok: false, code: "call_failed" };
       const content = Array.isArray(result.content) ? result.content : [];
       const text = content
         .filter((part): part is { type: "text"; text: string } =>
@@ -233,12 +257,38 @@ export async function callTelegramConnectorTool(
           && typeof (part as { text?: unknown }).text === "string")
         .map((part) => part.text)
         .join("\n");
-      return text.length > 0 ? text : null;
+      return text.length > 0 ? { ok: true, text } : { ok: false, code: "call_failed" };
     } finally {
       await client.close().catch(() => undefined);
     }
   } catch {
-    return null;
+    return { ok: false, code: await connectorReplacedSince(servedBy) ? "connector_restarting" : "call_failed" };
+  }
+}
+
+/**
+ * Whether the connector that was serving a call is no longer the one on the
+ * record — because the supervisor replaced it, or because it died and the
+ * replacement is on its way (#1087).
+ *
+ * This is what turns a bare transport failure into a distinguishable error.
+ * The kernel closes the sockets of a dying process before its parent hears
+ * that it died, so the answer is not available the instant the call fails:
+ * this waits a moment for the supervisor to notice, and only for a call that
+ * has already failed. Nothing else about a connector that is simply not
+ * answering is delayed.
+ */
+async function connectorReplacedSince(servedBy: number | null): Promise<boolean> {
+  if (servedBy === null) return false;
+  const deadline = Date.now() + RESTART_ATTRIBUTION_MS;
+  for (;;) {
+    const record = readConnectorRecord();
+    /* Torn down, or already replaced by a different process. */
+    if (record === null || record.pid !== servedBy) return true;
+    /* Still on the record, but the supervisor has written its crash down. */
+    if (readRestartState().lastCrashPid === servedBy) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, RESTART_ATTRIBUTION_POLL_MS));
   }
 }
 
@@ -332,6 +382,63 @@ function openConnectorStderrSink(): number | null {
   }
 }
 
+const REDACTED = "<redacted>";
+
+/* A traceback frame is the one line whose whole value is a file path: it is
+   kept structurally (path, line number, function) instead of being summarized,
+   because a code location is exactly what a crash report is for. */
+const STDERR_FRAME = /^\s*File "(.*)", line (\d+)(?:, in (.*))?$/;
+const STDERR_FRAME_NAME = /^[A-Za-z0-9_.<>]+$/;
+/* The fixed scaffolding Python prints around a traceback: no free text in it. */
+const STDERR_SCAFFOLD = new Set([
+  "Traceback (most recent call last):",
+  "During handling of the above exception, another exception occurred:",
+  "The above exception was the direct cause of the following exception:",
+]);
+
+/* Shapes that are diagnostic by construction and carry no account data: this
+   redactor's own markers, log timestamps, errno/signal names, qualified
+   exception types, the modules a connector traceback can name, the connector's
+   own read-tool names, protocol error constants, and the loopback address.
+   `<` and `>` are held out of the punctuation run so a marker this redactor
+   already wrote is re-read as one shape instead of being split apart. */
+const STDERR_TOKEN = new RegExp(
+  "(<[a-z]+>"
+  + "|\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}(?:[.,]\\d{1,6})?"
+  + "|\\[Errno \\d{1,5}\\]"
+  + "|\\bSIG[A-Z]{2,}\\d*\\b"
+  + "|\\b(?:[A-Za-z_][A-Za-z0-9_]*\\.)*[A-Za-z_][A-Za-z0-9_]*"
+  + "(?:Error|Exception|Warning|Exit|Interrupt|Timeout|Cancelled|Abort|Failure)\\b"
+  + "|\\b(?:telegram_mcp|telethon|mcp|anyio|asyncio|uvicorn|starlette|httpx"
+  + "|httpcore|sqlite3|socket|ssl|builtins|__main__)(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\b"
+  + "|\\b(?:get|list|search|export|resolve|incoming|wait)_[a-z][a-z_]{1,40}\\b"
+  + "|\\b[A-Z][A-Z0-9]*(?:[-_][A-Z0-9]+)+\\b"
+  + "|\\b127\\.0\\.0\\.1(?::\\d{1,5})?\\b"
+  + ")|([A-Za-z0-9_]+)|([ \\t]+)|([!-/:;=?@\\[-`{-~]+|[<>])|([^])",
+  "g",
+);
+const STDERR_COLLAPSE = /<redacted>(?:[ \t]*<redacted>)+/g;
+
+/**
+ * Keeps the structured diagnostics; drops every run of free text.
+ *
+ * The vendored runtime puts free-form exception text on stderr, and free-form
+ * text is where names, chat titles and message content live — a blacklist can
+ * only remove the shapes it already knows. So the summary is built the other
+ * way round: an exception class, a signal name, an errno, a protocol error
+ * constant and the modules a traceback names survive, punctuation survives (it
+ * carries no identity), and every other run collapses into `<redacted>`.
+ */
+function summarizeConnectorStderr(text: string): string {
+  const pieces: string[] = [];
+  STDERR_TOKEN.lastIndex = 0;
+  for (let match = STDERR_TOKEN.exec(text); match !== null; match = STDERR_TOKEN.exec(text)) {
+    const [whole, shape, , space, punctuation] = match;
+    pieces.push(shape !== undefined || space !== undefined || punctuation !== undefined ? whole : REDACTED);
+  }
+  return pieces.join("").replace(STDERR_COLLAPSE, REDACTED).replace(/[ \t]+$/, "");
+}
+
 /**
  * Redacts one connector stderr line before it is persisted.
  *
@@ -340,8 +447,16 @@ function openConnectorStderrSink(): number | null {
  * error helper logs the failing call's arguments verbatim
  * (`Error in <fn> (chat_id=…, query=…)`, see
  * `vendor/telegram-mcp/telegram_mcp/runtime.py`) and attaches a traceback
- * whose frames carry absolute paths under the operator's home. A crash
- * record has to say what died, never who was being read (#1087).
+ * whose frames carry absolute paths under the operator's home — and whose
+ * exception text is free-form, which is where a name, a chat title or a
+ * quoted message rides out. A crash record has to say what died, never who
+ * was being read (#1087).
+ *
+ * Known shapes are removed first, so what a crash log does keep still reads
+ * as a report: `@<user>` where a handle was, `<id>` where an id was,
+ * `key=<redacted>` where the vendored context format was. Then
+ * {@link summarizeConnectorStderr} decides the rest the other way round —
+ * nothing survives that is not a structured diagnostic or punctuation.
  *
  * `secrets` carries the values this Viewer already knows are credentials —
  * the connector bearer token and the Telegram string session — so an exact
@@ -350,13 +465,21 @@ function openConnectorStderrSink(): number | null {
 export function redactConnectorStderrLine(line: string, secrets: readonly string[] = []): string {
   let out = line;
   for (const secret of secrets) {
-    if (secret.length >= 8) out = out.split(secret).join("<redacted>");
+    if (secret.length >= 8) out = out.split(secret).join(REDACTED);
   }
   const home = os.homedir();
   if (home && home.length > 1) out = out.split(home).join("~");
+  /* Any other account's home, and the container's copy of this one. */
+  out = out.replace(/\/(home|Users)\/[^/\s:'"]+/g, "/$1/<user>");
+  if (STDERR_SCAFFOLD.has(out.trim())) return out.trim();
+  const frame = STDERR_FRAME.exec(out);
+  if (frame) {
+    const name = frame[3] === undefined
+      ? undefined
+      : (STDERR_FRAME_NAME.test(frame[3]) ? frame[3] : REDACTED);
+    return truncateStderrLine(`  File "${frame[1]}", line ${frame[2]}${name === undefined ? "" : `, in ${name}`}`);
+  }
   out = out
-    /* Any other account's home, and the container's copy of this one. */
-    .replace(/\/(home|Users)\/[^/\s:'"]+/g, "/$1/<user>")
     /* The vendored context format: `key=value` pairs lifted straight out of
        the tool arguments. Everything up to the next pair separator goes. */
     .replace(/\b([A-Za-z_]*(?:chat|user|peer|phone|contact|title|name|query|text|message|entity|alias|folder)[A-Za-z_]*)\s*=\s*[^,)]*/gi, "$1=<redacted>")
@@ -365,8 +488,12 @@ export function redactConnectorStderrLine(line: string, secrets: readonly string
     /* Chat/user/message ids and phone numbers. */
     .replace(/[+-]?\b\d{5,}\b/g, "<id>")
     /* Opaque high-entropy blobs — a session string, a token, a hash. */
-    .replace(/\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{24,}\b/g, "<redacted>");
-  return out.length > STDERR_LINE_CHARS ? `${out.slice(0, STDERR_LINE_CHARS)}…` : out;
+    .replace(/\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{24,}\b/g, REDACTED);
+  return truncateStderrLine(summarizeConnectorStderr(out));
+}
+
+function truncateStderrLine(line: string): string {
+  return line.length > STDERR_LINE_CHARS ? `${line.slice(0, STDERR_LINE_CHARS)}…` : line;
 }
 
 /** The last lines the connector printed before it died, redacted. Bounded
@@ -403,6 +530,12 @@ type ConnectorRecord = {
   connectorTokenSha256: string;
   command: string;
   entrypoint: string;
+  /** Whether the process runs under a crash monitor (#1087). A record written
+      before the monitor existed carries no marker and reads back as `legacy`:
+      that connector has no monitor to write an exit status down and this
+      Viewer is not its parent, so its crash can only be recorded as
+      `vanished`, with a null exit code and a null signal. */
+  supervision: "monitored" | "legacy";
 };
 
 let liveConnectorChild: {
@@ -431,7 +564,7 @@ function readConnectorRecord(): ConnectorRecord | null {
     if (row.version !== 1 || typeof row.pid !== "number" || !Number.isInteger(row.pid) || row.pid <= 1
       || typeof row.identity !== "string" || typeof row.credentialRef !== "string"
       || typeof row.connectorTokenSha256 !== "string" || typeof row.command !== "string" || typeof row.entrypoint !== "string") return null;
-    return row as ConnectorRecord;
+    return { ...(row as ConnectorRecord), supervision: row.supervision === "monitored" ? "monitored" : "legacy" };
   } catch {
     return null;
   }
@@ -472,6 +605,7 @@ function recordConnectorProcess(child: ConnectorChild, spec: ProcessSpec, bindin
     connectorTokenSha256: connectorTokenSha256(binding.connectorToken),
     command: spec.command,
     entrypoint: spec.args[0],
+    supervision: spec.env.LLV_TELEGRAM_STATE_DIR ? "monitored" : "legacy",
   };
   const tmp = `${pidFilePath()}.${process.pid}.tmp`;
   try {
@@ -522,6 +656,11 @@ type ConnectorCrashRecord = {
       recorded for it, so the code and signal are genuinely unknowable and
       both stay null. */
   observed: "exit" | "vanished";
+  /** Whether the process that died ran under a crash monitor. A `legacy`
+      connector — one still running from before the monitor existed — is the
+      one case where a null code AND a null signal are expected rather than a
+      gap: nothing was in a position to observe them (#1087). */
+  supervision: "monitored" | "legacy";
   stderr: string[];
 };
 
@@ -724,6 +863,7 @@ function watchConnectorExit(child: ConnectorChild, binding: ConnectorBinding, po
       exitCode: monitored ? monitored.exitCode : code,
       signal: monitored ? monitored.signal : signal ?? null,
       observed: "exit",
+      supervision: "monitored",
       stderr: connectorStderrTail(connectorSecrets(binding)),
     }, at);
     if (recorded) void restartAfterCrash(binding, ports, at);
@@ -763,6 +903,7 @@ function reapVanishedConnector(binding: ConnectorBinding, ports: TelegramConnect
     exitCode: monitored?.exitCode ?? null,
     signal: monitored?.signal ?? null,
     observed: monitored ? "exit" : "vanished",
+    supervision: record.supervision,
     stderr: connectorStderrTail(connectorSecrets(binding)),
   }, at);
 }
@@ -1111,7 +1252,8 @@ export async function telegramConnectorHealth(
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | null = null;
   const answer = await Promise.race([
-    callTool(url, session.connectorToken, "get_me", controller.signal).catch(() => null),
+    callTool(url, session.connectorToken, "get_me", controller.signal)
+      .catch((): ConnectorCallResult => ({ ok: false, code: "call_failed" })),
     new Promise<"busy">((resolve) => {
       timer = setTimeout(() => { controller.abort(); resolve("busy"); }, budget.probeTimeoutMs!);
       timer.unref?.();
@@ -1120,10 +1262,15 @@ export async function telegramConnectorHealth(
   if (timer) clearTimeout(timer);
   controller.abort();
   if (answer === "busy") return "busy";
+  /* A health call the supervisor's replacement took with it says nothing
+     about the account either, and the connector it would have torn down is
+     already gone — so it reads like a busy connector: no verdict, nothing
+     stopped, ask again once the replacement is up (#1087). */
+  if (!answer.ok) return answer.code === "connector_restarting" ? "busy" : null;
   /* An answer that is not the account — an upstream error string, a dead
      call — is no verdict: the bridge check must still get its chance to
      classify an expired or deauthorized session, which `get_me` cannot. */
-  const identity = parseConnectorIdentity(answer);
+  const identity = parseConnectorIdentity(answer.text);
   return identity ? { status: "connected", identity } : null;
 }
 

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -115,6 +115,11 @@ const PID_FILE = "connector.json";
 const STDERR_FILE = "connector-stderr.log";
 const CRASH_LOG_FILE = "connector-crashes.log";
 const RESTART_STATE_FILE = "connector-restarts.json";
+/* Written by the connector's own crash monitor (bin/telegram_connector_monitor.py)
+   at the moment the server child dies, so the exit code — or the signal, which
+   is the whole story for an OOM kill — outlives the Viewer generation that
+   spawned it. */
+const EXIT_FILE = "connector-exit.json";
 const STDERR_TAIL_LINES = 20;
 const STDERR_TAIL_BYTES = 8_192;
 const STDERR_LINE_CHARS = 400;
@@ -280,8 +285,40 @@ function telegramStateFile(name: string): string {
   return statePath("telegram", name);
 }
 
+/**
+ * How the connector's server child actually went, as its monitor recorded it
+ * (#1087).
+ *
+ * The Viewer spawns the monitor, and the monitor forks the server; the pid the
+ * supervisor records and signals is the monitor's, so a record is only this
+ * connector's when it names that pid. The monitor removes the file when it
+ * starts, so nothing here can be a previous generation's verdict.
+ */
+type ConnectorExitRecord = { monitorPid: number; pid: number; exitCode: number | null; signal: string | null };
+
+function readConnectorExitRecord(monitorPid: number): ConnectorExitRecord | null {
+  try {
+    const path = telegramStateFile(EXIT_FILE);
+    const stat = fs.lstatSync(path);
+    if (stat.isSymbolicLink() || !stat.isFile()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())) return null;
+    const row = JSON.parse(fs.readFileSync(path, "utf8")) as Partial<ConnectorExitRecord> & { version?: unknown };
+    if (row.version !== 1 || row.monitorPid !== monitorPid || typeof row.pid !== "number") return null;
+    return {
+      monitorPid,
+      pid: row.pid,
+      exitCode: typeof row.exitCode === "number" ? row.exitCode : null,
+      signal: typeof row.signal === "string" ? row.signal : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /** Append-only owner-only sink for the connector's stderr, truncated at every
-    spawn so the tail a crash record quotes is that process's own output. */
+    spawn so the tail a crash record quotes is that process's own output. The
+    monitor writes REDACTED lines here — it owns the server child's stderr and
+    filters every line on the way to disk, so nothing raw is ever persisted. */
 function openConnectorStderrSink(): number | null {
   try {
     if (ensureTelegramStateDir(true) === null) return null;
@@ -478,11 +515,12 @@ type ConnectorCrashRecord = {
   pid: number;
   exitCode: number | null;
   signal: string | null;
-  /** How the exit was noticed. `exit` is this Viewer's own child, so the
-      kernel handed us the code and signal. `vanished` is a connector this
-      Viewer only adopted (spawned by an earlier generation, so there is no
-      exit event to listen to): the disappearance is observed, the code and
-      signal are not knowable, and both stay null. */
+  /** How the exit was noticed. `exit` is an exit somebody waited for — this
+      Viewer's own child, or (for a connector spawned by an earlier generation)
+      the crash monitor that stayed its parent and wrote the status down.
+      `vanished` is the residue: the process is gone and no verdict was
+      recorded for it, so the code and signal are genuinely unknowable and
+      both stay null. */
   observed: "exit" | "vanished";
   stderr: string[];
 };
@@ -676,11 +714,15 @@ function watchConnectorExit(child: ConnectorChild, binding: ConnectorBinding, po
     if (deliberateStops.delete(pid)) return;
     if (liveConnectorChild?.pid === pid) liveConnectorChild = null;
     const at = ports.now();
+    /* The monitor waited on the SERVER child; what the kernel handed us is the
+       monitor's own mirrored status. Prefer the recorded verdict, and fall
+       back to ours when the connector ran unmonitored. */
+    const monitored = readConnectorExitRecord(pid);
     const recorded = recordConnectorCrash({
       at: new Date(at).toISOString(),
       pid,
-      exitCode: code,
-      signal: signal ?? null,
+      exitCode: monitored ? monitored.exitCode : code,
+      signal: monitored ? monitored.signal : signal ?? null,
       observed: "exit",
       stderr: connectorStderrTail(connectorSecrets(binding)),
     }, at);
@@ -689,19 +731,23 @@ function watchConnectorExit(child: ConnectorChild, binding: ConnectorBinding, po
 }
 
 /**
- * The crash record for an exit NOBODY was listening to (#1087).
+ * The crash record for an exit THIS Viewer was not listening to (#1087).
  *
  * A connector spawned by an earlier Viewer generation is adopted, not
- * re-parented: there is no exit event, so {@link watchConnectorExit} can
- * never fire for it — and after a Viewer restart that is EVERY connector the
- * operator has. Instead of a wrapper process to keep a handle alive, the
- * disappearance is noticed on the path that already runs on every status
- * read: the recorded pid is gone, this Viewer did not stop it, and the crash
- * is written with its stderr tail before the replacement spawn truncates the
- * sink. The exit code and signal are genuinely unknowable here and stay null.
+ * re-parented: there is no exit event, so {@link watchConnectorExit} can never
+ * fire for it — and after a Viewer restart that is EVERY connector the
+ * operator has. Two things cover that gap. The connector's own crash monitor
+ * stayed its parent across the Viewer restart and wrote the exit code or the
+ * killing signal down, so the record is complete. And the disappearance itself
+ * is noticed on the paths that already run on every status read, before the
+ * replacement spawn truncates the stderr sink.
  *
- * Returns true when a crash was recorded, so the caller can count the
- * restart it is about to perform.
+ * A process that died with no monitor at all (an older connector still running
+ * from before this change, a platform that could not fork) is still recorded —
+ * as `vanished`, with a null code and signal, because nothing observed them.
+ *
+ * Returns true when a crash was recorded, so the caller can count the restart
+ * it is about to perform.
  */
 function reapVanishedConnector(binding: ConnectorBinding, ports: TelegramConnectorPorts): boolean {
   const record = readConnectorRecord();
@@ -710,14 +756,43 @@ function reapVanishedConnector(binding: ConnectorBinding, ports: TelegramConnect
   if (procBackend.processIdentity(record.pid) === record.identity) return false;
   if (deliberateStops.delete(record.pid)) return false;
   const at = ports.now();
+  const monitored = readConnectorExitRecord(record.pid);
   return recordConnectorCrash({
     at: new Date(at).toISOString(),
     pid: record.pid,
-    exitCode: null,
-    signal: null,
-    observed: "vanished",
+    exitCode: monitored?.exitCode ?? null,
+    signal: monitored?.signal ?? null,
+    observed: monitored ? "exit" : "vanished",
     stderr: connectorStderrTail(connectorSecrets(binding)),
   }, at);
+}
+
+/**
+ * Records the crash of a connector that is already gone, BEFORE a caller tears
+ * the bookkeeping down (#1087).
+ *
+ * The health path stops the connector and deletes its record whenever the
+ * process cannot answer — including when it cannot answer because it is dead.
+ * Deleting the record first erases the only pointer to the crashed pid, and
+ * the crash then goes unrecorded, uncounted, and invisible. So the reap runs
+ * first, and the crash it writes is what the following
+ * {@link ensureTelegramConnector} recognises as the restart it is performing.
+ */
+export function reapTelegramConnectorCrash(
+  session: StoredTelegramSession,
+  ports: TelegramConnectorPorts = realPorts,
+): boolean {
+  return reapVanishedConnector(
+    { credentialRef: session.credentialRef, connectorToken: session.connectorToken },
+    ports,
+  );
+}
+
+/** A crash was recorded and no verified restart has followed it. The pid stamp
+    is cleared by {@link noteVerifiedRestart}, so this is exactly "the operator
+    is still missing the connector that died". */
+function crashAwaitingRestart(): boolean {
+  return readRestartState().lastCrashPid !== null;
 }
 
 async function restartAfterCrash(binding: ConnectorBinding, ports: TelegramConnectorPorts, at: number): Promise<void> {
@@ -904,7 +979,14 @@ export async function ensureTelegramConnector(
   ports: TelegramConnectorPorts = realPorts,
 ): Promise<ConnectorEnsureResult> {
   const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };
-  if (!reapVanishedConnector(binding, ports)) return await ensureConnectorNow(session, ports);
+  /* This call IS a restart when it follows a crash: one this pass just reaped,
+     or one already on the record that nothing has brought a connector back
+     from. The second case is the health path, which reaps and then tears the
+     pid record down before getting here (#1087). `restartsInFlight` keeps a
+     crash the exit watcher is already restarting from being counted twice. */
+  const isRestart = reapVanishedConnector(binding, ports)
+    || (restartsInFlight === 0 && crashAwaitingRestart());
+  if (!isRestart) return await ensureConnectorNow(session, ports);
   if (restartBurstExhausted(ports.now())) {
     markConnectorRestartFailed("connector_failed", binding.credentialRef);
     return { ok: false, code: "connector_failed" };

--- a/src/lib/telegram/contracts.ts
+++ b/src/lib/telegram/contracts.ts
@@ -8,7 +8,10 @@
  * and sanitized codes.
  */
 
-/** The connection lifecycle, in the exact phases issue #1059 names. */
+/** The connection lifecycle, in the exact phases issue #1059 names, plus the
+    transient `restarting` (#1087): the credential is fine and the account is
+    connected, but the shared connector process is being brought back after an
+    unexpected exit, so calls through it fail until it is verified ready. */
 export type TelegramPhase =
   | "disconnected"
   | "starting"
@@ -16,6 +19,7 @@ export type TelegramPhase =
   | "awaiting_password"
   | "verifying"
   | "connected"
+  | "restarting"
   | "expired"
   | "error";
 
@@ -53,6 +57,15 @@ export type TelegramLoginView = {
   passwordError: boolean;
 };
 
+/** Connector supervision as the browser sees it (#1087): how often the shared
+    process had to be restarted after an unexpected exit, and when the last one
+    happened. Deliberate stops (logout, local deletion, a refused read-only
+    surface) are NOT restarts — this counter only moves for crashes. */
+export type TelegramConnectorRestarts = {
+  last24h: number;
+  lastAt: string | null;
+};
+
 export type TelegramStatusPayload = {
   phase: TelegramPhase;
   login: TelegramLoginView | null;
@@ -64,6 +77,8 @@ export type TelegramStatusPayload = {
   /** Whether host API credentials (env or telegram.json) exist. A boolean
       only — the values themselves never cross this boundary (#1070). */
   credentialsConfigured: boolean;
+  /** Crash-restart history of the shared connector (#1087). */
+  connectorRestarts: TelegramConnectorRestarts;
 };
 
 export const NONTERMINAL_TELEGRAM_LOGIN_PHASES: ReadonlySet<TelegramPhase> = new Set([

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -530,3 +530,169 @@ test("a held call is answered with the restart error when the supervisor drains,
   expect(output.later.restart_header).toBe(true);
   expect(JSON.parse(output.later.body).error.code).toBe(-32001);
 });
+
+/* ------------------------------------------------------------------ #1087
+   The connector's crash monitor. The Viewer cannot learn how a process it did
+   not parent died — and after a Viewer restart it has parented none of them.
+   So the connector's own parent is a monitor that outlives the Viewer: it owns
+   the server child's stderr (redacting every line on the way to the sink) and
+   waits for it, writing the exit code — or the killing signal, which is the
+   whole story for an OOM kill — where the next Viewer generation can read it.
+   ------------------------------------------------------------------------ */
+
+/** A fake vendored tree whose `runner.main()` runs the given Python body. */
+function monitoredConnectorVendor(name: string, body: string[]): string {
+  const vendor = path.join(SANDBOX, name);
+  for (const directory of ["mcp/server", "telegram_mcp"]) {
+    fs.mkdirSync(path.join(vendor, directory), { recursive: true });
+    fs.writeFileSync(path.join(vendor, directory, "__init__.py"), "");
+  }
+  fs.writeFileSync(path.join(vendor, "mcp", "__init__.py"), "");
+  fs.writeFileSync(path.join(vendor, "mcp", "server", "fastmcp.py"), [
+    "class _Server:",
+    "    name = 'telegram'",
+    "class FastMCP:",
+    "    def __init__(self): self._mcp_server = _Server()",
+    "    def streamable_http_app(self):",
+    "        async def app(scope, receive, send): pass",
+    "        return app",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(vendor, "telegram_mcp", "runtime.py"), [
+    "from mcp.server.fastmcp import FastMCP",
+    "mcp = FastMCP()",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(vendor, "telegram_mcp", "runner.py"), ["def main():", ...body.map((line) => `    ${line}`), ""].join("\n"));
+  return vendor;
+}
+
+function runMonitoredConnector(vendor: string, stateDir: string, token: string) {
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  return Bun.spawnSync({
+    cmd: [python!, path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-mcp-server.py")],
+    env: {
+      ...process.env,
+      LLV_TELEGRAM_VENDOR_DIR: vendor,
+      LLV_TELEGRAM_MCP_TOKEN: token,
+      LLV_TELEGRAM_STATE_DIR: stateDir,
+      TELEGRAM_SESSION_STRING: "1ApWapzMBu4placeholder-not-a-real-session",
+    },
+    stdout: "pipe",
+    /* In production this fd is the Viewer's owner-only stderr sink; the
+       monitor writes the redacted stream to whatever it was given. */
+    stderr: "pipe",
+  });
+}
+
+test("the crash monitor records the server's exit code, and redacts its stderr before it is written (#1087)", () => {
+  const stateDir = path.join(SANDBOX, "monitor-exit-state");
+  const vendor = monitoredConnectorVendor("monitor-exit-vendor", [
+    "import sys",
+    "print('ERROR Error in get_messages (chat_id=-1001234567890, query=quarterly plan) - Code: MSG-ERR-042', file=sys.stderr)",
+    "print('session=' + __import__('os').environ['TELEGRAM_SESSION_STRING'] + ' refused', file=sys.stderr)",
+    "raise SystemExit(7)",
+  ]);
+  const result = runMonitoredConnector(vendor, stateDir, "E".repeat(43));
+
+  /* The monitor mirrors the child's fate, so a Viewer still listening reads
+     the same verdict the record carries. */
+  expect(result.exitCode).toBe(7);
+  const record = JSON.parse(fs.readFileSync(path.join(stateDir, "connector-exit.json"), "utf8")) as
+    { version: number; monitorPid: number; pid: number; exitCode: number | null; signal: string | null };
+  expect(record.version).toBe(1);
+  expect(record.exitCode).toBe(7);
+  expect(record.signal).toBeNull();
+  /* The monitor is the process the supervisor spawned and signals; the server
+     it waited on is a different pid. */
+  expect(record.pid).not.toBe(record.monitorPid);
+  expect(fs.lstatSync(path.join(stateDir, "connector-exit.json")).mode & 0o077).toBe(0);
+
+  /* Nothing raw was ever written: the identifiers and the credential are gone
+     before the line reaches the sink, and the error code survives. */
+  const written = result.stderr.toString();
+  expect(written).toContain("MSG-ERR-042");
+  expect(written).not.toContain("1001234567890");
+  expect(written).not.toContain("quarterly plan");
+  expect(written).not.toContain("1ApWapzMBu4placeholder-not-a-real-session");
+});
+
+test("a connector killed outright is recorded as the signal that killed it (#1087)", () => {
+  const stateDir = path.join(SANDBOX, "monitor-signal-state");
+  const vendor = monitoredConnectorVendor("monitor-signal-vendor", [
+    "import os, signal",
+    "os.kill(os.getpid(), signal.SIGKILL)",
+  ]);
+  const result = runMonitoredConnector(vendor, stateDir, "F".repeat(43));
+
+  /* The death an OOM kill produces: no traceback, no exit code, and before
+     the monitor nothing at all for the operator to read. */
+  const record = JSON.parse(fs.readFileSync(path.join(stateDir, "connector-exit.json"), "utf8")) as
+    { exitCode: number | null; signal: string | null };
+  expect(record.signal).toBe("SIGKILL");
+  expect(record.exitCode).toBeNull();
+  expect(result.exitCode).toBe(128 + 9);
+});
+
+test("the Python and TypeScript redactors cannot drift apart (#1087)", async () => {
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  const { redactConnectorStderrLine } = await import("./connector");
+  const secrets = ["1ApWapzMBu4placeholder-not-a-real-session", "G".repeat(43)];
+  const samples = [
+    "ERROR Error in get_messages (chat_id=-1001234567890, query=quarterly plan) - Code: MSG-ERR-042",
+    "resolved @a_real_handle for +380501234567",
+    `  File "${path.join(os.homedir(), "telethon", "client.py")}", line 5`,
+    `  File "/${"home"}/another-account/telethon/client.py", line 5`,
+    `session=${secrets[0]} refused`,
+    "Traceback (most recent call last):",
+    "MemoryError",
+  ];
+  const result = Bun.spawnSync({
+    cmd: [python!, "-c", [
+      "import json, sys",
+      `sys.path.insert(0, ${JSON.stringify(path.resolve(import.meta.dir, "..", "..", "..", "bin"))})`,
+      "from telegram_connector_monitor import redact_stderr_line",
+      "samples, secrets = json.load(sys.stdin)",
+      "print(json.dumps([redact_stderr_line(line, secrets) for line in samples]))",
+    ].join("\n")],
+    stdin: Buffer.from(JSON.stringify([samples, secrets])),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.stderr.toString()).toBe("");
+  expect(JSON.parse(result.stdout.toString())).toEqual(samples.map((line) => redactConnectorStderrLine(line, secrets)));
+});
+
+test("the supervisor's SIGTERM reaches the server through its monitor (#1087)", async () => {
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  const stateDir = path.join(SANDBOX, "monitor-term-state");
+  const readyFile = path.join(SANDBOX, "monitor-term-ready");
+  fs.rmSync(readyFile, { force: true });
+  const vendor = monitoredConnectorVendor("monitor-term-vendor", [
+    "import os, time",
+    `open(${JSON.stringify(readyFile)}, 'w').write('ready')`,
+    "while True: time.sleep(0.05)",
+  ]);
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  /* The supervisor signals the pid it recorded, which is the monitor's: the
+     monitor and the server it forked share an argv, so nothing else in the
+     supervisor had to learn about the fork. */
+  const proc = Bun.spawn({
+    cmd: [python!, path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-mcp-server.py")],
+    env: { ...process.env, LLV_TELEGRAM_VENDOR_DIR: vendor, LLV_TELEGRAM_MCP_TOKEN: "H".repeat(43), LLV_TELEGRAM_STATE_DIR: stateDir },
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const deadline = Date.now() + 5_000;
+  while (!fs.existsSync(readyFile) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(fs.existsSync(readyFile)).toBe(true);
+
+  proc.kill("SIGTERM");
+  await proc.exited;
+  const record = JSON.parse(fs.readFileSync(path.join(stateDir, "connector-exit.json"), "utf8")) as { signal: string | null };
+  expect(record.signal).toBe("SIGTERM");
+}, 15_000);

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -427,3 +427,91 @@ test("API credentials come from host configuration, not hardcoded values", () =>
     if (oldConfig === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = oldConfig;
   }
 });
+
+test("a stop names itself: requests during the drain, and a response the stop cut short, carry the restart error (#1087)", () => {
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  const fakeVendor = path.join(SANDBOX, "drain-wrapper-vendor");
+  for (const directory of ["mcp/server", "telegram_mcp"]) {
+    fs.mkdirSync(path.join(fakeVendor, directory), { recursive: true });
+    fs.writeFileSync(path.join(fakeVendor, directory, "__init__.py"), "");
+  }
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "__init__.py"), "");
+  /* A stand-in MCP app that starts an event-stream response and then returns
+     without finishing it — exactly what the vendored server does when the
+     supervisor's SIGTERM cancels the session task mid tool call. */
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "server", "fastmcp.py"), [
+    "class _Server:",
+    "    name = 'telegram'",
+    "class FastMCP:",
+    "    def __init__(self): self._mcp_server = _Server()",
+    "    def streamable_http_app(self):",
+    "        async def app(scope, receive, send):",
+    "            await receive()",
+    "            await send({'type': 'http.response.start', 'status': 200,",
+    "                        'headers': [(b'content-type', b'text/event-stream')]})",
+    "            await send({'type': 'http.response.body', 'body': b'', 'more_body': True})",
+    "        return app",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runtime.py"), [
+    "from mcp.server.fastmcp import FastMCP",
+    "mcp = FastMCP()",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runner.py"), [
+    "import asyncio, json, os",
+    "import __main__",
+    "from telegram_mcp.runtime import mcp",
+    "async def request(body):",
+    "    statuses, headers, chunks = [], [], []",
+    "    sent = {'done': False}",
+    "    async def receive(): return {'type': 'http.request', 'body': body, 'more_body': False}",
+    "    async def send(message):",
+    "        if message['type'] == 'http.response.start':",
+    "            statuses.append(message['status'])",
+    "            headers.extend(message.get('headers', []))",
+    "        if message['type'] == 'http.response.body': chunks.append(message.get('body', b''))",
+    "    token = os.environ['LLV_TELEGRAM_MCP_TOKEN'].encode()",
+    "    scope = {'type': 'http', 'path': '/mcp', 'method': 'POST',",
+    "             'headers': [(b'authorization', b'Bearer ' + token)]}",
+    "    await mcp.streamable_http_app()(scope, receive, send)",
+    "    return {'status': statuses[0], 'restart_header': any(k == b'x-llv-telegram-restarting' for k, _ in headers),",
+    "            'body': b''.join(chunks).decode()}",
+    "def main():",
+    "    call = json.dumps({'jsonrpc': '2.0', 'id': 42, 'method': 'tools/call'}).encode()",
+    "    cut_short = asyncio.run(request(call))",
+    "    __main__._begin_drain()",
+    "    draining = asyncio.run(request(call))",
+    "    print(json.dumps({'cut_short': cut_short, 'draining': draining}))",
+    "",
+  ].join("\n"));
+
+  const connectorToken = "D".repeat(43);
+  const result = Bun.spawnSync({
+    cmd: [python!, path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-mcp-server.py")],
+    env: { ...process.env, LLV_TELEGRAM_VENDOR_DIR: fakeVendor, LLV_TELEGRAM_MCP_TOKEN: connectorToken },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  const output = JSON.parse(result.stdout.toString()) as {
+    cut_short: { status: number; body: string };
+    draining: { status: number; restart_header: boolean; body: string };
+  };
+
+  /* The dropped in-flight call gets a JSON-RPC error addressed to its own
+     request id, instead of a stream that just stops. */
+  expect(output.cut_short.status).toBe(200);
+  expect(output.cut_short.body).toContain("event: message");
+  const frame = JSON.parse(output.cut_short.body.split("data: ")[1]!) as { id: number; error: { code: number; message: string } };
+  expect(frame.id).toBe(42);
+  expect(frame.error.code).toBe(-32001);
+  expect(frame.error.message).toContain("restarting");
+
+  /* A call that arrives after the signal is refused with the same named
+     reason, not a bare connection reset. */
+  expect(output.draining.status).toBe(503);
+  expect(output.draining.restart_header).toBe(true);
+  expect(JSON.parse(output.draining.body).error.code).toBe(-32001);
+});

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -619,6 +619,35 @@ test("the crash monitor records the server's exit code, and redacts its stderr b
   expect(written).not.toContain("1ApWapzMBu4placeholder-not-a-real-session");
 });
 
+test("free-form crash text reaches the sink as a diagnostic, never as an identity (#1087)", () => {
+  const stateDir = path.join(SANDBOX, "monitor-identity-state");
+  /* The vendored runtime raises with whatever Telethon put in the message,
+     and an exception message is free text: a name, a chat title, a quoted
+     message. A redactor that only removes the shapes it knows would keep
+     every one of these. */
+  const vendor = monitoredConnectorVendor("monitor-identity-vendor", [
+    "import sys",
+    "print('Traceback (most recent call last):', file=sys.stderr)",
+    "print('ValueError: No user has Alice Example as username', file=sys.stderr)",
+    "print('RuntimeError: could not read \"Демо Проєкт\" for Олена Приклад', file=sys.stderr)",
+    "print(\"telegram_mcp.runtime: last message text was 'send the documents tomorrow'\", file=sys.stderr)",
+    "raise SystemExit(6)",
+  ]);
+  const result = runMonitoredConnector(vendor, stateDir, "I".repeat(43));
+  expect(result.exitCode).toBe(6);
+  const written = result.stderr.toString();
+
+  for (const identity of ["Alice", "Example", "Демо", "Проєкт", "Олена", "Приклад", "documents", "tomorrow"]) {
+    expect(written).not.toContain(identity);
+  }
+  /* What a crash report is for survives: the shape of the failure and the
+     types that produced it. */
+  expect(written).toContain("Traceback (most recent call last):");
+  expect(written).toContain("ValueError");
+  expect(written).toContain("RuntimeError");
+  expect(written).toContain("telegram_mcp.runtime");
+});
+
 test("a connector killed outright is recorded as the signal that killed it (#1087)", () => {
   const stateDir = path.join(SANDBOX, "monitor-signal-state");
   const vendor = monitoredConnectorVendor("monitor-signal-vendor", [
@@ -649,6 +678,12 @@ test("the Python and TypeScript redactors cannot drift apart (#1087)", async () 
     `session=${secrets[0]} refused`,
     "Traceback (most recent call last):",
     "MemoryError",
+    /* Free text, where the two redactors have the most room to disagree. */
+    "ValueError: No user has Alice Example as username",
+    "RuntimeError: could not read \"Демо Проєкт\" for Олена Приклад",
+    "telethon.errors.rpcerrorlist.FloodWaitError: A wait of 420 seconds is required (caused by GetHistoryRequest)",
+    "OSError: [Errno 111] Connection refused",
+    "  File \"<string>\", line 1, in <module>",
   ];
   const result = Bun.spawnSync({
     cmd: [python!, "-c", [

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -428,7 +428,7 @@ test("API credentials come from host configuration, not hardcoded values", () =>
   }
 });
 
-test("a stop names itself: requests during the drain, and a response the stop cut short, carry the restart error (#1087)", () => {
+test("a held call is answered with the restart error when the supervisor drains, before any signal (#1087)", () => {
   const python = Bun.which("python3");
   expect(python).not.toBeNull();
   const fakeVendor = path.join(SANDBOX, "drain-wrapper-vendor");
@@ -437,10 +437,11 @@ test("a stop names itself: requests during the drain, and a response the stop cu
     fs.writeFileSync(path.join(fakeVendor, directory, "__init__.py"), "");
   }
   fs.writeFileSync(path.join(fakeVendor, "mcp", "__init__.py"), "");
-  /* A stand-in MCP app that starts an event-stream response and then returns
-     without finishing it — exactly what the vendored server does when the
-     supervisor's SIGTERM cancels the session task mid tool call. */
+  /* A stand-in MCP app that starts an event-stream response for a tool call
+     and then waits for Telegram forever — a call in flight, exactly what a
+     stop used to drop without a word. */
   fs.writeFileSync(path.join(fakeVendor, "mcp", "server", "fastmcp.py"), [
+    "import asyncio",
     "class _Server:",
     "    name = 'telegram'",
     "class FastMCP:",
@@ -451,6 +452,7 @@ test("a stop names itself: requests during the drain, and a response the stop cu
     "            await send({'type': 'http.response.start', 'status': 200,",
     "                        'headers': [(b'content-type', b'text/event-stream')]})",
     "            await send({'type': 'http.response.body', 'body': b'', 'more_body': True})",
+    "            await asyncio.Event().wait()",
     "        return app",
     "",
   ].join("\n"));
@@ -459,31 +461,39 @@ test("a stop names itself: requests during the drain, and a response the stop cu
     "mcp = FastMCP()",
     "",
   ].join("\n"));
+  /* One event loop, one app, three requests: a tool call held open, the
+     supervisor's pre-stop drain, and a caller that arrives afterwards. */
   fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runner.py"), [
     "import asyncio, json, os",
-    "import __main__",
     "from telegram_mcp.runtime import mcp",
-    "async def request(body):",
-    "    statuses, headers, chunks = [], [], []",
-    "    sent = {'done': False}",
+    "TOKEN = os.environ['LLV_TELEGRAM_MCP_TOKEN'].encode()",
+    "async def request(app, path, method, body, auth=True):",
+    "    out = {'status': None, 'headers': [], 'chunks': []}",
     "    async def receive(): return {'type': 'http.request', 'body': body, 'more_body': False}",
     "    async def send(message):",
     "        if message['type'] == 'http.response.start':",
-    "            statuses.append(message['status'])",
-    "            headers.extend(message.get('headers', []))",
-    "        if message['type'] == 'http.response.body': chunks.append(message.get('body', b''))",
-    "    token = os.environ['LLV_TELEGRAM_MCP_TOKEN'].encode()",
-    "    scope = {'type': 'http', 'path': '/mcp', 'method': 'POST',",
-    "             'headers': [(b'authorization', b'Bearer ' + token)]}",
-    "    await mcp.streamable_http_app()(scope, receive, send)",
-    "    return {'status': statuses[0], 'restart_header': any(k == b'x-llv-telegram-restarting' for k, _ in headers),",
-    "            'body': b''.join(chunks).decode()}",
-    "def main():",
+    "            out['status'] = message['status']",
+    "            out['headers'].extend(message.get('headers', []))",
+    "        if message['type'] == 'http.response.body': out['chunks'].append(message.get('body', b''))",
+    "    headers = [(b'authorization', b'Bearer ' + (TOKEN if auth else b'wrong'))]",
+    "    await app({'type': 'http', 'path': path, 'method': method, 'headers': headers}, receive, send)",
+    "    out['restart_header'] = any(k == b'x-llv-telegram-restarting' for k, _ in out['headers'])",
+    "    out['body'] = b''.join(out['chunks']).decode()",
+    "    del out['headers'], out['chunks']",
+    "    return out",
+    "async def drive():",
+    "    app = mcp.streamable_http_app()",
     "    call = json.dumps({'jsonrpc': '2.0', 'id': 42, 'method': 'tools/call'}).encode()",
-    "    cut_short = asyncio.run(request(call))",
-    "    __main__._begin_drain()",
-    "    draining = asyncio.run(request(call))",
-    "    print(json.dumps({'cut_short': cut_short, 'draining': draining}))",
+    "    held = asyncio.ensure_future(request(app, '/mcp', 'POST', call))",
+    "    await asyncio.sleep(0.05)",
+    "    assert not held.done(), 'the call must still be in flight'",
+    "    unauthorized = await request(app, '/llv-telegram-drain', 'POST', b'', auth=False)",
+    "    drain = await request(app, '/llv-telegram-drain', 'POST', b'')",
+    "    later = await request(app, '/mcp', 'POST', call)",
+    "    return {'held': await asyncio.wait_for(held, 2), 'drain': drain,",
+    "            'unauthorized': unauthorized, 'later': later}",
+    "def main():",
+    "    print(json.dumps(asyncio.run(drive())))",
     "",
   ].join("\n"));
 
@@ -494,24 +504,29 @@ test("a stop names itself: requests during the drain, and a response the stop cu
     stdout: "pipe",
     stderr: "pipe",
   });
+  expect(result.stderr.toString()).toBe("");
   expect(result.exitCode).toBe(0);
-  const output = JSON.parse(result.stdout.toString()) as {
-    cut_short: { status: number; body: string };
-    draining: { status: number; restart_header: boolean; body: string };
-  };
+  type Response = { status: number; restart_header: boolean; body: string };
+  const output = JSON.parse(result.stdout.toString()) as Record<"held" | "drain" | "unauthorized" | "later", Response>;
 
-  /* The dropped in-flight call gets a JSON-RPC error addressed to its own
-     request id, instead of a stream that just stops. */
-  expect(output.cut_short.status).toBe(200);
-  expect(output.cut_short.body).toContain("event: message");
-  const frame = JSON.parse(output.cut_short.body.split("data: ")[1]!) as { id: number; error: { code: number; message: string } };
+  /* The drain is authenticated like everything else on this surface. */
+  expect(output.unauthorized.status).toBe(401);
+  expect(output.drain.status).toBe(200);
+
+  /* The call that was in flight finishes with a JSON-RPC error addressed to
+     its own request id — while the process is still alive, so nothing about
+     this depends on the shutdown reaching a particular code path, and the
+     supervisor's SIGKILL escalation can no longer be what the caller meets. */
+  expect(output.held.status).toBe(200);
+  expect(output.held.body).toContain("event: message");
+  const frame = JSON.parse(output.held.body.split("data: ")[1]!) as { id: number; error: { code: number; message: string } };
   expect(frame.id).toBe(42);
   expect(frame.error.code).toBe(-32001);
   expect(frame.error.message).toContain("restarting");
 
-  /* A call that arrives after the signal is refused with the same named
+  /* A call that arrives after the drain is refused with the same named
      reason, not a bare connection reset. */
-  expect(output.draining.status).toBe(503);
-  expect(output.draining.restart_header).toBe(true);
-  expect(JSON.parse(output.draining.body).error.code).toBe(-32001);
+  expect(output.later.status).toBe(503);
+  expect(output.later.restart_header).toBe(true);
+  expect(JSON.parse(output.later.body).error.code).toBe(-32001);
 });

--- a/src/lib/telegram/packaging.ts
+++ b/src/lib/telegram/packaging.ts
@@ -246,6 +246,11 @@ export function connectorLaunchSpec(input: { sessionString: string; connectorTok
       TELEGRAM_EXPOSED_TOOLS: "read-only",
       LLV_TELEGRAM_MCP_TOKEN: input.connectorToken,
       LLV_TELEGRAM_VENDOR_DIR: vendor,
+      /* Where the crash monitor writes the exit status of a connector this
+         Viewer generation may not live to see die (#1087). The connector's
+         own state dir, which it already reads and writes through the vendored
+         tree — no wider Viewer state reaches the child. */
+      LLV_TELEGRAM_STATE_DIR: statePath("telegram"),
       MCP_TRANSPORT: "http",
       MCP_HOST: TELEGRAM_MCP_HOST,
       MCP_PORT: String(telegramMcpPort()),

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -737,6 +737,56 @@ test("health from the running connector never stops it — the read burst surviv
   expect(calls.ensure).toBe(1);
 });
 
+test("a connector busy with a burst of bounded reads is never torn down", async () => {
+  const adapter = new FakeAdapter();
+  const calls = { stop: 0, bridge: 0, ensure: 0 };
+  adapter.checkSession = async () => {
+    calls.bridge += 1;
+    return { status: "connected", identity: { name: "Account A", username: "account_a" } };
+  };
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  const checkedAt = "2026-08-20T11:58:00.000Z";
+  writeTelegramConnection({
+    version: 1,
+    status: "connected",
+    credentialRef: stored.credentialRef,
+    identity: { name: "Account A", username: "account_a" },
+    lastHealthCheckAt: checkedAt,
+    errorCode: null,
+  });
+
+  /* Four bounded reads are still open against the connector; the health call
+     queues behind them and runs out of budget. That is the exact moment the
+     old code killed the process and took every one of them with it (#1087). */
+  let settled = 0;
+  const reads = [0, 1, 2, 3].map(() => new Promise<string>((resolve) => {
+    setTimeout(() => { settled += 1; resolve("read done"); }, 30);
+  }));
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => { calls.ensure += 1; return { ok: true, url: "http://127.0.0.1:8809/mcp" }; },
+    stopConnector: () => { calls.stop += 1; },
+    registerHosts: () => HOSTS_REGISTERED,
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorHealth: async () => "busy",
+  });
+
+  const status = await service.checkHealth();
+  /* Nothing was signaled, the bridge never took the session, and the durable
+     verdict is the one the last COMPLETED check wrote — a missed deadline is
+     not a health reading in either direction. */
+  expect(calls.stop).toBe(0);
+  expect(calls.bridge).toBe(0);
+  expect(calls.ensure).toBe(0);
+  expect(status.phase).toBe("connected");
+  expect(status.lastHealthCheckAt).toBe(checkedAt);
+  expect(await Promise.all(reads)).toEqual(["read done", "read done", "read done", "read done"]);
+  expect(settled).toBe(4);
+});
+
 test("a connector that cannot answer falls back to the destructive bridge check", async () => {
   const adapter = new FakeAdapter();
   const order: string[] = [];

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -701,3 +701,121 @@ test("retry authorization cannot overwrite a preserved unsafe session", async ()
   expect(fs.readFileSync(telegramSessionPath())).toEqual(before);
   expect(fs.existsSync(path.join(path.dirname(telegramSessionPath()), "connector-token"))).toBe(false);
 });
+
+/* ----------------------------------------------------------------- #1087 */
+
+test("health from the running connector never stops it — the read burst survives", async () => {
+  const adapter = new FakeAdapter();
+  const calls = { stop: 0, connectorHealth: 0, ensure: 0, bridge: 0 };
+  adapter.checkSession = async () => {
+    calls.bridge += 1;
+    return { status: "connected", identity: { name: "Account A", username: "account_a" } };
+  };
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => { calls.ensure += 1; return { ok: true, url: "http://127.0.0.1:8809/mcp" }; },
+    stopConnector: () => { calls.stop += 1; },
+    registerHosts: () => HOSTS_REGISTERED,
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorHealth: async () => {
+      calls.connectorHealth += 1;
+      return { status: "connected", identity: { name: "Account A", username: "account_a" } };
+    },
+  });
+
+  const status = await service.checkHealth();
+  expect(status.phase).toBe("connected");
+  expect(status.identity?.username).toBe("account_a");
+  expect(calls.connectorHealth).toBe(1);
+  /* The teardown that used to kill every in-flight agent call never happens,
+     and the bridge is not spawned at all. */
+  expect(calls.stop).toBe(0);
+  expect(calls.bridge).toBe(0);
+  expect(calls.ensure).toBe(1);
+});
+
+test("a connector that cannot answer falls back to the destructive bridge check", async () => {
+  const adapter = new FakeAdapter();
+  const order: string[] = [];
+  adapter.checkSession = async () => {
+    order.push("bridge");
+    return { status: "connected", identity: { name: "Account A", username: null } };
+  };
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => { order.push("ensure"); return { ok: true, url: "http://127.0.0.1:8809/mcp" }; },
+    stopConnector: () => { order.push("stop"); },
+    registerHosts: () => { order.push("register"); return HOSTS_REGISTERED; },
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorHealth: async () => { order.push("connector"); return null; },
+  });
+
+  expect((await service.checkHealth()).phase).toBe("connected");
+  expect(order).toEqual(["connector", "stop", "bridge", "ensure", "register"]);
+});
+
+test("a connected account whose connector is coming back reads as restarting, with the 24 h count", () => {
+  const adapter = new FakeAdapter();
+  let restarting = true;
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => ({ ok: true, url: "http://127.0.0.1:8809/mcp" }),
+    stopConnector: () => {},
+    registerHosts: () => HOSTS_REGISTERED,
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorRestarts: () => ({ restarting, last24h: 3, lastAt: "2026-08-20T11:59:00.000Z" }),
+  });
+  writeTelegramConnection({
+    version: 1,
+    status: "connected",
+    credentialRef: "credential-generation-a",
+    identity: { name: "Account A", username: "account_a" },
+    lastHealthCheckAt: "2026-08-20T11:58:00.000Z",
+    errorCode: null,
+  });
+
+  const restartingStatus = service.status();
+  expect(restartingStatus.phase).toBe("restarting");
+  expect(restartingStatus.identity?.username).toBe("account_a");
+  expect(restartingStatus.connectorRestarts).toEqual({ last24h: 3, lastAt: "2026-08-20T11:59:00.000Z" });
+  /* Transient: once the replacement is verified, the phase is connected again
+     while the counter keeps the history. */
+  restarting = false;
+  const settled = service.status();
+  expect(settled.phase).toBe("connected");
+  expect(settled.connectorRestarts.last24h).toBe(3);
+});
+
+test("restart counts never mask a real phase: an errored connection stays an error", () => {
+  const adapter = new FakeAdapter();
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => ({ ok: true, url: "http://127.0.0.1:8809/mcp" }),
+    stopConnector: () => {},
+    registerHosts: () => HOSTS_REGISTERED,
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorRestarts: () => ({ restarting: true, last24h: 1, lastAt: "2026-08-20T11:59:00.000Z" }),
+  });
+  writeTelegramConnection({
+    version: 1,
+    status: "error",
+    credentialRef: "credential-generation-a",
+    identity: null,
+    lastHealthCheckAt: null,
+    errorCode: "connector_failed",
+  });
+  const status = service.status();
+  expect(status.phase).toBe("error");
+  expect(status.error?.code).toBe("connector_failed");
+  expect(status.connectorRestarts.last24h).toBe(1);
+});

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -869,3 +869,58 @@ test("restart counts never mask a real phase: an errored connection stays an err
   expect(status.error?.code).toBe("connector_failed");
   expect(status.connectorRestarts.last24h).toBe(1);
 });
+
+test("a dead connector's crash is recorded before the health teardown erases the pid record (#1087)", async () => {
+  /* The real crash bookkeeping over this file's isolated state dir: what is
+     under test is the ORDER the service does things in, so the parts that
+     write and read the record are the production ones. */
+  const { readTelegramConnectorCrashes, reapTelegramConnectorCrash } = await import("./connector");
+  const adapter = new FakeAdapter();
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  const stored = readTelegramSession()!;
+  const telegramDir = path.dirname(telegramSessionPath());
+  const pidFile = path.join(telegramDir, "connector.json");
+
+  /* A connector that is already gone: a pid nothing answers for, recorded the
+     way a previous Viewer generation left it, with the stderr it printed on
+     the way out still in the sink. */
+  const gone = Bun.spawn({ cmd: ["/bin/sh", "-c", "exit 0"], stdout: "ignore", stderr: "ignore" });
+  const deadPid = gone.pid;
+  await gone.exited;
+  fs.writeFileSync(pidFile, JSON.stringify({
+    version: 1,
+    pid: deadPid,
+    identity: "a-process-that-is-no-longer-there",
+    credentialRef: stored.credentialRef,
+    connectorTokenSha256: "0".repeat(64),
+    command: "/nonexistent/python",
+    entrypoint: "/nonexistent/telegram-mcp-server.py",
+  }), { mode: 0o600 });
+  fs.writeFileSync(path.join(telegramDir, "connector-stderr.log"), "MemoryError\n", { mode: 0o600 });
+  fs.writeFileSync(path.join(telegramDir, "connector-exit.json"), JSON.stringify({
+    version: 1, monitorPid: deadPid, pid: deadPid + 1, exitCode: null, signal: "SIGKILL",
+    at: "2026-08-20T11:59:00.000Z",
+  }), { mode: 0o600 });
+
+  const service = new TelegramConnectionService({
+    adapter,
+    ensureConnector: async () => ({ ok: true, url: "http://127.0.0.1:8809/mcp" }),
+    /* Exactly what the production teardown does to the record — the erasure
+       that used to take the crash with it. */
+    stopConnector: () => { fs.rmSync(pidFile, { force: true }); },
+    registerHosts: () => HOSTS_REGISTERED,
+    unregisterHosts: () => {},
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    credentialsConfigured: () => true,
+    connectorHealth: async () => null,
+    reapConnectorCrash: (session) => { reapTelegramConnectorCrash(session); },
+  });
+
+  expect((await service.checkHealth()).phase).toBe("connected");
+  expect(fs.existsSync(pidFile)).toBe(false);
+  const crashes = readTelegramConnectorCrashes();
+  expect(crashes).toHaveLength(1);
+  expect(crashes[0]!.pid).toBe(deadPid);
+  expect(crashes[0]!.signal).toBe("SIGKILL");
+  expect(crashes[0]!.stderr).toContain("MemoryError");
+});

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -39,9 +39,11 @@ export interface TelegramServicePorts {
       the browser as a boolean only (#1070). */
   credentialsConfigured(): boolean;
   /** Health from the RUNNING connector, without stopping it (#1087). `null`
-      means it could not answer and the destructive bridge check has to run.
-      Absent in tests that only exercise the bridge path. */
-  connectorHealth?(session: StoredTelegramSession): Promise<TelegramHealthResult | null>;
+      means it could not answer and the destructive bridge check has to run;
+      `"busy"` means it is alive and serving but did not finish inside the
+      budget, which is no reason to stop anything. Absent in tests that only
+      exercise the bridge path. */
+  connectorHealth?(session: StoredTelegramSession): Promise<TelegramHealthResult | "busy" | null>;
   /** Crash restarts of the shared connector, for the status payload (#1087). */
   connectorRestarts?(): TelegramConnectorRestarts & { restarting: boolean };
 }
@@ -442,10 +444,18 @@ export class TelegramConnectionService {
        teardown — which used to kill every in-flight agent read (a panel open
        during a fan-out of large `get_messages` calls took the connector down
        for ~20 s and still reported connected). */
-    let result: TelegramHealthResult | null = null;
+    let result: TelegramHealthResult | "busy" | null = null;
     try { result = (await this.ports.connectorHealth?.(session)) ?? null; }
     catch { result = null; }
     if (!this.lifecycleIsCurrent(generation)) return;
+    /* The connector is alive and serving, it just did not finish the health
+       call inside the budget — the signature of a fan-out of large reads.
+       Missing a health deadline proves nothing about the account and nothing
+       about the in-flight reads, so nothing is torn down and nothing durable
+       is rewritten: the previous verdict stands until a check completes
+       (#1087). Killing the process here is exactly the outage this issue
+       reports. */
+    if (result === "busy") return;
     if (result === null) {
       /* The connector cannot answer, so it is not serving anyone either: the
          bridge check may now take the session. The bridge uses the same

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 
 import { processTelegramAdapter, type TelegramAdapter, type TelegramEnrollmentEvent, type TelegramEnrollmentHandle, type TelegramHealthResult } from "./adapter";
-import { ensureTelegramConnector, stopTelegramConnector, telegramConnectorActivity, telegramConnectorHealth, type ConnectorEnsureResult } from "./connector";
+import { ensureTelegramConnector, reapTelegramConnectorCrash, stopTelegramConnector, telegramConnectorActivity, telegramConnectorHealth, type ConnectorEnsureResult } from "./connector";
 import type { TelegramConnectorRestarts, TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
 import { registerTelegramHosts, unregisterTelegramHosts, type TelegramHostRegistrationResult } from "./hostRegistration";
 import { telegramApiCredentials } from "./packaging";
@@ -46,6 +46,11 @@ export interface TelegramServicePorts {
   connectorHealth?(session: StoredTelegramSession): Promise<TelegramHealthResult | "busy" | null>;
   /** Crash restarts of the shared connector, for the status payload (#1087). */
   connectorRestarts?(): TelegramConnectorRestarts & { restarting: boolean };
+  /** Records the crash of a connector that is already gone, BEFORE this
+      service tears its pid record down (#1087). The teardown deletes the only
+      pointer to the crashed process, so a crash not written here is never
+      written at all. */
+  reapConnectorCrash?(session: StoredTelegramSession): void;
 }
 
 const productionPorts: TelegramServicePorts = {
@@ -58,6 +63,7 @@ const productionPorts: TelegramServicePorts = {
   credentialsConfigured: () => telegramApiCredentials() !== null,
   connectorHealth: (session) => telegramConnectorHealth(session),
   connectorRestarts: () => telegramConnectorActivity(),
+  reapConnectorCrash: (session) => { reapTelegramConnectorCrash(session); },
 };
 
 type LiveLogin = {
@@ -457,6 +463,12 @@ export class TelegramConnectionService {
        reports. */
     if (result === "busy") return;
     if (result === null) {
+      /* One reason a connector cannot answer is that it is dead. Write that
+         crash down FIRST: the teardown below removes the pid record, and with
+         it the only pointer to the process whose exit, stderr tail, and
+         restart nobody would otherwise ever see (#1087). */
+      try { this.ports.reapConnectorCrash?.(session); }
+      catch { /* bookkeeping never blocks the health path */ }
       /* The connector cannot answer, so it is not serving anyone either: the
          bridge check may now take the session. The bridge uses the same
          StringSession as the shared connector — release the long-lived owner

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 
-import { processTelegramAdapter, type TelegramAdapter, type TelegramEnrollmentEvent, type TelegramEnrollmentHandle } from "./adapter";
-import { ensureTelegramConnector, stopTelegramConnector, type ConnectorEnsureResult } from "./connector";
-import type { TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
+import { processTelegramAdapter, type TelegramAdapter, type TelegramEnrollmentEvent, type TelegramEnrollmentHandle, type TelegramHealthResult } from "./adapter";
+import { ensureTelegramConnector, stopTelegramConnector, telegramConnectorActivity, telegramConnectorHealth, type ConnectorEnsureResult } from "./connector";
+import type { TelegramConnectorRestarts, TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
 import { registerTelegramHosts, unregisterTelegramHosts, type TelegramHostRegistrationResult } from "./hostRegistration";
 import { telegramApiCredentials } from "./packaging";
 import {
@@ -38,6 +38,12 @@ export interface TelegramServicePorts {
   /** Whether host API credentials exist (env or telegram.json) — surfaced to
       the browser as a boolean only (#1070). */
   credentialsConfigured(): boolean;
+  /** Health from the RUNNING connector, without stopping it (#1087). `null`
+      means it could not answer and the destructive bridge check has to run.
+      Absent in tests that only exercise the bridge path. */
+  connectorHealth?(session: StoredTelegramSession): Promise<TelegramHealthResult | null>;
+  /** Crash restarts of the shared connector, for the status payload (#1087). */
+  connectorRestarts?(): TelegramConnectorRestarts & { restarting: boolean };
 }
 
 const productionPorts: TelegramServicePorts = {
@@ -48,6 +54,8 @@ const productionPorts: TelegramServicePorts = {
   unregisterHosts: () => unregisterTelegramHosts(),
   now: Date.now,
   credentialsConfigured: () => telegramApiCredentials() !== null,
+  connectorHealth: (session) => telegramConnectorHealth(session),
+  connectorRestarts: () => telegramConnectorActivity(),
 };
 
 type LiveLogin = {
@@ -126,6 +134,7 @@ export class TelegramConnectionService {
 
   status(): TelegramStatusPayload {
     if (this.login) {
+      const restarts = this.connectorRestarts();
       return {
         phase: this.login.phase,
         login: {
@@ -138,6 +147,7 @@ export class TelegramConnectionService {
         lastHealthCheckAt: null,
         error: null,
         credentialsConfigured: this.ports.credentialsConfigured(),
+        connectorRestarts: { last24h: restarts.last24h, lastAt: restarts.lastAt },
       };
     }
     let connection: StoredTelegramConnection;
@@ -150,15 +160,28 @@ export class TelegramConnectionService {
     return this.payloadFor(connection);
   }
 
+  private connectorRestarts(): TelegramConnectorRestarts & { restarting: boolean } {
+    try {
+      return this.ports.connectorRestarts?.() ?? { restarting: false, last24h: 0, lastAt: null };
+    } catch {
+      return { restarting: false, last24h: 0, lastAt: null };
+    }
+  }
+
   private payloadFor(connection: StoredTelegramConnection): TelegramStatusPayload {
+    const restarts = this.connectorRestarts();
     return {
-      phase: connection.status,
+      /* A connected account whose connector is being brought back after an
+         unexpected exit is NOT serving calls; say so instead of reporting
+         connected throughout the outage (#1087). */
+      phase: connection.status === "connected" && restarts.restarting ? "restarting" : connection.status,
       login: null,
       identity: connection.identity,
       credentialRef: connection.credentialRef,
       lastHealthCheckAt: connection.lastHealthCheckAt,
       error: connection.status === "error" && connection.errorCode ? { code: connection.errorCode } : null,
       credentialsConfigured: this.ports.credentialsConfigured(),
+      connectorRestarts: { last24h: restarts.last24h, lastAt: restarts.lastAt },
     };
   }
 
@@ -414,15 +437,28 @@ export class TelegramConnectionService {
       }
       return;
     }
-    /* The bridge uses the same StringSession as the shared connector. Release
-       the long-lived owner before the short health client acquires the
-       vendored per-session lock and connects. */
-    try { await this.ports.stopConnector(); }
-    catch {
-      this.recordError("connector_failed");
-      return;
+    /* #1087: ask the RUNNING connector first. It answers from the live
+       Telethon client it already owns, so a healthy account no longer costs a
+       teardown — which used to kill every in-flight agent read (a panel open
+       during a fan-out of large `get_messages` calls took the connector down
+       for ~20 s and still reported connected). */
+    let result: TelegramHealthResult | null = null;
+    try { result = (await this.ports.connectorHealth?.(session)) ?? null; }
+    catch { result = null; }
+    if (!this.lifecycleIsCurrent(generation)) return;
+    if (result === null) {
+      /* The connector cannot answer, so it is not serving anyone either: the
+         bridge check may now take the session. The bridge uses the same
+         StringSession as the shared connector — release the long-lived owner
+         before the short health client acquires the vendored per-session lock
+         and connects. */
+      try { await this.ports.stopConnector(); }
+      catch {
+        this.recordError("connector_failed");
+        return;
+      }
+      result = await this.ports.adapter.checkSession(session.sessionString);
     }
-    const result = await this.ports.adapter.checkSession(session.sessionString);
     if (!this.lifecycleIsCurrent(generation)) return;
     const checkedAt = new Date(this.ports.now()).toISOString();
     if (result.status === "connected") {


### PR DESCRIPTION
Closes #1087.

## Proven cause: the connector was not killed by concurrency — the Viewer killed it

Three findings, in the order they were established.

**1. Every fresh status read destroyed the connector.** `runHealthCheck` in
`src/lib/telegram/service.ts` called `stopConnector()` unconditionally before the
enrollment-bridge health check (the bridge needs the same `StringSession`, which
the vendored per-session lock hands to exactly one process), then re-spawned via
`ensureConnector`. `GET /api/telegram?fresh=1` is what the Telegram panel issues
every time it is opened. So opening the panel = SIGTERM (2 s grace, then SIGKILL)
→ bridge round trip → respawn → readiness probes: a ~10–25 s window in which the
loopback port is refused and every in-flight `tools/call` is dropped, ending with
`connection.json` written back to `connected`.

Confirmed live on the host, not just read from the source: the running connector's
kernel start time (`/proc/<pid>/stat` field 22 + `btime`) was `13:19:57.07`, and
`connection.json.lastHealthCheckAt` for the same connection was `13:19:57.913`.
The process serving the account had been spawned by the health check less than a
second earlier — exactly the report's "new pid with ~18 s uptime while the status
API still says connected". It happened again later in the same session (a second
new pid), with no reads in flight at all: the trigger is the status refresh, not load.

**2. The vendored server survives the burst from the repro.** Reproduced against
`vendor/telegram-mcp` itself — the real tree, real `mcp` 1.29.0 SDK, real
`bin/telegram-mcp-server.py` — with Telethon replaced by an offline stub so no
real account is touched: 3 concurrent `get_messages` with `page_size: 120`
succeed (2.5 s wall, all three answered), and so do 12 concurrent calls at
`page_size: 500` (244 KB per answer). The process stays up and the port stays
open in both. The HTTP/session layer is not what dies; the MCP session manager
already catches per-session exceptions (`streamable_http_manager.py`), and
`get_messages` catches everything itself, which is also why
`vendor-src/mcp_errors.log` was empty in the report.

**3. Nothing could have recorded a crash even if one had happened.** The
supervisor spawned with `stdio: ["ignore", "ignore", "ignore"]`, so the
connector's stderr went to `/dev/null`, and `mcp_errors.log` only receives
ERROR-level tool exceptions. A dropped in-flight call, reproduced against the
old entrypoint, surfaced to the caller as
`RemoteProtocolError: peer closed connection without sending complete message
body` — indistinguishable from a network blip, as the issue says.

Honest bound: I did not fan out three 120-message reads against the operator's
live account (it would use their real account and could take their connector
down), so a Telethon-level failure under real concurrency is not formally
excluded. Finding 1 alone reproduces every symptom in the report, and the crash
log added here is exactly the evidence that would settle it next time.

## The fix

**Health stops being destructive** (`service.ts`, `connector.ts`). When the
shared connector is up and ours, the health check asks *it*: `get_me` over the
already-verified read-only surface, which only a live, authorized Telethon client
can answer. That proves what the bridge proved, without a teardown. The
destructive bridge path stays as the fallback for exactly the case where it costs
nothing — a connector that cannot answer is not serving anyone either — and it
still classifies `expired`, which `get_me` cannot.

**A connector that is merely busy is never torn down.** The health call has three
outcomes, not two. A handshake that was *refused* (closed socket, bad proof, a
surface that is no longer read-only) is `null` and falls through to the bridge. A
handshake that *succeeded* while the account question ran out of its 15 s budget —
or a handshake that itself ran out of budget, which means the listener was there
and the event loop was saturated — is `"busy"`: the process is alive, ours, and
still serving, and a missed health deadline is no evidence that anything finished.
Nothing is stopped and no durable verdict is rewritten; the last completed check
stands and the next one asks again. Conflating that with "dead" is what turned a
fan-out of large reads into an outage.

**Crashes are recorded, and nothing raw is ever persisted** (`connector.ts`,
`bin/telegram_connector_monitor.py`). The child's stderr reaches
`state/telegram/connector-stderr.log` (0600, Viewer-owned, truncated per spawn so
a tail always belongs to the process that died) **only through the redactor** —
the monitor owns the server child's stderr and filters every line on the way to
the sink, so the identifiers never touch disk in the first place. An exit this
Viewer did not cause appends `{at, pid, exitCode, signal, observed, stderr[]}` to
`state/telegram/connector-crashes.log` (0600 ndjson, last 50 kept, stderr bounded
to 20 lines / 8 KB / 400 chars per line), and a verified restart is counted in
`state/telegram/connector-restarts.json` (timestamps trimmed to 24 h). The tail
copy is redacted again on the way into the crash log, which is idempotent.

That output is not innocent: the
vendored error helper logs the failing call's own arguments
(`Error in get_messages (chat_id=…, query=…)`, `telegram_mcp/runtime.py`) and
attaches a traceback whose frames carry absolute paths under the operator's home.
Ids and phone numbers, `@handles`, home paths, the vendored `key=value` context,
and this generation's own bearer token and string session (removed by value, not
by pattern) all go; the error code and the exception type survive, which is what a
crash report is for.

Deliberate stops — logout, local deletion, a refused read-only surface — are
marked before the first signal and are neither logged nor restarted.

**An exit this Viewer did not parent is recorded in full** (`bin/telegram_connector_monitor.py`).
A connector spawned by an earlier Viewer generation is adopted through the pid
file, not re-parented: it has no exit event, and the kernel hands an exit status
only to a process's own parent — so after a Viewer restart *every* connector the
operator has was invisible to the crash path, and the OOM kill a fan-out of large
reads invites is exactly the death that leaves no traceback to fall back on.

So the connector's parent is now something that survives the Viewer. The
entrypoint forks once, before anything heavy is imported: the child becomes the
server, and the parent stays as a monitor of a few kilobytes of standard library
whose whole job is to hold the child's stderr, `waitpid`, and write the verdict
to `state/telegram/connector-exit.json` (0600, removed at every monitor start, so
it can only ever hold the current generation's). A connector killed outright is
then recorded as `SIGKILL` rather than as an unexplained disappearance.

The monitor cost the supervisor nothing to learn: monitor and server share an
argv, so the recorded pid, the `/proc` identity fence, the argv check and every
signal path are unchanged — SIGTERM goes to the monitor, which forwards it and
lives to record what came of it. `PR_SET_PDEATHSIG` (with a portable ppid
watchdog behind it) means the SIGKILL escalation cannot strand a server holding
the loopback port.

The disappearance itself is still noticed on the paths that already run on every
status read, before the replacement spawn truncates the sink, so a connector that
died with no monitor at all — one still running from before this change, or a
platform that could not fork — is recorded as `vanished` with a null code and
signal. A crash is recorded exactly once whichever way it is noticed.

**A restart is counted only when the replacement comes back.** A respawn that
failed left the operator with no connector; calling that a completed restart said
the opposite of what happened. Now a failed respawn marks the durable connection
`error` / `connector_failed` instead of leaving `connected` standing over a dead
process, and the burst limiter reads the *crashes* rather than the successes — a
connector that dies five times inside 15 min and never comes back stops being
respawned just as surely as one that comes back and dies again. The connector is
brought back for the *same* stored credential only; a session the operator deleted
or replaced is never resurrected.

**Status contract** (`contracts.ts`): a transient `restarting` phase (overlaid on
a `connected` connection while a crash restart is in flight — an `error` phase is
never masked) and `connectorRestarts: { last24h, lastAt }` on every payload.

**A dropped call names itself, and no longer depends on how the process dies**
(`bin/telegram-mcp-server.py`, Viewer-owned). The first revision completed a
cut-short response *after* the ASGI app returned, which the SIGKILL escalation and
an unexpected exit both skip. Now the supervisor **asks before it signals**: an
authenticated `POST /llv-telegram-drain` over the same loopback surface latches the
drain, and every request already in flight is finished right then — cancelled
deliberately and answered with a JSON-RPC error addressed to its own request id —
while the process is still alive and its loop still runs. Only then does SIGTERM go
out. Requests arriving afterwards get `503` + `x-llv-telegram-restarting: 1` + the
same frame, after the bearer check, so an unauthenticated caller still only ever
sees `401`. The `signal.signal` monkeypatch is gone.

```
event: message
data: {"jsonrpc": "2.0", "id": 4, "error": {"code": -32001, "message": "Telegram connector is restarting: the Agent Log Viewer supervisor stopped this process. In-flight calls were dropped; retry shortly."}}
```

A response the app leaves unfinished for any *other* reason is completed too,
under `-32603` with its own message — never mislabelled as a restart.

**No vendored Python changed.** The fix needed nothing inside
`vendor/telegram-mcp`, so `PROVENANCE.md`, `SHA256SUMS` and the install guard
stand untouched; the drain lives in the Viewer-owned entrypoint.

**The crash is written before the health path erases the pointer to it**
(`service.ts`). A connector that cannot answer is torn down so the bridge can
take the session — and the teardown deletes `connector.json`, the only pointer to
the pid that died. The crash then went unrecorded, uncounted, and invisible: the
very case the reaper existed for. Now the health path reaps first, and the
`ensureTelegramConnector` that follows recognises a crash still awaiting a
connector as the restart it is performing, so the count and the transient
`restarting` state survive the erasure. A restart is still counted once, and
still only when the replacement verifies.

**A crash log that keeps diagnostics, not free text** (`connector.ts`,
`bin/telegram_connector_monitor.py`). The redactor was a blacklist, so it removed
the shapes it knew — ids, handles, `key=value` context, home paths, credential
values — and kept everything else. Everything else is where the identities are:
`ValueError: No user has <a name> as username` reached both owner-only logs
unchanged, and so did a chat title or a quoted message carried in an exception.

It now decides the other way round. An exception class (qualified or bare), a
signal name, an `[Errno N]`, a protocol error constant, a traceback frame (path,
line, function) and the modules a connector traceback can name survive; the
traceback scaffolding survives; punctuation survives, because it carries no
identity. Every other run of text collapses into one `<redacted>`, and a line is
bounded at 120 characters. The blacklist still runs first, so what remains still
reads as a report — `@<user>` where a handle was, `<id>` where an id was — and
what it misses no longer matters, because free text does not survive the second
pass at all. The Python monitor and the TypeScript tail share the rule, and the
drift test runs both over the same samples, free text included.

**A call dropped by a respawn names itself** (`connector.ts`). The pre-stop drain
answers calls in flight when the supervisor stops a connector it can still reach.
It cannot answer a call dropped by a process that is simply gone — after a
`SIGKILL` there is no event loop and no socket left to write a frame on — so the
Viewer-side call boundary answers instead: `callTelegramConnectorTool` now returns
`{ ok: false, code: "connector_restarting" }` when the process that was serving
the call is no longer the one on the record, and `call_failed` otherwise. The
Viewer knows which pid served the call, so this is a fact rather than a guess.
The kernel closes a dying process's sockets before its parent hears that it died,
so the check waits up to 250 ms for the supervisor to notice — only on a call
that has already failed, and nothing else is delayed by it. A health call that
comes back `connector_restarting` reads like a busy connector: no verdict,
nothing torn down.

The code stays inside that boundary and is deliberately NOT added to
`TelegramErrorCode`: it describes one call rather than the connection, the status
payload already carries the same event as the `restarting` phase and the 24 h
count, and `TelegramErrorCode` is exhaustively mapped inside
`src/components/TelegramConnect.tsx`, which this lane must not edit.

**A legacy connector says why it has no exit status** (`connector.ts`). The pid
record now carries `supervision: "monitored" | "legacy"`; a record written before
the crash monitor existed reads back as `legacy`, and its crash record carries
that too. A null exit code and a null signal then read as the one case where
nothing was in a position to observe them, instead of as a gap in the
exit-code/signal requirement.

## Declined, as exceeding #1087

**A Viewer-owned proxy holding the loopback port across a respawn.** The review
asked for a generation-aware boundary that survives child death and answers the
held call itself. The vendored server runs `FastMCP(..., stateless_http=True)`
(`vendor/telegram-mcp/telegram_mcp/runtime.py:120`), so each `tools/call` is one
standalone POST and there is no MCP session for a replacement process to
recognise as a previous generation's. The only construction that could answer
the caller in band is a Viewer-owned listener that keeps the port across the
respawn and hands it back to the replacement — whose failure mode is a connector
that can never bind. That is machinery heavier than the problem, and it risks
precisely the outage this issue is about. What ships instead is the boundary in
the Viewer's own hands, described above: the call fails with
`connector_restarting`. The one caller it cannot reach is an agent talking to
127.0.0.1 directly; for that caller the answer stays out of band and within one
status read — the crash recorded with the killing signal, the phase reading
`restarting`, and `connectorRestarts.last24h` moving.

**A forced replacement of a legacy connector.** The review asked for one drained
replacement of a connector still running from before the monitor. A pre-upgrade
process has no drain endpoint, so replacing it drops the reads it is serving with
no error at all — the exact failure #1087 is about — to fix bookkeeping about a
death that has not happened. The supervision state is recorded instead, and the
legacy process is replaced by a monitored one the first time it stops or dies,
which the tests cover.

**Removing the connector's request buffering.** The review asked for it as
superseded by the new boundary. It is not: the 64 KB cap in
`bin/telegram-mcp-server.py` is what lets the drain address its JSON-RPC error to
the request id that was cut short, which is the in-band half of the guarantee.

## Follow-up for the #1086 lane (UI)

`src/components/TelegramConnect.tsx` is deliberately not edited. The panel picks
up the new state through the existing payload, but it needs two additions there:

1. A health row for `status.connectorRestarts` — "Connector restarts (24 h): N,
   last <time>", hidden at `0` — the count the issue asks for. `lastAt` is an ISO
   string, formatted like the existing `telegram.lastCheck`.
2. `phaseColor()` currently falls through to `var(--color-accent)` for
   `restarting`, which reads as an in-progress phase and is fine as a default; a
   deliberate colour (warning-ish, distinct from `connected` green) would be
   better. The label key `telegram.status.restarting` already exists in both
   locales ("Connector restarting…" / "Конектор перезапускається…"), so nothing
   renders blank in the meantime.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test src/lib/telegram/connector.test.ts src/lib/telegram/service.test.ts src/lib/telegram/packaging.test.ts src/app/api/telegram/route.test.ts src/lib/i18n/i18n.test.ts` — 113 pass, 0 fail. Plus `src/components/TelegramConnect.{dom,render}.test.tsx` — 16 pass, 0 fail. Focused, isolated state dirs only; no suite sweeps `src/lib/agent/` or `src/app/api/runtime/`.
- `bunx eslint src/lib/telegram/` — clean.
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main)` — PASS.

Tests use a real child process as the fake connector, so exit code, signal and
stderr tail come from the kernel rather than a mock, and this file now claims its
own ephemeral `LLV_TELEGRAM_MCP_PORT` so the new pre-stop drain can never reach
whatever is listening on the real 8809.

The monitor is driven for real, not modelled: the committed tests run
`bin/telegram-mcp-server.py` under `python3` against a stub vendored tree and
assert that a server exiting `7` is recorded as `exitCode: 7` while its
identifiers and its session string never reach the stream, that a server killing
itself with `SIGKILL` is recorded as that signal, that the supervisor's SIGTERM
reaches the server through the monitor, and that the Python and TypeScript
redactors produce byte-identical output over the same samples so they cannot
drift.

What they cover: a crash recorded with its stderr; the crash log and stderr sink
owner-only; the tail redacted (sentinel id, query, foreign home path, handle,
phone, token and session — asserted against the on-disk log, not just the parsed
view), while the error code survives; **an adopted connector's crash reaped**
(asserting first that nothing heard the exit, then that the next supervisor pass
records it and counts the restart) — both with the monitor's verdict, where the
record carries the real killing signal, and without one, where it stays
`vanished`; **a crash reaped before the health path deletes the pid record still
counted as a restart** (RED-checked: without the fix the counter reads 0);
**three real bounded reads held open against a real process across a fresh health
check**, with the process alive afterwards and every read completing; a crash
restarting for the same credential, counted once; a deliberate stop being neither;
the burst limit stopping a crash loop; **a failed respawn not counted and the
durable status downgraded to `connector_failed`**; **a stop asking the connector
to drain before it signals it**, authenticated and ordered ahead of the SIGTERM;
health answering without a stop and never letting the account's phone number out
of `get_me`; a connector that cannot prove the account yielding no verdict;
**a busy connector reported `busy` and never stopped**, both when `get_me` runs
out of budget behind reads still in flight and when the handshake itself does.

Service tests cover the no-teardown path, the fallback ordering
(`connector → stop → bridge → ensure → register`), the `restarting` overlay with
the 24 h count, **a dead connector's crash recorded before the health teardown
erases its pid record** (real crash bookkeeping over an isolated state dir;
RED-checked: without the reap the crash log is empty), and **a busy connector
during a fresh health check**: nothing
signaled, the bridge never given the session, `lastHealthCheckAt` left at the last
*completed* check, and all four bounded reads resolving.

The drain was also verified end to end against the **real** MCP SDK over real
HTTP — a live `uvicorn` serving `FastMCP.streamable_http_app()` through the new
middleware, with a stub `telegram_mcp` (no account, no session, isolated port):
`initialize` / `tools/list` / `tools/call` all answer normally through the
task-wrapped middleware, a held `tools/call` (`id: 4`) comes back as the `-32001`
frame above the moment the drain arrives, and the next request is `503` with
`x-llv-telegram-restarting: 1`. That check is not committed, because it depends on
a provisioned venv; the committed Python test drives the same three requests
through the real entrypoint against a stub ASGI app.

Added this round: a crash whose free-form stderr carries a name, a Cyrillic
identity, a quoted title and message content — asserted absent from the crash log
on disk (Viewer-side redactor) and from the monitor's stream (Python redactor),
while `Traceback`, `ValueError`, `RuntimeError` and the module name survive; a
held call against a real process killed with `SIGKILL` mid-read, coming back
`{ ok: false, code: "connector_restarting" }` with the crash and the 24 h count
following it; and a legacy record being adopted rather than replaced, whose later
crash records `supervision: "legacy"` with a null code and signal while its
replacement records `monitored`. The legacy case was RED-checked: without the
supervision marker the crash record cannot say why the fields are null.
