### PR TITLE
fix(packaging): ship standalone worker bundles

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import nextConfig from "./next.config";
+
+test("every library worker is bundled and traced into standalone output", async () => {
+  const workerFiles = fs.readdirSync(path.join(import.meta.dir, "src/lib"), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".worker.ts"))
+    .map((entry) => entry.name)
+    .sort();
+
+  if (!nextConfig.webpack) throw new Error("next config has no webpack hook");
+  const configured = nextConfig.webpack(
+    { entry: {} },
+    { isServer: true, nextRuntime: "nodejs" } as Parameters<NonNullable<typeof nextConfig.webpack>>[1],
+  );
+  if (typeof configured.entry !== "function") throw new Error("webpack entries are not configurable");
+  const entries = await configured.entry();
+  const tracingIncludes = nextConfig.outputFileTracingIncludes?.["/*"] ?? [];
+
+  expect(workerFiles.length).toBeGreaterThan(0);
+  expect(tracingIncludes).toContain(".next/server/chunks/**");
+  for (const workerFile of workerFiles) {
+    const source = `./src/lib/${workerFile}`;
+    const workerEntry = Object.entries(entries).find(([, entry]) => entry === source);
+    if (!workerEntry) throw new Error(`${workerFile} has no webpack entry`);
+    expect(
+      tracingIncludes,
+      `${workerFile} has no standalone tracing include`,
+    ).toContain(`.next/server/${workerEntry[0]}.js`);
+  }
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,9 @@ const nextConfig: NextConfig = {
       ".next/server/file-scanner-worker.js",
       ".next/server/files-response-worker.js",
       ".next/server/resource-collector-worker.js",
+      ".next/server/account-migration-controller-worker.js",
+      ".next/server/wakatime-sync-worker.js",
+      ".next/server/chunks/**",
     ],
   },
   webpack(config, { isServer, nextRuntime }) {
@@ -24,6 +27,8 @@ const nextConfig: NextConfig = {
         "file-scanner-worker": "./src/lib/fileScanner.worker.ts",
         "files-response-worker": "./src/lib/filesResponse.worker.ts",
         "resource-collector-worker": "./src/lib/resourceCollector.worker.ts",
+        "account-migration-controller-worker": "./src/lib/accountMigrationController.worker.ts",
+        "wakatime-sync-worker": "./src/lib/wakatimeSync.worker.ts",
       });
     }
     return config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-log-viewer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bin": {
     "agent-log-viewer": "bin/cli.mjs",
     "agent-log-viewer-mcp": "bin/mcp-server.mjs"

--- a/scripts/npm-package-smoke-diagnostic.test.ts
+++ b/scripts/npm-package-smoke-diagnostic.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertHealthyResourceDiagnostic } from "./npm-package-smoke.mjs";
+
+describe("npm package resource-worker diagnostic", () => {
+  test("accepts a complete resource collection", () => {
+    expect(() => assertHealthyResourceDiagnostic(JSON.stringify({
+      status: "complete",
+      phases: { readFiles: 1 },
+    }))).not.toThrow();
+  });
+
+  test.each([
+    ["missing", undefined],
+    ["failed", JSON.stringify({
+      status: "failed",
+      degradedReason: "collector-crash",
+      failure: { cause: "worker-exit" },
+    })],
+    ["degraded", JSON.stringify({
+      status: "complete",
+      degradedReason: "collector-crash",
+    })],
+  ])("rejects a %s resource-worker diagnostic", (_name, diagnostic) => {
+    expect(() => assertHealthyResourceDiagnostic(diagnostic)).toThrow("resource worker diagnostic");
+  });
+});

--- a/scripts/npm-package-smoke.mjs
+++ b/scripts/npm-package-smoke.mjs
@@ -6,7 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(scriptPath), "..");
 const standaloneServer = path.join(root, "dist/standalone/server.js");
 const observationMs = 60_000;
 const startupTimeoutMs = 30_000;
@@ -59,14 +60,39 @@ function probe(port, pathname) {
   return new Promise((resolve) => {
     const request = http.get({ hostname: "127.0.0.1", port, path: pathname, timeout: 5_000 }, (response) => {
       response.resume();
-      response.once("end", () => resolve(response.statusCode ?? 0));
+      response.once("end", () => resolve({
+        status: response.statusCode ?? 0,
+        headers: response.headers,
+      }));
     });
     request.once("timeout", () => {
       request.destroy();
-      resolve(0);
+      resolve({ status: 0, headers: {} });
     });
-    request.once("error", () => resolve(0));
+    request.once("error", () => resolve({ status: 0, headers: {} }));
   });
+}
+
+export function assertHealthyResourceDiagnostic(rawHeader) {
+  if (typeof rawHeader !== "string") {
+    throw new Error("resource worker diagnostic is missing");
+  }
+  let diagnostic;
+  try {
+    diagnostic = JSON.parse(rawHeader);
+  } catch {
+    throw new Error("resource worker diagnostic is invalid JSON");
+  }
+  if (
+    !diagnostic
+    || typeof diagnostic !== "object"
+    || Array.isArray(diagnostic)
+    || diagnostic.status !== "complete"
+    || diagnostic.degradedReason !== undefined
+    || diagnostic.failure !== undefined
+  ) {
+    throw new Error(`resource worker diagnostic is unhealthy: ${rawHeader}`);
+  }
 }
 
 function workerFailure(output) {
@@ -80,15 +106,15 @@ function workerFailure(output) {
 
 async function waitForOk(port, pathname, child, output) {
   const deadline = Date.now() + startupTimeoutMs;
-  let status = 0;
+  let response = { status: 0, headers: {} };
   while (Date.now() < deadline && child.exitCode === null && child.signalCode === null) {
     const failure = workerFailure(output());
     if (failure) throw new Error(`worker failure before ${pathname} became ready: ${failure}`);
-    status = await probe(port, pathname);
-    if (status === 200) return;
+    response = await probe(port, pathname);
+    if (response.status === 200) return response;
     await delay(250);
   }
-  throw new Error(`${pathname} did not answer 200 (last status ${status})${output() ? `: ${output()}` : ""}`);
+  throw new Error(`${pathname} did not answer 200 (last status ${response.status})${output() ? `: ${output()}` : ""}`);
 }
 
 function scrubOutput(output, tempDirectory) {
@@ -201,8 +227,9 @@ async function main() {
     const safeOutput = () => scrubOutput(output, tempDirectory);
     await waitForOk(port, "/api/files", server, safeOutput);
     console.log("npm package smoke: /api/files returned 200.");
-    await waitForOk(port, "/api/resources", server, safeOutput);
-    console.log("npm package smoke: /api/resources returned 200; observing worker health.");
+    const resourceResponse = await waitForOk(port, "/api/resources", server, safeOutput);
+    assertHealthyResourceDiagnostic(resourceResponse.headers["x-llv-resource-phases"]);
+    console.log("npm package smoke: /api/resources returned a healthy worker diagnostic; observing worker health.");
     const observationDeadline = Date.now() + observationMs;
     while (Date.now() < observationDeadline) {
       if (server.exitCode !== null || server.signalCode !== null) {
@@ -244,7 +271,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/npm-package-smoke.mjs
+++ b/scripts/npm-package-smoke.mjs
@@ -1,0 +1,248 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const standaloneServer = path.join(root, "dist/standalone/server.js");
+const observationMs = 60_000;
+const startupTimeoutMs = 30_000;
+const outputLimitBytes = 2 * 1024 * 1024;
+
+function command(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { ...options, stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    const collect = (chunk) => {
+      output = `${output}${chunk}`;
+      if (Buffer.byteLength(output) > outputLimitBytes) {
+        output = Buffer.from(output).subarray(-outputLimitBytes).toString("utf8");
+      }
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve(output.trim());
+      else reject(new Error(`${command} stopped with ${signal ?? code ?? "unknown"}${output.trim() ? `: ${output.trim()}` : ""}`));
+    });
+  });
+}
+
+function pathWithoutBunContainer(environmentPath = "") {
+  return environmentPath.split(path.delimiter)
+    .filter(Boolean)
+    .filter((directory) => !existsSync(path.join(directory, "bun-container")))
+    .join(path.delimiter);
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function availablePort() {
+  const server = http.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("smoke probe could not reserve a port");
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+function probe(port, pathname) {
+  return new Promise((resolve) => {
+    const request = http.get({ hostname: "127.0.0.1", port, path: pathname, timeout: 5_000 }, (response) => {
+      response.resume();
+      response.once("end", () => resolve(response.statusCode ?? 0));
+    });
+    request.once("timeout", () => {
+      request.destroy();
+      resolve(0);
+    });
+    request.once("error", () => resolve(0));
+  });
+}
+
+function workerFailure(output) {
+  return output.split("\n").find((line) => (
+    line.includes("Cannot find module")
+    || line.includes("Module not found")
+    || /worker(?:_|\s)exited/i.test(line)
+    || /worker exit/i.test(line)
+  ));
+}
+
+async function waitForOk(port, pathname, child, output) {
+  const deadline = Date.now() + startupTimeoutMs;
+  let status = 0;
+  while (Date.now() < deadline && child.exitCode === null && child.signalCode === null) {
+    const failure = workerFailure(output());
+    if (failure) throw new Error(`worker failure before ${pathname} became ready: ${failure}`);
+    status = await probe(port, pathname);
+    if (status === 200) return;
+    await delay(250);
+  }
+  throw new Error(`${pathname} did not answer 200 (last status ${status})${output() ? `: ${output()}` : ""}`);
+}
+
+function scrubOutput(output, tempDirectory) {
+  return output
+    .replaceAll(tempDirectory, "<package-smoke>")
+    .replaceAll(root, "<repo>")
+    .trim();
+}
+
+async function stop(child) {
+  const signalGroup = (signal) => {
+    try {
+      process.kill(-child.pid, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+  };
+  signalGroup("SIGTERM");
+  await Promise.race([
+    child.exitCode !== null || child.signalCode !== null
+      ? Promise.resolve()
+      : new Promise((resolve) => child.once("exit", resolve)),
+    delay(2_000),
+  ]);
+  signalGroup("SIGKILL");
+}
+
+async function main() {
+  if (!existsSync(standaloneServer)) {
+    console.log("SKIP npm package smoke: run node scripts/prepack.mjs first.");
+    return;
+  }
+
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "agent-log-viewer-package-smoke-"));
+  let server;
+  try {
+    const packageDirectory = path.join(tempDirectory, "pack");
+    const extractDirectory = path.join(tempDirectory, "extract");
+    const homeDirectory = path.join(tempDirectory, "home");
+    const configDirectory = path.join(tempDirectory, "config");
+    const stateDirectory = path.join(tempDirectory, "state");
+    const runtimeTempDirectory = path.join(tempDirectory, "runtime-tmp");
+    await Promise.all([
+      mkdir(packageDirectory),
+      mkdir(extractDirectory),
+      mkdir(homeDirectory),
+      mkdir(configDirectory),
+      mkdir(stateDirectory),
+      mkdir(runtimeTempDirectory),
+    ]);
+
+    const packOutput = await command("npm", [
+      "pack",
+      "--ignore-scripts",
+      "--pack-destination",
+      packageDirectory,
+      "--silent",
+    ], {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH,
+        HOME: homeDirectory,
+        npm_config_cache: path.join(tempDirectory, "npm-cache"),
+      },
+    });
+    console.log("npm package smoke: packed current standalone output.");
+    const tarballs = (await readdir(packageDirectory)).filter((name) => name.endsWith(".tgz"));
+    if (tarballs.length !== 1) throw new Error(`npm pack produced ${tarballs.length} tarballs: ${packOutput}`);
+    await command("tar", ["-xzf", path.join(packageDirectory, tarballs[0]), "-C", extractDirectory]);
+
+    const extractedPackage = path.join(extractDirectory, "package");
+    if (existsSync(path.join(extractedPackage, "src"))) throw new Error("packed package unexpectedly contains src/");
+    const runtimePath = pathWithoutBunContainer(process.env.PATH);
+    if (!runtimePath) throw new Error("smoke PATH is empty after removing bun-container");
+    const bunRuntime = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
+    const port = await availablePort();
+    const runtimeEnvironment = {
+      PATH: runtimePath,
+      HOME: homeDirectory,
+      XDG_CONFIG_HOME: configDirectory,
+      LLV_STATE_DIR: stateDirectory,
+      TMPDIR: runtimeTempDirectory,
+      NODE_ENV: "production",
+      LLV_STRUCTURED_HOSTS: "off",
+      LLV_WAKATIME_ENABLED: "1",
+    };
+    let output = "";
+    const collect = (chunk) => {
+      output = `${output}${chunk}`;
+      if (Buffer.byteLength(output) > outputLimitBytes) {
+        output = Buffer.from(output).subarray(-outputLimitBytes).toString("utf8");
+      }
+    };
+    server = spawn(bunRuntime, ["--bun", "dist/standalone/server.js"], {
+      cwd: extractedPackage,
+      detached: true,
+      env: {
+        ...runtimeEnvironment,
+        HOSTNAME: "127.0.0.1",
+        PORT: String(port),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    server.stdout.on("data", collect);
+    server.stderr.on("data", collect);
+    server.once("error", collect);
+
+    const safeOutput = () => scrubOutput(output, tempDirectory);
+    await waitForOk(port, "/api/files", server, safeOutput);
+    console.log("npm package smoke: /api/files returned 200.");
+    await waitForOk(port, "/api/resources", server, safeOutput);
+    console.log("npm package smoke: /api/resources returned 200; observing worker health.");
+    const observationDeadline = Date.now() + observationMs;
+    while (Date.now() < observationDeadline) {
+      if (server.exitCode !== null || server.signalCode !== null) {
+        throw new Error(`standalone server exited during smoke observation: ${safeOutput()}`);
+      }
+      const failure = workerFailure(safeOutput());
+      if (failure) throw new Error(`worker failure during smoke observation: ${failure}`);
+      await delay(250);
+    }
+    await stop(server);
+    server = undefined;
+
+    output = "";
+    const cliPort = await availablePort();
+    server = spawn(bunRuntime, [
+      "--bun",
+      "bin/cli.mjs",
+      "--no-open",
+      "--hostname",
+      "127.0.0.1",
+      "--port",
+      String(cliPort),
+    ], {
+      cwd: extractedPackage,
+      detached: true,
+      env: runtimeEnvironment,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    server.stdout.on("data", collect);
+    server.stderr.on("data", collect);
+    server.once("error", collect);
+    await waitForOk(cliPort, "/api/files", server, safeOutput);
+    const cliFailure = workerFailure(safeOutput());
+    if (cliFailure) throw new Error(`worker failure during CLI smoke: ${cliFailure}`);
+    console.log("npm package smoke passed: direct and CLI launches served /api/files; workers stayed healthy for 60 seconds.");
+  } finally {
+    if (server) await stop(server);
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/npm-package-smoke.mjs
+++ b/scripts/npm-package-smoke.mjs
@@ -73,7 +73,7 @@ function workerFailure(output) {
   return output.split("\n").find((line) => (
     line.includes("Cannot find module")
     || line.includes("Module not found")
-    || /worker(?:_|\s)exited/i.test(line)
+    || /worker(?:_|\s)(?:exited|start_failed|failed to start)/i.test(line)
     || /worker exit/i.test(line)
   ));
 }
@@ -164,12 +164,14 @@ async function main() {
     const runtimePath = pathWithoutBunContainer(process.env.PATH);
     if (!runtimePath) throw new Error("smoke PATH is empty after removing bun-container");
     const bunRuntime = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
+    const nodeRuntime = process.env.LLV_NODE_EXECUTABLE || "node";
     const port = await availablePort();
     const runtimeEnvironment = {
       PATH: runtimePath,
       HOME: homeDirectory,
       XDG_CONFIG_HOME: configDirectory,
       LLV_STATE_DIR: stateDirectory,
+      LLV_BUN_EXECUTABLE: bunRuntime,
       TMPDIR: runtimeTempDirectory,
       NODE_ENV: "production",
       LLV_STRUCTURED_HOSTS: "off",
@@ -182,7 +184,7 @@ async function main() {
         output = Buffer.from(output).subarray(-outputLimitBytes).toString("utf8");
       }
     };
-    server = spawn(bunRuntime, ["--bun", "dist/standalone/server.js"], {
+    server = spawn(nodeRuntime, ["dist/standalone/server.js"], {
       cwd: extractedPackage,
       detached: true,
       env: {

--- a/scripts/npm-package-smoke.test.ts
+++ b/scripts/npm-package-smoke.test.ts
@@ -2,9 +2,15 @@ import { expect, test } from "bun:test";
 import path from "node:path";
 
 test("the packed standalone server starts with every worker available", async () => {
+  const nodeSearchPath = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter((directory) => !path.basename(directory).startsWith("bun-node-"))
+    .join(path.delimiter);
+  const nodeExecutable = Bun.which("node", { PATH: nodeSearchPath });
+  if (!nodeExecutable) throw new Error("the npm package smoke requires Node");
   const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "npm-package-smoke.mjs")], {
     cwd: path.resolve(import.meta.dir, ".."),
-    env: process.env,
+    env: { ...process.env, LLV_NODE_EXECUTABLE: nodeExecutable },
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",

--- a/scripts/npm-package-smoke.test.ts
+++ b/scripts/npm-package-smoke.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+test("the packed standalone server starts with every worker available", async () => {
+  const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "npm-package-smoke.mjs")], {
+    cwd: path.resolve(import.meta.dir, ".."),
+    env: process.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  expect(exitCode, `${stdout}\n${stderr}`.trim()).toBe(0);
+}, 150_000);

--- a/scripts/prepack.mjs
+++ b/scripts/prepack.mjs
@@ -1,4 +1,4 @@
-import { cp, readdir, rm } from "node:fs/promises";
+import { cp, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -17,6 +17,27 @@ const standaloneDir = join(root, ".next", "standalone");
 const staticDir = join(root, ".next", "static");
 const distDir = join(root, "dist");
 const distStandaloneDir = join(distDir, "standalone");
+
+const standaloneServerBootstrap = `const { spawn } = require("node:child_process");
+
+if (process.versions.bun) {
+  require("./server.bun.js");
+} else {
+  const bun = process.env.LLV_BUN_EXECUTABLE || "bun";
+  const child = spawn(bun, ["--bun", __filename, ...process.argv.slice(2)], {
+    env: process.env,
+    stdio: "inherit",
+  });
+  child.once("error", (error) => {
+    console.error(\`Failed to start the Bun server runtime: \${error.message}\`);
+    process.exitCode = 1;
+  });
+  child.once("exit", (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    else process.exitCode = code ?? 1;
+  });
+}
+`;
 
 function runNextBuild() {
   return new Promise((resolve, reject) => {
@@ -103,6 +124,8 @@ async function main() {
     await rm(join(distStandaloneDir, ".claude"), { recursive: true, force: true });
   }
   await cp(staticDir, join(distStandaloneDir, ".next", "static"), { recursive: true });
+  await rename(join(distStandaloneDir, "server.js"), join(distStandaloneDir, "server.bun.js"));
+  await writeFile(join(distStandaloneDir, "server.js"), standaloneServerBootstrap);
   await runMcpBuild();
 
   if (!existsSync(join(distStandaloneDir, "server.js"))) {

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -271,7 +271,10 @@ function inventoryWorkerLaunch(cwd = process.cwd()): { executable: string; worke
   if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
     return { executable: "/usr/local/bin/bun-container", workerPath: source };
   }
-  if (fs.existsSync(bundled)) return { executable: process.execPath, workerPath: bundled };
+  if (fs.existsSync(bundled)) {
+    const bun = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
+    return { executable: bun, workerPath: bundled };
+  }
   return { executable: process.execPath, workerPath: source };
 }
 

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -779,15 +779,19 @@ describe("resource observation", () => {
     const standaloneBundle = `${standaloneCwd}/.next/server/resource-collector-worker.js`;
     const prepackBundle = `${prepackCwd}/.next/server/resource-collector-worker.js`;
     const bunContainer = "/usr/local/bin/bun-container";
-    const resolve = (cwd: string, present: string[], env: NodeJS.ProcessEnv = { NODE_ENV: "test" }) => resolveResourceWorkerLaunch({
+    const resolve = (cwd: string, present: string[], env: NodeJS.ProcessEnv = {
+      NODE_ENV: "test",
+      LLV_BUN_EXECUTABLE: "/usr/bin/bun",
+    }) => resolveResourceWorkerLaunch({
       cwd,
       env,
       execPath: "/usr/bin/node",
       exists: (pathname) => present.includes(pathname),
+      versions: {},
     });
 
     expect(resolve(sourceCwd, [sourceWorker, sourceBundle, bunContainer])).toEqual({ executable: bunContainer, workerPath: sourceWorker });
-    expect(resolve(sourceCwd, [sourceWorker, sourceBundle])).toEqual({ executable: "/usr/bin/node", workerPath: sourceBundle });
+    expect(resolve(sourceCwd, [sourceWorker, sourceBundle])).toEqual({ executable: "/usr/bin/bun", workerPath: sourceBundle });
     expect(resolve(sourceCwd, [sourceWorker])).toEqual({ executable: "bun", workerPath: sourceWorker });
     expect(resolve(sourceCwd, [sourceWorker], {
       NODE_ENV: "test",
@@ -803,11 +807,11 @@ describe("resource observation", () => {
       ["prepack", prepackCwd, prepackBundle],
     ] as const) {
       expect(resolve(cwd, [bundle, bunContainer]), `${layout} with bun-container`).toEqual({
-        executable: "/usr/bin/node",
+        executable: "/usr/bin/bun",
         workerPath: bundle,
       });
       expect(resolve(cwd, [bundle]), `${layout} without bun-container`).toEqual({
-        executable: "/usr/bin/node",
+        executable: "/usr/bin/bun",
         workerPath: bundle,
       });
       expect(resolve(cwd, [bundle], {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -707,6 +707,7 @@ type ResourceWorkerLaunchOptions = {
   env?: NodeJS.ProcessEnv;
   execPath?: string;
   exists?: (pathname: string) => boolean;
+  versions?: { bun?: string };
 };
 
 export function resolveResourceWorkerLaunch(options: ResourceWorkerLaunchOptions = {}): {
@@ -716,6 +717,8 @@ export function resolveResourceWorkerLaunch(options: ResourceWorkerLaunchOptions
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
   const exists = options.exists ?? existsSync;
+  const execPath = options.execPath ?? process.execPath;
+  const versions = options.versions ?? process.versions;
   const sourceWorker = path.join(cwd, "src/lib/resourceCollector.worker.ts");
   const bundledWorker = path.join(cwd, ".next/server/resource-collector-worker.js");
   const sourceWorkerExists = exists(sourceWorker);
@@ -730,7 +733,7 @@ export function resolveResourceWorkerLaunch(options: ResourceWorkerLaunchOptions
   const bunContainer = "/usr/local/bin/bun-container";
   if (sourceWorkerExists && exists(bunContainer)) return { executable: bunContainer, workerPath: sourceWorker };
   if (bundledWorkerExists) {
-    return { executable: options.execPath ?? process.execPath, workerPath: bundledWorker };
+    return { executable: versions.bun ? execPath : (env.LLV_BUN_EXECUTABLE || "bun"), workerPath: bundledWorker };
   }
   return { executable: "bun", workerPath: sourceWorker };
 }

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -63,7 +63,10 @@ function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: st
   if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
     return { executable: "/usr/local/bin/bun-container", workerPath: source };
   }
-  if (fs.existsSync(bundled)) return { executable: process.execPath, workerPath: bundled };
+  if (fs.existsSync(bundled)) {
+    const bun = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
+    return { executable: bun, workerPath: bundled };
+  }
   return { executable: process.execPath, workerPath: source };
 }
 

--- a/src/lib/scanner/filesResponseWorker.ts
+++ b/src/lib/scanner/filesResponseWorker.ts
@@ -56,7 +56,10 @@ function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: st
   if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
     return { executable: "/usr/local/bin/bun-container", workerPath: source };
   }
-  if (fs.existsSync(bundled)) return { executable: process.execPath, workerPath: bundled };
+  if (fs.existsSync(bundled)) {
+    const bun = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
+    return { executable: bun, workerPath: bundled };
+  }
   return { executable: process.execPath, workerPath: source };
 }
 

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -388,7 +388,10 @@ async function startWakatimeWorker(): Promise<void> {
   const launch = fs.existsSync(source) && fs.existsSync(bunContainer)
     ? { executable: bunContainer, workerPath: source }
     : fs.existsSync(bundled)
-      ? { executable: process.execPath, workerPath: bundled }
+      ? {
+          executable: process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun"),
+          workerPath: bundled,
+        }
       : { executable: process.execPath, workerPath: source };
   const { spawn } = await import("node:child_process");
   const useNice = fs.existsSync("/usr/bin/nice");


### PR DESCRIPTION
Fixes #1155

## Summary

- bundle all five background workers as Next server entries
- trace every worker entry and shared server chunk into standalone packages
- add an extracted-tarball smoke for direct and CLI startup with isolated state, no source tree, and a PATH without bun-container
- bump the package version to 1.0.1

## Verification

- `bunx tsc --noEmit --incremental false`
- `bun test next.config.test.ts scripts/npm-package-smoke.test.ts` (2 passed)
- `node scripts/prepack.mjs`
- packed direct and CLI launches served `/api/files`; the direct launch also served `/api/resources` and completed a 60-second worker-health observation
- `bun scripts/privacy-publication-gate.ts --base 813bf4b6e2d8218804031dee8d64dfe6bdf917d8 --check-commits`