### PR TITLE
fix(runtime): revive orchestrator seats after viewer restart

### DIFF
--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -449,8 +449,14 @@ export async function adoptCodexRegistryHosts(
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
+        const current = registry.readOnlySnapshot().entries[sessionKeyId(entry.key)];
+        if (!current?.structuredHost || !shouldAdopt(current)) return;
         const claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
         if (!claimed?.structuredHost) return;
+        if (!shouldAdopt(claimed)) {
+          registry.releaseStructuredHostClaim(entry.key, claimed.claimOwner!, claimed.claimEpoch);
+          return;
+        }
         try {
           const host = await CodexAppServerHost.adopt(entry.key.sessionId, {
             ...optionsFor(claimed),
@@ -512,17 +518,28 @@ export async function adoptClaudeRegistryHosts(
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
+        const eligible = registry.readOnlySnapshot().entries[sessionKeyId(entry.key)];
+        if (!eligible?.structuredHost || !shouldAdopt(eligible)) return;
         let claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
         if (!claimed) {
           const current = registry.readOnlySnapshot().entries[`claude:${entry.key.sessionId}`];
           const orphan = current?.structuredHost?.kind === "claude-broker"
             ? current.structuredHost.process
             : null;
-          if (orphan && await terminateVerifiedClaudeOrphan(orphan, current?.claimOwner ?? null)) {
+          if (orphan
+            && current
+            && shouldAdopt(current)
+            && await terminateVerifiedClaudeOrphan(orphan, current.claimOwner ?? null)) {
+            const retry = registry.readOnlySnapshot().entries[sessionKeyId(entry.key)];
+            if (!retry?.structuredHost || !shouldAdopt(retry)) return;
             claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
           }
         }
         if (!claimed?.structuredHost) return;
+        if (!shouldAdopt(claimed)) {
+          registry.releaseStructuredHostClaim(entry.key, claimed.claimOwner!, claimed.claimEpoch);
+          return;
+        }
         try {
           const host = await ClaudeStreamBrokerHost.adopt(entry.key.sessionId, {
             ...optionsFor(claimed),

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -330,16 +330,20 @@ export function reconcileDeadStructuredRegistryHost(
 }
 
 /** Bounded reconciliation pass for completed conversation rows. Active conversation
-    recovery stays demand-driven, while terminal rows cannot retain a dead
-    engine process and its writer claim indefinitely. */
-export function reconcileDeadStructuredRegistryHosts(registry: AgentRegistry): void {
+    recovery stays demand-driven. `shouldRetain` protects rows the same startup
+    pass will re-host; every other terminal row releases its dead process claim. */
+export function reconcileDeadStructuredRegistryHosts(
+  registry: AgentRegistry,
+  shouldRetain: StructuredHostAdoptionFilter = () => false,
+): void {
   const snapshot = registry.readOnlySnapshot();
   for (const conversation of Object.values(snapshot.conversations)) {
     if (conversation.turn.state !== "terminal" && !conversation.supersededBy) continue;
     const generation = conversation.generations.at(-1);
     if (!generation) continue;
     const key = { engine: conversation.engine, sessionId: generation.id } as const;
-    if (!snapshot.entries[sessionKeyId(key)]?.structuredHost?.process) continue;
+    const entry = snapshot.entries[sessionKeyId(key)];
+    if (!entry?.structuredHost?.process || shouldRetain(entry)) continue;
     reconcileDeadStructuredRegistryHost(registry, conversation.id, key);
   }
 }

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1520,6 +1520,198 @@ test("viewer boot re-hosts previously hosted orchestrator seats and nudges each 
   }
 });
 
+test("viewer boot durably holds the orchestrator recovery nudge until the runtime client is available", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-held-recovery-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const sessionId = "25300000-0000-0000-0000-000000000005";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "idle",
+    turn: "terminal",
+  });
+  const originalEntry = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    ...originalEntry,
+    structuredHost: {
+      ...originalEntry.structuredHost!,
+      process: { pid: 2_000_000_005, startIdentity: "pre-restart-seat" },
+    },
+  });
+  const seat = activeSeat("seat-held-recovery", 5, conversation.id, artifactPath);
+  const key = { engine: "codex" as const, sessionId };
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+  try {
+    const adopted = await adoptStructuredHostsAtStartup({
+      registry,
+      client: null,
+      orchestratorSeats: () => [seat],
+      refreshTranscriptState: async () => {},
+      adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+        const entry = received.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+        if (!shouldAdopt(entry)) return [];
+        const processIdentity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+        const claimed = received.claimStructuredHost(entry.key, processIdentity, { allowUnhosted: true });
+        if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("seat host claim was unavailable");
+        const persisted = received.setStructuredHostClaimed(entry.key, {
+          ...claimed.structuredHost,
+          endpoint: "fake:held-recovery-seat",
+          process: processIdentity,
+        }, "idle", claimed.claimOwner, claimed.claimEpoch);
+        if (!persisted) throw new Error("seat host claim was lost");
+        return [{ key, host: host as never }];
+      },
+      adoptClaude: async () => [],
+    });
+
+    expect(adopted).toMatchObject([{ key, host }]);
+    const recoveryDeliveries = registry.pendingDeliveries(conversation.id).filter((delivery) =>
+      delivery.clientMessageId?.startsWith("orchestrator-restart-recovery-") === true);
+    expect(recoveryDeliveries).toMatchObject([{
+      state: expect.stringMatching(/^(held|assigned)$/),
+      text: expect.stringContaining("Viewer restarted"),
+    }]);
+    expect(ledger.writes).toEqual([]);
+
+    await bindStructuredDeliveryQueue(adopted, { registry, client });
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async ({ delivery, path: deliveryPath, clientMessageId }) =>
+        await deliverHeldStructuredMessage({
+          conversationId: conversation.id,
+          path: deliveryPath,
+          deliveryId: delivery.id,
+          clientMessageId,
+          text: delivery.text,
+          command: delivery.command,
+        }, {
+          enabled: () => true,
+          client: () => client,
+          registry: () => registry,
+        }) ?? "delivery-uncertain",
+    }, registry);
+    expect(ledger.writes).toEqual([expect.objectContaining({
+      id: recoveryDeliveries[0]!.command.operationId,
+      text: expect.stringContaining("Viewer restarted"),
+    })]);
+    expect(journal.operationResult(recoveryDeliveries[0]!.command.operationId)?.receipt.status).toBe("delivered");
+    expect(registry.pendingDeliveries(conversation.id).filter((delivery) =>
+      delivery.clientMessageId?.startsWith("orchestrator-restart-recovery-") === true)).toHaveLength(0);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startup retry admits one orchestrator recovery nudge after the first runtime admission fails", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-recovery-retry-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const baseClient = runtimeJournalClient(journal);
+  const sessionId = "25300000-0000-0000-0000-000000000006";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "idle",
+    turn: "terminal",
+  });
+  const originalEntry = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    ...originalEntry,
+    structuredHost: {
+      ...originalEntry.structuredHost!,
+      process: { pid: 2_000_000_006, startIdentity: "pre-restart-seat" },
+    },
+  });
+  const seat = activeSeat("seat-recovery-retry", 6, conversation.id, artifactPath);
+  const key = { engine: "codex" as const, sessionId };
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const recoveryAdmissionKeys: string[] = [];
+  const recoveryOperationIds: string[] = [];
+  const client = {
+    ...baseClient,
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "send" && command.text.startsWith("Viewer restarted")) {
+        if (!command.operationId) throw new Error("recovery admission requires an operation id");
+        recoveryAdmissionKeys.push(command.idempotencyKey);
+        recoveryOperationIds.push(command.operationId);
+        if (recoveryAdmissionKeys.length === 1) {
+          throw new RuntimeHostUnavailableError("runtime socket failed before recovery admission");
+        }
+      }
+      return baseClient.command(command);
+    },
+  } as RuntimeHostClient;
+  const scheduled: Array<() => void> = [];
+  let adoptionAttempts = 0;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client,
+    orchestratorSeats: () => [seat],
+    refreshTranscriptState: async () => {},
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+      if (adoptionAttempts > 0 || !shouldAdopt(entry)) return [];
+      adoptionAttempts += 1;
+      const processIdentity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+      const claimed = received.claimStructuredHost(entry.key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("seat host claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(entry.key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:retried-recovery-seat",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("seat host claim was lost");
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(didStructuredHostStartupFail()).toBe(true);
+    expect(scheduled).toHaveLength(1);
+    expect(adoptionAttempts).toBe(1);
+    expect(recoveryAdmissionKeys).toHaveLength(1);
+    expect(ledger.writes).toEqual([]);
+
+    scheduled.shift()!();
+    await waitFor(() => !didStructuredHostStartupFail() && ledger.writes.length === 1, 500);
+
+    expect(adoptionAttempts).toBe(1);
+    expect(new Set(recoveryAdmissionKeys).size).toBe(1);
+    expect(recoveryAdmissionKeys).toHaveLength(2);
+    expect(new Set(recoveryOperationIds).size).toBe(1);
+    expect(ledger.writes).toEqual([expect.objectContaining({
+      id: recoveryOperationIds[0],
+      text: expect.stringContaining("Viewer restarted"),
+    })]);
+    expect(journal.operationResult(recoveryOperationIds[0]!)?.receipt).toMatchObject({
+      idempotencyKey: recoveryAdmissionKeys[0],
+      status: "delivered",
+    });
+    expect(journal.snapshot().recentOperations.filter((receipt) =>
+      receipt.idempotencyKey.startsWith("orchestrator-restart-recovery-"))).toHaveLength(1);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test.each(["dead", "unhosted", "rotated"] as const)(
   "viewer boot skips an orchestrator seat that becomes %s during startup",
   async (transition) => {
@@ -1602,7 +1794,9 @@ test.each(["dead", "unhosted", "rotated"] as const)(
   },
 );
 
-test("startup retry releases a retained orchestrator host after seat rotation", async () => {
+test.each(["busy", "terminal"] as const)(
+  "startup retry preserves ordinary %s-host eligibility after seat rotation",
+  async (turn) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-retry-rotation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
@@ -1612,8 +1806,8 @@ test("startup retry releases a retained orchestrator host after seat rotation", 
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
-    turn: "busy",
-    activeTurnRef: "restart-interrupted-turn",
+    turn,
+    activeTurnRef: turn === "busy" ? "restart-interrupted-turn" : null,
   });
   const replacement = addStructuredRestartConversation(registry, directory, {
     sessionId: replacementSessionId,
@@ -1626,6 +1820,7 @@ test("startup retry releases a retained orchestrator host after seat rotation", 
   let releaseCalls = 0;
   let failClaudeAdoption = true;
   const ledger = createFakeDeliveryLedger();
+  const key = { engine: "codex" as const, sessionId };
   const host = Object.assign(new FakeEngineHost(ledger), {
     onStateChange: () => () => {},
     release: async () => { releaseCalls += 1; },
@@ -1670,10 +1865,20 @@ test("startup retry releases a retained orchestrator host after seat rotation", 
       conversation.id,
     )];
 
-    expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+    const retryResult = await adoptStructuredHostsAtStartup(dependencies);
     expect(adoptionAttempts).toBe(1);
-    expect(releaseCalls).toBe(1);
-    expect(ledger.writes).toEqual([]);
+    if (turn === "busy") {
+      expect(retryResult).toMatchObject([{ key, host }]);
+      expect(releaseCalls).toBe(0);
+      await waitFor(() => ledger.writes.length === 1);
+      expect(ledger.writes.map(({ text }) => text)).toEqual([
+        "Continue the interrupted turn from the transcript.",
+      ]);
+    } else {
+      expect(retryResult).toEqual([]);
+      expect(releaseCalls).toBe(1);
+      expect(ledger.writes).toEqual([]);
+    }
     expect(journal.snapshot().sessions.flatMap((session) => session.recentReceipts)
       .filter((receipt) => receipt.idempotencyKey.startsWith("orchestrator-restart-recovery-"))).toEqual([]);
   } finally {
@@ -1681,7 +1886,8 @@ test("startup retry releases a retained orchestrator host after seat rotation", 
     journal.close();
     fs.rmSync(directory, { recursive: true, force: true });
   }
-});
+},
+);
 
 test.each(["terminal", "superseded"] as const)(
   "%s Codex conversation stays outside startup continuation",

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -6,6 +6,8 @@ import { expect, spyOn, test } from "bun:test";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
+import { activeOrchestratorSeats, beginOrchestratorSeatIntent, completeOrchestratorSeatIntent } from "@/lib/orchestrator/seats";
+import { procBackend } from "@/lib/proc";
 import { turnStateFromRecords } from "@/lib/scanner/activity";
 import { RuntimeJournal } from "@/runtime-host/journal";
 import { runStructuredHostStartup } from "@/lib/viewerInstrumentation";
@@ -331,8 +333,8 @@ function projectHostedRestart(
   });
 }
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+async function waitFor(predicate: () => boolean, attempts = 100): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (predicate()) return;
     await Bun.sleep(1);
   }
@@ -1324,6 +1326,171 @@ test("a stale runtime-running projection cannot revive an idle registry host", a
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("viewer boot re-hosts previously hosted orchestrator seats and nudges each once", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-recovery-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const ledgers = new Map<string, ReturnType<typeof createFakeDeliveryLedger>>();
+  const adoptionAttempts: string[] = [];
+
+  const addSeat = (
+    project: string,
+    engine: "codex" | "claude",
+    sessionId: string,
+    status: "live" | "idle" | "dead",
+    turn: "busy" | "terminal" = "terminal",
+  ) => {
+    const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status,
+      turn,
+    });
+    if (status !== "dead") {
+      const entry = registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+      registry.upsert({
+        ...entry,
+        structuredHost: {
+          ...entry.structuredHost!,
+          process: { pid: engine === "codex" ? 2_000_000_001 : 2_000_000_002, startIdentity: `pre-restart-${sessionId}` },
+        },
+      });
+    }
+    const requestId = `seat_${project}`;
+    beginOrchestratorSeatIntent({ project, mandate: "run the checkpoint loop", clientRequestId: requestId, mode: "existing" });
+    completeOrchestratorSeatIntent({
+      project,
+      clientRequestId: requestId,
+      conversationId: conversation.id,
+      path: artifactPath,
+    });
+    return conversation;
+  };
+
+  const codexSessionId = "25300000-0000-0000-0000-000000000001";
+  const claudeSessionId = "25300000-0000-0000-0000-000000000002";
+  const deadSeatSessionId = "25300000-0000-0000-0000-000000000003";
+  const ordinarySessionId = "25300000-0000-0000-0000-000000000004";
+  const { codexSeat, claudeSeat, deadSeat, durableSeats } = (() => {
+    const isolatedEnvironment = {
+      HOME: path.join(directory, "home"),
+      XDG_CONFIG_HOME: path.join(directory, "config"),
+      LLV_STATE_DIR: path.join(directory, "state"),
+      TMPDIR: path.join(directory, "tmp"),
+    };
+    const previousEnvironment = Object.fromEntries(
+      Object.keys(isolatedEnvironment).map((key) => [key, process.env[key]]),
+    );
+    Object.assign(process.env, isolatedEnvironment);
+    for (const value of Object.values(isolatedEnvironment)) fs.mkdirSync(value, { recursive: true });
+    try {
+      const codexSeat = addSeat("seat-codex", "codex", codexSessionId, "idle", "busy");
+      const claudeSeat = addSeat("seat-claude", "claude", claudeSessionId, "live");
+      const deadSeat = addSeat("seat-dead", "codex", deadSeatSessionId, "dead");
+      return { codexSeat, claudeSeat, deadSeat, durableSeats: activeOrchestratorSeats() };
+    } finally {
+      for (const [key, value] of Object.entries(previousEnvironment)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  })();
+  addStructuredRestartConversation(registry, directory, {
+    engine: "claude",
+    sessionId: ordinarySessionId,
+    status: "idle",
+    turn: "terminal",
+  });
+
+  const adopt = async (
+    engine: "codex" | "claude",
+    received: AgentRegistry,
+    shouldAdopt: StructuredHostAdoptionFilter,
+  ) => Object.values(received.readOnlySnapshot().entries).flatMap((entry) => {
+    if (entry.key.engine !== engine || !entry.structuredHost || !shouldAdopt(entry)) return [];
+    const keyId = `${engine}:${entry.key.sessionId}`;
+    adoptionAttempts.push(keyId);
+    const processIdentity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+    const claimed = received.claimStructuredHost(entry.key, processIdentity, { allowUnhosted: true });
+    if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error(`seat host claim was unavailable: ${keyId}`);
+    const persisted = received.setStructuredHostClaimed(entry.key, {
+      ...claimed.structuredHost,
+      endpoint: `fake:recovered-${keyId}`,
+      process: processIdentity,
+    }, "idle", claimed.claimOwner, claimed.claimEpoch);
+    if (!persisted) throw new Error(`seat host claim was lost: ${keyId}`);
+    const ledger = createFakeDeliveryLedger();
+    ledgers.set(keyId, ledger);
+    const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+    return [{ key: entry.key, host: host as never }];
+  });
+
+  try {
+    const dependencies: StructuredStartupDependencies = {
+      registry,
+      client,
+      orchestratorSeats: () => durableSeats,
+      adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) =>
+        adopt("codex", received, shouldAdopt) as never,
+      adoptClaude: async (received, _optionsFor, _env, shouldAdopt = () => true) =>
+        adopt("claude", received, shouldAdopt) as never,
+    };
+
+    expect(durableSeats.map((seat) => seat.conversationId)).toEqual([
+      codexSeat.id,
+      claudeSeat.id,
+      deadSeat.id,
+    ]);
+    await adoptStructuredHostsAtStartup(dependencies);
+    expect(adoptionAttempts).toEqual([`codex:${codexSessionId}`, `claude:${claudeSessionId}`]);
+    await waitFor(() => [...ledgers.values()].reduce((total, ledger) => total + ledger.writes.length, 0) >= 2, 500);
+    expect(journal.snapshot().sessions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ conversationId: codexSeat.id, host: "hosted" }),
+      expect.objectContaining({ conversationId: claudeSeat.id, host: "hosted" }),
+    ]));
+    expect(registry.readOnlySnapshot().entries).toMatchObject({
+      [`codex:${codexSessionId}`]: { status: "idle", structuredHost: { process: { pid: process.pid } } },
+      [`claude:${claudeSessionId}`]: { status: "idle", structuredHost: { process: { pid: process.pid } } },
+    });
+
+    const writes = [...ledgers.values()].flatMap((ledger) => ledger.writes);
+    expect(writes).toHaveLength(2);
+    expect(writes.map((entry) => entry.text)).toEqual([
+      expect.stringContaining("Viewer restarted"),
+      expect.stringContaining("Viewer restarted"),
+    ]);
+    expect(new Set(writes.map((entry) => entry.id)).size).toBe(2);
+    const recoveredSessions = journal.snapshot().sessions.filter((session) =>
+      session.conversationId === codexSeat.id || session.conversationId === claudeSeat.id);
+    for (const session of recoveredSessions) {
+      const receipt = session.recentReceipts.find((candidate) =>
+        candidate.idempotencyKey.startsWith("orchestrator-restart-recovery-"));
+      expect(receipt).toBeDefined();
+      const conversation = registry.conversation(session.conversationId as `conversation_${string}`)!;
+      const replay = await enqueueStructuredMessage({
+        path: conversation.generations.at(-1)!.path,
+        conversationId: session.conversationId,
+        clientMessageId: receipt!.idempotencyKey,
+        text: receipt!.text ?? "",
+        images: [],
+      }, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+      });
+      expect(replay).toMatchObject({ ok: true, outcome: "delivered" });
+    }
+    expect([...ledgers.values()].flatMap((ledger) => ledger.writes)).toHaveLength(2);
+    expect(adoptionAttempts).not.toContain(`codex:${deadSeatSessionId}`);
+    expect(adoptionAttempts).not.toContain(`claude:${ordinarySessionId}`);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test.each(["terminal", "superseded"] as const)(

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -6,7 +6,12 @@ import { expect, spyOn, test } from "bun:test";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
-import { activeOrchestratorSeats, beginOrchestratorSeatIntent, completeOrchestratorSeatIntent } from "@/lib/orchestrator/seats";
+import {
+  activeOrchestratorSeats,
+  beginOrchestratorSeatIntent,
+  completeOrchestratorSeatIntent,
+  type OrchestratorSeat,
+} from "@/lib/orchestrator/seats";
 import { procBackend } from "@/lib/proc";
 import { turnStateFromRecords } from "@/lib/scanner/activity";
 import { RuntimeJournal } from "@/runtime-host/journal";
@@ -1100,6 +1105,28 @@ async function startupAdoptionAttempts(
   return attempts;
 }
 
+function activeSeat(
+  project: string,
+  seatEpoch: number,
+  conversationId: string,
+  artifactPath: string,
+  predecessorConversationId: string | null = null,
+): OrchestratorSeat {
+  return {
+    project,
+    seatEpoch,
+    conversationId,
+    path: artifactPath,
+    mandate: "run the checkpoint loop",
+    promptVersion: null,
+    predecessorConversationId,
+    state: "active",
+    intent: { clientRequestId: `seat-${project}-${seatEpoch}`, mode: "existing", launchId: null, error: null },
+    designatedAt: "2026-08-24T00:00:00.000Z",
+    activatedAt: "2026-08-24T00:00:01.000Z",
+  };
+}
+
 test("SQLite startup releases a completed stage host claim with pending delivery after its recorded process dies", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-dead-stage-owner-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, {
@@ -1486,6 +1513,169 @@ test("viewer boot re-hosts previously hosted orchestrator seats and nudges each 
     expect([...ledgers.values()].flatMap((ledger) => ledger.writes)).toHaveLength(2);
     expect(adoptionAttempts).not.toContain(`codex:${deadSeatSessionId}`);
     expect(adoptionAttempts).not.toContain(`claude:${ordinarySessionId}`);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test.each(["dead", "unhosted", "rotated"] as const)(
+  "viewer boot skips an orchestrator seat that becomes %s during startup",
+  async (transition) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-orchestrator-${transition}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    const client = runtimeJournalClient(journal);
+    const sessionId = "25300000-0000-0000-0000-000000000011";
+    const replacementSessionId = "25300000-0000-0000-0000-000000000012";
+    const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+      sessionId,
+      status: "live",
+      turn: "terminal",
+    });
+    const originalEntry = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+    registry.upsert({
+      ...originalEntry,
+      structuredHost: {
+        ...originalEntry.structuredHost!,
+        process: { pid: 2_000_000_011, startIdentity: "pre-restart-seat" },
+      },
+    });
+    const replacement = addStructuredRestartConversation(registry, directory, {
+      sessionId: replacementSessionId,
+      status: "dead",
+      turn: "terminal",
+    }).conversation;
+    const seat = activeSeat("seat-race", 11, conversation.id, artifactPath);
+    let seats: OrchestratorSeat[] = [seat];
+    const adoptionAttempts: string[] = [];
+    const ledger = createFakeDeliveryLedger();
+
+    try {
+      await adoptStructuredHostsAtStartup({
+        registry,
+        client,
+        orchestratorSeats: () => seats,
+        refreshTranscriptState: async () => {
+          if (transition === "rotated") {
+            seats = [activeSeat(
+              seat.project,
+              seat.seatEpoch + 1,
+              replacement.id,
+              replacement.generations.at(-1)!.path,
+              conversation.id,
+            )];
+            return;
+          }
+          const current = registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+          registry.upsert({ ...current, status: transition });
+        },
+        adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+          const entry = received.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+          if (!shouldAdopt(entry)) return [];
+          adoptionAttempts.push(`codex:${sessionId}`);
+          const processIdentity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+          const claimed = received.claimStructuredHost(entry.key, processIdentity, { allowUnhosted: true });
+          if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("seat host claim was unavailable");
+          const persisted = received.setStructuredHostClaimed(entry.key, {
+            ...claimed.structuredHost,
+            endpoint: "fake:invalidated-seat",
+            process: processIdentity,
+          }, "idle", claimed.claimOwner, claimed.claimEpoch);
+          if (!persisted) throw new Error("seat host claim was lost");
+          const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+          return [{ key: entry.key, host: host as never }];
+        },
+        adoptClaude: async () => [],
+      });
+
+      expect(adoptionAttempts).toEqual([]);
+      expect(ledger.writes).toEqual([]);
+      expect(journal.snapshot().sessions.flatMap((session) => session.recentReceipts)
+        .filter((receipt) => receipt.idempotencyKey.startsWith("orchestrator-restart-recovery-"))).toEqual([]);
+    } finally {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test("startup retry releases a retained orchestrator host after seat rotation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-retry-rotation-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const sessionId = "25300000-0000-0000-0000-000000000021";
+  const replacementSessionId = "25300000-0000-0000-0000-000000000022";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "restart-interrupted-turn",
+  });
+  const replacement = addStructuredRestartConversation(registry, directory, {
+    sessionId: replacementSessionId,
+    status: "dead",
+    turn: "terminal",
+  }).conversation;
+  const seat = activeSeat("seat-retry-race", 21, conversation.id, artifactPath);
+  let seats = [seat];
+  let adoptionAttempts = 0;
+  let releaseCalls = 0;
+  let failClaudeAdoption = true;
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), {
+    onStateChange: () => () => {},
+    release: async () => { releaseCalls += 1; },
+  });
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client,
+    orchestratorSeats: () => seats,
+    refreshTranscriptState: async () => {},
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+      if (adoptionAttempts > 0 || !shouldAdopt(entry)) return [];
+      adoptionAttempts += 1;
+      const processIdentity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+      const claimed = received.claimStructuredHost(entry.key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("seat host claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(entry.key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:retained-orchestrator",
+        process: processIdentity,
+      }, "live", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("seat host claim was lost");
+      return [{ key: entry.key, host: host as never }];
+    },
+    adoptClaude: async () => {
+      if (!failClaudeAdoption) return [];
+      failClaudeAdoption = false;
+      throw new RuntimeHostUnavailableError("runtime failed after orchestrator adoption");
+    },
+  };
+
+  try {
+    await expect(adoptStructuredHostsAtStartup(dependencies)).rejects.toThrow(
+      "runtime failed after orchestrator adoption",
+    );
+    expect(adoptionAttempts).toBe(1);
+    seats = [activeSeat(
+      seat.project,
+      seat.seatEpoch + 1,
+      replacement.id,
+      replacement.generations.at(-1)!.path,
+      conversation.id,
+    )];
+
+    expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+    expect(adoptionAttempts).toBe(1);
+    expect(releaseCalls).toBe(1);
+    expect(ledger.writes).toEqual([]);
+    expect(journal.snapshot().sessions.flatMap((session) => session.recentReceipts)
+      .filter((receipt) => receipt.idempotencyKey.startsWith("orchestrator-restart-recovery-"))).toEqual([]);
   } finally {
     await bindStructuredDeliveryQueue([], { registry, client: null });
     journal.close();

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -22,7 +22,7 @@ import {
   type AdoptedCodexHost,
   type StructuredHostAdoptionFilter,
 } from "./registry";
-import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import { RuntimeHostUnavailableError, runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationResult } from "./contracts";
 import {
   bindStructuredDeliveryQueue,
@@ -54,12 +54,10 @@ function retainedStartupHostIsCurrent(
   snapshot: RegistryFile,
   item: AdoptedStructuredHost,
   retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
-  restartRecoveryHostKeys: ReadonlySet<string> = new Set(),
 ): boolean {
   const key = sessionKeyId(item.key);
   const entry = snapshot.entries[key];
   if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") return false;
-  if (restartRecoveryHostKeys.has(key) && !retainedTerminalHostKeys.has(key)) return false;
   const conversation = Object.values(snapshot.conversations).find((candidate) =>
     candidate.engine === item.key.engine
       && candidate.generations.at(-1)?.id === item.key.sessionId);
@@ -73,11 +71,10 @@ async function revalidateRetainedStartupHosts(
   retained: readonly AdoptedStructuredHost[],
   snapshot: RegistryFile = registry.readOnlySnapshot(),
   retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
-  restartRecoveryHostKeys: ReadonlySet<string> = new Set(),
 ): Promise<AdoptedStructuredHost[]> {
   const current: AdoptedStructuredHost[] = [];
   for (const item of retained) {
-    if (retainedStartupHostIsCurrent(snapshot, item, retainedTerminalHostKeys, restartRecoveryHostKeys)) current.push(item);
+    if (retainedStartupHostIsCurrent(snapshot, item, retainedTerminalHostKeys)) current.push(item);
     else await item.host.release();
   }
   return current;
@@ -211,7 +208,7 @@ function orchestratorRestartRecoveriesByHostKey(
 
 async function enqueueOrchestratorRestartRecoveries(
   registry: AgentRegistry,
-  client: RuntimeHostClient,
+  client: RuntimeHostClient | null,
   targets: readonly OrchestratorRestartRecoveryTarget[],
   publishedHostKeys: ReadonlySet<string>,
   orchestratorSeats: () => OrchestratorSeat[],
@@ -237,6 +234,9 @@ async function enqueueOrchestratorRestartRecoveries(
       status: result?.status ?? 503,
       error: result?.error ?? "structured delivery unavailable",
     });
+    throw new RuntimeHostUnavailableError(
+      result?.error ?? "orchestrator restart recovery delivery admission failed",
+    );
   }
 }
 
@@ -484,10 +484,9 @@ function structuredStartupAdoptionFilter(
        revive a retired round, held work or not — the successor owns it. */
     if (conversation.supersededBy) return false;
     const orchestratorRecoveryTargets = orchestratorRecoveries.get(sessionKeyId(entry.key));
-    if (orchestratorRecoveryTargets) {
-      const seats = orchestratorSeats();
-      return orchestratorRecoveryTargets.some((target) =>
-        orchestratorRestartRecoveryTargetIsCurrent(registry, target, seats));
+    if (orchestratorRecoveryTargets?.some((target) =>
+      orchestratorRestartRecoveryTargetIsCurrent(registry, target, orchestratorSeats()))) {
+      return true;
     }
     const conversationId = registry.canonicalConversationId(conversation.id);
     const hasPendingWork = pendingDeliveryConversationIds.has(conversationId)
@@ -537,7 +536,6 @@ export async function adoptStructuredHostsAtStartup(
     orchestratorRestartRecoveryTargets(registry, orchestratorSeats()),
   );
   const orchestratorRecoveriesByHostKey = orchestratorRestartRecoveriesByHostKey(orchestratorRecoveries);
-  const restartRecoveryHostKeys = new Set(orchestratorRecoveriesByHostKey.keys());
   const controllerBoundEarly = client !== null;
   if (client && !hasStructuredDeliveryController(registry)) {
     await bindStructuredDeliveryQueue([], {
@@ -562,7 +560,6 @@ export async function adoptStructuredHostsAtStartup(
     retryAdoptedHosts,
     registry.readOnlySnapshot(),
     orchestratorHostKeys,
-    restartRecoveryHostKeys,
   );
   rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   /* Pending work makes a terminal conversation adoption-eligible. Clear any
@@ -681,19 +678,14 @@ export async function adoptStructuredHostsAtStartup(
     nextAdoptedHosts,
     registry.readOnlySnapshot(),
     orchestratorHostKeys,
-    restartRecoveryHostKeys,
   );
   rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   const candidateHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
-  const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) => {
-    const key = sessionKeyId(entry.key);
-    return restartRecoveryHostKeys.has(key)
-      ? candidateHostKeys.has(key) && shouldAdopt(entry)
-      : candidateHostKeys.has(key) || shouldAdopt(entry);
-  };
+  const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) =>
+    candidateHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
   const candidateCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex"
-      && !restartRecoveryHostKeys.has(sessionKeyId(item.key)),
+      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
   );
   const existingCodexContinuations = client
     ? await interruptedCodexContinuations(registry, client, candidateCodexHosts)
@@ -711,7 +703,6 @@ export async function adoptStructuredHostsAtStartup(
     nextAdoptedHosts,
     publicationSnapshot,
     orchestratorHostKeys,
-    restartRecoveryHostKeys,
   );
   rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   const finalShouldAdopt = structuredStartupAdoptionFilter(
@@ -722,12 +713,8 @@ export async function adoptStructuredHostsAtStartup(
     orchestratorSeats,
   );
   const finalHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
-  const shouldPublish: StructuredHostAdoptionFilter = (entry) => {
-    const key = sessionKeyId(entry.key);
-    return restartRecoveryHostKeys.has(key)
-      ? finalHostKeys.has(key) && finalShouldAdopt(entry)
-      : finalHostKeys.has(key) || finalShouldAdopt(entry);
-  };
+  const shouldPublish: StructuredHostAdoptionFilter = (entry) =>
+    finalHostKeys.has(sessionKeyId(entry.key)) || finalShouldAdopt(entry);
   const interruptedCodex = interruptedCodexConversations(
     registry,
     shouldPublish,
@@ -736,7 +723,7 @@ export async function adoptStructuredHostsAtStartup(
   );
   const finalCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex"
-      && !restartRecoveryHostKeys.has(sessionKeyId(item.key)),
+      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
   );
   reportProgress("finalizing structured delivery");
   if (controllerBoundEarly) {
@@ -744,14 +731,14 @@ export async function adoptStructuredHostsAtStartup(
   } else {
     await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry, client });
   }
+  await enqueueOrchestratorRestartRecoveries(
+    registry,
+    client,
+    orchestratorRecoveries,
+    finalHostKeys,
+    orchestratorSeats,
+  );
   if (client) {
-    await enqueueOrchestratorRestartRecoveries(
-      registry,
-      client,
-      orchestratorRecoveries,
-      finalHostKeys,
-      orchestratorSeats,
-    );
     await enqueueInterruptedCodexContinuations(
       registry,
       client,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import path from "node:path";
 
 import { accountManager } from "@/lib/accounts/manager";
@@ -7,6 +8,7 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
 import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
+import { activeOrchestratorSeats } from "@/lib/orchestrator/seats";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { readStableTailRecords } from "@/lib/scanner/activity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -28,6 +30,7 @@ import {
   hasStructuredDeliveryController,
 } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
+import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { materializeStructuredHostAccess, recoverPendingStructuredSpawns } from "./structuredSpawn";
 import { markStructuredHostStartupProgress, type StructuredHostStartupPhase } from "./startupStatus";
 
@@ -50,6 +53,7 @@ function retainAdoptedHosts(
 function retainedStartupHostIsCurrent(
   snapshot: RegistryFile,
   item: AdoptedStructuredHost,
+  retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
 ): boolean {
   const key = sessionKeyId(item.key);
   const entry = snapshot.entries[key];
@@ -58,18 +62,19 @@ function retainedStartupHostIsCurrent(
     candidate.engine === item.key.engine
       && candidate.generations.at(-1)?.id === item.key.sessionId);
   return Boolean(conversation
-    && conversation.turn.state !== "terminal"
-    && !conversation.supersededBy);
+    && !conversation.supersededBy
+    && (conversation.turn.state !== "terminal" || retainedTerminalHostKeys.has(key)));
 }
 
 async function revalidateRetainedStartupHosts(
   registry: AgentRegistry,
   retained: readonly AdoptedStructuredHost[],
   snapshot: RegistryFile = registry.readOnlySnapshot(),
+  retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
 ): Promise<AdoptedStructuredHost[]> {
   const current: AdoptedStructuredHost[] = [];
   for (const item of retained) {
-    if (retainedStartupHostIsCurrent(snapshot, item)) current.push(item);
+    if (retainedStartupHostIsCurrent(snapshot, item, retainedTerminalHostKeys)) current.push(item);
     else await item.host.release();
   }
   return current;
@@ -95,6 +100,69 @@ interface StructuredStartupSignals {
 const TRANSCRIPT_REFRESH_CONCURRENCY = 16;
 const INTERRUPTED_CODEX_CONTINUATION_OPERATION_PREFIX = "recovery-continuation";
 const INTERRUPTED_CODEX_CONTINUATION_TEXT = "Continue the interrupted turn from the transcript.";
+const ORCHESTRATOR_RESTART_RECOVERY_PREFIX = "orchestrator-restart-recovery";
+const ORCHESTRATOR_RESTART_RECOVERY_TEXT = "Viewer restarted and severed your structured host. You were re-hosted automatically. Resume your checkpoint loop and re-arm any scheduled work.";
+/* One module lifetime is one Viewer Node boot. Startup retries reuse this key;
+   a successor process mints a fresh recovery operation for the next restart. */
+const STRUCTURED_STARTUP_BOOT_ID = crypto.randomUUID();
+
+interface OrchestratorRestartRecoveryTarget {
+  conversationId: ViewerConversationId;
+  path: string;
+  seatEpoch: number;
+  hostKey: string;
+}
+
+function orchestratorRestartRecoveryTargets(
+  registry: AgentRegistry,
+  seats = activeOrchestratorSeats(),
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
+): OrchestratorRestartRecoveryTarget[] {
+  return seats.flatMap((seat) => {
+    if (!seat.conversationId?.startsWith("conversation_")) return [];
+    const conversationId = registry.canonicalConversationId(seat.conversationId as ViewerConversationId);
+    const conversation = snapshot.conversations[conversationId];
+    const generation = conversation?.generations.at(-1);
+    if (!conversation || !generation || conversation.supersededBy) return [];
+    const hostKey = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
+    const entry = snapshot.entries[hostKey];
+    const wasHosted = Boolean(entry?.structuredHost
+      && entry.host === null
+      && (entry.status === "live" || entry.status === "idle"));
+    return wasHosted
+      ? [{ conversationId, path: generation.path, seatEpoch: seat.seatEpoch, hostKey }]
+      : [];
+  });
+}
+
+async function enqueueOrchestratorRestartRecoveries(
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  targets: readonly OrchestratorRestartRecoveryTarget[],
+  publishedHostKeys: ReadonlySet<string>,
+): Promise<void> {
+  for (const target of targets) {
+    if (!publishedHostKeys.has(target.hostKey)) continue;
+    const clientMessageId = `${ORCHESTRATOR_RESTART_RECOVERY_PREFIX}-${STRUCTURED_STARTUP_BOOT_ID}-${target.seatEpoch}`;
+    const result = await enqueueStructuredMessage({
+      path: target.path,
+      conversationId: target.conversationId,
+      clientMessageId,
+      text: ORCHESTRATOR_RESTART_RECOVERY_TEXT,
+      images: [],
+    }, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+    });
+    if (result?.ok) continue;
+    console.error("[structured hosts] orchestrator restart recovery delivery failed", {
+      conversationId: target.conversationId,
+      status: result?.status ?? 503,
+      error: result?.error ?? "structured delivery unavailable",
+    });
+  }
+}
 
 function interruptedCodexContinuationOperationId(sessionId: string, claimEpoch: number): string {
   return `${INTERRUPTED_CODEX_CONTINUATION_OPERATION_PREFIX}-${sessionId}-${claimEpoch}`;
@@ -319,6 +387,7 @@ function structuredStartupAdoptionFilter(
   registry: AgentRegistry,
   signals: StructuredStartupSignals,
   snapshot: RegistryFile = registry.readOnlySnapshot(),
+  orchestratorHostKeys: ReadonlySet<string> = new Set(),
 ): StructuredHostAdoptionFilter {
   const conversationsByCurrentEntry = new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
@@ -337,6 +406,7 @@ function structuredStartupAdoptionFilter(
     /* A superseded conversation is terminal (issue #383): a boot can never
        revive a retired round, held work or not — the successor owns it. */
     if (conversation.supersededBy) return false;
+    if (orchestratorHostKeys.has(sessionKeyId(entry.key))) return true;
     const conversationId = registry.canonicalConversationId(conversation.id);
     const hasPendingWork = pendingDeliveryConversationIds.has(conversationId)
       || signals.pendingOperationConversationIds.has(conversationId);
@@ -357,6 +427,7 @@ function structuredStartupAdoptionFilter(
 export interface StructuredStartupDependencies {
   registry?: AgentRegistry;
   client?: RuntimeHostClient | null;
+  orchestratorSeats?: typeof activeOrchestratorSeats;
   refreshTranscriptState?: (registry: AgentRegistry) => Promise<void>;
   adopt?: typeof adoptCodexRegistryHosts;
   adoptClaude?: typeof adoptClaudeRegistryHosts;
@@ -376,6 +447,13 @@ export async function adoptStructuredHostsAtStartup(
   assertDarwinStructuredRuntime();
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
+  /* Capture hosted seat ownership before any awaited startup work can refresh
+     a terminal transcript or reconcile away the predecessor host wrapper. */
+  const orchestratorRecoveries = orchestratorRestartRecoveryTargets(
+    registry,
+    dependencies.orchestratorSeats?.() ?? activeOrchestratorSeats(),
+  );
+  const orchestratorHostKeys = new Set(orchestratorRecoveries.map((target) => target.hostKey));
   const controllerBoundEarly = client !== null;
   if (client && !hasStructuredDeliveryController(registry)) {
     await bindStructuredDeliveryQueue([], {
@@ -390,14 +468,24 @@ export async function adoptStructuredHostsAtStartup(
     totalHosts: null,
   });
   await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry);
-  let nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, retryAdoptedHosts);
+  let nextAdoptedHosts = await revalidateRetainedStartupHosts(
+    registry,
+    retryAdoptedHosts,
+    registry.readOnlySnapshot(),
+    orchestratorHostKeys,
+  );
   retryAdoptedHosts = nextAdoptedHosts;
   /* Pending work makes a terminal conversation adoption-eligible. Clear any
      provably dead wrapper before that decision so its stale writer fence
      cannot block the startup recovery path. */
-  reconcileDeadStructuredRegistryHosts(registry);
+  reconcileDeadStructuredRegistryHosts(registry, (entry) => orchestratorHostKeys.has(sessionKeyId(entry.key)));
   const signals = await structuredStartupSignals(registry, client);
-  const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
+  const shouldAdopt = structuredStartupAdoptionFilter(
+    registry,
+    signals,
+    registry.readOnlySnapshot(),
+    orchestratorHostKeys,
+  );
   const adoptionCandidates = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
     entry.structuredHost && shouldAdopt(entry));
   const codexCandidateCount = adoptionCandidates.filter((entry) => entry.key.engine === "codex").length;
@@ -496,16 +584,27 @@ export async function adoptStructuredHostsAtStartup(
   const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) =>
     candidateHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
   const candidateCodexHosts = nextAdoptedHosts.filter(
-    (item): item is AdoptedCodexHost => item.key.engine === "codex",
+    (item): item is AdoptedCodexHost => item.key.engine === "codex"
+      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
   );
   const existingCodexContinuations = client
     ? await interruptedCodexContinuations(registry, client, candidateCodexHosts)
     : new Map<string, RuntimeOperationResult>();
   await demoteSkippedStructuredRegistryHosts(registry, shouldRetainCandidateOrAdopt);
   const publicationSnapshot = registry.readOnlySnapshot();
-  nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, nextAdoptedHosts, publicationSnapshot);
+  nextAdoptedHosts = await revalidateRetainedStartupHosts(
+    registry,
+    nextAdoptedHosts,
+    publicationSnapshot,
+    orchestratorHostKeys,
+  );
   retryAdoptedHosts = nextAdoptedHosts;
-  const finalShouldAdopt = structuredStartupAdoptionFilter(registry, signals, publicationSnapshot);
+  const finalShouldAdopt = structuredStartupAdoptionFilter(
+    registry,
+    signals,
+    publicationSnapshot,
+    orchestratorHostKeys,
+  );
   const finalHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
   const shouldPublish: StructuredHostAdoptionFilter = (entry) =>
     finalHostKeys.has(sessionKeyId(entry.key)) || finalShouldAdopt(entry);
@@ -516,7 +615,8 @@ export async function adoptStructuredHostsAtStartup(
     publicationSnapshot,
   );
   const finalCodexHosts = nextAdoptedHosts.filter(
-    (item): item is AdoptedCodexHost => item.key.engine === "codex",
+    (item): item is AdoptedCodexHost => item.key.engine === "codex"
+      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
   );
   reportProgress("finalizing structured delivery");
   if (controllerBoundEarly) {
@@ -525,6 +625,7 @@ export async function adoptStructuredHostsAtStartup(
     await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry, client });
   }
   if (client) {
+    await enqueueOrchestratorRestartRecoveries(registry, client, orchestratorRecoveries, finalHostKeys);
     await enqueueInterruptedCodexContinuations(
       registry,
       client,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -8,7 +8,7 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
 import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
-import { activeOrchestratorSeats } from "@/lib/orchestrator/seats";
+import { activeOrchestratorSeats, type OrchestratorSeat } from "@/lib/orchestrator/seats";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { readStableTailRecords } from "@/lib/scanner/activity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -54,10 +54,12 @@ function retainedStartupHostIsCurrent(
   snapshot: RegistryFile,
   item: AdoptedStructuredHost,
   retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
+  restartRecoveryHostKeys: ReadonlySet<string> = new Set(),
 ): boolean {
   const key = sessionKeyId(item.key);
   const entry = snapshot.entries[key];
   if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") return false;
+  if (restartRecoveryHostKeys.has(key) && !retainedTerminalHostKeys.has(key)) return false;
   const conversation = Object.values(snapshot.conversations).find((candidate) =>
     candidate.engine === item.key.engine
       && candidate.generations.at(-1)?.id === item.key.sessionId);
@@ -71,10 +73,11 @@ async function revalidateRetainedStartupHosts(
   retained: readonly AdoptedStructuredHost[],
   snapshot: RegistryFile = registry.readOnlySnapshot(),
   retainedTerminalHostKeys: ReadonlySet<string> = new Set(),
+  restartRecoveryHostKeys: ReadonlySet<string> = new Set(),
 ): Promise<AdoptedStructuredHost[]> {
   const current: AdoptedStructuredHost[] = [];
   for (const item of retained) {
-    if (retainedStartupHostIsCurrent(snapshot, item, retainedTerminalHostKeys)) current.push(item);
+    if (retainedStartupHostIsCurrent(snapshot, item, retainedTerminalHostKeys, restartRecoveryHostKeys)) current.push(item);
     else await item.host.release();
   }
   return current;
@@ -107,10 +110,33 @@ const ORCHESTRATOR_RESTART_RECOVERY_TEXT = "Viewer restarted and severed your st
 const STRUCTURED_STARTUP_BOOT_ID = crypto.randomUUID();
 
 interface OrchestratorRestartRecoveryTarget {
+  project: string;
   conversationId: ViewerConversationId;
   path: string;
   seatEpoch: number;
   hostKey: string;
+}
+
+let retryOrchestratorRecoveries: OrchestratorRestartRecoveryTarget[] = [];
+
+function mergeOrchestratorRestartRecoveries(
+  retained: readonly OrchestratorRestartRecoveryTarget[],
+  captured: readonly OrchestratorRestartRecoveryTarget[],
+): OrchestratorRestartRecoveryTarget[] {
+  const targets = new Map<string, OrchestratorRestartRecoveryTarget>();
+  for (const target of [...retained, ...captured]) {
+    targets.set(`${target.project}\0${target.seatEpoch}\0${target.hostKey}`, target);
+  }
+  return [...targets.values()];
+}
+
+function rememberStructuredStartupRetry(
+  hosts: AdoptedStructuredHost[],
+  recoveries: readonly OrchestratorRestartRecoveryTarget[],
+): void {
+  retryAdoptedHosts = hosts;
+  const retainedHostKeys = new Set(hosts.map((item) => sessionKeyId(item.key)));
+  retryOrchestratorRecoveries = recoveries.filter((target) => retainedHostKeys.has(target.hostKey));
 }
 
 function orchestratorRestartRecoveryTargets(
@@ -130,9 +156,57 @@ function orchestratorRestartRecoveryTargets(
       && entry.host === null
       && (entry.status === "live" || entry.status === "idle"));
     return wasHosted
-      ? [{ conversationId, path: generation.path, seatEpoch: seat.seatEpoch, hostKey }]
+      ? [{ project: seat.project, conversationId, path: generation.path, seatEpoch: seat.seatEpoch, hostKey }]
       : [];
   });
+}
+
+function orchestratorRestartRecoveryTargetIsCurrent(
+  registry: AgentRegistry,
+  target: OrchestratorRestartRecoveryTarget,
+  seats: readonly OrchestratorSeat[],
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
+): boolean {
+  const seat = seats.find((candidate) => candidate.project === target.project);
+  if (!seat
+    || seat.state !== "active"
+    || seat.seatEpoch !== target.seatEpoch
+    || !seat.conversationId?.startsWith("conversation_")
+    || registry.canonicalConversationId(seat.conversationId as ViewerConversationId) !== target.conversationId) return false;
+  const conversation = snapshot.conversations[target.conversationId];
+  const generation = conversation?.generations.at(-1);
+  if (!conversation
+    || !generation
+    || conversation.supersededBy
+    || generation.path !== target.path
+    || sessionKeyId({ engine: conversation.engine, sessionId: generation.id }) !== target.hostKey) return false;
+  const entry = snapshot.entries[target.hostKey];
+  return Boolean(entry?.structuredHost
+    && entry.host === null
+    && (entry.status === "live" || entry.status === "idle"));
+}
+
+function currentOrchestratorRestartRecoveryHostKeys(
+  registry: AgentRegistry,
+  targets: readonly OrchestratorRestartRecoveryTarget[],
+  seats: readonly OrchestratorSeat[],
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
+): Set<string> {
+  return new Set(targets
+    .filter((target) => orchestratorRestartRecoveryTargetIsCurrent(registry, target, seats, snapshot))
+    .map((target) => target.hostKey));
+}
+
+function orchestratorRestartRecoveriesByHostKey(
+  targets: readonly OrchestratorRestartRecoveryTarget[],
+): Map<string, OrchestratorRestartRecoveryTarget[]> {
+  const byHostKey = new Map<string, OrchestratorRestartRecoveryTarget[]>();
+  for (const target of targets) {
+    const existing = byHostKey.get(target.hostKey) ?? [];
+    existing.push(target);
+    byHostKey.set(target.hostKey, existing);
+  }
+  return byHostKey;
 }
 
 async function enqueueOrchestratorRestartRecoveries(
@@ -140,9 +214,11 @@ async function enqueueOrchestratorRestartRecoveries(
   client: RuntimeHostClient,
   targets: readonly OrchestratorRestartRecoveryTarget[],
   publishedHostKeys: ReadonlySet<string>,
+  orchestratorSeats: () => OrchestratorSeat[],
 ): Promise<void> {
   for (const target of targets) {
-    if (!publishedHostKeys.has(target.hostKey)) continue;
+    if (!publishedHostKeys.has(target.hostKey)
+      || !orchestratorRestartRecoveryTargetIsCurrent(registry, target, orchestratorSeats())) continue;
     const clientMessageId = `${ORCHESTRATOR_RESTART_RECOVERY_PREFIX}-${STRUCTURED_STARTUP_BOOT_ID}-${target.seatEpoch}`;
     const result = await enqueueStructuredMessage({
       path: target.path,
@@ -387,7 +463,8 @@ function structuredStartupAdoptionFilter(
   registry: AgentRegistry,
   signals: StructuredStartupSignals,
   snapshot: RegistryFile = registry.readOnlySnapshot(),
-  orchestratorHostKeys: ReadonlySet<string> = new Set(),
+  orchestratorRecoveries: ReadonlyMap<string, readonly OrchestratorRestartRecoveryTarget[]> = new Map(),
+  orchestratorSeats: () => OrchestratorSeat[] = activeOrchestratorSeats,
 ): StructuredHostAdoptionFilter {
   const conversationsByCurrentEntry = new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
@@ -406,7 +483,12 @@ function structuredStartupAdoptionFilter(
     /* A superseded conversation is terminal (issue #383): a boot can never
        revive a retired round, held work or not — the successor owns it. */
     if (conversation.supersededBy) return false;
-    if (orchestratorHostKeys.has(sessionKeyId(entry.key))) return true;
+    const orchestratorRecoveryTargets = orchestratorRecoveries.get(sessionKeyId(entry.key));
+    if (orchestratorRecoveryTargets) {
+      const seats = orchestratorSeats();
+      return orchestratorRecoveryTargets.some((target) =>
+        orchestratorRestartRecoveryTargetIsCurrent(registry, target, seats));
+    }
     const conversationId = registry.canonicalConversationId(conversation.id);
     const hasPendingWork = pendingDeliveryConversationIds.has(conversationId)
       || signals.pendingOperationConversationIds.has(conversationId);
@@ -447,13 +529,15 @@ export async function adoptStructuredHostsAtStartup(
   assertDarwinStructuredRuntime();
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
+  const orchestratorSeats = dependencies.orchestratorSeats ?? activeOrchestratorSeats;
   /* Capture hosted seat ownership before any awaited startup work can refresh
      a terminal transcript or reconcile away the predecessor host wrapper. */
-  const orchestratorRecoveries = orchestratorRestartRecoveryTargets(
-    registry,
-    dependencies.orchestratorSeats?.() ?? activeOrchestratorSeats(),
+  const orchestratorRecoveries = mergeOrchestratorRestartRecoveries(
+    retryOrchestratorRecoveries,
+    orchestratorRestartRecoveryTargets(registry, orchestratorSeats()),
   );
-  const orchestratorHostKeys = new Set(orchestratorRecoveries.map((target) => target.hostKey));
+  const orchestratorRecoveriesByHostKey = orchestratorRestartRecoveriesByHostKey(orchestratorRecoveries);
+  const restartRecoveryHostKeys = new Set(orchestratorRecoveriesByHostKey.keys());
   const controllerBoundEarly = client !== null;
   if (client && !hasStructuredDeliveryController(registry)) {
     await bindStructuredDeliveryQueue([], {
@@ -468,13 +552,19 @@ export async function adoptStructuredHostsAtStartup(
     totalHosts: null,
   });
   await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry);
+  let orchestratorHostKeys = currentOrchestratorRestartRecoveryHostKeys(
+    registry,
+    orchestratorRecoveries,
+    orchestratorSeats(),
+  );
   let nextAdoptedHosts = await revalidateRetainedStartupHosts(
     registry,
     retryAdoptedHosts,
     registry.readOnlySnapshot(),
     orchestratorHostKeys,
+    restartRecoveryHostKeys,
   );
-  retryAdoptedHosts = nextAdoptedHosts;
+  rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   /* Pending work makes a terminal conversation adoption-eligible. Clear any
      provably dead wrapper before that decision so its stale writer fence
      cannot block the startup recovery path. */
@@ -484,7 +574,8 @@ export async function adoptStructuredHostsAtStartup(
     registry,
     signals,
     registry.readOnlySnapshot(),
-    orchestratorHostKeys,
+    orchestratorRecoveriesByHostKey,
+    orchestratorSeats,
   );
   const adoptionCandidates = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
     entry.structuredHost && shouldAdopt(entry));
@@ -537,7 +628,7 @@ export async function adoptStructuredHostsAtStartup(
   );
   completedHosts = Math.max(completedHosts, codexCandidateCount);
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, codex);
-  retryAdoptedHosts = nextAdoptedHosts;
+  rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   reportProgress("adopting Claude hosts");
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     registry,
@@ -578,36 +669,65 @@ export async function adoptStructuredHostsAtStartup(
   );
   completedHosts = Math.max(completedHosts, codexCandidateCount + claudeCandidateCount);
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
-  retryAdoptedHosts = nextAdoptedHosts;
+  rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   reportProgress("reconciling structured hosts");
+  orchestratorHostKeys = currentOrchestratorRestartRecoveryHostKeys(
+    registry,
+    orchestratorRecoveries,
+    orchestratorSeats(),
+  );
+  nextAdoptedHosts = await revalidateRetainedStartupHosts(
+    registry,
+    nextAdoptedHosts,
+    registry.readOnlySnapshot(),
+    orchestratorHostKeys,
+    restartRecoveryHostKeys,
+  );
+  rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   const candidateHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
-  const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) =>
-    candidateHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
+  const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) => {
+    const key = sessionKeyId(entry.key);
+    return restartRecoveryHostKeys.has(key)
+      ? candidateHostKeys.has(key) && shouldAdopt(entry)
+      : candidateHostKeys.has(key) || shouldAdopt(entry);
+  };
   const candidateCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex"
-      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
+      && !restartRecoveryHostKeys.has(sessionKeyId(item.key)),
   );
   const existingCodexContinuations = client
     ? await interruptedCodexContinuations(registry, client, candidateCodexHosts)
     : new Map<string, RuntimeOperationResult>();
   await demoteSkippedStructuredRegistryHosts(registry, shouldRetainCandidateOrAdopt);
   const publicationSnapshot = registry.readOnlySnapshot();
+  orchestratorHostKeys = currentOrchestratorRestartRecoveryHostKeys(
+    registry,
+    orchestratorRecoveries,
+    orchestratorSeats(),
+    publicationSnapshot,
+  );
   nextAdoptedHosts = await revalidateRetainedStartupHosts(
     registry,
     nextAdoptedHosts,
     publicationSnapshot,
     orchestratorHostKeys,
+    restartRecoveryHostKeys,
   );
-  retryAdoptedHosts = nextAdoptedHosts;
+  rememberStructuredStartupRetry(nextAdoptedHosts, orchestratorRecoveries);
   const finalShouldAdopt = structuredStartupAdoptionFilter(
     registry,
     signals,
     publicationSnapshot,
-    orchestratorHostKeys,
+    orchestratorRecoveriesByHostKey,
+    orchestratorSeats,
   );
   const finalHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
-  const shouldPublish: StructuredHostAdoptionFilter = (entry) =>
-    finalHostKeys.has(sessionKeyId(entry.key)) || finalShouldAdopt(entry);
+  const shouldPublish: StructuredHostAdoptionFilter = (entry) => {
+    const key = sessionKeyId(entry.key);
+    return restartRecoveryHostKeys.has(key)
+      ? finalHostKeys.has(key) && finalShouldAdopt(entry)
+      : finalHostKeys.has(key) || finalShouldAdopt(entry);
+  };
   const interruptedCodex = interruptedCodexConversations(
     registry,
     shouldPublish,
@@ -616,7 +736,7 @@ export async function adoptStructuredHostsAtStartup(
   );
   const finalCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex"
-      && !orchestratorHostKeys.has(sessionKeyId(item.key)),
+      && !restartRecoveryHostKeys.has(sessionKeyId(item.key)),
   );
   reportProgress("finalizing structured delivery");
   if (controllerBoundEarly) {
@@ -625,7 +745,13 @@ export async function adoptStructuredHostsAtStartup(
     await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry, client });
   }
   if (client) {
-    await enqueueOrchestratorRestartRecoveries(registry, client, orchestratorRecoveries, finalHostKeys);
+    await enqueueOrchestratorRestartRecoveries(
+      registry,
+      client,
+      orchestratorRecoveries,
+      finalHostKeys,
+      orchestratorSeats,
+    );
     await enqueueInterruptedCodexContinuations(
       registry,
       client,
@@ -639,6 +765,7 @@ export async function adoptStructuredHostsAtStartup(
   if (client) await recoverPendingStructuredSpawns(registry, client);
   adoptedHosts = nextAdoptedHosts;
   retryAdoptedHosts = [];
+  retryOrchestratorRecoveries = [];
   return adoptedHosts;
 }
 


### PR DESCRIPTION
## Summary

- capture durable orchestrator seats that were structured-hosted before viewer startup reconciliation
- re-host current seats through the existing startup adoption path and enqueue one boot-scoped recovery message after host publication
- revalidate seat epoch, canonical conversation, current generation, and hosted registry status at adoption and delivery boundaries
- preserve ordinary busy-host recovery after seat rotation while fencing obsolete seat nudges and releasing terminal seat-only predecessors
- durably hold recovery messages without a runtime client and retry one uncertain admission with the same boot-scoped key

## Verification

- `bunx tsc --noEmit --incremental false`
- `bun test src/lib/runtime/startup.test.ts` — 70 tests, 285 assertions
- `bun scripts/privacy-publication-gate.ts --base 03382cdb78737478e5f618789bd483318c99e597`
- `git diff --check`

Refs #253