### PR TITLE
feat(feed): message provenance — operator, inter-agent, and scaffold rows visually distinct (#1117)

### DIFF
--- a/src/app/api/log/provenance/route.ts
+++ b/src/app/api/log/provenance/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { flowRelayedMessageProvenance } from "@/lib/flows/relayProvenance";
 import { claudeMessageProvenance, type DeliveredMessageProvenance } from "@/lib/runtime/claudeMessageProvenance";
+import { deliveredMessageOccurrences } from "@/lib/runtime/deliveredMessageOccurrences";
+import type { DeliveredMessageOccurrence } from "@/lib/runtime/messageOrigin";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { pathAllowed } from "@/lib/scanner/roots";
 import type { ApiError } from "@/lib/types";
@@ -14,17 +15,17 @@ export interface MessageProvenanceResponse {
       (#1117). Only rows with real delivery evidence appear; the feed keeps
       today's rendering for everything else. */
   messages: Record<string, DeliveredMessageProvenance>;
-  /** Flow-relay authorship keyed by the relayed message's own trimmed text —
-      the join for deliveries that left no per-row evidence (legacy tmux relays
-      on both engines, pre-#1117 structured relays). */
-  relayedTexts: Record<string, DeliveredMessageProvenance>;
+  /** Occurrence evidence for deliveries that left no per-row identity —
+      legacy tmux pastes on both engines, flow relays, pre-#1117 structured
+      sends — each joined by the feed to the ONE row nearest its settlement. */
+  occurrences: DeliveredMessageOccurrence[];
 }
 
 /**
  * Delivery-evidence provenance for one conversation. The `messages` id join is
- * Claude-only (a non-Claude path yields an empty map); the flow-relay text
- * join serves both engines, since a legacy relay's transcript row looks the
- * same on each.
+ * Claude-only (a non-Claude path yields an empty map); the occurrence join
+ * serves both engines, since a legacy paste's transcript row looks the same
+ * on each.
  */
 export function GET(req: NextRequest): NextResponse<MessageProvenanceResponse | ApiError> {
   const rejection = rejectCrossOrigin(req);
@@ -34,7 +35,7 @@ export function GET(req: NextRequest): NextResponse<MessageProvenanceResponse | 
     return NextResponse.json({ error: "path not allowed" }, { status: 403 });
   }
   return NextResponse.json(
-    { messages: claudeMessageProvenance(path), relayedTexts: flowRelayedMessageProvenance(path) },
+    { messages: claudeMessageProvenance(path), occurrences: deliveredMessageOccurrences(path) },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/src/app/api/log/provenance/route.ts
+++ b/src/app/api/log/provenance/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { flowRelayedMessageProvenance } from "@/lib/flows/relayProvenance";
 import { claudeMessageProvenance, type DeliveredMessageProvenance } from "@/lib/runtime/claudeMessageProvenance";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { pathAllowed } from "@/lib/scanner/roots";
@@ -13,12 +14,17 @@ export interface MessageProvenanceResponse {
       (#1117). Only rows with real delivery evidence appear; the feed keeps
       today's rendering for everything else. */
   messages: Record<string, DeliveredMessageProvenance>;
+  /** Flow-relay authorship keyed by the relayed message's own trimmed text —
+      the join for deliveries that left no per-row evidence (legacy tmux relays
+      on both engines, pre-#1117 structured relays). */
+  relayedTexts: Record<string, DeliveredMessageProvenance>;
 }
 
 /**
- * Delivery-ledger provenance for one Claude conversation. Codex needs no
- * endpoint — its authorship rides the structured-user marker in the transcript
- * itself — so a non-Claude path simply answers with an empty map.
+ * Delivery-evidence provenance for one conversation. The `messages` id join is
+ * Claude-only (a non-Claude path yields an empty map); the flow-relay text
+ * join serves both engines, since a legacy relay's transcript row looks the
+ * same on each.
  */
 export function GET(req: NextRequest): NextResponse<MessageProvenanceResponse | ApiError> {
   const rejection = rejectCrossOrigin(req);
@@ -28,7 +34,7 @@ export function GET(req: NextRequest): NextResponse<MessageProvenanceResponse | 
     return NextResponse.json({ error: "path not allowed" }, { status: 403 });
   }
   return NextResponse.json(
-    { messages: claudeMessageProvenance(path) },
+    { messages: claudeMessageProvenance(path), relayedTexts: flowRelayedMessageProvenance(path) },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/src/app/api/log/provenance/route.ts
+++ b/src/app/api/log/provenance/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { claudeMessageProvenance, type DeliveredMessageProvenance } from "@/lib/runtime/claudeMessageProvenance";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { pathAllowed } from "@/lib/scanner/roots";
+import type { ApiError } from "@/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export interface MessageProvenanceResponse {
+  /** Delivered-message authorship keyed by the transcript row's engine uuid
+      (#1117). Only rows with real delivery evidence appear; the feed keeps
+      today's rendering for everything else. */
+  messages: Record<string, DeliveredMessageProvenance>;
+}
+
+/**
+ * Delivery-ledger provenance for one Claude conversation. Codex needs no
+ * endpoint — its authorship rides the structured-user marker in the transcript
+ * itself — so a non-Claude path simply answers with an empty map.
+ */
+export function GET(req: NextRequest): NextResponse<MessageProvenanceResponse | ApiError> {
+  const rejection = rejectCrossOrigin(req);
+  if (rejection) return rejection;
+  const path = req.nextUrl.searchParams.get("path") ?? "";
+  if (!path || !pathAllowed(path)) {
+    return NextResponse.json({ error: "path not allowed" }, { status: 403 });
+  }
+  return NextResponse.json(
+    { messages: claudeMessageProvenance(path) },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/app/api/tasks/[id]/send/route.ts
+++ b/src/app/api/tasks/[id]/send/route.ts
@@ -62,7 +62,10 @@ export async function POST(req: NextRequest, ctx: TaskRouteContext): Promise<Nex
   const outcomes: DeliveryOutcome[] = [];
   for (const targetPath of paths) {
     const entry = byPath.get(targetPath);
-    outcomes.push(await deliverConversationMessage({ pid: entry?.pid ?? null, path: targetPath, text, images: [] }));
+    /* #1117: a task send is the operator's own dispatch, and this route is
+       reachable only from operator surfaces — stamped server-side, like
+       /api/runtime/send, so the delivered card renders as the operator's. */
+    outcomes.push(await deliverConversationMessage({ pid: entry?.pid ?? null, path: targetPath, text, images: [], origin: { kind: "operator" } }));
   }
 
   const at = isoNow();

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -292,6 +292,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
     ...(typeof body.clientMessageId === "string" ? { clientMessageId: body.clientMessageId.slice(0, 128) } : {}),
     text,
     images,
+    ...(origin ? { origin } : {}),
     // The "on resume" profile (issue #241 §4): honored only when this send
     // reopens a finished conversation; a live pane ignores it.
     ...(typeof body.model === "string" ? { resumeModel: body.model } : {}),

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -14,6 +14,7 @@ import { completedFileScan } from "@/lib/scanner/scanCache";
 import { pathAllowed } from "@/lib/scanner/roots";
 import { allowedKillTarget, consumeKillTarget } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { parseMessageOrigin } from "@/lib/runtime/messageOrigin";
 import { materializeStructuredTerminal } from "@/lib/runtime/structuredTerminal";
 import { dispatchStructuredControl } from "@/lib/runtime/structuredControls";
 import {
@@ -263,6 +264,11 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
     return NextResponse.json({ error: "empty message" }, { status: 400 });
   }
 
+  /* #1117: message authorship declared by the caller — the in-process MCP
+     bindings stamp their sends `agent` with the server-attributed sender role.
+     Validated, never defaulted: a send without it stays unattributed. */
+  const origin = parseMessageOrigin((body as { origin?: unknown }).origin);
+
   if (structuredHostsEnabled()) {
     const { enqueueStructuredMessage } = await import("@/lib/runtime/structuredMessageDelivery");
     const structured = await enqueueStructuredMessage({
@@ -271,6 +277,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
       ...(typeof body.clientMessageId === "string" ? { clientMessageId: body.clientMessageId.slice(0, 128) } : {}),
       text: text.trim(),
       images,
+      ...(origin ? { origin } : {}),
     });
     if (structured) {
       const { status, ...response } = structured.ok ? { ...structured, status: 200 } : structured;

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -372,10 +372,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      empty conversation. */
   useToolActivityCues(feed.items, memoryKey, tailPath, tail.linesStart + tail.lines.length, Boolean(file) && !tail.loading);
   /* Delivered-message authorship (#1117): joins the Claude delivery ledger by
-     engine message id server-side, and the flow store's relayed texts on both
-     engines, resolving a delivered "system" row or a legacy relay paste into
-     the operator's bubble or the internal relay card at render time. Codex
-     structured rows carry their authorship in the transcript marker instead. */
+     engine message id server-side, and on both engines joins each settled
+     delivery occurrence (registry receipt or flow round: content digest,
+     settlement time, sender) to the one row nearest it, resolving a delivered
+     "system" row or a legacy paste into the operator's bubble or the internal
+     relay card at render time. Codex structured rows carry their authorship in
+     the transcript marker instead. */
   const provenanceLookup = useDeliveredMessageProvenance(
     file?.engine === "claude" || file?.engine === "codex" ? tailPath : null,
     feed.items,

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -36,6 +36,7 @@ import {
 } from "./conversation/outbox";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
+import { MessageProvenanceProvider, useDeliveredMessageProvenance } from "./feed/messageProvenance";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
 import { BoundedLru } from "./feed/scrollMemory";
 import { ConversationAttention } from "./runtime/ConversationAttention";
@@ -370,6 +371,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      loading gates the baseline so an unloaded feed is not mistaken for an
      empty conversation. */
   useToolActivityCues(feed.items, memoryKey, tailPath, tail.linesStart + tail.lines.length, Boolean(file) && !tail.loading);
+  /* Delivered-message authorship (#1117), Claude only: joins the delivery
+     ledger by engine message id server-side and resolves a delivered "system"
+     row into the operator's bubble or the internal relay card at render time.
+     Codex rows carry their authorship in the transcript marker instead. */
+  const provenanceLookup = useDeliveredMessageProvenance(file?.engine === "claude" ? tailPath : null, feed.items);
   const hiddenLocal = Math.max(0, feed.items.length - visibleCount);
   const visibleItems = hiddenLocal ? feed.items.slice(-visibleCount) : feed.items;
   const visibleStartIndex = feed.items.length - visibleItems.length;
@@ -484,12 +490,15 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      visible. The counts carry that occurrence information. */
   /* The launch's own first message identity (issue #648): a structured / MCP
      spawn journals its first user record with SDK / agent provenance, so the
-     transcript parser renders it as a SYSTEM row, not a `user` bubble — the
+     transcript parser CLASSIFIES it as a system row, not a `user` item — the
      echo-text retirement path would never see it. Its text is still the launch
      prompt's transcript echo, so treat a system-row row that matches a
      launch-owned bubble's own text (raw draft OR scaffolded echo) as that
      bubble's echo. Derived from the outbox so it survives adoption (which strips
-     the launch prompt fields from the server projection). */
+     the launch prompt fields from the server projection). Since #1117 the
+     RENDERER may resolve that same row into the operator's bubble or an
+     internal relay card from delivery evidence; the parse-level kind — what
+     everything here keys on — is unchanged. */
   const launchEchoKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const entry of outbox) {
@@ -506,9 +515,13 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     return feed.items.flatMap(({ anchorKey, key, item }) => {
       const text = "text" in item ? item.text : "";
       if (!text.trim()) return [];
-      /* A genuine user bubble is always an echo; a non-user row only echoes the
-         launch when it exactly carries a launch-owned bubble's own identity. */
-      if (item.kind !== "user" && !launchEchoKeys.has(text.trim())) return [];
+      /* A genuine user bubble is always an echo, and so is a delivered
+         structured message (#1117): the system-kind row carrying a ledger join
+         identity IS the send's transcript echo, whatever the renderer resolves
+         it into. Any other non-user row only echoes the launch when it exactly
+         carries a launch-owned bubble's own identity. */
+      const deliveredEcho = item.kind === "sysmsg" && Boolean(item.deliveredMessage);
+      if (item.kind !== "user" && !deliveredEcho && !launchEchoKeys.has(text.trim())) return [];
       return [{ generation: transcriptGeneration, id: anchorKey ?? `key:${key}`, text }];
     });
   }, [feed.items, transcriptGeneration, launchEchoKeys]);
@@ -555,7 +568,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho, launch?.initialMessage, launch?.deliveredAt, launch?.error, launchOwner, launchOwnsThisPane]);
   /* Settle the launch bubble from the delivery receipt the server projects
      (issue #648), independent of any transcript echo. A structured / MCP spawn's
-     first message is journaled as a system row (SDK / agent provenance), so echo
+     first message is journaled with SDK / agent provenance and parses as a
+     system-kind row (#1117 resolves its VISUAL at render time), so echo
      retirement can never fire; the delivered receipt is the proof the prompt
      reached the agent. It settles the bubble to `delivered` with the receipt time
      as `settledAt`, so it retires on the delivered TTL instead of spinning on
@@ -638,6 +652,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
 
   return (
     <RawLineProvider value={getRawLine}>
+    <MessageProvenanceProvider value={provenanceLookup}>
     <div className="flex min-h-0 flex-1 flex-col">
     {/* The pill anchors to the scroller wrapper — NOT the pane column — so the
         pinned status bar below is structurally outside its overlay area. */}
@@ -827,6 +842,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       <TurnStatusBar file={file} workingLabel={working.label} workingIcon={working.icon} compact={compact} />
     ) : null}
     </div>
+    </MessageProvenanceProvider>
     </RawLineProvider>
   );
 }

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -371,11 +371,15 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      loading gates the baseline so an unloaded feed is not mistaken for an
      empty conversation. */
   useToolActivityCues(feed.items, memoryKey, tailPath, tail.linesStart + tail.lines.length, Boolean(file) && !tail.loading);
-  /* Delivered-message authorship (#1117), Claude only: joins the delivery
-     ledger by engine message id server-side and resolves a delivered "system"
-     row into the operator's bubble or the internal relay card at render time.
-     Codex rows carry their authorship in the transcript marker instead. */
-  const provenanceLookup = useDeliveredMessageProvenance(file?.engine === "claude" ? tailPath : null, feed.items);
+  /* Delivered-message authorship (#1117): joins the Claude delivery ledger by
+     engine message id server-side, and the flow store's relayed texts on both
+     engines, resolving a delivered "system" row or a legacy relay paste into
+     the operator's bubble or the internal relay card at render time. Codex
+     structured rows carry their authorship in the transcript marker instead. */
+  const provenanceLookup = useDeliveredMessageProvenance(
+    file?.engine === "claude" || file?.engine === "codex" ? tailPath : null,
+    feed.items,
+  );
   const hiddenLocal = Math.max(0, feed.items.length - visibleCount);
   const visibleItems = hiddenLocal ? feed.items.slice(-visibleCount) : feed.items;
   const visibleStartIndex = feed.items.length - visibleItems.length;

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1955,6 +1955,9 @@ export function TmuxComposerCore({
               idempotencyKey: clientMessageId,
               clientMessageId,
               images: sentImages.map((image) => ({ base64: image.base64, mime: image.mime })),
+              /* #1117: the composer is the operator's own surface; the
+                 structured branch above is stamped server-side by /api/runtime/send. */
+              origin: { kind: "operator" },
               /* The "on resume" profile (issue #241 §4): when this send reopens a
                  finished root conversation, boot it with the model/effort the
                  strip's picker saved. Ignored for a live pane or a subagent relay. */

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -9,6 +9,7 @@ import { SelectedContextBadge } from "../SelectedContextBadge";
 import { CopyButton } from "./CopyButton";
 import { InboxImageCard } from "./InboxImage";
 import { md, mdBlocks } from "./markdown";
+import { useMessageProvenance, type ProvenanceLookup } from "./messageProvenance";
 import { tr, type Item } from "./parse";
 import { BlobCard } from "./cards/BlobCard";
 import { CmdGroupCard } from "./cards/CmdGroupCard";
@@ -24,10 +25,44 @@ import { WakeupCard } from "./cards/WakeupCard";
 import { SpeakButton } from "./SpeakButton";
 import { McpCallCard } from "../runtime/McpCallCard";
 
+/**
+ * Resolves a delivered Claude system row (#1117) with ledger evidence: an
+ * operator-authored delivery becomes the operator's own bubble, an inter-agent
+ * relay becomes the internal card naming the sender role. No evidence — no
+ * provider, unknown id, scaffold row — keeps the system row untouched.
+ */
+function resolveDeliveredItem(item: Item, provenance: ProvenanceLookup): Item {
+  if (item.kind !== "sysmsg" || !item.deliveredMessage) return item;
+  const resolved = provenance(item.deliveredMessage.engineMessageId);
+  if (resolved?.origin === "operator") {
+    return {
+      kind: "user",
+      ts: item.deliveredMessage.ts,
+      text: item.text,
+      ...(resolved.selectedContext ? { selectedContext: resolved.selectedContext } : {}),
+    };
+  }
+  if (resolved?.origin === "agent") {
+    return {
+      kind: "tmsg",
+      ts: item.deliveredMessage.ts,
+      dir: "in",
+      peer: resolved.senderRole ?? tr("render.agentPeer"),
+      summary: "",
+      text: item.text,
+      internal: true,
+    };
+  }
+  return item;
+}
+
 /* Memoized: feed items are immutable after buildFeed, so a pane re-render
    (poll tick, camera state, files refresh) skips re-parsing markdown for
-   every message that did not change. */
-export const FeedItem = memo(function FeedItem({ item, speakText }: { item: Item; speakText?: string }) {
+   every message that did not change. The provenance lookup arrives by context,
+   so a resolved map re-renders exactly the memoized consumers. */
+export const FeedItem = memo(function FeedItem({ item: sourceItem, speakText }: { item: Item; speakText?: string }) {
+  const provenance = useMessageProvenance();
+  const item = resolveDeliveredItem(sourceItem, provenance);
   if (item.kind === "image") return <ImageCard media={item.media} data={item.data} w={item.w} h={item.h} bytes={item.bytes} />;
   if (item.kind === "inbox-image") return <InboxImageCard name={item.name} path={item.path} />;
   if (item.kind === "blob") return <BlobCard bytes={item.bytes} text={item.text} />;
@@ -151,6 +186,14 @@ export const FeedItem = memo(function FeedItem({ item, speakText }: { item: Item
           <span className="flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
             <Mail className="h-3.5 w-3.5" aria-hidden />
           </span>
+          {/* #1117: an MCP/structured relay says outright that it is internal
+              traffic, and the peer pill names the sender ROLE, so the operator
+              never mistakes it for their own words or for scaffold. */}
+          {item.internal ? (
+            <span className="rounded-full border border-accent/40 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-accent">
+              {tr("render.internalTag")}
+            </span>
+          ) : null}
           <span className="text-[11px] font-semibold text-muted">{item.dir === "out" ? tr("render.toDir") : tr("render.fromDir")}</span>
           <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[11px] font-bold text-accent">{item.peer}</span>
           {item.delivery ? (

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -26,14 +26,24 @@ import { SpeakButton } from "./SpeakButton";
 import { McpCallCard } from "../runtime/McpCallCard";
 
 /**
- * Resolves a delivered Claude system row (#1117) with ledger evidence: an
- * operator-authored delivery becomes the operator's own bubble, an inter-agent
- * relay becomes the internal card naming the sender role. No evidence — no
- * provider, unknown id, scaffold row — keeps the system row untouched.
+ * Resolves a row with delivery evidence (#1117). A delivered Claude system row
+ * joins the ledger by engine message id — operator evidence becomes the
+ * operator's own bubble, agent evidence the internal card naming the sender
+ * role — and falls back to the flow-relay text join for pre-#1117 structured
+ * relays. A plain user bubble (a legacy tmux paste on either engine) becomes
+ * the internal card only when the flow store proves its exact text was a
+ * relayed round. No evidence — no provider, unknown id, scaffold row, the
+ * operator's own words — keeps the row untouched.
  */
 function resolveDeliveredItem(item: Item, provenance: ProvenanceLookup): Item {
+  if (item.kind === "user") {
+    /* A selected-context capture exists only on operator composer sends. */
+    if (item.selectedContext) return item;
+    const relayed = provenance.byText(item.text);
+    return relayed?.origin === "agent" ? internalCard(item.ts, item.text, relayed.senderRole) : item;
+  }
   if (item.kind !== "sysmsg" || !item.deliveredMessage) return item;
-  const resolved = provenance(item.deliveredMessage.engineMessageId);
+  const resolved = provenance.byId(item.deliveredMessage.engineMessageId) ?? provenance.byText(item.text);
   if (resolved?.origin === "operator") {
     return {
       kind: "user",
@@ -42,18 +52,20 @@ function resolveDeliveredItem(item: Item, provenance: ProvenanceLookup): Item {
       ...(resolved.selectedContext ? { selectedContext: resolved.selectedContext } : {}),
     };
   }
-  if (resolved?.origin === "agent") {
-    return {
-      kind: "tmsg",
-      ts: item.deliveredMessage.ts,
-      dir: "in",
-      peer: resolved.senderRole ?? tr("render.agentPeer"),
-      summary: "",
-      text: item.text,
-      internal: true,
-    };
-  }
+  if (resolved?.origin === "agent") return internalCard(item.deliveredMessage.ts, item.text, resolved.senderRole);
   return item;
+}
+
+function internalCard(ts: unknown, text: string, senderRole: string | undefined): Item {
+  return {
+    kind: "tmsg",
+    ts,
+    dir: "in",
+    peer: senderRole ?? tr("render.agentPeer"),
+    summary: "",
+    text,
+    internal: true,
+  };
 }
 
 /* Memoized: feed items are immutable after buildFeed, so a pane re-render

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -29,21 +29,22 @@ import { McpCallCard } from "../runtime/McpCallCard";
  * Resolves a row with delivery evidence (#1117). A delivered Claude system row
  * joins the ledger by engine message id — operator evidence becomes the
  * operator's own bubble, agent evidence the internal card naming the sender
- * role — and falls back to the flow-relay text join for pre-#1117 structured
- * relays. A plain user bubble (a legacy tmux paste on either engine) becomes
- * the internal card only when the flow store proves its exact text was a
- * relayed round. No evidence — no provider, unknown id, scaffold row, the
- * operator's own words — keeps the row untouched.
+ * role — and otherwise the occurrence join (pre-#1117 structured relays). A
+ * plain user bubble (a legacy tmux paste on either engine) becomes the
+ * internal card only when a settled agent delivery is joined to THIS row —
+ * same text, nearest its settlement time — so an operator's own message that
+ * repeats a relay's words stays the operator's. No evidence — no provider,
+ * unknown id, scaffold row, the operator's own words — keeps the row untouched.
  */
 function resolveDeliveredItem(item: Item, provenance: ProvenanceLookup): Item {
   if (item.kind === "user") {
     /* A selected-context capture exists only on operator composer sends. */
     if (item.selectedContext) return item;
-    const relayed = provenance.byText(item.text);
-    return relayed?.origin === "agent" ? internalCard(item.ts, item.text, relayed.senderRole) : item;
+    const resolved = provenance.forItem(item);
+    return resolved?.origin === "agent" ? internalCard(item.ts, item.text, resolved.senderRole) : item;
   }
   if (item.kind !== "sysmsg" || !item.deliveredMessage) return item;
-  const resolved = provenance.byId(item.deliveredMessage.engineMessageId) ?? provenance.byText(item.text);
+  const resolved = provenance.forItem(item);
   if (resolved?.origin === "operator") {
     return {
       kind: "user",

--- a/src/components/feed/deliveredOccurrences.test.ts
+++ b/src/components/feed/deliveredOccurrences.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+
+import type { DeliveredMessageOccurrence } from "@/lib/runtime/messageOrigin";
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
+
+import { assignDeliveredOccurrences, OCCURRENCE_WINDOW_MS } from "./deliveredOccurrences";
+import type { Item } from "./parse";
+
+/**
+ * The occurrence join is what keeps #1117 honest about authorship: evidence
+ * attaches to the one row its delivery produced, never to every row sharing
+ * the text.
+ */
+
+const RELAY_TEXT = "Review round findings are below.\n\nP1 — the held command drops its origin.";
+const RELAY_DIGEST = messageTextDigest(RELAY_TEXT);
+const T0 = Date.parse("2026-08-24T09:00:00.000Z");
+const iso = (offsetMs: number) => new Date(T0 + offsetMs).toISOString();
+
+function user(offsetMs: number, text = RELAY_TEXT): Item {
+  return { kind: "user", ts: iso(offsetMs), text };
+}
+
+function relay(offsetMs: number, senderRole = "reviewer"): DeliveredMessageOccurrence {
+  return { textDigest: RELAY_DIGEST, deliveredAt: iso(offsetMs), origin: "agent", senderRole };
+}
+
+test("an occurrence claims the nearest-in-time row with its text and leaves an identical row alone", () => {
+  const relayRow = user(500);
+  const operatorRow = user(3 * 60_000);
+  const assigned = assignDeliveredOccurrences([relayRow, operatorRow], [relay(0)]);
+  expect(assigned.get(relayRow)).toEqual({ origin: "agent", senderRole: "reviewer" });
+  expect(assigned.has(operatorRow)).toBe(false);
+  /* Mirrored order: the operator's identical message came first. */
+  const earlierOperator = user(-3 * 60_000);
+  const laterRelay = user(500);
+  const mirrored = assignDeliveredOccurrences([earlierOperator, laterRelay], [relay(0)]);
+  expect(mirrored.has(earlierOperator)).toBe(false);
+  expect(mirrored.get(laterRelay)).toEqual({ origin: "agent", senderRole: "reviewer" });
+});
+
+test("two deliveries of the same text claim two rows in settlement order, one each", () => {
+  const first = user(1_000);
+  const second = user(60_000 + 1_000);
+  const assigned = assignDeliveredOccurrences([first, second], [relay(60_000, "orchestrator"), relay(0, "reviewer")]);
+  expect(assigned.get(first)).toEqual({ origin: "agent", senderRole: "reviewer" });
+  expect(assigned.get(second)).toEqual({ origin: "agent", senderRole: "orchestrator" });
+  /* A third occurrence with no row left over claims nothing. */
+  const overflow = assignDeliveredOccurrences([first], [relay(0), relay(2_000)]);
+  expect(overflow.size).toBe(1);
+});
+
+test("a row outside the settlement window, without a timestamp, or with other text is never claimed", () => {
+  const farRow = user(OCCURRENCE_WINDOW_MS + 1_000);
+  const untimed: Item = { kind: "user", ts: undefined, text: RELAY_TEXT };
+  const otherText = user(100, "ship it once the checks pass");
+  const assigned = assignDeliveredOccurrences([farRow, untimed, otherText], [relay(0)]);
+  expect(assigned.size).toBe(0);
+  const edge = user(OCCURRENCE_WINDOW_MS);
+  expect(assignDeliveredOccurrences([edge], [relay(0)]).has(edge)).toBe(true);
+});
+
+test("rows the parser or ledger already attributed consume their occurrence so it cannot drift", () => {
+  const structuredRelay: Item = { kind: "tmsg", ts: iso(200), dir: "in", peer: "reviewer", summary: "", text: RELAY_TEXT, internal: true };
+  const operatorRepeat = user(40_000);
+  const assigned = assignDeliveredOccurrences([structuredRelay, operatorRepeat], [relay(0)]);
+  expect(assigned.has(structuredRelay)).toBe(true);
+  expect(assigned.has(operatorRepeat)).toBe(false);
+  const deliveredRow: Item = {
+    kind: "sysmsg",
+    label: "system",
+    text: RELAY_TEXT,
+    deliveredMessage: { engineMessageId: null, ts: iso(300) },
+  };
+  expect(assignDeliveredOccurrences([deliveredRow, operatorRepeat], [relay(0)]).has(deliveredRow)).toBe(true);
+});
+
+test("scaffold rows never take part, and the verbatim text matches when only trimming differs", () => {
+  const scaffold: Item = { kind: "sysmsg", label: "system", text: RELAY_TEXT };
+  const paddedRow = user(100, `${RELAY_TEXT}\n`);
+  const verbatim: DeliveredMessageOccurrence = { ...relay(0), textDigest: messageTextDigest(`${RELAY_TEXT}\n`) };
+  expect(assignDeliveredOccurrences([scaffold], [relay(0)]).size).toBe(0);
+  expect(assignDeliveredOccurrences([paddedRow], [relay(0)]).has(paddedRow)).toBe(true);
+  expect(assignDeliveredOccurrences([paddedRow], [verbatim]).has(paddedRow)).toBe(true);
+  expect(assignDeliveredOccurrences([paddedRow], []).size).toBe(0);
+  const corruptTime: DeliveredMessageOccurrence = { ...relay(0), deliveredAt: "when?" };
+  expect(assignDeliveredOccurrences([paddedRow], [corruptTime]).size).toBe(0);
+});

--- a/src/components/feed/deliveredOccurrences.ts
+++ b/src/components/feed/deliveredOccurrences.ts
@@ -1,0 +1,121 @@
+import type { DeliveredMessageOccurrence, DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
+
+import type { Item } from "./parse";
+
+/*
+ * The occurrence join of #1117: attaches each delivered-message occurrence
+ * (content digest + settlement time + authorship) to exactly ONE transcript
+ * row — the unclaimed row carrying the same text whose timestamp lies nearest
+ * the settlement — so evidence never fans out over every row that happens to
+ * repeat a text. Two identical rows, a relay and the operator's own message,
+ * resolve by time: the occurrence claims the row its delivery produced, and
+ * the other keeps today's rendering.
+ *
+ * Pure: the hook memoizes over it, and the tests drive it directly.
+ */
+
+/** How far a transcript row's timestamp may sit from its delivery's settlement.
+    A legacy paste into a pane that first has to resume its session lands
+    seconds after the receipt; nearest-wins inside this window keeps an
+    identical row minutes away from ever being mistaken for it. */
+export const OCCURRENCE_WINDOW_MS = 10 * 60 * 1000;
+
+export interface OccurrenceCandidate {
+  item: Item;
+  text: string;
+  tsMs: number;
+}
+
+/**
+ * The rows a delivery could have produced. Every row that IS a message —
+ * a user bubble, a relay card, a Claude SDK-delivered system row — takes part,
+ * including rows the parser or the ledger already attributed: they consume
+ * their own occurrence, so it can never drift onto a look-alike row. Scaffold
+ * rows carry no timestamped message identity and never take part.
+ */
+export function occurrenceCandidate(item: Item): OccurrenceCandidate | null {
+  let ts: unknown;
+  let text: string;
+  if (item.kind === "user" || item.kind === "tmsg") {
+    ts = item.ts;
+    text = item.text;
+  } else if (item.kind === "sysmsg" && item.deliveredMessage) {
+    ts = item.deliveredMessage.ts;
+    text = item.text;
+  } else {
+    return null;
+  }
+  if (!text.trim()) return null;
+  const tsMs = typeof ts === "string" || typeof ts === "number" ? new Date(ts).getTime() : Number.NaN;
+  if (!Number.isFinite(tsMs)) return null;
+  return { item, text, tsMs };
+}
+
+/* Items are immutable after the parse, so a row's digests are computed once
+   per object for the life of the page. */
+const digestCache = new WeakMap<Item, readonly string[]>();
+
+/** The digests a row can match: its trimmed text (what every admission
+    surface holds) and, when it differs, the verbatim text. */
+export function candidateDigests(candidate: OccurrenceCandidate): readonly string[] {
+  const cached = digestCache.get(candidate.item);
+  if (cached) return cached;
+  const trimmed = candidate.text.trim();
+  const digests = [messageTextDigest(trimmed)];
+  if (trimmed !== candidate.text) digests.push(messageTextDigest(candidate.text));
+  digestCache.set(candidate.item, digests);
+  return digests;
+}
+
+function provenanceOf(occurrence: DeliveredMessageOccurrence): DeliveredMessageProvenance {
+  return {
+    origin: occurrence.origin,
+    ...(occurrence.senderRole ? { senderRole: occurrence.senderRole } : {}),
+    ...(occurrence.selectedContext ? { selectedContext: occurrence.selectedContext } : {}),
+  };
+}
+
+/**
+ * One row per occurrence, nearest-in-time within the window, each row claimed
+ * at most once. Occurrences are visited in settlement order so an earlier
+ * delivery claims the earlier of two look-alike rows.
+ */
+export function assignDeliveredOccurrences(
+  items: Iterable<Item>,
+  occurrences: readonly DeliveredMessageOccurrence[],
+): Map<Item, DeliveredMessageProvenance> {
+  const assigned = new Map<Item, DeliveredMessageProvenance>();
+  if (occurrences.length === 0) return assigned;
+  const byDigest = new Map<string, OccurrenceCandidate[]>();
+  for (const item of items) {
+    const candidate = occurrenceCandidate(item);
+    if (!candidate) continue;
+    for (const digest of candidateDigests(candidate)) {
+      const pool = byDigest.get(digest);
+      if (pool) pool.push(candidate);
+      else byDigest.set(digest, [candidate]);
+    }
+  }
+  if (byDigest.size === 0) return assigned;
+  const ordered = occurrences
+    .map((occurrence) => ({ occurrence, settledMs: Date.parse(occurrence.deliveredAt) }))
+    .filter(({ settledMs }) => Number.isFinite(settledMs))
+    .sort((left, right) => left.settledMs - right.settledMs);
+  for (const { occurrence, settledMs } of ordered) {
+    const pool = byDigest.get(occurrence.textDigest);
+    if (!pool) continue;
+    let best: OccurrenceCandidate | null = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const candidate of pool) {
+      if (assigned.has(candidate.item)) continue;
+      const distance = Math.abs(candidate.tsMs - settledMs);
+      if (distance <= OCCURRENCE_WINDOW_MS && distance < bestDistance) {
+        best = candidate;
+        bestDistance = distance;
+      }
+    }
+    if (best) assigned.set(best.item, provenanceOf(occurrence));
+  }
+  return assigned;
+}

--- a/src/components/feed/messageProvenance.parse.test.tsx
+++ b/src/components/feed/messageProvenance.parse.test.tsx
@@ -123,8 +123,15 @@ const DELIVERED_ROW: Item = {
   deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:01.000Z" },
 };
 
-function renderWithProvenance(item: Item, provenance: Record<string, DeliveredMessageProvenance>): string {
-  const lookup: ProvenanceLookup = (id) => (id ? provenance[id] ?? null : null);
+function renderWithProvenance(
+  item: Item,
+  provenance: Record<string, DeliveredMessageProvenance>,
+  relayedTexts: Record<string, DeliveredMessageProvenance> = {},
+): string {
+  const lookup: ProvenanceLookup = {
+    byId: (id) => (id ? provenance[id] ?? null : null),
+    byText: (text) => relayedTexts[text.trim()] ?? null,
+  };
   return renderToStaticMarkup(
     <MessageProvenanceProvider value={lookup}>
       <FeedItem item={item} />
@@ -160,4 +167,64 @@ test("without evidence the delivered row keeps the current system style", () => 
   const resolved = renderWithProvenance(DELIVERED_ROW, {});
   expect(html).toBe(resolved);
   expect(html).not.toContain("bg-user");
+});
+
+/* The flow-relay text join (#1117 round 2): a legacy tmux relay writes only
+   engine input, so its transcript row is a plain user bubble on both engines.
+   The flow store's reconstruction of the relayed text is the evidence that
+   re-attributes it — and only an exact match ever does. */
+
+const RELAYED_TEXT = "Review round findings are below.\n\nP1 — the held command drops its origin.";
+const RELAYED_EVIDENCE: Record<string, DeliveredMessageProvenance> = {
+  [RELAYED_TEXT]: { origin: "agent", senderRole: "reviewer" },
+};
+
+test("a claude legacy relay paste resolves into the internal card through the text join", () => {
+  setLocale("en");
+  const items = claudeItems([JSON.stringify({
+    type: "user",
+    timestamp: "2026-07-31T09:00:02.000Z",
+    message: { role: "user", content: RELAYED_TEXT },
+  })]);
+  const row = items.find((item) => item.kind === "user");
+  expect(row).toBeDefined();
+  const html = renderWithProvenance(row!, {}, RELAYED_EVIDENCE);
+  expect(html).toContain("internal");
+  expect(html).toContain("reviewer");
+  expect(html).not.toContain("bg-user");
+});
+
+test("a codex legacy relay paste resolves into the internal card through the text join", () => {
+  setLocale("en");
+  const items = codexItems([codexUserLine(RELAYED_TEXT)]);
+  const row = items.find((item) => item.kind === "user");
+  expect(row).toBeDefined();
+  const html = renderWithProvenance(row!, {}, RELAYED_EVIDENCE);
+  expect(html).toContain("internal");
+  expect(html).toContain("reviewer");
+  expect(html).not.toContain("bg-user");
+});
+
+test("an operator bubble with different text never matches the relay evidence", () => {
+  setLocale("en");
+  const html = renderWithProvenance(
+    { kind: "user", ts: "2026-07-31T09:00:03.000Z", text: "ship it once the checks pass" },
+    {},
+    RELAYED_EVIDENCE,
+  );
+  expect(html).toContain("bg-user");
+  expect(html).not.toContain("internal");
+});
+
+test("a delivered row whose ledger id never resolved falls back to the relay text join", () => {
+  setLocale("en");
+  const historicalRelay: Item = {
+    kind: "sysmsg",
+    label: "system",
+    text: RELAYED_TEXT,
+    deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:04.000Z" },
+  };
+  const html = renderWithProvenance(historicalRelay, {}, RELAYED_EVIDENCE);
+  expect(html).toContain("internal");
+  expect(html).toContain("reviewer");
 });

--- a/src/components/feed/messageProvenance.parse.test.tsx
+++ b/src/components/feed/messageProvenance.parse.test.tsx
@@ -3,10 +3,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { setLocale } from "@/lib/i18n";
 import { encodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
-import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import type { DeliveredMessageOccurrence, DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
 
 import { FeedItem } from "./FeedItem";
-import { MessageProvenanceProvider, type ProvenanceLookup } from "./messageProvenance";
+import { MessageProvenanceProvider, provenanceLookupFor } from "./messageProvenance";
 import { createFeedSession, type Item } from "./parse";
 
 /**
@@ -14,29 +15,33 @@ import { createFeedSession, type Item } from "./parse";
  * renderer: the operator's message is the operator's bubble, an inter-agent
  * relay is the visibly labelled internal card naming the sender role, and true
  * scaffold keeps the system row. Codex carries authorship in the structured
- * marker; Claude joins the delivery ledger through the provenance context.
+ * marker; Claude joins the delivery ledger through the provenance context; a
+ * delivery that left no per-row identity on either engine joins by occurrence.
  */
 
 /* Assembled from parts so the invented id can never fingerprint as a real
    engine message identifier on the publication gate. */
 const ENGINE_MESSAGE_ID = ["11111111", "2222", "4333", "8444", "555555555555"].join("-");
 
+const T0 = Date.parse("2026-07-31T09:00:00.000Z");
+const at = (offsetMs: number) => new Date(T0 + offsetMs).toISOString();
+
 function codexItems(lines: string[]): Item[] {
   const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
   return session.feed(lines, 0, false).items.map((entry) => entry.item);
 }
 
-function codexUserLine(recordText: string): string {
+function codexUserLine(recordText: string, timestamp = at(1_000)): string {
   return JSON.stringify({
-    timestamp: "2026-07-31T09:00:01.000Z",
+    timestamp,
     type: "response_item",
     payload: { type: "message", role: "user", content: [{ type: "input_text", text: recordText }] },
   });
 }
 
-function codexEventLine(recordText: string): string {
+function codexEventLine(recordText: string, timestamp = at(1_000)): string {
   return JSON.stringify({
-    timestamp: "2026-07-31T09:00:01.000Z",
+    timestamp,
     type: "event_msg",
     payload: { type: "user_message", message: recordText },
   });
@@ -47,6 +52,11 @@ function claudeItems(lines: string[]): Item[] {
   return session.feed(lines, 0, false).items.map((entry) => entry.item);
 }
 
+/** A legacy tmux paste on Claude: a plain user row with no SDK provenance. */
+function claudeUserLine(text: string, timestamp = at(1_000)): string {
+  return JSON.stringify({ type: "user", timestamp, message: { role: "user", content: text } });
+}
+
 test("a codex agent-origin record renders as the internal relay card, not a user bubble", () => {
   const items = codexItems([
     codexUserLine(encodeCodexStructuredUserText("Implement issue #12 in this worktree.", undefined, null, { kind: "agent", role: "orchestrator" })),
@@ -55,7 +65,7 @@ test("a codex agent-origin record renders as the internal relay card, not a user
   const relay = items.find((item) => item.kind === "tmsg");
   expect(relay).toEqual({
     kind: "tmsg",
-    ts: "2026-07-31T09:00:01.000Z",
+    ts: at(1_000),
     dir: "in",
     peer: "orchestrator",
     summary: "",
@@ -92,14 +102,14 @@ test("a claude SDK-delivered message parses as a system row carrying its ledger 
   const items = claudeItems([JSON.stringify({
     type: "user",
     uuid: ENGINE_MESSAGE_ID,
-    timestamp: "2026-07-31T09:00:01.000Z",
+    timestamp: at(1_000),
     promptSource: "sdk",
     message: { role: "user", content: [{ type: "text", text: "please rerun the failing check" }] },
   })]);
   const row = items.find((item) => item.kind === "sysmsg");
   expect(row!.kind === "sysmsg" && row!.deliveredMessage).toEqual({
     engineMessageId: ENGINE_MESSAGE_ID,
-    ts: "2026-07-31T09:00:01.000Z",
+    ts: at(1_000),
   });
 });
 
@@ -120,30 +130,32 @@ const DELIVERED_ROW: Item = {
   kind: "sysmsg",
   label: "system",
   text: "please rerun the failing check",
-  deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:01.000Z" },
+  deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: at(1_000) },
 };
 
-function renderWithProvenance(
-  item: Item,
-  provenance: Record<string, DeliveredMessageProvenance>,
-  relayedTexts: Record<string, DeliveredMessageProvenance> = {},
-): string {
-  const lookup: ProvenanceLookup = {
-    byId: (id) => (id ? provenance[id] ?? null : null),
-    byText: (text) => relayedTexts[text.trim()] ?? null,
-  };
-  return renderToStaticMarkup(
+interface Evidence {
+  messages?: Record<string, DeliveredMessageProvenance>;
+  occurrences?: DeliveredMessageOccurrence[];
+}
+
+/** Renders every row of one feed under the lookup the hook would build from
+    this evidence, so the occurrence join sees the whole window. */
+function renderAll(items: Item[], evidence: Evidence): string[] {
+  const lookup = provenanceLookupFor(evidence, items);
+  return items.map((item) => renderToStaticMarkup(
     <MessageProvenanceProvider value={lookup}>
       <FeedItem item={item} />
     </MessageProvenanceProvider>,
-  );
+  ));
+}
+
+function renderWithProvenance(item: Item, evidence: Evidence): string {
+  return renderAll([item], evidence)[0];
 }
 
 test("ledger evidence resolves a delivered row into the operator's own bubble", () => {
   setLocale("en");
-  const html = renderWithProvenance(DELIVERED_ROW, {
-    [ENGINE_MESSAGE_ID]: { origin: "operator" },
-  });
+  const html = renderWithProvenance(DELIVERED_ROW, { messages: { [ENGINE_MESSAGE_ID]: { origin: "operator" } } });
   expect(html).toContain("bg-user");
   expect(html).toContain("please rerun the failing check");
   expect(html).not.toContain("system");
@@ -152,7 +164,7 @@ test("ledger evidence resolves a delivered row into the operator's own bubble", 
 test("ledger evidence resolves a delivered row into the internal card naming the sender role", () => {
   setLocale("en");
   const html = renderWithProvenance(DELIVERED_ROW, {
-    [ENGINE_MESSAGE_ID]: { origin: "agent", senderRole: "orchestrator" },
+    messages: { [ENGINE_MESSAGE_ID]: { origin: "agent", senderRole: "orchestrator" } },
   });
   expect(html).toContain("internal");
   expect(html).toContain("orchestrator");
@@ -169,62 +181,138 @@ test("without evidence the delivered row keeps the current system style", () => 
   expect(html).not.toContain("bg-user");
 });
 
-/* The flow-relay text join (#1117 round 2): a legacy tmux relay writes only
+/* The occurrence join (#1117 rounds 2–3): a legacy tmux paste writes only
    engine input, so its transcript row is a plain user bubble on both engines.
-   The flow store's reconstruction of the relayed text is the evidence that
-   re-attributes it — and only an exact match ever does. */
+   The delivery's own settled receipt — content digest, settlement time, the
+   origin stamped at admission — is the evidence that re-attributes it, and it
+   attaches to exactly one row: the one nearest the settlement. */
 
+const MANDATE = "Implement issue #12 in this worktree, then report back.";
 const RELAYED_TEXT = "Review round findings are below.\n\nP1 — the held command drops its origin.";
-const RELAYED_EVIDENCE: Record<string, DeliveredMessageProvenance> = {
-  [RELAYED_TEXT]: { origin: "agent", senderRole: "reviewer" },
-};
 
-test("a claude legacy relay paste resolves into the internal card through the text join", () => {
+function occurrence(text: string, deliveredAt: string, provenance: DeliveredMessageProvenance): DeliveredMessageOccurrence {
+  return { textDigest: messageTextDigest(text), deliveredAt, ...provenance };
+}
+
+test("a generic legacy MCP send into a tmux-owned claude conversation renders as the internal card naming the sender role", () => {
   setLocale("en");
-  const items = claudeItems([JSON.stringify({
-    type: "user",
-    timestamp: "2026-07-31T09:00:02.000Z",
-    message: { role: "user", content: RELAYED_TEXT },
-  })]);
-  const row = items.find((item) => item.kind === "user");
-  expect(row).toBeDefined();
-  const html = renderWithProvenance(row!, {}, RELAYED_EVIDENCE);
+  const items = claudeItems([claudeUserLine(MANDATE, at(1_000))]);
+  expect(items.find((item) => item.kind === "user")).toBeDefined();
+  const [html] = renderAll(items, {
+    occurrences: [occurrence(MANDATE, at(0), { origin: "agent", senderRole: "orchestrator" })],
+  });
   expect(html).toContain("internal");
-  expect(html).toContain("reviewer");
+  expect(html).toContain("orchestrator");
+  expect(html).toContain("Implement issue #12");
   expect(html).not.toContain("bg-user");
 });
 
-test("a codex legacy relay paste resolves into the internal card through the text join", () => {
+test("a generic legacy MCP send into a tmux-owned codex conversation renders as the internal card naming the sender role", () => {
   setLocale("en");
-  const items = codexItems([codexUserLine(RELAYED_TEXT)]);
-  const row = items.find((item) => item.kind === "user");
-  expect(row).toBeDefined();
-  const html = renderWithProvenance(row!, {}, RELAYED_EVIDENCE);
+  const items = codexItems([codexUserLine(MANDATE, at(1_000)), codexEventLine(MANDATE, at(1_200))]);
+  expect(items.filter((item) => item.kind === "user")).toHaveLength(1);
+  const [html] = renderAll(items, {
+    occurrences: [occurrence(MANDATE, at(0), { origin: "agent", senderRole: "orchestrator" })],
+  });
   expect(html).toContain("internal");
-  expect(html).toContain("reviewer");
+  expect(html).toContain("orchestrator");
   expect(html).not.toContain("bg-user");
 });
 
-test("an operator bubble with different text never matches the relay evidence", () => {
+test("a legacy operator send keeps the operator's bubble on both engines", () => {
   setLocale("en");
-  const html = renderWithProvenance(
-    { kind: "user", ts: "2026-07-31T09:00:03.000Z", text: "ship it once the checks pass" },
-    {},
-    RELAYED_EVIDENCE,
-  );
+  const evidence: Evidence = { occurrences: [occurrence("what is left on the branch?", at(0), { origin: "operator" })] };
+  for (const items of [
+    claudeItems([claudeUserLine("what is left on the branch?", at(1_000))]),
+    codexItems([codexUserLine("what is left on the branch?", at(1_000))]),
+  ]) {
+    const [html] = renderAll(items, evidence);
+    expect(html).toContain("bg-user");
+    expect(html).not.toContain("internal");
+  }
+});
+
+test("two identical rows — a relay and the operator's own message — resolve by settlement time on claude", () => {
+  setLocale("en");
+  const relayEvidence: Evidence = { occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })] };
+  /* The relay landed first; the operator repeated its text minutes later. */
+  const relayFirst = claudeItems([claudeUserLine(RELAYED_TEXT, at(1_000)), claudeUserLine(RELAYED_TEXT, at(4 * 60_000))]);
+  const [relay, operator] = renderAll(relayFirst, relayEvidence);
+  expect(relay).toContain("internal");
+  expect(relay).toContain("reviewer");
+  expect(operator).toContain("bg-user");
+  expect(operator).not.toContain("internal");
+  /* Mirrored: the operator said it first, the relay repeated it. */
+  const operatorFirst = claudeItems([claudeUserLine(RELAYED_TEXT, at(-4 * 60_000)), claudeUserLine(RELAYED_TEXT, at(1_000))]);
+  const [earlier, later] = renderAll(operatorFirst, relayEvidence);
+  expect(earlier).toContain("bg-user");
+  expect(earlier).not.toContain("internal");
+  expect(later).toContain("internal");
+});
+
+test("two identical rows — a relay and the operator's own message — resolve by settlement time on codex", () => {
+  setLocale("en");
+  const relayEvidence: Evidence = { occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })] };
+  const relayFirst = codexItems([
+    codexUserLine(RELAYED_TEXT, at(1_000)),
+    codexEventLine(RELAYED_TEXT, at(1_100)),
+    codexUserLine(RELAYED_TEXT, at(4 * 60_000)),
+    codexEventLine(RELAYED_TEXT, at(4 * 60_000 + 100)),
+  ]);
+  expect(relayFirst.filter((item) => item.kind === "user")).toHaveLength(2);
+  const [relay, operator] = renderAll(relayFirst, relayEvidence);
+  expect(relay).toContain("internal");
+  expect(relay).toContain("reviewer");
+  expect(operator).toContain("bg-user");
+  expect(operator).not.toContain("internal");
+  const operatorFirst = codexItems([
+    codexUserLine(RELAYED_TEXT, at(-4 * 60_000)),
+    codexUserLine(RELAYED_TEXT, at(1_000)),
+  ]);
+  const [earlier, later] = renderAll(operatorFirst, relayEvidence);
+  expect(earlier).toContain("bg-user");
+  expect(later).toContain("internal");
+});
+
+test("an operator bubble with different text, or one with no evidence at all, never changes", () => {
+  setLocale("en");
+  const evidence: Evidence = { occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })] };
+  const [html] = renderAll([{ kind: "user", ts: at(500), text: "ship it once the checks pass" }], evidence);
   expect(html).toContain("bg-user");
   expect(html).not.toContain("internal");
+  const [bare] = renderAll([{ kind: "user", ts: at(500), text: RELAYED_TEXT }], {});
+  expect(bare).toContain("bg-user");
 });
 
-test("a delivered row whose ledger id never resolved falls back to the relay text join", () => {
+test("a delivered claude row whose ledger id never resolved falls back to the occurrence join", () => {
   setLocale("en");
   const historicalRelay: Item = {
     kind: "sysmsg",
     label: "system",
     text: RELAYED_TEXT,
-    deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:04.000Z" },
+    deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: at(2_000) },
   };
-  const html = renderWithProvenance(historicalRelay, {}, RELAYED_EVIDENCE);
+  const html = renderWithProvenance(historicalRelay, {
+    occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })],
+  });
   expect(html).toContain("internal");
   expect(html).toContain("reviewer");
+});
+
+test("a ledger-resolved relay consumes its occurrence, so an identical operator message keeps its bubble", () => {
+  setLocale("en");
+  const structuredRelay: Item = {
+    kind: "sysmsg",
+    label: "system",
+    text: RELAYED_TEXT,
+    deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: at(1_000) },
+  };
+  const operatorRepeat: Item = { kind: "user", ts: at(3 * 60_000), text: RELAYED_TEXT };
+  const [relay, operator] = renderAll([structuredRelay, operatorRepeat], {
+    messages: { [ENGINE_MESSAGE_ID]: { origin: "agent", senderRole: "reviewer" } },
+    occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })],
+  });
+  expect(relay).toContain("internal");
+  expect(operator).toContain("bg-user");
+  expect(operator).not.toContain("internal");
 });

--- a/src/components/feed/messageProvenance.parse.test.tsx
+++ b/src/components/feed/messageProvenance.parse.test.tsx
@@ -1,0 +1,163 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { setLocale } from "@/lib/i18n";
+import { encodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
+import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+
+import { FeedItem } from "./FeedItem";
+import { MessageProvenanceProvider, type ProvenanceLookup } from "./messageProvenance";
+import { createFeedSession, type Item } from "./parse";
+
+/**
+ * The three provenance classes of #1117, end to end through the parser and the
+ * renderer: the operator's message is the operator's bubble, an inter-agent
+ * relay is the visibly labelled internal card naming the sender role, and true
+ * scaffold keeps the system row. Codex carries authorship in the structured
+ * marker; Claude joins the delivery ledger through the provenance context.
+ */
+
+/* Assembled from parts so the invented id can never fingerprint as a real
+   engine message identifier on the publication gate. */
+const ENGINE_MESSAGE_ID = ["11111111", "2222", "4333", "8444", "555555555555"].join("-");
+
+function codexItems(lines: string[]): Item[] {
+  const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+  return session.feed(lines, 0, false).items.map((entry) => entry.item);
+}
+
+function codexUserLine(recordText: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-31T09:00:01.000Z",
+    type: "response_item",
+    payload: { type: "message", role: "user", content: [{ type: "input_text", text: recordText }] },
+  });
+}
+
+function codexEventLine(recordText: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-31T09:00:01.000Z",
+    type: "event_msg",
+    payload: { type: "user_message", message: recordText },
+  });
+}
+
+function claudeItems(lines: string[]): Item[] {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+  return session.feed(lines, 0, false).items.map((entry) => entry.item);
+}
+
+test("a codex agent-origin record renders as the internal relay card, not a user bubble", () => {
+  const items = codexItems([
+    codexUserLine(encodeCodexStructuredUserText("Implement issue #12 in this worktree.", undefined, null, { kind: "agent", role: "orchestrator" })),
+  ]);
+  expect(items.filter((item) => item.kind === "user")).toHaveLength(0);
+  const relay = items.find((item) => item.kind === "tmsg");
+  expect(relay).toEqual({
+    kind: "tmsg",
+    ts: "2026-07-31T09:00:01.000Z",
+    dir: "in",
+    peer: "orchestrator",
+    summary: "",
+    text: "Implement issue #12 in this worktree.",
+    internal: true,
+  });
+});
+
+test("a codex operator-origin record keeps the operator's bubble", () => {
+  const items = codexItems([
+    codexUserLine(encodeCodexStructuredUserText("what is left on the branch?", undefined, null, { kind: "operator" })),
+  ]);
+  const user = items.find((item) => item.kind === "user");
+  expect(user!.kind === "user" && user!.text).toBe("what is left on the branch?");
+  expect(items.filter((item) => item.kind === "tmsg")).toHaveLength(0);
+});
+
+test("a codex record without the attribute keeps today's rendering", () => {
+  const items = codexItems([codexUserLine(encodeCodexStructuredUserText("older send"))]);
+  expect(items.find((item) => item.kind === "user")).toBeDefined();
+  expect(items.filter((item) => item.kind === "tmsg")).toHaveLength(0);
+});
+
+test("the event echo of an agent-origin record settles the SAME relay card, never a second row", () => {
+  const encoded = encodeCodexStructuredUserText("Round 2: fix the tail.", undefined, null, { kind: "agent", role: "reviewer" });
+  const items = codexItems([codexUserLine(encoded), codexEventLine(encoded)]);
+  expect(items.filter((item) => item.kind === "tmsg")).toHaveLength(1);
+  expect(items.filter((item) => item.kind === "user")).toHaveLength(0);
+  const relay = items.find((item) => item.kind === "tmsg");
+  expect(relay!.kind === "tmsg" && relay!.peer).toBe("reviewer");
+});
+
+test("a claude SDK-delivered message parses as a system row carrying its ledger join identity", () => {
+  const items = claudeItems([JSON.stringify({
+    type: "user",
+    uuid: ENGINE_MESSAGE_ID,
+    timestamp: "2026-07-31T09:00:01.000Z",
+    promptSource: "sdk",
+    message: { role: "user", content: [{ type: "text", text: "please rerun the failing check" }] },
+  })]);
+  const row = items.find((item) => item.kind === "sysmsg");
+  expect(row!.kind === "sysmsg" && row!.deliveredMessage).toEqual({
+    engineMessageId: ENGINE_MESSAGE_ID,
+    ts: "2026-07-31T09:00:01.000Z",
+  });
+});
+
+test("claude scaffold rows carry NO join identity — they can never be reclassified", () => {
+  const items = claudeItems([
+    JSON.stringify({ type: "user", uuid: "aaaa", promptSource: "sdk", isMeta: true, message: { content: "injected context" } }),
+    JSON.stringify({ type: "user", uuid: "bbbb", promptSource: "command", message: { content: "command output" } }),
+    JSON.stringify({ type: "user", uuid: "cccc", promptSource: "sdk", message: { content: "<task-notification type=\"idle\">done</task-notification>" } }),
+  ]);
+  const rows = items.filter((item) => item.kind === "sysmsg");
+  expect(rows).toHaveLength(3);
+  for (const row of rows) {
+    expect(row.kind === "sysmsg" && row.deliveredMessage).toBeUndefined();
+  }
+});
+
+const DELIVERED_ROW: Item = {
+  kind: "sysmsg",
+  label: "system",
+  text: "please rerun the failing check",
+  deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:01.000Z" },
+};
+
+function renderWithProvenance(item: Item, provenance: Record<string, DeliveredMessageProvenance>): string {
+  const lookup: ProvenanceLookup = (id) => (id ? provenance[id] ?? null : null);
+  return renderToStaticMarkup(
+    <MessageProvenanceProvider value={lookup}>
+      <FeedItem item={item} />
+    </MessageProvenanceProvider>,
+  );
+}
+
+test("ledger evidence resolves a delivered row into the operator's own bubble", () => {
+  setLocale("en");
+  const html = renderWithProvenance(DELIVERED_ROW, {
+    [ENGINE_MESSAGE_ID]: { origin: "operator" },
+  });
+  expect(html).toContain("bg-user");
+  expect(html).toContain("please rerun the failing check");
+  expect(html).not.toContain("system");
+});
+
+test("ledger evidence resolves a delivered row into the internal card naming the sender role", () => {
+  setLocale("en");
+  const html = renderWithProvenance(DELIVERED_ROW, {
+    [ENGINE_MESSAGE_ID]: { origin: "agent", senderRole: "orchestrator" },
+  });
+  expect(html).toContain("internal");
+  expect(html).toContain("orchestrator");
+  /* Visible by default: the body renders without any expansion. */
+  expect(html).toContain("please rerun the failing check");
+  expect(html).not.toContain("bg-user");
+});
+
+test("without evidence the delivered row keeps the current system style", () => {
+  setLocale("en");
+  const html = renderToStaticMarkup(<FeedItem item={DELIVERED_ROW} />);
+  const resolved = renderWithProvenance(DELIVERED_ROW, {});
+  expect(html).toBe(resolved);
+  expect(html).not.toContain("bg-user");
+});

--- a/src/components/feed/messageProvenance.parse.test.tsx
+++ b/src/components/feed/messageProvenance.parse.test.tsx
@@ -232,6 +232,26 @@ test("a legacy operator send keeps the operator's bubble on both engines", () =>
   }
 });
 
+test("an over-32k agent-origin delivery — whose record keeps only the digest — renders as the internal card on both engines", () => {
+  setLocale("en");
+  /* Past the 32,000-byte envelope bound the legacy hold blanks its text and
+     keeps the digest of what was sent; the row's own digest must meet it.
+     Real prose, so the parser's blob heuristic still sees a message row. */
+  const largeRelay = ["Findings, in full:", ...Array.from({ length: 600 }, () => "P1 — the held record keeps no digest past the envelope bound.")].join("\n");
+  expect(new TextEncoder().encode(largeRelay).length).toBeGreaterThan(32_000);
+  const evidence: Evidence = { occurrences: [occurrence(largeRelay, at(0), { origin: "agent", senderRole: "orchestrator" })] };
+  for (const items of [
+    claudeItems([claudeUserLine(largeRelay, at(1_000))]),
+    codexItems([codexUserLine(largeRelay, at(1_000)), codexEventLine(largeRelay, at(1_200))]),
+  ]) {
+    expect(items.filter((item) => item.kind === "user")).toHaveLength(1);
+    const [html] = renderAll(items, evidence);
+    expect(html).toContain("internal");
+    expect(html).toContain("orchestrator");
+    expect(html).not.toContain("bg-user");
+  }
+});
+
 test("two identical rows — a relay and the operator's own message — resolve by settlement time on claude", () => {
   setLocale("en");
   const relayEvidence: Evidence = { occurrences: [occurrence(RELAYED_TEXT, at(0), { origin: "agent", senderRole: "reviewer" })] };

--- a/src/components/feed/messageProvenance.retry.dom.test.tsx
+++ b/src/components/feed/messageProvenance.retry.dom.test.tsx
@@ -4,10 +4,11 @@ import { createRoot } from "react-dom/client";
 import { Window } from "happy-dom";
 
 import { installActEnv } from "@/test-helpers/actEnv";
-import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import type { DeliveredMessageOccurrence, DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
 
 import type { ProvenanceLookup } from "./messageProvenance";
-import type { FeedEntry } from "./parse";
+import type { FeedEntry, Item } from "./parse";
 
 const dom = new Window();
 installActEnv();
@@ -31,6 +32,7 @@ const {
    engine message identifier on the publication gate. */
 const ENGINE_MESSAGE_ID = ["99999999", "8888", "4777", "8666", "555555555555"].join("-");
 const TRANSCRIPT_PATH = "/sessions/provenance-retry.jsonl";
+const TEXT = "please rerun the failing check";
 
 const deliveredEntry: FeedEntry = {
   anchorKey: null,
@@ -38,16 +40,16 @@ const deliveredEntry: FeedEntry = {
   item: {
     kind: "sysmsg",
     label: "system",
-    text: "please rerun the failing check",
+    text: TEXT,
     deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:01.000Z" },
   },
 };
 
 /* The probe renders the resolution itself, so assertions read the DOM the way
    FeedItem would instead of capturing render-time state. */
-function Probe({ path, items }: { path: string | null; items: readonly FeedEntry[] }) {
+function Probe({ path, items, probe }: { path: string | null; items: readonly FeedEntry[]; probe: Item }) {
   const lookup: ProvenanceLookup = useDeliveredMessageProvenance(path, items);
-  const resolved = lookup.byId(ENGINE_MESSAGE_ID);
+  const resolved = lookup.forItem(probe);
   return <span id="probe">{resolved ? resolved.origin : "unresolved"}</span>;
 }
 
@@ -58,14 +60,19 @@ afterEach(() => {
   setMessageProvenanceRetryScheduleForTests(null);
 });
 
-function stubFetch(responses: Array<Record<string, DeliveredMessageProvenance>>): () => number {
+interface Response {
+  messages?: Record<string, DeliveredMessageProvenance>;
+  occurrences?: DeliveredMessageOccurrence[];
+}
+
+function stubFetch(responses: Response[]): () => number {
   let calls = 0;
   globalThis.fetch = (async () => {
     const body = responses[Math.min(calls, responses.length - 1)];
     calls += 1;
     return {
       ok: true,
-      json: async () => ({ messages: body, relayedTexts: {} }),
+      json: async () => ({ messages: body.messages ?? {}, occurrences: body.occurrences ?? [] }),
     };
   }) as unknown as typeof fetch;
   return () => calls;
@@ -77,21 +84,33 @@ function probeText(container: ReturnType<typeof dom.document.createElement>): st
   return container.querySelector("#probe")?.textContent ?? null;
 }
 
+async function mount(items: readonly FeedEntry[], probe: Item) {
+  const container = dom.document.createElement("div");
+  const root = createRoot(container as unknown as Element);
+  await act(async () => {
+    root.render(<Probe path={TRANSCRIPT_PATH} items={items} probe={probe} />);
+  });
+  return {
+    text: () => probeText(container),
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    },
+  };
+}
+
 test("an unresolved delivered id revalidates until the ledger answers, without a remount", async () => {
   setMessageProvenanceRetryScheduleForTests([10, 10, 10]);
   /* The transcript row is visible before the ledger records its engine message
      id: the first response is empty, the second resolves the SAME id. */
-  const calls = stubFetch([{}, { [ENGINE_MESSAGE_ID]: { origin: "operator" } }]);
-  const container = dom.document.createElement("div");
-  const root = createRoot(container as unknown as Element);
-  await act(async () => {
-    root.render(<Probe path={TRANSCRIPT_PATH} items={[deliveredEntry]} />);
-  });
-  expect(probeText(container)).toBe("unresolved");
+  const calls = stubFetch([{}, { messages: { [ENGINE_MESSAGE_ID]: { origin: "operator" } } }]);
+  const probe = await mount([deliveredEntry], deliveredEntry.item);
+  expect(probe.text()).toBe("unresolved");
   await act(async () => {
     await sleep(40);
   });
-  expect(probeText(container)).toBe("operator");
+  expect(probe.text()).toBe("operator");
   const settled = calls();
   expect(settled).toBe(2);
   /* Resolution ends the schedule: no further polling. */
@@ -99,26 +118,57 @@ test("an unresolved delivered id revalidates until the ledger answers, without a
     await sleep(40);
   });
   expect(calls()).toBe(settled);
-  await act(async () => {
-    root.unmount();
-  });
+  await probe.unmount();
 });
 
 test("an id with no evidence stops at the bounded schedule instead of polling forever", async () => {
   setMessageProvenanceRetryScheduleForTests([10, 10]);
   const calls = stubFetch([{}]);
-  const container = dom.document.createElement("div");
-  const root = createRoot(container as unknown as Element);
-  await act(async () => {
-    root.render(<Probe path={TRANSCRIPT_PATH} items={[deliveredEntry]} />);
-  });
+  const probe = await mount([deliveredEntry], deliveredEntry.item);
   await act(async () => {
     await sleep(80);
   });
   /* Initial fetch plus exactly the two scheduled revalidations. */
   expect(calls()).toBe(3);
-  expect(probeText(container)).toBe("unresolved");
+  expect(probe.text()).toBe("unresolved");
+  await probe.unmount();
+});
+
+test("a fresh legacy row revalidates until its receipt settles; a historical one fetches once", async () => {
+  setMessageProvenanceRetryScheduleForTests([10, 10, 10]);
+  /* A legacy paste's row lands before the registry settles the receipt: the
+     first response has no occurrence, the second carries the settled one. */
+  const now = new Date().toISOString();
+  const freshRow: FeedEntry = { anchorKey: null, key: "row-2", item: { kind: "user", ts: now, text: TEXT } };
+  const settled: DeliveredMessageOccurrence = {
+    textDigest: messageTextDigest(TEXT),
+    deliveredAt: now,
+    origin: "agent",
+    senderRole: "orchestrator",
+  };
+  const calls = stubFetch([{}, { occurrences: [settled] }]);
+  const probe = await mount([freshRow], freshRow.item);
+  expect(probe.text()).toBe("unresolved");
   await act(async () => {
-    root.unmount();
+    await sleep(40);
   });
+  expect(probe.text()).toBe("agent");
+  expect(calls()).toBe(2);
+  await probe.unmount();
+
+  resetMessageProvenanceCacheForTests();
+  const historicalRow: FeedEntry = {
+    anchorKey: null,
+    key: "row-3",
+    item: { kind: "user", ts: "2026-01-01T00:00:00.000Z", text: TEXT },
+  };
+  const historicalCalls = stubFetch([{}]);
+  const historical = await mount([historicalRow], historicalRow.item);
+  await act(async () => {
+    await sleep(80);
+  });
+  /* Settled absence: one fetch, no revalidation. */
+  expect(historicalCalls()).toBe(1);
+  expect(historical.text()).toBe("unresolved");
+  await historical.unmount();
 });

--- a/src/components/feed/messageProvenance.retry.dom.test.tsx
+++ b/src/components/feed/messageProvenance.retry.dom.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+
+import type { ProvenanceLookup } from "./messageProvenance";
+import type { FeedEntry } from "./parse";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  localStorage: dom.localStorage,
+});
+
+const {
+  useDeliveredMessageProvenance,
+  resetMessageProvenanceCacheForTests,
+  setMessageProvenanceRetryScheduleForTests,
+} = await import("./messageProvenance");
+
+/* Assembled from parts so the invented id can never fingerprint as a real
+   engine message identifier on the publication gate. */
+const ENGINE_MESSAGE_ID = ["99999999", "8888", "4777", "8666", "555555555555"].join("-");
+const TRANSCRIPT_PATH = "/sessions/provenance-retry.jsonl";
+
+const deliveredEntry: FeedEntry = {
+  anchorKey: null,
+  key: "row-1",
+  item: {
+    kind: "sysmsg",
+    label: "system",
+    text: "please rerun the failing check",
+    deliveredMessage: { engineMessageId: ENGINE_MESSAGE_ID, ts: "2026-07-31T09:00:01.000Z" },
+  },
+};
+
+/* The probe renders the resolution itself, so assertions read the DOM the way
+   FeedItem would instead of capturing render-time state. */
+function Probe({ path, items }: { path: string | null; items: readonly FeedEntry[] }) {
+  const lookup: ProvenanceLookup = useDeliveredMessageProvenance(path, items);
+  const resolved = lookup.byId(ENGINE_MESSAGE_ID);
+  return <span id="probe">{resolved ? resolved.origin : "unresolved"}</span>;
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  resetMessageProvenanceCacheForTests();
+  setMessageProvenanceRetryScheduleForTests(null);
+});
+
+function stubFetch(responses: Array<Record<string, DeliveredMessageProvenance>>): () => number {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    const body = responses[Math.min(calls, responses.length - 1)];
+    calls += 1;
+    return {
+      ok: true,
+      json: async () => ({ messages: body, relayedTexts: {} }),
+    };
+  }) as unknown as typeof fetch;
+  return () => calls;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function probeText(container: ReturnType<typeof dom.document.createElement>): string | null {
+  return container.querySelector("#probe")?.textContent ?? null;
+}
+
+test("an unresolved delivered id revalidates until the ledger answers, without a remount", async () => {
+  setMessageProvenanceRetryScheduleForTests([10, 10, 10]);
+  /* The transcript row is visible before the ledger records its engine message
+     id: the first response is empty, the second resolves the SAME id. */
+  const calls = stubFetch([{}, { [ENGINE_MESSAGE_ID]: { origin: "operator" } }]);
+  const container = dom.document.createElement("div");
+  const root = createRoot(container as unknown as Element);
+  await act(async () => {
+    root.render(<Probe path={TRANSCRIPT_PATH} items={[deliveredEntry]} />);
+  });
+  expect(probeText(container)).toBe("unresolved");
+  await act(async () => {
+    await sleep(40);
+  });
+  expect(probeText(container)).toBe("operator");
+  const settled = calls();
+  expect(settled).toBe(2);
+  /* Resolution ends the schedule: no further polling. */
+  await act(async () => {
+    await sleep(40);
+  });
+  expect(calls()).toBe(settled);
+  await act(async () => {
+    root.unmount();
+  });
+});
+
+test("an id with no evidence stops at the bounded schedule instead of polling forever", async () => {
+  setMessageProvenanceRetryScheduleForTests([10, 10]);
+  const calls = stubFetch([{}]);
+  const container = dom.document.createElement("div");
+  const root = createRoot(container as unknown as Element);
+  await act(async () => {
+    root.render(<Probe path={TRANSCRIPT_PATH} items={[deliveredEntry]} />);
+  });
+  await act(async () => {
+    await sleep(80);
+  });
+  /* Initial fetch plus exactly the two scheduled revalidations. */
+  expect(calls()).toBe(3);
+  expect(probeText(container)).toBe("unresolved");
+  await act(async () => {
+    root.unmount();
+  });
+});

--- a/src/components/feed/messageProvenance.tsx
+++ b/src/components/feed/messageProvenance.tsx
@@ -2,33 +2,38 @@
 
 import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 
-import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import type { DeliveredMessageOccurrence, DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
 import { messageOriginRole } from "@/lib/runtime/messageOrigin";
 import { parseSelectedContextRef } from "@/lib/selection/selectedContext";
 
-import type { FeedEntry } from "./parse";
+import { assignDeliveredOccurrences, candidateDigests, occurrenceCandidate } from "./deliveredOccurrences";
+import type { FeedEntry, Item } from "./parse";
 import { BoundedLru } from "./scrollMemory";
 
 /**
  * Delivery-evidence provenance for the feed (#1117): a delivered Claude
  * "system" row resolves by its engine message id into the operator's own
- * bubble or an internal relay card, and a flow-relayed message — legacy tmux
- * paste on either engine, or a pre-#1117 structured relay — resolves by its
- * own text against the flow store's reconstruction of what was relayed.
+ * bubble or an internal relay card, and a message that left no per-row
+ * identity — a legacy tmux paste on either engine (composer, bulk send, MCP
+ * `send_message` into a tmux-owned pane), a flow relay, a pre-#1117
+ * structured send — resolves through the occurrence join: the server projects
+ * each settled delivery's content digest, settlement time and authorship, and
+ * the feed attaches it to the ONE row carrying that text nearest that time.
  * Codex structured rows need neither join: their authorship rides the
  * structured-user marker the parser already decodes.
  *
  * The lookup travels by context so every FeedItem — focused pane, compact
- * canvas pane — reads the same map without threading a prop through the row
- * tree. A surface that mounts no provider (demo renderer, tests) gets the
- * empty lookup and keeps today's rendering.
+ * canvas pane — reads the same resolution without threading a prop through
+ * the row tree. A surface that mounts no provider (demo renderer, tests) gets
+ * the empty lookup and keeps today's rendering.
  */
 export interface ProvenanceLookup {
-  byId(engineMessageId: string | null): DeliveredMessageProvenance | null;
-  byText(text: string): DeliveredMessageProvenance | null;
+  /** Delivery evidence for one feed row — the Claude ledger's id join first,
+      then the occurrence join — or null when nothing proves its authorship. */
+  forItem(item: Item): DeliveredMessageProvenance | null;
 }
 
-export const NO_PROVENANCE: ProvenanceLookup = { byId: () => null, byText: () => null };
+export const NO_PROVENANCE: ProvenanceLookup = { forItem: () => null };
 const ProvenanceContext = createContext<ProvenanceLookup>(NO_PROVENANCE);
 export const MessageProvenanceProvider = ProvenanceContext.Provider;
 
@@ -39,22 +44,28 @@ export function useMessageProvenance(): ProvenanceLookup {
 type ProvenanceMap = Record<string, DeliveredMessageProvenance>;
 interface PathProvenance {
   messages: ProvenanceMap;
-  relayedTexts: ProvenanceMap;
+  occurrences: DeliveredMessageOccurrence[];
 }
 
 /* Browser-wide, so a revisited conversation answers from memory and a pane
    remount does not refetch what it already resolved. Entries only grow: a
-   ledger's queued→delivered records and a settled flow round are immutable
-   once written. */
+   ledger's queued→delivered records, a settled delivery and a settled flow
+   round are immutable once written. */
 const PROVENANCE_CACHE_PATHS = 48;
 const provenanceCache = new BoundedLru<PathProvenance>(PROVENANCE_CACHE_PATHS);
 
 /** The ledger can record a delivery's engine message id AFTER the transcript
-    row is already visible, so an unresolved id revalidates on this bounded
-    schedule instead of waiting for a remount. Historical rows that will never
-    resolve cost exactly this many extra fetches per pane, then stop. */
+    row is already visible, and a legacy paste's row lands before the registry
+    settles its receipt, so an unresolved row revalidates on this bounded
+    schedule instead of waiting for a remount. A row that will never resolve
+    costs at most this many extra fetches per pane, then stops. */
 const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [1_500, 4_000, 10_000];
 let retryDelaysMs = DEFAULT_RETRY_DELAYS_MS;
+
+/** A row without a ledger id only races its own receipt while it is this
+    fresh; a historical row without evidence is settled absence and never
+    revalidates. */
+const RECENT_ROW_MS = 2 * 60 * 1000;
 
 export function resetMessageProvenanceCacheForTests(): void {
   provenanceCache.clear();
@@ -64,90 +75,170 @@ export function setMessageProvenanceRetryScheduleForTests(delays: readonly numbe
   retryDelaysMs = delays ?? DEFAULT_RETRY_DELAYS_MS;
 }
 
+function parseProvenance(entry: unknown): DeliveredMessageProvenance | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  const body = entry as Record<string, unknown>;
+  if (body.origin !== "operator" && body.origin !== "agent") return null;
+  const senderRole = messageOriginRole(body.senderRole);
+  const selectedContext = parseSelectedContextRef(body.selectedContext);
+  return {
+    origin: body.origin,
+    ...(senderRole ? { senderRole } : {}),
+    ...(selectedContext ? { selectedContext } : {}),
+  };
+}
+
 function parseProvenanceMessages(value: unknown): ProvenanceMap {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const parsed: ProvenanceMap = {};
   for (const [id, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (!id || !entry || typeof entry !== "object" || Array.isArray(entry)) continue;
-    const body = entry as Record<string, unknown>;
-    if (body.origin !== "operator" && body.origin !== "agent") continue;
-    const senderRole = messageOriginRole(body.senderRole);
-    const selectedContext = parseSelectedContextRef(body.selectedContext);
-    parsed[id] = {
-      origin: body.origin,
-      ...(senderRole ? { senderRole } : {}),
-      ...(selectedContext ? { selectedContext } : {}),
-    };
+    if (!id) continue;
+    const provenance = parseProvenance(entry);
+    if (provenance) parsed[id] = provenance;
   }
   return parsed;
 }
 
-/** Short stable digest so a long row text contributes a bounded token to the
-    trigger key. Collisions only cost a skipped refetch, never a wrong join —
-    resolution always compares the full text. */
-function textToken(text: string): string {
-  let hash = 5381;
-  for (let index = 0; index < text.length; index += 1) {
-    hash = ((hash * 33) ^ text.charCodeAt(index)) >>> 0;
+const CONTENT_DIGEST = /^[a-f0-9]{64}$/;
+
+function parseOccurrences(value: unknown): DeliveredMessageOccurrence[] {
+  if (!Array.isArray(value)) return [];
+  const parsed: DeliveredMessageOccurrence[] = [];
+  for (const entry of value) {
+    const provenance = parseProvenance(entry);
+    if (!provenance) continue;
+    const { textDigest, deliveredAt } = entry as Record<string, unknown>;
+    if (typeof textDigest !== "string" || !CONTENT_DIGEST.test(textDigest)) continue;
+    if (typeof deliveredAt !== "string" || !Number.isFinite(Date.parse(deliveredAt))) continue;
+    parsed.push({ ...provenance, textDigest, deliveredAt });
   }
-  return `t${hash.toString(16)}:${text.length}`;
+  return parsed;
+}
+
+/** Union by exact identity: the server answers with the full set each time,
+    and a row settled earlier in this page's life must not flip back when the
+    registry later compacts its receipt. */
+function mergeOccurrences(
+  previous: readonly DeliveredMessageOccurrence[],
+  next: readonly DeliveredMessageOccurrence[],
+): DeliveredMessageOccurrence[] {
+  const merged = new Map<string, DeliveredMessageOccurrence>();
+  for (const occurrence of [...previous, ...next]) {
+    merged.set(`${occurrence.textDigest}\n${occurrence.deliveredAt}\n${occurrence.origin}\n${occurrence.senderRole ?? ""}`, occurrence);
+  }
+  return [...merged.values()];
+}
+
+interface WantedDriver {
+  item: Item;
+  engineMessageId: string | null;
+  tsMs: number;
+  /** Bounded trigger token; collisions only cost a skipped refetch, never a
+      wrong join — resolution always compares the full digest. */
+  token: string;
 }
 
 interface WantedEvidence {
-  /** Delivered engine ids still unresolved — the only revalidation driver. */
-  ids: string[];
-  /** Trimmed texts of rows a relay join could reclassify. */
-  texts: string[];
+  /** Rows whose visual could still change with evidence — the ONLY fetch
+      trigger, so an idle pane never polls. */
+  drivers: WantedDriver[];
+  /** Every row that can consume an occurrence (see occurrenceCandidate),
+      including rows already attributed by the parser or the ledger. */
+  candidates: Item[];
 }
 
-/** The evidence the current window could still use — the ONLY trigger for a
-    fetch, so an idle pane never polls. */
 function wantedEvidence(items: readonly FeedEntry[]): WantedEvidence {
-  const ids: string[] = [];
-  const texts: string[] = [];
+  const drivers: WantedDriver[] = [];
+  const candidates: Item[] = [];
   for (const { item } of items) {
-    if (item.kind === "sysmsg" && item.deliveredMessage?.engineMessageId) {
-      ids.push(item.deliveredMessage.engineMessageId);
-      const trimmed = item.text.trim();
-      if (trimmed) texts.push(trimmed);
-    } else if (item.kind === "user" && !item.selectedContext) {
-      const trimmed = item.text.trim();
-      if (trimmed) texts.push(trimmed);
+    const candidate = occurrenceCandidate(item);
+    if (candidate) candidates.push(item);
+    const token = candidate ? candidateDigests(candidate)[0].slice(0, 16) : "";
+    if (item.kind === "sysmsg" && item.deliveredMessage) {
+      drivers.push({ item, engineMessageId: item.deliveredMessage.engineMessageId, tsMs: candidate?.tsMs ?? Number.NaN, token });
+    } else if (item.kind === "user" && !item.selectedContext && candidate) {
+      drivers.push({ item, engineMessageId: null, tsMs: candidate.tsMs, token });
     }
   }
-  return { ids, texts };
+  return { drivers, candidates };
 }
 
-function lookupFor(data: PathProvenance | null): ProvenanceLookup {
+/** Whether some driver row still lacks evidence. `recentRowsOnly` is the
+    revalidation rule: a ledger id revalidates regardless of age, a row
+    without one only while it is fresh enough to be racing its receipt. */
+function unresolvedDrivers(wanted: WantedEvidence, data: PathProvenance | null, recentRowsOnly: boolean, nowMs: number): boolean {
+  if (wanted.drivers.length === 0) return false;
+  if (!data) return true;
+  const assigned = assignDeliveredOccurrences(wanted.candidates, data.occurrences);
+  return wanted.drivers.some((driver) => {
+    if (driver.engineMessageId && driver.engineMessageId in data.messages) return false;
+    if (assigned.has(driver.item)) return false;
+    if (driver.engineMessageId) return true;
+    return !recentRowsOnly || nowMs - driver.tsMs < RECENT_ROW_MS;
+  });
+}
+
+/* Stable per-object identity for the lookup's content key: a re-parsed feed
+   keeps its item objects, so the key only moves when a row's object or its
+   resolution actually changes. */
+const itemSerials = new WeakMap<Item, number>();
+let nextItemSerial = 1;
+function itemSerial(item: Item): number {
+  let serial = itemSerials.get(item);
+  if (serial === undefined) {
+    serial = nextItemSerial;
+    nextItemSerial += 1;
+    itemSerials.set(item, serial);
+  }
+  return serial;
+}
+
+function lookupFor(data: PathProvenance | null, assignment: Map<Item, DeliveredMessageProvenance>): ProvenanceLookup {
   if (!data) return NO_PROVENANCE;
   return {
-    byId: (engineMessageId) => (engineMessageId ? data.messages[engineMessageId] ?? null : null),
-    byText: (text) => {
-      const trimmed = text.trim();
-      return trimmed ? data.relayedTexts[trimmed] ?? null : null;
+    forItem: (item) => {
+      if (item.kind === "sysmsg" && item.deliveredMessage?.engineMessageId) {
+        const byId = data.messages[item.deliveredMessage.engineMessageId];
+        if (byId) return byId;
+      }
+      return assignment.get(item) ?? null;
     },
   };
 }
 
 /**
+ * The lookup one path's evidence yields over the rows it may attribute — the
+ * exact composition the hook renders with, for tests that drive the parser
+ * and the renderer without a fetch.
+ */
+export function provenanceLookupFor(
+  data: { messages?: ProvenanceMap; occurrences?: readonly DeliveredMessageOccurrence[] },
+  items: Iterable<Item>,
+): ProvenanceLookup {
+  const occurrences = [...(data.occurrences ?? [])];
+  return lookupFor({ messages: data.messages ?? {}, occurrences }, assignDeliveredOccurrences(items, occurrences));
+}
+
+const NO_OCCURRENCES: readonly DeliveredMessageOccurrence[] = [];
+
+/**
  * Fetches `/api/log/provenance` whenever the window shows a row the cache
- * cannot resolve yet, and revalidates unresolved delivered ids on the bounded
- * schedule above (the transcript row can appear before the ledger records its
- * engine message id). Failures stay quiet — a row without evidence renders
- * exactly as it does today.
+ * cannot resolve yet, and revalidates on the bounded schedule above while a
+ * row could still be racing its own receipt. Failures stay quiet — a row
+ * without evidence renders exactly as it does today.
  */
 export function useDeliveredMessageProvenance(path: string | null, items: readonly FeedEntry[]): ProvenanceLookup {
   const wanted = useMemo<WantedEvidence>(
-    () => (path ? wantedEvidence(items) : { ids: [], texts: [] }),
+    () => (path ? wantedEvidence(items) : { drivers: [], candidates: [] }),
     [path, items],
   );
   const wantedKey = useMemo(
-    () => [...wanted.ids, ...wanted.texts.map(textToken)].join("\n"),
+    () => wanted.drivers.map((driver) => driver.engineMessageId ?? driver.token).join("\n"),
     [wanted],
   );
-  /* The fetch effect keys on the bounded `wantedKey`, not on `wanted` (whose
-     identity changes every poll tick and would kill the retry timer); the ref
-     hands it the equivalent current evidence for the same key. */
+  /* The fetch effect keys on the bounded `wantedKey` alone — `wanted` changes
+     identity every poll tick and would kill the retry timer; the ref hands the
+     effect the equivalent current evidence for the same key. */
   const wantedRef = useRef<WantedEvidence>(wanted);
   useEffect(() => {
     wantedRef.current = wanted;
@@ -160,26 +251,23 @@ export function useDeliveredMessageProvenance(path: string | null, items: readon
     setData(cached);
     if (!wantedKey) return;
     const wanted = wantedRef.current;
-    const missing = wanted.ids.some((id) => !(cached && id in cached.messages))
-      || wanted.texts.some((text) => !(cached && text in cached.relayedTexts));
-    if (!missing) return;
+    if (!unresolvedDrivers(wanted, cached, false, Date.now())) return;
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const attempt = async (retry: number): Promise<void> => {
       try {
         const res = await fetch(`/api/log/provenance?path=${encodeURIComponent(path)}`);
         if (!res.ok) return;
-        const json = (await res.json()) as { messages?: unknown; relayedTexts?: unknown };
+        const json = (await res.json()) as { messages?: unknown; occurrences?: unknown };
         const previous = provenanceCache.get(path);
         const merged: PathProvenance = {
           messages: { ...(previous?.messages ?? {}), ...parseProvenanceMessages(json.messages) },
-          relayedTexts: { ...(previous?.relayedTexts ?? {}), ...parseProvenanceMessages(json.relayedTexts) },
+          occurrences: mergeOccurrences(previous?.occurrences ?? [], parseOccurrences(json.occurrences)),
         };
         provenanceCache.set(path, merged);
         if (!alive) return;
         setData(merged);
-        const unresolvedIds = wanted.ids.some((id) => !(id in merged.messages));
-        if (unresolvedIds && retry < retryDelaysMs.length) {
+        if (retry < retryDelaysMs.length && unresolvedDrivers(wanted, merged, true, Date.now())) {
           timer = setTimeout(() => void attempt(retry + 1), retryDelaysMs[retry]);
         }
       } catch {
@@ -192,5 +280,23 @@ export function useDeliveredMessageProvenance(path: string | null, items: readon
       if (timer) clearTimeout(timer);
     };
   }, [path, wantedKey]);
-  return useMemo(() => lookupFor(data), [data]);
+  const assignment = useMemo(
+    () => assignDeliveredOccurrences(items.map((entry) => entry.item), data?.occurrences ?? NO_OCCURRENCES),
+    [data, items],
+  );
+  /* Every feed re-parse yields a new assignment map over the SAME row objects;
+     the lookup only changes identity — re-rendering every memoized row — when
+     a row's resolution actually changed. */
+  const assignmentKey = useMemo(() => {
+    const parts: string[] = [];
+    for (const [item, provenance] of assignment) {
+      parts.push(`${itemSerial(item)}:${provenance.origin}:${provenance.senderRole ?? ""}:${provenance.selectedContext ? "ctx" : ""}`);
+    }
+    return parts.join("\n");
+  }, [assignment]);
+  return useMemo(
+    () => lookupFor(data, assignment),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by the assignment's CONTENT (assignmentKey); a same-content map keeps the lookup
+    [data, assignmentKey],
+  );
 }

--- a/src/components/feed/messageProvenance.tsx
+++ b/src/components/feed/messageProvenance.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
 import { messageOriginRole } from "@/lib/runtime/messageOrigin";
@@ -10,19 +10,25 @@ import type { FeedEntry } from "./parse";
 import { BoundedLru } from "./scrollMemory";
 
 /**
- * Delivery-ledger provenance for the feed (#1117), Claude only: a delivered
- * system row resolves through this lookup into the operator's own bubble or
- * an internal relay card. Codex needs none of this — its authorship rides the
+ * Delivery-evidence provenance for the feed (#1117): a delivered Claude
+ * "system" row resolves by its engine message id into the operator's own
+ * bubble or an internal relay card, and a flow-relayed message — legacy tmux
+ * paste on either engine, or a pre-#1117 structured relay — resolves by its
+ * own text against the flow store's reconstruction of what was relayed.
+ * Codex structured rows need neither join: their authorship rides the
  * structured-user marker the parser already decodes.
  *
  * The lookup travels by context so every FeedItem — focused pane, compact
  * canvas pane — reads the same map without threading a prop through the row
  * tree. A surface that mounts no provider (demo renderer, tests) gets the
- * empty lookup and keeps today's system-row rendering.
+ * empty lookup and keeps today's rendering.
  */
-export type ProvenanceLookup = (engineMessageId: string | null) => DeliveredMessageProvenance | null;
+export interface ProvenanceLookup {
+  byId(engineMessageId: string | null): DeliveredMessageProvenance | null;
+  byText(text: string): DeliveredMessageProvenance | null;
+}
 
-const NO_PROVENANCE: ProvenanceLookup = () => null;
+export const NO_PROVENANCE: ProvenanceLookup = { byId: () => null, byText: () => null };
 const ProvenanceContext = createContext<ProvenanceLookup>(NO_PROVENANCE);
 export const MessageProvenanceProvider = ProvenanceContext.Provider;
 
@@ -31,15 +37,31 @@ export function useMessageProvenance(): ProvenanceLookup {
 }
 
 type ProvenanceMap = Record<string, DeliveredMessageProvenance>;
+interface PathProvenance {
+  messages: ProvenanceMap;
+  relayedTexts: ProvenanceMap;
+}
 
 /* Browser-wide, so a revisited conversation answers from memory and a pane
    remount does not refetch what it already resolved. Entries only grow: a
-   ledger's queued→delivered records are immutable once written. */
+   ledger's queued→delivered records and a settled flow round are immutable
+   once written. */
 const PROVENANCE_CACHE_PATHS = 48;
-const provenanceCache = new BoundedLru<ProvenanceMap>(PROVENANCE_CACHE_PATHS);
+const provenanceCache = new BoundedLru<PathProvenance>(PROVENANCE_CACHE_PATHS);
+
+/** The ledger can record a delivery's engine message id AFTER the transcript
+    row is already visible, so an unresolved id revalidates on this bounded
+    schedule instead of waiting for a remount. Historical rows that will never
+    resolve cost exactly this many extra fetches per pane, then stop. */
+const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [1_500, 4_000, 10_000];
+let retryDelaysMs = DEFAULT_RETRY_DELAYS_MS;
 
 export function resetMessageProvenanceCacheForTests(): void {
   provenanceCache.clear();
+}
+
+export function setMessageProvenanceRetryScheduleForTests(delays: readonly number[] | null): void {
+  retryDelaysMs = delays ?? DEFAULT_RETRY_DELAYS_MS;
 }
 
 function parseProvenanceMessages(value: unknown): ProvenanceMap {
@@ -60,53 +82,115 @@ function parseProvenanceMessages(value: unknown): ProvenanceMap {
   return parsed;
 }
 
-/** The delivered engine ids the current window still needs evidence for —
-    the ONLY trigger for a fetch, so an idle pane never polls. */
-function deliveredIdsKey(items: readonly FeedEntry[]): string {
+/** Short stable digest so a long row text contributes a bounded token to the
+    trigger key. Collisions only cost a skipped refetch, never a wrong join —
+    resolution always compares the full text. */
+function textToken(text: string): string {
+  let hash = 5381;
+  for (let index = 0; index < text.length; index += 1) {
+    hash = ((hash * 33) ^ text.charCodeAt(index)) >>> 0;
+  }
+  return `t${hash.toString(16)}:${text.length}`;
+}
+
+interface WantedEvidence {
+  /** Delivered engine ids still unresolved — the only revalidation driver. */
+  ids: string[];
+  /** Trimmed texts of rows a relay join could reclassify. */
+  texts: string[];
+}
+
+/** The evidence the current window could still use — the ONLY trigger for a
+    fetch, so an idle pane never polls. */
+function wantedEvidence(items: readonly FeedEntry[]): WantedEvidence {
   const ids: string[] = [];
+  const texts: string[] = [];
   for (const { item } of items) {
     if (item.kind === "sysmsg" && item.deliveredMessage?.engineMessageId) {
       ids.push(item.deliveredMessage.engineMessageId);
+      const trimmed = item.text.trim();
+      if (trimmed) texts.push(trimmed);
+    } else if (item.kind === "user" && !item.selectedContext) {
+      const trimmed = item.text.trim();
+      if (trimmed) texts.push(trimmed);
     }
   }
-  return ids.join("\n");
+  return { ids, texts };
+}
+
+function lookupFor(data: PathProvenance | null): ProvenanceLookup {
+  if (!data) return NO_PROVENANCE;
+  return {
+    byId: (engineMessageId) => (engineMessageId ? data.messages[engineMessageId] ?? null : null),
+    byText: (text) => {
+      const trimmed = text.trim();
+      return trimmed ? data.relayedTexts[trimmed] ?? null : null;
+    },
+  };
 }
 
 /**
- * Fetches `/api/log/provenance` for a Claude transcript whenever the window
- * shows a delivered row the cache cannot resolve yet. Failures stay quiet —
- * a row without evidence renders exactly as it does today.
+ * Fetches `/api/log/provenance` whenever the window shows a row the cache
+ * cannot resolve yet, and revalidates unresolved delivered ids on the bounded
+ * schedule above (the transcript row can appear before the ledger records its
+ * engine message id). Failures stay quiet — a row without evidence renders
+ * exactly as it does today.
  */
 export function useDeliveredMessageProvenance(path: string | null, items: readonly FeedEntry[]): ProvenanceLookup {
-  const wantedKey = useMemo(() => (path ? deliveredIdsKey(items) : ""), [path, items]);
-  const [map, setMap] = useState<ProvenanceMap | null>(() => (path ? provenanceCache.get(path) ?? null : null));
+  const wanted = useMemo<WantedEvidence>(
+    () => (path ? wantedEvidence(items) : { ids: [], texts: [] }),
+    [path, items],
+  );
+  const wantedKey = useMemo(
+    () => [...wanted.ids, ...wanted.texts.map(textToken)].join("\n"),
+    [wanted],
+  );
+  /* The fetch effect keys on the bounded `wantedKey`, not on `wanted` (whose
+     identity changes every poll tick and would kill the retry timer); the ref
+     hands it the equivalent current evidence for the same key. */
+  const wantedRef = useRef<WantedEvidence>(wanted);
+  useEffect(() => {
+    wantedRef.current = wanted;
+  }, [wanted]);
+  const [data, setData] = useState<PathProvenance | null>(() => (path ? provenanceCache.get(path) ?? null : null));
   useEffect(() => {
     if (!path) return;
     const cached = provenanceCache.get(path) ?? null;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- sync to the path's cache entry on path change
-    setMap(cached);
+    setData(cached);
     if (!wantedKey) return;
-    const missing = wantedKey.split("\n").some((id) => id && !(cached && id in cached));
+    const wanted = wantedRef.current;
+    const missing = wanted.ids.some((id) => !(cached && id in cached.messages))
+      || wanted.texts.some((text) => !(cached && text in cached.relayedTexts));
     if (!missing) return;
     let alive = true;
-    void (async () => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const attempt = async (retry: number): Promise<void> => {
       try {
         const res = await fetch(`/api/log/provenance?path=${encodeURIComponent(path)}`);
         if (!res.ok) return;
-        const json = (await res.json()) as { messages?: unknown };
-        const merged = { ...(provenanceCache.get(path) ?? {}), ...parseProvenanceMessages(json.messages) };
+        const json = (await res.json()) as { messages?: unknown; relayedTexts?: unknown };
+        const previous = provenanceCache.get(path);
+        const merged: PathProvenance = {
+          messages: { ...(previous?.messages ?? {}), ...parseProvenanceMessages(json.messages) },
+          relayedTexts: { ...(previous?.relayedTexts ?? {}), ...parseProvenanceMessages(json.relayedTexts) },
+        };
         provenanceCache.set(path, merged);
-        if (alive) setMap(merged);
+        if (!alive) return;
+        setData(merged);
+        const unresolvedIds = wanted.ids.some((id) => !(id in merged.messages));
+        if (unresolvedIds && retry < retryDelaysMs.length) {
+          timer = setTimeout(() => void attempt(retry + 1), retryDelaysMs[retry]);
+        }
       } catch {
-        /* quiet: absence renders as today's system row */
+        /* quiet: absence renders as today's row */
       }
-    })();
+    };
+    void attempt(0);
     return () => {
       alive = false;
+      if (timer) clearTimeout(timer);
     };
   }, [path, wantedKey]);
-  return useMemo<ProvenanceLookup>(
-    () => (engineMessageId) => (engineMessageId && map ? map[engineMessageId] ?? null : null),
-    [map],
-  );
+  return useMemo(() => lookupFor(data), [data]);
 }

--- a/src/components/feed/messageProvenance.tsx
+++ b/src/components/feed/messageProvenance.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import { messageOriginRole } from "@/lib/runtime/messageOrigin";
+import { parseSelectedContextRef } from "@/lib/selection/selectedContext";
+
+import type { FeedEntry } from "./parse";
+import { BoundedLru } from "./scrollMemory";
+
+/**
+ * Delivery-ledger provenance for the feed (#1117), Claude only: a delivered
+ * system row resolves through this lookup into the operator's own bubble or
+ * an internal relay card. Codex needs none of this — its authorship rides the
+ * structured-user marker the parser already decodes.
+ *
+ * The lookup travels by context so every FeedItem — focused pane, compact
+ * canvas pane — reads the same map without threading a prop through the row
+ * tree. A surface that mounts no provider (demo renderer, tests) gets the
+ * empty lookup and keeps today's system-row rendering.
+ */
+export type ProvenanceLookup = (engineMessageId: string | null) => DeliveredMessageProvenance | null;
+
+const NO_PROVENANCE: ProvenanceLookup = () => null;
+const ProvenanceContext = createContext<ProvenanceLookup>(NO_PROVENANCE);
+export const MessageProvenanceProvider = ProvenanceContext.Provider;
+
+export function useMessageProvenance(): ProvenanceLookup {
+  return useContext(ProvenanceContext);
+}
+
+type ProvenanceMap = Record<string, DeliveredMessageProvenance>;
+
+/* Browser-wide, so a revisited conversation answers from memory and a pane
+   remount does not refetch what it already resolved. Entries only grow: a
+   ledger's queued→delivered records are immutable once written. */
+const PROVENANCE_CACHE_PATHS = 48;
+const provenanceCache = new BoundedLru<ProvenanceMap>(PROVENANCE_CACHE_PATHS);
+
+export function resetMessageProvenanceCacheForTests(): void {
+  provenanceCache.clear();
+}
+
+function parseProvenanceMessages(value: unknown): ProvenanceMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const parsed: ProvenanceMap = {};
+  for (const [id, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!id || !entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const body = entry as Record<string, unknown>;
+    if (body.origin !== "operator" && body.origin !== "agent") continue;
+    const senderRole = messageOriginRole(body.senderRole);
+    const selectedContext = parseSelectedContextRef(body.selectedContext);
+    parsed[id] = {
+      origin: body.origin,
+      ...(senderRole ? { senderRole } : {}),
+      ...(selectedContext ? { selectedContext } : {}),
+    };
+  }
+  return parsed;
+}
+
+/** The delivered engine ids the current window still needs evidence for —
+    the ONLY trigger for a fetch, so an idle pane never polls. */
+function deliveredIdsKey(items: readonly FeedEntry[]): string {
+  const ids: string[] = [];
+  for (const { item } of items) {
+    if (item.kind === "sysmsg" && item.deliveredMessage?.engineMessageId) {
+      ids.push(item.deliveredMessage.engineMessageId);
+    }
+  }
+  return ids.join("\n");
+}
+
+/**
+ * Fetches `/api/log/provenance` for a Claude transcript whenever the window
+ * shows a delivered row the cache cannot resolve yet. Failures stay quiet —
+ * a row without evidence renders exactly as it does today.
+ */
+export function useDeliveredMessageProvenance(path: string | null, items: readonly FeedEntry[]): ProvenanceLookup {
+  const wantedKey = useMemo(() => (path ? deliveredIdsKey(items) : ""), [path, items]);
+  const [map, setMap] = useState<ProvenanceMap | null>(() => (path ? provenanceCache.get(path) ?? null : null));
+  useEffect(() => {
+    if (!path) return;
+    const cached = provenanceCache.get(path) ?? null;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync to the path's cache entry on path change
+    setMap(cached);
+    if (!wantedKey) return;
+    const missing = wantedKey.split("\n").some((id) => id && !(cached && id in cached));
+    if (!missing) return;
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/log/provenance?path=${encodeURIComponent(path)}`);
+        if (!res.ok) return;
+        const json = (await res.json()) as { messages?: unknown };
+        const merged = { ...(provenanceCache.get(path) ?? {}), ...parseProvenanceMessages(json.messages) };
+        provenanceCache.set(path, merged);
+        if (alive) setMap(merged);
+      } catch {
+        /* quiet: absence renders as today's system row */
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [path, wantedKey]);
+  return useMemo<ProvenanceLookup>(
+    () => (engineMessageId) => (engineMessageId && map ? map[engineMessageId] ?? null : null),
+    [map],
+  );
+}

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -6,10 +6,11 @@ import {
   VERDICT_LINE_RE,
   type ReviewCardItem,
 } from "@/lib/review";
-import { isClaudeProtocolUser } from "@/lib/claudeProtocolUser";
+import { isClaudeProtocolUser, isClaudeSdkDeliveredUser } from "@/lib/claudeProtocolUser";
 import { getLocale, translate } from "@/lib/i18n";
 import { inboxImageExt, MAX_INBOX_IMAGE_BYTES } from "@/lib/imagePolicy";
 import { decodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
+import type { MessageOrigin } from "@/lib/runtime/messageOrigin";
 import type { SelectedContextRef } from "@/lib/selection/selectedContext";
 import { isViewerMcpServer } from "@/lib/mcp/presentation";
 import type { FileEntry } from "@/lib/types";
@@ -193,6 +194,10 @@ export type Tmsg = {
   /** Outgoing only: delivery state recovered from the tool result. */
   delivery?: "ok" | "err";
   msgId?: string;
+  /** #1117: an MCP/structured inter-agent relay rather than a teammate
+      envelope — the card adds an explicit "internal" tag and `peer` names the
+      sender ROLE the delivery evidence attributed, not a teammate id. */
+  internal?: boolean;
 };
 export type CmdGroupItem = {
   kind: "cmd-group";
@@ -227,7 +232,11 @@ export type Item =
   | { kind: "image"; media: string; data: string; w?: number; h?: number; bytes?: number }
   | { kind: "inbox-image"; name: string; path: string }
   | { kind: "blob"; bytes: number; text: string; sourceId?: string }
-  | { kind: "sysmsg"; label: string; text: string }
+  /* `deliveredMessage` (#1117): set on a Claude user row that is a REAL message
+     delivered through the structured/SDK path — its engine uuid joins the
+     delivery ledger, so the renderer can resolve it into the operator's bubble
+     or an internal relay card. Without evidence it renders as this system row. */
+  | { kind: "sysmsg"; label: string; text: string; deliveredMessage?: { engineMessageId: string | null; ts: unknown } }
   | { kind: "compact"; ts: unknown; trigger?: string; preTokens?: number; summary?: string }
   | { kind: "raw"; text: string; err: boolean };
 
@@ -426,6 +435,10 @@ interface CodexUserContent {
       canonical structured-user marker. Absent on every record written before
       the field existed, and on every turn that carried none. */
   selectedContext?: SelectedContextRef | null;
+  /** Authorship stamped on the marker at delivery (#1117). `agent` renders as
+      an internal relay card; `operator` and records that predate the attribute
+      keep the user bubble. */
+  origin?: MessageOrigin | null;
 }
 
 /* Codex has added content-part variants over time. Keep the text path broad,
@@ -1644,8 +1657,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   };
   /* Inbound teammate traffic arrives as user text wrapped in <teammate-message>;
      idle_notification JSON bodies collapse to a thin service-style row. */
-  const addUserText = (ts: unknown, text: string, isHarness = false) => {
-    if (isHarness) return void addSysMsg(text, tr("render.system"));
+  const addUserText = (ts: unknown, text: string, isHarness = false, deliveredMessage?: { engineMessageId: string | null; ts: unknown }) => {
+    if (isHarness) return void addSysMsg(text, tr("render.system"), deliveredMessage);
     const rest = text.replace(TMSG_RE, (_whole, _tag: string, attrs: string, body: string) => {
       const peer = tmsgAttr(attrs, "teammate_id") || tmsgAttr(attrs, "from") || tr("render.teammate");
       const summary = tmsgAttr(attrs, "summary");
@@ -1683,15 +1696,28 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   /* Codex stores human input and harness context in user-role response rows.
      Known envelope markers identify harness rows. Echoed composer messages
      keep their user classification even when their text starts similarly. */
-  const addSysMsg = (text: string, fallbackLabel?: string) => {
-    push({ kind: "sysmsg", label: sysMsgLabel(text, fallbackLabel), text });
+  const addSysMsg = (text: string, fallbackLabel?: string, deliveredMessage?: { engineMessageId: string | null; ts: unknown }) => {
+    push({ kind: "sysmsg", label: sysMsgLabel(text, fallbackLabel), text, ...(deliveredMessage ? { deliveredMessage } : {}) });
   };
+  /* An agent-origin structured record (#1117) is inter-agent traffic: it
+     renders as the internal relay card naming the sender role, never as the
+     operator's own bubble. Operator and pre-attribute records keep the bubble. */
+  const internalRelayItem = (ts: unknown, text: string, origin: MessageOrigin): Tmsg => ({
+    kind: "tmsg",
+    ts,
+    dir: "in",
+    peer: origin.role ?? tr("render.agentPeer"),
+    summary: "",
+    text,
+    internal: true,
+  });
   const emitCodexUserContent = (ts: unknown, content: CodexUserContent): PendingCodexUser => {
     const entrySeqs: number[] = [];
     const emit = (item: Item) => entrySeqs.push(push(item));
     const { cleaned, images } = extractInboxImages(content.text);
     const voice = cleaned ? parseRealtimeDelegation(cleaned) : null;
     if (voice) emit({ kind: "voice", ts, ...voice });
+    else if (cleaned && content.origin?.kind === "agent") emit(internalRelayItem(ts, cleaned, content.origin));
     else if (cleaned) emit({ kind: "user", ts, text: cleaned, ...(content.selectedContext ? { selectedContext: content.selectedContext } : {}) });
     for (const image of images) emit({ kind: "inbox-image", name: image.name, path: image.path });
     for (const attachment of content.attachments) emit(attachment);
@@ -1750,15 +1776,23 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (!pending) return;
     const { cleaned, images } = extractInboxImages(decoded.text);
     if (cleaned) {
-      const userSeq = pending.entrySeqs.find((seq) => {
+      /* The echo replaces its provisional row LIKE FOR LIKE: an internal relay
+         stays the relay card (with the echo's timestamp), a user text stays
+         the bubble — the echo must never re-author the message. */
+      const internal = decoded.origin?.kind === "agent";
+      const echoItem: Item = internal
+        ? internalRelayItem(ts, cleaned, decoded.origin!)
+        : { kind: "user", ts, text: cleaned };
+      const matchSeq = pending.entrySeqs.find((seq) => {
         const idx = entryIndex(seq);
-        return idx >= 0 && entries[idx]?.item.kind === "user";
+        const kind = idx >= 0 ? entries[idx]?.item.kind : undefined;
+        return internal ? kind === "tmsg" : kind === "user";
       });
-      if (userSeq !== undefined) {
-        const idx = entryIndex(userSeq);
-        entries[idx] = { ...entries[idx], item: { kind: "user", ts, text: cleaned } };
+      if (matchSeq !== undefined) {
+        const idx = entryIndex(matchSeq);
+        entries[idx] = { ...entries[idx], item: echoItem };
       } else {
-        pending.entrySeqs.push(push({ kind: "user", ts, text: cleaned }));
+        pending.entrySeqs.push(push(echoItem));
       }
     }
     for (const image of images) pending.entrySeqs.push(push({ kind: "inbox-image", name: image.name, path: image.path }));
@@ -1915,10 +1949,17 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         return;
       }
       const isHarness = isClaudeProtocolUser(obj);
-      if (typeof content === "string") addUserText(ts, content, isHarness);
+      /* #1117: an SDK-delivered REAL message renders as a system row only for
+         lack of evidence — its engine uuid joins the delivery ledger, so the
+         renderer can resolve the row into the operator's bubble or an internal
+         relay card. Scaffold rows carry no join identity and stay system. */
+      const deliveredMessage = isClaudeSdkDeliveredUser(obj)
+        ? { engineMessageId: textPart(obj.uuid) || null, ts }
+        : undefined;
+      if (typeof content === "string") addUserText(ts, content, isHarness, deliveredMessage);
       else {
         for (const part of arr(content)) {
-          if (part.type === "text") addUserText(ts, textPart(part.text), isHarness);
+          if (part.type === "text") addUserText(ts, textPart(part.text), isHarness, deliveredMessage);
           else if (part.type === "image") pushImage(part, fileWrap);
           else if (part.type === "tool_result") {
             const inner = arr(part.content);

--- a/src/components/feed/scrollMemory.ts
+++ b/src/components/feed/scrollMemory.ts
@@ -27,4 +27,8 @@ export class BoundedLru<Value> {
       this.values.delete(oldest);
     }
   }
+
+  clear(): void {
+    this.values.clear();
+  }
 }

--- a/src/components/scheme/BulkActionBar.tsx
+++ b/src/components/scheme/BulkActionBar.tsx
@@ -218,7 +218,8 @@ export const BulkActionBar = memo(function BulkActionBar({
         }
         const items = await execute("message", [...byPath.keys()], (path) => {
           const node = byPath.get(path);
-          return postJson("/api/tmux", { pid: node?.file.pid ?? undefined, path, text, images });
+          /* #1117: a bulk send is the operator's own message to each target. */
+          return postJson("/api/tmux", { pid: node?.file.pid ?? undefined, path, text, images, origin: { kind: "operator" } });
         });
         if (items.length && items.every((item) => item.ok)) {
           composer.setText("");

--- a/src/components/tasks/broadcast.ts
+++ b/src/components/tasks/broadcast.ts
@@ -15,7 +15,8 @@ export async function tmuxSend(file: FileEntry, text: string, images: BroadcastI
     const res = await fetch("/api/tmux", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ pid: file.pid ?? undefined, path: file.path, text, images }),
+      /* #1117: a broadcast is the operator's own message to each target. */
+      body: JSON.stringify({ pid: file.pid ?? undefined, path: file.path, text, images, origin: { kind: "operator" } }),
     });
     const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
     if (!res.ok || !json?.ok) return json?.error ?? translate(getLocale(), "common.failedSend");

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -1,6 +1,7 @@
 import type { AgentEngine } from "@/lib/agent/cli";
 import { grantedMcpServers, type McpGrantPolicy } from "@/lib/agent/mcpAllowlist";
 import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
+import type { MessageOrigin } from "@/lib/runtime/messageOrigin";
 import type { StructuredImageRef } from "@/lib/runtime/structuredContent";
 import type { AgentGoal, AgentPlan, EngineLimits, LimitsProvenance } from "@/lib/types";
 
@@ -267,6 +268,12 @@ export interface HeldDeliveryCommand {
   kind: "send" | "steer";
   policy: "queue" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
+  /** Message authorship stamped at admission (#1117), persisted on the held
+      record so a migration-held delivery replays with the same attribution.
+      Excluded from the request digest: a replay that gains or loses the stamp
+      is the same logical message, never a conflict, and records written before
+      the field existed stay compatible. */
+  origin?: MessageOrigin;
 }
 
 export interface HeldDeliveryCommandInput {
@@ -274,6 +281,7 @@ export interface HeldDeliveryCommandInput {
   kind?: HeldDeliveryCommand["kind"];
   policy?: HeldDeliveryCommand["policy"];
   turnId?: string | null;
+  origin?: MessageOrigin;
 }
 
 export interface HeldDelivery {

--- a/src/lib/accounts/migration/deliveryPort.ts
+++ b/src/lib/accounts/migration/deliveryPort.ts
@@ -26,6 +26,9 @@ export function createMigrationDeliveryPort(
       images: [],
       clientMessageId,
       reservedDeliveryId: delivery.id,
+      /* #1117: the authorship persisted on the held command replays with the
+         message, so a re-routed hold re-attributes exactly as admitted. */
+      ...(delivery.command.origin ? { origin: delivery.command.origin } : {}),
     });
     return migrationDeliveryOutcome(result);
   });

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -57,6 +57,7 @@ import {
 } from "./registryBackendIdentity";
 import { SqliteAgentRegistryStore, type SqliteRegistrySnapshot } from "./sqliteRegistryStore";
 import type { ResumePaneRecord } from "@/lib/resumePanesFile";
+import { parseMessageOrigin } from "@/lib/runtime/messageOrigin";
 import { assertStructuredTextEnvelope, parseStructuredImageRefs, structuredContent, type StructuredImageRef } from "@/lib/runtime/structuredContent";
 
 export type AgentHostStatus = "starting" | "live" | "idle" | "handoff" | "unhosted" | "dead";
@@ -1397,6 +1398,11 @@ function canonicalHeldDeliveryCommand(
       : "interrupt-active",
   };
   if (value?.turnId === null || typeof value?.turnId === "string") command.turnId = value.turnId;
+  /* #1117: authorship rides the held record so a migration replay keeps it.
+     Re-validated on every normalization — a corrupt persisted origin drops
+     rather than replaying as a forged attribution. */
+  const origin = parseMessageOrigin(value?.origin);
+  if (origin) command.origin = origin;
   return command;
 }
 

--- a/src/lib/claudeProtocolUser.ts
+++ b/src/lib/claudeProtocolUser.ts
@@ -87,6 +87,25 @@ export function isClaudeProtocolUser(record: Record<string, unknown>): boolean {
   );
 }
 
+/**
+ * True when a Claude user record is a REAL MESSAGE that reached the engine
+ * through the structured/SDK delivery path (#1117): the feed renders it as a
+ * system row by default, but its uuid joins the delivery ledger's
+ * `engineMessageId`, so ledger evidence can reclassify it as the operator's
+ * own bubble or an inter-agent relay. Scaffold shapes — meta records, command
+ * caveats, task notifications, interrupt sentinels, compaction summaries —
+ * are excluded: they have no author to recover and must stay system rows.
+ */
+export function isClaudeSdkDeliveredUser(record: Record<string, unknown>): boolean {
+  if (str(record.promptSource) !== "sdk") return false;
+  if (record.isMeta === true || record.isCompactSummary === true || "interruptedMessageId" in record) return false;
+  const originKind = originKindOf(record);
+  if (originKind && originKind !== "human") return false;
+  const text = claudeUserText(rec(record.message).content).trim();
+  if (!text) return false;
+  return !(isClaudeInterruptSentinelText(text) || isCommandCaveatText(text) || isTaskNotificationText(text));
+}
+
 /** True when a Claude user record is journaled metadata that must never open
     or steer a work-duration window. Narrower than the feed contract: SDK and
     idle-delivered peer/coordinator prompts render as system rows but DO

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -9,6 +9,8 @@ import { emptyLaunchProfile } from "./accounts/migration/contracts";
 import { drainHeldDeliveries } from "./accounts/migration/coordinator";
 import { cleanupFailedImageDelivery, deliverConversationMessage, killConversation, migrationDeliveryOutcome, reconfigureConversation, resumeConversation, type DeliveryFailure } from "./delivery";
 import type { RuntimeHostClient } from "./runtime/client";
+import { heldDeliveryOccurrences } from "./runtime/deliveredMessageOccurrences";
+import { messageTextDigest } from "./runtime/messageTextDigest";
 import { recoverDeadStructuredConversation } from "./runtime/structuredRecovery";
 import type { FileEntry } from "./types";
 import { TmuxDeliveryUncertainError } from "./tmux";
@@ -770,6 +772,56 @@ test("large text uses a request-local reservation and still reaches ordinary del
   expect(outcome.ok).toBe(true);
   expect(delivered).toBe(text);
   expect(registry.holdDelivery(conversation.id, "", "large-text", "ephemeral-text")).toMatchObject({ state: "delivered", text: "" });
+});
+
+test("an over-32k agent-origin delivery keeps the digest of the delivered text, so it still projects as internal on both engines (#1117)", async () => {
+  type Overrides = NonNullable<Parameters<typeof deliverConversationMessage>[1]>;
+  for (const engine of ["claude", "codex"] as const) {
+    const registry = new AgentRegistry(path.join(SANDBOX, `${engine}-large-relay-registry.json`));
+    setAgentRegistryForTests(registry);
+    const pathname = path.join(SANDBOX, `${engine}-large-relay-fixture.jsonl`);
+    fs.writeFileSync(pathname, "");
+    const conversation = registry.ensureConversation(engine, pathname, "default");
+    /* Over the 32,000-byte envelope bound: the held record blanks this text
+       and keeps only a digest, which must be the digest of what was sent. */
+    const text = `Findings for the ${engine} worker, in full:\n${"x".repeat(32_000)}`;
+    const clientMessageId = `${engine}-large-relay`;
+    let delivered = "";
+
+    const outcome = await deliverConversationMessage({
+      pid: 1, path: pathname, conversationId: conversation.id, text, images: [], clientMessageId,
+      origin: { kind: "agent", role: "orchestrator" },
+    }, {
+      recover: async () => null,
+      pathAllowed: () => true,
+      listFiles: async () => [{ root: `${engine}-sessions`, path: pathname, project: "p", mtime: 0, size: 0 } as unknown as FileEntry],
+      resumeSpecFor: (() => ({ command: "resume", transcript: pathname, launchProfile: emptyLaunchProfile() })) as unknown as Overrides["resumeSpecFor"],
+      deliver: async ({ payload }: { payload: string }) => {
+        delivered = payload;
+        return { ok: true as const, outcome: "resumed" as const, target: "%7" };
+      },
+    });
+
+    expect(outcome).toMatchObject({ ok: true });
+    /* Engine input is untouched: the full text went to the host. */
+    expect(delivered).toBe(text);
+    const snapshot = registry.readOnlySnapshot();
+    const record = Object.values(snapshot.heldDeliveries).find((item) => item.clientMessageId === clientMessageId);
+    expect(record).toMatchObject({
+      state: "delivered",
+      payloadKind: "ephemeral-text",
+      text: "",
+      contentDigest: messageTextDigest(text),
+      command: { origin: { kind: "agent", role: "orchestrator" } },
+    });
+    expect(heldDeliveryOccurrences(pathname, snapshot)).toEqual([{
+      textDigest: messageTextDigest(text),
+      deliveredAt: record!.deliveredAt!,
+      origin: "agent",
+      senderRole: "orchestrator",
+      clientMessageId,
+    }]);
+  }
 });
 
 test("ordinary delivery on the active account skips the lazy-migration registry write", async () => {

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -12,6 +12,7 @@ import { transcriptLiveOwnership, type TranscriptLiveOwnership } from "@/lib/sca
 import { procBackend } from "@/lib/proc";
 import { recoverDeadStructuredConversation } from "@/lib/runtime/structuredRecovery";
 import type { MessageOrigin } from "@/lib/runtime/messageOrigin";
+import { structuredContent } from "@/lib/runtime/structuredContent";
 import type { RuntimeOperationReceipt } from "@/lib/runtime/contracts";
 import { detectBlockingGate, parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
 import type { FileEntry } from "@/lib/types";
@@ -628,13 +629,26 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     if (deliveryFence(conversation) === "held" && requestLocalPayload) return failure("request-local delivery waits for migration completion", 409);
     let queued;
     try {
+      const heldText = textBytes > 32_000 ? "" : text;
+      /* #1117: the digest is the only content evidence a delivered record
+         keeps (its text is blanked at settlement), and it is what joins a
+         legacy paste to its transcript row. Stamped at admission so the
+         record carries it whatever path settles it. */
+      let contentDigest: string | null = null;
+      if (heldText) {
+        try {
+          contentDigest = structuredContent(heldText, []).contentDigest;
+        } catch {
+          contentDigest = null;
+        }
+      }
       queued = registry.holdDelivery(
         conversation.id,
-        textBytes > 32_000 ? "" : text,
+        heldText,
         message.clientMessageId ?? null,
         images.length ? "ephemeral-images" : textBytes > 32_000 ? "ephemeral-text" : "text",
         [],
-        null,
+        contentDigest,
         message.origin ? { origin: message.origin } : {},
       );
     } catch (error) {

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -632,15 +632,15 @@ export async function deliverConversationMessage(message: ConversationMessage, o
       const heldText = textBytes > 32_000 ? "" : text;
       /* #1117: the digest is the only content evidence a delivered record
          keeps (its text is blanked at settlement), and it is what joins a
-         legacy paste to its transcript row. Stamped at admission so the
-         record carries it whatever path settles it. */
+         legacy paste to its transcript row. Stamped at admission from the
+         text actually delivered — before an oversized payload is blanked
+         from the record — so an over-bound agent relay still projects; the
+         plaintext itself stays request-local. */
       let contentDigest: string | null = null;
-      if (heldText) {
-        try {
-          contentDigest = structuredContent(heldText, []).contentDigest;
-        } catch {
-          contentDigest = null;
-        }
+      try {
+        contentDigest = structuredContent(text, []).contentDigest;
+      } catch {
+        contentDigest = null;
       }
       queued = registry.holdDelivery(
         conversation.id,

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -11,6 +11,7 @@ import { pathAllowed } from "@/lib/scanner/roots";
 import { transcriptLiveOwnership, type TranscriptLiveOwnership } from "@/lib/scanner/transcripts";
 import { procBackend } from "@/lib/proc";
 import { recoverDeadStructuredConversation } from "@/lib/runtime/structuredRecovery";
+import type { MessageOrigin } from "@/lib/runtime/messageOrigin";
 import type { RuntimeOperationReceipt } from "@/lib/runtime/contracts";
 import { detectBlockingGate, parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
 import type { FileEntry } from "@/lib/types";
@@ -537,6 +538,11 @@ export interface ConversationMessage {
   resumeModel?: string | null;
   resumeEffort?: string | null;
   resumeFast?: boolean | null;
+  /** Message authorship stamped by the admitting surface (#1117). Rides the
+      structured enqueue when the conversation recovers structured, and persists
+      on the legacy hold's command so the evidence survives even when the paste
+      itself — engine input this path must not change — cannot carry it. */
+  origin?: MessageOrigin;
 }
 
 interface DeliveryOverrides {
@@ -586,6 +592,7 @@ export async function deliverConversationMessage(message: ConversationMessage, o
           clientMessageId: message.clientMessageId,
           text,
           hasImages: images.length > 0,
+          ...(message.origin ? { origin: message.origin } : {}),
         }, {
           registry: () => registry,
         });
@@ -626,6 +633,9 @@ export async function deliverConversationMessage(message: ConversationMessage, o
         textBytes > 32_000 ? "" : text,
         message.clientMessageId ?? null,
         images.length ? "ephemeral-images" : textBytes > 32_000 ? "ephemeral-text" : "text",
+        [],
+        null,
+        message.origin ? { origin: message.origin } : {},
       );
     } catch (error) {
       return failure(error, 409);

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -379,6 +379,9 @@ export async function sendToImplementer(
           conversationId: recovered.conversationId,
           clientMessageId: relayClientMessageId(flow),
           text,
+          /* #1117: a relayed verdict is inter-agent traffic from the round's
+             reviewer, and the feed labels it exactly that way. */
+          origin: { kind: "agent", role: "reviewer" },
         },
         { registry: () => registry },
       );

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -329,10 +329,11 @@ export interface RelayDeliveryOverrides {
   onTransportSelected?: (transport: RelayDeliveryTransport) => void;
 }
 
-/** The durable structured-delivery identity of a round's relay. Exported so a
-    test can address the exact reservation the delivery journal settles. */
-export function relayClientMessageId(flow: Flow): string {
-  const round = flow.rounds?.at(-1);
+/** The durable structured-delivery identity of a round's relay — the current
+    round's by default, or any settled round's when given, so provenance can
+    name the reservation each round's relay settled under (#1117). Exported so
+    a test can address the exact reservation the delivery journal settles. */
+export function relayClientMessageId(flow: Flow, round: Round | undefined = flow.rounds?.at(-1)): string {
   const deliveryAttempt = round?.relayDeliveryAttempt ?? 0;
   const identity = `${flow.id}:${round?.n ?? "legacy"}:${round?.reviewerBindingId ?? "legacy"}`
     + (deliveryAttempt > 0 ? `:retry:${deliveryAttempt}` : "");

--- a/src/lib/flows/relayProvenance.test.ts
+++ b/src/lib/flows/relayProvenance.test.ts
@@ -6,6 +6,7 @@ import { afterAll, expect, test } from "bun:test";
 
 import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
 
+import { relayClientMessageId } from "./engine";
 import { relayPrompt } from "./prompts";
 import { flowRelayedMessageOccurrences } from "./relayProvenance";
 import type { Flow, Round } from "./types";
@@ -18,27 +19,48 @@ const FINDINGS = "P1 — the held command drops its origin across the migration 
 const DELIVERED_AT = "2026-08-24T09:00:00.000Z";
 
 function flowWith(rounds: Array<Partial<Round>>, implementerPath = IMPLEMENTER_PATH): Flow {
-  return { implementerPath, rounds } as unknown as Flow;
+  return { id: "flow-provenance", implementerPath, rounds } as unknown as Flow;
 }
 
-function settledRound(findingsPath: string, deliveredPath = IMPLEMENTER_PATH): Partial<Round> {
+function settledRound(findingsPath: string, deliveredPath = IMPLEMENTER_PATH, n = 1): Partial<Round> {
   return {
+    n,
+    reviewerBindingId: `binding-${n}`,
     findingsPath,
     relayDelivery: { path: deliveredPath, deliveredAt: DELIVERED_AT },
   };
 }
 
-test("a settled relay round joins its reconstructed text digest and settlement time as reviewer traffic", () => {
+test("a settled relay round joins its reconstructed text digest, settlement time, and relay identity as reviewer traffic", () => {
   const findingsPath = path.join(sandbox, "round-1-findings.md");
   fs.writeFileSync(findingsPath, FINDINGS);
   const round = settledRound(findingsPath);
-  const occurrences = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
+  const flow = flowWith([round]);
+  const occurrences = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, { flows: () => [flow] });
   expect(occurrences).toEqual([{
     textDigest: messageTextDigest(relayPrompt(round as Round, FINDINGS)),
     deliveredAt: DELIVERED_AT,
     origin: "agent",
     senderRole: "reviewer",
+    clientMessageId: relayClientMessageId(flow, round as Round),
   }]);
+});
+
+test("each settled round carries the identity its own structured relay reserved, computed from that round alone", () => {
+  const findingsPath = path.join(sandbox, "round-identity-findings.md");
+  fs.writeFileSync(findingsPath, FINDINGS);
+  const first = settledRound(findingsPath, IMPLEMENTER_PATH, 1);
+  /* A definitive relay failure advanced this round's delivery attempt before
+     the retry settled: the identity that settled is the retried one. */
+  const second: Partial<Round> = { ...settledRound(findingsPath, IMPLEMENTER_PATH, 2), relayDeliveryAttempt: 1 };
+  const flow = flowWith([first, second]);
+  const ids = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, { flows: () => [flow] })
+    .map((occurrence) => occurrence.clientMessageId);
+  expect(ids).toEqual([relayClientMessageId(flow, first as Round), relayClientMessageId(flow, second as Round)]);
+  expect(new Set(ids).size).toBe(2);
+  /* The engine settles the live relay under the current round's identity. */
+  expect(ids[1]).toBe(relayClientMessageId(flow));
+  for (const id of ids) expect(id).toMatch(/^flow_relay_[a-f0-9]{32}$/);
 });
 
 test("the flow's current implementer path still matches a relay delivered to a predecessor path", () => {

--- a/src/lib/flows/relayProvenance.test.ts
+++ b/src/lib/flows/relayProvenance.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, expect, test } from "bun:test";
+
+import { relayPrompt } from "./prompts";
+import { flowRelayedMessageProvenance } from "./relayProvenance";
+import type { Flow, Round } from "./types";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-relay-provenance-"));
+afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+
+const IMPLEMENTER_PATH = "/sessions/implementer-transcript.jsonl";
+const FINDINGS = "P1 — the held command drops its origin across the migration window.\n";
+
+function flowWith(rounds: Array<Partial<Round>>, implementerPath = IMPLEMENTER_PATH): Flow {
+  return { implementerPath, rounds } as unknown as Flow;
+}
+
+function settledRound(findingsPath: string, deliveredPath = IMPLEMENTER_PATH): Partial<Round> {
+  return {
+    findingsPath,
+    relayDelivery: { path: deliveredPath, deliveredAt: "2026-08-24T09:00:00.000Z" },
+  };
+}
+
+test("a settled relay round joins its reconstructed text as reviewer traffic", () => {
+  const findingsPath = path.join(sandbox, "round-1-findings.md");
+  fs.writeFileSync(findingsPath, FINDINGS);
+  const round = settledRound(findingsPath);
+  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
+  const relayedText = relayPrompt(round as Round, FINDINGS).trim();
+  expect(map[relayedText]).toEqual({ origin: "agent", senderRole: "reviewer" });
+  expect(Object.keys(map)).toHaveLength(1);
+});
+
+test("the flow's current implementer path still matches a relay delivered to a predecessor path", () => {
+  const findingsPath = path.join(sandbox, "round-2-findings.md");
+  fs.writeFileSync(findingsPath, FINDINGS);
+  const round = settledRound(findingsPath, "/sessions/predecessor-transcript.jsonl");
+  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
+  expect(Object.keys(map)).toHaveLength(1);
+});
+
+test("unsettled rounds, pruned artifacts, and other transcripts contribute nothing", () => {
+  const findingsPath = path.join(sandbox, "round-3-findings.md");
+  fs.writeFileSync(findingsPath, FINDINGS);
+  const unsettled: Partial<Round> = { findingsPath, relayDelivery: null };
+  const pruned = settledRound(path.join(sandbox, "missing-findings.md"));
+  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, {
+    flows: () => [
+      flowWith([unsettled, pruned]),
+      flowWith([settledRound(findingsPath, "/sessions/another-transcript.jsonl")], "/sessions/another-transcript.jsonl"),
+    ],
+  });
+  expect(map).toEqual({});
+});
+
+test("a failing flow store degrades to absence, never an error", () => {
+  expect(flowRelayedMessageProvenance(IMPLEMENTER_PATH, {
+    flows: () => { throw new Error("store unavailable"); },
+  })).toEqual({});
+});

--- a/src/lib/flows/relayProvenance.test.ts
+++ b/src/lib/flows/relayProvenance.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 
 import { afterAll, expect, test } from "bun:test";
 
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
+
 import { relayPrompt } from "./prompts";
-import { flowRelayedMessageProvenance } from "./relayProvenance";
+import { flowRelayedMessageOccurrences } from "./relayProvenance";
 import type { Flow, Round } from "./types";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-relay-provenance-"));
@@ -13,6 +15,7 @@ afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 
 const IMPLEMENTER_PATH = "/sessions/implementer-transcript.jsonl";
 const FINDINGS = "P1 — the held command drops its origin across the migration window.\n";
+const DELIVERED_AT = "2026-08-24T09:00:00.000Z";
 
 function flowWith(rounds: Array<Partial<Round>>, implementerPath = IMPLEMENTER_PATH): Flow {
   return { implementerPath, rounds } as unknown as Flow;
@@ -21,44 +24,48 @@ function flowWith(rounds: Array<Partial<Round>>, implementerPath = IMPLEMENTER_P
 function settledRound(findingsPath: string, deliveredPath = IMPLEMENTER_PATH): Partial<Round> {
   return {
     findingsPath,
-    relayDelivery: { path: deliveredPath, deliveredAt: "2026-08-24T09:00:00.000Z" },
+    relayDelivery: { path: deliveredPath, deliveredAt: DELIVERED_AT },
   };
 }
 
-test("a settled relay round joins its reconstructed text as reviewer traffic", () => {
+test("a settled relay round joins its reconstructed text digest and settlement time as reviewer traffic", () => {
   const findingsPath = path.join(sandbox, "round-1-findings.md");
   fs.writeFileSync(findingsPath, FINDINGS);
   const round = settledRound(findingsPath);
-  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
-  const relayedText = relayPrompt(round as Round, FINDINGS).trim();
-  expect(map[relayedText]).toEqual({ origin: "agent", senderRole: "reviewer" });
-  expect(Object.keys(map)).toHaveLength(1);
+  const occurrences = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
+  expect(occurrences).toEqual([{
+    textDigest: messageTextDigest(relayPrompt(round as Round, FINDINGS)),
+    deliveredAt: DELIVERED_AT,
+    origin: "agent",
+    senderRole: "reviewer",
+  }]);
 });
 
 test("the flow's current implementer path still matches a relay delivered to a predecessor path", () => {
   const findingsPath = path.join(sandbox, "round-2-findings.md");
   fs.writeFileSync(findingsPath, FINDINGS);
   const round = settledRound(findingsPath, "/sessions/predecessor-transcript.jsonl");
-  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
-  expect(Object.keys(map)).toHaveLength(1);
+  const occurrences = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, { flows: () => [flowWith([round])] });
+  expect(occurrences).toHaveLength(1);
 });
 
-test("unsettled rounds, pruned artifacts, and other transcripts contribute nothing", () => {
+test("unsettled rounds, unparseable settlement times, pruned artifacts, and other transcripts contribute nothing", () => {
   const findingsPath = path.join(sandbox, "round-3-findings.md");
   fs.writeFileSync(findingsPath, FINDINGS);
   const unsettled: Partial<Round> = { findingsPath, relayDelivery: null };
+  const corruptTime: Partial<Round> = { findingsPath, relayDelivery: { path: IMPLEMENTER_PATH, deliveredAt: "when?" } };
   const pruned = settledRound(path.join(sandbox, "missing-findings.md"));
-  const map = flowRelayedMessageProvenance(IMPLEMENTER_PATH, {
+  const occurrences = flowRelayedMessageOccurrences(IMPLEMENTER_PATH, {
     flows: () => [
-      flowWith([unsettled, pruned]),
+      flowWith([unsettled, corruptTime, pruned]),
       flowWith([settledRound(findingsPath, "/sessions/another-transcript.jsonl")], "/sessions/another-transcript.jsonl"),
     ],
   });
-  expect(map).toEqual({});
+  expect(occurrences).toEqual([]);
 });
 
 test("a failing flow store degrades to absence, never an error", () => {
-  expect(flowRelayedMessageProvenance(IMPLEMENTER_PATH, {
+  expect(flowRelayedMessageOccurrences(IMPLEMENTER_PATH, {
     flows: () => { throw new Error("store unavailable"); },
-  })).toEqual({});
+  })).toEqual([]);
 });

--- a/src/lib/flows/relayProvenance.ts
+++ b/src/lib/flows/relayProvenance.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
-import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+import type { DeliveredMessageOccurrence } from "@/lib/runtime/messageOrigin";
+import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
 
 import { relayPrompt } from "./prompts";
 import { loadFlows } from "./store";
@@ -13,8 +14,8 @@ import type { Flow } from "./types";
  * relay wrote a ledger record without an origin. The flow record IS existing
  * durable evidence for both — each round persists its findings artifact and
  * its settled `relayDelivery` — so the exact relayed text can be reconstructed
- * and joined to the transcript row that echoes it, the same text-identity
- * convention the feed already uses for launch echoes.
+ * and its digest joined, together with the settlement time, to the ONE
+ * transcript row that echoes that delivery.
  *
  * Absence stays honest: an unreadable findings artifact or an unsettled round
  * contributes nothing, and an unmatched row keeps today's rendering.
@@ -24,38 +25,43 @@ export interface FlowRelayProvenanceDependencies {
   flows?: () => Flow[];
 }
 
-const RELAY_SENDER: DeliveredMessageProvenance = { origin: "agent", senderRole: "reviewer" };
-
 /**
- * `trimmed relayed text → provenance` for one implementer transcript. Every
- * failure degrades to an empty or partial map, never an error.
+ * One occurrence per settled relay round of one implementer transcript.
+ * Every failure degrades to an empty or partial list, never an error.
  */
-export function flowRelayedMessageProvenance(
+export function flowRelayedMessageOccurrences(
   transcriptPath: string,
   dependencies: FlowRelayProvenanceDependencies = {},
-): Record<string, DeliveredMessageProvenance> {
-  if (!transcriptPath) return {};
+): DeliveredMessageOccurrence[] {
+  if (!transcriptPath) return [];
   let flows: Flow[];
   try {
     flows = (dependencies.flows ?? loadFlows)();
   } catch {
-    return {};
+    return [];
   }
-  const relayed: Record<string, DeliveredMessageProvenance> = {};
+  const occurrences: DeliveredMessageOccurrence[] = [];
   for (const flow of flows) {
     for (const round of flow.rounds) {
       /* Only a settled relay is evidence that this text reached a transcript;
-         the round records where it landed. The flow's current implementer path
-         also matches, so a conversation continued past the relay keeps it. */
-      if (!round.relayDelivery || !round.findingsPath) continue;
-      if (round.relayDelivery.path !== transcriptPath && flow.implementerPath !== transcriptPath) continue;
+         the round records where and when it landed. The flow's current
+         implementer path also matches, so a conversation continued past the
+         relay keeps it. */
+      const delivery = round.relayDelivery;
+      if (!delivery?.deliveredAt || !Number.isFinite(Date.parse(delivery.deliveredAt)) || !round.findingsPath) continue;
+      if (delivery.path !== transcriptPath && flow.implementerPath !== transcriptPath) continue;
       try {
         const findings = fs.readFileSync(round.findingsPath, "utf8");
-        relayed[relayPrompt(round, findings).trim()] = RELAY_SENDER;
+        occurrences.push({
+          textDigest: messageTextDigest(relayPrompt(round, findings)),
+          deliveredAt: delivery.deliveredAt,
+          origin: "agent",
+          senderRole: "reviewer",
+        });
       } catch {
         /* A pruned findings artifact loses only this round's attribution. */
       }
     }
   }
-  return relayed;
+  return occurrences;
 }

--- a/src/lib/flows/relayProvenance.ts
+++ b/src/lib/flows/relayProvenance.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+
+import type { DeliveredMessageProvenance } from "@/lib/runtime/messageOrigin";
+
+import { relayPrompt } from "./prompts";
+import { loadFlows } from "./store";
+import type { Flow } from "./types";
+
+/*
+ * Relay provenance from the flow store (#1117), for the delivery paths that
+ * leave no per-message evidence of their own: a legacy tmux relay writes only
+ * engine input (which provenance must not change), and a pre-#1117 structured
+ * relay wrote a ledger record without an origin. The flow record IS existing
+ * durable evidence for both — each round persists its findings artifact and
+ * its settled `relayDelivery` — so the exact relayed text can be reconstructed
+ * and joined to the transcript row that echoes it, the same text-identity
+ * convention the feed already uses for launch echoes.
+ *
+ * Absence stays honest: an unreadable findings artifact or an unsettled round
+ * contributes nothing, and an unmatched row keeps today's rendering.
+ */
+
+export interface FlowRelayProvenanceDependencies {
+  flows?: () => Flow[];
+}
+
+const RELAY_SENDER: DeliveredMessageProvenance = { origin: "agent", senderRole: "reviewer" };
+
+/**
+ * `trimmed relayed text → provenance` for one implementer transcript. Every
+ * failure degrades to an empty or partial map, never an error.
+ */
+export function flowRelayedMessageProvenance(
+  transcriptPath: string,
+  dependencies: FlowRelayProvenanceDependencies = {},
+): Record<string, DeliveredMessageProvenance> {
+  if (!transcriptPath) return {};
+  let flows: Flow[];
+  try {
+    flows = (dependencies.flows ?? loadFlows)();
+  } catch {
+    return {};
+  }
+  const relayed: Record<string, DeliveredMessageProvenance> = {};
+  for (const flow of flows) {
+    for (const round of flow.rounds) {
+      /* Only a settled relay is evidence that this text reached a transcript;
+         the round records where it landed. The flow's current implementer path
+         also matches, so a conversation continued past the relay keeps it. */
+      if (!round.relayDelivery || !round.findingsPath) continue;
+      if (round.relayDelivery.path !== transcriptPath && flow.implementerPath !== transcriptPath) continue;
+      try {
+        const findings = fs.readFileSync(round.findingsPath, "utf8");
+        relayed[relayPrompt(round, findings).trim()] = RELAY_SENDER;
+      } catch {
+        /* A pruned findings artifact loses only this round's attribution. */
+      }
+    }
+  }
+  return relayed;
+}

--- a/src/lib/flows/relayProvenance.ts
+++ b/src/lib/flows/relayProvenance.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import type { DeliveredMessageOccurrence } from "@/lib/runtime/messageOrigin";
 import { messageTextDigest } from "@/lib/runtime/messageTextDigest";
 
+import { relayClientMessageId } from "./engine";
 import { relayPrompt } from "./prompts";
 import { loadFlows } from "./store";
 import type { Flow } from "./types";
@@ -16,6 +17,11 @@ import type { Flow } from "./types";
  * its settled `relayDelivery` — so the exact relayed text can be reconstructed
  * and its digest joined, together with the settlement time, to the ONE
  * transcript row that echoes that delivery.
+ *
+ * Each occurrence also names the round's own relay identity — the client-
+ * message id a structured relay reserves its registry record under — so the
+ * projector can tell a relay the registry also settled (one delivery, two
+ * stores) from one it never saw, without comparing text or time.
  *
  * Absence stays honest: an unreadable findings artifact or an unsettled round
  * contributes nothing, and an unmatched row keeps today's rendering.
@@ -57,6 +63,7 @@ export function flowRelayedMessageOccurrences(
           deliveredAt: delivery.deliveredAt,
           origin: "agent",
           senderRole: "reviewer",
+          clientMessageId: relayClientMessageId(flow, round),
         });
       } catch {
         /* A pruned findings artifact loses only this round's attribution. */

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1105,6 +1105,8 @@ export const en = {
   "render.showJson": "show JSON",
   "render.toDir": "to",
   "render.fromDir": "from",
+  "render.internalTag": "internal",
+  "render.agentPeer": "agent",
   "render.delivered": "delivered",
   "render.notDelivered": "not delivered",
   "render.reasoning": "agent reasoning",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1074,6 +1074,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "render.showJson": "показати JSON",
   "render.toDir": "до",
   "render.fromDir": "від",
+  "render.internalTag": "внутрішнє",
+  "render.agentPeer": "агент",
   "render.delivered": "доставлено",
   "render.notDelivered": "не доставлено",
   "render.reasoning": "міркування агента",

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1423,6 +1423,9 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
     clientMessageId: deliveryId,
     text: body,
     images: [],
+    /* #1117: a directive relay is inter-agent traffic — the manager's feed
+       names the gateway (or attributed caller role), never the operator. */
+    origin: mcpSenderOrigin(dependencies),
   });
   return {
     directiveId: deliveryId,

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -68,6 +68,7 @@ import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessi
 import { listRoles, resolveSpawnRole } from "@/lib/roles/registry";
 import type { RoleDefinition, RoleParameter } from "@/lib/roles/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
+import { messageOriginRole, type MessageOrigin } from "@/lib/runtime/messageOrigin";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
 import {
   SELECTED_TAIL_MAX_BYTES,
@@ -337,9 +338,35 @@ export function callerAttributionFrom(
   };
 }
 
-function attributionOf(dependencies: ViewerMcpDomainDependencies): CallerAttribution {
+function attributionOf(dependencies: Pick<ViewerMcpDomainDependencies, "callerAttribution" | "attentionAuthority">): CallerAttribution {
   return dependencies.callerAttribution?.()
     ?? callerAttributionFrom(dependencies.attentionAuthority(), () => false);
+}
+
+/**
+ * Message authorship for a send issued through this MCP server (#1117): every
+ * MCP caller is an agent, and the role is the server's own attribution — never
+ * a caller claim. Attribution reads process ancestry, so a fault there costs
+ * only the role, not the send.
+ */
+function mcpSenderOrigin(
+  dependencies: Partial<Pick<ViewerMcpDomainDependencies, "callerAttribution" | "attentionAuthority">>,
+): MessageOrigin {
+  let attribution: CallerAttribution | null = null;
+  try {
+    attribution = dependencies.callerAttribution?.()
+      ?? (dependencies.attentionAuthority
+        ? callerAttributionFrom(dependencies.attentionAuthority(), () => false)
+        : null);
+  } catch {
+    attribution = null;
+  }
+  const role = attribution?.kind === "manager"
+    ? "orchestrator"
+    : attribution?.kind === "gateway"
+      ? "gateway"
+      : messageOriginRole(attribution?.role);
+  return { kind: "agent", ...(role ? { role } : {}) };
 }
 
 /**
@@ -613,7 +640,8 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies)
 async function sendMessage(
   args: McpToolArgs,
   control: ViewerControlDependencies,
-  dependencies: Pick<ViewerMcpDomainDependencies, "registrySnapshot">,
+  dependencies: Pick<ViewerMcpDomainDependencies, "registrySnapshot"> &
+    Partial<Pick<ViewerMcpDomainDependencies, "callerAttribution" | "attentionAuthority">>,
 ): Promise<McpToolPayload> {
   const conversationId = text(args.conversationId);
   const transcriptPath = text(args.transcriptPath) || text(args.path);
@@ -626,6 +654,9 @@ async function sendMessage(
     clientMessageId: requestId(args),
     text: message,
     images: [],
+    /* #1117: an MCP send is inter-agent traffic by definition; the sender role
+       is the server's own caller attribution, so the feed can say WHO relayed. */
+    origin: mcpSenderOrigin(dependencies),
   });
   /* The registry's OWN lookup over the projection this call already holds (#845),
      rather than a local reimplementation of it. The alias walk is multi-hop and
@@ -1576,7 +1607,11 @@ async function createOrchestrator(args: McpToolArgs, control: ViewerControlDepen
  * their idempotency keys from this call's, so a retry replays instead of
  * duplicating, and the response says which path ran.
  */
-async function sendMessageToOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
+async function sendMessageToOrchestrator(
+  args: McpToolArgs,
+  control: ViewerControlDependencies,
+  dependencies: Partial<Pick<ViewerMcpDomainDependencies, "callerAttribution" | "attentionAuthority">> = {},
+): Promise<McpToolPayload> {
   const project = canonicalOrchestratorProject(required(args, "project"));
   const message = requiredMessageText(args);
   const key = requestId(args);
@@ -1602,6 +1637,7 @@ async function sendMessageToOrchestrator(args: McpToolArgs, control: ViewerContr
     clientMessageId: key,
     text: message,
     images: [],
+    origin: mcpSenderOrigin(dependencies),
   });
   return redactPayload({
     project,
@@ -2456,7 +2492,7 @@ export function viewerMcpBindings(
     bridge_directive: (args) => bridgeDirective(args, controlDependencies, domainDependencies),
     get_orchestrator: (args) => getOrchestrator(args, domainDependencies),
     create_orchestrator: (args) => createOrchestrator(args, controlDependencies),
-    send_message_to_orchestrator: (args) => sendMessageToOrchestrator(args, controlDependencies),
+    send_message_to_orchestrator: (args) => sendMessageToOrchestrator(args, controlDependencies, domainDependencies),
     rotate_orchestrator: (args) => rotateOrchestrator(args, controlDependencies),
   };
 }

--- a/src/lib/runtime/claudeMessageProvenance.test.ts
+++ b/src/lib/runtime/claudeMessageProvenance.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { RegistryFile } from "@/lib/agent/registry";
+
+import { claudeMessageProvenance } from "./claudeMessageProvenance";
+import { FileClaudeDeliveryLedger } from "./claudeStreamBrokerHost";
+import { captureSelectedContext } from "@/lib/selection/selectedContext";
+
+/**
+ * The ledger→feed join of #1117: delivery evidence written at admission time
+ * answers "who authored this transcript row" by engine message id. New sends
+ * carry a stamped origin; older ledgers still classify through the evidence
+ * they already have (the operator's selected-context capture, a spawn
+ * operation's launch receipt); anything unproven is omitted, never guessed.
+ */
+
+/* Assembled from parts so the invented id can never fingerprint as a real
+   session identifier on the publication gate. */
+const SESSION_ID = ["11111111", "2222", "4333", "8444", "555555555550"].join("-");
+const TRANSCRIPT = `/tmp/llv-provenance-fixture/${SESSION_ID}.jsonl`;
+
+const REFERENCE = captureSelectedContext({
+  context: { project: "atlas" },
+  slice: { focusedPath: "fixtures/projects/atlas/worker-a.jsonl", selectedPaths: [] },
+  cards: [{ path: "fixtures/projects/atlas/worker-a.jsonl", conversationId: "conversation_atlas_a", label: "Worker A" }],
+  identity: { viewSessionId: "vs-synthetic-1", deviceId: "dev-synthetic-1" },
+  revision: 2,
+  now: Date.parse("2026-07-31T09:00:00.000Z"),
+});
+
+const tmpDirs: string[] = [];
+
+function newLedger(): FileClaudeDeliveryLedger {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-provenance-"));
+  tmpDirs.push(dir);
+  return new FileClaudeDeliveryLedger(dir);
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function emptySnapshot(overrides: Partial<Pick<RegistryFile, "receipts" | "conversations">> = {}): RegistryFile {
+  return { receipts: {}, conversations: {}, ...overrides } as RegistryFile;
+}
+
+test("a stamped operator send resolves to the operator with its selected-context badge", () => {
+  const ledger = newLedger();
+  ledger.recordQueued(SESSION_ID, {
+    id: "op-1",
+    text: "please rerun the failing check",
+    selectedContext: REFERENCE,
+    origin: { kind: "operator" },
+  }, "turn-started");
+  ledger.confirmDelivered(SESSION_ID, "op-1", "engine-uuid-1");
+
+  const map = claudeMessageProvenance(TRANSCRIPT, { ledger, registrySnapshot: () => emptySnapshot() });
+  expect(map["engine-uuid-1"]).toEqual({ origin: "operator", selectedContext: REFERENCE });
+});
+
+test("a stamped agent send resolves to an internal relay naming the sender role", () => {
+  const ledger = newLedger();
+  ledger.recordQueued(SESSION_ID, {
+    id: "op-2",
+    text: "Round 2 verdict: REQUEST_CHANGES",
+    origin: { kind: "agent", role: "reviewer" },
+  }, "queued-next-turn");
+  ledger.confirmDelivered(SESSION_ID, "op-2", "engine-uuid-2");
+
+  const map = claudeMessageProvenance(TRANSCRIPT, { ledger, registrySnapshot: () => emptySnapshot() });
+  expect(map["engine-uuid-2"]).toEqual({ origin: "agent", senderRole: "reviewer" });
+});
+
+test("a pre-#1117 operator send still resolves through its selected-context capture", () => {
+  const ledger = newLedger();
+  ledger.recordQueued(SESSION_ID, {
+    id: "op-3",
+    text: "розкажи що плануєш робити",
+    selectedContext: REFERENCE,
+  }, "turn-started");
+  ledger.confirmDelivered(SESSION_ID, "op-3", "engine-uuid-3");
+
+  const map = claudeMessageProvenance(TRANSCRIPT, { ledger, registrySnapshot: () => emptySnapshot() });
+  expect(map["engine-uuid-3"]).toEqual({ origin: "operator", selectedContext: REFERENCE });
+});
+
+test("a pre-#1117 spawn first message classifies through its launch receipt's delegation depth", () => {
+  const ledger = newLedger();
+  ledger.recordQueued(SESSION_ID, { id: "spawn_message_launch-root", text: "build the thing" }, "turn-started");
+  ledger.confirmDelivered(SESSION_ID, "spawn_message_launch-root", "engine-uuid-4");
+  ledger.recordQueued(SESSION_ID, { id: "spawn_message_launch-delegated", text: "stage mandate" }, "queued-next-turn");
+  ledger.confirmDelivered(SESSION_ID, "spawn_message_launch-delegated", "engine-uuid-5");
+
+  const snapshot = emptySnapshot({
+    receipts: {
+      "launch-root": { delegationDepth: 0, parentConversationId: null },
+      "launch-delegated": { delegationDepth: 2, parentConversationId: "conversation_parent" },
+    } as unknown as RegistryFile["receipts"],
+    conversations: {
+      conversation_parent: { agentRole: "orchestrator", generations: [] },
+    } as unknown as RegistryFile["conversations"],
+  });
+  const map = claudeMessageProvenance(TRANSCRIPT, { ledger, registrySnapshot: () => snapshot });
+  expect(map["engine-uuid-4"]).toEqual({ origin: "operator" });
+  expect(map["engine-uuid-5"]).toEqual({ origin: "agent", senderRole: "orchestrator" });
+});
+
+test("undelivered entries, unproven entries and a missing ledger resolve to nothing", () => {
+  const ledger = newLedger();
+  ledger.recordQueued(SESSION_ID, { id: "op-queued-only", text: "still waiting" }, "queued-next-turn");
+  ledger.recordQueued(SESSION_ID, { id: "op-no-evidence", text: "who sent this?" }, "turn-started");
+  ledger.confirmDelivered(SESSION_ID, "op-no-evidence", "engine-uuid-6");
+
+  const map = claudeMessageProvenance(TRANSCRIPT, { ledger, registrySnapshot: () => emptySnapshot() });
+  expect(map).toEqual({});
+  expect(claudeMessageProvenance("/tmp/does-not-exist/nope.jsonl", { ledger: newLedger(), registrySnapshot: () => emptySnapshot() })).toEqual({});
+  expect(claudeMessageProvenance("/tmp/not-a-transcript.log", { ledger, registrySnapshot: () => emptySnapshot() })).toEqual({});
+});

--- a/src/lib/runtime/claudeMessageProvenance.ts
+++ b/src/lib/runtime/claudeMessageProvenance.ts
@@ -1,0 +1,112 @@
+import path from "node:path";
+
+import { agentRegistry, type RegistryFile } from "@/lib/agent/registry";
+
+import { FileClaudeDeliveryLedger, type ClaudeDeliveryLedger, type ClaudeDeliveryState } from "./claudeStreamBrokerHost";
+import { messageOriginRole, type DeliveredMessageProvenance } from "./messageOrigin";
+
+export type { DeliveredMessageProvenance };
+
+/*
+ * The feed-facing authorship of delivered Claude messages (#1117), keyed by
+ * the transcript row's own uuid (the ledger's `engineMessageId`).
+ *
+ * A Claude transcript row journaled through the structured broker carries only
+ * SDK provenance, so the feed cannot tell the operator's words from an
+ * inter-agent relay by reading the row. The broker's delivery ledger CAN: each
+ * queued record carries the admission-stamped origin (new sends), the
+ * operator's selected-context capture (#844 sends), or a spawn operation id
+ * whose receipt records the launch's delegation depth (legacy first messages).
+ * This module is that join, done server-side where the ledger lives.
+ *
+ * Absence is honest: an entry with no evidence is omitted, and the feed keeps
+ * rendering its row exactly as before.
+ */
+
+export interface ClaudeMessageProvenanceDependencies {
+  ledger?: ClaudeDeliveryLedger;
+  registrySnapshot?: () => RegistryFile;
+}
+
+const SPAWN_MESSAGE_PREFIX = "spawn_message_";
+
+function spawnEntryProvenance(
+  entryId: string,
+  transcriptPath: string,
+  snapshot: RegistryFile,
+): DeliveredMessageProvenance | null {
+  const launchId = entryId.slice(SPAWN_MESSAGE_PREFIX.length);
+  const receipt = snapshot.receipts[launchId];
+  /* The receipt is the first authority; a conversation that recorded its own
+     delegation depth (#393) answers for receipts already pruned. */
+  const depth = receipt?.delegationDepth
+    ?? Object.values(snapshot.conversations)
+      .find((conversation) => conversation.generations.some((generation) => generation.path === transcriptPath))
+      ?.delegationDepth
+    ?? null;
+  if (depth === null) return null;
+  if (depth === 0) return { origin: "operator" };
+  const parentId = receipt?.parentConversationId;
+  const role = messageOriginRole(parentId ? snapshot.conversations[parentId]?.agentRole ?? undefined : undefined);
+  return { origin: "agent", ...(role ? { senderRole: role } : {}) };
+}
+
+function entryProvenance(
+  state: ClaudeDeliveryState,
+  transcriptPath: string,
+  snapshot: () => RegistryFile,
+): DeliveredMessageProvenance | null {
+  const entry = state.entry;
+  if (entry.origin) {
+    const role = entry.origin.kind === "agent" ? messageOriginRole(entry.origin.role) : undefined;
+    return {
+      origin: entry.origin.kind,
+      ...(role ? { senderRole: role } : {}),
+      ...(entry.origin.kind === "operator" && entry.selectedContext ? { selectedContext: entry.selectedContext } : {}),
+    };
+  }
+  /* Pre-#1117 evidence. A selected-context capture exists only on operator
+     composer sends; a spawn operation id resolves through its launch receipt. */
+  if (entry.selectedContext) return { origin: "operator", selectedContext: entry.selectedContext };
+  if (entry.id.startsWith(SPAWN_MESSAGE_PREFIX)) return spawnEntryProvenance(entry.id, transcriptPath, snapshot());
+  return null;
+}
+
+/**
+ * `engineMessageId → provenance` for one Claude transcript. Reads only that
+ * conversation's own ledger file; every failure (no ledger, malformed ledger,
+ * unavailable registry) degrades to an empty or partial map, never an error —
+ * missing provenance renders as today's system row.
+ */
+export function claudeMessageProvenance(
+  transcriptPath: string,
+  dependencies: ClaudeMessageProvenanceDependencies = {},
+): Record<string, DeliveredMessageProvenance> {
+  if (!transcriptPath.endsWith(".jsonl")) return {};
+  const sessionId = path.basename(transcriptPath, ".jsonl");
+  if (!sessionId) return {};
+  const ledger = dependencies.ledger ?? new FileClaudeDeliveryLedger();
+  let states: ClaudeDeliveryState[];
+  try {
+    states = ledger.load(sessionId);
+  } catch {
+    return {};
+  }
+  let cached: RegistryFile | null = null;
+  const snapshot = () => {
+    cached ??= (dependencies.registrySnapshot ?? (() => agentRegistry().readOnlySnapshot()))();
+    return cached;
+  };
+  const provenance: Record<string, DeliveredMessageProvenance> = {};
+  for (const state of states) {
+    if (!state.delivered || !state.engineMessageId) continue;
+    let resolved: DeliveredMessageProvenance | null;
+    try {
+      resolved = entryProvenance(state, transcriptPath, snapshot);
+    } catch {
+      resolved = null;
+    }
+    if (resolved) provenance[state.engineMessageId] = resolved;
+  }
+  return provenance;
+}

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -955,6 +955,7 @@ export class CodexAppServerHost implements EngineHost {
       ...(normalized.expectedTurnId !== undefined ? { expectedTurnId: normalized.expectedTurnId } : {}),
       ...(normalized.runtime ? { runtime: normalized.runtime } : {}),
       ...(normalized.selectedContext ? { selectedContext: normalized.selectedContext } : {}),
+      ...(normalized.origin ? { origin: normalized.origin } : {}),
     };
     if (!entry.id) throw new Error("queue entry id is required");
     const confirmed = await this.confirmedDelivery(entry);
@@ -974,6 +975,9 @@ export class CodexAppServerHost implements EngineHost {
              canonical structured-user record, so it survives a restart and a
              re-parse and the transcript row renders the composer badge. */
           normalized.selectedContext,
+          /* #1117: authorship lands on the same record, so the feed can tell
+             the operator's bubble from an inter-agent relay without a join. */
+          normalized.origin,
         ),
       },
     ];

--- a/src/lib/runtime/codexStructuredUserText.test.ts
+++ b/src/lib/runtime/codexStructuredUserText.test.ts
@@ -32,6 +32,7 @@ test("a plain structured record still round-trips with no reference", () => {
     structured: true,
     contentDigest: null,
     selectedContext: null,
+    origin: null,
   });
 });
 
@@ -42,6 +43,7 @@ test("the digest form written before this field still decodes", () => {
     structured: true,
     contentDigest: DIGEST,
     selectedContext: null,
+    origin: null,
   });
 });
 
@@ -51,6 +53,7 @@ test("unstructured text is untouched", () => {
     structured: false,
     contentDigest: null,
     selectedContext: null,
+    origin: null,
   });
 });
 
@@ -62,6 +65,7 @@ test("the reference persists on the record and comes back typed", () => {
     structured: true,
     contentDigest: null,
     selectedContext: REFERENCE,
+    origin: null,
   });
 });
 
@@ -72,6 +76,7 @@ test("the reference and the content digest ride the same marker", () => {
     structured: true,
     contentDigest: DIGEST,
     selectedContext: REFERENCE,
+    origin: null,
   });
 });
 
@@ -96,6 +101,7 @@ test("a corrupt or forged reference decodes as absent and never breaks the recor
     structured: true,
     contentDigest: null,
     selectedContext: null,
+    origin: null,
   });
 });
 
@@ -105,4 +111,55 @@ test("the operator's own text is never mistaken for a marker", () => {
   );
   expect(decoded.text).toBe("<!-- llv:structured-user ctx=zzz -->\nnot a marker");
   expect(decoded.selectedContext).toEqual(REFERENCE);
+});
+
+/* #1117: authorship rides the same marker, so the feed can tell the operator's
+   own words from an inter-agent relay without any join. */
+
+test("an operator origin persists on the record and comes back typed", () => {
+  const encoded = encodeCodexStructuredUserText("Look at that one.", undefined, null, { kind: "operator" });
+  expect(decodeCodexStructuredUserText(encoded)).toEqual({
+    text: "Look at that one.",
+    structured: true,
+    contentDigest: null,
+    selectedContext: null,
+    origin: { kind: "operator" },
+  });
+});
+
+test("an agent origin carries its sender role", () => {
+  const encoded = encodeCodexStructuredUserText("Round 2 verdict: fix the tail.", undefined, null, { kind: "agent", role: "reviewer" });
+  expect(decodeCodexStructuredUserText(encoded)).toEqual({
+    text: "Round 2 verdict: fix the tail.",
+    structured: true,
+    contentDigest: null,
+    selectedContext: null,
+    origin: { kind: "agent", role: "reviewer" },
+  });
+});
+
+test("origin, sender, digest and reference all ride one marker line", () => {
+  const encoded = encodeCodexStructuredUserText("Look at that one.", DIGEST, REFERENCE, { kind: "agent", role: "orchestrator" });
+  expect(encoded.split("\n")).toHaveLength(2);
+  expect(decodeCodexStructuredUserText(encoded)).toEqual({
+    text: "Look at that one.",
+    structured: true,
+    contentDigest: DIGEST,
+    selectedContext: REFERENCE,
+    origin: { kind: "agent", role: "orchestrator" },
+  });
+});
+
+test("a corrupt origin or sender costs only that attribute, never the record", () => {
+  const forgedOrigin = `<!-- llv:structured-user origin=root -->\nLook at that one.`;
+  expect(decodeCodexStructuredUserText(forgedOrigin).origin).toBeNull();
+  expect(decodeCodexStructuredUserText(forgedOrigin).structured).toBe(true);
+  const overlongRole = `<!-- llv:structured-user origin=agent sender=${"r".repeat(80)} -->\nLook at that one.`;
+  expect(decodeCodexStructuredUserText(overlongRole).origin).toEqual({ kind: "agent" });
+});
+
+test("an unsafe role is dropped at encode time, so the marker stays one line", () => {
+  const encoded = encodeCodexStructuredUserText("hello", undefined, null, { kind: "agent", role: "bad role >" });
+  expect(encoded.startsWith("<!-- llv:structured-user origin=agent -->\n")).toBe(true);
+  expect(decodeCodexStructuredUserText(encoded).origin).toEqual({ kind: "agent" });
 });

--- a/src/lib/runtime/codexStructuredUserText.ts
+++ b/src/lib/runtime/codexStructuredUserText.ts
@@ -4,14 +4,19 @@ import {
   type SelectedContextRef,
 } from "@/lib/selection/selectedContext";
 
+import { messageOriginRole, type MessageOrigin } from "./messageOrigin";
+
 /**
  * The marker line that makes a Codex app-server user record recognisably OURS.
  *
  * It is one HTML comment on the record's first line, carrying named attributes:
- * `sha256` (the structured content digest, when images make the echo lossy) and
- * `ctx` (the selected-card reference, #844). Both are optional and independent,
- * and the two older forms — bare marker, and marker with only a digest — decode
- * byte-identically to what they always did. Transcripts are not migrated.
+ * `sha256` (the structured content digest, when images make the echo lossy),
+ * `ctx` (the selected-card reference, #844), and since #1117 `origin`
+ * (`operator` | `agent`) with an optional `sender` role token — authorship
+ * stamped at delivery time so the feed can tell the operator's own words from
+ * inter-agent traffic. All attributes are optional and independent, and every
+ * older form — bare marker, marker with only a digest — decodes byte-identically
+ * to what it always did. Transcripts are not migrated.
  *
  * Attributes are `name=value` whose values may hold anything but a space and a
  * `>`, so the marker cannot be broken open by its own payload and stays on one
@@ -34,16 +39,26 @@ export interface DecodedCodexStructuredUserText {
   /** The selected-card reference this turn was admitted with, or null. A
       corrupt or forged value decodes as null: the record still reads. */
   selectedContext: SelectedContextRef | null;
+  /** Authorship stamped at delivery (#1117), or null when the record predates
+      the attribute or the value did not validate — the feed then keeps its
+      current rendering rather than guessing. */
+  origin: MessageOrigin | null;
 }
 
 export function encodeCodexStructuredUserText(
   text: string,
   contentDigest?: string,
   selectedContext?: SelectedContextRef | null,
+  origin?: MessageOrigin | null,
 ): string {
   const attributes: string[] = [];
   if (contentDigest) attributes.push(`sha256=${contentDigest}`);
   if (selectedContext) attributes.push(`ctx=${encodeSelectedContextRef(selectedContext)}`);
+  if (origin) {
+    attributes.push(`origin=${origin.kind}`);
+    const role = messageOriginRole(origin.role);
+    if (role) attributes.push(`sender=${role}`);
+  }
   if (attributes.length === 0) return STRUCTURED_USER_MARKER + text;
   return `<!-- llv:structured-user ${attributes.join(" ")} -->\n${text}`;
 }
@@ -53,19 +68,27 @@ export function decodeCodexStructuredUserText(value: string): DecodedCodexStruct
   if (marker) {
     let contentDigest: string | null = null;
     let selectedContext: SelectedContextRef | null = null;
+    let originKind: MessageOrigin["kind"] | null = null;
+    let senderRole: string | undefined;
     for (const [, name, attribute] of marker[1]!.matchAll(ATTRIBUTE)) {
       if (name === "sha256" && SHA256.test(attribute!)) contentDigest = attribute!;
       if (name === "ctx") selectedContext = decodeSelectedContextRef(attribute!);
+      if (name === "origin" && (attribute === "operator" || attribute === "agent")) originKind = attribute;
+      if (name === "sender") senderRole = messageOriginRole(attribute);
     }
-    return { text: value.slice(marker[0].length), structured: true, contentDigest, selectedContext };
+    const origin: MessageOrigin | null = originKind
+      ? { kind: originKind, ...(originKind === "agent" && senderRole ? { role: senderRole } : {}) }
+      : null;
+    return { text: value.slice(marker[0].length), structured: true, contentDigest, selectedContext, origin };
   }
   if (!value.startsWith(STRUCTURED_USER_MARKER)) {
-    return { text: value, structured: false, contentDigest: null, selectedContext: null };
+    return { text: value, structured: false, contentDigest: null, selectedContext: null, origin: null };
   }
   return {
     text: value.slice(STRUCTURED_USER_MARKER.length),
     structured: true,
     contentDigest: null,
     selectedContext: null,
+    origin: null,
   };
 }

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -6,6 +6,7 @@ import type { Workflow } from "@/lib/workflows/types";
 import type { RuntimeLiveTurn } from "@/lib/runtime/liveTurn";
 import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 import type { SelectedContextRef } from "@/lib/selection/selectedContext";
+import type { MessageOrigin } from "./messageOrigin";
 import type { RuntimeImageCapability, StructuredImageRef } from "./structuredContent";
 
 export const RUNTIME_SCHEMA_VERSION = 1;
@@ -239,6 +240,10 @@ export interface RuntimeSendCommand extends RuntimeCommandBase {
       offered none — an EXPLICIT empty selection is the `none` variant, which is
       present. */
   selectedContext?: SelectedContextRef;
+  /** #1117: who authored this message, stamped by the admitting surface and
+      carried on the durable send effect so delivery evidence (ledger record,
+      structured-user marker) can say operator vs inter-agent. */
+  origin?: MessageOrigin;
 }
 
 /**

--- a/src/lib/runtime/deliveredMessageOccurrences.test.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "bun:test";
+
+import type { RegistryFile } from "@/lib/agent/registry";
+import type { HeldDelivery } from "@/lib/accounts/migration/contracts";
+
+import { deliveredMessageOccurrences, heldDeliveryOccurrences } from "./deliveredMessageOccurrences";
+import type { DeliveredMessageOccurrence } from "./messageOrigin";
+import { messageTextDigest } from "./messageTextDigest";
+
+/**
+ * The registry→feed occurrence projection of #1117: a delivered held record
+ * keeps its origin stamp, content digest, and settlement time, and those three
+ * facts are exactly what the feed needs to attribute one transcript row. Any
+ * record missing one of them, or belonging to another conversation, is not
+ * evidence and contributes nothing.
+ */
+
+const TRANSCRIPT = "/sessions/worker-transcript.jsonl";
+const RELAY_DIGEST = messageTextDigest("Round 2 verdict: REQUEST_CHANGES");
+const MANDATE_DIGEST = messageTextDigest("Implement issue #12 in this worktree.");
+const OPERATOR_DIGEST = messageTextDigest("what is left on the branch?");
+
+function delivery(overrides: Partial<HeldDelivery> & { id: string }): HeldDelivery {
+  return {
+    conversationId: "conversation_worker",
+    runtimeConversationId: "conversation_worker",
+    text: "",
+    createdAt: "2026-08-24T09:00:00.000Z",
+    clientMessageId: null,
+    payloadKind: "text",
+    runtimeImages: [],
+    contentDigest: MANDATE_DIGEST,
+    artifactPaths: [],
+    command: { operationId: overrides.id, kind: "send", policy: "queue", origin: { kind: "agent", role: "orchestrator" } },
+    requestDigest: null,
+    state: "delivered",
+    generationId: "gen-1",
+    attempts: 1,
+    assignedAt: "2026-08-24T09:00:00.000Z",
+    deliveredAt: "2026-08-24T09:00:01.000Z",
+    error: null,
+    ...overrides,
+  } as HeldDelivery;
+}
+
+function snapshot(deliveries: HeldDelivery[]): RegistryFile {
+  return {
+    conversations: {
+      conversation_worker: {
+        id: "conversation_worker",
+        engine: "claude",
+        generations: [{ id: "gen-1", path: TRANSCRIPT }],
+        continuityPaths: [],
+      },
+      conversation_other: {
+        id: "conversation_other",
+        engine: "codex",
+        generations: [{ id: "gen-9", path: "/sessions/other-transcript.jsonl" }],
+        continuityPaths: [],
+      },
+    },
+    conversationAliases: { conversation_worker_old: "conversation_worker" },
+    heldDeliveries: Object.fromEntries(deliveries.map((item) => [item.id, item])),
+  } as unknown as RegistryFile;
+}
+
+test("a delivered, stamped record projects its digest, settlement time, and sender", () => {
+  const occurrences = heldDeliveryOccurrences(TRANSCRIPT, snapshot([
+    delivery({ id: "d-mandate" }),
+    delivery({
+      id: "d-operator",
+      contentDigest: OPERATOR_DIGEST,
+      deliveredAt: "2026-08-24T09:05:00.000Z",
+      command: { operationId: "d-operator", kind: "send", policy: "queue", origin: { kind: "operator" } },
+    }),
+  ]));
+  expect(occurrences).toEqual([
+    { textDigest: MANDATE_DIGEST, deliveredAt: "2026-08-24T09:00:01.000Z", origin: "agent", senderRole: "orchestrator" },
+    { textDigest: OPERATOR_DIGEST, deliveredAt: "2026-08-24T09:05:00.000Z", origin: "operator" },
+  ]);
+});
+
+test("a record addressed through a conversation alias still belongs to the transcript's conversation", () => {
+  const occurrences = heldDeliveryOccurrences(TRANSCRIPT, snapshot([
+    delivery({ id: "d-alias", conversationId: "conversation_worker_old" as HeldDelivery["conversationId"] }),
+  ]));
+  expect(occurrences).toHaveLength(1);
+});
+
+test("undelivered, unstamped, digest-less, corrupt, and foreign records contribute nothing", () => {
+  const occurrences = heldDeliveryOccurrences(TRANSCRIPT, snapshot([
+    delivery({ id: "d-held", state: "held", deliveredAt: null }),
+    delivery({ id: "d-failed", state: "failed", deliveredAt: null }),
+    delivery({ id: "d-unstamped", command: { operationId: "d-unstamped", kind: "send", policy: "queue" } }),
+    delivery({ id: "d-no-digest", contentDigest: null }),
+    delivery({ id: "d-bad-digest", contentDigest: "not-a-digest" }),
+    delivery({ id: "d-bad-time", deliveredAt: "yesterday-ish" }),
+    delivery({
+      id: "d-forged",
+      command: { operationId: "d-forged", kind: "send", policy: "queue", origin: { kind: "root" } as unknown as HeldDelivery["command"]["origin"] },
+    }),
+    delivery({ id: "d-foreign", conversationId: "conversation_other" as HeldDelivery["conversationId"] }),
+  ]));
+  expect(occurrences).toEqual([]);
+  expect(heldDeliveryOccurrences("/sessions/unknown.jsonl", snapshot([delivery({ id: "d-1" })]))).toEqual([]);
+});
+
+const RELAY: DeliveredMessageOccurrence = {
+  textDigest: RELAY_DIGEST,
+  deliveredAt: "2026-08-24T09:10:00.000Z",
+  origin: "agent",
+  senderRole: "reviewer",
+};
+
+test("a flow relay the registry also settled counts once; a relay it never saw is added", () => {
+  const registrySnapshot = () => snapshot([
+    delivery({
+      id: "d-structured-relay",
+      contentDigest: RELAY_DIGEST,
+      deliveredAt: "2026-08-24T09:10:04.000Z",
+      command: { operationId: "d-structured-relay", kind: "send", policy: "queue", origin: { kind: "agent", role: "reviewer" } },
+    }),
+  ]);
+  const legacyRelay: DeliveredMessageOccurrence = { ...RELAY, deliveredAt: "2026-08-24T11:00:00.000Z" };
+  const occurrences = deliveredMessageOccurrences(TRANSCRIPT, {
+    registrySnapshot,
+    relayOccurrences: () => [legacyRelay, RELAY],
+  });
+  expect(occurrences).toEqual([
+    { textDigest: RELAY_DIGEST, deliveredAt: "2026-08-24T09:10:04.000Z", origin: "agent", senderRole: "reviewer" },
+    legacyRelay,
+  ]);
+});
+
+test("each source degrades to absence on its own, and the result is settlement-ordered", () => {
+  const registrySnapshot = () => snapshot([
+    delivery({ id: "d-late", deliveredAt: "2026-08-24T12:00:00.000Z" }),
+  ]);
+  expect(deliveredMessageOccurrences(TRANSCRIPT, {
+    registrySnapshot: () => { throw new Error("registry unavailable"); },
+    relayOccurrences: () => [RELAY],
+  })).toEqual([RELAY]);
+  expect(deliveredMessageOccurrences(TRANSCRIPT, {
+    registrySnapshot,
+    relayOccurrences: () => { throw new Error("flow store unavailable"); },
+  })).toHaveLength(1);
+  const ordered = deliveredMessageOccurrences(TRANSCRIPT, { registrySnapshot, relayOccurrences: () => [RELAY] });
+  expect(ordered.map((occurrence) => occurrence.deliveredAt)).toEqual([
+    "2026-08-24T09:10:00.000Z",
+    "2026-08-24T12:00:00.000Z",
+  ]);
+  expect(deliveredMessageOccurrences("", { registrySnapshot, relayOccurrences: () => [RELAY] })).toEqual([]);
+});

--- a/src/lib/runtime/deliveredMessageOccurrences.test.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.test.ts
@@ -64,11 +64,12 @@ function snapshot(deliveries: HeldDelivery[]): RegistryFile {
   } as unknown as RegistryFile;
 }
 
-test("a delivered, stamped record projects its digest, settlement time, and sender", () => {
+test("a delivered, stamped record projects its digest, settlement time, sender, and client-message identity", () => {
   const occurrences = heldDeliveryOccurrences(TRANSCRIPT, snapshot([
     delivery({ id: "d-mandate" }),
     delivery({
       id: "d-operator",
+      clientMessageId: "composer-7",
       contentDigest: OPERATOR_DIGEST,
       deliveredAt: "2026-08-24T09:05:00.000Z",
       command: { operationId: "d-operator", kind: "send", policy: "queue", origin: { kind: "operator" } },
@@ -76,7 +77,7 @@ test("a delivered, stamped record projects its digest, settlement time, and send
   ]));
   expect(occurrences).toEqual([
     { textDigest: MANDATE_DIGEST, deliveredAt: "2026-08-24T09:00:01.000Z", origin: "agent", senderRole: "orchestrator" },
-    { textDigest: OPERATOR_DIGEST, deliveredAt: "2026-08-24T09:05:00.000Z", origin: "operator" },
+    { textDigest: OPERATOR_DIGEST, deliveredAt: "2026-08-24T09:05:00.000Z", origin: "operator", clientMessageId: "composer-7" },
   ]);
 });
 
@@ -112,24 +113,76 @@ const RELAY: DeliveredMessageOccurrence = {
   senderRole: "reviewer",
 };
 
-test("a flow relay the registry also settled counts once; a relay it never saw is added", () => {
+/** The identity a structured relay reserves its registry record under. */
+const STRUCTURED_RELAY_ID = "flow_relay_round2";
+
+function relayRecord(overrides: Partial<HeldDelivery> & { id: string }): HeldDelivery {
+  return delivery({
+    contentDigest: RELAY_DIGEST,
+    deliveredAt: "2026-08-24T09:10:04.000Z",
+    command: { operationId: overrides.id, kind: "send", policy: "queue", origin: { kind: "agent", role: "reviewer" } },
+    ...overrides,
+  });
+}
+
+test("one structured relay in both stores is one occurrence, joined by the round's identity; a relay the registry never reserved is added", () => {
   const registrySnapshot = () => snapshot([
-    delivery({
-      id: "d-structured-relay",
-      contentDigest: RELAY_DIGEST,
-      deliveredAt: "2026-08-24T09:10:04.000Z",
-      command: { operationId: "d-structured-relay", kind: "send", policy: "queue", origin: { kind: "agent", role: "reviewer" } },
-    }),
+    relayRecord({ id: "d-structured-relay", clientMessageId: STRUCTURED_RELAY_ID }),
   ]);
-  const legacyRelay: DeliveredMessageOccurrence = { ...RELAY, deliveredAt: "2026-08-24T11:00:00.000Z" };
+  const structuredRelay: DeliveredMessageOccurrence = { ...RELAY, clientMessageId: STRUCTURED_RELAY_ID };
+  const legacyRelay: DeliveredMessageOccurrence = { ...RELAY, deliveredAt: "2026-08-24T11:00:00.000Z", clientMessageId: "flow_relay_round3" };
   const occurrences = deliveredMessageOccurrences(TRANSCRIPT, {
     registrySnapshot,
-    relayOccurrences: () => [legacyRelay, RELAY],
+    relayOccurrences: () => [legacyRelay, structuredRelay],
   });
+  /* The registry's settlement wins for the shared delivery; the identity
+     itself never reaches the wire. */
   expect(occurrences).toEqual([
     { textDigest: RELAY_DIGEST, deliveredAt: "2026-08-24T09:10:04.000Z", origin: "agent", senderRole: "reviewer" },
-    legacyRelay,
+    { textDigest: RELAY_DIGEST, deliveredAt: "2026-08-24T11:00:00.000Z", origin: "agent", senderRole: "reviewer" },
   ]);
+});
+
+test("an operator message and a legacy relay with identical text within ten minutes are two occurrences", () => {
+  /* The operator repeated the relay's words four minutes after it landed.
+     Text and time agree, the delivery identities differ, and only a shared
+     identity may collapse two records into one. */
+  const registrySnapshot = () => snapshot([
+    delivery({
+      id: "d-operator-repeat",
+      clientMessageId: "composer-1",
+      contentDigest: RELAY_DIGEST,
+      deliveredAt: "2026-08-24T09:14:00.000Z",
+      command: { operationId: "d-operator-repeat", kind: "send", policy: "queue", origin: { kind: "operator" } },
+    }),
+  ]);
+  const legacyRelay: DeliveredMessageOccurrence = { ...RELAY, clientMessageId: STRUCTURED_RELAY_ID };
+  expect(deliveredMessageOccurrences(TRANSCRIPT, { registrySnapshot, relayOccurrences: () => [legacyRelay] })).toEqual([
+    { textDigest: RELAY_DIGEST, deliveredAt: "2026-08-24T09:10:00.000Z", origin: "agent", senderRole: "reviewer" },
+    { textDigest: RELAY_DIGEST, deliveredAt: "2026-08-24T09:14:00.000Z", origin: "operator" },
+  ]);
+  /* Neither side naming an identity is the all-legacy case: still two. */
+  const unnamedOperator = () => snapshot([
+    delivery({
+      id: "d-operator-unnamed",
+      contentDigest: RELAY_DIGEST,
+      deliveredAt: "2026-08-24T09:14:00.000Z",
+      command: { operationId: "d-operator-unnamed", kind: "send", policy: "queue", origin: { kind: "operator" } },
+    }),
+  ]);
+  expect(deliveredMessageOccurrences(TRANSCRIPT, { registrySnapshot: unnamedOperator, relayOccurrences: () => [RELAY] })).toHaveLength(2);
+});
+
+test("a pre-#1117 structured round, whose registry record carries no origin stamp, still surfaces through the flow store", () => {
+  const registrySnapshot = () => snapshot([
+    relayRecord({
+      id: "d-unstamped-relay",
+      clientMessageId: STRUCTURED_RELAY_ID,
+      command: { operationId: "d-unstamped-relay", kind: "send", policy: "queue" },
+    }),
+  ]);
+  const structuredRelay: DeliveredMessageOccurrence = { ...RELAY, clientMessageId: STRUCTURED_RELAY_ID };
+  expect(deliveredMessageOccurrences(TRANSCRIPT, { registrySnapshot, relayOccurrences: () => [structuredRelay] })).toEqual([RELAY]);
 });
 
 test("each source degrades to absence on its own, and the result is settlement-ordered", () => {

--- a/src/lib/runtime/deliveredMessageOccurrences.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.ts
@@ -14,8 +14,14 @@ import { parseMessageOrigin, type DeliveredMessageOccurrence } from "./messageOr
  * content digest of the delivered text, and the settlement time. Together
  * they name ONE occurrence: the transcript row carrying that text nearest to
  * that time. The flow store contributes the relays the registry never saw
- * (legacy transport, pre-#1117 structured rounds); a round whose settlement
- * the registry also holds is the same delivery and must not count twice.
+ * (legacy transport, pre-#1117 structured rounds).
+ *
+ * The two stores describe the same delivery exactly once, joined by identity:
+ * a structured relay reserves its registry record under the round's own
+ * client-message id, and that id is the only thing that may collapse a flow
+ * occurrence into a held one. An operator message that repeats a relay's
+ * words minutes apart is a second delivery, and both must survive for the
+ * feed to attribute each to its own row.
  *
  * Absence is honest: a record without a stamp, a digest, or a settlement time
  * contributes nothing, and the feed keeps rendering unmatched rows as today.
@@ -28,12 +34,9 @@ export interface DeliveredMessageOccurrenceDependencies {
 
 const CONTENT_DIGEST = /^[a-f0-9]{64}$/;
 
-/** A flow round's settlement and the registry record it settled from describe
-    one delivery; they agree on the digest and land within this window. */
-export const SAME_DELIVERY_WINDOW_MS = 10 * 60 * 1000;
-
 /** Delivered, origin-stamped held records of the conversation that owns
-    `transcriptPath`, projected as occurrences. */
+    `transcriptPath`, projected as occurrences. Each carries the record's
+    client-message id (when the transport reserved one) as its join identity. */
 export function heldDeliveryOccurrences(transcriptPath: string, snapshot: RegistryFile): DeliveredMessageOccurrence[] {
   const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
   const conversation = lookup.conversationForPath(transcriptPath);
@@ -52,9 +55,22 @@ export function heldDeliveryOccurrences(transcriptPath: string, snapshot: Regist
       deliveredAt: delivery.deliveredAt,
       origin: origin.kind,
       ...(origin.kind === "agent" && origin.role ? { senderRole: origin.role } : {}),
+      ...(delivery.clientMessageId ? { clientMessageId: delivery.clientMessageId } : {}),
     });
   }
   return occurrences;
+}
+
+/** The wire shape of one occurrence: the join identity has done its work. */
+function wireOccurrence(occurrence: DeliveredMessageOccurrence): DeliveredMessageOccurrence {
+  const { textDigest, deliveredAt, origin, senderRole, selectedContext } = occurrence;
+  return {
+    textDigest,
+    deliveredAt,
+    origin,
+    ...(senderRole ? { senderRole } : {}),
+    ...(selectedContext ? { selectedContext } : {}),
+  };
 }
 
 /**
@@ -80,13 +96,17 @@ export function deliveredMessageOccurrences(
   } catch {
     relayed = [];
   }
+  /* A relay whose identity a projected held record carries IS that record:
+     the registry settled the same delivery. Every other relay — a legacy tmux
+     transport, a pre-#1117 structured round whose record has no origin stamp
+     and so projected nothing — is evidence the registry cannot supply. */
+  const settled = new Set(held.map((occurrence) => occurrence.clientMessageId).filter(Boolean));
   const merged = [...held];
   for (const relay of relayed) {
-    const relayedAt = Date.parse(relay.deliveredAt);
-    const alreadyHeld = held.some((occurrence) =>
-      occurrence.textDigest === relay.textDigest
-      && Math.abs(Date.parse(occurrence.deliveredAt) - relayedAt) <= SAME_DELIVERY_WINDOW_MS);
-    if (!alreadyHeld) merged.push(relay);
+    if (relay.clientMessageId && settled.has(relay.clientMessageId)) continue;
+    merged.push(relay);
   }
-  return merged.sort((left, right) => Date.parse(left.deliveredAt) - Date.parse(right.deliveredAt));
+  return merged
+    .sort((left, right) => Date.parse(left.deliveredAt) - Date.parse(right.deliveredAt))
+    .map(wireOccurrence);
 }

--- a/src/lib/runtime/deliveredMessageOccurrences.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.ts
@@ -1,0 +1,92 @@
+import { agentRegistry, readOnlyConversationLookupFromSnapshot, type RegistryFile } from "@/lib/agent/registry";
+import { flowRelayedMessageOccurrences } from "@/lib/flows/relayProvenance";
+
+import { parseMessageOrigin, type DeliveredMessageOccurrence } from "./messageOrigin";
+
+/*
+ * Occurrence evidence for one conversation's delivered messages (#1117): the
+ * join for every delivery that left no per-row identity in the transcript.
+ *
+ * The registry's held-delivery record is the durable receipt of every message
+ * admitted through the Viewer — the composer's legacy paste, an MCP
+ * `send_message` relayed into a tmux-owned pane, a migration-held send — and
+ * it keeps three facts past settlement: the admission-stamped origin, the
+ * content digest of the delivered text, and the settlement time. Together
+ * they name ONE occurrence: the transcript row carrying that text nearest to
+ * that time. The flow store contributes the relays the registry never saw
+ * (legacy transport, pre-#1117 structured rounds); a round whose settlement
+ * the registry also holds is the same delivery and must not count twice.
+ *
+ * Absence is honest: a record without a stamp, a digest, or a settlement time
+ * contributes nothing, and the feed keeps rendering unmatched rows as today.
+ */
+
+export interface DeliveredMessageOccurrenceDependencies {
+  registrySnapshot?: () => RegistryFile;
+  relayOccurrences?: (transcriptPath: string) => DeliveredMessageOccurrence[];
+}
+
+const CONTENT_DIGEST = /^[a-f0-9]{64}$/;
+
+/** A flow round's settlement and the registry record it settled from describe
+    one delivery; they agree on the digest and land within this window. */
+export const SAME_DELIVERY_WINDOW_MS = 10 * 60 * 1000;
+
+/** Delivered, origin-stamped held records of the conversation that owns
+    `transcriptPath`, projected as occurrences. */
+export function heldDeliveryOccurrences(transcriptPath: string, snapshot: RegistryFile): DeliveredMessageOccurrence[] {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const conversation = lookup.conversationForPath(transcriptPath);
+  if (!conversation) return [];
+  const occurrences: DeliveredMessageOccurrence[] = [];
+  for (const delivery of Object.values(snapshot.heldDeliveries)) {
+    if (delivery.state !== "delivered" || !delivery.deliveredAt || !delivery.contentDigest) continue;
+    if (lookup.canonicalConversationId(delivery.conversationId) !== conversation.id) continue;
+    if (!CONTENT_DIGEST.test(delivery.contentDigest) || !Number.isFinite(Date.parse(delivery.deliveredAt))) continue;
+    /* Re-validated here as well as at normalization: a forged or corrupt
+       persisted stamp drops, and can never re-author a row. */
+    const origin = parseMessageOrigin(delivery.command?.origin);
+    if (!origin) continue;
+    occurrences.push({
+      textDigest: delivery.contentDigest,
+      deliveredAt: delivery.deliveredAt,
+      origin: origin.kind,
+      ...(origin.kind === "agent" && origin.role ? { senderRole: origin.role } : {}),
+    });
+  }
+  return occurrences;
+}
+
+/**
+ * Every occurrence the feed may join for one transcript, settlement-ordered.
+ * Each source degrades to absence on its own, so an unavailable registry
+ * still leaves the flow relays and vice versa.
+ */
+export function deliveredMessageOccurrences(
+  transcriptPath: string,
+  dependencies: DeliveredMessageOccurrenceDependencies = {},
+): DeliveredMessageOccurrence[] {
+  if (!transcriptPath) return [];
+  let held: DeliveredMessageOccurrence[] = [];
+  try {
+    const snapshot = (dependencies.registrySnapshot ?? (() => agentRegistry().readOnlySnapshot()))();
+    held = heldDeliveryOccurrences(transcriptPath, snapshot);
+  } catch {
+    held = [];
+  }
+  let relayed: DeliveredMessageOccurrence[] = [];
+  try {
+    relayed = (dependencies.relayOccurrences ?? flowRelayedMessageOccurrences)(transcriptPath);
+  } catch {
+    relayed = [];
+  }
+  const merged = [...held];
+  for (const relay of relayed) {
+    const relayedAt = Date.parse(relay.deliveredAt);
+    const alreadyHeld = held.some((occurrence) =>
+      occurrence.textDigest === relay.textDigest
+      && Math.abs(Date.parse(occurrence.deliveredAt) - relayedAt) <= SAME_DELIVERY_WINDOW_MS);
+    if (!alreadyHeld) merged.push(relay);
+  }
+  return merged.sort((left, right) => Date.parse(left.deliveredAt) - Date.parse(right.deliveredAt));
+}

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -1,5 +1,6 @@
 import type { SelectedContextRef } from "@/lib/selection/selectedContext";
 
+import type { MessageOrigin } from "./messageOrigin";
 import type { RuntimeSendSettings } from "./contracts";
 import type { RuntimeVoiceDelivery, RuntimeVoiceResponse } from "./voiceDelivery";
 import {
@@ -25,6 +26,11 @@ export interface QueueEntry {
       submitted. Hosts that can persist it write it onto the canonical
       structured-user record; the rest ignore it, exactly as with `runtime`. */
   selectedContext?: SelectedContextRef;
+  /** #1117: who authored this message, stamped at admission. The Claude
+      broker journals it on the delivery ledger's queued record; the Codex
+      host stamps it onto the structured-user marker. Absent = unknown, and
+      the feed keeps its current rendering. */
+  origin?: MessageOrigin;
 }
 
 export interface NormalizedQueueEntry {
@@ -34,6 +40,7 @@ export interface NormalizedQueueEntry {
   expectedTurnId?: string | null;
   runtime?: RuntimeSendSettings;
   selectedContext?: SelectedContextRef;
+  origin?: MessageOrigin;
 }
 
 export function normalizeQueueEntry(entry: QueueEntry): NormalizedQueueEntry {
@@ -46,6 +53,7 @@ export function normalizeQueueEntry(entry: QueueEntry): NormalizedQueueEntry {
     ...(entry.expectedTurnId !== undefined ? { expectedTurnId: entry.expectedTurnId } : {}),
     ...(entry.runtime ? { runtime: entry.runtime } : {}),
     ...(entry.selectedContext ? { selectedContext: entry.selectedContext } : {}),
+    ...(entry.origin ? { origin: entry.origin } : {}),
   };
 }
 

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -118,6 +118,9 @@ export async function handleRuntimeCommand(
         ...(rawImages ? { images: rawImages } : command.images?.length ? { imageRefs: command.images } : {}),
         ...(command.runtime ? { runtime: command.runtime } : {}),
         ...(command.selectedContext ? { selectedContext: command.selectedContext } : {}),
+        /* #1117: this route is the operator's own composer surface, so
+           authorship is stamped HERE, server-side — never read off the body. */
+        origin: { kind: "operator" },
       }, {
         enabled: dependencies.structuredEnabled ?? (() => structuredHostsEnabled()),
         client: () => client,

--- a/src/lib/runtime/messageOrigin.ts
+++ b/src/lib/runtime/messageOrigin.ts
@@ -1,0 +1,63 @@
+/**
+ * Who authored a structured/MCP-delivered message (#1117).
+ *
+ * Every structured delivery flows through one admission chokepoint, and the
+ * feed cannot tell the operator's own words from inter-agent relays without a
+ * durable authorship fact stamped there. This module is that fact's vocabulary:
+ *
+ *  - `operator` — typed (or spoken) by the human on a Viewer surface.
+ *  - `agent`    — sent by another session through MCP `send_message`, a flow
+ *    relay, or a delegated spawn's first message. `role` names the sender as
+ *    the server attributed it (orchestrator, reviewer, a role preset id, …).
+ *
+ * Scaffold rows carry NO origin: absence means "no delivery evidence", and the
+ * feed keeps rendering such rows exactly as before. Classification must never
+ * guess, so parsing drops anything it cannot validate rather than coercing it.
+ *
+ * Pure and dependency-free on purpose: the Codex marker decode runs in the
+ * browser feed parser, so this module must not pull in Node-only helpers.
+ */
+
+import type { SelectedContextRef } from "@/lib/selection/selectedContext";
+
+export interface MessageOrigin {
+  kind: "operator" | "agent";
+  /** Sender role for agent origins, as attributed server-side at admission.
+      Bounded to one marker-safe token so it can ride the structured-user
+      marker and a journaled ledger record without a second escaping scheme. */
+  role?: string;
+}
+
+/**
+ * The feed-facing authorship of one delivered message, keyed by the transcript
+ * row's engine message id: the wire shape of `/api/log/provenance` and the
+ * value the renderer resolves a delivered system row with. Client-safe on
+ * purpose — the server join module and the browser share this one type.
+ */
+export interface DeliveredMessageProvenance {
+  origin: "operator" | "agent";
+  senderRole?: string;
+  /** Carried through for operator rows so the bubble renders the same
+      selected-card badge the composer showed at submission (#844). */
+  selectedContext?: SelectedContextRef;
+}
+
+/** Same grammar as the other opaque marker tokens: no whitespace, no `>`. */
+const ROLE_TOKEN = /^[A-Za-z0-9_.:-]{1,64}$/;
+
+export function messageOriginRole(value: unknown): string | undefined {
+  return typeof value === "string" && ROLE_TOKEN.test(value) ? value : undefined;
+}
+
+/**
+ * Validate an untrusted origin — a request body, a journal payload, a replayed
+ * record. Returns null when the value is not an origin at all; a corrupt role
+ * costs only the role, never the record's authorship kind.
+ */
+export function parseMessageOrigin(value: unknown): MessageOrigin | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const body = value as Record<string, unknown>;
+  if (body.kind !== "operator" && body.kind !== "agent") return null;
+  const role = body.kind === "agent" ? messageOriginRole(body.role) : undefined;
+  return { kind: body.kind, ...(role ? { role } : {}) };
+}

--- a/src/lib/runtime/messageOrigin.ts
+++ b/src/lib/runtime/messageOrigin.ts
@@ -12,7 +12,7 @@
  *
  * Scaffold rows carry NO origin: absence means "no delivery evidence", and the
  * feed keeps rendering such rows exactly as before. Classification must never
- * guess, so parsing drops anything it cannot validate rather than coercing it.
+ * guess, so parsing drops anything it cannot validate; nothing is coerced.
  *
  * Pure and dependency-free on purpose: the Codex marker decode runs in the
  * browser feed parser, so this module must not pull in Node-only helpers.
@@ -40,6 +40,21 @@ export interface DeliveredMessageProvenance {
   /** Carried through for operator rows so the bubble renders the same
       selected-card badge the composer showed at submission (#844). */
   selectedContext?: SelectedContextRef;
+}
+
+/**
+ * One delivered message's occurrence evidence: the join for deliveries that
+ * leave no per-row identity — a legacy tmux paste on either engine, a flow
+ * relay, a pre-#1117 structured send. `textDigest` is the registry's content
+ * digest of the delivered text (see `messageTextDigest`) and `deliveredAt`
+ * its settlement time, so the feed can attach the evidence to exactly ONE
+ * transcript row: the nearest-in-time row carrying the same text. The time is
+ * what makes the join occurrence-specific — an operator's own message that
+ * happens to repeat a relay's text stays the operator's.
+ */
+export interface DeliveredMessageOccurrence extends DeliveredMessageProvenance {
+  textDigest: string;
+  deliveredAt: string;
 }
 
 /** Same grammar as the other opaque marker tokens: no whitespace, no `>`. */

--- a/src/lib/runtime/messageOrigin.ts
+++ b/src/lib/runtime/messageOrigin.ts
@@ -55,6 +55,12 @@ export interface DeliveredMessageProvenance {
 export interface DeliveredMessageOccurrence extends DeliveredMessageProvenance {
   textDigest: string;
   deliveredAt: string;
+  /** The delivery's stable client-message id, when its transport reserved one
+      (a structured send, a flow round's relay). Server-side join key only: two
+      evidence stores that recorded the same delivery agree on it, so their
+      occurrences collapse to one before serialization. Stripped from the
+      wire shape. */
+  clientMessageId?: string;
 }
 
 /** Same grammar as the other opaque marker tokens: no whitespace, no `>`. */

--- a/src/lib/runtime/messageTextDigest.test.ts
+++ b/src/lib/runtime/messageTextDigest.test.ts
@@ -1,0 +1,41 @@
+import crypto from "node:crypto";
+
+import { expect, test } from "bun:test";
+
+import { messageTextDigest, sha256Hex } from "./messageTextDigest";
+import { structuredContent } from "./structuredContent";
+
+/**
+ * The browser-side digest must equal the registry's `contentDigest` exactly:
+ * the feed's occurrence join (#1117) compares the two as opaque strings, so
+ * any drift silently loses every legacy attribution.
+ */
+
+const SAMPLES = [
+  "please rerun the failing check",
+  "Round 2 verdict: REQUEST_CHANGES\n\n- P1 — the held command drops its origin.",
+  "розкажи що плануєш робити далі, і чому саме так",
+  "emoji 🚀 and surrogate pairs 𝄞 survive the encoding",
+  /* Lengths around the SHA-256 block boundaries exercise every padding branch. */
+  "x".repeat(55 - 24),
+  "x".repeat(56 - 24),
+  "x".repeat(64 - 24),
+  "y".repeat(120),
+  "z".repeat(12_000),
+  "tab\tand \"quotes\" and back\\slash and a trailing newline\n",
+];
+
+test("messageTextDigest equals the registry's structured content digest for text-only messages", () => {
+  for (const sample of SAMPLES) {
+    expect(messageTextDigest(sample)).toBe(structuredContent(sample, []).contentDigest);
+  }
+});
+
+test("sha256Hex matches node:crypto across block-boundary lengths and the empty input", () => {
+  for (const length of [0, 1, 55, 56, 63, 64, 65, 119, 120, 1_000]) {
+    const bytes = new Uint8Array(length).map((_, index) => (index * 31 + 7) & 0xff);
+    expect(sha256Hex(bytes)).toBe(crypto.createHash("sha256").update(bytes).digest("hex"));
+  }
+  expect(sha256Hex(new TextEncoder().encode("abc")))
+    .toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+});

--- a/src/lib/runtime/messageTextDigest.ts
+++ b/src/lib/runtime/messageTextDigest.ts
@@ -1,0 +1,97 @@
+/**
+ * The content digest of a text-only delivered message, computed the same way
+ * on both sides of the feed's occurrence join (#1117).
+ *
+ * The registry keeps exactly one piece of content evidence on a delivered
+ * record — `contentDigest`, the SHA-256 of the structured-content envelope —
+ * because the text itself is blanked at settlement. The feed therefore joins
+ * a transcript row to its delivery by digesting the row's own text with the
+ * identical algorithm. `structuredContent.ts` owns the canonical form but
+ * hashes through `node:crypto`, which the browser cannot load, so this module
+ * carries a dependency-free SHA-256 and the parity test pins the two together.
+ *
+ * Pure and Node-free on purpose: it runs inside the feed renderer.
+ */
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const rotr = (value: number, bits: number): number => (value >>> bits) | (value << (32 - bits));
+
+/** Lowercase hex SHA-256 of a byte string (FIPS 180-4). */
+export function sha256Hex(bytes: Uint8Array): string {
+  const state = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  /* Padding: 0x80, zeros to 56 mod 64, then the 64-bit big-endian bit length. */
+  const padded = new Uint8Array(Math.ceil((bytes.length + 9) / 64) * 64);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  const bitLength = bytes.length * 8;
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 0x1_0000_0000), false);
+  view.setUint32(padded.length - 4, bitLength >>> 0, false);
+  const schedule = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) schedule[index] = view.getUint32(offset + index * 4, false);
+    for (let index = 16; index < 64; index += 1) {
+      const w15 = schedule[index - 15];
+      const w2 = schedule[index - 2];
+      const s0 = rotr(w15, 7) ^ rotr(w15, 18) ^ (w15 >>> 3);
+      const s1 = rotr(w2, 17) ^ rotr(w2, 19) ^ (w2 >>> 10);
+      schedule[index] = (schedule[index - 16] + s0 + schedule[index - 7] + s1) >>> 0;
+    }
+    let a = state[0];
+    let b = state[1];
+    let c = state[2];
+    let d = state[3];
+    let e = state[4];
+    let f = state[5];
+    let g = state[6];
+    let h = state[7];
+    for (let index = 0; index < 64; index += 1) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const t1 = (h + S1 + ch + K[index] + schedule[index]) >>> 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const t2 = (S0 + maj) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + t1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (t1 + t2) >>> 0;
+    }
+    state[0] = (state[0] + a) >>> 0;
+    state[1] = (state[1] + b) >>> 0;
+    state[2] = (state[2] + c) >>> 0;
+    state[3] = (state[3] + d) >>> 0;
+    state[4] = (state[4] + e) >>> 0;
+    state[5] = (state[5] + f) >>> 0;
+    state[6] = (state[6] + g) >>> 0;
+    state[7] = (state[7] + h) >>> 0;
+  }
+  let hex = "";
+  for (const word of state) hex += word.toString(16).padStart(8, "0");
+  return hex;
+}
+
+/**
+ * `contentDigest` of a text-only structured message: the canonical envelope
+ * `{ text, images: [] }` that `structuredContentDigest` hashes, so a delivered
+ * held record's digest and a transcript row's digest agree byte for byte.
+ */
+export function messageTextDigest(text: string): string {
+  return sha256Hex(new TextEncoder().encode(JSON.stringify({ text, images: [] })));
+}

--- a/src/lib/runtime/selectedContextAdmission.test.ts
+++ b/src/lib/runtime/selectedContextAdmission.test.ts
@@ -150,5 +150,6 @@ test("the record the host writes carries the reference on the canonical marker",
     structured: true,
     contentDigest: null,
     selectedContext: REFERENCE,
+    origin: null,
   });
 });

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -1,5 +1,6 @@
 import { parseSelectedContextRef, type SelectedContextRef } from "@/lib/selection/selectedContext";
 
+import { parseMessageOrigin, type MessageOrigin } from "./messageOrigin";
 import type { RuntimeSendSettings } from "./contracts";
 import type { CompactCapableHost, DeliveryReceipt, EngineHost, QueueEntry } from "./engineHost";
 import { hostSupportsCompact, StructuredCompactError } from "./engineHost";
@@ -60,6 +61,8 @@ interface SendEffect {
   /** #844: the selected-card reference the operator submitted with. Replayed
       from the durable payload, never re-read from a live view. */
   selectedContext?: SelectedContextRef;
+  /** #1117: authorship stamped at admission, replayed from the durable payload. */
+  origin?: MessageOrigin;
   eventSeq: number;
 }
 
@@ -166,6 +169,7 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
   /* A malformed reference drops the same way malformed settings do: the
      message must never be stranded by its own provenance. */
   const selectedContext = parseSelectedContextRef(effect.payload.selectedContext);
+  const origin = parseMessageOrigin(effect.payload.origin);
   return {
     operationId,
     conversationId,
@@ -177,6 +181,7 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
     ...(policy ? { policy } : {}),
     ...(runtime ? { runtime } : {}),
     ...(selectedContext ? { selectedContext } : {}),
+    ...(origin ? { origin } : {}),
   };
 }
 
@@ -505,6 +510,7 @@ export class StructuredDeliveryQueue {
         expectedTurnId: effect.policy === "interrupt-active" ? null : deliveryFence,
         ...(effect.runtime ? { runtime: effect.runtime } : {}),
         ...(effect.selectedContext ? { selectedContext: effect.selectedContext } : {}),
+        ...(effect.origin ? { origin: effect.origin } : {}),
       };
       await this.port.transition(
         effect.operationId,

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -2166,3 +2166,95 @@ test("a post-admission settlement failure preserves the accepted receipt as deli
   });
   expect(commands).toBe(1);
 });
+
+test("a runtime-synchronization hold persists the admission origin, and a replay without it stays compatible", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  const dependencies = {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+    startupFailed: () => false,
+  };
+
+  const held = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "held-origin-message",
+    text: "relay held across the synchronization window",
+    hasImages: false,
+    origin: { kind: "agent", role: "orchestrator" },
+  }, dependencies);
+
+  expect(held).toMatchObject({ ok: true, structured: true, outcome: "held" });
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "held-origin-message",
+    command: { origin: { kind: "agent", role: "orchestrator" } },
+  }]);
+
+  /* The origin is excluded from the request digest: the same logical message
+     replayed without the stamp answers from the reservation, never a 409. */
+  expect(await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "held-origin-message",
+    text: "relay held across the synchronization window",
+    hasImages: false,
+  }, dependencies)).toMatchObject({ ok: true, structured: true, outcome: "held" });
+  expect(registry.pendingDeliveries(conversation.id)).toHaveLength(1);
+});
+
+for (const engine of ["claude", "codex"] as const) {
+  test(`a migration-held delivery replays its persisted origin into the host command — ${engine}`, async () => {
+    const { conversation } = registryWithConversation("default", engine);
+    const origin = engine === "claude"
+      ? { kind: "operator" as const }
+      : { kind: "agent" as const, role: "reviewer" };
+    let command: unknown;
+    const receipt = () => ({
+      operationId: "held-origin-replay",
+      idempotencyKey: "held-origin-replay-message",
+      conversationId: conversation.id,
+      kind: "send" as const,
+      status: "delivered" as const,
+      queuePosition: 1,
+      at: "2026-07-13T00:00:00.000Z",
+      revision: 2,
+    });
+    const client = {
+      snapshot: async () => snapshot(conversation.id, engine),
+      command: async (value: unknown) => {
+        command = value;
+        return { operationId: "held-origin-replay", replayed: false, receipt: receipt() };
+      },
+      operationStatus: async () => ({ operationId: "held-origin-replay", replayed: true, receipt: receipt() }),
+    } as unknown as RuntimeHostClient;
+
+    const outcome = await deliverHeldStructuredMessage({
+      conversationId: conversation.id,
+      path: artifactPath,
+      deliveryId: "held-origin-replay",
+      clientMessageId: "held-origin-replay-message",
+      text: "after the migration window",
+      command: {
+        operationId: "held-origin-replay",
+        kind: "send",
+        policy: "interrupt-active",
+        origin,
+      },
+    }, {
+      enabled: () => true,
+      client: () => client,
+      kick: async () => {},
+    });
+
+    expect(outcome).toBe("delivered");
+    expect(command).toMatchObject({
+      kind: "send",
+      operationId: "held-origin-replay",
+      text: "after the migration window",
+      origin,
+    });
+  });
+}

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -14,6 +14,7 @@ import type { HeldDelivery, HeldDeliveryCommand, ViewerConversationId } from "@/
 
 import type { SelectedContextRef } from "@/lib/selection/selectedContext";
 
+import type { MessageOrigin } from "./messageOrigin";
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt, RuntimeOperationResult, RuntimeSendSettings, RuntimeSession } from "./contracts";
 import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
@@ -50,6 +51,11 @@ export interface StructuredMessageRequest {
       effect so a replayed key re-delivers naming the SAME card, and the
       transcript record keeps the reference the operator actually submitted. */
   selectedContext?: SelectedContextRef;
+  /** Message authorship stamped by the admitting surface (#1117): rides the
+      durable send effect onto the delivery evidence (Claude ledger record,
+      Codex structured-user marker). A migration hold drops it, like the two
+      fields above — the held command format predates it and stays untouched. */
+  origin?: MessageOrigin;
 }
 
 export type StructuredMessageResult =
@@ -866,6 +872,7 @@ export async function enqueueStructuredMessage(
       ...(request.turnId !== undefined ? { turnId: request.turnId } : {}),
       ...(request.runtime ? { runtime: request.runtime } : {}),
       ...(request.selectedContext ? { selectedContext: request.selectedContext } : {}),
+      ...(request.origin ? { origin: request.origin } : {}),
     });
     const result = commandResult;
     const receipt = result.receipt;

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -53,8 +53,9 @@ export interface StructuredMessageRequest {
   selectedContext?: SelectedContextRef;
   /** Message authorship stamped by the admitting surface (#1117): rides the
       durable send effect onto the delivery evidence (Claude ledger record,
-      Codex structured-user marker). A migration hold drops it, like the two
-      fields above — the held command format predates it and stays untouched. */
+      Codex structured-user marker). A migration hold persists it on the held
+      command and replays it at drain time, so a held operator message never
+      resurfaces as a system row nor a held relay as an operator bubble. */
   origin?: MessageOrigin;
 }
 
@@ -196,6 +197,7 @@ function commandInput(request: StructuredMessageRequest) {
     ...(request.kind ? { kind: request.kind } : {}),
     ...(request.policy ? { policy: request.policy } : {}),
     ...(request.turnId !== undefined ? { turnId: request.turnId } : {}),
+    ...(request.origin ? { origin: request.origin } : {}),
   };
 }
 
@@ -508,6 +510,9 @@ export async function deliverHeldStructuredMessage(
       contentDigest: content.contentDigest,
       policy: command.policy,
       ...(command.turnId !== undefined ? { turnId: command.turnId } : {}),
+      /* #1117: the authorship persisted on the held record survives the
+         migration hold — the drained message re-attributes exactly as admitted. */
+      ...(command.origin ? { origin: command.origin } : {}),
     });
     try {
       await (dependencies.kick ?? kickStructuredDeliveryQueue)();

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -29,6 +29,7 @@ import { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
 import { CodexAppServerHost } from "./codexAppServerHost";
 import { isRuntimeHostTransportFailure, type RuntimeHostClient } from "./client";
 import { StructuredHostAdoptionCleanupError, type EngineHost, type HostState } from "./engineHost";
+import { messageOriginRole, type MessageOrigin } from "./messageOrigin";
 import { runtimeSettingsCapability, type RuntimeOperationResult, type RuntimeSession } from "./contracts";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
 import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "./structuredDeliveryController";
@@ -353,6 +354,7 @@ export async function reconcileStructuredSpawnReplay(
       && effect.cwd === current.cwd
       && (prompt.trim() || imageRefs.length)
     ) {
+      const readmittedOrigin = spawnMessageOrigin(current, registry);
       const readmitted = await enqueueStructuredMessage({
         path: current.artifactPath,
         conversationId: current.conversationId,
@@ -360,6 +362,7 @@ export async function reconcileStructuredSpawnReplay(
         operationId: `spawn_message_${launchId}`,
         text: prompt,
         imageRefs,
+        ...(readmittedOrigin ? { origin: readmittedOrigin } : {}),
       }, {
         client: () => client,
         registry: () => registry,
@@ -1202,6 +1205,7 @@ export async function recoverPendingStructuredSpawns(
     }
     if (imageRefs === null) throw new Error(`structured spawn recovery has invalid image refs for ${receipt.launchId}`);
     if (prompt.trim() || imageRefs.length) {
+      const origin = spawnMessageOrigin(receipt, registry);
       const delivered = await enqueueStructuredMessage({
         path: receipt.artifactPath,
         conversationId: receipt.conversationId,
@@ -1209,6 +1213,7 @@ export async function recoverPendingStructuredSpawns(
         operationId: `spawn_message_${receipt.launchId}`,
         text: prompt,
         imageRefs,
+        ...(origin ? { origin } : {}),
       }, {
         client: () => client,
         registry: () => registry,
@@ -1363,8 +1368,24 @@ async function defaultBindHost(
     : await bindClaudeHostPersistence(registry, key, host as ClaudeStreamBrokerHost, claimOwner, claimEpoch, releasedStatus);
 }
 
+/**
+ * Authorship of a spawn's FIRST message (#1117), from the receipt's recorded
+ * delegation depth: 0 is an operator/external root whose prompt the operator
+ * typed; a deeper launch was delegated, so its mandate is inter-agent traffic
+ * from the parent conversation (named by its role when the registry knows one).
+ * Legacy receipts without a depth stay unattributed — the feed must not guess.
+ */
+function spawnMessageOrigin(receipt: SpawnReceipt, registry: AgentRegistry): MessageOrigin | undefined {
+  if (receipt.delegationDepth === 0) return { kind: "operator" };
+  if (receipt.delegationDepth === null || receipt.delegationDepth === undefined) return undefined;
+  const parent = receipt.parentConversationId ? registry.conversation(receipt.parentConversationId) : null;
+  const role = messageOriginRole(parent?.agentRole ?? undefined);
+  return { kind: "agent", ...(role ? { role } : {}) };
+}
+
 async function defaultDeliverFirst(input: StructuredSpawnInput, artifactPath: string): Promise<void | "held"> {
   if (!input.prompt.trim() && !input.imageRefs?.length) return;
+  const origin = spawnMessageOrigin(input.receipt, input.registry);
   const delivered = await enqueueStructuredMessage({
     path: artifactPath,
     conversationId: input.receipt.conversationId,
@@ -1372,6 +1393,7 @@ async function defaultDeliverFirst(input: StructuredSpawnInput, artifactPath: st
     operationId: `spawn_message_${input.receipt.launchId}`,
     text: input.prompt,
     imageRefs: input.imageRefs,
+    ...(origin ? { origin } : {}),
   }, {
     client: () => input.client,
     registry: () => input.registry,

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -522,6 +522,11 @@ test("send operations converge by idempotency key and persist one receipt and ef
   expect(journal.snapshot().sessions[0]?.recentReceipts).toHaveLength(1);
   expect(() => journal.executeOperation({ ...command, text: "different" })).toThrow("idempotency key already belongs to another request");
   expect(() => journal.executeOperation({ ...command, idempotencyKey: "send-key-two" })).toThrow("operationId already belongs to another request");
+  /* #1117: authorship is server-derived metadata — caller attribution can
+     lawfully differ between a call and its replay — so a changed origin must
+     replay, never conflict. */
+  expect(journal.executeOperation({ ...command, origin: { kind: "agent" as const, role: "reviewer" } }))
+    .toEqual({ ...first, replayed: true });
   journal.close();
 });
 

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -376,6 +376,10 @@ export class RuntimeJournal {
     const operationId = command.operationId?.trim() || newOperationId();
     const requestValue = { ...command } as Record<string, unknown>;
     delete requestValue.operationId;
+    /* #1117: authorship is server-derived metadata (caller attribution can
+       lawfully differ between a call and its replay), so it must never turn a
+       legitimate idempotent replay into a request-hash conflict. */
+    delete requestValue.origin;
     if (command.kind === "answer") requestValue.resolution = { sha256: createHash("sha256").update(stableJson(command.resolution)).digest("hex") };
     const requestJson = stableJson(requestValue);
     const requestHash = createHash("sha256").update(requestJson).digest("hex");


### PR DESCRIPTION
Implements #1117.

## Design (brief)

One durable authorship fact, stamped at the single admission chokepoint every structured delivery already flows through, and carried on the delivery evidence each engine already has — no engine changes.

**Stamping.** `MessageOrigin = { kind: "operator" | "agent"; role? }` rides `QueueEntry` → durable send effect → engine host:

| surface | stamp |
| --- | --- |
| `/api/runtime/send` (composer) | `operator`, server-side — never read off the body |
| MCP `send_message` / `send_message_to_orchestrator` | `agent` + server-attributed caller role (`manager` → `orchestrator`, `gateway`, else the role preset) |
| review-flow relay | `agent` / `reviewer` |
| spawn first message | from the launch receipt's delegation depth: `0` → `operator`; deeper → `agent` named by the parent conversation's role |

**Evidence per engine.**
- **Codex** — the `llv:structured-user` marker gains `origin=`/`sender=` attributes, so authorship is stamped into the journaled row at delivery time. Old markers decode byte-identically; unknown attributes are ignored in both directions, and a corrupt value costs only that attribute.
- **Claude** — the broker's delivery ledger journals the origin on each `queued` record; new `GET /api/log/provenance` joins ledger evidence to transcript rows by the recorded `engineMessageId`. Legacy ledgers still classify: a selected-context capture (#844) ⇒ operator; a `spawn_message_<launchId>` entry ⇒ the receipt's recorded delegation depth (#393). Anything unproven is omitted — the feed never guesses.
- The runtime journal excludes `origin` from the idempotency request hash, so a replay whose caller attribution lawfully changed still replays instead of conflicting.

**Rendering.** Three visually distinct classes, consistent with the existing feed language:
- **operator** — the existing user bubble, including the selected-context badge from the ledger record;
- **internal** — the existing teammate-message card with an explicit `internal` tag and the sender role in the peer pill, visible by default;
- **scaffold** — the current collapsed `system · N` row, untouched.

Claude rows keep their parse-level system kind (launch-echo retirement and outbox logic key on it) and resolve their visual at render time through a provenance context; a delivered row now also counts as its send's transcript echo, so the optimistic composer bubble retires the moment the echo lands instead of overlapping the resolved bubble.

## Acceptance

1. **Orchestrator/agent relay** renders as the internal card naming the sender role, on both engines (Codex: marker attrs; Claude: ledger join). Visible by default; separate from scaffold.
2. **Operator messages** render as the operator's bubble on every structured path, including the spawn first message (delegation depth 0 → operator, covering existing spawns via the legacy receipt fallback).
3. **True scaffold** (meta records, caveats, task notifications, interrupt sentinels, compaction summaries) carries no join identity and keeps the current system style.
4. **Both engines** covered; rows without any evidence keep today's rendering exactly.
5. Provenance derives from existing delivery evidence (ledger selected-context / engine-message-id join) or is stamped at delivery time; **no engine changes**.

## Verification

- `bun tsc --noEmit` clean.
- Touched test files, run by explicit path (all pass):
  - `src/lib/runtime/codexStructuredUserText.test.ts` (13), `claudeMessageProvenance.test.ts` (5, new), `selectedContextAdmission.test.ts`, `structuredMessageDelivery.test.ts` (48), `structuredDeliveryQueue.test.ts`, `codexAppServerHost.test.ts` (112), `claudeStreamBrokerHost.test.ts` (49), `http.test.ts`, `structuredSpawn.terminalize.test.ts`
  - `src/components/feed/messageProvenance.parse.test.tsx` (9, new), `parse.test.ts`, `selectedContext.parse.test.tsx`, `mcpIdentity.parse.test.tsx`, `FeedItem.actions.render.test.tsx`, `voicePersona.render.test.tsx`, `scrollMemory.test.ts`, `messageLinks/artifactAnchor/actionGeometry` DOM tests
  - `src/components/LogFeed.{liveToolRows,outboxTailOrder,spawnPathFlip}.dom.test.tsx`
  - `src/lib/flows/engine.test.ts` (46), `src/lib/mcp/bindings.test.ts` + `orchestratorTools.test.ts` (44), `src/app/api/tmux/route.test.ts`, `src/runtime-host/journal.test.ts` (67, incl. new origin-replay regression), `src/lib/i18n/i18n.test.ts`
- `privacy-publication-gate` (with known-value fingerprints, `--check-commits`): PASS.

## Round 2 (review fixes)

- **Bounded revalidation of the ledger join** — a transcript row can appear before the ledger records its `engineMessageId`; the provenance hook now revalidates unresolved ids on a bounded schedule (1.5s/4s/10s) instead of waiting for a remount. New hook test covers empty-then-resolved for the same id and budget exhaustion (`messageProvenance.retry.dom.test.tsx`).
- **Held-migration origin** — the admission origin persists on the held-delivery command (excluded from the request digest, so pre-existing records and unstamped replays stay compatible) and replays into the host command at drain time on both engines, including the legacy replay port. New tests in `structuredMessageDelivery.test.ts` (51 total).
- **Admission-surface coverage** — origin is now stamped on the legacy composer branch, bulk sends (`BulkActionBar`), broadcasts (`tasks/broadcast`), the task send route (server-side, like `/api/runtime/send`), the bridge directive relay, and the tmux route's legacy fall-through, which also persists it on the legacy hold as client-message evidence.
- **Legacy relay join** — flow reviewer relays delivered over legacy tmux (and pre-#1117 structured relays whose ledger rows carry no origin) resolve through the flow store's own durable evidence: `/api/log/provenance` reconstructs each settled round's relayed text from its findings artifact (`flows/relayProvenance.ts`), and the feed resolves an exact-text match — the launch-echo convention — into the internal reviewer card on both engines. Engine input is unchanged; unmatched rows keep today's rendering.
- Additional runs by path (all pass): `relayProvenance.test.ts` (4, new), `delivery.test.ts` (35), `registry.test.ts` (121) + `registry.admission.test.ts`, `migration/coordinator.test.ts` (105), `mcp/bridgeDirective.test.ts`, composer `migrationHold`/`heldRelease`/`selectedContext`/`staleKey`/`viewerPrelude` DOM tests. The `TmuxComposer.{dom,reconciliation,runtimeSnapshot}` failures are pre-existing at the merge-base and reviewed HEAD (verified in a throwaway worktree). `tsc` clean; privacy gate (incl. `--check-commits`) PASS.

## Round 3 (review fixes)

- **Occurrence join replaces the text join.** `/api/log/provenance` now returns `occurrences`: one entry per settled delivery — the registry's content digest of the delivered text, its settlement time, and the admission-stamped origin. The feed (`feed/deliveredOccurrences.ts`) attaches each occurrence to exactly **one** row: the unclaimed row carrying that text whose timestamp lies nearest the settlement (10-minute window, settlement order). Two identical rows — a relay and the operator's own message — resolve by time on both engines; rows the parser or the ledger already attributed consume their own occurrence so it can never drift onto a look-alike. Adversarial identical-row tests exist for Claude and Codex (`messageProvenance.parse.test.tsx`) plus the pure assignment (`deliveredOccurrences.test.ts`).
- **Legacy MCP origins reach the feed.** `runtime/deliveredMessageOccurrences.ts` projects the conversation's delivered, origin-stamped held records (alias-resolved, re-validated) into occurrences, so a generic `send_message` into a tmux-owned Claude or Codex conversation renders as the internal card naming the sender role while operator sends keep the bubble (exact-path tests for both engines). The legacy hold now stamps its content digest at admission (`delivery.ts`), the only content evidence a delivered record keeps. Engine input and delivery semantics are unchanged.
- **Digest parity.** `runtime/messageTextDigest.ts` is a dependency-free SHA-256 over the same `{ text, images: [] }` envelope the registry hashes, pinned to `structuredContent(...).contentDigest` by test, so the browser can compute a row's digest without `node:crypto` or `crypto.subtle` (unavailable on the non-secure-context deploy origin).
- **Flow relays** (`flows/relayProvenance.ts`) contribute occurrences too, deduped against a held record that settled the same delivery; a fresh legacy row revalidates on the existing bounded schedule (a paste's row lands before the receipt settles), a historical row without evidence fetches once.
- Verification: `bunx tsc --noEmit --incremental false` clean; eslint clean on every changed file; `git diff --check` clean; privacy gate (`--require-known-values --check-commits`) PASS. Touched test files by path, all green: `messageTextDigest.test.ts` (2, new), `deliveredMessageOccurrences.test.ts` (5, new), `deliveredOccurrences.test.ts` (5, new), `relayProvenance.test.ts` (4), `messageProvenance.parse.test.tsx` (18), `messageProvenance.retry.dom.test.tsx` (3), `delivery.test.ts`, `api/tmux/route.test.ts`, `claudeMessageProvenance.test.ts`, `FeedItem.actions.render.test.tsx`, `selectedContext.parse.test.tsx`, `LogFeed.{liveToolRows,outboxTailOrder,spawnPathFlip}.dom.test.tsx`.

## Round 4 (review fixes)

- **Occurrence dedupe by delivery identity.** The digest-plus-ten-minute-window comparison in `runtime/deliveredMessageOccurrences.ts` is gone. Each flow relay occurrence now carries the identity its round's structured relay reserved in the registry (`relayClientMessageId`, now computable for any settled round), each held occurrence carries the record's own `clientMessageId`, and only a shared identity collapses the two stores' evidence into one occurrence. The identity is a server-side join key and never reaches the wire. Covered: an operator message and a legacy relay with identical text four minutes apart are two occurrences; one structured relay present in both stores is exactly one; a pre-#1117 structured round whose record has no origin stamp still surfaces from the flow store; each round's identity is computed from that round alone (retry attempt included).
- **Digest stamped before the 32k blanking.** `delivery.ts` now digests the text actually delivered before an over-bound payload is blanked from the held record, so an oversized agent-origin relay into a tmux-owned Claude or Codex conversation still projects as internal. Plaintext stays request-local; engine input and delivery semantics are unchanged. Covered end to end on both engines: the delivered record keeps `contentDigest` of the full text plus the agent origin and projects through `heldDeliveryOccurrences` (`delivery.test.ts`), and a >32k row joined to that occurrence renders as the internal card naming the sender role (`messageProvenance.parse.test.tsx`).
- Verification: `bunx tsc --noEmit --incremental false` clean; eslint clean on every changed file; `git diff --check` clean; privacy gate vs merge-base with `--check-commits` PASS. Touched test files by path, all green (119 across 7 files): `deliveredMessageOccurrences.test.ts` (7), `relayProvenance.test.ts` (5), `delivery.test.ts`, `messageProvenance.parse.test.tsx` (18), `deliveredOccurrences.test.ts`, `messageTextDigest.test.ts`, `flows/engine.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

