### PR TITLE
fix(orchestrator): require successor mandate acknowledgement

### DIFF
--- a/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { OrchestratorSeat } from "@/lib/orchestrator/seats";
+import { translate } from "@/lib/i18n";
+import { ORCHESTRATOR_PROMPT_VERSION } from "@/lib/orchestrator/prompt";
+import type { FileEntry } from "@/lib/types";
+
+import type { OrchestratorPanelState } from "../orchestrator/seatState";
+import { MobileOrchestratorSheet } from "./MobileOrchestratorSheet";
+
+const designatedAt = "2026-08-24T09:00:00.000Z";
+const firstTurnAt = Date.parse("2026-08-24T09:00:01.000Z");
+const firstStatusAt = Date.parse("2026-08-24T09:00:03.000Z");
+
+const seat: OrchestratorSeat = {
+  project: "atlas",
+  seatEpoch: 4,
+  conversationId: "conversation_orchestrator",
+  path: "/transcripts/orchestrator.jsonl",
+  mandate: "run the board",
+  promptVersion: ORCHESTRATOR_PROMPT_VERSION,
+  predecessorConversationId: null,
+  state: "active",
+  intent: { clientRequestId: "req-11111111", mode: "spawn", launchId: "launch-1", error: null },
+  designatedAt,
+  activatedAt: "2026-08-24T09:00:02.000Z",
+};
+
+const state: Extract<OrchestratorPanelState, { kind: "live" }> = {
+  kind: "live",
+  seat,
+  conversationId: seat.conversationId!,
+  liveness: "stalled",
+  rotation: null,
+  transition: null,
+};
+
+function stalledFile(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/transcripts/orchestrator.jsonl",
+    root: "claude-projects",
+    name: "orchestrator.jsonl",
+    project: "atlas",
+    title: "Orchestrator",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_760_000_000,
+    size: 10,
+    activity: "stalled",
+    proc: "running",
+    pid: 42,
+    model: "opus",
+    conversationId: seat.conversationId,
+    pendingQuestion: null,
+    waitingInput: null,
+    lastTurn: { startedAt: firstTurnAt, endedAt: null },
+    lastAssistantMessageAt: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+const quietCopy = translate("en", "orchPanel.stalled");
+
+function quietBannerCount(file: FileEntry): number {
+  const html = renderToStaticMarkup(
+    <MobileOrchestratorSheet
+      project="atlas"
+      projectName="Atlas"
+      state={state}
+      file={file}
+      pendingMandate=""
+      submitting={false}
+      onConfirm={() => undefined}
+      onRecheck={() => undefined}
+      onOpenConversation={() => undefined}
+      onClose={() => undefined}
+    />,
+  );
+  return html.split(quietCopy).length - 1;
+}
+
+test("the mobile sheet hides the quiet banner while the first mandate turn is in flight", () => {
+  expect(quietBannerCount(stalledFile())).toBe(0);
+});
+
+test("the mobile sheet keeps the quiet banner hidden after acknowledgement in the current turn", () => {
+  expect(quietBannerCount(stalledFile({ lastAssistantMessageAt: firstStatusAt }))).toBe(0);
+});
+
+test("the mobile sheet shows the quiet banner for a later stalled turn", () => {
+  expect(quietBannerCount(stalledFile({
+    lastTurn: { startedAt: Date.parse("2026-08-24T09:30:00.000Z"), endedAt: null },
+    lastAssistantMessageAt: firstStatusAt,
+  }))).toBe(1);
+});
+
+test("the mobile sheet preserves the quiet warning when assistant history is unknown", () => {
+  expect(quietBannerCount(stalledFile({ lastAssistantMessageAt: undefined }))).toBe(1);
+});

--- a/src/components/mobile/MobileOrchestratorSheet.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.tsx
@@ -12,7 +12,7 @@ import { useLocale, type MessageKey } from "@/lib/i18n";
 import { ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
 import type { FileEntry } from "@/lib/types";
 
-import type { OrchestratorPanelState, RotationHint, SeatTransition } from "../orchestrator/seatState";
+import { orchestratorQuietBannerEligible, type OrchestratorPanelState, type RotationHint, type SeatTransition } from "../orchestrator/seatState";
 import { readSeatDraftField, writeSeatDraftField } from "./orchestratorDraftStorage";
 import { ROW_STATE_LABEL, ROW_TONE, orchestratorRowView } from "./orchestratorRowState";
 
@@ -357,7 +357,7 @@ function LiveView({ state, file }: { state: Extract<OrchestratorPanelState, { ki
       </div>
       {state.transition ? <TransitionCard transition={state.transition} /> : null}
       {state.rotation ? <RotationCard rotation={state.rotation} /> : null}
-      {state.liveness === "stalled" ? <Note tone="warning">{t("orchPanel.stalled")}</Note> : null}
+      {orchestratorQuietBannerEligible(state, file) ? <Note tone="warning">{t("orchPanel.stalled")}</Note> : null}
       {state.liveness === "resumable" ? <Note tone="quiet">{t("orchPanel.resumable")}</Note> : null}
       {file ? (
         <p className="text-ui leading-4 text-muted">{t("orchMobile.liveHint")}</p>

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -25,6 +25,7 @@ import { OrchestratorConversation } from "./OrchestratorConversation";
 import {
   deriveOrchestratorPanelState,
   deriveRotateDraftState,
+  orchestratorQuietBannerEligible,
   seatRequestSettled,
   type OrchestratorPanelState,
   type OrchestratorSeatStatus,
@@ -357,7 +358,7 @@ export function OrchestratorPanel({
           {state.rotation ? <RotationBanner rotation={state.rotation} /> : null}
           {rotating ? null : (
             <>
-              {state.liveness === "stalled" ? (
+              {orchestratorQuietBannerEligible(state, file) ? (
                 <p className="shrink-0 border-b border-border bg-warning-soft px-3 py-1.5 text-ui text-warning" role="status">
                   {t("orchPanel.stalled")}
                 </p>

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -9,6 +9,7 @@ import {
   deriveOrchestratorPanelState,
   deriveRotateDraftState,
   newSeatRequestId,
+  orchestratorQuietBannerEligible,
   parseSeatStatus,
   ROTATION_CONTEXT_PERCENT,
   seatRequestSettled,
@@ -179,6 +180,45 @@ describe("the panel names every state in the map (#977)", () => {
       kind: "live",
       transition: { kind: "error", error: "spawn did not report an accepted launch" },
     });
+  });
+});
+
+describe("the gone-quiet banner waits for the mandate's first visible acknowledgement (#1118)", () => {
+  const active = seat({
+    designatedAt: "2026-08-24T09:00:00.000Z",
+    activatedAt: "2026-08-24T09:00:02.000Z",
+  });
+  const stalled = (overrides: Partial<FileEntry> = {}) => file({
+    activity: "stalled",
+    lastTurn: { startedAt: Date.parse("2026-08-24T09:00:01.000Z"), endedAt: null },
+    lastAssistantMessageAt: null,
+    ...overrides,
+  });
+
+  test("a fresh seat's first mandate turn stays in flight before any visible assistant status", () => {
+    const state = deriveOrchestratorPanelState({ ...base, status: status({ seat: active }), file: stalled(), surface: "live-root" });
+    expect(orchestratorQuietBannerEligible(state, stalled())).toBe(false);
+  });
+
+  test("an assistant status in the current mandate turn acknowledges it and keeps the banner retired", () => {
+    const acknowledged = stalled({ lastAssistantMessageAt: Date.parse("2026-08-24T09:00:03.000Z") });
+    const state = deriveOrchestratorPanelState({ ...base, status: status({ seat: active }), file: acknowledged, surface: "live-root" });
+    expect(orchestratorQuietBannerEligible(state, acknowledged)).toBe(false);
+  });
+
+  test("a later turn that goes quiet after the mandate acknowledgement remains eligible", () => {
+    const later = stalled({
+      lastTurn: { startedAt: Date.parse("2026-08-24T09:30:00.000Z"), endedAt: null },
+      lastAssistantMessageAt: Date.parse("2026-08-24T09:00:03.000Z"),
+    });
+    const state = deriveOrchestratorPanelState({ ...base, status: status({ seat: active }), file: later, surface: "live-root" });
+    expect(orchestratorQuietBannerEligible(state, later)).toBe(true);
+  });
+
+  test("unknown assistant history fails closed and preserves the warning", () => {
+    const unknown = stalled({ lastAssistantMessageAt: undefined });
+    const state = deriveOrchestratorPanelState({ ...base, status: status({ seat: active }), file: unknown, surface: "live-root" });
+    expect(orchestratorQuietBannerEligible(state, unknown)).toBe(true);
   });
 });
 

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -226,6 +226,27 @@ export function deriveOrchestratorPanelState(input: {
   return { kind: "draft", vacated: Boolean(status.seat) && !status.exists };
 }
 
+/** The warning is eligible only after the mandate has produced a visible
+    assistant message and a later turn has gone quiet. While the mandate is
+    still awaiting its first visible status, or the current turn already
+    contains that status, the operator-action warning stays hidden. */
+export function orchestratorQuietBannerEligible(
+  state: OrchestratorPanelState,
+  file: FileEntry | null,
+): boolean {
+  if (state.kind !== "live" || state.liveness !== "stalled" || !file) return false;
+  const turn = file.lastTurn;
+  if (!turn || turn.endedAt !== null) return true;
+  const assistantAt = file.lastAssistantMessageAt;
+  if (typeof assistantAt === "number" && assistantAt >= turn.startedAt) return false;
+
+  const designatedAt = Date.parse(state.seat.designatedAt);
+  const mandateStillAwaitsStatus = Number.isFinite(designatedAt)
+    && turn.startedAt >= designatedAt
+    && (assistantAt === null || (typeof assistantAt === "number" && assistantAt < designatedAt));
+  return !mandateStillAwaitsStatus;
+}
+
 /**
  * A client-side failure outranks the durable read only while the read has not
  * caught up with it: the server's own record is the truth as soon as it shows

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -71,8 +71,16 @@ test("bridge reports survive as the second channel, for the operator away from t
 
 /* Seats record the mandate version they were spawned on; `get_orchestrator` reports
    this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
-test("the default mandate is at version 7", () => {
-  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(7);
+test("the default mandate is at version 8", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(8);
+});
+
+test("the mandate requires a visible first-turn status even when every mission is already complete", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Initial visible status");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Your first turn after receiving this mandate");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("inventory the mandate missions and state your plan");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("all mandate missions are complete; standing by");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("generic continuation nudge");
 });
 
 /* #1016 — the seat had the attention tool and never used it: nothing it read said

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -3,7 +3,13 @@ import { expect, test } from "bun:test";
 import { FOCUS_TARGET_KINDS } from "@/lib/attention/targets";
 import { BRIDGE_REPORT_CLASSES } from "@/lib/bridge/types";
 
-import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "./prompt";
+import {
+  ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE,
+  ORCHESTRATOR_PROMPT_VERSION,
+  ORCHESTRATOR_SPAWN_CONFIG,
+  ORCHESTRATOR_SYSTEM_PROMPT,
+  orchestratorMandateForDelivery,
+} from "./prompt";
 
 test("the manager draft defaults to Claude Opus 5 on low effort through the role preset", () => {
   /* OrchestratorPanel seeds its shared launch controls from this live preset. */
@@ -81,6 +87,16 @@ test("the mandate requires a visible first-turn status even when every mission i
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("inventory the mandate missions and state your plan");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("all mandate missions are complete; standing by");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("generic continuation nudge");
+});
+
+test("mandate delivery keys off directive content and appends it exactly once", () => {
+  const custom = "Caller-edited current-version mandate";
+  const delivered = orchestratorMandateForDelivery(custom);
+
+  expect(delivered).toStartWith(custom);
+  expect(delivered.split(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)).toHaveLength(2);
+  expect(orchestratorMandateForDelivery(delivered)).toBe(delivered);
+  expect(orchestratorMandateForDelivery(ORCHESTRATOR_SYSTEM_PROMPT)).toBe(ORCHESTRATOR_SYSTEM_PROMPT);
 });
 
 /* #1016 — the seat had the attention tool and never used it: nothing it read said

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -95,11 +95,11 @@ YOU decide when to deploy, and you execute it yourself. Your authority is your d
 - Replacing manual spawns is a non-goal: the user's own agents keep working; you coordinate, you do not take over.
 - Re-derive board state per turn from bounded snapshots rather than accumulating it in context.`;
 
-/** Every seat receives the initial-status contract. The versioned default owns
-    it directly; bespoke and older mandates receive it as delivery scaffold
-    without changing the mandate stored on the seat. */
-export function orchestratorMandateForDelivery(mandate: string, promptVersion: number | null): string {
-  return promptVersion === ORCHESTRATOR_PROMPT_VERSION
+/** Every seat receives the initial-status contract. Delivery checks the text
+    itself because caller-edited mandates may retain the current prompt version.
+    The stored mandate stays raw, and retries append the directive at most once. */
+export function orchestratorMandateForDelivery(mandate: string): string {
+  return mandate.includes(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)
     ? mandate
     : `${mandate}\n\n${ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE}`;
 }

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -13,7 +13,8 @@
  * a walk of validation errors. v6 (#1016) adds the third way of reaching the
  * operator — their screen: when to move it, and the target shapes to move it with,
  * so a seat steers attention to the work instead of describing where to look. v7
- * starts requested pipelines by default and reserves drafts for explicit requests. */
+ * starts requested pipelines by default and reserves drafts for explicit requests.
+ * v8 requires a visible first-turn status, including the completed-mandate case. */
 
 /** Initial draft values. The operator may choose any engine, model, account, and
     effort the shared launch controls support before creating the project seat. */
@@ -29,9 +30,16 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 7;
+export const ORCHESTRATOR_PROMPT_VERSION = 8;
+
+/** Appended to bespoke and stale mandates at delivery time; the current
+    versioned default already contains it. */
+export const ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE = `## Initial visible status
+Your first turn after receiving this mandate must produce a visible assistant status in this conversation. When work remains, inventory the mandate missions and state your plan in that status. When every mission is already complete, reply exactly: "all mandate missions are complete; standing by". A generic continuation nudge never replaces or suppresses this first visible status.`;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
+
+${ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE}
 
 ## Two channels to the operator
 The operator talks to whoever they want, you included. When they write in your own conversation, answer them there — directly, plainly, helpfully, in your own voice, at whatever length the question deserves. That channel is sanctioned and first-class: what you write in it reaches them, and a question they put to you is yours to answer.
@@ -86,3 +94,12 @@ YOU decide when to deploy, and you execute it yourself. Your authority is your d
 - The llv-conveyor skill in this checkout is your playbook; follow its spawn-auth notes for agent-initiated calls.
 - Replacing manual spawns is a non-goal: the user's own agents keep working; you coordinate, you do not take over.
 - Re-derive board state per turn from bounded snapshots rather than accumulating it in context.`;
+
+/** Every seat receives the initial-status contract. The versioned default owns
+    it directly; bespoke and older mandates receive it as delivery scaffold
+    without changing the mandate stored on the seat. */
+export function orchestratorMandateForDelivery(mandate: string, promptVersion: number | null): string {
+  return promptVersion === ORCHESTRATOR_PROMPT_VERSION
+    ? mandate
+    : `${mandate}\n\n${ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE}`;
+}

--- a/src/lib/orchestrator/seatCommand.test.ts
+++ b/src/lib/orchestrator/seatCommand.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE,
+  ORCHESTRATOR_PROMPT_VERSION,
+  ORCHESTRATOR_SYSTEM_PROMPT,
+} from "./prompt";
 import { setRetireManagerForTests } from "./retire";
 import { executeOrchestratorRotation, executeOrchestratorSeatRequest, type SeatCommandDependencies } from "./seatCommand";
 import { activeOrchestratorSeats, orchestratorRevocations, orchestratorSeatFor } from "./seats";
@@ -122,6 +127,25 @@ test("spawn mode designates and injects together: mandate rides the spawn prompt
   expect(pending).toBeNull();
 });
 
+test("a caller-edited current-version mandate receives the status directive without changing stored text", async () => {
+  const { deps, recorded } = dependencies();
+  const mandate = "custom current-version mandate";
+  const result = await executeOrchestratorSeatRequest({
+    ...spawnRequest("req_00000021"),
+    mandate,
+    promptVersion: ORCHESTRATOR_PROMPT_VERSION,
+  }, deps);
+
+  expect(result.status).toBe(200);
+  const delivered = String(recorded.spawns[0]!.prompt);
+  expect(delivered).toStartWith(mandate);
+  expect(delivered.split(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)).toHaveLength(2);
+  expect(orchestratorSeatFor("proj-a").active).toMatchObject({
+    mandate,
+    promptVersion: ORCHESTRATOR_PROMPT_VERSION,
+  });
+});
+
 test("an admitted asynchronous spawn activates the seat from its durable conversation id", async () => {
   const { deps } = dependencies({
     spawn: async () => ({
@@ -212,11 +236,12 @@ test("a completed request replayed by its key spawns and delivers NOTHING a seco
   expect(recorded.deliveries).toHaveLength(0);
 });
 
-test("selecting an EXISTING conversation delivers the mandate without spawning a duplicate", async () => {
+test("selecting an EXISTING conversation delivers a caller-edited current-version mandate once", async () => {
   const { deps, recorded } = dependencies();
   const result = await executeOrchestratorSeatRequest({
     project: "proj-a",
     mandate: "updated mandate",
+    promptVersion: ORCHESTRATOR_PROMPT_VERSION,
     clientRequestId: "req_00000002",
     conversationId: OLD_ID,
   }, deps);
@@ -228,8 +253,12 @@ test("selecting an EXISTING conversation delivers the mandate without spawning a
     clientMessageId: "orchmandate_req_00000002",
   });
   expect(recorded.deliveries[0]!.text).toStartWith("updated mandate");
-  expect(recorded.deliveries[0]!.text).toContain("all mandate missions are complete; standing by");
-  expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(OLD_ID);
+  expect(recorded.deliveries[0]!.text.split(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)).toHaveLength(2);
+  expect(orchestratorSeatFor("proj-a").active).toMatchObject({
+    conversationId: OLD_ID,
+    mandate: "updated mandate",
+    promptVersion: ORCHESTRATOR_PROMPT_VERSION,
+  });
 });
 
 test("a replayed adoption keeps its original target during an ABA-shaped retry", async () => {
@@ -389,6 +418,37 @@ test("rotation composes a bounded handoff, switches designation atomically, and 
   expect(retiredHosts).toEqual([]);
 });
 
+test("a current-version rotation override receives one directive while its stored mandate stays raw", async () => {
+  const seeded = dependencies();
+  await executeOrchestratorSeatRequest({
+    ...spawnRequest("req_00000022"),
+    mandate: ORCHESTRATOR_SYSTEM_PROMPT,
+    promptVersion: ORCHESTRATOR_PROMPT_VERSION,
+  }, seeded.deps);
+
+  const successor = "conversation_66666666-6666-4666-8666-666666666666";
+  const { deps, recorded } = dependencies({
+    spawn: async (body) => {
+      recorded.spawns.push(body);
+      return { status: 200, body: { ok: true, conversationId: successor, path: "/tmp/successor-override.jsonl" } };
+    },
+  });
+  const result = await executeOrchestratorRotation({
+    project: "proj-a",
+    clientRequestId: "req_00000023",
+    mandate: "rotation override mandate",
+  }, deps);
+
+  expect(result.status).toBe(200);
+  const delivered = String(recorded.spawns[0]!.prompt);
+  expect(delivered).toStartWith("rotation override mandate");
+  expect(delivered.split(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)).toHaveLength(2);
+  const active = orchestratorSeatFor("proj-a").active;
+  expect(active).toMatchObject({ conversationId: successor, promptVersion: ORCHESTRATOR_PROMPT_VERSION });
+  expect(active?.mandate).toStartWith("rotation override mandate");
+  expect(active?.mandate).not.toContain(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE);
+});
+
 test("an adoption racing an in-flight rotation is refused while the rotation keeps one durable successor", async () => {
   const seeded = dependencies();
   await executeOrchestratorSeatRequest(spawnRequest("req_00000020"), seeded.deps);
@@ -469,6 +529,7 @@ test("a pending replay completes with the ORIGINAL mandate, not a recomposed one
   const prompts = recorded.spawns.map((body) => String(body.prompt));
   expect(prompts[0]).toBe(prompts[1]);
   expect(prompts[0]).toStartWith("own the board");
+  expect(prompts[0]!.split(ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE)).toHaveLength(2);
   expect(prompts[0]).not.toContain("recomposed differently");
 });
 

--- a/src/lib/orchestrator/seatCommand.test.ts
+++ b/src/lib/orchestrator/seatCommand.test.ts
@@ -112,9 +112,10 @@ test("spawn mode designates and injects together: mandate rides the spawn prompt
   expect(recorded.spawns[0]).toMatchObject({
     role: "orchestrator",
     project: "proj-a",
-    ["prompt"]: "own the board",
     clientAttemptId: "req_00000001",
   });
+  expect(String(recorded.spawns[0]!.prompt)).toStartWith("own the board");
+  expect(String(recorded.spawns[0]!.prompt)).toContain("all mandate missions are complete; standing by");
   const { active, pending } = orchestratorSeatFor("proj-a");
   expect(active?.conversationId).toBe(NEW_ID);
   expect(active?.mandate).toBe("own the board");
@@ -221,11 +222,13 @@ test("selecting an EXISTING conversation delivers the mandate without spawning a
   }, deps);
   expect(result.status).toBe(200);
   expect(recorded.spawns).toHaveLength(0);
-  expect(recorded.deliveries).toEqual([{
+  expect(recorded.deliveries).toHaveLength(1);
+  expect(recorded.deliveries[0]).toMatchObject({
     conversationId: OLD_ID,
     clientMessageId: "orchmandate_req_00000002",
-    text: "updated mandate",
-  }]);
+  });
+  expect(recorded.deliveries[0]!.text).toStartWith("updated mandate");
+  expect(recorded.deliveries[0]!.text).toContain("all mandate missions are complete; standing by");
   expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe(OLD_ID);
 });
 
@@ -371,6 +374,7 @@ test("rotation composes a bounded handoff, switches designation atomically, and 
   expect(spawnedPrompt).toContain(NEW_ID);
   expect(spawnedPrompt).toContain("[doing] Ship the handoff (task_1)");
   expect(spawnedPrompt).toContain("Prioritize the review queue.");
+  expect(spawnedPrompt).toContain("all mandate missions are complete; standing by");
 
   const { active } = orchestratorSeatFor("proj-a");
   expect(active?.conversationId).toBe(SUCCESSOR);
@@ -462,7 +466,10 @@ test("a pending replay completes with the ORIGINAL mandate, not a recomposed one
   await executeOrchestratorSeatRequest(spawnRequest(), deps);
   /* The retry recomposes a different mandate; the durable intent's text wins. */
   await executeOrchestratorSeatRequest({ ...spawnRequest(), mandate: "recomposed differently" }, deps);
-  expect(recorded.spawns.map((body) => body.prompt)).toEqual(["own the board", "own the board"]);
+  const prompts = recorded.spawns.map((body) => String(body.prompt));
+  expect(prompts[0]).toBe(prompts[1]);
+  expect(prompts[0]).toStartWith("own the board");
+  expect(prompts[0]).not.toContain("recomposed differently");
 });
 
 test("rotation preserves the requested effort end to end into the successor spawn body", async () => {

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -394,10 +394,7 @@ export async function executeOrchestratorSeatRequest(
       clientMessageId: `orchmandate_${clientRequestId}`,
       /* On a pending replay the ORIGINAL intent's mandate is what completes:
          a retry that recomposed its text must not deliver a second variant. */
-      text: orchestratorMandateForDelivery(
-        begun.kind === "replay" ? begun.seat.mandate : mandate,
-        begun.kind === "replay" ? begun.seat.promptVersion : promptVersion,
-      ),
+      text: orchestratorMandateForDelivery(begun.kind === "replay" ? begun.seat.mandate : mandate),
     });
     if (!delivery.ok) {
       const error = delivery.error ?? "mandate delivery failed";
@@ -456,10 +453,7 @@ export async function executeOrchestratorSeatRequest(
   /* A pending replay spawns the ORIGINAL intent's mandate: the spawn receipt is
      matched by clientAttemptId AND request digest, so a recomposed retry would
      otherwise conflict with its own first attempt. */
-  const spawnMandate = orchestratorMandateForDelivery(
-    begun.kind === "replay" ? begun.seat.mandate : mandate,
-    begun.kind === "replay" ? begun.seat.promptVersion : promptVersion,
-  );
+  const spawnMandate = orchestratorMandateForDelivery(begun.kind === "replay" ? begun.seat.mandate : mandate);
 
   const spawnFields = ["engine", "model", "cwd", "effort", "fast", "accountId", "images", "roleParams", "allowSubagents"] as const;
   const cwd = resolveOrchestratorCwd(project, rawBody.cwd);

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -12,6 +12,7 @@ import { projectForCwd } from "@/lib/scanner/describe";
 import { resolveSpawnRole } from "@/lib/roles/registry";
 
 import { loadTasks } from "@/lib/tasks/store";
+import { orchestratorMandateForDelivery } from "./prompt";
 import {
   beginOrchestratorSeatIntent,
   completeOrchestratorSeatIntent,
@@ -393,7 +394,10 @@ export async function executeOrchestratorSeatRequest(
       clientMessageId: `orchmandate_${clientRequestId}`,
       /* On a pending replay the ORIGINAL intent's mandate is what completes:
          a retry that recomposed its text must not deliver a second variant. */
-      text: begun.kind === "replay" ? begun.seat.mandate : mandate,
+      text: orchestratorMandateForDelivery(
+        begun.kind === "replay" ? begun.seat.mandate : mandate,
+        begun.kind === "replay" ? begun.seat.promptVersion : promptVersion,
+      ),
     });
     if (!delivery.ok) {
       const error = delivery.error ?? "mandate delivery failed";
@@ -452,7 +456,10 @@ export async function executeOrchestratorSeatRequest(
   /* A pending replay spawns the ORIGINAL intent's mandate: the spawn receipt is
      matched by clientAttemptId AND request digest, so a recomposed retry would
      otherwise conflict with its own first attempt. */
-  const spawnMandate = begun.kind === "replay" ? begun.seat.mandate : mandate;
+  const spawnMandate = orchestratorMandateForDelivery(
+    begun.kind === "replay" ? begun.seat.mandate : mandate,
+    begun.kind === "replay" ? begun.seat.promptVersion : promptVersion,
+  );
 
   const spawnFields = ["engine", "model", "cwd", "effort", "fast", "accountId", "images", "roleParams", "allowSubagents"] as const;
   const cwd = resolveOrchestratorCwd(project, rawBody.cwd);

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -13,7 +13,7 @@ import { tickWorkflows } from "../workflows/engine";
 import { activityVerdict, transcriptTurnResult } from "./activity";
 import type { ConversationCatalogEntry } from "./conversationCatalog";
 import { ctxFor } from "./context";
-import { lastTurnFor } from "./turnDuration";
+import { lastAssistantMessageAtFor, lastTurnFor } from "./turnDuration";
 import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
 import { entryEffort, entryEffortResult, entryFast } from "./effort";
 import { linkEntries } from "./links";
@@ -313,6 +313,7 @@ async function listFilesInternal(
     entry.goal = goalFor(entry);
     entry.ctx = ctxFor(entry);
     entry.lastTurn = lastTurnFor(entry);
+    entry.lastAssistantMessageAt = lastAssistantMessageAtFor(entry);
     entry.pendingWakeup = pendingWakeupFor(entry);
     pendingQuestionFor(entry);
   });

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -1,7 +1,7 @@
 import type { FileEntry } from "../types";
 import { resolveTarget } from "../tmux";
 import { ctxFor } from "./context";
-import { lastTurnFor } from "./turnDuration";
+import { lastAssistantMessageAtFor, lastTurnFor } from "./turnDuration";
 import { discoverFiles } from "./discover";
 import { entryEffort, entryEffortResult, entryFast } from "./effort";
 import { linkEntries } from "./links";
@@ -99,6 +99,7 @@ async function runObservation(signal?: AbortSignal): Promise<FileEntry[]> {
     if (probe.atComposer && entry.activity === "stalled") { entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle"; entry.activityReason = "pane_at_composer"; }
     entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
     entry.lastTurn = lastTurnFor(entry);
+    entry.lastAssistantMessageAt = lastAssistantMessageAtFor(entry);
     entry.pendingWakeup = pendingWakeupFor(entry);
   }, signal);
   throwIfCancelled(signal);

--- a/src/lib/scanner/turnDuration.test.ts
+++ b/src/lib/scanner/turnDuration.test.ts
@@ -39,6 +39,11 @@ const claudeAssistantTool = (timestamp: string) => ({
   timestamp,
   message: { role: "assistant", stop_reason: null, content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }] },
 });
+const claudeSyntheticNoOp = (timestamp: string) => ({
+  type: "assistant",
+  timestamp,
+  message: { role: "assistant", model: "<synthetic>", stop_reason: null, content: [{ type: "text", text: "No response requested." }] },
+});
 const claudeInterrupt = (timestamp: string, extra: Record<string, unknown> = { interruptedMessageId: "msg-1" }) => ({
   type: "user",
   timestamp,
@@ -92,10 +97,28 @@ describe("lastTurnFromRecords — Claude", () => {
 
     expect(result.operatorActionsAtMs).toEqual([ms("2026-07-14T07:03:00.000Z")]);
     expect(result.unprovenancedUserActionsAtMs).toEqual([ms("2026-07-14T07:00:00.000Z")]);
+    expect(result.assistantMessagesAtMs).toEqual([
+      ms("2026-07-14T07:00:05.000Z"),
+      ms("2026-07-14T07:05:00.000Z"),
+    ]);
     expect(result.windows).toEqual([{
       startedAt: ms("2026-07-14T07:00:00.000Z"),
       endedAt: ms("2026-07-14T07:05:00.000Z"),
     }]);
+  });
+
+  test("tracks visible assistant acknowledgements and excludes tool-only and synthetic no-op records", () => {
+    const result = recentTurnActivityFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "mandate"),
+        claudeAssistantTool("2026-07-14T10:00:01.000Z"),
+        claudeAssistantOpen("2026-07-14T10:00:02.000Z"),
+        claudeSyntheticNoOp("2026-07-14T10:00:03.000Z"),
+      ],
+      false,
+    );
+
+    expect(result.assistantMessagesAtMs).toEqual([ms("2026-07-14T10:00:02.000Z")]);
   });
 
   test("enumerates every completed turn in chronological order", () => {
@@ -475,6 +498,20 @@ describe("lastTurnFromRecords — Codex", () => {
     expect(result.unprovenancedUserActionsAtMs).toEqual([]);
   });
 
+  test("tracks a visible Codex assistant message in the current turn", () => {
+    const result = recentTurnActivityFromRecords(
+      [
+        codexUser("2026-07-14T10:00:00.000Z", "mandate"),
+        codexTaskStarted("2026-07-14T10:00:01.000Z"),
+        codexToolCall("2026-07-14T10:00:02.000Z", "c1"),
+        codexAgentMessage("2026-07-14T10:00:03.000Z"),
+      ],
+      true,
+    );
+
+    expect(result.assistantMessagesAtMs).toEqual([ms("2026-07-14T10:00:03.000Z")]);
+  });
+
   test("enumerates completed turns followed by the final open turn", () => {
     expect(recentTurnWindowsFromRecords(
       [
@@ -598,6 +635,10 @@ test("a truncated transcript prefix reports the gap and never fabricates a turn 
       complete: true,
       operatorActionsAtMs: [],
       unprovenancedUserActionsAtMs: [ms("2026-07-14T10:00:00.000Z")],
+      assistantMessagesAtMs: [
+        ms("2026-07-14T08:01:00.000Z"),
+        ms("2026-07-14T10:01:00.000Z"),
+      ],
       windows: [{
         startedAt: ms("2026-07-14T10:00:00.000Z"),
         endedAt: ms("2026-07-14T10:01:00.000Z"),

--- a/src/lib/scanner/turnDuration.ts
+++ b/src/lib/scanner/turnDuration.ts
@@ -10,12 +10,13 @@ type RecordLike = Record<string, unknown>;
 // v5: meta/command user records no longer open windows (issue #406) — persisted
 // v4 boundaries could start before the real initiating prompt.
 const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v5");
-const recentTurnWindowsCache = globalCache<[number, number, RecentTurnWindows]>("recent-turn-windows-v2");
+const recentTurnWindowsCache = globalCache<[number, number, RecentTurnWindows]>("recent-turn-windows-v3");
 
 export interface RecentTurnWindows {
   windows: TurnBoundary[];
   operatorActionsAtMs?: number[];
   unprovenancedUserActionsAtMs?: number[];
+  assistantMessagesAtMs?: number[];
   prefixTruncated: boolean;
   complete: boolean;
 }
@@ -24,6 +25,28 @@ function parseMillis(value: unknown): number | null {
   if (typeof value !== "string") return null;
   const millis = Date.parse(value);
   return Number.isFinite(millis) ? millis : null;
+}
+
+/** A real assistant message the conversation renders as prose. Tool-only
+    records are activity without an acknowledgment, and Claude's synthetic
+    no-op is deliberately invisible in the feed. */
+function visibleAssistantMessage(record: RecordLike, codex: boolean): boolean {
+  if (codex) {
+    const payload = recordValue(record.payload) ?? {};
+    const type = stringValue(payload.type);
+    if (type === "agent_message") return (stringValue(payload.message) ?? "").trim().length > 0;
+    if (type !== "message" || payload.role !== "assistant") return false;
+    return recordsValue(payload.content).some(
+      (part) => (stringValue(part.text) ?? stringValue(part.output_text) ?? "").trim().length > 0,
+    );
+  }
+  if (record.type !== "assistant" || record.isApiErrorMessage === true) return false;
+  const message = recordValue(record.message) ?? {};
+  if (stringValue(message.model) === "<synthetic>") return false;
+  if (typeof message.content === "string") return message.content.trim().length > 0;
+  return recordsValue(message.content).some(
+    (part) => part.type === "text" && (stringValue(part.text) ?? "").trim().length > 0,
+  );
 }
 
 /** True when a transcript record is a prompt that opens a turn — a human or
@@ -166,12 +189,14 @@ export function recentTurnWindowsFromRecords(records: RecordLike[], codex: boole
 export function recentTurnActivityFromRecords(
   records: RecordLike[],
   codex: boolean,
-): Pick<RecentTurnWindows, "windows" | "operatorActionsAtMs" | "unprovenancedUserActionsAtMs"> {
+): Pick<RecentTurnWindows, "windows" | "operatorActionsAtMs" | "unprovenancedUserActionsAtMs" | "assistantMessagesAtMs"> {
   const operatorActions = new Set<number>();
   const unprovenancedUserActions = new Set<number>();
+  const assistantMessages = new Set<number>();
   for (const record of records) {
     const atMs = parseMillis(record.timestamp);
     if (atMs === null) continue;
+    if (visibleAssistantMessage(record, codex)) assistantMessages.add(atMs);
     if (codex) {
       const payload = recordValue(record.payload) ?? {};
       let text = "";
@@ -199,6 +224,7 @@ export function recentTurnActivityFromRecords(
     windows: recentTurnWindowsFromRecords(records, codex),
     operatorActionsAtMs: [...operatorActions].sort((left, right) => left - right),
     unprovenancedUserActionsAtMs: [...unprovenancedUserActions].sort((left, right) => left - right),
+    assistantMessagesAtMs: [...assistantMessages].sort((left, right) => left - right),
   };
 }
 
@@ -239,4 +265,15 @@ export function lastTurnFor(entry: FileEntry): TurnBoundary | null {
   const boundary = recent.windows.at(-1) ?? null;
   if (recent.complete) turnBoundaryCache.set(entry.path, [entry.size, mtimeMs, boundary]);
   return boundary;
+}
+
+/** Newest visible assistant acknowledgment carried by the same bounded,
+    identity-keyed read as {@link lastTurnFor}. */
+export function lastAssistantMessageAtFor(entry: FileEntry): number | null | undefined {
+  const conversationRoot = entry.root === "claude-projects" || entry.root === "codex-sessions";
+  if (!conversationRoot || !entry.path.endsWith(".jsonl")) return null;
+  const recent = recentTurnWindowsFor(entry);
+  const last = recent.assistantMessagesAtMs?.at(-1);
+  if (typeof last === "number") return last;
+  return recent.prefixTruncated ? undefined : null;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -211,6 +211,13 @@ export interface FileEntry {
       and the card meta row parks the run length in a tooltip. Absent when no
       turn boundary can be derived from the transcript tail (issue #231). */
   lastTurn?: TurnBoundary | null;
+  /** Timestamp of the newest visible assistant message in the transcript tail,
+      in Unix epoch milliseconds. Synthetic no-op records and tool-only
+      assistant records do not count: this is acknowledgment evidence the
+      operator could actually see. Null means the complete scanned tail carried
+      no such message; absent means the derivation has not run or a truncated
+      prefix prevents that conclusion. */
+  lastAssistantMessageAt?: number | null;
   /** Best-effort TUI scrape fallback for prompts without a transcript protocol. */
   waitingInput: WaitingInput | null;
   /** Live pane wall or fresh structured account exhaustion. */


### PR DESCRIPTION
## Summary

- require every fresh, bespoke, stale, and rotated orchestrator mandate to produce a visible first-turn status
- give completed mandates the explicit `all mandate missions are complete; standing by` response contract
- keep the gone-quiet banner hidden while the initial mandate still awaits its first visible status or the current turn has acknowledged it
- preserve the warning for later stalled turns and unknown truncated transcript history

## Verification

- `bun test src/lib/orchestrator/prompt.test.ts src/lib/orchestrator/seatCommand.test.ts src/lib/scanner/turnDuration.test.ts src/components/orchestrator/seatState.test.ts` (114 pass)
- `bun tsc --noEmit`
- `bun scripts/privacy-publication-gate.ts --base origin/main`

Fixes #1118
