### PR TITLE
fix: attribute pause and resume actions to the real caller

### DIFF
--- a/src/components/pipelines/PipelineStrip.render.test.tsx
+++ b/src/components/pipelines/PipelineStrip.render.test.tsx
@@ -33,6 +33,12 @@ function pipeline(over: Partial<Pipeline>): Pipeline {
 
 const render = (p: Pipeline) => renderToStaticMarkup(<PipelineStrip pipeline={p} />);
 
+test("a paused pipeline card renders the attributed actor (#1121)", () => {
+  for (const detail of ["paused by operator", "paused by orchestrator conversation_orchestrator"]) {
+    expect(render(pipeline({ state: "paused", pausedState: "running", stateDetail: detail }))).toContain(detail);
+  }
+});
+
 test("a verdict-less errored attempt still exposes the verdict popover trigger", () => {
   const p = pipeline({ runs: [{ stageId: "build", attempts: [attempt({ state: "failed", error: "spawn failed: tmux pane gone" })] }] });
   /* No verdict, but the error must be reachable — the trigger renders. */

--- a/src/lib/flows/commands.set-roles.test.ts
+++ b/src/lib/flows/commands.set-roles.test.ts
@@ -76,13 +76,23 @@ test("resuming a known legacy pre-actuation relay failure clears its stale check
 
   const resumed = patchFlow("f1", { action: "resume" }).flow!;
 
-  expect(resumed).toMatchObject({ state: "relaying", pausedState: null, stateDetail: null });
+  expect(resumed).toMatchObject({ state: "relaying", pausedState: null, stateDetail: "resumed by operator" });
   expect(resumed.rounds[0]).toMatchObject({
     relayStartedAt: null,
     relayDeliveryTransport: null,
     relayRetryAt: null,
     relayRetryRequiresIdempotency: false,
   });
+});
+
+test("pause and resume accept a calling agent identity (#1121)", () => {
+  seed({ state: "reviewing" });
+  const actor = { kind: "agent" as const, role: "reviewer", conversationId: "conversation_reviewer" };
+
+  const paused = patchFlow("f1", { action: "pause" }, actor).flow!;
+  expect(paused).toMatchObject({ state: "paused", stateDetail: "paused by reviewer conversation_reviewer" });
+  const resumed = patchFlow("f1", { action: "resume" }, actor).flow!;
+  expect(resumed).toMatchObject({ state: "reviewing", stateDetail: "resumed by reviewer conversation_reviewer" });
 });
 
 test("set-roles rejects a reviewer config the CLI cannot launch (issue #118 Finding 3)", () => {

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -6,6 +6,7 @@ import { validateLaunchModel } from "@/lib/agent/models";
 import { agentRegistry } from "@/lib/agent/registry";
 import { headCwd } from "@/lib/agent/transcript";
 import { livePaneTarget } from "@/lib/delivery";
+import { OPERATOR_PAUSE_RESUME_ACTOR, pauseResumeDetail, type PauseResumeActor } from "@/lib/pauseResumeActor";
 import { projectForCwd } from "@/lib/scanner/describe";
 import { isShellCommand } from "@/lib/status";
 import { killPane, paneInfo } from "@/lib/tmux";
@@ -21,7 +22,7 @@ import type { CreateFlowRequest, Flow, PatchFlowRequest, RoleConfig, Round } fro
 /**
  * User-facing flow commands: creating a flow from an HTTP request and the
  * PATCH actions (pause/resume/advance/retry/extend/close). The poller-driven
- * transitions live in engine.ts; these are the transitions a human triggers.
+ * transitions live in engine.ts; these are the transitions an external caller triggers.
  */
 
 function validateRole(value: unknown): RoleConfig | null {
@@ -388,7 +389,11 @@ export async function closeFlow(id: string): Promise<{
   });
 }
 
-export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; error?: string; status?: number } {
+export function patchFlow(
+  id: string,
+  req: PatchFlowRequest,
+  actor: PauseResumeActor | null = OPERATOR_PAUSE_RESUME_ACTOR,
+): { flow?: Flow; error?: string; status?: number } {
   const flows = loadFlows();
   const flow = flows.find((item) => item.id === id);
   if (!flow) return { error: "flow not found", status: 404 };
@@ -397,7 +402,7 @@ export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; err
     if (flow.state !== "paused" && flow.state !== "closed") {
       flow.pausedState = flow.state;
       flow.state = "paused";
-      flow.stateDetail = "paused by user";
+      flow.stateDetail = pauseResumeDetail("paused", actor);
     }
   } else if (req.action === "resume") {
     if (flow.state === "paused") {
@@ -409,7 +414,7 @@ export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; err
       }
       flow.state = flow.pausedState && flow.pausedState !== "paused" ? flow.pausedState : "waiting_ready";
       flow.pausedState = null;
-      flow.stateDetail = null;
+      flow.stateDetail = pauseResumeDetail("resumed", actor);
     }
   } else if (req.action === "set-mode") {
     if (req.mode !== "auto" && req.mode !== "manual") return { error: "mode must be auto or manual", status: 400 };

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -637,15 +637,16 @@ test("flow tools read durable flows and return a stable action receipt", async (
     { id: "flow_closed", project: "viewer", state: "closed", closedAt: "2026-07-23T01:00:00.000Z" },
     { id: "flow_other", project: "other", state: "waiting_ready", closedAt: null },
   ];
-  const actions: Array<{ id: string; action: string }> = [];
+  const actions: Array<{ id: string; action: string; actor: unknown }> = [];
   const bindings = viewerMcpBindings(undefined, undefined, {
     getFlowsWithPresets: () => ({ flows, presets: [] }),
-    patchFlow: (id: string, request: { action: string }) => {
-      actions.push({ id, action: request.action });
+    patchFlow: (id: string, request: { action: string }, actor: unknown) => {
+      actions.push({ id, action: request.action, actor });
       return { flow: { ...flows[0], id, state: "paused" } };
     },
     cancelRound: async () => ({ flow: flows[0] }),
     closeFlow: async () => ({ flow: flows[0] }),
+    callerAttribution: () => ({ kind: "agent", conversationId: "conversation_reviewer", role: "reviewer" }),
   } as never);
 
   expect(await bindings.list_flows({ clientRequestId: "list-flows", project: "viewer" })).toMatchObject({
@@ -665,7 +666,11 @@ test("flow tools read durable flows and return a stable action receipt", async (
   });
   expect(actionOperationId).toMatch(/^mcp_flow_action_[0-9a-f]{24}$/);
   expect((actionResult.receipt as { operationId: string }).operationId).toBe(actionOperationId);
-  expect(actions).toEqual([{ id: "flow_open", action: "pause" }]);
+  expect(actions).toEqual([{
+    id: "flow_open",
+    action: "pause",
+    actor: { kind: "agent", role: "reviewer", conversationId: "conversation_reviewer" },
+  }]);
 });
 
 test("list_pipelines applies project, state, and closed filters to the durable registry", async () => {
@@ -904,10 +909,15 @@ test("a refused pipeline close exposes its host report through MCP, not only pro
     stillRunning: [{ stageId: "build", attempt: 2, conversationId: "conversation_build", agentPath: null, paneId: "%7", error: "structured runtime host is unavailable" }],
     worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
   };
+  let pauseActor: unknown;
   const bindings = viewerMcpBindings(undefined, undefined, {
-    patchPipeline: async (_id: string, request: { action?: string }) => (request.action === "close"
-      ? { error: "could not stop stage build attempt 2 (conversation_build): structured runtime host is unavailable", status: 409, close }
-      : { pipeline: { id: "pipeline_1", state: "paused" } }),
+    patchPipeline: async (_id: string, request: { action?: string }, _ports: unknown, actor: unknown) => {
+      if (request.action === "pause") pauseActor = actor;
+      return request.action === "close"
+        ? { error: "could not stop stage build attempt 2 (conversation_build): structured runtime host is unavailable", status: 409, close }
+        : { pipeline: { id: "pipeline_1", state: "paused" } };
+    },
+    callerAttribution: () => ({ kind: "manager", conversationId: "conversation_orchestrator", role: "orchestrator" }),
   } as never);
   const results = new Map<string, McpToolResult>();
   const service = createMcpToolService(bindings, {
@@ -937,6 +947,7 @@ test("a refused pipeline close exposes its host report through MCP, not only pro
   });
   expect(paused).toMatchObject({ ok: true, pipelineId: "pipeline_1" });
   expect((paused as { details?: unknown }).details).toBeUndefined();
+  expect(pauseActor).toEqual({ kind: "agent", role: "orchestrator", conversationId: "conversation_orchestrator" });
 });
 
 test("agent_activity reports the liveness snapshot and journals the stalls it finds (#645)", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -59,6 +59,7 @@ import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import { PIPELINE_LIST_DEFAULT_LIMIT, projectPipelineListRows } from "@/lib/pipelines/listProjection";
 import { findPipelineRecord, loadPipelinesForList } from "@/lib/pipelines/store";
 import type { CreatePipelineRequest, PatchPipelineRequest, Pipeline, PipelineAction } from "@/lib/pipelines/types";
+import type { PauseResumeActor } from "@/lib/pauseResumeActor";
 import { listFiles } from "@/lib/scanner";
 import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
 import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
@@ -340,6 +341,16 @@ export function callerAttributionFrom(
 function attributionOf(dependencies: ViewerMcpDomainDependencies): CallerAttribution {
   return dependencies.callerAttribution?.()
     ?? callerAttributionFrom(dependencies.attentionAuthority(), () => false);
+}
+
+/** MCP mutations always remain agent-attributed, including an unidentified caller. */
+function pauseResumeActorOf(dependencies: ViewerMcpDomainDependencies): PauseResumeActor {
+  const attribution = attributionOf(dependencies);
+  return {
+    kind: "agent",
+    role: attribution.role ?? (attribution.kind === "manager" ? "orchestrator" : attribution.kind === "gateway" ? "gateway" : null),
+    conversationId: attribution.conversationId,
+  };
 }
 
 /**
@@ -690,7 +701,9 @@ async function pipelineAction(args: McpToolArgs, dependencies: ViewerMcpDomainDe
   const pipelineId = required(args, "pipelineId");
   const action = required(args, "action") as PipelineAction;
   const request = withoutKeys(args, ["pipelineId", "clientRequestId"]);
-  const result = await dependencies.patchPipeline(pipelineId, request as PatchPipelineRequest);
+  const result = action === "pause" || action === "resume"
+    ? await dependencies.patchPipeline(pipelineId, request as PatchPipelineRequest, undefined, pauseResumeActorOf(dependencies))
+    : await dependencies.patchPipeline(pipelineId, request as PatchPipelineRequest);
   if (!result.pipeline) {
     const message = result.error ?? "could not update pipeline";
     /* A refused close carries the hosts it stopped and the one it could not
@@ -1734,7 +1747,9 @@ async function flowAction(args: McpToolArgs, dependencies: ViewerMcpDomainDepend
     ? await dependencies.cancelRound(flowId)
     : action === "close"
       ? await dependencies.closeFlow(flowId)
-      : dependencies.patchFlow(flowId, request);
+      : action === "pause" || action === "resume"
+        ? dependencies.patchFlow(flowId, request, pauseResumeActorOf(dependencies))
+        : dependencies.patchFlow(flowId, request);
   if (!result.flow) throw new Error(result.error ?? "could not update flow");
   const operationId = mcpOperationId("flow_action", requestId(args));
   return redactPayload({ flowId, flow: result.flow, ...mutationReceipt(operationId) });

--- a/src/lib/pauseResumeActor.ts
+++ b/src/lib/pauseResumeActor.ts
@@ -1,0 +1,22 @@
+export type PauseResumeActor =
+  | { kind: "operator" }
+  | { kind: "agent"; role: string | null; conversationId: string | null };
+
+export const OPERATOR_PAUSE_RESUME_ACTOR: PauseResumeActor = { kind: "operator" };
+
+function identityPart(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+/** Durable board-card detail for an externally requested pause or resume. */
+export function pauseResumeDetail(
+  action: "paused" | "resumed",
+  actor: PauseResumeActor | null,
+): string | null {
+  if (actor === null) return null;
+  if (actor.kind === "operator") return `${action} by operator`;
+  const role = identityPart(actor.role) ?? "agent";
+  const conversationId = identityPart(actor.conversationId);
+  return `${action} by ${role}${conversationId ? ` ${conversationId}` : ""}`;
+}

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -340,6 +340,28 @@ async function exhaustVerdictRecovery(h: ReturnType<typeof harness>, entries: Fi
   await tickPipelines(entries, h.ports);
 }
 
+test("pause and resume state details name the operator or calling agent (#1121)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+
+  const operatorPause = await patchPipeline(pipeline.id, { action: "pause" }, h.ports);
+  expect(operatorPause.pipeline).toMatchObject({ state: "paused", stateDetail: "paused by operator" });
+  const operatorResume = await patchPipeline(pipeline.id, { action: "resume" }, h.ports);
+  expect(operatorResume.pipeline).toMatchObject({ state: "provisioning", stateDetail: "resumed by operator" });
+
+  const agent = { kind: "agent" as const, role: "orchestrator", conversationId: "conversation_orchestrator" };
+  const agentPause = await patchPipeline(pipeline.id, { action: "pause" }, h.ports, agent);
+  expect(agentPause.pipeline).toMatchObject({
+    state: "paused",
+    stateDetail: "paused by orchestrator conversation_orchestrator",
+  });
+  const agentResume = await patchPipeline(pipeline.id, { action: "resume" }, h.ports, agent);
+  expect(agentResume.pipeline).toMatchObject({
+    state: "provisioning",
+    stateDetail: "resumed by orchestrator conversation_orchestrator",
+  });
+});
+
 async function withRuntimeSnapshot(
   snapshot: Record<string, unknown> | ((requestNumber: number) => Record<string, unknown>),
   run: () => Promise<void>,

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -16,6 +16,7 @@ import { lastAssistantMessage, readFindingsFile } from "@/lib/flows/findings";
 import { loadFlows } from "@/lib/flows/store";
 import type { CreateFlowRequest, Flow, RoleConfig } from "@/lib/flows/types";
 import { persistHandoffLineage, rememberHandoffChild } from "@/lib/handoffLineage";
+import { OPERATOR_PAUSE_RESUME_ACTOR, pauseResumeDetail, type PauseResumeActor } from "@/lib/pauseResumeActor";
 import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
 import { redactBounded } from "@/lib/monitor/redact";
 import { parseReview, type ReviewFinding } from "@/lib/review";
@@ -180,7 +181,7 @@ export interface PipelinePorts {
   conversationIdForPath(pathname: string): string | null;
   pipelineAdoptionCandidates(pipelineId: string): PipelineAdoptionCandidate[];
   createFlow(req: CreateFlowRequest, entries: FileEntry[]): Promise<{ flow?: Flow; error?: string }>;
-  patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string): { error?: string; status?: number };
+  patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string, actor?: PauseResumeActor | null): { error?: string; status?: number };
   closeFlow(id: string): Promise<{
     flow?: Flow;
     error?: string;
@@ -667,8 +668,8 @@ export function defaultPipelinePorts(): PipelinePorts {
       flowSnapshot = null;
       return result;
     },
-    patchFlow: (id, action, note) => {
-      const result = patchFlow(id, { action, ...(note ? { note } : {}) });
+    patchFlow: (id, action, note, actor = null) => {
+      const result = patchFlow(id, { action, ...(note ? { note } : {}) }, actor);
       flowSnapshot = null;
       return result;
     },
@@ -3220,6 +3221,7 @@ export async function patchPipeline(
   id: string,
   req: PatchPipelineRequest,
   ports: PipelinePorts = defaultPipelinePorts(),
+  actor: PauseResumeActor | null = OPERATOR_PAUSE_RESUME_ACTOR,
 ): Promise<PipelineMutationResult> {
   return withPipelineMutation(async (pipelines, persist) => {
     const pipeline = pipelines.find((item) => item.id === id);
@@ -3432,16 +3434,16 @@ export async function patchPipeline(
         pipeline.pausedState = pipeline.state;
         pipeline.state = "paused";
         pipeline.pausedAt = ports.now();
-        pipeline.stateDetail = "paused by user";
-        if (flow && flow.state !== "paused" && flow.state !== "closed") ports.patchFlow(flow.id, "pause");
+        pipeline.stateDetail = pauseResumeDetail("paused", actor);
+        if (flow && flow.state !== "paused" && flow.state !== "closed") ports.patchFlow(flow.id, "pause", undefined, actor);
       }
     } else if (req.action === "resume") {
       if (pipeline.state !== "paused") return { error: "pipeline is not paused", status: 409 };
       pipeline.state = pipeline.pausedState ?? "running";
       pipeline.pausedState = null;
       pipeline.resumedAt = ports.now();
-      pipeline.stateDetail = null;
-      if (flow?.state === "paused") ports.patchFlow(flow.id, "resume");
+      pipeline.stateDetail = pauseResumeDetail("resumed", actor);
+      if (flow?.state === "paused") ports.patchFlow(flow.id, "resume", undefined, actor);
     } else if (req.action === "retry-stage") {
       if (pipeline.state !== "needs_decision") return { error: "pipeline does not have a stage awaiting retry", status: 409 };
       const recoveryRefusal = verdictRecoveryResetRefusal(pipeline, attempt, ports);

--- a/src/lib/workflows/engine.test.ts
+++ b/src/lib/workflows/engine.test.ts
@@ -541,11 +541,17 @@ test("pause holds the phase; resume returns to it", async () => {
   const wf = createWf(harness.ports);
   await tickWorkflows([], harness.ports);
   const paused = await patchWorkflow(wf.id, { action: "pause" }, harness.ports);
-  expect(paused.workflow?.state).toBe("paused");
+  expect(paused.workflow).toMatchObject({ state: "paused", stateDetail: "paused by operator" });
   await tickWorkflows([], harness.ports); // parked: the tick leaves it alone
   expect(load(wf.id).state).toBe("paused");
   const resumed = await patchWorkflow(wf.id, { action: "resume" }, harness.ports);
-  expect(resumed.workflow?.state).toBe("implementing");
+  expect(resumed.workflow).toMatchObject({ state: "implementing", stateDetail: "resumed by operator" });
+
+  const actor = { kind: "agent" as const, role: "builder", conversationId: "conversation_builder" };
+  const agentPause = await patchWorkflow(wf.id, { action: "pause" }, harness.ports, actor);
+  expect(agentPause.workflow).toMatchObject({ state: "paused", stateDetail: "paused by builder conversation_builder" });
+  const agentResume = await patchWorkflow(wf.id, { action: "resume" }, harness.ports, actor);
+  expect(agentResume.workflow).toMatchObject({ state: "implementing", stateDetail: "resumed by builder conversation_builder" });
 });
 
 test("close stops the embedded flow and keeps worktree state on the record", async () => {

--- a/src/lib/workflows/engine.ts
+++ b/src/lib/workflows/engine.ts
@@ -12,6 +12,7 @@ import { lastAssistantMessage } from "@/lib/flows/findings";
 import { loadFlows } from "@/lib/flows/store";
 import type { CreateFlowRequest, Flow, RoleConfig } from "@/lib/flows/types";
 import { persistHandoffLineage, rememberHandoffChild } from "@/lib/handoffLineage";
+import { OPERATOR_PAUSE_RESUME_ACTOR, pauseResumeDetail, type PauseResumeActor } from "@/lib/pauseResumeActor";
 import { isNativeCodexSubagentTranscript } from "@/lib/scanner/codexNative";
 import { projectForCwd } from "@/lib/scanner/describe";
 import { isShellCommand } from "@/lib/status";
@@ -492,6 +493,7 @@ export async function patchWorkflow(
   id: string,
   req: PatchWorkflowRequest,
   ports: WorkflowPorts = defaultPorts(),
+  actor: PauseResumeActor | null = OPERATOR_PAUSE_RESUME_ACTOR,
 ): Promise<{ workflow?: Workflow; error?: string; status?: number }> {
   const workflows = loadWorkflows();
   const wf = workflows.find((item) => item.id === id);
@@ -501,13 +503,13 @@ export async function patchWorkflow(
     if (wf.state !== "paused" && !TERMINAL_STATES.has(wf.state)) {
       if (wf.state !== "needs_decision") wf.pausedState = wf.state;
       wf.state = "paused";
-      wf.stateDetail = "paused by user";
+      wf.stateDetail = pauseResumeDetail("paused", actor);
     }
   } else if (req.action === "resume") {
     if (wf.state === "paused" || wf.state === "needs_decision") {
       wf.state = wf.pausedState && !PARKED_STATES.has(wf.pausedState) ? wf.pausedState : "provisioning";
       wf.pausedState = null;
-      wf.stateDetail = null;
+      wf.stateDetail = pauseResumeDetail("resumed", actor);
     }
   } else if (req.action === "advance") {
     const phase = phaseOf(wf);


### PR DESCRIPTION
## Summary

- label operator pause and resume actions as operator-originated
- inject the MCP caller role and conversation into pipeline and flow mutations
- share actor-aware state details across pipelines, flows, and workflows
- cover operator, agent, MCP propagation, and board-card rendering

## Verification

- `bun test src/lib/pipelines/engine.test.ts src/lib/mcp/bindings.test.ts src/lib/flows/commands.set-roles.test.ts src/lib/workflows/engine.test.ts src/components/pipelines/PipelineStrip.render.test.tsx` (277 pass)
- `bunx tsc --noEmit --incremental false`
- `bun scripts/privacy-publication-gate.ts --base 38073735a8f47e714f97786c5085df429da9606f`

Fixes #1121