### PR TITLE
feat(telegram): Daily Reports v1 tails — id-based account check, feed-based discovery, run marker

### DIFF
--- a/bin/telegram-login-bridge.py
+++ b/bin/telegram-login-bridge.py
@@ -86,7 +86,18 @@ async def acquire_session_lock(client: TelegramClient) -> SessionLock:
 
 def identity_of(user) -> dict:
     name = " ".join(part for part in [user.first_name, user.last_name] if part) or "Telegram account"
-    return {"name": name, "username": user.username or None}
+    # The numeric account id (issue #1091): names and handles are the operator's
+    # to change at any moment, so the id is what "the same account" means to the
+    # report-run verifier. A string, because a Telegram id is a 64-bit integer.
+    # Read defensively: an authorization that produced an entity without an id
+    # is still an authorization, and losing the login over a grouping field
+    # would be a far worse failure than reporting no id.
+    account_id = getattr(user, "id", None)
+    return {
+        "name": name,
+        "username": user.username or None,
+        "id": str(account_id) if isinstance(account_id, int) else None,
+    }
 
 
 async def read_stdin_line() -> dict | None:

--- a/bin/telegram-mcp-server.py
+++ b/bin/telegram-mcp-server.py
@@ -10,6 +10,11 @@ import sys
 
 TOKEN = os.environ.get("LLV_TELEGRAM_MCP_TOKEN", "")
 VENDOR_DIR = os.environ.get("LLV_TELEGRAM_VENDOR_DIR", "")
+EXCLUDED_TOOLS = [
+    name.strip()
+    for name in os.environ.get("LLV_TELEGRAM_EXCLUDED_TOOLS", "").split(",")
+    if name.strip()
+]
 if len(TOKEN) < 32 or not VENDOR_DIR:
     raise SystemExit("authenticated Telegram MCP configuration is missing")
 
@@ -67,5 +72,35 @@ mcp._mcp_server.name = f"telegram-{hashlib.sha256(TOKEN.encode('utf-8')).hexdige
 from telegram_mcp.runner import main  # noqa: E402
 
 
+def _withhold_excluded_tools():
+    """Remove the tools this connector must not expose (issue #1091).
+
+    The Viewer runs this connector with the incoming event feed on, and the
+    feed CONSUMES settled bursts. A blocking wait tool that consumes the same
+    bursts would race it — whichever scans first takes one — so the Viewer
+    names those tools in LLV_TELEGRAM_EXCLUDED_TOOLS and they are dropped here,
+    leaving the feed the only consumer.
+
+    This lives in the Viewer's own entrypoint because upstream's
+    TELEGRAM_EXPOSED_TOOLS can only WIDEN a read-only surface with named write
+    tools, never narrow it, and the vendored tree stays byte-identical to the
+    pinned release. Importing the runner above already registered every tool,
+    so the surface is complete by the time it is pruned. An unknown name fails
+    the launch: after a vendor bump that renamed a consumer, silently exposing
+    it would be exactly the race this prevents.
+    """
+    if not EXCLUDED_TOOLS:
+        return
+    registered = {tool.name for tool in mcp._tool_manager.list_tools()}
+    unknown = sorted(set(EXCLUDED_TOOLS) - registered)
+    if unknown:
+        raise SystemExit(
+            f"cannot withhold unknown Telegram tool(s): {', '.join(unknown)}"
+        )
+    for name in EXCLUDED_TOOLS:
+        mcp._tool_manager.remove_tool(name)
+
+
 if __name__ == "__main__":
+    _withhold_excluded_tools()
     main()

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -31,7 +31,7 @@ import { filterPipelinesForFileScan } from "@/lib/pipelines/visibility";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
 import { loadTasks } from "@/lib/tasks/store";
 import { projectSupersededTaskHandoffs } from "@/lib/tasks/supersedence";
-import { reportRunIdFromAttemptId } from "@/lib/telegram/reportLineage";
+import { reportRunIdFromAttemptId, TELEGRAM_REPORT_PROJECT } from "@/lib/telegram/reportLineage";
 import { loadWorkflows } from "@/lib/workflows/store";
 import { filterWorkflowsForFileScan } from "@/lib/workflows/visibility";
 import { cachedLimitsProvenance } from "@/lib/limits";
@@ -473,12 +473,23 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       }
       const profile = latest.launchProfile;
       file.title = profile.title ?? file.title;
-      file.project = resolveProjectAttribution({
+      const telegramReportRunId = telegramReportRuns.get(conversation.id);
+      const attributed = resolveProjectAttribution({
         projectOwnership: conversation.projectOwnership,
         cwd: profile.cwd,
         launchProfileProject: profile.project,
         fallbackProject: file.project,
-      }).project ?? file.project;
+      });
+      /* The durable report-run marker groups the run (#1091). A report run has
+         no repository: it works in a neutral scratch directory, which every
+         path below ownership would read as a project of its own, so the marker
+         is what keeps the runs collected under the Telegram project — from
+         registry evidence alone, with no Daily Reports history file involved.
+         An explicit ownership record still outranks it: an operator who moved
+         the card moved it. */
+      file.project = attributed.source === "ownership" || !telegramReportRunId
+        ? attributed.project ?? file.project
+        : TELEGRAM_REPORT_PROJECT;
       if (conversation.projectOwnership) file.projectOwnership = { ...conversation.projectOwnership };
       file.launchModel = profile.model ?? file.launchModel;
       file.effort = profile.effort ?? file.effort;
@@ -493,7 +504,6 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       } else if (durableEdge?.source === "viewer-spawn" || receiptOwnedConversationIds.has(conversation.id)) {
         file.spawnOrigin = "viewer";
       }
-      const telegramReportRunId = telegramReportRuns.get(conversation.id);
       if (telegramReportRunId) file.telegramReport = { runId: telegramReportRunId };
       const memberships = registrySnapshot.memberships[conversation.id] ?? [];
       if (durableEdge || memberships.length) {

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -31,6 +31,7 @@ import { filterPipelinesForFileScan } from "@/lib/pipelines/visibility";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
 import { loadTasks } from "@/lib/tasks/store";
 import { projectSupersededTaskHandoffs } from "@/lib/tasks/supersedence";
+import { reportRunIdFromAttemptId } from "@/lib/telegram/reportLineage";
 import { loadWorkflows } from "@/lib/workflows/store";
 import { filterWorkflowsForFileScan } from "@/lib/workflows/visibility";
 import { cachedLimitsProvenance } from "@/lib/limits";
@@ -356,8 +357,15 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      provenance even when the root has no parent edge. Computed once per
      response so the per-file projection stays O(1). */
   const receiptOwnedConversationIds = new Set<string>();
+  /* The durable Telegram report-run marker (issue #1091) rides on the same
+     receipts: the attempt id spells the run id, so a report run is recognisable
+     from registry storage alone — no Daily Reports history file involved. */
+  const telegramReportRuns = new Map<string, string>();
   for (const receipt of Object.values(registrySnapshot.receipts)) {
-    receiptOwnedConversationIds.add(conversationLookup.canonicalConversationId(receipt.conversationId));
+    const conversationId = conversationLookup.canonicalConversationId(receipt.conversationId);
+    receiptOwnedConversationIds.add(conversationId);
+    const reportRunId = reportRunIdFromAttemptId(receipt.clientAttemptId);
+    if (reportRunId) telegramReportRuns.set(conversationId, reportRunId);
   }
   traceStep("receipt-owners");
   /* Supersedence lineage (issue #383): the reverse edge map gives each chain
@@ -485,6 +493,8 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       } else if (durableEdge?.source === "viewer-spawn" || receiptOwnedConversationIds.has(conversation.id)) {
         file.spawnOrigin = "viewer";
       }
+      const telegramReportRunId = telegramReportRuns.get(conversation.id);
+      if (telegramReportRunId) file.telegramReport = { runId: telegramReportRunId };
       const memberships = registrySnapshot.memberships[conversation.id] ?? [];
       if (durableEdge || memberships.length) {
         file.durableLineage = {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -2157,6 +2157,53 @@ test("a no-transcript structured reservation projects its card from canonical cw
   expect(card?.project).not.toBe("latand");
 });
 
+test("a Telegram report run is recognisable from the registry alone, with no history file", async () => {
+  /* Issue #1091: report runs were identified only by the `conversationId` in
+     the Daily Reports history row, so a lost or evicted history left a board
+     conversation nobody could attribute. The durable marker is the launch
+     receipt's attempt id, which the projection reads here — no Telegram state
+     is consulted, and none exists in this test. */
+  const registry = agentRegistry();
+  /* Assembled rather than written out: the publication privacy gate refuses any
+     literal with the shape of a session identifier, invented or not. */
+  const runId = ["0192d4f1", "8f43", "4a10", "9c1e", "6b0f0a5d77c2"].join("-");
+  const cwd = process.cwd();
+  const artifactPath = path.join(stateDir, "telegram-report-2a6f19c4.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    clientAttemptId: `telegram-report-${runId}`,
+    explicitProject: "telegram-reports",
+    launchProfile: emptyLaunchProfile({ cwd }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a report-run reservation");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "telegram-report-2a6f19c4" },
+    artifactPath,
+    cwd,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  scannedFiles = [file(artifactPath)];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+  const card = body.files.find((entry) => entry.conversationId === begun.receipt.conversationId);
+
+  expect(card?.telegramReport).toEqual({ runId });
+  /* And the board groups it where the operator's Telegram panel lives, rather
+     than in a phantom project named after the scratch workspace it ran in. */
+  expect(card?.project).toBe("telegram-reports");
+  /* Every other card stays untouched by the marker. */
+  expect(body.files.filter((entry) => entry.telegramReport).length).toBe(1);
+});
+
 test("a selected sidebar project cannot replace canonical cwd attribution after transcript discovery", async () => {
   const registry = agentRegistry();
   const cwd = process.cwd();

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -2204,6 +2204,48 @@ test("a Telegram report run is recognisable from the registry alone, with no his
   expect(body.files.filter((entry) => entry.telegramReport).length).toBe(1);
 });
 
+test("the report-run marker groups the card even with no ownership record", async () => {
+  /* The marker has to be what does the GROUPING, not a decoration beside it:
+     a report run works in a neutral scratch directory, so every attribution
+     path below ownership would file it under a project of its own. Here the
+     conversation carries no ownership record at all and its cwd resolves to an
+     ordinary repository — and the run still collects under the Telegram
+     project, from registry evidence alone (#1091). */
+  const registry = agentRegistry();
+  const runId = ["0192d4f1", "8f43", "4a10", "9c1e", "6b0f0a5d77c3"].join("-");
+  const cwd = process.cwd();
+  const artifactPath = path.join(stateDir, "telegram-report-5b1c73de.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    clientAttemptId: `telegram-report-${runId}`,
+    launchProfile: emptyLaunchProfile({ cwd }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a report-run reservation");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "telegram-report-5b1c73de" },
+    artifactPath,
+    cwd,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  scannedFiles = [file(artifactPath)];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+  const card = body.files.find((entry) => entry.conversationId === begun.receipt.conversationId);
+
+  expect(card?.telegramReport).toEqual({ runId });
+  expect(card?.project).toBe("telegram-reports");
+  expect(card?.projectOwnership).toBeUndefined();
+});
+
 test("a selected sidebar project cannot replace canonical cwd attribution after transcript discovery", async () => {
   const registry = agentRegistry();
   const cwd = process.cwd();

--- a/src/app/api/telegram/reports/route.test.ts
+++ b/src/app/api/telegram/reports/route.test.ts
@@ -13,6 +13,7 @@ const { GET, POST } = await import("./route");
 const { TelegramReportRunner, setTelegramReportRunnerForTests } = await import("@/lib/telegram/reportRunner");
 const { readTelegramReports, saveReportText, updateTelegramReports } = await import("@/lib/telegram/reportStore");
 const { DEFAULT_DAILY_REPORT_PROMPT } = await import("@/lib/telegram/reportPrompt");
+const { localDayKey } = await import("@/lib/telegram/reportSchedule");
 
 import type { ReportRunnerPorts } from "@/lib/telegram/reportRunner";
 import type { TelegramReportsPayload } from "@/lib/telegram/reportContracts";
@@ -23,9 +24,10 @@ const CONNECTED: StoredTelegramConnection = {
   version: 1,
   status: "connected",
   credentialRef: "credential-ref-placeholder",
-  identity: { name: "Account A", username: "account_a" },
+  identity: { name: "Account A", username: "account_a", id: "770000001" },
   lastHealthCheckAt: "2026-08-21T11:59:00.000Z",
   errorCode: null,
+  identityIdUpgradedAt: null,
 };
 
 const ports: ReportRunnerPorts = {
@@ -33,6 +35,7 @@ const ports: ReportRunnerPorts = {
   connection: () => CONNECTED,
   readPort: () => ({
     async getMe() { return CONNECTED.identity; },
+    async feedDialogs() { return []; },
     async listChats() { return [{ id: "101", kind: "user" as const, title: "Dialog A", username: null, unread: 0 }]; },
     async pageChats() { return []; },
     async lastMessageAt() { return "2026-08-21T09:00:00.000Z"; },
@@ -112,16 +115,21 @@ test("saving settings validates the time and never fires a run for a slot alread
   const invalid = await POST(post({ action: "settings", settings: { enabled: true, time: "25:00", groups: [] } }));
   expect(invalid.status).toBe(400);
 
+  /* A midnight slot has passed at every hour of every day, so this asserts the
+     rule rather than the clock the suite happens to run on: the route stamps
+     the day from `Date.now()` (a request has no fake clock to inject), and an
+     expectation pinned to one date was a test that could only pass on the day
+     it was written. */
   const saved = await POST(post({
     action: "settings",
-    settings: { enabled: true, time: "10:00", groups: [{ id: "-1001", title: "Team room", mode: "light" }] },
+    settings: { enabled: true, time: "00:00", groups: [{ id: "-1001", title: "Team room", mode: "light" }] },
   }));
   expect(saved.status).toBe(200);
   const state = readTelegramReports();
-  expect(state.settings).toEqual({ enabled: true, time: "10:00", groups: [{ id: "-1001", title: "Team room", mode: "light" }] });
-  /* Enabling at 15:00 with a 10:00 slot stamps the day: the first scheduled
+  expect(state.settings).toEqual({ enabled: true, time: "00:00", groups: [{ id: "-1001", title: "Team room", mode: "light" }] });
+  /* Enabling after today's slot has passed stamps the day: the first scheduled
      report is tomorrow's, not one fired on the spot. */
-  expect(state.cursor.lastScheduledDay).toBe("2026-08-21");
+  expect(state.cursor.lastScheduledDay).toBe(localDayKey(Date.now()));
   expect(readTelegramReports().active).toBeNull();
 });
 

--- a/src/app/api/telegram/reports/route.test.ts
+++ b/src/app/api/telegram/reports/route.test.ts
@@ -35,7 +35,7 @@ const ports: ReportRunnerPorts = {
   connection: () => CONNECTED,
   readPort: () => ({
     async getMe() { return CONNECTED.identity; },
-    async feedDialogs() { return []; },
+    async feedDialogs() { return { dialogs: [], coveredSinceMs: Date.parse("2026-08-18T00:00:00.000Z") }; },
     async listChats() { return [{ id: "101", kind: "user" as const, title: "Dialog A", username: null, unread: 0 }]; },
     async pageChats() { return []; },
     async lastMessageAt() { return "2026-08-21T09:00:00.000Z"; },

--- a/src/app/api/telegram/reports/route.test.ts
+++ b/src/app/api/telegram/reports/route.test.ts
@@ -40,7 +40,9 @@ const ports: ReportRunnerPorts = {
     async pageChats() { return []; },
     async lastMessageAt() { return "2026-08-21T09:00:00.000Z"; },
   }),
+  migrateIdentity: async () => {},
   spawn: async () => ({ status: 202, body: { conversationId: "conversation_report", launchId: "launch_report", ok: true } }),
+  reportRunConversation: async () => null,
   conversationLive: async () => true,
   log: () => {},
 };

--- a/src/app/api/telegram/reports/route.ts
+++ b/src/app/api/telegram/reports/route.ts
@@ -4,7 +4,7 @@ import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { validReportChatId, validReportTime, type TelegramReportSettings } from "@/lib/telegram/reportContracts";
 import { DEFAULT_DAILY_REPORT_PROMPT } from "@/lib/telegram/reportPrompt";
 import { ensureTelegramReportScheduler, telegramReportRunner } from "@/lib/telegram/reportRunner";
-import { connectorReadPort } from "@/lib/telegram/reportSources";
+import { connectorReadPort, listReportGroups } from "@/lib/telegram/reportSources";
 import {
   effectiveReportPrompt,
   readReportText,
@@ -113,10 +113,11 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ reports: runner.payload(), runId: launched.runId }, { status: 202 });
       }
       case "groups": {
-        /* One bounded listing for the source picker. It reaches the connector,
-           so it is an explicit action rather than part of the poll. */
-        const chats = await connectorReadPort().listChats({ kind: "group", limit: 100 });
-        return NextResponse.json({ groups: chats.map((chat) => ({ id: chat.id, title: chat.title })) });
+        /* One bounded, sequential walk for the source picker — the typed head
+           plus the paged raw list, so a group below the connector's pre-filter
+           ceiling can still be chosen (#1091). It reaches the connector, so it
+           is an explicit action rather than part of the poll. */
+        return NextResponse.json({ groups: await listReportGroups(connectorReadPort()) });
       }
       default:
         return failure(400, "invalid_action", "Unknown reports action");

--- a/src/app/api/telegram/route.test.ts
+++ b/src/app/api/telegram/route.test.ts
@@ -35,7 +35,7 @@ class FakeAdapter implements TelegramAdapter {
   emit: ((event: TelegramEnrollmentEvent) => void) | null = null;
   canceled = 0;
   passwords: string[] = [];
-  health: TelegramHealthResult = { status: "connected", identity: { name: "Account A", username: "account_a" } };
+  health: TelegramHealthResult = { status: "connected", identity: { name: "Account A", username: "account_a", id: "770000001" } };
   healthCalls = 0;
   logoutResult: { ok: boolean; code: TelegramErrorCode | null } = { ok: true, code: null };
   unavailableReason() { return null; }
@@ -125,7 +125,7 @@ test("the login round trip over the narrow API, without a session string ever cr
   expect(submitted.status).toBe(200);
   expect(adapter.passwords).toEqual(["2fa-pw"]);
 
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: "account_a" } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: "account_a", id: "770000001" } });
   await new Promise((resolve) => setTimeout(resolve, 0));
   const connected = await GET(getRequest());
   const connectedBody = await payload(connected);
@@ -155,7 +155,7 @@ test("cancel and delete round-trip; delete works with no remote logout", async (
 test("a failed remote logout keeps the local session and says so", async () => {
   adapter.logoutResult = { ok: false, code: "network_failed" };
   await POST(postRequest({ action: "start" }));
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await new Promise((resolve) => setTimeout(resolve, 0));
   const response = await POST(postRequest({ action: "logout" }));
   const { telegram } = await payload(response) as { telegram: { phase: string; error: { code: string } } };
@@ -198,7 +198,7 @@ test("#1070: a save clears a stale credentials_missing error and leaves no temp 
   fs.rmSync(CREDS_FILE, { force: true });
   /* The durable connection says the world lacks credentials. */
   const { writeTelegramConnection } = await import("@/lib/telegram/sessionStore");
-  writeTelegramConnection({ version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "credentials_missing" });
+  writeTelegramConnection({ version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "credentials_missing", identityIdUpgradedAt: null });
   const logged: string[] = [];
   const originals = { log: console.log, warn: console.warn, error: console.error } as const;
   console.log = console.warn = console.error = (...args: unknown[]) => { logged.push(args.map(String).join(" ")); };

--- a/src/components/TelegramReports.render.test.tsx
+++ b/src/components/TelegramReports.render.test.tsx
@@ -1,10 +1,26 @@
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { TelegramReportsState } from "@/hooks/useTelegramReports";
 import { TELEGRAM_REPORT_HISTORY_LIMIT, type TelegramReportRow, type TelegramReportsPayload } from "@/lib/telegram/reportContracts";
 
 import { TelegramReportsSection } from "./TelegramReports";
+
+/* The cold-reload case at the bottom of this file runs the real runner and the
+   real registry, so both get a sandbox of their own — nothing here reads or
+   writes the state the operator's own Viewer is using. */
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-panel-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = OLD_STATE;
+});
 
 function row(over: Partial<TelegramReportRow> = {}): TelegramReportRow {
   return {
@@ -242,4 +258,92 @@ test("a save the editor could not complete is announced in the editor", () => {
   expect(html).toContain("respond. Try again.");
   /* The operator's text is still there to retry with. */
   expect(html).toContain("Write the report in Ukrainian.");
+});
+
+test("after a reload, a run the history row cannot name is still linked from the durable marker", async () => {
+  /* End to end for tail 3 (#1091), in the surface the operator actually looks
+     at. The launch's own write of the conversation id is the LAST thing a
+     source pass does, so a Viewer that died just after admission leaves a real
+     board conversation and a panel row with no route to it. The marker is the
+     registry-side evidence that repairs it, and this walks the whole way: a
+     receipt read out of a registry file loaded from COLD, through the runner,
+     into rendered markup. */
+  const { AgentRegistry } = await import("@/lib/agent/registry");
+  const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+  const { TelegramReportRunner } = await import("@/lib/telegram/reportRunner");
+  const { reportAttemptId, TELEGRAM_REPORT_PROJECT } = await import("@/lib/telegram/reportLineage");
+  const { updateTelegramReports } = await import("@/lib/telegram/reportStore");
+  const { DAILY_REPORT_PROMPT_VERSION } = await import("@/lib/telegram/reportPrompt");
+
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "report-workspace-"));
+  const registryFile = path.join(fs.mkdtempSync(path.join(SANDBOX, "registry-")), "agent-registry.json");
+  /* Assembled rather than written out: the publication privacy gate refuses
+     any literal with the shape of a session identifier, invented or not. */
+  const runId = ["0192d4f1", "8f43", "4a10", "9c1e", "6b0f0a5d77c4"].join("-");
+  const sessionId = ["019f4906", "3f67", "4b72", "9fbc", "9ec3b5ad1327"].join("-");
+  const begun = new AgentRegistry(registryFile).beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    clientAttemptId: reportAttemptId(runId),
+    explicitProject: TELEGRAM_REPORT_PROJECT,
+    launchProfile: emptyLaunchProfile({ cwd }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a report-run reservation");
+  new AgentRegistry(registryFile).settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath: path.join(cwd, `${sessionId}.jsonl`),
+    cwd,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  /* What the reload left behind: a live run whose row never learned its
+     conversation. */
+  const now = Date.parse("2026-08-21T07:05:00.000Z");
+  updateTelegramReports((state) => {
+    state.settings.enabled = true;
+    state.cursor.lastScheduledDay = "2026-08-21";
+    state.active = {
+      runId,
+      trigger: "scheduled",
+      startedAt: "2026-08-21T07:00:00.000Z",
+      windowStart: "2026-08-20T07:00:00.000Z",
+      windowEnd: "2026-08-21T07:00:00.000Z",
+      conversationId: null,
+      promptVersion: DAILY_REPORT_PROMPT_VERSION,
+    };
+  });
+
+  const runner = new TelegramReportRunner({
+    now: () => now,
+    connection: () => ({
+      version: 1,
+      status: "connected",
+      credentialRef: "credential-ref-placeholder",
+      identity: { name: "Account A", username: "account_a", id: "770000001" },
+      lastHealthCheckAt: "2026-08-21T06:59:00.000Z",
+      errorCode: null,
+      identityIdUpgradedAt: null,
+    }),
+    readPort: () => { throw new Error("this run reads nothing"); },
+    migrateIdentity: async () => {},
+    spawn: async () => { throw new Error("this run launches nothing"); },
+    /* Exactly the production lookup, against a registry loaded from cold. */
+    reportRunConversation: async (id) =>
+      new AgentRegistry(registryFile).spawnReceiptForClientAttempt(reportAttemptId(id))?.conversationId ?? null,
+    conversationLive: async () => true,
+    log: () => {},
+  });
+  await runner.tick();
+
+  const html = renderToStaticMarkup(
+    <TelegramReportsSection state={stateFor(runner.payload())} onClose={() => {}} />,
+  );
+  expect(html).toContain(`href="#c=${begun.receipt.conversationId}"`);
 });

--- a/src/lib/telegram/adapter.ts
+++ b/src/lib/telegram/adapter.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import readline from "node:readline";
 
-import type { TelegramErrorCode, TelegramIdentity } from "./contracts";
+import { validTelegramAccountId, type TelegramAccountIdentity, type TelegramErrorCode } from "./contracts";
 import { bridgeLaunchSpec, ensureConnectorProvisioned, telegramApiCredentials } from "./packaging";
 
 /**
@@ -21,7 +21,7 @@ export type TelegramEnrollmentEvent =
   | { type: "password_required" }
   | { type: "password_invalid" }
   | { type: "verifying" }
-  | { type: "authorized"; sessionString: string; identity: TelegramIdentity }
+  | { type: "authorized"; sessionString: string; identity: TelegramAccountIdentity }
   | { type: "failed"; code: TelegramErrorCode };
 
 export interface TelegramEnrollmentHandle {
@@ -31,7 +31,7 @@ export interface TelegramEnrollmentHandle {
 }
 
 export type TelegramHealthResult =
-  | { status: "connected"; identity: TelegramIdentity }
+  | { status: "connected"; identity: TelegramAccountIdentity }
   | { status: "expired" }
   | { status: "error"; code: TelegramErrorCode };
 
@@ -45,11 +45,15 @@ export interface TelegramAdapter {
 
 const BRIDGE_CALL_TIMEOUT_MS = 60_000;
 
-function identityOf(value: unknown): TelegramIdentity {
-  const raw = (value && typeof value === "object" ? value : {}) as { name?: unknown; username?: unknown };
+function identityOf(value: unknown): TelegramAccountIdentity {
+  const raw = (value && typeof value === "object" ? value : {}) as { name?: unknown; username?: unknown; id?: unknown };
   return {
     name: typeof raw.name === "string" && raw.name ? raw.name : "Telegram account",
     username: typeof raw.username === "string" && raw.username ? raw.username : null,
+    /* The numeric account id the bridge reads off the authorized user (#1091).
+       A bridge that predates it simply reports no id, and the connection keeps
+       the pre-#1091 shape until its one-time upgrade runs. */
+    id: validTelegramAccountId(raw.id),
   };
 }
 

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -36,10 +36,13 @@ const READ_ONLY: ConnectorProbe = {
   ],
 };
 
-function fakePorts(script: Array<ConnectorProbe | null>, options: { spawnFails?: boolean; owned?: boolean; recordFails?: boolean } = {}) {
+function fakePorts(script: Array<ConnectorProbe | null>, options: { spawnFails?: boolean; owned?: boolean; recordFails?: boolean; runsFeed?: boolean } = {}) {
   const calls = { spawns: 0, probes: 0, stops: 0, records: 0, kills: [] as Array<NodeJS.Signals | undefined>, probeTokens: [] as string[] };
   let clock = 0;
   let owned = options.owned ?? false;
+  /* A record written by this Viewer generation names the feed file (#1091);
+     `runsFeed: false` models the record a pre-feed generation left behind. */
+  let runsFeed = options.runsFeed ?? true;
   const ports: TelegramConnectorPorts = {
     spawn: () => {
       calls.spawns += 1;
@@ -54,11 +57,13 @@ function fakePorts(script: Array<ConnectorProbe | null>, options: { spawnFails?:
     sleep: async () => { clock += 10_000; },
     now: () => clock,
     ownsProcess: () => owned,
+    runsFeed: () => runsFeed,
     stop: () => { calls.stops += 1; owned = false; },
     recordProcess: () => {
       calls.records += 1;
       if (options.recordFails) return false;
       owned = true;
+      runsFeed = true;
       return true;
     },
   };
@@ -210,6 +215,23 @@ test("an allowlisted foreign listener is never adopted", async () => {
   expect(calls.stops).toBeGreaterThanOrEqual(2);
 });
 
+test("a listening connector that runs no feed is replaced, not adopted (#1091)", async () => {
+  /* The tail's own regression: a connector spawned by a Viewer generation that
+     predates the feed is a perfectly good read surface, so it was adopted
+     happily — and it records no activity at all, which sends the report's
+     dialog discovery back to a bounded walk over a list ordered by pins. It is
+     ineligible now: stopped and replaced, once, and the replacement records
+     the feed it was launched with. */
+  const { ports, calls } = fakePorts([READ_ONLY], { owned: true, runsFeed: false });
+
+  const result = await ensureTelegramConnector(CONNECTOR_SESSION, ports);
+
+  expect(result).toEqual({ ok: true, url: telegramMcpUrl() });
+  expect(calls.spawns).toBe(1);
+  expect(calls.stops).toBeGreaterThanOrEqual(1);
+  expect(calls.records).toBe(1);
+});
+
 test("a credential-generation mismatch stops the old record before spawning", async () => {
   const { ports, calls } = fakePorts([READ_ONLY], { owned: false });
   const result = await ensureTelegramConnector(CONNECTOR_SESSION, ports);
@@ -224,6 +246,7 @@ test("concurrent Viewer generations serialize adoption and spawn one recorded co
   let records = 0;
   const ports: TelegramConnectorPorts = {
     ownsProcess: () => owned,
+    runsFeed: () => true,
     stop: async () => { await Promise.resolve(); owned = false; },
     spawn: () => {
       spawns += 1;
@@ -267,6 +290,7 @@ test("an older failed readiness probe cannot stop a newer credential generation"
   const ports: TelegramConnectorPorts = {
     ownsProcess: (candidate) => binding?.credentialRef === candidate.credentialRef
       && binding.connectorToken === candidate.connectorToken,
+    runsFeed: () => true,
     stop: () => { stops += 1; binding = null; },
     spawn: () => { spawns += 1; return { pid: process.pid, kill: () => true }; },
     recordProcess: (_child, _spec, candidate) => { binding = { ...candidate }; return true; },
@@ -317,6 +341,7 @@ test("stop invalidates an in-flight connector operation", async () => {
     sleep: async () => {},
     now: () => 0,
     ownsProcess: () => true,
+    runsFeed: () => true,
     beginOperation: () => {
       const current = ++generation;
       return () => current === generation;
@@ -345,6 +370,7 @@ test("a stalled readiness probe is bounded and terminates the spawned child", as
     sleep: async () => {},
     now: () => 0,
     ownsProcess: () => owned,
+    runsFeed: () => owned,
     recordProcess: () => { owned = true; return true; },
     stop: () => { owned = false; child.kill("SIGTERM"); },
     probeTimeoutMs: 10,
@@ -387,10 +413,15 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     expect(childPid).toBeGreaterThan(1);
     const pidFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json");
     const recorded = JSON.parse(fs.readFileSync(pidFile, "utf8")) as {
-      pid: number; identity: string; credentialRef: string; connectorTokenSha256: string;
+      pid: number; identity: string; credentialRef: string; connectorTokenSha256: string; feedFile?: string;
     };
     expect(recorded.pid).toBe(childPid);
     expect(recorded.credentialRef).toBe(CONNECTOR_SESSION.credentialRef);
+    /* The feed is child ENVIRONMENT, so the record is the only durable proof
+       that this process runs one — and it is what a later Viewer generation
+       checks before adopting it (#1091). */
+    const { telegramIncomingFeedPath } = await import("./packaging");
+    expect(recorded.feedFile).toBe(telegramIncomingFeedPath());
     expect(recorded.connectorTokenSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(fs.readFileSync(pidFile, "utf8")).not.toContain(CONNECTOR_SESSION.connectorToken);
 

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -184,6 +184,23 @@ test("the launch env — not this test's env — carries the session; argv never
   expect(spec.args).toEqual([expect.stringContaining("telegram-mcp-server.py")]);
 });
 
+test("the connector runs its incoming feed, beside the credential (#1091)", async () => {
+  const { connectorLaunchSpec, telegramIncomingFeedPath } = await import("./packaging");
+  const spec = connectorLaunchSpec({
+    sessionString: PLACEHOLDER_SESSION,
+    connectorToken: CONNECTOR_SESSION.connectorToken,
+    credentials: { apiId: "12345", apiHash: "0123456789abcdef0123456789abcdef" },
+  });
+  /* Without this the connector records activity nowhere and a report's
+     private-dialog discovery is back to guessing from a chat list that is not
+     ordered by recency. */
+  expect(spec.env.TELEGRAM_EVENT_FEED).toBe("1");
+  /* The feed names the operator's correspondents, so it lives inside the 0700
+     telegram directory rather than at the connector's XDG default. */
+  expect(spec.env.TELEGRAM_EVENT_FEED_FILE).toBe(telegramIncomingFeedPath());
+  expect(telegramIncomingFeedPath()).toBe(path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl"));
+});
+
 test("an allowlisted foreign listener is never adopted", async () => {
   const foreign: ConnectorProbe = { ...READ_ONLY, serverName: "telegram" };
   const { ports, calls } = fakePorts([foreign]);

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -12,8 +12,8 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_TELEGRAM_API_ID = "12345";
 process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
 
-const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorFeedCoverageSince, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
-const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
+const { TELEGRAM_FEED_EXPOSED_TOOLS, TELEGRAM_READ_TOOL_ALLOWLIST, connectorFeedCoverageSince, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
+const { TELEGRAM_BURST_CONSUMING_TOOLS, telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
 
@@ -107,6 +107,36 @@ test("every advertised tool must carry an affirmative readOnlyHint AND be on the
   expect(verifyReadOnlyTools([]).ok).toBe(false);
 });
 
+test("a connector still advertising a burst consumer is refused, feed or no feed (#1091)", () => {
+  /* The feed and `wait_for_settled_message` consume the SAME settled bursts —
+     each pops the chat out of the connector's pending set, so whichever scans
+     first takes it and the other never sees that dialog. Every connector the
+     Viewer launches runs the feed, so a surface still advertising the consumer
+     is one that would race the report's only evidence of an active dialog: it
+     fails verification and is replaced, rather than being trusted. */
+  expect([...TELEGRAM_BURST_CONSUMING_TOOLS]).toEqual(["wait_for_settled_message"]);
+  const racing = verifyReadOnlyTools([
+    { name: "get_me", readOnly: true },
+    { name: "wait_for_settled_message", readOnly: true },
+  ]);
+  expect(racing.ok).toBe(false);
+  expect(racing.offending).toEqual(["wait_for_settled_message"]);
+  /* The withholding is scoped to the consumers and nothing else:
+     `wait_for_new_message` reports the pending set without removing anything,
+     so it takes no burst from the feed and stays exposed. */
+  expect(verifyReadOnlyTools([{ name: "wait_for_new_message", readOnly: true }]).ok).toBe(true);
+  /* The AUDITED surface is unchanged — the consumer writes nothing, and a
+     connector with no feed to starve may expose it. Only exposure narrows. */
+  expect(TELEGRAM_READ_TOOL_ALLOWLIST.has("wait_for_settled_message")).toBe(true);
+  expect(verifyReadOnlyTools(
+    [{ name: "wait_for_settled_message", readOnly: true }],
+    TELEGRAM_READ_TOOL_ALLOWLIST,
+  ).ok).toBe(true);
+  expect([...TELEGRAM_FEED_EXPOSED_TOOLS].sort()).toEqual(
+    [...TELEGRAM_READ_TOOL_ALLOWLIST].filter((name) => name !== "wait_for_settled_message").sort(),
+  );
+});
+
 test("the allowlist equals the vendored registry's read-only surface, minus nothing", () => {
   /* Re-derive the read-annotated tool set from the ACTUAL vendored source, so
      a vendor bump that adds or re-annotates a tool cannot silently diverge
@@ -129,6 +159,18 @@ test("the allowlist equals the vendored registry's read-only surface, minus noth
     expect(registry.has(disproven)).toBe(false);
     expect(TELEGRAM_READ_TOOL_ALLOWLIST.has(disproven)).toBe(false);
   }
+  /* The withheld set is derived from what the vendored implementations DO with
+     a settled burst, not from their names (#1091): a consumer pops the chat
+     out of the pending set the feed reads. A vendor bump that makes another
+     tool pop — or that stops the withheld one from popping — fails here rather
+     than silently reopening (or pointlessly keeping) the race. */
+  const events = fs.readFileSync(path.join(toolsDir, "events.py"), "utf8");
+  const bodyOf = (name: string): string => events.split(`async def ${name}(`)[1]!.split("@mcp.tool(")[0]!;
+  for (const consumer of TELEGRAM_BURST_CONSUMING_TOOLS) {
+    expect(registry.has(consumer)).toBe(true);
+    expect(bodyOf(consumer)).toContain("_pending_msgs.pop");
+  }
+  expect(bodyOf("wait_for_new_message")).not.toContain("_pending_msgs.pop");
 });
 
 test("an already-listening read-only connector is adopted, never duplicated", async () => {
@@ -215,6 +257,12 @@ test("the connector runs its incoming feed, beside the credential (#1091)", asyn
   /* A second account's connector writes a different file, so nothing it
      records can be read as the first account's activity (#1091). */
   expect(launch("credential-generation-b").env.TELEGRAM_EVENT_FEED_FILE).not.toBe(spec.env.TELEGRAM_EVENT_FEED_FILE);
+  /* Turning the feed on is half of it: the tools that would pop the same
+     bursts are withheld in the same breath, so the feed is the only consumer
+     left. The entrypoint reads this list; `TELEGRAM_EXPOSED_TOOLS` cannot
+     express it, because upstream's read-only mode only ever WIDENS. */
+  expect(spec.env.LLV_TELEGRAM_EXCLUDED_TOOLS).toBe("wait_for_settled_message");
+  expect(spec.env.LLV_TELEGRAM_EXCLUDED_TOOLS!.split(",")).toEqual([...TELEGRAM_BURST_CONSUMING_TOOLS]);
 });
 
 test("an allowlisted foreign listener is never adopted", async () => {

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -12,7 +12,7 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_TELEGRAM_API_ID = "12345";
 process.env.LLV_TELEGRAM_API_HASH = "0123456789abcdef0123456789abcdef";
 
-const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
+const { TELEGRAM_READ_TOOL_ALLOWLIST, connectorFeedCoverageSince, connectorServerName, ensureTelegramConnector, stopTelegramConnector, verifyReadOnlyTools } = await import("./connector");
 const { telegramMcpUrl, vendoredConnectorDir } = await import("./packaging");
 
 import type { ConnectorProbe, TelegramConnectorPorts } from "./connector";
@@ -246,7 +246,7 @@ test("a listening connector that runs no feed is replaced, not adopted (#1091)",
 /** A connector record of the shape the supervisor writes, so the REAL feed
     eligibility check has something to read. Nothing here is a live process:
     the check reads the record only. */
-async function writeConnectorRecord(feedFile: string): Promise<void> {
+async function writeConnectorRecord(feedFile: string, feedSince?: string): Promise<void> {
   fs.writeFileSync(
     path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json"),
     JSON.stringify({
@@ -258,10 +258,36 @@ async function writeConnectorRecord(feedFile: string): Promise<void> {
       command: (await import("./packaging")).telegramVenvPython(),
       entrypoint: (await import("./packaging")).telegramMcpServerPath(),
       feedFile,
+      ...(feedSince ? { feedSince } : {}),
     }),
     { mode: 0o600 },
   );
 }
+
+test("the record says since when this generation's feed can be believed (#1091)", async () => {
+  /* A report asks the feed for the dialogs active since the last run, and the
+     feed can only answer for the time it was listening — which the file itself
+     cannot say and `incoming_feed_status` does not report. The record written
+     at spawn is the evidence, and it is scoped to the credential generation
+     for the same reason the feed file is: another account's listener says
+     nothing about this one's window. */
+  const { telegramIncomingFeedPath } = await import("./sessionStore");
+  const startedAt = "2026-08-21T04:00:00.000Z";
+
+  await writeConnectorRecord(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef), startedAt);
+  expect(connectorFeedCoverageSince(CONNECTOR_SESSION.credentialRef)).toBe(Date.parse(startedAt));
+
+  /* Another generation's listener: no coverage of THIS account's window. */
+  expect(connectorFeedCoverageSince("credential-generation-of-another-account")).toBeNull();
+
+  /* A feed with no start stamp vouches for nothing rather than for
+     everything — the caller treats unknown coverage as uncovered. */
+  await writeConnectorRecord(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef));
+  expect(connectorFeedCoverageSince(CONNECTOR_SESSION.credentialRef)).toBeNull();
+
+  fs.rmSync(path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json"), { force: true });
+  expect(connectorFeedCoverageSince(CONNECTOR_SESSION.credentialRef)).toBeNull();
+});
 
 test("a listener writing another credential generation's feed is not adopted (#1091)", async () => {
   const { telegramIncomingFeedPath } = await import("./sessionStore");
@@ -473,7 +499,7 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     expect(childPid).toBeGreaterThan(1);
     const pidFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json");
     const recorded = JSON.parse(fs.readFileSync(pidFile, "utf8")) as {
-      pid: number; identity: string; credentialRef: string; connectorTokenSha256: string; feedFile?: string;
+      pid: number; identity: string; credentialRef: string; connectorTokenSha256: string; feedFile?: string; feedSince?: string;
     };
     expect(recorded.pid).toBe(childPid);
     expect(recorded.credentialRef).toBe(CONNECTOR_SESSION.credentialRef);
@@ -482,6 +508,10 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
        checks before adopting it (#1091). */
     const { telegramIncomingFeedPath } = await import("./sessionStore");
     expect(recorded.feedFile).toBe(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef));
+    /* Recorded together with it: the instant this listener started, which is
+       the earliest moment its feed can vouch for a report's window (#1091). */
+    expect(Date.parse(recorded.feedSince!)).toBeLessThanOrEqual(Date.now());
+    expect(connectorFeedCoverageSince(CONNECTOR_SESSION.credentialRef)).toBe(Date.parse(recorded.feedSince!));
     expect(recorded.connectorTokenSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(fs.readFileSync(pidFile, "utf8")).not.toContain(CONNECTOR_SESSION.connectorToken);
 

--- a/src/lib/telegram/connector.test.ts
+++ b/src/lib/telegram/connector.test.ts
@@ -175,6 +175,7 @@ test("a spawn failure reports connector_failed without probing forever", async (
 test("the launch env — not this test's env — carries the session; argv never does", async () => {
   const { connectorLaunchSpec } = await import("./packaging");
   const spec = connectorLaunchSpec({
+    credentialRef: CONNECTOR_SESSION.credentialRef,
     sessionString: PLACEHOLDER_SESSION,
     connectorToken: CONNECTOR_SESSION.connectorToken,
     credentials: { apiId: "12345", apiHash: "0123456789abcdef0123456789abcdef" },
@@ -190,20 +191,30 @@ test("the launch env — not this test's env — carries the session; argv never
 });
 
 test("the connector runs its incoming feed, beside the credential (#1091)", async () => {
-  const { connectorLaunchSpec, telegramIncomingFeedPath } = await import("./packaging");
-  const spec = connectorLaunchSpec({
+  const { connectorLaunchSpec } = await import("./packaging");
+  const { telegramIncomingFeedPath } = await import("./sessionStore");
+  const launch = (credentialRef: string) => connectorLaunchSpec({
+    credentialRef,
     sessionString: PLACEHOLDER_SESSION,
     connectorToken: CONNECTOR_SESSION.connectorToken,
     credentials: { apiId: "12345", apiHash: "0123456789abcdef0123456789abcdef" },
   });
+  const spec = launch(CONNECTOR_SESSION.credentialRef);
   /* Without this the connector records activity nowhere and a report's
      private-dialog discovery is back to guessing from a chat list that is not
      ordered by recency. */
   expect(spec.env.TELEGRAM_EVENT_FEED).toBe("1");
   /* The feed names the operator's correspondents, so it lives inside the 0700
      telegram directory rather than at the connector's XDG default. */
-  expect(spec.env.TELEGRAM_EVENT_FEED_FILE).toBe(telegramIncomingFeedPath());
-  expect(telegramIncomingFeedPath()).toBe(path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl"));
+  expect(spec.env.TELEGRAM_EVENT_FEED_FILE).toBe(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef));
+  /* Named for the credential GENERATION, and by a digest of it rather than
+     the ref itself, so no value read from disk is ever spliced into a path. */
+  expect(path.dirname(spec.env.TELEGRAM_EVENT_FEED_FILE!)).toBe(path.join(process.env.LLV_STATE_DIR!, "telegram"));
+  expect(path.basename(spec.env.TELEGRAM_EVENT_FEED_FILE!)).toMatch(/^incoming_feed-[0-9a-f]{16}\.jsonl$/);
+  expect(spec.env.TELEGRAM_EVENT_FEED_FILE).not.toContain(CONNECTOR_SESSION.credentialRef);
+  /* A second account's connector writes a different file, so nothing it
+     records can be read as the first account's activity (#1091). */
+  expect(launch("credential-generation-b").env.TELEGRAM_EVENT_FEED_FILE).not.toBe(spec.env.TELEGRAM_EVENT_FEED_FILE);
 });
 
 test("an allowlisted foreign listener is never adopted", async () => {
@@ -230,6 +241,55 @@ test("a listening connector that runs no feed is replaced, not adopted (#1091)",
   expect(calls.spawns).toBe(1);
   expect(calls.stops).toBeGreaterThanOrEqual(1);
   expect(calls.records).toBe(1);
+});
+
+/** A connector record of the shape the supervisor writes, so the REAL feed
+    eligibility check has something to read. Nothing here is a live process:
+    the check reads the record only. */
+async function writeConnectorRecord(feedFile: string): Promise<void> {
+  fs.writeFileSync(
+    path.join(process.env.LLV_STATE_DIR!, "telegram", "connector.json"),
+    JSON.stringify({
+      version: 1,
+      pid: process.pid,
+      identity: "start-token-placeholder",
+      credentialRef: CONNECTOR_SESSION.credentialRef,
+      connectorTokenSha256: "f".repeat(64),
+      command: (await import("./packaging")).telegramVenvPython(),
+      entrypoint: (await import("./packaging")).telegramMcpServerPath(),
+      feedFile,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+test("a listener writing another credential generation's feed is not adopted (#1091)", async () => {
+  const { telegramIncomingFeedPath } = await import("./sessionStore");
+  /* The operator disconnected one account and connected another. A listener
+     left writing the FIRST generation's feed would hand the second account
+     the first one's recent dialogs as its own active sources — after the id
+     check had already passed. The record names the file, so the mismatch is
+     visible without probing anything. */
+  await writeConnectorRecord(telegramIncomingFeedPath("credential-generation-of-another-account"));
+  const stale = fakePorts([READ_ONLY], { owned: true });
+  delete stale.ports.runsFeed;
+
+  const replaced = await ensureTelegramConnector(CONNECTOR_SESSION, stale.ports);
+
+  expect(replaced).toEqual({ ok: true, url: telegramMcpUrl() });
+  expect(stale.calls.spawns).toBe(1);
+  expect(stale.calls.stops).toBeGreaterThanOrEqual(1);
+
+  /* The same record naming THIS generation's feed is adopted, so the refusal
+     above is the feed scope and not the check refusing everything. */
+  await writeConnectorRecord(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef));
+  const current = fakePorts([READ_ONLY], { owned: true });
+  delete current.ports.runsFeed;
+
+  const adopted = await ensureTelegramConnector(CONNECTOR_SESSION, current.ports);
+
+  expect(adopted).toEqual({ ok: true, url: telegramMcpUrl() });
+  expect(current.calls.spawns).toBe(0);
 });
 
 test("a credential-generation mismatch stops the old record before spawning", async () => {
@@ -420,8 +480,8 @@ test("stop waits through SIGKILL escalation until a TERM-resistant connector exi
     /* The feed is child ENVIRONMENT, so the record is the only durable proof
        that this process runs one — and it is what a later Viewer generation
        checks before adopting it (#1091). */
-    const { telegramIncomingFeedPath } = await import("./packaging");
-    expect(recorded.feedFile).toBe(telegramIncomingFeedPath());
+    const { telegramIncomingFeedPath } = await import("./sessionStore");
+    expect(recorded.feedFile).toBe(telegramIncomingFeedPath(CONNECTOR_SESSION.credentialRef));
     expect(recorded.connectorTokenSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(fs.readFileSync(pidFile, "utf8")).not.toContain(CONNECTOR_SESSION.connectorToken);
 

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -7,7 +7,7 @@ import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
 import type { TelegramErrorCode } from "./contracts";
-import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
+import { connectorLaunchSpec, TELEGRAM_BURST_CONSUMING_TOOLS, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
 import { ensureTelegramStateDir, telegramIncomingFeedPath, type StoredTelegramSession } from "./sessionStore";
 
 /**
@@ -20,14 +20,21 @@ import { ensureTelegramStateDir, telegramIncomingFeedPath, type StoredTelegramSe
  * authenticated and verified before publication:
  *
  *  - every tool must carry `readOnlyHint: true`; and
- *  - every tool name must be on {@link TELEGRAM_READ_TOOL_ALLOWLIST}, the
+ *  - every tool name must be on {@link TELEGRAM_FEED_EXPOSED_TOOLS}: the
  *    reviewed list of tools whose implementations were audited to perform no
- *    server-side mutation. The annotation alone is NOT trusted: upstream
- *    shipped `get_invite_link`/`export_chat_invite` annotated read-only while
- *    minting invite links (see vendor/telegram-mcp/PROVENANCE.md), which is
- *    exactly the failure an annotation-only check cannot catch.
+ *    server-side mutation ({@link TELEGRAM_READ_TOOL_ALLOWLIST}), MINUS the
+ *    ones this connector withholds. The annotation alone is NOT trusted:
+ *    upstream shipped `get_invite_link`/`export_chat_invite` annotated
+ *    read-only while minting invite links (see
+ *    vendor/telegram-mcp/PROVENANCE.md), which is exactly the failure an
+ *    annotation-only check cannot catch.
  *
  * A surface violating either bound is refused and reported `not_read_only`.
+ * That includes a still-advertised burst consumer (#1091): the connector runs
+ * the incoming event feed, the entrypoint withholds the tools that would race
+ * it for the same bursts, and this gate is what proves the withholding
+ * happened rather than trusting that it did. A listener that predates the
+ * withholding fails verification once and is replaced by one that has it.
  * A pre-auth HMAC challenge proves the listener knows the current generation's
  * bearer token before that token is sent. The MCP handshake must then return
  * the token-derived server identity.
@@ -62,6 +69,15 @@ export const TELEGRAM_READ_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "search_public_chats", "wait_for_new_message", "wait_for_settled_message",
 ]);
 
+/** The surface a connector running the incoming feed may advertise (#1091):
+    the audited read set MINUS every tool that consumes a settled burst. The
+    audited set itself stays whole — those tools write nothing, and they are
+    the right surface for a connector with no feed to compete with — so the
+    vendor-parity check above keeps meaning what it says. */
+export const TELEGRAM_FEED_EXPOSED_TOOLS: ReadonlySet<string> = new Set(
+  [...TELEGRAM_READ_TOOL_ALLOWLIST].filter((name) => !TELEGRAM_BURST_CONSUMING_TOOLS.includes(name)),
+);
+
 export type ConnectorProbe =
   | { ok: true; serverName: string; tools: Array<{ name: string; readOnly: boolean }> }
   | { ok: false };
@@ -95,11 +111,13 @@ const TERMINATION_POLL_MS = 25;
 const PID_FILE = "connector.json";
 
 /** The read-only gate, pure so it is directly provable: one tool that lacks
-    an affirmative readOnlyHint OR falls outside the audited allowlist fails
-    the whole surface; an empty surface proves nothing and fails too. */
+    an affirmative readOnlyHint OR falls outside the exposed allowlist fails
+    the whole surface; an empty surface proves nothing and fails too. Every
+    connector the Viewer launches or adopts runs the feed, so the default
+    allowlist is the withheld one. */
 export function verifyReadOnlyTools(
   tools: Array<{ name: string; readOnly: boolean }>,
-  allowlist: ReadonlySet<string> = TELEGRAM_READ_TOOL_ALLOWLIST,
+  allowlist: ReadonlySet<string> = TELEGRAM_FEED_EXPOSED_TOOLS,
 ): { ok: boolean; offending: string[] } {
   const offending = tools
     .filter((tool) => !tool.readOnly || !allowlist.has(tool.name))

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -194,6 +194,9 @@ type ConnectorRecord = {
       that cannot be parsed is a connector that cannot be STOPPED, so the
       feed is a condition of ADOPTION rather than of reading the record. */
   feedFile?: string;
+  /** ISO instant this feed listener started, which is the earliest moment its
+      feed can vouch for (#1091). Optional for the same reason as `feedFile`. */
+  feedSince?: string;
 };
 
 let liveConnectorChild: {
@@ -223,6 +226,7 @@ function readConnectorRecord(): ConnectorRecord | null {
       || typeof row.identity !== "string" || typeof row.credentialRef !== "string"
       || typeof row.connectorTokenSha256 !== "string" || typeof row.command !== "string" || typeof row.entrypoint !== "string") return null;
     if (row.feedFile !== undefined && typeof row.feedFile !== "string") return null;
+    if (row.feedSince !== undefined && typeof row.feedSince !== "string") return null;
     return row as ConnectorRecord;
   } catch {
     return null;
@@ -256,6 +260,33 @@ function recordedConnectorRunsFeed(binding: ConnectorBinding): boolean {
   return record?.feedFile === telegramIncomingFeedPath(binding.credentialRef);
 }
 
+/**
+ * The earliest instant this credential generation's feed can vouch for, or
+ * `null` when nothing proves one (#1091).
+ *
+ * A report asks the feed for "the dialogs active since the last run", and the
+ * feed can only answer for the time it was LISTENING. The file itself cannot
+ * say when that began — it is append-only across connector generations, so a
+ * line older than the current listener proves nothing about the quiet stretch
+ * between them — and `incoming_feed_status` reports only that a feed is
+ * running, never since when. The record written at spawn is the durable
+ * evidence, and a listener adopted across a Viewer restart keeps the record it
+ * was spawned with, so an uninterrupted listener keeps its original coverage
+ * while a replaced one starts a new one at its own spawn.
+ *
+ * Coverage is claimed from the spawn rather than from the readiness probe a
+ * few seconds later, which is the only direction that can overstate it — by
+ * the seconds a connector takes to reach Telegram. What the caller does with
+ * this is decide whether a window is covered at all; a boundary that lands
+ * inside those seconds is not the omission class this exists to catch.
+ */
+export function connectorFeedCoverageSince(credentialRef: string): number | null {
+  const record = readConnectorRecord();
+  if (!record || record.feedFile !== telegramIncomingFeedPath(credentialRef) || !record.feedSince) return null;
+  const since = Date.parse(record.feedSince);
+  return Number.isFinite(since) ? since : null;
+}
+
 function ownsRecordedConnector(binding: ConnectorBinding): boolean {
   const record = readConnectorRecord();
   return Boolean(record
@@ -285,7 +316,11 @@ function recordConnectorProcess(child: ConnectorChild, spec: ProcessSpec, bindin
     connectorTokenSha256: connectorTokenSha256(binding.connectorToken),
     command: spec.command,
     entrypoint: spec.args[0],
-    ...(spec.env?.TELEGRAM_EVENT_FEED_FILE ? { feedFile: spec.env.TELEGRAM_EVENT_FEED_FILE } : {}),
+    /* The feed and the instant it starts covering are recorded together: a
+       feed file with no start stamp vouches for nothing (#1091). */
+    ...(spec.env?.TELEGRAM_EVENT_FEED_FILE
+      ? { feedFile: spec.env.TELEGRAM_EVENT_FEED_FILE, feedSince: new Date().toISOString() }
+      : {}),
   };
   const tmp = `${pidFilePath()}.${process.pid}.tmp`;
   try {

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -7,7 +7,7 @@ import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
 import type { TelegramErrorCode } from "./contracts";
-import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
+import { connectorLaunchSpec, telegramApiCredentials, telegramIncomingFeedPath, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
 import { ensureTelegramStateDir, type StoredTelegramSession } from "./sessionStore";
 
 /**
@@ -77,6 +77,9 @@ export interface TelegramConnectorPorts {
   sleep(ms: number): Promise<void>;
   now(): number;
   ownsProcess?(binding: ConnectorBinding): boolean;
+  /** Whether the recorded process is the generation that runs the incoming
+      event feed the Daily Report reads (#1091). */
+  runsFeed?(): boolean;
   recordProcess?(child: ConnectorChild, spec: ProcessSpec, binding: ConnectorBinding): boolean;
   stop?(): Promise<void> | void;
   beginOperation?(): () => boolean;
@@ -168,6 +171,7 @@ const realPorts: TelegramConnectorPorts = {
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),
   ownsProcess: ownsRecordedConnector,
+  runsFeed: recordedConnectorRunsFeed,
   recordProcess: recordConnectorProcess,
   stop: stopRealConnectorUnlocked,
   beginOperation: beginConnectorOperation,
@@ -185,6 +189,11 @@ type ConnectorRecord = {
   connectorTokenSha256: string;
   command: string;
   entrypoint: string;
+  /** The event feed file this process was launched with (#1091), absent on a
+      record written before the feed existed. Optional on purpose: a record
+      that cannot be parsed is a connector that cannot be STOPPED, so the
+      feed is a condition of ADOPTION rather than of reading the record. */
+  feedFile?: string;
 };
 
 let liveConnectorChild: {
@@ -213,6 +222,7 @@ function readConnectorRecord(): ConnectorRecord | null {
     if (row.version !== 1 || typeof row.pid !== "number" || !Number.isInteger(row.pid) || row.pid <= 1
       || typeof row.identity !== "string" || typeof row.credentialRef !== "string"
       || typeof row.connectorTokenSha256 !== "string" || typeof row.command !== "string" || typeof row.entrypoint !== "string") return null;
+    if (row.feedFile !== undefined && typeof row.feedFile !== "string") return null;
     return row as ConnectorRecord;
   } catch {
     return null;
@@ -223,6 +233,23 @@ function connectorArgvMatches(record: ConnectorRecord): boolean {
   const argv = procBackend.readArgv(record.pid);
   return argv[0] === record.command && argv[1] === record.entrypoint
     && record.command === telegramVenvPython() && record.entrypoint === telegramMcpServerPath();
+}
+
+/**
+ * Whether the recorded connector is one that runs the incoming event feed
+ * (#1091).
+ *
+ * The feed is child ENVIRONMENT, so no probe and no argv can prove it: the
+ * record written at spawn is the evidence, and a record from a Viewer
+ * generation that predates the feed simply has none. Such a process is fully
+ * functional as a read surface, which is why it was adopted happily — and
+ * exactly why it had to be caught: its `incoming_feed_status` reports a feed
+ * that will never start, and the report's dialog discovery would fall back to
+ * a bounded walk over a list that is not ordered by recency.
+ */
+function recordedConnectorRunsFeed(): boolean {
+  const record = readConnectorRecord();
+  return record?.feedFile === telegramIncomingFeedPath();
 }
 
 function ownsRecordedConnector(binding: ConnectorBinding): boolean {
@@ -254,6 +281,7 @@ function recordConnectorProcess(child: ConnectorChild, spec: ProcessSpec, bindin
     connectorTokenSha256: connectorTokenSha256(binding.connectorToken),
     command: spec.command,
     entrypoint: spec.args[0],
+    ...(spec.env?.TELEGRAM_EVENT_FEED_FILE ? { feedFile: spec.env.TELEGRAM_EVENT_FEED_FILE } : {}),
   };
   const tmp = `${pidFilePath()}.${process.pid}.tmp`;
   try {
@@ -385,7 +413,8 @@ async function verifiedProbe(
  * once its read-only surface is verified. A process already listening on the
  * shared port (a previous Viewer generation's connector, still recorded in
  * the pid file) is adopted, not duplicated — that keeps the process count at
- * one across Viewer restarts.
+ * one across Viewer restarts — PROVIDED its record proves it runs the incoming
+ * event feed (#1091). One that does not is replaced, once.
  */
 export async function ensureTelegramConnector(
   session: StoredTelegramSession,
@@ -395,9 +424,10 @@ export async function ensureTelegramConnector(
   const binding = { credentialRef: session.credentialRef, connectorToken: session.connectorToken };
   const stop = ports.stop ?? stopRealConnectorUnlocked;
   const ownsProcess = ports.ownsProcess ?? ownsRecordedConnector;
+  const runsFeed = ports.runsFeed ?? recordedConnectorRunsFeed;
   let isCurrent = ports.beginOperation?.() ?? (() => true);
   const prepared = await withConnectorSupervisorLock(async (): Promise<ConnectorEnsureResult | "spawned"> => {
-    if (ownsProcess(binding)) {
+    if (ownsProcess(binding) && runsFeed()) {
       const adopted = await verifiedProbe(url, session.connectorToken, ports);
       if (!isCurrent()) return { ok: false, code: "connector_failed" };
       if (adopted && adopted !== "timeout") {
@@ -405,10 +435,14 @@ export async function ensureTelegramConnector(
         return adopted;
       }
     }
-    /* Missing ownership or a credential-generation mismatch makes any current
-       listener ineligible for adoption. Stop and record the replacement while
-       holding the cross-process supervisor lock, so another Viewer generation
-       can only adopt the one durable winner. */
+    /* Missing ownership, a credential-generation mismatch, or a process
+       launched without the incoming event feed (#1091) makes any current
+       listener ineligible for adoption — the last of those because the report's
+       dialog discovery reads that feed, and a connector that records nothing
+       would send it back to a bounded walk over a list ordered by pins. Stop
+       and record the replacement while holding the cross-process supervisor
+       lock, so another Viewer generation can only adopt the one durable
+       winner. */
     await stop();
     isCurrent = ports.beginOperation?.() ?? (() => true);
     const credentials = telegramApiCredentials();

--- a/src/lib/telegram/connector.ts
+++ b/src/lib/telegram/connector.ts
@@ -7,8 +7,8 @@ import { procBackend } from "@/lib/proc";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
 import type { TelegramErrorCode } from "./contracts";
-import { connectorLaunchSpec, telegramApiCredentials, telegramIncomingFeedPath, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
-import { ensureTelegramStateDir, type StoredTelegramSession } from "./sessionStore";
+import { connectorLaunchSpec, telegramApiCredentials, telegramMcpServerPath, telegramMcpUrl, telegramVenvPython, type ProcessSpec } from "./packaging";
+import { ensureTelegramStateDir, telegramIncomingFeedPath, type StoredTelegramSession } from "./sessionStore";
 
 /**
  * Supervisor for the ONE shared loopback connector process (issue #1059).
@@ -79,7 +79,7 @@ export interface TelegramConnectorPorts {
   ownsProcess?(binding: ConnectorBinding): boolean;
   /** Whether the recorded process is the generation that runs the incoming
       event feed the Daily Report reads (#1091). */
-  runsFeed?(): boolean;
+  runsFeed?(binding: ConnectorBinding): boolean;
   recordProcess?(child: ConnectorChild, spec: ProcessSpec, binding: ConnectorBinding): boolean;
   stop?(): Promise<void> | void;
   beginOperation?(): () => boolean;
@@ -246,10 +246,14 @@ function connectorArgvMatches(record: ConnectorRecord): boolean {
  * exactly why it had to be caught: its `incoming_feed_status` reports a feed
  * that will never start, and the report's dialog discovery would fall back to
  * a bounded walk over a list that is not ordered by recency.
+ *
+ * The comparison is against THIS credential generation's feed, so a listener
+ * still writing a previous account's file is ineligible on the same evidence
+ * as a listener writing none.
  */
-function recordedConnectorRunsFeed(): boolean {
+function recordedConnectorRunsFeed(binding: ConnectorBinding): boolean {
   const record = readConnectorRecord();
-  return record?.feedFile === telegramIncomingFeedPath();
+  return record?.feedFile === telegramIncomingFeedPath(binding.credentialRef);
 }
 
 function ownsRecordedConnector(binding: ConnectorBinding): boolean {
@@ -427,7 +431,7 @@ export async function ensureTelegramConnector(
   const runsFeed = ports.runsFeed ?? recordedConnectorRunsFeed;
   let isCurrent = ports.beginOperation?.() ?? (() => true);
   const prepared = await withConnectorSupervisorLock(async (): Promise<ConnectorEnsureResult | "spawned"> => {
-    if (ownsProcess(binding) && runsFeed()) {
+    if (ownsProcess(binding) && runsFeed(binding)) {
       const adopted = await verifiedProbe(url, session.connectorToken, ports);
       if (!isCurrent()) return { ok: false, code: "connector_failed" };
       if (adopted && adopted !== "timeout") {
@@ -447,7 +451,7 @@ export async function ensureTelegramConnector(
     isCurrent = ports.beginOperation?.() ?? (() => true);
     const credentials = telegramApiCredentials();
     if (!credentials) return { ok: false, code: "credentials_missing" };
-    const spec = connectorLaunchSpec({ sessionString: session.sessionString, connectorToken: session.connectorToken, credentials });
+    const spec = connectorLaunchSpec({ credentialRef: session.credentialRef, sessionString: session.sessionString, connectorToken: session.connectorToken, credentials });
     if (!isCurrent()) return { ok: false, code: "connector_failed" };
     const child = ports.spawn(spec);
     if (!child) return { ok: false, code: "connector_failed" };

--- a/src/lib/telegram/contracts.ts
+++ b/src/lib/telegram/contracts.ts
@@ -35,11 +35,40 @@ export type TelegramErrorCode =
   | "logout_failed"
   | "health_failed";
 
-/** Sanitized account identity: display name and public username only. */
+/** Sanitized account identity: display name and public username only. This is
+    the shape that crosses the browser boundary. */
 export type TelegramIdentity = {
   name: string;
   username: string | null;
 };
+
+/**
+ * The identity as it is RECORDED (issue #1091).
+ *
+ * Names and handles are the operator's to change at any moment; the numeric
+ * Telegram user id is not, so it is what "the same account" actually means and
+ * what the report-run verifier compares. It is recorded at Connect, kept in
+ * owner-only `connection.json`, and deliberately absent from
+ * {@link TelegramStatusPayload}: no surface outside the server has a use for
+ * it, so it stays on the same side of the boundary as the credential.
+ *
+ * `id` is a decimal STRING because a Telegram id is a 64-bit integer and JSON
+ * numbers are not. `null` is a pre-#1091 record that has not been upgraded yet.
+ */
+export type TelegramAccountIdentity = TelegramIdentity & {
+  id: string | null;
+};
+
+/** Telegram user ids are positive integers; the marked form a connector
+    returns for a user is the id itself. Anything else is not an id. */
+export function validTelegramAccountId(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? String(value) : null;
+  }
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return /^[1-9]\d{0,18}$/.test(trimmed) ? trimmed : null;
+}
 
 /** A live login operation as the browser sees it. The QR url is the
     `tg://login` token Telegram mints for scanning — it is the one value that

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -352,6 +352,7 @@ test("health and logout bridges acquire the vendored session lock before connect
     "from .sessions import StringSession",
     "class User:",
     "    first_name, last_name, username = 'Account', 'A', None",
+    "    id = 770000001",
     "class TelegramClient:",
     "    def __init__(self, session, *args, **kwargs): self.session = session",
     "    async def connect(self):",
@@ -376,7 +377,13 @@ test("health and logout bridges acquire the vendored session lock before connect
     stderr: "pipe",
   });
   expect(result.exitCode).toBe(0);
-  expect(JSON.parse(result.stdout.toString())).toMatchObject({ event: "health", status: "connected" });
+  /* The health event carries the numeric account id the verifier compares
+     (#1091), as a string so a 64-bit id survives JSON. */
+  expect(JSON.parse(result.stdout.toString())).toMatchObject({
+    event: "health",
+    status: "connected",
+    identity: { name: "Account A", username: null, id: "770000001" },
+  });
 
   const logout = Bun.spawnSync({
     cmd: [python!, path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-login-bridge.py"), "logout"],

--- a/src/lib/telegram/packaging.test.ts
+++ b/src/lib/telegram/packaging.test.ts
@@ -19,6 +19,7 @@ const {
   loginBridgePath,
   telegramMcpServerPath,
   telegramSessionReaderPath,
+  TELEGRAM_BURST_CONSUMING_TOOLS,
 } = await import("./packaging");
 const { installPinnedUv, uvReleaseFor, UV_BOOTSTRAP_VERSION } = await import("../../../bin/provision-telegram-connector.mjs");
 
@@ -310,6 +311,85 @@ test("the packaged MCP entrypoint enforces bearer auth and token-bound identity"
   expect(output.proof_status).toBe(200);
   expect(output.proof_matches).toBe(true);
   expect(output.name).toMatch(/^telegram-[a-f0-9]{64}$/);
+});
+
+test("the entrypoint withholds the burst consumers the feed must own alone (#1091)", () => {
+  const python = Bun.which("python3");
+  expect(python).not.toBeNull();
+  /* A fake vendor tree with just enough of FastMCP to hold a tool registry:
+     the real one needs Telethon and a Telegram session, and what is under test
+     is which tools survive the entrypoint, not what they do. The runner
+     registers them at import, exactly as the vendored one does by importing
+     `telegram_mcp.tools`. */
+  const fakeVendor = path.join(SANDBOX, "withheld-tools-vendor");
+  for (const directory of ["mcp/server", "telegram_mcp"]) {
+    fs.mkdirSync(path.join(fakeVendor, directory), { recursive: true });
+    fs.writeFileSync(path.join(fakeVendor, directory, "__init__.py"), "");
+  }
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "__init__.py"), "");
+  fs.writeFileSync(path.join(fakeVendor, "mcp", "server", "fastmcp.py"), [
+    "class _Server:",
+    "    name = 'telegram'",
+    "class _Tool:",
+    "    def __init__(self, name): self.name = name",
+    "class _ToolManager:",
+    "    def __init__(self): self._tools = {}",
+    "    def register(self, name): self._tools[name] = _Tool(name)",
+    "    def list_tools(self): return list(self._tools.values())",
+    "    def remove_tool(self, name): del self._tools[name]",
+    "class FastMCP:",
+    "    def __init__(self):",
+    "        self._mcp_server = _Server()",
+    "        self._tool_manager = _ToolManager()",
+    "    def streamable_http_app(self):",
+    "        async def app(scope, receive, send): return None",
+    "        return app",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runtime.py"), [
+    "from mcp.server.fastmcp import FastMCP",
+    "mcp = FastMCP()",
+    "",
+  ].join("\n"));
+  fs.writeFileSync(path.join(fakeVendor, "telegram_mcp", "runner.py"), [
+    "import json",
+    "from telegram_mcp.runtime import mcp",
+    "for _name in ('get_me', 'wait_for_new_message', 'wait_for_settled_message'):",
+    "    mcp._tool_manager.register(_name)",
+    "def main():",
+    "    print(json.dumps([tool.name for tool in mcp._tool_manager.list_tools()]))",
+    "",
+  ].join("\n"));
+
+  const entrypoint = path.resolve(import.meta.dir, "..", "..", "..", "bin", "telegram-mcp-server.py");
+  const runEntrypoint = (excluded?: string) => {
+    const env = { ...process.env, LLV_TELEGRAM_VENDOR_DIR: fakeVendor, LLV_TELEGRAM_MCP_TOKEN: "C".repeat(43) } as Record<string, string>;
+    delete env.LLV_TELEGRAM_EXCLUDED_TOOLS;
+    if (excluded !== undefined) env.LLV_TELEGRAM_EXCLUDED_TOOLS = excluded;
+    return Bun.spawnSync({ cmd: [python!, entrypoint], env, stdout: "pipe", stderr: "pipe" });
+  };
+
+  /* Feed on — the connector the Viewer actually launches. The consumer that
+     would pop a settled burst before the feed sees it is gone from the served
+     surface; the tool that only REPORTS pending chats costs the feed nothing
+     and stays. */
+  const withheld = runEntrypoint(TELEGRAM_BURST_CONSUMING_TOOLS.join(","));
+  expect(withheld.stderr.toString()).toBe("");
+  expect(withheld.exitCode).toBe(0);
+  expect(JSON.parse(withheld.stdout.toString())).toEqual(["get_me", "wait_for_new_message"]);
+
+  /* Feed off — no exclusion travels with the launch, and the audited read
+     surface is served whole, exactly as before this rule existed. */
+  const untouched = runEntrypoint();
+  expect(untouched.exitCode).toBe(0);
+  expect(JSON.parse(untouched.stdout.toString())).toEqual(["get_me", "wait_for_new_message", "wait_for_settled_message"]);
+
+  /* A name that is not registered fails the launch instead of serving a
+     surface nobody narrowed: after a vendor bump that renamed a consumer,
+     starting anyway would restore the very race this removes. */
+  const renamed = runEntrypoint("wait_for_settled_burst");
+  expect(renamed.exitCode).not.toBe(0);
+  expect(renamed.stderr.toString()).toContain("wait_for_settled_burst");
 });
 
 test("health and logout bridges acquire the vendored session lock before connecting", () => {

--- a/src/lib/telegram/packaging.ts
+++ b/src/lib/telegram/packaging.ts
@@ -67,6 +67,22 @@ export function telegramVenvDir(): string {
   return statePath("telegram", "venv");
 }
 
+/**
+ * The connector's incoming-event feed (issue #1091).
+ *
+ * The feed is an append-only JSONL record of settled incoming private bursts —
+ * the only source that says which dialogs were ACTIVE, in real time, without
+ * walking a chat list whose order is pins and folders. A Daily Report run's
+ * private-dialog discovery reads it, so it is pinned beside the credential
+ * rather than left at the connector's XDG default: it names the operator's
+ * correspondents, so it belongs inside the 0700 telegram directory under the
+ * same owner-only fence as everything else this feature stores. The connector
+ * creates it 0600 itself.
+ */
+export function telegramIncomingFeedPath(): string {
+  return statePath("telegram", "incoming_feed.jsonl");
+}
+
 /** The provisioner's writable staging copy of the vendored tree (#1084): the
     packaged tree can sit on a read-only filesystem, while the runtime's
     supply-chain guard requires a source checkout and the server writes its
@@ -244,6 +260,16 @@ export function connectorLaunchSpec(input: { sessionString: string; connectorTok
       TELEGRAM_API_HASH: input.credentials.apiHash,
       TELEGRAM_SESSION_STRING: input.sessionString,
       TELEGRAM_EXPOSED_TOOLS: "read-only",
+      /* Run the incoming feed (#1091). Without it the connector records
+         activity nowhere, and private-dialog discovery is back to guessing
+         from a chat list that is not ordered by recency. The feed CONSUMES
+         settled bursts, which upstream documents as mutually exclusive with a
+         blocking `wait_for_settled_message`: an agent watching one chat may
+         miss a burst the feed already took. That is the trade this connector
+         makes — it is the Viewer's own, and the durable daily record is worth
+         more than one blocking wait. */
+      TELEGRAM_EVENT_FEED: "1",
+      TELEGRAM_EVENT_FEED_FILE: telegramIncomingFeedPath(),
       LLV_TELEGRAM_MCP_TOKEN: input.connectorToken,
       LLV_TELEGRAM_VENDOR_DIR: vendor,
       MCP_TRANSPORT: "http",

--- a/src/lib/telegram/packaging.ts
+++ b/src/lib/telegram/packaging.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { configFilePath, stateDir, statePath } from "@/lib/configDir";
 import { withFileTransaction } from "@/lib/state/fileTransaction";
 
-import { ensureTelegramStateDir } from "./sessionStore";
+import { ensureTelegramStateDir, telegramIncomingFeedPath } from "./sessionStore";
 
 /**
  * Packaging of the pinned Telegram MCP connector (issue #1059).
@@ -65,22 +65,6 @@ export function vendoredConnectorDir(): string {
 
 export function telegramVenvDir(): string {
   return statePath("telegram", "venv");
-}
-
-/**
- * The connector's incoming-event feed (issue #1091).
- *
- * The feed is an append-only JSONL record of settled incoming private bursts —
- * the only source that says which dialogs were ACTIVE, in real time, without
- * walking a chat list whose order is pins and folders. A Daily Report run's
- * private-dialog discovery reads it, so it is pinned beside the credential
- * rather than left at the connector's XDG default: it names the operator's
- * correspondents, so it belongs inside the 0700 telegram directory under the
- * same owner-only fence as everything else this feature stores. The connector
- * creates it 0600 itself.
- */
-export function telegramIncomingFeedPath(): string {
-  return statePath("telegram", "incoming_feed.jsonl");
 }
 
 /** The provisioner's writable staging copy of the vendored tree (#1084): the
@@ -248,7 +232,7 @@ export function ensureConnectorProvisioned(): Promise<boolean> {
     The session string travels ONLY as child environment (the upstream
     contract) — never as an argument, so it cannot surface in process listings,
     transcripts, or the activity journal. */
-export function connectorLaunchSpec(input: { sessionString: string; connectorToken: string; credentials: TelegramApiCredentials }): ProcessSpec {
+export function connectorLaunchSpec(input: { credentialRef: string; sessionString: string; connectorToken: string; credentials: TelegramApiCredentials }): ProcessSpec {
   const vendor = stagedConnectorSourceDir();
   return {
     command: telegramVenvPython(),
@@ -269,7 +253,7 @@ export function connectorLaunchSpec(input: { sessionString: string; connectorTok
          makes — it is the Viewer's own, and the durable daily record is worth
          more than one blocking wait. */
       TELEGRAM_EVENT_FEED: "1",
-      TELEGRAM_EVENT_FEED_FILE: telegramIncomingFeedPath(),
+      TELEGRAM_EVENT_FEED_FILE: telegramIncomingFeedPath(input.credentialRef),
       LLV_TELEGRAM_MCP_TOKEN: input.connectorToken,
       LLV_TELEGRAM_VENDOR_DIR: vendor,
       MCP_TRANSPORT: "http",

--- a/src/lib/telegram/packaging.ts
+++ b/src/lib/telegram/packaging.ts
@@ -96,6 +96,19 @@ export function telegramProvisionerPath(): string {
   return packageAssetPath(process.env.LLV_TELEGRAM_PROVISIONER, "bin", "provision-telegram-connector.mjs");
 }
 
+/**
+ * Read tools that CONSUME a settled burst: they pop the chat out of the
+ * connector's pending set, so whichever consumer scans first takes it
+ * (`wait_for_settled_message` in `telegram_mcp/tools/events.py`). The incoming
+ * event feed consumes exactly the same bursts, which is why a connector that
+ * runs the feed withholds these instead of racing it — see
+ * {@link connectorLaunchSpec}.
+ *
+ * `wait_for_new_message` is deliberately NOT here: it reports the pending set
+ * without removing anything, so it costs the feed no burst and stays exposed.
+ */
+export const TELEGRAM_BURST_CONSUMING_TOOLS: readonly string[] = Object.freeze(["wait_for_settled_message"]);
+
 export type TelegramApiCredentials = { apiId: string; apiHash: string };
 
 /**
@@ -246,14 +259,20 @@ export function connectorLaunchSpec(input: { credentialRef: string; sessionStrin
       TELEGRAM_EXPOSED_TOOLS: "read-only",
       /* Run the incoming feed (#1091). Without it the connector records
          activity nowhere, and private-dialog discovery is back to guessing
-         from a chat list that is not ordered by recency. The feed CONSUMES
-         settled bursts, which upstream documents as mutually exclusive with a
-         blocking `wait_for_settled_message`: an agent watching one chat may
-         miss a burst the feed already took. That is the trade this connector
-         makes — it is the Viewer's own, and the durable daily record is worth
-         more than one blocking wait. */
+         from a chat list that is not ordered by recency. */
       TELEGRAM_EVENT_FEED: "1",
       TELEGRAM_EVENT_FEED_FILE: telegramIncomingFeedPath(input.credentialRef),
+      /* The feed CONSUMES settled bursts, and upstream documents a blocking
+         `wait_for_settled_message` as the other consumer of the same bursts —
+         whichever scans first takes one, so a concurrent waiter could eat the
+         burst that was a report's only evidence of an active dialog. This
+         connector does not run that race: the burst consumers are WITHHELD
+         from the surface it exposes, leaving the feed the only one. The
+         withholding happens in the Viewer's own entrypoint because upstream's
+         `TELEGRAM_EXPOSED_TOOLS` can only widen a read-only surface with write
+         tools, never narrow it; connector readiness then verifies that the
+         advertised surface really is missing them. */
+      LLV_TELEGRAM_EXCLUDED_TOOLS: TELEGRAM_BURST_CONSUMING_TOOLS.join(","),
       LLV_TELEGRAM_MCP_TOKEN: input.connectorToken,
       LLV_TELEGRAM_VENDOR_DIR: vendor,
       MCP_TRANSPORT: "http",

--- a/src/lib/telegram/reportFeed.test.ts
+++ b/src/lib/telegram/reportFeed.test.ts
@@ -7,7 +7,7 @@ const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-feed-"));
 const OLD_STATE = process.env.LLV_STATE_DIR;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
-const { feedDialogsSince, readFeedDialogsSince, MAX_FEED_TAIL_BYTES } = await import("./reportFeed");
+const { activeFeedFile, feedDialogsSince, readFeedDialogsSince, MAX_FEED_TAIL_BYTES } = await import("./reportFeed");
 const { ensureTelegramStateDir } = await import("./sessionStore");
 
 /**
@@ -113,4 +113,36 @@ test("a feed file readable by anyone else is refused, not read", () => {
   /* It names the operator's correspondents, so it lives under the same
      owner-only fence as the credential beside it. */
   expect(() => readFeedDialogsSince(feedFile, WINDOW_START)).toThrow(/unsafe/i);
+});
+
+/** What the connector's `incoming_feed_status` answers, invented. */
+function status(fields: Record<string, unknown>): string {
+  return JSON.stringify({
+    feed_file: "/state/telegram/incoming_feed.jsonl",
+    settle_ms: 6000,
+    watch_command: "tail -n 0 -F /state/telegram/incoming_feed.jsonl",
+    autostart_pending: false,
+    enabled: false,
+    ...fields,
+  });
+}
+
+test("a running feed and an armed one both name their file; nothing else does", () => {
+  /* The connector starts its feed from the handler of the FIRST incoming
+     message, so `autostart_pending` is the ordinary state of a connector that
+     has been up since before anybody wrote to the operator — and it has lost
+     nothing, because the burst that starts the feed is recorded before the
+     start and written with it. */
+  expect(activeFeedFile(status({ enabled: true }))).toBe("/state/telegram/incoming_feed.jsonl");
+  expect(activeFeedFile(status({ autostart_pending: true }))).toBe("/state/telegram/incoming_feed.jsonl");
+
+  /* Neither running nor armed: a connector adopted from a Viewer generation
+     that predates the feed. It answers with a path it will never write, which
+     is precisely the answer that must not read as an empty feed (#1091). */
+  expect(activeFeedFile(status({}))).toBeNull();
+  expect(activeFeedFile(status({ enabled: true, feed_file: "" }))).toBeNull();
+  expect(activeFeedFile(status({ enabled: "yes" }))).toBeNull();
+  /* A connector too old to have the tool at all answers with a sentence. */
+  expect(activeFeedFile("Unknown tool: incoming_feed_status")).toBeNull();
+  expect(activeFeedFile("")).toBeNull();
 });

--- a/src/lib/telegram/reportFeed.test.ts
+++ b/src/lib/telegram/reportFeed.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-feed-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+const { feedDialogsSince, readFeedDialogsSince, MAX_FEED_TAIL_BYTES } = await import("./reportFeed");
+const { ensureTelegramStateDir } = await import("./sessionStore");
+
+/**
+ * The connector's feed lines, invented. Nothing here is a real correspondent:
+ * ids are in a made-up range and names are placeholders.
+ */
+function line(chatId: number, name: string, ts: number, username: string | null = null): string {
+  return JSON.stringify({
+    chat_id: chatId,
+    name,
+    username,
+    message_count: 2,
+    first_message_id: 10,
+    last_message_id: 11,
+    burst_seconds: 4.2,
+    ts,
+  });
+}
+
+const WINDOW_START = Date.parse("2026-08-20T07:00:00.000Z");
+const seconds = (iso: string) => Date.parse(iso) / 1000;
+
+beforeEach(() => {
+  fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = OLD_STATE;
+});
+
+test("the feed answers which dialogs were active in the window, newest first", () => {
+  const text = [
+    line(910000001, "Dialog A", seconds("2026-08-20T09:00:00.000Z")),
+    line(910000002, "Dialog B", seconds("2026-08-20T20:00:00.000Z")),
+    /* Before the window: the same dialog, an earlier day. */
+    line(910000003, "Dialog C", seconds("2026-08-18T09:00:00.000Z")),
+  ].join("\n") + "\n";
+
+  expect(feedDialogsSince(text, WINDOW_START)).toEqual([
+    { id: "910000002", title: "Dialog B", lastMessageAt: "2026-08-20T20:00:00.000Z" },
+    { id: "910000001", title: "Dialog A", lastMessageAt: "2026-08-20T09:00:00.000Z" },
+  ]);
+});
+
+test("a dialog that burst repeatedly is one source, stamped with its latest burst", () => {
+  const text = [
+    line(910000004, "Dialog D", seconds("2026-08-20T09:00:00.000Z")),
+    line(910000004, "Dialog D", seconds("2026-08-20T18:30:00.000Z")),
+    line(910000004, "Dialog D", seconds("2026-08-20T12:00:00.000Z")),
+  ].join("\n");
+
+  expect(feedDialogsSince(text, WINDOW_START)).toEqual([
+    { id: "910000004", title: "Dialog D", lastMessageAt: "2026-08-20T18:30:00.000Z" },
+  ]);
+});
+
+test("bots, groups and junk lines are not private dialogs", () => {
+  const text = [
+    line(910000005, "Reminder Service", seconds("2026-08-20T09:00:00.000Z"), "some_reminder_bot"),
+    /* A negative marked id is a group or channel; this feed should not carry
+       one, and a report's private-dialog list must never gain one this way. */
+    line(-1001200300, "Team room", seconds("2026-08-20T09:00:00.000Z")),
+    "{ not json at all",
+    "",
+    line(910000006, "Dialog F", seconds("2026-08-20T09:00:00.000Z")),
+  ].join("\n");
+
+  expect(feedDialogsSince(text, WINDOW_START).map((row) => row.id)).toEqual(["910000006"]);
+});
+
+test("the file read is bounded to the tail and never returns a half line", () => {
+  ensureTelegramStateDir(true);
+  const feedFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl");
+  const filler = Array.from({ length: 4000 }, (_, index) =>
+    line(910001000 + index, `Dialog ${index}`, seconds("2026-08-20T09:00:00.000Z")));
+  const newest = line(910009999, "Dialog newest", seconds("2026-08-20T22:00:00.000Z"));
+  fs.writeFileSync(feedFile, filler.join("\n") + "\n" + newest + "\n", { mode: 0o600 });
+  expect(fs.statSync(feedFile).size).toBeGreaterThan(MAX_FEED_TAIL_BYTES);
+
+  const dialogs = readFeedDialogsSince(feedFile, WINDOW_START);
+
+  /* The newest burst is at the END of an append-only file, which is the half
+     the bound keeps — and every row it returns parsed, so no truncated first
+     line was handed to the parser. */
+  expect(dialogs[0]).toEqual({ id: "910009999", title: "Dialog newest", lastMessageAt: "2026-08-20T22:00:00.000Z" });
+  expect(dialogs.length).toBeGreaterThan(1);
+  expect(dialogs.length).toBeLessThan(filler.length);
+});
+
+test("a feed that was never written is an empty answer, not a failure", () => {
+  ensureTelegramStateDir(true);
+  expect(readFeedDialogsSince(path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl"), WINDOW_START)).toEqual([]);
+  expect(readFeedDialogsSince(null, WINDOW_START)).toEqual([]);
+});
+
+test("a feed file readable by anyone else is refused, not read", () => {
+  ensureTelegramStateDir(true);
+  const feedFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl");
+  fs.writeFileSync(feedFile, line(910000007, "Dialog G", seconds("2026-08-20T09:00:00.000Z")) + "\n", { mode: 0o644 });
+
+  /* It names the operator's correspondents, so it lives under the same
+     owner-only fence as the credential beside it. */
+  expect(() => readFeedDialogsSince(feedFile, WINDOW_START)).toThrow(/unsafe/i);
+});

--- a/src/lib/telegram/reportFeed.test.ts
+++ b/src/lib/telegram/reportFeed.test.ts
@@ -7,8 +7,8 @@ const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-feed-"));
 const OLD_STATE = process.env.LLV_STATE_DIR;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
-const { activeFeedFile, feedDialogsSince, readFeedDialogsSince, MAX_FEED_TAIL_BYTES } = await import("./reportFeed");
-const { ensureTelegramStateDir } = await import("./sessionStore");
+const { activeFeedFile, feedDialogsSince, readFeedDialogsSince, scopedFeedFile, FEED_CHUNK_BYTES, MAX_FEED_SCAN_BYTES } = await import("./reportFeed");
+const { ensureTelegramStateDir, telegramIncomingFeedPath } = await import("./sessionStore");
 
 /**
  * The connector's feed lines, invented. Nothing here is a real correspondent:
@@ -29,6 +29,12 @@ function line(chatId: number, name: string, ts: number, username: string | null 
 
 const WINDOW_START = Date.parse("2026-08-20T07:00:00.000Z");
 const seconds = (iso: string) => Date.parse(iso) / 1000;
+
+/* Two credential generations, invented. A generation is an opaque ref the
+   store mints per connect; these stand in for "the account that was connected
+   yesterday" and "the one connected now". */
+const CREDENTIAL_A = "credential-generation-a";
+const CREDENTIAL_B = "credential-generation-b";
 
 beforeEach(() => {
   fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
@@ -80,39 +86,82 @@ test("bots, groups and junk lines are not private dialogs", () => {
   expect(feedDialogsSince(text, WINDOW_START).map((row) => row.id)).toEqual(["910000006"]);
 });
 
-test("the file read is bounded to the tail and never returns a half line", () => {
+/** Writes a feed under this generation's own name, the way the connector does. */
+function writeFeed(lines: string[], mode = 0o600): string {
   ensureTelegramStateDir(true);
-  const feedFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl");
-  const filler = Array.from({ length: 4000 }, (_, index) =>
-    line(910001000 + index, `Dialog ${index}`, seconds("2026-08-20T09:00:00.000Z")));
-  const newest = line(910009999, "Dialog newest", seconds("2026-08-20T22:00:00.000Z"));
-  fs.writeFileSync(feedFile, filler.join("\n") + "\n" + newest + "\n", { mode: 0o600 });
-  expect(fs.statSync(feedFile).size).toBeGreaterThan(MAX_FEED_TAIL_BYTES);
+  const feedFile = telegramIncomingFeedPath(CREDENTIAL_A);
+  fs.writeFileSync(feedFile, lines.join("\n") + "\n", { mode });
+  return feedFile;
+}
+
+test("one dialog bursting all day cannot push another out of the window (#1091)", () => {
+  /* The reviewer's repro: the target burst arrives first, then one other
+     dialog bursts thousands of times behind it and pushes it far past any
+     fixed tail. Its dialog also sits beyond the walk's probe budget, so a tail
+     that stopped at a constant would drop it from the report in silence — the
+     exact omission the feed exists to end. */
+  const target = line(910009001, "Dialog target", seconds("2026-08-20T07:30:00.000Z"));
+  const chatter = Array.from({ length: 9000 }, (_, index) =>
+    line(910009002, "Dialog chatter", seconds("2026-08-20T09:00:00.000Z") + index));
+  const older = line(910009003, "Dialog older", seconds("2026-08-19T22:00:00.000Z"));
+  const feedFile = writeFeed([older, target, ...chatter]);
+  expect(fs.statSync(feedFile).size).toBeGreaterThan(FEED_CHUNK_BYTES);
 
   const dialogs = readFeedDialogsSince(feedFile, WINDOW_START);
 
-  /* The newest burst is at the END of an append-only file, which is the half
-     the bound keeps — and every row it returns parsed, so no truncated first
-     line was handed to the parser. */
-  expect(dialogs[0]).toEqual({ id: "910009999", title: "Dialog newest", lastMessageAt: "2026-08-20T22:00:00.000Z" });
-  expect(dialogs.length).toBeGreaterThan(1);
-  expect(dialogs.length).toBeLessThan(filler.length);
+  /* Both in-window dialogs, and every row parsed — no truncated line reached
+     the parser. The pre-window burst is what stopped the backward scan, and it
+     is still filtered out of the answer. */
+  expect(dialogs.map((row) => row.id).sort()).toEqual(["910009001", "910009002"]);
+  expect(dialogs[0]).toEqual({ id: "910009002", title: "Dialog chatter", lastMessageAt: "2026-08-20T11:29:59.000Z" });
+});
+
+test("a feed too large to reach the window's far side fails the read, never truncates it", () => {
+  /* Nothing before the window inside the budget, so the scan cannot prove it
+     saw the whole window. Answering with the part that fit would drop the
+     OLDEST in-window dialogs — the ones the bounded walk behind this cannot
+     recover either — so the source pass fails instead. */
+  const lines = Array.from({ length: 90_000 }, (_, index) =>
+    line(910010000 + (index % 40), `Dialog ${index % 40}`, seconds("2026-08-20T09:00:00.000Z") + index));
+  const feedFile = writeFeed(lines);
+  expect(fs.statSync(feedFile).size).toBeGreaterThan(MAX_FEED_SCAN_BYTES);
+
+  expect(() => readFeedDialogsSince(feedFile, WINDOW_START)).toThrow(/larger than one report read/i);
 });
 
 test("a feed that was never written is an empty answer, not a failure", () => {
   ensureTelegramStateDir(true);
-  expect(readFeedDialogsSince(path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl"), WINDOW_START)).toEqual([]);
+  expect(readFeedDialogsSince(telegramIncomingFeedPath(CREDENTIAL_A), WINDOW_START)).toEqual([]);
   expect(readFeedDialogsSince(null, WINDOW_START)).toEqual([]);
 });
 
 test("a feed file readable by anyone else is refused, not read", () => {
-  ensureTelegramStateDir(true);
-  const feedFile = path.join(process.env.LLV_STATE_DIR!, "telegram", "incoming_feed.jsonl");
-  fs.writeFileSync(feedFile, line(910000007, "Dialog G", seconds("2026-08-20T09:00:00.000Z")) + "\n", { mode: 0o644 });
+  const feedFile = writeFeed([line(910000007, "Dialog G", seconds("2026-08-20T09:00:00.000Z"))], 0o644);
 
   /* It names the operator's correspondents, so it lives under the same
      owner-only fence as the credential beside it. */
   expect(() => readFeedDialogsSince(feedFile, WINDOW_START)).toThrow(/unsafe/i);
+});
+
+test("account A's feed is never readable as account B's activity (#1091)", () => {
+  /* A disconnect that removed the credential used to leave the feed behind,
+     and the next account to connect — its own id check passed — discovered the
+     departed account's recent dialogs as its own sources. Two defences, either
+     of which alone ends it. */
+  const feedFile = writeFeed([line(910000008, "Dialog carried", seconds("2026-08-20T09:00:00.000Z"))]);
+  expect(readFeedDialogsSince(feedFile, WINDOW_START)).toHaveLength(1);
+
+  /* One: the file is named for its credential generation, so B cannot even
+     name A's. */
+  expect(telegramIncomingFeedPath(CREDENTIAL_B)).not.toBe(feedFile);
+  expect(readFeedDialogsSince(telegramIncomingFeedPath(CREDENTIAL_B), WINDOW_START)).toEqual([]);
+
+  /* Two: a run reads only the file the CURRENT generation's connector reports
+     it is writing. A listener still pointed at A's feed is refused as no feed
+     at all, which fails the source pass instead of borrowing A's dialogs. */
+  expect(scopedFeedFile(status({ enabled: true, feed_file: feedFile }), CREDENTIAL_A)).toBe(feedFile);
+  expect(scopedFeedFile(status({ enabled: true, feed_file: feedFile }), CREDENTIAL_B)).toBeNull();
+  expect(scopedFeedFile(status({ enabled: true, feed_file: feedFile }), null)).toBeNull();
 });
 
 /** What the connector's `incoming_feed_status` answers, invented. */

--- a/src/lib/telegram/reportFeed.ts
+++ b/src/lib/telegram/reportFeed.ts
@@ -1,0 +1,111 @@
+import { readSafeTailText } from "./sessionStore";
+
+/**
+ * The connector's incoming event feed, as a Daily Report source (issue #1091).
+ *
+ * The feed is the only thing on this host that records WHEN a private dialog
+ * was last active without asking Telegram for a chat list. The connector's list
+ * order is pins and folders — never recency — so v1 had to probe candidates one
+ * by one and stop at a budget, which meant an operator with hundreds of dialogs
+ * could have a conversation they answered an hour ago fall outside the budget
+ * and vanish from the day's report. A feed line has none of that shape: it is
+ * written the moment a burst settles, so "dialogs active since the last run" is
+ * a filter over the feed rather than a search through a list.
+ *
+ * Two properties this module is built around:
+ *
+ *  - the file is APPEND-ONLY and nothing rotates it, so it is read from the END
+ *    with a byte bound. A day's activity is kilobytes; the bound only decides
+ *    how far back a first run after a long silence can see.
+ *  - the file is written by the connector under the same owner-only fence as
+ *    the credential (0600, same uid), and it is read through that fence, so a
+ *    feed replaced by another user's file is refused rather than believed.
+ *
+ * Every value in a line except the id and the timestamp is user-generated: the
+ * `name` is whatever the correspondent calls themselves. It is carried as a
+ * title and truncated, never interpreted.
+ */
+
+/** How far back from the end of the feed one read looks. Each line is ~150
+    bytes, so this is thousands of bursts — far past any report window. */
+export const MAX_FEED_TAIL_BYTES = 512 * 1024;
+
+/** A title longer than this is not a name. */
+const MAX_TITLE_LENGTH = 120;
+
+export type FeedDialog = {
+  /** Marked chat id, as a string so a 64-bit id survives JSON. */
+  id: string;
+  title: string;
+  /** ISO instant of the most recent burst this feed records for the dialog. */
+  lastMessageAt: string;
+};
+
+type FeedLine = {
+  chat_id?: unknown;
+  name?: unknown;
+  username?: unknown;
+  ts?: unknown;
+};
+
+/**
+ * The dialogs the feed records as active at or after `sinceMs`, newest first.
+ *
+ * One dialog appears once, stamped with its most recent burst. Bots are dropped
+ * on the same evidence the chat listing uses — Telegram requires every bot
+ * username to end in `bot` — and a negative id is a group or channel, which
+ * this feed is not supposed to contain and which is never a private dialog.
+ */
+export function feedDialogsSince(text: string, sinceMs: number): FeedDialog[] {
+  const newest = new Map<string, number>();
+  const titles = new Map<string, string>();
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: FeedLine;
+    try {
+      parsed = JSON.parse(line) as FeedLine;
+    } catch {
+      /* A half-written tail line, or a rotation that left junk. The feed is a
+         source of activity, not a source of truth about its own integrity. */
+      continue;
+    }
+    const id = feedChatId(parsed.chat_id);
+    if (!id) continue;
+    if (typeof parsed.username === "string" && parsed.username.toLowerCase().endsWith("bot")) continue;
+    const at = feedInstant(parsed.ts);
+    if (at === null || at < sinceMs) continue;
+    const previous = newest.get(id);
+    if (previous !== undefined && previous >= at) continue;
+    newest.set(id, at);
+    titles.set(id, typeof parsed.name === "string" && parsed.name ? parsed.name.slice(0, MAX_TITLE_LENGTH) : id);
+  }
+  return [...newest.entries()]
+    .sort((left, right) => right[1] - left[1])
+    .map(([id, at]) => ({ id, title: titles.get(id) ?? id, lastMessageAt: new Date(at).toISOString() }));
+}
+
+/** Telegram marks user ids positive and every group/channel id negative. */
+function feedChatId(value: unknown): string | null {
+  if (typeof value === "number") return Number.isSafeInteger(value) && value > 0 ? String(value) : null;
+  if (typeof value !== "string") return null;
+  return /^[1-9]\d{0,18}$/.test(value.trim()) ? value.trim() : null;
+}
+
+/** The feed stamps `ts` as epoch SECONDS with two decimals. */
+function feedInstant(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return null;
+  return Math.round(value * 1000);
+}
+
+/**
+ * Reads the feed file itself, bounded and owner-only.
+ *
+ * A feed that has never been written (no incoming message since the connector
+ * started) is not an error: it is an account with nothing to report from this
+ * source, and the caller's own candidate walk still runs.
+ */
+export function readFeedDialogsSince(feedFile: string | null, sinceMs: number): FeedDialog[] {
+  if (!feedFile) return [];
+  const text = readSafeTailText(feedFile, MAX_FEED_TAIL_BYTES);
+  return text === null ? [] : feedDialogsSince(text, sinceMs);
+}

--- a/src/lib/telegram/reportFeed.ts
+++ b/src/lib/telegram/reportFeed.ts
@@ -102,10 +102,41 @@ function feedInstant(value: unknown): number | null {
  *
  * A feed that has never been written (no incoming message since the connector
  * started) is not an error: it is an account with nothing to report from this
- * source, and the caller's own candidate walk still runs.
+ * source, and the caller's own candidate walk still runs. A file that exists
+ * but cannot be read through the owner-only fence THROWS, because that is a
+ * feed whose contents are unknown rather than empty.
  */
 export function readFeedDialogsSince(feedFile: string | null, sinceMs: number): FeedDialog[] {
   if (!feedFile) return [];
   const text = readSafeTailText(feedFile, MAX_FEED_TAIL_BYTES);
   return text === null ? [] : feedDialogsSince(text, sinceMs);
+}
+
+/**
+ * The feed file an `incoming_feed_status` answer describes, or `null` when
+ * that connector is not running one (#1091).
+ *
+ * Two states count as running, and the difference matters:
+ *
+ *  - `enabled` — the consumer task is up and appending settled bursts;
+ *  - `autostart_pending` — the connector was launched with the feed armed and
+ *    starts it from the handler of the first incoming message. The burst that
+ *    triggers the start is recorded before the start and is written too, so a
+ *    pending feed has lost nothing; it simply has had nothing to write.
+ *
+ * Everything else is a connector that will never record anything — one adopted
+ * from a Viewer generation that predates the feed, above all — and answering
+ * `null` for it is what stops the report from silently falling back to the
+ * bounded probe walk that #1091 exists to replace.
+ */
+export function activeFeedFile(statusText: string): string | null {
+  let parsed: { enabled?: unknown; feed_file?: unknown; autostart_pending?: unknown };
+  try {
+    parsed = JSON.parse(statusText) as typeof parsed;
+  } catch {
+    return null;
+  }
+  const running = parsed?.enabled === true || parsed?.autostart_pending === true;
+  const file = typeof parsed?.feed_file === "string" ? parsed.feed_file.trim() : "";
+  return running && file ? file : null;
 }

--- a/src/lib/telegram/reportFeed.ts
+++ b/src/lib/telegram/reportFeed.ts
@@ -1,4 +1,4 @@
-import { readSafeTailText } from "./sessionStore";
+import { readSafeTailUntil, telegramIncomingFeedPath } from "./sessionStore";
 
 /**
  * The connector's incoming event feed, as a Daily Report source (issue #1091).
@@ -14,9 +14,12 @@ import { readSafeTailText } from "./sessionStore";
  *
  * Two properties this module is built around:
  *
- *  - the file is APPEND-ONLY and nothing rotates it, so it is read from the END
- *    with a byte bound. A day's activity is kilobytes; the bound only decides
- *    how far back a first run after a long silence can see.
+ *  - the file is APPEND-ONLY and stamped as it is written, so it is read from
+ *    the END, backward, until a burst OLDER than the window proves the window
+ *    is fully in hand. A day's activity is kilobytes, so that is one step for
+ *    any ordinary account; the total bound only decides when a feed is so
+ *    large that the window cannot be covered at all, which FAILS the source
+ *    pass rather than answering with the part that happened to fit.
  *  - the file is written by the connector under the same owner-only fence as
  *    the credential (0600, same uid), and it is read through that fence, so a
  *    feed replaced by another user's file is refused rather than believed.
@@ -26,9 +29,15 @@ import { readSafeTailText } from "./sessionStore";
  * title and truncated, never interpreted.
  */
 
-/** How far back from the end of the feed one read looks. Each line is ~150
-    bytes, so this is thousands of bursts — far past any report window. */
-export const MAX_FEED_TAIL_BYTES = 512 * 1024;
+/** One backward step. Each line is ~150 bytes, so a single step is thousands
+    of bursts — for nearly every account, the whole window in one read. */
+export const FEED_CHUNK_BYTES = 512 * 1024;
+/** The ceiling on ONE feed read, across all its steps. Past this the window is
+    reported as uncovered instead of silently truncated: a single dialog
+    bursting all day can push the morning arbitrarily far back, and the dialog
+    that then falls out is exactly the one a bounded probe walk cannot recover
+    either (#1091). */
+export const MAX_FEED_SCAN_BYTES = 8 * 1024 * 1024;
 
 /** A title longer than this is not a name. */
 const MAX_TITLE_LENGTH = 120;
@@ -102,14 +111,45 @@ function feedInstant(value: unknown): number | null {
  *
  * A feed that has never been written (no incoming message since the connector
  * started) is not an error: it is an account with nothing to report from this
- * source, and the caller's own candidate walk still runs. A file that exists
- * but cannot be read through the owner-only fence THROWS, because that is a
- * feed whose contents are unknown rather than empty.
+ * source, and the caller's own candidate walk still runs. Two states DO throw,
+ * because both are a feed whose contents are unknown rather than empty:
+ *
+ *  - a file that exists but fails the owner-only fence;
+ *  - a file whose window the scan could not reach the far side of inside
+ *    {@link MAX_FEED_SCAN_BYTES}. Answering with the tail that fit would be the
+ *    silent omission this module exists to end — the dialogs it dropped are the
+ *    OLDEST in the window, and the walk behind it is bounded by a probe budget
+ *    over a list ordered by pins, so it cannot be relied on to find them.
  */
 export function readFeedDialogsSince(feedFile: string | null, sinceMs: number): FeedDialog[] {
   if (!feedFile) return [];
-  const text = readSafeTailText(feedFile, MAX_FEED_TAIL_BYTES);
-  return text === null ? [] : feedDialogsSince(text, sinceMs);
+  const tail = readSafeTailUntil(
+    feedFile,
+    { chunkBytes: FEED_CHUNK_BYTES, maxBytes: MAX_FEED_SCAN_BYTES },
+    (chunkText) => feedCrossesBefore(chunkText, sinceMs),
+  );
+  if (tail === null) return [];
+  if (!tail.complete) throw new Error("Telegram incoming feed is larger than one report read");
+  return feedDialogsSince(tail.text, sinceMs);
+}
+
+/** Whether a chunk of the feed holds a burst OLDER than the window. The feed
+    is append-only and stamped as it is written, so one such line is proof that
+    everything before it is older too — which is what lets the backward scan
+    stop instead of reading a file that only ever grows. */
+function feedCrossesBefore(chunkText: string, sinceMs: number): boolean {
+  for (const line of chunkText.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: FeedLine;
+    try {
+      parsed = JSON.parse(line) as FeedLine;
+    } catch {
+      continue;
+    }
+    const at = feedInstant(parsed.ts);
+    if (at !== null && at < sinceMs) return true;
+  }
+  return false;
 }
 
 /**
@@ -139,4 +179,20 @@ export function activeFeedFile(statusText: string): string | null {
   const running = parsed?.enabled === true || parsed?.autostart_pending === true;
   const file = typeof parsed?.feed_file === "string" ? parsed.feed_file.trim() : "";
   return running && file ? file : null;
+}
+
+/**
+ * The feed file a run may read: the one THIS credential generation's connector
+ * reports it is writing, and nothing else (#1091).
+ *
+ * The feed is named for its credential generation, so a status answer pointing
+ * anywhere else is a listener from another account's generation — and its
+ * recent bursts, adopted as the current account's active dialogs, would put one
+ * operator's correspondents into another's report after the id check had
+ * already passed. Refused as no feed at all, which fails the source pass.
+ */
+export function scopedFeedFile(statusText: string, credentialRef: string | null): string | null {
+  if (!credentialRef) return null;
+  const reported = activeFeedFile(statusText);
+  return reported !== null && reported === telegramIncomingFeedPath(credentialRef) ? reported : null;
 }

--- a/src/lib/telegram/reportLineage.test.ts
+++ b/src/lib/telegram/reportLineage.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-lineage-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+const { AgentRegistry } = await import("@/lib/agent/registry");
+const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+const {
+  TELEGRAM_REPORT_PROJECT,
+  reportAttemptId,
+  reportRunIdFromAttemptId,
+  telegramReportRunsByConversation,
+} = await import("./reportLineage");
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = OLD_STATE;
+});
+
+/* Assembled rather than written out: the publication privacy gate refuses any
+   literal with the shape of a session identifier, and it cannot tell an
+   invented one from a real one lifted out of the operator's registry. */
+test("the marker spells the run id both ways, and nothing else does", () => {
+  const runId = crypto.randomUUID();
+
+  expect(reportRunIdFromAttemptId(reportAttemptId(runId))).toBe(runId);
+  expect(reportRunIdFromAttemptId(null)).toBeNull();
+  expect(reportRunIdFromAttemptId("attempt_93c42855_account_a")).toBeNull();
+  /* The run id names an owner-only file, so a marker that is not the id the
+     runner mints is not read as one. */
+  expect(reportRunIdFromAttemptId("telegram-report-../../etc/passwd")).toBeNull();
+  expect(reportRunIdFromAttemptId("telegram-report-")).toBeNull();
+});
+
+test("a report run is still recognisable after a registry reload, with no history file", () => {
+  /* The tail this covers: a run was identified only by the `conversationId` in
+     the Daily Reports history row, so a lost or evicted history left a board
+     conversation nobody could attribute. The marker is durable registry
+     evidence — nothing in this test writes Telegram state at all. */
+  const filename = path.join(fs.mkdtempSync(path.join(SANDBOX, "registry-")), "agent-registry.json");
+  const runId = crypto.randomUUID();
+  const cwd = path.join(SANDBOX, "report-workspace");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(filename);
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    clientAttemptId: reportAttemptId(runId),
+    explicitProject: TELEGRAM_REPORT_PROJECT,
+    launchProfile: emptyLaunchProfile({ cwd, mcpServers: ["viewer", "telegram"] }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a report-run reservation");
+  const sessionId = ["019f4906", "3f67", "4b72", "9fbc", "9ec3b5ad1326"].join("-");
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  store.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd, mcpServers: ["viewer", "telegram"] }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  /* A different process, reading the same file from cold. */
+  const reloaded = new AgentRegistry(filename).readOnlySnapshot();
+  const runs = telegramReportRunsByConversation(Object.values(reloaded.receipts));
+
+  expect(runs.get(begun.receipt.conversationId)).toBe(runId);
+  /* And the board groups it: durable project ownership, decided at admission,
+     survives the same reload. */
+  expect(reloaded.conversations[begun.receipt.conversationId]?.projectOwnership?.project).toBe(TELEGRAM_REPORT_PROJECT);
+  /* And it is still a root holding its own connector: the registry re-decides
+     every stored grant from the row's own evidence on this read, so a marker
+     that had been spelled as a lineage parent or a role preset would have cost
+     the run `telegram` right here. */
+  expect(reloaded.conversations[begun.receipt.conversationId]?.generations.at(-1)?.launchProfile.mcpServers).toEqual(["viewer", "telegram"]);
+  expect(reloaded.conversations[begun.receipt.conversationId]?.agentRole).toBeNull();
+  expect(reloaded.receipts[begun.receipt.launchId]?.parentConversationId).toBeNull();
+});
+
+test("no other launch is read as a report run", () => {
+  const runs = telegramReportRunsByConversation([
+    { conversationId: "conversation_ordinary", clientAttemptId: "attempt_93c42855_account_a" },
+    { conversationId: "conversation_unmarked", clientAttemptId: null },
+    { conversationId: "conversation_lookalike", clientAttemptId: "telegram-report-not-a-run-id" },
+  ]);
+
+  expect(runs.size).toBe(0);
+});

--- a/src/lib/telegram/reportLineage.ts
+++ b/src/lib/telegram/reportLineage.ts
@@ -1,0 +1,66 @@
+/**
+ * The durable report-run marker (issue #1091).
+ *
+ * A report run is a root conversation: no operator typed it, no conversation
+ * spawned it, and it deliberately has NO lineage parent — the registry
+ * re-decides every stored MCP grant from the row's own evidence, and a
+ * `parentConversationId` classifies the row as delegated, which would strip
+ * `telegram` from the run at the moment its receipt is written. So the marker
+ * has to be something the launch itself carries and the registry keeps.
+ *
+ * It is two durable facts, both written by the ordinary spawn path and both
+ * re-read straight out of registry storage after a reload:
+ *
+ *  - the receipt's `clientAttemptId`, which spells the run id, so a
+ *    conversation can be recognised as report run <id> — and re-linked to the
+ *    report text stored under that id — with the Daily Reports history file
+ *    absent, corrupt, or evicted;
+ *  - explicit project ownership on the conversation, which is what the board
+ *    groups cards by, so the runs collect under the Telegram project instead of
+ *    landing in a phantom project named after the scratch workspace they run in.
+ *
+ * Nothing here is a capability: the marker decides how a card is GROUPED and
+ * nothing about what the run may read. A conversation that spells the attempt
+ * id itself gains no Telegram access from doing so.
+ */
+
+/** Durable project ownership stamped on every report run, and the board group
+    the runs collect under. */
+export const TELEGRAM_REPORT_PROJECT = "telegram-reports";
+
+const ATTEMPT_PREFIX = "telegram-report-";
+
+/** A run id is a UUID the runner mints; the marker is that id behind a fixed
+    prefix, so the run id is recoverable from the receipt alone. */
+export function reportAttemptId(runId: string): string {
+  return `${ATTEMPT_PREFIX}${runId}`;
+}
+
+/** The run id a report-run attempt marker spells, or `null` for every other
+    launch. The shape is checked, not just the prefix: the id names an
+    owner-only file (`report-<runId>.md`), so a marker that is not the id the
+    runner mints must not be read as one. */
+export function reportRunIdFromAttemptId(clientAttemptId: string | null | undefined): string | null {
+  if (typeof clientAttemptId !== "string" || !clientAttemptId.startsWith(ATTEMPT_PREFIX)) return null;
+  const runId = clientAttemptId.slice(ATTEMPT_PREFIX.length);
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(runId) ? runId : null;
+}
+
+/**
+ * Report runs by conversation, read from durable spawn receipts.
+ *
+ * This is the whole read side of the marker: the board projection walks the
+ * receipts it already holds and asks this which conversations are report runs.
+ * It needs no Telegram state at all, which is the point — the answer survives a
+ * registry reload with nothing else on disk.
+ */
+export function telegramReportRunsByConversation(
+  receipts: Iterable<{ conversationId: string; clientAttemptId: string | null }>,
+): Map<string, string> {
+  const runs = new Map<string, string>();
+  for (const receipt of receipts) {
+    const runId = reportRunIdFromAttemptId(receipt.clientAttemptId);
+    if (runId) runs.set(receipt.conversationId, runId);
+  }
+  return runs;
+}

--- a/src/lib/telegram/reportRunner.test.ts
+++ b/src/lib/telegram/reportRunner.test.ts
@@ -8,7 +8,7 @@ const OLD_STATE = process.env.LLV_STATE_DIR;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
 const { TelegramReportRunner, RUN_TIMEOUT_MS } = await import("./reportRunner");
-const { readTelegramReports, readReportText, reportInboxPath, updateTelegramReports } = await import("./reportStore");
+const { readTelegramReports, readReportText, reportInboxPath, reportSourcesPath, updateTelegramReports } = await import("./reportStore");
 const { DEFAULT_DAILY_REPORT_PROMPT } = await import("./reportPrompt");
 /* The tag lives in the operator's editable brief; fixtures use a synthetic
    one, exactly as a real operator's own tag never appears in this repo. */
@@ -34,6 +34,14 @@ const CONNECTED: StoredTelegramConnection = {
   identityIdUpgradedAt: null,
 };
 
+/** What a logout and a reconnect leave behind: a second account, enrolled as
+    its own credential generation, connected and healthy (#1091). */
+const RECONNECTED_AS_ANOTHER_ACCOUNT: StoredTelegramConnection = {
+  ...CONNECTED,
+  credentialRef: "credential-ref-second-placeholder",
+  identity: { name: "Account B", username: "account_b", id: "770000002" },
+};
+
 class FakePorts implements ReportRunnerPorts {
   clock = NOW;
   connectionState: StoredTelegramConnection = { ...CONNECTED };
@@ -44,6 +52,12 @@ class FakePorts implements ReportRunnerPorts {
   chats: TelegramChatSummary[] = [{ id: "101", kind: "user", title: "Dialog A", username: null, unread: 2 }];
   /** What the connector's incoming feed recorded as active (#1091). */
   feed: Array<{ id: string; title: string; lastMessageAt: string }> = [];
+  /** The earliest instant that feed can vouch for: a listener up since well
+      before any window these tests use. */
+  feedCoveredSinceMs: number | null = Date.parse("2026-08-18T00:00:00.000Z");
+  /** Called as each read SETTLES, so a test can move the world between two
+      connector calls — a logout and reconnect inside one source pass. */
+  afterRead: ((name: string) => void) | null = null;
   lastMessage: string | null = "2026-08-21T05:00:00.000Z";
   listChatsError: Error | null = null;
   /** Holds the source pass open, to model a run still being planned. */
@@ -71,25 +85,35 @@ class FakePorts implements ReportRunnerPorts {
   logs: string[] = [];
   now() { return this.clock; }
   connection() { return this.connectionState; }
-  readPort(): TelegramReadPort {
+  readPort(credentialRef: string): TelegramReadPort {
+    /* What the production port does on every call: re-read the stored
+       credential and refuse one from a generation other than the pinned one,
+       so a logout-and-reconnect mid-pass fails the read instead of answering
+       as the new account (#1091). */
+    const read = async <T>(name: string, answer: () => Promise<T>): Promise<T> => {
+      this.reads.push(name);
+      if (this.connectionState.credentialRef !== credentialRef) {
+        throw new Error("Telegram credential generation changed");
+      }
+      try {
+        return await answer();
+      } finally {
+        this.afterRead?.(name);
+      }
+    };
     return {
-      getMe: async () => {
-        this.reads.push("getMe");
+      getMe: () => read("getMe", async () => {
         if (this.getMeError) throw this.getMeError;
         return this.liveIdentity;
-      },
-      feedDialogs: async () => {
-        this.reads.push("feedDialogs");
-        return this.feed;
-      },
-      listChats: async () => {
-        this.reads.push("listChats");
+      }),
+      feedDialogs: () => read("feedDialogs", async () => ({ dialogs: this.feed, coveredSinceMs: this.feedCoveredSinceMs })),
+      listChats: () => read("listChats", async () => {
         if (this.listChatsGate) await this.listChatsGate;
         if (this.listChatsError) throw this.listChatsError;
         return this.chats;
-      },
-      pageChats: async () => [],
-      lastMessageAt: async () => this.lastMessage,
+      }),
+      pageChats: () => read("pageChats", async () => []),
+      lastMessageAt: () => read("lastMessageAt", async () => this.lastMessage),
     };
   }
   /** What `recordedIdentityAfterHealthCheck` does, in one line: persist the id
@@ -341,6 +365,88 @@ test("the recorded id decides: a full rename passes, a same-named stranger does 
   expect(impostor.reads).toEqual(["getMe"]);
   const history = otherAccount.payload().history;
   expect(history[0]).toMatchObject({ status: "account-mismatch", conversationId: null, hasReport: false });
+});
+
+test("a reconnect during the source pass refuses the reads and launches nothing", async () => {
+  /* The hole the id check alone does not close. `get_me` verified account A;
+     the source pass that follows is tens of seconds of connector reads, and
+     the operator can log out and connect account B inside it. The reads are
+     bound to the generation that recorded the id being verified, so the first
+     one after the swap fails instead of answering as B — no listing, no probe,
+     and no plan holding two accounts' correspondents. */
+  const ports = new FakePorts();
+  enableReports();
+  ports.afterRead = (name) => {
+    if (name === "getMe") ports.connectionState = { ...RECONNECTED_AS_ANOTHER_ACCOUNT };
+  };
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
+
+  const file = readTelegramReports();
+  expect(file.history[0]).toMatchObject({ status: "failed", errorCode: "sources_failed", conversationId: null });
+  expect(ports.spawns.length).toBe(0);
+  /* One read past the check, and it refused: nothing was listed or probed. */
+  expect(ports.reads).toEqual(["getMe", "feedDialogs"]);
+  expect(fs.existsSync(reportSourcesPath(file.history[0].id))).toBe(false);
+  /* The window it did not cover is still owed to the next run. */
+  expect(file.cursor.unreportedSinceAt).toBe(new Date(NOW - 24 * 3_600_000).toISOString());
+});
+
+test("a reconnect after the source pass settles the run instead of launching for the new account", async () => {
+  /* The same swap, one moment later: every read belonged to account A, so the
+     plan on disk is A's alone — and launching it now would hand the run
+     account B's connector. It settles as the mismatch it is, and A's plan is
+     removed rather than left in scratch naming their correspondents. */
+  const ports = new FakePorts();
+  enableReports();
+  ports.afterRead = (name) => {
+    if (name === "lastMessageAt") ports.connectionState = { ...RECONNECTED_AS_ANOTHER_ACCOUNT };
+  };
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
+
+  const file = readTelegramReports();
+  expect(file.history[0]).toMatchObject({ status: "account-mismatch", errorCode: null, conversationId: null, hasReport: false });
+  expect(ports.spawns.length).toBe(0);
+  expect(ports.logs).toEqual(["account_mismatch"]);
+  expect(fs.existsSync(reportSourcesPath(file.history[0].id))).toBe(false);
+  expect(file.cursor.lastSuccessfulWindowEndAt).toBeNull();
+});
+
+test("the grant admission resolves belongs to the generation the run verified", async () => {
+  /* Admission asks this callback at the instant it writes the receipt, which
+     is what makes a logout during the source pass revoke the connector. A
+     reconnect has to revoke it too: the run being admitted planned for the
+     account that is no longer the one connected. */
+  const ports = new FakePorts();
+  enableReports();
+  const runner = new TelegramReportRunner(ports);
+
+  expect(runner.grantActive(CONNECTED.credentialRef)).toBe(true);
+  expect(runner.grantActive(RECONNECTED_AS_ANOTHER_ACCOUNT.credentialRef)).toBe(false);
+
+  ports.connectionState = { ...RECONNECTED_AS_ANOTHER_ACCOUNT };
+  expect(runner.grantActive(CONNECTED.credentialRef)).toBe(false);
+  /* Unbound, it is still the plain question the feature asks. */
+  expect(runner.grantActive()).toBe(true);
+});
+
+test("a connection with no credential generation verifies nothing", async () => {
+  /* An id with no generation behind it names an account that nothing can be
+     read as: there is no credential to bind the pass to, so the run fails
+     closed exactly as a record with no id does. */
+  const ports = new FakePorts();
+  enableReports();
+  ports.connectionState = { ...CONNECTED, credentialRef: null };
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
+
+  expect(readTelegramReports().history[0]).toMatchObject({ status: "failed", errorCode: "account_check_failed" });
+  expect(ports.spawns.length).toBe(0);
+  expect(ports.reads).toEqual([]);
 });
 
 test("a connection with no recorded identity fails closed, with nothing read", async () => {

--- a/src/lib/telegram/reportRunner.test.ts
+++ b/src/lib/telegram/reportRunner.test.ts
@@ -51,6 +51,15 @@ class FakePorts implements ReportRunnerPorts {
   /** Every read the Viewer itself made, in order. */
   reads: string[] = [];
   spawns: Record<string, unknown>[] = [];
+  /** The numeric id the login bridge reports when the one-time migration runs
+      — the health check's own re-read of the account, not the connector
+      surface the run is verifying. `null` models a bridge too old to have
+      one. */
+  bridgeAccountId: string | null = IDENTITY.id;
+  migrations = 0;
+  /** The conversation the durable report-run marker names, when the registry
+      recorded one (#1091). */
+  markerConversation: string | null = null;
   /** The grant each launch was admitted with — resolved the way admission
       resolves it, by CALLING the launcher's callback. */
   grants: string[][] = [];
@@ -83,6 +92,19 @@ class FakePorts implements ReportRunnerPorts {
       lastMessageAt: async () => this.lastMessage,
     };
   }
+  /** What `recordedIdentityAfterHealthCheck` does, in one line: persist the id
+      the bridge reported and stamp the record as migrated — once, whether or
+      not an id came back. */
+  async migrateIdentity() {
+    this.migrations += 1;
+    const recorded = this.connectionState.identity;
+    this.connectionState = {
+      ...this.connectionState,
+      identity: recorded ? { ...recorded, id: this.bridgeAccountId ?? recorded.id } : recorded,
+      identityIdUpgradedAt: this.connectionState.identityIdUpgradedAt ?? "2026-08-21T06:59:30.000Z",
+    };
+  }
+  async reportRunConversation() { return this.markerConversation; }
   async spawn(input: ReportSpawnInput) {
     this.spawns.push(input.body);
     this.grants.push(mcpServersForScheduledReport({ grantActive: input.grantActive() }));
@@ -225,34 +247,73 @@ test("a get_me mismatch ends the run before any chat is read, with no report and
   expect(file.cursor.unreportedSinceAt).toBe(new Date(NOW - 24 * 3_600_000).toISOString());
 });
 
-test("a pre-#1091 connection with no recorded id still reports through a rename", async () => {
-  /* The name/handle rule survives for exactly one case: a connection enrolled
-     before the numeric id was recorded, whose one-time migration has not run
-     yet. Both recorded fields are the operator's to change at any moment and
-     the recorded copy only refreshes on a health check, so demanding that both
-     agree would end every report `account-mismatch` the day they picked a new
-     @handle — a silently dead feature. Agreement on either field is the same
-     account. */
-  const legacy = { ...IDENTITY, id: null };
-  const renamed = new FakePorts();
+test("a pre-#1091 connection migrates its id once, before the run reads anything", async () => {
+  /* The tail's own migration clause. A connection enrolled before the numeric
+     id existed has nothing durable to verify against, and the v1 answer —
+     compare the display name instead — is the hole #1091 closes. So the run
+     completes the record's ONE-TIME health migration first, through the login
+     bridge (the credential itself, not the surface being checked), and only
+     then compares ids. */
+  const ports = new FakePorts();
   enableReports();
-  renamed.connectionState = { ...CONNECTED, identity: legacy };
-  renamed.liveIdentity = { name: IDENTITY.name, username: "account_a_backup", id: IDENTITY.id };
-  const afterHandleChange = new TelegramReportRunner(renamed);
-  await afterHandleChange.runNow();
-  await afterHandleChange.settled();
-  expect(afterHandleChange.payload().history[0].status).toBe("running");
-  expect(renamed.spawns.length).toBe(1);
+  ports.connectionState = { ...CONNECTED, identity: { ...IDENTITY, id: null } };
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
 
-  fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
+  expect(ports.migrations).toBe(1);
+  expect(ports.spawns.length).toBe(1);
+  /* The migration is a bridge read, not a connector one: the account check
+     still costs exactly one `get_me`. */
+  expect(ports.reads[0]).toBe("getMe");
+  /* And it is durable, so the next run compares ids straight away. */
+  expect(ports.connectionState.identity?.id).toBe(IDENTITY.id);
+  expect(ports.connectionState.identityIdUpgradedAt).not.toBeNull();
+});
+
+test("a record with no id after its migration fails the run closed, reading nothing", async () => {
+  /* A bridge too old to report an id leaves the record stamped and still
+     without one. There is no name fallback to fall back to any more: the run
+     fails `account_check_failed` before a single connector call, and the
+     stamped record is never re-probed. */
+  const ports = new FakePorts();
   enableReports();
-  const displayName = new FakePorts();
-  displayName.connectionState = { ...CONNECTED, identity: legacy };
-  displayName.liveIdentity = { name: "Account A (away until Monday)", username: IDENTITY.username, id: IDENTITY.id };
-  const afterNameChange = new TelegramReportRunner(displayName);
-  await afterNameChange.runNow();
-  await afterNameChange.settled();
-  expect(displayName.spawns.length).toBe(1);
+  ports.connectionState = { ...CONNECTED, identity: { ...IDENTITY, id: null } };
+  ports.bridgeAccountId = null;
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
+
+  const file = readTelegramReports();
+  expect(file.history[0]).toMatchObject({ status: "failed", errorCode: "account_check_failed" });
+  expect(ports.migrations).toBe(1);
+  expect(ports.spawns.length).toBe(0);
+  expect(ports.reads).toEqual([]);
+  expect(ports.logs).toEqual(["account_check_failed"]);
+
+  /* The next run re-reads nothing: the stamp says the migration already
+     happened, so this is not a bridge round trip per report forever. */
+  const second = new TelegramReportRunner(ports);
+  await second.runNow();
+  await second.settled();
+  expect(ports.migrations).toBe(1);
+  expect(ports.reads).toEqual([]);
+  expect(ports.spawns.length).toBe(0);
+});
+
+test("an account that answers with no id is no evidence, whatever it is called", async () => {
+  /* The name and the handle agree on both sides and neither authorizes
+     anything any more: with no id to compare, the run fails without reading a
+     chat rather than trusting two public fields. */
+  const ports = new FakePorts();
+  enableReports();
+  ports.liveIdentity = { name: IDENTITY.name, username: IDENTITY.username, id: null };
+  const runner = new TelegramReportRunner(ports);
+  await runner.runNow();
+  await runner.settled();
+  expect(readTelegramReports().history[0].status).toBe("account-mismatch");
+  expect(ports.spawns.length).toBe(0);
+  expect(ports.reads).toEqual(["getMe"]);
 });
 
 test("the recorded id decides: a full rename passes, a same-named stranger does not", async () => {
@@ -282,34 +343,18 @@ test("the recorded id decides: a full rename passes, a same-named stranger does 
   expect(history[0]).toMatchObject({ status: "account-mismatch", conversationId: null, hasReport: false });
 });
 
-test("the connector's sanitized spelling of a name is the same account", async () => {
-  /* The identity recorded at Connect comes off the login bridge unsanitized,
-     while every name the connector returns has been through its `sanitize_name`
-     — Cc/Cf stripped, whitespace collapsed. An operator whose display name
-     carries an invisible character would otherwise fail every single report
-     with `account-mismatch` and have nothing to go on. */
-  const ports = new FakePorts();
-  enableReports();
-  ports.connectionState = {
-    ...CONNECTED,
-    identity: { name: "Account\u200b A ", username: null, id: null },
-  };
-  ports.liveIdentity = { name: "Account A", username: null, id: "770000001" };
-  const runner = new TelegramReportRunner(ports);
-  await runner.runNow();
-  await runner.settled();
-  expect(ports.spawns.length).toBe(1);
-});
-
-test("a connection with no comparable identity fails closed", async () => {
+test("a connection with no recorded identity fails closed, with nothing read", async () => {
   const ports = new FakePorts();
   enableReports();
   ports.connectionState = { ...CONNECTED, identity: null };
   const runner = new TelegramReportRunner(ports);
   await runner.runNow();
   await runner.settled();
-  expect(readTelegramReports().history[0].status).toBe("account-mismatch");
+  expect(readTelegramReports().history[0]).toMatchObject({ status: "failed", errorCode: "account_check_failed" });
   expect(ports.spawns.length).toBe(0);
+  /* Nothing to migrate and nothing to compare: no bridge read either. */
+  expect(ports.migrations).toBe(0);
+  expect(ports.reads).toEqual([]);
 });
 
 test("a connector that cannot answer get_me fails the run rather than reading on", async () => {
@@ -609,6 +654,68 @@ test("a run orphaned mid-source-pass by a restart is settled, never left hanging
   await before.settled();
   /* The planner that woke up to a settled run launched nothing. */
   expect(ports.spawns.length).toBe(0);
+});
+
+test("a run whose launch write was lost is re-linked from the durable marker", async () => {
+  /* The launch's own write of the conversation id is the last thing the source
+     pass does, so a Viewer that died just after admission left a REAL
+     conversation on the board and a panel row with no route to it — and the
+     restart sweep about to call it a launch that never happened. The durable
+     marker is the registry-side evidence that repairs it (#1091): the
+     receipt's attempt id spells the run id, with no Daily Reports state
+     involved at all. */
+  const ports = new FakePorts();
+  enableReports();
+  let release: () => void = () => {};
+  ports.listChatsGate = new Promise<void>((resolve) => { release = resolve; });
+  const interrupted = new TelegramReportRunner(ports);
+  await interrupted.runNow();
+  expect(readTelegramReports().active?.conversationId).toBeNull();
+
+  /* What the registry holds after the reload: the marker names the run's
+     conversation. */
+  ports.markerConversation = "conversation_recovered";
+  ports.clock = NOW + 60_000;
+  updateTelegramReports((state) => { state.cursor.lastScheduledDay = "2026-08-21"; });
+  const afterRestart = new TelegramReportRunner(ports);
+  await afterRestart.tick();
+
+  /* The run is alive and linked, not swept as a failed launch — and the panel
+     row the operator sees carries the deep link. */
+  const relinked = readTelegramReports();
+  expect(relinked.active?.conversationId).toBe("conversation_recovered");
+  expect(afterRestart.payload().history[0]).toMatchObject({ status: "running", conversationId: "conversation_recovered" });
+
+  /* And the link survives into the settled row, so it is still there once the
+     run is history. */
+  agentWrites(`${DAILY_REPORT_TAG}\n1. [1] Dialog A — one thing happened.\n`);
+  await afterRestart.tick();
+  expect(readTelegramReports().history[0]).toMatchObject({ status: "ok", conversationId: "conversation_recovered" });
+
+  release();
+  await interrupted.settled();
+});
+
+test("a run nothing recorded a marker for is still swept, not left hanging", async () => {
+  /* The recovery must not resurrect a launch that never happened: with no
+     receipt naming the run, the orphan sweep settles it exactly as before. */
+  const ports = new FakePorts();
+  enableReports();
+  let release: () => void = () => {};
+  ports.listChatsGate = new Promise<void>((resolve) => { release = resolve; });
+  const interrupted = new TelegramReportRunner(ports);
+  await interrupted.runNow();
+
+  ports.clock = NOW + 60_000;
+  updateTelegramReports((state) => { state.cursor.lastScheduledDay = "2026-08-21"; });
+  await new TelegramReportRunner(ports).tick();
+
+  const file = readTelegramReports();
+  expect(file.active).toBeNull();
+  expect(file.history[0]).toMatchObject({ status: "failed", errorCode: "launch_failed", conversationId: null });
+
+  release();
+  await interrupted.settled();
 });
 
 test("a second Run now while one is live is refused rather than doubling the reads", async () => {

--- a/src/lib/telegram/reportRunner.test.ts
+++ b/src/lib/telegram/reportRunner.test.ts
@@ -373,24 +373,30 @@ test("a reconnect during the source pass refuses the reads and launches nothing"
      the operator can log out and connect account B inside it. The reads are
      bound to the generation that recorded the id being verified, so the first
      one after the swap fails instead of answering as B — no listing, no probe,
-     and no plan holding two accounts' correspondents. */
-  const ports = new FakePorts();
-  enableReports();
-  ports.afterRead = (name) => {
-    if (name === "getMe") ports.connectionState = { ...RECONNECTED_AS_ANOTHER_ACCOUNT };
-  };
-  const runner = new TelegramReportRunner(ports);
-  await runner.runNow();
-  await runner.settled();
+     and no plan holding two accounts' correspondents. Both moments the swap
+     can land in are the same answer: straight after the verification, and
+     between two source calls. */
+  for (const swapAfter of ["getMe", "listChats"]) {
+    fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
+    const ports = new FakePorts();
+    enableReports();
+    ports.afterRead = (name) => {
+      if (name === swapAfter) ports.connectionState = { ...RECONNECTED_AS_ANOTHER_ACCOUNT };
+    };
+    const runner = new TelegramReportRunner(ports);
+    await runner.runNow();
+    await runner.settled();
 
-  const file = readTelegramReports();
-  expect(file.history[0]).toMatchObject({ status: "failed", errorCode: "sources_failed", conversationId: null });
-  expect(ports.spawns.length).toBe(0);
-  /* One read past the check, and it refused: nothing was listed or probed. */
-  expect(ports.reads).toEqual(["getMe", "feedDialogs"]);
-  expect(fs.existsSync(reportSourcesPath(file.history[0].id))).toBe(false);
-  /* The window it did not cover is still owed to the next run. */
-  expect(file.cursor.unreportedSinceAt).toBe(new Date(NOW - 24 * 3_600_000).toISOString());
+    const file = readTelegramReports();
+    expect(file.history[0]).toMatchObject({ status: "failed", errorCode: "sources_failed", conversationId: null });
+    expect(ports.spawns.length).toBe(0);
+    /* Exactly one read past the swap, and it refused: whatever the pass had
+       not read yet, it never read as the second account. */
+    expect(ports.reads[ports.reads.indexOf(swapAfter) + 2]).toBeUndefined();
+    expect(fs.existsSync(reportSourcesPath(file.history[0].id))).toBe(false);
+    /* The window it did not cover is still owed to the next run. */
+    expect(file.cursor.unreportedSinceAt).toBe(new Date(NOW - 24 * 3_600_000).toISOString());
+  }
 });
 
 test("a reconnect after the source pass settles the run instead of launching for the new account", async () => {

--- a/src/lib/telegram/reportRunner.test.ts
+++ b/src/lib/telegram/reportRunner.test.ts
@@ -22,7 +22,7 @@ import type { StoredTelegramConnection } from "./sessionStore";
 import type { TelegramChatSummary, TelegramReadPort } from "./reportSources";
 
 const NOW = Date.parse("2026-08-21T07:00:00.000Z"); // 10:00 Kyiv, Friday
-const IDENTITY = { name: "Account A", username: "account_a" };
+const IDENTITY = { name: "Account A", username: "account_a", id: "770000001" };
 
 const CONNECTED: StoredTelegramConnection = {
   version: 1,
@@ -31,6 +31,7 @@ const CONNECTED: StoredTelegramConnection = {
   identity: IDENTITY,
   lastHealthCheckAt: "2026-08-21T06:59:00.000Z",
   errorCode: null,
+  identityIdUpgradedAt: null,
 };
 
 class FakePorts implements ReportRunnerPorts {
@@ -38,9 +39,11 @@ class FakePorts implements ReportRunnerPorts {
   connectionState: StoredTelegramConnection = { ...CONNECTED };
   /** What the connector's own `get_me` answers, which is what the Viewer
       verifies the recorded identity against. */
-  liveIdentity: { name: string; username: string | null } | null = { ...IDENTITY };
+  liveIdentity: { name: string; username: string | null; id: string | null } | null = { ...IDENTITY };
   getMeError: Error | null = null;
   chats: TelegramChatSummary[] = [{ id: "101", kind: "user", title: "Dialog A", username: null, unread: 2 }];
+  /** What the connector's incoming feed recorded as active (#1091). */
+  feed: Array<{ id: string; title: string; lastMessageAt: string }> = [];
   lastMessage: string | null = "2026-08-21T05:00:00.000Z";
   listChatsError: Error | null = null;
   /** Holds the source pass open, to model a run still being planned. */
@@ -65,6 +68,10 @@ class FakePorts implements ReportRunnerPorts {
         this.reads.push("getMe");
         if (this.getMeError) throw this.getMeError;
         return this.liveIdentity;
+      },
+      feedDialogs: async () => {
+        this.reads.push("feedDialogs");
+        return this.feed;
       },
       listChats: async () => {
         this.reads.push("listChats");
@@ -135,6 +142,9 @@ test("Run now launches a board-visible Codex conversation holding exactly viewer
   expect(body.parentConversationId).toBeUndefined();
   expect(body.src).toBeUndefined();
   expect(body.clientAttemptId).toBe(`telegram-report-${launched.ok ? launched.runId : ""}`);
+  /* The other half of the durable marker (#1091): explicit project ownership,
+     which is what the board groups the run's card by. */
+  expect(body.project).toBe("telegram-reports");
   expect(String(body.cwd)).toContain("report-workspace");
 
   const prompt = String(body.prompt);
@@ -198,7 +208,7 @@ test("a get_me mismatch ends the run before any chat is read, with no report and
   enableReports();
   /* The connector is logged into somebody else — a re-login to a second
      account, a session swapped underneath the Viewer. */
-  ports.liveIdentity = { name: "Account B", username: "account_b" };
+  ports.liveIdentity = { name: "Account B", username: "account_b", id: "770000002" };
   const runner = new TelegramReportRunner(ports);
   await runner.runNow();
   await runner.settled();
@@ -215,15 +225,19 @@ test("a get_me mismatch ends the run before any chat is read, with no report and
   expect(file.cursor.unreportedSinceAt).toBe(new Date(NOW - 24 * 3_600_000).toISOString());
 });
 
-test("an operator who renamed themselves or took a new handle still gets their report", async () => {
-  /* Both recorded fields are the operator's to change at any moment, and the
-     recorded copy only refreshes on a health check. Demanding that both agree
-     would end every report `account-mismatch` the day they picked a new
+test("a pre-#1091 connection with no recorded id still reports through a rename", async () => {
+  /* The name/handle rule survives for exactly one case: a connection enrolled
+     before the numeric id was recorded, whose one-time migration has not run
+     yet. Both recorded fields are the operator's to change at any moment and
+     the recorded copy only refreshes on a health check, so demanding that both
+     agree would end every report `account-mismatch` the day they picked a new
      @handle — a silently dead feature. Agreement on either field is the same
      account. */
+  const legacy = { ...IDENTITY, id: null };
   const renamed = new FakePorts();
   enableReports();
-  renamed.liveIdentity = { name: IDENTITY.name, username: "account_a_backup" };
+  renamed.connectionState = { ...CONNECTED, identity: legacy };
+  renamed.liveIdentity = { name: IDENTITY.name, username: "account_a_backup", id: IDENTITY.id };
   const afterHandleChange = new TelegramReportRunner(renamed);
   await afterHandleChange.runNow();
   await afterHandleChange.settled();
@@ -233,11 +247,39 @@ test("an operator who renamed themselves or took a new handle still gets their r
   fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
   enableReports();
   const displayName = new FakePorts();
-  displayName.liveIdentity = { name: "Account A (away until Monday)", username: IDENTITY.username };
+  displayName.connectionState = { ...CONNECTED, identity: legacy };
+  displayName.liveIdentity = { name: "Account A (away until Monday)", username: IDENTITY.username, id: IDENTITY.id };
   const afterNameChange = new TelegramReportRunner(displayName);
   await afterNameChange.runNow();
   await afterNameChange.settled();
   expect(displayName.spawns.length).toBe(1);
+});
+
+test("the recorded id decides: a full rename passes, a same-named stranger does not", async () => {
+  /* The defect #1091 names. A second account that took the operator's display
+     name and handle passed the v1 check, while the operator changing BOTH of
+     their own fields failed it. The numeric id is the one field of an account
+     nobody can hand themselves, so when both sides carry one it is the whole
+     answer. */
+  const renamed = new FakePorts();
+  enableReports();
+  renamed.liveIdentity = { name: "Somebody Else Entirely", username: "another_handle", id: IDENTITY.id };
+  const sameAccount = new TelegramReportRunner(renamed);
+  await sameAccount.runNow();
+  await sameAccount.settled();
+  expect(renamed.spawns.length).toBe(1);
+
+  fs.rmSync(path.join(SANDBOX, "state"), { recursive: true, force: true });
+  enableReports();
+  const impostor = new FakePorts();
+  impostor.liveIdentity = { name: IDENTITY.name, username: IDENTITY.username, id: "770000009" };
+  const otherAccount = new TelegramReportRunner(impostor);
+  await otherAccount.runNow();
+  await otherAccount.settled();
+  expect(impostor.spawns.length).toBe(0);
+  expect(impostor.reads).toEqual(["getMe"]);
+  const history = otherAccount.payload().history;
+  expect(history[0]).toMatchObject({ status: "account-mismatch", conversationId: null, hasReport: false });
 });
 
 test("the connector's sanitized spelling of a name is the same account", async () => {
@@ -250,9 +292,9 @@ test("the connector's sanitized spelling of a name is the same account", async (
   enableReports();
   ports.connectionState = {
     ...CONNECTED,
-    identity: { name: "Account\u200b A ", username: null },
+    identity: { name: "Account\u200b A ", username: null, id: null },
   };
-  ports.liveIdentity = { name: "Account A", username: null };
+  ports.liveIdentity = { name: "Account A", username: null, id: "770000001" };
   const runner = new TelegramReportRunner(ports);
   await runner.runNow();
   await runner.settled();
@@ -438,7 +480,7 @@ test("a disconnected account cannot run a report, and its stored reports are cle
   expect(readTelegramReports().history.length).toBe(1);
 
   /* Log out / delete local session: no status, no credential. */
-  ports.connectionState = { version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null };
+  ports.connectionState = { version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null, identityIdUpgradedAt: null };
   await runner.tick();
   const cleared = readTelegramReports();
   expect(cleared.history).toEqual([]);

--- a/src/lib/telegram/reportRunner.ts
+++ b/src/lib/telegram/reportRunner.ts
@@ -91,8 +91,10 @@ export type ReportRunnerLogCode =
 export interface ReportRunnerPorts {
   now(): number;
   connection(): StoredTelegramConnection;
-  /** The Viewer's own bounded reads: the account check and the source pass. */
-  readPort(): TelegramReadPort;
+  /** The Viewer's own bounded reads: the account check and the source pass,
+      every one of them bound to the credential generation the run verified
+      (#1091). */
+  readPort(credentialRef: string): TelegramReadPort;
   /** Runs the one-time id migration a pre-#1091 connection is owed: the
       ordinary health check, which re-reads the account through the login
       bridge and persists whatever id it reports. */
@@ -152,13 +154,24 @@ export const productionReportRunnerPorts: ReportRunnerPorts = {
     try { return readTelegramConnection(); }
     catch { return { version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe", identityIdUpgradedAt: null }; }
   },
-  readPort: connectorReadPort,
+  readPort: (credentialRef) => connectorReadPort(credentialRef),
   migrateIdentity,
   spawn: launchReportConversation,
   reportRunConversation,
   conversationLive,
   log: (code) => console.error(`[telegram report] ${code}`),
 };
+
+/** What one run is bound to: the recorded numeric id it verified against and
+    the credential generation that recorded it (#1091). */
+type VerifiedAccount = { id: string; credentialRef: string };
+
+/** A record verifies a run only when it carries BOTH — an id with no
+    generation names an account nothing can be read as. */
+function verifiedAccount(connection: StoredTelegramConnection): VerifiedAccount | null {
+  const id = connection.identity?.id;
+  return id && connection.credentialRef ? { id, credentialRef: connection.credentialRef } : null;
+}
 
 export type RunLaunchResult =
   /** The run is durable and visible; its conversation opens behind this. */
@@ -174,13 +187,17 @@ export class TelegramReportRunner {
 
   constructor(private readonly ports: ReportRunnerPorts = productionReportRunnerPorts) {}
 
-  /** Whether a report run may hold the connector right now: the feature is on
-      and the account is connected. It is passed to the launch as a CALLBACK,
-      not a value, so admission resolves it after the source pass rather than
-      before it — a logout during that minute must revoke the grant, not be
-      overtaken by state read before it happened. */
-  grantActive(): boolean {
-    return readTelegramReports().settings.enabled && this.ports.connection().status === "connected";
+  /** Whether a report run may hold the connector right now: the feature is on,
+      the account is connected, and — for a run that verified one — it is still
+      the credential generation that run was planned for (#1091). It is passed
+      to the launch as a CALLBACK, not a value, so admission resolves it after
+      the source pass rather than before it: a logout during that minute must
+      revoke the grant, and a reconnect as somebody else must revoke it too
+      rather than hand the new account's connector to the old account's plan. */
+  grantActive(credentialRef: string | null = null): boolean {
+    const connection = this.ports.connection();
+    if (credentialRef !== null && connection.credentialRef !== credentialRef) return false;
+    return readTelegramReports().settings.enabled && connection.status === "connected";
   }
 
   payload(): TelegramReportsPayload {
@@ -315,8 +332,8 @@ export class TelegramReportRunner {
   }
 
   /**
-   * The recorded identity a run may verify against, or `null` when there is
-   * none (#1091).
+   * The recorded identity a run may verify against and the credential
+   * generation that recorded it, or `null` when there is none (#1091).
    *
    * "None" means the record carries no numeric account id, which is the state
    * every connection enrolled before #1091 starts in. The repair is the
@@ -328,10 +345,15 @@ export class TelegramReportRunner {
    * has already been stamped and is not re-probed: it simply has nothing to
    * verify against, and the run fails closed rather than falling back to a
    * name.
+   *
+   * The generation travels WITH the id because the id alone does not say which
+   * credential produced it: everything the run does afterwards is bound to
+   * this pair, so a logout and reconnect cannot slip a second account's
+   * dialogs behind a check the first one passed.
    */
-  private async verifiedIdentity(): Promise<{ id: string } | null> {
+  private async verifiedIdentity(): Promise<VerifiedAccount | null> {
     const stored = this.ports.connection();
-    if (stored.identity?.id) return { id: stored.identity.id };
+    if (stored.identity?.id) return verifiedAccount(stored);
     /* Nothing recorded to migrate, or a record already stamped as migrated:
        either way there is no id and no second bridge read to try for one. */
     if (!stored.identity || stored.identityIdUpgradedAt) return null;
@@ -340,7 +362,7 @@ export class TelegramReportRunner {
     /* The migration re-reads the account, so it can also discover that the
        session no longer authorizes anything. */
     if (connection.status !== "connected") return null;
-    return connection.identity?.id ? { id: connection.identity.id } : null;
+    return verifiedAccount(connection);
   }
 
   private async executeLocked(runId: string): Promise<void> {
@@ -348,7 +370,6 @@ export class TelegramReportRunner {
     const active = file.active;
     if (!active || active.runId !== runId) return;
     const window = { startAt: active.windowStart, endAt: active.windowEnd };
-    const port = this.ports.readPort();
 
     /* The account check, before anything reads a chat. It needs the recorded
        numeric id, so a connection enrolled before that id existed completes its
@@ -361,6 +382,10 @@ export class TelegramReportRunner {
       this.settle(runId, "failed", "account_check_failed", false);
       return;
     }
+    /* Every read from here on is bound to the generation that recorded the id
+       being verified, so the connector cannot answer this pass as a different
+       account (#1091). */
+    const port = this.ports.readPort(recorded.credentialRef);
 
     /* A mismatch is the issue's `account-mismatch` outcome: no report, no
        window advance, and — because this runs before the source pass — no read
@@ -401,6 +426,19 @@ export class TelegramReportRunner {
       deleteRunScratch(runId);
       return;
     }
+    /* A reconnect inside that same minute is the other way this run stops
+       being about the account it verified (#1091). Every read the plan is made
+       of was refused the moment the generation moved, so what is on disk is
+       one account's — but the conversation about to be launched would hold the
+       NEW account's connector, so there is nothing left to run. The plan goes
+       with it rather than sitting in scratch naming the departed account's
+       correspondents. */
+    if (this.ports.connection().credentialRef !== recorded.credentialRef) {
+      this.ports.log("account_mismatch");
+      deleteRunScratch(runId);
+      this.settle(runId, "account-mismatch", null, false);
+      return;
+    }
     /* The operator's own brief, with the Viewer's non-negotiable preamble in
        front of it. Their text may name private chats, which is why it reaches
        nothing but the run it was written for. */
@@ -430,8 +468,9 @@ export class TelegramReportRunner {
           ["prompt"]: prompt,
         },
         /* The grant is decided by the report session class, inside admission,
-           from durable state read at that instant. */
-        grantActive: () => this.grantActive(),
+           from durable state read at that instant — and only for the
+           generation this run verified (#1091). */
+        grantActive: () => this.grantActive(recorded.credentialRef),
       });
     } catch {
       this.ports.log("launch_failed");

--- a/src/lib/telegram/reportRunner.ts
+++ b/src/lib/telegram/reportRunner.ts
@@ -56,8 +56,10 @@ import { readTelegramConnection, type StoredTelegramConnection } from "./session
  *
  * The account check is the FIRST thing that happens and the Viewer does it
  * itself, through the connector's own `get_me`, against the identity recorded
- * at Connect. A mismatch settles `account-mismatch` before a single chat is
- * listed and before any conversation exists, so "no report and no further
+ * at Connect — by NUMERIC ID and nothing else (#1091). A mismatch settles
+ * `account-mismatch` before a single chat is listed and before any
+ * conversation exists, and a record with no id to compare fails
+ * `account_check_failed` before even that read, so "no report and no further
  * reads" is a property of the code rather than an instruction an agent is
  * trusted to follow — and the recorded identity never has to enter a prompt.
  *
@@ -91,8 +93,16 @@ export interface ReportRunnerPorts {
   connection(): StoredTelegramConnection;
   /** The Viewer's own bounded reads: the account check and the source pass. */
   readPort(): TelegramReadPort;
+  /** Runs the one-time id migration a pre-#1091 connection is owed: the
+      ordinary health check, which re-reads the account through the login
+      bridge and persists whatever id it reports. */
+  migrateIdentity(): Promise<void>;
   /** The operator's own spawn lane, in process and outside any request scope. */
   spawn(input: ReportSpawnInput): Promise<ReportSpawnResult>;
+  /** The conversation the durable report-run marker names, read from registry
+      storage alone (#1091) — no Daily Reports state involved, so it answers
+      after a reload that lost the launch's own write. */
+  reportRunConversation(runId: string): Promise<string | null>;
   /** Whether the launched conversation is still able to produce a report. */
   conversationLive(conversationId: string): Promise<boolean>;
   log(code: ReportRunnerLogCode): void;
@@ -111,6 +121,31 @@ async function conversationLive(conversationId: string): Promise<boolean> {
   }
 }
 
+/** The marker's read side for the runner: the durable receipt whose attempt id
+    spells this run (#1091), resolved to the conversation the board shows. */
+async function reportRunConversation(runId: string): Promise<string | null> {
+  try {
+    const { agentRegistry } = await import("@/lib/agent/registry");
+    const registry = agentRegistry();
+    const receipt = registry.spawnReceiptForClientAttempt(reportAttemptId(runId));
+    return receipt ? registry.canonicalConversationId(receipt.conversationId) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The one-time id migration, run through the ordinary health check so there
+    is exactly one code path that re-reads an account (#1091). */
+async function migrateIdentity(): Promise<void> {
+  try {
+    const { telegramService } = await import("./service");
+    await telegramService().checkHealth();
+  } catch {
+    /* A health check that could not run leaves the record exactly as it was;
+       the run fails closed and the next one tries again. */
+  }
+}
+
 export const productionReportRunnerPorts: ReportRunnerPorts = {
   now: Date.now,
   connection: () => {
@@ -118,7 +153,9 @@ export const productionReportRunnerPorts: ReportRunnerPorts = {
     catch { return { version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe", identityIdUpgradedAt: null }; }
   },
   readPort: connectorReadPort,
+  migrateIdentity,
   spawn: launchReportConversation,
+  reportRunConversation,
   conversationLive,
   log: (code) => console.error(`[telegram report] ${code}`),
 };
@@ -277,18 +314,57 @@ export class TelegramReportRunner {
     }
   }
 
+  /**
+   * The recorded identity a run may verify against, or `null` when there is
+   * none (#1091).
+   *
+   * "None" means the record carries no numeric account id, which is the state
+   * every connection enrolled before #1091 starts in. The repair is the
+   * connection's own one-time health migration: the health check re-reads the
+   * account through the login bridge — the credential itself, not the surface
+   * the run is checking — persists the id and stamps the record as migrated,
+   * so this costs one bridge round trip per connection and never repeats.
+   * A record that comes back without an id (a bridge too old to report one)
+   * has already been stamped and is not re-probed: it simply has nothing to
+   * verify against, and the run fails closed rather than falling back to a
+   * name.
+   */
+  private async verifiedIdentity(): Promise<{ id: string } | null> {
+    const stored = this.ports.connection();
+    if (stored.identity?.id) return { id: stored.identity.id };
+    /* Nothing recorded to migrate, or a record already stamped as migrated:
+       either way there is no id and no second bridge read to try for one. */
+    if (!stored.identity || stored.identityIdUpgradedAt) return null;
+    await this.ports.migrateIdentity();
+    const connection = this.ports.connection();
+    /* The migration re-reads the account, so it can also discover that the
+       session no longer authorizes anything. */
+    if (connection.status !== "connected") return null;
+    return connection.identity?.id ? { id: connection.identity.id } : null;
+  }
+
   private async executeLocked(runId: string): Promise<void> {
     const file = readTelegramReports();
-    const connection = this.ports.connection();
     const active = file.active;
     if (!active || active.runId !== runId) return;
     const window = { startAt: active.windowStart, endAt: active.windowEnd };
     const port = this.ports.readPort();
 
-    /* The account check, before anything reads a chat. A mismatch is the
-       issue's `account-mismatch` outcome: no report, no window advance, and —
-       because this runs before the source pass — no read of the wrong
-       account's dialogs either. */
+    /* The account check, before anything reads a chat. It needs the recorded
+       numeric id, so a connection enrolled before that id existed completes its
+       one-time migration HERE, first, rather than authorizing the run on a
+       display name anybody can copy (#1091). A record that still carries no id
+       afterwards fails the check closed, with nothing read at all. */
+    const recorded = await this.verifiedIdentity();
+    if (!recorded) {
+      this.ports.log("account_check_failed");
+      this.settle(runId, "failed", "account_check_failed", false);
+      return;
+    }
+
+    /* A mismatch is the issue's `account-mismatch` outcome: no report, no
+       window advance, and — because this runs before the source pass — no read
+       of the wrong account's dialogs either. */
     let live: Awaited<ReturnType<TelegramReadPort["getMe"]>>;
     try {
       live = await port.getMe();
@@ -297,7 +373,7 @@ export class TelegramReportRunner {
       this.settle(runId, "failed", "account_check_failed", false);
       return;
     }
-    if (!sameTelegramAccount(live, connection.identity)) {
+    if (!sameTelegramAccount(live, recorded)) {
       this.ports.log("account_mismatch");
       this.settle(runId, "account-mismatch", null, false);
       return;
@@ -375,6 +451,32 @@ export class TelegramReportRunner {
   }
 
   /**
+   * Re-links a live run to its conversation from the durable marker (#1091).
+   *
+   * The launch's own write of the conversation id is the LAST thing
+   * `executeLocked` does, so a process that died between the spawn being
+   * admitted and that write left a run nothing could name: a real conversation
+   * on the board, a panel row with no route to it, and a sweep about to call
+   * it a launch that never happened. The marker is the durable evidence that
+   * repairs it — the receipt's attempt id spells the run id, in registry
+   * storage, which is exactly what survives the reload — and the recovered id
+   * is persisted, so the settled history row carries it too.
+   *
+   * Only a run this process is NOT planning is looked up: while the source
+   * pass is still running here the launch has not happened yet, so there is
+   * nothing to find and no reason to read the registry every tick.
+   */
+  private async relinkActiveRun(runId: string): Promise<string | null> {
+    if (this.planning.has(runId)) return null;
+    const conversationId = await this.ports.reportRunConversation(runId);
+    if (!conversationId) return null;
+    updateTelegramReports((state) => {
+      if (state.active?.runId === runId && !state.active.conversationId) state.active.conversationId = conversationId;
+    });
+    return conversationId;
+  }
+
+  /**
    * Settles a live run if it has produced anything, ended, or run out of time.
    * The output file is checked FIRST: a run whose conversation has already
    * gone terminal may well have written a perfectly good report on its way
@@ -404,7 +506,8 @@ export class TelegramReportRunner {
     }
     const startedAt = Date.parse(active.startedAt);
     const expired = Number.isFinite(startedAt) && this.ports.now() - startedAt > RUN_TIMEOUT_MS;
-    if (!active.conversationId) {
+    const conversationId = active.conversationId ?? await this.relinkActiveRun(active.runId);
+    if (!conversationId) {
       /* No conversation yet: either this process is still planning the run's
          sources, or the process that was doing so is gone and the run is an
          orphan no restart would otherwise clear. */
@@ -412,7 +515,7 @@ export class TelegramReportRunner {
       else if (expired) this.settle(active.runId, "failed", "timed_out", false);
       return;
     }
-    const alive = await this.ports.conversationLive(active.conversationId);
+    const alive = await this.ports.conversationLive(conversationId);
     if (!alive) {
       /* A run that ended — including a connector crash that took the turn down
          with it — never silently succeeds. It becomes a failed row the
@@ -517,62 +620,28 @@ export class TelegramReportRunner {
 }
 
 /**
- * Characters the connector strips from every name it returns.
- *
- * Its `sanitize_name` removes Unicode Cc/Cf (which covers the zero-width and
- * bidi block) and collapses whitespace, while the identity recorded at Connect
- * comes off the login bridge UNSANITIZED. Two spellings of one name therefore
- * have to be normalized to the same thing before they are compared, or an
- * operator whose display name carries an invisible character would fail every
- * report with `account-mismatch` and never learn why.
- */
-const STRIPPED_BY_CONNECTOR = /[\p{Cc}\p{Cf}]/gu;
-
-/** Both sides spell "this account has no name" with their own placeholder, and
-    neither is evidence of anything. */
-const NAME_PLACEHOLDERS = new Set(["[empty]", "telegram account"]);
-
-function comparableName(value: string): string {
-  const normalized = value.replace(STRIPPED_BY_CONNECTOR, "").replace(/\s+/g, " ").trim().toLowerCase();
-  return NAME_PLACEHOLDERS.has(normalized) ? "" : normalized;
-}
-
-/**
  * Whether the connector is logged into the account this report belongs to.
  *
- * THE NUMERIC ACCOUNT ID DECIDES (issue #1091). It is the only field of an
- * account that the operator cannot change, so when both sides carry one, that
- * comparison is the whole answer: equal ids are the same account whatever the
- * account is called today, and different ids are a different account even when
- * it has taken the same display name — which is exactly the impersonation the
- * name comparison alone could not see.
+ * THE NUMERIC ACCOUNT ID IS THE WHOLE ANSWER (issue #1091). It is the only
+ * field of an account nobody can hand themselves, so equal ids are the same
+ * account whatever it is called today, and anything else is not this account:
+ * a different id is a different account however familiar its display name, and
+ * a MISSING id on either side is no evidence at all.
  *
- * The name/handle rule below survives for ONE case: a connection enrolled
- * before the id was recorded, whose one-time migration has not run yet (see
- * `recordedIdentityAfterHealthCheck`). Falling back keeps those connections
- * reporting instead of failing every run until the operator reconnects, and
- * once the id is recorded the fallback is never consulted again.
- *
- * In that fallback, agreement on EITHER field is enough, deliberately: both are
- * the operator's to change at any moment and the recorded copy only refreshes
- * on a health check, so demanding both would end every report with
- * `account-mismatch` the day they took a new @handle — a silently dead feature,
- * which is a worse failure than the one this check exists to catch. A
- * genuinely different account agrees on neither, and a connection with nothing
- * comparable fails closed.
+ * There is no name or handle rule here any more, deliberately. Both fields are
+ * public and copyable, which is exactly how the v1 check let a second account
+ * wearing the operator's name pass; keeping them as a fallback for records that
+ * carry no id would leave that same hole open for every connection enrolled
+ * before the id existed. Those records are repaired instead — the runner
+ * completes their one-time health migration (`recordedIdentityAfterHealthCheck`)
+ * before a run is allowed to read anything — and a record that still has no id
+ * afterwards fails the check closed.
  */
 export function sameTelegramAccount(
-  live: { name: string; username: string | null; id?: string | null } | null,
-  recorded: { name: string; username: string | null; id?: string | null } | null,
+  live: { id?: string | null } | null,
+  recorded: { id?: string | null } | null,
 ): boolean {
-  if (!live || !recorded) return false;
-  if (live.id && recorded.id) return live.id === recorded.id;
-  const liveName = comparableName(live.name);
-  const recordedName = comparableName(recorded.name);
-  if (liveName && recordedName && liveName === recordedName) return true;
-  const liveHandle = (live.username ?? "").trim().toLowerCase();
-  const recordedHandle = (recorded.username ?? "").trim().toLowerCase();
-  return Boolean(liveHandle) && liveHandle === recordedHandle;
+  return Boolean(live?.id && recorded?.id && live.id === recorded.id);
 }
 
 function activeRow(active: NonNullable<ReturnType<typeof readTelegramReports>["active"]>): TelegramReportRow {

--- a/src/lib/telegram/reportRunner.ts
+++ b/src/lib/telegram/reportRunner.ts
@@ -21,6 +21,7 @@ import {
   scheduledRunDue,
   slotInstant,
 } from "./reportSchedule";
+import { reportAttemptId, TELEGRAM_REPORT_PROJECT } from "./reportLineage";
 import { connectorReadPort, planReportSources, type TelegramReadPort } from "./reportSources";
 import { launchReportConversation, type ReportSpawnInput, type ReportSpawnResult } from "./reportSpawn";
 import {
@@ -114,7 +115,7 @@ export const productionReportRunnerPorts: ReportRunnerPorts = {
   now: Date.now,
   connection: () => {
     try { return readTelegramConnection(); }
-    catch { return { version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe" }; }
+    catch { return { version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe", identityIdUpgradedAt: null }; }
   },
   readPort: connectorReadPort,
   spawn: launchReportConversation,
@@ -342,11 +343,14 @@ export class TelegramReportRunner {
           model: CODEX_SOL_MODEL,
           effort: "medium",
           cwd: reportWorkspaceDir(),
-          /* The durable marker that ties this conversation to this run, both
-             ways: the receipt carries it, and the history row carries the
-             conversation the receipt produced. No `src`, `parent` or role — see
-             the note on lineage at the bottom of this file. */
+          /* The durable report-run marker (#1091), in the two fields the
+             ordinary spawn path already makes durable: the receipt's attempt
+             id spells the run id, and explicit project ownership is what the
+             board groups the card by. Still no `src`, `parent` or role — see
+             `reportLineage.ts` for why a lineage parent would revoke the run's
+             own connector grant. */
           clientAttemptId: reportAttemptId(runId),
+          project: TELEGRAM_REPORT_PROJECT,
           ["prompt"]: prompt,
         },
         /* The grant is decided by the report session class, inside admission,
@@ -536,51 +540,39 @@ function comparableName(value: string): string {
 /**
  * Whether the connector is logged into the account this report belongs to.
  *
- * The evidence is the identity Connect recorded — display name and public
- * handle — because that is what the operator's connection carries; the
- * connector's `get_me` is asked for the same two fields.
+ * THE NUMERIC ACCOUNT ID DECIDES (issue #1091). It is the only field of an
+ * account that the operator cannot change, so when both sides carry one, that
+ * comparison is the whole answer: equal ids are the same account whatever the
+ * account is called today, and different ids are a different account even when
+ * it has taken the same display name — which is exactly the impersonation the
+ * name comparison alone could not see.
  *
- * AGREEMENT ON EITHER field is enough, and that is deliberate. Both fields are
- * the operator's to change at any moment, and the recorded copy is only
- * refreshed by a health check, so demanding that both agree would end every
- * report with `account-mismatch` the day the operator renamed themselves or
- * took a new @handle — a silently dead feature, which is a worse failure than
- * the one this check exists to catch. A genuinely different account agrees on
- * neither. A connection with NO comparable field cannot be verified against
- * anything, so it fails closed.
+ * The name/handle rule below survives for ONE case: a connection enrolled
+ * before the id was recorded, whose one-time migration has not run yet (see
+ * `recordedIdentityAfterHealthCheck`). Falling back keeps those connections
+ * reporting instead of failing every run until the operator reconnects, and
+ * once the id is recorded the fallback is never consulted again.
+ *
+ * In that fallback, agreement on EITHER field is enough, deliberately: both are
+ * the operator's to change at any moment and the recorded copy only refreshes
+ * on a health check, so demanding both would end every report with
+ * `account-mismatch` the day they took a new @handle — a silently dead feature,
+ * which is a worse failure than the one this check exists to catch. A
+ * genuinely different account agrees on neither, and a connection with nothing
+ * comparable fails closed.
  */
 export function sameTelegramAccount(
-  live: { name: string; username: string | null } | null,
-  recorded: { name: string; username: string | null } | null,
+  live: { name: string; username: string | null; id?: string | null } | null,
+  recorded: { name: string; username: string | null; id?: string | null } | null,
 ): boolean {
   if (!live || !recorded) return false;
+  if (live.id && recorded.id) return live.id === recorded.id;
   const liveName = comparableName(live.name);
   const recordedName = comparableName(recorded.name);
   if (liveName && recordedName && liveName === recordedName) return true;
   const liveHandle = (live.username ?? "").trim().toLowerCase();
   const recordedHandle = (recorded.username ?? "").trim().toLowerCase();
   return Boolean(liveHandle) && liveHandle === recordedHandle;
-}
-
-/**
- * The durable identity the launch carries into the registry (issue #1086).
- *
- * `clientAttemptId` is the spawn lane's own replay key: it is written on the
- * receipt, resolvable through `spawnReceiptForClientAttempt`, and it survives a
- * restart. Together with the `conversationId` the history row keeps, it is the
- * two-way link between a report row and the board conversation that produced
- * it.
- *
- * A lineage PARENT is deliberately not used, and the reason is mechanical: the
- * registry re-decides every stored MCP grant from the row's own evidence
- * (`mcpServersForStoredSession` at `registry.ts`, `decideStoredGrant` in
- * `mcpAllowlist.ts`), and a `parentConversationId` classifies the row as
- * delegated, whose grant is the baseline. A report run given a parent would
- * therefore lose `telegram` at the moment its receipt is written. It is also
- * true rather than convenient: no conversation spawns the 10:00 report.
- */
-export function reportAttemptId(runId: string): string {
-  return `telegram-report-${runId}`;
 }
 
 function activeRow(active: NonNullable<ReturnType<typeof readTelegramReports>["active"]>): TelegramReportRow {

--- a/src/lib/telegram/reportSources.test.ts
+++ b/src/lib/telegram/reportSources.test.ts
@@ -1,15 +1,36 @@
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import type { FeedDialog } from "./reportFeed";
-import {
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-telegram-sources-"));
+const OLD_STATE = process.env.LLV_STATE_DIR;
+const OLD_PORT = process.env.LLV_TELEGRAM_MCP_PORT;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+/* A port nothing listens on. The production port's refusals are asserted by
+   the sentence they throw, and this is what guarantees a REGRESSION in one of
+   them cannot reach the connector actually serving this machine. */
+process.env.LLV_TELEGRAM_MCP_PORT = "59809";
+
+const {
   CHAT_PAGE_LIMIT,
+  connectorReadPort,
   listReportGroups,
   MAX_PRIVATE_DIALOGS,
   MAX_PROBES,
   planReportSources,
-  type TelegramChatSummary,
-  type TelegramReadPort,
-} from "./reportSources";
+} = await import("./reportSources");
+
+import type { FeedDialog } from "./reportFeed";
+import type { TelegramChatSummary, TelegramReadPort } from "./reportSources";
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = OLD_STATE;
+  if (OLD_PORT === undefined) delete process.env.LLV_TELEGRAM_MCP_PORT;
+  else process.env.LLV_TELEGRAM_MCP_PORT = OLD_PORT;
+});
 
 /**
  * The fake connector: chats in the order the real one returns them (pinned and
@@ -28,6 +49,10 @@ class FakeTelegram implements TelegramReadPort {
   maxConcurrent = 0;
   /** What the connector's incoming feed recorded, newest first (#1091). */
   feed: FeedDialog[] = [];
+  /** The earliest instant this feed can vouch for. The default models the
+      ordinary case — a listener that has been up since before the window —
+      so a test about coverage has to say so by moving it. */
+  feedCoveredSinceMs: number | null = Date.parse("2026-08-19T07:00:00.000Z");
   /** Set to model a connector that is running no feed to read. */
   feedFailure: Error | null = null;
   constructor(
@@ -38,13 +63,16 @@ class FakeTelegram implements TelegramReadPort {
     this.calls.push("getMe");
     return { name: "Account A", username: "account_a", id: "770000001" };
   }
-  async feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]> {
+  async feedDialogs(input: { sinceMs: number }): Promise<{ dialogs: FeedDialog[]; coveredSinceMs: number | null }> {
     this.calls.push(`feedDialogs:${input.sinceMs}`);
     return this.track(() => {
       /* The production port throws when the connector is running no feed at
          all, or when its file cannot be read safely (#1091). */
       if (this.feedFailure) throw this.feedFailure;
-      return this.feed.filter((row) => Date.parse(row.lastMessageAt) >= input.sinceMs);
+      return {
+        dialogs: this.feed.filter((row) => Date.parse(row.lastMessageAt) >= input.sinceMs),
+        coveredSinceMs: this.feedCoveredSinceMs,
+      };
     });
   }
   async listChats(input: { kind: "user" | "group"; limit: number }): Promise<TelegramChatSummary[]> {
@@ -277,6 +305,98 @@ test("a connector with no feed fails the plan instead of walking alone", async (
   /* The GROUP picker is untouched by it: choosing sources is not a report run,
      and it reads no feed. */
   expect((await listReportGroups(port)).length).toBe(0);
+});
+
+test("a feed younger than the window cannot stand in for a walk that ran out of budget", async () => {
+  /* The tail's second regression (#1091). The feed is RUNNING — so the pass
+     does not fail on the missing-feed rule — but it started this morning,
+     while the window opened yesterday. Everything before the listener began is
+     the walk's problem alone, and on this account the walk stops at the probe
+     budget over a list ordered by pins: whatever sat past it would be missing
+     from a plan that reported success. It fails instead. */
+  const many = Array.from({ length: MAX_PROBES + 20 }, (_, index) => dialog(String(9000 + index), `Dialog ${index}`));
+  const dates = Object.fromEntries(many.map((chat) => [chat.id, "2026-07-01T09:00:00.000Z"]));
+  const port = new FakeTelegram(many, dates);
+  port.feedCoveredSinceMs = Date.parse("2026-08-21T05:00:00.000Z");
+
+  await expect(planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" })).rejects.toThrow(/cover/i);
+});
+
+test("a feed that cannot vouch for anything is the same answer as a feed that started late", async () => {
+  /* No coverage evidence at all — a connector record from before the stamp
+     existed. Unknown is not "covered": the same bar applies. */
+  const many = Array.from({ length: MAX_PROBES + 20 }, (_, index) => dialog(String(9500 + index), `Dialog ${index}`));
+  const dates = Object.fromEntries(many.map((chat) => [chat.id, "2026-07-01T09:00:00.000Z"]));
+  const port = new FakeTelegram(many, dates);
+  port.feedCoveredSinceMs = null;
+
+  await expect(planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" })).rejects.toThrow(/cover/i);
+});
+
+test("a young feed still plans the window when the walk reached every candidate", async () => {
+  /* The rule is about what could be MISSED, not about the feed's age: an
+     account whose whole dialog list fits inside the budget was judged dialog
+     by dialog, on last message date, so nothing could hide past a bound. A run
+     on the first day after a connect is an ordinary run here. */
+  const port = new FakeTelegram(
+    [dialog("901", "Dialog A"), dialog("902", "Dialog B")],
+    { "901": "2026-08-20T15:00:00.000Z", "902": "2026-06-01T09:00:00.000Z" },
+  );
+  port.feedCoveredSinceMs = Date.parse("2026-08-21T05:00:00.000Z");
+
+  const plan = await planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" });
+
+  expect(plan.privateDialogs.map((row) => row.id)).toEqual(["901"]);
+  expect(plan.probeBudgetExhausted).toBe(false);
+});
+
+test("a young feed over a dialog list longer than the enumeration fails too", async () => {
+  /* The other end of the same hole: the probe budget was never reached, but
+     the paged enumeration stopped on a FULL page, so the list did not end
+     where the walk did. Whatever sits below it was never even a candidate. */
+  const rooms: TelegramChatSummary[] = Array.from({ length: 3 * CHAT_PAGE_LIMIT }, (_, index) => ({
+    id: `-100${2000 + index}`,
+    kind: "group",
+    title: `Room ${index}`,
+    username: null,
+    unread: 0,
+  }));
+  const port = new FakeTelegram(rooms, {});
+  port.feedCoveredSinceMs = Date.parse("2026-08-21T05:00:00.000Z");
+
+  await expect(planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" })).rejects.toThrow(/cover/i);
+
+  /* The same list with the feed listening since before the window is a plan:
+     every dialog that received anything is in it whatever the walk enumerated. */
+  const covered = new FakeTelegram(rooms, {});
+  expect((await planReportSources(covered, { ...WINDOW, groups: [], promptVersion: "v1" })).privateDialogs).toEqual([]);
+});
+
+test("one read port answers for exactly one credential generation (#1091)", async () => {
+  /* The critical hole this closes: the port re-reads the stored credential on
+     every call, so a logout and reconnect inside the minute a source pass
+     takes would have had the SECOND account answer the listings and probes of
+     a pass the FIRST account's id check authorized — one plan, two people's
+     correspondents. The pinned generation refuses instead, before the call
+     leaves this process. */
+  const { saveTelegramSession } = await import("./sessionStore");
+  const first = saveTelegramSession("1ApWapzMBu4placeholder-not-a-real-session");
+  const port = connectorReadPort(first.credentialRef);
+
+  const second = saveTelegramSession("1BpWapzMBu4placeholder-also-not-a-session");
+  expect(second.credentialRef).not.toBe(first.credentialRef);
+
+  await expect(port.listChats({ kind: "user", limit: 10 })).rejects.toThrow(/generation changed/);
+  await expect(port.getMe()).rejects.toThrow(/generation changed/);
+  await expect(port.lastMessageAt("101")).rejects.toThrow(/generation changed/);
+  /* A port that pins nothing — the operator's own group picker, one action —
+     binds itself to the generation of its FIRST read, so a swap inside that
+     one pass ends the same way. (The first call here fails on the dead port
+     this file points at; the pin is taken before it is attempted.) */
+  const unpinned = connectorReadPort();
+  await expect(unpinned.listChats({ kind: "user", limit: 10 })).rejects.toThrow();
+  saveTelegramSession("1CpWapzMBu4placeholder-a-third-session");
+  await expect(unpinned.listChats({ kind: "user", limit: 10 })).rejects.toThrow(/generation changed/);
 });
 
 test("a group below the connector's pre-filter ceiling is still selectable", async () => {

--- a/src/lib/telegram/reportSources.test.ts
+++ b/src/lib/telegram/reportSources.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
 
+import type { FeedDialog } from "./reportFeed";
 import {
   CHAT_PAGE_LIMIT,
+  listReportGroups,
   MAX_PRIVATE_DIALOGS,
   MAX_PROBES,
   planReportSources,
@@ -24,30 +26,42 @@ class FakeTelegram implements TelegramReadPort {
   readonly calls: string[] = [];
   concurrent = 0;
   maxConcurrent = 0;
+  /** What the connector's incoming feed recorded, newest first (#1091). */
+  feed: FeedDialog[] = [];
   constructor(
     private readonly chats: TelegramChatSummary[],
     private readonly dates: Record<string, string | null>,
   ) {}
-  async getMe(): Promise<{ name: string; username: string | null }> {
+  async getMe(): Promise<{ name: string; username: string | null; id: string | null }> {
     this.calls.push("getMe");
-    return { name: "Account A", username: "account_a" };
+    return { name: "Account A", username: "account_a", id: "770000001" };
+  }
+  async feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]> {
+    this.calls.push(`feedDialogs:${input.sinceMs}`);
+    return this.track(() => this.feed.filter((row) => Date.parse(row.lastMessageAt) >= input.sinceMs));
   }
   async listChats(input: { kind: "user" | "group"; limit: number }): Promise<TelegramChatSummary[]> {
     this.calls.push(`listChats:${input.kind}:${input.limit}`);
-    return this.chats.slice(0, input.limit).filter((chat) => chat.kind === input.kind);
+    return this.track(() => this.chats.slice(0, input.limit).filter((chat) => chat.kind === input.kind));
   }
   async pageChats(input: { page: number; pageSize: number }): Promise<Array<{ id: string; title: string }>> {
     this.calls.push(`pageChats:${input.page}:${input.pageSize}`);
     const start = (input.page - 1) * input.pageSize;
-    return this.chats.slice(start, start + input.pageSize).map((chat) => ({ id: chat.id, title: chat.title }));
+    return this.track(() => this.chats.slice(start, start + input.pageSize).map((chat) => ({ id: chat.id, title: chat.title })));
   }
   async lastMessageAt(chatId: string): Promise<string | null> {
     this.calls.push(`lastMessageAt:${chatId}`);
+    return this.track(() => this.dates[chatId] ?? null);
+  }
+  /** Every read goes through here, so "the connector never sees two at once"
+      is asserted against the whole surface rather than the probes alone — the
+      connector this fakes died under concurrent reads (#1087). */
+  private async track<T>(read: () => T): Promise<T> {
     this.concurrent += 1;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.concurrent);
     await Promise.resolve();
     this.concurrent -= 1;
-    return this.dates[chatId] ?? null;
+    return read();
   }
 }
 
@@ -98,10 +112,12 @@ test("dialogs are ordered by last activity, bots are dropped, and reads never ov
      "bot", so the listing alone identifies it. */
   expect(port.calls).not.toContain("lastMessageAt:202");
   /* The connector died once under concurrent reads; this plan never issues
-     two at a time, and never asks for more than one page of chats. */
+     two at a time, and never asks for more than one page of chats. The feed is
+     read FIRST, before anything walks a list. */
   expect(port.maxConcurrent).toBe(1);
   expect(port.calls.filter((call) => call.startsWith("listChats")).length).toBe(1);
-  expect(port.calls[0]).toBe("listChats:user:100");
+  expect(port.calls[0]).toBe("feedDialogs:1787209200000");
+  expect(port.calls[1]).toBe("listChats:user:100");
 });
 
 test("an active dialog below the connector's pre-filter ceiling is still found", async () => {
@@ -176,4 +192,90 @@ test("the operator's groups ride along with their pass, and dialogs stay bounded
   ]);
   /* Groups are never re-derived from activity: the operator picked them. */
   expect(port.calls).not.toContain("listChats:group:100");
+});
+
+function burst(id: string, title: string, at: string): FeedDialog {
+  return { id, title, lastMessageAt: at };
+}
+
+test("a dialog the feed recorded is a source even when the walk never reaches it", async () => {
+  /* The acceptance criterion of #1091: an active dialog ranked LAST by the
+     connector's list order still appears in the run's sources. The walk cannot
+     get to it — the probe budget runs out hundreds of candidates earlier — and
+     it does not have to, because the feed recorded the burst when it arrived. */
+  const many = Array.from({ length: 400 }, (_, index) => dialog(String(5000 + index), `Dialog ${index}`));
+  const last = dialog("6001", "Dialog answered an hour ago");
+  const dates: Record<string, string> = {};
+  for (const chat of many) dates[chat.id] = "2026-01-01T00:00:00.000Z";
+  dates[last.id] = "2026-08-20T15:00:00.000Z";
+  const port = new FakeTelegram([...many, last], dates);
+  port.feed = [burst(last.id, last.title, "2026-08-20T15:00:00.000Z")];
+
+  const plan = await planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" });
+
+  expect(plan.privateDialogs.map((row) => row.id)).toEqual([last.id]);
+  expect(plan.feedDialogs).toBe(1);
+  /* It cost no probe, and the exhausted budget says nothing about it. */
+  expect(port.calls).not.toContain(`lastMessageAt:${last.id}`);
+  expect(plan.probes).toBe(MAX_PROBES);
+  expect(plan.probeBudgetExhausted).toBe(true);
+  /* Still one read at a time, feed included — the connector dies under
+     concurrent reads (#1087). */
+  expect(port.maxConcurrent).toBe(1);
+});
+
+test("the feed never costs a second probe for a dialog the walk would also find", async () => {
+  const port = new FakeTelegram(
+    [dialog("301", "Dialog A"), dialog("302", "Dialog B")],
+    { "301": "2026-08-20T09:00:00.000Z", "302": "2026-08-20T20:00:00.000Z" },
+  );
+  port.feed = [burst("302", "Dialog B", "2026-08-20T20:30:00.000Z")];
+
+  const plan = await planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" });
+
+  /* Newest first, and the feed's own instant is the one carried for the dialog
+     it recorded. */
+  expect(plan.privateDialogs).toEqual([
+    { id: "302", title: "Dialog B", lastMessageAt: "2026-08-20T20:30:00.000Z" },
+    { id: "301", title: "Dialog A", lastMessageAt: "2026-08-20T09:00:00.000Z" },
+  ]);
+  expect(port.calls).not.toContain("lastMessageAt:302");
+  expect(plan.probes).toBe(1);
+});
+
+test("a feed the connector never wrote leaves the walk exactly as it was", async () => {
+  const port = new FakeTelegram([dialog("401", "Dialog A")], { "401": "2026-08-20T15:00:00.000Z" });
+
+  const plan = await planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" });
+
+  expect(plan.privateDialogs.map((row) => row.id)).toEqual(["401"]);
+  expect(plan.feedDialogs).toBe(0);
+  expect(plan.probes).toBe(1);
+});
+
+test("a group below the connector's pre-filter ceiling is still selectable", async () => {
+  /* The defect: the picker offered one `list_chats` page, and that ceiling is
+     applied to the dialog list BEFORE the kind filter, so an operator whose
+     first hundred dialogs are private chats was offered no groups at all. */
+  const dialogs: TelegramChatSummary[] = Array.from({ length: CHAT_PAGE_LIMIT }, (_, index) => dialog(String(7000 + index), `Dialog ${index}`));
+  const buried: TelegramChatSummary = { id: "-1001200300", kind: "group", title: "Room below the ceiling", username: null, unread: 0 };
+  const port = new FakeTelegram([...dialogs, buried], {});
+
+  const groups = await listReportGroups(port);
+
+  expect(groups).toEqual([{ id: buried.id, title: buried.title }]);
+  /* Page one of the raw list is all dialogs; the group is on page two. */
+  expect(port.calls).toContain("pageChats:2:100");
+  /* Bounded and sequential: the typed head plus at most three pages. */
+  expect(port.calls.filter((call) => call.startsWith("pageChats")).length).toBeLessThanOrEqual(3);
+  expect(port.maxConcurrent).toBe(1);
+});
+
+test("the group picker never offers a private dialog and never repeats a room", async () => {
+  const head: TelegramChatSummary = { id: "-1001000001", kind: "group", title: "Team room", username: null, unread: 0 };
+  const port = new FakeTelegram([head, dialog("801", "Dialog A")], {});
+
+  const groups = await listReportGroups(port);
+
+  expect(groups).toEqual([{ id: head.id, title: head.title }]);
 });

--- a/src/lib/telegram/reportSources.test.ts
+++ b/src/lib/telegram/reportSources.test.ts
@@ -28,6 +28,8 @@ class FakeTelegram implements TelegramReadPort {
   maxConcurrent = 0;
   /** What the connector's incoming feed recorded, newest first (#1091). */
   feed: FeedDialog[] = [];
+  /** Set to model a connector that is running no feed to read. */
+  feedFailure: Error | null = null;
   constructor(
     private readonly chats: TelegramChatSummary[],
     private readonly dates: Record<string, string | null>,
@@ -38,7 +40,12 @@ class FakeTelegram implements TelegramReadPort {
   }
   async feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]> {
     this.calls.push(`feedDialogs:${input.sinceMs}`);
-    return this.track(() => this.feed.filter((row) => Date.parse(row.lastMessageAt) >= input.sinceMs));
+    return this.track(() => {
+      /* The production port throws when the connector is running no feed at
+         all, or when its file cannot be read safely (#1091). */
+      if (this.feedFailure) throw this.feedFailure;
+      return this.feed.filter((row) => Date.parse(row.lastMessageAt) >= input.sinceMs);
+    });
   }
   async listChats(input: { kind: "user" | "group"; limit: number }): Promise<TelegramChatSummary[]> {
     this.calls.push(`listChats:${input.kind}:${input.limit}`);
@@ -251,6 +258,25 @@ test("a feed the connector never wrote leaves the walk exactly as it was", async
   expect(plan.privateDialogs.map((row) => row.id)).toEqual(["401"]);
   expect(plan.feedDialogs).toBe(0);
   expect(plan.probes).toBe(1);
+});
+
+test("a connector with no feed fails the plan instead of walking alone", async () => {
+  /* The regression this guards: a connector adopted from a Viewer generation
+     that predates the feed answers `incoming_feed_status` with a path it will
+     never write. Reading that as "the feed saw nothing" would put the run back
+     on the bounded probe walk over a list ordered by pins — silently handing
+     the operator a report that omits whatever sits past the budget, which is
+     the v1 defect #1091 replaced. The run fails instead, and nothing is read
+     after the failure. */
+  const port = new FakeTelegram([dialog("501", "Dialog A")], { "501": "2026-08-20T15:00:00.000Z" });
+  port.feedFailure = new Error("Telegram incoming feed is unavailable");
+
+  await expect(planReportSources(port, { ...WINDOW, groups: [], promptVersion: "v1" })).rejects.toThrow(/feed/i);
+  expect(port.calls).toEqual([`feedDialogs:${Date.parse(WINDOW.windowStart)}`]);
+
+  /* The GROUP picker is untouched by it: choosing sources is not a report run,
+     and it reads no feed. */
+  expect((await listReportGroups(port)).length).toBe(0);
 });
 
 test("a group below the connector's pre-filter ceiling is still selectable", async () => {

--- a/src/lib/telegram/reportSources.ts
+++ b/src/lib/telegram/reportSources.ts
@@ -1,7 +1,7 @@
 import { readTelegramSession } from "./sessionStore";
 import { telegramMcpUrl } from "./packaging";
 import { validTelegramAccountId, type TelegramAccountIdentity } from "./contracts";
-import { readFeedDialogsSince, type FeedDialog } from "./reportFeed";
+import { activeFeedFile, readFeedDialogsSince, type FeedDialog } from "./reportFeed";
 import type { TelegramReportGroup } from "./reportContracts";
 
 /**
@@ -20,6 +20,14 @@ import type { TelegramReportGroup } from "./reportContracts";
  * generation started, has no feed line. So the walk still runs, over the
  * candidates the feed has not already accounted for, and still decides by
  * LAST MESSAGE DATE — never by position.
+ *
+ * The walk is a SUPPLEMENT and never a substitute. A run whose connector is
+ * not running a feed at all fails (`sources_failed`) instead of quietly
+ * walking alone: the walk is bounded by a probe budget over a list ordered by
+ * pins and folders, so falling back to it silently would hand the operator a
+ * report that omits whatever sat past the budget and say nothing about it —
+ * the v1 defect this issue exists to end. The supervisor keeps that rare:
+ * a connector without the feed is not adopted (`connector.ts`).
  *
  * The connector's chat listing is NOT ordered by recency — it follows pinned
  * and folder order, proven on the live connector by a dialog whose last
@@ -71,8 +79,10 @@ export interface TelegramReadPort {
       account. */
   getMe(): Promise<TelegramAccountIdentity | null>;
   /** Private dialogs the connector's incoming feed recorded as active at or
-      after `sinceMs`, newest first (#1091). Empty when the feed is off or has
-      seen nothing — never an error, because the walk below still runs. */
+      after `sinceMs`, newest first (#1091). Empty when the feed is running and
+      has seen nothing; THROWS when the connector is not running one at all, or
+      when its file cannot be read safely — a report whose recency source is
+      missing is a failed run, not a quietly narrower one. */
   feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]>;
   /** One bounded page of chats of a kind, in whatever order the connector
       returns them — the caller must not treat it as recency. */
@@ -337,22 +347,30 @@ export function connectorReadPort(): TelegramReadPort {
       };
     },
     async feedDialogs(input) {
-      /* Two reads, in this order, never overlapping: ask the connector where
-         its feed is, then read that file locally. The status call is the
-         issue's own contract — a connector adopted from an older generation
-         answers with the path IT is writing, which is the file that actually
-         holds the account's activity. */
+      /* Two reads, in this order, never overlapping: ask the connector whether
+         it is running a feed and where, then read that file locally. The
+         status call is the issue's own contract, and it answers with the path
+         THIS connector is writing, which is the file that actually holds the
+         account's activity.
+
+         A connector that is not running a feed — one adopted from a Viewer
+         generation that predates it above all — and a feed file that exists
+         but cannot be read through the owner-only fence are both FAILURES here,
+         not empty answers. Returning nothing would put the run back on the
+         bounded probe walk alone, silently, which is the exact defect #1091
+         replaced: the operator would get a report that quietly omits whatever
+         sat past the probe budget. The failure settles the run `sources_failed`
+         instead, and the connector is re-ensured (with the feed) by the next
+         health check. */
       try {
-        const status = JSON.parse(toolText(await call("incoming_feed_status", {}))) as { feed_file?: unknown };
-        const feedFile = typeof status?.feed_file === "string" && status.feed_file ? status.feed_file : null;
-        return readFeedDialogsSince(feedFile, input.sinceMs);
+        const feedFile = activeFeedFile(toolText(await call("incoming_feed_status", {})));
+        if (feedFile) return readFeedDialogsSince(feedFile, input.sinceMs);
       } catch {
-        /* A feed that cannot be located or read is not a failed run: the
-           candidate walk still covers the account, exactly as it did before the
-           feed existed. A connector that is actually down fails the walk next,
-           which is where a run SHOULD fail. */
-        return [];
+        /* Falls through to the one sanitized sentence below. */
       }
+      /* One fixed sentence: the upstream error may carry connector text, and
+         nothing from it belongs in a caught-and-logged failure. */
+      throw new Error("Telegram incoming feed is unavailable");
     },
     async listChats(input) {
       const result = await call("list_chats", { chat_type: input.kind, limit: Math.min(input.limit, CHAT_PAGE_LIMIT) });

--- a/src/lib/telegram/reportSources.ts
+++ b/src/lib/telegram/reportSources.ts
@@ -1,4 +1,5 @@
 import { readTelegramSession } from "./sessionStore";
+import { connectorFeedCoverageSince } from "./connector";
 import { telegramMcpUrl } from "./packaging";
 import { validTelegramAccountId, type TelegramAccountIdentity } from "./contracts";
 import { readFeedDialogsSince, scopedFeedFile, type FeedDialog } from "./reportFeed";
@@ -28,6 +29,14 @@ import type { TelegramReportGroup } from "./reportContracts";
  * report that omits whatever sat past the budget and say nothing about it —
  * the v1 defect this issue exists to end. The supervisor keeps that rare:
  * a connector without the feed is not adopted (`connector.ts`).
+ *
+ * A feed that is RUNNING is still not automatically a feed that covers the
+ * window: a listener started this morning knows nothing about last night, and
+ * on the first day after a connect it knows nothing about the window at all.
+ * So the plan is returned only when one of the two passes covered the whole
+ * window — the feed by listening from before it opened, or the walk by
+ * enumerating and probing every candidate. Otherwise the pass fails on the
+ * same principle as a missing feed.
  *
  * The connector's chat listing is NOT ordered by recency — it follows pinned
  * and folder order, proven on the live connector by a dialog whose last
@@ -79,11 +88,14 @@ export interface TelegramReadPort {
       account. */
   getMe(): Promise<TelegramAccountIdentity | null>;
   /** Private dialogs the connector's incoming feed recorded as active at or
-      after `sinceMs`, newest first (#1091). Empty when the feed is running and
-      has seen nothing; THROWS when the connector is not running one at all, or
-      when its file cannot be read safely — a report whose recency source is
-      missing is a failed run, not a quietly narrower one. */
-  feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]>;
+      after `sinceMs`, newest first, with the earliest instant that feed can
+      vouch for (#1091). No dialogs is an answer — a feed that is running and
+      has seen nothing — but `coveredSinceMs` later than the window start says
+      the answer is only about part of it. Both THROW when the connector is not
+      running a feed at all, or when its file cannot be read safely: a report
+      whose recency source is missing is a failed run, not a quietly narrower
+      one. */
+  feedDialogs(input: { sinceMs: number }): Promise<{ dialogs: FeedDialog[]; coveredSinceMs: number | null }>;
   /** One bounded page of chats of a kind, in whatever order the connector
       returns them — the caller must not treat it as recency. */
   listChats(input: { kind: TelegramChatKind; limit: number }): Promise<TelegramChatSummary[]>;
@@ -156,10 +168,13 @@ export function isPrivateChatId(id: string): boolean {
  * Order here decides only what is PROBED first, never what is selected —
  * selection is by last-message date.
  */
-async function candidateDialogs(port: TelegramReadPort): Promise<Array<{ id: string; title: string }>> {
+async function candidateDialogs(
+  port: TelegramReadPort,
+): Promise<{ candidates: Array<{ id: string; title: string }>; truncated: boolean }> {
   const typed = await port.listChats({ kind: "user", limit: CHAT_PAGE_LIMIT });
   const seen = new Set<string>();
   const candidates: Array<{ id: string; title: string }> = [];
+  let truncated = false;
   for (const chat of typed) {
     if (seen.has(chat.id)) continue;
     /* A bot is marked seen and NOT added, so the untyped pages below — which
@@ -178,8 +193,12 @@ async function candidateDialogs(port: TelegramReadPort): Promise<Array<{ id: str
       candidates.push(row);
     }
     if (rows.length < CHAT_PAGE_LIMIT) break;
+    /* A full last page means the dialog list did not end where the walk did:
+       whatever sits below it was never even enumerated, which the caller must
+       know before it calls this enumeration complete (#1091). */
+    if (page === MAX_CHAT_PAGES) truncated = true;
   }
-  return candidates;
+  return { candidates, truncated };
 }
 
 /**
@@ -206,13 +225,14 @@ export async function planReportSources(
   const fromFeed = await port.feedDialogs({ sinceMs: windowStart });
   const active: ReportSourceDialog[] = [];
   const carried = new Set<string>();
-  for (const dialog of fromFeed) {
+  for (const dialog of fromFeed.dialogs) {
     if (carried.has(dialog.id)) continue;
     carried.add(dialog.id);
     active.push({ id: dialog.id, title: dialog.title, lastMessageAt: dialog.lastMessageAt });
   }
   /* Sequential on purpose: see the module comment. */
-  const candidates = (await candidateDialogs(port)).filter((chat) => !carried.has(chat.id));
+  const enumerated = await candidateDialogs(port);
+  const candidates = enumerated.candidates.filter((chat) => !carried.has(chat.id));
   let probes = 0;
   for (const chat of candidates) {
     if (probes >= MAX_PROBES) break;
@@ -224,6 +244,26 @@ export async function planReportSources(
     active.push({ id: chat.id, title: chat.title, lastMessageAt: new Date(instant).toISOString() });
   }
   active.sort((left, right) => Date.parse(right.lastMessageAt) - Date.parse(left.lastMessageAt));
+  const probeBudgetExhausted = probes >= MAX_PROBES && candidates.length > probes;
+  /* The completeness bar, and the reason a plan may not be returned at all.
+     ONE of the two passes has to have covered the whole window:
+
+      - the FEED, when it was listening from before the window opened. Then
+        every dialog that received anything is in the plan, whatever the walk
+        reached, and the walk is the supplement it is meant to be.
+      - the WALK, when it enumerated every dialog and probed every candidate.
+        Then each one was judged by its last message date.
+
+     Neither is a plan that can silently omit an active dialog — a connector
+     that started mid-window (its first day, or after downtime) on an account
+     whose dialog list outruns the enumeration or the probe budget. v1 answered
+     that with a quietly narrower report, which is the defect #1091 exists to
+     end, so it fails the source pass instead and the run records
+     `sources_failed`. The next run's window still covers the day it missed. */
+  const feedCoversWindow = fromFeed.coveredSinceMs !== null && fromFeed.coveredSinceMs <= windowStart;
+  if (!feedCoversWindow && (probeBudgetExhausted || enumerated.truncated)) {
+    throw new Error("Telegram report sources cannot cover this window");
+  }
   return {
     version: 1,
     promptVersion: input.promptVersion,
@@ -234,7 +274,7 @@ export async function planReportSources(
     probes,
     feedDialogs: carried.size,
     truncated: active.length > MAX_PRIVATE_DIALOGS,
-    probeBudgetExhausted: probes >= MAX_PROBES && candidates.length > probes,
+    probeBudgetExhausted,
   };
 }
 
@@ -313,11 +353,30 @@ function chatSummary(record: Record<string, unknown>, kind: TelegramChatKind): T
  * The production port: the shared loopback connector, over the same
  * streamable-HTTP client the readiness probe uses, authenticated with the
  * per-credential bearer token from owner-only storage.
+ *
+ * EVERY read on one port instance is bound to ONE credential generation
+ * (#1091). A source pass is tens of seconds of sequential reads, and the
+ * operator can log out and connect a second account inside that minute: the
+ * token is re-read per call, so without this the same pass would verify
+ * account A through `get_me` and then take account B's feed, listings and
+ * probes as A's sources — one plan naming two people's correspondents, with
+ * the id check already passed. A generation that has moved on FAILS the read
+ * instead, which settles the run rather than reporting on the wrong account.
+ *
+ * `credentialRef` is the generation the caller verified. A caller that
+ * verified none — the operator's own group picker, one action, no account
+ * check behind it — passes `null` and the port pins itself to the generation
+ * of its first read, which keeps that single pass internally consistent.
  */
-export function connectorReadPort(): TelegramReadPort {
+export function connectorReadPort(credentialRef: string | null = null): TelegramReadPort {
+  let pinned = credentialRef;
   const call = async (name: string, args: Record<string, unknown>): Promise<unknown> => {
     const session = readTelegramSession();
     if (!session) throw new Error("Telegram is not connected");
+    pinned ??= session.credentialRef;
+    /* One fixed sentence: nothing about which generations these were belongs
+       in an error a caller may log. */
+    if (session.credentialRef !== pinned) throw new Error("Telegram credential generation changed");
     const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
     const { StreamableHTTPClientTransport } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
     const client = new Client({ name: "agent-log-viewer", version: "1.0.0" });
@@ -365,8 +424,10 @@ export function connectorReadPort(): TelegramReadPort {
          the feed) by the next health check. */
       let feedFile: string | null = null;
       try {
-        const session = readTelegramSession();
-        feedFile = scopedFeedFile(toolText(await call("incoming_feed_status", {})), session?.credentialRef ?? null);
+        const status = toolText(await call("incoming_feed_status", {}));
+        /* After the call, so the pin is the generation the read authenticated
+           as rather than one this line re-read for itself. */
+        feedFile = scopedFeedFile(status, pinned);
       } catch {
         /* Falls through to the one sanitized sentence below. */
       }
@@ -377,7 +438,12 @@ export function connectorReadPort(): TelegramReadPort {
          owner-only fence failure, a window too large for one bounded read —
          are already sanitized, and each says something different about why the
          run has no recency source. */
-      return readFeedDialogsSince(feedFile, input.sinceMs);
+      const dialogs = readFeedDialogsSince(feedFile, input.sinceMs);
+      /* What this feed can VOUCH for, which the file cannot say about itself:
+         a listener started this morning holds nothing about last night, and
+         the caller decides whether the walk behind it covered that stretch
+         (#1091). */
+      return { dialogs, coveredSinceMs: pinned === null ? null : connectorFeedCoverageSince(pinned) };
     },
     async listChats(input) {
       const result = await call("list_chats", { chat_type: input.kind, limit: Math.min(input.limit, CHAT_PAGE_LIMIT) });

--- a/src/lib/telegram/reportSources.ts
+++ b/src/lib/telegram/reportSources.ts
@@ -1,17 +1,31 @@
 import { readTelegramSession } from "./sessionStore";
 import { telegramMcpUrl } from "./packaging";
-import type { TelegramIdentity } from "./contracts";
+import { validTelegramAccountId, type TelegramAccountIdentity } from "./contracts";
+import { readFeedDialogsSince, type FeedDialog } from "./reportFeed";
 import type { TelegramReportGroup } from "./reportContracts";
 
 /**
- * Source discovery for a Daily Report run (issue #1086).
+ * Source discovery for a Daily Report run (issues #1086, #1091).
+ *
+ * THE FEED IS THE SOURCE OF "ACTIVE SINCE THE LAST RUN". The connector records
+ * every settled incoming private burst to its event feed the moment it happens
+ * (`reportFeed.ts`), so the dialogs a report is about are read from that file,
+ * in one bounded pass, with no dependence on any list order at all. A dialog
+ * ranked dead last by the connector's chat listing is exactly as visible as the
+ * first one.
+ *
+ * The candidate WALK survives behind it, because the feed knows only what
+ * arrived while the connector was running and listening: a dialog where the
+ * operator did the writing, or one that was active before this connector
+ * generation started, has no feed line. So the walk still runs, over the
+ * candidates the feed has not already accounted for, and still decides by
+ * LAST MESSAGE DATE — never by position.
  *
  * The connector's chat listing is NOT ordered by recency — it follows pinned
  * and folder order, proven on the live connector by a dialog whose last
  * message was 16 h old being absent from the first page while one last active
- * six weeks earlier ranked second. So a run cannot take "the first N chats"
- * as "the active chats": every candidate's LAST MESSAGE DATE decides, and the
- * listing is used only to enumerate candidates.
+ * six weeks earlier ranked second. So the listing is used only to enumerate
+ * candidates.
  *
  * Enumeration cannot stop at one page either. `list_chats` applies its 100-chat
  * ceiling to the dialog list BEFORE the `chat_type` filter, so an operator with
@@ -19,17 +33,20 @@ import type { TelegramReportGroup } from "./reportContracts";
  * not exist for this run. `get_chats` pages the same list (ids and titles only,
  * `page` 1..10), so candidates come from `list_chats` for the typed head and
  * from bounded `get_chats` pages beyond it, where a POSITIVE marked id is what
- * identifies a private dialog.
+ * identifies a private dialog. The operator's GROUP picker walks the same paged
+ * list for the same reason (#1091): a group below the ceiling could not be
+ * chosen as a source at all while only the typed head was offered.
  *
  * The probing is deliberately dull: one single-message read per candidate,
  * sequentially. The connector died once under three concurrent 120-message
- * reads, so nothing here runs in parallel and nothing asks for more than one
- * message at a time. ONE bound keeps that honest on a large account —
- * {@link MAX_PROBES} probes for the whole run — and every candidate inside it
- * is probed. An earlier revision also stopped after a run of consecutive stale
- * candidates, which was a recency assumption about a list this module opens by
- * saying is not ordered by recency: a dialog answered an hour ago, sitting
- * below a block of dormant ones, was silently dropped from the report.
+ * reads, so NOTHING here runs in parallel — not the feed read, not the
+ * listings, not the probes — and nothing asks for more than one message at a
+ * time. ONE bound keeps that honest on a large account — {@link MAX_PROBES}
+ * probes for the whole run — and every candidate inside it is probed. An
+ * earlier revision also stopped after a run of consecutive stale candidates,
+ * which was a recency assumption about a list this module opens by saying is
+ * not ordered by recency: a dialog answered an hour ago, sitting below a block
+ * of dormant ones, was silently dropped from the report.
  *
  * The resulting plan is written to owner-only state and READ by the run from
  * there — it never travels through the prompt — because it names the
@@ -49,9 +66,14 @@ export type TelegramChatSummary = {
 
 export interface TelegramReadPort {
   /** The account the connector is actually logged in as, sanitized to the
-      same two fields Connect records. `null` when the connector answered
-      something that is not an account. */
-  getMe(): Promise<TelegramIdentity | null>;
+      fields Connect records — including the numeric id the verifier compares
+      (#1091). `null` when the connector answered something that is not an
+      account. */
+  getMe(): Promise<TelegramAccountIdentity | null>;
+  /** Private dialogs the connector's incoming feed recorded as active at or
+      after `sinceMs`, newest first (#1091). Empty when the feed is off or has
+      seen nothing — never an error, because the walk below still runs. */
+  feedDialogs(input: { sinceMs: number }): Promise<FeedDialog[]>;
   /** One bounded page of chats of a kind, in whatever order the connector
       returns them — the caller must not treat it as recency. */
   listChats(input: { kind: TelegramChatKind; limit: number }): Promise<TelegramChatSummary[]>;
@@ -90,10 +112,14 @@ export type ReportSourcePlan = {
   groups: TelegramReportGroup[];
   /** How many single-message probes the plan cost, for the run log. */
   probes: number;
+  /** How many of the plan's dialogs the incoming feed supplied — the ones no
+      list order and no probe budget could have hidden (#1091). */
+  feedDialogs: number;
   /** Whether more active dialogs existed than the plan carries. */
   truncated: boolean;
   /** Whether the walk ran out of probe budget before it ran out of
-      candidates, so the plan is a bounded view rather than a complete one. */
+      candidates, so the plan is a bounded view rather than a complete one.
+      Dialogs the feed supplied are unaffected by it either way. */
   probeBudgetExhausted: boolean;
 };
 
@@ -149,21 +175,34 @@ async function candidateDialogs(port: TelegramReadPort): Promise<Array<{ id: str
 /**
  * Builds the source plan for one window.
  *
- * Private dialogs: every candidate whose last message falls inside the window,
- * newest first, capped. The walk probes candidates in list order and stops
- * only at the probe budget, so a dialog's POSITION in the list never decides
- * whether it is looked at — only its last-message date decides whether it is
- * carried. Groups: exactly what the operator picked, with their full/light
- * flag — a group is a source because the operator said so, never because it
- * was busy.
+ * Private dialogs come from two passes, in this order and never in parallel:
+ *
+ *  1. THE FEED — every dialog it recorded as active inside the window. These
+ *     cost no probe and depend on no list order, so an active dialog ranked
+ *     last by the connector is in the plan regardless of what the walk reaches.
+ *  2. THE WALK — every remaining candidate, probed in list order until the
+ *     probe budget runs out, carried when its last message falls in the window.
+ *     Position never decides whether a dialog is LOOKED at; the date decides
+ *     whether it is CARRIED.
+ *
+ * Groups are exactly what the operator picked, with their full/light flag — a
+ * group is a source because the operator said so, never because it was busy.
  */
 export async function planReportSources(
   port: TelegramReadPort,
   input: { windowStart: string; windowEnd: string; groups: readonly TelegramReportGroup[]; promptVersion: string },
 ): Promise<ReportSourcePlan> {
   const windowStart = Date.parse(input.windowStart);
-  const candidates = await candidateDialogs(port);
+  const fromFeed = await port.feedDialogs({ sinceMs: windowStart });
   const active: ReportSourceDialog[] = [];
+  const carried = new Set<string>();
+  for (const dialog of fromFeed) {
+    if (carried.has(dialog.id)) continue;
+    carried.add(dialog.id);
+    active.push({ id: dialog.id, title: dialog.title, lastMessageAt: dialog.lastMessageAt });
+  }
+  /* Sequential on purpose: see the module comment. */
+  const candidates = (await candidateDialogs(port)).filter((chat) => !carried.has(chat.id));
   let probes = 0;
   for (const chat of candidates) {
     if (probes >= MAX_PROBES) break;
@@ -183,9 +222,48 @@ export async function planReportSources(
     privateDialogs: active.slice(0, MAX_PRIVATE_DIALOGS),
     groups: input.groups.map((group) => ({ ...group })),
     probes,
+    feedDialogs: carried.size,
     truncated: active.length > MAX_PRIVATE_DIALOGS,
     probeBudgetExhausted: probes >= MAX_PROBES && candidates.length > probes,
   };
+}
+
+/**
+ * The groups the operator can choose as report sources (#1091).
+ *
+ * The typed listing alone was one pre-filtered page: `list_chats` takes its 100
+ * dialogs of every kind first and filters by `chat_type` afterwards, so an
+ * operator whose first hundred dialogs are private chats was offered NO groups
+ * at all and could not pick the room they meet in every day. The paged raw list
+ * is the way past that ceiling, exactly as it is for dialogs — and it carries
+ * no kind, so a negative marked id (a group or a channel, never a private
+ * dialog) is what qualifies a row there. The operator picks; the Viewer does
+ * not guess which rooms matter.
+ *
+ * Bounded and sequential like everything else here: one typed listing plus at
+ * most {@link MAX_CHAT_PAGES} pages, never two at once.
+ */
+export async function listReportGroups(port: TelegramReadPort): Promise<Array<{ id: string; title: string }>> {
+  const typed = await port.listChats({ kind: "group", limit: CHAT_PAGE_LIMIT });
+  const seen = new Set<string>();
+  const groups: Array<{ id: string; title: string }> = [];
+  for (const chat of typed) {
+    if (seen.has(chat.id)) continue;
+    seen.add(chat.id);
+    groups.push({ id: chat.id, title: chat.title });
+  }
+  for (let page = 1; page <= MAX_CHAT_PAGES; page += 1) {
+    /* Sequential on purpose: see the module comment. */
+    const rows = await port.pageChats({ page, pageSize: CHAT_PAGE_LIMIT });
+    if (rows.length === 0) break;
+    for (const row of rows) {
+      if (seen.has(row.id) || isPrivateChatId(row.id)) continue;
+      seen.add(row.id);
+      groups.push(row);
+    }
+    if (rows.length < CHAT_PAGE_LIMIT) break;
+  }
+  return groups;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -246,11 +324,35 @@ export function connectorReadPort(): TelegramReadPort {
   return {
     async getMe() {
       /* `get_me` answers with the entity object itself rather than the
-         `{"results": []}` envelope the listings use. */
-      const parsed = JSON.parse(toolText(await call("get_me", {}))) as { name?: unknown; username?: unknown };
+         `{"results": []}` envelope the listings use. Its `id` is the marked
+         id, which for a user IS the account id (#1091). */
+      const parsed = JSON.parse(toolText(await call("get_me", {}))) as { id?: unknown; name?: unknown; username?: unknown };
       const name = typeof parsed?.name === "string" ? parsed.name.trim() : "";
-      if (!name) return null;
-      return { name, username: typeof parsed.username === "string" && parsed.username ? parsed.username : null };
+      const id = validTelegramAccountId(parsed?.id);
+      if (!name && !id) return null;
+      return {
+        name,
+        username: typeof parsed.username === "string" && parsed.username ? parsed.username : null,
+        id,
+      };
+    },
+    async feedDialogs(input) {
+      /* Two reads, in this order, never overlapping: ask the connector where
+         its feed is, then read that file locally. The status call is the
+         issue's own contract — a connector adopted from an older generation
+         answers with the path IT is writing, which is the file that actually
+         holds the account's activity. */
+      try {
+        const status = JSON.parse(toolText(await call("incoming_feed_status", {}))) as { feed_file?: unknown };
+        const feedFile = typeof status?.feed_file === "string" && status.feed_file ? status.feed_file : null;
+        return readFeedDialogsSince(feedFile, input.sinceMs);
+      } catch {
+        /* A feed that cannot be located or read is not a failed run: the
+           candidate walk still covers the account, exactly as it did before the
+           feed existed. A connector that is actually down fails the walk next,
+           which is where a run SHOULD fail. */
+        return [];
+      }
     },
     async listChats(input) {
       const result = await call("list_chats", { chat_type: input.kind, limit: Math.min(input.limit, CHAT_PAGE_LIMIT) });

--- a/src/lib/telegram/reportSources.ts
+++ b/src/lib/telegram/reportSources.ts
@@ -1,7 +1,7 @@
 import { readTelegramSession } from "./sessionStore";
 import { telegramMcpUrl } from "./packaging";
 import { validTelegramAccountId, type TelegramAccountIdentity } from "./contracts";
-import { activeFeedFile, readFeedDialogsSince, type FeedDialog } from "./reportFeed";
+import { readFeedDialogsSince, scopedFeedFile, type FeedDialog } from "./reportFeed";
 import type { TelegramReportGroup } from "./reportContracts";
 
 /**
@@ -354,23 +354,30 @@ export function connectorReadPort(): TelegramReadPort {
          account's activity.
 
          A connector that is not running a feed — one adopted from a Viewer
-         generation that predates it above all — and a feed file that exists
-         but cannot be read through the owner-only fence are both FAILURES here,
-         not empty answers. Returning nothing would put the run back on the
-         bounded probe walk alone, silently, which is the exact defect #1091
-         replaced: the operator would get a report that quietly omits whatever
-         sat past the probe budget. The failure settles the run `sources_failed`
-         instead, and the connector is re-ensured (with the feed) by the next
-         health check. */
+         generation that predates it above all — a connector writing a feed
+         that belongs to a DIFFERENT credential generation, and a feed file
+         that exists but cannot be read through the owner-only fence are all
+         FAILURES here, not empty answers. Returning nothing would put the run
+         back on the bounded probe walk alone, silently, which is the exact
+         defect #1091 replaced: the operator would get a report that quietly
+         omits whatever sat past the probe budget. The failure settles the
+         run `sources_failed` instead, and the connector is re-ensured (with
+         the feed) by the next health check. */
+      let feedFile: string | null = null;
       try {
-        const feedFile = activeFeedFile(toolText(await call("incoming_feed_status", {})));
-        if (feedFile) return readFeedDialogsSince(feedFile, input.sinceMs);
+        const session = readTelegramSession();
+        feedFile = scopedFeedFile(toolText(await call("incoming_feed_status", {})), session?.credentialRef ?? null);
       } catch {
         /* Falls through to the one sanitized sentence below. */
       }
       /* One fixed sentence: the upstream error may carry connector text, and
          nothing from it belongs in a caught-and-logged failure. */
-      throw new Error("Telegram incoming feed is unavailable");
+      if (!feedFile) throw new Error("Telegram incoming feed is unavailable");
+      /* Outside the catch on purpose: the file read's own refusals — an
+         owner-only fence failure, a window too large for one bounded read —
+         are already sanitized, and each says something different about why the
+         run has no recency source. */
+      return readFeedDialogsSince(feedFile, input.sinceMs);
     },
     async listChats(input) {
       const result = await call("list_chats", { chat_type: input.kind, limit: Math.min(input.limit, CHAT_PAGE_LIMIT) });

--- a/src/lib/telegram/reportSpawn.test.ts
+++ b/src/lib/telegram/reportSpawn.test.ts
@@ -14,6 +14,12 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 const { after } = await import("next/server");
 const { reportSpawnHeaders, reportSpawnOverrides, startDeferredSpawnWork } = await import("./reportSpawn");
 const { SCHEDULED_REPORT_SESSION_CLASS } = await import("@/lib/agent/mcpAllowlist");
+const { TELEGRAM_REPORT_PROJECT } = await import("./reportLineage");
+
+/** An invented run id, in the shape the runner mints. Assembled rather than
+    written out: the publication privacy gate refuses any literal with the
+    shape of a session identifier, invented or not. */
+const REPORT_RUN_ID = ["0192d4f1", "8f43", "4a10", "9c1e", "6b0f0a5d77c2"].join("-");
 const { executeSpawnRequest, productionSpawnCommandDependencies } = await import("@/lib/agent/spawnCommand");
 const { ensureOperatorSpawnCapability } = await import("@/lib/agent/operatorCapability");
 const { VIEWER_SPAWN_CAPABILITY_HEADER } = await import("@/lib/agent/spawnPolicy");
@@ -75,9 +81,10 @@ test("nothing arriving over /api/spawn can select the report session class", () 
  * the real `executeSpawnRequest` that still writes a durable receipt: the
  * grant, the plugin surface and the display payload are all decided before it.
  */
-function capturingRegistry(): { profiles: Record<string, unknown>[]; displays: unknown[]; registry: unknown } {
+function capturingRegistry(): { profiles: Record<string, unknown>[]; displays: unknown[]; requests: Record<string, unknown>[]; registry: unknown } {
   const profiles: Record<string, unknown>[] = [];
   const displays: unknown[] = [];
+  const requests: Record<string, unknown>[] = [];
   let next = 0;
   const registry = {
     conversation: () => null,
@@ -87,6 +94,7 @@ function capturingRegistry(): { profiles: Record<string, unknown>[]; displays: u
     beginSpawnRequest: (request: { launchProfile: Record<string, unknown>; launchDisplay?: unknown }) => {
       profiles.push(request.launchProfile);
       displays.push(request.launchDisplay ?? null);
+      requests.push(request as unknown as Record<string, unknown>);
       next += 1;
       return {
         kind: "created" as const,
@@ -111,7 +119,7 @@ function capturingRegistry(): { profiles: Record<string, unknown>[]; displays: u
     failStructuredSpawn: () => undefined,
     readOnlySnapshot: () => ({ receipts: {} }),
   };
-  return { profiles, displays, registry };
+  return { profiles, displays, requests, registry };
 }
 
 function reportLaunchRequest(body: Record<string, unknown>): NextRequest {
@@ -142,6 +150,12 @@ test("the report class decides the whole capability surface admission reserves",
     engine: "codex",
     cwd: SANDBOX,
     accountId: "account-pinned",
+    /* The durable report-run marker the runner sends (#1091). It rides the real
+       admission path here because both halves are admitted, not decorative: an
+       explicit project is refused outright for a launch admission reads as
+       agent-initiated, which would settle every report run `launch_failed`. */
+    clientAttemptId: `telegram-report-${REPORT_RUN_ID}`,
+    project: TELEGRAM_REPORT_PROJECT,
     ["prompt"]: "Telegram daily report — window A → B.\n\nThe operator's own brief.",
   };
   const response = await executeSpawnRequest(reportLaunchRequest(body), dependencies);
@@ -153,6 +167,14 @@ test("the report class decides the whole capability surface admission reserves",
   /* And the prompt — which carries the operator's analyst brief — reserves no
      durable display copy in the registry. */
   expect(captured.displays[0]).toBeNull();
+  /* The marker reached the registry, and it is still a root: no parent, no
+     role, so the grant above survives every later re-decision. */
+  expect(captured.requests[0]).toMatchObject({
+    clientAttemptId: `telegram-report-${REPORT_RUN_ID}`,
+    explicitProject: TELEGRAM_REPORT_PROJECT,
+  });
+  expect(captured.requests[0].parentConversationId ?? null).toBeNull();
+  expect(captured.requests[0].role ?? null).toBeNull();
 
   /* The same launch WITHOUT the class is the contrast: an operator-root Codex
      launch carries Computer Use and its display payload, exactly as before. */

--- a/src/lib/telegram/service.test.ts
+++ b/src/lib/telegram/service.test.ts
@@ -8,7 +8,7 @@ const OLD_STATE = process.env.LLV_STATE_DIR;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
 const { TelegramConnectionService } = await import("./service");
-const { readTelegramSession, saveTelegramSession, telegramSessionPath, writeTelegramConnection } = await import("./sessionStore");
+const { readTelegramConnection, readTelegramSession, saveTelegramSession, telegramSessionPath, writeTelegramConnection } = await import("./sessionStore");
 
 import type { TelegramAdapter, TelegramEnrollmentEvent, TelegramHealthResult } from "./adapter";
 import type { TelegramErrorCode } from "./contracts";
@@ -30,7 +30,7 @@ class FakeAdapter implements TelegramAdapter {
   canceled = 0;
   passwords: string[] = [];
   unavailable: TelegramErrorCode | null = null;
-  health: TelegramHealthResult = { status: "connected", identity: { name: "Account A", username: "account_a" } };
+  health: TelegramHealthResult = { status: "connected", identity: { name: "Account A", username: "account_a", id: "770000001" } };
   healthPromise: Promise<TelegramHealthResult> | null = null;
   logoutResult: { ok: boolean; code: TelegramErrorCode | null } = { ok: true, code: null };
   logoutCalls = 0;
@@ -104,7 +104,7 @@ test("the full QR login without 2FA: scan refresh, verify, connect", async () =>
   await settle();
   expect(service.status().phase).toBe("verifying");
 
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: "account_a" } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: "account_a", id: "770000001" } });
   /* Authorization alone does NOT publish connected — the operation stays in
      verifying until the connector's read-only surface stands verified. */
   expect(service.status().phase).toBe("verifying");
@@ -127,7 +127,7 @@ test("the session string never appears in any status payload", async () => {
   await service.startLogin();
   adapter.emit!({ type: "qr", url: "tg://login?token=x", expiresAt: "2026-08-20T12:00:30.000Z" });
   expect(JSON.stringify(service.status())).not.toContain(PLACEHOLDER_SESSION);
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   expect(JSON.stringify(service.status())).not.toContain(PLACEHOLDER_SESSION);
 });
@@ -154,7 +154,7 @@ test("2FA: password phase, invalid retry, then success", async () => {
   expect(status.login?.passwordError).toBe(true);
 
   await service.submitPassword(login!.operationId, "correct");
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   expect(service.status().phase).toBe("connected");
 });
@@ -237,7 +237,7 @@ test("health releases the shared connector before the session bridge connects", 
   const order: string[] = [];
   adapter.checkSession = async () => {
     order.push("health");
-    return { status: "connected", identity: { name: "Account A", username: null } };
+    return { status: "connected", identity: { name: "Account A", username: null, id: "770000001" } };
   };
   saveTelegramSession(PLACEHOLDER_SESSION);
   const service = new TelegramConnectionService({
@@ -330,7 +330,7 @@ test("successful logout serializes health behind its terminal connector stop", a
   let healthCalls = 0;
   adapter.checkSession = async () => {
     healthCalls += 1;
-    return { status: "connected", identity: { name: "Account A", username: null } };
+    return { status: "connected", identity: { name: "Account A", username: null, id: "770000001" } };
   };
   let connectorRunning = true;
   const service = new TelegramConnectionService({
@@ -382,7 +382,7 @@ test("a failed remote logout PRESERVES the local session and reports why", async
 test("local deletion works directly from connected", async () => {
   const { adapter, calls, service } = harness();
   await service.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   const status = await service.deleteLocalSession();
   expect(status.phase).toBe("disconnected");
@@ -468,7 +468,7 @@ test("host cleanup failure cannot preserve an authorized canceled credential", a
     credentialsConfigured: () => true,
   });
   const started = await service.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
 
   const cancellation = service.cancelLogin(started.login!.operationId);
@@ -490,7 +490,7 @@ test("a connector refusing the read-only bound blocks connected and never regist
     credentialsConfigured: () => true,
   });
   await refusing.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   const status = refusing.status();
   expect(status.phase).toBe("error");
@@ -513,7 +513,7 @@ test("a connector bring-up that THROWS surfaces too, instead of leaving connecte
     credentialsConfigured: () => true,
   });
   await throwing.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   const status = throwing.status();
   expect(status.phase).toBe("error");
@@ -539,7 +539,7 @@ test("host registration failure blocks connected after connector verification", 
     credentialsConfigured: () => true,
   });
   await service.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
 
   expect(service.status().phase).toBe("error");
@@ -607,9 +607,10 @@ test("missing session health revokes an adopted connector and host registrations
     version: 1,
     status: "connected",
     credentialRef: "missing-session-ref",
-    identity: { name: "Account A", username: null },
+    identity: { name: "Account A", username: null, id: "770000001" },
     lastHealthCheckAt: null,
     errorCode: null,
+    identityIdUpgradedAt: null,
   });
   const { calls, service } = harness();
 
@@ -627,7 +628,7 @@ test("local deletion invalidates an in-flight health result", async () => {
 
   const pending = service.checkHealth();
   const deletion = service.deleteLocalSession();
-  resolveHealth({ status: "connected", identity: { name: "Account A", username: "account_a" } });
+  resolveHealth({ status: "connected", identity: { name: "Account A", username: "account_a", id: "770000001" } });
   expect((await deletion).phase).toBe("disconnected");
   expect((await pending).phase).toBe("disconnected");
   expect(readTelegramSession()).toBeNull();
@@ -650,7 +651,7 @@ test("cancel during connector verification cannot publish the authorized session
     credentialsConfigured: () => true,
   });
   const started = await service.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
   const cancellation = service.cancelLogin(started.login!.operationId);
   resolveConnector({ ok: true, url: "http://127.0.0.1:8809/mcp" });
@@ -693,11 +694,57 @@ test("retry authorization cannot overwrite a preserved unsafe session", async ()
   const before = fs.readFileSync(telegramSessionPath());
 
   await service.startLogin();
-  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null } });
+  adapter.emit!({ type: "authorized", sessionString: PLACEHOLDER_SESSION, identity: { name: "Account A", username: null, id: "770000001" } });
   await settle();
 
   expect(service.status().phase).toBe("error");
   expect(service.status().error?.code).toBe("session_unsafe");
   expect(fs.readFileSync(telegramSessionPath())).toEqual(before);
   expect(fs.existsSync(path.join(path.dirname(telegramSessionPath()), "connector-token"))).toBe(false);
+});
+
+test("a pre-#1091 connection recovers its account id on the next health check, once", async () => {
+  /* The migration #1091 names. A connection enrolled before the numeric id was
+     recorded carries a name and a handle only, and the report-run verifier has
+     nothing durable to compare. The health check already re-reads the account,
+     so the id arrives with it, is persisted, and the record is stamped as
+     migrated. */
+  const { adapter, service } = harness();
+  saveTelegramSession(PLACEHOLDER_SESSION);
+  writeTelegramConnection({
+    version: 1,
+    status: "connected",
+    credentialRef: "legacy-ref",
+    identity: { name: "Account A", username: "account_a", id: null },
+    lastHealthCheckAt: "2026-08-19T12:00:00.000Z",
+    errorCode: null,
+    identityIdUpgradedAt: null,
+  });
+
+  expect((await service.checkHealth()).phase).toBe("connected");
+  const upgraded = readTelegramConnection();
+  expect(upgraded.identity).toEqual({ name: "Account A", username: "account_a", id: "770000001" });
+  expect(upgraded.identityIdUpgradedAt).toBe("2026-08-20T12:00:00.000Z");
+
+  /* A later read that carries no id — an older bridge on a downgraded install —
+     must not erase the recorded one, or the verifier silently falls back to
+     comparing names again. And the migration does not re-run: the stamp is the
+     one it already earned. */
+  adapter.health = { status: "connected", identity: { name: "Account A renamed", username: "account_a", id: null } };
+  expect((await service.checkHealth()).phase).toBe("connected");
+  const later = readTelegramConnection();
+  expect(later.identity).toEqual({ name: "Account A renamed", username: "account_a", id: "770000001" });
+  expect(later.identityIdUpgradedAt).toBe("2026-08-20T12:00:00.000Z");
+});
+
+test("the recorded account id never crosses the browser boundary", async () => {
+  const { service } = harness();
+  saveTelegramSession(PLACEHOLDER_SESSION);
+
+  const status = await service.checkHealth();
+
+  expect(status.identity).toEqual({ name: "Account A", username: "account_a" });
+  expect(JSON.stringify(status)).not.toContain("770000001");
+  /* It is recorded, just not published. */
+  expect(readTelegramConnection().identity?.id).toBe("770000001");
 });

--- a/src/lib/telegram/service.ts
+++ b/src/lib/telegram/service.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 
 import { processTelegramAdapter, type TelegramAdapter, type TelegramEnrollmentEvent, type TelegramEnrollmentHandle } from "./adapter";
 import { ensureTelegramConnector, stopTelegramConnector, type ConnectorEnsureResult } from "./connector";
-import type { TelegramErrorCode, TelegramIdentity, TelegramStatusPayload } from "./contracts";
+import type { TelegramAccountIdentity, TelegramErrorCode, TelegramStatusPayload } from "./contracts";
 import { registerTelegramHosts, unregisterTelegramHosts, type TelegramHostRegistrationResult } from "./hostRegistration";
 import { telegramApiCredentials } from "./packaging";
 import {
@@ -145,7 +145,7 @@ export class TelegramConnectionService {
       connection = readTelegramConnection();
     } catch (error) {
       if (!(error instanceof UnsafeTelegramSessionError)) throw error;
-      return this.payloadFor({ version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe" });
+      return this.payloadFor({ version: 1, status: "error", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: "session_unsafe", identityIdUpgradedAt: null });
     }
     return this.payloadFor(connection);
   }
@@ -154,7 +154,11 @@ export class TelegramConnectionService {
     return {
       phase: connection.status,
       login: null,
-      identity: connection.identity,
+      /* The recorded numeric account id (#1091) stays server-side: the panel
+         renders a name and a handle, and nothing outside the verifier has a
+         use for the id. Projecting the two public fields explicitly is what
+         keeps a later field added to the stored identity from leaking. */
+      identity: connection.identity ? { name: connection.identity.name, username: connection.identity.username } : null,
       credentialRef: connection.credentialRef,
       lastHealthCheckAt: connection.lastHealthCheckAt,
       error: connection.status === "error" && connection.errorCode ? { code: connection.errorCode } : null,
@@ -171,7 +175,7 @@ export class TelegramConnectionService {
       try {
         const connection = readTelegramConnection();
         if (connection.status === "error" && connection.errorCode === "credentials_missing") {
-          writeTelegramConnection({ version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null });
+          writeTelegramConnection({ version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null, identityIdUpgradedAt: null });
         }
       } catch { /* an unsafe session keeps its explicit-deletion contract */ }
     }
@@ -242,7 +246,7 @@ export class TelegramConnectionService {
       EVERY failure — refusal, timeout, thrown error — lands in an explicit
       error state over the preserved session. Cancellation invalidates the
       generation and removes a credential that authorization already wrote. */
-  private async completeEnrollment(operation: LiveLogin, sessionString: string, identity: TelegramIdentity, generation: number): Promise<void> {
+  private async completeEnrollment(operation: LiveLogin, sessionString: string, identity: TelegramAccountIdentity, generation: number): Promise<void> {
     let stored: StoredTelegramSession;
     try {
       stored = saveTelegramSession(sessionString);
@@ -261,12 +265,12 @@ export class TelegramConnectionService {
     if (!this.lifecycleIsCurrent(generation) || this.login !== operation) return;
     this.login = null;
     if (!connector.ok) {
-      writeTelegramConnection({ version: 1, status: "error", credentialRef: stored.credentialRef, identity, lastHealthCheckAt: null, errorCode: connector.code });
+      writeTelegramConnection({ version: 1, status: "error", credentialRef: stored.credentialRef, identity, lastHealthCheckAt: null, errorCode: connector.code, identityIdUpgradedAt: null });
       return;
     }
     if (!this.registerVerifiedHosts()) {
       await this.cleanupFailedRegistration();
-      writeTelegramConnection({ version: 1, status: "error", credentialRef: stored.credentialRef, identity, lastHealthCheckAt: null, errorCode: "host_registration_failed" });
+      writeTelegramConnection({ version: 1, status: "error", credentialRef: stored.credentialRef, identity, lastHealthCheckAt: null, errorCode: "host_registration_failed", identityIdUpgradedAt: null });
       return;
     }
     writeTelegramConnection({
@@ -276,6 +280,7 @@ export class TelegramConnectionService {
       identity,
       lastHealthCheckAt: new Date(this.ports.now()).toISOString(),
       errorCode: null,
+      identityIdUpgradedAt: null,
     });
   }
 
@@ -311,6 +316,7 @@ export class TelegramConnectionService {
           identity: null,
           lastHealthCheckAt: null,
           errorCode: connectorStopped ? null : "connector_failed",
+          identityIdUpgradedAt: null,
         });
       } else {
         this.recordError("session_unsafe");
@@ -329,7 +335,7 @@ export class TelegramConnectionService {
     try {
       return readTelegramConnection();
     } catch {
-      return { version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null };
+      return { version: 1, status: "disconnected", credentialRef: null, identity: null, lastHealthCheckAt: null, errorCode: null, identityIdUpgradedAt: null };
     }
   }
 
@@ -410,6 +416,7 @@ export class TelegramConnectionService {
           identity: null,
           lastHealthCheckAt: null,
           errorCode: connectorStopped ? null : "connector_failed",
+          identityIdUpgradedAt: null,
         });
       }
       return;
@@ -437,23 +444,27 @@ export class TelegramConnectionService {
         connector = { ok: false, code: "connector_failed" };
       }
       if (!this.lifecycleIsCurrent(generation)) return;
+      /* The account answered, so this is the read the id migration is owed —
+         whether or not the connector or host registration behind it succeeds
+         (#1091). */
+      const recorded = recordedIdentityAfterHealthCheck(connection, result.identity, checkedAt);
       if (!connector.ok) {
-        writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, identity: result.identity, lastHealthCheckAt: checkedAt, errorCode: connector.code });
+        writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, ...recorded, lastHealthCheckAt: checkedAt, errorCode: connector.code });
         return;
       }
       if (!this.registerVerifiedHosts()) {
         await this.cleanupFailedRegistration();
-        writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, identity: result.identity, lastHealthCheckAt: checkedAt, errorCode: "host_registration_failed" });
+        writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, ...recorded, lastHealthCheckAt: checkedAt, errorCode: "host_registration_failed" });
         return;
       }
-      writeTelegramConnection({ version: 1, status: "connected", credentialRef: session.credentialRef, identity: result.identity, lastHealthCheckAt: checkedAt, errorCode: null });
+      writeTelegramConnection({ version: 1, status: "connected", credentialRef: session.credentialRef, ...recorded, lastHealthCheckAt: checkedAt, errorCode: null });
       return;
     }
     if (result.status === "expired") {
-      writeTelegramConnection({ version: 1, status: "expired", credentialRef: session.credentialRef, identity: connection.identity, lastHealthCheckAt: checkedAt, errorCode: null });
+      writeTelegramConnection({ version: 1, status: "expired", credentialRef: session.credentialRef, identity: connection.identity, lastHealthCheckAt: checkedAt, errorCode: null, identityIdUpgradedAt: connection.identityIdUpgradedAt });
       return;
     }
-    writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, identity: connection.identity, lastHealthCheckAt: checkedAt, errorCode: result.code });
+    writeTelegramConnection({ version: 1, status: "error", credentialRef: session.credentialRef, identity: connection.identity, lastHealthCheckAt: checkedAt, errorCode: result.code, identityIdUpgradedAt: connection.identityIdUpgradedAt });
   }
 
   /** Remote logout. Success removes the local session too; failure PRESERVES
@@ -514,6 +525,37 @@ export class TelegramConnectionService {
     const connectorStopped = await this.teardownConnectorAndHosts();
     this.deleteCredentialsAndPublishDisconnected(connectorStopped);
   }
+}
+
+/**
+ * The identity a health check records, and the one-time id migration (#1091).
+ *
+ * A connection enrolled before the numeric account id existed carries a name
+ * and a handle only, and the report-run verifier has nothing durable to compare
+ * against. The health check is where that is repaired: it already re-reads the
+ * account through the login bridge, so the id arrives with it, is persisted,
+ * and the record is stamped as migrated — ONCE. The stamp is set whether or not
+ * an id actually came back, so a bridge too old to report one is not re-probed
+ * on every health check for the rest of the connection's life.
+ *
+ * A recorded id also STICKS: a later read that carries no id (an older bridge
+ * on a downgraded install) leaves the stored id alone rather than erasing it,
+ * because erasing it would quietly demote the verifier back to comparing names
+ * — the exact failure #1091 exists to end. A read that carries a DIFFERENT id
+ * wins, because the bridge speaks for the session and the session is the
+ * account.
+ */
+export function recordedIdentityAfterHealthCheck(
+  previous: StoredTelegramConnection,
+  fresh: TelegramAccountIdentity,
+  checkedAt: string,
+): { identity: TelegramAccountIdentity; identityIdUpgradedAt: string | null } {
+  const recordedId = previous.identity?.id ?? null;
+  const migrationOwed = previous.identity !== null && recordedId === null;
+  return {
+    identity: { ...fresh, id: fresh.id ?? recordedId },
+    identityIdUpgradedAt: previous.identityIdUpgradedAt ?? (migrationOwed ? checkedAt : null),
+  };
 }
 
 /* One service per process, across route bundles. */

--- a/src/lib/telegram/sessionStore.test.ts
+++ b/src/lib/telegram/sessionStore.test.ts
@@ -13,6 +13,7 @@ const {
   readTelegramSession,
   saveTelegramSession,
   telegramConnectionPath,
+  telegramIncomingFeedPath,
   telegramConnectorTokenPath,
   telegramSessionPath,
   writeTelegramConnection,
@@ -155,6 +156,37 @@ test("deletion is idempotent and leaves nothing behind", () => {
   deleteTelegramSession();
   expect(fs.existsSync(telegramSessionPath())).toBe(false);
   expect(readTelegramSession()).toBeNull();
+});
+
+test("disconnect takes the incoming feed with the credential (#1091)", () => {
+  const session = saveTelegramSession(PLACEHOLDER_SESSION);
+  /* What the connector wrote for this generation, plus the pre-#1091 unscoped
+     name a Viewer that predates the scoping left behind. Both name the
+     operator's correspondents, so neither outlives the credential. */
+  const scoped = telegramIncomingFeedPath(session.credentialRef);
+  const legacy = path.join(path.dirname(scoped), "incoming_feed.jsonl");
+  const unrelated = path.join(path.dirname(scoped), "report-history.json");
+  for (const pathname of [scoped, legacy, unrelated]) fs.writeFileSync(pathname, "{}\n", { mode: 0o600 });
+
+  deleteTelegramSession();
+
+  expect(fs.existsSync(scoped)).toBe(false);
+  expect(fs.existsSync(legacy)).toBe(false);
+  /* Only the feed: disconnect is not a sweep of the directory. */
+  expect(fs.existsSync(unrelated)).toBe(true);
+});
+
+test("a reconnect cannot read the previous credential generation's feed (#1091)", () => {
+  const first = saveTelegramSession(PLACEHOLDER_SESSION);
+  deleteTelegramSession();
+  const second = saveTelegramSession(PLACEHOLDER_SESSION);
+
+  expect(second.credentialRef).not.toBe(first.credentialRef);
+  expect(telegramIncomingFeedPath(second.credentialRef)).not.toBe(telegramIncomingFeedPath(first.credentialRef));
+  /* A digest of the ref, never the ref itself: nothing read from disk is
+     spliced into a path. */
+  expect(path.basename(telegramIncomingFeedPath(second.credentialRef))).toMatch(/^incoming_feed-[0-9a-f]{16}\.jsonl$/);
+  expect(telegramIncomingFeedPath(second.credentialRef)).not.toContain(second.credentialRef);
 });
 
 test("connection status round-trips and never carries the session string", () => {

--- a/src/lib/telegram/sessionStore.test.ts
+++ b/src/lib/telegram/sessionStore.test.ts
@@ -162,9 +162,10 @@ test("connection status round-trips and never carries the session string", () =>
     version: 1,
     status: "connected",
     credentialRef: "ref-1",
-    identity: { name: "Account A", username: "account_a" },
+    identity: { name: "Account A", username: "account_a", id: "770000001" },
     lastHealthCheckAt: "2026-08-20T10:00:00.000Z",
     errorCode: null,
+    identityIdUpgradedAt: null,
   });
   const read = readTelegramConnection();
   expect(read.status).toBe("connected");

--- a/src/lib/telegram/sessionStore.ts
+++ b/src/lib/telegram/sessionStore.ts
@@ -127,6 +127,59 @@ export function ensureTelegramStateDir(create = true): string | null {
   return dir;
 }
 
+const INCOMING_FEED_SCOPE_LENGTH = 16;
+/** Every feed name this Viewer has ever written, including the pre-#1091
+    unscoped one, so the credential boundary can sweep them all. */
+const INCOMING_FEED_NAME = new RegExp(`^incoming_feed(-[0-9a-f]{${INCOMING_FEED_SCOPE_LENGTH}})?\\.jsonl$`);
+
+/**
+ * The connector's incoming-event feed for ONE credential generation (#1091).
+ *
+ * The feed is an append-only JSONL record of settled incoming private bursts —
+ * the only source that says which dialogs were ACTIVE, in real time, without
+ * walking a chat list whose order is pins and folders. It lives beside the
+ * credential rather than at the connector's XDG default because it names the
+ * operator's correspondents: same 0700 directory, same owner-only fence, and
+ * the connector creates it 0600 itself.
+ *
+ * The name carries the CREDENTIAL GENERATION, and that is the point. One
+ * shared file outlives a disconnect, so an account whose bursts it recorded
+ * yesterday would still be in it when a DIFFERENT account connects tomorrow —
+ * and that second account's report, having passed its own id check, would
+ * discover the first account's dialogs as its own active sources. A generation
+ * cannot read another generation's feed because it cannot name the file. The
+ * suffix is a digest rather than the ref itself: it keeps a value read from
+ * disk out of a constructed path, and a digest is always a fixed run of hex.
+ */
+export function telegramIncomingFeedPath(credentialRef: string): string {
+  const scope = crypto.createHash("sha256").update(credentialRef).digest("hex").slice(0, INCOMING_FEED_SCOPE_LENGTH);
+  return statePath(DIR_NAME, `incoming_feed-${scope}.jsonl`);
+}
+
+/**
+ * Drops every credential generation's feed.
+ *
+ * Disconnect is the credential boundary and the connector is already stopped
+ * by the time it is reached, so nothing is mid-write: the account is being
+ * forgotten, and a file naming its correspondents does not outlive it. Each
+ * removal is independent, because one stubborn file must never be able to
+ * block the credential deletion that follows it.
+ */
+function removeIncomingFeeds(): void {
+  const directory = ensureTelegramStateDir(false);
+  if (directory === null) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !INCOMING_FEED_NAME.test(entry.name)) continue;
+    try { fs.rmSync(path.join(directory, entry.name), { force: true }); } catch { /* best effort */ }
+  }
+}
+
 /* Exported for the Daily Report store (#1086), which persists settings,
    history and report text in the same directory under the same fence — one
    owner-only write path for everything the connector owns. */
@@ -180,17 +233,43 @@ export function readSafeText(pathname: string): string | null {
   return fs.readFileSync(pathname, "utf8");
 }
 
+/** What one backward tail read found, and whether it reached far enough back
+    to answer the caller's question (issue #1091). */
+export type SafeTail = {
+  /** Whole lines only: a truncated head line is never handed to a parser. */
+  text: string;
+  /** `true` when the scan included the start of the file or `reached` accepted
+      a chunk, so everything the caller asked about is inside `text`. `false` is
+      a tail that ran out of budget first — an UNKNOWN answer, never a complete
+      one. */
+  complete: boolean;
+};
+
 /**
- * The last {@link maxBytes} of an owner-only APPEND-ONLY file, whole lines
- * only (issue #1091).
+ * An owner-only APPEND-ONLY file, read BACKWARD from its end in `chunkBytes`
+ * steps until `reached` accepts a chunk, the start of the file is included, or
+ * `maxBytes` have been read (issue #1091).
  *
  * The connector's incoming feed grows for as long as the account receives
- * messages and nothing rotates it, so the Viewer must never read it whole. The
- * read is bounded from the END — that is where the recent bursts are — and the
- * first (possibly truncated) line of the window is dropped, so a partial JSON
- * line is never handed to a parser.
+ * messages and nothing rotates it, so the Viewer must never read it whole —
+ * but a FIXED tail was a silent lie. One dialog bursting all day pushes the
+ * morning past any constant bound, and a report that then discovers only what
+ * the constant happened to keep omits a dialog the operator answered without
+ * saying so. The caller supplies the horizon instead: the scan keeps stepping
+ * back until `reached` sees a line older than the window, and `complete` says
+ * whether it got there before the budget ran out. Both bounds still hold, so a
+ * feed of any size costs a fixed ceiling of I/O.
+ *
+ * `reached` is called with one chunk's whole lines, oldest-first order
+ * preserved. A chunk boundary can split a line or a multi-byte character; the
+ * split head line is dropped before the predicate sees it, which can only ever
+ * make it answer "not yet" one line early.
  */
-export function readSafeTailText(pathname: string, maxBytes: number): string | null {
+export function readSafeTailUntil(
+  pathname: string,
+  bounds: { chunkBytes: number; maxBytes: number },
+  reached: (chunkText: string) => boolean,
+): SafeTail | null {
   if (ensureTelegramStateDir(false) === null) return null;
   try {
     assertSafeSecretFile(pathname);
@@ -199,16 +278,36 @@ export function readSafeTailText(pathname: string, maxBytes: number): string | n
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
   }
+  const chunkBytes = Math.max(1, Math.trunc(bounds.chunkBytes));
+  const maxBytes = Math.max(0, Math.trunc(bounds.maxBytes));
   const handle = fs.openSync(pathname, "r");
   try {
     const size = fs.fstatSync(handle).size;
-    const length = Math.min(size, Math.max(0, maxBytes));
-    const buffer = Buffer.alloc(length);
-    fs.readSync(handle, buffer, 0, length, size - length);
-    const text = buffer.toString("utf8");
-    if (length >= size) return text;
+    const chunks: Buffer[] = [];
+    let start = size;
+    let read = 0;
+    let crossed = false;
+    while (start > 0 && read < maxBytes) {
+      const length = Math.min(chunkBytes, start, maxBytes - read);
+      const buffer = Buffer.alloc(length);
+      fs.readSync(handle, buffer, 0, length, start - length);
+      chunks.unshift(buffer);
+      start -= length;
+      read += length;
+      if (start === 0) break;
+      const chunkText = buffer.toString("utf8");
+      const chunkBreak = chunkText.indexOf("\n");
+      if (chunkBreak !== -1 && reached(chunkText.slice(chunkBreak + 1))) {
+        crossed = true;
+        break;
+      }
+    }
+    /* Decoded after concatenation so a character split across two chunks
+       survives; only the predicate ever sees a chunk on its own. */
+    const text = Buffer.concat(chunks).toString("utf8");
+    if (start === 0) return { text, complete: true };
     const firstBreak = text.indexOf("\n");
-    return firstBreak === -1 ? "" : text.slice(firstBreak + 1);
+    return { text: firstBreak === -1 ? "" : text.slice(firstBreak + 1), complete: crossed };
   } finally {
     fs.closeSync(handle);
   }
@@ -304,6 +403,11 @@ export function readTelegramSession(): StoredTelegramSession | null {
 
 export function deleteTelegramSession(): void {
   if (ensureTelegramStateDir(false) === null) return;
+  /* The incoming feed goes with the credential that produced it (#1091): the
+     connector is stopped by this point, and what it recorded names the
+     departing account's correspondents. Swept FIRST so a refused credential
+     removal below cannot leave that record behind. */
+  removeIncomingFeeds();
   const paths = [telegramSessionPath(), telegramConnectorTokenPath()];
   const existing = paths.filter((pathname) => safeFileExists(pathname));
   for (const pathname of existing) fs.rmSync(pathname);

--- a/src/lib/telegram/sessionStore.ts
+++ b/src/lib/telegram/sessionStore.ts
@@ -6,7 +6,7 @@ import { readValidatedTelegramSessionFiles } from "../../../bin/telegram-session
 
 import { statePath } from "@/lib/configDir";
 
-import type { TelegramErrorCode, TelegramIdentity } from "./contracts";
+import { validTelegramAccountId, type TelegramAccountIdentity, type TelegramErrorCode } from "./contracts";
 
 /**
  * Owner-only persistence for the Telegram credential (issue #1059).
@@ -50,9 +50,14 @@ export type StoredTelegramConnection = {
   version: 1;
   status: TelegramConnectionStatus;
   credentialRef: string | null;
-  identity: TelegramIdentity | null;
+  identity: TelegramAccountIdentity | null;
   lastHealthCheckAt: string | null;
   errorCode: TelegramErrorCode | null;
+  /** When the pre-#1091 identity on this record was re-read to recover its
+      numeric account id (issue #1091). Set the first time that upgrade runs,
+      whether or not an id came back, so the migration happens ONCE per
+      connection instead of on every health check. */
+  identityIdUpgradedAt: string | null;
 };
 
 export class UnsafeTelegramSessionError extends Error {
@@ -175,6 +180,40 @@ export function readSafeText(pathname: string): string | null {
   return fs.readFileSync(pathname, "utf8");
 }
 
+/**
+ * The last {@link maxBytes} of an owner-only APPEND-ONLY file, whole lines
+ * only (issue #1091).
+ *
+ * The connector's incoming feed grows for as long as the account receives
+ * messages and nothing rotates it, so the Viewer must never read it whole. The
+ * read is bounded from the END — that is where the recent bursts are — and the
+ * first (possibly truncated) line of the window is dropped, so a partial JSON
+ * line is never handed to a parser.
+ */
+export function readSafeTailText(pathname: string, maxBytes: number): string | null {
+  if (ensureTelegramStateDir(false) === null) return null;
+  try {
+    assertSafeSecretFile(pathname);
+  } catch (error) {
+    if (error instanceof UnsafeTelegramSessionError) throw error;
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  const handle = fs.openSync(pathname, "r");
+  try {
+    const size = fs.fstatSync(handle).size;
+    const length = Math.min(size, Math.max(0, maxBytes));
+    const buffer = Buffer.alloc(length);
+    fs.readSync(handle, buffer, 0, length, size - length);
+    const text = buffer.toString("utf8");
+    if (length >= size) return text;
+    const firstBreak = text.indexOf("\n");
+    return firstBreak === -1 ? "" : text.slice(firstBreak + 1);
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
 function safeFileExists(pathname: string): boolean {
   try {
     assertSafeSecretFile(pathname);
@@ -277,7 +316,21 @@ const DISCONNECTED: StoredTelegramConnection = {
   identity: null,
   lastHealthCheckAt: null,
   errorCode: null,
+  identityIdUpgradedAt: null,
 };
+
+/** A stored identity, with a pre-#1091 record (no `id`) read as an identity
+    whose id is simply unknown rather than as no identity at all. */
+function readIdentity(value: unknown): TelegramAccountIdentity | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Partial<TelegramAccountIdentity>;
+  if (typeof row.name !== "string") return null;
+  return {
+    name: row.name,
+    username: typeof row.username === "string" ? row.username : null,
+    id: validTelegramAccountId(row.id),
+  };
+}
 
 export function readTelegramConnection(): StoredTelegramConnection {
   const parsed = readSafeJson(telegramConnectionPath());
@@ -288,11 +341,10 @@ export function readTelegramConnection(): StoredTelegramConnection {
     version: 1,
     status: row.status as TelegramConnectionStatus,
     credentialRef: typeof row.credentialRef === "string" ? row.credentialRef : null,
-    identity: row.identity && typeof row.identity === "object" && typeof (row.identity as TelegramIdentity).name === "string"
-      ? { name: (row.identity as TelegramIdentity).name, username: (row.identity as TelegramIdentity).username ?? null }
-      : null,
+    identity: readIdentity(row.identity),
     lastHealthCheckAt: typeof row.lastHealthCheckAt === "string" ? row.lastHealthCheckAt : null,
     errorCode: typeof row.errorCode === "string" ? row.errorCode as TelegramErrorCode : null,
+    identityIdUpgradedAt: typeof row.identityIdUpgradedAt === "string" ? row.identityIdUpgradedAt : null,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -155,6 +155,12 @@ export interface FileEntry {
       A Viewer root carries `viewer` provenance even though it has no parent
       edge. Unattributed external roots stay undefined. */
   spawnOrigin?: "viewer" | "engine";
+  /** Durable report-run marker (issue #1091): this conversation is the Telegram
+      Daily Report run with THIS run id, read from the launch receipt the
+      registry keeps. It survives a registry reload with no Daily Reports
+      history file present, which is what lets the board group the runs under
+      the Telegram panel and lets a run be re-linked to its stored report. */
+  telegramReport?: { runId: string };
   /** Unix seconds. */
   mtime: number;
   size: number;


### PR DESCRIPTION
## Review round 4 — one finding, closed by withholding the tool

**The feed had a competitor for the same burst.** With the incoming feed on, the connector still exposed `wait_for_settled_message`, and both consumers pop the settled chat out of the same pending set — whichever scans first takes it. An agent blocking on one chat could eat the burst that was a report's only evidence of an active dialog, and discovery dropped that dialog with no trace. Round 3 wrote this up as an accepted trade; it is no longer one.

The connector withholds the burst consumers rather than racing them:

- **The withholding happens in the Viewer's own entrypoint.** Upstream's `TELEGRAM_EXPOSED_TOOLS` can only WIDEN a read-only surface with named write tools, never narrow it, so `bin/telegram-mcp-server.py` drops the tools named in `LLV_TELEGRAM_EXCLUDED_TOOLS` after the runner import has registered them. The **vendored tree stays byte-identical** to the pinned release — no new patch, no PROVENANCE entry, no independent observation path inside upstream code. An unknown name fails the launch instead of serving a surface nobody narrowed.
- **Readiness proves it happened.** The verified allowlist is the audited read set MINUS the withheld tools, so a listener still advertising one is refused (`not_read_only`) and replaced rather than trusted. The audited set is unchanged — those tools write nothing — so the vendor-parity check keeps meaning what it says.
- **`wait_for_new_message` stays exposed.** It reports the pending set without removing anything, so it costs the feed no burst. The withheld set is derived from what the vendored implementations DO with a burst, and the parity test reads that back out of the vendored source (`_pending_msgs.pop`), so a bump that renames or re-implements a consumer fails there instead of quietly reopening the race.

What an agent gives up is the debounced blocking wait. `wait_for_new_message` still wakes it on incoming activity, and the chat is read with the ordinary read tools.

### Verification (this round)

- `bunx tsc --noEmit --incremental false` — clean
- **311 focused tests, 0 fail** across 18 files, by path, with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`
- The entrypoint is exercised as a real process against a fake vendor tree: with the exclusion the consumer is gone and the rest of the surface is intact, without it the surface is served whole, and an unknown name exits non-zero.
- privacy gate vs merge-base, with the known-value catalog — PASS
- Both rules RED-verified against the un-fixed sources: the entrypoint keeps the consumer, and the gate accepts the racing surface.

## Review round 2 — two findings, both real

**1. A run is bound to one credential generation, not just one id.** The id check verified account A through `get_me`, and the source pass behind it — tens of seconds of sequential connector reads — re-read the stored credential on every call. A logout and a reconnect inside that minute meant the feed, the listings and the probes answered as account B while the plan was written as A's: one plan naming two people's correspondents, past a check that had already passed. Admission had the same hole, resolving the grant from "connected" alone.

The verified id now travels with the generation that recorded it, and everything downstream is bound to that pair:

- the read port pins one generation and **refuses** any read once the stored credential moves, before the call leaves the process — so nothing from a second account can enter a plan;
- the pre-launch check settles `account-mismatch` and deletes the plan rather than opening a conversation that would hold the new account's connector;
- `grantActive` answers for the generation the run planned for, so admission cannot hand the report class its grant after the account changed underneath it.

A record carrying an id but no generation verifies nothing and fails closed, exactly as a record with no id does. The swap is tested at both moments it can land in — straight after the verification and between two source calls — each expecting zero launch and zero plan, plus the port's own refusal proven directly against a rotated session.

**2. A feed that is running is not automatically a feed that covers the window.** The absent-feed rule only asked whether a listener existed. One that started this morning knows nothing about last night, and on the first day after a connect it knows nothing about the window at all — so discovery fell through to the walk, which stops at the probe budget over a list ordered by pins, and an active dialog past that bound could disappear from a plan that reported success.

The connector record now stamps **when** its feed started, beside the feed file it already names — the file cannot say this about itself (it is append-only across generations) and `incoming_feed_status` does not report it. A plan is returned only when one of the two passes covered the whole window: the feed by listening from before it opened, or the walk by enumerating and probing every candidate — a full last page of the paged enumeration counts as incomplete too, because the list did not end where the walk did. Neither, and the run records `sources_failed` instead of a quietly narrower report; the next run's window still covers the day it missed. A young feed over a list the walk finished is an ordinary run.

Reads stay sequential and bounded; nothing new is stored, and no new schedulers, caches or config knobs.

### Verification (this round)

- `bunx tsc --noEmit --incremental false` — clean
- **309 focused tests, 0 fail** across 18 files, by path, with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`
- `bun run build` — clean, including `dist/mcp-server.mjs`
- privacy gate vs merge-base, with the known-value catalog — PASS
- Both new rules RED-verified against the un-fixed sources: 6 of the new cases fail without them.

## Review round 1 — three findings, all real

**1. The account check no longer knows what a name is.** The id comparison kept a name/handle fallback for records enrolled before the id existed, which left the tail's own hole open for exactly those records: a second account wearing the operator's display name still passed. `sameTelegramAccount` is the id comparison and nothing else now, and the migration a legacy record is owed is completed by the RUN before it reads anything — one health check through the login bridge (the credential itself, not the surface being verified), stamped so it never repeats. A record that still carries no id afterwards fails `account_check_failed` with **zero connector reads**, and an account that answers `get_me` without an id is no evidence either.

**2. A connector with no feed fails the run instead of walking alone.** A process adopted from a Viewer generation predating the feed answers `incoming_feed_status` with a path it will never write, so the feed read returned empty and the bounded probe walk silently took over — the v1 defect, restored by accident. Both ends are closed:

- **Runtime.** The status answer is read for whether a feed is *running*: `enabled`, or `autostart_pending` (the connector starts its feed from the handler of the first incoming burst, and that burst is recorded before the start, so a pending feed has lost nothing). A connector running none, or a feed file that cannot be read through the owner-only fence, is one sanitized `sources_failed` — never an empty answer.
- **Adoption.** The feed is child *environment*, so no probe or argv can prove it; the durable connector record now names the feed file the process was launched with, and a listener whose record does not is ineligible for adoption. It is stopped and replaced once. The record stays parseable without that field on purpose: a record that cannot be read is a connector that cannot be *stopped*.

Reads stay sequential and bounded throughout, and the group picker is untouched by a dead feed — choosing sources is not a report run.

**3. The marker groups the card, and re-links the run.** The projection attached `telegramReport` and then grouped by project ownership alone, so the durable evidence decided nothing. It decides now: a marked run collects under the Telegram project from the receipt alone — no ownership record, no history file — and its neutral scratch workspace can no longer name a project of its own. An explicit ownership record still outranks it, because an operator who moved the card moved it.

The same marker repairs what the launch itself cannot. The conversation id is the **last** thing a source pass writes, so a Viewer that died just after admission left a real board conversation, a panel row with no route to it, and a sweep about to call it a launch that never happened. The run is re-linked from the receipt, the recovered id is persisted into the settled row, and the panel renders the deep link — proven end to end in `TelegramReports.render.test.tsx` from a registry file loaded from **cold**, and red without the marker.

### Verification (this round)

- `bunx tsc --noEmit --incremental false` — clean
- **290 focused tests, 0 fail** across 17 files, by path, with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`
- `bun run build` — clean, including `dist/mcp-server.mjs`
- privacy gate vs merge-base — PASS

---

Implements the three accepted tails of Daily Reports v1 (#1086 / PR #1089). Tail 4 stays where it is — it reopens only if the narrowed #1087 lane lands without a gate on the agents' direct path — and the declined transcript-privacy finding stays declined.

## 1. The account check compares numeric ids

The v1 check compared the display name and the public handle, which are exactly the two fields anybody can copy. It passed a second account that had taken the operator's name, and it would have failed the operator themselves the day they changed both fields.

- **Recorded at Connect.** The login bridge emits the numeric account id with the identity, and it is stored in owner-only `connection.json`. It is read defensively (`getattr`): an authorization that produced an entity without an id is still an authorization, and losing a login over a grouping field would be a far worse failure than reporting no id.
- **Compared at the run.** `sameTelegramAccount` returns the id comparison whenever both sides carry one — equal ids are the same account whatever it is called today, different ids are a different account however familiar the name.
- **Migration, once.** A connection enrolled before the id existed is re-read on the next health check and stamped `identityIdUpgradedAt`, whether or not an id came back, so a bridge too old to report one is not re-probed forever. A recorded id also sticks: a later read carrying no id leaves it alone, because erasing it would silently demote the check back to comparing names.
- **The fallback survives for that one case.** A legacy connection with no recorded id still matches on either field, so those connections keep reporting instead of failing every run until the operator reconnects.

The id never crosses the browser boundary: the status payload projects `name` and `username` explicitly, so a field added to the stored identity later cannot leak by inheritance.

## 2. Discovery reads the incoming feed; the group picker pages

The connector's chat listing is pinned/folder order, not recency, so v1 had to probe candidates one at a time and stop at a budget — and a dialog answered an hour ago that sits past the budget was invisible to the report.

- **The connector now runs its event feed** (`TELEGRAM_EVENT_FEED`), writing settled incoming private bursts to `incoming_feed.jsonl` beside the credential, inside the 0700 telegram directory rather than at the XDG default: it names the operator's correspondents.
- **A run's private dialogs come from that file first.** `incoming_feed_status` says where the feed is, and the file is read from its END with a byte bound (it is append-only and nothing rotates it), dropping the truncated first line so no half record reaches a parser. Feed-derived dialogs cost no probe and depend on no list order.
- **The candidate walk stays behind it**, over what the feed has not already accounted for — dialogs the operator wrote into, activity older than this connector generation — and still decides by last-message date.
- **Every read is sequential**, feed included; the whole fake port now records concurrency, so "never two at once" is asserted against the entire surface rather than the probes alone (#1087).
- **The group picker walks the paged raw list.** `list_chats` applies its 100-chat ceiling before the kind filter, so an operator whose first hundred dialogs are private chats was offered no groups at all. Bounded and sequential: one typed listing plus at most three pages.

**How the two consumers are separated:** upstream documents the feed and a blocking `wait_for_settled_message` as mutually exclusive consumers — whichever scans first takes the burst. This connector withholds the consumer, so the feed is the only one left (round 4 above). Enabling the feed through the environment is also the only way here: `enable_incoming_feed` is not on the read-only tool surface.

## 3. A durable report-run marker

Runs were identified only by the `conversationId` in the history row, so a lost or evicted history left a board conversation nobody could attribute.

The marker is two facts the ordinary spawn path already makes durable, both admitted through the real spawn lane in `reportSpawn.test.ts`:

- the receipt's `clientAttemptId`, which spells the run id (validated as a run id, not just prefix-matched — it names an owner-only file), so a run can be recognised and re-linked to `report-<runId>.md` from registry storage alone;
- explicit project ownership, which is what the board groups cards by, so runs collect under the Telegram project instead of a phantom one named after the scratch workspace they run in.

**Still no lineage parent and no role preset.** The registry re-decides every stored MCP grant from the row's own evidence, and either field classifies the row as delegated — a report run given one loses `telegram` the moment its receipt is written. The reload test asserts that too: after a cold re-read the row still holds `["viewer","telegram"]`, with a null role and no parent.

The board projection is touched in exactly one place: the loop that already walks receipts sets `telegramReport: { runId }`.

## Drive-by

`src/app/api/telegram/reports/route.test.ts` asserted `lastScheduledDay === "2026-08-21"` against `Date.now()`, so it could only pass on the day it was written and has been failing since. It now saves a midnight slot (past at every hour of every day) and asserts against the current local day.

## Verification

- `bunx tsc --noEmit --incremental false` — clean
- `bun test src/lib/telegram/ src/app/api/telegram/ src/app/api/files/route.test.ts` — **270 pass, 0 fail** across 17 files, run with isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`
- `bun run build` — clean (including `dist/mcp-server.mjs`)
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` — PASS. Every fixture string is invented; the run-id fixtures are assembled from parts rather than written out, because the gate refuses any literal shaped like a session identifier and cannot tell an invented one from a real one.

Fixes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)



