### PR TITLE
feat(projects): create-project flow offers to create a missing directory

### DIFF
--- a/src/app/api/projects/create/route.ts
+++ b/src/app/api/projects/create/route.ts
@@ -12,6 +12,8 @@ const headers = { "Cache-Control": "no-store" };
 const FAILURE_STATUS: Record<string, number> = {
   INVALID_NAME: 400,
   INVALID_ROOT: 400,
+  MISSING_DIRECTORY: 400,
+  MKDIR_FAILED: 500,
   DUPLICATE_PROJECT: 409,
   STORE_ERROR: 500,
 };
@@ -39,7 +41,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   for (const entry of conversationCatalogSnapshot()) {
     existing.add(canonicalProject(entry.project));
   }
-  const result = createManualProject(name, root, existing);
+  const result = createManualProject(name, root, existing, { createMissingRoot: record?.createRoot === true });
   if (!result.ok) {
     return NextResponse.json(
       { error: result.code, message: result.message },

--- a/src/components/ProjectRail.dom.test.tsx
+++ b/src/components/ProjectRail.dom.test.tsx
@@ -249,6 +249,76 @@ test("create-project flow: submit, duplicate refusal message, then success selec
   expect(container.querySelector("form")).toBeNull();
 });
 
+/* Issue #1122: for a missing directory the rail swaps the dead-end error for
+   a "create directory and project" action that resubmits with the mkdir
+   opt-in, and a failed mkdir reads back its cause. */
+test("create-project flow: missing directory offers mkdir-and-create instead of dead-ending", async () => {
+  const selections: string[] = [];
+  const creations: Array<[string, string, boolean]> = [];
+  let outcome: CreateProjectOutcome = { ok: false, code: "MISSING_DIRECTORY" };
+  const container = renderRail((project) => selections.push(project), {
+    onCreateProject: async (name, root, options) => {
+      creations.push([name, root, options?.createRoot === true]);
+      return outcome;
+    },
+  });
+  flushSync(() => container.querySelector('button[aria-label="Create project"]')!.dispatchEvent(click()));
+  const form = container.querySelector("form")!;
+  const inputs = [...form.querySelectorAll("input")] as HTMLInputElement[];
+  const type = (input: HTMLInputElement, value: string) => {
+    const propsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"))!;
+    (input as unknown as Record<string, { onChange: (event: unknown) => void }>)[propsKey]!
+      .onChange({ target: { value } });
+  };
+  flushSync(() => {
+    type(inputs[0]!, "Fresh Project");
+    type(inputs[1]!, "/data/projects/fresh");
+  });
+  const submit = () =>
+    form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event);
+  const settle = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  };
+  const offerButton = () =>
+    ([...container.querySelectorAll("button")] as HTMLElement[])
+      .find((button) => button.textContent === "Create directory and project");
+
+  flushSync(submit);
+  await settle();
+  expect(creations).toEqual([["Fresh Project", "/data/projects/fresh", false]]);
+  expect(container.textContent).toContain("This directory doesn't exist yet");
+  expect(offerButton()).toBeDefined();
+
+  /* Editing the root retracts the offer — it was made for the typed path. */
+  flushSync(() => type(inputs[1]!, "/data/projects/fresher"));
+  expect(offerButton()).toBeUndefined();
+  flushSync(submit);
+  await settle();
+  expect(offerButton()).toBeDefined();
+
+  /* The offered action resubmits with the mkdir opt-in; a failed mkdir reads
+     back its cause and retracts the offer. */
+  outcome = { ok: false, code: "MKDIR_FAILED", message: "EACCES: permission denied, mkdir '/data/projects/fresher'" };
+  flushSync(() => offerButton()!.dispatchEvent(click()));
+  await settle();
+  expect(creations[creations.length - 1]).toEqual(["Fresh Project", "/data/projects/fresher", true]);
+  expect(container.textContent).toContain("Couldn't create the directory");
+  expect(container.textContent).toContain("EACCES");
+  expect(offerButton()).toBeUndefined();
+  expect(selections).toEqual([]);
+
+  /* Success through the offer selects the project and closes the form. */
+  outcome = { ok: false, code: "MISSING_DIRECTORY" };
+  flushSync(submit);
+  await settle();
+  outcome = { ok: true, project: "dir-0123456789abcdef0123456789abcdef" };
+  flushSync(() => offerButton()!.dispatchEvent(click()));
+  await settle();
+  expect(selections).toEqual(["dir-0123456789abcdef0123456789abcdef"]);
+  expect(container.querySelector("form")).toBeNull();
+});
+
 /* Restore the real fetch for any later test file sharing this process. */
 afterAll(() => {
   globalThis.fetch = realFetch;

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import type { CreateProjectOutcome } from "@/hooks/useProjectCuration";
+import type { CreateProjectOutcome, CreateProjectRequestOptions } from "@/hooks/useProjectCuration";
 import { projectMatchesQuery } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
@@ -44,7 +44,7 @@ interface Props {
   now: number;
   onSelect: (project: string) => void;
   onToggleCrown?: (project: string, crowned: boolean) => void;
-  onCreateProject?: (name: string, root: string) => Promise<CreateProjectOutcome>;
+  onCreateProject?: (name: string, root: string, options?: CreateProjectRequestOptions) => Promise<CreateProjectOutcome>;
 }
 
 const EMPTY_CROWNS: ReadonlySet<string> = new Set();
@@ -290,7 +290,7 @@ function CreateProjectForm({
   onCreated,
   onCancel,
 }: {
-  onCreate: (name: string, root: string) => Promise<CreateProjectOutcome>;
+  onCreate: (name: string, root: string, options?: CreateProjectRequestOptions) => Promise<CreateProjectOutcome>;
   onCreated: (project: string) => void;
   onCancel: () => void;
 }) {
@@ -299,11 +299,14 @@ function CreateProjectForm({
   const [name, setName] = useState("");
   const [root, setRoot] = useState("");
   const [error, setError] = useState<string | null>(null);
+  /* Set on a MISSING_DIRECTORY refusal: the error line turns into a notice
+     and the mkdir-and-create action renders below it (issue #1122). */
+  const [offerCreateRoot, setOfferCreateRoot] = useState(false);
   const [busy, setBusy] = useState(false);
   const inputClass = `w-full rounded-[9px] border border-border bg-canvas px-2.5 text-[12px] outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
     isMobile ? "min-h-11" : "py-1.5"
   }`;
-  const submit = async () => {
+  const submit = async (createRoot = false) => {
     if (busy) return;
     if (!name.trim()) {
       setError(t("rail.invalidName"));
@@ -315,10 +318,20 @@ function CreateProjectForm({
     }
     setBusy(true);
     setError(null);
-    const outcome = await onCreate(name.trim(), root.trim());
+    setOfferCreateRoot(false);
+    const outcome = await onCreate(name.trim(), root.trim(), createRoot ? { createRoot: true } : undefined);
     setBusy(false);
     if (outcome.ok) {
       onCreated(outcome.project);
+      return;
+    }
+    if (outcome.code === "MISSING_DIRECTORY") {
+      setOfferCreateRoot(true);
+      setError(t("rail.missingRoot"));
+      return;
+    }
+    if (outcome.code === "MKDIR_FAILED") {
+      setError(outcome.message ? `${t("rail.mkdirFailed")} — ${outcome.message}` : t("rail.mkdirFailed"));
       return;
     }
     const key = CREATE_ERROR_KEYS[outcome.code];
@@ -345,9 +358,26 @@ function CreateProjectForm({
         placeholder={t("rail.newProjectRoot")}
         value={root}
         spellCheck={false}
-        onChange={(event) => setRoot(event.target.value)}
+        onChange={(event) => {
+          setRoot(event.target.value);
+          setOfferCreateRoot(false);
+        }}
       />
-      {error ? <div className="px-0.5 text-[11px] font-semibold text-danger">{error}</div> : null}
+      {error ? (
+        <div className={`px-0.5 text-[11px] font-semibold ${offerCreateRoot ? "text-warning" : "text-danger"}`}>{error}</div>
+      ) : null}
+      {offerCreateRoot ? (
+        <button
+          type="button"
+          disabled={busy}
+          className={`w-full rounded-[9px] border border-border bg-card text-[12px] font-semibold hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60 ${
+            isMobile ? "min-h-11" : "py-1.5"
+          }`}
+          onClick={() => void submit(true)}
+        >
+          {t("rail.createRootAndProject")}
+        </button>
+      ) : null}
       <div className="flex gap-1.5">
         <button
           type="submit"

--- a/src/hooks/useProjectCuration.ts
+++ b/src/hooks/useProjectCuration.ts
@@ -6,13 +6,18 @@ import type { ProjectCatalogEntry } from "@/lib/types";
 
 export type CreateProjectOutcome =
   | { ok: true; project: string }
-  | { ok: false; code: string };
+  | { ok: false; code: string; message?: string };
+
+export interface CreateProjectRequestOptions {
+  /** Ask the server to mkdir a missing root before creating the project. */
+  createRoot?: boolean;
+}
 
 export interface UseProjectCuration {
   /** Server crowns with this tab's optimistic toggles layered on top. */
   crownedProjects: ReadonlySet<string>;
   toggleCrown: (project: string, crowned: boolean) => void;
-  createProject: (name: string, root: string) => Promise<CreateProjectOutcome>;
+  createProject: (name: string, root: string, options?: CreateProjectRequestOptions) => Promise<CreateProjectOutcome>;
   /** Freshly created projects, overlaid until the server catalog carries them. */
   createdCatalog: ProjectCatalogEntry[];
 }
@@ -88,13 +93,13 @@ export function useProjectCuration(
     });
   }, []);
 
-  const createProject = useCallback(async (name: string, root: string): Promise<CreateProjectOutcome> => {
+  const createProject = useCallback(async (name: string, root: string, options?: CreateProjectRequestOptions): Promise<CreateProjectOutcome> => {
     let response: Response;
     try {
       response = await fetch("/api/projects/create", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ name, root }),
+        body: JSON.stringify(options?.createRoot ? { name, root, createRoot: true } : { name, root }),
       });
     } catch {
       return { ok: false, code: "NETWORK" };
@@ -107,7 +112,11 @@ export function useProjectCuration(
     }
     const record = payload && typeof payload === "object" ? payload as Record<string, unknown> : null;
     if (!response.ok || typeof record?.project !== "string") {
-      return { ok: false, code: typeof record?.error === "string" ? record.error : "ERROR" };
+      return {
+        ok: false,
+        code: typeof record?.error === "string" ? record.error : "ERROR",
+        message: typeof record?.message === "string" ? record.message : undefined,
+      };
     }
     const entry: ProjectCatalogEntry = {
       project: record.project,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -90,6 +90,9 @@ export const en = {
   "rail.creating": "Creating…",
   "rail.invalidName": "Enter a project name",
   "rail.invalidRoot": "Directory not found",
+  "rail.missingRoot": "This directory doesn't exist yet",
+  "rail.createRootAndProject": "Create directory and project",
+  "rail.mkdirFailed": "Couldn't create the directory",
   "rail.duplicateProject": "This project already exists",
   "rail.createFailed": "Couldn't create the project",
 

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -85,6 +85,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "rail.creating": "Створення…",
   "rail.invalidName": "Вкажіть назву проєкту",
   "rail.invalidRoot": "Теку не знайдено",
+  "rail.missingRoot": "Такої теки ще немає",
+  "rail.createRootAndProject": "Створити теку і проєкт",
+  "rail.mkdirFailed": "Не вдалося створити теку",
   "rail.duplicateProject": "Такий проєкт уже існує",
   "rail.createFailed": "Не вдалося створити проєкт",
 

--- a/src/lib/projects/curation.test.ts
+++ b/src/lib/projects/curation.test.ts
@@ -115,9 +115,49 @@ test("duplicate identities are refused, in the store and against the visible cat
 test("invalid inputs are refused without touching the store", () => {
   expect(createManualProject("", path.join(SANDBOX, "plain-folder"))).toMatchObject({ ok: false, code: "INVALID_NAME" });
   expect(createManualProject("Name", "relative/path")).toMatchObject({ ok: false, code: "INVALID_ROOT" });
-  expect(createManualProject("Name", path.join(SANDBOX, "missing-folder"))).toMatchObject({ ok: false, code: "INVALID_ROOT" });
   const file = path.join(SANDBOX, "a-file");
   fs.writeFileSync(file, "not a directory\n");
   expect(createManualProject("Name", file)).toMatchObject({ ok: false, code: "INVALID_ROOT" });
+  expect(projectCurationSnapshot().manualProjects).toEqual([]);
+});
+
+test("a missing directory refuses with MISSING_DIRECTORY; opting in mkdirs recursively and creates", () => {
+  const root = path.join(SANDBOX, "missing-folder", "nested");
+  expect(createManualProject("Name", root)).toMatchObject({ ok: false, code: "MISSING_DIRECTORY" });
+  expect(fs.existsSync(root)).toBe(false);
+  expect(projectCurationSnapshot().manualProjects).toEqual([]);
+
+  const created = createManualProject("Fresh", root, new Set(), { createMissingRoot: true });
+  if (!created.ok) throw new Error(`expected creation, got ${created.code}`);
+  expect(fs.statSync(root).isDirectory()).toBe(true);
+  expect(created.entry.project).toBe(projectIdentityFromDirectory(root)!.project);
+  expect(created.entry.root).toBe(fs.realpathSync.native(root));
+
+  resetProjectCurationForTests();
+  expect(projectCurationSnapshot().manualProjects).toEqual([created.entry]);
+});
+
+test("createMissingRoot never overrides the relative-path and file-path refusals", () => {
+  expect(createManualProject("Name", "relative/path", new Set(), { createMissingRoot: true }))
+    .toMatchObject({ ok: false, code: "INVALID_ROOT" });
+  const file = path.join(SANDBOX, "still-a-file");
+  fs.writeFileSync(file, "not a directory\n");
+  expect(createManualProject("Name", file, new Set(), { createMissingRoot: true }))
+    .toMatchObject({ ok: false, code: "INVALID_ROOT" });
+  expect(fs.statSync(file).isFile()).toBe(true);
+  expect(projectCurationSnapshot().manualProjects).toEqual([]);
+});
+
+test("a failed mkdir surfaces MKDIR_FAILED with the readable cause", () => {
+  const sealed = path.join(SANDBOX, "sealed");
+  fs.mkdirSync(sealed, { mode: 0o500 });
+  try {
+    const denied = createManualProject("Name", path.join(sealed, "child"), new Set(), { createMissingRoot: true });
+    expect(denied).toMatchObject({ ok: false, code: "MKDIR_FAILED" });
+    if (denied.ok) throw new Error("expected a failure");
+    expect(denied.message).toContain("EACCES");
+  } finally {
+    fs.chmodSync(sealed, 0o700);
+  }
   expect(projectCurationSnapshot().manualProjects).toEqual([]);
 });

--- a/src/lib/projects/curation.ts
+++ b/src/lib/projects/curation.ts
@@ -29,7 +29,21 @@ interface ProjectCurationFile extends ProjectCurationSnapshot {
   schemaVersion: 1;
 }
 
-export type CreateProjectFailure = "INVALID_NAME" | "INVALID_ROOT" | "DUPLICATE_PROJECT" | "STORE_ERROR";
+export type CreateProjectFailure =
+  | "INVALID_NAME"
+  | "INVALID_ROOT"
+  /** The root is a plausible absolute path whose directory does not exist yet —
+      the one refusal the client can turn into a "create directory" offer. */
+  | "MISSING_DIRECTORY"
+  | "MKDIR_FAILED"
+  | "DUPLICATE_PROJECT"
+  | "STORE_ERROR";
+
+export interface CreateProjectOptions {
+  /** Create the missing root directory (recursive mkdir) instead of refusing
+      with MISSING_DIRECTORY. Relative paths and file paths still refuse. */
+  createMissingRoot?: boolean;
+}
 
 export type CreateProjectResult =
   | { ok: true; entry: ManualProject }
@@ -156,6 +170,7 @@ export function createManualProject(
   name: string,
   root: string,
   existingProjects: ReadonlySet<string> = new Set(),
+  options: CreateProjectOptions = {},
 ): CreateProjectResult {
   const displayName = name.trim();
   if (!displayName || displayName.length > 80) {
@@ -168,9 +183,22 @@ export function createManualProject(
   let resolved: string;
   try {
     resolved = fs.realpathSync.native(requested);
+  } catch {
+    if (!options.createMissingRoot) {
+      return { ok: false, code: "MISSING_DIRECTORY", message: "directory does not exist" };
+    }
+    try {
+      fs.mkdirSync(requested, { recursive: true });
+      resolved = fs.realpathSync.native(requested);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return { ok: false, code: "MKDIR_FAILED", message: detail };
+    }
+  }
+  try {
     if (!fs.statSync(resolved).isDirectory()) throw new Error("not a directory");
   } catch {
-    return { ok: false, code: "INVALID_ROOT", message: "directory does not exist" };
+    return { ok: false, code: "INVALID_ROOT", message: "path does not point at a directory" };
   }
   const repositoryRoot = repositoryRootForPath(resolved);
   const identity = (repositoryRoot ? projectIdentityFromRepositoryRoot(repositoryRoot) : null)


### PR DESCRIPTION
Closes #1122.

## What

Entering a valid absolute path to a directory that does not exist in the sidebar create-project flow now surfaces a "Create directory and project" action in place of the dead-end "Directory not found" error. The action resubmits the same create call with a `createRoot` opt-in, which performs a recursive mkdir and proceeds with project creation in one flow.

## How

- `createManualProject` (src/lib/projects/curation.ts) splits the old catch-all `INVALID_ROOT` refusal: a missing directory now refuses with the dedicated `MISSING_DIRECTORY` code, and a new `options.createMissingRoot` flag performs `fs.mkdirSync(..., { recursive: true })` before the normal identity/duplicate/persist path. A failed mkdir returns `MKDIR_FAILED` carrying the fs error message. Relative paths and paths pointing at files keep refusing with `INVALID_ROOT`.
- `/api/projects/create` passes `createRoot: true` from the payload through and maps the new codes (400 / 500).
- `useProjectCuration.createProject` accepts the opt-in, sends it in the POST body, and now carries the server `message` on failures so the mkdir cause is readable.
- `ProjectRail`'s create form renders the `MISSING_DIRECTORY` refusal as a warning notice plus the mkdir-and-create button; editing the root retracts the offer. `MKDIR_FAILED` shows the localized line with the fs cause appended.
- i18n: `rail.missingRoot`, `rail.createRootAndProject`, `rail.mkdirFailed` in en and uk.

No extra scaffolding beyond the directory itself — no git init, no templates.

## Verification

- `tsc --noEmit` clean.
- `bun test src/lib/projects/curation.test.ts src/components/ProjectRail.dom.test.tsx` — 16 pass, 0 fail. New coverage: missing directory refuses then creates recursively on opt-in; the opt-in never overrides the relative-path/file-path refusals; a permission-denied mkdir surfaces `MKDIR_FAILED` with `EACCES` in the message; the rail offers, retracts on edit, reads the mkdir cause back, and completes creation through the offer.
- `bun run privacy:check` — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)