### PR TITLE
fix(telegram): concurrency gate + visible connector restarts (#1087)

### DIFF
--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Authenticated entrypoint for the packaged Telegram MCP connector."""
 
+import asyncio
 import hashlib
 import hmac
+import json
 import os
 import re
 import sys
@@ -51,11 +53,115 @@ class BearerAuthMiddleware:
         await self.app(scope, receive, send)
 
 
+# Issue #1087: three concurrent get_messages pages took the whole connector
+# down for ~20 s, and every agent session shares this one process. Agents call
+# the loopback port directly, so this wrapper — the Viewer-owned ASGI seam the
+# vendored app already runs behind — is the only chokepoint on their path.
+# Tool calls beyond the cap queue instead of piling onto the account client;
+# a request that waits out the bound is refused, never dropped silently.
+GATE_LIMIT = 2
+GATE_WAIT_SECONDS = 30.0
+
+
+def _is_tool_call(body: bytes) -> bool:
+    """Only tools/call is gated: the handshake, tools/list and the session
+    stream must stay free or the Viewer's own readiness probe would queue
+    behind agent reads and be read as a dead connector."""
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    if isinstance(payload, list):
+        return any(isinstance(item, dict) and item.get("method") == "tools/call" for item in payload)
+    return isinstance(payload, dict) and payload.get("method") == "tools/call"
+
+
+async def _buffer_request(receive):
+    """Reads the request body so the method can be inspected, and returns a
+    receive callable that replays it to the wrapped app unchanged."""
+    messages = []
+    body = b""
+    while True:
+        message = await receive()
+        messages.append(message)
+        if message.get("type") != "http.request":
+            break
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    index = 0
+
+    async def replay():
+        nonlocal index
+        if index < len(messages):
+            message = messages[index]
+            index += 1
+            return message
+        return await receive()
+
+    return body, replay
+
+
+def _release_late(slots):
+    """Gives back a slot granted after its waiter already gave up."""
+    def release(task):
+        if not task.cancelled() and task.exception() is None:
+            slots.release()
+    return release
+
+
+class ToolCallGate:
+    def __init__(self, app, limit: int = GATE_LIMIT, wait_seconds: float = GATE_WAIT_SECONDS):
+        self.app = app
+        self.limit = limit
+        self.wait_seconds = wait_seconds
+        self._semaphore = None
+
+    def _slots(self):
+        # Created on first use so it binds to the loop the server runs on.
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.limit)
+        return self._semaphore
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+        body, replay = await _buffer_request(receive)
+        if not _is_tool_call(body):
+            await self.app(scope, replay, send)
+            return
+        slots = self._slots()
+        waiter = asyncio.ensure_future(slots.acquire())
+        try:
+            # The WAIT times out; the acquire itself is never cancelled, so a
+            # slot handed over at that exact moment cannot be lost — a lost
+            # slot would shrink the cap permanently.
+            await asyncio.wait_for(asyncio.shield(waiter), self.wait_seconds)
+        except asyncio.TimeoutError:
+            waiter.add_done_callback(_release_late(slots))
+            await send({
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"retry-after", b"1"),
+                ],
+            })
+            await send({"type": "http.response.body", "body": b"Telegram connector is busy"})
+            return
+        try:
+            await self.app(scope, replay, send)
+        finally:
+            slots.release()
+
+
 _original_streamable_http_app = FastMCP.streamable_http_app
 
 
 def _authenticated_streamable_http_app(self):
-    return BearerAuthMiddleware(_original_streamable_http_app(self), TOKEN)
+    """Auth outermost: an unauthorized request must not consume a gate slot."""
+    return BearerAuthMiddleware(ToolCallGate(_original_streamable_http_app(self)), TOKEN)
 
 
 FastMCP.streamable_http_app = _authenticated_streamable_http_app

--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -53,32 +53,30 @@ class BearerAuthMiddleware:
         await self.app(scope, receive, send)
 
 
-# Issue #1087: three concurrent get_messages pages took the whole connector
-# down for ~20 s, and every agent session shares this one process. Agents call
-# the loopback port directly, so this wrapper — the Viewer-owned ASGI seam the
-# vendored app already runs behind — is the only chokepoint on their path.
-# Tool calls beyond the cap queue instead of piling onto the account client;
-# a request that waits out the bound is refused, never dropped silently.
+# Issue #1087: three concurrent get_messages pages took the whole connector down
+# for ~20 s, and every agent session shares this one process. Agents call the
+# loopback port directly, so this wrapper — the Viewer-owned ASGI seam the
+# vendored app already runs behind — is the only chokepoint on their path. Tool
+# calls past the cap queue; one that waits out the bound is refused, not dropped.
 GATE_LIMIT = 2
 GATE_WAIT_SECONDS = 30.0
 
 
 def _is_tool_call(body: bytes) -> bool:
-    """Only tools/call is gated: the handshake, tools/list and the session
-    stream must stay free or the Viewer's own readiness probe would queue
-    behind agent reads and be read as a dead connector."""
+    """Only tools/call is gated: the handshake, tools/list and the session stream
+    must stay free or the Viewer's own readiness probe would queue behind agent
+    reads and be read as a dead connector."""
     try:
         payload = json.loads(body)
     except (ValueError, UnicodeDecodeError):
         return False
-    if isinstance(payload, list):
-        return any(isinstance(item, dict) and item.get("method") == "tools/call" for item in payload)
-    return isinstance(payload, dict) and payload.get("method") == "tools/call"
+    items = payload if isinstance(payload, list) else [payload]
+    return any(isinstance(item, dict) and item.get("method") == "tools/call" for item in items)
 
 
 async def _buffer_request(receive):
-    """Reads the request body so the method can be inspected, and returns a
-    receive callable that replays it to the wrapped app unchanged."""
+    """Reads the body so the method can be inspected, and returns a receive
+    callable that replays it to the wrapped app unchanged."""
     messages = []
     body = b""
     while True:
@@ -94,20 +92,11 @@ async def _buffer_request(receive):
     async def replay():
         nonlocal index
         if index < len(messages):
-            message = messages[index]
             index += 1
-            return message
+            return messages[index - 1]
         return await receive()
 
     return body, replay
-
-
-def _release_late(slots):
-    """Gives back a slot granted after its waiter already gave up."""
-    def release(task):
-        if not task.cancelled() and task.exception() is None:
-            slots.release()
-    return release
 
 
 class ToolCallGate:
@@ -134,20 +123,15 @@ class ToolCallGate:
         slots = self._slots()
         waiter = asyncio.ensure_future(slots.acquire())
         try:
-            # The WAIT times out; the acquire itself is never cancelled, so a
-            # slot handed over at that exact moment cannot be lost — a lost
-            # slot would shrink the cap permanently.
+            # The WAIT times out; the acquire itself is never cancelled, so a slot
+            # handed over at that exact moment is given back rather than lost — a
+            # lost slot would shrink the cap permanently.
             await asyncio.wait_for(asyncio.shield(waiter), self.wait_seconds)
         except asyncio.TimeoutError:
-            waiter.add_done_callback(_release_late(slots))
-            await send({
-                "type": "http.response.start",
-                "status": 503,
-                "headers": [
-                    (b"content-type", b"text/plain; charset=utf-8"),
-                    (b"retry-after", b"1"),
-                ],
-            })
+            waiter.add_done_callback(
+                lambda granted: None if granted.cancelled() or granted.exception() else slots.release())
+            await send({"type": "http.response.start", "status": 503, "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"), (b"retry-after", b"1")]})
             await send({"type": "http.response.body", "body": b"Telegram connector is busy"})
             return
         try:

--- a/evidence/issue-1059/drive.ts
+++ b/evidence/issue-1059/drive.ts
@@ -136,6 +136,8 @@ function payload(over: Partial<TelegramStatusPayload>): TelegramStatusPayload {
       credentialsConfigured: true,
     lastHealthCheckAt: null,
     error: null,
+    restartsLast24h: 0,
+    lastRestartAt: null,
     ...over,
   };
 }

--- a/src/app/api/telegram/route.test.ts
+++ b/src/app/api/telegram/route.test.ts
@@ -23,7 +23,16 @@ delete process.env.LLV_TELEGRAM_API_HASH;
 const { GET, POST } = await import("./route");
 const { TelegramConnectionService, setTelegramServiceForTests } = await import("@/lib/telegram/service");
 const { readTelegramSession, writeTelegramConnection } = await import("@/lib/telegram/sessionStore");
-const { recordConnectorRestart } = await import("@/lib/telegram/connectorRestarts");
+const { confirmConnectorRestart, recordConnectorCrash } = await import("@/lib/telegram/connectorRestarts");
+
+/* A completed restart: a detected death whose replacement then verified. The
+   two-step API is what the supervisor drives; tests that only need the settled
+   result say it in one line. */
+function recordCompletedRestart(crash: { exitCode: number | null; signal: string | null }, at: number): void {
+  recordConnectorCrash(crash, at);
+  confirmConnectorRestart();
+}
+
 const { telegramApiCredentials } = await import("@/lib/telegram/packaging");
 
 import type { TelegramAdapter, TelegramEnrollmentEvent, TelegramHealthResult } from "@/lib/telegram/adapter";
@@ -272,7 +281,7 @@ test("#1087: the status payload carries the restart row and the transient restar
     lastHealthCheckAt: new Date(now).toISOString(),
     errorCode: null,
   });
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, now - 5_000);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, now - 5_000);
   const { telegram } = await payload(await GET(getRequest())) as {
     telegram: { phase: string; restartsLast24h: number; lastRestartAt: string };
   };

--- a/src/app/api/telegram/route.test.ts
+++ b/src/app/api/telegram/route.test.ts
@@ -22,7 +22,8 @@ delete process.env.LLV_TELEGRAM_API_HASH;
 
 const { GET, POST } = await import("./route");
 const { TelegramConnectionService, setTelegramServiceForTests } = await import("@/lib/telegram/service");
-const { readTelegramSession } = await import("@/lib/telegram/sessionStore");
+const { readTelegramSession, writeTelegramConnection } = await import("@/lib/telegram/sessionStore");
+const { recordConnectorRestart } = await import("@/lib/telegram/connectorRestarts");
 const { telegramApiCredentials } = await import("@/lib/telegram/packaging");
 
 import type { TelegramAdapter, TelegramEnrollmentEvent, TelegramHealthResult } from "@/lib/telegram/adapter";
@@ -259,4 +260,26 @@ test("cross-origin fresh health is rejected before Telegram state changes", asyn
   const response = await GET(getRequest("?fresh=1", { origin: "https://example.test" }));
   expect(response.status).toBe(403);
   expect(adapter.healthCalls).toBe(0);
+});
+
+test("#1087: the status payload carries the restart row and the transient restarting phase", async () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+  writeTelegramConnection({
+    version: 1,
+    status: "connected",
+    credentialRef: "credential-generation-a",
+    identity: { name: "Account A", username: "account_a" },
+    lastHealthCheckAt: new Date(now).toISOString(),
+    errorCode: null,
+  });
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, now - 5_000);
+  const { telegram } = await payload(await GET(getRequest())) as {
+    telegram: { phase: string; restartsLast24h: number; lastRestartAt: string };
+  };
+  expect(telegram.phase).toBe("restarting");
+  expect(telegram.restartsLast24h).toBe(1);
+  expect(telegram.lastRestartAt).toBe(new Date(now - 5_000).toISOString());
+  /* Counts and a timestamp only: the crash record itself stays server-side. */
+  expect(JSON.stringify(telegram)).not.toContain("exitCode");
+  expect(JSON.stringify(telegram)).not.toContain("signal");
 });

--- a/src/components/TelegramConnect.dom.test.tsx
+++ b/src/components/TelegramConnect.dom.test.tsx
@@ -47,6 +47,8 @@ function stateFor(
       credentialsConfigured: true,
       lastHealthCheckAt: null,
       error: null,
+      restartsLast24h: 0,
+      lastRestartAt: null,
       ...status,
     },
     busy: false,

--- a/src/components/TelegramConnect.render.test.tsx
+++ b/src/components/TelegramConnect.render.test.tsx
@@ -16,6 +16,8 @@ function stateFor(status: Partial<TelegramStatusPayload>, failure: { code: strin
       credentialsConfigured: true,
       lastHealthCheckAt: null,
       error: null,
+      restartsLast24h: 0,
+      lastRestartAt: null,
       ...status,
     },
     busy: false,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -701,6 +701,7 @@ export const en = {
   "telegram.status.awaiting_password": "Password needed",
   "telegram.status.verifying": "Verifying…",
   "telegram.status.connected": "Connected",
+  "telegram.status.restarting": "Restarting…",
   "telegram.status.expired": "Session expired",
   "telegram.status.error": "Error",
   "telegram.connect": "Connect Telegram",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -687,6 +687,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "telegram.status.awaiting_password": "Потрібен пароль",
   "telegram.status.verifying": "Перевірка…",
   "telegram.status.connected": "Підключено",
+  "telegram.status.restarting": "Перезапуск…",
   "telegram.status.expired": "Сесія завершилась",
   "telegram.status.error": "Помилка",
   "telegram.connect": "Підключити Telegram",

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -14,6 +14,7 @@ process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
 
 const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
+const { readConnectorRestarts, recordConnectorRestart } = await import("./connectorRestarts");
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
@@ -380,6 +381,9 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     await stopTelegramConnector();
     expect(() => process.kill(childPid, 0)).toThrow();
     expect(fs.existsSync(pidFile)).toBe(false);
+    /* #1087: the Viewer asked for this exit, so it is not a crash and never
+       reaches the restart count the panel shows. */
+    expect(readConnectorRestarts().restarts).toBe(0);
   } finally {
     delete process.env.LLV_TELEGRAM_PYTHON;
     delete process.env.LLV_TELEGRAM_SERVER_BRIDGE;
@@ -388,3 +392,28 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     }
   }
 }, 5_000);
+
+test("a call dropped by the supervisor's own respawn reports connector_restarting", async () => {
+  /* A restart the supervisor recorded moments ago (#1087): the connector that
+     will not answer right now is the one being replaced, so the caller gets
+     the restart code instead of an indistinguishable connector_failed. */
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, 0);
+  const { ports, calls } = fakePorts([], { spawnFails: true });
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "connector_restarting" });
+  expect(calls.spawns).toBe(1);
+});
+
+test("a refused read-only surface keeps its own diagnosis inside the restart window", async () => {
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, 0);
+  const { ports } = fakePorts([{
+    ok: true,
+    serverName: connectorServerName(CONNECTOR_SESSION.connectorToken),
+    tools: [{ name: "send_message", readOnly: false }],
+  }], { owned: true });
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "not_read_only" });
+});
+
+test("without a recorded restart a failure stays connector_failed", async () => {
+  const { ports } = fakePorts([], { spawnFails: true });
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "connector_failed" });
+});

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -14,7 +14,16 @@ process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
 
 const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
-const { readConnectorRestarts, recordConnectorRestart } = await import("./connectorRestarts");
+const { confirmConnectorRestart, readConnectorRestarts, recordConnectorCrash } = await import("./connectorRestarts");
+
+/* A completed restart: a detected death whose replacement then verified. The
+   two-step API is what the supervisor drives; tests that only need the settled
+   result say it in one line. */
+function recordCompletedRestart(crash: { exitCode: number | null; signal: string | null }, at: number): void {
+  recordConnectorCrash(crash, at);
+  confirmConnectorRestart();
+}
+
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
@@ -397,14 +406,14 @@ test("a call dropped by the supervisor's own respawn reports connector_restartin
   /* A restart the supervisor recorded moments ago (#1087): the connector that
      will not answer right now is the one being replaced, so the caller gets
      the restart code instead of an indistinguishable connector_failed. */
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, 0);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, 0);
   const { ports, calls } = fakePorts([], { spawnFails: true });
   expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "connector_restarting" });
   expect(calls.spawns).toBe(1);
 });
 
 test("a refused read-only surface keeps its own diagnosis inside the restart window", async () => {
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, 0);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, 0);
   const { ports } = fakePorts([{
     ok: true,
     serverName: connectorServerName(CONNECTOR_SESSION.connectorToken),
@@ -416,4 +425,54 @@ test("a refused read-only surface keeps its own diagnosis inside the restart win
 test("without a recorded restart a failure stays connector_failed", async () => {
   const { ports } = fakePorts([], { spawnFails: true });
   expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "connector_failed" });
+});
+
+/** A connector recorded by an earlier Viewer generation, now dead: the record
+    survives (a stop would have removed it), but nothing here ever held its
+    exit channel. */
+function writeDeadAdoptedRecord(): void {
+  const pidFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json");
+  fs.writeFileSync(pidFile, JSON.stringify({
+    version: 1,
+    pid: 2,
+    identity: "start-token-of-a-process-that-is-gone",
+    credentialRef: CONNECTOR_SESSION.credentialRef,
+    connectorTokenSha256: "a".repeat(64),
+    command: "/does/not/matter/python",
+    entrypoint: "/does/not/matter/telegram-mcp-server.py",
+  }), { mode: 0o600 });
+}
+
+test("an adopted connector that died is recovered as a restart once the replacement verifies", async () => {
+  /* #1087: an adopted process has no exit channel this Viewer can watch, so
+     its death is detected from the surviving pid file instead — with the exit
+     code and signal genuinely unknown rather than invented. */
+  writeDeadAdoptedRecord();
+  const { ports, calls } = fakePorts([READ_ONLY]);
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: true, url: telegramMcpUrl() });
+  expect(calls.spawns).toBe(1);
+  const state = readConnectorRestarts();
+  expect(state.restarts).toBe(1);
+  expect(state.pending).toBeNull();
+  expect(state.recent[0]!.exitCode).toBeNull();
+  expect(state.recent[0]!.signal).toBeNull();
+});
+
+test("a respawn that never comes back is detected but not counted as a restart", async () => {
+  writeDeadAdoptedRecord();
+  const { ports } = fakePorts([], { spawnFails: true });
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: false, code: "connector_failed" });
+  const state = readConnectorRestarts();
+  /* The death is on the record, but the panel must not claim a restart the
+     connector never completed — and with no counted restart there is no grace
+     window, so the caller keeps the real connector_failed above. */
+  expect(state.pending).not.toBeNull();
+  expect(state.restarts).toBe(0);
+  expect(state.lastRestartAt).toBeNull();
+});
+
+test("a first spawn with no prior connector is not counted as a restart", async () => {
+  const { ports } = fakePorts([READ_ONLY]);
+  expect(await ensureTelegramConnector(CONNECTOR_SESSION, ports)).toEqual({ ok: true, url: telegramMcpUrl() });
+  expect(readConnectorRestarts()).toMatchObject({ restarts: 0, lastRestartAt: null, pending: null });
 });

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -6,7 +6,7 @@ import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
-import { RESTART_GRACE_MS, restartedWithin, watchConnectorCrash } from "./connectorRestarts";
+import { RESTART_GRACE_MS, confirmConnectorRestart, recordConnectorCrash, restartedWithin, watchConnectorCrash } from "./connectorRestarts";
 import type { TelegramConnectorErrorCode } from "./contracts";
 import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
 import { ensureTelegramStateDir, type StoredTelegramSession } from "./sessionStore";
@@ -72,8 +72,8 @@ export type ConnectorEnsureResult = { ok: true; url: string } | { ok: false; cod
 type ConnectorChild = {
   pid?: number;
   kill(signal?: NodeJS.Signals): boolean;
-  /** Present on a child THIS process spawned, so its exit code and signal can
-      be recorded as a crash (#1087). An adopted process has none. */
+  /** Present on a child THIS process spawned, so its exit code and signal are
+      recordable (#1087); an adopted process has none. */
   once?(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
 };
 type ConnectorBinding = Pick<StoredTelegramSession, "credentialRef" | "connectorToken">;
@@ -198,8 +198,8 @@ type LiveConnectorChild = {
   child: ConnectorChild;
   pid: number;
   identity: string;
-  /** Set before the Viewer terminates it, so an operator stop, a logout or a
-      health-check restart is never counted as a crash. */
+  /** Set before the Viewer terminates it: an operator stop, a logout or a
+      health-check restart is not a crash. */
   expectedExit: boolean;
 };
 
@@ -307,6 +307,14 @@ function targetIsAlive(target: Pick<TerminationTarget, "pid" | "identity">): boo
   return procBackend.processIdentity(target.pid) === target.identity;
 }
 
+/** #1087 adopted-process recovery: a stop removes the record, so a surviving
+    record with a dead pid is an uncommanded death of a connector with no exit
+    channel to watch. Detected before the replacement overwrites the record. */
+function detectRecordedConnectorDeath(): void {
+  const recorded = readConnectorRecord();
+  if (recorded && !targetIsAlive(recorded)) recordConnectorCrash({ exitCode: null, signal: null });
+}
+
 async function waitForTargetsToExit(targets: TerminationTarget[], timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (targets.some(targetIsAlive) && Date.now() < deadline) {
@@ -407,10 +415,9 @@ export async function ensureTelegramConnector(
   ports: TelegramConnectorPorts = realPorts,
 ): Promise<ConnectorEnsureResult> {
   const result = await ensureVerifiedConnector(session, ports);
-  /* #1087: a connector that failed to answer right after a recorded respawn
-     was dropped BY that respawn, not by a broken configuration. Only the
-     generic `connector_failed` is re-read this way — a refused read-only
-     surface or missing credentials keeps its own diagnosis. */
+  /* #1087: a call that failed to answer right after a counted restart was
+     dropped BY that respawn. Only the generic `connector_failed` is re-read
+     this way — a refused surface or missing credentials keeps its diagnosis. */
   if (!result.ok && result.code === "connector_failed" && restartedWithin(RESTART_GRACE_MS, ports.now())) {
     return { ok: false, code: "connector_restarting" };
   }
@@ -439,6 +446,7 @@ async function ensureVerifiedConnector(
        listener ineligible for adoption. Stop and record the replacement while
        holding the cross-process supervisor lock, so another Viewer generation
        can only adopt the one durable winner. */
+    detectRecordedConnectorDeath();
     await stop();
     isCurrent = ports.beginOperation?.() ?? (() => true);
     const credentials = telegramApiCredentials();
@@ -469,7 +477,10 @@ async function ensureVerifiedConnector(
       return { ok: false, code: "connector_failed" };
     }
     if (ready) {
+      /* The replacement answered, so a detected death is now a completed
+         restart; a respawn that never verifies is never counted as one. */
       if (!ready.ok) await stopThisGeneration();
+      else confirmConnectorRestart();
       return ready;
     }
     await ports.sleep(PROBE_INTERVAL_MS);

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -6,7 +6,8 @@ import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
-import type { TelegramErrorCode } from "./contracts";
+import { RESTART_GRACE_MS, restartedWithin, watchConnectorCrash } from "./connectorRestarts";
+import type { TelegramConnectorErrorCode } from "./contracts";
 import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
 import { ensureTelegramStateDir, type StoredTelegramSession } from "./sessionStore";
 
@@ -66,9 +67,15 @@ export type ConnectorProbe =
   | { ok: true; serverName: string; tools: Array<{ name: string; readOnly: boolean }> }
   | { ok: false };
 
-export type ConnectorEnsureResult = { ok: true; url: string } | { ok: false; code: TelegramErrorCode };
+export type ConnectorEnsureResult = { ok: true; url: string } | { ok: false; code: TelegramConnectorErrorCode };
 
-type ConnectorChild = { pid?: number; kill(signal?: NodeJS.Signals): boolean };
+type ConnectorChild = {
+  pid?: number;
+  kill(signal?: NodeJS.Signals): boolean;
+  /** Present on a child THIS process spawned, so its exit code and signal can
+      be recorded as a crash (#1087). An adopted process has none. */
+  once?(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+};
 type ConnectorBinding = Pick<StoredTelegramSession, "credentialRef" | "connectorToken">;
 
 export interface TelegramConnectorPorts {
@@ -187,11 +194,16 @@ type ConnectorRecord = {
   entrypoint: string;
 };
 
-let liveConnectorChild: {
+type LiveConnectorChild = {
   child: ConnectorChild;
   pid: number;
   identity: string;
-} | null = null;
+  /** Set before the Viewer terminates it, so an operator stop, a logout or a
+      health-check restart is never counted as a crash. */
+  expectedExit: boolean;
+};
+
+let liveConnectorChild: LiveConnectorChild | null = null;
 let supervisorGeneration = 0;
 
 function beginConnectorOperation(): () => boolean {
@@ -245,7 +257,9 @@ function recordConnectorProcess(child: ConnectorChild, spec: ProcessSpec, bindin
     terminateChildImmediately(child);
     return false;
   }
-  liveConnectorChild = { child, pid, identity };
+  const live: LiveConnectorChild = { child, pid, identity, expectedExit: false };
+  liveConnectorChild = live;
+  watchConnectorCrash(child, () => live.expectedExit || liveConnectorChild !== live);
   const record: ConnectorRecord = {
     version: 1,
     pid,
@@ -305,6 +319,7 @@ async function stopRealConnectorUnlocked(): Promise<void> {
   supervisorGeneration += 1;
   const targets = new Map<number, TerminationTarget>();
   const child = liveConnectorChild;
+  if (child) child.expectedExit = true;
   if (child && targetIsAlive(child)) {
     targets.set(child.pid, {
       pid: child.pid,
@@ -390,6 +405,21 @@ async function verifiedProbe(
 export async function ensureTelegramConnector(
   session: StoredTelegramSession,
   ports: TelegramConnectorPorts = realPorts,
+): Promise<ConnectorEnsureResult> {
+  const result = await ensureVerifiedConnector(session, ports);
+  /* #1087: a connector that failed to answer right after a recorded respawn
+     was dropped BY that respawn, not by a broken configuration. Only the
+     generic `connector_failed` is re-read this way — a refused read-only
+     surface or missing credentials keeps its own diagnosis. */
+  if (!result.ok && result.code === "connector_failed" && restartedWithin(RESTART_GRACE_MS, ports.now())) {
+    return { ok: false, code: "connector_restarting" };
+  }
+  return result;
+}
+
+async function ensureVerifiedConnector(
+  session: StoredTelegramSession,
+  ports: TelegramConnectorPorts,
 ): Promise<ConnectorEnsureResult> {
   const url = telegramMcpUrl();
   const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };

--- a/src/lib/telegram/connectorRestarts.test.ts
+++ b/src/lib/telegram/connectorRestarts.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/* Isolated state: this suite must never read or write the operator's own
+   Telegram connector state. */
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-restarts-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+const {
+  RESTART_COUNT_WINDOW_MS,
+  RESTART_GRACE_MS,
+  readConnectorRestarts,
+  recordConnectorRestart,
+  restartedWithin,
+  restartsWithin,
+  watchConnectorCrash,
+} = await import("./connectorRestarts");
+
+const NOW = Date.parse("2026-08-20T12:00:00.000Z");
+const HOUR = 60 * 60 * 1000;
+
+function restartsFile(): string {
+  return path.join(process.env.LLV_STATE_DIR!, "telegram", "restarts.json");
+}
+
+beforeEach(() => {
+  fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+});
+afterAll(() => {
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = OLD_STATE;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+test("no state at all reads as no restarts, never as a failure", () => {
+  expect(readConnectorRestarts()).toEqual({ version: 1, restarts: 0, lastRestartAt: null, recent: [] });
+  expect(restartsWithin(RESTART_COUNT_WINDOW_MS, NOW)).toBe(0);
+  expect(restartedWithin(RESTART_GRACE_MS, NOW)).toBe(false);
+});
+
+test("a crash record is structured only: exit code, signal, timestamp", () => {
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW);
+  const state = readConnectorRestarts();
+  expect(state.restarts).toBe(1);
+  expect(state.lastRestartAt).toBe(new Date(NOW).toISOString());
+  /* The connector's stderr can carry chat titles and message text. The record
+     has exactly three fields, and none of them is output. */
+  expect(Object.keys(state.recent[0]!).sort()).toEqual(["at", "exitCode", "signal"]);
+  expect(state.recent[0]).toEqual({ at: new Date(NOW).toISOString(), exitCode: null, signal: "SIGKILL" });
+  expect(fs.statSync(restartsFile()).mode & 0o077).toBe(0);
+});
+
+test("the count the panel shows is the last 24 h; the total keeps every restart", () => {
+  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
+  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  const state = readConnectorRestarts();
+  expect(state.restarts).toBe(3);
+  expect(state.lastRestartAt).toBe(new Date(NOW - 5_000).toISOString());
+  expect(restartsWithin(RESTART_COUNT_WINDOW_MS, NOW, state)).toBe(2);
+});
+
+test("the grace window is what makes a dropped call readable as a restart", () => {
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW);
+  expect(restartedWithin(RESTART_GRACE_MS, NOW + 29_000)).toBe(true);
+  expect(restartedWithin(RESTART_GRACE_MS, NOW + 31_000)).toBe(false);
+});
+
+test("only an exit the Viewer did not ask for counts as a restart", () => {
+  const listeners: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
+  const child = {
+    once(_event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) {
+      listeners.push(listener);
+      return this;
+    },
+  };
+
+  /* A logout, a health-check stop or an operator disconnect terminates the
+     connector on purpose — that is not a crash. */
+  watchConnectorCrash(child, () => true, () => NOW);
+  listeners.pop()!(null, "SIGTERM");
+  expect(readConnectorRestarts().restarts).toBe(0);
+
+  watchConnectorCrash(child, () => false, () => NOW);
+  listeners.pop()!(139, null);
+  expect(readConnectorRestarts().recent[0]).toEqual({ at: new Date(NOW).toISOString(), exitCode: 139, signal: null });
+});
+
+test("an adopted connector with no exit channel is watched without throwing", () => {
+  expect(() => watchConnectorCrash({}, () => false, () => NOW)).not.toThrow();
+  expect(readConnectorRestarts().restarts).toBe(0);
+});
+
+test("corrupt state degrades to no restarts instead of breaking status", () => {
+  fs.mkdirSync(path.dirname(restartsFile()), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(restartsFile(), "{not json", { mode: 0o600 });
+  expect(readConnectorRestarts().restarts).toBe(0);
+  /* And the next real restart still lands. */
+  recordConnectorRestart({ exitCode: 0, signal: null }, NOW);
+  expect(readConnectorRestarts().restarts).toBe(1);
+});

--- a/src/lib/telegram/connectorRestarts.test.ts
+++ b/src/lib/telegram/connectorRestarts.test.ts
@@ -12,8 +12,9 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 const {
   RESTART_COUNT_WINDOW_MS,
   RESTART_GRACE_MS,
+  confirmConnectorRestart,
   readConnectorRestarts,
-  recordConnectorRestart,
+  recordConnectorCrash,
   restartedWithin,
   restartsWithin,
   watchConnectorCrash,
@@ -26,6 +27,11 @@ function restartsFile(): string {
   return path.join(process.env.LLV_STATE_DIR!, "telegram", "restarts.json");
 }
 
+function recordCompletedRestart(crash: { exitCode: number | null; signal: string | null }, at: number): void {
+  recordConnectorCrash(crash, at);
+  confirmConnectorRestart();
+}
+
 beforeEach(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
 });
@@ -36,27 +42,64 @@ afterAll(() => {
 });
 
 test("no state at all reads as no restarts, never as a failure", () => {
-  expect(readConnectorRestarts()).toEqual({ version: 1, restarts: 0, lastRestartAt: null, recent: [] });
+  expect(readConnectorRestarts()).toEqual({ version: 1, restarts: 0, lastRestartAt: null, recent: [], pending: null });
   expect(restartsWithin(RESTART_COUNT_WINDOW_MS, NOW)).toBe(0);
   expect(restartedWithin(RESTART_GRACE_MS, NOW)).toBe(false);
 });
 
 test("a crash record is structured only: exit code, signal, timestamp", () => {
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW);
-  const state = readConnectorRestarts();
-  expect(state.restarts).toBe(1);
-  expect(state.lastRestartAt).toBe(new Date(NOW).toISOString());
+  recordConnectorCrash({ exitCode: null, signal: "SIGKILL" }, NOW);
   /* The connector's stderr can carry chat titles and message text. The record
      has exactly three fields, and none of them is output. */
-  expect(Object.keys(state.recent[0]!).sort()).toEqual(["at", "exitCode", "signal"]);
-  expect(state.recent[0]).toEqual({ at: new Date(NOW).toISOString(), exitCode: null, signal: "SIGKILL" });
+  const pending = readConnectorRestarts().pending!;
+  expect(Object.keys(pending).sort()).toEqual(["at", "exitCode", "signal"]);
+  expect(pending).toEqual({ at: new Date(NOW).toISOString(), exitCode: null, signal: "SIGKILL" });
   expect(fs.statSync(restartsFile()).mode & 0o077).toBe(0);
 });
 
+test("a detected crash is persisted at once but is not yet a counted restart", () => {
+  recordConnectorCrash({ exitCode: 139, signal: null }, NOW);
+  const detected = readConnectorRestarts();
+  expect(detected.pending).not.toBeNull();
+  /* The respawn has not verified yet, so nothing the operator reads as a
+     completed restart has happened. */
+  expect(detected.restarts).toBe(0);
+  expect(detected.lastRestartAt).toBeNull();
+  expect(restartsWithin(RESTART_COUNT_WINDOW_MS, NOW, detected)).toBe(0);
+  expect(restartedWithin(RESTART_GRACE_MS, NOW, detected)).toBe(false);
+});
+
+test("a replacement that verifies turns the detected crash into one counted restart", () => {
+  recordConnectorCrash({ exitCode: 139, signal: null }, NOW);
+  confirmConnectorRestart();
+  const state = readConnectorRestarts();
+  expect(state.restarts).toBe(1);
+  expect(state.pending).toBeNull();
+  /* Timed from the death, so the grace window covers the calls it dropped. */
+  expect(state.lastRestartAt).toBe(new Date(NOW).toISOString());
+  expect(state.recent[0]).toEqual({ at: new Date(NOW).toISOString(), exitCode: 139, signal: null });
+});
+
+test("a respawn that never verifies is never counted as a completed restart", () => {
+  recordConnectorCrash({ exitCode: 137, signal: null }, NOW);
+  /* Retry after retry, with no replacement ever answering: the crash stays
+     detected, and the panel keeps showing zero completed restarts. */
+  recordConnectorCrash({ exitCode: 137, signal: null }, NOW + 1_000);
+  expect(readConnectorRestarts().restarts).toBe(0);
+  /* The first detection wins, so the exit code the watched child reported is
+     not overwritten by a later sweep that has none. */
+  expect(readConnectorRestarts().pending).toEqual({ at: new Date(NOW).toISOString(), exitCode: 137, signal: null });
+});
+
+test("confirming without a detected crash is a no-op: a first spawn is not a restart", () => {
+  confirmConnectorRestart();
+  expect(readConnectorRestarts()).toEqual({ version: 1, restarts: 0, lastRestartAt: null, recent: [], pending: null });
+});
+
 test("the count the panel shows is the last 24 h; the total keeps every restart", () => {
-  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
-  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  recordCompletedRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
+  recordCompletedRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
   const state = readConnectorRestarts();
   expect(state.restarts).toBe(3);
   expect(state.lastRestartAt).toBe(new Date(NOW - 5_000).toISOString());
@@ -64,12 +107,12 @@ test("the count the panel shows is the last 24 h; the total keeps every restart"
 });
 
 test("the grace window is what makes a dropped call readable as a restart", () => {
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW);
   expect(restartedWithin(RESTART_GRACE_MS, NOW + 29_000)).toBe(true);
   expect(restartedWithin(RESTART_GRACE_MS, NOW + 31_000)).toBe(false);
 });
 
-test("only an exit the Viewer did not ask for counts as a restart", () => {
+test("only an exit the Viewer did not ask for is detected as a crash", () => {
   const listeners: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
   const child = {
     once(_event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) {
@@ -82,16 +125,16 @@ test("only an exit the Viewer did not ask for counts as a restart", () => {
      connector on purpose — that is not a crash. */
   watchConnectorCrash(child, () => true, () => NOW);
   listeners.pop()!(null, "SIGTERM");
-  expect(readConnectorRestarts().restarts).toBe(0);
+  expect(readConnectorRestarts().pending).toBeNull();
 
   watchConnectorCrash(child, () => false, () => NOW);
   listeners.pop()!(139, null);
-  expect(readConnectorRestarts().recent[0]).toEqual({ at: new Date(NOW).toISOString(), exitCode: 139, signal: null });
+  expect(readConnectorRestarts().pending).toEqual({ at: new Date(NOW).toISOString(), exitCode: 139, signal: null });
 });
 
 test("an adopted connector with no exit channel is watched without throwing", () => {
   expect(() => watchConnectorCrash({}, () => false, () => NOW)).not.toThrow();
-  expect(readConnectorRestarts().restarts).toBe(0);
+  expect(readConnectorRestarts().pending).toBeNull();
 });
 
 test("corrupt state degrades to no restarts instead of breaking status", () => {
@@ -99,6 +142,6 @@ test("corrupt state degrades to no restarts instead of breaking status", () => {
   fs.writeFileSync(restartsFile(), "{not json", { mode: 0o600 });
   expect(readConnectorRestarts().restarts).toBe(0);
   /* And the next real restart still lands. */
-  recordConnectorRestart({ exitCode: 0, signal: null }, NOW);
+  recordCompletedRestart({ exitCode: 0, signal: null }, NOW);
   expect(readConnectorRestarts().restarts).toBe(1);
 });

--- a/src/lib/telegram/connectorRestarts.ts
+++ b/src/lib/telegram/connectorRestarts.ts
@@ -6,32 +6,25 @@ import { statePath } from "@/lib/configDir";
 import { ensureTelegramStateDir } from "./sessionStore";
 
 /**
- * Visible connector restarts (issue #1087).
- *
- * The supervisor used to respawn a crashed connector silently: the status
- * surface kept saying `connected` while in-flight agent calls were dropped.
- * This module is the durable memory of those respawns — a count, the last
- * restart time, and a STRUCTURED-ONLY crash record.
- *
- * Structured-only is deliberate: exit code, signal and timestamp are the whole
- * record. The connector's stderr can carry chat titles, usernames and message
- * text, so no line of it is ever persisted here or projected to the browser.
+ * Visible connector restarts (issue #1087), in two steps. A death is persisted
+ * the moment it is DETECTED, as a structured-only crash record — exit code,
+ * signal and timestamp are the whole record, because connector stderr can carry
+ * chat titles, usernames and message text. It becomes a COUNTED restart only
+ * once a replacement has verified: a respawn that never came back is a standing
+ * failure, not a completed restart.
  */
 
-export type TelegramConnectorCrash = {
-  at: string;
-  exitCode: number | null;
-  signal: string | null;
-};
+export type TelegramConnectorCrash = { at: string; exitCode: number | null; signal: string | null };
 
 export type TelegramConnectorRestarts = {
   version: 1;
-  /** Restarts recorded since the file was created. */
+  /** Replacements that verified. */
   restarts: number;
   lastRestartAt: string | null;
-  /** Newest first, capped: enough to count a day's restarts, bounded so a
-      crash loop cannot grow the file without limit. */
+  /** Counted restarts, newest first, capped so a crash loop cannot grow the file. */
   recent: TelegramConnectorCrash[];
+  /** A detected death whose replacement has not verified yet. */
+  pending: TelegramConnectorCrash | null;
 };
 
 const RESTARTS_FILE = "restarts.json";
@@ -39,55 +32,45 @@ const RECENT_LIMIT = 64;
 
 /** The window the status payload counts restarts over. */
 export const RESTART_COUNT_WINDOW_MS = 24 * 60 * 60 * 1000;
-/** How long after a recorded restart a failed call reads as a restart drop. */
+/** How long after a counted restart a failed call reads as a restart drop. */
 export const RESTART_GRACE_MS = 30_000;
 
-const NO_RESTARTS: TelegramConnectorRestarts = Object.freeze({ version: 1, restarts: 0, lastRestartAt: null, recent: [] }) as TelegramConnectorRestarts;
+const NO_RESTARTS: TelegramConnectorRestarts = Object.freeze({ version: 1, restarts: 0, lastRestartAt: null, recent: [], pending: null }) as TelegramConnectorRestarts;
 
 function restartsPath(): string {
   return statePath("telegram", RESTARTS_FILE);
 }
 
-function isCrash(value: unknown): value is TelegramConnectorCrash {
+function asCrash(value: unknown): TelegramConnectorCrash | null {
   const row = value as Partial<TelegramConnectorCrash> | null;
-  return Boolean(row && typeof row === "object"
-    && typeof row.at === "string" && !Number.isNaN(Date.parse(row.at))
-    && (row.exitCode === null || typeof row.exitCode === "number")
-    && (row.signal === null || typeof row.signal === "string"));
+  if (!row || typeof row !== "object" || typeof row.at !== "string" || Number.isNaN(Date.parse(row.at))) return null;
+  if (!(row.exitCode === null || typeof row.exitCode === "number") || !(row.signal === null || typeof row.signal === "string")) return null;
+  return { at: row.at, exitCode: row.exitCode ?? null, signal: row.signal ?? null };
 }
 
-/** Absent, unreadable or malformed state means "no restarts known" — this is
-    a diagnostic surface and must never fail a status read. */
+/** Absent, unreadable or malformed state means "no restarts known" — this is a
+    diagnostic surface and must never fail a status read. */
 export function readConnectorRestarts(): TelegramConnectorRestarts {
   try {
     if (ensureTelegramStateDir(false) === null) return NO_RESTARTS;
     const row = JSON.parse(fs.readFileSync(restartsPath(), "utf8")) as Partial<TelegramConnectorRestarts>;
     if (row.version !== 1 || typeof row.restarts !== "number" || !Number.isFinite(row.restarts)) return NO_RESTARTS;
+    const recent = (Array.isArray(row.recent) ? row.recent : []).map(asCrash);
     return {
       version: 1,
       restarts: Math.max(0, Math.trunc(row.restarts)),
       lastRestartAt: typeof row.lastRestartAt === "string" ? row.lastRestartAt : null,
-      recent: Array.isArray(row.recent) ? row.recent.filter(isCrash).slice(0, RECENT_LIMIT) : [],
+      recent: recent.filter((crash): crash is TelegramConnectorCrash => crash !== null).slice(0, RECENT_LIMIT),
+      pending: asCrash(row.pending),
     };
   } catch {
     return NO_RESTARTS;
   }
 }
 
-/** Appends one restart. Owner-only, atomic, and never throws: a diagnostic
-    write must not take down the supervisor path that produced it. */
-export function recordConnectorRestart(
-  crash: { exitCode: number | null; signal: string | null },
-  now: number = Date.now(),
-): void {
-  const previous = readConnectorRestarts();
-  const at = new Date(now).toISOString();
-  const next: TelegramConnectorRestarts = {
-    version: 1,
-    restarts: previous.restarts + 1,
-    lastRestartAt: at,
-    recent: [{ at, exitCode: crash.exitCode, signal: crash.signal }, ...previous.recent].slice(0, RECENT_LIMIT),
-  };
+/** Owner-only, atomic, and never throws: a diagnostic write must not take down
+    the supervisor path that produced it. */
+function writeConnectorRestarts(next: TelegramConnectorRestarts): void {
   const target = restartsPath();
   const tmp = path.join(path.dirname(target), `.${RESTARTS_FILE}.${process.pid}.tmp`);
   try {
@@ -99,39 +82,50 @@ export function recordConnectorRestart(
   }
 }
 
-export function restartsWithin(
-  windowMs: number,
-  now: number = Date.now(),
-  state: TelegramConnectorRestarts = readConnectorRestarts(),
-): number {
+/** Detection. The first detection of a death wins, so the exit code a watched
+    child reported is not overwritten by the pid-file sweep that notices the
+    same death without one. */
+export function recordConnectorCrash(crash: { exitCode: number | null; signal: string | null }, now: number = Date.now()): void {
+  const previous = readConnectorRestarts();
+  if (previous.pending) return;
+  writeConnectorRestarts({ ...previous, pending: { at: new Date(now).toISOString(), ...crash } });
+}
+
+/** Completion: a replacement verified, so the detected death becomes a counted
+    restart, timed from the death itself. With nothing detected this is a no-op
+    — a first spawn or an operator reconnect is not a restart. */
+export function confirmConnectorRestart(): void {
+  const previous = readConnectorRestarts();
+  const pending = previous.pending;
+  if (!pending) return;
+  writeConnectorRestarts({
+    version: 1,
+    restarts: previous.restarts + 1,
+    lastRestartAt: pending.at,
+    recent: [pending, ...previous.recent].slice(0, RECENT_LIMIT),
+    pending: null,
+  });
+}
+
+export function restartsWithin(windowMs: number, now = Date.now(), state = readConnectorRestarts()): number {
   return state.recent.filter((crash) => now - Date.parse(crash.at) < windowMs).length;
 }
 
-export function restartedWithin(
-  windowMs: number,
-  now: number = Date.now(),
-  state: TelegramConnectorRestarts = readConnectorRestarts(),
-): boolean {
+export function restartedWithin(windowMs: number, now = Date.now(), state = readConnectorRestarts()): boolean {
   if (state.lastRestartAt === null) return false;
   const since = now - Date.parse(state.lastRestartAt);
   return Number.isFinite(since) && since >= 0 && since < windowMs;
 }
 
-type ExitWatchable = {
-  once?(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
-};
+type ExitWatchable = { once?(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown };
 
-/** Records the exit of a connector this Viewer spawned, unless the Viewer
-    asked for it — a logout or a health-check stop is not a crash. Only a
-    child of this process can report an exit code at all; a connector adopted
-    from an earlier Viewer generation exits unobserved. */
-export function watchConnectorCrash(
-  child: ExitWatchable,
-  expected: () => boolean,
-  now: () => number = Date.now,
-): void {
+/** Detects the exit of a connector this Viewer spawned, unless the Viewer asked
+    for it — a logout or a health-check stop is not a crash. A connector adopted
+    from an earlier Viewer generation has no exit channel here; its death is
+    detected from the pid file by the supervisor instead. */
+export function watchConnectorCrash(child: ExitWatchable, expected: () => boolean, now: () => number = Date.now): void {
   child.once?.("exit", (code, signal) => {
     if (expected()) return;
-    recordConnectorRestart({ exitCode: typeof code === "number" ? code : null, signal: signal ?? null }, now());
+    recordConnectorCrash({ exitCode: typeof code === "number" ? code : null, signal: signal ?? null }, now());
   });
 }

--- a/src/lib/telegram/connectorRestarts.ts
+++ b/src/lib/telegram/connectorRestarts.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+import { ensureTelegramStateDir } from "./sessionStore";
+
+/**
+ * Visible connector restarts (issue #1087).
+ *
+ * The supervisor used to respawn a crashed connector silently: the status
+ * surface kept saying `connected` while in-flight agent calls were dropped.
+ * This module is the durable memory of those respawns — a count, the last
+ * restart time, and a STRUCTURED-ONLY crash record.
+ *
+ * Structured-only is deliberate: exit code, signal and timestamp are the whole
+ * record. The connector's stderr can carry chat titles, usernames and message
+ * text, so no line of it is ever persisted here or projected to the browser.
+ */
+
+export type TelegramConnectorCrash = {
+  at: string;
+  exitCode: number | null;
+  signal: string | null;
+};
+
+export type TelegramConnectorRestarts = {
+  version: 1;
+  /** Restarts recorded since the file was created. */
+  restarts: number;
+  lastRestartAt: string | null;
+  /** Newest first, capped: enough to count a day's restarts, bounded so a
+      crash loop cannot grow the file without limit. */
+  recent: TelegramConnectorCrash[];
+};
+
+const RESTARTS_FILE = "restarts.json";
+const RECENT_LIMIT = 64;
+
+/** The window the status payload counts restarts over. */
+export const RESTART_COUNT_WINDOW_MS = 24 * 60 * 60 * 1000;
+/** How long after a recorded restart a failed call reads as a restart drop. */
+export const RESTART_GRACE_MS = 30_000;
+
+const NO_RESTARTS: TelegramConnectorRestarts = Object.freeze({ version: 1, restarts: 0, lastRestartAt: null, recent: [] }) as TelegramConnectorRestarts;
+
+function restartsPath(): string {
+  return statePath("telegram", RESTARTS_FILE);
+}
+
+function isCrash(value: unknown): value is TelegramConnectorCrash {
+  const row = value as Partial<TelegramConnectorCrash> | null;
+  return Boolean(row && typeof row === "object"
+    && typeof row.at === "string" && !Number.isNaN(Date.parse(row.at))
+    && (row.exitCode === null || typeof row.exitCode === "number")
+    && (row.signal === null || typeof row.signal === "string"));
+}
+
+/** Absent, unreadable or malformed state means "no restarts known" — this is
+    a diagnostic surface and must never fail a status read. */
+export function readConnectorRestarts(): TelegramConnectorRestarts {
+  try {
+    if (ensureTelegramStateDir(false) === null) return NO_RESTARTS;
+    const row = JSON.parse(fs.readFileSync(restartsPath(), "utf8")) as Partial<TelegramConnectorRestarts>;
+    if (row.version !== 1 || typeof row.restarts !== "number" || !Number.isFinite(row.restarts)) return NO_RESTARTS;
+    return {
+      version: 1,
+      restarts: Math.max(0, Math.trunc(row.restarts)),
+      lastRestartAt: typeof row.lastRestartAt === "string" ? row.lastRestartAt : null,
+      recent: Array.isArray(row.recent) ? row.recent.filter(isCrash).slice(0, RECENT_LIMIT) : [],
+    };
+  } catch {
+    return NO_RESTARTS;
+  }
+}
+
+/** Appends one restart. Owner-only, atomic, and never throws: a diagnostic
+    write must not take down the supervisor path that produced it. */
+export function recordConnectorRestart(
+  crash: { exitCode: number | null; signal: string | null },
+  now: number = Date.now(),
+): void {
+  const previous = readConnectorRestarts();
+  const at = new Date(now).toISOString();
+  const next: TelegramConnectorRestarts = {
+    version: 1,
+    restarts: previous.restarts + 1,
+    lastRestartAt: at,
+    recent: [{ at, exitCode: crash.exitCode, signal: crash.signal }, ...previous.recent].slice(0, RECENT_LIMIT),
+  };
+  const target = restartsPath();
+  const tmp = path.join(path.dirname(target), `.${RESTARTS_FILE}.${process.pid}.tmp`);
+  try {
+    ensureTelegramStateDir(true);
+    fs.writeFileSync(tmp, JSON.stringify(next), { mode: 0o600 });
+    fs.renameSync(tmp, target);
+  } catch {
+    try { fs.rmSync(tmp, { force: true }); } catch { /* nothing else to clean */ }
+  }
+}
+
+export function restartsWithin(
+  windowMs: number,
+  now: number = Date.now(),
+  state: TelegramConnectorRestarts = readConnectorRestarts(),
+): number {
+  return state.recent.filter((crash) => now - Date.parse(crash.at) < windowMs).length;
+}
+
+export function restartedWithin(
+  windowMs: number,
+  now: number = Date.now(),
+  state: TelegramConnectorRestarts = readConnectorRestarts(),
+): boolean {
+  if (state.lastRestartAt === null) return false;
+  const since = now - Date.parse(state.lastRestartAt);
+  return Number.isFinite(since) && since >= 0 && since < windowMs;
+}
+
+type ExitWatchable = {
+  once?(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+};
+
+/** Records the exit of a connector this Viewer spawned, unless the Viewer
+    asked for it — a logout or a health-check stop is not a crash. Only a
+    child of this process can report an exit code at all; a connector adopted
+    from an earlier Viewer generation exits unobserved. */
+export function watchConnectorCrash(
+  child: ExitWatchable,
+  expected: () => boolean,
+  now: () => number = Date.now,
+): void {
+  child.once?.("exit", (code, signal) => {
+    if (expected()) return;
+    recordConnectorRestart({ exitCode: typeof code === "number" ? code : null, signal: signal ?? null }, now());
+  });
+}

--- a/src/lib/telegram/contracts.ts
+++ b/src/lib/telegram/contracts.ts
@@ -17,9 +17,8 @@ export type TelegramPhase =
   | "verifying"
   | "connected"
   /** Transient (#1087): the connector was respawned moments ago, so calls in
-      that window can be dropped. Never persisted — the durable record keeps
-      the connection status, and this phase is projected from the restart
-      state while the grace window is open. */
+      that window can be dropped. Never persisted — it is projected from the
+      restart state while the grace window is open. */
   | "restarting"
   | "expired"
   | "error";
@@ -40,10 +39,9 @@ export type TelegramErrorCode =
   | "logout_failed"
   | "health_failed";
 
-/** The connector seam adds one code the browser never receives verbatim: a
-    call the supervisor's own respawn dropped (#1087). The status payload
-    projects it as the `restarting` phase, so the panel's durable error
-    vocabulary above stays exactly the set it already renders. */
+/** The connector seam adds one code the browser never receives verbatim: a call
+    the supervisor's own respawn dropped (#1087). The status payload projects it
+    as the `restarting` phase, so the panel's vocabulary above is unchanged. */
 export type TelegramConnectorErrorCode = TelegramErrorCode | "connector_restarting";
 
 /** Sanitized account identity: display name and public username only. */

--- a/src/lib/telegram/contracts.ts
+++ b/src/lib/telegram/contracts.ts
@@ -16,6 +16,11 @@ export type TelegramPhase =
   | "awaiting_password"
   | "verifying"
   | "connected"
+  /** Transient (#1087): the connector was respawned moments ago, so calls in
+      that window can be dropped. Never persisted — the durable record keeps
+      the connection status, and this phase is projected from the restart
+      state while the grace window is open. */
+  | "restarting"
   | "expired"
   | "error";
 
@@ -34,6 +39,12 @@ export type TelegramErrorCode =
   | "not_read_only"
   | "logout_failed"
   | "health_failed";
+
+/** The connector seam adds one code the browser never receives verbatim: a
+    call the supervisor's own respawn dropped (#1087). The status payload
+    projects it as the `restarting` phase, so the panel's durable error
+    vocabulary above stays exactly the set it already renders. */
+export type TelegramConnectorErrorCode = TelegramErrorCode | "connector_restarting";
 
 /** Sanitized account identity: display name and public username only. */
 export type TelegramIdentity = {
@@ -64,6 +75,10 @@ export type TelegramStatusPayload = {
   /** Whether host API credentials (env or telegram.json) exist. A boolean
       only — the values themselves never cross this boundary (#1070). */
   credentialsConfigured: boolean;
+  /** Connector respawns the Viewer observed in the last 24 h, and when the
+      last one happened (#1087). Structured counts only — no crash output. */
+  restartsLast24h: number;
+  lastRestartAt: string | null;
 };
 
 export const NONTERMINAL_TELEGRAM_LOGIN_PHASES: ReadonlySet<TelegramPhase> = new Set([

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -312,6 +312,98 @@ test("the packaged MCP entrypoint enforces bearer auth and token-bound identity"
   expect(output.name).toMatch(/^telegram-[a-f0-9]{64}$/);
 });
 
+test("the packaged MCP entrypoint caps concurrent tool calls and refuses a call that waits out the bound", () => {
+  /* #1087: agents reach the connector's loopback port directly, so this
+     Viewer-owned ASGI wrapper is the only chokepoint on their path. Three
+     concurrent large reads used to take the shared process down. */
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  const fakeVendor = path.join(SANDBOX, "gate-wrapper-vendor");
+  for (const directory of ["mcp/server", "telegram_mcp"]) {
+    fs.mkdirSync(path.join(fakeVendor, directory), { recursive: true });
+    fs.writeFileSync(path.join(fakeVendor, directory, "__init__.py"), "");
+  }
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "__init__.py"), "");
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "server", "fastmcp.py"), [
+    "import asyncio",
+    "STATE = {'active': 0, 'peak': 0}",
+    "class _Server:",
+    "    name = 'telegram'",
+    "class FastMCP:",
+    "    def __init__(self): self._mcp_server = _Server()",
+    "    def streamable_http_app(self):",
+    "        async def app(scope, receive, send):",
+    "            await receive()",
+    "            STATE['active'] += 1",
+    "            STATE['peak'] = max(STATE['peak'], STATE['active'])",
+    "            await asyncio.sleep(0.02)",
+    "            STATE['active'] -= 1",
+    "            await send({'type': 'http.response.start', 'status': 200, 'headers': []})",
+    "            await send({'type': 'http.response.body', 'body': b''})",
+    "        return app",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runtime.py"), [
+    "from mcp.server.fastmcp import FastMCP",
+    "mcp = FastMCP()",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runner.py"), [
+    "import asyncio, json, os",
+    "from mcp.server.fastmcp import STATE",
+    "from telegram_mcp.runtime import mcp",
+    "TOOL_CALL = json.dumps({'jsonrpc': '2.0', 'id': 1, 'method': 'tools/call'}).encode()",
+    "TOOL_LIST = json.dumps({'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list'}).encode()",
+    "async def request(app, body, headers):",
+    "    statuses = []",
+    "    async def receive(): return {'type': 'http.request', 'body': body, 'more_body': False}",
+    "    async def send(message):",
+    "        if message['type'] == 'http.response.start': statuses.append(message['status'])",
+    "    await app({'type': 'http', 'headers': headers, 'path': '/mcp', 'method': 'POST'}, receive, send)",
+    "    return statuses[0]",
+    "async def run_all(token):",
+    "    import __main__ as entry",
+    "    headers = [(b'authorization', b'Bearer ' + token)]",
+    "    app = mcp.streamable_http_app()",
+    "    STATE['peak'] = 0",
+    "    calls = await asyncio.gather(*(request(app, TOOL_CALL, headers) for _ in range(4)))",
+    "    gated_peak = STATE['peak']",
+    "    STATE['peak'] = 0",
+    "    lists = await asyncio.gather(*(request(app, TOOL_LIST, headers) for _ in range(4)))",
+    "    list_peak = STATE['peak']",
+    "    tight = entry.ToolCallGate(entry._original_streamable_http_app(mcp), limit=1, wait_seconds=0.001)",
+    "    bounded = await asyncio.gather(*(request(tight, TOOL_CALL, headers) for _ in range(2)))",
+    "    after = [await request(tight, TOOL_CALL, headers), await request(tight, TOOL_CALL, headers)]",
+    "    return {'calls': sorted(calls), 'gated_peak': gated_peak, 'lists': sorted(lists),",
+    "            'list_peak': list_peak, 'bounded': sorted(bounded), 'after': after}",
+    "def main():",
+    "    print(json.dumps(asyncio.run(run_all(os.environ['LLV_TELEGRAM_MCP_TOKEN'].encode()))))",
+    "",
+  ].join("\n"));
+  const result = Bun.spawnSync({
+    cmd: [python!, path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-mcp-server.py")],
+    env: { ...process.env, LLV_TELEGRAM_VENDOR_DIR: fakeVendor, LLV_TELEGRAM_MCP_TOKEN: "C".repeat(43) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.stderr.toString()).toBe("");
+  expect(result.exitCode).toBe(0);
+  const output = JSON.parse(result.stdout.toString()) as {
+    calls: number[]; gated_peak: number; lists: number[]; list_peak: number; bounded: number[]; after: number[];
+  };
+  /* Four concurrent tool calls all succeed — at most two of them at a time. */
+  expect(output.calls).toEqual([200, 200, 200, 200]);
+  expect(output.gated_peak).toBe(2);
+  /* The handshake surface stays ungated, so the Viewer's readiness probe can
+     never queue behind agent reads and be mistaken for a dead connector. */
+  expect(output.lists).toEqual([200, 200, 200, 200]);
+  expect(output.list_peak).toBe(4);
+  /* Waiting out the bound is refused, not dropped silently. */
+  expect(output.bounded).toEqual([200, 503]);
+  /* And a refused wait gives its slot back: the cap survives the timeout. */
+  expect(output.after).toEqual([200, 200]);
+});
+
 test("health and logout bridges acquire the vendored session lock before connecting", () => {
   const python = Bun.which("python3");
   expect(python).not.toBeNull();

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -9,7 +9,16 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
 const { TelegramConnectionService } = await import("./service");
 const { readTelegramSession, saveTelegramSession, telegramSessionPath, writeTelegramConnection } = await import("./sessionStore");
-const { recordConnectorRestart } = await import("./connectorRestarts");
+const { confirmConnectorRestart, recordConnectorCrash } = await import("./connectorRestarts");
+
+/* A completed restart: a detected death whose replacement then verified. The
+   two-step API is what the supervisor drives; tests that only need the settled
+   result say it in one line. */
+function recordCompletedRestart(crash: { exitCode: number | null; signal: string | null }, at: number): void {
+  recordConnectorCrash(crash, at);
+  confirmConnectorRestart();
+}
+
 
 import type { TelegramAdapter, TelegramEnrollmentEvent, TelegramHealthResult } from "./adapter";
 import type { TelegramErrorCode } from "./contracts";
@@ -722,7 +731,7 @@ test("a fresh connector respawn shows as the transient restarting phase", async 
      the status surface kept saying connected. */
   const { service } = harness();
   connectedConnection();
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
   const status = service.status();
   expect(status.phase).toBe("restarting");
   expect(status.lastRestartAt).toBe(new Date(NOW - 5_000).toISOString());
@@ -732,22 +741,22 @@ test("a fresh connector respawn shows as the transient restarting phase", async 
 test("the restart count the panel reads covers the last 24 h only", async () => {
   const { service } = harness();
   connectedConnection();
-  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
-  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  recordCompletedRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
+  recordCompletedRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
   expect(service.status().restartsLast24h).toBe(2);
 });
 
 test("a respawn-dropped call reads as restarting, then as the connector failure it is", async () => {
   const { service } = harness();
   connectedConnection("connector_restarting");
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 10_000);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 10_000);
   expect(service.status().phase).toBe("restarting");
   expect(service.status().error).toBeNull();
 
   /* Once the grace window closes, a connector that never came back is a real
      failure again — in the vocabulary the panel already renders. */
-  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5 * HOUR);
+  recordCompletedRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5 * HOUR);
   const stale = service.status();
   expect(stale.phase).toBe("error");
   expect(stale.error).toEqual({ code: "connector_failed" });

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -9,6 +9,7 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
 const { TelegramConnectionService } = await import("./service");
 const { readTelegramSession, saveTelegramSession, telegramSessionPath, writeTelegramConnection } = await import("./sessionStore");
+const { recordConnectorRestart } = await import("./connectorRestarts");
 
 import type { TelegramAdapter, TelegramEnrollmentEvent, TelegramHealthResult } from "./adapter";
 import type { TelegramErrorCode } from "./contracts";
@@ -700,4 +701,64 @@ test("retry authorization cannot overwrite a preserved unsafe session", async ()
   expect(service.status().error?.code).toBe("session_unsafe");
   expect(fs.readFileSync(telegramSessionPath())).toEqual(before);
   expect(fs.existsSync(path.join(path.dirname(telegramSessionPath()), "connector-token"))).toBe(false);
+});
+
+const NOW = Date.parse("2026-08-20T12:00:00.000Z");
+const HOUR = 60 * 60 * 1000;
+
+function connectedConnection(errorCode: "connector_restarting" | null = null) {
+  writeTelegramConnection({
+    version: 1,
+    status: errorCode ? "error" : "connected",
+    credentialRef: "credential-generation-a",
+    identity: { name: "Account A", username: "account_a" },
+    lastHealthCheckAt: new Date(NOW).toISOString(),
+    errorCode,
+  });
+}
+
+test("a fresh connector respawn shows as the transient restarting phase", async () => {
+  /* #1087: the supervisor used to replace a crashed connector silently while
+     the status surface kept saying connected. */
+  const { service } = harness();
+  connectedConnection();
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  const status = service.status();
+  expect(status.phase).toBe("restarting");
+  expect(status.lastRestartAt).toBe(new Date(NOW - 5_000).toISOString());
+  expect(status.error).toBeNull();
+});
+
+test("the restart count the panel reads covers the last 24 h only", async () => {
+  const { service } = harness();
+  connectedConnection();
+  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 30 * HOUR);
+  recordConnectorRestart({ exitCode: 1, signal: null }, NOW - 20 * HOUR);
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5_000);
+  expect(service.status().restartsLast24h).toBe(2);
+});
+
+test("a respawn-dropped call reads as restarting, then as the connector failure it is", async () => {
+  const { service } = harness();
+  connectedConnection("connector_restarting");
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 10_000);
+  expect(service.status().phase).toBe("restarting");
+  expect(service.status().error).toBeNull();
+
+  /* Once the grace window closes, a connector that never came back is a real
+     failure again — in the vocabulary the panel already renders. */
+  recordConnectorRestart({ exitCode: null, signal: "SIGKILL" }, NOW - 5 * HOUR);
+  const stale = service.status();
+  expect(stale.phase).toBe("error");
+  expect(stale.error).toEqual({ code: "connector_failed" });
+  expect(stale.restartsLast24h).toBe(2);
+});
+
+test("a status with no restarts at all reports a zeroed restart row", async () => {
+  const { service } = harness();
+  connectedConnection();
+  const status = service.status();
+  expect(status.phase).toBe("connected");
+  expect(status.restartsLast24h).toBe(0);
+  expect(status.lastRestartAt).toBeNull();
 });

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -2,7 +2,14 @@ import crypto from "node:crypto";
 
 import { processTelegramAdapter, type TelegramAdapter, type TelegramEnrollmentEvent, type TelegramEnrollmentHandle } from "./adapter";
 import { ensureTelegramConnector, stopTelegramConnector, type ConnectorEnsureResult } from "./connector";
-import type { TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
+import {
+  RESTART_COUNT_WINDOW_MS,
+  RESTART_GRACE_MS,
+  readConnectorRestarts,
+  restartedWithin,
+  restartsWithin,
+} from "./connectorRestarts";
+import type { TelegramConnectorErrorCode, TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
 import { registerTelegramHosts, unregisterTelegramHosts, type TelegramHostRegistrationResult } from "./hostRegistration";
 import { telegramApiCredentials } from "./packaging";
 import {
@@ -49,6 +56,13 @@ const productionPorts: TelegramServicePorts = {
   now: Date.now,
   credentialsConfigured: () => telegramApiCredentials() !== null,
 };
+
+/** The browser's vocabulary is the durable one: a respawn-dropped call is
+    told through the `restarting` phase, and if it is still standing when the
+    grace window closes it reads as the connector failure it was. */
+function durableErrorCode(code: TelegramConnectorErrorCode): TelegramErrorCode {
+  return code === "connector_restarting" ? "connector_failed" : code;
+}
 
 type LiveLogin = {
   operationId: string;
@@ -138,6 +152,7 @@ export class TelegramConnectionService {
         lastHealthCheckAt: null,
         error: null,
         credentialsConfigured: this.ports.credentialsConfigured(),
+        ...this.restartView(),
       };
     }
     let connection: StoredTelegramConnection;
@@ -151,14 +166,37 @@ export class TelegramConnectionService {
   }
 
   private payloadFor(connection: StoredTelegramConnection): TelegramStatusPayload {
+    /* #1087: a call the supervisor's own respawn dropped reads as the
+       transient `restarting` phase while the grace window is open, and falls
+       back to the durable connector error once it closes — so a connector
+       that never comes back still surfaces as a real failure. */
+    const restarts = readConnectorRestarts();
+    const restarting = restartedWithin(RESTART_GRACE_MS, this.ports.now(), restarts)
+      && (connection.status === "connected" || connection.errorCode === "connector_restarting");
+    const error = connection.status === "error" && connection.errorCode && !restarting
+      ? { code: durableErrorCode(connection.errorCode) }
+      : null;
     return {
-      phase: connection.status,
+      phase: restarting ? "restarting" : connection.status,
       login: null,
       identity: connection.identity,
       credentialRef: connection.credentialRef,
       lastHealthCheckAt: connection.lastHealthCheckAt,
-      error: connection.status === "error" && connection.errorCode ? { code: connection.errorCode } : null,
+      error,
       credentialsConfigured: this.ports.credentialsConfigured(),
+      ...this.restartView(restarts),
+    };
+  }
+
+  /** The restart health row (#1087): how many respawns the Viewer observed in
+      the last 24 h and when the last one was. Counts only — the crash record
+      behind them is structured and never leaves the server. */
+  private restartView(
+    restarts = readConnectorRestarts(),
+  ): Pick<TelegramStatusPayload, "restartsLast24h" | "lastRestartAt"> {
+    return {
+      restartsLast24h: restartsWithin(RESTART_COUNT_WINDOW_MS, this.ports.now(), restarts),
+      lastRestartAt: restarts.lastRestartAt,
     };
   }
 
@@ -318,7 +356,7 @@ export class TelegramConnectionService {
     } catch { /* durable status cleanup was still attempted independently */ }
   }
 
-  private recordError(code: TelegramErrorCode): void {
+  private recordError(code: TelegramConnectorErrorCode): void {
     const connection = this.safeConnection();
     /* A failed RE-connect over a still-stored session keeps that session and
        its identity; only the status and code change. */

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -57,9 +57,9 @@ const productionPorts: TelegramServicePorts = {
   credentialsConfigured: () => telegramApiCredentials() !== null,
 };
 
-/** The browser's vocabulary is the durable one: a respawn-dropped call is
-    told through the `restarting` phase, and if it is still standing when the
-    grace window closes it reads as the connector failure it was. */
+/** The browser's vocabulary is the durable one: a respawn-dropped call is told
+    through the `restarting` phase, and reads as the connector failure it was
+    once the grace window closes. */
 function durableErrorCode(code: TelegramConnectorErrorCode): TelegramErrorCode {
   return code === "connector_restarting" ? "connector_failed" : code;
 }
@@ -166,10 +166,10 @@ export class TelegramConnectionService {
   }
 
   private payloadFor(connection: StoredTelegramConnection): TelegramStatusPayload {
-    /* #1087: a call the supervisor's own respawn dropped reads as the
-       transient `restarting` phase while the grace window is open, and falls
-       back to the durable connector error once it closes — so a connector
-       that never comes back still surfaces as a real failure. */
+    /* #1087: a call the supervisor's own respawn dropped reads as the transient
+       `restarting` phase while the grace window is open, and falls back to the
+       durable error once it closes — a connector that never comes back is a
+       real failure. */
     const restarts = readConnectorRestarts();
     const restarting = restartedWithin(RESTART_GRACE_MS, this.ports.now(), restarts)
       && (connection.status === "connected" || connection.errorCode === "connector_restarting");
@@ -188,9 +188,9 @@ export class TelegramConnectionService {
     };
   }
 
-  /** The restart health row (#1087): how many respawns the Viewer observed in
-      the last 24 h and when the last one was. Counts only — the crash record
-      behind them is structured and never leaves the server. */
+  /** The restart health row (#1087): counted respawns in the last 24 h and when
+      the last one was. Counts only — the structured crash record behind them
+      never leaves the server. */
   private restartView(
     restarts = readConnectorRestarts(),
   ): Pick<TelegramStatusPayload, "restartsLast24h" | "lastRestartAt"> {

--- a/src/lib/telegram/sessionStore.ts
+++ b/src/lib/telegram/sessionStore.ts
@@ -52,9 +52,8 @@ export type StoredTelegramConnection = {
   credentialRef: string | null;
   identity: TelegramIdentity | null;
   lastHealthCheckAt: string | null;
-  /** The connector seam's vocabulary (#1087): a respawn-dropped call is
-      recorded as `connector_restarting`, which the status projection turns
-      into the transient `restarting` phase. */
+  /** The connector seam's vocabulary (#1087): a respawn-dropped call is stored
+      as `connector_restarting` and projected as the `restarting` phase. */
   errorCode: TelegramConnectorErrorCode | null;
 };
 

--- a/src/lib/telegram/sessionStore.ts
+++ b/src/lib/telegram/sessionStore.ts
@@ -6,7 +6,7 @@ import { readValidatedTelegramSessionFiles } from "../../../bin/telegram-session
 
 import { statePath } from "@/lib/configDir";
 
-import type { TelegramErrorCode, TelegramIdentity } from "./contracts";
+import type { TelegramConnectorErrorCode, TelegramIdentity } from "./contracts";
 
 /**
  * Owner-only persistence for the Telegram credential (issue #1059).
@@ -52,7 +52,10 @@ export type StoredTelegramConnection = {
   credentialRef: string | null;
   identity: TelegramIdentity | null;
   lastHealthCheckAt: string | null;
-  errorCode: TelegramErrorCode | null;
+  /** The connector seam's vocabulary (#1087): a respawn-dropped call is
+      recorded as `connector_restarting`, which the status projection turns
+      into the transient `restarting` phase. */
+  errorCode: TelegramConnectorErrorCode | null;
 };
 
 export class UnsafeTelegramSessionError extends Error {
@@ -275,7 +278,7 @@ export function readTelegramConnection(): StoredTelegramConnection {
       ? { name: (row.identity as TelegramIdentity).name, username: (row.identity as TelegramIdentity).username ?? null }
       : null,
     lastHealthCheckAt: typeof row.lastHealthCheckAt === "string" ? row.lastHealthCheckAt : null,
-    errorCode: typeof row.errorCode === "string" ? row.errorCode as TelegramErrorCode : null,
+    errorCode: typeof row.errorCode === "string" ? row.errorCode as TelegramConnectorErrorCode : null,
   };
 }
 


### PR DESCRIPTION
Narrowed successor to #1088 (closed as over-built: +2800 lines, a separate Python monitor process, a crash classifier and drain middleware). This branch restarts from `main` and delivers only what #1087's Expected section asks for, in **345 changed lines of product code** (331 additions + 14 deletions), no new processes and no vendored-Python edits.

## Where the gate actually sits

`hostRegistration.ts` writes `telegramMcpUrl()` — `http://127.0.0.1:<port>/mcp` — into both host tables, and that is the connector's own worker port. **Agent tool calls never pass through the Viewer**, so a gate in the supervisor or the status service would have gated nothing an agent does.

The smallest existing chokepoint on the agents' path is `bin/telegram-mcp-server.py`, the Viewer-owned ASGI wrapper the vendored app already runs behind (it is where bearer auth and the HMAC proof endpoint already live; it is not vendored code). `ToolCallGate` sits inside it:

- at most **2 concurrent `tools/call`** requests; the rest queue;
- a queued request that waits out **30 s** is refused with `503`, never dropped silently, and its slot is given back if it is granted late (so a timeout cannot shrink the cap permanently);
- **only `tools/call` is gated.** The handshake, `tools/list` and the session stream stay free — otherwise the Viewer's own 5 s readiness probe would queue behind agent reads, time out, and the supervisor would kill a healthy connector;
- auth stays outermost, so an unauthorized request cannot consume a slot.

## Visible restarts

`src/lib/telegram/connectorRestarts.ts` — `<state>/telegram/restarts.json`, owner-only — records a respawn in **two steps**:

- **Detection.** The moment a death is seen, a **structured-only** crash record is persisted: exit code, signal, timestamp. No stderr line is persisted or projected, because connector output can carry chat titles, usernames and message text. It lands in a `pending` slot.
- **Completion.** Only once a replacement has actually verified does that crash become a counted restart (`restarts`, `lastRestartAt`, `recent`). A respawn that never comes back therefore stays a standing `connector_failed` instead of inflating `restartsLast24h` and opening a grace window on a connector that is simply gone. The counted restart is timed from the **death**, so the window still covers the calls that death dropped.

Detection does not depend on holding the child's exit channel. A stop always ends in `removeConnectorRecord()`, so a **surviving pid record with a dead pid is an uncommanded death** — which is how a connector **adopted from an earlier Viewer generation** is now recovered, with exit code and signal genuinely `null` rather than invented. The watched-child path still contributes the real exit code and signal, and first detection wins so the pid-file sweep cannot overwrite it with nulls. A termination the Viewer asked for (logout, health-check stop, operator disconnect) is never a crash.

- `contracts.ts` gains the transient `restarting` phase and `restartsLast24h` / `lastRestartAt` on the status payload; `GET /api/telegram` carries them.
- A `connector_failed` within **30 s** of a counted restart is re-read as the sanitized `connector_restarting`. Once the grace window closes it falls back to `connector_failed`, so a connector that never comes back still surfaces as a real failure.

`src/components/TelegramConnect.tsx` is untouched (#1086 lane owns it). That is why `connector_restarting` lives on the connector→service seam (`TelegramConnectorErrorCode`) and reaches the browser as the `restarting` phase rather than as a new member of the panel's error-code map — adding it to `TelegramErrorCode` would require editing that file's exhaustive `Record`. The `telegram.status.restarting` string is in both dictionaries, so the phase renders as soon as the panel shows it.

## Review round 1 (PR #1090)

| Finding | Disposition |
| --- | --- |
| Restart count/time written at child exit, before a replacement verified; adopted exits unobserved | **Fixed** — two-phase detect/confirm above, plus pid-file recovery of adopted deaths |
| 359 changed product lines exceeds the ~350 budget | **Fixed** — 345 |
| Move `connector_restarting` attribution onto the registered agent call path | **Declined**, reason below |

### Declined: attributing a dropped call from inside the connector process

The finding asks for `connector_restarting` to be produced on the agents' own HTTP path — i.e. inside `bin/telegram-mcp-server.py` — and for a held `tools/call` to be covered across replacement. Not done, for three reasons:

1. **The incident has no process left to answer.** #1087 is an *uncommanded* death: `curl: (7) Failed to connect`, then a new pid. Once the process is gone, the agent's socket is reset by the kernel; no code inside that process can turn it into a JSON-RPC error. Only an always-on proxy *in front* of the port could — which is exactly the separate monitor process and drain middleware #1088 was closed for, and the narrowed spec forbids new processes.
2. **A commanded replacement is not a drop either.** On the supervisor's `SIGTERM`, uvicorn stops accepting and then *waits for in-flight requests*, running lifespan shutdown only afterwards. A queued `tools/call` is therefore either served or killed by the supervisor's `SIGKILL` escalation, with no window in which the ASGI layer both knows a replacement is coming and still owns the socket.
3. **The condition in the requirement is Viewer-side state.** "when a restart was **recorded** within the last 30 s" is a read of `restarts.json`, which the connector process neither writes nor reads; making it read that file would be new cross-language coupling for a case reason 1 already rules out.

What is delivered instead: every Viewer-side connector call (`ensureTelegramConnector`, and the health check through it) returns the sanitized `connector_restarting` inside the window, and the operator-visible surface (`GET /api/telegram`, the panel phase) shows `restarting` with the last restart time and the 24 h count — which is what #1087's Expected section actually asks for. #1087's Expected names the concurrency cap, the recorded crash with a transient `restarting` state and last restart time, and the 24 h restart row; it does not ask for an agent-facing wire error.

## Verification

| Gate | Result |
| --- | --- |
| `bunx tsc --noEmit` | clean |
| touched tests by path (isolated `TMPDIR`, isolated state dirs, fake connector process) | 109 pass / 0 fail |
| `bunx eslint` on touched paths | clean |
| `python3 -m py_compile bin/telegram-mcp-server.py` | clean |
| privacy publication gate vs merge-base | PASS |
| changed product lines | 345 (≤ ~350) |

Tests: concurrency cap, ungated handshake, bounded-wait refusal and slot recovery (against a fake vendor tree, the existing entrypoint-test pattern); structured-only crash record; detected-but-not-counted crash; counted restart on a verified replacement; a respawn that never verifies; adopted-connector recovery from the pid file; first spawn is not a restart; expected vs unexpected exit; 24 h counting window; `connector_restarting` mapping and its negatives; the transient phase and the restart row in the service and in the `/api/telegram` payload. No suite sweeps `src/lib/agent/` or `src/app/api/runtime/`.

Not deployed.

Closes #1087.
