### PR TITLE
fix(orchestrator): the #1149 seat session cache belongs to the dock, not to every surface

### DIFF
--- a/src/components/Viewer.orchestratorDock.dom.test.tsx
+++ b/src/components/Viewer.orchestratorDock.dom.test.tsx
@@ -167,8 +167,6 @@ test("the header button toggles the dock and the choice survives a reload", asyn
 
   await act(async () => { toggle.click(); });
   expect(dock(host)).not.toBeNull();
-  /* Under the PROJECT's own key since #1149; `OPEN_KEY` itself only seeds a
-     project that has never answered, and nothing writes it. */
   expect(dom.localStorage.getItem(`${OPEN_KEY}:${PROJECT}`)).toBe("1");
   expect((host.querySelector("[data-orchestrator-toggle]") as HTMLButtonElement).getAttribute("aria-pressed")).toBe("true");
 

--- a/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorRow.dom.test.tsx
@@ -58,7 +58,6 @@ mock.module("@/hooks/useLogTail", () => ({
 }));
 
 const { MobileFocusView } = await import("./MobileFocusView");
-const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
 
 interface SeatAnswer { seat: unknown; pending: unknown; exists: boolean }
 interface Recorded { url: string; method: string; body: Record<string, unknown> }
@@ -93,9 +92,6 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 beforeEach(() => {
-  /* Each test is a tab that has never read this project's seat; the answer is
-     cached per project for the session since #1149. */
-  resetOrchestratorSeatCacheForTests();
   requests.length = 0;
   seatAnswer = { seat: null, pending: null, exists: true };
   postSeat = async () => new Response(JSON.stringify({ ok: true, state: "starting" }), { status: 200, headers: { "content-type": "application/json" } });

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -113,7 +113,9 @@ export function OrchestratorPanel({
   onClose: () => void;
 }) {
   const { t } = useLocale();
-  const { status, failed, refresh } = useOrchestratorSeat(project);
+  /* `remember`: the dock remounts on every project switch, so a revisited
+     project paints its last seat instead of a round-trip's loading (#1149). */
+  const { status, failed, refresh } = useOrchestratorSeat(project, true);
   const [formError, setFormError] = useState<string | null>(null);
   const [mandate, setMandateState] = useState(() => readDraftField(project, "mandate") || ORCHESTRATOR_SYSTEM_PROMPT);
   /* The conversation the open rotate draft is replacing. Non-null IS the rotate

--- a/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
+++ b/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
@@ -101,9 +101,10 @@ afterEach(() => {
 
 /** Everything the panel derives its state from, as two attributes: the seat
     answer (or the absence that renders as `loading`) and the incumbent's model,
-    which is what the header would name. */
+    which is what the header would name. `remember` is on because this stands in
+    for the DOCK, which is the surface a project switch remounts. */
 function Probe({ project }: { project: string }) {
-  const { status, failed } = useOrchestratorSeat(project);
+  const { status, failed } = useOrchestratorSeat(project, true);
   const { incumbent } = useOrchestratorIncumbent(project, Boolean(status?.seat));
   return (
     <div
@@ -218,4 +219,50 @@ test("a failed re-read keeps the project's own last answer, never another projec
   expect(dock.seat()).toBe("loading");
   await settle();
   expect(dock.seat()).toBe("unavailable");
+});
+
+/*
+ * The other half of the same guarantee: the cache is the DOCK's, and a surface
+ * that mounts once per project — the phone's pinned row — does not read from it.
+ * Sharing it there would trade nothing for something real: a seat that cannot
+ * be read would go on reporting the last one that could, on the one surface
+ * where «unavailable» is the whole warning.
+ */
+
+/** The phone's shape: the same hook, left at its default. */
+function FreshProbe({ project }: { project: string }) {
+  const { status, failed } = useOrchestratorSeat(project);
+  return <div data-seat={status ? status.seat?.conversationId ?? "vacant" : failed ? "unavailable" : "loading"} />;
+}
+
+test("a surface that does not ask to remember reads fresh, so an unreadable seat reads as unavailable", async () => {
+  seats.set("atlas", "conversation_atlas");
+
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  const seat = () => host.querySelector("div[data-seat]")!.getAttribute("data-seat");
+
+  /* A dock elsewhere in the tab has already answered for this project... */
+  const dock = mountProbe();
+  dock.open("atlas");
+  await settle();
+  expect(dock.seat()).toBe("conversation_atlas");
+
+  /* ...and this surface still loads rather than borrowing that answer. */
+  flushSync(() => root.render(<FreshProbe project="atlas" />));
+  expect(seat()).toBe("loading");
+  await settle();
+  expect(seat()).toBe("conversation_atlas");
+
+  /* Remounted with every read failing — what a phone opened on a broken host
+     does. It reports the failure instead of the answer it once had. */
+  globalThis.fetch = (async () => {
+    throw new Error("network dropped");
+  }) as unknown as typeof fetch;
+  flushSync(() => root.render(<FreshProbe key="remount" project="atlas" />));
+  expect(seat()).toBe("loading");
+  await settle();
+  expect(seat()).toBe("unavailable");
 });

--- a/src/components/orchestrator/useOrchestratorSeat.ts
+++ b/src/components/orchestrator/useOrchestratorSeat.ts
@@ -30,12 +30,17 @@ interface ScopedRead {
 /**
  * Every answer this tab has been given, keyed by project (#1149).
  *
- * The panel is RE-SEATED on a project switch — a fresh mount, because its draft
- * belongs to one project — so the answer cannot live in its state and survive.
- * Here it does: a project the operator has already visited paints its last
- * answer in the FIRST commit after the switch and the effect below revalidates
- * behind it, instead of paying a round-trip to be told what it already knew.
- * The loading state is left to a project this tab has never answered for.
+ * The DOCK is re-seated on a project switch — a fresh mount, because its draft
+ * belongs to one project — so its answer cannot live in component state and
+ * survive. Here it does: a project the operator has already visited paints its
+ * last answer in the FIRST commit after the switch and the effect below
+ * revalidates behind it, instead of paying a round-trip to be told what it
+ * already knew. The loading state is left to a project this tab has never
+ * answered for.
+ *
+ * Only surfaces that ask for it read from here (`remember` below). A surface
+ * that never switches projects gains nothing from a cache and loses something
+ * real to it: a seat it cannot read would keep reporting the last one it could.
  *
  * Session-only, in memory: a seat that changed while the tab was closed must
  * still be READ, never restored from disk.
@@ -55,30 +60,45 @@ export async function fetchOrchestratorSeat(project: string, signal?: AbortSigna
 const cachedSeat = (project: string | null): ScopedRead | null => (project ? answers.get(project) ?? null : null);
 
 /**
- * The project's orchestrator seat, polled — and answered at once for a project
- * this tab already read (stale while it revalidates, #1149).
+ * The project's orchestrator seat, polled. `project` null (Overview, or the
+ * panel closed) reads nothing at all.
  *
- * `project` null (Overview, or the panel closed) reads nothing at all.
+ * `remember` opts into the session cache above (#1149), which the dock needs
+ * because a project switch remounts it. It is off by default: a caller that
+ * mounts once per project — the phone's pinned row — reads fresh, so «the seat
+ * cannot be read» stays readable as itself instead of being papered over by an
+ * earlier answer.
  */
-export function useOrchestratorSeat(project: string | null): OrchestratorSeatRead {
-  const [read, setRead] = useState<ScopedRead | null>(() => cachedSeat(project));
+export function useOrchestratorSeat(project: string | null, remember = false): OrchestratorSeatRead {
+  const [read, setRead] = useState<ScopedRead | null>(() => (remember ? cachedSeat(project) : null));
   /* Every answer carries the project it answered for, so a project switch
      invalidates the previous seat HERE, in render, with no effect and no frame
      in which the old incumbent shows under the new project's name. What takes
-     its place is what THIS project last answered, not «loading». */
-  const current = read && read.project === project ? read : cachedSeat(project);
+     its place is what THIS project last answered — «loading» only where there
+     is no cache to answer from. */
+  const current = read && read.project === project ? read : (remember ? cachedSeat(project) : null);
 
   const settle = useCallback((target: string, status: OrchestratorSeatStatus | null, failed: boolean) => {
-    const next: ScopedRead = {
+    if (remember) {
+      const next: ScopedRead = {
+        project: target,
+        /* A failed re-read keeps the last good answer for the SAME project; the
+           cache is keyed by project, so it can never resurrect another's. */
+        status: status ?? answers.get(target)?.status ?? null,
+        failed,
+      };
+      answers.set(target, next);
+      setRead(next);
+      return;
+    }
+    setRead((previous) => ({
       project: target,
-      /* A failed re-read keeps the last good answer for the SAME project; the
-         cache is keyed by project, so it can never resurrect another's. */
-      status: status ?? answers.get(target)?.status ?? null,
+      /* The same rule with only this mount to remember: a failed re-read keeps
+         the last good answer for the SAME project, and never another's. */
+      status: status ?? (previous?.project === target ? previous.status : null),
       failed,
-    };
-    answers.set(target, next);
-    setRead(next);
-  }, []);
+    }));
+  }, [remember]);
 
   const refresh = useCallback(async () => {
     if (!project) return;


### PR DESCRIPTION
Round-3 review follow-up for #1149. PR #1150 merged before the fix pass ran, so this carries the two findings on its own branch; the diff is only the fix.

Behavioural acceptance (1)–(5) of #1149 passed review. Two ownership-fence findings did not:

| Finding | Now |
| --- | --- |
| `src/components/mobile/mobileOrchestratorRow.dom.test.tsx` — cache-reset import + `beforeEach` call outside the fence | **Gone.** File is byte-identical to the pre-#1149 file. |
| `src/components/Viewer.orchestratorDock.dom.test.tsx` — assertions changed outside the fence | **2 changed lines**, down from 4. Irreducible; proof below. |

Out-of-fence residue for the whole of #1149 is now one file and two lines.

## The mobile finding, fixed at its root

#1149 gave `useOrchestratorSeat` an unconditional module-level cache. The phone's pinned row reads the same hook, so it inherited a cache it has no use for and one real cost: a seat the row *cannot* read went on reporting the last one it could, on the one surface where `unavailable` is the whole warning. Within the suite that showed up as each test inheriting the previous test's answer, which is what the reset call was papering over.

The cache is now opt-in — `useOrchestratorSeat(project, remember)` — and only `OrchestratorPanel` asks for it. The dock is the surface a project switch remounts, and the only one the issue is about; a surface that mounts once per project reads fresh, exactly as before #1149.

New in-fence coverage pins both halves in `orchestratorAnswerCache.dom.test.tsx`: a surface that does not ask to remember still loads on mount even while the dock holds an answer for the same project, and reports `unavailable` when every read fails. Checked RED against the unconditional cache — it read `conversation_atlas` where `loading` belongs.

## The Viewer test residue, and why it cannot reach zero

Restored verbatim, the file fails **one** assertion and only that one:

```
expect(dom.localStorage.getItem(OPEN_KEY)).toBe("1");
error: expect(received).toBe(expected)
Expected: "1"
Received: null
    at src/components/Viewer.orchestratorDock.dom.test.tsx:170:46
(fail) the header button toggles the dock and the choice survives a reload
 3 pass  1 fail
```

Its other three tests pass unchanged through the seed. The only way to make that one pass is to write the legacy global key on toggle — and with that write added, the issue's own acceptance breaks:

```
  /* ...and only that project's. Atlas still reads the seed, and the seed is
     never written to. */
  expect(dockOpenFor("atlas")).toBe(true);
error: expect(received).toBe(expected)
Expected: true
Received: false
    at src/components/orchestrator/OrchestratorDock.dom.test.tsx:437:32
```

Closing the dock in one project would turn it off in every project that only reads the seed — the bug #1149 reports. #1011's width migration states the rule the issue says to mirror: nothing writes the legacy key.

## Gates

| Gate | Result |
| --- | --- |
| `bunx tsc --noEmit --incremental false` | exit 0 |
| `bun run build` | exit 0 (webpack compile, TypeScript, page data, `dist/mcp-server.mjs`) |
| privacy gate `--check-commits` vs merge-base | PASS |
| `eslint` on the touched files | clean |

Focused tests, by path — 65 pass, 0 fail:

| File | |
| --- | --- |
| `orchestrator/orchestratorAnswerCache.dom.test.tsx` | 4 |
| `orchestrator/OrchestratorPanel.dom.test.tsx` | 30 |
| `orchestrator/OrchestratorDock.dom.test.tsx` | 12 |
| `orchestrator/dockOpenState.dom.test.tsx` | 2 |
| `Viewer.orchestratorDock.dom.test.tsx` | 4 |
| `mobile/mobileOrchestratorRow.dom.test.tsx` | 13 — passing with the file back at its pre-#1149 content |

🤖 Generated with [Claude Code](https://claude.com/claude-code)