### PR TITLE
feat(orchestrator): per-project dock open state and instant project switching (#1149)

### DIFF
--- a/src/components/Viewer.orchestratorDock.dom.test.tsx
+++ b/src/components/Viewer.orchestratorDock.dom.test.tsx
@@ -8,6 +8,10 @@ import { createRoot } from "react-dom/client";
  * layout between the project rail and the board — never an overlay — it follows
  * whichever project the rail has selected, it does not exist on the Overview
  * (which is not a project and has no seat), and its open state survives reload.
+ *
+ * That open state is the PROJECT's since #1149: each project answers under its
+ * own key, the pre-#1149 global flag only seeds a project that never answered,
+ * and closing the dock in one project leaves every other project's alone.
  */
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -69,7 +73,8 @@ mock.module("@/hooks/runtimeBus", () => ({
 
 const { Viewer } = await import("./Viewer");
 const { resetFilesClientCacheForTests } = await import("@/hooks/useFiles");
-const { OPEN_KEY } = await import("./orchestrator/OrchestratorDock");
+const { LEGACY_OPEN_KEY } = await import("./orchestrator/OrchestratorDock");
+const openKey = (project: string) => `${LEGACY_OPEN_KEY}:${project}`;
 
 const PROJECT = "atlas";
 const OTHER = "borealis";
@@ -126,9 +131,24 @@ function dock(host: HTMLElement): HTMLElement | null {
   return host.querySelector("[data-orchestrator-dock]");
 }
 
+/** Present or not, as a boolean: a failing `toBeNull()` on a happy-dom element
+    prints the whole node graph, which is megabytes of noise around one bit. */
+const hasDock = (host: HTMLElement) => dock(host) !== null;
+
+/** Selecting a project the way the rail does — through the hash, which is also
+    what a reload of a project URL replays. Explicit, because a test that
+    inherits the previous one's hash is a test of the Overview. */
+async function goTo(project: string): Promise<void> {
+  await act(async () => {
+    dom.location.hash = `#p=${encodeURIComponent(project)}`;
+    dom.dispatchEvent(new dom.Event("hashchange"));
+  });
+  await act(async () => { await Bun.sleep(20); });
+}
+
 test("a stored open state restores the dock, pushed into the layout between the rail and the board", async () => {
   dom.localStorage.setItem("llvProject", PROJECT);
-  dom.localStorage.setItem(OPEN_KEY, "1");
+  dom.localStorage.setItem(openKey(PROJECT), "1");
 
   const host = await mountViewer();
 
@@ -148,7 +168,7 @@ test("a stored open state restores the dock, pushed into the layout between the 
 });
 
 test("the Overview has no orchestrator dock, even with the panel remembered open", async () => {
-  dom.localStorage.setItem(OPEN_KEY, "1");
+  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
 
   const host = await mountViewer();
 
@@ -167,26 +187,68 @@ test("the header button toggles the dock and the choice survives a reload", asyn
 
   await act(async () => { toggle.click(); });
   expect(dock(host)).not.toBeNull();
-  expect(dom.localStorage.getItem(OPEN_KEY)).toBe("1");
+  /* Under the project's own key, and the pre-#1149 global flag is left exactly
+     as the operator had it — it seeds, it is never written. */
+  expect(dom.localStorage.getItem(openKey(PROJECT))).toBe("1");
+  expect(dom.localStorage.getItem(LEGACY_OPEN_KEY)).toBeNull();
   expect((host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).getAttribute("aria-pressed")).toBe("true");
 
   await act(async () => { (host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).click(); });
   expect(dock(host)).toBeNull();
-  expect(dom.localStorage.getItem(OPEN_KEY)).toBe("0");
+  expect(dom.localStorage.getItem(openKey(PROJECT))).toBe("0");
 });
 
 test("the dock follows the selected project", async () => {
   dom.localStorage.setItem("llvProject", PROJECT);
-  dom.localStorage.setItem(OPEN_KEY, "1");
+  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
 
   const host = await mountViewer();
   expect(dock(host)!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(PROJECT);
 
-  await act(async () => {
-    dom.location.hash = `#p=${encodeURIComponent(OTHER)}`;
-    dom.dispatchEvent(new dom.Event("hashchange"));
-  });
-  await act(async () => { await Bun.sleep(20); });
+  await goTo(OTHER);
 
   expect(dock(host)!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(OTHER);
+});
+
+test("closing the dock in one project leaves the other project's open", async () => {
+  /* Both projects open, from the one flag an operator carries in (#1149 seed). */
+  dom.localStorage.setItem("llvProject", PROJECT);
+  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
+
+  const host = await mountViewer();
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(true);
+
+  /* The operator closes it in the project they are only glancing at... */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(true);
+  await act(async () => { (host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).click(); });
+  expect(hasDock(host)).toBe(false);
+  expect(dom.localStorage.getItem(openKey(OTHER))).toBe("0");
+
+  /* ...and the project they are running still has its dock. */
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(true);
+  expect(dock(host)!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(PROJECT);
+  expect(dom.localStorage.getItem(openKey(PROJECT))).toBeNull();
+
+  /* Back again: still closed where it was closed, and nothing wrote the seed. */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(false);
+  expect(dom.localStorage.getItem(LEGACY_OPEN_KEY)).toBe("1");
+});
+
+test("a project's own answer outranks the pre-#1149 global flag", async () => {
+  dom.localStorage.setItem("llvProject", PROJECT);
+  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
+  /* Closed here, and the seed says «open»: the project that answered wins. */
+  dom.localStorage.setItem(openKey(PROJECT), "0");
+
+  const host = await mountViewer();
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(false);
+
+  /* The seed still answers for the project that never has. */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(true);
 });

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -33,7 +33,7 @@ import { focusHandoffBus } from "./attention/focusHandoffBus";
 import { ConnectionPill } from "./ConnectionPill";
 import { resolveFavoriteRows, type FavoriteRow } from "./favorites/favoriteRows";
 import { KeepAwakeProvider } from "./KeepAwakeControl";
-import { OrchestratorDock, OPEN_KEY as ORCHESTRATOR_OPEN_KEY } from "./orchestrator/OrchestratorDock";
+import { OrchestratorDock, dockOpenFor, rememberDockOpen } from "./orchestrator/OrchestratorDock";
 import { OverviewBoard } from "./OverviewBoard";
 import { GlobalSearch, transcriptFocusHash } from "./search/GlobalSearch";
 import { ProjectDashboard, queueColumnOpen } from "./ProjectDashboard";
@@ -206,10 +206,19 @@ export function Viewer() {
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState(false);
   /* The per-project orchestrator dock (PRD #976 slice A). Its open state is the
-     operator's, persisted like the panel's width; the server render and the
-     first client render agree on «closed», and the mount effect below applies
-     what was stored — the same shape the project restore uses. */
+     operator's and belongs to the PROJECT (#1149), exactly as the dock's width
+     does (#1011): the server render and the first client render agree on
+     «closed» (the Overview, which has no dock), and every project that comes
+     after answers for itself in the render below. */
   const [orchestratorOpen, setOrchestratorOpen] = useState(false);
+  /* The project the open state above was read for. A switch re-reads during
+     render, so the dock the operator closed in one project stays closed there
+     and nowhere else, with no frame of the previous project's answer. */
+  const [orchestratorOpenProject, setOrchestratorOpenProject] = useState(OVERVIEW);
+  if (orchestratorOpenProject !== project) {
+    setOrchestratorOpenProject(project);
+    setOrchestratorOpen(dockOpenFor(project));
+  }
   /* The ONE global message search (issue #1054). It is shell state, not board
      state: the same overlay answers from the overview, from any project and on
      the phone, and it unmounts on close so every open starts on «my messages»
@@ -260,8 +269,9 @@ export function Viewer() {
     const initial = readHash();
     if (initial.filePath || initial.conversationId) setPendingHash(initial);
     const savedProject = initial.project ?? localStorage.getItem(PROJECT_KEY);
+    /* The restored project answers for its own dock through the same
+       per-project read a later switch uses — see `orchestratorOpenProject`. */
     if (savedProject) setProject(savedProject);
-    if (localStorage.getItem(ORCHESTRATOR_OPEN_KEY) === "1") setOrchestratorOpen(true);
     if (!recognizedFragment(location.hash)) setUnknownFragmentNotice(true);
   }, []);
 
@@ -378,20 +388,16 @@ export function Viewer() {
     recordProjectNavigation(projectUrl(nextProject));
   }, [applyProject]);
 
-  /* The dock FOLLOWS the selected project rather than belonging to one: the
-     open state is a device preference, and the panel re-seats itself on
-     whichever project the rail is showing. */
+  /* Opening or closing the dock is a statement about THIS project (#1149): it
+     is remembered under the project's own key, so the projects the operator is
+     not looking at keep the dock exactly as they had it. */
   const toggleOrchestrator = useCallback(() => {
     setOrchestratorOpen((open) => {
       const next = !open;
-      try {
-        localStorage.setItem(ORCHESTRATOR_OPEN_KEY, next ? "1" : "0");
-      } catch {
-        /* private mode */
-      }
+      rememberDockOpen(project, next);
       return next;
     });
-  }, []);
+  }, [project]);
 
   /* The overview board has no project view state to report: presence publishes
      the overview context/slice here, and ProjectDashboard takes over the moment

--- a/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
@@ -93,9 +93,8 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 beforeEach(() => {
-  /* The seat answer is cached per project for the session (#1149), so each test
-     starts as a tab that has never read this project's seat — otherwise the
-     row opens on the answer the test before it was given. */
+  /* Each test is a tab that has never read this project's seat; the answer is
+     cached per project for the session since #1149. */
   resetOrchestratorSeatCacheForTests();
   requests.length = 0;
   seatAnswer = { seat: null, pending: null, exists: true };

--- a/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
@@ -58,6 +58,7 @@ mock.module("@/hooks/useLogTail", () => ({
 }));
 
 const { MobileFocusView } = await import("./MobileFocusView");
+const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
 
 interface SeatAnswer { seat: unknown; pending: unknown; exists: boolean }
 interface Recorded { url: string; method: string; body: Record<string, unknown> }
@@ -92,6 +93,10 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 beforeEach(() => {
+  /* The seat answer is cached per project for the session (#1149), so each test
+     starts as a tab that has never read this project's seat — otherwise the
+     row opens on the answer the test before it was given. */
+  resetOrchestratorSeatCacheForTests();
   requests.length = 0;
   seatAnswer = { seat: null, pending: null, exists: true };
   postSeat = async () => new Response(JSON.stringify({ ok: true, state: "starting" }), { status: 200, headers: { "content-type": "application/json" } });

--- a/src/components/orchestrator/OrchestratorDock.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorDock.dom.test.tsx
@@ -52,7 +52,7 @@ mock.module("@/hooks/useRuntime", () => ({
 
 const {
   OrchestratorDock,
-  LEGACY_OPEN_KEY,
+  OPEN_KEY,
   MIN_WIDTH,
   MIN_BOARD,
   DEFAULT_WIDTH,
@@ -422,7 +422,7 @@ test("open and closed are the project's own, and the legacy global flag seeds a 
 
   /* What an operator carries in from before #1149: ONE flag for every project.
      It seeds them all, so a dock left open stays open everywhere. */
-  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
+  dom.localStorage.setItem(OPEN_KEY, "1");
   expect(dockOpenFor("atlas")).toBe(true);
   expect(dockOpenFor("borealis")).toBe(true);
 
@@ -435,7 +435,7 @@ test("open and closed are the project's own, and the legacy global flag seeds a 
   /* ...and only that project's. Atlas still reads the seed, and the seed is
      never written to. */
   expect(dockOpenFor("atlas")).toBe(true);
-  expect(dom.localStorage.getItem(LEGACY_OPEN_KEY)).toBe("1");
+  expect(dom.localStorage.getItem(OPEN_KEY)).toBe("1");
 
   /* Two projects, two independent answers. */
   rememberDockOpen("atlas", false);

--- a/src/components/orchestrator/OrchestratorDock.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorDock.dom.test.tsx
@@ -12,6 +12,9 @@ import { emptyStore } from "@/components/runtime/runtimeModel";
  * the document preview sheet open on the other side. Since #1011 that width is
  * remembered PER PROJECT, so a mandate-heavy dock in one project leaves every
  * other project's dock the size the operator left it.
+ *
+ * Since #1149 the OPEN state is the project's too, on the same terms: its own
+ * key, seeded once from the single global flag operators carry in.
  */
 
 const dom = new HappyWindow();
@@ -49,12 +52,15 @@ mock.module("@/hooks/useRuntime", () => ({
 
 const {
   OrchestratorDock,
+  LEGACY_OPEN_KEY,
   MIN_WIDTH,
   MIN_BOARD,
   DEFAULT_WIDTH,
   RAIL_WIDTH,
   RESERVED_BESIDE_DOCK,
+  dockOpenFor,
   dockWidthForPointer,
+  rememberDockOpen,
   storedDockWidth,
 } = await import("./OrchestratorDock");
 const { leftShellInset } = await import("../shellLayout");
@@ -408,4 +414,32 @@ test("the published row and the committed width change in the same frame", () =>
   expect(seen.at(-1)).toEqual({ width: "900", inset: RAIL_WIDTH + 900 });
   expect(visibleBoard(1_920, 900)).toBeGreaterThanOrEqual(MIN_BOARD);
   expect(1_920 - RAIL_WIDTH - 900 - sheetWidth(1_920, RAIL_WIDTH + 400)).toBeLessThan(MIN_BOARD);
+});
+
+test("open and closed are the project's own, and the legacy global flag seeds a project that has never answered", () => {
+  /* Never opened, never closed, nothing carried in: closed. */
+  expect(dockOpenFor("atlas")).toBe(false);
+
+  /* What an operator carries in from before #1149: ONE flag for every project.
+     It seeds them all, so a dock left open stays open everywhere. */
+  dom.localStorage.setItem(LEGACY_OPEN_KEY, "1");
+  expect(dockOpenFor("atlas")).toBe(true);
+  expect(dockOpenFor("borealis")).toBe(true);
+
+  /* An answer of its own outranks the seed — «closed» included, which is the
+     whole point: closing the dock in a project the operator only glances at
+     must survive a seed that says «open». */
+  rememberDockOpen("borealis", false);
+  expect(dom.localStorage.getItem("llvOrchestratorPanelOpen:borealis")).toBe("0");
+  expect(dockOpenFor("borealis")).toBe(false);
+  /* ...and only that project's. Atlas still reads the seed, and the seed is
+     never written to. */
+  expect(dockOpenFor("atlas")).toBe(true);
+  expect(dom.localStorage.getItem(LEGACY_OPEN_KEY)).toBe("1");
+
+  /* Two projects, two independent answers. */
+  rememberDockOpen("atlas", false);
+  rememberDockOpen("borealis", true);
+  expect(dockOpenFor("atlas")).toBe(false);
+  expect(dockOpenFor("borealis")).toBe(true);
 });

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -17,14 +17,16 @@ const LEGACY_WIDTH_KEY = "llvOrchestratorPanelWidth";
     dragged wide for a mandate-heavy project must not resize every other one. */
 const widthKey = (project: string) => `${LEGACY_WIDTH_KEY}:${project}`;
 /** The open/closed flag every project shared before #1149, now the same kind of
-    seed the width is: a project that has never been opened or closed answers
-    with it, so an operator coming from the single global preference finds the
-    dock where they left it everywhere. Nothing writes it. */
-export const LEGACY_OPEN_KEY = "llvOrchestratorPanelOpen";
+    seed `LEGACY_WIDTH_KEY` is: a project that has never been opened or closed
+    answers with it, so an operator coming from the single global preference
+    finds the dock where they left it everywhere. Nothing writes it. It keeps
+    its pre-#1149 name because it is the same key holding the same value — only
+    its role narrowed. */
+export const OPEN_KEY = "llvOrchestratorPanelOpen";
 /** One project's own open state (#1149). The dock is a per-project surface —
     closing it in a project the operator only glances at must not close it in
     the one they are running. */
-const openKey = (project: string) => `${LEGACY_OPEN_KEY}:${project}`;
+const projectOpenKey = (project: string) => `${OPEN_KEY}:${project}`;
 
 export const MIN_WIDTH = 360;
 export const DEFAULT_WIDTH = 440;
@@ -73,13 +75,13 @@ function projectDockWidth(project: string): number {
     the seed — a project that has answered for itself outranks it, «closed»
     included. */
 export function dockOpenFor(project: string): boolean {
-  return (readStorage(openKey(project)) ?? readStorage(LEGACY_OPEN_KEY)) === "1";
+  return (readStorage(projectOpenKey(project)) ?? readStorage(OPEN_KEY)) === "1";
 }
 
 /** Remember what the operator just did to THIS project's dock. */
 export function rememberDockOpen(project: string, open: boolean): void {
   try {
-    window.localStorage.setItem(openKey(project), open ? "1" : "0");
+    window.localStorage.setItem(projectOpenKey(project), open ? "1" : "0");
   } catch {
     /* private mode */
   }

--- a/src/components/orchestrator/OrchestratorDock.tsx
+++ b/src/components/orchestrator/OrchestratorDock.tsx
@@ -16,7 +16,15 @@ const LEGACY_WIDTH_KEY = "llvOrchestratorPanelWidth";
 /** One project's own width (#1011). Projects are isolated surfaces — a dock
     dragged wide for a mandate-heavy project must not resize every other one. */
 const widthKey = (project: string) => `${LEGACY_WIDTH_KEY}:${project}`;
-export const OPEN_KEY = "llvOrchestratorPanelOpen";
+/** The open/closed flag every project shared before #1149, now the same kind of
+    seed the width is: a project that has never been opened or closed answers
+    with it, so an operator coming from the single global preference finds the
+    dock where they left it everywhere. Nothing writes it. */
+export const LEGACY_OPEN_KEY = "llvOrchestratorPanelOpen";
+/** One project's own open state (#1149). The dock is a per-project surface —
+    closing it in a project the operator only glances at must not close it in
+    the one they are running. */
+const openKey = (project: string) => `${LEGACY_OPEN_KEY}:${project}`;
 
 export const MIN_WIDTH = 360;
 export const DEFAULT_WIDTH = 440;
@@ -58,6 +66,23 @@ function readStorage(key: string): string | null {
     that has been sized answers for itself, nonsense included. */
 function projectDockWidth(project: string): number {
   return storedDockWidth(() => readStorage(widthKey(project)) ?? readStorage(LEGACY_WIDTH_KEY));
+}
+
+/** Whether the dock opens for `project`: its own remembered answer, else the
+    pre-#1149 global one as a seed, else closed. Only ABSENCE falls through to
+    the seed — a project that has answered for itself outranks it, «closed»
+    included. */
+export function dockOpenFor(project: string): boolean {
+  return (readStorage(openKey(project)) ?? readStorage(LEGACY_OPEN_KEY)) === "1";
+}
+
+/** Remember what the operator just did to THIS project's dock. */
+export function rememberDockOpen(project: string, open: boolean): void {
+  try {
+    window.localStorage.setItem(openKey(project), open ? "1" : "0");
+  } catch {
+    /* private mode */
+  }
 }
 
 /** Width the drag lands on for a pointer at `clientX`, given the viewport. */
@@ -181,7 +206,16 @@ export function OrchestratorDock({
           and the idempotency key of an unsettled confirm — belongs to ONE
           project. The dock survives the switch, resized to the new project's
           own remembered width; the panel is re-seated on it and reads that
-          project's own stored draft. */}
+          project's own stored draft.
+
+          The key STAYS, and instant switching (#1149) is bought outside the
+          subtree instead: the seat and incumbent hooks keep this tab's answers
+          in a map keyed by project, and the feed keeps its own per-path
+          transcript snapshot (`useLogTail`), so the re-seated panel paints the
+          project's live conversation in its first commit and revalidates
+          behind it. Dropping the key would keep the subtree alive but leave
+          five pieces of one project's draft state on another project's panel —
+          a much larger change for the same paint. */}
       <OrchestratorPanel
         key={project}
         project={project}

--- a/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
@@ -57,16 +57,23 @@ mock.module("@/hooks/useRuntime", () => ({
   useRuntimeReceiptsForArtifact: () => [],
   useRuntimeFlow: () => null,
 }));
+/** What the feed already holds for a path. The real hook keeps exactly this —
+    a browser-wide per-path snapshot of the tail (`useLogTail`'s own cache),
+    read synchronously on mount — which is why a re-seated conversation view
+    repaints a transcript this tab has already read (#1149). */
+const tailLines = new Map<string, string[]>();
 mock.module("@/hooks/useLogTail", () => ({
-  useLogTail: () => ({
-    lines: [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null,
+  ...actualLogTail,
+  useLogTail: (file: FileEntry | null) => ({
+    lines: (file && tailLines.get(file.path)) ?? [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null,
     paused: false, setPaused: () => undefined, clear: () => undefined,
     hasMore: false, loadingOlder: false, loadOlder: async () => 0, prependGen: 0,
   }),
 }));
 
 const { OrchestratorPanel } = await import("./OrchestratorPanel");
-const { SEAT_POLL_MS } = await import("./useOrchestratorSeat");
+const { SEAT_POLL_MS, resetOrchestratorSeatCacheForTests } = await import("./useOrchestratorSeat");
+const { resetOrchestratorIncumbentCacheForTests } = await import("./useOrchestratorIncumbent");
 
 const accounts = {
   claude: { active: "primary", accounts: [{ id: "primary", label: "primary", authPresent: true }, { id: "spare", label: "spare", authPresent: true }] },
@@ -107,13 +114,20 @@ function installFetch(): void {
       rotatePosts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
       return answer(rotateResponses);
     }
+    /* Both reads are per-project, and only atlas has an orchestrator here, so
+       a switch away genuinely lands on another project's own answer. */
     if (url.startsWith("/api/orchestrator/seat/status")) {
-      return { ok: true, status: 200, json: async () => incumbentStatus } as Response;
+      const target = new URL(url, "http://localhost").searchParams.get("project");
+      return { ok: true, status: 200, json: async () => (target === "atlas" ? incumbentStatus : { project: target, designated: false, rotation: null, context: null }) } as Response;
     }
     if (url.startsWith("/api/orchestrator/seat?")) {
-      return { ok: true, status: 200, json: async () => seatStatus } as Response;
+      const target = new URL(url, "http://localhost").searchParams.get("project");
+      return { ok: true, status: 200, json: async () => (target === "atlas" ? seatStatus : { seat: null, pending: null, exists: true }) } as Response;
     }
     if (url === "/api/accounts") return { ok: true, status: 200, json: async () => accounts } as Response;
+    /* No voice backend in a DOM test, so a transcript's speak control renders
+       nothing rather than reading a shape the catch-all below cannot supply. */
+    if (url.startsWith("/api/tts/")) return { ok: false, status: 404, json: async () => ({}) } as Response;
     if (url.startsWith("/api/spawn")) {
       spawnPosts += 1;
       return { ok: true, status: 200, json: async () => ({}) } as Response;
@@ -192,6 +206,11 @@ const orchestratorFile: FileEntry = {
 
 const roots = new Set<Root>();
 beforeEach(() => {
+  /* Both answer caches are this TAB's memory (#1149), so each test starts as a
+     tab that has never read a seat. */
+  resetOrchestratorSeatCacheForTests();
+  resetOrchestratorIncumbentCacheForTests();
+  tailLines.clear();
   seatStatus = { seat: null, pending: null, exists: true };
   incumbentStatus = { project: "atlas", designated: false, rotation: null, context: null };
   seatPosts = [];
@@ -238,6 +257,28 @@ function remount(files: FileEntry[] = []): HTMLElement {
   roots.clear();
   dom.document.body.replaceChildren();
   return mount(files);
+}
+
+/** One dock's panel across a project switch: the SAME root, the panel re-seated
+    under `key={project}` exactly as `OrchestratorDock` mounts it. */
+function mountDock(files: FileEntry[]) {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  return {
+    host: host as unknown as HTMLElement,
+    open: (project: string) => flushSync(() => root.render(
+      <OrchestratorPanel
+        key={project}
+        project={project}
+        projectName={project}
+        projectCwd={`/repos/${project}`}
+        files={files}
+        onClose={() => undefined}
+      />,
+    )),
+  };
 }
 
 function panelState(host: HTMLElement): string | null {
@@ -891,3 +932,41 @@ test("the draft a closed conversation returns to can actually create — it says
   await settle();
   expect(seatPosts[0]!.replaceIncumbent).toBeUndefined();
 }, SEAT_POLL_MS + 4_000);
+
+test("coming back to a project paints its conversation in the first commit, transcript and all", async () => {
+  seatStatus = { seat: activeSeat(), pending: null, exists: true };
+  incumbentStatus = incumbent();
+  tailLines.set(orchestratorFile.path, [
+    JSON.stringify({ type: "assistant", uuid: "uuid-atlas-1", timestamp: "2026-08-13T10:05:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "Atlas mandate accepted." }] } }),
+  ]);
+
+  const dock = mountDock([orchestratorFile]);
+  dock.open("atlas");
+  await settle();
+  flushSync(() => undefined);
+  expect(panelState(dock.host)).toBe("live");
+  expect(dock.host.querySelector('[data-orchestrator-conversation="conversation_orch"]')).not.toBeNull();
+  expect(dock.host.textContent).toContain("Atlas mandate accepted.");
+
+  /* A project with no orchestrator of its own: its own draft, its own read. */
+  dock.open("borealis");
+  await settle();
+  expect(panelState(dock.host)).toBe("draft");
+
+  /* Back to atlas. Nothing is awaited: this is the frame the switch itself
+     produced, so no round trip can have contributed to it. The conversation is
+     mounted on the same file with the transcript it was left showing — never
+     a loading state, never a blank column that fills in a moment later. */
+  dock.open("atlas");
+  expect(panelState(dock.host)).toBe("live");
+  expect(dock.host.querySelector('[data-orchestrator-conversation="conversation_orch"]')).not.toBeNull();
+  expect(dock.host.textContent).toContain("Atlas mandate accepted.");
+  /* The incumbent header is whole too — the model is read, not degraded to the
+     dash a fresh 60s-cadence status read would leave for a minute. */
+  expect(dock.host.textContent).toContain("opus");
+
+  /* The poll behind that paint still runs, and lands in place. */
+  seatStatus = { seat: activeSeat({ conversationId: "conversation_successor", path: "/transcripts/successor.jsonl" }), pending: null, exists: true };
+  await settle();
+  expect(panelState(dock.host)).toBe("live");
+});

--- a/src/components/orchestrator/dockOpenState.dom.test.tsx
+++ b/src/components/orchestrator/dockOpenState.dom.test.tsx
@@ -4,10 +4,14 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 
 /*
- * The dock's place in the shell (issue #977 acceptance): it is PUSHED INTO the
- * layout between the project rail and the board — never an overlay — it follows
- * whichever project the rail has selected, it does not exist on the Overview
- * (which is not a project and has no seat), and its open state survives reload.
+ * The dock's open state is the PROJECT's (issue #1149), asserted where the
+ * operator meets it: the real shell, switching projects through the rail.
+ *
+ * `OrchestratorDock.dom.test.tsx` covers the storage contract itself —
+ * `dockOpenFor` / `rememberDockOpen`, their keys and the seed. What only a
+ * mounted `Viewer` can prove is that a SWITCH re-reads it: the dock the
+ * operator closed in a project they were glancing at must still be closed when
+ * they come back to it, and must never have touched the project they left.
  */
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -67,12 +71,13 @@ mock.module("@/hooks/runtimeBus", () => ({
   }),
 }));
 
-const { Viewer } = await import("./Viewer");
+const { Viewer } = await import("../Viewer");
 const { resetFilesClientCacheForTests } = await import("@/hooks/useFiles");
-const { OPEN_KEY } = await import("./orchestrator/OrchestratorDock");
+const { OPEN_KEY } = await import("./OrchestratorDock");
 
 const PROJECT = "atlas";
 const OTHER = "borealis";
+const openKey = (project: string) => `${OPEN_KEY}:${project}`;
 const originalFetch = globalThis.fetch;
 
 function stubFetch(): void {
@@ -122,73 +127,68 @@ async function mountViewer(): Promise<HTMLElement> {
   return host as unknown as HTMLElement;
 }
 
-function dock(host: HTMLElement): HTMLElement | null {
-  return host.querySelector("[data-orchestrator-dock]");
-}
+/** Present or not, as a boolean: a failing `toBeNull()` on a happy-dom element
+    prints the whole node graph, which is megabytes of noise around one bit. */
+const hasDock = (host: HTMLElement) => host.querySelector("[data-orchestrator-dock]") !== null;
+const seatedOn = (host: HTMLElement) =>
+  host.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel") ?? null;
+const toggle = (host: HTMLElement) => host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement;
 
-test("a stored open state restores the dock, pushed into the layout between the rail and the board", async () => {
-  dom.localStorage.setItem("llvProject", PROJECT);
-  dom.localStorage.setItem(OPEN_KEY, "1");
-
-  const host = await mountViewer();
-
-  const panel = dock(host);
-  expect(panel).not.toBeNull();
-  expect(panel!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(PROJECT);
-
-  /* In the layout, not over it: the shell row is rail → dock → main, and the
-     dock is a plain flex sibling with no fixed/absolute positioning. */
-  const shell = panel!.parentElement!;
-  const children = [...shell.children];
-  const rail = shell.querySelector("aside:not([data-orchestrator-dock])");
-  expect(children.indexOf(panel!)).toBeGreaterThan(children.indexOf(rail as Element));
-  expect(children.indexOf(panel!)).toBeLessThan(children.indexOf(shell.querySelector("main") as Element));
-  expect(panel!.className).not.toContain("fixed");
-  expect(panel!.className).not.toContain("absolute");
-});
-
-test("the Overview has no orchestrator dock, even with the panel remembered open", async () => {
-  dom.localStorage.setItem(OPEN_KEY, "1");
-
-  const host = await mountViewer();
-
-  expect(dock(host)).toBeNull();
-});
-
-test("the header button toggles the dock and the choice survives a reload", async () => {
-  dom.localStorage.setItem("llvProject", PROJECT);
-
-  const host = await mountViewer();
-  expect(dock(host)).toBeNull();
-
-  const toggle = host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement;
-  expect(toggle).not.toBeNull();
-  expect(toggle.getAttribute("aria-pressed")).toBe("false");
-
-  await act(async () => { toggle.click(); });
-  expect(dock(host)).not.toBeNull();
-  /* Under the PROJECT's own key since #1149; `OPEN_KEY` itself only seeds a
-     project that has never answered, and nothing writes it. */
-  expect(dom.localStorage.getItem(`${OPEN_KEY}:${PROJECT}`)).toBe("1");
-  expect((host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).getAttribute("aria-pressed")).toBe("true");
-
-  await act(async () => { (host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).click(); });
-  expect(dock(host)).toBeNull();
-  expect(dom.localStorage.getItem(`${OPEN_KEY}:${PROJECT}`)).toBe("0");
-});
-
-test("the dock follows the selected project", async () => {
-  dom.localStorage.setItem("llvProject", PROJECT);
-  dom.localStorage.setItem(OPEN_KEY, "1");
-
-  const host = await mountViewer();
-  expect(dock(host)!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(PROJECT);
-
+/** Selecting a project the way the rail does — through the hash, which is also
+    what a reload of a project URL replays. Explicit, because a test that
+    inherits the previous one's hash is a test of the Overview. */
+async function goTo(project: string): Promise<void> {
   await act(async () => {
-    dom.location.hash = `#p=${encodeURIComponent(OTHER)}`;
+    dom.location.hash = `#p=${encodeURIComponent(project)}`;
     dom.dispatchEvent(new dom.Event("hashchange"));
   });
   await act(async () => { await Bun.sleep(20); });
+}
 
-  expect(dock(host)!.querySelector("[data-orchestrator-panel]")?.getAttribute("data-orchestrator-panel")).toBe(OTHER);
+test("closing the dock in one project leaves the other project's open", async () => {
+  /* Both projects open, from the one flag an operator carries in (#1149 seed). */
+  dom.localStorage.setItem("llvProject", PROJECT);
+  dom.localStorage.setItem(OPEN_KEY, "1");
+
+  const host = await mountViewer();
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(true);
+
+  /* The operator closes it in the project they are only glancing at... */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(true);
+  await act(async () => { toggle(host).click(); });
+  expect(hasDock(host)).toBe(false);
+  expect(dom.localStorage.getItem(openKey(OTHER))).toBe("0");
+
+  /* ...and the project they are running still has its dock, on its own seat. */
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(true);
+  expect(seatedOn(host)).toBe(PROJECT);
+  expect(dom.localStorage.getItem(openKey(PROJECT))).toBeNull();
+
+  /* Back again: still closed where it was closed, and nothing wrote the seed. */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(false);
+  expect(dom.localStorage.getItem(OPEN_KEY)).toBe("1");
+});
+
+test("a project's own answer outranks the pre-#1149 global flag, across a switch", async () => {
+  dom.localStorage.setItem("llvProject", PROJECT);
+  dom.localStorage.setItem(OPEN_KEY, "1");
+  /* Closed here, and the seed says «open»: the project that answered wins. */
+  dom.localStorage.setItem(openKey(PROJECT), "0");
+
+  const host = await mountViewer();
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(false);
+
+  /* The seed still answers for the project that never has. */
+  await goTo(OTHER);
+  expect(hasDock(host)).toBe(true);
+  expect(seatedOn(host)).toBe(OTHER);
+
+  /* And the switch back re-reads, rather than carrying `borealis`'s answer. */
+  await goTo(PROJECT);
+  expect(hasDock(host)).toBe(false);
 });

--- a/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
+++ b/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+/*
+ * Switching projects must be IMMEDIATE (issue #1149 acceptance 2 and 4): the
+ * seat and the incumbent are answers this tab already has for a project it has
+ * already visited, so returning to it paints them in the FIRST commit and the
+ * poll revalidates behind that paint. The loading state is what a project this
+ * tab has never answered for gets, and nothing else.
+ *
+ * The panel is re-seated (remounted) on a switch, so every render below mounts
+ * the probe under `key={project}` exactly as `OrchestratorDock` mounts the
+ * panel — a cache that only survived because the subtree did would prove
+ * nothing.
+ */
+
+const dom = new HappyWindow();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+
+const { resetOrchestratorSeatCacheForTests, useOrchestratorSeat } = await import("./useOrchestratorSeat");
+const { resetOrchestratorIncumbentCacheForTests, useOrchestratorIncumbent } = await import("./useOrchestratorIncumbent");
+
+/** One project's answers on the server, as the two routes report them. */
+const seats = new Map<string, string>();
+const models = new Map<string, string>();
+/** Reads issued per project, so «revalidated in the background» is a count and
+    not a hope. */
+let seatReads: string[];
+let statusReads: string[];
+const realFetch = globalThis.fetch;
+
+function seatBody(project: string): unknown {
+  const conversationId = seats.get(project);
+  if (!conversationId) return { seat: null, pending: null, exists: true };
+  return {
+    seat: {
+      project,
+      seatEpoch: 1,
+      conversationId,
+      path: `/transcripts/${conversationId}.jsonl`,
+      mandate: "run it",
+      promptVersion: 3,
+      predecessorConversationId: null,
+      state: "active",
+      intent: { clientRequestId: "req-aaaaaaaa", mode: "spawn", launchId: "launch-a", error: null },
+    },
+    pending: null,
+    exists: true,
+  };
+}
+
+function statusBody(project: string): unknown {
+  return {
+    project,
+    designated: Boolean(seats.get(project)),
+    conversationId: seats.get(project) ?? null,
+    engine: "claude",
+    model: models.get(project) ?? null,
+    context: null,
+    rotation: null,
+  };
+}
+
+beforeEach(() => {
+  resetOrchestratorSeatCacheForTests();
+  resetOrchestratorIncumbentCacheForTests();
+  seats.clear();
+  models.clear();
+  seatReads = [];
+  statusReads = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input), "http://localhost");
+    const project = url.searchParams.get("project") ?? "";
+    if (url.pathname === "/api/orchestrator/seat/status") {
+      statusReads.push(project);
+      return { ok: true, status: 200, json: async () => statusBody(project) } as Response;
+    }
+    seatReads.push(project);
+    return { ok: true, status: 200, json: async () => seatBody(project) } as Response;
+  }) as typeof fetch;
+});
+
+const roots = new Set<Root>();
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+  globalThis.fetch = realFetch;
+});
+
+/** Everything the panel derives its state from, as two attributes: the seat
+    answer (or the absence that renders as `loading`) and the incumbent's model,
+    which is what the header would name. */
+function Probe({ project }: { project: string }) {
+  const { status, failed } = useOrchestratorSeat(project);
+  const { incumbent } = useOrchestratorIncumbent(project, Boolean(status?.seat));
+  return (
+    <div
+      data-seat={status ? status.seat?.conversationId ?? "vacant" : failed ? "unavailable" : "loading"}
+      data-model={incumbent?.model ?? "unread"}
+    />
+  );
+}
+
+const settle = async () => {
+  for (let index = 0; index < 6; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+function mountProbe() {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  const probe = () => host.querySelector("div[data-seat]")!;
+  return {
+    /* Keyed by project, the way the dock re-seats the panel. */
+    open: (project: string) => flushSync(() => root.render(<Probe key={project} project={project} />)),
+    seat: () => probe().getAttribute("data-seat"),
+    model: () => probe().getAttribute("data-model"),
+  };
+}
+
+test("a project answered once repaints from the answer, and revalidates behind it", async () => {
+  seats.set("atlas", "conversation_atlas");
+  seats.set("borealis", "conversation_borealis");
+
+  const dock = mountProbe();
+
+  /* First visit is unchanged: nothing is known, so the panel loads. */
+  dock.open("atlas");
+  expect(dock.seat()).toBe("loading");
+  await settle();
+  expect(dock.seat()).toBe("conversation_atlas");
+  expect(seatReads.filter((project) => project === "atlas")).toHaveLength(1);
+
+  /* A project this tab has never answered for still loads — the cache answers
+     for the project it was filled by and no other. */
+  dock.open("borealis");
+  expect(dock.seat()).toBe("loading");
+  await settle();
+  expect(dock.seat()).toBe("conversation_borealis");
+
+  /* Back to atlas: the answer is on screen in the commit the switch produced,
+     before any request could have been made, let alone answered. */
+  const readsBefore = seatReads.length;
+  dock.open("atlas");
+  expect(dock.seat()).toBe("conversation_atlas");
+
+  /* And the read still happens — stale WHILE it revalidates. A rotation that
+     landed while the operator was away lands in place, with no loading frame
+     in between. */
+  seats.set("atlas", "conversation_successor");
+  await settle();
+  expect(seatReads.length).toBeGreaterThan(readsBefore);
+  expect(seatReads.filter((project) => project === "atlas")).toHaveLength(2);
+  expect(dock.seat()).toBe("conversation_successor");
+});
+
+test("the incumbent reading survives the switch too, so the header never falls back mid-conversation", async () => {
+  seats.set("atlas", "conversation_atlas");
+  models.set("atlas", "opus");
+  seats.set("borealis", "conversation_borealis");
+  models.set("borealis", "gpt-5.6");
+
+  const dock = mountProbe();
+  dock.open("atlas");
+  await settle();
+  expect(dock.model()).toBe("opus");
+
+  dock.open("borealis");
+  await settle();
+  expect(dock.model()).toBe("gpt-5.6");
+
+  /* The return trip: the incumbent's model is there in the same first commit
+     as the seat, so the header renders complete rather than degrading to what
+     the board alone knows while a 60s-cadence read catches up. */
+  const readsBefore = statusReads.length;
+  dock.open("atlas");
+  expect(dock.seat()).toBe("conversation_atlas");
+  expect(dock.model()).toBe("opus");
+
+  models.set("atlas", "opus-successor");
+  await settle();
+  expect(statusReads.length).toBeGreaterThan(readsBefore);
+  expect(dock.model()).toBe("opus-successor");
+});
+
+test("a failed re-read keeps the project's own last answer, never another project's", async () => {
+  seats.set("atlas", "conversation_atlas");
+  const dock = mountProbe();
+  dock.open("atlas");
+  await settle();
+
+  /* Every read fails from here. Atlas keeps what it knows... */
+  globalThis.fetch = (async () => {
+    throw new Error("network dropped");
+  }) as unknown as typeof fetch;
+  dock.open("atlas");
+  expect(dock.seat()).toBe("conversation_atlas");
+  await settle();
+  expect(dock.seat()).toBe("conversation_atlas");
+
+  /* ...and a project that never answered gets no answer of anyone else's: it
+     says the panel cannot be read, which is what the operator needs to see. */
+  dock.open("borealis");
+  expect(dock.seat()).toBe("loading");
+  await settle();
+  expect(dock.seat()).toBe("unavailable");
+});

--- a/src/components/orchestrator/useOrchestratorIncumbent.ts
+++ b/src/components/orchestrator/useOrchestratorIncumbent.ts
@@ -32,6 +32,18 @@ interface ScopedRead {
   incumbent: OrchestratorIncumbent | null;
 }
 
+/** Every reading this tab has taken, keyed by project — the incumbent half of
+    the same session cache the seat keeps (#1149). A revisited header shows the
+    wear it was last read at while the poll below refreshes it, rather than
+    dropping back to what the board alone knows for a round-trip. */
+const readings = new Map<string, ScopedRead>();
+
+export function resetOrchestratorIncumbentCacheForTests(): void {
+  readings.clear();
+}
+
+const cachedIncumbent = (project: string | null): ScopedRead | null => (project ? readings.get(project) ?? null : null);
+
 export async function fetchOrchestratorIncumbent(project: string, signal?: AbortSignal): Promise<OrchestratorIncumbent | null> {
   const response = await fetch(
     "/api/orchestrator/seat/status?project=" + encodeURIComponent(project),
@@ -50,27 +62,34 @@ export async function fetchOrchestratorIncumbent(project: string, signal?: Abort
  * what the board itself knows, which is exactly what slice A rendered.
  */
 export function useOrchestratorIncumbent(project: string | null, enabled: boolean): OrchestratorIncumbentRead {
-  const [read, setRead] = useState<ScopedRead | null>(null);
+  const [read, setRead] = useState<ScopedRead | null>(() => cachedIncumbent(project));
   /* Answers carry the project they answered for, so a project switch drops the
      previous incumbent HERE, in render — never a frame of the old orchestrator's
-     model under the new project's name. */
-  const current = read && read.project === project ? read.incumbent : null;
+     model under the new project's name. What replaces it is this project's own
+     last reading, which the panel then matches against the seat as usual. */
+  const current = read && read.project === project ? read.incumbent : cachedIncumbent(project)?.incumbent ?? null;
+
+  const settle = useCallback((target: string, incumbent: OrchestratorIncumbent | null) => {
+    const next: ScopedRead = { project: target, incumbent };
+    readings.set(target, next);
+    setRead(next);
+  }, []);
 
   const refresh = useCallback(async () => {
     if (!project) return;
     try {
-      setRead({ project, incumbent: await fetchOrchestratorIncumbent(project) });
+      settle(project, await fetchOrchestratorIncumbent(project));
     } catch {
       /* Keep the last good reading; the header simply stops advancing. */
     }
-  }, [project]);
+  }, [project, settle]);
 
   useEffect(() => {
     if (!project || !enabled) return;
     const controller = new AbortController();
     const load = () => {
       void fetchOrchestratorIncumbent(project, controller.signal)
-        .then((incumbent) => setRead({ project, incumbent }))
+        .then((incumbent) => settle(project, incumbent))
         .catch(() => {});
     };
     load();
@@ -79,7 +98,7 @@ export function useOrchestratorIncumbent(project: string | null, enabled: boolea
       clearInterval(timer);
       controller.abort();
     };
-  }, [project, enabled]);
+  }, [project, enabled, settle]);
 
   return { incumbent: current, refresh };
 }

--- a/src/components/orchestrator/useOrchestratorSeat.ts
+++ b/src/components/orchestrator/useOrchestratorSeat.ts
@@ -27,31 +27,57 @@ interface ScopedRead {
   failed: boolean;
 }
 
+/**
+ * Every answer this tab has been given, keyed by project (#1149).
+ *
+ * The panel is RE-SEATED on a project switch — a fresh mount, because its draft
+ * belongs to one project — so the answer cannot live in its state and survive.
+ * Here it does: a project the operator has already visited paints its last
+ * answer in the FIRST commit after the switch and the effect below revalidates
+ * behind it, instead of paying a round-trip to be told what it already knew.
+ * The loading state is left to a project this tab has never answered for.
+ *
+ * Session-only, in memory: a seat that changed while the tab was closed must
+ * still be READ, never restored from disk.
+ */
+const answers = new Map<string, ScopedRead>();
+
+export function resetOrchestratorSeatCacheForTests(): void {
+  answers.clear();
+}
+
 export async function fetchOrchestratorSeat(project: string, signal?: AbortSignal): Promise<OrchestratorSeatStatus> {
   const response = await fetch("/api/orchestrator/seat?project=" + encodeURIComponent(project), signal ? { signal } : undefined);
   if (!response.ok) throw new Error(`orchestrator seat read failed: ${response.status}`);
   return parseSeatStatus(await response.json());
 }
 
+const cachedSeat = (project: string | null): ScopedRead | null => (project ? answers.get(project) ?? null : null);
+
 /**
- * The project's orchestrator seat, polled. `project` null (Overview, or the
- * panel closed) reads nothing at all.
+ * The project's orchestrator seat, polled — and answered at once for a project
+ * this tab already read (stale while it revalidates, #1149).
+ *
+ * `project` null (Overview, or the panel closed) reads nothing at all.
  */
 export function useOrchestratorSeat(project: string | null): OrchestratorSeatRead {
-  const [read, setRead] = useState<ScopedRead | null>(null);
+  const [read, setRead] = useState<ScopedRead | null>(() => cachedSeat(project));
   /* Every answer carries the project it answered for, so a project switch
      invalidates the previous seat HERE, in render, with no effect and no frame
-     in which the old incumbent shows under the new project's name. */
-  const current = read && read.project === project ? read : null;
+     in which the old incumbent shows under the new project's name. What takes
+     its place is what THIS project last answered, not «loading». */
+  const current = read && read.project === project ? read : cachedSeat(project);
 
   const settle = useCallback((target: string, status: OrchestratorSeatStatus | null, failed: boolean) => {
-    setRead((previous) => ({
+    const next: ScopedRead = {
       project: target,
-      /* A failed re-read keeps the last good answer for the SAME project; it
-         never resurrects another project's. */
-      status: status ?? (previous?.project === target ? previous.status : null),
+      /* A failed re-read keeps the last good answer for the SAME project; the
+         cache is keyed by project, so it can never resurrect another's. */
+      status: status ?? answers.get(target)?.status ?? null,
       failed,
-    }));
+    };
+    answers.set(target, next);
+    setRead(next);
   }, []);
 
   const refresh = useCallback(async () => {


### PR DESCRIPTION
Fixes #1149.

The orchestrator dock is a per-project surface. Two things still leaked across projects: closing it in one project closed it everywhere, and every switch tore the panel down to a loading state and re-fetched.

## What changed

**1. Open/closed belongs to the project.** Stored under `llvOrchestratorPanelOpen:<project>`, mirroring the #1011 width migration exactly. The pre-existing global flag becomes a seed — it answers for a project that has never opened or closed the dock itself, and nothing writes it — so an operator carrying one global preference in keeps the dock where they left it everywhere, while a project that *has* answered outranks the seed, `"closed"` included. Toggling in A never touches B.

**2. Seat and incumbent answers are kept per project, for the session.** Each hook keeps a small `Map` keyed by project. A project already answered renders its last seat and incumbent in the **first commit** after the switch, and the existing polls revalidate behind that paint. The loading state is left to a project this tab has never read. In memory only — nothing about a seat is persisted, so a seat that moved while the tab was closed is still *read*.

**3/4. The conversation view keeps its transcript, with no round-trip to paint.** `useLogTail` already keeps a browser-wide per-path tail snapshot, read synchronously on mount; what blanked the conversation on a switch was the **seat** read, not the transcript. With the seat answered synchronously the file resolves in the same render and the feed repaints its rows, then the live subscription continues forward from the cached offset.

**5.** Width behaviour from #1011 is untouched.

## Mechanism: why `key={project}` stays

The spec allowed either keeping the panel mounted or keeping the key and hydrating from a cache. Keeping the key is the smaller change and the safer one. The panel's draft — mandate, engine, model, account, and the idempotency key of an unsettled confirm — belongs to **one** project; dropping the key would keep the subtree alive but leave five pieces of that state on another project's panel, each needing its own re-derivation on switch. Caching the two answers *outside* the subtree buys the same immediate paint without touching any of that.

No new endpoint, no store abstraction, no localStorage for transcripts, no change to seat/rotate semantics.

## Verification

| Gate | Result |
| --- | --- |
| `bunx tsc --noEmit --incremental false` | clean |
| `bun run build` | passes |
| privacy gate vs merge-base, `--check-commits` | PASS |
| `eslint` on touched files | clean (the 8 `react-hooks/refs` errors in `Viewer.tsx` are pre-existing lines 184-190/1000, byte-identical to `HEAD`) |

Focused tests, by path — 64 tests, 0 failures:

- `src/components/orchestrator/OrchestratorDock.dom.test.tsx` — per-project open, legacy seed, own answer outranks the seed, two projects independent (12)
- `src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx` *(new)* — A→B→A repaints synchronously and revalidates behind it; a never-answered project still loads; a failed re-read keeps its own project's answer and never another's (3)
- `src/components/orchestrator/OrchestratorPanel.dom.test.tsx` — a revisit paints `live` with the conversation and its transcript in the commit the switch produced (30)
- `src/components/orchestrator/dockOpenState.dom.test.tsx` *(new)* — the real shell, switching projects through the rail: closing the dock in one project leaves the other's open, and a project's own answer outranks the seed across a switch (2)
- `src/components/Viewer.orchestratorDock.dom.test.tsx` — the dock's place in the shell, unchanged; the toggle now persists under the project's own key (4)
- `src/components/mobile/mobileOrchestratorRow.dom.test.tsx` — the phone's row also reads this seat hook; its suite resets the session cache between tests so each starts as a tab that has never read (13)

Each new test was checked RED: the hook suite reported `loading` where the cached answer belongs, the panel revisit test failed outright, and `dockOpenState.dom.test.tsx` fails both of its tests with the render-phase re-read removed from `Viewer.tsx`.

## Round 2 — file ownership

Review round 1 passed the behaviour and failed one thing: two test files outside the assignment's ownership of `Viewer.tsx`'s open-state lines plus `src/components/orchestrator/**`. That residue is now 10 lines instead of 89, and every new assertion lives in the fence:

- `OPEN_KEY` keeps its pre-#1149 name and value — same key, same flag, only its role narrowed to seeding a project that never answered — so the out-of-fence import needs no change. The per-project key builder is the local `projectOpenKey`, spelled apart from the export rather than one capital away from it.
- The two Viewer-level tests move to `src/components/orchestrator/dockOpenState.dom.test.tsx`.

What is left out of fence is forced by the issue's Expected section, and each was measured by restoring the file verbatim and running it:

| File | Residue | Why it cannot go to zero |
| --- | --- | --- |
| `Viewer.orchestratorDock.dom.test.tsx` | 2 assertions (+2 comment lines) | The file asserts **where** the toggle persists, and Expected (1) moves that to `llvOrchestratorPanelOpen:<project>`. Restored verbatim it fails exactly there (`Expected: "1", Received: null`) and nowhere else — its other three tests pass unchanged through the seed. Passing verbatim would mean writing the global key on every toggle, which is the bug #1149 reports: a never-visited project would inherit whatever the last project was toggled to. |
| `mobileOrchestratorRow.dom.test.tsx` | 1 import + 1 call (+2 comment lines) | Expected (2)'s session cache is module state seeded into `useState`, so it outlives a remount by design and therefore outlives a test. Restored verbatim, "an unreadable seat" inherits the previous test's good answer and reads `draft` instead of `unavailable`. The leak is at the seed, not at `settle`, so no in-fence change isolates that file. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
