### PR TITLE
fix(runtime): raise the runtime-host response frame bound to 64 MiB (#1145)

### DIFF
--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -3,10 +3,14 @@ import net from "node:net";
 import type { RuntimeEventInput, RuntimeOperationCommand, RuntimeOperationResult, RuntimePendingEffect, RuntimeReceiptStatus, RuntimeReplay, RuntimeRetryOptions, RuntimeSnapshot, RuntimeSocketRequest, RuntimeSocketResponse, ViewerDeploymentReceipt, ViewerDeploymentRequest, ViewerDeploymentStatus } from "./contracts";
 import { runtimeHostSocket } from "./flags";
 
-// Exact-SHA handoff briefly pairs the new Viewer with the previous runtime
-// host. Its pre-compaction snapshot can exceed 8 MiB; the successor host
-// projects dead-session live text away and returns to the smaller steady state.
-const MAX_RESPONSE_FRAME_BYTES = 16 * 1024 * 1024;
+// The snapshot frame carries every hosted session, and a hosted session keeps
+// its liveTurn text until its host dies — idle hosts never retire (#747), so
+// the frame grows with every finished turn. On 2026-08-24 it crossed 16 MiB
+// (551 sessions, 357 with liveTurn) and every viewer→runtime call failed as
+// "unavailable": no spawn, kill, or archive could run and the deploy probe
+// failed (#1145). The bound stays a last-resort guard against a runaway host;
+// the durable fix is a bounded snapshot on the journal side.
+const MAX_RESPONSE_FRAME_BYTES = 64 * 1024 * 1024;
 export const RUNTIME_SNAPSHOT_REQUEST_TIMEOUT_MS = 10_000;
 export const VIEWER_DEPLOYMENT_REQUEST_TIMEOUT_MS = 120_000;
 


### PR DESCRIPTION
Hotfix for #1145 (root cause in the issue comments): the runtime snapshot frame crossed the 16 MiB client bound, which turned every viewer→runtime call into `runtime host response exceeds limit` → `RuntimeHostUnavailableError`. Spawns, kill, archive and the deploy health probe were all blocked, so the fix could not ship through the conveyor; applied by the orchestrator directly.

Change: `MAX_RESPONSE_FRAME_BYTES` 16 MiB → 64 MiB in `src/lib/runtime/client.ts`, comment records the mechanism. The runtime-host inbound request bound (512 KiB, `socket.ts`) is unrelated and unchanged.

Verification: `bunx tsc --noEmit --incremental false` clean; privacy gate PASS vs merge-base.

Follow-up (durable, separate lane): bound the snapshot itself — null `liveTurn` for idle sessions, prune terminal deployments/edges — and retire idle hosts (#747/#1142).