### PR TITLE
fix(runtime-host): bound runtime snapshot frames

### DIFF
--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -648,6 +648,89 @@ test("snapshot omits stale terminal-session edges while durable rows remain", ()
   journal.close();
 });
 
+test("snapshot retains an old edge when a recent terminal checkpoint was compacted", () => {
+  const dir = sandbox("compacted-terminal-edge");
+  const filename = path.join(dir, "events.sqlite");
+  const day = 24 * 60 * 60 * 1_000;
+  let now = 0;
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => now });
+  journal.executeOperation({
+    kind: "spawn",
+    conversationId: "child-compacted-terminal",
+    operationId: "operation-compacted-terminal",
+    idempotencyKey: "spawn-compacted-terminal",
+    engine: "codex",
+    cwd: "repo",
+    "prompt": "Run the fixture",
+    parentConversationId: "parent",
+    sessionId: "session-compacted-terminal",
+  });
+
+  now = 6 * day;
+  journal.append({
+    scope: runtimeScope("session", "child-compacted-terminal"),
+    kind: "session-status",
+    payload: { host: "dead", turn: "idle" },
+  });
+  journal.append({
+    scope: runtimeScope("session", "unrelated-session"),
+    kind: "session-status",
+    payload: { host: "hosted", turn: "idle" },
+  });
+  journal.compact(1);
+  now = 8 * day;
+
+  const raw = new Database(filename, { readonly: true });
+  expect(raw.query<{ count: number }, []>(`
+    SELECT COUNT(*) AS count
+    FROM entities AS session
+    JOIN events AS event ON event.seq = session.checkpoint_seq
+    WHERE session.kind = 'session' AND session.id = 'child-compacted-terminal'
+  `).get()?.count).toBe(0);
+  expect(raw.query<{ count: number }, []>(`
+    SELECT COUNT(*) AS count FROM entities WHERE kind = 'edge'
+  `).get()?.count).toBe(1);
+  raw.close();
+
+  expect(journal.snapshot().edges.map((edge) => edge.id))
+    .toEqual(["edge-operation-compacted-terminal"]);
+  journal.close();
+});
+
+test("journal backfills entity update times when reopening a legacy schema", () => {
+  const dir = sandbox("legacy-entity-update-time");
+  const filename = path.join(dir, "events.sqlite");
+  const initial = new RuntimeJournal(filename, { now: () => 123 });
+  initial.append({
+    scope: runtimeScope("session", "legacy-session"),
+    kind: "session-status",
+    payload: { host: "dead", turn: "idle" },
+  });
+  initial.close();
+
+  const legacy = new Database(filename);
+  legacy.exec(`
+    ALTER TABLE entities RENAME TO entities_with_update_time;
+    CREATE TABLE entities (
+      kind TEXT NOT NULL, id TEXT NOT NULL, revision INTEGER NOT NULL,
+      state_json TEXT NOT NULL, checkpoint_seq INTEGER NOT NULL,
+      PRIMARY KEY(kind, id)
+    );
+    INSERT INTO entities(kind, id, revision, state_json, checkpoint_seq)
+    SELECT kind, id, revision, state_json, checkpoint_seq FROM entities_with_update_time;
+    DROP TABLE entities_with_update_time;
+  `);
+  legacy.close();
+
+  const reopened = new RuntimeJournal(filename, { now: () => 999 });
+  const migrated = new Database(filename, { readonly: true });
+  expect(migrated.query<{ updated_at: number }, [string, string]>(`
+    SELECT updated_at FROM entities WHERE kind = ? AND id = ?
+  `).get("session", "legacy-session")?.updated_at).toBe(123);
+  migrated.close();
+  reopened.close();
+});
+
 test("issue 51 keeps tool work running until authoritative turn completion", () => {
   const dir = sandbox("terminal-axes");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
@@ -2830,6 +2913,43 @@ test("snapshotJson rebuilds only when the database has changed", () => {
   const second = journal.snapshotJson();
   expect(second).not.toBe(first);
   expect(JSON.parse(second).snapshotSeq).toBe(2);
+  journal.close();
+});
+
+test("snapshotJson expires terminal-session edges without a database change", () => {
+  const dir = sandbox("snapshot-cache-edge-expiry");
+  let now = 100;
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => now });
+  journal.executeOperation({
+    kind: "spawn",
+    conversationId: "child-expiring-edge",
+    operationId: "operation-expiring-edge",
+    idempotencyKey: "spawn-expiring-edge",
+    engine: "codex",
+    cwd: "repo",
+    "prompt": "Run the fixture",
+    parentConversationId: "parent",
+    sessionId: "session-expiring-edge",
+  });
+  journal.append({
+    scope: runtimeScope("session", "child-expiring-edge"),
+    kind: "session-status",
+    payload: { host: "dead", turn: "idle" },
+  });
+
+  const before = journal.snapshotJson();
+  const beforeSnapshot = JSON.parse(before) as ReturnType<RuntimeJournal["snapshot"]>;
+  expect(beforeSnapshot.edges.map((edge) => edge.id)).toEqual(["edge-operation-expiring-edge"]);
+  expect(journal.snapshotJson()).toBe(before);
+
+  now += RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS;
+  expect(journal.snapshotJson()).toBe(before);
+  now += 1;
+  const after = journal.snapshotJson();
+  const afterSnapshot = JSON.parse(after) as ReturnType<RuntimeJournal["snapshot"]>;
+  expect(afterSnapshot.snapshotSeq).toBe(beforeSnapshot.snapshotSeq);
+  expect(afterSnapshot.edges).toEqual([]);
+  expect(journal.snapshot().edges).toEqual([]);
   journal.close();
 });
 

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -12,11 +12,17 @@ import type { Flow } from "@/lib/flows/types";
 import { UnixRuntimeHostClient } from "@/lib/runtime/client";
 import { runtimePresentationReceipt, runtimeScope } from "@/lib/runtime/contracts";
 import { projectEngineHostEvent } from "@/lib/runtime/engineHostEvents";
+import { LIVE_TURN_TEXT_LIMIT } from "@/lib/runtime/liveTurn";
 import { structuredContentDigest, type StructuredImageRef } from "@/lib/runtime/structuredContent";
 import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 import { RuntimeHost, RuntimeHostFence } from "./host";
-import { RuntimeJournal, RuntimeJournalFault } from "./journal";
+import {
+  RuntimeJournal,
+  RuntimeJournalFault,
+  RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS,
+  RUNTIME_SNAPSHOT_TERMINAL_DEPLOYMENT_LIMIT,
+} from "./journal";
 import { serveRuntimeHost } from "./socket";
 
 function sandbox(name: string): string {
@@ -454,6 +460,191 @@ test("snapshot bounds inactive session history while retaining every active sess
   expect(ids.has("conversation_dead_299")).toBeTrue();
   expect(ids.has("conversation_dead_000")).toBeFalse();
   expect(journal.sessionState("conversation_dead_000")).toMatchObject({ host: "dead" });
+  journal.close();
+});
+
+test("snapshot drops large live turns from every hosted idle session", () => {
+  const dir = sandbox("bounded-idle-live-turns");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { maxEvents: 1_000, now: () => 100 });
+  const sessionCount = 300;
+  for (let index = 0; index < sessionCount; index += 1) {
+    const conversationId = `conversation_idle_${String(index).padStart(3, "0")}`;
+    journal.append({
+      scope: runtimeScope("session", conversationId),
+      kind: "session-status",
+      payload: {
+        conversationId,
+        sessionKey: { engine: "codex", sessionId: `session-${index}` },
+        hostKind: "codex-app-server",
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        capabilities: { steer: true, structuredAttention: true },
+      },
+    });
+  }
+
+  // Recreate the oversized durable rows that predated live-turn bounding.
+  const legacyText = "x".repeat(LIVE_TURN_TEXT_LIMIT);
+  const raw = new Database(filename);
+  raw.query(`
+    UPDATE entities
+    SET state_json = json_set(
+      state_json,
+      '$.liveTurn',
+      json(?)
+    )
+    WHERE kind = 'session'
+  `).run(JSON.stringify({ turnId: "turn-finished", text: legacyText }));
+  raw.close();
+
+  expect(sessionCount * Buffer.byteLength(legacyText)).toBeGreaterThan(16 * 1024 * 1024);
+  expect(journal.sessionState("conversation_idle_000")?.liveTurn?.text).toHaveLength(LIVE_TURN_TEXT_LIMIT);
+  const json = journal.snapshotJson();
+  const snapshot = JSON.parse(json) as ReturnType<RuntimeJournal["snapshot"]>;
+  expect(snapshot.sessions).toHaveLength(sessionCount);
+  expect(snapshot.sessions.every((session) => session.liveTurn === null)).toBeTrue();
+  expect(Buffer.byteLength(json)).toBeLessThan(4 * 1024 * 1024);
+  journal.close();
+});
+
+test("snapshot nulls live turns for every non-running turn axis regardless of host", () => {
+  const dir = sandbox("non-running-live-turns");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { now: () => 100 });
+  for (const [turn, host] of [
+    ["idle", "hosted"],
+    ["unknown", "dead"],
+    ["interrupt_requested", "unhosted"],
+  ] as const) {
+    journal.append({
+      scope: runtimeScope("session", `conversation-${turn}`),
+      kind: "session-status",
+      payload: {
+        conversationId: `conversation-${turn}`,
+        host,
+        turn,
+        liveTurn: { turnId: `turn-${turn}`, text: "stale live text" },
+      },
+    });
+  }
+
+  expect(journal.snapshot().sessions.map((session) => session.liveTurn)).toEqual([null, null, null]);
+  journal.close();
+});
+
+test("snapshot caps a legacy running live turn to its marked UTF-8 tail", () => {
+  const dir = sandbox("bounded-running-live-turn");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { now: () => 100 });
+  journal.append({
+    scope: runtimeScope("session", "conversation-running"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conversation-running",
+      sessionKey: { engine: "codex", sessionId: "session-running" },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "running",
+      provenance: "structured",
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: "turn-running",
+    },
+  });
+
+  const tail = "tail-界";
+  const legacyText = `${"🫶🏽".repeat(LIVE_TURN_TEXT_LIMIT)}${tail}`;
+  const raw = new Database(filename);
+  const row = raw.query<{ state_json: string }, [string, string]>(
+    "SELECT state_json FROM entities WHERE kind = ? AND id = ?",
+  ).get("session", "conversation-running")!;
+  const state = JSON.parse(row.state_json) as Record<string, unknown>;
+  state.liveTurn = { turnId: "turn-running", text: legacyText };
+  raw.query("UPDATE entities SET state_json = ? WHERE kind = ? AND id = ?")
+    .run(JSON.stringify(state), "session", "conversation-running");
+  raw.close();
+
+  expect(Buffer.byteLength(journal.sessionState("conversation-running")?.liveTurn?.text ?? ""))
+    .toBeGreaterThan(LIVE_TURN_TEXT_LIMIT);
+  const liveTurn = journal.snapshot().sessions[0]?.liveTurn;
+  expect(liveTurn).not.toBeNull();
+  expect(Buffer.byteLength(liveTurn?.text ?? "")).toBeLessThanOrEqual(LIVE_TURN_TEXT_LIMIT);
+  expect(liveTurn?.text.endsWith(tail)).toBeTrue();
+  expect(liveTurn?.items?.some((item) => (item.omittedChars ?? 0) > 0)).toBeTrue();
+  journal.close();
+});
+
+test("snapshot retains active and newest terminal deployments without deleting history", () => {
+  const dir = sandbox("bounded-deployments");
+  let now = 100;
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { now: () => now });
+  const terminalIds: string[] = [];
+  for (let index = 0; index < RUNTIME_SNAPSHOT_TERMINAL_DEPLOYMENT_LIMIT + 5; index += 1) {
+    const receipt = journal.admitViewerDeployment({
+      idempotencyKey: `deployment-${index}`,
+      requestedRevision: `requested-${index}`,
+      revision: `revision-${index}`,
+    }, { pid: index + 1, startIdentity: null });
+    if (receipt.state !== "accepted") throw new Error("deployment fixture was not admitted");
+    terminalIds.push(receipt.deploymentId);
+    now += 1;
+    journal.updateViewerDeployment(receipt.deploymentId, { phase: "succeeded", terminal: true });
+    now += 1;
+  }
+  const active = journal.admitViewerDeployment({
+    idempotencyKey: "deployment-active",
+    requestedRevision: "requested-active",
+    revision: "revision-active",
+  }, { pid: 99, startIdentity: null });
+  if (active.state !== "accepted") throw new Error("active deployment fixture was not admitted");
+
+  const snapshotIds = new Set(journal.snapshot().deployments.map((deployment) => deployment.deploymentId));
+  expect(snapshotIds.size).toBe(RUNTIME_SNAPSHOT_TERMINAL_DEPLOYMENT_LIMIT + 1);
+  expect(snapshotIds.has(active.deploymentId)).toBeTrue();
+  expect(snapshotIds.has(terminalIds[0]!)).toBeFalse();
+  expect(snapshotIds.has(terminalIds.at(-1)!)).toBeTrue();
+  expect(journal.viewerDeployment(terminalIds[0]!)).toMatchObject({ terminal: true, phase: "succeeded" });
+  journal.close();
+});
+
+test("snapshot omits stale terminal-session edges while durable rows remain", () => {
+  const dir = sandbox("bounded-edges");
+  const filename = path.join(dir, "events.sqlite");
+  let now = 100;
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => now });
+  const spawn = (suffix: string) => journal.executeOperation({
+    kind: "spawn",
+    conversationId: `child-${suffix}`,
+    operationId: `operation-${suffix}`,
+    idempotencyKey: `spawn-${suffix}`,
+    engine: "codex",
+    cwd: "repo",
+    "prompt": "Run the fixture",
+    parentConversationId: "parent",
+    sessionId: `session-${suffix}`,
+  });
+  const setHost = (suffix: string, host: "hosted" | "dead" | "unhosted") => journal.append({
+    scope: runtimeScope("session", `child-${suffix}`),
+    kind: "session-status",
+    payload: { host, turn: "idle" },
+  });
+
+  spawn("stale-dead");
+  setHost("stale-dead", "dead");
+  spawn("recent-terminal");
+  setHost("recent-terminal", "hosted");
+  spawn("active-old");
+  setHost("active-old", "hosted");
+  now += RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS + 1;
+  setHost("recent-terminal", "unhosted");
+
+  const edgeIds = journal.snapshot().edges.map((edge) => edge.id);
+  expect(edgeIds).toEqual(["edge-operation-active-old", "edge-operation-recent-terminal"]);
+  const raw = new Database(filename, { readonly: true });
+  expect(raw.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM entities WHERE kind = 'edge'",
+  ).get()?.count).toBe(3);
+  raw.close();
   journal.close();
 });
 

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -274,7 +274,7 @@ export class RuntimeJournal {
   private readonly secretKey: Buffer;
   private readonly waiters = new Set<() => void>();
   private fault: string | null = null;
-  private snapshotCache: { changes: number; json: string } | null = null;
+  private snapshotCache: { changes: number; expiresAt: number | null; json: string } | null = null;
   private receiptSweepCursor = 0;
 
   constructor(filename: string, options: RuntimeJournalOptions = {}) {
@@ -303,7 +303,7 @@ export class RuntimeJournal {
       CREATE TABLE IF NOT EXISTS projections (scope TEXT PRIMARY KEY, revision INTEGER NOT NULL, state_json TEXT NOT NULL, checkpoint_seq INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS entities (
         kind TEXT NOT NULL, id TEXT NOT NULL, revision INTEGER NOT NULL,
-        state_json TEXT NOT NULL, checkpoint_seq INTEGER NOT NULL,
+        state_json TEXT NOT NULL, checkpoint_seq INTEGER NOT NULL, updated_at INTEGER,
         PRIMARY KEY(kind, id)
       );
       CREATE TABLE IF NOT EXISTS outbox (id TEXT PRIMARY KEY, kind TEXT NOT NULL, payload_json TEXT NOT NULL, event_seq INTEGER NOT NULL, state TEXT NOT NULL);
@@ -328,6 +328,7 @@ export class RuntimeJournal {
     `);
     this.migrateOperationIdempotencyScope();
     this.migrateLegacyEvents();
+    this.migrateEntityUpdatedAt();
     for (const row of this.db.query<EventRow, []>("SELECT * FROM events WHERE producer_key IS NOT NULL").all()) {
       this.db.query("INSERT INTO producer_receipts(producer_kind, producer_key, event_json) VALUES (?, ?, ?) ON CONFLICT(producer_kind, producer_key) DO NOTHING")
         .run(row.producer_kind, row.producer_key, stableJson(toEvent(row)));
@@ -716,13 +717,17 @@ export class RuntimeJournal {
   }
 
   snapshot(): RuntimeSnapshot {
+    return this.snapshotAt(this.now());
+  }
+
+  private snapshotAt(now: number): RuntimeSnapshot {
     this.db.exec("BEGIN");
     try {
       const snapshot: RuntimeSnapshot = {
         schemaVersion: RUNTIME_SCHEMA_VERSION,
         snapshotSeq: Number(this.meta("published_seq")),
         retentionFloorSeq: Number(this.meta("anchor_seq")),
-        serverTime: new Date(this.now()).toISOString(),
+        serverTime: new Date(now).toISOString(),
         runtime: { hostEpoch: Number(this.meta("host_epoch")), health: this.meta("health") },
         filesRevision: Number(this.meta("files_revision")),
         sessions: this.snapshotSessionValues().map((session) => ({
@@ -739,7 +744,7 @@ export class RuntimeJournal {
         recentOperations: visibleReceipts(
           this.recentEntityValues<RuntimeOperationReceipt>("operation", 100),
         ).map(runtimePresentationReceipt),
-        edges: this.snapshotEdgeValues(),
+        edges: this.snapshotEdgeValues(now),
         flows: this.scopedValues<RuntimeSnapshot["flows"][number]["value"]>("flow"),
         workflows: this.scopedValues<RuntimeSnapshot["workflows"][number]["value"]>("workflow"),
         tasks: this.scopedValues<RuntimeSnapshot["tasks"][number]["value"]>("task"),
@@ -753,19 +758,24 @@ export class RuntimeJournal {
     }
   }
 
-  /** Serialized snapshot, rebuilt only when the database has changed since the
-      cached build. Concurrent snapshot consumers otherwise stack full O(state)
-      rebuilds on the event loop until every socket request exceeds the
-      client's timeout and the retry storm keeps the host saturated (the
-      2026-08-04 spawn freeze). total_changes() counts every row this
-      connection has written, so no mutation path needs to remember to
-      invalidate. serverTime inside the cached frame dates from the last
-      mutation; no consumer reads it. */
+  /** Serialized snapshot, rebuilt when the database changes or the next
+      retained terminal edge reaches its age boundary. Concurrent snapshot
+      consumers otherwise stack full O(state) rebuilds on the event loop until
+      every socket request exceeds the client's timeout and the retry storm
+      keeps the host saturated (the 2026-08-04 spawn freeze). total_changes()
+      counts every row this connection has written, so no mutation path needs
+      to remember to invalidate. The time expiry covers the only projection
+      whose visibility changes without a write. serverTime inside the cached
+      frame dates from the last rebuild; no consumer reads it. */
   snapshotJson(): string {
     const changes = this.totalChanges();
-    if (this.snapshotCache?.changes === changes) return this.snapshotCache.json;
-    const json = JSON.stringify(this.snapshot());
-    this.snapshotCache = { changes, json };
+    const now = this.now();
+    if (this.snapshotCache?.changes === changes
+      && (this.snapshotCache.expiresAt === null || now < this.snapshotCache.expiresAt)) {
+      return this.snapshotCache.json;
+    }
+    const json = JSON.stringify(this.snapshotAt(now));
+    this.snapshotCache = { changes, expiresAt: this.snapshotEdgeExpiry(now), json };
     return json;
   }
 
@@ -1965,28 +1975,43 @@ export class RuntimeJournal {
       .sort((left, right) => left.conversationId.localeCompare(right.conversationId));
   }
 
-  private snapshotEdgeValues(): RuntimeEdge[] {
-    const cutoff = this.now() - RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS;
+  private snapshotEdgeValues(now: number): RuntimeEdge[] {
     const terminalSessions = new Map(this.db.query<{
       id: string;
       last_changed_at: number | null;
     }, [string, string, string]>(`
-      SELECT session.id, event.created_at AS last_changed_at
+      SELECT session.id, session.updated_at AS last_changed_at
       FROM entities AS session
-      LEFT JOIN events AS event ON event.seq = session.checkpoint_seq
       WHERE session.kind = ?
         AND json_extract(session.state_json, '$.host') IN (?, ?)
     `).all("session", "dead", "unhosted").map((row) => [row.id, row.last_changed_at]));
 
     return this.entityValues<RuntimeEdge>("edge").filter((edge) => {
       if (!terminalSessions.has(edge.childConversationId)) return true;
-      const edgeCreatedAt = Date.parse(edge.createdAt);
-      // Compacted legacy sessions have no event row left for checkpoint_seq;
-      // their immutable lineage edge is the remaining durable age evidence.
-      const lastChangedAt = terminalSessions.get(edge.childConversationId)
-        ?? (Number.isFinite(edgeCreatedAt) ? edgeCreatedAt : null);
-      return lastChangedAt === null || lastChangedAt >= cutoff;
+      const lastChangedAt = terminalSessions.get(edge.childConversationId);
+      return lastChangedAt === null
+        || lastChangedAt === undefined
+        || now <= lastChangedAt + RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS;
     });
+  }
+
+  private snapshotEdgeExpiry(now: number): number | null {
+    return this.db.query<{ expires_at: number | null }, [number, string, string, number, number]>(`
+      SELECT MIN(session.updated_at + ? + 1) AS expires_at
+      FROM entities AS edge
+      JOIN entities AS session
+        ON session.kind = 'session'
+        AND session.id = json_extract(edge.state_json, '$.childConversationId')
+      WHERE edge.kind = 'edge'
+        AND json_extract(session.state_json, '$.host') IN (?, ?)
+        AND session.updated_at + ? >= ?
+    `).get(
+      RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS,
+      "dead",
+      "unhosted",
+      RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS,
+      now,
+    )?.expires_at ?? null;
   }
 
   private snapshotDeploymentValues(): ViewerDeploymentStatus[] {
@@ -2020,7 +2045,15 @@ export class RuntimeJournal {
   }
 
   private upsertEntity(kind: string, id: string, revision: number, value: unknown, seq: number): void {
-    this.db.query("INSERT INTO entities(kind, id, revision, state_json, checkpoint_seq) VALUES (?, ?, ?, ?, ?) ON CONFLICT(kind, id) DO UPDATE SET revision=excluded.revision, state_json=excluded.state_json, checkpoint_seq=excluded.checkpoint_seq").run(kind, id, revision, stableJson(value), seq);
+    this.db.query(`
+      INSERT INTO entities(kind, id, revision, state_json, checkpoint_seq, updated_at)
+      VALUES (?, ?, ?, ?, ?, (SELECT created_at FROM events WHERE seq = ?))
+      ON CONFLICT(kind, id) DO UPDATE SET
+        revision = excluded.revision,
+        state_json = excluded.state_json,
+        checkpoint_seq = excluded.checkpoint_seq,
+        updated_at = excluded.updated_at
+    `).run(kind, id, revision, stableJson(value), seq, seq);
   }
 
   private insertEffect(effect: RuntimeEffect, seq: number): void {
@@ -2156,6 +2189,19 @@ export class RuntimeJournal {
       UPDATE events SET producer_kind = 'viewer-compat' WHERE producer_kind IS NULL;
       UPDATE events SET causation_id = operation_id WHERE causation_id IS NULL AND operation_id IS NOT NULL;
     `);
+  }
+
+  private migrateEntityUpdatedAt(): void {
+    const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(entities)").all().map((row) => row.name));
+    if (!columns.has("updated_at")) this.db.exec("ALTER TABLE entities ADD COLUMN updated_at INTEGER");
+    this.db.query(`
+      UPDATE entities
+      SET updated_at = COALESCE(
+        (SELECT created_at FROM events WHERE events.seq = entities.checkpoint_seq),
+        ?
+      )
+      WHERE updated_at IS NULL
+    `).run(this.now());
   }
 
   private meta(key: string): string {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -52,6 +52,8 @@ import { runtimeImageCapability } from "@/lib/runtime/runtimeImageStore";
 export class RuntimeJournalFault extends Error {}
 
 export const RUNTIME_SNAPSHOT_INACTIVE_SESSION_LIMIT = 128;
+export const RUNTIME_SNAPSHOT_TERMINAL_DEPLOYMENT_LIMIT = 50;
+export const RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
 
 type EventRow = {
   seq: number;
@@ -725,23 +727,23 @@ export class RuntimeJournal {
         filesRevision: Number(this.meta("files_revision")),
         sessions: this.snapshotSessionValues().map((session) => ({
           ...session,
-          // A terminal host has no live stream to resume. The durable entity
-          // retains its audit state while the browser snapshot drops transient
-          // text that can otherwise dominate every reconnect frame.
-          ...((session.host === "dead" || session.host === "unhosted")
-            ? { liveTurn: null }
-            : {}),
+          // Only a running turn has live text to resume. Re-normalizing here
+          // also caps legacy rows to the 64 KiB UTF-8 tail; omittedChars is the
+          // explicit marker that lets consumers disclose the clipped prefix.
+          liveTurn: session.turn === "running"
+            ? normalizeRuntimeLiveTurn(session.liveTurn)
+            : null,
           recentReceipts: visibleReceipts(session.recentReceipts).map(runtimePresentationReceipt),
         })),
         attentions: this.entityValues<RuntimeAttention>("attention"),
         recentOperations: visibleReceipts(
           this.recentEntityValues<RuntimeOperationReceipt>("operation", 100),
         ).map(runtimePresentationReceipt),
-        edges: this.entityValues<RuntimeEdge>("edge"),
+        edges: this.snapshotEdgeValues(),
         flows: this.scopedValues<RuntimeSnapshot["flows"][number]["value"]>("flow"),
         workflows: this.scopedValues<RuntimeSnapshot["workflows"][number]["value"]>("workflow"),
         tasks: this.scopedValues<RuntimeSnapshot["tasks"][number]["value"]>("task"),
-        deployments: this.entityValues<ViewerDeploymentStatus>("deployment"),
+        deployments: this.snapshotDeploymentValues(),
       };
       this.db.exec("COMMIT");
       return snapshot;
@@ -1961,6 +1963,50 @@ export class RuntimeJournal {
     return [...active, ...inactive]
       .map((row) => JSON.parse(row.state_json) as RuntimeSession)
       .sort((left, right) => left.conversationId.localeCompare(right.conversationId));
+  }
+
+  private snapshotEdgeValues(): RuntimeEdge[] {
+    const cutoff = this.now() - RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS;
+    const terminalSessions = new Map(this.db.query<{
+      id: string;
+      last_changed_at: number | null;
+    }, [string, string, string]>(`
+      SELECT session.id, event.created_at AS last_changed_at
+      FROM entities AS session
+      LEFT JOIN events AS event ON event.seq = session.checkpoint_seq
+      WHERE session.kind = ?
+        AND json_extract(session.state_json, '$.host') IN (?, ?)
+    `).all("session", "dead", "unhosted").map((row) => [row.id, row.last_changed_at]));
+
+    return this.entityValues<RuntimeEdge>("edge").filter((edge) => {
+      if (!terminalSessions.has(edge.childConversationId)) return true;
+      const edgeCreatedAt = Date.parse(edge.createdAt);
+      // Compacted legacy sessions have no event row left for checkpoint_seq;
+      // their immutable lineage edge is the remaining durable age evidence.
+      const lastChangedAt = terminalSessions.get(edge.childConversationId)
+        ?? (Number.isFinite(edgeCreatedAt) ? edgeCreatedAt : null);
+      return lastChangedAt === null || lastChangedAt >= cutoff;
+    });
+  }
+
+  private snapshotDeploymentValues(): ViewerDeploymentStatus[] {
+    const nonTerminal = this.db.query<{ state_json: string }, [string]>(`
+      SELECT state_json
+      FROM entities
+      WHERE kind = ?
+        AND COALESCE(json_extract(state_json, '$.terminal'), 0) != 1
+    `).all("deployment");
+    const terminal = this.db.query<{ state_json: string }, [string, number]>(`
+      SELECT state_json
+      FROM entities
+      WHERE kind = ?
+        AND json_extract(state_json, '$.terminal') = 1
+      ORDER BY checkpoint_seq DESC, id DESC
+      LIMIT ?
+    `).all("deployment", RUNTIME_SNAPSHOT_TERMINAL_DEPLOYMENT_LIMIT);
+    return [...nonTerminal, ...terminal]
+      .map((row) => JSON.parse(row.state_json) as ViewerDeploymentStatus)
+      .sort((left, right) => left.deploymentId.localeCompare(right.deploymentId));
   }
 
   private recentEntityValues<T>(kind: string, limit: number): T[] {


### PR DESCRIPTION
## Summary

- emit `liveTurn` only while the session turn is actively running
- normalize running legacy live turns to the 64 KiB UTF-8 tail and retain the existing `omittedChars` marker
- retain every non-terminal deployment plus the 50 newest terminal deployments in the frame
- omit lineage edges after seven days of terminal child-session inactivity while preserving durable rows
- keep the `total_changes` snapshot cache behavior unchanged

## Verification

- `bun test src/runtime-host/journal.test.ts` — 72 passed
- `bunx tsc --noEmit --incremental false`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main) --check-commits`

Refs #1145