### PR TITLE
fix(flows): tolerant findings parse + fallback count so REQUEST_CHANGES never shows 0 findings (#930)

### DIFF
--- a/src/lib/flows/findings.test.ts
+++ b/src/lib/flows/findings.test.ts
@@ -42,7 +42,7 @@ function fixtureRound(): Round {
     accountId: "default",
     attemptedAccounts: ["codex:default"],
     autoRetryCount: 0,
-    sessionId: "11111111-2222-4333-8444-555555555555",
+    sessionId: "round-1-reviewer-session",
     reviewerPid: null,
     reviewerIdentity: null,
     reviewerPane: null,
@@ -125,4 +125,54 @@ test("recovers a legacy managed Claude verdict from the engine resolved by its f
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("counts findings for reviewer formats that escape the bulleted-bold field contract (#930)", () => {
+  const headingFields = `VERDICT: REQUEST_CHANGES
+
+### Finding 1
+**Severity:** High
+**File:** src/example/alpha.ts
+**Line:** 42
+**Title:** Retry loop drops the deadline
+**Explanation:** The helper rebuilds the deadline on every attempt.
+
+### Finding 2
+**Severity:** Medium
+**File:** src/example/beta.ts
+**Title:** Missing null guard
+**Explanation:** The lookup assumes the map always holds the key.
+`;
+  const plainBulletFields = `VERDICT: REQUEST_CHANGES
+
+- Severity: Medium
+- File: src/example/alpha.ts
+- Line: 42
+- Title: Retry loop drops the deadline
+- Explanation: The deadline is recomputed per attempt.
+
+- Severity: Low
+- File: src/example/beta.ts
+- Title: Missing null guard
+- Explanation: The lookup assumes the map always holds the key.
+`;
+  const proseBullets = `VERDICT: REQUEST_CHANGES
+
+- **HIGH — src/example/alpha.ts:42 — Retry loop drops the deadline.** The helper recomputes the deadline per attempt.
+- **MEDIUM — src/example/beta.ts:17 — Missing null guard.** The lookup assumes the map always holds the key.
+- **LOW — src/example/gamma.ts:8 — Stale comment.** The comment describes the previous contract.
+`;
+
+  expect(parseFindings(headingFields)).toMatchObject({ verdict: "REQUEST_CHANGES", findingsCount: 2 });
+  expect(parseFindings(plainBulletFields)).toMatchObject({ verdict: "REQUEST_CHANGES", findingsCount: 2 });
+  expect(parseFindings(proseBullets)).toMatchObject({ verdict: "REQUEST_CHANGES", findingsCount: 3 });
+});
+
+test("keeps an approving prose review at zero findings", () => {
+  const approval = `VERDICT: APPROVE
+
+The parser change is scoped to the two files and the regression tests cover every observed format.
+Residual risk is low: the fallback count only runs for a requested-changes verdict.
+`;
+  expect(parseFindings(approval)).toMatchObject({ verdict: "APPROVE", findingsCount: 0 });
 });

--- a/src/lib/flows/findings.ts
+++ b/src/lib/flows/findings.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-import { parseReview, VERDICT_LINE_RE } from "@/lib/review";
+import { countFindingBlocks, parseReview, VERDICT_LINE_RE } from "@/lib/review";
 import { tailRecords } from "@/lib/scanner/activity";
 import { recordValue, recordsValue, stringValue } from "@/lib/scanner/json";
 import type { FileEntry } from "@/lib/types";
@@ -85,9 +85,14 @@ export function parseFindings(text: string): ParsedFindings | null {
   const verdict = text.match(VERDICT_LINE_RE)?.[1] as ReviewVerdict | undefined;
   if (!verdict) return null;
   const review = parseReview(text, null);
+  const structured = review?.findings.length ?? 0;
+  // A requested-changes round always names something; when the reviewer's prose
+  // escapes the structured contract, fall back to counting blocks so the board
+  // never badges it as zero findings (#930).
+  const findingsCount = structured > 0 || verdict !== "REQUEST_CHANGES" ? structured : countFindingBlocks(text);
   return {
     verdict,
-    findingsCount: review?.findings.length ?? 0,
+    findingsCount,
     content: normalizeFindings(verdict, text),
   };
 }

--- a/src/lib/review.test.ts
+++ b/src/lib/review.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+
+import { countFindingBlocks, parseReview } from "./review";
+
+const HEADING_FIELDS = `VERDICT: REQUEST_CHANGES
+
+### Finding 1
+**Severity:** High
+**File:** src/example/alpha.ts
+**Line:** 42
+**Title:** Retry loop drops the deadline
+**Explanation:** The helper rebuilds the deadline on every attempt, so a slow call never aborts.
+
+### Finding 2
+**Severity:** Medium
+**File:** src/example/beta.ts
+**Title:** Missing null guard
+**Explanation:** The lookup assumes the map always holds the key.
+`;
+
+const PLAIN_BULLET_FIELDS = `VERDICT: REQUEST_CHANGES
+
+Findings
+
+- Severity: Medium
+- File: src/example/alpha.ts
+- Line: 42
+- Title: Retry loop drops the deadline
+- Explanation: The deadline is recomputed per attempt.
+
+- Severity: Low
+- File: src/example/beta.ts
+- Title: Missing null guard
+- Explanation: The lookup assumes the map always holds the key.
+`;
+
+const PROSE_BULLETS = `VERDICT: REQUEST_CHANGES
+
+- **HIGH — src/example/alpha.ts:42 — Retry loop drops the deadline.** The helper recomputes the deadline on every attempt.
+- **MEDIUM — src/example/beta.ts:17 — Missing null guard.** The lookup assumes the map always holds the key.
+`;
+
+test("parses field lines that carry the label without a leading bullet", () => {
+  expect(parseReview(HEADING_FIELDS, null)?.findings).toMatchObject([
+    { severity: "High", file: "src/example/alpha.ts", line: 42, title: "Retry loop drops the deadline" },
+    { severity: "Medium", file: "src/example/beta.ts", title: "Missing null guard" },
+  ]);
+});
+
+test("parses bulleted field lines that are not bold", () => {
+  expect(parseReview(PLAIN_BULLET_FIELDS, null)?.findings).toMatchObject([
+    { severity: "Medium", file: "src/example/alpha.ts", line: 42, title: "Retry loop drops the deadline" },
+    { severity: "Low", file: "src/example/beta.ts", title: "Missing null guard" },
+  ]);
+});
+
+test("keeps parsing the bulleted-and-bold field contract", () => {
+  const review = parseReview(
+    "VERDICT: REQUEST_CHANGES\n\n- **Severity:** Critical\n- **File:** src/example/alpha.ts\n- **Title:** Unsafe cast\n- **Explanation:** The cast hides a null.\n",
+    null,
+  );
+  expect(review?.findings).toMatchObject([{ severity: "Critical", file: "src/example/alpha.ts", title: "Unsafe cast" }]);
+});
+
+test("strips the trailing marker of a whole-line bold field label", () => {
+  const review = parseReview(
+    "VERDICT: REQUEST_CHANGES\n\n**Severity: High**\n**File: src/example/alpha.ts**\n**Title: Unsafe cast**\n**Explanation: The cast hides a null.**\n",
+    null,
+  );
+  expect(review?.findings).toMatchObject([
+    { severity: "High", file: "src/example/alpha.ts", title: "Unsafe cast", body: "The cast hides a null." },
+  ]);
+});
+
+test("counts finding blocks from headings, severity bullets, or nothing at all", () => {
+  expect(countFindingBlocks(HEADING_FIELDS)).toBe(2);
+  expect(countFindingBlocks(PROSE_BULLETS)).toBe(2);
+  expect(countFindingBlocks("VERDICT: APPROVE\n\nThe change is scoped and the tests cover it.\n")).toBe(0);
+});

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -22,8 +22,13 @@ export interface ReviewCardItem {
 export const RAW_DEBUG_KEEP = 24_000;
 export const VERDICT_LINE_RE = /^\s*(?:VERDICT:\s*)?(REQUEST_CHANGES|APPROVE|COMMENT)\b/m;
 const FINDING_ITEM_RE = /^\s*(\d+)[.)]\s+(.*)$/;
-const FINDING_HEADING_RE = /^\s*#{1,6}\s+finding\s+\d+\s*$/i;
-const FINDING_FIELD_RE = /^\s*[-*]\s+\*\*(severity|file|line|title|explanation):\*\*\s*(.*)$/i;
+const FINDING_HEADING_RE = /^\s*#{1,6}\s+finding\s+\d+\b.*$/i;
+/** Reviewers label the same fields with any mix of leading bullet and bold, so
+    accept `- **Severity:** High`, `**Severity:** High`, `- Severity: High` and
+    `Severity: High` as the one field contract (#930). */
+const FINDING_FIELD_RE =
+  /^\s*(?:[-*+]\s+)?(?:\*\*|__)?(severity|file|line|title|explanation)(?:\*\*|__)?\s*:\s*(?:\*\*|__)?\s*(.*)$/i;
+const TOP_LEVEL_BULLET_RE = /^[-*+]\s+(.*)$/;
 const SEVERITY_RE = /(?:\[(P[0-3])\]|\b(Critical|High|Medium|Low|Info|P[0-3])\b)/i;
 const PATH_RE =
   /((?:\.{1,2}\/|\/|~\/)?[\w@.+-][\w@.+\-/]*\.(?:tsx?|jsx?|mjs|cjs|mts|cts|py|go|rs|md|json|ya?ml|toml|css|scss|html|sql|sh|env|ftl|txt))(?::(\d+))?/i;
@@ -101,6 +106,15 @@ function inlineValue(value: string): string {
   return value.trim().replace(/^`([^`]*)`$/, "$1");
 }
 
+/** Strip the bold markers a whole-line `**Severity: High**` label leaves behind
+    once the field name has been matched. */
+function fieldValue(value: string): string {
+  const trimmed = value.trim();
+  const wrapped = trimmed.match(/^\*\*([\s\S]*)\*\*$/);
+  if (wrapped) return wrapped[1]!.trim();
+  return trimmed.replace(/\*\*$/, "").trim();
+}
+
 /** Current Codex reviewers emit labelled Markdown bullets, optionally grouped
     under `### Finding N` headings. Parse that stable field contract directly so
     the flow engine and review cards share the same finding count and metadata. */
@@ -135,7 +149,7 @@ function parseStructuredFindings(text: string): ReviewFinding[] {
       const key = field[1]!.toLowerCase() as keyof StructuredFinding;
       if (key === "severity" && current?.severity) flush();
       current ??= {};
-      current[key] = field[2]?.trim() ?? "";
+      current[key] = fieldValue(field[2] ?? "");
       activeField = key;
       continue;
     }
@@ -146,6 +160,22 @@ function parseStructuredFindings(text: string): ReviewFinding[] {
   }
   flush();
   return findings;
+}
+
+/** Display-only fallback for reviewers whose findings never reach the field
+    contract above: count `### Finding N` blocks, else top-level bullets that
+    carry a severity token, so a REQUEST_CHANGES verdict with a written-out
+    findings file never reports zero (#930). */
+export function countFindingBlocks(text: string): number {
+  const lines = text.split("\n");
+  const headings = lines.filter((line) => FINDING_HEADING_RE.test(line)).length;
+  if (headings > 0) return headings;
+  let bullets = 0;
+  for (const line of lines) {
+    const bullet = line.match(TOP_LEVEL_BULLET_RE);
+    if (bullet && SEVERITY_RE.test(bullet[1] ?? "")) bullets += 1;
+  }
+  return bullets;
 }
 
 export function parseReview(text: string, ts: unknown): ReviewCardItem | null {


### PR DESCRIPTION
Fixes #930.

## Mechanism

`FINDING_FIELD_RE` required a field line to be **both** a bullet and bold, and `parseFindings` counted only the structured parse. Three reviewer shapes therefore parsed as zero findings while `VERDICT_LINE_RE` still read REQUEST_CHANGES, so the board badged a requested-changes round with no findings.

## Change (2 files + their tests)

`src/lib/review.ts`
- `FINDING_FIELD_RE` accepts an optional leading bullet and optional bold around the label: `- **Severity:** High`, `**Severity:** High`, `- Severity: High`, `Severity: High`, `**Severity: High**`. New `fieldValue()` normalizes the captured value so a whole-line bold label loses its trailing marker.
- `FINDING_HEADING_RE` tolerates a titled heading (`### Finding 1: …`).
- New exported `countFindingBlocks(text)`: counts `### Finding N` blocks, else top-level bullets carrying a severity token (reuses the existing `SEVERITY_RE`).

`src/lib/flows/findings.ts`
- `parseFindings` falls back to `countFindingBlocks` only when the verdict is REQUEST_CHANGES and the structured parse came back empty.

Verdict detection and flow control are untouched; `findingsCount` stays display-only.

## Result on the three observed formats

| format | structured | reported count |
| --- | --- | --- |
| `### Finding N` + unbulleted `**Severity:**` fields | 2 | 2 |
| bulleted fields without bold (`- Severity: Medium`) | 2 | 2 |
| prose bullets (`- **HIGH — file:line — title.** …`) | 0 | 3 (fallback) |
| APPROVE with prose | 0 | 0 |

## Verification

- `bun test src/lib/review.test.ts src/lib/flows/findings.test.ts` → 11 pass, 0 fail (new `src/lib/review.test.ts`; regression tests for all three formats and APPROVE-prose in `findings.test.ts`).
- `bun test src/components/feed/parse.test.ts src/lib/tts.test.ts src/lib/view/compactText.test.ts` (the other `parseReview` consumers) → 91 pass, 0 fail.
- `bunx tsc --noEmit` → clean; `bunx eslint` on the four files → clean.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` → PASS. The round fixture's session id lost its UUID shape: that literal predates this change but `resource_identifier` fires on any touched file carrying it. Snippets in the tests are synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)