### PR TITLE
fix(runtime): read-only stage scratch lives under the shared state dir and leaves HOME to the shim (#1104)

### DIFF
--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -202,9 +202,9 @@ test.skipIf(!scratchHome)("real Codex app-server accepts the read-only scratch p
       ...optionsFor(adoptedAccess),
       initialEventCursor: cursor,
     });
-    const adoptedScratch = await commandExec(adopted, 'printf adopted > "$HOME/adopted"');
+    const adoptedScratch = await commandExec(adopted, 'printf adopted > "$TMPDIR/adopted"');
     expect(adoptedScratch.exitCode).toBe(0);
-    expect(fs.readFileSync(path.join(adoptedAccess.env.HOME!, "adopted"), "utf8")).toBe("adopted");
+    expect(fs.readFileSync(path.join(adoptedAccess.env.TMPDIR!, "adopted"), "utf8")).toBe("adopted");
     const adoptedCheckout = await commandExec(adopted, 'printf blocked > "$CHECKOUT_PROBE"', {
       CHECKOUT_PROBE: checkoutProbe,
     });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -35,23 +35,34 @@ class MemoryEventStore implements RuntimeEventStore {
 }
 
 test("read-only structured hosts receive one writable isolated scratch root", () => {
-  const scratchParent = fs.mkdtempSync(path.join(os.tmpdir(), "llv-read-only-scratch-test-"));
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-read-only-scratch-test-"));
+  const stateDirectory = path.join(directory, "state");
+  const previousStateDirectory = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = stateDirectory;
   try {
     const access = materializeStructuredHostAccess(
       true,
-      { NODE_ENV: "test", HOME: "/shared/home", XDG_CONFIG_HOME: "/shared/config" },
+      {
+        NODE_ENV: "test",
+        HOME: "/shared/home",
+        XDG_CONFIG_HOME: "/shared/config",
+        XDG_CACHE_HOME: "/shared/cache",
+        TMPDIR: "/container-private/tmp",
+      },
       "capability",
-      scratchParent,
     );
 
     expect(access.env).toMatchObject({
       NODE_ENV: "test",
       LLV_SPAWN_CAPABILITY: "capability",
-      HOME: path.join(access.scratchDirectory!, "home"),
-      XDG_CONFIG_HOME: path.join(access.scratchDirectory!, "config"),
+      HOME: "/shared/home",
+      XDG_CONFIG_HOME: "/shared/config",
+      XDG_CACHE_HOME: "/shared/cache",
       TMPDIR: path.join(access.scratchDirectory!, "tmp"),
       GH_CONFIG_DIR: "/shared/config/gh",
     });
+    expect(path.dirname(access.scratchDirectory!)).toBe(path.join(stateDirectory, "scratch"));
+    expect(access.scratchDirectory!.startsWith(`${stateDirectory}${path.sep}`)).toBeTrue();
     expect(access.codex).toEqual({
       permissionProfile: READ_ONLY_STAGE_PERMISSION_PROFILE,
       permissionProfileConfig: `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(access.scratchDirectory)}="write"}}`,
@@ -61,21 +72,22 @@ test("read-only structured hosts receive one writable isolated scratch root", ()
       releaseCleanup: expect.any(Function),
     });
     expect(fs.statSync(access.scratchDirectory!).mode & 0o777).toBe(0o700);
-    for (const name of ["home", "config", "tmp"]) {
-      expect(fs.statSync(path.join(access.scratchDirectory!, name)).mode & 0o777).toBe(0o700);
-    }
+    expect(fs.statSync(path.join(access.scratchDirectory!, "tmp")).mode & 0o777).toBe(0o700);
 
     access.cleanup();
     expect(fs.existsSync(access.scratchDirectory!)).toBeFalse();
 
-    const readWrite = materializeStructuredHostAccess(false, { NODE_ENV: "test", HOME: "/shared/home" }, "capability", scratchParent);
+    const sourceEnv: NodeJS.ProcessEnv = { NODE_ENV: "test", HOME: "/shared/home", TMPDIR: "/original/tmp" };
+    const readWrite = materializeStructuredHostAccess(false, sourceEnv, "capability", directory);
     expect(readWrite).toMatchObject({
-      env: { HOME: "/shared/home", LLV_SPAWN_CAPABILITY: "capability" },
+      env: { ...sourceEnv, LLV_SPAWN_CAPABILITY: "capability" },
       codex: { sandbox: "danger-full-access" },
       scratchDirectory: null,
     });
   } finally {
-    fs.rmSync(scratchParent, { recursive: true, force: true });
+    if (previousStateDirectory === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDirectory;
+    fs.rmSync(directory, { recursive: true, force: true });
   }
 });
 

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -127,6 +127,9 @@ test("startup retry preserves a host registered after the first attempt fails", 
 
 test("server startup delegates managed rows with file credentials and their launch profile", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));
+  const stateDirectory = path.join(directory, "state");
+  const previousStateDirectory = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = stateDirectory;
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const artifactPath = "/managed/sessions/startup-thread.jsonl";
   const conversation = registry.ensureConversation("codex", artifactPath, "managed");
@@ -166,26 +169,36 @@ test("server startup delegates managed rows with file credentials and their laun
   });
   let codexOptions: unknown;
   let claudeOptions: unknown;
-  await adoptStructuredHostsAtStartup({
-    registry,
-    resolveCodexOwner: () => ({ home: "/managed", kind: "managed" }),
-    resolveClaudeOwner: () => ({
-      home: "/managed-claude",
-      kind: "managed",
-      transcriptRoot: "/managed-claude/projects",
-      env: { NODE_ENV: "test", CLAUDE_CONFIG_DIR: "/managed-claude" },
-    }),
-    adopt: async (received, optionsFor) => {
-      expect(received).toBe(registry);
-      codexOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
-      return [];
-    },
-    adoptClaude: async (received, optionsFor) => {
-      expect(received).toBe(registry);
-      claudeOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
-      return [];
-    },
-  });
+  try {
+    await adoptStructuredHostsAtStartup({
+      registry,
+      resolveCodexOwner: () => ({ home: "/managed", kind: "managed" }),
+      resolveClaudeOwner: () => ({
+        home: "/managed-claude",
+        kind: "managed",
+        transcriptRoot: "/managed-claude/projects",
+        env: {
+          NODE_ENV: "test",
+          HOME: "/operator-home",
+          XDG_CONFIG_HOME: "/operator-config",
+          CLAUDE_CONFIG_DIR: "/managed-claude",
+        },
+      }),
+      adopt: async (received, optionsFor) => {
+        expect(received).toBe(registry);
+        codexOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
+        return [];
+      },
+      adoptClaude: async (received, optionsFor) => {
+        expect(received).toBe(registry);
+        claudeOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
+        return [];
+      },
+    });
+  } finally {
+    if (previousStateDirectory === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDirectory;
+  }
   const codexCleanup = (codexOptions as { releaseCleanup?: () => void }).releaseCleanup;
   const claudeCleanup = (claudeOptions as { releaseCleanup?: () => void }).releaseCleanup;
   expect(codexOptions).toMatchObject({
@@ -198,9 +211,8 @@ test("server startup delegates managed rows with file credentials and their laun
     forwardGitHubConfig: true,
     releaseCleanup: expect.any(Function),
     env: {
-      HOME: expect.stringContaining("llv-read-only-stage-"),
-      XDG_CONFIG_HOME: expect.stringContaining("llv-read-only-stage-"),
-      TMPDIR: expect.stringContaining("llv-read-only-stage-"),
+      HOME: process.env.HOME,
+      TMPDIR: expect.stringContaining(path.join(stateDirectory, "scratch", "llv-read-only-stage-")),
       LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
     },
   });
@@ -208,7 +220,11 @@ test("server startup delegates managed rows with file credentials and their laun
     cwd: "/repo",
     claudeConfigDir: "/managed-claude",
     claudeProjectsDir: "/managed-claude/projects",
-    env: { CLAUDE_CONFIG_DIR: "/managed-claude" },
+    env: {
+      HOME: "/operator-home",
+      XDG_CONFIG_HOME: "/operator-config",
+      CLAUDE_CONFIG_DIR: "/managed-claude",
+    },
     model: "gpt-5.4-mini",
     effort: "high",
     allowSubagents: true,
@@ -218,10 +234,14 @@ test("server startup delegates managed rows with file credentials and their laun
     releaseCleanup: expect.any(Function),
   });
   expect(claudeOptions).toMatchObject({
-    env: { LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
+    env: {
+      TMPDIR: expect.stringContaining(path.join(stateDirectory, "scratch", "llv-read-only-stage-")),
+      LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+    },
   });
   codexCleanup?.();
   claudeCleanup?.();
+  fs.rmSync(directory, { recursive: true, force: true });
 });
 
 function runtimeJournalClient(journal: RuntimeJournal): RuntimeHostClient {

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -11,6 +11,7 @@ import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKe
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
 import { prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
+import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { hasUserAuthoredMessage } from "@/lib/session/reader";
 import { hardenedRedact } from "@/lib/view/compactText";
@@ -67,7 +68,7 @@ export function materializeStructuredHostAccess(
   readOnly: boolean,
   sourceEnv: NodeJS.ProcessEnv,
   capability: string | null,
-  scratchParent = os.tmpdir(),
+  scratchParent?: string,
 ): StructuredHostAccessMaterialization {
   const baseEnv = {
     ...sourceEnv,
@@ -83,23 +84,19 @@ export function materializeStructuredHostAccess(
     };
   }
 
-  const scratchDirectory = fs.mkdtempSync(path.join(scratchParent, "llv-read-only-stage-"));
+  const resolvedScratchParent = scratchParent ?? statePath("scratch");
+  fs.mkdirSync(resolvedScratchParent, { recursive: true, mode: 0o700 });
+  const scratchDirectory = fs.mkdtempSync(path.join(resolvedScratchParent, "llv-read-only-stage-"));
   try {
     fs.chmodSync(scratchDirectory, 0o700);
-    const directories = {
-      HOME: path.join(scratchDirectory, "home"),
-      XDG_CONFIG_HOME: path.join(scratchDirectory, "config"),
-      TMPDIR: path.join(scratchDirectory, "tmp"),
-    };
-    for (const directory of Object.values(directories)) {
-      fs.mkdirSync(directory, { mode: 0o700 });
-    }
+    const temporaryDirectory = path.join(scratchDirectory, "tmp");
+    fs.mkdirSync(temporaryDirectory, { mode: 0o700 });
     const permissionProfileConfig = `permissions.${READ_ONLY_STAGE_PERMISSION_PROFILE}={extends=":read-only",filesystem={${JSON.stringify(scratchDirectory)}="write"}}`;
     const cleanup = () => fs.rmSync(scratchDirectory, { recursive: true, force: true });
     return {
       env: {
         ...baseEnv,
-        ...directories,
+        TMPDIR: temporaryDirectory,
         GH_CONFIG_DIR: githubConfigDirectory(sourceEnv),
       },
       codex: {


### PR DESCRIPTION
## Summary

- Create each read-only stage scratch directory under the Viewer state directory's `scratch/` root, which is visible from the container and host mount namespaces.
- Preserve the account environment's `HOME`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME`; route writable compiler and test temporary state through the shared scratch `TMPDIR`.
- Keep the existing `llv-read-only-stage` permission profile scoped to that scratch root and retain release cleanup.
- Cover default state-root placement, environment preservation, cleanup, read-write behavior, startup adoption for both engines, and the real Codex fresh/adopted host cycle.

The Docker nsenter shim remains unchanged. Preserving `HOME` keeps its working-directory and binary resolution aligned with the operator installation, while `CODEX_HOME` and `CLAUDE_CONFIG_DIR` continue to select account authentication.

## Verification

- `bunx tsc --noEmit --incremental false`
- `bun test src/lib/runtime/codexAppServerHost.test.ts src/lib/runtime/codexAppServerHost.integration.test.ts src/lib/runtime/startup.test.ts` — 177 passed
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` — pass

All verification used isolated `HOME`, `XDG_CONFIG_HOME`, `LLV_STATE_DIR`, and `TMPDIR`.

Fixes #1104
