### PR TITLE
feat(orchestrator): provision viewer MCP for structured spawns

### DIFF
--- a/src/app/api/orchestrator/seat/route.test.ts
+++ b/src/app/api/orchestrator/seat/route.test.ts
@@ -12,7 +12,7 @@ import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { orchestratorSeatFor } from "@/lib/orchestrator/seats";
 
 import { POST as rotatePost } from "../rotate/route";
-import { POST as seatPost } from "./route";
+import { GET as seatGet, POST as seatPost } from "./route";
 
 /*
  * BLOCKING 1 (#758 review), the route half: the designation surface refuses a
@@ -24,12 +24,15 @@ import { POST as seatPost } from "./route";
 
 let sandbox = "";
 let previousStateDir: string | undefined;
+let previousHome: string | undefined;
 const WORKER_CAPABILITY = crypto.randomBytes(32).toString("base64url");
 
 beforeEach(() => {
   previousStateDir = process.env.LLV_STATE_DIR;
+  previousHome = process.env.HOME;
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-seat-route-"));
   process.env.LLV_STATE_DIR = sandbox;
+  process.env.HOME = sandbox;
   setCallerConversationResolverForTests((digest) =>
     digest === crypto.createHash("sha256").update(WORKER_CAPABILITY).digest("hex")
       ? "conversation_worker"
@@ -40,6 +43,8 @@ afterEach(() => {
   setCallerConversationResolverForTests(null);
   if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
   else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
@@ -72,4 +77,18 @@ test("a capability-presenting agent is refused designation at both routes, and n
   const { active, pending } = orchestratorSeatFor("proj-a");
   expect(active).toBeNull();
   expect(pending).toBeNull();
+});
+
+test("the seat read reports the Viewer MCP definition resolved for the project cwd", async () => {
+  const project = path.join(sandbox, "project");
+  fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+
+  const missing = await seatGet(new NextRequest(`http://127.0.0.1/api/orchestrator/seat?project=proj-a&cwd=${encodeURIComponent(project)}`));
+  expect(await missing.json()).toMatchObject({ viewerMcpRegistered: false });
+
+  fs.writeFileSync(path.join(project, ".mcp.json"), JSON.stringify({
+    mcpServers: { viewer: { type: "stdio", command: "project-viewer" } },
+  }));
+  const registered = await seatGet(new NextRequest(`http://127.0.0.1/api/orchestrator/seat?project=proj-a&cwd=${encodeURIComponent(project)}`));
+  expect(await registered.json()).toMatchObject({ viewerMcpRegistered: true });
 });

--- a/src/app/api/orchestrator/seat/route.ts
+++ b/src/app/api/orchestrator/seat/route.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
+import os from "node:os";
 
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireOperatorAuthority } from "@/lib/agent/operatorAuthority";
+import { viewerMcpRegistered } from "@/lib/agent/spawnPolicy";
 import { executeOrchestratorSeatRequest } from "@/lib/orchestrator/seatCommand";
 import { orchestratorSeatFor, type OrchestratorSeat } from "@/lib/orchestrator/seats";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
@@ -21,16 +23,20 @@ interface SeatStatus {
   /** Whether the active seat's transcript is still on disk; false invites a
       resume or a replacement from the same draft surface. */
   exists: boolean;
+  viewerMcpRegistered: boolean;
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse<SeatStatus | ApiError>> {
   const project = req.nextUrl.searchParams.get("project")?.trim() ?? "";
   if (!project) return NextResponse.json({ error: "project is required" }, { status: 400 });
+  const cwd = req.nextUrl.searchParams.get("cwd")?.trim() || undefined;
+  const home = process.env.HOME?.trim() || os.homedir();
   const { active, pending } = orchestratorSeatFor(project);
   return NextResponse.json({
     seat: active,
     pending,
     exists: active !== null && (active.path === null || fs.existsSync(active.path)),
+    viewerMcpRegistered: viewerMcpRegistered(home, cwd),
   });
 }
 

--- a/src/components/mobile/MobileOrchestratorRow.tsx
+++ b/src/components/mobile/MobileOrchestratorRow.tsx
@@ -74,7 +74,8 @@ export function MobileOrchestratorRow({
   onOpenConversation: (file: FileEntry) => void;
 }) {
   const { t } = useLocale();
-  const { status, failed, refresh } = useOrchestratorSeat(project);
+  const projectCwd = useMemo(() => draftWorkingDirectory(files, project), [files, project]);
+  const { status, failed, refresh } = useOrchestratorSeat(project, projectCwd || undefined);
   const [submitting, setSubmitting] = useState(false);
   /* The guard is SYNCHRONOUS: two taps in one event batch both read the same
      render's `submitting`, so a state flag alone lets the second through. The
@@ -101,11 +102,6 @@ export function MobileOrchestratorRow({
   const surface = useSeatSurface(file);
   const state = deriveOrchestratorPanelState({ status, statusFailed: failed, submitting, submitFailure, file, surface });
   const view = orchestratorRowView(state, { conversationReady: Boolean(file) });
-  /* The project's own newest checkout, exactly as the board's drafts resolve it.
-     Empty simply omits the field, and the seat route resolves the project's own
-     root itself — the operator never types a directory on a phone. */
-  const projectCwd = useMemo(() => draftWorkingDirectory(files, project), [files, project]);
-
   /* A key kept through an unknown outcome is released the moment the seat read
      says where it landed. Held any longer it becomes a trap: the seat command
      answers a replay of a COMPLETED intent with the old seat, so the next
@@ -305,6 +301,7 @@ export function MobileOrchestratorRow({
           state={state}
           file={file}
           pendingMandate={status?.pending?.mandate ?? ""}
+          viewerMcpRegistered={status?.viewerMcpRegistered === true}
           submitting={submitting}
           onConfirm={(payload) => void confirm(payload)}
           onRecheck={() => void refresh()}

--- a/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
@@ -72,6 +72,7 @@ function quietBannerCount(file: FileEntry): number {
       state={state}
       file={file}
       pendingMandate=""
+      viewerMcpRegistered={false}
       submitting={false}
       onConfirm={() => undefined}
       onRecheck={() => undefined}

--- a/src/components/mobile/MobileOrchestratorSheet.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.tsx
@@ -61,6 +61,7 @@ export function MobileOrchestratorSheet({
   state,
   file,
   pendingMandate,
+  viewerMcpRegistered,
   submitting,
   onConfirm,
   onRecheck,
@@ -76,6 +77,7 @@ export function MobileOrchestratorSheet({
   /** The pending intent's own mandate, replayed verbatim when a stuck
       designation is resumed. */
   pendingMandate: string;
+  viewerMcpRegistered: boolean;
   submitting: boolean;
   onConfirm: (payload: SeatConfirmPayload) => void;
   onRecheck: () => void;
@@ -269,6 +271,14 @@ export function MobileOrchestratorSheet({
                   </p>
                 </div>
               )}
+
+              <p
+                className="shrink-0 rounded-control border border-border bg-card px-3 py-2 font-mono text-caption text-secondary"
+                data-viewer-mcp-status={viewerMcpRegistered ? "registered" : "missing"}
+                role="status"
+              >
+                {t(viewerMcpRegistered ? "orchPanel.viewerMcpRegistered" : "orchPanel.viewerMcpMissing")}
+              </p>
 
               {/* The shared launch module, in the phone's own layout: the same
                   fields and the same invariants the dock has, lifted to 44px

--- a/src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx
@@ -60,7 +60,7 @@ const G = globalThis as Record<string, unknown>;
 
 let boardRevision = 1;
 let boardPrefs: Record<string, unknown> = {};
-let seatAnswer: unknown = { seat: null, pending: null, exists: true };
+let seatAnswer: unknown = { seat: null, pending: null, exists: true, viewerMcpRegistered: false };
 const seatPosts: Record<string, unknown>[] = [];
 const emptyPrefs = () => ({
   manual: [], hidden: [], expanded: [], favorites: [], foldedEngineChildIds: [],
@@ -162,7 +162,7 @@ beforeEach(() => {
   boardRevision = 1;
   boardPrefs = {};
   catalogRows = [];
-  seatAnswer = { seat: null, pending: null, exists: true };
+  seatAnswer = { seat: null, pending: null, exists: true, viewerMcpRegistered: false };
   seatPosts.length = 0;
   dom.document.body.replaceChildren();
   dom.sessionStorage.clear();
@@ -255,6 +255,8 @@ test("a project with nothing in it still offers the create row — the leaf wher
   await settle();
   const sheet = host.querySelector('[data-testid="mobile-orchestrator-sheet"]') as unknown as HTMLElement;
   expect(sheet).not.toBeNull();
+  expect(sheet.querySelector("[data-viewer-mcp-status]")?.textContent).toContain("scripts/install-mcp.sh");
+  expect(sheet.querySelector("[data-viewer-mcp-status]")?.textContent).toContain("claude mcp add viewer");
   expect((sheet.querySelector("[data-orchestrator-mandate]") as unknown as HTMLTextAreaElement).value.length).toBeGreaterThan(0);
   flushSync(() => (sheet.querySelector("[data-orchestrator-confirm]") as unknown as HTMLButtonElement).click());
   expect(await waitFor(() => seatPosts.length === 1)).toBe(true);

--- a/src/components/mobile/orchestratorRowState.test.ts
+++ b/src/components/mobile/orchestratorRowState.test.ts
@@ -32,6 +32,10 @@ const seat = (over: Record<string, unknown> = {}) => ({
 const pending = (over: Record<string, unknown> = {}) =>
   seat({ conversationId: null, state: "pending", activatedAt: null, ...over });
 
+type SeatStatusFixture = Omit<OrchestratorSeatStatus, "viewerMcpRegistered"> & {
+  viewerMcpRegistered?: boolean;
+};
+
 const conversation: FileEntry = {
   path: "/orchestrator.jsonl", root: "claude-projects", name: "orchestrator.jsonl", project: "atlas",
   title: "Run the Atlas board", engine: "claude", kind: "session", fmt: "claude", parent: null,
@@ -40,7 +44,7 @@ const conversation: FileEntry = {
 } as FileEntry;
 
 function rowFor(input: {
-  status: OrchestratorSeatStatus | null;
+  status: SeatStatusFixture | null;
   statusFailed?: boolean;
   submitting?: boolean;
   file?: FileEntry | null;
@@ -48,7 +52,7 @@ function rowFor(input: {
 }) {
   const file = input.file ?? null;
   const state = deriveOrchestratorPanelState({
-    status: input.status,
+    status: input.status ? { viewerMcpRegistered: false, ...input.status } : null,
     statusFailed: input.statusFailed ?? false,
     submitting: input.submitting ?? false,
     submitFailure: null,

--- a/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
@@ -84,6 +84,7 @@ interface SeatFile {
   seat: Record<string, unknown> | null;
   pending: Record<string, unknown> | null;
   exists: boolean;
+  viewerMcpRegistered?: boolean;
 }
 
 let seatStatus: SeatFile;
@@ -211,7 +212,7 @@ beforeEach(() => {
   resetOrchestratorSeatCacheForTests();
   resetOrchestratorIncumbentCacheForTests();
   tailLines.clear();
-  seatStatus = { seat: null, pending: null, exists: true };
+  seatStatus = { seat: null, pending: null, exists: true, viewerMcpRegistered: false };
   incumbentStatus = { project: "atlas", designated: false, rotation: null, context: null };
   seatPosts = [];
   rotatePosts = [];
@@ -303,6 +304,8 @@ test("with no orchestrator the panel is a draft prefilled with the default manda
   flushSync(() => undefined);
 
   expect(panelState(host)).toBe("draft");
+  expect(host.querySelector("[data-viewer-mcp-status]")?.textContent).toContain("scripts/install-mcp.sh");
+  expect(host.querySelector("[data-viewer-mcp-status]")?.textContent).toContain("claude mcp add viewer");
   const mandate = host.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement;
   expect(mandate.value).toBe(ORCHESTRATOR_SYSTEM_PROMPT);
   /* Cwd is the project's own root, stated and never typed. */
@@ -327,6 +330,14 @@ test("with no orchestrator the panel is a draft prefilled with the default manda
   expect(String(seatPosts[0]!.clientRequestId)).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
   /* An edited mandate is bespoke — it records no approved-prompt version. */
   expect(seatPosts[0]!.promptVersion).toBeUndefined();
+});
+
+test("the orchestrator draft confirms a resolved Viewer MCP registration", async () => {
+  seatStatus = { seat: null, pending: null, exists: true, viewerMcpRegistered: true };
+  const host = mount();
+  await settle();
+
+  expect(host.querySelector("[data-viewer-mcp-status]")?.textContent).toContain("viewer MCP: registered ✓");
 });
 
 test("an unedited mandate records the approved prompt version", async () => {

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -113,7 +113,7 @@ export function OrchestratorPanel({
   onClose: () => void;
 }) {
   const { t } = useLocale();
-  const { status, failed, refresh } = useOrchestratorSeat(project);
+  const { status, failed, refresh } = useOrchestratorSeat(project, projectCwd);
   const [formError, setFormError] = useState<string | null>(null);
   const [mandate, setMandateState] = useState(() => readDraftField(project, "mandate") || ORCHESTRATOR_SYSTEM_PROMPT);
   /* The conversation the open rotate draft is replacing. Non-null IS the rotate
@@ -414,6 +414,7 @@ export function OrchestratorPanel({
           projectName={projectName}
           cwd={projectCwd}
           launch={launch}
+          viewerMcpRegistered={status?.viewerMcpRegistered === true}
           onMandate={setMandate}
           onRestore={() => setMandate(ORCHESTRATOR_SYSTEM_PROMPT)}
           onConfirm={() => confirmCreate()}
@@ -521,6 +522,7 @@ function RotateDraft({
       projectName={projectName}
       cwd={cwd}
       launch={launch}
+      viewerMcpRegistered={status?.viewerMcpRegistered === true}
       onMandate={(value) => {
         setMandateState(value);
         writeField("Rotate", project, "mandate", value === seat.mandate ? "" : value);
@@ -552,6 +554,7 @@ function OrchestratorDraft({
   projectName,
   cwd,
   launch,
+  viewerMcpRegistered,
   onMandate,
   onRestore,
   onConfirm,
@@ -566,6 +569,7 @@ function OrchestratorDraft({
   projectName: string;
   cwd?: string;
   launch: ReturnType<typeof useAgentLaunchDraft>;
+  viewerMcpRegistered: boolean;
   onMandate: (value: string) => void;
   onRestore: () => void;
   onConfirm: () => void;
@@ -621,6 +625,14 @@ function OrchestratorDraft({
             </p>
           </div>
         )}
+
+        <p
+          className="shrink-0 rounded-control border border-border bg-canvas px-3 py-2 font-mono text-caption text-secondary"
+          data-viewer-mcp-status={viewerMcpRegistered ? "registered" : "missing"}
+          role="status"
+        >
+          {t(viewerMcpRegistered ? "orchPanel.viewerMcpRegistered" : "orchPanel.viewerMcpMissing")}
+        </p>
 
         <div className="shrink-0">
           <AgentLaunchControls draft={launch} disabled={submitting} stacked />

--- a/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
+++ b/src/components/orchestrator/orchestratorAnswerCache.dom.test.tsx
@@ -34,15 +34,16 @@ const { resetOrchestratorIncumbentCacheForTests, useOrchestratorIncumbent } = aw
 /** One project's answers on the server, as the two routes report them. */
 const seats = new Map<string, string>();
 const models = new Map<string, string>();
+const viewerMcpCwds = new Set<string>();
 /** Reads issued per project, so «revalidated in the background» is a count and
     not a hope. */
 let seatReads: string[];
 let statusReads: string[];
 const realFetch = globalThis.fetch;
 
-function seatBody(project: string): unknown {
+function seatBody(project: string, cwd: string): unknown {
   const conversationId = seats.get(project);
-  if (!conversationId) return { seat: null, pending: null, exists: true };
+  if (!conversationId) return { seat: null, pending: null, exists: true, viewerMcpRegistered: viewerMcpCwds.has(cwd) };
   return {
     seat: {
       project,
@@ -57,6 +58,7 @@ function seatBody(project: string): unknown {
     },
     pending: null,
     exists: true,
+    viewerMcpRegistered: viewerMcpCwds.has(cwd),
   };
 }
 
@@ -77,6 +79,7 @@ beforeEach(() => {
   resetOrchestratorIncumbentCacheForTests();
   seats.clear();
   models.clear();
+  viewerMcpCwds.clear();
   seatReads = [];
   statusReads = [];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -87,7 +90,7 @@ beforeEach(() => {
       return { ok: true, status: 200, json: async () => statusBody(project) } as Response;
     }
     seatReads.push(project);
-    return { ok: true, status: 200, json: async () => seatBody(project) } as Response;
+    return { ok: true, status: 200, json: async () => seatBody(project, url.searchParams.get("cwd") ?? "") } as Response;
   }) as typeof fetch;
 });
 
@@ -99,16 +102,16 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-/** Everything the panel derives its state from, as two attributes: the seat
-    answer (or the absence that renders as `loading`) and the incumbent's model,
-    which is what the header would name. */
-function Probe({ project }: { project: string }) {
-  const { status, failed } = useOrchestratorSeat(project);
+/** Everything the panel derives its state from: the seat answer (or loading),
+    the incumbent model, and the cwd-scoped Viewer MCP preflight. */
+function Probe({ project, cwd }: { project: string; cwd?: string }) {
+  const { status, failed } = useOrchestratorSeat(project, cwd);
   const { incumbent } = useOrchestratorIncumbent(project, Boolean(status?.seat));
   return (
     <div
       data-seat={status ? status.seat?.conversationId ?? "vacant" : failed ? "unavailable" : "loading"}
       data-model={incumbent?.model ?? "unread"}
+      data-viewer-mcp={status?.viewerMcpRegistered ? "registered" : "missing"}
     />
   );
 }
@@ -125,12 +128,30 @@ function mountProbe() {
   roots.add(root);
   const probe = () => host.querySelector("div[data-seat]")!;
   return {
-    /* Keyed by project, the way the dock re-seats the panel. */
-    open: (project: string) => flushSync(() => root.render(<Probe key={project} project={project} />)),
+    /* Keyed by project and cwd, the status scope the panel opens. */
+    open: (project: string, cwd?: string) => flushSync(() => root.render(<Probe key={`${project}:${cwd ?? ""}`} project={project} cwd={cwd} />)),
     seat: () => probe().getAttribute("data-seat"),
     model: () => probe().getAttribute("data-model"),
+    viewerMcp: () => probe().getAttribute("data-viewer-mcp"),
   };
 }
+
+test("the Viewer MCP preflight cache is scoped by cwd inside one grouped project", async () => {
+  const dock = mountProbe();
+  viewerMcpCwds.add("/repo/atlas/registered");
+
+  dock.open("atlas", "/repo/atlas/missing");
+  await settle();
+  expect(dock.viewerMcp()).toBe("missing");
+
+  dock.open("atlas", "/repo/atlas/registered");
+  expect(dock.seat()).toBe("loading");
+  await settle();
+  expect(dock.viewerMcp()).toBe("registered");
+
+  dock.open("atlas", "/repo/atlas/missing");
+  expect(dock.viewerMcp()).toBe("missing");
+});
 
 test("a project answered once repaints from the answer, and revalidates behind it", async () => {
   seats.set("atlas", "conversation_atlas");

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -34,7 +34,7 @@ function seat(overrides: Partial<OrchestratorSeat> = {}): OrchestratorSeat {
 }
 
 function status(overrides: Partial<OrchestratorSeatStatus> = {}): OrchestratorSeatStatus {
-  return { seat: null, pending: null, exists: true, ...overrides };
+  return { seat: null, pending: null, exists: true, viewerMcpRegistered: false, ...overrides };
 }
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
@@ -320,15 +320,16 @@ describe("the rotate draft renders the same two states the create draft does (#9
 
 describe("seat status parsing", () => {
   test("a malformed body reads as no seat rather than throwing", () => {
-    expect(parseSeatStatus(null)).toEqual({ seat: null, pending: null, exists: true });
+    expect(parseSeatStatus(null)).toEqual({ seat: null, pending: null, exists: true, viewerMcpRegistered: false });
     expect(parseSeatStatus({ seat: { project: 7 }, pending: [], exists: false }))
-      .toEqual({ seat: null, pending: null, exists: false });
+      .toEqual({ seat: null, pending: null, exists: false, viewerMcpRegistered: false });
   });
 
   test("a well-formed seat keeps the fields the panel renders from", () => {
-    const parsed = parseSeatStatus({ seat: seat(), pending: null, exists: true });
+    const parsed = parseSeatStatus({ seat: seat(), pending: null, exists: true, viewerMcpRegistered: true });
     expect(parsed.seat?.conversationId).toBe("conversation_orchestrator");
     expect(parsed.seat?.intent.clientRequestId).toBe("req-11111111");
+    expect(parsed.viewerMcpRegistered).toBe(true);
   });
 });
 

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -28,16 +28,20 @@ export interface OrchestratorSeatStatus {
   /** False once the active seat's transcript has left the disk — the operator
       closed the conversation card, so the panel returns to the draft. */
   exists: boolean;
+  /** Whether Claude resolves an operator-authored Viewer MCP definition for
+      the project cwd. Structured spawns can supply their own definition. */
+  viewerMcpRegistered: boolean;
 }
 
 /** Crash-safe read of the seat route's body: anything malformed reads as «no
     seat», which lands the panel on the draft rather than on a broken render. */
 export function parseSeatStatus(body: unknown): OrchestratorSeatStatus {
-  const raw = body as { seat?: unknown; pending?: unknown; exists?: unknown } | null;
+  const raw = body as { seat?: unknown; pending?: unknown; exists?: unknown; viewerMcpRegistered?: unknown } | null;
   return {
     seat: seatOf(raw?.seat),
     pending: seatOf(raw?.pending),
     exists: raw?.exists !== false,
+    viewerMcpRegistered: raw?.viewerMcpRegistered === true,
   };
 }
 

--- a/src/components/orchestrator/useOrchestratorSeat.ts
+++ b/src/components/orchestrator/useOrchestratorSeat.ts
@@ -23,12 +23,13 @@ interface ScopedRead {
   /** The project this answer is about; an answer for any other project is
       reconciled away at render time rather than shown for a frame. */
   project: string;
+  cwd: string;
   status: OrchestratorSeatStatus | null;
   failed: boolean;
 }
 
 /**
- * Every answer this tab has been given, keyed by project (#1149).
+ * Every answer this tab has been given, keyed by project and cwd (#1149).
  *
  * The panel is RE-SEATED on a project switch — a fresh mount, because its draft
  * belongs to one project — so the answer cannot live in its state and survive.
@@ -41,18 +42,23 @@ interface ScopedRead {
  * still be READ, never restored from disk.
  */
 const answers = new Map<string, ScopedRead>();
+const readKey = (project: string, cwd: string | undefined): string => `${project}\0${cwd ?? ""}`;
 
 export function resetOrchestratorSeatCacheForTests(): void {
   answers.clear();
 }
 
-export async function fetchOrchestratorSeat(project: string, signal?: AbortSignal): Promise<OrchestratorSeatStatus> {
-  const response = await fetch("/api/orchestrator/seat?project=" + encodeURIComponent(project), signal ? { signal } : undefined);
+export async function fetchOrchestratorSeat(project: string, cwd?: string, signal?: AbortSignal): Promise<OrchestratorSeatStatus> {
+  const query = new URLSearchParams({ project });
+  if (cwd) query.set("cwd", cwd);
+  const response = await fetch("/api/orchestrator/seat?" + query, signal ? { signal } : undefined);
   if (!response.ok) throw new Error(`orchestrator seat read failed: ${response.status}`);
   return parseSeatStatus(await response.json());
 }
 
-const cachedSeat = (project: string | null): ScopedRead | null => (project ? answers.get(project) ?? null : null);
+const cachedSeat = (project: string | null, cwd: string | undefined): ScopedRead | null => (
+  project ? answers.get(readKey(project, cwd)) ?? null : null
+);
 
 /**
  * The project's orchestrator seat, polled — and answered at once for a project
@@ -60,43 +66,47 @@ const cachedSeat = (project: string | null): ScopedRead | null => (project ? ans
  *
  * `project` null (Overview, or the panel closed) reads nothing at all.
  */
-export function useOrchestratorSeat(project: string | null): OrchestratorSeatRead {
-  const [read, setRead] = useState<ScopedRead | null>(() => cachedSeat(project));
-  /* Every answer carries the project it answered for, so a project switch
+export function useOrchestratorSeat(project: string | null, cwd?: string): OrchestratorSeatRead {
+  const [read, setRead] = useState<ScopedRead | null>(() => cachedSeat(project, cwd));
+  /* Every answer carries the project and cwd it answered for, so a scope switch
      invalidates the previous seat HERE, in render, with no effect and no frame
-     in which the old incumbent shows under the new project's name. What takes
-     its place is what THIS project last answered, not «loading». */
-  const current = read && read.project === project ? read : cachedSeat(project);
+     in which another checkout's preflight appears under this draft. */
+  const current = read && read.project === project && read.cwd === (cwd ?? "")
+    ? read
+    : cachedSeat(project, cwd);
 
-  const settle = useCallback((target: string, status: OrchestratorSeatStatus | null, failed: boolean) => {
+  const settle = useCallback((target: string, targetCwd: string | undefined, status: OrchestratorSeatStatus | null, failed: boolean) => {
+    const key = readKey(target, targetCwd);
     const next: ScopedRead = {
       project: target,
+      cwd: targetCwd ?? "",
       /* A failed re-read keeps the last good answer for the SAME project; the
-         cache is keyed by project, so it can never resurrect another's. */
-      status: status ?? answers.get(target)?.status ?? null,
+         cache is keyed by project and cwd, so it cannot resurrect another
+         checkout's registration status. */
+      status: status ?? answers.get(key)?.status ?? null,
       failed,
     };
-    answers.set(target, next);
+    answers.set(key, next);
     setRead(next);
   }, []);
 
   const refresh = useCallback(async () => {
     if (!project) return;
     try {
-      settle(project, await fetchOrchestratorSeat(project), false);
+      settle(project, cwd, await fetchOrchestratorSeat(project, cwd), false);
     } catch {
-      settle(project, null, true);
+      settle(project, cwd, null, true);
     }
-  }, [project, settle]);
+  }, [cwd, project, settle]);
 
   useEffect(() => {
     if (!project) return;
     const controller = new AbortController();
     const load = () => {
-      void fetchOrchestratorSeat(project, controller.signal)
-        .then((status) => settle(project, status, false))
+      void fetchOrchestratorSeat(project, cwd, controller.signal)
+        .then((status) => settle(project, cwd, status, false))
         .catch((cause: unknown) => {
-          if ((cause as { name?: string }).name !== "AbortError") settle(project, null, true);
+          if ((cause as { name?: string }).name !== "AbortError") settle(project, cwd, null, true);
         });
     };
     load();
@@ -105,7 +115,7 @@ export function useOrchestratorSeat(project: string | null): OrchestratorSeatRea
       clearInterval(timer);
       controller.abort();
     };
-  }, [project, settle]);
+  }, [cwd, project, settle]);
 
   return { status: current?.status ?? null, failed: current?.failed ?? false, refresh };
 }

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_MULTI_AGENT_HOOK_MATCHER, NATIVE_MULTI_AGENT_TOOLS, NATIVE_SUBAGENT_DENY_MESSAGE, prepareManagedClaudeSpawnHome, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
+import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_MULTI_AGENT_HOOK_MATCHER, NATIVE_MULTI_AGENT_TOOLS, NATIVE_SUBAGENT_DENY_MESSAGE, prepareManagedClaudeSpawnHome, viewerMcpServerEntry, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
 
 const homes: string[] = [];
 const TELEGRAM_HEADERS = {
@@ -165,6 +165,47 @@ test("Claude native MCP config defaults to the registered Viewer server only", (
 
   expect(mcpConfig.mcpServers).toEqual({ viewer: { type: "stdio", command: "viewer-mcp" } });
   expect(JSON.parse(fs.readFileSync(installed.settingsPath, "utf8"))).not.toHaveProperty("mcpServers");
+});
+
+test("Claude native MCP config supplies the packaged Viewer server on a fresh install", () => {
+  const accountHome = home();
+  const launcher = path.resolve(process.cwd(), "bin", "mcp-server.mjs");
+
+  const installed = applyClaudeSpawnPolicy(accountHome, { profileId: "fresh-mcp", cwd: "/repo" });
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+
+  expect(mcpConfig.mcpServers).toEqual({
+    viewer: { type: "stdio", command: "bun", args: [launcher] },
+  });
+  expect(viewerMcpServerEntry()).toEqual({ command: "bun", args: [launcher] });
+  expect(fs.existsSync(launcher)).toBe(true);
+  expect(fs.existsSync(path.join(accountHome, ".claude.json"))).toBe(false);
+});
+
+test("the packaged Viewer entry fails before writing an unusable launcher path", () => {
+  expect(() => viewerMcpServerEntry(home())).toThrow("Viewer MCP launcher could not be resolved");
+});
+
+test("Claude native MCP config preserves an operator Viewer definition byte-for-byte", () => {
+  const accountHome = home();
+  const statePath = path.join(accountHome, ".claude.json");
+  const operatorState = JSON.stringify({
+    theme: "dark",
+    mcpServers: {
+      viewer: { type: "stdio", command: "operator-viewer", args: ["--custom"] },
+    },
+  }, null, 2) + "\n";
+  fs.writeFileSync(statePath, operatorState);
+
+  const installed = applyClaudeSpawnPolicy(accountHome, { profileId: "operator-mcp", cwd: "/repo" });
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+
+  expect(mcpConfig.mcpServers.viewer).toEqual({ type: "stdio", command: "operator-viewer", args: ["--custom"] });
+  expect(fs.readFileSync(statePath, "utf8")).toBe(operatorState);
 });
 
 test("Claude native MCP config merges project scope between user and local scopes", () => {

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -43,6 +43,24 @@ export const CODEX_VIEWER_SPAWN_FEATURES = {
   multi_agent: false,
 } as const;
 
+export interface ViewerMcpServerEntry {
+  command: string;
+  args: string[];
+}
+
+/** The package-owned Viewer server, from either a checkout root or the
+    standalone server directory used by the published CLI. */
+export function viewerMcpServerEntry(packageCwd = process.cwd()): ViewerMcpServerEntry {
+  const direct = path.resolve(packageCwd, "bin", "mcp-server.mjs");
+  const fromStandalone = path.resolve(packageCwd, "..", "..", "bin", "mcp-server.mjs");
+  const launcher = [direct, fromStandalone].find((candidate) => fs.existsSync(candidate));
+  if (!launcher) throw new Error(`Viewer MCP launcher could not be resolved from package cwd: ${packageCwd}`);
+  return {
+    command: "bun",
+    args: [launcher],
+  };
+}
+
 export interface ClaudeSpawnPolicyResult {
   settingsPath: string;
   mcpConfigPath: string;
@@ -115,25 +133,44 @@ function claudeProjectMcpServers(cwd: string | undefined): JsonObject {
   return record(readSettings(configPath).mcpServers) ?? {};
 }
 
-function claudeMcpServers(
-  pathname: string,
+/** Resolves Claude's registered MCP definitions with the same scope precedence
+    used when a structured spawn builds its strict per-spawn config. */
+export function resolveClaudeMcpServers(
+  home: string,
   cwd: string | undefined,
-  allowlist: readonly string[] | undefined,
+  mcpStatePath = path.join(home, ".claude.json"),
 ): JsonObject {
-  if (!fs.existsSync(pathname)) return {};
-  const state = readSettings(pathname);
+  const state = fs.existsSync(mcpStatePath) ? readSettings(mcpStatePath) : {};
   const rootServers = record(state.mcpServers) ?? {};
   const projects = record(state.projects);
   const project = cwd && projects ? record(projects[cwd]) : null;
   const sharedProjectServers = claudeProjectMcpServers(cwd);
   const localProjectServers = record(project?.mcpServers) ?? {};
-  const registered = { ...rootServers, ...sharedProjectServers, ...localProjectServers };
+  return { ...rootServers, ...sharedProjectServers, ...localProjectServers };
+}
+
+export function viewerMcpRegistered(
+  home: string,
+  cwd: string | undefined,
+  mcpStatePath?: string,
+): boolean {
+  return record(resolveClaudeMcpServers(home, cwd, mcpStatePath).viewer) !== null;
+}
+
+function claudeMcpServers(
+  home: string,
+  cwd: string | undefined,
+  allowlist: readonly string[] | undefined,
+  mcpStatePath?: string,
+): JsonObject {
+  const registered = resolveClaudeMcpServers(home, cwd, mcpStatePath);
   /* The grant bound is enforced again here (issue #739): the per-spawn
      `--strict-mcp-config` file is copied from the re-validated list, so a
      server the Viewer cannot grant is never written into it. */
   const names = grantedMcpServers(allowlist);
   return Object.fromEntries(names.flatMap((name) => {
-    const definition = record(registered[name]);
+    const definition = record(registered[name])
+      ?? (name === "viewer" ? { type: "stdio", ...viewerMcpServerEntry() } : null);
     return definition ? [[name, definition]] : [];
   }));
 }
@@ -236,9 +273,10 @@ export function applyClaudeSpawnPolicy(
     ? settings
     : { ...settings, disableAllHooks: false, allowManagedHooksOnly: false };
   const mcpServers = claudeMcpServers(
-    options.mcpStatePath ?? path.join(home, ".claude.json"),
+    home,
     options.cwd,
     options.mcpServers,
+    options.mcpStatePath,
   );
   const includedMcpServers = new Set(Object.keys(mcpServers));
   const excludedProjectMcpServers = Object.keys(claudeProjectMcpServers(options.cwd))

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import { viewerMcpServerEntry } from "./agent/spawnPolicy";
 import { headlessCodexThreadConfig } from "./codexHeadlessConfig";
 
 test("headless Codex threads allow only the registered Viewer MCP server", () => {
@@ -20,9 +21,12 @@ test("headless Codex threads allow only the registered Viewer MCP server", () =>
   });
 });
 
-test("configurations without Viewer disable every registered MCP server", () => {
+test("configurations without Viewer add the packaged server and disable every unrelated MCP server", () => {
   expect(headlessCodexThreadConfig({ config: { mcp_servers: { docs: {} } } })).toEqual({
-    mcp_servers: { docs: { enabled: false } },
+    mcp_servers: {
+      docs: { enabled: false },
+      viewer: { ...viewerMcpServerEntry(), enabled: true, default_tools_approval_mode: "approve" },
+    },
     features: { plugins: false, apps: false, multi_agent: false, realtime_conversation: true },
     include_apps_instructions: false,
   });

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -1,4 +1,4 @@
-import { CODEX_VIEWER_SPAWN_FEATURES } from "@/lib/agent/spawnPolicy";
+import { CODEX_VIEWER_SPAWN_FEATURES, viewerMcpServerEntry } from "@/lib/agent/spawnPolicy";
 import { grantedMcpServers } from "@/lib/agent/mcpAllowlist";
 import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 
@@ -38,12 +38,16 @@ export function headlessCodexThreadConfig(
      table is materialized from the re-validated list, so a launch profile
      edited by hand cannot turn a server on for this thread. */
   const enabled = new Set(grantedMcpServers(mcpServers));
+  const viewerMissing = record(servers.viewer) === null;
+  const materializedServers = viewerMissing && enabled.has("viewer")
+    ? { ...servers, viewer: viewerMcpServerEntry() }
+    : servers;
   /* The plugin subsystem is off for every session that holds no grant, which
      is the default. A grant turns it on for THIS thread only — never for the
      app-server, never in the operator's configuration. */
   const granted = grantedPlugins(plugins);
   return {
-    mcp_servers: Object.fromEntries(Object.entries(servers).map(([name, server]) => {
+    mcp_servers: Object.fromEntries(Object.entries(materializedServers).map(([name, server]) => {
       const configuredApproval = record(server)?.default_tools_approval_mode;
       const approval = name === "viewer"
         ? "approve"
@@ -51,6 +55,7 @@ export function headlessCodexThreadConfig(
           ? configuredApproval
           : null;
       return [name, {
+        ...(name === "viewer" && viewerMissing ? server as JsonObject : {}),
         enabled: enabled.has(name),
         ...(approval ? { default_tools_approval_mode: approval } : {}),
       }];

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1815,6 +1815,8 @@ export const en = {
   "orchPanel.draftTitle": "Create this project's orchestrator",
   "orchPanel.draftHint": "It runs in {project}, owns this board, and answers you here. The text below is delivered to it as its first message — edit it however you like.",
   "orchPanel.draftHintVacated": "The previous orchestrator's conversation is gone. Create a new one for {project}; the text below is delivered as its first message.",
+  "orchPanel.viewerMcpRegistered": "viewer MCP: registered ✓",
+  "orchPanel.viewerMcpMissing": "viewer MCP: run scripts/install-mcp.sh or claude mcp add viewer -- bun ./bin/mcp-server.mjs",
   "orchPanel.mandate": "Mandate",
   "orchPanel.mandateSent": "Sent as the first message",
   "orchPanel.restoreDefault": "Restore default",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1775,6 +1775,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "orchPanel.draftTitle": "Створити оркестратора для цього проєкту",
   "orchPanel.draftHint": "Він працює в {project}, володіє цією дошкою і відповідає вам тут. Текст нижче буде доставлено йому як перше повідомлення — редагуйте як завгодно.",
   "orchPanel.draftHintVacated": "Розмова попереднього оркестратора зникла. Створіть нового для {project}; текст нижче буде доставлено як перше повідомлення.",
+  "orchPanel.viewerMcpRegistered": "viewer MCP: зареєстровано ✓",
+  "orchPanel.viewerMcpMissing": "viewer MCP: виконайте scripts/install-mcp.sh або claude mcp add viewer -- bun ./bin/mcp-server.mjs",
   "orchPanel.mandate": "Мандат",
   "orchPanel.mandateSent": "Надсилається як перше повідомлення",
   "orchPanel.restoreDefault": "Повернути типовий",


### PR DESCRIPTION
## Summary

- share Claude MCP resolution between structured spawn policy and the orchestrator draft preflight
- supply the packaged Viewer MCP launcher in per-spawn Claude and Codex configuration when no registration resolves
- show registered/remedy status in desktop and mobile orchestrator drafts while preserving user definitions and files

## Verification

- `bunx tsc --noEmit --incremental false`
- 172 focused tests across 11 exact test files with isolated home and state roots
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits`

Fixes #1164