### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-log-viewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "bin": {
     "agent-log-viewer": "bin/cli.mjs",
     "agent-log-viewer-mcp": "bin/mcp-server.mjs"


### PR DESCRIPTION
Version bump only. Release 1.0.2 = 1.0.1 + #1161 (runtime host supervised by the CLI, structured-only pipelines from bunx) + #1164 + #1165. Tag v1.0.2 follows the merge.