### PR TITLE
fix(pipelines): read-only reviewer stages get writable scratch; reviewer scaffold stops promising network (#1052)

### DIFF
--- a/src/lib/roles/defaults.ts
+++ b/src/lib/roles/defaults.ts
@@ -46,7 +46,7 @@ export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
       { key: "mode", label: "Mode", description: "Reviewer context mode.", kind: "select", options: ["fresh"] },
       { key: "parallelN", label: "Parallel passes", description: "Independent review passes.", kind: "integer", min: 1, max: 8 },
     ],
-    promptScaffold: `You are a fresh-context Reviewer. Inspect {{diffSource}} with lens {{lens}}. Run {{parallelN}} independent pass(es), preserving their axes. Return severity-ranked findings with file:line evidence, or exactly NO FINDINGS when the diff is clean. Every finding is an actionable fix plan: clear problem statement, fix intent, constraints, and acceptance criteria. No copy-paste code unless absolutely necessary. ${REVIEW_FRAME_RULES}`,
+    promptScaffold: `You are a fresh-context Reviewer. Inspect {{diffSource}} with lens {{lens}}. Run {{parallelN}} independent pass(es), preserving their axes. Report the reviewed SHA. State plainly when GitHub or DNS access was unavailable. Classify any gate blocked by sandbox limits as an environmental note and keep it out of code findings. Run TypeScript checks with bunx tsc --noEmit --incremental false so they do not need a tsbuildinfo write in the checkout. Return severity-ranked findings with file:line evidence, or exactly NO FINDINGS when the diff is clean. Every finding is an actionable fix plan: clear problem statement, fix intent, constraints, and acceptance criteria. No copy-paste code unless absolutely necessary. ${REVIEW_FRAME_RULES}`,
     safetyFences: REVIEW_FENCES,
     capabilities: ["read-only"],
   },

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -81,6 +81,10 @@ test("resolved prompts carry role safety fences and reject cross-engine inherite
   expect(reviewer.ok && reviewer.value.prompt).toContain("Read-only mode: edits, staging, commits, pushes, service restarts, and GitHub comments are prohibited.");
   expect(reviewer.ok && reviewer.value.prompt).toContain("actionable fix plan");
   expect(reviewer.ok && reviewer.value.prompt).toContain("No copy-paste code unless absolutely necessary.");
+  expect(reviewer.ok && reviewer.value.prompt).toContain("Report the reviewed SHA.");
+  expect(reviewer.ok && reviewer.value.prompt).toContain("State plainly when GitHub or DNS access was unavailable.");
+  expect(reviewer.ok && reviewer.value.prompt).toContain("environmental note");
+  expect(reviewer.ok && reviewer.value.prompt).toContain("bunx tsc --noEmit --incremental false");
 
   expect(resolveSpawnRole({ role: "builder", roleParams: { mode: "plain" }, engine: "claude" })).toEqual({
     ok: false,

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -395,6 +395,26 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test("forwards GitHub config only for read-only scratch hosts", async () => {
+    for (const forwardGitHubConfig of [false, true]) {
+      const child = new FakeClaude(new RecordingDeliveryLedger());
+      const captured: { options?: SpawnOptionsWithoutStdio } = {};
+      const host = await ClaudeStreamBrokerHost.start({
+        cwd: "/repo",
+        env: { NODE_ENV: "test", GH_CONFIG_DIR: "/shared/config/gh" },
+        forwardGitHubConfig,
+        eventStore: new MemoryEventStore(),
+        deliveryLedger: new RecordingDeliveryLedger(),
+        readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+        spawnProcess: fakeSpawn(child, captured),
+      });
+      expect(captured.options?.env?.GH_CONFIG_DIR).toBe(
+        forwardGitHubConfig ? "/shared/config/gh" : undefined,
+      );
+      await host.release();
+    }
+  });
+
   test("read-only hosts deny mutation and native sub-agent tools", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -190,6 +190,8 @@ export interface ClaudeStreamBrokerHostOptions {
   permissionMode?: string;
   tools?: string[];
   env?: NodeJS.ProcessEnv;
+  forwardGitHubConfig?: boolean;
+  releaseCleanup?: () => void;
   requestTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
@@ -297,9 +299,14 @@ export function redactClaudeHostDiagnostic(value: unknown): string {
 
 const safeError = redactClaudeHostDiagnostic;
 
-function subscriptionEnv(source: NodeJS.ProcessEnv, claudeConfigDir?: string): NodeJS.ProcessEnv {
+function subscriptionEnv(
+  source: NodeJS.ProcessEnv,
+  claudeConfigDir?: string,
+  forwardGitHubConfig = false,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
   for (const name of CHILD_ENV_ALLOWLIST) if (source[name] !== undefined) env[name] = source[name];
+  if (forwardGitHubConfig && source.GH_CONFIG_DIR !== undefined) env.GH_CONFIG_DIR = source.GH_CONFIG_DIR;
   if (claudeConfigDir) env.CLAUDE_CONFIG_DIR = claudeConfigDir;
   return env;
 }
@@ -480,6 +487,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private ledgerFailed = false;
   private writerFence: (() => boolean) | null = null;
   private releasePromise: Promise<void> | null = null;
+  private releaseCleanup: (() => void) | null;
   private terminationTimer: ReturnType<typeof setTimeout> | null = null;
   private terminationStarted = false;
   private readonly reapedPromise: Promise<void>;
@@ -501,6 +509,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.signalProcess = options.signalProcess ?? process.kill;
+    this.releaseCleanup = options.releaseCleanup ?? null;
     this.cursor = options.initialEventCursor ?? 0;
     this.protocolVersion = auth.version ?? null;
     this.account = { type: auth.authMethod, planType: auth.subscriptionType };
@@ -548,9 +557,20 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     options: ClaudeStreamBrokerHostOptions,
   ): Promise<ClaudeStreamBrokerHost> {
     const binary = options.binary ?? process.env.LLV_CLAUDE_BINARY ?? "claude";
-    const env = subscriptionEnv(options.env ?? process.env, options.claudeConfigDir);
-    const auth = await (options.readAuthStatus?.() ?? claudeCliAuthStatus(binary, env, options.cwd));
+    const env = subscriptionEnv(
+      options.env ?? process.env,
+      options.claudeConfigDir,
+      options.forwardGitHubConfig === true,
+    );
+    let auth: ClaudeAuthStatus;
+    try {
+      auth = await (options.readAuthStatus?.() ?? claudeCliAuthStatus(binary, env, options.cwd));
+    } catch (error) {
+      options.releaseCleanup?.();
+      throw error;
+    }
     if (!auth.loggedIn || auth.authMethod !== "claude.ai" || !auth.subscriptionType) {
+      options.releaseCleanup?.();
       throw new Error("Claude stream hosting requires a claude.ai subscription login");
     }
     const args = [
@@ -587,11 +607,17 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     if (options.tools) args.push("--tools", options.tools.join(","));
     const spawnProcess = options.spawnProcess ?? ((command, childArgs, spawnOptions) =>
       spawn(command, childArgs, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
-    const child = spawnProcess(binary, args, {
-      cwd: options.cwd,
-      env: withTelegramConnectorGrant(env, options.mcpServers),
-      detached: true,
-    });
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnProcess(binary, args, {
+        cwd: options.cwd,
+        env: withTelegramConnectorGrant(env, options.mcpServers),
+        detached: true,
+      });
+    } catch (error) {
+      options.releaseCleanup?.();
+      throw error;
+    }
     const host = new ClaudeStreamBrokerHost(child, { sessionId }, auth, options);
     try {
       host.restore();
@@ -1091,6 +1117,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.emit({ kind: "session-status", status: "unhosted" });
     if (this.ledgerFailed) this.notifyStateListeners();
     this.closeSubscribers();
+    const cleanup = this.releaseCleanup;
+    this.releaseCleanup = null;
+    cleanup?.();
   }
 
   private async waitForReap(timeoutMs: number): Promise<boolean> {

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -6,16 +6,45 @@ import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeEvent } from "./engineHost";
 import { FileRuntimeEventStore } from "./eventStore";
 import { pathIsInside, prepareCodexIntegrationTestHome } from "./integrationTestHome";
+import { materializeStructuredHostAccess, READ_ONLY_STAGE_PERMISSION_PROFILE } from "./structuredSpawn";
 import { buildPipeline, PIPELINES_SCHEMA_VERSION } from "@/lib/pipelines/store";
 
 const codexBinary = process.env.LLV_CODEX_BINARY ?? "codex";
 const isolatedHome = prepareCodexIntegrationTestHome(codexBinary);
 const mcpHome = prepareCodexIntegrationTestHome(codexBinary);
+const scratchHome = prepareCodexIntegrationTestHome(codexBinary);
 
 afterAll(() => {
   isolatedHome?.cleanup();
   mcpHome?.cleanup();
+  scratchHome?.cleanup();
 });
+
+type CommandExecResult = { exitCode: number; stdout: string; stderr: string };
+
+function hostRpc(
+  host: CodexAppServerHost,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const rpc = (host as unknown as {
+    rpc(method: string, params: Record<string, unknown>): Promise<unknown>;
+  }).rpc.bind(host);
+  return rpc(method, params);
+}
+
+async function commandExec(
+  host: CodexAppServerHost,
+  command: string,
+  env?: Record<string, string>,
+): Promise<CommandExecResult> {
+  return await hostRpc(host, "command/exec", {
+    command: ["/bin/sh", "-lc", command],
+    permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
+    timeoutMs: 10_000,
+    ...(env ? { env } : {}),
+  }) as CommandExecResult;
+}
 
 async function waitFor(
   iterator: AsyncIterator<RuntimeEvent>,
@@ -116,6 +145,66 @@ function nativeViewerCall(event: RuntimeEvent, pipelineId: string, server: strin
     && item.error == null
     && JSON.stringify(item.result).includes(pipelineId);
 }
+
+test.skipIf(!scratchHome)("real Codex app-server accepts the read-only scratch profile for fresh and adopted threads", async () => {
+  if (!scratchHome) throw new Error("isolated Codex subscription home is unavailable");
+  const checkoutDirectory = path.join(scratchHome.directory, "checkout");
+  fs.mkdirSync(checkoutDirectory, { mode: 0o700 });
+  const access = materializeStructuredHostAccess(
+    true,
+    scratchHome.env,
+    "integration-capability",
+    scratchHome.directory,
+  );
+  const eventStore = new FileRuntimeEventStore(path.join(scratchHome.directory, "events"));
+  const options = {
+    cwd: checkoutDirectory,
+    binary: codexBinary,
+    codexHome: scratchHome.codexHome,
+    env: access.env,
+    fileAuthCredentials: true,
+    permissionProfile: access.codex.permissionProfile,
+    permissionProfileConfig: access.codex.permissionProfileConfig,
+    approvalPolicy: "never",
+    requestTimeoutMs: 60_000,
+    eventStore,
+  };
+  const checkoutProbe = path.join(checkoutDirectory, "must-stay-absent");
+  let host: CodexAppServerHost | null = null;
+  let adopted: CodexAppServerHost | null = null;
+  try {
+    host = await CodexAppServerHost.start(options);
+    const freshScratch = await commandExec(host, 'printf fresh > "$TMPDIR/fresh"');
+    expect(freshScratch.exitCode).toBe(0);
+    expect(fs.readFileSync(path.join(access.env.TMPDIR!, "fresh"), "utf8")).toBe("fresh");
+    const freshCheckout = await commandExec(host, 'printf blocked > "$CHECKOUT_PROBE"', {
+      CHECKOUT_PROBE: checkoutProbe,
+    });
+    expect(freshCheckout.exitCode).not.toBe(0);
+    expect(fs.existsSync(checkoutProbe)).toBeFalse();
+
+    const threadId = host.identity.threadId;
+    await hostRpc(host, "thread/name/set", { threadId, name: "Read-only scratch profile probe" });
+    const cursor = (await host.health()).eventCursor;
+    await host.release();
+    host = null;
+
+    adopted = await CodexAppServerHost.adopt(threadId, { ...options, initialEventCursor: cursor });
+    const adoptedScratch = await commandExec(adopted, 'printf adopted > "$HOME/adopted"');
+    expect(adoptedScratch.exitCode).toBe(0);
+    expect(fs.readFileSync(path.join(access.env.HOME!, "adopted"), "utf8")).toBe("adopted");
+    const adoptedCheckout = await commandExec(adopted, 'printf blocked > "$CHECKOUT_PROBE"', {
+      CHECKOUT_PROBE: checkoutProbe,
+    });
+    expect(adoptedCheckout.exitCode).not.toBe(0);
+    expect(fs.existsSync(checkoutProbe)).toBeFalse();
+  } finally {
+    await host?.release();
+    await adopted?.release();
+    access.cleanup();
+    scratchHome.cleanup();
+  }
+}, 120_000);
 
 async function exerciseNativeViewer(
   host: CodexAppServerHost,

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -150,33 +150,34 @@ test.skipIf(!scratchHome)("real Codex app-server accepts the read-only scratch p
   if (!scratchHome) throw new Error("isolated Codex subscription home is unavailable");
   const checkoutDirectory = path.join(scratchHome.directory, "checkout");
   fs.mkdirSync(checkoutDirectory, { mode: 0o700 });
-  const access = materializeStructuredHostAccess(
+  const freshAccess = materializeStructuredHostAccess(
     true,
     scratchHome.env,
     "integration-capability",
     scratchHome.directory,
   );
   const eventStore = new FileRuntimeEventStore(path.join(scratchHome.directory, "events"));
-  const options = {
+  const optionsFor = (access: ReturnType<typeof materializeStructuredHostAccess>) => ({
     cwd: checkoutDirectory,
     binary: codexBinary,
     codexHome: scratchHome.codexHome,
     env: access.env,
     fileAuthCredentials: true,
-    permissionProfile: access.codex.permissionProfile,
-    permissionProfileConfig: access.codex.permissionProfileConfig,
+    ...access.codex,
+    ...access.host,
     approvalPolicy: "never",
     requestTimeoutMs: 60_000,
     eventStore,
-  };
+  });
   const checkoutProbe = path.join(checkoutDirectory, "must-stay-absent");
   let host: CodexAppServerHost | null = null;
   let adopted: CodexAppServerHost | null = null;
+  let adoptedAccess: ReturnType<typeof materializeStructuredHostAccess> | null = null;
   try {
-    host = await CodexAppServerHost.start(options);
+    host = await CodexAppServerHost.start(optionsFor(freshAccess));
     const freshScratch = await commandExec(host, 'printf fresh > "$TMPDIR/fresh"');
     expect(freshScratch.exitCode).toBe(0);
-    expect(fs.readFileSync(path.join(access.env.TMPDIR!, "fresh"), "utf8")).toBe("fresh");
+    expect(fs.readFileSync(path.join(freshAccess.env.TMPDIR!, "fresh"), "utf8")).toBe("fresh");
     const freshCheckout = await commandExec(host, 'printf blocked > "$CHECKOUT_PROBE"', {
       CHECKOUT_PROBE: checkoutProbe,
     });
@@ -188,11 +189,22 @@ test.skipIf(!scratchHome)("real Codex app-server accepts the read-only scratch p
     const cursor = (await host.health()).eventCursor;
     await host.release();
     host = null;
+    expect(fs.existsSync(freshAccess.scratchDirectory!)).toBeFalse();
 
-    adopted = await CodexAppServerHost.adopt(threadId, { ...options, initialEventCursor: cursor });
+    adoptedAccess = materializeStructuredHostAccess(
+      true,
+      scratchHome.env,
+      "integration-capability-restarted",
+      scratchHome.directory,
+    );
+    expect(adoptedAccess.scratchDirectory).not.toBe(freshAccess.scratchDirectory);
+    adopted = await CodexAppServerHost.adopt(threadId, {
+      ...optionsFor(adoptedAccess),
+      initialEventCursor: cursor,
+    });
     const adoptedScratch = await commandExec(adopted, 'printf adopted > "$HOME/adopted"');
     expect(adoptedScratch.exitCode).toBe(0);
-    expect(fs.readFileSync(path.join(access.env.HOME!, "adopted"), "utf8")).toBe("adopted");
+    expect(fs.readFileSync(path.join(adoptedAccess.env.HOME!, "adopted"), "utf8")).toBe("adopted");
     const adoptedCheckout = await commandExec(adopted, 'printf blocked > "$CHECKOUT_PROBE"', {
       CHECKOUT_PROBE: checkoutProbe,
     });
@@ -201,8 +213,8 @@ test.skipIf(!scratchHome)("real Codex app-server accepts the read-only scratch p
   } finally {
     await host?.release();
     await adopted?.release();
-    access.cleanup();
-    scratchHome.cleanup();
+    freshAccess.cleanup();
+    adoptedAccess?.cleanup();
   }
 }, 120_000);
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -56,6 +56,10 @@ test("read-only structured hosts receive one writable isolated scratch root", ()
       permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
       permissionProfileConfig: `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(access.scratchDirectory)}="write"}}`,
     });
+    expect(access.host).toEqual({
+      forwardGitHubConfig: true,
+      releaseCleanup: expect.any(Function),
+    });
     expect(fs.statSync(access.scratchDirectory!).mode & 0o777).toBe(0o700);
     for (const name of ["home", "config", "tmp"]) {
       expect(fs.statSync(path.join(access.scratchDirectory!, name)).mode & 0o777).toBe(0o700);
@@ -435,6 +439,7 @@ describe("CodexAppServerHost", () => {
         cwd: "/repo",
         permissionProfile,
         permissionProfileConfig,
+        forwardGitHubConfig: true,
         env: { NODE_ENV: "test" as const, GH_CONFIG_DIR: "/shared/config/gh" },
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(server, captured),
@@ -455,6 +460,18 @@ describe("CodexAppServerHost", () => {
       expect(params).not.toHaveProperty("sandbox");
       await host.release();
     }
+
+    const readWriteServer = new FakeAppServer("read-write-thread");
+    const readWriteCapture: { options?: SpawnOptionsWithoutStdio } = {};
+    const readWriteHost = await CodexAppServerHost.start({
+      cwd: "/repo",
+      sandbox: "danger-full-access",
+      env: { NODE_ENV: "test", GH_CONFIG_DIR: "/shared/config/gh" },
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(readWriteServer, readWriteCapture),
+    });
+    expect(readWriteCapture.options?.env?.GH_CONFIG_DIR).toBeUndefined();
+    await readWriteHost.release();
   });
 
   test("starts a client-managed V3 WebRTC call on the hosted thread", async () => {
@@ -3471,6 +3488,8 @@ describe("CodexAppServerHost", () => {
 
   test("startup adoption retains an unreaped Codex child until late cleanup converges", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-uncertain-codex-adoption-"));
+    const scratchDirectory = path.join(directory, "scratch");
+    fs.mkdirSync(scratchDirectory);
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
     const sessionId = "uncertain-codex-adoption";
     registry.upsert({
@@ -3505,6 +3524,7 @@ describe("CodexAppServerHost", () => {
         shutdownGraceMs: 2,
         spawnProcess: fakeSpawn(server),
         signalProcess: () => {},
+        releaseCleanup: () => fs.rmSync(scratchDirectory, { recursive: true, force: true }),
         ...ownedFakeProcess,
       }),
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
@@ -3520,6 +3540,7 @@ describe("CodexAppServerHost", () => {
         writerClaimEpoch: 3,
       },
     });
+    expect(fs.existsSync(scratchDirectory)).toBeTrue();
 
     server.emit("close", 0, "SIGKILL");
     await Bun.sleep(0);
@@ -3528,6 +3549,7 @@ describe("CodexAppServerHost", () => {
       claimOwner: null,
       structuredHost: { endpoint: "stdio:released", process: null },
     });
+    expect(fs.existsSync(scratchDirectory)).toBeFalse();
   });
 
   test("concurrent startup adoption creates one writer and advances its claim epoch", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -37,7 +37,12 @@ class MemoryEventStore implements RuntimeEventStore {
 test("read-only structured hosts receive one writable isolated scratch root", () => {
   const scratchParent = fs.mkdtempSync(path.join(os.tmpdir(), "llv-read-only-scratch-test-"));
   try {
-    const access = materializeStructuredHostAccess(true, { NODE_ENV: "test", HOME: "/shared/home" }, "capability", scratchParent);
+    const access = materializeStructuredHostAccess(
+      true,
+      { NODE_ENV: "test", HOME: "/shared/home", XDG_CONFIG_HOME: "/shared/config" },
+      "capability",
+      scratchParent,
+    );
 
     expect(access.env).toMatchObject({
       NODE_ENV: "test",
@@ -45,6 +50,7 @@ test("read-only structured hosts receive one writable isolated scratch root", ()
       HOME: path.join(access.scratchDirectory!, "home"),
       XDG_CONFIG_HOME: path.join(access.scratchDirectory!, "config"),
       TMPDIR: path.join(access.scratchDirectory!, "tmp"),
+      GH_CONFIG_DIR: "/shared/config/gh",
     });
     expect(access.codex).toEqual({
       permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
@@ -424,11 +430,12 @@ describe("CodexAppServerHost", () => {
     const permissionProfileConfig = 'permissions.llv-read-only-stage={extends=":read-only",filesystem={"/scratch"="write"}}';
     for (const threadId of [null, "scratch-thread"] as const) {
       const server = new FakeAppServer(threadId ?? "scratch-thread");
-      const captured: { args?: string[] } = {};
+      const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
       const options = {
         cwd: "/repo",
         permissionProfile,
         permissionProfileConfig,
+        env: { NODE_ENV: "test" as const, GH_CONFIG_DIR: "/shared/config/gh" },
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(server, captured),
       };
@@ -437,9 +444,11 @@ describe("CodexAppServerHost", () => {
         : await CodexAppServerHost.start(options);
 
       expect(captured.args).toEqual([
+        "-c", `default_permissions=${JSON.stringify(permissionProfile)}`,
         "-c", permissionProfileConfig,
         "app-server", "--enable", "realtime_conversation",
       ]);
+      expect(captured.options?.env?.GH_CONFIG_DIR).toBe("/shared/config/gh");
       const method = threadId ? "thread/resume" : "thread/start";
       const params = server.requests.find((request) => request.method === method)?.params as Record<string, unknown>;
       expect(params).toMatchObject({ permissions: permissionProfile });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -16,6 +16,7 @@ import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 import type { HostState, RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContent, type StructuredImageRef } from "./structuredContent";
+import { materializeStructuredHostAccess, READ_ONLY_STAGE_PERMISSION_PROFILE } from "./structuredSpawn";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
 import { DEFAULT_VOICE_PERSONA, VOICE_PERSONA_FILE, legacyVoicePersonaBootstrapItemId, voicePersona } from "./voicePersona";
 
@@ -32,6 +33,41 @@ class MemoryEventStore implements RuntimeEventStore {
     this.events.set(threadId, events);
   }
 }
+
+test("read-only structured hosts receive one writable isolated scratch root", () => {
+  const scratchParent = fs.mkdtempSync(path.join(os.tmpdir(), "llv-read-only-scratch-test-"));
+  try {
+    const access = materializeStructuredHostAccess(true, { NODE_ENV: "test", HOME: "/shared/home" }, "capability", scratchParent);
+
+    expect(access.env).toMatchObject({
+      NODE_ENV: "test",
+      LLV_SPAWN_CAPABILITY: "capability",
+      HOME: path.join(access.scratchDirectory!, "home"),
+      XDG_CONFIG_HOME: path.join(access.scratchDirectory!, "config"),
+      TMPDIR: path.join(access.scratchDirectory!, "tmp"),
+    });
+    expect(access.codex).toEqual({
+      permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
+      permissionProfileConfig: `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(access.scratchDirectory)}="write"}}`,
+    });
+    expect(fs.statSync(access.scratchDirectory!).mode & 0o777).toBe(0o700);
+    for (const name of ["home", "config", "tmp"]) {
+      expect(fs.statSync(path.join(access.scratchDirectory!, name)).mode & 0o777).toBe(0o700);
+    }
+
+    access.cleanup();
+    expect(fs.existsSync(access.scratchDirectory!)).toBeFalse();
+
+    const readWrite = materializeStructuredHostAccess(false, { NODE_ENV: "test", HOME: "/shared/home" }, "capability", scratchParent);
+    expect(readWrite).toMatchObject({
+      env: { HOME: "/shared/home", LLV_SPAWN_CAPABILITY: "capability" },
+      codex: { sandbox: "danger-full-access" },
+      scratchDirectory: null,
+    });
+  } finally {
+    fs.rmSync(scratchParent, { recursive: true, force: true });
+  }
+});
 
 class FailingEventStore implements RuntimeEventStore {
   readonly stored: RuntimeEvent[] = [];
@@ -381,6 +417,35 @@ describe("CodexAppServerHost", () => {
       },
     });
     await host.release();
+  });
+
+  test("applies the isolated read-only-stage permission profile to fresh and adopted threads", async () => {
+    const permissionProfile = "llv-read-only-stage";
+    const permissionProfileConfig = 'permissions.llv-read-only-stage={extends=":read-only",filesystem={"/scratch"="write"}}';
+    for (const threadId of [null, "scratch-thread"] as const) {
+      const server = new FakeAppServer(threadId ?? "scratch-thread");
+      const captured: { args?: string[] } = {};
+      const options = {
+        cwd: "/repo",
+        permissionProfile,
+        permissionProfileConfig,
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(server, captured),
+      };
+      const host = threadId
+        ? await CodexAppServerHost.adopt(threadId, options)
+        : await CodexAppServerHost.start(options);
+
+      expect(captured.args).toEqual([
+        "-c", permissionProfileConfig,
+        "app-server", "--enable", "realtime_conversation",
+      ]);
+      const method = threadId ? "thread/resume" : "thread/start";
+      const params = server.requests.find((request) => request.method === method)?.params as Record<string, unknown>;
+      expect(params).toMatchObject({ permissions: permissionProfile });
+      expect(params).not.toHaveProperty("sandbox");
+      await host.release();
+    }
   });
 
   test("starts a client-managed V3 WebRTC call on the hosted thread", async () => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -175,6 +175,8 @@ export interface CodexAppServerHostOptions {
   plugins?: readonly string[];
   fileAuthCredentials?: boolean;
   sandbox?: string;
+  permissionProfile?: string;
+  permissionProfileConfig?: string;
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
@@ -745,6 +747,7 @@ export class CodexAppServerHost implements EngineHost {
       spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
     const args = [
       ...(options.fileAuthCredentials ? ["-c", "cli_auth_credentials_store=file"] : []),
+      ...(options.permissionProfileConfig ? ["-c", options.permissionProfileConfig] : []),
       "app-server",
       "--enable",
       "realtime_conversation",
@@ -789,11 +792,17 @@ export class CodexAppServerHost implements EngineHost {
         granted,
       );
       const result = threadId
-        ? await provisional.rpc("thread/resume", { threadId, config })
+        ? await provisional.rpc("thread/resume", {
+          threadId,
+          ...(options.permissionProfile ? { permissions: options.permissionProfile } : {}),
+          config,
+        })
         : await provisional.rpc("thread/start", {
           cwd: options.cwd,
           ...(options.model ? { model: options.model } : {}),
-          sandbox: options.sandbox ?? "read-only",
+          ...(options.permissionProfile
+            ? { permissions: options.permissionProfile }
+            : { sandbox: options.sandbox ?? "read-only" }),
           approvalPolicy: options.approvalPolicy ?? "never",
           config,
         });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -177,6 +177,8 @@ export interface CodexAppServerHostOptions {
   sandbox?: string;
   permissionProfile?: string;
   permissionProfileConfig?: string;
+  forwardGitHubConfig?: boolean;
+  releaseCleanup?: () => void;
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
@@ -235,7 +237,6 @@ const CHILD_ENV_ALLOWLIST = [
   "TERM",
   "COLORTERM",
   "NO_COLOR",
-  "GH_CONFIG_DIR",
   "XDG_CONFIG_HOME",
   "XDG_CACHE_HOME",
   "XDG_DATA_HOME",
@@ -386,12 +387,18 @@ function stderrExitDiagnostic(value: string): string {
     .slice(0, 430);
 }
 
-function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string, desktopSession = false): NodeJS.ProcessEnv {
+function subscriptionEnv(
+  source: NodeJS.ProcessEnv,
+  codexHome?: string,
+  desktopSession = false,
+  forwardGitHubConfig = false,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
   const names = desktopSession ? [...CHILD_ENV_ALLOWLIST, ...DESKTOP_ENV_ALLOWLIST] : CHILD_ENV_ALLOWLIST;
   for (const name of names) {
     if (source[name] !== undefined) env[name] = source[name];
   }
+  if (forwardGitHubConfig && source.GH_CONFIG_DIR !== undefined) env.GH_CONFIG_DIR = source.GH_CONFIG_DIR;
   if (codexHome) env.CODEX_HOME = codexHome;
   return env;
 }
@@ -682,6 +689,7 @@ export class CodexAppServerHost implements EngineHost {
   private resolveTermination: (() => void) | null = null;
   private failureCleanupTimer: ReturnType<typeof setTimeout> | null = null;
   private releasePromise: Promise<void> | null = null;
+  private releaseCleanup: (() => void) | null;
   private writerFence: (() => boolean) | null = null;
   private ledgerFailed = false;
   private failure: Error | null = null;
@@ -703,6 +711,7 @@ export class CodexAppServerHost implements EngineHost {
     this.signalProcess = options.signalProcess ?? process.kill;
     this.processIdentity = options.processIdentity ?? ((pid) => procBackend.processIdentity(pid));
     this.pidAlive = options.pidAlive ?? ((pid) => procBackend.pidAlive(pid));
+    this.releaseCleanup = options.releaseCleanup ?? null;
     this.childStartIdentity = child.pid ? this.processIdentity(child.pid) : null;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.resolveImagePath = options.resolveImagePath ?? ((ref) => {
@@ -759,14 +768,25 @@ export class CodexAppServerHost implements EngineHost {
       "realtime_conversation",
     ];
     const granted = grantedPlugins(options.plugins);
-    const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {
-      cwd: options.cwd,
-      env: withTelegramConnectorGrant(
-        subscriptionEnv(options.env ?? process.env, options.codexHome, granted.length > 0),
-        options.mcpServers,
-      ),
-      detached: true,
-    });
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {
+        cwd: options.cwd,
+        env: withTelegramConnectorGrant(
+          subscriptionEnv(
+            options.env ?? process.env,
+            options.codexHome,
+            granted.length > 0,
+            options.forwardGitHubConfig === true,
+          ),
+          options.mcpServers,
+        ),
+        detached: true,
+      });
+    } catch (error) {
+      options.releaseCleanup?.();
+      throw error;
+    }
     const provisional = new CodexAppServerHost(child, { threadId: threadId ?? "pending", path: null }, options);
     try {
       const initialized = record(await provisional.rpc("initialize", {
@@ -1812,6 +1832,9 @@ export class CodexAppServerHost implements EngineHost {
     this.setSessionStatus("unhosted", []);
     if (this.ledgerFailed || !this.eventLedgerRestored) this.notifyStateListeners();
     this.closeSubscribers();
+    const cleanup = this.releaseCleanup;
+    this.releaseCleanup = null;
+    cleanup?.();
   }
 
   private completeGroupCleanupAfterReap(): void {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -235,6 +235,7 @@ const CHILD_ENV_ALLOWLIST = [
   "TERM",
   "COLORTERM",
   "NO_COLOR",
+  "GH_CONFIG_DIR",
   "XDG_CONFIG_HOME",
   "XDG_CACHE_HOME",
   "XDG_DATA_HOME",
@@ -747,7 +748,12 @@ export class CodexAppServerHost implements EngineHost {
       spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
     const args = [
       ...(options.fileAuthCredentials ? ["-c", "cli_auth_credentials_store=file"] : []),
-      ...(options.permissionProfileConfig ? ["-c", options.permissionProfileConfig] : []),
+      ...(options.permissionProfile && options.permissionProfileConfig
+        ? [
+          "-c", `default_permissions=${JSON.stringify(options.permissionProfile)}`,
+          "-c", options.permissionProfileConfig,
+        ]
+        : []),
       "app-server",
       "--enable",
       "realtime_conversation",

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -186,13 +186,23 @@ test("server startup delegates managed rows with file credentials and their laun
       return [];
     },
   });
+  const codexCleanup = (codexOptions as { releaseCleanup?: () => void }).releaseCleanup;
+  const claudeCleanup = (claudeOptions as { releaseCleanup?: () => void }).releaseCleanup;
   expect(codexOptions).toMatchObject({
     cwd: "/repo",
     codexHome: "/managed",
     fileAuthCredentials: true,
     model: "gpt-5.4-mini",
     effort: "high",
-    env: { LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
+    permissionProfile: "llv-read-only-stage",
+    forwardGitHubConfig: true,
+    releaseCleanup: expect.any(Function),
+    env: {
+      HOME: expect.stringContaining("llv-read-only-stage-"),
+      XDG_CONFIG_HOME: expect.stringContaining("llv-read-only-stage-"),
+      TMPDIR: expect.stringContaining("llv-read-only-stage-"),
+      LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+    },
   });
   expect(claudeOptions).toMatchObject({
     cwd: "/repo",
@@ -204,10 +214,14 @@ test("server startup delegates managed rows with file credentials and their laun
     allowSubagents: true,
     readOnly: true,
     permissionMode: "plan",
+    forwardGitHubConfig: true,
+    releaseCleanup: expect.any(Function),
   });
   expect(claudeOptions).toMatchObject({
     env: { LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
   });
+  codexCleanup?.();
+  claudeCleanup?.();
 });
 
 function runtimeJournalClient(journal: RuntimeJournal): RuntimeHostClient {

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -7,7 +7,6 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
 import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
-import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { readStableTailRecords } from "@/lib/scanner/activity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -29,7 +28,7 @@ import {
   hasStructuredDeliveryController,
 } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
-import { recoverPendingStructuredSpawns } from "./structuredSpawn";
+import { materializeStructuredHostAccess, recoverPendingStructuredSpawns } from "./structuredSpawn";
 import { markStructuredHostStartupProgress, type StructuredHostStartupPhase } from "./startupStatus";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
@@ -419,6 +418,11 @@ export async function adoptStructuredHostsAtStartup(
     (entry) => {
       const owner = resolveCodexOwner(entry);
       const capability = registry.rotateSpawnCapabilityForPath(entry.artifactPath);
+      const access = materializeStructuredHostAccess(
+        entry.launchProfile?.readOnly === true,
+        startupEnvironment,
+        capability,
+      );
       return {
         cwd: entry.cwd,
         codexHome: owner?.home,
@@ -430,10 +434,9 @@ export async function adoptStructuredHostsAtStartup(
         /* Re-adoption replays the durable grant (issue #687) — a session never
            gains or loses Computer Use by being picked up again at startup. */
         plugins: entry.launchProfile?.plugins ?? [],
-        env: {
-          ...startupEnvironment,
-          ...(capability ? { [VIEWER_SPAWN_CAPABILITY_ENV]: capability } : {}),
-        },
+        ...access.codex,
+        ...access.host,
+        env: access.env,
       };
     },
     startupEnvironment,
@@ -454,7 +457,11 @@ export async function adoptStructuredHostsAtStartup(
       const owner = resolveClaudeOwner(entry);
       const capability = registry.rotateSpawnCapabilityForPath(entry.artifactPath);
       const env = withoutWakatimeCredential(owner?.env ?? startupEnvironment);
-      if (capability) env[VIEWER_SPAWN_CAPABILITY_ENV] = capability;
+      const access = materializeStructuredHostAccess(
+        entry.launchProfile?.readOnly === true,
+        env,
+        capability,
+      );
       return {
         cwd: entry.cwd,
         claudeConfigDir: owner?.kind === "managed" ? owner.home : undefined,
@@ -466,7 +473,8 @@ export async function adoptStructuredHostsAtStartup(
           ? path.join(owner.home, ".claude.json")
           : owner ? path.join(path.dirname(owner.home), ".claude.json") : undefined,
         readOnly: entry.launchProfile?.readOnly === true,
-        env,
+        env: access.env,
+        ...access.host,
         model: entry.launchProfile?.model ?? undefined,
         effort: entry.launchProfile?.effort ?? undefined,
         permissionMode: effectiveClaudePermissionMode(entry.launchProfile ?? {}),

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -48,6 +48,12 @@ export interface StructuredHostAccessMaterialization {
   cleanup(): void;
 }
 
+function githubConfigDirectory(sourceEnv: NodeJS.ProcessEnv): string {
+  if (sourceEnv.GH_CONFIG_DIR) return sourceEnv.GH_CONFIG_DIR;
+  const home = sourceEnv.HOME || os.homedir();
+  return path.join(sourceEnv.XDG_CONFIG_HOME || path.join(home, ".config"), "gh");
+}
+
 /** A read-only stage keeps the checkout under Codex's read-only profile while
     adding one private write root for temporary and test state. */
 export function materializeStructuredHostAccess(
@@ -79,7 +85,11 @@ export function materializeStructuredHostAccess(
     }
     const permissionProfileConfig = `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(scratchDirectory)}="write"}}`;
     return {
-      env: { ...baseEnv, ...directories },
+      env: {
+        ...baseEnv,
+        ...directories,
+        GH_CONFIG_DIR: githubConfigDirectory(sourceEnv),
+      },
       codex: {
         permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
         permissionProfileConfig,

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -44,6 +44,10 @@ export interface StructuredHostAccessMaterialization {
     permissionProfile?: string;
     permissionProfileConfig?: string;
   };
+  host: {
+    forwardGitHubConfig?: boolean;
+    releaseCleanup?: () => void;
+  };
   scratchDirectory: string | null;
   cleanup(): void;
 }
@@ -59,14 +63,18 @@ function githubConfigDirectory(sourceEnv: NodeJS.ProcessEnv): string {
 export function materializeStructuredHostAccess(
   readOnly: boolean,
   sourceEnv: NodeJS.ProcessEnv,
-  capability: string,
+  capability: string | null,
   scratchParent = os.tmpdir(),
 ): StructuredHostAccessMaterialization {
-  const baseEnv = { ...sourceEnv, LLV_SPAWN_CAPABILITY: capability };
+  const baseEnv = {
+    ...sourceEnv,
+    ...(capability ? { LLV_SPAWN_CAPABILITY: capability } : {}),
+  };
   if (!readOnly) {
     return {
       env: baseEnv,
       codex: { sandbox: "danger-full-access" },
+      host: {},
       scratchDirectory: null,
       cleanup: () => {},
     };
@@ -84,6 +92,7 @@ export function materializeStructuredHostAccess(
       fs.mkdirSync(directory, { mode: 0o700 });
     }
     const permissionProfileConfig = `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(scratchDirectory)}="write"}}`;
+    const cleanup = () => fs.rmSync(scratchDirectory, { recursive: true, force: true });
     return {
       env: {
         ...baseEnv,
@@ -94,8 +103,12 @@ export function materializeStructuredHostAccess(
         permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
         permissionProfileConfig,
       },
+      host: {
+        forwardGitHubConfig: true,
+        releaseCleanup: cleanup,
+      },
       scratchDirectory,
-      cleanup: () => fs.rmSync(scratchDirectory, { recursive: true, force: true }),
+      cleanup,
     };
   } catch (error) {
     fs.rmSync(scratchDirectory, { recursive: true, force: true });
@@ -849,62 +862,50 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
   }
   const access = materializeStructuredHostAccess(profile.readOnly === true, input.account.env, capability);
   const env = access.env;
-  try {
-    let host: SpawnedStructuredHost;
-    if (input.engine === "codex") {
-      const options = {
-        cwd: input.spec.cwd,
-        codexHome: input.account.home,
-        fileAuthCredentials: input.account.kind === "managed",
-        model: profile.model ?? undefined,
-        effort: profile.effort ?? undefined,
-        allowSubagents: profile.allowSubagents,
-        mcpServers: profile.mcpServers,
-        /* Plugin grant from the durable profile (issue #687): present only for
-           an operator-launched root session that did not opt out. */
-        plugins: profile.plugins,
-        ...access.codex,
-        approvalPolicy: profile.permissionMode ?? undefined,
-        initialEventCursor,
-        env,
-      };
-      host = resumeSessionId
-        ? await CodexAppServerHost.adopt(resumeSessionId, options)
-        : await CodexAppServerHost.start(options);
-    } else {
-      const sessionId = resumeSessionId ?? (input.spec.transcript ? path.basename(input.spec.transcript, ".jsonl") : undefined);
-      const options = {
-        cwd: input.spec.cwd,
-        claudeConfigDir: input.account.home,
-        claudeProjectsDir: input.account.transcriptRoot,
-        spawnPolicyBaseSettingsPath: structuredClaudeSpawnPolicyBaseSettingsPath(input.account),
-        allowSubagents: profile.allowSubagents,
-        mcpServers: profile.mcpServers,
-        mcpStatePath: input.account.kind === "managed"
-          ? path.join(input.account.home, ".claude.json")
-          : path.join(path.dirname(input.account.home), ".claude.json"),
-        readOnly: profile.readOnly === true,
-        model: profile.model ?? undefined,
-        effort: profile.effort ?? undefined,
-        permissionMode: effectiveClaudePermissionMode(profile),
-        initialEventCursor,
-        env,
-      };
-      host = resumeSessionId
-        ? await ClaudeStreamBrokerHost.adopt(resumeSessionId, options)
-        : await ClaudeStreamBrokerHost.start({ ...options, ...(sessionId ? { sessionId } : {}) });
-    }
-    if (!access.scratchDirectory) return host;
-    const release = host.release.bind(host);
-    host.release = async () => {
-      await release();
-      access.cleanup();
+  if (input.engine === "codex") {
+    const options = {
+      cwd: input.spec.cwd,
+      codexHome: input.account.home,
+      fileAuthCredentials: input.account.kind === "managed",
+      model: profile.model ?? undefined,
+      effort: profile.effort ?? undefined,
+      allowSubagents: profile.allowSubagents,
+      mcpServers: profile.mcpServers,
+      /* Plugin grant from the durable profile (issue #687): present only for
+         an operator-launched root session that did not opt out. */
+      plugins: profile.plugins,
+      ...access.codex,
+      ...access.host,
+      approvalPolicy: profile.permissionMode ?? undefined,
+      initialEventCursor,
+      env,
     };
-    return host;
-  } catch (error) {
-    access.cleanup();
-    throw error;
+    return resumeSessionId
+      ? await CodexAppServerHost.adopt(resumeSessionId, options)
+      : await CodexAppServerHost.start(options);
   }
+  const sessionId = resumeSessionId ?? (input.spec.transcript ? path.basename(input.spec.transcript, ".jsonl") : undefined);
+  const options = {
+    cwd: input.spec.cwd,
+    claudeConfigDir: input.account.home,
+    claudeProjectsDir: input.account.transcriptRoot,
+    spawnPolicyBaseSettingsPath: structuredClaudeSpawnPolicyBaseSettingsPath(input.account),
+    allowSubagents: profile.allowSubagents,
+    mcpServers: profile.mcpServers,
+    mcpStatePath: input.account.kind === "managed"
+      ? path.join(input.account.home, ".claude.json")
+      : path.join(path.dirname(input.account.home), ".claude.json"),
+    readOnly: profile.readOnly === true,
+    model: profile.model ?? undefined,
+    effort: profile.effort ?? undefined,
+    permissionMode: effectiveClaudePermissionMode(profile),
+    initialEventCursor,
+    env,
+    ...access.host,
+  };
+  return resumeSessionId
+    ? await ClaudeStreamBrokerHost.adopt(resumeSessionId, options)
+    : await ClaudeStreamBrokerHost.start({ ...options, ...(sessionId ? { sessionId } : {}) });
 }
 
 export function structuredResumeSessionId(

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import type { AccountContext } from "@/lib/accounts/contracts";
@@ -33,6 +35,63 @@ export const INITIAL_MESSAGE_TIMEOUT_MS = 30_000;
 const INITIAL_MESSAGE_POLL_MS = 250;
 export const ADMISSION_RETRY_ATTEMPTS = 3;
 const ADMISSION_RETRY_BACKOFF_MS = 250;
+export const READ_ONLY_STAGE_PERMISSION_PROFILE = "llv-read-only-stage";
+
+export interface StructuredHostAccessMaterialization {
+  env: NodeJS.ProcessEnv;
+  codex: {
+    sandbox?: string;
+    permissionProfile?: string;
+    permissionProfileConfig?: string;
+  };
+  scratchDirectory: string | null;
+  cleanup(): void;
+}
+
+/** A read-only stage keeps the checkout under Codex's read-only profile while
+    adding one private write root for temporary and test state. */
+export function materializeStructuredHostAccess(
+  readOnly: boolean,
+  sourceEnv: NodeJS.ProcessEnv,
+  capability: string,
+  scratchParent = os.tmpdir(),
+): StructuredHostAccessMaterialization {
+  const baseEnv = { ...sourceEnv, LLV_SPAWN_CAPABILITY: capability };
+  if (!readOnly) {
+    return {
+      env: baseEnv,
+      codex: { sandbox: "danger-full-access" },
+      scratchDirectory: null,
+      cleanup: () => {},
+    };
+  }
+
+  const scratchDirectory = fs.mkdtempSync(path.join(scratchParent, "llv-read-only-stage-"));
+  try {
+    fs.chmodSync(scratchDirectory, 0o700);
+    const directories = {
+      HOME: path.join(scratchDirectory, "home"),
+      XDG_CONFIG_HOME: path.join(scratchDirectory, "config"),
+      TMPDIR: path.join(scratchDirectory, "tmp"),
+    };
+    for (const directory of Object.values(directories)) {
+      fs.mkdirSync(directory, { mode: 0o700 });
+    }
+    const permissionProfileConfig = `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(scratchDirectory)}="write"}}`;
+    return {
+      env: { ...baseEnv, ...directories },
+      codex: {
+        permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
+        permissionProfileConfig,
+      },
+      scratchDirectory,
+      cleanup: () => fs.rmSync(scratchDirectory, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    fs.rmSync(scratchDirectory, { recursive: true, force: true });
+    throw error;
+  }
+}
 
 /** Runtime admission calls carry the durable launch id as their idempotency
     key, so a replay lands on the original receipt. Production #367 saw
@@ -770,7 +829,6 @@ export function structuredClaudeSpawnPolicyBaseSettingsPath(
 
 async function defaultStartHost(input: StructuredSpawnInput, capability: string): Promise<SpawnedStructuredHost> {
   const profile = input.spec.launchProfile ?? {} as LaunchProfile;
-  const env = { ...input.account.env, LLV_SPAWN_CAPABILITY: capability };
   const resumeSessionId = structuredResumeSessionId(input);
   const initialEventCursor = resumeSessionId
     ? input.registry.readOnlySnapshot().entries[sessionKeyId({ engine: input.engine, sessionId: resumeSessionId })]?.structuredHost?.eventCursor
@@ -779,48 +837,64 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
     && (!Number.isSafeInteger(initialEventCursor) || initialEventCursor < 0)) {
     throw new Error("structured resume event cursor is invalid");
   }
-  if (input.engine === "codex") {
-    const options = {
-      cwd: input.spec.cwd,
-      codexHome: input.account.home,
-      fileAuthCredentials: input.account.kind === "managed",
-      model: profile.model ?? undefined,
-      effort: profile.effort ?? undefined,
-      allowSubagents: profile.allowSubagents,
-      mcpServers: profile.mcpServers,
-      /* Plugin grant from the durable profile (issue #687): present only for
-         an operator-launched root session that did not opt out. */
-      plugins: profile.plugins,
-      sandbox: profile.readOnly ? "read-only" : "danger-full-access",
-      approvalPolicy: profile.permissionMode ?? undefined,
-      initialEventCursor,
-      env,
+  const access = materializeStructuredHostAccess(profile.readOnly === true, input.account.env, capability);
+  const env = access.env;
+  try {
+    let host: SpawnedStructuredHost;
+    if (input.engine === "codex") {
+      const options = {
+        cwd: input.spec.cwd,
+        codexHome: input.account.home,
+        fileAuthCredentials: input.account.kind === "managed",
+        model: profile.model ?? undefined,
+        effort: profile.effort ?? undefined,
+        allowSubagents: profile.allowSubagents,
+        mcpServers: profile.mcpServers,
+        /* Plugin grant from the durable profile (issue #687): present only for
+           an operator-launched root session that did not opt out. */
+        plugins: profile.plugins,
+        ...access.codex,
+        approvalPolicy: profile.permissionMode ?? undefined,
+        initialEventCursor,
+        env,
+      };
+      host = resumeSessionId
+        ? await CodexAppServerHost.adopt(resumeSessionId, options)
+        : await CodexAppServerHost.start(options);
+    } else {
+      const sessionId = resumeSessionId ?? (input.spec.transcript ? path.basename(input.spec.transcript, ".jsonl") : undefined);
+      const options = {
+        cwd: input.spec.cwd,
+        claudeConfigDir: input.account.home,
+        claudeProjectsDir: input.account.transcriptRoot,
+        spawnPolicyBaseSettingsPath: structuredClaudeSpawnPolicyBaseSettingsPath(input.account),
+        allowSubagents: profile.allowSubagents,
+        mcpServers: profile.mcpServers,
+        mcpStatePath: input.account.kind === "managed"
+          ? path.join(input.account.home, ".claude.json")
+          : path.join(path.dirname(input.account.home), ".claude.json"),
+        readOnly: profile.readOnly === true,
+        model: profile.model ?? undefined,
+        effort: profile.effort ?? undefined,
+        permissionMode: effectiveClaudePermissionMode(profile),
+        initialEventCursor,
+        env,
+      };
+      host = resumeSessionId
+        ? await ClaudeStreamBrokerHost.adopt(resumeSessionId, options)
+        : await ClaudeStreamBrokerHost.start({ ...options, ...(sessionId ? { sessionId } : {}) });
+    }
+    if (!access.scratchDirectory) return host;
+    const release = host.release.bind(host);
+    host.release = async () => {
+      await release();
+      access.cleanup();
     };
-    return resumeSessionId
-      ? await CodexAppServerHost.adopt(resumeSessionId, options)
-      : await CodexAppServerHost.start(options);
+    return host;
+  } catch (error) {
+    access.cleanup();
+    throw error;
   }
-  const sessionId = resumeSessionId ?? (input.spec.transcript ? path.basename(input.spec.transcript, ".jsonl") : undefined);
-  const options = {
-    cwd: input.spec.cwd,
-    claudeConfigDir: input.account.home,
-    claudeProjectsDir: input.account.transcriptRoot,
-    spawnPolicyBaseSettingsPath: structuredClaudeSpawnPolicyBaseSettingsPath(input.account),
-    allowSubagents: profile.allowSubagents,
-    mcpServers: profile.mcpServers,
-    mcpStatePath: input.account.kind === "managed"
-      ? path.join(input.account.home, ".claude.json")
-      : path.join(path.dirname(input.account.home), ".claude.json"),
-    readOnly: profile.readOnly === true,
-    model: profile.model ?? undefined,
-    effort: profile.effort ?? undefined,
-    permissionMode: effectiveClaudePermissionMode(profile),
-    initialEventCursor,
-    env,
-  };
-  return resumeSessionId
-    ? await ClaudeStreamBrokerHost.adopt(resumeSessionId, options)
-    : await ClaudeStreamBrokerHost.start({ ...options, ...(sessionId ? { sessionId } : {}) });
 }
 
 export function structuredResumeSessionId(


### PR DESCRIPTION
## Summary

- Give read-only structured stage hosts a private writable scratch root and route HOME, XDG_CONFIG_HOME, and TMPDIR into it.
- Keep the checkout read-only through a Codex permission profile that grants writes only to the scratch root.
- Rematerialize scratch access during Viewer startup adoption for Codex and Claude reviewer hosts.
- Preserve GitHub CLI authentication for read-only scratch hosts through conditional GH_CONFIG_DIR forwarding.
- Update the reviewer scaffold to report the reviewed SHA, disclose unavailable GitHub or DNS access, classify sandbox-blocked gates as environmental notes, and run TypeScript without incremental checkout state.

## Review findings resolved

- Startup adoption now creates a fresh scratch root and reapplies the read-only Codex permission profile after Viewer restart.
- Scratch cleanup belongs to the host release lifecycle, so an unreaped host retained after StructuredHostAdoptionCleanupError keeps its scratch root until late cleanup converges.
- GH_CONFIG_DIR forwarding is enabled only for read-only scratch hosts. Read-write builder host environments retain their previous allowlist behavior.
- The custom Codex profile is paired with default_permissions before app-server startup.

## Verification

- bunx tsc --noEmit
- 230 tests passed across src/lib/runtime/codexAppServerHost.test.ts, src/lib/runtime/claudeStreamBrokerHost.test.ts, src/lib/runtime/startup.test.ts, and src/lib/roles/registry.test.ts with isolated HOME, XDG_CONFIG_HOME, TMPDIR, and LLV_STATE_DIR
- 3 real Codex app-server integration tests passed in src/lib/runtime/codexAppServerHost.integration.test.ts; fresh and restart-adopted hosts wrote only to separate scratch roots and rejected checkout writes
- bun scripts/privacy-publication-gate.ts --base <merge-base>: PASS

## Follow-up

The engine budget change remains in its separately owned lane. src/lib/pipelines/engine.ts remains unchanged in this PR. Engine accounting must recognize verdicts whose only findings are environmental tags such as EROFS, DNS unavailable, or GitHub unreachable and keep those verdicts from consuming fail-edge or max-round budgets. Verdicts that also contain actionable code findings should continue through the ordinary failure path.

Relates to #1052.