### PR TITLE
fix(pipelines): close terminalizes dead attempts from evidence; verdict parser accepts object findings; exhaustion keeps an exit (#1047, #988, #879)

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -4103,22 +4103,25 @@ test("retry and skip leave verdict-recovery exhaustion only when reset preserves
     expect(refused.error).toContain("close");
     expect(dirty.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
 
-    const unpushed = harness();
-    const unpushedPipeline = await exhaust(unpushed);
-    const unpushedHead = "a".repeat(40);
-    const unpushedExec = unpushed.ports.exec;
-    unpushed.ports.exec = (command, args, cwd) => {
+    const publishedAhead = harness();
+    const publishedAheadPipeline = await exhaust(publishedAhead);
+    const publishedAheadHead = "a".repeat(40);
+    const publishedAheadExec = publishedAhead.ports.exec;
+    publishedAhead.ports.exec = (command, args, cwd) => {
       if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") {
-        return { code: 0, stdout: `${unpushedHead}\n`, stderr: "" };
+        return { code: 0, stdout: `${publishedAheadHead}\n`, stderr: "" };
       }
-      return unpushedExec(command, args, cwd);
+      if (command === "git" && args[0] === "ls-remote") {
+        return { code: 0, stdout: `${publishedAheadHead}\trefs/heads/${publishedAheadPipeline.branch}\n`, stderr: "" };
+      }
+      return publishedAheadExec(command, args, cwd);
     };
 
-    const unpublished = await patchPipeline(unpushedPipeline.id, { action }, unpushed.ports);
+    const refusedAhead = await patchPipeline(publishedAheadPipeline.id, { action }, publishedAhead.ports);
 
-    expect(unpublished.status).toBe(409);
-    expect(unpublished.error).toContain("close");
-    expect(unpushed.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
+    expect(refusedAhead.status).toBe(409);
+    expect(refusedAhead.error).toContain("close");
+    expect(publishedAhead.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
   }
 });
 
@@ -4667,7 +4670,10 @@ test("close terminalizes host-unavailable attempts from durable evidence and rec
     stored.state = "needs_decision";
     stored.stateDetail = attempt.error;
     savePipelines([stored]);
-    h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+    const stopError = evidence === "registry-absent"
+      ? "structured host termination is unavailable"
+      : "structured host termination target is unavailable";
+    h.setStageHost("conversation_stage_1", { outcome: "failed", error: stopError });
 
     if (evidence === "terminal-transcript") {
       h.setHostsResident(true);
@@ -4684,11 +4690,11 @@ test("close terminalizes host-unavailable attempts from durable evidence and rec
 
     expect(closed.error).toBeUndefined();
     expect(closed.close?.alreadyStopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
-    expect(closed.close?.notes).toMatchObject([{ stageId: "plan", attempt: 1, detail: expect.stringContaining("structured runtime host is unavailable") }]);
+    expect(closed.close?.notes).toMatchObject([{ stageId: "plan", attempt: 1, detail: expect.stringContaining(stopError) }]);
     const terminal = loadPipelines()[0]!;
     expect(terminal.state).toBe("closed");
     expect(terminal.runs[0]!.attempts[0]!.completedAt).toBeTruthy();
-    expect(terminal.stateDetail).toContain("structured runtime host is unavailable");
+    expect(terminal.stateDetail).toContain(stopError);
   }
 });
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -4590,6 +4590,30 @@ test("a pane the teardown can identify as this stage's is stopped, not refused (
   expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: "closed; stopped 1 stage host" });
 });
 
+test("close terminalizes a running attempt after confirmed host and pane absence (#1047, #988)", async () => {
+  for (const absent of ["structured-host", "pane"] as const) {
+    const h = harness();
+    const pipeline = await create(h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    const stored = loadPipelines()[0]!;
+    const attempt = stored.runs[0]!.attempts[0]!;
+    expect(attempt).toMatchObject({ state: "running", completedAt: null });
+    if (absent === "structured-host") attempt.paneId = null;
+    else h.setPaneStop({ outcome: "not-running" });
+    savePipelines([stored]);
+
+    const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+    expect(closed.error).toBeUndefined();
+    expect(closed.close?.alreadyStopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+    expect(loadPipelines()[0]!.runs[0]!.attempts[0]).toMatchObject({
+      state: "failed",
+      completedAt: expect.any(String),
+    });
+  }
+});
+
 test("a pane that cannot be identified is reported, never killed (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
@@ -4655,6 +4679,30 @@ test("a stage host that cannot be stopped refuses the close instead of hiding it
   expect(stored.state).not.toBe("closed");
   expect(stored.closedAt).toBeNull();
   expect(stored.stateDetail).toContain("structured host ownership is unavailable");
+});
+
+test("terminal transcript prose without a valid fenced verdict cannot dismiss a resident host (#1047, #988)", async () => {
+  for (const text of [
+    "Review completed with no findings.",
+    "Review completed.\n\n```json\n{\"status\":\"pass\",\"findings\":\"none\",\"confidence\":0.9}\n```",
+  ]) {
+    const h = harness();
+    const pipeline = await create(h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    h.setHostsResident(true);
+    h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+    h.durableTurns.set("/codex/stage-1.jsonl", {
+      turn: "terminal",
+      message: { text, ts: 5_000_000 },
+    });
+
+    const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+    expect(refused.status).toBe(409);
+    expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+    expect(loadPipelines()[0]).toMatchObject({ state: "running", closedAt: null });
+  }
 });
 
 test("close terminalizes host-unavailable attempts from durable evidence and records the failure (#1047, #988)", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2150,6 +2150,62 @@ test("newer same-conversation evidence supersedes an exhausted recovery exactly 
   expect(current.lastPassedCommit).toBe(STAGE_HEAD);
 });
 
+test("verdict recovery normalizes object findings and still rejects a missing core status (#879)", async () => {
+  const accepted = harness();
+  await runningStructuredStage(accepted);
+  accepted.setConversationActive(false);
+  accepted.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: {
+      text: [
+        "The review found one defect.",
+        "",
+        "```json",
+        JSON.stringify({
+          status: "fail",
+          findings: [{ severity: "medium", file: "src/lib/example.ts", line: 57, summary: "Preserve the accepted revision." }],
+          confidence: 0.87,
+        }),
+        "```",
+      ].join("\n"),
+      ts: 5_000_000,
+    },
+  });
+
+  await tickPipelines([], accepted.ports);
+
+  expect(loadPipelines()[0]!.runs[0]!.attempts[0]).toMatchObject({
+    state: "failed",
+    verdict: {
+      status: "fail",
+      findings: ["medium — src/lib/example.ts:57 — Preserve the accepted revision."],
+      confidence: 0.87,
+    },
+  });
+
+  const rejected = harness();
+  await runningStructuredStage(rejected);
+  rejected.setConversationActive(false);
+  rejected.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: {
+      text: `\`\`\`json\n${JSON.stringify({ findings: [{ severity: "medium", summary: "Missing status." }], confidence: 0.87 })}\n\`\`\``,
+      ts: 5_000_000,
+    },
+  });
+
+  await tickPipelines([], rejected.ports);
+
+  expect(loadPipelines()[0]!.runs[0]!.attempts[0]).toMatchObject({
+    state: "running",
+    verdict: null,
+    verdictRecovery: {
+      state: "pending",
+      reason: "canonical completed assistant turn is missing a valid status, findings, or confidence field",
+    },
+  });
+});
+
 test("terminal ingestion after process exit advances a trailing-marker verdict once after restart (#707)", async () => {
   const h = harness();
   await runningStructuredStage(h);
@@ -4010,24 +4066,60 @@ test("a corrupt SQLite pipeline row skips the tick without escalating", async ()
   savePipelines([]);
 });
 
-test("retry and skip never reset a verdict-recovery attempt", async () => {
-  const h = harness();
-  const pipeline = await create(h.ports);
-  await tickPipelines([], h.ports);
-  await tickPipelines([], h.ports);
-  h.messages.set("/codex/stage-1.jsonl", { text: "narrative without a JSON verdict", ts: 2_000_000 });
-  const entries = [entry("/codex/stage-1.jsonl")];
-  await tickPipelines(entries, h.ports);
-  await exhaustVerdictRecovery(h, entries);
-  expect(loadPipelines()[0]!.state).toBe("needs_decision");
+test("retry and skip leave verdict-recovery exhaustion only when reset preserves all work (#879)", async () => {
+  const exhaust = async (h: ReturnType<typeof harness>) => {
+    const pipeline = await create(h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    h.messages.set("/codex/stage-1.jsonl", { text: "narrative without a JSON verdict", ts: 2_000_000 });
+    const entries = [entry("/codex/stage-1.jsonl")];
+    await tickPipelines(entries, h.ports);
+    await exhaustVerdictRecovery(h, entries);
+    expect(loadPipelines()[0]!.state).toBe("needs_decision");
+    return pipeline;
+  };
 
-  const blockedRetry = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
-  expect(blockedRetry.status).toBe(409);
-  expect(blockedRetry.error).toContain("preserve its worktree and conversation lineage");
-  const blockedSkip = await patchPipeline(pipeline.id, { action: "skip-stage" }, h.ports);
-  expect(blockedSkip.status).toBe(409);
-  expect(blockedSkip.error).toContain("preserve its worktree and conversation lineage");
-  expect(h.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
+  for (const action of ["retry-stage", "skip-stage"] as const) {
+    const clean = harness();
+    const cleanPipeline = await exhaust(clean);
+    clean.setPaneAlive(false);
+
+    const recovered = await patchPipeline(cleanPipeline.id, { action }, clean.ports);
+
+    expect(recovered.error).toBeUndefined();
+    expect(clean.calls.some((call) => call.includes("reset --hard"))).toBe(true);
+    expect(clean.calls.some((call) => call.includes("clean -fd"))).toBe(true);
+
+    const dirty = harness();
+    const dirtyPipeline = await exhaust(dirty);
+    const baseExec = dirty.ports.exec;
+    dirty.ports.exec = (command, args, cwd) => command === "git" && args[0] === "status"
+      ? { code: 0, stdout: " M src/lib/example.ts\n", stderr: "" }
+      : baseExec(command, args, cwd);
+
+    const refused = await patchPipeline(dirtyPipeline.id, { action }, dirty.ports);
+
+    expect(refused.status).toBe(409);
+    expect(refused.error).toContain("close");
+    expect(dirty.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
+
+    const unpushed = harness();
+    const unpushedPipeline = await exhaust(unpushed);
+    const unpushedHead = "a".repeat(40);
+    const unpushedExec = unpushed.ports.exec;
+    unpushed.ports.exec = (command, args, cwd) => {
+      if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") {
+        return { code: 0, stdout: `${unpushedHead}\n`, stderr: "" };
+      }
+      return unpushedExec(command, args, cwd);
+    };
+
+    const unpublished = await patchPipeline(unpushedPipeline.id, { action }, unpushed.ports);
+
+    expect(unpublished.status).toBe(409);
+    expect(unpublished.error).toContain("close");
+    expect(unpushed.calls.some((call) => call.includes("reset --hard") || call.includes("clean -fd"))).toBe(false);
+  }
 });
 
 test("retry and skip recover a completed pane-hosted semantic contradiction", async () => {
@@ -4320,6 +4412,7 @@ test("an adopted stage child is stopped and counted, never silently left running
     paneId: "%9",
   });
   savePipelines(stored);
+  h.setHostsResident(true);
   h.setStageHost("conversation_stage_1", { outcome: "stopped" });
   h.setStageHost("conversation_helper", { outcome: "stopped" });
 
@@ -4350,6 +4443,7 @@ test("an adopted child that cannot be stopped keeps the lane visible (#670)", as
     paneId: null,
   });
   savePipelines(stored);
+  h.setHostsResident(true);
   h.setStageHost("conversation_stage_1", { outcome: "stopped" });
   h.setStageHost("conversation_helper", { outcome: "failed", error: "structured host ownership is unavailable" });
 
@@ -4395,6 +4489,7 @@ test("an acknowledgement never dismisses a host that is provably still running (
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
+  h.setHostsResident(true);
   h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured host ownership is unavailable" });
 
   const refused = await patchPipeline(pipeline.id, { action: "close", acknowledgeHosts: true }, h.ports);
@@ -4543,6 +4638,7 @@ test("a stage host that cannot be stopped refuses the close instead of hiding it
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
+  h.setHostsResident(true);
   h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured host ownership is unavailable" });
 
   const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
@@ -4556,6 +4652,44 @@ test("a stage host that cannot be stopped refuses the close instead of hiding it
   expect(stored.state).not.toBe("closed");
   expect(stored.closedAt).toBeNull();
   expect(stored.stateDetail).toContain("structured host ownership is unavailable");
+});
+
+test("close terminalizes host-unavailable attempts from durable evidence and records the failure (#1047, #988)", async () => {
+  for (const evidence of ["registry-absent", "terminal-transcript"] as const) {
+    const h = harness();
+    const pipeline = await create(h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    const stored = loadPipelines()[0]!;
+    const attempt = stored.runs[0]!.attempts[0]!;
+    attempt.state = "needs_decision";
+    attempt.error = "operator decision was resolved after the work merged";
+    stored.state = "needs_decision";
+    stored.stateDetail = attempt.error;
+    savePipelines([stored]);
+    h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+
+    if (evidence === "terminal-transcript") {
+      h.setHostsResident(true);
+      h.durableTurns.set("/codex/stage-1.jsonl", {
+        turn: "terminal",
+        message: {
+          text: "Completed review.\n\n```json\n{\"status\":\"needs_decision\",\"findings\":[],\"confidence\":0.9}\n```",
+          ts: 5_000_000,
+        },
+      });
+    }
+
+    const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+    expect(closed.error).toBeUndefined();
+    expect(closed.close?.alreadyStopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+    expect(closed.close?.notes).toMatchObject([{ stageId: "plan", attempt: 1, detail: expect.stringContaining("structured runtime host is unavailable") }]);
+    const terminal = loadPipelines()[0]!;
+    expect(terminal.state).toBe("closed");
+    expect(terminal.runs[0]!.attempts[0]!.completedAt).toBeTruthy();
+    expect(terminal.stateDetail).toContain("structured runtime host is unavailable");
+  }
 });
 
 test("closing preserves uncommitted stage work and names what it left behind (#670)", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -112,6 +112,8 @@ export type PipelineCloseReport = {
   acknowledged: Array<PipelineStageHostRef & { detail: string }>;
   /** Hosts that survived teardown, so the close cannot claim to be clean. */
   stillRunning: Array<PipelineStageHostRef & { error: string }>;
+  /** Stop failures demoted by durable terminal evidence. */
+  notes: Array<PipelineStageHostRef & { detail: string }>;
   /** Uncommitted stage work preserved in the worktree; null when unprovisioned. */
   worktree: { dir: string; uncommitted: string[]; truncated: boolean; error?: string } | null;
 };
@@ -723,6 +725,58 @@ function unixMs(value: string | null): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function verdictFindingPart(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function normalizeVerdictFinding(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const finding = value as Record<string, unknown>;
+  const severity = verdictFindingPart(finding.severity);
+  const file = verdictFindingPart(finding.file);
+  const line = verdictFindingPart(finding.line);
+  const summary = verdictFindingPart(finding.summary);
+  const location = file ? `${file}${line ? `:${line}` : ""}` : line ? `line ${line}` : null;
+  const normalized = [severity, location, summary].filter((part): part is string => Boolean(part));
+  return normalized.length > 0 ? normalized.join(" — ") : value;
+}
+
+/** Reviewer scaffolds naturally produce structured findings. The shared parser
+    still owns fence selection and all verdict validation; this adapter changes
+    only recognized finding objects in its final JSON candidate. */
+function normalizeVerdictFindingObjects(text: string): string {
+  const matches = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
+  const candidate = matches.at(-1);
+  if (!candidate || candidate.index === undefined) return text;
+  let value: unknown;
+  try {
+    value = JSON.parse(candidate[1] ?? "");
+  } catch {
+    return text;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return text;
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.findings) || !record.findings.some((finding) => finding && typeof finding === "object" && !Array.isArray(finding))) {
+    return text;
+  }
+  const normalized = { ...record, findings: record.findings.map(normalizeVerdictFinding) };
+  const fullCandidate = candidate[0];
+  const rawCandidate = candidate[1] ?? "";
+  const rawOffset = fullCandidate.indexOf(rawCandidate);
+  const payloadStart = candidate.index + rawOffset;
+  return `${text.slice(0, payloadStart)}${JSON.stringify(normalized)}${text.slice(payloadStart + rawCandidate.length)}`;
+}
+
+function parsePipelineStageVerdict(text: string) {
+  return parseStageVerdict(normalizeVerdictFindingObjects(text));
+}
+
+function pipelineStageVerdictRejectionReason(text: string): string {
+  return stageVerdictRejectionReason(normalizeVerdictFindingObjects(text));
+}
+
 function recoveryCheckAt(now: string): string {
   return new Date(unixMs(now) + VERDICT_RECOVERY_INTERVAL_MS).toISOString();
 }
@@ -1069,7 +1123,7 @@ async function reconcileHistoricalAttempts(pipeline: Pipeline, entries: FileEntr
         changed = JSON.stringify(attempt) !== before || changed;
         continue;
       }
-      const parsed = parseStageVerdict(durable.message!.text);
+      const parsed = parsePipelineStageVerdict(durable.message!.text);
       attempt.completedAt = new Date(durable.message!.ts).toISOString();
       attempt.output = null;
       if (!parsed) {
@@ -1626,7 +1680,7 @@ async function tickRunStage(
   const durable = await ports.durableTurnEvidence(attempt.effectiveRole.engine, attempt.agentPath);
   const durableTerminal = durable?.turn === "terminal" && durable.message !== null && durable.message.ts > unixMs(attempt.startedAt);
   if (durable && durableTerminal) {
-    const parsed = parseStageVerdict(durable.message!.text);
+    const parsed = parsePipelineStageVerdict(durable.message!.text);
     if (parsed && (!hostUnavailablePastGrace || "verdict" in parsed)) {
       markVerdictRecoverySucceeded(attempt, ports.now(), durable.message!.ts);
       settleStageVerdict(pipeline, stage, attempt, parsed, ports, persist);
@@ -1637,7 +1691,7 @@ async function tickRunStage(
         pipeline,
         attempt,
         ports,
-        stageVerdictRejectionReason(durable.message!.text),
+        pipelineStageVerdictRejectionReason(durable.message!.text),
         durable.message!.ts,
       );
       return;
@@ -1700,13 +1754,13 @@ async function tickRunStage(
     }
     return;
   }
-  const parsed = parseStageVerdict(message.text);
+  const parsed = parsePipelineStageVerdict(message.text);
   if (!parsed) {
     recordVerdictRecoveryMiss(
       pipeline,
       attempt,
       ports,
-      stageVerdictRejectionReason(message.text),
+      pipelineStageVerdictRejectionReason(message.text),
       message.ts,
     );
     return;
@@ -2144,7 +2198,7 @@ async function reconcileExhaustedVerdictRecovery(
     || message.ts <= unixMs(attempt.startedAt)
     || message.ts <= (recovery.messageTs ?? 0)
   ) return false;
-  const parsed = parseStageVerdict(message.text);
+  const parsed = parsePipelineStageVerdict(message.text);
   if (!parsed || "failureReason" in parsed) return false;
 
   attempt.state = "running";
@@ -2900,12 +2954,65 @@ async function orphanAgentPane(
   return { error: `stage agent may still be running in pane ${attempt.paneId}; wait for it to exit or kill the pane first`, status: 409 };
 }
 
-function verdictRecoveryResetRefusal(attempt: PipelineStageAttempt | null): { error: string; status: number } | null {
+function verdictRecoveryResetRefusal(
+  pipeline: Pipeline,
+  attempt: PipelineStageAttempt | null,
+  ports: PipelinePorts,
+): { error: string; status: number } | null {
   if (attempt?.verdictRecovery?.state !== "exhausted") return null;
-  return {
-    error: "automatic verdict recovery exhausted; preserve its worktree and conversation lineage, then continue the same conversation or close the pipeline",
-    status: 409,
-  };
+  const refusal = (reason: string) => ({
+    error: `automatic verdict recovery exhausted; retry-stage and skip-stage require a reset-safe worktree: ${reason}. Preserve the work or use close`,
+    status: 409 as const,
+  });
+  if (!pipeline.lastPassedCommit) return refusal("the pipeline has no passed-stage commit");
+  const local = currentPipelineBranchHead(pipeline, ports.exec);
+  if (!local.ok) return refusal(local.error);
+  if (local.sha === pipeline.lastPassedCommit) return null;
+
+  const ancestor = ports.exec(
+    "git",
+    ["merge-base", "--is-ancestor", pipeline.lastPassedCommit, local.sha],
+    pipeline.worktreeDir,
+  );
+  if (ancestor.code !== 0) {
+    return refusal("the worktree HEAD is outside the accepted last-passed history");
+  }
+  const remote = currentPipelineRemoteBranchHead(pipeline, ports.exec);
+  if (!remote.ok) return refusal(remote.error);
+  if (remote.sha !== local.sha) {
+    return refusal("the worktree has unpushed commits beyond the last-passed commit");
+  }
+  return null;
+}
+
+function isHostUnavailableStopFailure(error: string): boolean {
+  const normalized = error.toLowerCase();
+  return normalized.includes("runtime host is unavailable")
+    || normalized.includes("structured host ownership is unavailable");
+}
+
+async function closeStopFailureEvidence(
+  candidate: StageHostCandidate,
+  ports: PipelinePorts,
+): Promise<string | null> {
+  try {
+    if (!(await ports.stageHostResident(candidate.target))) return "the host registry entry is dead or absent";
+  } catch {
+    // An unreadable registry leaves the transcript as the remaining authority.
+  }
+  if (!candidate.target.agentPath) return null;
+  const durable = await ports.durableTurnEvidence(candidate.attempt.effectiveRole.engine, candidate.target.agentPath);
+  if (durable?.turn !== "terminal" || !durable.message) return null;
+  if (durable.message.ts <= unixMs(candidate.attempt.startedAt)) return null;
+  return "the attempt transcript holds a completed final assistant turn";
+}
+
+function terminalizeAttemptForClose(candidate: StageHostCandidate, note: string, ports: PipelinePorts): void {
+  if (!TERMINAL_ATTEMPT_STATES.has(candidate.attempt.state)) {
+    candidate.attempt.state = "failed";
+    candidate.attempt.error = note;
+  }
+  candidate.attempt.completedAt ??= ports.now();
 }
 
 /**
@@ -2938,6 +3045,7 @@ function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
       if (seen.has(identity)) continue;
       seen.add(identity);
       candidates.push({
+        attempt,
         target: {
           stageId: run.stageId,
           attempt: attempt.n,
@@ -2959,7 +3067,7 @@ function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
 
 /** A launched host plus whether its attempt's turn ended, which decides only
     whether the pane heuristic may speak for it. */
-type StageHostCandidate = { target: PipelineStageHostRef; turnSettled: boolean };
+type StageHostCandidate = { attempt: PipelineStageAttempt; target: PipelineStageHostRef; turnSettled: boolean };
 
 /** Ceiling on a close's whole host teardown, holding the pipelines transaction. */
 const CLOSE_TEARDOWN_BUDGET_MS = 10_000;
@@ -3000,6 +3108,7 @@ function closeSummary(report: PipelineCloseReport): string | null {
   if (report.acknowledged.length > 0) {
     parts.push(`dismissed ${report.acknowledged.length} unconfirmed host${report.acknowledged.length === 1 ? "" : "s"} on the operator's word`);
   }
+  for (const note of report.notes) parts.push(`${note.detail} for ${stageHostLabel(note)}`);
   if (report.worktree?.error) {
     parts.push(`could not read the worktree at ${report.worktree.dir}: ${report.worktree.error}`);
   } else {
@@ -3239,7 +3348,7 @@ export async function patchPipeline(
       if (flow?.state === "paused") ports.patchFlow(flow.id, "resume");
     } else if (req.action === "retry-stage") {
       if (pipeline.state !== "needs_decision") return { error: "pipeline does not have a stage awaiting retry", status: 409 };
-      const recoveryRefusal = verdictRecoveryResetRefusal(attempt);
+      const recoveryRefusal = verdictRecoveryResetRefusal(pipeline, attempt, ports);
       if (recoveryRefusal) return recoveryRefusal;
       const explicitReceiptRetry = req.stageId !== undefined || req.launchId !== undefined;
       if (explicitReceiptRetry && (typeof req.stageId !== "string" || typeof req.launchId !== "string")) {
@@ -3348,7 +3457,7 @@ export async function patchPipeline(
       pipeline.stateDetail = null;
     } else if (req.action === "skip-stage") {
       if (pipeline.state !== "needs_decision" || !stage) return { error: "pipeline does not have a stage awaiting a decision", status: 409 };
-      const recoveryRefusal = verdictRecoveryResetRefusal(attempt);
+      const recoveryRefusal = verdictRecoveryResetRefusal(pipeline, attempt, ports);
       if (recoveryRefusal) return recoveryRefusal;
       const orphan = await orphanAgentPane(attempt, ports);
       if (orphan) return orphan;
@@ -3471,7 +3580,7 @@ export async function patchPipeline(
       if (req.acknowledgeHosts !== undefined && typeof req.acknowledgeHosts !== "boolean") {
         return { error: "acknowledgeHosts must be a boolean", status: 400 };
       }
-      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], acknowledged: [], reviewers: [], stillRunning: [], worktree: null };
+      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], acknowledged: [], reviewers: [], stillRunning: [], notes: [], worktree: null };
       /* Each host's confirmation is bounded, but N of them multiply, and this
          whole loop holds the pipelines file transaction — every other pipeline
          mutation and the controller tick queue behind it. So the aggregate is
@@ -3481,7 +3590,8 @@ export async function patchPipeline(
       const teardownDeadline = ports.monotonicNow() + CLOSE_TEARDOWN_BUDGET_MS;
       const candidates = launchedStageHosts(pipeline);
       for (let index = 0; index < candidates.length; index += 1) {
-        const { target, turnSettled } = candidates[index]!;
+        const candidate = candidates[index]!;
+        const { target, turnSettled } = candidate;
         if (index > 0 && ports.monotonicNow() >= teardownDeadline) {
           for (const remaining of candidates.slice(index)) {
             close.unconfirmed.push({
@@ -3494,8 +3604,19 @@ export async function patchPipeline(
         }
         const result = await ports.stopStageAgent(target);
         if (result.outcome === "stopped") close.stopped.push(target);
-        else if (result.outcome === "failed") close.stillRunning.push({ ...target, error: result.error });
-        else if (result.outcome === "unconfirmed") {
+        else if (result.outcome === "failed") {
+          const evidence = isHostUnavailableStopFailure(result.error)
+            ? await closeStopFailureEvidence(candidate, ports)
+            : null;
+          if (evidence) {
+            const detail = `stop failed with "${result.error}"; terminalized from ${evidence}`;
+            close.alreadyStopped.push(target);
+            close.notes.push({ ...target, detail });
+            terminalizeAttemptForClose(candidate, detail, ports);
+          } else {
+            close.stillRunning.push({ ...target, error: result.error });
+          }
+        } else if (result.outcome === "unconfirmed") {
           close.unconfirmed.push({ ...target, operationId: result.operationId, detail: result.detail });
         } else if (!turnSettled && target.paneId) {
           /* The registry knows no host, but the attempt never finished its turn

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -2984,7 +2984,9 @@ async function closeStopFailureEvidence(
   const durable = await ports.durableTurnEvidence(candidate.attempt.effectiveRole.engine, candidate.target.agentPath);
   if (durable?.turn !== "terminal" || !durable.message) return null;
   if (durable.message.ts <= unixMs(candidate.attempt.startedAt)) return null;
-  return "the attempt transcript holds a completed final assistant turn";
+  const parsed = parsePipelineStageVerdict(durable.message.text);
+  if (!parsed || "failureReason" in parsed) return null;
+  return "the attempt transcript holds a completed final assistant turn with a valid fenced verdict";
 }
 
 function terminalizeAttemptForClose(candidate: StageHostCandidate, note: string, ports: PipelinePorts): void {
@@ -3604,8 +3606,14 @@ export async function patchPipeline(
           if (pane.outcome === "stopped") close.stopped.push(target);
           else if (pane.outcome === "failed") close.stillRunning.push({ ...target, error: pane.error });
           else if (pane.outcome === "unknown") close.unconfirmed.push({ ...target, operationId: null, detail: pane.detail });
-          else close.alreadyStopped.push(target);
-        } else close.alreadyStopped.push(target);
+          else {
+            close.alreadyStopped.push(target);
+            terminalizeAttemptForClose(candidate, "the stage pane was already absent when the pipeline closed", ports);
+          }
+        } else {
+          close.alreadyStopped.push(target);
+          terminalizeAttemptForClose(candidate, "the stage host was already absent when the pipeline closed", ports);
+        }
       }
       close.worktree = closeWorktreeReport(pipeline, ports);
       if (close.stillRunning.length > 0) {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -2968,27 +2968,7 @@ function verdictRecoveryResetRefusal(
   const local = currentPipelineBranchHead(pipeline, ports.exec);
   if (!local.ok) return refusal(local.error);
   if (local.sha === pipeline.lastPassedCommit) return null;
-
-  const ancestor = ports.exec(
-    "git",
-    ["merge-base", "--is-ancestor", pipeline.lastPassedCommit, local.sha],
-    pipeline.worktreeDir,
-  );
-  if (ancestor.code !== 0) {
-    return refusal("the worktree HEAD is outside the accepted last-passed history");
-  }
-  const remote = currentPipelineRemoteBranchHead(pipeline, ports.exec);
-  if (!remote.ok) return refusal(remote.error);
-  if (remote.sha !== local.sha) {
-    return refusal("the worktree has unpushed commits beyond the last-passed commit");
-  }
-  return null;
-}
-
-function isHostUnavailableStopFailure(error: string): boolean {
-  const normalized = error.toLowerCase();
-  return normalized.includes("runtime host is unavailable")
-    || normalized.includes("structured host ownership is unavailable");
+  return refusal(`the worktree HEAD ${local.sha} differs from the last-passed commit ${pipeline.lastPassedCommit}`);
 }
 
 async function closeStopFailureEvidence(
@@ -3605,9 +3585,7 @@ export async function patchPipeline(
         const result = await ports.stopStageAgent(target);
         if (result.outcome === "stopped") close.stopped.push(target);
         else if (result.outcome === "failed") {
-          const evidence = isHostUnavailableStopFailure(result.error)
-            ? await closeStopFailureEvidence(candidate, ports)
-            : null;
+          const evidence = await closeStopFailureEvidence(candidate, ports);
           if (evidence) {
             const detail = `stop failed with "${result.error}"; terminalized from ${evidence}`;
             close.alreadyStopped.push(target);


### PR DESCRIPTION
## Summary

- terminalize failed stage-host stops when the registry shows no resident host or the durable transcript shows a completed valid fenced verdict
- normalize structured verdict findings into plain strings before the existing verdict validation
- permit exhausted retry-stage and skip-stage only when the worktree is clean at the exact `lastPassedCommit`, with `close` named in refusal messages

Closes #1047
Closes #988
Closes #879

## Verification

- `bun test src/lib/pipelines/engine.test.ts` (186 pass)
- `bunx tsc --noEmit`
- `bun scripts/privacy-publication-gate.ts --base 37eb008ab62c95bb5279c27c3bd314e2cf8235dd` (PASS)