### PR TITLE
fix(pipelines): require affirmative stage death evidence (#1109)

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -341,10 +341,11 @@ async function exhaustVerdictRecovery(h: ReturnType<typeof harness>, entries: Fi
 }
 
 async function withRuntimeSnapshot(
-  snapshot: Record<string, unknown>,
+  snapshot: Record<string, unknown> | ((requestNumber: number) => Record<string, unknown>),
   run: () => Promise<void>,
 ): Promise<void> {
   const socketPath = path.join(process.env.LLV_STATE_DIR!, `runtime-${crypto.randomUUID()}.sock`);
+  let requestNumber = 0;
   const server = net.createServer((socket) => {
     let frame = "";
     socket.on("data", (chunk) => {
@@ -352,7 +353,8 @@ async function withRuntimeSnapshot(
       const newline = frame.indexOf("\n");
       if (newline < 0) return;
       const request = JSON.parse(frame.slice(0, newline)) as { id: string };
-      socket.end(`${JSON.stringify({ id: request.id, ok: true, result: snapshot })}\n`);
+      const result = typeof snapshot === "function" ? snapshot(requestNumber++) : snapshot;
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, result })}\n`);
     });
   });
   await new Promise<void>((resolve, reject) => {
@@ -1768,6 +1770,40 @@ test("an unindexed rollout stays running while its structured host is alive and 
       verdict: null,
     });
     expect(current.runs[0]!.attempts[0]!.verdictRecovery).toBeUndefined();
+  });
+});
+
+test("a dead runtime snapshot cannot poison later hosted idle evidence in the same tick (#1109)", async () => {
+  let snapshotReads = 0;
+  await withRuntimeSnapshot((requestNumber) => {
+    snapshotReads += 1;
+    return {
+      sessions: [{
+        conversationId: "conversation_stage_1",
+        host: requestNumber === 0 ? "dead" : "hosted",
+        turn: "idle",
+        attentionIds: [],
+      }],
+    };
+  }, async () => {
+    const h = harness();
+    await runningStructuredStage(h);
+    const runtimePorts = defaultPipelinePorts();
+    let primedDeadProjection = false;
+    h.ports.conversationAgentActive = async (conversationId) => {
+      if (!primedDeadProjection) {
+        primedDeadProjection = true;
+        expect(await runtimePorts.conversationAgentActive(conversationId)).toBe(false);
+      }
+      return runtimePorts.conversationAgentActive(conversationId);
+    };
+
+    await tickPipelines([], h.ports);
+
+    const current = loadPipelines()[0]!;
+    expect(current.state).toBe("running");
+    expect(current.runs[0]!.attempts[0]!.verdictRecovery).toBeUndefined();
+    expect(snapshotReads).toBe(2);
   });
 });
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, expect, spyOn, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { Database } from "bun:sqlite";
@@ -337,6 +338,39 @@ async function exhaustVerdictRecovery(h: ReturnType<typeof harness>, entries: Fi
   await tickPipelines(entries, h.ports);
   h.advanceWallClock(30_000);
   await tickPipelines(entries, h.ports);
+}
+
+async function withRuntimeSnapshot(
+  snapshot: Record<string, unknown>,
+  run: () => Promise<void>,
+): Promise<void> {
+  const socketPath = path.join(process.env.LLV_STATE_DIR!, `runtime-${crypto.randomUUID()}.sock`);
+  const server = net.createServer((socket) => {
+    let frame = "";
+    socket.on("data", (chunk) => {
+      frame += String(chunk);
+      const newline = frame.indexOf("\n");
+      if (newline < 0) return;
+      const request = JSON.parse(frame.slice(0, newline)) as { id: string };
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, result: snapshot })}\n`);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const priorSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  process.env.LLV_RUNTIME_HOST_SOCKET = socketPath;
+  try {
+    await run();
+  } finally {
+    if (priorSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = priorSocket;
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
 }
 
 function boardTask(id: string, project = "viewer"): BoardTask {
@@ -1707,6 +1741,129 @@ test("a worker that dies after transcript discovery enters bounded verdict recov
   await exhaustVerdictRecovery(h);
   expect(loadPipelines()[0]!.state).toBe("needs_decision");
   expect(loadPipelines()[0]!.stateDetail).toContain("canonical stage transcript is not yet readable");
+});
+
+test("an unindexed rollout stays running while its structured host is alive and idle (#1109)", async () => {
+  await withRuntimeSnapshot({
+    sessions: [{
+      conversationId: "conversation_stage_1",
+      host: "hosted",
+      turn: "idle",
+      attentionIds: [],
+    }],
+  }, async () => {
+    const h = harness();
+    await runningStructuredStage(h);
+    h.ports.conversationAgentActive = defaultPipelinePorts().conversationAgentActive;
+
+    for (let tick = 0; tick < 4; tick += 1) {
+      if (tick > 0) h.advanceWallClock(30_000);
+      await tickPipelines([], h.ports);
+    }
+
+    const current = loadPipelines()[0]!;
+    expect(current.state).toBe("running");
+    expect(current.runs[0]!.attempts[0]).toMatchObject({
+      state: "running",
+      verdict: null,
+    });
+    expect(current.runs[0]!.attempts[0]!.verdictRecovery).toBeUndefined();
+  });
+});
+
+test("a phase-budget overrun cannot spend an unindexed transcript recovery check (#1109)", async () => {
+  for (const overrun of ["before-read", "during-read"] as const) {
+    const h = harness();
+    await runningStructuredStage(h);
+    let monotonicMs = 0;
+    let durableReads = 0;
+    h.setMonotonicClock(() => monotonicMs);
+    h.ports.conversationAgentActive = async () => {
+      if (overrun === "before-read") monotonicMs = 15_000;
+      return false;
+    };
+    h.ports.durableTurnEvidence = async () => {
+      durableReads += 1;
+      if (overrun === "during-read") monotonicMs = 15_000;
+      return null;
+    };
+
+    await tickPipelines([], h.ports);
+
+    const current = loadPipelines()[0]!;
+    expect(current.state).toBe("running");
+    expect(current.runs[0]!.attempts[0]!.verdictRecovery).toBeUndefined();
+    expect(durableReads).toBe(overrun === "before-read" ? 0 : 1);
+  }
+});
+
+test("an unindexed rollout parks once its structured host is dead past grace (#1109)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(false);
+  const unavailableSince = h.ports.now();
+  h.ports.conversationHostUnavailableSince = async () => unavailableSince;
+  h.advanceWallClock(5 * 60_000);
+
+  await tickPipelines([], h.ports);
+
+  const current = loadPipelines()[0]!;
+  expect(current).toMatchObject({
+    state: "needs_decision",
+    stateDetail: "historical attempt completed without a valid final JSON verdict",
+  });
+  expect(current.runs[0]!.attempts[0]).toMatchObject({
+    state: "failed",
+    verdict: null,
+    error: "historical attempt completed without a valid final JSON verdict",
+  });
+});
+
+test("an exhausted false park ingests its live host's late verdict without a duplicate attempt (#1109)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(true);
+  const stored = loadPipelines()[0]!;
+  const attempt = stored.runs[0]!.attempts[0]!;
+  const parkedAt = h.ports.now();
+  attempt.state = "needs_decision";
+  attempt.completedAt = parkedAt;
+  attempt.error = "stage verdict recovery exhausted after 3 checks: canonical stage transcript is not yet readable after structured stage termination";
+  attempt.verdictRecovery = {
+    state: "exhausted",
+    checks: 3,
+    maxChecks: 3,
+    startedAt: parkedAt,
+    lastCheckedAt: parkedAt,
+    nextCheckAt: null,
+    reason: "canonical stage transcript is not yet readable after structured stage termination",
+    messageTs: null,
+  };
+  stored.state = "needs_decision";
+  stored.stateDetail = attempt.error;
+  savePipelines([stored]);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: { text: PASS_TEXT, ts: 5_000_000 },
+  });
+
+  await tickPipelines([], h.ports);
+
+  const recovered = loadPipelines()[0]!;
+  expect(recovered.cursor).toEqual({
+    stageId: "build",
+    state: "running",
+    input: "integration complete",
+    activatedBy: { stageId: "plan", attempt: 1, edge: "pass" },
+  });
+  expect(recovered.runs[0]!.attempts).toHaveLength(1);
+  expect(recovered.runs[0]!.attempts[0]).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass", confidence: 0.9 },
+    verdictRecovery: { state: "recovered", checks: 3, messageTs: 5_000_000 },
+  });
+  expect(recovered.runs[1]!.attempts).toHaveLength(1);
+  expect(h.calls.filter((call) => call.startsWith("spawn:"))).toHaveLength(2);
 });
 
 test("a dead structured host past grace fails through the stage fail edge (#973)", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -624,8 +624,8 @@ export function defaultPipelinePorts(): PipelinePorts {
       const session = snapshot.sessions.find((item) => item.conversationId === conversationId);
       if (!session) return null;
       if (["dead", "unhosted", "conflict"].includes(session.host)) return false;
-      if (session.turn === "idle") return false;
       if (session.turn === "running" || session.turn === "interrupt_requested" || session.attentionIds.length > 0) return true;
+      /* A hosted idle turn is an inter-turn state with unknown agent activity. */
       return null;
     },
     conversationHostUnavailableSince: async (conversationId) => {
@@ -691,6 +691,9 @@ const MISSING_STAGE_VERDICT = "stage completed without a valid final JSON verdic
 const HISTORICAL_MISSING_STAGE_VERDICT = "historical attempt completed without a valid final JSON verdict";
 const VERDICT_RECOVERY_MAX_CHECKS = 3;
 const VERDICT_RECOVERY_INTERVAL_MS = 30_000;
+/** Matches the production controller's default phase lease. A slow tick may
+    still accept positive evidence; late negative evidence cannot consume recovery. */
+const VERDICT_RECOVERY_ACCOUNTING_BUDGET_MS = 15_000;
 const SPAWN_HANDSHAKE_MAX_ATTEMPTS = 3;
 const SPAWN_HANDSHAKE_RETRY_DELAY_MS = 1_000;
 const DEAD_RUNNING_ATTEMPT_GRACE_MS = 3 * 60_000;
@@ -1521,7 +1524,9 @@ async function tickRunStage(
   entries: FileEntry[],
   ports: PipelinePorts,
   persist: () => void,
+  recoveryAccountingDeadline: number,
 ): Promise<void> {
+  const canSpendRecoveryCheck = () => ports.monotonicNow() < recoveryAccountingDeadline;
   const prior = currentAttempt(pipeline, stage.id);
   const attempt = pipeline.cursor?.state === "pending" && prior && ["passed", "failed", "needs_decision", "skipped"].includes(prior.state)
     ? newAttempt(pipeline, stage)
@@ -1672,6 +1677,8 @@ async function tickRunStage(
     && unixMs(ports.now()) - unavailableAt >= DEAD_RUNNING_ATTEMPT_GRACE_MS;
   if (entry && structuredActive !== false && scanProjectsOpenTurn && !hostUnavailablePastGrace) return;
 
+  if (!canSpendRecoveryCheck()) return;
+
   /* The transcript artifact is the completion authority (#337). A terminal turn
      whose completion evidence belongs to this attempt and ends in a valid fenced
      verdict settles once — even when the runtime ledger is stale `running`, the
@@ -1687,6 +1694,7 @@ async function tickRunStage(
       return;
     }
     if (!hostUnavailablePastGrace) {
+      if (!canSpendRecoveryCheck()) return;
       recordVerdictRecoveryMiss(
         pipeline,
         attempt,
@@ -1709,7 +1717,7 @@ async function tickRunStage(
     /* A readable durable artifact means the disappearance is a projection loss,
        not an ended stage — wait for the scan or the terminal turn evidence. */
     if (durable) return;
-    if (structuredActive === false) {
+    if (structuredActive === false && canSpendRecoveryCheck()) {
       recordVerdictRecoveryMiss(
         pipeline,
         attempt,
@@ -1717,7 +1725,11 @@ async function tickRunStage(
         "canonical stage transcript is not yet readable after structured stage termination",
         null,
       );
-    } else if (attempt.paneId && !(await ports.paneAgentAlive(attempt.paneId))) {
+    } else if (
+      attempt.paneId
+      && !(await ports.paneAgentAlive(attempt.paneId))
+      && canSpendRecoveryCheck()
+    ) {
       recordVerdictRecoveryMiss(
         pipeline,
         attempt,
@@ -1735,7 +1747,7 @@ async function tickRunStage(
   if (durable?.turn === "busy" && !attempt.paneId) return;
   const message = ports.lastMessage(entry);
   if (!message || message.ts <= unixMs(attempt.startedAt)) {
-    if (structuredActive === false) {
+    if (structuredActive === false && canSpendRecoveryCheck()) {
       recordVerdictRecoveryMiss(
         pipeline,
         attempt,
@@ -1743,7 +1755,11 @@ async function tickRunStage(
         "canonical completed assistant turn has not been ingested after structured stage termination",
         message?.ts ?? null,
       );
-    } else if (attempt.paneId && !(await ports.paneAgentAlive(attempt.paneId))) {
+    } else if (
+      attempt.paneId
+      && !(await ports.paneAgentAlive(attempt.paneId))
+      && canSpendRecoveryCheck()
+    ) {
       recordVerdictRecoveryMiss(
         pipeline,
         attempt,
@@ -1756,6 +1772,7 @@ async function tickRunStage(
   }
   const parsed = parsePipelineStageVerdict(message.text);
   if (!parsed) {
+    if (!canSpendRecoveryCheck()) return;
     recordVerdictRecoveryMiss(
       pipeline,
       attempt,
@@ -2034,7 +2051,13 @@ async function tickReviewStage(
   }
 }
 
-async function tickPipeline(pipeline: Pipeline, entries: FileEntry[], ports: PipelinePorts, persist: () => void): Promise<boolean> {
+async function tickPipeline(
+  pipeline: Pipeline,
+  entries: FileEntry[],
+  ports: PipelinePorts,
+  persist: () => void,
+  recoveryAccountingDeadline: number,
+): Promise<boolean> {
   const before = JSON.stringify(pipeline);
   if (pipeline.state === "provisioning") {
     if (!pipeline.baseBranch || !pipeline.baseRef || !pipeline.lastPassedCommit) {
@@ -2060,7 +2083,9 @@ async function tickPipeline(pipeline: Pipeline, entries: FileEntry[], ports: Pip
   } else if (pipeline.state === "running") {
     const stage = currentStage(pipeline);
     if (!stage) park(pipeline, "pipeline cursor points to an unknown stage");
-    else if (stage.kind === "run") await tickRunStage(pipeline, stage, entries, ports, persist);
+    else if (stage.kind === "run") {
+      await tickRunStage(pipeline, stage, entries, ports, persist, recoveryAccountingDeadline);
+    }
     else await tickReviewStage(pipeline, stage, entries, ports, persist);
   }
   return JSON.stringify(pipeline) !== before;
@@ -2382,6 +2407,7 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
   if (tickStore.__llvPipelineTick) return { pipelines: [], changed: false };
   tickStore.__llvPipelineTick = true;
   let followUp = false;
+  const recoveryAccountingDeadline = ports.monotonicNow() + VERDICT_RECOVERY_ACCOUNTING_BUDGET_MS;
   try {
     const result = await withPipelineControllerMutation(async (pipelines, persist) => {
       let changed = false;
@@ -2398,7 +2424,13 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
         pipelineChanged = await reconcileUnconfirmedHosts(pipeline, ports) || pipelineChanged;
         pipelineChanged = await reconcileTerminalStageHosts(pipeline, ports) || pipelineChanged;
         if (!TERMINAL_STATES.has(pipeline.state) && pipeline.state !== "paused" && pipeline.state !== "needs_decision") {
-          pipelineChanged = await tickPipeline(pipeline, entries, ports, persistPipeline) || pipelineChanged;
+          pipelineChanged = await tickPipeline(
+            pipeline,
+            entries,
+            ports,
+            persistPipeline,
+            recoveryAccountingDeadline,
+          ) || pipelineChanged;
         }
         if (pipelineChanged) {
           changed = true;

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -623,7 +623,12 @@ export function defaultPipelinePorts(): PipelinePorts {
       }
       const session = snapshot.sessions.find((item) => item.conversationId === conversationId);
       if (!session) return null;
-      if (["dead", "unhosted", "conflict"].includes(session.host)) return false;
+      if (["dead", "unhosted", "conflict"].includes(session.host)) {
+        /* A host may be adopted again during this controller pass. Do not let
+           affirmative death evidence poison later liveness checks in the tick. */
+        runtimeSnapshot = null;
+        return false;
+      }
       if (session.turn === "running" || session.turn === "interrupt_requested" || session.attentionIds.length > 0) return true;
       /* A hosted idle turn is an inter-turn state with unknown agent activity. */
       return null;


### PR DESCRIPTION
Fixes #1109

## Summary

- Classify a hosted idle runtime session as unknown agent activity. Only dead, unhosted, and conflict host states return affirmative termination evidence.
- Give each pipeline tick a 15-second recovery-accounting lease aligned with the production controller phase deadline. A durable read skipped after that lease, or a negative read that crosses it, consumes no verdict-recovery check. Positive terminal evidence can still settle the attempt.
- Preserve the existing dead-host grace behavior: an unindexed transcript with a host unavailable past grace still parks with the historical missing-verdict error.

## Live-host recovery mechanism

This PR uses mechanism (a). `reconcileExhaustedVerdictRecovery` continues evaluating the existing `needs_decision` attempt. When the live host's terminal verdict becomes readable, the engine settles that same attempt and advances the pipeline. The regression verifies one attempt remains in the recovered stage before the next stage starts.

## Verification

All commands used isolated `HOME`, `XDG_CONFIG_HOME`, `LLV_STATE_DIR`, and `TMPDIR` where runtime state could be read.

- `bun test src/lib/pipelines/engine.test.ts` (190 passed)
- `bunx tsc --noEmit`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base 97c24856e5b0af09935b63a5fb9addee9fc0cb66`
- `git diff --check`

The production build retains the existing `::highlight(tts-karaoke)` CSS optimizer warning.
