### PR TITLE
feat(mcp): archive and unarchive conversations

### DIFF
--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,106 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { agentRegistry, RegistryReadError } from "@/lib/agent/registry";
-import type { BoardMutationV1 } from "@/lib/board/mutations";
-import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "@/lib/board/store";
-import { validateBoardPatchRequest } from "@/lib/board/validation";
+import { applyBoardCommand } from "@/lib/board/command";
+import { boardFor, BoardStoreError } from "@/lib/board/store";
+import { readBoardPatchPayload } from "@/lib/board/validation";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { ViewValidationError } from "@/lib/view/validation";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 const headers = { "Cache-Control": "no-store" };
-
-function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[]): BoardMutationV1[] {
-  const mentionedPaths = new Set<string>();
-  for (const mutation of mutations) {
-    if (mutation.kind === "close" || mutation.kind === "restore") mentionedPaths.add(mutation.path);
-    if (mutation.kind === "reconcile-roots") {
-      for (const pathname of mutation.roots) mentionedPaths.add(pathname);
-    }
-    if (mutation.kind === "remap-paths") {
-      for (const pair of mutation.pairs) {
-        mentionedPaths.add(pair.from);
-        mentionedPaths.add(pair.to);
-      }
-    }
-  }
-  if (mentionedPaths.size === 0) return [...mutations];
-
-  let snapshot: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>;
-  try {
-    snapshot = agentRegistry().readOnlySnapshot();
-  } catch (error) {
-    if (error instanceof RegistryReadError) return [...mutations];
-    throw error;
-  }
-
-  const excludedByConversation = new Map<string, Set<string>>();
-  const excludedPaths = new Set<string>();
-  for (const conversation of Object.values(snapshot.conversations)) {
-    const excluded = new Set(conversation.abandonedContinuityPaths);
-    if (conversation.migration && conversation.migration.phase !== "committed") {
-      for (const pathname of conversation.migration.pendingContinuityPaths) excluded.add(pathname);
-    }
-    excludedByConversation.set(conversation.id, excluded);
-    for (const pathname of excluded) excludedPaths.add(pathname);
-  }
-  for (const cleanup of Object.values(snapshot.pendingSuccessorCleanups)) {
-    const excluded = excludedByConversation.get(cleanup.conversationId);
-    if (!excluded) continue;
-    for (const pathname of [...cleanup.receipt.continuityPaths, cleanup.receipt.path]) {
-      excluded.add(pathname);
-      excludedPaths.add(pathname);
-    }
-  }
-
-  const safeMutations = mutations.map((mutation): BoardMutationV1 => {
-    if (mutation.kind === "reconcile-roots") {
-      return { ...mutation, roots: mutation.roots.filter((pathname) => !excludedPaths.has(pathname)) };
-    }
-    if (mutation.kind === "remap-paths") {
-      return {
-        ...mutation,
-        pairs: mutation.pairs.filter(({ from, to }) => !excludedPaths.has(from) && !excludedPaths.has(to)),
-      };
-    }
-    return mutation;
-  });
-
-  const suppliedRemapSources = new Set<string>();
-  for (const mutation of safeMutations) {
-    if (mutation.kind === "remap-paths") {
-      for (const pair of mutation.pairs) {
-        suppliedRemapSources.add(pair.from);
-      }
-    }
-  }
-
-  const pairs: Array<{ from: string; to: string }> = [];
-  const pairedSources = new Set(suppliedRemapSources);
-  for (const conversation of Object.values(snapshot.conversations)) {
-    if (conversation.generations.length < 2) continue;
-    const excludedContinuityPaths = excludedByConversation.get(conversation.id) ?? new Set<string>();
-    const continuityPaths = conversation.continuityPaths.filter((pathname) => !excludedContinuityPaths.has(pathname));
-    const paths = [
-      ...conversation.generations.map((generation) => generation.path),
-      ...continuityPaths,
-    ];
-    const conversationWasMentioned = paths.some((pathname) => mentionedPaths.has(pathname))
-      || [...excludedContinuityPaths].some((pathname) => mentionedPaths.has(pathname));
-    if (!conversationWasMentioned) continue;
-    const target = conversation.generations.at(-1)?.path;
-    if (!target) continue;
-    for (const source of paths) {
-      if (source === target || pairedSources.has(source)) continue;
-      pairedSources.add(source);
-      pairs.push({ from: source, to: target });
-    }
-  }
-  return pairs.length > 0
-    ? [{ kind: "remap-paths", pairs }, ...safeMutations]
-    : safeMutations;
-}
 
 export function GET(request: NextRequest): NextResponse {
   const rejection = rejectCrossOrigin(request);
@@ -119,10 +27,7 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
   const rejection = rejectCrossOrigin(request);
   if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
   try {
-    const payload = await validateBoardPatchRequest(request);
-    const result = payload.mutations
-      ? mutateBoard(payload.project, payload.baseRevision, mutationsWithConversationAliases(payload.mutations))
-      : patchBoard(payload.project, payload.baseRevision, payload.patch!);
+    const result = applyBoardCommand(await readBoardPatchPayload(request));
     if (!result.ok) return NextResponse.json({ error: "BOARD_REVISION_CONFLICT", board: result.board }, { status: 409, headers });
     /* `applied` lets the caller tell its own committed write from a no-op that
        was accepted against a board some other writer produced (#38). */

--- a/src/lib/board/command.ts
+++ b/src/lib/board/command.ts
@@ -1,0 +1,123 @@
+import { agentRegistry, RegistryReadError, type RegistryFile } from "@/lib/agent/registry";
+import type { BoardMutationV1 } from "@/lib/board/mutations";
+import { mutateBoard, patchBoard } from "@/lib/board/store";
+import { validateBoardPatchPayload } from "@/lib/board/validation";
+
+interface BoardCommandDependencies {
+  patchBoard: typeof patchBoard;
+  mutateBoard: typeof mutateBoard;
+  registrySnapshot(): RegistryFile;
+}
+
+const productionDependencies: BoardCommandDependencies = {
+  patchBoard,
+  mutateBoard,
+  registrySnapshot: () => agentRegistry().readOnlySnapshot(),
+};
+
+function mutationsWithConversationAliases(
+  mutations: readonly BoardMutationV1[],
+  registrySnapshot: () => RegistryFile,
+): BoardMutationV1[] {
+  const mentionedPaths = new Set<string>();
+  for (const mutation of mutations) {
+    if (mutation.kind === "close" || mutation.kind === "restore") mentionedPaths.add(mutation.path);
+    if (mutation.kind === "reconcile-roots") {
+      for (const pathname of mutation.roots) mentionedPaths.add(pathname);
+    }
+    if (mutation.kind === "remap-paths") {
+      for (const pair of mutation.pairs) {
+        mentionedPaths.add(pair.from);
+        mentionedPaths.add(pair.to);
+      }
+    }
+  }
+  if (mentionedPaths.size === 0) return [...mutations];
+
+  let snapshot: RegistryFile;
+  try {
+    snapshot = registrySnapshot();
+  } catch (error) {
+    if (error instanceof RegistryReadError) return [...mutations];
+    throw error;
+  }
+
+  const excludedByConversation = new Map<string, Set<string>>();
+  const excludedPaths = new Set<string>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    const excluded = new Set(conversation.abandonedContinuityPaths);
+    if (conversation.migration && conversation.migration.phase !== "committed") {
+      for (const pathname of conversation.migration.pendingContinuityPaths) excluded.add(pathname);
+    }
+    excludedByConversation.set(conversation.id, excluded);
+    for (const pathname of excluded) excludedPaths.add(pathname);
+  }
+  for (const cleanup of Object.values(snapshot.pendingSuccessorCleanups)) {
+    const excluded = excludedByConversation.get(cleanup.conversationId);
+    if (!excluded) continue;
+    for (const pathname of [...cleanup.receipt.continuityPaths, cleanup.receipt.path]) {
+      excluded.add(pathname);
+      excludedPaths.add(pathname);
+    }
+  }
+
+  const safeMutations = mutations.map((mutation): BoardMutationV1 => {
+    if (mutation.kind === "reconcile-roots") {
+      return { ...mutation, roots: mutation.roots.filter((pathname) => !excludedPaths.has(pathname)) };
+    }
+    if (mutation.kind === "remap-paths") {
+      return {
+        ...mutation,
+        pairs: mutation.pairs.filter(({ from, to }) => !excludedPaths.has(from) && !excludedPaths.has(to)),
+      };
+    }
+    return mutation;
+  });
+
+  const suppliedRemapSources = new Set<string>();
+  for (const mutation of safeMutations) {
+    if (mutation.kind === "remap-paths") {
+      for (const pair of mutation.pairs) suppliedRemapSources.add(pair.from);
+    }
+  }
+
+  const pairs: Array<{ from: string; to: string }> = [];
+  const pairedSources = new Set(suppliedRemapSources);
+  for (const conversation of Object.values(snapshot.conversations)) {
+    if (conversation.generations.length < 2) continue;
+    const excludedContinuityPaths = excludedByConversation.get(conversation.id) ?? new Set<string>();
+    const continuityPaths = conversation.continuityPaths.filter((pathname) => !excludedContinuityPaths.has(pathname));
+    const paths = [
+      ...conversation.generations.map((generation) => generation.path),
+      ...continuityPaths,
+    ];
+    const conversationWasMentioned = paths.some((pathname) => mentionedPaths.has(pathname))
+      || [...excludedContinuityPaths].some((pathname) => mentionedPaths.has(pathname));
+    if (!conversationWasMentioned) continue;
+    const target = conversation.generations.at(-1)?.path;
+    if (!target) continue;
+    for (const source of paths) {
+      if (source === target || pairedSources.has(source)) continue;
+      pairedSources.add(source);
+      pairs.push({ from: source, to: target });
+    }
+  }
+  return pairs.length > 0
+    ? [{ kind: "remap-paths", pairs }, ...safeMutations]
+    : safeMutations;
+}
+
+export function applyBoardCommand(
+  input: unknown,
+  overrides: Partial<BoardCommandDependencies> = {},
+): ReturnType<typeof patchBoard> {
+  const dependencies = { ...productionDependencies, ...overrides };
+  const payload = validateBoardPatchPayload(input);
+  return payload.mutations
+    ? dependencies.mutateBoard(
+        payload.project,
+        payload.baseRevision,
+        mutationsWithConversationAliases(payload.mutations, dependencies.registrySnapshot),
+      )
+    : dependencies.patchBoard(payload.project, payload.baseRevision, payload.patch!);
+}

--- a/src/lib/board/validation.ts
+++ b/src/lib/board/validation.ts
@@ -113,8 +113,10 @@ function rejectMutationAliasCycles(mutations: readonly BoardMutationV1[]): void 
   }
 }
 
-export async function validateBoardPatchRequest(request: Request): Promise<{ project: string; baseRevision: number; patch?: BoardPatch; mutations?: BoardMutationV1[] }> {
-  const body = record(await readBoundedJson(request, MAX_BOARD_BODY_BYTES), "request");
+export type ValidatedBoardPatchPayload = { project: string; baseRevision: number; patch?: BoardPatch; mutations?: BoardMutationV1[] };
+
+export function validateBoardPatchPayload(value: unknown): ValidatedBoardPatchPayload {
+  const body = record(value, "request");
   exact(body, ["schemaVersion", "project", "baseRevision", "patch", "mutations"], "request");
   if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
   if (typeof body.project !== "string" || body.project.length === 0 || body.project.length > 256) throw new ViewValidationError("INVALID_REQUEST", "invalid project");
@@ -147,4 +149,12 @@ export async function validateBoardPatchRequest(request: Request): Promise<{ pro
     patch.taskPanelOpen = rawPatch.taskPanelOpen;
   }
   return { project: body.project, baseRevision: body.baseRevision as number, patch };
+}
+
+export async function readBoardPatchPayload(request: Request): Promise<unknown> {
+  return readBoundedJson(request, MAX_BOARD_BODY_BYTES);
+}
+
+export async function validateBoardPatchRequest(request: Request): Promise<ValidatedBoardPatchPayload> {
+  return validateBoardPatchPayload(await readBoardPatchPayload(request));
 }

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -871,6 +871,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   const currentPath = "/fixtures/fixture-project/current.jsonl";
   const deletedGhostPath = "/fixtures/fixture-project/deleted-ghost.jsonl";
   const spawnPath = "spawn:launch_fixture_placeholder";
+  const unknownPath = "/fixtures/fixture-project/unknown.jsonl";
   const launchProfile = {
     cwd: "/fixtures/fixture-project",
     project,
@@ -914,6 +915,9 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     registrySnapshot: () => registrySnapshot,
     completedFileScan: async () => {
       scanCalls += 1;
+      expect(boardFor(project, boardFile).prefs.hidden).toEqual(scanCalls === 1
+        ? [currentPath, deletedGhostPath, spawnPath]
+        : []);
       throw new Error("ghost archiving must not require a transcript scan");
     },
     boardFor: (key: string) => boardFor(key, boardFile),
@@ -936,6 +940,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { transcriptPath: deletedGhostPath },
       { transcriptPath: spawnPath },
       { transcriptPath: predecessorPath },
+      { transcriptPath: unknownPath },
     ],
   });
 
@@ -948,6 +953,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { conversationId: "conversation_deleted_ghost", transcriptPath: deletedGhostPath, project, outcome: "archived" },
       { conversationId: "conversation_spawn_placeholder", transcriptPath: spawnPath, project, outcome: "archived" },
       { conversationId: "conversation_current", transcriptPath: currentPath, project, outcome: "already-archived" },
+      { conversationId: null, transcriptPath: unknownPath, project: null, outcome: "resolution-failed" },
     ],
   });
   expect(boardFor(project, boardFile)).toMatchObject({
@@ -982,7 +988,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { conversationId: "conversation_current" },
       { transcriptPath: deletedGhostPath },
       { transcriptPath: spawnPath },
-      { transcriptPath: "/fixtures/fixture-project/unknown.jsonl" },
+      { transcriptPath: unknownPath },
     ],
   });
   expect(restored).toMatchObject({
@@ -990,12 +996,84 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { conversationId: "conversation_current", transcriptPath: currentPath, outcome: "unarchived" },
       { outcome: "unarchived" },
       { outcome: "unarchived" },
-      { project: null, outcome: "not-found" },
+      { project: null, outcome: "resolution-failed" },
     ],
   });
   expect(boardFor(project, boardFile)).toMatchObject({ revision: 2, prefs: { hidden: [] } });
   expect(runtimeCalls).toBe(0);
-  expect(scanCalls).toBe(1);
+  expect(scanCalls).toBe(2);
+});
+
+test("conversation_action attributes archive outcomes only when its board command applied", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-archive-race-"));
+  sandboxes.push(sandbox);
+  const boardFile = path.join(sandbox, "board.json");
+  const project = "fixture-concurrent-project";
+  const transcriptPath = "/fixtures/concurrent-project/session.jsonl";
+  const emptyRegistrySnapshot = new AgentRegistry(path.join(sandbox, "agent-registry.json")).readOnlySnapshot();
+  const registrySnapshot: typeof emptyRegistrySnapshot = {
+    ...emptyRegistrySnapshot,
+    conversations: {
+      conversation_concurrent: {
+        id: "conversation_concurrent",
+        generations: [{
+          path: transcriptPath,
+          launchProfile: { cwd: "/fixtures/concurrent-project", project, model: null, effort: null },
+        }],
+        continuityPaths: [],
+        abandonedContinuityPaths: [],
+        migration: null,
+        projectOwnership: {
+          project,
+          source: "operator",
+          setAt: "2026-08-24T08:00:00.000Z",
+          operationId: "ownership_conversation_concurrent",
+        },
+      } as never,
+    },
+  };
+  let commandCalls = 0;
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    registrySnapshot: () => registrySnapshot,
+    boardFor: (key: string) => boardFor(key, boardFile),
+    applyBoardCommand: (input: unknown, snapshot: typeof registrySnapshot) => {
+      commandCalls += 1;
+      if (commandCalls === 1) {
+        expect(patchBoard(project, 0, { hidden: [transcriptPath] }, boardFile)).toMatchObject({ ok: true, applied: true });
+      } else {
+        expect(mutateBoard(project, 1, [{ kind: "restore", path: transcriptPath, placement: "auto" }], boardFile))
+          .toMatchObject({ ok: true, applied: true });
+      }
+      return applyBoardCommand(input, {
+        registrySnapshot: () => snapshot,
+        patchBoard: (key, revision, patch) => patchBoard(key, revision, patch, boardFile),
+        mutateBoard: (key, revision, mutations) => mutateBoard(key, revision, mutations, boardFile),
+      });
+    },
+  } as never);
+
+  const archived = await bindings.conversation_action({
+    clientRequestId: "archive-concurrent-content",
+    action: "archive",
+    conversationId: "conversation_concurrent",
+  });
+  expect(archived).toMatchObject({
+    projectsTouched: [],
+    outcomes: [{ transcriptPath, project, outcome: "already-archived" }],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({ revision: 1, prefs: { hidden: [transcriptPath] } });
+
+  const unarchived = await bindings.conversation_action({
+    clientRequestId: "unarchive-concurrent-content",
+    action: "unarchive",
+    conversationId: "conversation_concurrent",
+  });
+  expect(unarchived).toMatchObject({
+    projectsTouched: [],
+    outcomes: [{ transcriptPath, project, outcome: "not-found" }],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({ revision: 2, prefs: { hidden: [] } });
+  expect(commandCalls).toBe(2);
 });
 
 test("conversation_action refuses archive batches above 100 before reading board or runtime state", async () => {

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
+import { applyBoardCommand } from "@/lib/board/command";
 import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
 import { DeadlineExceededError } from "@/lib/deadline";
 import { CORPUS_BODY_MARKERS, pipelineCorpus } from "@/lib/pipelines/fixtures/corpus";
@@ -880,6 +881,8 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     id,
     generations: paths.map((pathname) => ({ path: pathname, launchProfile })),
     continuityPaths: [],
+    abandonedContinuityPaths: [],
+    migration: null,
     projectOwnership: {
       project,
       source: "operator",
@@ -887,12 +890,13 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       operationId: `ownership_${id}`,
     },
   });
-  const registrySnapshot = {
+  const emptyRegistrySnapshot = new AgentRegistry(path.join(sandbox, "agent-registry.json")).readOnlySnapshot();
+  const registrySnapshot: typeof emptyRegistrySnapshot = {
+    ...emptyRegistrySnapshot,
     conversations: {
-      conversation_current: conversation("conversation_current", [predecessorPath, currentPath]),
-      conversation_deleted_ghost: conversation("conversation_deleted_ghost", [deletedGhostPath]),
+      conversation_current: conversation("conversation_current", [predecessorPath, currentPath]) as never,
+      conversation_deleted_ghost: conversation("conversation_deleted_ghost", [deletedGhostPath]) as never,
     },
-    conversationAliases: {},
     receipts: {
       launch_fixture_placeholder: {
         launchId: "launch_fixture_placeholder",
@@ -901,10 +905,8 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
         explicitProject: project,
         cwd: "/fixtures/fixture-project",
         launchProfile,
-      },
+      } as never,
     },
-    lineageEdges: {},
-    memberships: {},
   };
   let runtimeCalls = 0;
   let scanCalls = 0;
@@ -915,10 +917,11 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       throw new Error("ghost archiving must not require a transcript scan");
     },
     boardFor: (key: string) => boardFor(key, boardFile),
-    patchBoard: (key: string, revision: number, patch: Parameters<typeof patchBoard>[2]) =>
-      patchBoard(key, revision, patch, boardFile),
-    mutateBoard: (key: string, revision: number, mutations: Parameters<typeof mutateBoard>[2]) =>
-      mutateBoard(key, revision, mutations, boardFile),
+    applyBoardCommand: (input: unknown, snapshot: typeof registrySnapshot) => applyBoardCommand(input, {
+      registrySnapshot: () => snapshot,
+      patchBoard: (key, revision, patch) => patchBoard(key, revision, patch, boardFile),
+      mutateBoard: (key, revision, mutations) => mutateBoard(key, revision, mutations, boardFile),
+    }),
     applyConversationAction: async () => {
       runtimeCalls += 1;
       throw new Error("archive must not enter runtime conversation control");
@@ -932,7 +935,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { conversationId: "conversation_current" },
       { transcriptPath: deletedGhostPath },
       { transcriptPath: spawnPath },
-      { conversationId: "conversation_current" },
+      { transcriptPath: predecessorPath },
     ],
   });
 
@@ -949,6 +952,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   });
   expect(boardFor(project, boardFile)).toMatchObject({
     revision: 1,
+    pathAliases: {},
     prefs: { hidden: [currentPath, deletedGhostPath, spawnPath] },
   });
   expect(boardFor(project, boardFile).prefs.hidden).not.toContain(predecessorPath);
@@ -957,7 +961,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     clientRequestId: "archive-ghosts-again",
     action: "archive",
     targets: [
-      { conversationId: "conversation_current" },
+      { transcriptPath: predecessorPath },
       { transcriptPath: deletedGhostPath },
       { transcriptPath: spawnPath },
     ],
@@ -983,7 +987,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   });
   expect(restored).toMatchObject({
     outcomes: [
-      { outcome: "unarchived" },
+      { conversationId: "conversation_current", transcriptPath: currentPath, outcome: "unarchived" },
       { outcome: "unarchived" },
       { outcome: "unarchived" },
       { project: null, outcome: "not-found" },

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
+import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
 import { DeadlineExceededError } from "@/lib/deadline";
 import { CORPUS_BODY_MARKERS, pipelineCorpus } from "@/lib/pipelines/fixtures/corpus";
 import type { Pipeline } from "@/lib/pipelines/types";
@@ -601,7 +602,7 @@ test("board_snapshot returns an inert bounded board projection with durable line
         conversation_worker: [{ kind: "pipeline", containerId: "pipeline_608", role: "builder" }],
       },
     }),
-    boardFor: () => ({ schemaVersion: 1, revision: 7, updatedAt: "2026-07-23T00:00:00.000Z", prefs: { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false } }),
+    boardFor: () => ({ schemaVersion: 1, revision: 7, updatedAt: "2026-07-23T00:00:00.000Z", prefs: { manual: [], hidden: ["/sessions/hidden-a.jsonl", "/sessions/hidden-b.jsonl"], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false } }),
     noteWrite: () => { writes += 1; },
   } as never);
 
@@ -614,6 +615,7 @@ test("board_snapshot returns an inert bounded board projection with durable line
 
   expect(result).toMatchObject({
     count: 1,
+    hiddenCount: 2,
     board: { revision: 7 },
     conversations: [{
       conversationId: "conversation_worker",
@@ -857,6 +859,156 @@ test("conversation_action delegates to the ownership-fenced conversation command
     operationId,
     receipt: { operationId, status: "queued" },
   });
+});
+
+test("conversation_action archives current generations, deleted ghosts, and spawn placeholders through board placement", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-archive-"));
+  sandboxes.push(sandbox);
+  const boardFile = path.join(sandbox, "board.json");
+  const project = "fixture-owned-project";
+  const predecessorPath = "/fixtures/fixture-project/predecessor.jsonl";
+  const currentPath = "/fixtures/fixture-project/current.jsonl";
+  const deletedGhostPath = "/fixtures/fixture-project/deleted-ghost.jsonl";
+  const spawnPath = "spawn:launch_fixture_placeholder";
+  const launchProfile = {
+    cwd: "/fixtures/fixture-project",
+    project,
+    model: null,
+    effort: null,
+  };
+  const conversation = (id: string, paths: string[]) => ({
+    id,
+    generations: paths.map((pathname) => ({ path: pathname, launchProfile })),
+    continuityPaths: [],
+    projectOwnership: {
+      project,
+      source: "operator",
+      setAt: "2026-08-24T08:00:00.000Z",
+      operationId: `ownership_${id}`,
+    },
+  });
+  const registrySnapshot = {
+    conversations: {
+      conversation_current: conversation("conversation_current", [predecessorPath, currentPath]),
+      conversation_deleted_ghost: conversation("conversation_deleted_ghost", [deletedGhostPath]),
+    },
+    conversationAliases: {},
+    receipts: {
+      launch_fixture_placeholder: {
+        launchId: "launch_fixture_placeholder",
+        conversationId: "conversation_spawn_placeholder",
+        createdAt: "2026-08-24T08:05:00.000Z",
+        explicitProject: project,
+        cwd: "/fixtures/fixture-project",
+        launchProfile,
+      },
+    },
+    lineageEdges: {},
+    memberships: {},
+  };
+  let runtimeCalls = 0;
+  let scanCalls = 0;
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    registrySnapshot: () => registrySnapshot,
+    completedFileScan: async () => {
+      scanCalls += 1;
+      throw new Error("ghost archiving must not require a transcript scan");
+    },
+    boardFor: (key: string) => boardFor(key, boardFile),
+    patchBoard: (key: string, revision: number, patch: Parameters<typeof patchBoard>[2]) =>
+      patchBoard(key, revision, patch, boardFile),
+    mutateBoard: (key: string, revision: number, mutations: Parameters<typeof mutateBoard>[2]) =>
+      mutateBoard(key, revision, mutations, boardFile),
+    applyConversationAction: async () => {
+      runtimeCalls += 1;
+      throw new Error("archive must not enter runtime conversation control");
+    },
+  } as never);
+
+  const first = await bindings.conversation_action({
+    clientRequestId: "archive-ghosts-first",
+    action: "archive",
+    targets: [
+      { conversationId: "conversation_current" },
+      { transcriptPath: deletedGhostPath },
+      { transcriptPath: spawnPath },
+      { conversationId: "conversation_current" },
+    ],
+  });
+
+  expect(first).toMatchObject({
+    action: "archive",
+    project,
+    projectsTouched: [project],
+    outcomes: [
+      { conversationId: "conversation_current", transcriptPath: currentPath, project, outcome: "archived" },
+      { conversationId: "conversation_deleted_ghost", transcriptPath: deletedGhostPath, project, outcome: "archived" },
+      { conversationId: "conversation_spawn_placeholder", transcriptPath: spawnPath, project, outcome: "archived" },
+      { conversationId: "conversation_current", transcriptPath: currentPath, project, outcome: "already-archived" },
+    ],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({
+    revision: 1,
+    prefs: { hidden: [currentPath, deletedGhostPath, spawnPath] },
+  });
+  expect(boardFor(project, boardFile).prefs.hidden).not.toContain(predecessorPath);
+
+  const replayByContent = await bindings.conversation_action({
+    clientRequestId: "archive-ghosts-again",
+    action: "archive",
+    targets: [
+      { conversationId: "conversation_current" },
+      { transcriptPath: deletedGhostPath },
+      { transcriptPath: spawnPath },
+    ],
+  });
+  expect(replayByContent).toMatchObject({
+    outcomes: [
+      { outcome: "already-archived" },
+      { outcome: "already-archived" },
+      { outcome: "already-archived" },
+    ],
+  });
+  expect(boardFor(project, boardFile).revision).toBe(1);
+
+  const restored = await bindings.conversation_action({
+    clientRequestId: "unarchive-ghosts",
+    action: "unarchive",
+    targets: [
+      { conversationId: "conversation_current" },
+      { transcriptPath: deletedGhostPath },
+      { transcriptPath: spawnPath },
+      { transcriptPath: "/fixtures/fixture-project/unknown.jsonl" },
+    ],
+  });
+  expect(restored).toMatchObject({
+    outcomes: [
+      { outcome: "unarchived" },
+      { outcome: "unarchived" },
+      { outcome: "unarchived" },
+      { project: null, outcome: "not-found" },
+    ],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({ revision: 2, prefs: { hidden: [] } });
+  expect(runtimeCalls).toBe(0);
+  expect(scanCalls).toBe(1);
+});
+
+test("conversation_action refuses archive batches above 100 before reading board or runtime state", async () => {
+  let reads = 0;
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    registrySnapshot: () => { reads += 1; return {} as never; },
+    boardFor: () => { reads += 1; return {} as never; },
+    applyConversationAction: async () => { reads += 1; return {} as never; },
+  } as never);
+  const targets = Array.from({ length: 101 }, (_, index) => ({ transcriptPath: `/fixtures/project/session-${index}.jsonl` }));
+
+  await expect(bindings.conversation_action({
+    clientRequestId: "archive-too-many",
+    action: "archive",
+    targets,
+  })).rejects.toThrow("targets supports at most 100 conversations per call");
+  expect(reads).toBe(0);
 });
 
 test("conversation_migration delegates to the revision-fenced migration command with a stable receipt", async () => {

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -20,7 +20,12 @@ import { productionLivenessSources } from "@/lib/lifecycle/liveness";
 import { refreshLifecycleJournal } from "@/lib/lifecycle/projector";
 
 import { defaultMcpSpawnRoleParams, viewerMcpBindings } from "./bindings";
-import { createMcpToolService, MemoryMcpReceiptStore, type McpToolResult } from "./server";
+import {
+  createMcpToolService,
+  MemoryMcpReceiptStore,
+  type McpReceiptStore,
+  type McpToolResult,
+} from "./server";
 
 const sandboxes: string[] = [];
 const originalStateDir = process.env.LLV_STATE_DIR;
@@ -862,7 +867,7 @@ test("conversation_action delegates to the ownership-fenced conversation command
   });
 });
 
-test("conversation_action archives current generations, deleted ghosts, and spawn placeholders through board placement", async () => {
+test("conversation_action archives ghosts and reconciles interrupted receipts without another board revision", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-archive-"));
   sandboxes.push(sandbox);
   const boardFile = path.join(sandbox, "board.json");
@@ -872,6 +877,24 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   const deletedGhostPath = "/fixtures/fixture-project/deleted-ghost.jsonl";
   const spawnPath = "spawn:launch_fixture_placeholder";
   const unknownPath = "/fixtures/fixture-project/unknown.jsonl";
+  const interruptedReceiptStore = (expectedKey: string): { store: McpReceiptStore; completed: McpToolResult[] } => {
+    const completed: McpToolResult[] = [];
+    return {
+      completed,
+      store: {
+        claim: (key) => {
+          expect(key).toBe(expectedKey);
+          return completed[0]
+            ? { kind: "replay", result: completed[0] }
+            : { kind: "pending", unfinishedAgeMs: 4_000 };
+        },
+        complete: (key, _digest, result) => {
+          expect(key).toBe(expectedKey);
+          completed.push(result);
+        },
+      },
+    };
+  };
   const launchProfile = {
     cwd: "/fixtures/fixture-project",
     project,
@@ -915,7 +938,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     registrySnapshot: () => registrySnapshot,
     completedFileScan: async () => {
       scanCalls += 1;
-      expect(boardFor(project, boardFile).prefs.hidden).toEqual(scanCalls === 1
+      expect(boardFor(project, boardFile).prefs.hidden).toEqual(scanCalls <= 2
         ? [currentPath, deletedGhostPath, spawnPath]
         : []);
       throw new Error("ghost archiving must not require a transcript scan");
@@ -932,7 +955,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     },
   } as never);
 
-  const first = await bindings.conversation_action({
+  const archiveArgs = {
     clientRequestId: "archive-ghosts-first",
     action: "archive",
     targets: [
@@ -942,7 +965,8 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { transcriptPath: predecessorPath },
       { transcriptPath: unknownPath },
     ],
-  });
+  };
+  const first = await bindings.conversation_action(archiveArgs);
 
   expect(first).toMatchObject({
     action: "archive",
@@ -963,6 +987,31 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   });
   expect(boardFor(project, boardFile).prefs.hidden).not.toContain(predecessorPath);
 
+  const interruptedArchive = interruptedReceiptStore("conversation_action:archive-ghosts-first");
+  const archiveRecovery = createMcpToolService(bindings, interruptedArchive.store);
+  const recoveredArchive = await archiveRecovery.callTool("conversation_action", archiveArgs);
+  expect(recoveredArchive).toMatchObject({
+    ok: true,
+    projectsTouched: [],
+    outcomes: [
+      { transcriptPath: currentPath, outcome: "already-archived" },
+      { transcriptPath: deletedGhostPath, outcome: "already-archived" },
+      { transcriptPath: spawnPath, outcome: "already-archived" },
+      { transcriptPath: currentPath, outcome: "already-archived" },
+      { transcriptPath: unknownPath, outcome: "resolution-failed" },
+    ],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({
+    revision: 1,
+    prefs: { hidden: [currentPath, deletedGhostPath, spawnPath] },
+  });
+  expect(interruptedArchive.completed).toEqual([recoveredArchive]);
+  expect(await archiveRecovery.callTool("conversation_action", archiveArgs)).toEqual({
+    ...recoveredArchive,
+    replayed: true,
+  });
+  expect(boardFor(project, boardFile).revision).toBe(1);
+
   const replayByContent = await bindings.conversation_action({
     clientRequestId: "archive-ghosts-again",
     action: "archive",
@@ -981,7 +1030,7 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
   });
   expect(boardFor(project, boardFile).revision).toBe(1);
 
-  const restored = await bindings.conversation_action({
+  const unarchiveArgs = {
     clientRequestId: "unarchive-ghosts",
     action: "unarchive",
     targets: [
@@ -990,7 +1039,8 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
       { transcriptPath: spawnPath },
       { transcriptPath: unknownPath },
     ],
-  });
+  };
+  const restored = await bindings.conversation_action(unarchiveArgs);
   expect(restored).toMatchObject({
     outcomes: [
       { conversationId: "conversation_current", transcriptPath: currentPath, outcome: "unarchived" },
@@ -1000,8 +1050,24 @@ test("conversation_action archives current generations, deleted ghosts, and spaw
     ],
   });
   expect(boardFor(project, boardFile)).toMatchObject({ revision: 2, prefs: { hidden: [] } });
+
+  const interruptedUnarchive = interruptedReceiptStore("conversation_action:unarchive-ghosts");
+  const unarchiveRecovery = createMcpToolService(bindings, interruptedUnarchive.store);
+  const recoveredUnarchive = await unarchiveRecovery.callTool("conversation_action", unarchiveArgs);
+  expect(recoveredUnarchive).toMatchObject({
+    ok: true,
+    projectsTouched: [],
+    outcomes: [
+      { transcriptPath: currentPath, outcome: "not-found" },
+      { transcriptPath: deletedGhostPath, outcome: "not-found" },
+      { transcriptPath: spawnPath, outcome: "not-found" },
+      { transcriptPath: unknownPath, outcome: "resolution-failed" },
+    ],
+  });
+  expect(boardFor(project, boardFile)).toMatchObject({ revision: 2, prefs: { hidden: [] } });
+  expect(interruptedUnarchive.completed).toEqual([recoveredUnarchive]);
   expect(runtimeCalls).toBe(0);
-  expect(scanCalls).toBe(2);
+  expect(scanCalls).toBe(4);
 });
 
 test("conversation_action attributes archive outcomes only when its board command applied", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -2066,25 +2066,35 @@ function writeArchivePlacement(
   paths: readonly string[],
   snapshot: RegistrySnapshot,
   dependencies: ViewerMcpDomainDependencies,
-): ReturnType<typeof boardFor> {
+): { board: ReturnType<typeof boardFor>; appliedPaths: ReadonlySet<string> } {
   let board = dependencies.boardFor(project);
+  const appliedPaths = new Set<string>();
   for (let attempt = 0; attempt < 4; attempt += 1) {
+    const pendingPaths = [...new Set(paths.map((pathname) => canonicalBoardPath(board, pathname)))]
+      .filter((pathname) => action === "archive"
+        ? !board.prefs.hidden.includes(pathname)
+        : board.prefs.hidden.includes(pathname));
+    if (pendingPaths.length === 0) return { board, appliedPaths };
+
     const result = dependencies.applyBoardCommand({
       schemaVersion: 1,
       project,
       baseRevision: board.revision,
       ...(action === "archive"
-        ? { patch: { hidden: [...paths] } }
+        ? { patch: { hidden: pendingPaths } }
         : {
-            mutations: paths.map((pathname) => ({
+            mutations: pendingPaths.map((pathname) => ({
               kind: "restore" as const,
               path: pathname,
               placement: "auto" as const,
             })),
           }),
     }, snapshot);
-    if (result.ok) return result.board;
     board = result.board;
+    if (result.ok && result.applied) {
+      for (const pathname of pendingPaths) appliedPaths.add(canonicalBoardPath(board, pathname));
+      return { board, appliedPaths };
+    }
   }
   throw new Error(`board state changed repeatedly while ${action === "archive" ? "archiving" : "unarchiving"} conversations`);
 }
@@ -2098,72 +2108,81 @@ async function archiveConversationAction(
   const { inputs, selectedTarget } = conversationArchiveInputs(args, dependencies);
   const snapshot = dependencies.registrySnapshot();
   const resolved = inputs.map((input) => resolveArchiveTargetFromRegistry(input, snapshot));
-  if (resolved.some((target) => target === null)) {
-    const files = await dependencies.completedFileScan().then((read) => read.snapshot.files).catch(() => [] as FileEntry[]);
-    for (let index = 0; index < resolved.length; index += 1) {
-      resolved[index] ??= resolveArchiveTargetFromFiles(inputs[index]!, files);
-    }
-  }
-  throwIfCallEnded(context);
-
   const outcomes: Array<Record<string, unknown>> = [];
-  const grouped = new Map<string, Array<{ index: number; target: ResolvedConversationArchiveTarget }>>();
-  for (let index = 0; index < resolved.length; index += 1) {
-    const target = resolved[index];
-    if (!target) {
+  const resolvedProjects = new Set<string>();
+  const projectsTouched = new Set<string>();
+  const applyResolved = (members: Array<{ index: number; target: ResolvedConversationArchiveTarget }>): void => {
+    const grouped = new Map<string, Array<{ index: number; target: ResolvedConversationArchiveTarget }>>();
+    for (const member of members) {
+      const projectMembers = grouped.get(member.target.project) ?? [];
+      projectMembers.push(member);
+      grouped.set(member.target.project, projectMembers);
+      resolvedProjects.add(member.target.project);
+    }
+
+    for (const [project, projectMembers] of grouped) {
+      throwIfCallEnded(context);
+      const write = writeArchivePlacement(
+        project,
+        action,
+        projectMembers.map(({ target }) => target.transcriptPath),
+        snapshot,
+        dependencies,
+      );
+      if (write.appliedPaths.size > 0) projectsTouched.add(project);
+      const attributedPaths = new Set<string>();
+      for (const { index, target } of projectMembers) {
+        const transcriptPath = canonicalBoardPath(write.board, target.transcriptPath);
+        const applied = write.appliedPaths.has(transcriptPath) && !attributedPaths.has(transcriptPath);
+        if (applied) attributedPaths.add(transcriptPath);
+        outcomes[index] = {
+          conversationId: target.conversationId,
+          transcriptPath,
+          project,
+          outcome: action === "archive"
+            ? applied ? "archived" : "already-archived"
+            : applied ? "unarchived" : "not-found",
+        };
+      }
+    }
+  };
+
+  applyResolved(resolved.flatMap((target, index) => target ? [{ index, target }] : []));
+
+  const unresolvedIndexes = resolved.flatMap((target, index) => target ? [] : [index]);
+  if (unresolvedIndexes.length > 0) {
+    let files: readonly FileEntry[] | null = null;
+    try {
+      files = (await dependencies.completedFileScan()).snapshot.files;
+    } catch {
+      files = null;
+    }
+    throwIfCallEnded(context);
+    const scanResolved: Array<{ index: number; target: ResolvedConversationArchiveTarget }> = [];
+    for (const index of unresolvedIndexes) {
+      const target = files ? resolveArchiveTargetFromFiles(inputs[index]!, files) : null;
+      if (target) {
+        resolved[index] = target;
+        scanResolved.push({ index, target });
+        continue;
+      }
       outcomes[index] = {
         conversationId: inputs[index]!.conversationId || null,
         transcriptPath: inputs[index]!.transcriptPath || null,
         project: null,
-        outcome: "not-found",
-      };
-      continue;
-    }
-    const members = grouped.get(target.project) ?? [];
-    members.push({ index, target });
-    grouped.set(target.project, members);
-  }
-
-  const projectsTouched: string[] = [];
-  for (const [project, members] of grouped) {
-    throwIfCallEnded(context);
-    const board = dependencies.boardFor(project);
-    const hidden = new Set(board.prefs.hidden);
-    const changedPaths: string[] = [];
-    for (const { index, target } of members) {
-      const transcriptPath = canonicalBoardPath(board, target.transcriptPath);
-      const wasHidden = hidden.has(transcriptPath);
-      const outcome = action === "archive"
-        ? wasHidden ? "already-archived" : "archived"
-        : wasHidden ? "unarchived" : "not-found";
-      if (action === "archive" && !wasHidden) {
-        hidden.add(transcriptPath);
-        changedPaths.push(transcriptPath);
-      }
-      if (action === "unarchive" && wasHidden) {
-        hidden.delete(transcriptPath);
-        changedPaths.push(transcriptPath);
-      }
-      outcomes[index] = {
-        conversationId: target.conversationId,
-        transcriptPath,
-        project,
-        outcome,
+        outcome: files ? "not-found" : "resolution-failed",
       };
     }
-    if (changedPaths.length > 0) {
-      writeArchivePlacement(project, action, [...new Set(changedPaths)], snapshot, dependencies);
-      projectsTouched.push(project);
-    }
+    applyResolved(scanResolved);
   }
 
   const operationId = mcpOperationId("conversation_action", requestId(args));
-  const projects = [...grouped.keys()];
+  const projects = [...resolvedProjects];
   return redactPayload({
     action,
     outcomes,
     project: projects.length === 1 ? projects[0] : null,
-    projectsTouched,
+    projectsTouched: [...projectsTouched],
     ...mutationReceipt(operationId),
     ...selectedContextEcho(selectedTarget),
   });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -27,7 +27,8 @@ import {
   isGeometricTarget,
 } from "@/lib/attention/targets";
 import type { AttentionRequestV1, FocusIntent, FocusTarget, ZoomIntent } from "@/lib/attention/types";
-import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
+import { applyBoardCommand } from "@/lib/board/command";
+import { boardFor } from "@/lib/board/store";
 import { applyConversationAction } from "@/lib/conversation/actions";
 import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { cancelRound, closeFlow, patchFlow } from "@/lib/flows/commands";
@@ -238,8 +239,7 @@ export interface ViewerMcpDomainDependencies {
   completedFileScan(options?: Parameters<typeof completedFileScan>[0]): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
-  patchBoard: typeof patchBoard;
-  mutateBoard: typeof mutateBoard;
+  applyBoardCommand(input: unknown, snapshot: RegistrySnapshot): ReturnType<typeof applyBoardCommand>;
   getFlowsWithPresets(): ReturnType<typeof getFlowsWithPresets>;
   patchFlow: typeof patchFlow;
   cancelRound: typeof cancelRound;
@@ -432,8 +432,7 @@ export const productionDomainDependencies: ViewerMcpDomainDependencies = {
   completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
   boardFor,
-  patchBoard,
-  mutateBoard,
+  applyBoardCommand: (input, snapshot) => applyBoardCommand(input, { registrySnapshot: () => snapshot }),
   getFlowsWithPresets,
   patchFlow,
   cancelRound,
@@ -2026,9 +2025,8 @@ function resolveArchiveTargetFromRegistry(
   const receipt = pathReceipt ?? (conversationId ? latestReceiptForConversation(snapshot, conversationId) : null);
   if (requestedConversationId && !conversation && !receipt) return null;
 
-  const transcriptPath = requestedConversationId
-    ? conversation?.generations.at(-1)?.path ?? (receipt ? `spawn:${receipt.launchId}` : "")
-    : input.transcriptPath;
+  const transcriptPath = conversation?.generations.at(-1)?.path
+    ?? (requestedConversationId && receipt ? `spawn:${receipt.launchId}` : input.transcriptPath);
   if (!transcriptPath) return null;
   const project = projectForArchiveTarget(conversation, receipt);
   if (!project) return null;
@@ -2066,17 +2064,25 @@ function writeArchivePlacement(
   project: string,
   action: "archive" | "unarchive",
   paths: readonly string[],
+  snapshot: RegistrySnapshot,
   dependencies: ViewerMcpDomainDependencies,
 ): ReturnType<typeof boardFor> {
   let board = dependencies.boardFor(project);
   for (let attempt = 0; attempt < 4; attempt += 1) {
-    const result = action === "archive"
-      ? dependencies.patchBoard(project, board.revision, { hidden: [...paths] })
-      : dependencies.mutateBoard(project, board.revision, paths.map((pathname) => ({
-          kind: "restore" as const,
-          path: pathname,
-          placement: "auto" as const,
-        })));
+    const result = dependencies.applyBoardCommand({
+      schemaVersion: 1,
+      project,
+      baseRevision: board.revision,
+      ...(action === "archive"
+        ? { patch: { hidden: [...paths] } }
+        : {
+            mutations: paths.map((pathname) => ({
+              kind: "restore" as const,
+              path: pathname,
+              placement: "auto" as const,
+            })),
+          }),
+    }, snapshot);
     if (result.ok) return result.board;
     board = result.board;
   }
@@ -2146,7 +2152,7 @@ async function archiveConversationAction(
       };
     }
     if (changedPaths.length > 0) {
-      writeArchivePlacement(project, action, [...new Set(changedPaths)], dependencies);
+      writeArchivePlacement(project, action, [...new Set(changedPaths)], snapshot, dependencies);
       projectsTouched.push(project);
     }
   }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -27,7 +27,7 @@ import {
   isGeometricTarget,
 } from "@/lib/attention/targets";
 import type { AttentionRequestV1, FocusIntent, FocusTarget, ZoomIntent } from "@/lib/attention/types";
-import { boardFor } from "@/lib/board/store";
+import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
 import { applyConversationAction } from "@/lib/conversation/actions";
 import { DeadlineExceededError, deadlineSignal } from "@/lib/deadline";
 import { cancelRound, closeFlow, patchFlow } from "@/lib/flows/commands";
@@ -75,6 +75,7 @@ import {
   type BoundedTranscriptTail,
 } from "@/lib/selection/resolve";
 import { readSession, type SessionReadResult } from "@/lib/session/reader";
+import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
@@ -237,6 +238,8 @@ export interface ViewerMcpDomainDependencies {
   completedFileScan(options?: Parameters<typeof completedFileScan>[0]): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
+  patchBoard: typeof patchBoard;
+  mutateBoard: typeof mutateBoard;
   getFlowsWithPresets(): ReturnType<typeof getFlowsWithPresets>;
   patchFlow: typeof patchFlow;
   cancelRound: typeof cancelRound;
@@ -429,6 +432,8 @@ export const productionDomainDependencies: ViewerMcpDomainDependencies = {
   completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
   boardFor,
+  patchBoard,
+  mutateBoard,
   getFlowsWithPresets,
   patchFlow,
   cancelRound,
@@ -1695,10 +1700,12 @@ async function boardSnapshot(
         } : null,
       };
     });
+  const board = project ? dependencies.boardFor(project) : null;
   return redactPayload({
     count: conversations.length,
     conversations,
-    board: project ? dependencies.boardFor(project) : null,
+    hiddenCount: board?.prefs.hidden.length ?? null,
+    board,
   });
 }
 
@@ -1909,12 +1916,263 @@ async function resources(args: McpToolArgs, dependencies: ViewerMcpDomainDepende
   return redactPayload({ ...await dependencies.readResources(args.fresh === true) });
 }
 
+type ConversationArchiveInput = {
+  conversationId: string;
+  transcriptPath: string;
+};
+
+type ResolvedConversationArchiveTarget = {
+  conversationId: string | null;
+  transcriptPath: string;
+  project: string;
+};
+
+function conversationArchiveInputs(
+  args: McpToolArgs,
+  dependencies: ViewerMcpDomainDependencies,
+): { inputs: ConversationArchiveInput[]; selectedTarget: ReturnType<typeof resolveSelectedContext>["target"] | null } {
+  if (args.targets !== undefined) {
+    if (!Array.isArray(args.targets) || args.targets.length === 0) {
+      throw new Error("targets must be a non-empty list");
+    }
+    if (args.targets.length > 100) throw new Error("targets supports at most 100 conversations per call");
+    if (text(args.conversationId) || text(args.transcriptPath) || text(args.path) || args.selectedContext !== undefined) {
+      throw new Error("targets cannot be combined with conversationId, transcriptPath or selectedContext");
+    }
+    return {
+      inputs: args.targets.map((candidate, index) => {
+        if (!objectRecord(candidate)) throw new Error(`targets[${index}] must be an object`);
+        const conversationId = text(candidate.conversationId);
+        const transcriptPath = text(candidate.transcriptPath);
+        if (!conversationId && !transcriptPath) {
+          throw new Error(`targets[${index}] requires conversationId or transcriptPath`);
+        }
+        return { conversationId, transcriptPath };
+      }),
+      selectedTarget: null,
+    };
+  }
+
+  const selected = resolveSelectedContext(
+    args,
+    text(args.conversationId),
+    dependencies.selectedContext ?? productionSelectedContextDependencies,
+  );
+  const conversationId = selected.conversationId;
+  const transcriptPath = text(args.transcriptPath) || text(args.path);
+  if (!conversationId && !transcriptPath) {
+    throw new Error("conversationId, transcriptPath or selectedContext is required");
+  }
+  return { inputs: [{ conversationId, transcriptPath }], selectedTarget: selected.target };
+}
+
+function latestReceiptForConversation(
+  snapshot: RegistrySnapshot,
+  conversationId: string,
+): RegistrySnapshot["receipts"][string] | null {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  return Object.values(snapshot.receipts ?? {})
+    .filter((receipt) => lookup.canonicalConversationId(receipt.conversationId) === conversationId)
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0] ?? null;
+}
+
+function projectForArchiveTarget(
+  conversation: RegistrySnapshot["conversations"][string] | null,
+  receipt: RegistrySnapshot["receipts"][string] | null,
+  fallbackProject: string | null = null,
+): string | null {
+  const generation = conversation?.generations.at(-1);
+  const explicitOwnership = conversation?.projectOwnership
+    ?? (receipt?.explicitProject
+      ? {
+          project: receipt.explicitProject,
+          source: "operator" as const,
+          setAt: receipt.createdAt,
+          operationId: receipt.launchId,
+        }
+      : null);
+  return resolveProjectAttribution({
+    projectOwnership: explicitOwnership,
+    cwd: generation?.launchProfile.cwd ?? receipt?.cwd,
+    launchProfileProject: generation?.launchProfile.project ?? receipt?.launchProfile.project,
+    fallbackProject: fallbackProject ?? (receipt?.cwd ? path.basename(receipt.cwd) : null),
+  }).project;
+}
+
+function resolveArchiveTargetFromRegistry(
+  input: ConversationArchiveInput,
+  snapshot: RegistrySnapshot,
+): ResolvedConversationArchiveTarget | null {
+  const lookup = readOnlyConversationLookupFromSnapshot(snapshot);
+  const requestedConversationId = input.conversationId;
+  if (requestedConversationId && !requestedConversationId.startsWith("conversation_")) return null;
+
+  const canonicalId = requestedConversationId
+    ? lookup.canonicalConversationId(requestedConversationId as `conversation_${string}`)
+    : null;
+  const byId = canonicalId ? snapshot.conversations[canonicalId] ?? null : null;
+  const launchId = input.transcriptPath.startsWith("spawn:") ? input.transcriptPath.slice("spawn:".length) : "";
+  const pathReceipt = launchId ? snapshot.receipts?.[launchId] ?? null : null;
+  const byPath = input.transcriptPath && !pathReceipt
+    ? lookup.conversationForPath(input.transcriptPath)
+    : null;
+  const pathConversationId = pathReceipt
+    ? lookup.canonicalConversationId(pathReceipt.conversationId)
+    : byPath?.id ?? null;
+  if (canonicalId && pathConversationId && canonicalId !== pathConversationId) return null;
+
+  const conversation = byId ?? byPath ?? (pathConversationId ? snapshot.conversations[pathConversationId] ?? null : null);
+  const conversationId = conversation?.id ?? canonicalId ?? pathConversationId;
+  const receipt = pathReceipt ?? (conversationId ? latestReceiptForConversation(snapshot, conversationId) : null);
+  if (requestedConversationId && !conversation && !receipt) return null;
+
+  const transcriptPath = requestedConversationId
+    ? conversation?.generations.at(-1)?.path ?? (receipt ? `spawn:${receipt.launchId}` : "")
+    : input.transcriptPath;
+  if (!transcriptPath) return null;
+  const project = projectForArchiveTarget(conversation, receipt);
+  if (!project) return null;
+  return { conversationId: conversationId ?? null, transcriptPath, project };
+}
+
+function resolveArchiveTargetFromFiles(
+  input: ConversationArchiveInput,
+  files: readonly FileEntry[],
+): ResolvedConversationArchiveTarget | null {
+  const matches = files
+    .filter((entry) => input.transcriptPath ? entry.path === input.transcriptPath : entry.conversationId === input.conversationId)
+    .sort((left, right) => right.mtime - left.mtime);
+  const entry = matches[0];
+  if (!entry) return null;
+  return {
+    conversationId: entry.conversationId ?? (input.conversationId || null),
+    transcriptPath: entry.path,
+    project: entry.project,
+  };
+}
+
+function canonicalBoardPath(board: ReturnType<typeof boardFor>, pathname: string): string {
+  let current = pathname;
+  const seen = new Set<string>();
+  while (board.pathAliases?.[current] !== undefined) {
+    if (seen.has(current)) throw new Error("board path alias cycle");
+    seen.add(current);
+    current = board.pathAliases[current]!;
+  }
+  return current;
+}
+
+function writeArchivePlacement(
+  project: string,
+  action: "archive" | "unarchive",
+  paths: readonly string[],
+  dependencies: ViewerMcpDomainDependencies,
+): ReturnType<typeof boardFor> {
+  let board = dependencies.boardFor(project);
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const result = action === "archive"
+      ? dependencies.patchBoard(project, board.revision, { hidden: [...paths] })
+      : dependencies.mutateBoard(project, board.revision, paths.map((pathname) => ({
+          kind: "restore" as const,
+          path: pathname,
+          placement: "auto" as const,
+        })));
+    if (result.ok) return result.board;
+    board = result.board;
+  }
+  throw new Error(`board state changed repeatedly while ${action === "archive" ? "archiving" : "unarchiving"} conversations`);
+}
+
+async function archiveConversationAction(
+  args: McpToolArgs,
+  action: "archive" | "unarchive",
+  dependencies: ViewerMcpDomainDependencies,
+  context: McpToolCallContext,
+): Promise<McpToolPayload> {
+  const { inputs, selectedTarget } = conversationArchiveInputs(args, dependencies);
+  const snapshot = dependencies.registrySnapshot();
+  const resolved = inputs.map((input) => resolveArchiveTargetFromRegistry(input, snapshot));
+  if (resolved.some((target) => target === null)) {
+    const files = await dependencies.completedFileScan().then((read) => read.snapshot.files).catch(() => [] as FileEntry[]);
+    for (let index = 0; index < resolved.length; index += 1) {
+      resolved[index] ??= resolveArchiveTargetFromFiles(inputs[index]!, files);
+    }
+  }
+  throwIfCallEnded(context);
+
+  const outcomes: Array<Record<string, unknown>> = [];
+  const grouped = new Map<string, Array<{ index: number; target: ResolvedConversationArchiveTarget }>>();
+  for (let index = 0; index < resolved.length; index += 1) {
+    const target = resolved[index];
+    if (!target) {
+      outcomes[index] = {
+        conversationId: inputs[index]!.conversationId || null,
+        transcriptPath: inputs[index]!.transcriptPath || null,
+        project: null,
+        outcome: "not-found",
+      };
+      continue;
+    }
+    const members = grouped.get(target.project) ?? [];
+    members.push({ index, target });
+    grouped.set(target.project, members);
+  }
+
+  const projectsTouched: string[] = [];
+  for (const [project, members] of grouped) {
+    throwIfCallEnded(context);
+    const board = dependencies.boardFor(project);
+    const hidden = new Set(board.prefs.hidden);
+    const changedPaths: string[] = [];
+    for (const { index, target } of members) {
+      const transcriptPath = canonicalBoardPath(board, target.transcriptPath);
+      const wasHidden = hidden.has(transcriptPath);
+      const outcome = action === "archive"
+        ? wasHidden ? "already-archived" : "archived"
+        : wasHidden ? "unarchived" : "not-found";
+      if (action === "archive" && !wasHidden) {
+        hidden.add(transcriptPath);
+        changedPaths.push(transcriptPath);
+      }
+      if (action === "unarchive" && wasHidden) {
+        hidden.delete(transcriptPath);
+        changedPaths.push(transcriptPath);
+      }
+      outcomes[index] = {
+        conversationId: target.conversationId,
+        transcriptPath,
+        project,
+        outcome,
+      };
+    }
+    if (changedPaths.length > 0) {
+      writeArchivePlacement(project, action, [...new Set(changedPaths)], dependencies);
+      projectsTouched.push(project);
+    }
+  }
+
+  const operationId = mcpOperationId("conversation_action", requestId(args));
+  const projects = [...grouped.keys()];
+  return redactPayload({
+    action,
+    outcomes,
+    project: projects.length === 1 ? projects[0] : null,
+    projectsTouched,
+    ...mutationReceipt(operationId),
+    ...selectedContextEcho(selectedTarget),
+  });
+}
+
 async function conversationAction(
   args: McpToolArgs,
   dependencies: ViewerMcpDomainDependencies,
   context: McpToolCallContext = {},
 ): Promise<McpToolPayload> {
   throwIfCallEnded(context);
+  const action = required(args, "action");
+  if (action === "archive" || action === "unarchive") {
+    return archiveConversationAction(args, action, dependencies, context);
+  }
   /* #844 §7: the selected card is actionable from its reference alone. The
      identity comes back from one keyed registry lookup, so no `operator_snapshot`
      and no scan stands between "the operator pointed at that card" and acting on
@@ -1936,7 +2194,7 @@ async function conversationAction(
     operationId,
     conversationId,
     transcriptPath,
-    action: required(args, "action"),
+    action,
     key: text(args.key),
     label: args.label,
     question: args.question,

--- a/src/lib/mcp/presentation.ts
+++ b/src/lib/mcp/presentation.ts
@@ -303,6 +303,8 @@ export function describeMcpCall(
       resume: "Resuming",
       compact: "Compacting",
       "dialog-key": "Answering dialog in",
+      archive: "Archiving",
+      unarchive: "Unarchiving",
     };
     const verb = verbs[action] ?? "Controlling";
     return {

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -292,6 +292,41 @@ test("get_conversation listTools publishes every bounded tail target", async () 
   });
 });
 
+test("conversation_action publishes archive actions, current-generation semantics, and the 100-target bound", async () => {
+  let calls = 0;
+  await withProtocolClient(inertBindings({
+    conversation_action: async () => { calls += 1; return {}; },
+  }), async (client) => {
+    const listed = await client.listTools();
+    const tool = listed.tools.find((candidate) => candidate.name === "conversation_action");
+    const action = tool?.inputSchema.properties?.action as { enum?: string[] } | undefined;
+    const targets = tool?.inputSchema.properties?.targets as {
+      maxItems?: number;
+      items?: { properties?: Record<string, unknown> };
+    } | undefined;
+
+    expect(action?.enum).toEqual(expect.arrayContaining(["archive", "unarchive"]));
+    expect(tool?.description).toContain("current generation path");
+    expect(tool?.description).toContain("readable transcript");
+    expect(targets?.maxItems).toBe(100);
+    expect(Object.keys(targets?.items?.properties ?? {})).toEqual(expect.arrayContaining([
+      "conversationId",
+      "transcriptPath",
+    ]));
+
+    const result = await client.callTool({
+      name: "conversation_action",
+      arguments: {
+        clientRequestId: "archive-schema-overflow",
+        action: "archive",
+        targets: Array.from({ length: 101 }, (_, index) => ({ transcriptPath: `/fixtures/project/session-${index}.jsonl` })),
+      },
+    });
+    expect(result.isError).toBe(true);
+  });
+  expect(calls).toBe(0);
+});
+
 test("search_transcripts publishes its body-query, project, cursor, and bounded page schema", async () => {
   await withProtocolClient(inertBindings(), async (client) => {
     const listed = await client.listTools();

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -23,6 +23,7 @@ import {
   createMcpToolService,
   type McpToolBindings,
   type McpReceiptStore,
+  type McpToolResult,
 } from "./server";
 
 const scratch: string[] = [];
@@ -565,6 +566,37 @@ describe("MCP tool service", () => {
 
     release();
     await first;
+  });
+
+  test("only archive and unarchive recover an interrupted conversation action receipt", async () => {
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    const bindingCalls: string[] = [];
+    bindings.conversation_action = async (args) => {
+      bindingCalls.push(String(args.action));
+      return { operationId: `operation_${String(args.action)}` };
+    };
+
+    for (const action of ["archive", "unarchive", "interrupt", "kill", "resume"] as const) {
+      const completed: McpToolResult[] = [];
+      const pendingStore: McpReceiptStore = {
+        claim: () => ({ kind: "pending", unfinishedAgeMs: 4_000 }),
+        complete: (_key, _digest, result) => { completed.push(result); },
+      };
+      const result = await createMcpToolService(bindings, pendingStore).callTool("conversation_action", {
+        clientRequestId: `interrupted-${action}`,
+        conversationId: "conversation_fixture",
+        action,
+      });
+
+      if (action === "archive" || action === "unarchive") {
+        expect(result).toMatchObject({ ok: true, operationId: `operation_${action}` });
+        expect(completed).toEqual([result]);
+      } else {
+        expect(result).toMatchObject({ ok: false, code: "call_interrupted", replayed: true });
+        expect(completed).toEqual([]);
+      }
+    }
+    expect(bindingCalls).toEqual(["archive", "unarchive"]);
   });
 
   test("agent_activity keeps a durable receipt: it appends to the same journal lifecycle_events does", async () => {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1629,12 +1629,12 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   get_conversation: "Read a conversation summary and its recent messages and tools. With tailLines, conversationId or selectedContext uses the bounded identity path, while transcriptPath uses the validated pinned reader; both return a bounded raw tail without a corpus scan.",
   deploy_exact_sha: "Deploy one full commit SHA. The designated orchestrator decides when to deploy and calls this directly; authority is the server-attributed designated seat, and nobody asks the operator for a confirmation, a phrase, or a SHA. Idempotent by clientRequestId; deployments serialize at the runtime host.",
   get_pipeline: "Read one pipeline by durable id.",
-  board_snapshot: "Read a bounded, redacted snapshot of the Viewer board and durable placement.",
+  board_snapshot: "Read a bounded, redacted snapshot of the Viewer board, durable placement, and the selected project's hidden conversation count.",
   list_flows: "List durable implement-review flows.",
   get_flow: "Read one implement-review flow by durable id.",
   flow_action: "Apply a supported action to an implement-review flow.",
   list_pipelines: "List durable pipelines as bounded board cards: id, task, project, branch/worktree, state and stateDetail, cursor stage, task links, and a per-stage summary (role, engine, attempt count, latest attempt's state and verdict). Deliberately carries no bodies — the spec, stage prompts, role scaffolds and every attempt's input/output transcript are read with get_pipeline, which still returns the whole record. hasSpec tells you a spec exists; long free text is truncated.",
-  conversation_action: "Interrupt, kill, resume, compact, or answer a dialog for a Viewer conversation. Names the conversation by id, transcript path, or the selected-card reference the operator's turn carried — the last resolves directly, with no operator_snapshot call.",
+  conversation_action: "Control or archive Viewer conversations. interrupt, kill, resume, compact, and dialog-key accept one conversation by id, transcript path, or selected-card reference. archive and unarchive also accept up to 100 targets; they update the existing board hidden placement without requiring a live host or readable transcript. A conversationId resolves server-side to its current generation path. Archive execution requires the operator root or a designated orchestrator seat and retains conversation_action's existing cross-project reach.",
   operator_snapshot: "Read the bounded, secret-redacted Viewer state currently visible to the operator.",
   list_tasks: "List durable board tasks.",
   get_task: "Read one durable board task.",
@@ -1665,6 +1665,14 @@ const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key
    that pinned today's fields would reject tomorrow's evidence at the door. */
 const selectedContextSchema = z.union([z.string().min(1), z.record(z.string(), z.unknown())]).optional()
   .describe("Selected-card reference from the operator's turn (the `ctx=` marker token, or the decoded object). Resolves the conversation through a bounded identity lookup — no operator_snapshot needed.");
+const conversationArchiveTargetSchema = z.object({
+  conversationId: z.string().min(1).optional()
+    .describe("Durable Viewer conversation id. Resolves to the current generation path."),
+  transcriptPath: z.string().min(1).optional()
+    .describe("Exact board transcript path, including a spawn:<launchId> placeholder."),
+}).strict().refine((target) => Boolean(target.conversationId || target.transcriptPath), {
+  message: "conversationId or transcriptPath is required",
+});
 const entityIdSchema = z.string().min(1);
 const snapshotStringSchema = z.string()
   .min(MIN_SNAPSHOT_STRING_LENGTH)
@@ -1926,10 +1934,14 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   }).passthrough(),
   conversation_action: z.object({
     clientRequestId: clientRequestIdSchema,
-    conversationId: z.string().optional(),
-    transcriptPath: z.string().optional(),
+    conversationId: z.string().optional()
+      .describe("Durable Viewer conversation id. Archive actions resolve it to the current generation path."),
+    transcriptPath: z.string().optional()
+      .describe("Exact transcript or spawn:<launchId> board path."),
     selectedContext: selectedContextSchema,
-    action: z.enum(["interrupt", "kill", "resume", "compact", "dialog-key"]),
+    targets: z.array(conversationArchiveTargetSchema).min(1).max(100).optional()
+      .describe("Archive/unarchive list form. Cannot be combined with the single-target fields."),
+    action: z.enum(["interrupt", "kill", "resume", "compact", "dialog-key", "archive", "unarchive"]),
     key: z.enum(["1", "2", "3", "4", "5", "6", "7", "8", "9", "Tab", "Enter", "Escape"]).optional(),
     label: z.string().optional(),
     question: z.string().optional(),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -108,7 +108,7 @@ const MUTATING_MCP_TOOL_NAMES = new Set<McpToolName>([
 ]);
 
 /**
- * Tools whose binding is idempotent over its own durable state, so a claim the
+ * Calls whose binding is idempotent over its own durable state, so a claim the
  * previous process never settled is RECONCILED by re-running the binding
  * rather than answered `call_interrupted` forever (#873 review, finding 3).
  *
@@ -119,10 +119,21 @@ const MUTATING_MCP_TOOL_NAMES = new Set<McpToolName>([
  * permanent dead end becomes the deterministic answer to what actually
  * happened. The digest check above still refuses a same-id call with
  * different arguments.
+ *
+ * Archive and unarchive qualify at the action level: board hidden placement is
+ * content-idempotent, so a retry after the board write converges without
+ * another revision. Other conversation actions still require live runtime
+ * ownership and remain outside interrupted recovery.
  */
 const INTERRUPTED_RECOVERABLE_TOOLS: ReadonlySet<McpToolName> = new Set<McpToolName>([
   "request_attention",
 ]);
+
+function interruptedCallIsRecoverable(toolName: McpToolName, args: McpToolArgs): boolean {
+  if (INTERRUPTED_RECOVERABLE_TOOLS.has(toolName)) return true;
+  if (toolName !== "conversation_action") return false;
+  return args.action === "archive" || args.action === "unarchive";
+}
 
 export type McpToolArgs = Record<string, unknown> & { clientRequestId?: unknown };
 export type McpToolPayload = Record<string, unknown>;
@@ -1530,7 +1541,7 @@ export function createMcpToolService(
           outcome = "conflict";
           return failure(toolName, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
         }
-        if (claim.kind === "pending" && !INTERRUPTED_RECOVERABLE_TOOLS.has(typedTool)) {
+        if (claim.kind === "pending" && !interruptedCallIsRecoverable(typedTool, effectiveArgs)) {
           outcome = "pending";
           unfinishedAgeMs = claim.unfinishedAgeMs;
           return failure(toolName, requestId, "call_interrupted", "The previous MCP process ended before this call completed", true, true);

--- a/src/lib/mcp/toolAllowlist.service.test.ts
+++ b/src/lib/mcp/toolAllowlist.service.test.ts
@@ -76,6 +76,22 @@ test("a refused tool never reaches its binding", async () => {
   expect(calls).toEqual(["deployment_status"]);
 });
 
+test("a worker archive receives the standard permission failure without reaching board mutation", async () => {
+  const { calls, service: tools } = service("worker");
+  const result = await tools.callTool("conversation_action", {
+    clientRequestId: "worker-archive",
+    conversationId: "conversation_target",
+    action: "archive",
+  });
+
+  expect(result).toMatchObject({
+    ok: false,
+    code: "tool_not_permitted",
+    retryable: false,
+  });
+  expect(calls).toEqual([]);
+});
+
 test("a refusal does not spend the clientRequestId, so a later designation still works", async () => {
   const calls: string[] = [];
   const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [

--- a/src/lib/mcp/toolAllowlist.test.ts
+++ b/src/lib/mcp/toolAllowlist.test.ts
@@ -12,11 +12,9 @@ import {
 } from "./toolAllowlist";
 
 /*
- * B+ item 1: the full Viewer MCP surface is present and callable in EVERY
- * agent session. Classification — gateway, worker, manager, unidentified —
- * labels origins; it never makes a tool disappear and it gates no operation
- * here. Deploy authority is derived in the deploy binding itself, from the
- * same server-attributed identity chain (#795).
+ * B+ item 1: the full Viewer MCP surface is present in every agent session.
+ * Archive execution is the scoped operation-level exception: root and a
+ * durably designated orchestrator seat may change board visibility.
  */
 
 const MANAGER_CONVERSATION = "conversation_manager";
@@ -45,6 +43,30 @@ test("every session classification holds the FULL tool surface — enumerated ov
 test("the gateway may message ANY conversation — role no longer restricts recipients", () => {
   const gateway = mcpCallerIdentity({ kind: "root", conversationId: "conversation_root" });
   expect(permitMcpTool(gateway, "send_message").allowed).toBe(true);
+});
+
+test("archive and unarchive admit only root or a durably designated orchestrator", () => {
+  const archiveArgs = { action: "archive" };
+  const root = mcpCallerIdentity({ kind: "root", conversationId: "conversation_root" });
+  const manager = mcpCallerIdentity(
+    { kind: "worker", conversationId: MANAGER_CONVERSATION, role: "builder" },
+    MANAGER,
+  );
+  const worker = mcpCallerIdentity({ kind: "worker", conversationId: "conversation_builder", role: "builder" }, MANAGER);
+  const unidentified = mcpCallerIdentity({ kind: "unidentified" }, MANAGER);
+
+  expect(permitMcpTool(root, "conversation_action", archiveArgs).allowed).toBe(true);
+  expect(permitMcpTool(manager, "conversation_action", archiveArgs).allowed).toBe(true);
+  expect(permitMcpTool(manager, "conversation_action", { action: "unarchive" }).allowed).toBe(true);
+  expect(permitMcpTool(worker, "conversation_action", archiveArgs)).toMatchObject({
+    allowed: false,
+    code: "tool_not_permitted",
+  });
+  expect(permitMcpTool(unidentified, "conversation_action", archiveArgs)).toMatchObject({
+    allowed: false,
+    code: "tool_not_permitted",
+  });
+  expect(permitMcpTool(worker, "conversation_action", { action: "kill" }).allowed).toBe(true);
 });
 
 test("host health admission reaches exactly the two deployment reads and no agent action", () => {

--- a/src/lib/mcp/toolAllowlist.ts
+++ b/src/lib/mcp/toolAllowlist.ts
@@ -21,6 +21,9 @@ import type { McpToolArgs, McpToolName } from "./server";
  *  - DEPLOY EXECUTION. Only the designated orchestrator seat executes
  *    `deploy_exact_sha`; that authority is derived and refused in the deploy
  *    binding itself, from the same server-attributed identity chain.
+ *  - BOARD ARCHIVING. `conversation_action archive|unarchive` is admitted only
+ *    for the operator root and a durably designated orchestrator seat. The
+ *    action retains conversation_action's existing cross-project reach.
  *
  * The exact-SHA deploy contract, idempotency keys, typed-target validation,
  * receipts and redaction are all enforced in their own layers and are
@@ -90,16 +93,15 @@ export function mcpCallerIdentity(
 }
 
 /**
- * Whether this call is permitted. Everything is allowed for every agent
- * session; the one exception is the health-probe credential's bounded reads.
- * Nothing in the ARGUMENTS is consulted — a permit decision reads identity and
- * tool name only, so no caller can talk its way past this. Refusals carry a
- * code the MCP failure envelope surfaces verbatim, so a refused caller learns
- * what to do instead of retrying into a wall.
+ * Whether this call is permitted. Agent sessions retain the full surface;
+ * archive execution additionally requires the operator root or a designated
+ * orchestrator identity. The health-probe credential remains bounded to its
+ * two reads. Refusals carry a code the MCP failure envelope surfaces verbatim.
  */
 export function permitMcpTool(
   identity: McpCallerIdentity,
   toolName: McpToolName,
+  args: McpToolArgs = {},
 ): McpToolVerdict {
   if (identity.kind === "health-probe") {
     return HEALTH_PROBE_TOOL_SET.has(toolName)
@@ -109,6 +111,17 @@ export function permitMcpTool(
         code: "tool_not_permitted",
         error: `${toolName} is outside the managed MCP health-probe surface.`,
       };
+  }
+  if (toolName === "conversation_action" && (args.action === "archive" || args.action === "unarchive")) {
+    const authorized = identity.kind === "unrestricted" && identity.reason === "manager"
+      || identity.kind === "restricted" && identity.reason === "gateway";
+    if (!authorized) {
+      return {
+        allowed: false,
+        code: "tool_not_permitted",
+        error: "conversation archive actions require the operator root or a designated orchestrator seat",
+      };
+    }
   }
   return ALLOWED;
 }
@@ -187,6 +200,6 @@ export interface McpToolPolicy {
     server. */
 export function mcpToolPolicy(identity: () => McpCallerIdentity): McpToolPolicy {
   return {
-    permit: (toolName) => permitMcpTool(identity(), toolName),
+    permit: (toolName, args) => permitMcpTool(identity(), toolName, args),
   };
 }


### PR DESCRIPTION
## Summary

- add archive and unarchive actions to conversation_action, including batches of up to 100 targets
- resolve ghost and spawn-placeholder board paths from durable registry data, independent of host or transcript availability
- expose hiddenCount from project-scoped board_snapshot responses
- restrict archive execution to operator root and durably designated orchestrator seats

Fixes #1129

## Path semantics

A conversationId resolves to its current generation path. The board and UI already fold predecessor generations into the current card and remap placement aliases forward, so hiding the current board path hides the conversation tile the operator sees. An explicit transcriptPath targets that board path directly; existing board aliases still canonicalize it. spawn:<launchId> placeholders resolve from durable launch receipts.

Cross-project behavior stays aligned with conversation_action kill: a designated orchestrator seat may target another project, and the response names the resolved project per target.

## Verification

- 105 focused MCP tests
- bunx tsc --noEmit --incremental false
- bun run build
- privacy publication gate against the merge base