### PR TITLE
feat(orchestrator): ship mandate v9 onboarding

### DIFF
--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1014,22 +1014,23 @@ export function TmuxComposer(props: TmuxComposerProps) {
     portals the form into) and the props the composer needs, republished every
     render because `file` is a fresh snapshot each board poll. */
 function VoiceComposerCardSlot({ cardId, composerProps, primary }: { cardId: string; composerProps: TmuxComposerProps; primary: boolean }) {
+  const placeId = useId();
   const publishNode = useCallback(
     (node: HTMLDivElement | null) => {
       if (!node) return undefined;
-      return publishVoiceComposerCardNode(cardId, node, primary);
+      return publishVoiceComposerCardNode(cardId, node, primary, placeId);
     },
-    [cardId, primary],
+    [cardId, placeId, primary],
   );
   useEffect(() => {
-    publishVoiceComposerCardProps(cardId, {
+    publishVoiceComposerCardProps(cardId, placeId, {
       file: composerProps.file,
       pollPaused: composerProps.pollPaused ?? false,
       deadHost: composerProps.deadHost ?? false,
       sendBlockedReason: composerProps.sendBlockedReason ?? null,
       placeholder: composerProps.placeholder,
     });
-  });
+  }, [cardId, composerProps.deadHost, composerProps.file, composerProps.placeholder, composerProps.pollPaused, composerProps.sendBlockedReason, placeId]);
   return <div ref={publishNode} data-testid="voice-composer-card-slot" className="contents" />;
 }
 

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -973,6 +973,9 @@ export interface TmuxComposerProps {
       is attempted while it is set, so no /api/tmux request can fire against an
       as-yet-unclassified host. */
   sendBlockedReason?: string | null;
+  /** Optional surface-specific placeholder, such as the orchestrator dock's
+      project-scoped prompt. Ordinary conversation cards keep their defaults. */
+  placeholder?: string;
   /** This surface is the operator's conversation WINDOW, not an incidental card
       of the same conversation, so the one hoisted composer belongs here even
       while a board card for it is also on screen (the orchestrator dock, #977).
@@ -1024,6 +1027,7 @@ function VoiceComposerCardSlot({ cardId, composerProps, primary }: { cardId: str
       pollPaused: composerProps.pollPaused ?? false,
       deadHost: composerProps.deadHost ?? false,
       sendBlockedReason: composerProps.sendBlockedReason ?? null,
+      placeholder: composerProps.placeholder,
     });
   });
   return <div ref={publishNode} data-testid="voice-composer-card-slot" className="contents" />;
@@ -1041,6 +1045,7 @@ export function TmuxComposerCore({
   pollPaused = false,
   deadHost = false,
   sendBlockedReason = null,
+  placeholder,
   dockNode,
 }: TmuxComposerProps & {
   /** Absent: render the form inline (the card owns the composer, as ever).
@@ -2175,13 +2180,13 @@ export function TmuxComposerCore({
   const composerBar = (
     <ComposerBar
       composer={composer}
-      placeholder={unresolvedOwnership
+      placeholder={placeholder ?? (unresolvedOwnership
         ? t("composer.placeholderResolving")
         : relayMode
           ? t("composer.placeholderRelay")
           : spawnMode
             ? t("composer.placeholderSpawn")
-            : t("composer.placeholderSend")}
+            : t("composer.placeholderSend"))}
       textareaAriaLabel={t("composer.textAria")}
       imageAriaLabel={t("composer.addImages")}
       sendLabelIdle={spawnMode ? t("composer.launchAgent") : t("composer.sendToAgent")}

--- a/src/components/orchestrator/OrchestratorConversation.tsx
+++ b/src/components/orchestrator/OrchestratorConversation.tsx
@@ -23,7 +23,7 @@ const noop = () => undefined;
  * conversation also has a card on the board behind the panel, and the one
  * hoisted composer must render HERE while both are on screen.
  */
-export function OrchestratorConversation({ file }: { file: FileEntry }) {
+export function OrchestratorConversation({ file, projectName }: { file: FileEntry; projectName: string }) {
   const { t } = useLocale();
   const { caps } = useAgentCapabilities(file);
   const deadHost = caps.surface === "dead";
@@ -43,7 +43,13 @@ export function OrchestratorConversation({ file }: { file: FileEntry }) {
         compact
       />
       <AgentControlStrip file={file} />
-      <TmuxComposer file={file} deadHost={deadHost} sendBlockedReason={sendBlockedReason} primaryPlace />
+      <TmuxComposer
+        file={file}
+        deadHost={deadHost}
+        sendBlockedReason={sendBlockedReason}
+        placeholder={t("composer.placeholderOrchestrator", { project: projectName })}
+        primaryPlace
+      />
     </div>
   );
 }

--- a/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
@@ -452,7 +452,7 @@ test("an active seat mounts the REAL conversation column — feed and composer, 
   expect(panelState(host)).toBe("live");
   expect(host.querySelector('[data-orchestrator-conversation="conversation_orch"]')).not.toBeNull();
   expect(host.querySelector("[data-agent-control-strip]")).not.toBeNull();
-  expect(host.querySelector("textarea")).not.toBeNull();
+  expect((host.querySelector("textarea") as HTMLTextAreaElement).placeholder).toBe("what should get done in Atlas?");
   /* No draft on a seated project: a second create is not offered at all. */
   expect(confirmButton(host)).toBeNull();
 });

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -388,7 +388,7 @@ export function OrchestratorPanel({
               onCancel={() => setRotateFrom(null)}
             />
           ) : file ? (
-            <OrchestratorConversation file={file} />
+            <OrchestratorConversation file={file} projectName={projectName} />
           ) : (
             <Centered>
               <LoaderCircle className="h-5 w-5 animate-spin text-muted" aria-hidden />

--- a/src/components/voice/VoiceComposerHost.tsx
+++ b/src/components/voice/VoiceComposerHost.tsx
@@ -90,6 +90,7 @@ export function VoiceComposerHost() {
             pollPaused={props.pollPaused}
             deadHost={props.deadHost}
             sendBlockedReason={props.sendBlockedReason}
+            placeholder={props.placeholder}
             dockNode={getVoiceComposerCardNode(cardId)}
           />
         );

--- a/src/components/voice/voiceComposerPlaces.test.ts
+++ b/src/components/voice/voiceComposerPlaces.test.ts
@@ -4,9 +4,12 @@ import { Window } from "happy-dom";
 import {
   getVoiceComposerCardIds,
   getVoiceComposerCardNode,
+  getVoiceComposerCardProps,
   publishVoiceComposerCardNode,
+  publishVoiceComposerCardProps,
   resetVoiceSlotsForTest,
 } from "./voiceSlots";
+import type { FileEntry } from "@/lib/types";
 
 /*
  * Several surfaces can be on screen for ONE conversation at once — the board
@@ -22,6 +25,13 @@ const node = (id: string) => {
   element.id = id;
   return element as unknown as HTMLElement;
 };
+const props = (placeholder?: string) => ({
+  file: {} as FileEntry,
+  pollPaused: false,
+  deadHost: false,
+  sendBlockedReason: null,
+  placeholder,
+});
 
 afterEach(() => resetVoiceSlotsForTest());
 
@@ -65,6 +75,20 @@ test("retracting the primary hands the composer back to the ordinary card", () =
   retractDock();
 
   expect(getVoiceComposerCardNode("conversation_a")).toBe(board);
+});
+
+test("a primary place keeps its placeholder when an ordinary card publishes later", () => {
+  const dock = node("dock");
+  const board = node("board");
+  const retractDock = publishVoiceComposerCardNode("conversation_a", dock, true, "dock");
+  publishVoiceComposerCardNode("conversation_a", board, false, "board");
+  publishVoiceComposerCardProps("conversation_a", "dock", props("what should get done in Atlas?"));
+  publishVoiceComposerCardProps("conversation_a", "board", props());
+
+  expect(getVoiceComposerCardProps("conversation_a")?.placeholder).toBe("what should get done in Atlas?");
+
+  retractDock();
+  expect(getVoiceComposerCardProps("conversation_a")?.placeholder).toBeUndefined();
 });
 
 test("the last place leaving removes the conversation entirely", () => {

--- a/src/components/voice/voiceSlots.ts
+++ b/src/components/voice/voiceSlots.ts
@@ -89,6 +89,7 @@ export interface VoiceComposerCardProps {
   pollPaused: boolean;
   deadHost: boolean;
   sendBlockedReason: string | null;
+  placeholder?: string;
 }
 
 /**
@@ -147,7 +148,8 @@ export function publishVoiceComposerCardProps(cardId: string, props: VoiceCompos
     && current.file === props.file
     && current.pollPaused === props.pollPaused
     && current.deadHost === props.deadHost
-    && current.sendBlockedReason === props.sendBlockedReason) {
+    && current.sendBlockedReason === props.sendBlockedReason
+    && current.placeholder === props.placeholder) {
     return;
   }
   composerCardProps.set(cardId, props);

--- a/src/components/voice/voiceSlots.ts
+++ b/src/components/voice/voiceSlots.ts
@@ -109,12 +109,16 @@ export interface VoiceComposerCardProps {
  * form out of the dock the operator is typing in.
  */
 interface ComposerPlace {
+  id: string | HTMLElement;
   node: HTMLElement;
   primary: boolean;
 }
 
+type ComposerPlaceId = string | HTMLElement;
+
 const composerCardNodes = new Map<string, ComposerPlace[]>();
 const composerCardProps = new Map<string, VoiceComposerCardProps>();
+const composerCardPropsByPlace = new Map<string, Map<ComposerPlaceId, VoiceComposerCardProps>>();
 
 /** How many `VoiceComposerHost`s are mounted (production: exactly one).
     Cards defer their composer to the host ONLY while a host exists, so an
@@ -123,17 +127,35 @@ const composerCardProps = new Map<string, VoiceComposerCardProps>();
 let composerHosts = 0;
 
 /** A surface's place for the hoisted composer. Returns the retraction. */
-export function publishVoiceComposerCardNode(cardId: string, node: HTMLElement, primary = false): () => void {
-  const place: ComposerPlace = { node, primary };
+function refreshVoiceComposerCardProps(cardId: string): boolean {
+  const places = composerCardNodes.get(cardId);
+  const selected = places?.findLast((place) => place.primary) ?? places?.[places.length - 1];
+  const next = selected ? composerCardPropsByPlace.get(cardId)?.get(selected.id) : undefined;
+  /* With no places the host may be parking a live-call composer. Retain the
+     last snapshot until the host explicitly releases that conversation. */
+  if (!next || composerCardProps.get(cardId) === next) return false;
+  composerCardProps.set(cardId, next);
+  return true;
+}
+
+/** A surface's place for the hoisted composer. Returns the retraction. */
+export function publishVoiceComposerCardNode(cardId: string, node: HTMLElement, primary = false, placeId: string | null = null): () => void {
+  const id: ComposerPlaceId = placeId ?? node;
+  const place: ComposerPlace = { id, node, primary };
   composerCardNodes.set(cardId, [...(composerCardNodes.get(cardId) ?? []), place]);
+  refreshVoiceComposerCardProps(cardId);
   notify();
   return () => {
     const places = composerCardNodes.get(cardId);
     if (!places) return;
     const remaining = places.filter((entry) => entry !== place);
     if (remaining.length === places.length) return;
+    const propsByPlace = composerCardPropsByPlace.get(cardId);
+    propsByPlace?.delete(id);
+    if (propsByPlace?.size === 0) composerCardPropsByPlace.delete(cardId);
     if (remaining.length) composerCardNodes.set(cardId, remaining);
     else composerCardNodes.delete(cardId);
+    refreshVoiceComposerCardProps(cardId);
     notify();
   };
 }
@@ -142,18 +164,11 @@ export function publishVoiceComposerCardNode(cardId: string, node: HTMLElement, 
     the composer of an active call outlives its card and needs SOMETHING to render
     with; stale runtime detail refreshes through the composer's own hooks. Released
     by `forgetVoiceComposerCardProps` once no composer renders from them. */
-export function publishVoiceComposerCardProps(cardId: string, props: VoiceComposerCardProps): void {
-  const current = composerCardProps.get(cardId);
-  if (current
-    && current.file === props.file
-    && current.pollPaused === props.pollPaused
-    && current.deadHost === props.deadHost
-    && current.sendBlockedReason === props.sendBlockedReason
-    && current.placeholder === props.placeholder) {
-    return;
-  }
-  composerCardProps.set(cardId, props);
-  notify();
+export function publishVoiceComposerCardProps(cardId: string, placeId: ComposerPlaceId, props: VoiceComposerCardProps): void {
+  const byPlace = composerCardPropsByPlace.get(cardId) ?? new Map<ComposerPlaceId, VoiceComposerCardProps>();
+  byPlace.set(placeId, props);
+  composerCardPropsByPlace.set(cardId, byPlace);
+  if (refreshVoiceComposerCardProps(cardId)) notify();
 }
 
 /**
@@ -167,7 +182,8 @@ export function publishVoiceComposerCardProps(cardId: string, props: VoiceCompos
  * of the tab.
  */
 export function forgetVoiceComposerCardProps(cardId: string): void {
-  if (!composerCardProps.delete(cardId)) return;
+  const changed = composerCardProps.delete(cardId) || composerCardPropsByPlace.delete(cardId);
+  if (!changed) return;
   notify();
 }
 
@@ -226,6 +242,7 @@ export function resetVoiceSlotsForTest(): void {
   composerSlots.clear();
   composerCardNodes.clear();
   composerCardProps.clear();
+  composerCardPropsByPlace.clear();
   composerHosts = 0;
   listeners.clear();
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -372,6 +372,7 @@ export const en = {
   "composer.placeholderSpawn": "prompt — the agent will start…",
   "composer.placeholderResolving": "message the agent — reconnecting to its session…",
   "composer.placeholderSend": "message the agent…",
+  "composer.placeholderOrchestrator": "what should get done in {project}?",
   "composer.textAria": "Text for the agent",
   /* Chat-first mobile composer (issue #419 reopened): the model/reasoning +
      attachment second row folds behind this compact primary-row action so the

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -369,6 +369,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.placeholderSpawn": "промпт — агент запуститься…",
   "composer.placeholderResolving": "написати агенту — відновлюємо з'єднання з сесією…",
   "composer.placeholderSend": "написати агенту…",
+  "composer.placeholderOrchestrator": "що зробити в {project}?",
   "composer.textAria": "Текст для агента",
   "composer.optionsShow": "Показати параметри повідомлення",
   "composer.optionsHide": "Сховати параметри повідомлення",

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -76,17 +76,25 @@ test("bridge reports survive as the second channel, for the operator away from t
 });
 
 /* Seats record the mandate version they were spawned on; `get_orchestrator` reports
-   this constant as defaultPromptVersion, so a v3 seat reads as stale without a diff. */
-test("the default mandate is at version 8", () => {
-  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(8);
+   this constant as defaultPromptVersion, so an older seat reads as stale without a diff. */
+test("the default mandate is at version 9", () => {
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBe(9);
 });
 
-test("the mandate requires a visible first-turn status even when every mission is already complete", () => {
+test("the mandate greets a fresh seat and preserves the exact rotation standby status", () => {
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("## Initial visible status");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Your first turn after receiving this mandate");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("FRESH seat with no missions");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("Ready in {project}.\nTell me what to ship — I open lanes, spawn implementers and reviewers, and merge on APPROVE. Nothing starts until you ask.");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("ROTATION");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("inventory the mandate missions and state your plan");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("all mandate missions are complete; standing by");
   expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("generic continuation nudge");
+});
+
+test("the conveyor skill reference is portable across checkouts", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("If this checkout carries an llv-conveyor skill, it is your playbook; otherwise the conveyor rules above are the playbook.");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain("The llv-conveyor skill in this checkout is your playbook");
 });
 
 test("mandate delivery keys off directive content and appends it exactly once", () => {

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -14,7 +14,7 @@
  * operator — their screen: when to move it, and the target shapes to move it with,
  * so a seat steers attention to the work instead of describing where to look. v7
  * starts requested pipelines by default and reserves drafts for explicit requests.
- * v8 requires a visible first-turn status, including the completed-mandate case. */
+ * v9 greets a fresh seat and keeps the completed-mandate case explicit. */
 
 /** Initial draft values. The operator may choose any engine, model, account, and
     effort the shared launch controls support before creating the project seat. */
@@ -30,12 +30,15 @@ export const ORCHESTRATOR_SPAWN_CONFIG = {
     `ORCHESTRATOR_SYSTEM_PROMPT`: seats record the version their mandate was
     based on, and `get_orchestrator` reports it so a stale incumbent is visible
     without diffing prompts. */
-export const ORCHESTRATOR_PROMPT_VERSION = 8;
+export const ORCHESTRATOR_PROMPT_VERSION = 9;
 
 /** Appended to bespoke and stale mandates at delivery time; the current
     versioned default already contains it. */
 export const ORCHESTRATOR_INITIAL_STATUS_DIRECTIVE = `## Initial visible status
-Your first turn after receiving this mandate must produce a visible assistant status in this conversation. When work remains, inventory the mandate missions and state your plan in that status. When every mission is already complete, reply exactly: "all mandate missions are complete; standing by". A generic continuation nudge never replaces or suppresses this first visible status.`;
+Your first turn after receiving this mandate must produce a visible assistant status in this conversation. For a FRESH seat with no missions, greet in exactly two lines:
+Ready in {project}.
+Tell me what to ship — I open lanes, spawn implementers and reviewers, and merge on APPROVE. Nothing starts until you ask.
+Use the actual project name in place of {project}. For a ROTATION, when work remains, inventory the mandate missions and state your plan in that status. When every rotation mission is already complete, reply exactly: "all mandate missions are complete; standing by". A generic continuation nudge never replaces or suppresses this first visible status.`;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Manager (issues #182, #691) — the agent that owns the board and runs the whole conveyor through the viewer's own HTTP API and MCP tools. You never act outside them.
 
@@ -91,7 +94,7 @@ YOU decide when to deploy, and you execute it yourself. Your authority is your d
 
 ## Fences
 - Operate exclusively through the viewer API and MCP tools (spawn, flows, pipelines, tasks, files, agent/snapshot, tmux). No direct process or runtime manipulation.
-- The llv-conveyor skill in this checkout is your playbook; follow its spawn-auth notes for agent-initiated calls.
+- If this checkout carries an llv-conveyor skill, it is your playbook; otherwise the conveyor rules above are the playbook.
 - Replacing manual spawns is a non-goal: the user's own agents keep working; you coordinate, you do not take over.
 - Re-derive board state per turn from bounded snapshots rather than accumulating it in context.`;
 

--- a/src/lib/roles/defaults.ts
+++ b/src/lib/roles/defaults.ts
@@ -12,6 +12,8 @@ const REVIEW_FENCES = [
 const REVIEW_FRAME_RULES =
   "Two standing rules. (1) Anchor the frame: when the assignment carries the requester's originating requirement, validate the work against that verbatim requirement, never against the artifact's previous revision — WRONG-PREMISE (\"this does not serve the original requirement\") is an expected verdict and outranks any finding about internal rigour. (2) Over-engineering pass: on every review, flag machinery heavier than the problem it solves (a library plus wrapper where a native primitive does), name the simpler mechanism, and report what to cut — OVER-BUILT is a first-class verdict, and a round that only removes scope is a successful round.";
 
+const VIEWER_BASE_URL = `http://127.0.0.1:${process.env.PORT?.trim() || "8898"}`;
+
 export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
   {
     id: "orchestrator",
@@ -27,9 +29,9 @@ export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
       { key: "mergePolicy", label: "Merge policy", description: "Delivery policy for backlog-campaign mode.", kind: "select", options: ["pr", "merge"] },
       { key: "completionPolicy", label: "Completion policy", description: "Terminal policy for backlog-campaign mode.", kind: "select", options: ["pr-opened", "merged", "released"] },
     ],
-    promptScaffold: `You are the Orchestrator. Drive work through the production Viewer API at http://127.0.0.1:8898. Use fresh empty sessions with src lineage; forks are disabled. Keep every worker visible and controllable in the Viewer.\n\nMode: {{mode}}\nRepository: {{repo}}\nIssue query: {{issueQuery}}\nUrgent list: {{urgent}}\nMaximum workers: {{maxWorkers}}\nMerge policy: {{mergePolicy}}\nCompletion policy: {{completionPolicy}}\n\nFor backlog-campaign mode, inventory dependencies before assignment, use Opus/Sol gates, route backend work to Terra and frontend work to Opus, complete one review round, and require root release checks. Before a Viewer replacement, preserve the external-worker deployment barrier.`,
+    promptScaffold: `You are the Orchestrator. Drive work through the production Viewer API at ${VIEWER_BASE_URL}. Use fresh empty sessions with src lineage; forks are disabled. Keep every worker visible and controllable in the Viewer.\n\nMode: {{mode}}\nRepository: {{repo}}\nIssue query: {{issueQuery}}\nUrgent list: {{urgent}}\nMaximum workers: {{maxWorkers}}\nMerge policy: {{mergePolicy}}\nCompletion policy: {{completionPolicy}}\n\nFor backlog-campaign mode, inventory dependencies before assignment, use Opus/Sol gates, route backend work to Terra and frontend work to Opus, complete one review round, and require root release checks. Before a Viewer replacement, preserve the external-worker deployment barrier.`,
     safetyFences: [
-      "Viewer control uses http://127.0.0.1:8898 with src lineage.",
+      `Viewer control uses ${VIEWER_BASE_URL} with src lineage.`,
       "Fresh empty sessions only; forks are disabled.",
       "One owner holds a file at a time across active worktrees.",
     ],

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -36,7 +36,15 @@ test("role registry exposes the frozen eight role ids and campaign-ready orchest
     completionPolicy: "released",
   });
   expect(orchestrator.ok && orchestrator.value.config).toEqual({ engine: "claude", model: "opus", effort: "high" });
-  expect(orchestrator.ok && orchestrator.value.prompt).toContain("127.0.0.1:8898");
+  expect(orchestrator.ok && orchestrator.value.prompt).toContain(`http://127.0.0.1:${process.env.PORT?.trim() || "8898"}`);
+  expect(orchestrator.ok && orchestrator.value.prompt).toContain("Repository: Latand/live-log-viewer-next");
+  expect(orchestrator.ok && orchestrator.value.prompt).toContain("Issue query: is:open");
+  expect(orchestrator.ok && orchestrator.value.prompt).toContain("Urgent list: #35");
+
+  const standard = resolveRole("orchestrator");
+  expect(standard.ok && standard.value.prompt).not.toContain("Repository:");
+  expect(standard.ok && standard.value.prompt).not.toContain("Issue query:");
+  expect(standard.ok && standard.value.prompt).not.toContain("Urgent list:");
 
   expect(resolveRole("builder", { mode: "plain", domain: "general" })).toMatchObject({
     ok: true,

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -62,7 +62,9 @@ export function validateRoleParams(
 }
 
 function renderScaffold(template: string, params: RoleParamValues): string {
-  return template.replace(/\{\{([A-Za-z][A-Za-z0-9]*)\}\}/g, (_match, key: string) => String(params[key] ?? ""));
+  return template
+    .replace(/\{\{([A-Za-z][A-Za-z0-9]*)\}\}/g, (_match, key: string) => String(params[key] ?? ""))
+    .replace(/^(Repository|Issue query|Urgent list):\s*\n/gm, "");
 }
 
 /**


### PR DESCRIPTION
## Summary

- greet fresh orchestrator seats and preserve rotation mission status
- make the role scaffold follow the launch port and omit empty campaign fields
- add project-scoped English/Ukrainian dock composer placeholders

## Verification

- `bun test src/lib/orchestrator/prompt.test.ts src/lib/roles/registry.test.ts src/components/orchestrator/OrchestratorPanel.dom.test.tsx`
- `bunx tsc --noEmit --incremental false`
- `bun run build`
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits`

Fixes #1165