### PR TITLE
fix(flows): retry review host claims and ingest hidden verdicts

### DIFF
--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -226,6 +226,7 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
       return identity ? { ...identity, prNumber: null, mergedAt: null, checkedAt: null, source: null } : null;
     })(),
     kickoffDelivery: null,
+    hostClaim: null,
     rounds: [],
     createdAt: isoNow(),
     closedAt: null,

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -1413,17 +1413,17 @@ test("a definitive structured journal rejection retries with a fresh identity an
   const journal = new RuntimeJournal(path.join(process.env.LLV_STATE_DIR!, "relay-retry-runtime.sqlite"), { structuredHosts: true });
   const registry = agentRegistry();
   const sessionId = ["079f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-");
-  const implementer = writeCodexEntry("relay-retry-implementer.jsonl", {
+  const implementer = writeCodexEntry(`relay-retry-${sessionId}.jsonl`, {
     id: sessionId,
     cwd: "/repo",
   }, Date.now() / 1_000);
-  const conversation = registry.ensureConversation("codex", implementer.path, null);
+  const conversation = registry.ensureConversation("codex", implementer.path, "account-a");
   const launchProfile = emptyLaunchProfile({ cwd: "/repo" });
   registry.upsert({
     key: { engine: "codex", sessionId },
     artifactPath: implementer.path,
     cwd: "/repo",
-    accountId: null,
+    accountId: "account-a",
     launchProfile,
     status: "idle",
     host: null,
@@ -1504,23 +1504,33 @@ test("a definitive structured journal rejection retries with a fresh identity an
   try {
     await tickFlows([implementer]);
     const retrying = loadFlows()[0]!;
+    const retryDetail = retrying.stateDetail ?? "";
+    const accountRef = retrying.hostClaim?.accountRef ?? "";
     expect(retrying).toMatchObject({
       state: "relaying",
       pausedState: null,
       stateDetail: expect.stringContaining("retrying automatically (1/3)"),
+      hostClaim: {
+        sessionKey: `codex:${sessionId}`,
+        accountRef: expect.stringMatching(/^managed:[0-9a-f]{12}$/),
+      },
       rounds: [{
         relayRetryCount: 1,
         relayDeliveryAttempt: 1,
         relayRetryAt: expect.any(String),
         relayStartedAt: null,
         relayedAt: null,
-        error: "structured resume host claim is unavailable",
+        error: expect.stringContaining(`structured host claim codex:${sessionId}`),
       }],
     });
+    expect(retryDetail.includes(`structured host claim codex:${sessionId}`)).toBe(true);
+    expect(retryDetail.includes(accountRef)).toBe(true);
+    expect(retryDetail.includes("account-a")).toBe(false);
     expect(commands).toHaveLength(1);
 
-    Object.assign(retrying.rounds[0]!, { relayRetryAt: "2026-08-05T20:47:08.000Z" });
-    saveFlows([retrying]);
+    const readyToRetry = loadFlows()[0]!;
+    Object.assign(readyToRetry.rounds[0]!, { relayRetryAt: "2026-08-05T20:47:08.000Z" });
+    saveFlows([readyToRetry]);
     await tickFlows([implementer]);
 
     expect(commands).toHaveLength(2);
@@ -1547,6 +1557,72 @@ test("a definitive structured journal rejection retries with a fresh identity an
   } finally {
     restoreDelivery();
     journal.close();
+  }
+});
+
+test("a deterministic structured host claim failure exhausts bounded retries with the same safe claim identity (#921)", async () => {
+  const registry = agentRegistry();
+  const sessionId = ["179f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-");
+  const implementer = writeCodexEntry(`claim-exhaustion-${sessionId}.jsonl`, {
+    id: sessionId,
+    cwd: "/repo",
+  }, Date.now() / 1_000);
+  const conversation = registry.ensureConversation("codex", implementer.path, "account-a");
+  let sends = 0;
+  const restoreDelivery = setRelayDeliveryForTest(async (flow, entries, text, options) => sendToImplementer(flow, entries, text, {
+    ...options,
+    recover: async () => {
+      sends += 1;
+      throw new Error("structured resume host claim is unavailable");
+    },
+    enqueueStructured: async () => { throw new Error("claim failure reached delivery actuation"); },
+  }));
+  const findingsPath = path.join(process.env.LLV_STATE_DIR!, "claim-exhaustion-findings.md");
+  fs.writeFileSync(findingsPath, "VERDICT: REQUEST_CHANGES\n\nRepair the deterministic claim failure.\n");
+  saveFlows([raceFlow({
+    id: "flow-claim-exhaustion",
+    implementerPath: implementer.path,
+    implementerConversationId: conversation.id,
+    state: "relaying",
+    rounds: [{
+      ...newRound(raceFlow({ rounds: [] }), "marker", "head ready"),
+      findingsPath,
+      verdict: "REQUEST_CHANGES",
+      findingsCount: 1,
+      reviewedAt: "2026-08-06T14:19:00.000Z",
+      terminalAt: "2026-08-06T14:19:00.000Z",
+    }],
+  })]);
+
+  try {
+    for (let failure = 1; failure <= 4; failure += 1) {
+      await tickFlows([implementer]);
+      const current = loadFlows()[0]!;
+      const accountRef = current.hostClaim?.accountRef ?? "";
+      const expectedClaim = `structured host claim codex:${sessionId} on account ${accountRef}`;
+      expect(current.hostClaim?.sessionKey).toBe(`codex:${sessionId}`);
+      expect(accountRef).toMatch(/^managed:[0-9a-f]{12}$/);
+      expect((current.stateDetail ?? "").includes(expectedClaim)).toBe(true);
+      expect((current.stateDetail ?? "").includes("account-a")).toBe(false);
+      if (failure <= 3) {
+        expect(current).toMatchObject({
+          state: "relaying",
+          rounds: [{ relayRetryCount: failure, relayRetryAt: expect.any(String) }],
+        });
+        const readyToRetry = loadFlows()[0]!;
+        readyToRetry.rounds[0]!.relayRetryAt = "2026-08-06T14:19:01.000Z";
+        saveFlows([readyToRetry]);
+      } else {
+        expect(current).toMatchObject({
+          state: "needs_decision",
+          stateDetail: expect.stringContaining("relay delivery failed after 3 automatic retries"),
+          rounds: [{ relayRetryCount: 3, relayRetryAt: null, error: expect.stringContaining(expectedClaim) }],
+        });
+      }
+    }
+    expect(sends).toBe(4);
+  } finally {
+    restoreDelivery();
   }
 });
 

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -6,8 +6,8 @@ import { freshSpecFor, resumeSpecFor } from "@/lib/agent/cli";
 import { accountManager } from "@/lib/accounts/manager";
 import type { AccountContext } from "@/lib/accounts/contracts";
 import { deliverToTranscriptHost } from "@/lib/agent/transcriptHost";
-import { agentRegistry, type AgentRegistry, type SpawnBeginResult, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
-import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
+import { agentRegistry, type AgentRegistry, type RegistryConversation, type SpawnBeginResult, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { headCwd } from "@/lib/agent/transcript";
 import { isNativeCodexSubagentTranscript } from "@/lib/scanner/codexNative";
@@ -106,6 +106,7 @@ function cloneFlows(flows: Flow[]): Flow[] {
       implementer: { ...flow.roles.implementer },
       reviewer: { ...flow.roles.reviewer },
     },
+    hostClaim: flow.hostClaim ? { ...flow.hostClaim } : null,
     reviewerFallback: flow.reviewerFallback ? { ...flow.reviewerFallback } : null,
     rounds: flow.rounds.map((round) => ({
       ...round,
@@ -294,6 +295,28 @@ function currentConversationPath(conversationId: string | null | undefined, fall
   return agentRegistry().canonicalPath(fallback);
 }
 
+function safeAccountRef(accountId: string | null | undefined): NonNullable<Flow["hostClaim"]>["accountRef"] {
+  if (!accountId) return "unknown";
+  if (accountId === "default") return "default";
+  return `managed:${crypto.createHash("sha256").update(accountId).digest("hex").slice(0, 12)}`;
+}
+
+function rememberImplementerHostClaim(flow: Flow, conversation: RegistryConversation | null): void {
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) return;
+  flow.hostClaim = {
+    sessionKey: sessionKeyId({ engine: conversation.engine, sessionId: generation.id }),
+    accountRef: safeAccountRef(generation.accountId ?? conversation.pinnedAccountId ?? null),
+  };
+}
+
+function claimFailureDetail(flow: Flow, detail: string): string {
+  if (!flow.hostClaim || !/structured (?:resume )?host claim is unavailable|structured host ownership is unavailable/i.test(detail)) {
+    return detail;
+  }
+  return `structured host claim ${flow.hostClaim.sessionKey} on account ${flow.hostClaim.accountRef} failed: ${detail}`;
+}
+
 export interface RelayDeliveryOverrides {
   recover?: typeof recoverDeadStructuredConversation;
   enqueueStructured?: typeof enqueueStructuredMessage;
@@ -337,10 +360,17 @@ export async function sendToImplementer(
     ? registry.conversation(flow.implementerConversationId as `conversation_${string}`)
     : registry.conversationForPath(entry.path);
   if (conversation) {
-    const recovered = await (overrides.recover ?? recoverDeadStructuredConversation)(
-      { path: entry.path, conversationId: conversation.id },
-      { registry },
-    );
+    rememberImplementerHostClaim(flow, conversation);
+    let recovered;
+    try {
+      recovered = await (overrides.recover ?? recoverDeadStructuredConversation)(
+        { path: entry.path, conversationId: conversation.id },
+        { registry },
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(claimFailureDetail(flow, detail), { cause: error });
+    }
     if (recovered) {
       overrides.onTransportSelected?.("structured");
       const structured = await (overrides.enqueueStructured ?? enqueueStructuredMessage)(
@@ -357,10 +387,11 @@ export async function sendToImplementer(
         if (structured.transportUncertain || structured.receipt?.status === "uncertain") {
           throw new StructuredRelayDeliveryUncertainError(structured.error);
         }
-        throw new Error(structured.error);
+        throw new Error(claimFailureDetail(flow, structured.error));
       }
       return recovered.path;
     }
+    flow.hostClaim = null;
   }
   /* A restart leaves an uncertain send window. The structured queue dedupes
      the stable client-message id above; legacy pane delivery has no comparable

--- a/src/lib/flows/store.test.ts
+++ b/src/lib/flows/store.test.ts
@@ -148,6 +148,7 @@ test("flow specs persist in SQLite and legacy flow entries import on first boot"
       reviewerFallback: configuredReviewerFallback(),
       pausedState: null,
       kickoffDelivery: null,
+      hostClaim: null,
     }]);
   } finally {
     if (previousState === undefined) delete process.env.LLV_STATE_DIR;

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -100,6 +100,8 @@ export const FLOWS_SCHEMA_VERSION = 3;
 
 type FlowFile = { schemaVersion?: unknown; flows?: unknown };
 type PresetFile = { presets?: unknown };
+const SAFE_HOST_CLAIM_SESSION = /^(?:claude|codex):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const SAFE_HOST_CLAIM_ACCOUNT = /^(?:default|unknown|managed:[0-9a-f]{12})$/;
 
 function atomicWriteJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -150,6 +152,10 @@ function isFlow(value: unknown): value is Flow {
     (flow.headRef === undefined || flow.headRef === null || typeof flow.headRef === "string") &&
     (flow.targetSha === undefined || flow.targetSha === null || typeof flow.targetSha === "string") &&
     (flow.spec === undefined || typeof flow.spec === "string") &&
+    (flow.hostClaim === undefined || flow.hostClaim === null || (
+      SAFE_HOST_CLAIM_SESSION.test(flow.hostClaim.sessionKey)
+      && SAFE_HOST_CLAIM_ACCOUNT.test(flow.hostClaim.accountRef)
+    )) &&
     Array.isArray(flow.rounds)
   );
 }
@@ -204,7 +210,11 @@ function flowsFileSignature(): string {
     records stay pristine while callers mutate and save their copies. Deeper
     config leaves are shared; nothing mutates their internals in place. */
 function reviveCachedFlows(flows: Flow[]): Flow[] {
-  return flows.map((flow) => ({ ...flow, rounds: flow.rounds.map((round) => ({ ...round })) }));
+  return flows.map((flow) => ({
+    ...flow,
+    hostClaim: flow.hostClaim ? { ...flow.hostClaim } : null,
+    rounds: flow.rounds.map((round) => ({ ...round })),
+  }));
 }
 
 /** The normalized flow projection keeps the signature cache introduced for
@@ -269,6 +279,7 @@ function parseFlowsFromDisk(): Flow[] {
       : flow.reviewerFallback ?? null,
     pausedState: flow.pausedState ?? null,
     kickoffDelivery: flow.kickoffDelivery ?? null,
+    hostClaim: flow.hostClaim ?? null,
     rounds: flow.rounds.map((round) => ({
       ...round,
       reviewerConversationId: round.reviewerConversationId ?? null,
@@ -318,6 +329,7 @@ function decodeFlow(value: unknown): Flow | null {
       : flow.reviewerFallback ?? null,
     pausedState: flow.pausedState ?? null,
     kickoffDelivery: flow.kickoffDelivery ?? null,
+    hostClaim: flow.hostClaim ?? null,
     rounds: flow.rounds.map((round) => ({
       ...round,
       reviewerConversationId: round.reviewerConversationId ?? null,

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -35,6 +35,14 @@ export type ViewerFlowDelivery = {
   deliveredAt: string;
 };
 
+/** Safe durable address of the structured implementer host a flow tried to
+    claim. Managed account ids are label-derived, so the public flow record
+    carries only a stable digest instead of the raw id. */
+export type FlowHostClaim = {
+  sessionKey: string;
+  accountRef: "default" | "unknown" | `managed:${string}`;
+};
+
 export type RelayDeliveryTransport = "structured" | "legacy";
 
 export type FlowBlock = {
@@ -173,6 +181,8 @@ export type Flow = {
   mergeEvidence?: FlowMergeEvidence | null;
   /** Exact transcript generation that received the Viewer-generated kickoff. */
   kickoffDelivery?: ViewerFlowDelivery | null;
+  /** Latest structured implementer-host claim selected by kickoff or relay. */
+  hostClaim?: FlowHostClaim | null;
   rounds: Round[];
   createdAt: string;
   closedAt: string | null;

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3260,6 +3260,49 @@ test("a paused review flow parks its pipeline", async () => {
   expect(loadPipelines()[0]!.stateDetail).toContain("kickoff delivery failed");
 });
 
+test("a review-flow host claim retry keeps the stage running with the safe claim detail (#921)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  const claim = {
+    sessionKey: `codex:${["179f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-")}`,
+    accountRef: "managed:fc164f825080",
+  } as const;
+  flow.hostClaim = claim;
+  flow.state = "relaying";
+  flow.stateDetail = `relay delivery failed; retrying automatically (2/3): structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
+
+  await tickPipelines([], h.ports);
+
+  const retrying = loadPipelines()[0]!;
+  expect(retrying).toMatchObject({
+    state: "running",
+    stateDetail: `review flow host claim retry: ${flow.stateDetail}`,
+  });
+  expect(retrying.runs[1]!.attempts[0]).toMatchObject({
+    state: "reviewing",
+    error: null,
+    reviewFlowSync: {
+      relayState: "relaying",
+      hostClaim: claim,
+    },
+  });
+
+  flow.state = "fixing";
+  flow.stateDetail = null;
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]).toMatchObject({ state: "running", stateDetail: null });
+});
+
 test("a bound review flow paused while relaying resumes without operator action", async () => {
   const h = harness();
   const stages = [
@@ -3339,6 +3382,101 @@ test("a bound review flow paused while relaying resumes without operator action"
     error: null,
   });
   expect(loadPipelines()[0]).toMatchObject({ state: "running", stateDetail: null });
+});
+
+test("a parked review stage settles from the latest of ten completed flow verdicts (#921)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  const claim = {
+    sessionKey: `codex:${["279f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-")}`,
+    accountRef: "managed:fc164f825080",
+  } as const;
+  flow.hostClaim = claim;
+  flow.state = "paused";
+  flow.pausedState = "relaying";
+  flow.stateDetail = `structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision" });
+
+  const flowDir = path.join(process.env.LLV_STATE_DIR!, "flows", flow.id);
+  const privateWorktree = path.join(process.env.LLV_STATE_DIR!, "private-worktree");
+  fs.mkdirSync(flowDir, { recursive: true });
+  flow.cwd = privateWorktree;
+  flow.rounds = Array.from({ length: 10 }, (_, index) => {
+    const n = index + 1;
+    const findingsPath = path.join(flowDir, `round-${n}-review.md`);
+    const content = n === 10
+      ? [
+          "VERDICT: REQUEST_CHANGES",
+          "",
+          "### Finding 1",
+          "- **Severity:** High",
+          `- **File:** ${path.join(privateWorktree, "src/lib/claim.ts")}`,
+          "- **Line:** 42",
+          "- **Title:** Claim failure stays invisible",
+          "- **Explanation:** Surface the completed verdict on the stage.",
+          "",
+          "### Finding 2",
+          "- **Severity:** Medium",
+          "- **File:** src/lib/flows/state.ts",
+          "- **Line:** 17",
+          "- **Title:** Round count is stale",
+          "- **Explanation:** Keep the latest completed round authoritative.",
+          "",
+        ].join("\n")
+      : `VERDICT: REQUEST_CHANGES\n\nRound ${n} requested changes.\n`;
+    fs.writeFileSync(findingsPath, content);
+    return {
+      n,
+      verdict: "REQUEST_CHANGES",
+      findingsCount: n === 10 ? 2 : 1,
+      findingsPath,
+      reviewHeadSha: ORIGIN_MAIN_SHA,
+      reviewedAt: `2026-08-06T${String(4 + n).padStart(2, "0")}:19:00.000Z`,
+      terminalAt: `2026-08-06T${String(4 + n).padStart(2, "0")}:19:00.000Z`,
+      reviewerPath: `/codex/reviewer-${n}.jsonl`,
+      reviewerConversationId: `conversation_reviewer_${n}`,
+    } as never;
+  });
+  flow.state = "needs_decision";
+  flow.pausedState = null;
+  flow.stateDetail = `relay delivery failed after 3 automatic retries: structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
+
+  await tickPipelines([entry("/codex/reviewer-10.jsonl")], h.ports);
+
+  const settled = loadPipelines()[0]!;
+  const attempt = settled.runs[1]!.attempts[0]!;
+  expect(settled).toMatchObject({ state: "needs_decision" });
+  expect(attempt).toMatchObject({
+    state: "failed",
+    completedAt: expect.any(String),
+    verdict: {
+      status: "fail",
+      findings: [
+        flow.stateDetail,
+        "High — src/lib/claim.ts:42 — Claim failure stays invisible",
+        "Medium — src/lib/flows/state.ts:17 — Round count is stale",
+      ],
+    },
+    reviewFlowSync: {
+      roundCount: 10,
+      verdict: "REQUEST_CHANGES",
+      hostClaim: claim,
+    },
+  });
+  expect(settled.stateDetail).toBe(flow.stateDetail);
+  expect(attempt.output).toContain("Review flow round 10: REQUEST_CHANGES");
+  expect(JSON.stringify(attempt)).not.toContain(privateWorktree);
 });
 
 test("an operator pause during relay stays paused across pipeline reconciliation", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3413,7 +3413,7 @@ test("a bound review flow paused while relaying resumes without operator action"
   expect(loadPipelines()[0]).toMatchObject({ state: "running", stateDetail: null });
 });
 
-test("a parked review stage ingests ten verdicts across three attempts exactly once (#921)", async () => {
+test("a parked review stage ingests ten verdicts when relay terminalization races ingestion (#921)", async () => {
   const h = harness();
   const stages = [
     { id: "build", kind: "run", prompt: "build", next: "review" },
@@ -3430,6 +3430,7 @@ test("a parked review stage ingests ten verdicts across three attempts exactly o
     accountRef: "managed:fc164f825080",
   } as const;
   const privateWorktree = path.join(process.env.LLV_STATE_DIR!, "private-worktree");
+  const startupClaimError = "review flow paused during startup: structured resume host claim is unavailable";
   let completedRounds = 0;
   const populateRounds = (flow: Flow, count: number): void => {
     const flowDir = path.join(process.env.LLV_STATE_DIR!, "flows", flow.id);
@@ -3470,53 +3471,106 @@ test("a parked review stage ingests ten verdicts across three attempts exactly o
         reviewHeadSha: ORIGIN_MAIN_SHA,
         reviewedAt,
         terminalAt: reviewedAt,
+        relayStartedAt: null,
+        relayDeliveryTransport: null,
+        relayDelivery: null,
+        relayPendingSettlement: null,
+        relayRetryAt: null,
+        relayedAt: null,
+        error: null,
         reviewerPath: `/codex/${flow.id}-reviewer-${n}.jsonl`,
         reviewerConversationId: `conversation_${flow.id}_reviewer_${n}`,
       } as never;
     });
   };
-  const parkAndRetry = async (flow: Flow, rounds: number): Promise<void> => {
-    populateRounds(flow, rounds);
-    flow.state = "done_comment";
+
+  const parkAtStartupClaim = (flow: Flow): void => {
+    flow.cwd = privateWorktree;
+    flow.hostClaim = claim;
+    flow.state = "relaying";
+    flow.pausedState = null;
     flow.stateDetail = null;
-    await tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports);
-    expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision" });
+    const pipeline = loadPipelines()[0]!;
+    const attempt = pipeline.runs[1]!.attempts.at(-1)!;
+    pipeline.state = "needs_decision";
+    pipeline.stateDetail = startupClaimError;
+    attempt.state = "needs_decision";
+    attempt.error = startupClaimError;
+    savePipelines([pipeline]);
+  };
+
+  const recordHiddenRoundsAndRetry = async (flow: Flow, rounds: number): Promise<void> => {
+    parkAtStartupClaim(flow);
+    expect(loadPipelines()[0]).toMatchObject({
+      state: "needs_decision",
+      stateDetail: startupClaimError,
+    });
+
+    /* The incident's round artifacts appeared only after the parent stage had
+       already parked. Keep the flow live while its read projection records the
+       hidden rounds; the operator's retry then closes that attempt. */
+    populateRounds(flow, rounds);
+    const projected = structuredClone(loadPipelines()[0]!);
+    expect(reconcileEmbeddedReviewFlows(
+      [projected],
+      [flow],
+      flow.rounds.at(-1)!.reviewedAt!,
+    )).toBe(true);
+    savePipelines([projected]);
+    expect(loadPipelines()[0]).toMatchObject({
+      state: "needs_decision",
+      stateDetail: startupClaimError,
+    });
+
     await patchPipeline(loadPipelines()[0]!.id, { action: "retry-stage" }, h.ports);
+    expect(flow.state).toBe("closed");
     await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
   };
 
-  await parkAndRetry(h.flows.get("flow-1")!, 2);
-  await parkAndRetry(h.flows.get("flow-2")!, 3);
+  await recordHiddenRoundsAndRetry(h.flows.get("flow-1")!, 2);
+  await recordHiddenRoundsAndRetry(h.flows.get("flow-2")!, 3);
 
   const flow = h.flows.get("flow-3")!;
+  parkAtStartupClaim(flow);
   populateRounds(flow, 5);
   expect(completedRounds).toBe(10);
-  flow.state = "needs_decision";
-  flow.pausedState = null;
-  flow.stateDetail = `relay delivery failed after 3 automatic retries: structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
-
-  /* Exercise the read-side projection before the controller consumes the same
-     terminal generation. Its write must remain compatible with the later
-     one-shot verdict settlement. */
-  const projected = structuredClone(loadPipelines()[0]!);
-  expect(reconcileEmbeddedReviewFlows(
-    [projected],
-    [...h.flows.values()],
-    "2026-08-06T15:20:00.000Z",
-  )).toBe(true);
-  savePipelines([projected]);
-
-  await tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports);
-  expect(loadPipelines()[0]).toMatchObject({
-    state: "needs_decision",
-    stateDetail: expect.stringContaining("review loop ended in needs_decision"),
+  const finalRound = flow.rounds.at(-1)!;
+  finalRound.relayRetryCount = 3;
+  const claimFailure = `structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
+  const terminalDetail = `relay delivery failed after 3 automatic retries: ${claimFailure}`;
+  let releaseRelay!: () => void;
+  let markRelayStarted!: () => void;
+  const relayStarted = new Promise<void>((resolve) => { markRelayStarted = resolve; });
+  const relayReleased = new Promise<void>((resolve) => { releaseRelay = resolve; });
+  const restoreDelivery = setRelayDeliveryForTest(async () => {
+    markRelayStarted();
+    await relayReleased;
+    throw new Error(claimFailure);
   });
 
-  const raced = await Promise.all([
-    tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports),
-    tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports),
-  ]);
-  expect(raced.filter((result) => result.changed)).toHaveLength(1);
+  let flowChanged: boolean;
+  let ingested: Awaited<ReturnType<typeof tickPipelines>>;
+  try {
+    const flowTick = tickFlow(
+      flow,
+      [entry("/codex/stage-1.jsonl")],
+      new Map([["/codex/stage-1.jsonl", entry("/codex/stage-1.jsonl")]]),
+      () => {},
+    );
+    await relayStarted;
+    /* Resolve the in-flight relay immediately before the controller reads the
+       parked stage. The relay exhausts its fourth claim attempt while the
+       controller is entering ingestion, so the terminal flow generation and
+       the parent settlement contend in one real flow/pipeline race. */
+    releaseRelay();
+    const pipelineTick = tickPipelines([entry(finalRound.reviewerPath!)], h.ports);
+    [flowChanged, ingested] = await Promise.all([flowTick, pipelineTick]);
+  } finally {
+    restoreDelivery();
+  }
+  expect(flowChanged).toBe(true);
+  expect(ingested.changed).toBe(true);
+  expect(flow).toMatchObject({ state: "needs_decision", stateDetail: terminalDetail });
 
   const settled = loadPipelines()[0]!;
   const reviewAttempts = settled.runs[1]!.attempts;
@@ -3530,7 +3584,7 @@ test("a parked review stage ingests ten verdicts across three attempts exactly o
     verdict: {
       status: "fail",
       findings: [
-        flow.stateDetail,
+        terminalDetail,
         "High — src/lib/claim.ts:42 — Claim failure stays invisible",
         "Medium — src/lib/flows/state.ts:17 — Round count is stale",
       ],
@@ -3541,7 +3595,9 @@ test("a parked review stage ingests ten verdicts across three attempts exactly o
       hostClaim: claim,
     },
   });
-  expect(settled.stateDetail).toBe(flow.stateDetail);
+  expect(reviewAttempts.filter((candidate) => candidate.verdict !== null)).toHaveLength(1);
+  expect(reviewAttempts.filter((candidate) => candidate.completedAt !== null)).toHaveLength(1);
+  expect(settled.stateDetail).toBe(terminalDetail);
   expect(attempt.output).toContain("Review flow round 5: REQUEST_CHANGES");
   expect(JSON.stringify(attempt)).not.toContain(privateWorktree);
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3303,6 +3303,35 @@ test("a review-flow host claim retry keeps the stage running with the safe claim
   expect(loadPipelines()[0]).toMatchObject({ state: "running", stateDetail: null });
 });
 
+test("an accepted-but-unsettled relay retry is not mislabeled as a host-claim failure (#921, #1065)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  flow.hostClaim = {
+    sessionKey: `codex:${["189f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-")}`,
+    accountRef: "managed:fc164f825080",
+  };
+  flow.state = "relaying";
+  flow.stateDetail = "relay delivery failed; retrying automatically (1/3): structured relay was accepted but never settled in the delivery journal";
+
+  await tickPipelines([], h.ports);
+
+  expect(loadPipelines()[0]).toMatchObject({
+    state: "running",
+    stateDetail: `review flow relay retry: ${flow.stateDetail}`,
+  });
+  expect(loadPipelines()[0]!.stateDetail).not.toContain("host claim retry");
+});
+
 test("a bound review flow paused while relaying resumes without operator action", async () => {
   const h = harness();
   const stages = [
@@ -3384,7 +3413,7 @@ test("a bound review flow paused while relaying resumes without operator action"
   expect(loadPipelines()[0]).toMatchObject({ state: "running", stateDetail: null });
 });
 
-test("a parked review stage settles from the latest of ten completed flow verdicts (#921)", async () => {
+test("a parked review stage ingests ten verdicts across three attempts exactly once (#921)", async () => {
   const h = harness();
   const stages = [
     { id: "build", kind: "run", prompt: "build", next: "review" },
@@ -3396,67 +3425,105 @@ test("a parked review stage settles from the latest of ten completed flow verdic
   await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
-  const flow = h.flows.get("flow-1")!;
   const claim = {
     sessionKey: `codex:${["279f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-")}`,
     accountRef: "managed:fc164f825080",
   } as const;
-  flow.hostClaim = claim;
-  flow.state = "paused";
-  flow.pausedState = "relaying";
-  flow.stateDetail = `structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
-  await tickPipelines([], h.ports);
-  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision" });
-
-  const flowDir = path.join(process.env.LLV_STATE_DIR!, "flows", flow.id);
   const privateWorktree = path.join(process.env.LLV_STATE_DIR!, "private-worktree");
-  fs.mkdirSync(flowDir, { recursive: true });
-  flow.cwd = privateWorktree;
-  flow.rounds = Array.from({ length: 10 }, (_, index) => {
-    const n = index + 1;
-    const findingsPath = path.join(flowDir, `round-${n}-review.md`);
-    const content = n === 10
-      ? [
-          "VERDICT: REQUEST_CHANGES",
-          "",
-          "### Finding 1",
-          "- **Severity:** High",
-          `- **File:** ${path.join(privateWorktree, "src/lib/claim.ts")}`,
-          "- **Line:** 42",
-          "- **Title:** Claim failure stays invisible",
-          "- **Explanation:** Surface the completed verdict on the stage.",
-          "",
-          "### Finding 2",
-          "- **Severity:** Medium",
-          "- **File:** src/lib/flows/state.ts",
-          "- **Line:** 17",
-          "- **Title:** Round count is stale",
-          "- **Explanation:** Keep the latest completed round authoritative.",
-          "",
-        ].join("\n")
-      : `VERDICT: REQUEST_CHANGES\n\nRound ${n} requested changes.\n`;
-    fs.writeFileSync(findingsPath, content);
-    return {
-      n,
-      verdict: "REQUEST_CHANGES",
-      findingsCount: n === 10 ? 2 : 1,
-      findingsPath,
-      reviewHeadSha: ORIGIN_MAIN_SHA,
-      reviewedAt: `2026-08-06T${String(4 + n).padStart(2, "0")}:19:00.000Z`,
-      terminalAt: `2026-08-06T${String(4 + n).padStart(2, "0")}:19:00.000Z`,
-      reviewerPath: `/codex/reviewer-${n}.jsonl`,
-      reviewerConversationId: `conversation_reviewer_${n}`,
-    } as never;
-  });
+  let completedRounds = 0;
+  const populateRounds = (flow: Flow, count: number): void => {
+    const flowDir = path.join(process.env.LLV_STATE_DIR!, "flows", flow.id);
+    fs.mkdirSync(flowDir, { recursive: true });
+    flow.cwd = privateWorktree;
+    flow.hostClaim = claim;
+    flow.rounds = Array.from({ length: count }, (_, index) => {
+      const n = index + 1;
+      completedRounds += 1;
+      const findingsPath = path.join(flowDir, `round-${n}-review.md`);
+      const content = completedRounds === 10
+        ? [
+            "VERDICT: REQUEST_CHANGES",
+            "",
+            "### Finding 1",
+            "- **Severity:** High",
+            `- **File:** ${path.join(privateWorktree, "src/lib/claim.ts")}`,
+            "- **Line:** 42",
+            "- **Title:** Claim failure stays invisible",
+            "- **Explanation:** Surface the completed verdict on the stage.",
+            "",
+            "### Finding 2",
+            "- **Severity:** Medium",
+            "- **File:** src/lib/flows/state.ts",
+            "- **Line:** 17",
+            "- **Title:** Round count is stale",
+            "- **Explanation:** Keep the latest completed round authoritative.",
+            "",
+          ].join("\n")
+        : `VERDICT: REQUEST_CHANGES\n\nCompleted review ${completedRounds} requested changes.\n`;
+      fs.writeFileSync(findingsPath, content);
+      const reviewedAt = `2026-08-06T${String(4 + completedRounds).padStart(2, "0")}:19:00.000Z`;
+      return {
+        n,
+        verdict: "REQUEST_CHANGES",
+        findingsCount: completedRounds === 10 ? 2 : 1,
+        findingsPath,
+        reviewHeadSha: ORIGIN_MAIN_SHA,
+        reviewedAt,
+        terminalAt: reviewedAt,
+        reviewerPath: `/codex/${flow.id}-reviewer-${n}.jsonl`,
+        reviewerConversationId: `conversation_${flow.id}_reviewer_${n}`,
+      } as never;
+    });
+  };
+  const parkAndRetry = async (flow: Flow, rounds: number): Promise<void> => {
+    populateRounds(flow, rounds);
+    flow.state = "done_comment";
+    flow.stateDetail = null;
+    await tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports);
+    expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision" });
+    await patchPipeline(loadPipelines()[0]!.id, { action: "retry-stage" }, h.ports);
+    await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  };
+
+  await parkAndRetry(h.flows.get("flow-1")!, 2);
+  await parkAndRetry(h.flows.get("flow-2")!, 3);
+
+  const flow = h.flows.get("flow-3")!;
+  populateRounds(flow, 5);
+  expect(completedRounds).toBe(10);
   flow.state = "needs_decision";
   flow.pausedState = null;
   flow.stateDetail = `relay delivery failed after 3 automatic retries: structured host claim ${claim.sessionKey} on account ${claim.accountRef} failed: structured resume host claim is unavailable`;
 
-  await tickPipelines([entry("/codex/reviewer-10.jsonl")], h.ports);
+  /* Exercise the read-side projection before the controller consumes the same
+     terminal generation. Its write must remain compatible with the later
+     one-shot verdict settlement. */
+  const projected = structuredClone(loadPipelines()[0]!);
+  expect(reconcileEmbeddedReviewFlows(
+    [projected],
+    [...h.flows.values()],
+    "2026-08-06T15:20:00.000Z",
+  )).toBe(true);
+  savePipelines([projected]);
+
+  await tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports);
+  expect(loadPipelines()[0]).toMatchObject({
+    state: "needs_decision",
+    stateDetail: expect.stringContaining("review loop ended in needs_decision"),
+  });
+
+  const raced = await Promise.all([
+    tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports),
+    tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports),
+  ]);
+  expect(raced.filter((result) => result.changed)).toHaveLength(1);
 
   const settled = loadPipelines()[0]!;
-  const attempt = settled.runs[1]!.attempts[0]!;
+  const reviewAttempts = settled.runs[1]!.attempts;
+  const attempt = reviewAttempts[2]!;
   expect(settled).toMatchObject({ state: "needs_decision" });
+  expect(reviewAttempts).toHaveLength(3);
+  expect(reviewAttempts.map((candidate) => candidate.reviewFlowSync?.roundCount)).toEqual([2, 3, 5]);
   expect(attempt).toMatchObject({
     state: "failed",
     completedAt: expect.any(String),
@@ -3469,14 +3536,19 @@ test("a parked review stage settles from the latest of ten completed flow verdic
       ],
     },
     reviewFlowSync: {
-      roundCount: 10,
+      roundCount: 5,
       verdict: "REQUEST_CHANGES",
       hostClaim: claim,
     },
   });
   expect(settled.stateDetail).toBe(flow.stateDetail);
-  expect(attempt.output).toContain("Review flow round 10: REQUEST_CHANGES");
+  expect(attempt.output).toContain("Review flow round 5: REQUEST_CHANGES");
   expect(JSON.stringify(attempt)).not.toContain(privateWorktree);
+
+  const stableSettlement = JSON.stringify(loadPipelines()[0]);
+  const repeated = await tickPipelines([entry(flow.rounds.at(-1)!.reviewerPath!)], h.ports);
+  expect(repeated.changed).toBe(false);
+  expect(JSON.stringify(loadPipelines()[0])).toBe(stableSettlement);
 });
 
 test("an operator pause during relay stays paused across pipeline reconciliation", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1167,6 +1167,18 @@ const TERMINAL_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
   "approved", "done_comment", "needs_decision", "closed",
 ]);
 const REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX = "review flow host claim retry: ";
+const REVIEW_FLOW_RELAY_RETRY_PREFIX = "review flow relay retry: ";
+
+function reviewFlowRetryDetail(flow: Flow): string | null {
+  if (flow.state !== "relaying" || !flow.stateDetail?.includes("retrying automatically")) return null;
+  const claimFailure = flow.hostClaim
+    ? `structured host claim ${flow.hostClaim.sessionKey} on account ${flow.hostClaim.accountRef} failed:`
+    : null;
+  const prefix = claimFailure && flow.stateDetail.includes(claimFailure)
+    ? REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX
+    : REVIEW_FLOW_RELAY_RETRY_PREFIX;
+  return `${prefix}${flow.stateDetail}`;
+}
 
 function flowSourceUpdatedAt(flow: Flow): string | null {
   const values = [flow.createdAt, flow.closedAt];
@@ -2042,14 +2054,13 @@ async function tickReviewStage(
     attempt.reviewHeadSha = capturedReviewHead;
     persist();
   }
-  const hostClaimRetryDetail = flow.state === "relaying"
-    && flow.hostClaim
-    && flow.stateDetail?.includes("retrying automatically")
-    ? `${REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX}${flow.stateDetail}`
-    : null;
-  if (hostClaimRetryDetail) {
-    pipeline.stateDetail = hostClaimRetryDetail;
-  } else if (pipeline.stateDetail?.startsWith(REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX)) {
+  const retryDetail = reviewFlowRetryDetail(flow);
+  if (retryDetail) {
+    pipeline.stateDetail = retryDetail;
+  } else if (
+    pipeline.stateDetail?.startsWith(REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX)
+    || pipeline.stateDetail?.startsWith(REVIEW_FLOW_RELAY_RETRY_PREFIX)
+  ) {
     pipeline.stateDetail = null;
   }
   if (flow.state === "approved") {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -12,11 +12,13 @@ import { transcriptAllowed } from "@/lib/agent/spawnParent";
 import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { headCwd } from "@/lib/agent/transcript";
 import { MAX_FLOW_NOTE_LENGTH, closeFlow, createFlowFromRequest, isRecoverableLegacyRelayFailurePause, patchFlow } from "@/lib/flows/commands";
-import { lastAssistantMessage } from "@/lib/flows/findings";
+import { lastAssistantMessage, readFindingsFile } from "@/lib/flows/findings";
 import { loadFlows } from "@/lib/flows/store";
 import type { CreateFlowRequest, Flow, RoleConfig } from "@/lib/flows/types";
 import { persistHandoffLineage, rememberHandoffChild } from "@/lib/handoffLineage";
 import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
+import { redactBounded } from "@/lib/monitor/redact";
+import { parseReview, type ReviewFinding } from "@/lib/review";
 import { spawnStructuredConversation } from "@/lib/runtime/structuredSpawn";
 import { projectForCwd } from "@/lib/scanner/describe";
 import { loadTasks } from "@/lib/tasks/store";
@@ -1164,6 +1166,7 @@ function attachReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow): voi
 const TERMINAL_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
   "approved", "done_comment", "needs_decision", "closed",
 ]);
+const REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX = "review flow host claim retry: ";
 
 function flowSourceUpdatedAt(flow: Flow): string | null {
   const values = [flow.createdAt, flow.closedAt];
@@ -1190,6 +1193,7 @@ function synchronizeReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow,
     verdict: round?.verdict ?? null,
     relayState: flow.state,
     terminalState: TERMINAL_REVIEW_FLOW_STATES.has(flow.state) ? flow.state : null,
+    hostClaim: flow.hostClaim ?? null,
     sourceUpdatedAt,
   };
   const generation = crypto.createHash("sha256").update(JSON.stringify({
@@ -2038,6 +2042,16 @@ async function tickReviewStage(
     attempt.reviewHeadSha = capturedReviewHead;
     persist();
   }
+  const hostClaimRetryDetail = flow.state === "relaying"
+    && flow.hostClaim
+    && flow.stateDetail?.includes("retrying automatically")
+    ? `${REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX}${flow.stateDetail}`
+    : null;
+  if (hostClaimRetryDetail) {
+    pipeline.stateDetail = hostClaimRetryDetail;
+  } else if (pipeline.stateDetail?.startsWith(REVIEW_FLOW_HOST_CLAIM_RETRY_PREFIX)) {
+    pipeline.stateDetail = null;
+  }
   if (flow.state === "approved") {
     const fenceError = reviewHeadFenceError(pipeline, attempt, ports);
     if (fenceError) {
@@ -2144,7 +2158,53 @@ function terminalReviewFlowError(flow: Flow): string | null {
   return `review loop ended in ${flow.state}: ${flow.stateDetail ?? "operator decision required"}`;
 }
 
-function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boolean {
+function safeFlowFinding(flow: Flow, finding: ReviewFinding): string {
+  const rawFile = finding.file?.trim() ?? "";
+  let safeFile = rawFile;
+  if (rawFile && path.isAbsolute(rawFile)) {
+    const relative = path.relative(flow.cwd, rawFile);
+    safeFile = relative && !relative.startsWith("..") && !path.isAbsolute(relative)
+      ? relative
+      : path.basename(rawFile);
+  }
+  const location = safeFile
+    ? `${redactBounded(safeFile, 400)}${finding.line ? `:${finding.line}` : ""}`
+    : finding.line ? `line ${finding.line}` : "";
+  return [finding.severity, location, redactBounded(finding.title, 400)]
+    .filter(Boolean)
+    .join(" — ");
+}
+
+/** Terminal flow evidence can outlive the stage-side relay that launched it.
+    Parse the latest completed artifact through the flow's canonical parser,
+    then adapt it to the pipeline verdict interface so normal settlement owns
+    fail-edge routing and the board receives structured findings. */
+function terminalFlowStageVerdict(flow: Flow): ParsedStageVerdict | null {
+  if (flow.state !== "needs_decision" && flow.state !== "done_comment" && flow.state !== "closed") return null;
+  const round = flow.rounds.findLast((candidate) => candidate.verdict !== null);
+  if (!round?.findingsPath || round.verdict === "APPROVE") return null;
+  const parsed = readFindingsFile(round);
+  if (!parsed || parsed.verdict !== round.verdict) return null;
+  const review = parseReview(parsed.content, round.reviewedAt);
+  const reviewFindings = (review?.findings ?? []).map((finding) => safeFlowFinding(flow, finding));
+  const findings = [
+    ...(flow.stateDetail ? [redactBounded(flow.stateDetail, 2_000)] : []),
+    ...reviewFindings,
+  ].slice(0, 50);
+  if (reviewFindings.length === 0 && findings.length < 50) {
+    findings.push(`Review flow round ${round.n} returned ${parsed.verdict}; open the round artifact for details.`);
+  }
+  return {
+    verdict: {
+      status: parsed.verdict === "REQUEST_CHANGES" ? "fail" : "needs_decision",
+      findings,
+      confidence: 1,
+    },
+    output: `Review flow round ${round.n}: ${parsed.verdict}\n\n${findings.map((finding) => `- ${finding}`).join("\n")}`,
+  };
+}
+
+function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts, persist: () => void): boolean {
   if (pipeline.state !== "needs_decision") return false;
   const stage = currentStage(pipeline);
   if (stage?.kind !== "review-loop") return false;
@@ -2157,6 +2217,12 @@ function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boo
     || !flow
     || !RECONCILABLE_REVIEW_FLOW_STATES.has(flow.state)
   ) return false;
+  const flowVerdict = terminalFlowStageVerdict(flow);
+  if (flowVerdict) {
+    synchronizeReviewFlowAttempt(attempt, flow, ports.now());
+    settleStageVerdict(pipeline, stage, attempt, flowVerdict, ports, persist);
+    return true;
+  }
   if (flow.state === "paused") {
     if (!isRecoverableLegacyRelayFailurePause(flow)) return false;
     const resumed = ports.patchFlow(flow.id, "resume");
@@ -2425,7 +2491,7 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
         pipelineChanged = await reconcileExhaustedVerdictRecovery(pipeline, ports, persistPipeline) || pipelineChanged;
         pipelineChanged = reconcileParkedVerdictMiss(pipeline, ports) || pipelineChanged;
         pipelineChanged = reconcileParkedStructuredSpawn(pipeline, ports) || pipelineChanged;
-        pipelineChanged = reconcileBoundReviewFlow(pipeline, ports) || pipelineChanged;
+        pipelineChanged = reconcileBoundReviewFlow(pipeline, ports, persistPipeline) || pipelineChanged;
         pipelineChanged = await reconcileUnconfirmedHosts(pipeline, ports) || pipelineChanged;
         pipelineChanged = await reconcileTerminalStageHosts(pipeline, ports) || pipelineChanged;
         if (!TERMINAL_STATES.has(pipeline.state) && pipeline.state !== "paused" && pipeline.state !== "needs_decision") {

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -75,6 +75,13 @@ function isReviewFlowSync(value: unknown): boolean {
   if (value === undefined) return true;
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const sync = value as Record<string, unknown>;
+  const hostClaim = sync.hostClaim as Record<string, unknown> | null | undefined;
+  const hostClaimValid = hostClaim === undefined || hostClaim === null || (
+    typeof hostClaim === "object"
+    && !Array.isArray(hostClaim)
+    && /^(?:claude|codex):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(String(hostClaim.sessionKey))
+    && /^(?:default|unknown|managed:[0-9a-f]{12})$/.test(String(hostClaim.accountRef))
+  );
   const flowStates = ["waiting_ready", "spawn_pending", "spawning", "reviewing", "relay_pending", "relaying", "fixing", "approved", "done_comment", "needs_decision", "paused", "closed"];
   return typeof sync.generation === "string"
     && (sync.sourceRevision === undefined || (Number.isInteger(sync.sourceRevision) && (sync.sourceRevision as number) >= 0))
@@ -84,6 +91,7 @@ function isReviewFlowSync(value: unknown): boolean {
     && (sync.verdict === null || ["APPROVE", "REQUEST_CHANGES", "COMMENT"].includes(String(sync.verdict)))
     && flowStates.includes(String(sync.relayState))
     && (sync.terminalState === null || flowStates.includes(String(sync.terminalState)))
+    && hostClaimValid
     && typeof sync.synchronizedAt === "string"
     && isNullableString(sync.sourceUpdatedAt)
     && (sync.lagMs === null || (typeof sync.lagMs === "number" && Number.isFinite(sync.lagMs) && sync.lagMs >= 0));

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -149,6 +149,7 @@ export type PipelineStageAttempt = {
     verdict: import("@/lib/flows/types").ReviewVerdict | null;
     relayState: import("@/lib/flows/types").FlowState;
     terminalState: import("@/lib/flows/types").FlowState | null;
+    hostClaim?: import("@/lib/flows/types").FlowHostClaim | null;
     synchronizedAt: string;
     sourceUpdatedAt: string | null;
     lagMs: number | null;


### PR DESCRIPTION
## Summary

- record the review flow engine/session claim with a pseudonymous account reference and carry that identity through bounded retry and terminal errors
- keep the bound pipeline stage running while a host claim retries, with the same claim visible in flow and stage state
- ingest the latest completed flow artifact when a terminal flow outlives a parked stage, then settle through the existing pipeline verdict path with publication-safe findings
- cover four deterministic claim failures and the ten-completed-rounds regression from the incident evidence

## Verification

- `bun test src/lib/flows/engine.test.ts src/lib/flows/commands.durable.test.ts src/lib/flows/store.test.ts src/lib/pipelines/engine.test.ts src/lib/pipelines/store.test.ts` — 273 passed
- `bunx tsc --noEmit --incremental false`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base 9355e4eb1fab0781fc4bd2a850a6b00bcf7feb40`

Fixes #921
