### PR TITLE
design(feed): rebuild the wakeup card in the feed's quiet language (#1124)

### DIFF
--- a/src/components/feed/cards/WakeupCard.dom.test.tsx
+++ b/src/components/feed/cards/WakeupCard.dom.test.tsx
@@ -36,6 +36,26 @@ function toolEvent(w: WakeupEventInfo): ToolEvent {
   };
 }
 
+test("expanding a routine card mounts the raw plan as monospace payload", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const w = wakeup({ fireAt: Date.now() + 60_000, reason: "Fallback poll", prompt: "stage: verify\nresume the round" });
+  flushSync(() => root!.render(<WakeupCard event={toolEvent(w)} wakeup={w} />));
+
+  // Collapsed by default: the internal prompt is not in the DOM at all.
+  expect(container.textContent).toContain("Fallback poll");
+  expect(container.textContent).not.toContain("stage: verify");
+
+  const details = container.querySelector("details")!;
+  (details as unknown as { open: boolean }).open = true;
+  flushSync(() => details.dispatchEvent(new dom.Event("toggle") as unknown as Event));
+
+  const pre = container.querySelector("pre")!;
+  expect(pre.textContent).toContain("stage: verify");
+  expect(pre.className).toContain("font-mono");
+});
+
 test("stops the countdown interval once the wakeup fires", () => {
   const realSet = globalThis.setInterval;
   const realClear = globalThis.clearInterval;

--- a/src/components/feed/cards/WakeupCard.render.test.tsx
+++ b/src/components/feed/cards/WakeupCard.render.test.tsx
@@ -23,39 +23,56 @@ function render(wakeup: WakeupEventInfo, over: Partial<ToolEvent> = {}) {
   return renderToStaticMarkup(<WakeupCard event={event(wakeup, over)} wakeup={wakeup} />);
 }
 
-test("an active wakeup renders the reason, an absolute time and a countdown", () => {
+test("an active wakeup is a quiet row: full reason plus ONE fused schedule element", () => {
   const html = render(info());
   expect(html).toContain("Fallback poll");
-  expect(html).toContain("wakes at");
-  expect(html).toContain("in ");
-  // The plan (prompt) is present behind its expander.
-  expect(html).toContain("Continue the issue");
-  expect(html).toContain("wake plan");
+  // The absolute time and the countdown are one element, stated exactly once.
+  expect(html.split("wakes at").length - 1).toBe(1);
+  expect(html.split("in 20 min").length - 1).toBe(1);
+  // Routine scheduling carries no alarm chrome and never truncates the reason.
+  expect(html).not.toContain("warning");
+  expect(html).not.toContain("truncate");
+  // The raw plan stays collapsed and unmounted until the row is expanded.
+  expect(html).not.toContain("Continue the issue");
+  expect(html).not.toContain('open="');
 });
 
-test("a superseded FUTURE wakeup reads an inactive 'was set for' headline", () => {
+test("a superseded FUTURE wakeup reads an inactive 'was set for' element", () => {
   const html = render(info({ superseded: true }));
   expect(html).toContain("superseded");
   expect(html).toContain("was set for");
   expect(html).not.toContain("wakes at");
 });
 
-test("an elapsed wakeup renders the fired state", () => {
+test("an elapsed wakeup renders the fired state without a countdown", () => {
   const html = render(info({ fireAt: PAST }));
   expect(html).toContain("fired at");
+  expect(html).not.toContain("· in");
 });
 
-test("a wakeup without a fire time still shows its reason and plan", () => {
+test("a wakeup without a fire time still shows its reason", () => {
   const html = render(info({ fireAt: null }));
   expect(html).toContain("Fallback poll");
-  expect(html).toContain("Continue the issue");
+  expect(html).toContain("wakeup scheduled");
 });
 
-test("a failed (rejected) wakeup shows the failed state and the harness error", () => {
+test("a rejected wakeup keeps the alarm: danger edge, open, harness error visible", () => {
   const html = render(info({ failed: true }), { status: "err", outputPreview: "delaySeconds must be between 60 and 3600", outputTruncated: false });
   expect(html).toContain("scheduling failed");
+  expect(html).toContain("border-danger");
+  expect(html).toContain('open=""');
   // No live countdown for a rejected schedule.
-  expect(html).not.toContain("in 20 min");
+  expect(html).not.toContain("· in");
   // The actionable rejection reason stays visible.
   expect(html).toContain("delaySeconds must be between 60 and 3600");
+});
+
+test("the wake plan renders as marked internal monospace payload, not prose", () => {
+  const html = render(info({ failed: true, prompt: "## Stage verify\nResume the review round" }), { status: "err" });
+  expect(html).toContain("wake plan");
+  expect(html).toContain("internal prompt");
+  // The raw text stays literal in a mono <pre>: markdown never becomes prose.
+  expect(html).toContain("## Stage verify");
+  expect(html).not.toContain("<h2");
+  expect(html).toMatch(/<pre[^>]*font-mono/);
 });

--- a/src/components/feed/cards/WakeupCard.tsx
+++ b/src/components/feed/cards/WakeupCard.tsx
@@ -5,28 +5,62 @@ import { useEffect, useState } from "react";
 import { useLocale } from "@/lib/i18n";
 import { wakeupPhase } from "@/lib/wakeup";
 
-import { ChevronRight, GlyphIcon } from "../../icons";
+import { GlyphIcon } from "../../icons";
 import { fmtWakeClock, fmtWakeRelative } from "../../wakeupFormat";
-import { mdBlocks } from "../markdown";
 import { type ToolEvent, type WakeupEventInfo } from "../parse";
 import { OutputPreview } from "./OutputPreview";
 
+/* The raw wake-plan prompt is orchestrator payload — stage ids, SHAs, playbook
+   steps — so it renders as bare monospace text and is never fed through the
+   markdown pipeline: internal machine text must not masquerade as user-facing
+   prose (issue #1124). A rejected call keeps the harness's bounded error output
+   above it, so the reason it was refused stays visible. */
+function WakeupBody({ event, wakeup }: { event: ToolEvent; wakeup: WakeupEventInfo }) {
+  const { t } = useLocale();
+  return (
+    <div className="mb-1 mt-1 rounded-surface bg-sunken px-2.5 py-2">
+      {wakeup.failed && event.outputPreview.trim() ? (
+        <div className="mb-2">
+          <OutputPreview output={event.outputPreview} truncated={event.outputTruncated} />
+        </div>
+      ) : null}
+      {wakeup.prompt ? (
+        <>
+          <div className="mb-1 flex flex-wrap items-center gap-1.5 text-[10.5px] font-semibold text-muted">
+            <span className="uppercase tracking-wide">{t("wakeup.plan")}</span>
+            <span className="rounded-md border border-border bg-card px-1.5 py-px font-mono font-normal">
+              {t("wakeup.planInternal")}
+            </span>
+          </div>
+          <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-[11px] leading-snug text-secondary">
+            {wakeup.prompt}
+          </pre>
+        </>
+      ) : (
+        <span className="text-[11px] text-muted">{t("wakeup.noPlan")}</span>
+      )}
+    </div>
+  );
+}
+
 /**
- * A `ScheduleWakeup` call as a dedicated card: the reason is the visible
- * summary, the absolute fire time carries a live countdown, and the wake plan
- * (the prompt) sits behind an expander as readable text (issue #161). Only the
- * newest successful wakeup of a conversation is active; a superseded, elapsed,
- * or rejected one shows a quiet past/failed state. A rejected call also surfaces
- * the harness's bounded error output so the reason it was refused stays visible.
+ * A `ScheduleWakeup` call in the feed's own quiet language (issue #1124): the
+ * same borderless row idiom as a tool line — glyph, the full reason (wrapping,
+ * never truncated), and ONE schedule element that fuses the absolute fire time
+ * with the live countdown, stated exactly once. Routine scheduling is neutral
+ * chrome; alarm styling is reserved for a genuinely rejected call, which keeps
+ * the danger edge and opens to show the harness's refusal. The wake plan sits
+ * collapsed behind the row and mounts only on first expand, so a long feed
+ * never carries walls of internal prompt text in its DOM.
  */
 export function WakeupCard({ event, wakeup }: { event: ToolEvent; wakeup: WakeupEventInfo }) {
   const { locale, t } = useLocale();
-  const { fireAt, superseded, failed, reason, prompt } = wakeup;
+  const { fireAt, superseded, failed, reason } = wakeup;
 
   const [now, setNow] = useState(() => Date.now());
-  // A superseded, failed, or already-fired card is static; only a genuinely
-  // pending one counts down. `active` is derived from the CURRENT clock, so the
-  // interval below stops the moment the fire time passes (issue #161 review).
+  // Only a genuinely pending schedule counts down. `active` is derived from the
+  // CURRENT clock, so the interval below stops the moment the fire time passes
+  // (issue #161 review). A superseded or failed card is static.
   const phase = failed ? "failed" : superseded ? "superseded" : wakeupPhase(fireAt, now);
   const active = phase === "pending";
   useEffect(() => {
@@ -36,78 +70,55 @@ export function WakeupCard({ event, wakeup }: { event: ToolEvent; wakeup: Wakeup
   }, [active]);
 
   const clock = fireAt !== null ? fmtWakeClock(fireAt, locale) : "";
-  const relative = active && fireAt !== null ? fmtWakeRelative(fireAt, now, t) : "";
 
-  /* The state badge: an amber live countdown while pending, an error label when
-     the scheduling call was rejected, a quiet grey label once fired/superseded. */
-  const badge = failed
-    ? { text: t("wakeup.failed"), tone: "text-danger" }
-    : superseded
-      ? { text: t("wakeup.superseded"), tone: "text-muted" }
-      : phase === "pending"
-        ? { text: relative, tone: "text-warning" }
-        : phase === "fired"
-          ? { text: clock ? t("wakeup.firedAt", { time: clock }) : t("wakeup.fired"), tone: "text-muted" }
-          : { text: "", tone: "text-muted" };
-
-  /* The headline follows the card's state before it reads the clock: a
-     superseded FUTURE schedule reads "was set for" and never promises to wake
-     (issue #161 review). Only a still-active or already-fired schedule speaks of
-     its time as future or past. */
-  const headline = failed
+  /* The single time element. A superseded FUTURE schedule reads "was set for"
+     and never promises to wake (issue #161 review); only a still-active or
+     already-fired schedule speaks of its time as future or past. */
+  const schedule = failed
     ? t("wakeup.failed")
-    : !clock
-      ? t("wakeup.noTime")
-      : superseded
-        ? t("wakeup.wasSetFor", { time: clock })
-        : fireAt !== null && fireAt <= now
-          ? t("wakeup.firedAt", { time: clock })
-          : t("wakeup.wakesAt", { time: clock });
+    : superseded
+      ? clock
+        ? `${t("wakeup.wasSetFor", { time: clock })} · ${t("wakeup.superseded")}`
+        : t("wakeup.superseded")
+      : active && fireAt !== null
+        ? `${t("wakeup.wakesAt", { time: clock })} · ${fmtWakeRelative(fireAt, now, t)}`
+        : phase === "fired"
+          ? clock
+            ? t("wakeup.firedAt", { time: clock })
+            : t("wakeup.fired")
+          : t("wakeup.noTime");
 
-  const cardTone = active ? "border-warning/45 bg-warning-soft" : failed ? "border-danger/35 bg-card" : "border-border bg-card";
-  const iconTone = active ? "bg-warning-soft text-warning" : failed ? "bg-danger-soft text-danger" : "bg-sunken text-muted";
+  const rowTone = failed ? "border-l-2 border-danger bg-danger-soft pl-2 pr-1 text-danger" : "text-muted";
+  const reasonTone = failed ? "font-semibold" : superseded ? "text-muted" : "text-secondary";
+  const scheduleTone = failed ? "font-semibold text-danger" : "text-muted";
+
+  // The body mounts lazily on first expand (same contract as ToolLine); a
+  // rejected call opens immediately so its refusal is visible without a click.
+  const [mounted, setMounted] = useState(failed);
 
   return (
-    <details className={`group/wake my-2.5 ml-9 overflow-hidden rounded-surface border ${cardTone}`} open={active || failed}>
-      <summary className="flex min-h-[44px] cursor-pointer list-none items-center gap-2.5 px-3 py-2">
-        <span className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-lg ${iconTone}`}>
-          <GlyphIcon name="clock" className="h-3.5 w-3.5" />
-        </span>
-        <span className="flex min-w-0 flex-1 flex-col">
-          <span className="truncate text-[12.5px] font-semibold" title={reason || headline}>
+    <details
+      className="ml-9"
+      open={failed}
+      onToggle={(e) => {
+        if (e.currentTarget.open) setMounted(true);
+      }}
+    >
+      <summary
+        className={`flex cursor-pointer list-none items-start gap-2 rounded-control py-0.5 text-ui hover:bg-sunken [@media(pointer:coarse)]:min-h-11 [&::-webkit-details-marker]:hidden ${rowTone}`}
+      >
+        <GlyphIcon name="clock" className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        {/* The reason wraps in full (grow/shrink around a 10rem basis); on a
+            narrow viewport the schedule element drops to its own line instead
+            of squeezing the reason into a sliver column. */}
+        <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span className={`min-w-0 grow shrink basis-40 leading-snug [overflow-wrap:anywhere] ${reasonTone}`}>
             {reason || t("wakeup.card")}
           </span>
-          <span className="truncate text-[11px] text-muted">{headline}</span>
+          <span className={`ml-auto whitespace-nowrap text-[11px] tabular-nums ${scheduleTone}`}>{schedule}</span>
         </span>
-        {badge.text ? (
-          <span className={`shrink-0 text-[11px] font-bold tabular-nums ${badge.tone}`}>{badge.text}</span>
-        ) : null}
       </summary>
-      <div className="border-t border-border px-3 py-2">
-        <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11.5px] text-muted">
-          <span className={`font-semibold ${failed ? "text-danger" : "text-primary"}`}>{headline}</span>
-          {relative ? <span>· {relative}</span> : null}
-          {superseded ? <span className="rounded-md bg-sunken px-1.5 py-0.5">{t("wakeup.superseded")}</span> : null}
-        </div>
-        {/* The harness's rejection message (already redacted and bounded on the
-            ToolEvent), so a refused schedule keeps its actionable detail. */}
-        {failed && event.outputPreview.trim() ? (
-          <div className="mb-2">
-            <OutputPreview output={event.outputPreview} truncated={event.outputTruncated} />
-          </div>
-        ) : null}
-        {prompt ? (
-          <details className="group/plan">
-            <summary className="inline-flex min-h-[44px] cursor-pointer list-none items-center gap-1.5 text-[11.5px] font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
-              <ChevronRight className="h-3 w-3 transition-transform group-open/plan:rotate-90" aria-hidden />
-              {t("wakeup.plan")}
-            </summary>
-            <div className="border-t border-border pt-2 text-[12.5px] leading-snug">{mdBlocks(prompt)}</div>
-          </details>
-        ) : (
-          <span className="text-[11.5px] text-muted">{t("wakeup.noPlan")}</span>
-        )}
-      </div>
+      {mounted ? <WakeupBody event={event} wakeup={wakeup} /> : null}
     </details>
   );
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1183,6 +1183,7 @@ export const en = {
   "wakeup.superseded": "superseded",
   "wakeup.noTime": "wakeup scheduled",
   "wakeup.plan": "wake plan",
+  "wakeup.planInternal": "internal prompt",
   "wakeup.noPlan": "no wake plan given",
   "wakeup.inRel": "in {rel}",
   "wakeup.agoRel": "{rel} ago",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1152,6 +1152,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "wakeup.superseded": "замінено",
   "wakeup.noTime": "пробудження заплановано",
   "wakeup.plan": "план пробудження",
+  "wakeup.planInternal": "внутрішній промпт",
   "wakeup.noPlan": "план пробудження не задано",
   "wakeup.inRel": "через {rel}",
   "wakeup.agoRel": "{rel} тому",


### PR DESCRIPTION
Closes #1124.

## Design

The card now speaks the feed's own idiom — the quiet borderless tool-line row — instead of a bordered amber banner:

- **Routine schedules are neutral chrome.** Clock glyph + muted/secondary text, `hover:bg-sunken`, no border, no amber. All colors come from role tokens, so light/dark stay consistent.
- **One line of truth.** The reason renders in full and wraps (`[overflow-wrap:anywhere]`, no `truncate`), and a single schedule element fuses the absolute time with the live countdown: `wakes at 11:08 · in 14 min`. Superseded reads `was set for 11:08 · superseded`; fired reads `fired at 11:08`. Nothing repeats.
- **Mobile.** The reason keeps a 10rem flex basis, so on narrow widths the schedule element wraps to its own right-aligned line instead of squeezing the reason into a sliver column. Coarse pointers get the 44px tap target.
- **The raw wake plan is marked internal payload.** Collapsed by default and lazy-mounted on first expand (same contract as ToolLine, so long feeds carry no walls of prompt text in the DOM). It renders as a bare monospace `<pre>` under a `wake plan · internal prompt` label and bypasses the markdown pipeline entirely — stage ids, SHAs and playbook steps stay literal machine text.
- **Alarm styling survives only for a genuinely rejected call**: danger left edge (the ToolLine error idiom), open by default, with the harness's bounded refusal output visible.

## Changes

- `src/components/feed/cards/WakeupCard.tsx` — rebuilt from scratch; countdown lifecycle (1s tick, stops at fire time) preserved.
- `src/lib/i18n/en.ts`, `uk.ts` — new `wakeup.planInternal` key ("internal prompt" / "внутрішній промпт"); all existing keys reused.
- `WakeupCard.render.test.tsx` — rewritten around the new anatomy: single fused schedule element (counted once), no `warning` classes and no `truncate` on routine cards, plan unmounted while collapsed, danger/open/error assertions for a rejected call, markdown-in-prompt stays literal inside a mono `<pre>`.
- `WakeupCard.dom.test.tsx` — kept the interval-stops test; added expand-mounts-the-mono-plan test.

`WakeupChip.tsx`, `wakeupFormat.ts` and `parse.ts` needed no changes — the existing parsed shape and formatters carry the new card.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test src/components/feed/cards/WakeupCard.render.test.tsx src/components/feed/cards/WakeupCard.dom.test.tsx src/lib/i18n/i18n.test.ts` — 22 pass, 0 fail.
- `bun run privacy:check` — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)