### PR TITLE
perf(mcp): project agent_activity reads the cached catalog and honours the call deadline (#860)

### DIFF
--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -12,7 +12,9 @@ import type { RoleDefinition } from "@/lib/roles/types";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
+import type { CompletedGenerationRead } from "@/lib/lifecycle/inventorySelection";
 import { queryLifecycleEvents } from "@/lib/lifecycle/journal";
+import { productionLivenessSources } from "@/lib/lifecycle/liveness";
 import { refreshLifecycleJournal } from "@/lib/lifecycle/projector";
 
 import { defaultMcpSpawnRoleParams, viewerMcpBindings } from "./bindings";
@@ -978,6 +980,155 @@ test("agent_activity reports the liveness snapshot and journals the stalls it fi
   });
   expect(journaled).toHaveLength(1);
 });
+
+/**
+ * #860 — the two bounds the project-scoped liveness read was missing at this
+ * binding: the catalog it reads and the caller's lifetime.
+ */
+function activityRow(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects" as FileEntry["root"],
+    name: path.basename(overrides.path),
+    project: "viewer",
+    title: "stage agent",
+    engine: "codex",
+    kind: "session",
+    fmt: "claude" as FileEntry["fmt"],
+    parent: null,
+    mtime: Date.parse("2026-08-22T08:55:00.000Z") / 1000,
+    size: 4096,
+    activity: "idle",
+    activityReason: "mtime_old",
+    proc: null,
+    pid: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+test("project-scoped agent_activity selects from the binding's cached catalog and forces no fresh sweep (#860)", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-activity-catalog-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const now = Date.parse("2026-08-22T09:00:00.000Z");
+  const catalogReads: Array<{ signal?: AbortSignal | null }> = [];
+  let freshSweeps = 0;
+  let handedCatalog: CompletedGenerationRead | null = null;
+  const files = [
+    activityRow({ path: "/corpus/viewer/live.jsonl", activity: "stalled", activityReason: "jsonl_turn_stalled", conversationId: "conversation_selected" }),
+    activityRow({ path: "/corpus/viewer/idle.jsonl" }),
+    activityRow({ path: "/corpus/other/live.jsonl", project: "other", activity: "stalled", activityReason: "jsonl_turn_stalled" }),
+  ];
+  /* The completed generation the board path reads. A fresh whole-corpus sweep
+     would have to come through one of the two counters below. */
+  const cachedCatalogRead: CompletedGenerationRead = async (options) => {
+    catalogReads.push(options ?? {});
+    return {
+      snapshot: { files, projectCatalog: [], complete: true },
+      generation: 11,
+      targetGeneration: 11,
+      cacheStatus: "hit" as const,
+      requestCount: 1,
+      cloneDurationMs: 0,
+    };
+  };
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    completedFileScan: cachedCatalogRead,
+    listFiles: async () => { freshSweeps += 1; return files; },
+    /* Production's own selection wiring over whatever catalog read the binding
+       hands in, with only the environment-touching seams stubbed. The fallback
+       keeps a regression here off the real scanner instead of sweeping the
+       machine the test runs on. */
+    livenessSources: (catalog?: { completedFileScan?: CompletedGenerationRead }) => ({
+      ...productionLivenessSources({ completedFileScan: (handedCatalog = catalog?.completedFileScan ?? null) ?? cachedCatalogRead }),
+      now: () => now,
+      probe: { now: () => now, pidAlive: () => false, processIdentity: () => null },
+      registrySnapshot: () => ({ entries: {}, conversations: {} }),
+      pipelines: () => [],
+      describeTranscript: async () => null,
+      transcriptEvidence: async () => ({ turn: "busy", lastRecordTs: Date.parse("2026-08-22T08:40:00.000Z") }),
+      listFiles: async () => { freshSweeps += 1; return files; },
+    }),
+    refreshLifecycleJournal: () => ({ appended: 0, skipped: 0, throttled: false }),
+  } as never);
+
+  const result = await bindings.agent_activity({
+    clientRequestId: "activity-860-catalog",
+    project: "viewer",
+    liveOnly: true,
+    limit: 10,
+  });
+
+  expect(result).toMatchObject({ count: 1 });
+  expect(result.selection).toMatchObject({
+    scope: "project",
+    freshScan: false,
+    generation: 11,
+    cacheStatus: "hit",
+    scanned: 3,
+    matched: 1,
+    selected: 1,
+  });
+  expect((result.conversations as Array<Record<string, unknown>>)[0]).toMatchObject({
+    conversationId: "conversation_selected",
+    project: "viewer",
+  });
+  expect(freshSweeps).toBe(0);
+  expect(catalogReads).toHaveLength(1);
+  /* The catalog the read consumed is the binding's own, so `agent_activity` and
+     `board_snapshot` share one generation. */
+  expect(handedCatalog as CompletedGenerationRead | null).toBe(cachedCatalogRead);
+});
+
+test("agent_activity stops the liveness read at the call deadline instead of hanging the caller (#860)", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-activity-deadline-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  let observed: AbortSignal | null = null;
+  let journalWrites = 0;
+  let entered: () => void = () => {};
+  const reached = new Promise<void>((resolve) => { entered = resolve; });
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    livenessSources: () => ({
+      now: () => Date.now(),
+      probe: { now: () => Date.now(), pidAlive: () => false, processIdentity: () => null },
+      registrySnapshot: () => ({ entries: {}, conversations: {} }),
+      pipelines: () => [],
+      describeTranscript: async () => null,
+      transcriptEvidence: async () => null,
+      /* A cold generation that never publishes — the 70-second shape the issue
+         reported. Only the caller's signal can end this call. */
+      selectInventory: (_request: unknown, options?: { signal?: AbortSignal | null }) => new Promise<never>((_resolve, reject) => {
+        observed = options?.signal ?? null;
+        options?.signal?.addEventListener(
+          "abort",
+          () => { reject(new DOMException("catalog selection cancelled", "AbortError")); },
+          { once: true },
+        );
+        entered();
+      }),
+    }),
+    refreshLifecycleJournal: () => { journalWrites += 1; return { appended: 0, skipped: 0, throttled: false }; },
+  } as never);
+
+  const pending = bindings.agent_activity(
+    { clientRequestId: "activity-860-deadline", project: "viewer", liveOnly: true, limit: 10 },
+    { deadlineAt: Date.now() + 25 },
+  );
+  await reached;
+
+  /* Self-bounded: a regression that ignores the deadline fails this assertion
+     instead of hanging the suite on a call that never returns. */
+  const guard = new Promise<never>((_resolve, reject) => {
+    setTimeout(() => { reject(new Error("agent_activity did not stop at the call deadline")); }, 2_000);
+  });
+  await expect(Promise.race([pending, guard])).rejects.toThrow("catalog selection cancelled");
+  expect(observed).not.toBeNull();
+  expect((observed as unknown as AbortSignal).aborted).toBe(true);
+  expect((observed as unknown as AbortSignal).reason).toBeInstanceOf(DeadlineExceededError);
+  /* Nothing was journaled: the call that no caller is waiting for records no
+     lifecycle evidence either. */
+  expect(journalWrites).toBe(0);
+}, 10_000);
 
 test("lifecycle_events projects the runtime deployment ledger into the journal (#686)", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-deploy-events-"));

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -35,7 +35,13 @@ import { getFlowsWithPresets } from "@/lib/flows/engine";
 import type { PatchFlowRequest } from "@/lib/flows/types";
 import { pollLifecycleDigest, type LifecycleDigestRequest } from "@/lib/lifecycle/digest";
 import { queryLifecycleEvents, type LifecycleEventQuery } from "@/lib/lifecycle/journal";
-import { agentLivenessSnapshot, productionLivenessSources, type AgentLivenessSources } from "@/lib/lifecycle/liveness";
+import type { CompletedGenerationRead } from "@/lib/lifecycle/inventorySelection";
+import {
+  agentLivenessSnapshot,
+  productionLivenessSources,
+  DEFAULT_EVIDENCE_DEADLINE_MS,
+  type AgentLivenessSources,
+} from "@/lib/lifecycle/liveness";
 import { refreshLifecycleJournal } from "@/lib/lifecycle/projector";
 import { isLifecycleEventType } from "@/lib/lifecycle/vocabulary";
 import { recordManagerReport } from "@/lib/bridge/service";
@@ -247,7 +253,11 @@ export interface ViewerMcpDomainDependencies {
   readResources: typeof readResources;
   applyConversationAction: typeof applyConversationAction;
   applyConversationMigration: typeof applyConversationMigration;
-  livenessSources(): AgentLivenessSources;
+  /** Sources for the liveness read. The catalog seam travels in (#860) so a
+      project-scoped `agent_activity` consumes the SAME completed generation
+      `board_snapshot` reads instead of forcing a private whole-corpus sweep.
+      Partial harnesses that build fixed sources may ignore the argument. */
+  livenessSources(catalog?: { completedFileScan?: CompletedGenerationRead }): AgentLivenessSources;
   queryLifecycleEvents: typeof queryLifecycleEvents;
   pollLifecycleDigest: typeof pollLifecycleDigest;
   refreshLifecycleJournal: typeof refreshLifecycleJournal;
@@ -1973,18 +1983,46 @@ async function conversationMigration(args: McpToolArgs, dependencies: ViewerMcpD
  * it never echoes a pipeline's own claim about a stage. A stall observed here
  * is also journaled (#686), so the sweep leaves a durable record.
  */
-async function agentActivity(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): Promise<McpToolPayload> {
-  const sources = dependencies.livenessSources();
-  const snapshot = await agentLivenessSnapshot({
-    conversationId: text(args.conversationId) || undefined,
-    transcriptPath: (text(args.transcriptPath) || text(args.path)) || undefined,
-    project: text(args.project) || undefined,
-    liveOnly: args.liveOnly === true,
-    stallAfterMs: typeof args.stallAfterMs === "number" ? args.stallAfterMs : undefined,
-    limit: typeof args.limit === "number" ? args.limit : undefined,
-  }, sources);
-  const journal = dependencies.refreshLifecycleJournal({ liveness: snapshot.conversations });
-  return redactPayload({ ...snapshot, journaled: journal.appended });
+async function agentActivity(
+  args: McpToolArgs,
+  dependencies: ViewerMcpDomainDependencies,
+  context: McpToolCallContext = {},
+): Promise<McpToolPayload> {
+  throwIfCallEnded(context);
+  /* #860: the caller's lifetime reaches the read. Without it a project-scoped
+     call kept its generation wait and its transcript tails running after the
+     caller had given up — the shape the 70-second stall was reported as. */
+  const remainingMs = context.deadlineAt === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(0, context.deadlineAt - Date.now());
+  const deadline = deadlineSignal(remainingMs, {
+    signal: context.signal,
+    reason: "MCP tool deadline exceeded",
+  });
+  try {
+    /* The catalog the board already reads. One completed generation serves both,
+       so this call opens no scan of its own. */
+    const sources = dependencies.livenessSources({ completedFileScan: dependencies.completedFileScan });
+    const snapshot = await agentLivenessSnapshot({
+      conversationId: text(args.conversationId) || undefined,
+      transcriptPath: (text(args.transcriptPath) || text(args.path)) || undefined,
+      project: text(args.project) || undefined,
+      liveOnly: args.liveOnly === true,
+      stallAfterMs: typeof args.stallAfterMs === "number" ? args.stallAfterMs : undefined,
+      limit: typeof args.limit === "number" ? args.limit : undefined,
+      signal: deadline.signal,
+      /* A call with less time left than the standard evidence budget degrades
+         the remaining rows to the scan projection rather than spending a budget
+         its caller will not be there to receive. */
+      ...(Number.isFinite(remainingMs)
+        ? { evidenceDeadlineMs: Math.min(DEFAULT_EVIDENCE_DEADLINE_MS, remainingMs) }
+        : {}),
+    }, sources);
+    const journal = dependencies.refreshLifecycleJournal({ liveness: snapshot.conversations });
+    return redactPayload({ ...snapshot, journaled: journal.appended });
+  } finally {
+    deadline.release();
+  }
 }
 
 function lifecycleEventType(value: unknown): LifecycleEventQuery["type"] {
@@ -2411,7 +2449,7 @@ export function viewerMcpBindings(
     resources: (args) => resources(args, domainDependencies),
     conversation_action: (args, context) => conversationAction(args, domainDependencies, context),
     conversation_migration: (args) => conversationMigration(args, domainDependencies),
-    agent_activity: (args) => agentActivity(args, domainDependencies),
+    agent_activity: (args, context) => agentActivity(args, domainDependencies, context),
     lifecycle_events: (args) => lifecycleEvents(args, controlDependencies, domainDependencies),
     request_attention: (args, context) => requestAttention(args, domainDependencies, context),
     bridge_report: (args) => Promise.resolve(bridgeReport(args, domainDependencies)),


### PR DESCRIPTION
Closes the MCP-binding half of #860.

## What was wrong

`agentActivity` in `src/lib/mcp/bindings.ts` built its liveness sources with no catalog seam and was dispatched as `(args) => …`, so it never received the `McpToolCallContext`. Two consequences, both named in the issue:

- The read could not join the completed scanner generation `board_snapshot` already consumes; production wiring fell back to the module default rather than the binding's own `completedFileScan`, so the two catalog surfaces did not provably share one generation.
- No `signal` and no deadline-derived budget reached the read. A caller that timed out left the generation wait and the transcript tails running — the shape reported as `agent_activity(project, liveOnly, limit: 10)` still unreturned after 70 seconds while `board_snapshot(project, …)` answered the same project in 91 ms.

## What changed

- `ViewerMcpDomainDependencies.livenessSources` takes the catalog seam, and the binding hands in its own `completedFileScan`. `agent_activity` and `board_snapshot` now read ONE completed generation; no whole-corpus sweep is forced for the project path.
- `agent_activity` is dispatched as `(args, context)` and forwards it exactly the way `get_conversation` and `conversation_action` do: `throwIfCallEnded` up front, one `deadlineSignal` derived from `context.deadlineAt`/`context.signal`, released in a `finally`. The signal reaches selection and tail hydration, so cancellation stops outstanding work.
- The evidence budget is capped by whatever the call has left (`min(DEFAULT_EVIDENCE_DEADLINE_MS, remaining)`), so a short call degrades the remaining rows to the scan projection instead of spending a budget its caller will not be there to receive.

`liveOnly` and `limit` semantics are untouched — both are applied by the selection the liveness helper already owned, before any transcript is opened. No new cache layer, no new config, no change outside `src/lib/mcp/`.

## Tests

Two cases added to `src/lib/mcp/bindings.test.ts`, both RED against the parent commit:

- *project-scoped `agent_activity` selects from the binding's cached catalog and forces no fresh sweep* — asserts the catalog read the binding passed is its own, that the selection reports the injected generation with `freshScan: false`, and that neither legacy `listFiles` adapter is called. RED before: the catalog argument arrived `null`.
- *`agent_activity` stops the liveness read at the call deadline instead of hanging the caller* — a selection that never publishes a generation; the call ends with the deadline reason on the signal it received and nothing journaled. RED before: the call never returned (the test is self-bounded so a regression fails rather than hangs).

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test src/lib/mcp/bindings.test.ts` — 27 pass, 0 fail (run by path, isolated `LLV_STATE_DIR`/`XDG_CONFIG_HOME`).
- `bun test src/lib/mcp/server.test.ts` — 32 pass, 0 fail (same isolation; covers the `agent_activity` receipt path).
- `bunx eslint` on both touched files — clean.
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` — PASS.

Not in scope here: `list_conversations` adoption of the same seam (it reads the catalog over the Viewer control API), and the exact-SHA deploy/production verification the issue still tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)