### PR TITLE
fix(spawn): retire placeholders when transcripts are readable

### DIFF
--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -91,14 +91,72 @@ test("issue 1108: a readable registry generation retires its placeholder in the 
       path: artifactPath,
       conversationId: launch.conversationId,
       generation: 1,
-      activity: "recent",
-      activityReason: "structured_spawn_recovered",
+      activity: "live",
+      activityReason: "mtime_fresh",
     });
     expect(projection.cards[0]!.spawn).toBeUndefined();
     expect(projection.facts.get(artifactPath)).toMatchObject({
       conversationId: launch.conversationId,
       generation: 1,
     });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108 review: a keyed receipt never adopts an uncorrelated conversation generation", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-key-mismatch-"));
+  const priorPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    fs.writeFileSync(priorPath, `${JSON.stringify({ type: "user", message: "prior generation" })}\n`);
+    const launch = settledLaunch(directory, priorPath);
+    const snapshot = launch.registry.snapshot();
+    const receipt = snapshot.receipts[launch.launchId]!;
+    receipt.key = { engine: "codex", sessionId: "different-session" };
+    receipt.artifactPath = null;
+
+    const projection = projectLaunchConversations([scannedFile(priorPath)], snapshot, launch.createdMs + 1_000);
+    expect(projection.cards).toEqual([
+      expect.objectContaining({
+        path: `spawn:${launch.launchId}`,
+        conversationId: launch.conversationId,
+      }),
+    ]);
+    expect(projection.facts.size).toBe(0);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108 review: an unbound launch against an existing conversation keeps its placeholder", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-unbound-existing-"));
+  const priorPath = path.join(directory, "prior-generation.jsonl");
+  try {
+    fs.writeFileSync(priorPath, `${JSON.stringify({ type: "user", message: "prior generation" })}\n`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const existing = registry.ensureConversation("codex", priorPath, "work");
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      conversationId: existing.id,
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+
+    const projection = projectLaunchConversations(
+      [scannedFile(priorPath)],
+      registry.snapshot(),
+      Date.parse(begun.receipt.createdAt) + 1_000,
+    );
+    expect(projection.cards).toEqual([
+      expect.objectContaining({
+        path: `spawn:${begun.receipt.launchId}`,
+        conversationId: existing.id,
+      }),
+    ]);
+    expect(projection.facts.size).toBe(0);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
@@ -199,10 +257,15 @@ test("issue 1108: scanner adoption replaces the synthesized transcript without d
     fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "indexed later" })}\n`);
     const launch = settledLaunch(directory, artifactPath);
     const snapshot = launch.registry.snapshot();
-    expect(projectLaunchConversations([], snapshot, launch.createdMs + 1_000).cards.map((entry) => entry.path))
-      .toEqual([artifactPath]);
+    const synthesized = projectLaunchConversations([], snapshot, launch.createdMs + 1_000).cards;
+    expect(synthesized.map((entry) => entry.path)).toEqual([artifactPath]);
+    expect(synthesized[0]).toMatchObject({ activity: "live", activityReason: "mtime_fresh" });
 
     const scanned = scannedFile(artifactPath);
+    scanned.mtime = synthesized[0]!.mtime;
+    scanned.size = synthesized[0]!.size;
+    scanned.activity = "live";
+    scanned.activityReason = "mtime_fresh";
     let probes = 0;
     const indexed = projectLaunchConversations(
       [scanned],
@@ -214,6 +277,10 @@ test("issue 1108: scanner adoption replaces the synthesized transcript without d
       },
     );
     expect([scanned, ...indexed.cards].map((entry) => entry.path)).toEqual([artifactPath]);
+    expect(scanned).toMatchObject({
+      activity: synthesized[0]!.activity,
+      activityReason: synthesized[0]!.activityReason,
+    });
     expect(indexed.facts.has(artifactPath)).toBe(true);
     expect(probes).toBe(0);
   } finally {

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -10,6 +10,8 @@ import type { FileEntry } from "@/lib/types";
 import { AgentRegistry } from "./registry";
 import { preallocatedStructuredSpawnCards, projectLaunchConversations } from "./spawnProjection";
 
+const SETTLED_SESSION_ID = "019f7b8a-" + "9f75-7dc0-b231-17f7eadd7fe0";
+
 function scannedFile(pathname: string): FileEntry {
   return {
     path: pathname,
@@ -43,38 +45,177 @@ function observeArtifact(registry: AgentRegistry, artifactPath: string, cwd: str
   }]);
 }
 
-test("a settled artifact stays projected across restart until inventory observes it", () => {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-scan-lag-"));
-  const filename = path.join(directory, "agent-registry.json");
-  const artifactPath = path.join(directory, "019f7b8a_9f75_7dc0_b231_17f7eadd7fe0.jsonl");
+function settledLaunch(directory: string, artifactPath: string) {
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: directory,
+    transport: "structured",
+    accountId: "work",
+    clientAttemptId: "scan_lag_20260717_a1",
+    requestDigest: "c".repeat(64),
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+  });
+  if (begun.kind !== "created") throw new Error("expected structured launch creation");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: SETTLED_SESSION_ID },
+    artifactPath,
+    cwd: directory,
+    accountId: "work",
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    status: "unhosted",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  return {
+    registry,
+    launchId: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    createdMs: Date.parse(begun.receipt.createdAt),
+  };
+}
+
+test("issue 1108: a readable registry generation retires its placeholder in the same projection and preserves identity", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-readable-generation-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
   try {
     fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "scan lag" })}\n`);
-    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
-    const begun = registry.beginSpawnRequest({
-      engine: "codex",
-      cwd: directory,
-      transport: "structured",
-      accountId: "work",
-      clientAttemptId: "scan_lag_20260717_a1",
-      requestDigest: "c".repeat(64),
-      launchProfile: emptyLaunchProfile({ cwd: directory }),
-    });
-    if (begun.kind !== "created") throw new Error("expected structured launch creation");
-    registry.settleSpawn(begun.receipt.launchId, {
-      key: { engine: "codex", sessionId: "019f7b8a-" + "9f75-7dc0-b231-17f7eadd7fe0" },
-      artifactPath,
-      cwd: directory,
-      accountId: "work",
-      launchProfile: emptyLaunchProfile({ cwd: directory }),
-      status: "unhosted",
-      host: null,
-      claimEpoch: 0,
-      claimOwner: null,
-      pendingAction: null,
-    });
+    const launch = settledLaunch(directory, artifactPath);
+    observeArtifact(launch.registry, artifactPath, directory);
 
-    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
-    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toHaveLength(1);
+    const projection = projectLaunchConversations([], launch.registry.snapshot(), launch.createdMs + 1_000);
+    expect(projection.cards).toHaveLength(1);
+    expect(projection.cards[0]).toMatchObject({
+      path: artifactPath,
+      conversationId: launch.conversationId,
+      generation: 1,
+      activity: "recent",
+      activityReason: "structured_spawn_recovered",
+    });
+    expect(projection.cards[0]!.spawn).toBeUndefined();
+    expect(projection.facts.get(artifactPath)).toMatchObject({
+      conversationId: launch.conversationId,
+      generation: 1,
+    });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108: a known generation whose file is missing keeps its placeholder", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-missing-generation-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    const launch = settledLaunch(directory, artifactPath);
+
+    const projection = projectLaunchConversations([], launch.registry.snapshot(), launch.createdMs + 1_000);
+    expect(projection.cards).toEqual([
+      expect.objectContaining({
+        path: `spawn:${launch.launchId}`,
+        conversationId: launch.conversationId,
+      }),
+    ]);
+    expect(projection.facts.size).toBe(0);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108: projection probes one authoritative path at most once per placeholder", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-bounded-probe-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    const launch = settledLaunch(directory, artifactPath);
+    let probes = 0;
+
+    const projection = projectLaunchConversations(
+      [],
+      launch.registry.snapshot(),
+      launch.createdMs + 1_000,
+      (pathname) => {
+        probes += 1;
+        expect(pathname).toBe(artifactPath);
+        return false;
+      },
+    );
+    expect(probes).toBe(1);
+    expect(projection.cards[0]!.path).toBe(`spawn:${launch.launchId}`);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108: a readable runtime entry path materializes before a generation is registered", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-runtime-artifact-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "runtime path" })}\n`);
+    const launch = settledLaunch(directory, artifactPath);
+    const snapshot = launch.registry.snapshot();
+    const receipt = snapshot.receipts[launch.launchId]!;
+    expect(receipt.key).not.toBeNull();
+    expect(snapshot.entries[`${receipt.key!.engine}:${receipt.key!.sessionId}`]?.artifactPath).toBe(artifactPath);
+    snapshot.conversations[launch.conversationId]!.generations = [];
+    receipt.artifactPath = null;
+
+    const projection = projectLaunchConversations([], snapshot, launch.createdMs + 1_000);
+    expect(projection.cards).toEqual([
+      expect.objectContaining({
+        path: artifactPath,
+        conversationId: launch.conversationId,
+      }),
+    ]);
+    expect(projection.cards[0]!.spawn).toBeUndefined();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108: a known generation flips from placeholder to transcript when the file appears", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-later-generation-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    const launch = settledLaunch(directory, artifactPath);
+    const snapshot = launch.registry.snapshot();
+
+    expect(projectLaunchConversations([], snapshot, launch.createdMs + 1_000).cards[0]!.path)
+      .toBe(`spawn:${launch.launchId}`);
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "now readable" })}\n`);
+
+    const materialized = projectLaunchConversations([], snapshot, launch.createdMs + 2_000);
+    expect(materialized.cards.map((entry) => entry.path)).toEqual([artifactPath]);
+    expect(materialized.cards[0]!.conversationId).toBe(launch.conversationId);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108: scanner adoption replaces the synthesized transcript without duplicate rows", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-scanner-adoption-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "indexed later" })}\n`);
+    const launch = settledLaunch(directory, artifactPath);
+    const snapshot = launch.registry.snapshot();
+    expect(projectLaunchConversations([], snapshot, launch.createdMs + 1_000).cards.map((entry) => entry.path))
+      .toEqual([artifactPath]);
+
+    const scanned = scannedFile(artifactPath);
+    let probes = 0;
+    const indexed = projectLaunchConversations(
+      [scanned],
+      snapshot,
+      launch.createdMs + 2_000,
+      () => {
+        probes += 1;
+        return true;
+      },
+    );
+    expect([scanned, ...indexed.cards].map((entry) => entry.path)).toEqual([artifactPath]);
+    expect(indexed.facts.has(artifactPath)).toBe(true);
+    expect(probes).toBe(0);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
@@ -297,7 +438,7 @@ test("issue 614: a transcript-less launch projects the queued prompt as the firs
   }
 });
 
-test("issue 614: a materialized launch whose transcript a scoped scan omits keeps its window until the live conversation is in the response", () => {
+test("issues 614 and 1108: a readable transcript omitted by a scoped scan keeps the window on its real path", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-614-pre-adoption-continuity-"));
   const artifactPath = path.join(directory, "019f8dbe_e6cc_9e62_40df_06fb8f88b8a1.jsonl");
   try {
@@ -325,13 +466,14 @@ test("issue 614: a materialized launch whose transcript a scoped scan omits keep
     const snapshot = registry.snapshot();
     expect(snapshot.receipts[begun.receipt.launchId]?.artifactLifecycle).toBe("materialized");
 
-    /* The #614 vanish: inventory materialized the transcript, but the canonical
-       project poll that the operator is watching has not carried it yet. The
-       window must NOT blink out — the launch keeps its window while the
-       transcript still exists on disk and the launch is recent. */
+    /* Inventory materialized the transcript while the canonical project poll
+       still omitted it. The launch keeps one stable window and advances that
+       window to the readable transcript path during the active adoption grace. */
     const gap = projectLaunchConversations([], snapshot, createdMs + 17_000);
     expect(gap.cards).toHaveLength(1);
-    expect(gap.cards[0]!).toMatchObject({ path: `spawn:${begun.receipt.launchId}` });
+    expect(gap.cards[0]!).toMatchObject({ path: artifactPath, conversationId: begun.receipt.conversationId });
+    expect(gap.cards[0]!.spawn).toBeUndefined();
+    expect(gap.facts.get(artifactPath)).toMatchObject({ state: "recovered", initialMessage: "delivered" });
 
     /* The receipt-to-transcript handoff in ONE response: the live transcript
        arrives, the launch folds into that single window as transient facts, and
@@ -400,10 +542,15 @@ test("issue 615 HIGH1: the launch prompt projects from the durable display paylo
 
     const scanLag = projectLaunchConversations([], snapshot, createdMs + 20_000);
     expect(scanLag.cards).toHaveLength(1);
-    expect(scanLag.cards[0]!.spawn).toMatchObject({ prompt: "LLV615_RAW_PROMPT", promptImages: 2, promptEcho: "scaffold\n\nLLV615_RAW_PROMPT" });
-    /* The delivered receipt time is projected so the client can settle the launch
-       bubble even when the transcript echo never matches (issue #648). */
-    const deliveredAt = scanLag.cards[0]!.spawn!.deliveredAt;
+    expect(scanLag.cards[0]!).toMatchObject({ path: artifactPath, conversationId: begun.receipt.conversationId });
+    const scanLagFacts = scanLag.facts.get(artifactPath)!;
+    expect(scanLagFacts).toMatchObject({ state: "recovered" });
+    expect(scanLagFacts.prompt).toBeUndefined();
+    expect(scanLagFacts.promptEcho).toBeUndefined();
+    expect(scanLagFacts.promptImages).toBeUndefined();
+    /* The delivered receipt time remains available after the readable transcript
+       path takes over the window (issue #648). */
+    const deliveredAt = scanLagFacts.deliveredAt;
     expect(typeof deliveredAt).toBe("number");
     expect(Number.isFinite(deliveredAt)).toBe(true);
 

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expect, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { activityVerdict } from "@/lib/scanner/activity";
 import type { FileEntry } from "@/lib/types";
 
 import { AgentRegistry } from "./registry";
@@ -283,6 +284,44 @@ test("issue 1108: scanner adoption replaces the synthesized transcript without d
     });
     expect(indexed.facts.has(artifactPath)).toBe(true);
     expect(probes).toBe(0);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 1108 review: stale terminal turn evidence yields to an artifact changed before scanner adoption", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1108-stale-turn-evidence-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  const observedAtMs = Date.now();
+  try {
+    fs.writeFileSync(artifactPath, [
+      JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }),
+      JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }),
+      "",
+    ].join("\n"));
+    fs.utimesSync(artifactPath, new Date(observedAtMs - 1_000), new Date(observedAtMs - 1_000));
+    const launch = settledLaunch(directory, artifactPath);
+    launch.registry.reconcileConversations([{
+      engine: "codex",
+      path: artifactPath,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      turn: { state: "terminal", source: "lifecycle", terminalAt: new Date(observedAtMs - 1_000).toISOString() },
+      observedAt: new Date(observedAtMs).toISOString(),
+    }]);
+
+    fs.appendFileSync(artifactPath, `${JSON.stringify({ type: "event_msg", payload: { type: "task_started" } })}\n`);
+    const changedMtimeMs = observedAtMs + 1_000;
+    fs.utimesSync(artifactPath, new Date(changedMtimeMs), new Date(changedMtimeMs));
+    const stat = fs.statSync(artifactPath);
+    const scanner = activityVerdict("codex-sessions", artifactPath, stat.mtimeMs / 1_000, stat.size);
+    expect(scanner).toMatchObject({ state: "live", reason: "jsonl_turn_open" });
+
+    const projected = projectLaunchConversations([], launch.registry.snapshot(), changedMtimeMs + 1_000).cards[0]!;
+    expect(projected).toMatchObject({
+      activity: scanner.state,
+      activityReason: "mtime_fresh",
+    });
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -184,13 +184,20 @@ function authoritativeArtifactPath(
 function scannerCompatibleActivity(
   snapshot: RegistryFile,
   receipt: SpawnReceipt,
-  mtime: number,
+  mtimeMs: number,
   nowMs: number,
 ): Pick<FileEntry, "activity" | "activityReason"> {
   const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   const conversationId = lookup.canonicalConversationId(receipt.conversationId);
-  const turn = lookup.conversation(conversationId)?.turn;
-  const age = nowMs / 1_000 - mtime;
+  const observedTurn = lookup.conversation(conversationId)?.turn;
+  const turnObservedAtMs = Date.parse(observedTurn?.observedAt ?? "");
+  /* Conversation turn state can lag an actively growing artifact between
+     inventory passes. Reuse it only when its observation covers this stat;
+     otherwise the scanner's mtime tiers are the shared bounded fallback. */
+  const turn = Number.isFinite(turnObservedAtMs) && turnObservedAtMs >= Math.trunc(mtimeMs)
+    ? observedTurn
+    : null;
+  const age = (nowMs - mtimeMs) / 1_000;
   if (turn?.state === "busy") {
     return age < 180
       ? { activity: "live", activityReason: "jsonl_turn_open" }
@@ -226,7 +233,7 @@ function projectedTranscriptEntry(
   if (probe && typeof probe === "object") {
     entry.mtime = probe.mtimeMs / 1000;
     entry.size = probe.size;
-    Object.assign(entry, scannerCompatibleActivity(snapshot, receipt, entry.mtime, nowMs));
+    Object.assign(entry, scannerCompatibleActivity(snapshot, receipt, probe.mtimeMs, nowMs));
   }
   return entry;
 }

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -149,30 +149,111 @@ function launchFactsWithoutPrompt(spawn: StructuredSpawnCardState): StructuredSp
   return facts;
 }
 
+type ArtifactProbeResult = Pick<fs.Stats, "mtimeMs" | "size"> | boolean | null;
+
+type MaterializedEntry = {
+  entry: FileEntry | null;
+  projected: boolean;
+  artifactPresent: boolean;
+};
+
+/** One authoritative artifact path for this launch. The exact registered
+    generation wins, followed by the runtime registry entry and receipt path.
+    The newest conversation generation covers legacy receipts whose native key
+    was never persisted. Selecting once bounds projection to one disk probe. */
+function authoritativeArtifactPath(
+  snapshot: RegistryFile,
+  receipt: SpawnReceipt,
+): string | null {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const conversationId = lookup.canonicalConversationId(receipt.conversationId);
+  const generations = lookup.conversation(conversationId)?.generations ?? [];
+  const exactGeneration = receipt.key
+    ? generations.find((generation) => generation.id === receipt.key?.sessionId)
+    : undefined;
+  const runtimeEntry = receipt.key
+    ? snapshot.entries[`${receipt.key.engine}:${receipt.key.sessionId}`]
+    : undefined;
+  return exactGeneration?.path
+    ?? runtimeEntry?.artifactPath
+    ?? receipt.artifactPath
+    ?? generations.at(-1)?.path
+    ?? null;
+}
+
+/** Minimal transcript identity used during scanner lag. Scanner-derived fields
+    replace these values when its row arrives; conversation identity, generation,
+    launch activity, project placement, and lineage remain stable throughout. */
+function projectedTranscriptEntry(
+  snapshot: RegistryFile,
+  receipt: SpawnReceipt,
+  spawn: StructuredSpawnCardState,
+  scannedPaths: ReadonlySet<string>,
+  nowMs: number,
+  artifactPath: string,
+  probe: ArtifactProbeResult,
+): FileEntry {
+  const entry = spawnCard(snapshot, receipt, spawn, scannedPaths, nowMs);
+  entry.path = artifactPath;
+  entry.name = path.basename(artifactPath);
+  delete entry.spawn;
+  if (probe && typeof probe === "object") {
+    entry.mtime = probe.mtimeMs / 1000;
+    entry.size = probe.size;
+  }
+  return entry;
+}
+
 /** The scanned transcript entry that already represents a launch's conversation.
     A `spawn:` placeholder is never itself an answer here — it IS the projection
     this lookup decides against. Resolution runs off the durable conversation
     record (its generations, newest first) so it works before `/api/files`
-    annotates `conversationId` onto scanned entries, with the receipt's own
-    artifact path and an already-annotated id as fallbacks. */
+    annotates `conversationId` onto scanned entries. During scanner lag, one
+    readable-file probe creates the same transcript identity immediately. */
 function materializedEntry(
   byPath: ReadonlyMap<string, FileEntry>,
   files: readonly FileEntry[],
   snapshot: RegistryFile,
   receipt: SpawnReceipt,
-): FileEntry | null {
+  spawn: StructuredSpawnCardState,
+  scannedPaths: ReadonlySet<string>,
+  nowMs: number,
+  artifactProbe: (pathname: string) => ArtifactProbeResult,
+): MaterializedEntry {
   const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   const conversationId = lookup.canonicalConversationId(receipt.conversationId);
   const generations = lookup.conversation(conversationId)?.generations ?? [];
+  const artifactPath = authoritativeArtifactPath(snapshot, receipt);
+  if (artifactPath && !isSpawnPlaceholderPath(artifactPath)) {
+    const scanned = byPath.get(artifactPath);
+    if (scanned && !isSpawnPlaceholderPath(scanned.path)) {
+      return { entry: scanned, projected: false, artifactPresent: true };
+    }
+    const probe = artifactProbe(artifactPath);
+    if (probe) {
+      const projectsTranscript = receipt.artifactLifecycle === "pending" || withinAdoptionGrace(receipt, nowMs);
+      if (!projectsTranscript) return { entry: null, projected: false, artifactPresent: true };
+      return {
+        entry: projectedTranscriptEntry(snapshot, receipt, spawn, scannedPaths, nowMs, artifactPath, probe),
+        projected: true,
+        artifactPresent: true,
+      };
+    }
+  }
   for (let index = generations.length - 1; index >= 0; index -= 1) {
     const candidate = byPath.get(generations[index]!.path);
-    if (candidate && !isSpawnPlaceholderPath(candidate.path)) return candidate;
+    if (candidate && !isSpawnPlaceholderPath(candidate.path)) {
+      return { entry: candidate, projected: false, artifactPresent: false };
+    }
   }
   if (receipt.artifactPath) {
     const candidate = byPath.get(receipt.artifactPath);
-    if (candidate && !isSpawnPlaceholderPath(candidate.path)) return candidate;
+    if (candidate && !isSpawnPlaceholderPath(candidate.path)) {
+      return { entry: candidate, projected: false, artifactPresent: false };
+    }
   }
-  return files.find((file) => file.conversationId === conversationId && !isSpawnPlaceholderPath(file.path)) ?? null;
+  const annotated = files.find((file) => file.conversationId === conversationId && !isSpawnPlaceholderPath(file.path)) ?? null;
+  return { entry: annotated, projected: false, artifactPresent: false };
 }
 
 /** A projected launch placeholder path (`spawn:<launchId>`). */
@@ -252,15 +333,15 @@ function withinAdoptionGrace(receipt: SpawnReceipt, nowMs: number): boolean {
   return !Number.isFinite(createdMs) || nowMs - createdMs < TERMINAL_SPAWN_RECENT_MS;
 }
 
-/** Disk existence of a materialized artifact, the discriminator between the
-    #614 pre-adoption gap (the transcript exists but this scan omitted it — keep
-    the window) and a deleted transcript (gone — retire the window). Injected so
-    the projection stays a deterministic read model in tests. */
-function artifactOnDisk(pathname: string): boolean {
+/** One stat plus a read-access check verifies the authoritative artifact and
+    captures the minimal metadata for its temporary transcript row. */
+function readableArtifact(pathname: string): ArtifactProbeResult {
   try {
-    return fs.existsSync(pathname);
+    const stat = fs.statSync(pathname);
+    fs.accessSync(pathname, fs.constants.R_OK);
+    return stat.isFile() ? { mtimeMs: stat.mtimeMs, size: stat.size } : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -271,8 +352,8 @@ function artifactOnDisk(pathname: string): boolean {
  * - `facts` — the live transcript already represents this conversation, so the
  *   launch contributes transient status chips INSIDE that conversation window.
  *   It never projects a second board entry.
- * - `cards` — nothing has materialized yet, so the launch itself projects the
- *   conversation window in its earliest state.
+ * - `cards` — projection-owned rows: the launch placeholder while no readable
+ *   artifact exists, then a minimal real-path row until the scanner carries it.
  * - `routes` — `spawn:<launchId>` → canonical conversation id, so a refresh or
  *   a copied launch deep link resolves to the live conversation for as long as
  *   the receipt is board history at all.
@@ -289,7 +370,7 @@ export function projectLaunchConversations(
   files: readonly FileEntry[],
   snapshot: RegistryFile,
   nowMs = Date.now(),
-  artifactExists: (pathname: string) => boolean = artifactOnDisk,
+  artifactProbe: (pathname: string) => ArtifactProbeResult = readableArtifact,
 ): LaunchProjection {
   const byPath = new Map(files.map((file) => [file.path, file]));
   const scannedPaths = new Set(byPath.keys());
@@ -306,9 +387,21 @@ export function projectLaunchConversations(
        Retirement happens ONLY here — when the adopted live conversation is
        available in the SAME response — so the window never blinks out before its
        transcript reaches the view. */
-    const live = materializedEntry(byPath, files, snapshot, receipt);
-    if (live) {
-      if (transientLaunchFact(spawn, receipt.createdAt, nowMs)) facts.set(live.path, launchFactsWithoutPrompt(spawn));
+    const materialized = materializedEntry(
+      byPath,
+      files,
+      snapshot,
+      receipt,
+      spawn,
+      scannedPaths,
+      nowMs,
+      artifactProbe,
+    );
+    if (materialized.entry) {
+      if (materialized.projected) cards.push(materialized.entry);
+      if (transientLaunchFact(spawn, receipt.createdAt, nowMs)) {
+        facts.set(materialized.entry.path, launchFactsWithoutPrompt(spawn));
+      }
       continue;
     }
     /* No live transcript in this payload: the launch still owns the window
@@ -321,8 +414,7 @@ export function projectLaunchConversations(
        of resurrecting a phantom placeholder. A still-`pending` launch always
        projects — inventory has never materialized its artifact. */
     if (receipt.artifactLifecycle !== "pending") {
-      const present = Boolean(receipt.artifactPath && artifactExists(receipt.artifactPath));
-      if (!present || !withinAdoptionGrace(receipt, nowMs)) continue;
+      if (!materialized.artifactPresent || !withinAdoptionGrace(receipt, nowMs)) continue;
     }
     cards.push(spawnCard(snapshot, receipt, spawn, scannedPaths, nowMs));
   }

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -159,8 +159,9 @@ type MaterializedEntry = {
 
 /** One authoritative artifact path for this launch. The exact registered
     generation wins, followed by the runtime registry entry and receipt path.
-    The newest conversation generation covers legacy receipts whose native key
-    was never persisted. Selecting once bounds projection to one disk probe. */
+    Every candidate is correlated to this receipt; an unrelated newest
+    conversation generation can never retire a fresh placeholder. Selecting
+    once bounds projection to one disk probe. */
 function authoritativeArtifactPath(
   snapshot: RegistryFile,
   receipt: SpawnReceipt,
@@ -177,8 +178,33 @@ function authoritativeArtifactPath(
   return exactGeneration?.path
     ?? runtimeEntry?.artifactPath
     ?? receipt.artifactPath
-    ?? generations.at(-1)?.path
     ?? null;
+}
+
+function scannerCompatibleActivity(
+  snapshot: RegistryFile,
+  receipt: SpawnReceipt,
+  mtime: number,
+  nowMs: number,
+): Pick<FileEntry, "activity" | "activityReason"> {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const conversationId = lookup.canonicalConversationId(receipt.conversationId);
+  const turn = lookup.conversation(conversationId)?.turn;
+  const age = nowMs / 1_000 - mtime;
+  if (turn?.state === "busy") {
+    return age < 180
+      ? { activity: "live", activityReason: "jsonl_turn_open" }
+      : { activity: "stalled", activityReason: "jsonl_turn_stalled" };
+  }
+  if (turn?.state === "terminal") {
+    return {
+      activity: age < 900 ? "recent" : "idle",
+      activityReason: "jsonl_turn_completed",
+    };
+  }
+  if (age < 20) return { activity: "live", activityReason: "mtime_fresh" };
+  if (age < 900) return { activity: "recent", activityReason: "mtime_recent" };
+  return { activity: "idle", activityReason: "mtime_old" };
 }
 
 /** Minimal transcript identity used during scanner lag. Scanner-derived fields
@@ -200,19 +226,17 @@ function projectedTranscriptEntry(
   if (probe && typeof probe === "object") {
     entry.mtime = probe.mtimeMs / 1000;
     entry.size = probe.size;
+    Object.assign(entry, scannerCompatibleActivity(snapshot, receipt, entry.mtime, nowMs));
   }
   return entry;
 }
 
-/** The scanned transcript entry that already represents a launch's conversation.
-    A `spawn:` placeholder is never itself an answer here — it IS the projection
-    this lookup decides against. Resolution runs off the durable conversation
-    record (its generations, newest first) so it works before `/api/files`
-    annotates `conversationId` onto scanned entries. During scanner lag, one
-    readable-file probe creates the same transcript identity immediately. */
+/** The receipt-correlated transcript entry for a launch. A `spawn:` placeholder
+    is never itself an answer here. A scanned row wins when its path matches the
+    receipt's authoritative evidence; during scanner lag, one readable-file
+    probe creates the same transcript identity immediately. */
 function materializedEntry(
   byPath: ReadonlyMap<string, FileEntry>,
-  files: readonly FileEntry[],
   snapshot: RegistryFile,
   receipt: SpawnReceipt,
   spawn: StructuredSpawnCardState,
@@ -220,9 +244,6 @@ function materializedEntry(
   nowMs: number,
   artifactProbe: (pathname: string) => ArtifactProbeResult,
 ): MaterializedEntry {
-  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
-  const conversationId = lookup.canonicalConversationId(receipt.conversationId);
-  const generations = lookup.conversation(conversationId)?.generations ?? [];
   const artifactPath = authoritativeArtifactPath(snapshot, receipt);
   if (artifactPath && !isSpawnPlaceholderPath(artifactPath)) {
     const scanned = byPath.get(artifactPath);
@@ -240,20 +261,7 @@ function materializedEntry(
       };
     }
   }
-  for (let index = generations.length - 1; index >= 0; index -= 1) {
-    const candidate = byPath.get(generations[index]!.path);
-    if (candidate && !isSpawnPlaceholderPath(candidate.path)) {
-      return { entry: candidate, projected: false, artifactPresent: false };
-    }
-  }
-  if (receipt.artifactPath) {
-    const candidate = byPath.get(receipt.artifactPath);
-    if (candidate && !isSpawnPlaceholderPath(candidate.path)) {
-      return { entry: candidate, projected: false, artifactPresent: false };
-    }
-  }
-  const annotated = files.find((file) => file.conversationId === conversationId && !isSpawnPlaceholderPath(file.path)) ?? null;
-  return { entry: annotated, projected: false, artifactPresent: false };
+  return { entry: null, projected: false, artifactPresent: false };
 }
 
 /** A projected launch placeholder path (`spawn:<launchId>`). */
@@ -389,7 +397,6 @@ export function projectLaunchConversations(
        transcript reaches the view. */
     const materialized = materializedEntry(
       byPath,
-      files,
       snapshot,
       receipt,
       spawn,


### PR DESCRIPTION
## Summary

- Retire a structured launch placeholder in the same projection pass once its receipt-correlated registry or runtime artifact path is a readable file.
- Preserve conversation identity while rejecting unrelated prior generations for keyed-mismatch and unbound-launch cases.
- Derive synthesized transcript activity from stat age and durable turn evidence with scanner-compatible states.
- Preserve missing-artifact, bounded-probe, adoption-grace, and scanner deduplication behavior.

## Verification

- Focused spawn projection and bounded-failure tests: 35 passed
- TypeScript: `bunx tsc --noEmit --incremental false`
- Production build: `bun run build`
- Publication privacy gate against the merge base

Fixes #1108
