### PR TITLE
feat(attention): name the decision on the dock badge, the toast and the queue rows

### DIFF
--- a/src/components/Viewer.attentionMount.test.ts
+++ b/src/components/Viewer.attentionMount.test.ts
@@ -45,3 +45,28 @@ test("the shell registers the navigator half of the handoff", () => {
      handoff needs both. */
   expect(code).toMatch(/focusHandoffBus\.setShell\(/);
 });
+
+/*
+ * The same defect class for the attention TOAST and the popover rows (issue
+ * #1167): both moved out of the shell into `./attention/*` so the decision line
+ * they now carry could be tested directly. A component with its own green suite
+ * and no mount is the exact failure this file exists to catch, and the old
+ * inline markup would go on rendering «Agent is waiting for a reply» beside it.
+ */
+
+test("the shell renders the attention toast on both surfaces, and no longer inlines its own", () => {
+  expect(code).toMatch(/import\s*\{[^}]*\bAttentionToast\b[^}]*\}\s*from\s*"\.\/attention\/AttentionToast"/);
+  const mounted = code.match(/<AttentionToast\b/g) ?? [];
+  /* Desktop floats it under the island; the phone docks it in flow. */
+  expect(mounted).toHaveLength(2);
+  /* The generic wording is the toast component's own fallback now. The shell
+     keeping a copy is how a second, decision-less toast comes back. */
+  expect(code).not.toContain("viewer.agentWaiting");
+});
+
+test("the shell renders the popover rows from the island's own component", () => {
+  expect(code).toMatch(/import\s*\{[^}]*\bAttentionQueueRow\b[^}]*\}\s*from\s*"\.\/attention\/AttentionIsland"/);
+  expect(code).toMatch(/<AttentionQueueRow\b/);
+  /* The row's own line derivation replaced the shell's parallel snippet. */
+  expect(code).not.toContain("attentionSnippet");
+});

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -18,12 +18,13 @@ import { useViewPresence } from "@/hooks/useViewPresence";
 import { OVERVIEW_CONTEXT, OVERVIEW_SLICE, viewBus } from "@/hooks/viewPresenceBus";
 import { projectDisplayName } from "@/lib/displayNames";
 import { canonicalClientProject } from "@/lib/projects/clientAliases";
-import { type TFunction, useLocale } from "@/lib/i18n";
+import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
 import { advanceAttentionCycle, attentionId, buildAttentionQueue, STALLED_ATTENTION_TTL, type AttentionItem } from "./attention";
 import { AttentionHost } from "./attention/AttentionHost";
-import { AttentionIsland } from "./attention/AttentionIsland";
+import { AttentionIsland, AttentionQueueRow } from "./attention/AttentionIsland";
+import { AttentionToast } from "./attention/AttentionToast";
 import { purgeLegacyOperatorCredential } from "./operatorCredential";
 import { ArtifactPreviewHost } from "./preview/ArtifactPreviewHost";
 import { VoiceBridgeRelayHost } from "./voice/VoiceBridgeRelayHost";
@@ -41,7 +42,7 @@ import { isChildConversation, OVERVIEW, projectKey } from "./projectModel";
 import { ProjectRail } from "./ProjectRail";
 import { DeploymentStatusPill } from "./runtime/DeploymentStatusPill";
 import { StagingBadge } from "./StagingBadge";
-import { activityDot, cleanTitle, fmtAge } from "./utils";
+import { activityDot, cleanTitle } from "./utils";
 
 const PROJECT_KEY = "llvProject";
 
@@ -106,20 +107,6 @@ const STALE_FOCUS_REPLAY_MS = 8_000;
     new target, or dismisses it — a notice that evaporates while the hash stays
     put lands the tab back on the silent default view this fix exists to kill. */
 const UNKNOWN_FRAGMENT_NOTICE_MS = 6_000;
-
-/** One-line reason a queue item waits: question header, screen tail, or the stalled wording. */
-function attentionSnippet(t: TFunction, item: AttentionItem): string {
-  const q = item.file.pendingQuestion;
-  if (q) {
-    if (q.kind === "plan") return t("status.awaitingPlan");
-    const first = q.questions?.[0];
-    return first?.header || first?.question.split("\n")[0] || t("status.awaitingAnswer");
-  }
-  if (item.file.rateLimit) return t("status.rateLimited");
-  const w = item.file.waitingInput;
-  if (w) return w.menu?.question.split("\n")[0] || w.screenTail || t("status.awaitingTerminal");
-  return t("status.stalled");
-}
 
 export function Viewer() {
   const { t } = useLocale();
@@ -865,25 +852,7 @@ export function Viewer() {
             {t("attention.popoverTitle")}
           </div>
           {queue.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              className="flex w-full min-w-0 flex-col gap-0.5 rounded-[8px] px-2.5 py-2 text-left hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              onClick={() => jumpToItem(item)}
-            >
-              <span className="flex w-full min-w-0 items-center gap-1.5">
-                <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-primary">
-                  {cleanTitle(item.file.title, 90)}
-                </span>
-                <span className="shrink-0 rounded-full border border-border bg-canvas px-1.5 text-[10px] font-semibold text-muted" title={item.project}>
-                  {projectDisplayName(item.project, item.file.projectName)}
-                </span>
-                <span className="shrink-0 text-[10.5px] text-muted">{fmtAge(item.since)}</span>
-              </span>
-              <span className={`w-full truncate text-[11px] ${item.tier === "stalled" ? "text-warning" : "text-muted"}`}>
-                {attentionSnippet(t, item)}
-              </span>
-            </button>
+            <AttentionQueueRow key={item.id} item={item} onOpen={() => jumpToItem(item)} />
           ))}
         </div>
       ) : null}
@@ -932,25 +901,15 @@ export function Viewer() {
           <div className="pointer-events-none fixed right-4 top-12 z-50 flex flex-col items-end gap-2">
             {attentionBadge}
             {toastFile ? (
-              <div className="pointer-events-auto flex max-w-[360px] gap-2 rounded-[8px] border border-warning/45 bg-warning-soft px-4 py-3 text-[13px] font-semibold text-primary shadow-1">
-                <button
-                  className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-                  onClick={() => {
-                    openFile(toastFile);
-                    setToastPath(null);
-                  }}
-                >
-                  <span className="block text-[11px] font-bold text-warning">{t("viewer.agentWaiting")}</span>
-                  <span className="line-clamp-2">{toastFile.title}</span>
-                </button>
-                <button
-                  className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-                  aria-label={t("viewer.closeNotification")}
-                  onClick={() => setToastPath(null)}
-                >
-                  <X className="h-3.5 w-3.5" aria-hidden />
-                </button>
-              </div>
+              <AttentionToast
+                file={toastFile}
+                mobile={false}
+                onOpen={() => {
+                  openFile(toastFile);
+                  setToastPath(null);
+                }}
+                onDismiss={() => setToastPath(null)}
+              />
             ) : null}
           </div>
         )}
@@ -959,25 +918,15 @@ export function Viewer() {
             own space and never covers the toolbar. Its open target and 44px close
             are both full tap-height. */}
         {isMobile && toastFile ? (
-          <div className="flex shrink-0 items-stretch gap-2 border-b border-warning/45 bg-warning-soft pl-3 pr-1.5 py-1.5">
-            <button
-              className="flex min-h-11 min-w-0 flex-1 flex-col justify-center text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              onClick={() => {
-                openFile(toastFile);
-                setToastPath(null);
-              }}
-            >
-              <span className="block text-[11px] font-bold text-warning">{t("viewer.agentWaiting")}</span>
-              <span className="truncate text-[13px] font-semibold text-primary">{toastFile.title}</span>
-            </button>
-            <button
-              className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              aria-label={t("viewer.closeNotification")}
-              onClick={() => setToastPath(null)}
-            >
-              <X className="h-5 w-5" aria-hidden />
-            </button>
-          </div>
+          <AttentionToast
+            file={toastFile}
+            mobile
+            onOpen={() => {
+              openFile(toastFile);
+              setToastPath(null);
+            }}
+            onDismiss={() => setToastPath(null)}
+          />
         ) : null}
         {project === OVERVIEW ? (
           <OverviewBoard

--- a/src/components/attention/AttentionIsland.dom.test.tsx
+++ b/src/components/attention/AttentionIsland.dom.test.tsx
@@ -19,7 +19,7 @@ Object.assign(globalThis, {
   localStorage: dom.localStorage,
 });
 
-const { AttentionIsland } = await import("./AttentionIsland");
+const { AttentionIsland, AttentionQueueRow } = await import("./AttentionIsland");
 const { advanceAttentionCycle, buildAttentionQueue } = await import("../attention");
 type FileEntry = import("@/lib/types").FileEntry;
 type AttentionItem = import("../attention").AttentionItem;
@@ -236,4 +236,59 @@ test("an emptied queue leaves both routes quiet", async () => {
   expect(document.querySelector("[data-attention-next]")).toBeNull();
   expect(document.querySelector("[data-attention-zero]")).not.toBeNull();
   expect(served).toEqual([]);
+});
+
+/* ------------------------------------------------------------------------- *
+ * The popover rows NAME the decision (issue #1167). The count says how many
+ * agents are waiting; a row that only repeats the conversation title still
+ * leaves the operator to open each one to find out what it wants.
+ * ------------------------------------------------------------------------- */
+
+function pendingQuestion(header: string): FileEntry["pendingQuestion"] {
+  return {
+    kind: "question",
+    toolUseId: `tool-${header}`,
+    transcriptPath: "/alpha-question",
+    pid: 4242,
+    paneTarget: null,
+    askedAt: "2026-08-25T10:00:00.000Z",
+    questions: [{ header, question: `${header}?`, multiSelect: false, options: [] }],
+  } as FileEntry["pendingQuestion"];
+}
+
+function questionItem(overrides: Partial<FileEntry> = {}): AttentionItem {
+  const file = { ...entry("/alpha-question", "alpha", NOW - 120), waitingInput: null, pendingQuestion: pendingQuestion("Rollout window"), ...overrides } as FileEntry;
+  return buildAttentionQueue([file], NOW)[0]!;
+}
+
+test("a queue row carries the decision line, the title, the project and the age", async () => {
+  const item = questionItem({
+    title: "Ship the rollout",
+    durableLineage: { kind: "spawn", role: "builder", parentConversationId: null, reviewsConversationId: null, memberships: [] },
+  } as Partial<FileEntry>);
+  const opened: string[] = [];
+  const host = await render(<AttentionQueueRow item={item} onOpen={() => opened.push(item.id)} />);
+
+  const row = host.querySelector("[data-attention-row]")!;
+  expect(row.getAttribute("data-attention-row")).toBe(item.id);
+  expect(row.textContent).toContain("Ship the rollout");
+  /* The one shared line: the decision, then who is asking. */
+  expect(host.querySelector("[data-attention-decision]")!.textContent).toBe("Rollout window · Builder");
+  expect(row.textContent).toContain("alpha");
+
+  await click(row);
+  expect(opened).toEqual([item.id]);
+});
+
+test("a terminal prompt and a stalled agent each keep their own wording", async () => {
+  const terminal = buildAttentionQueue([entry("/alpha-terminal", "alpha", NOW - 60)], NOW)[0]!;
+  let host = await render(<AttentionQueueRow item={terminal} onOpen={() => {}} />);
+  expect(host.querySelector("[data-attention-decision]")!.textContent).toBe("❯ 1. Yes");
+  await act(async () => { root?.unmount(); });
+  document.body.replaceChildren();
+
+  const stalledFile = { ...entry("/alpha-stalled", "alpha", NOW - 60), waitingInput: null, activity: "stalled", proc: "running", mtime: NOW - 60 } as FileEntry;
+  const stalled = buildAttentionQueue([stalledFile], NOW)[0]!;
+  host = await render(<AttentionQueueRow item={stalled} onOpen={() => {}} />);
+  expect(host.querySelector("[data-attention-decision]")!.textContent).toBe("interrupted or awaiting permission");
 });

--- a/src/components/attention/AttentionIsland.dom.test.tsx
+++ b/src/components/attention/AttentionIsland.dom.test.tsx
@@ -281,9 +281,12 @@ test("a queue row carries the decision line, the title, the project and the age"
 });
 
 test("a terminal prompt and a stalled agent each keep their own wording", async () => {
+  /* The prompt is named by its KIND, never by the menu the terminal happens to
+     be drawing: «❯ 1. Yes» names the options, and a row that says it has told
+     the operator nothing about what they are being asked to allow. */
   const terminal = buildAttentionQueue([entry("/alpha-terminal", "alpha", NOW - 60)], NOW)[0]!;
   let host = await render(<AttentionQueueRow item={terminal} onOpen={() => {}} />);
-  expect(host.querySelector("[data-attention-decision]")!.textContent).toBe("❯ 1. Yes");
+  expect(host.querySelector("[data-attention-decision]")!.textContent).toBe("permission prompt");
   await act(async () => { root?.unmount(); });
   document.body.replaceChildren();
 

--- a/src/components/attention/AttentionIsland.dom.test.tsx
+++ b/src/components/attention/AttentionIsland.dom.test.tsx
@@ -132,7 +132,10 @@ test("mobile keeps the compact count and a 44px Next, and hides the desktop-only
  * Viewer wires them (keys over the project queue, Next over the global one).
  * ------------------------------------------------------------------------- */
 
-const NOW = 1_800_000_000;
+/* The wall clock: a row re-derives its decision line on render, and the stalled
+   tier only counts while a process is behind the transcript and the signal is
+   fresh — so its fixtures age against the same clock the render reads. */
+const NOW = Math.floor(Date.now() / 1000);
 
 function entry(path: string, project: string, since: number): FileEntry {
   return {

--- a/src/components/attention/AttentionIsland.tsx
+++ b/src/components/attention/AttentionIsland.tsx
@@ -2,7 +2,12 @@
 
 import { ChevronRight, Filter, TriangleAlert } from "lucide-react";
 
+import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
+
+import type { AttentionItem } from "../attention";
+import { cleanTitle, fmtAge } from "../utils";
+import { decisionLine } from "./decision";
 
 interface Props {
   /** buildAttentionQueue's length, passed in so every surface shows one number. */
@@ -113,5 +118,42 @@ export function AttentionIsland({ count, mobile, queueOpen, filterActive, onTogg
         </>
       )}
     </div>
+  );
+}
+
+/**
+ * One row of the island's popover — the queue as a list, in the order
+ * `buildAttentionQueue` fixed.
+ *
+ * The second line is the DECISION (issue #1167), from the one `decisionLine`
+ * the toast and the orchestrator dock badge also read. A row that repeats only
+ * the conversation title leaves the operator opening each waiting agent to
+ * learn what it wants, which is the work the queue exists to remove.
+ */
+export function AttentionQueueRow({ item, onOpen }: { item: AttentionItem; onOpen: () => void }) {
+  const { t, locale } = useLocale();
+  return (
+    <button
+      type="button"
+      data-attention-row={item.id}
+      className="flex w-full min-w-0 flex-col gap-0.5 rounded-[8px] px-2.5 py-2 text-left hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      onClick={onOpen}
+    >
+      <span className="flex w-full min-w-0 items-center gap-1.5">
+        <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-primary">
+          {cleanTitle(item.file.title, 90)}
+        </span>
+        <span className="shrink-0 rounded-full border border-border bg-canvas px-1.5 text-[10px] font-semibold text-muted" title={item.project}>
+          {projectDisplayName(item.project, item.file.projectName)}
+        </span>
+        <span className="shrink-0 text-[10.5px] text-muted">{fmtAge(item.since)}</span>
+      </span>
+      <span
+        data-attention-decision
+        className={`w-full truncate text-[11px] ${item.tier === "stalled" ? "text-warning" : "text-muted"}`}
+      >
+        {decisionLine(t, locale, item.file) ?? t("status.stalled")}
+      </span>
+    </button>
   );
 }

--- a/src/components/attention/AttentionToast.dom.test.tsx
+++ b/src/components/attention/AttentionToast.dom.test.tsx
@@ -29,6 +29,8 @@ Object.assign(globalThis, {
 });
 
 const { AttentionToast } = await import("./AttentionToast");
+const { AttentionQueueRow } = await import("./AttentionIsland");
+const { buildAttentionQueue } = await import("../attention");
 type FileEntry = import("@/lib/types").FileEntry;
 
 let root: Root | null = null;
@@ -46,6 +48,12 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
     root.render(node);
   });
   return host;
+}
+
+async function unmount() {
+  await act(async () => { root?.unmount(); });
+  root = null;
+  document.body.replaceChildren();
 }
 
 const click = (element: Element) =>
@@ -107,19 +115,57 @@ test("the title is the decision plus the role, and the body stays the conversati
   expect(host.textContent).toContain("Ship the rollout");
 });
 
-test("a plan, a wall and a terminal prompt each name themselves", async () => {
-  const cases: Array<[Partial<FileEntry>, string]> = [
-    [{ pendingQuestion: { ...question, kind: "plan", plan: "1. read 2. write" } }, "plan approval"],
-    [{ rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: null } }, "rate-limited"],
-    [{ waitingInput: { since: NOW - 60, screenTail: "  ", target: "llv:0.0", menu: null } }, "permission prompt"],
-  ];
-  for (const [overrides, expected] of cases) {
+/**
+ * Every kind of wait the queue counts, with the ONE line it must read as.
+ *
+ * A terminal prompt is «permission prompt» whatever the screen is drawing, and
+ * a header-less question is the generic word rather than a slice of its own
+ * body: a title assembled from scraped text names the OPTIONS on screen, not
+ * the decision, and «❯ 1. Yes» is what that produced.
+ */
+const WAITS: Array<[string, Partial<FileEntry>, string]> = [
+  ["a question, by its header", { pendingQuestion: question }, "Rollout window"],
+  [
+    "a header-less question, by the generic word",
+    { pendingQuestion: { ...question, questions: [{ header: "", question: "Which capture runs first?", multiSelect: false, options: [] }] } },
+    "a question",
+  ],
+  ["a plan", { pendingQuestion: { ...question, kind: "plan", plan: "1. read 2. write" } }, "plan approval"],
+  ["a wall", { rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: null } }, "rate-limited"],
+  [
+    "a terminal prompt, whatever the menu says",
+    { waitingInput: { since: NOW - 60, screenTail: "❯ 1. Yes", target: "llv:0.0", menu: { question: "Allow the write to src/?", tabs: [], options: [] } } },
+    "permission prompt",
+  ],
+  ["an interrupted turn", { activity: "stalled", mtime: NOW - 60 }, "interrupted or awaiting permission"],
+];
+
+test("a plan, a wall, a terminal prompt and an interrupted turn each name themselves", async () => {
+  for (const [, overrides, expected] of WAITS) {
     const host = await render(
       <AttentionToast file={file(overrides as Partial<FileEntry>)} mobile={false} onOpen={() => {}} onDismiss={() => {}} />,
     );
     expect(title(host)).toBe(expected);
-    await act(async () => { root?.unmount(); });
-    document.body.replaceChildren();
+    await unmount();
+  }
+});
+
+test("the toast title and the island popover row are the SAME line, for every kind of wait", async () => {
+  for (const [, overrides] of WAITS) {
+    const entry = file(overrides as Partial<FileEntry>);
+    const item = buildAttentionQueue([entry], NOW)[0]!;
+
+    let host = await render(<AttentionToast file={entry} mobile={false} onOpen={() => {}} onDismiss={() => {}} />);
+    const toastLine = title(host);
+    await unmount();
+
+    host = await render(<AttentionQueueRow item={item} onOpen={() => {}} />);
+    const rowLine = host.querySelector("[data-attention-decision]")?.textContent ?? null;
+    await unmount();
+
+    /* Not the generic fallback either: a counted wait always has a name. */
+    expect(toastLine).not.toBe("Agent is waiting for a reply");
+    expect(rowLine).toBe(toastLine);
   }
 });
 

--- a/src/components/attention/AttentionToast.dom.test.tsx
+++ b/src/components/attention/AttentionToast.dom.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+
+/*
+ * The toast NAMES the decision (issue #1167).
+ *
+ * It used to say «Agent is waiting for a reply» over every wait there is — a
+ * plan, a permission prompt, a rate-limit wall and a five-option question all
+ * read the same, so the only way to learn what an agent wanted was to open it.
+ * It now carries the same line the island popover row and the orchestrator dock
+ * badge carry, and it stays a two-target surface: open, or dismiss.
+ */
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  MouseEvent: dom.MouseEvent,
+  Event: dom.Event,
+  localStorage: dom.localStorage,
+});
+
+const { AttentionToast } = await import("./AttentionToast");
+type FileEntry = import("@/lib/types").FileEntry;
+
+let root: Root | null = null;
+afterEach(async () => {
+  if (root) await act(async () => { root?.unmount(); });
+  root = null;
+  document.body.replaceChildren();
+});
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host);
+    root.render(node);
+  });
+  return host;
+}
+
+const click = (element: Element) =>
+  act(async () => {
+    element.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never);
+  });
+
+const NOW = 1_800_000_000;
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    root: "claude-projects",
+    name: "worker.jsonl",
+    path: "/transcripts/worker.jsonl",
+    project: "alpha",
+    title: "Ship the rollout",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW - 30,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 4242,
+    model: "opus",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+const question = {
+  kind: "question" as const,
+  toolUseId: "tool-use-1",
+  transcriptPath: "/transcripts/worker.jsonl",
+  pid: 4242,
+  paneTarget: null,
+  askedAt: "2026-08-25T10:00:00.000Z",
+  questions: [{ header: "Rollout window", question: "Approve the proposed rollout window", multiSelect: false, options: [] }],
+};
+
+const title = (host: HTMLElement) => host.querySelector("[data-attention-toast-title]")?.textContent ?? null;
+
+test("the title is the decision plus the role, and the body stays the conversation", async () => {
+  const host = await render(
+    <AttentionToast
+      file={file({
+        pendingQuestion: question,
+        durableLineage: { kind: "spawn", role: "builder", parentConversationId: null, reviewsConversationId: null, memberships: [] },
+      } as Partial<FileEntry>)}
+      mobile={false}
+      onOpen={() => {}}
+      onDismiss={() => {}}
+    />,
+  );
+
+  expect(title(host)).toBe("Rollout window · Builder");
+  expect(host.textContent).toContain("Ship the rollout");
+});
+
+test("a plan, a wall and a terminal prompt each name themselves", async () => {
+  const cases: Array<[Partial<FileEntry>, string]> = [
+    [{ pendingQuestion: { ...question, kind: "plan", plan: "1. read 2. write" } }, "plan approval"],
+    [{ rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: null } }, "rate-limited"],
+    [{ waitingInput: { since: NOW - 60, screenTail: "  ", target: "llv:0.0", menu: null } }, "permission prompt"],
+  ];
+  for (const [overrides, expected] of cases) {
+    const host = await render(
+      <AttentionToast file={file(overrides as Partial<FileEntry>)} mobile={false} onOpen={() => {}} onDismiss={() => {}} />,
+    );
+    expect(title(host)).toBe(expected);
+    await act(async () => { root?.unmount(); });
+    document.body.replaceChildren();
+  }
+});
+
+test("a toast still up after its question was answered elsewhere falls back rather than inventing a decision", async () => {
+  const host = await render(<AttentionToast file={file()} mobile={false} onOpen={() => {}} onDismiss={() => {}} />);
+  expect(title(host)).toBe("Agent is waiting for a reply");
+});
+
+test("open and dismiss stay separate targets, on the phone at full tap height", async () => {
+  const events: string[] = [];
+  const host = await render(
+    <AttentionToast
+      file={file({ pendingQuestion: question } as Partial<FileEntry>)}
+      mobile
+      onOpen={() => events.push("open")}
+      onDismiss={() => events.push("dismiss")}
+    />,
+  );
+
+  const open = host.querySelector("[data-attention-toast-open]")!;
+  const dismiss = host.querySelector("[data-attention-toast-dismiss]")!;
+  expect(open.className).toContain("min-h-11");
+  expect(dismiss.className).toContain("h-11");
+  await click(open);
+  await click(dismiss);
+  expect(events).toEqual(["open", "dismiss"]);
+});

--- a/src/components/attention/AttentionToast.dom.test.tsx
+++ b/src/components/attention/AttentionToast.dom.test.tsx
@@ -30,7 +30,7 @@ Object.assign(globalThis, {
 
 const { AttentionToast } = await import("./AttentionToast");
 const { AttentionQueueRow } = await import("./AttentionIsland");
-const { buildAttentionQueue } = await import("../attention");
+const { buildAttentionQueue, STALLED_ATTENTION_TTL } = await import("../attention");
 type FileEntry = import("@/lib/types").FileEntry;
 
 let root: Root | null = null;
@@ -61,7 +61,10 @@ const click = (element: Element) =>
     element.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never);
   });
 
-const NOW = 1_800_000_000;
+/* The wall clock, because the components derive attention eligibility on it:
+   a stalled transcript counts only while a process is behind it and the signal
+   is fresh, so its fixtures have to age against the same clock the render uses. */
+const NOW = Math.floor(Date.now() / 1000);
 
 function file(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
@@ -172,6 +175,29 @@ test("the toast title and the island popover row are the SAME line, for every ki
 test("a toast still up after its question was answered elsewhere falls back rather than inventing a decision", async () => {
   const host = await render(<AttentionToast file={file()} mobile={false} onOpen={() => {}} onDismiss={() => {}} />);
   expect(title(host)).toBe("Agent is waiting for a reply");
+});
+
+/**
+ * The toast holds a file the operator has not dismissed, so it outlives its own
+ * signal routinely — and it must never name a decision the popover behind it
+ * does not list. An interrupted transcript is only a wait while a process is
+ * still behind it and the signal is fresh; past either, the toast falls back to
+ * the generic wording instead of announcing a prompt nobody is holding.
+ */
+const ABANDONED: Array<[string, Partial<FileEntry>]> = [
+  ["the agent already exited", { activity: "stalled", proc: "done", mtime: NOW - 60 }],
+  ["the interruption is dead context", { activity: "stalled", proc: "running", mtime: NOW - STALLED_ATTENTION_TTL - 60 }],
+];
+
+test("an interrupted turn nobody is behind names no decision, on the toast or in the queue", async () => {
+  for (const [, overrides] of ABANDONED) {
+    const entry = file(overrides as Partial<FileEntry>);
+    expect(buildAttentionQueue([entry], NOW)).toHaveLength(0);
+
+    const host = await render(<AttentionToast file={entry} mobile={false} onOpen={() => {}} onDismiss={() => {}} />);
+    expect(title(host)).toBe("Agent is waiting for a reply");
+    await unmount();
+  }
 });
 
 test("open and dismiss stay separate targets, on the phone at full tap height", async () => {

--- a/src/components/attention/AttentionToast.tsx
+++ b/src/components/attention/AttentionToast.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { useLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { decisionLine } from "./decision";
+
+/**
+ * The «this agent needs you» toast (issue #1167).
+ *
+ * It used to announce a wait — «Agent is waiting for a reply» — over every wait
+ * there is, so a plan, a permission prompt, a rate-limit wall and a five-option
+ * question all read identically and the only way to learn what an agent wanted
+ * was to open it. The title is now the DECISION, from the one `decisionLine`
+ * the island popover rows and the orchestrator dock badge also read.
+ *
+ * The generic wording survives as the fallback and nothing more: a toast the
+ * operator has not dismissed can outlive its own signal (the question was
+ * answered from another surface), and inventing a decision for a conversation
+ * that no longer carries one is worse than saying nothing specific.
+ *
+ * Desktop floats it under the attention island so a new toast visually docks
+ * into the badge; the phone hands it the full width of an in-flow banner above
+ * the board, where it reserves its own space instead of covering the toolbar.
+ * Open and dismiss stay two separate targets in both.
+ */
+export function AttentionToast({ file, mobile, onOpen, onDismiss }: {
+  file: FileEntry;
+  mobile: boolean;
+  onOpen: () => void;
+  onDismiss: () => void;
+}) {
+  const { t, locale } = useLocale();
+  const title = decisionLine(t, locale, file) ?? t("viewer.agentWaiting");
+
+  if (mobile) {
+    return (
+      <div className="flex shrink-0 items-stretch gap-2 border-b border-warning/45 bg-warning-soft pl-3 pr-1.5 py-1.5" data-attention-toast>
+        <button
+          data-attention-toast-open
+          className="flex min-h-11 min-w-0 flex-1 flex-col justify-center text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          onClick={onOpen}
+        >
+          <span data-attention-toast-title className="block text-[11px] font-bold text-warning">{title}</span>
+          <span className="truncate text-[13px] font-semibold text-primary">{file.title}</span>
+        </button>
+        <button
+          data-attention-toast-dismiss
+          className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          aria-label={t("viewer.closeNotification")}
+          onClick={onDismiss}
+        >
+          <X className="h-5 w-5" aria-hidden />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-attention-toast
+      className="pointer-events-auto flex max-w-[360px] gap-2 rounded-[8px] border border-warning/45 bg-warning-soft px-4 py-3 text-[13px] font-semibold text-primary shadow-1"
+    >
+      <button
+        data-attention-toast-open
+        className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        onClick={onOpen}
+      >
+        <span data-attention-toast-title className="block text-[11px] font-bold text-warning">{title}</span>
+        <span className="line-clamp-2">{file.title}</span>
+      </button>
+      <button
+        data-attention-toast-dismiss
+        className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        aria-label={t("viewer.closeNotification")}
+        onClick={onDismiss}
+      >
+        <X className="h-3.5 w-3.5" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/src/components/attention/decision.test.ts
+++ b/src/components/attention/decision.test.ts
@@ -63,11 +63,20 @@ describe("the decision behind a wait is named, never merely announced", () => {
     expect(decisionLine(t, "en", file({ pendingQuestion: question() }))).toBe("Hero frame");
   });
 
-  test("a header-less question falls back to the question's own first line, then to the generic wording", () => {
-    const firstLine = file({
+  test("a header-less question is the generic wording, NEVER the question body", () => {
+    /* The body is a paragraph written to be read inside the conversation. On a
+       badge it truncates into nonsense, so an absent header buys the generic
+       word rather than a sentence fragment. */
+    const bodyOnly = file({
       pendingQuestion: question({ questions: [{ header: "", question: "Which capture runs first?\nBoth are cheap.", multiSelect: false, options: [] }] }),
     });
-    expect(decisionLine(t, "en", firstLine)).toBe("Which capture runs first?");
+    expect(attentionDecision(bodyOnly)).toEqual({ kind: "question", header: null });
+    expect(decisionLine(t, "en", bodyOnly)).toBe("a question");
+
+    const blank = file({
+      pendingQuestion: question({ questions: [{ header: "   ", question: "Which capture runs first?", multiSelect: false, options: [] }] }),
+    });
+    expect(decisionLine(t, "en", blank)).toBe("a question");
 
     const nothing = file({ pendingQuestion: question({ questions: [] }) });
     expect(decisionLine(t, "en", nothing)).toBe("a question");
@@ -86,22 +95,17 @@ describe("the decision behind a wait is named, never merely announced", () => {
     expect(decisionLine(t, "en", unknown)).toBe("rate-limited");
   });
 
-  test("a terminal prompt is named by its own menu question, then its screen tail, then «permission prompt»", () => {
-    const menu = file({
-      waitingInput: {
-        since: NOW - 60,
-        screenTail: "> 1. Yes",
-        target: "llv:0.0",
-        menu: { question: "Allow the write to src/?\nIt touches two files.", tabs: [], options: [] },
-      },
-    });
-    expect(decisionLine(t, "en", menu)).toBe("Allow the write to src/?");
-
-    const tail = file({ waitingInput: { since: NOW - 60, screenTail: "\n  Do you want to proceed?  \n> 1. Yes\n", target: "llv:0.0", menu: null } });
-    expect(decisionLine(t, "en", tail)).toBe("Do you want to proceed?");
-
-    const bare = file({ waitingInput: { since: NOW - 60, screenTail: "   ", target: "llv:0.0", menu: null } });
-    expect(decisionLine(t, "en", bare)).toBe("permission prompt");
+  test("every terminal prompt is «permission prompt» — the screen names the options, not the decision", () => {
+    const scraped = [
+      { since: NOW - 60, screenTail: "> 1. Yes", target: "llv:0.0", menu: { question: "Allow the write to src/?", tabs: [], options: [] } },
+      { since: NOW - 60, screenTail: "\n  Do you want to proceed?  \n❯ 1. Yes\n", target: "llv:0.0", menu: null },
+      { since: NOW - 60, screenTail: "   ", target: "llv:0.0", menu: null },
+    ];
+    for (const waitingInput of scraped) {
+      const waiting = file({ waitingInput } as Partial<FileEntry>);
+      expect(attentionDecision(waiting)).toEqual({ kind: "permission" });
+      expect(decisionLine(t, "en", waiting)).toBe("permission prompt");
+    }
   });
 
   test("an interrupted agent keeps the interrupted wording", () => {

--- a/src/components/attention/decision.test.ts
+++ b/src/components/attention/decision.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+
+import { translate, type TFunction } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { attentionId } from "../attention";
+import { attentionDecision, decisionLine } from "./decision";
+
+/*
+ * The ONE decision line (issue #1167).
+ *
+ * The dock badge, the toast and the island popover used to carry three parallel
+ * strings for the same wait — "Agent is waiting for a reply" said nothing about
+ * WHICH decision, and the popover derived its own snippet. These tests pin the
+ * single derivation they now share, and pin its precedence to `attentionId`'s:
+ * the surface that NAMES the wait must be talking about the signal the queue
+ * COUNTED, or a toast and a badge start describing different things.
+ */
+
+const t: TFunction = (key, params) => translate("en", key, params);
+const tUk: TFunction = (key, params) => translate("uk", key, params);
+
+const NOW = 1_800_000_000;
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/transcripts/worker.jsonl",
+    root: "claude-projects",
+    name: "worker.jsonl",
+    project: "atlas",
+    title: "Worker",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: NOW - 30,
+    size: 10,
+    activity: "live",
+    proc: null,
+    pid: null,
+    model: "opus",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+function question(overrides: Record<string, unknown> = {}): FileEntry["pendingQuestion"] {
+  return {
+    kind: "question",
+    toolUseId: "tool-use-1",
+    transcriptPath: "/transcripts/worker.jsonl",
+    pid: 4242,
+    paneTarget: null,
+    askedAt: "2026-08-25T10:00:00.000Z",
+    questions: [{ header: "Hero frame", question: "Choose the hero framing for the README", multiSelect: false, options: [] }],
+    ...overrides,
+  } as FileEntry["pendingQuestion"];
+}
+
+describe("the decision behind a wait is named, never merely announced", () => {
+  test("a structured question is named by its header", () => {
+    expect(decisionLine(t, "en", file({ pendingQuestion: question() }))).toBe("Hero frame");
+  });
+
+  test("a header-less question falls back to the question's own first line, then to the generic wording", () => {
+    const firstLine = file({
+      pendingQuestion: question({ questions: [{ header: "", question: "Which capture runs first?\nBoth are cheap.", multiSelect: false, options: [] }] }),
+    });
+    expect(decisionLine(t, "en", firstLine)).toBe("Which capture runs first?");
+
+    const nothing = file({ pendingQuestion: question({ questions: [] }) });
+    expect(decisionLine(t, "en", nothing)).toBe("a question");
+  });
+
+  test("a plan is plan approval, whatever its questions say", () => {
+    const plan = file({ pendingQuestion: question({ kind: "plan", plan: "1. read 2. write", questions: [{ header: "Ignore me", question: "?", multiSelect: false, options: [] }] }) });
+    expect(attentionDecision(plan)).toEqual({ kind: "plan" });
+    expect(decisionLine(t, "en", plan)).toBe("plan approval");
+  });
+
+  test("a rate-limited agent says until when, and drops the clock when the engine never reported one", () => {
+    const until = file({ rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: Date.parse("2026-08-25T14:30:00.000Z") / 1000 } });
+    expect(decisionLine(t, "en", until)).toMatch(/^rate-limited until \d\d:\d\d$/);
+    const unknown = file({ rateLimit: { source: "pane", accountId: null, window: null, resetAt: null } });
+    expect(decisionLine(t, "en", unknown)).toBe("rate-limited");
+  });
+
+  test("a terminal prompt is named by its own menu question, then its screen tail, then «permission prompt»", () => {
+    const menu = file({
+      waitingInput: {
+        since: NOW - 60,
+        screenTail: "> 1. Yes",
+        target: "llv:0.0",
+        menu: { question: "Allow the write to src/?\nIt touches two files.", tabs: [], options: [] },
+      },
+    });
+    expect(decisionLine(t, "en", menu)).toBe("Allow the write to src/?");
+
+    const tail = file({ waitingInput: { since: NOW - 60, screenTail: "\n  Do you want to proceed?  \n> 1. Yes\n", target: "llv:0.0", menu: null } });
+    expect(decisionLine(t, "en", tail)).toBe("Do you want to proceed?");
+
+    const bare = file({ waitingInput: { since: NOW - 60, screenTail: "   ", target: "llv:0.0", menu: null } });
+    expect(decisionLine(t, "en", bare)).toBe("permission prompt");
+  });
+
+  test("an interrupted agent keeps the interrupted wording", () => {
+    const stalled = file({ activity: "stalled", proc: "running" });
+    expect(attentionDecision(stalled)).toEqual({ kind: "stalled" });
+    expect(decisionLine(t, "en", stalled)).toBe("interrupted or awaiting permission");
+  });
+
+  test("a conversation carrying no signal at all names nothing", () => {
+    expect(attentionDecision(file())).toBeNull();
+    expect(decisionLine(t, "en", file())).toBeNull();
+  });
+});
+
+describe("the role label rides along when the conversation carries one", () => {
+  test("a durable role is appended, localized, after the decision", () => {
+    const builder = file({
+      pendingQuestion: question(),
+      durableLineage: { kind: "spawn", role: "builder", parentConversationId: null, reviewsConversationId: null, memberships: [] },
+    });
+    expect(decisionLine(t, "en", builder)).toBe("Hero frame · Builder");
+    expect(decisionLine(tUk, "uk", builder)).toBe("Hero frame · Білдер");
+  });
+
+  test("an unknown role id still attributes the wait rather than dropping it", () => {
+    const custom = file({
+      pendingQuestion: question(),
+      durableLineage: { kind: "spawn", role: "shipwright", parentConversationId: null, reviewsConversationId: null, memberships: [] },
+    });
+    expect(decisionLine(t, "en", custom)).toBe("Hero frame · shipwright");
+  });
+
+  test("a role-less conversation is the decision alone — no empty separator", () => {
+    const anonymous = file({
+      pendingQuestion: question(),
+      durableLineage: { kind: "spawn", role: null, parentConversationId: null, reviewsConversationId: null, memberships: [] },
+    });
+    expect(decisionLine(t, "en", anonymous)).toBe("Hero frame");
+  });
+});
+
+describe("the naming follows the queue's own precedence, so one wait is never two things", () => {
+  test("every signal precedence step matches attentionId's, question over rate limit over terminal over stalled", () => {
+    const all = file({
+      pendingQuestion: question(),
+      rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: null },
+      waitingInput: { since: NOW - 60, screenTail: "> 1. Yes", target: "llv:0.0", menu: null },
+      activity: "stalled",
+      proc: "running",
+    });
+    expect(attentionDecision(all)).toEqual({ kind: "question", header: "Hero frame" });
+
+    const withoutQuestion = file({ ...all, pendingQuestion: null });
+    expect(attentionDecision(withoutQuestion)?.kind).toBe("rate-limit");
+
+    const terminalOnly = file({ ...all, pendingQuestion: null, rateLimit: null });
+    expect(attentionDecision(terminalOnly)?.kind).toBe("permission");
+  });
+
+  test("every file the queue counts is a file the line can name", () => {
+    const counted = [
+      file({ pendingQuestion: question() }),
+      file({ rateLimit: { source: "pane", accountId: null, window: null, resetAt: null } }),
+      file({ waitingInput: { since: NOW - 60, screenTail: "> 1. Yes", target: "llv:0.0", menu: null } }),
+      file({ activity: "stalled", proc: "running" }),
+    ];
+    for (const entry of counted) {
+      expect(attentionId(entry, NOW)).not.toBeNull();
+      expect(decisionLine(t, "en", entry)).not.toBeNull();
+    }
+  });
+});

--- a/src/components/attention/decision.test.ts
+++ b/src/components/attention/decision.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { translate, type TFunction } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
-import { attentionId } from "../attention";
-import { attentionDecision, decisionLine } from "./decision";
+import { attentionId, buildAttentionQueue, STALLED_ATTENTION_TTL } from "../attention";
+import { decisionLine } from "./decision";
 
 /*
  * The ONE decision line (issue #1167).
@@ -12,9 +12,9 @@ import { attentionDecision, decisionLine } from "./decision";
  * The dock badge, the toast and the island popover used to carry three parallel
  * strings for the same wait — "Agent is waiting for a reply" said nothing about
  * WHICH decision, and the popover derived its own snippet. These tests pin the
- * single derivation they now share, and pin its precedence to `attentionId`'s:
- * the surface that NAMES the wait must be talking about the signal the queue
- * COUNTED, or a toast and a badge start describing different things.
+ * single derivation they now share, and pin it to the queue's own reading: the
+ * surface that NAMES a wait must be talking about a signal the queue COUNTED,
+ * or a toast and a badge start describing different things.
  */
 
 const t: TFunction = (key, params) => translate("en", key, params);
@@ -58,9 +58,29 @@ function question(overrides: Record<string, unknown> = {}): FileEntry["pendingQu
   } as FileEntry["pendingQuestion"];
 }
 
+/** The line as an English surface renders it, on the queue's own clock. */
+const line = (entry: FileEntry, now: number = NOW) => decisionLine(t, "en", entry, now);
+
+function membership(role: string): NonNullable<FileEntry["durableLineage"]>["memberships"][number] {
+  return {
+    kind: "pipeline",
+    containerId: "pipeline-atlas",
+    role,
+    slot: "implement:1",
+    stageId: "implement",
+    stageOrder: 0,
+    round: 1,
+    parentConversationId: null,
+  };
+}
+
+function lineage(overrides: Partial<NonNullable<FileEntry["durableLineage"]>> = {}): FileEntry["durableLineage"] {
+  return { kind: "spawn", role: null, parentConversationId: null, reviewsConversationId: null, memberships: [], ...overrides };
+}
+
 describe("the decision behind a wait is named, never merely announced", () => {
   test("a structured question is named by its header", () => {
-    expect(decisionLine(t, "en", file({ pendingQuestion: question() }))).toBe("Hero frame");
+    expect(line(file({ pendingQuestion: question() }))).toBe("Hero frame");
   });
 
   test("a header-less question is the generic wording, NEVER the question body", () => {
@@ -70,29 +90,27 @@ describe("the decision behind a wait is named, never merely announced", () => {
     const bodyOnly = file({
       pendingQuestion: question({ questions: [{ header: "", question: "Which capture runs first?\nBoth are cheap.", multiSelect: false, options: [] }] }),
     });
-    expect(attentionDecision(bodyOnly)).toEqual({ kind: "question", header: null });
-    expect(decisionLine(t, "en", bodyOnly)).toBe("a question");
+    expect(line(bodyOnly)).toBe("a question");
 
     const blank = file({
       pendingQuestion: question({ questions: [{ header: "   ", question: "Which capture runs first?", multiSelect: false, options: [] }] }),
     });
-    expect(decisionLine(t, "en", blank)).toBe("a question");
+    expect(line(blank)).toBe("a question");
 
     const nothing = file({ pendingQuestion: question({ questions: [] }) });
-    expect(decisionLine(t, "en", nothing)).toBe("a question");
+    expect(line(nothing)).toBe("a question");
   });
 
   test("a plan is plan approval, whatever its questions say", () => {
     const plan = file({ pendingQuestion: question({ kind: "plan", plan: "1. read 2. write", questions: [{ header: "Ignore me", question: "?", multiSelect: false, options: [] }] }) });
-    expect(attentionDecision(plan)).toEqual({ kind: "plan" });
-    expect(decisionLine(t, "en", plan)).toBe("plan approval");
+    expect(line(plan)).toBe("plan approval");
   });
 
   test("a rate-limited agent says until when, and drops the clock when the engine never reported one", () => {
     const until = file({ rateLimit: { source: "account", accountId: "primary", window: "session", resetAt: Date.parse("2026-08-25T14:30:00.000Z") / 1000 } });
-    expect(decisionLine(t, "en", until)).toMatch(/^rate-limited until \d\d:\d\d$/);
+    expect(line(until)).toMatch(/^rate-limited until \d\d:\d\d$/);
     const unknown = file({ rateLimit: { source: "pane", accountId: null, window: null, resetAt: null } });
-    expect(decisionLine(t, "en", unknown)).toBe("rate-limited");
+    expect(line(unknown)).toBe("rate-limited");
   });
 
   test("every terminal prompt is «permission prompt» — the screen names the options, not the decision", () => {
@@ -102,48 +120,116 @@ describe("the decision behind a wait is named, never merely announced", () => {
       { since: NOW - 60, screenTail: "   ", target: "llv:0.0", menu: null },
     ];
     for (const waitingInput of scraped) {
-      const waiting = file({ waitingInput } as Partial<FileEntry>);
-      expect(attentionDecision(waiting)).toEqual({ kind: "permission" });
-      expect(decisionLine(t, "en", waiting)).toBe("permission prompt");
+      expect(line(file({ waitingInput } as Partial<FileEntry>))).toBe("permission prompt");
     }
   });
 
   test("an interrupted agent keeps the interrupted wording", () => {
-    const stalled = file({ activity: "stalled", proc: "running" });
-    expect(attentionDecision(stalled)).toEqual({ kind: "stalled" });
-    expect(decisionLine(t, "en", stalled)).toBe("interrupted or awaiting permission");
+    expect(line(file({ activity: "stalled", proc: "running" }))).toBe("interrupted or awaiting permission");
   });
 
   test("a conversation carrying no signal at all names nothing", () => {
-    expect(attentionDecision(file())).toBeNull();
-    expect(decisionLine(t, "en", file())).toBeNull();
+    expect(line(file())).toBeNull();
   });
 });
 
-describe("the role label rides along when the conversation carries one", () => {
+/*
+ * The queue decides WHETHER a conversation is waiting; this module only decides
+ * what to call it. A line that outran that gate is how a toast came to announce
+ * «interrupted or awaiting permission» over an agent that had already exited,
+ * with no matching row anywhere in the popover behind it.
+ */
+describe("only a wait the queue counts is a wait the line will name", () => {
+  test("an interrupted transcript whose agent already exited is nobody's to answer", () => {
+    const abandoned = file({ activity: "stalled", proc: "done" });
+    expect(attentionId(abandoned, NOW)).toBeNull();
+    expect(line(abandoned)).toBeNull();
+  });
+
+  test("an interrupted transcript past the stalled TTL is dead context, not a pending prompt", () => {
+    const expired = file({ activity: "stalled", proc: "running", mtime: NOW - STALLED_ATTENTION_TTL - 1 });
+    expect(attentionId(expired, NOW)).toBeNull();
+    expect(line(expired)).toBeNull();
+
+    /* The far side of the same boundary still counts, and still gets named. */
+    const fresh = file({ activity: "stalled", proc: "running", mtime: NOW - STALLED_ATTENTION_TTL + 1 });
+    expect(line(fresh)).toBe("interrupted or awaiting permission");
+  });
+
+  test("every file the queue counts is a file the line can name, and no other file is", () => {
+    const counted = [
+      file({ pendingQuestion: question() }),
+      file({ rateLimit: { source: "pane", accountId: null, window: null, resetAt: null } }),
+      file({ waitingInput: { since: NOW - 60, screenTail: "> 1. Yes", target: "llv:0.0", menu: null } }),
+      file({ activity: "stalled", proc: "running" }),
+    ];
+    for (const entry of counted) {
+      expect(attentionId(entry, NOW)).not.toBeNull();
+      expect(line(entry)).not.toBeNull();
+    }
+
+    const uncounted = [
+      file(),
+      file({ activity: "stalled", proc: "done" }),
+      file({ activity: "stalled", proc: "running", mtime: NOW - STALLED_ATTENTION_TTL - 60 }),
+    ];
+    for (const entry of uncounted) {
+      expect(buildAttentionQueue([entry], NOW)).toHaveLength(0);
+      expect(line(entry)).toBeNull();
+    }
+  });
+});
+
+describe("the role label rides along when the conversation's evidence names one", () => {
   test("a durable role is appended, localized, after the decision", () => {
-    const builder = file({
-      pendingQuestion: question(),
-      durableLineage: { kind: "spawn", role: "builder", parentConversationId: null, reviewsConversationId: null, memberships: [] },
-    });
-    expect(decisionLine(t, "en", builder)).toBe("Hero frame · Builder");
-    expect(decisionLine(tUk, "uk", builder)).toBe("Hero frame · Білдер");
+    const builder = file({ pendingQuestion: question(), durableLineage: lineage({ role: "builder" }) });
+    expect(line(builder)).toBe("Hero frame · Builder");
+    expect(decisionLine(tUk, "uk", builder, NOW)).toBe("Hero frame · Білдер");
   });
 
   test("an unknown role id still attributes the wait rather than dropping it", () => {
-    const custom = file({
-      pendingQuestion: question(),
-      durableLineage: { kind: "spawn", role: "shipwright", parentConversationId: null, reviewsConversationId: null, memberships: [] },
-    });
-    expect(decisionLine(t, "en", custom)).toBe("Hero frame · shipwright");
+    const custom = file({ pendingQuestion: question(), durableLineage: lineage({ role: "shipwright" }) });
+    expect(line(custom)).toBe("Hero frame · shipwright");
   });
 
-  test("a role-less conversation is the decision alone — no empty separator", () => {
-    const anonymous = file({
+  /*
+   * A pipeline or flow seat is real evidence of the job an agent was given, and
+   * the registry has always read it that way (`conversationAgentRole` falls
+   * through to the newest membership). The read model routinely carries
+   * `role: null` beside one — an adopted stage records the membership and no
+   * conversation role — and that agent was rendering as nobody.
+   */
+  test("a membership-only agent is attributed by its container seat", () => {
+    const staged = file({ pendingQuestion: question(), durableLineage: lineage({ role: null, memberships: [membership("builder")] }) });
+    expect(line(staged)).toBe("Hero frame · Builder");
+    expect(decisionLine(tUk, "uk", staged, NOW)).toBe("Hero frame · Білдер");
+  });
+
+  test("the newest seat wins, and the conversation's own role outranks every seat", () => {
+    const rotated = file({
       pendingQuestion: question(),
-      durableLineage: { kind: "spawn", role: null, parentConversationId: null, reviewsConversationId: null, memberships: [] },
+      durableLineage: lineage({ role: null, memberships: [membership("builder"), membership("reviewer")] }),
     });
-    expect(decisionLine(t, "en", anonymous)).toBe("Hero frame");
+    expect(line(rotated)).toBe("Hero frame · Reviewer");
+
+    const declared = file({
+      pendingQuestion: question(),
+      durableLineage: lineage({ role: "orchestrator", memberships: [membership("builder")] }),
+    });
+    expect(line(declared)).toBe("Hero frame · Orchestrator");
+  });
+
+  test("a seat with no role of its own attributes nobody", () => {
+    /* A role-less pipeline stage records the literal placeholder «agent», which
+       is the absence of a role spelled as a word — «· agent» is noise. */
+    const unnamed = file({ pendingQuestion: question(), durableLineage: lineage({ role: null, memberships: [membership("agent")] }) });
+    expect(line(unnamed)).toBe("Hero frame");
+
+    const anonymous = file({ pendingQuestion: question(), durableLineage: lineage({ role: null }) });
+    expect(line(anonymous)).toBe("Hero frame");
+
+    const untracked = file({ pendingQuestion: question() });
+    expect(line(untracked)).toBe("Hero frame");
   });
 });
 
@@ -156,25 +242,9 @@ describe("the naming follows the queue's own precedence, so one wait is never tw
       activity: "stalled",
       proc: "running",
     });
-    expect(attentionDecision(all)).toEqual({ kind: "question", header: "Hero frame" });
-
-    const withoutQuestion = file({ ...all, pendingQuestion: null });
-    expect(attentionDecision(withoutQuestion)?.kind).toBe("rate-limit");
-
-    const terminalOnly = file({ ...all, pendingQuestion: null, rateLimit: null });
-    expect(attentionDecision(terminalOnly)?.kind).toBe("permission");
-  });
-
-  test("every file the queue counts is a file the line can name", () => {
-    const counted = [
-      file({ pendingQuestion: question() }),
-      file({ rateLimit: { source: "pane", accountId: null, window: null, resetAt: null } }),
-      file({ waitingInput: { since: NOW - 60, screenTail: "> 1. Yes", target: "llv:0.0", menu: null } }),
-      file({ activity: "stalled", proc: "running" }),
-    ];
-    for (const entry of counted) {
-      expect(attentionId(entry, NOW)).not.toBeNull();
-      expect(decisionLine(t, "en", entry)).not.toBeNull();
-    }
+    expect(line(all)).toBe("Hero frame");
+    expect(line(file({ ...all, pendingQuestion: null }))).toBe("rate-limited");
+    expect(line(file({ ...all, pendingQuestion: null, rateLimit: null }))).toBe("permission prompt");
+    expect(line(file({ ...all, pendingQuestion: null, rateLimit: null, waitingInput: null }))).toBe("interrupted or awaiting permission");
   });
 });

--- a/src/components/attention/decision.ts
+++ b/src/components/attention/decision.ts
@@ -1,0 +1,114 @@
+import { roleNameById } from "@/components/builderCopy";
+import { formatRateLimitTime } from "@/components/rateLimit";
+import type { Locale, TFunction } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+/**
+ * What a waiting agent is actually blocked on, and the ONE line that says it
+ * (issue #1167).
+ *
+ * The dock badge, the toast and the island popover all answer the same
+ * question — «what do you owe this agent?» — and each used to answer it in its
+ * own words: the toast said «Agent is waiting for a reply» and named no
+ * decision at all, while the popover derived a snippet of its own. Three
+ * parallel strings over one signal is how a toast and a badge start describing
+ * different things, so the derivation lives here once and every surface reads
+ * it.
+ *
+ * The precedence below MIRRORS `attentionId`'s, deliberately and in the same
+ * order: the surface that NAMES a wait has to be talking about the signal the
+ * queue COUNTED. `attentionId` stays the only authority on whether a
+ * conversation is waiting at all (a stalled transcript needs a live process and
+ * a fresh mtime before it counts) — this module only names what it found, so a
+ * caller asks the queue first and asks for words second.
+ */
+export type AttentionDecision =
+  /** A structured question: `header` is the agent's own label for it. */
+  | { kind: "question"; header: string | null }
+  /** A plan awaiting approval. */
+  | { kind: "plan" }
+  /** An engine or account wall, with the reset moment when one was reported. */
+  | { kind: "rate-limit"; resetAt: number | null }
+  /** A terminal prompt, named by whatever the screen gave up. */
+  | { kind: "permission"; prompt: string | null }
+  /** An interrupted turn — no question on screen, but nobody is working. */
+  | { kind: "stalled" };
+
+/** First non-empty line of a scraped block, tidied for a one-line surface. */
+function firstLine(text: string | null | undefined): string | null {
+  if (!text) return null;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (line) return line;
+  }
+  return null;
+}
+
+/**
+ * The decision a conversation is blocked on, or null when it carries no signal.
+ *
+ * Precedence, identical to `attentionId`'s: a structured question, then a
+ * rate-limit wall, then the screen-scrape fallback, then the stalled state.
+ */
+export function attentionDecision(file: FileEntry): AttentionDecision | null {
+  const pending = file.pendingQuestion;
+  if (pending) {
+    if (pending.kind === "plan") return { kind: "plan" };
+    const first = pending.questions?.[0];
+    return { kind: "question", header: firstLine(first?.header) ?? firstLine(first?.question) };
+  }
+  if (file.rateLimit) return { kind: "rate-limit", resetAt: file.rateLimit.resetAt };
+  const waiting = file.waitingInput;
+  if (waiting) return { kind: "permission", prompt: firstLine(waiting.menu?.question) ?? firstLine(waiting.screenTail) };
+  if (file.activity === "stalled") return { kind: "stalled" };
+  return null;
+}
+
+/** The decision alone, without attribution. */
+function decisionText(t: TFunction, locale: Locale, decision: AttentionDecision): string {
+  switch (decision.kind) {
+    case "question":
+      return decision.header ?? t("attention.decisionQuestion");
+    case "plan":
+      return t("attention.decisionPlan");
+    case "rate-limit":
+      /* The wording the rate-limit badge already uses, so the wall reads the
+         same wherever the operator meets it. */
+      return decision.resetAt
+        ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(decision.resetAt, locale) })
+        : t("rateLimit.badge");
+    case "permission":
+      return decision.prompt ?? t("attention.decisionPermission");
+    case "stalled":
+      return t("status.stalled");
+  }
+}
+
+/**
+ * Who is waiting, when the conversation carries a durable role.
+ *
+ * Only the conversation's OWN role counts (`durableLineage.role` — the launch
+ * receipt's `agentRole`, or the durable spawn edge behind it). Container
+ * memberships are deliberately not consulted: a stage slot names the agent's
+ * place in a pipeline rather than the job it is doing, and «Member» beside a
+ * decision tells the operator nothing they did not already know.
+ */
+function roleLabel(t: TFunction, file: FileEntry): string | null {
+  const role = file.durableLineage?.role;
+  return role ? roleNameById(t, role) : null;
+}
+
+/**
+ * The one line every attention surface shows: the decision, plus the agent's
+ * role when the conversation names one. Null when there is no signal to name —
+ * a surface with a stale target (a toast still up after its question was
+ * answered elsewhere) falls back to its own generic wording rather than
+ * inventing a decision.
+ */
+export function decisionLine(t: TFunction, locale: Locale, file: FileEntry): string | null {
+  const decision = attentionDecision(file);
+  if (!decision) return null;
+  const role = roleLabel(t, file);
+  const text = decisionText(t, locale, decision);
+  return role ? `${text} · ${role}` : text;
+}

--- a/src/components/attention/decision.ts
+++ b/src/components/attention/decision.ts
@@ -44,12 +44,11 @@ const UNNAMED_ROLE = "agent";
  */
 function roleLabel(t: TFunction, file: FileEntry): string | null {
   const lineage = file.durableLineage;
-  const direct = lineage?.role?.trim();
-  const role = direct
-    || lineage?.memberships.filter((membership) => {
-      const value = membership.role.trim();
-      return value && value !== UNNAMED_ROLE;
-    }).at(-1)?.role.trim();
+  const seat = lineage?.memberships.findLast((membership) => {
+    const named = membership.role.trim();
+    return named !== "" && named !== UNNAMED_ROLE;
+  });
+  const role = lineage?.role?.trim() || seat?.role.trim();
   return role ? roleNameById(t, role) : null;
 }
 

--- a/src/components/attention/decision.ts
+++ b/src/components/attention/decision.ts
@@ -23,43 +23,43 @@ import type { FileEntry } from "@/lib/types";
  * caller asks the queue first and asks for words second.
  */
 export type AttentionDecision =
-  /** A structured question: `header` is the agent's own label for it. */
+  /** A structured question, named by the agent's OWN label for it — never by
+      the question body, which is a paragraph written to be read inside the
+      conversation and truncates into nonsense on a badge. Null header means the
+      agent shipped none, and the generic wording stands in. */
   | { kind: "question"; header: string | null }
   /** A plan awaiting approval. */
   | { kind: "plan" }
   /** An engine or account wall, with the reset moment when one was reported. */
   | { kind: "rate-limit"; resetAt: number | null }
-  /** A terminal prompt, named by whatever the screen gave up. */
-  | { kind: "permission"; prompt: string | null }
+  /** A terminal prompt. Deliberately payload-free: the only text a scraped
+      prompt offers is the menu it is drawing («❯ 1. Yes»), which names the
+      OPTIONS rather than the decision. */
+  | { kind: "permission" }
   /** An interrupted turn — no question on screen, but nobody is working. */
   | { kind: "stalled" };
-
-/** First non-empty line of a scraped block, tidied for a one-line surface. */
-function firstLine(text: string | null | undefined): string | null {
-  if (!text) return null;
-  for (const raw of text.split("\n")) {
-    const line = raw.trim();
-    if (line) return line;
-  }
-  return null;
-}
 
 /**
  * The decision a conversation is blocked on, or null when it carries no signal.
  *
  * Precedence, identical to `attentionId`'s: a structured question, then a
  * rate-limit wall, then the screen-scrape fallback, then the stalled state.
+ *
+ * Each kind is named from a FIXED vocabulary — the agent's own question header,
+ * or one of three localized phrases. Nothing is lifted out of a question body
+ * or off a scraped screen: a line assembled from whatever the terminal happened
+ * to be drawing is not a decision the operator can recognize, and it is what
+ * put «❯ 1. Yes» in front of them as the name of a wait.
  */
 export function attentionDecision(file: FileEntry): AttentionDecision | null {
   const pending = file.pendingQuestion;
   if (pending) {
     if (pending.kind === "plan") return { kind: "plan" };
-    const first = pending.questions?.[0];
-    return { kind: "question", header: firstLine(first?.header) ?? firstLine(first?.question) };
+    const header = pending.questions?.[0]?.header?.trim();
+    return { kind: "question", header: header || null };
   }
   if (file.rateLimit) return { kind: "rate-limit", resetAt: file.rateLimit.resetAt };
-  const waiting = file.waitingInput;
-  if (waiting) return { kind: "permission", prompt: firstLine(waiting.menu?.question) ?? firstLine(waiting.screenTail) };
+  if (file.waitingInput) return { kind: "permission" };
   if (file.activity === "stalled") return { kind: "stalled" };
   return null;
 }
@@ -78,7 +78,7 @@ function decisionText(t: TFunction, locale: Locale, decision: AttentionDecision)
         ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(decision.resetAt, locale) })
         : t("rateLimit.badge");
     case "permission":
-      return decision.prompt ?? t("attention.decisionPermission");
+      return t("attention.decisionPermission");
     case "stalled":
       return t("status.stalled");
   }

--- a/src/components/attention/decision.ts
+++ b/src/components/attention/decision.ts
@@ -1,11 +1,12 @@
 import { roleNameById } from "@/components/builderCopy";
-import { formatRateLimitTime } from "@/components/rateLimit";
+import { rateLimitText } from "@/components/rateLimit";
 import type { Locale, TFunction } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
+import { attentionId } from "../attention";
+
 /**
- * What a waiting agent is actually blocked on, and the ONE line that says it
- * (issue #1167).
+ * The ONE line every attention surface shows for a waiting agent (issue #1167).
  *
  * The dock badge, the toast and the island popover all answer the same
  * question — «what do you owe this agent?» — and each used to answer it in its
@@ -15,100 +16,81 @@ import type { FileEntry } from "@/lib/types";
  * different things, so the derivation lives here once and every surface reads
  * it.
  *
- * The precedence below MIRRORS `attentionId`'s, deliberately and in the same
- * order: the surface that NAMES a wait has to be talking about the signal the
- * queue COUNTED. `attentionId` stays the only authority on whether a
- * conversation is waiting at all (a stalled transcript needs a live process and
- * a fresh mtime before it counts) — this module only names what it found, so a
- * caller asks the queue first and asks for words second.
+ * `attentionId` is the eligibility authority, and this module CALLS it rather
+ * than re-deciding: a conversation the queue does not count is a conversation
+ * this line refuses to name. That gate is load-bearing for the stalled tier,
+ * whose signal needs a live process and a fresh mtime before it is anyone's to
+ * answer — without it a toast left up over an abandoned session announced
+ * «interrupted or awaiting permission» while the popover behind it held no such
+ * row, which is the one-signal-two-descriptions defect this issue exists to
+ * remove.
  */
-export type AttentionDecision =
-  /** A structured question, named by the agent's OWN label for it — never by
-      the question body, which is a paragraph written to be read inside the
-      conversation and truncates into nonsense on a badge. Null header means the
-      agent shipped none, and the generic wording stands in. */
-  | { kind: "question"; header: string | null }
-  /** A plan awaiting approval. */
-  | { kind: "plan" }
-  /** An engine or account wall, with the reset moment when one was reported. */
-  | { kind: "rate-limit"; resetAt: number | null }
-  /** A terminal prompt. Deliberately payload-free: the only text a scraped
-      prompt offers is the menu it is drawing («❯ 1. Yes»), which names the
-      OPTIONS rather than the decision. */
-  | { kind: "permission" }
-  /** An interrupted turn — no question on screen, but nobody is working. */
-  | { kind: "stalled" };
+
+/** The role a pipeline stage records when its stage carries no role at all
+    (`engine.ts` writes `roleId ?? "agent"`). It is the ABSENCE of a role
+    spelled as a word, so it attributes nothing and never reaches the line. */
+const UNNAMED_ROLE = "agent";
 
 /**
- * The decision a conversation is blocked on, or null when it carries no signal.
+ * Who is waiting, when the conversation's evidence names a role.
  *
- * Precedence, identical to `attentionId`'s: a structured question, then a
- * rate-limit wall, then the screen-scrape fallback, then the stalled state.
- *
- * Each kind is named from a FIXED vocabulary — the agent's own question header,
- * or one of three localized phrases. Nothing is lifted out of a question body
- * or off a scraped screen: a line assembled from whatever the terminal happened
- * to be drawing is not a decision the operator can recognize, and it is what
- * put «❯ 1. Yes» in front of them as the name of a wait.
- */
-export function attentionDecision(file: FileEntry): AttentionDecision | null {
-  const pending = file.pendingQuestion;
-  if (pending) {
-    if (pending.kind === "plan") return { kind: "plan" };
-    const header = pending.questions?.[0]?.header?.trim();
-    return { kind: "question", header: header || null };
-  }
-  if (file.rateLimit) return { kind: "rate-limit", resetAt: file.rateLimit.resetAt };
-  if (file.waitingInput) return { kind: "permission" };
-  if (file.activity === "stalled") return { kind: "stalled" };
-  return null;
-}
-
-/** The decision alone, without attribution. */
-function decisionText(t: TFunction, locale: Locale, decision: AttentionDecision): string {
-  switch (decision.kind) {
-    case "question":
-      return decision.header ?? t("attention.decisionQuestion");
-    case "plan":
-      return t("attention.decisionPlan");
-    case "rate-limit":
-      /* The wording the rate-limit badge already uses, so the wall reads the
-         same wherever the operator meets it. */
-      return decision.resetAt
-        ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(decision.resetAt, locale) })
-        : t("rateLimit.badge");
-    case "permission":
-      return t("attention.decisionPermission");
-    case "stalled":
-      return t("status.stalled");
-  }
-}
-
-/**
- * Who is waiting, when the conversation carries a durable role.
- *
- * Only the conversation's OWN role counts (`durableLineage.role` — the launch
- * receipt's `agentRole`, or the durable spawn edge behind it). Container
- * memberships are deliberately not consulted: a stage slot names the agent's
- * place in a pipeline rather than the job it is doing, and «Member» beside a
- * decision tells the operator nothing they did not already know.
+ * The same fail-open ladder the registry walks in `conversationAgentRole`: the
+ * conversation's own role first (`durableLineage.role` already collapses the
+ * launch receipt's `agentRole` and the durable spawn edge behind it), then its
+ * newest container membership — the read model keeps memberships in the order
+ * the registry appended them, so the last row is the newest. A stage slot is
+ * real evidence of the job an agent was given; dropping it left a pipeline
+ * builder's question attributed to nobody.
  */
 function roleLabel(t: TFunction, file: FileEntry): string | null {
-  const role = file.durableLineage?.role;
+  const lineage = file.durableLineage;
+  const direct = lineage?.role?.trim();
+  const role = direct
+    || lineage?.memberships.filter((membership) => {
+      const value = membership.role.trim();
+      return value && value !== UNNAMED_ROLE;
+    }).at(-1)?.role.trim();
   return role ? roleNameById(t, role) : null;
 }
 
 /**
- * The one line every attention surface shows: the decision, plus the agent's
- * role when the conversation names one. Null when there is no signal to name —
- * a surface with a stale target (a toast still up after its question was
- * answered elsewhere) falls back to its own generic wording rather than
- * inventing a decision.
+ * The wait itself, from a FIXED vocabulary — the agent's own question header,
+ * or one of three localized phrases, or the rate-limit badge's own wording.
+ *
+ * Nothing is lifted out of a question body or off a scraped screen: a line
+ * assembled from whatever the terminal happened to be drawing names the OPTIONS
+ * rather than the decision, and it is what put «❯ 1. Yes» in front of the
+ * operator as the name of a wait.
+ *
+ * The ladder is `attentionId`'s precedence, in its order, over a file that
+ * already qualified — which is what makes the stalled tail honest rather than a
+ * catch-all.
  */
-export function decisionLine(t: TFunction, locale: Locale, file: FileEntry): string | null {
-  const decision = attentionDecision(file);
-  if (!decision) return null;
+function decisionText(t: TFunction, locale: Locale, file: FileEntry): string {
+  const pending = file.pendingQuestion;
+  if (pending) {
+    if (pending.kind === "plan") return t("attention.decisionPlan");
+    /* Never the question BODY: it is a paragraph written to be read inside the
+       conversation, and it truncates into nonsense on a badge. */
+    return pending.questions?.[0]?.header?.trim() || t("attention.decisionQuestion");
+  }
+  if (file.rateLimit) return rateLimitText(t, locale, file.rateLimit);
+  if (file.waitingInput) return t("attention.decisionPermission");
+  return t("status.stalled");
+}
+
+/**
+ * The decision a conversation owes the operator, plus its role when the
+ * evidence names one — or null when the queue counts no wait here at all.
+ *
+ * A surface holding a stale target (a toast still up after its question was
+ * answered elsewhere, an agent that exited mid-turn) falls back to its own
+ * generic wording rather than inventing a decision. `now` is epoch SECONDS and
+ * defaults to the wall clock, exactly as `attentionId` does.
+ */
+export function decisionLine(t: TFunction, locale: Locale, file: FileEntry, now?: number): string | null {
+  if (attentionId(file, now) === null) return null;
+  const decision = decisionText(t, locale, file);
   const role = roleLabel(t, file);
-  const text = decisionText(t, locale, decision);
-  return role ? `${text} · ${role}` : text;
+  return role ? `${decision} · ${role}` : decision;
 }

--- a/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
@@ -32,6 +32,7 @@ const state: Extract<OrchestratorPanelState, { kind: "live" }> = {
   seat,
   conversationId: seat.conversationId!,
   liveness: "stalled",
+  attention: null,
   bindFailure: null,
   rotation: null,
   transition: null,

--- a/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
@@ -1439,3 +1439,61 @@ test("coming back to a project paints its conversation in the first commit, tran
   await settle();
   expect(panelState(dock.host)).toBe("live");
 });
+
+/* ------------------------------------------------------------------------- *
+ * The dock badge names the decision it is holding (issue #1167): «live» and
+ * «live, and holding a question up at you» used to be the same word.
+ * ------------------------------------------------------------------------- */
+
+const stateBadge = (host: HTMLElement) => host.querySelector("[data-orchestrator-badge]") as HTMLElement;
+
+const orchestratorQuestion = {
+  kind: "question" as const,
+  toolUseId: "tool-use-orch",
+  transcriptPath: "/transcripts/orch.jsonl",
+  pid: 4_242,
+  paneTarget: null,
+  askedAt: "2026-08-25T10:00:00.000Z",
+  questions: [{ header: "Rollout window", question: "Approve the proposed rollout window", multiSelect: false, options: [] }],
+};
+
+test("a seat holding a question badges «needs you» in the warning tone, and names the decision", async () => {
+  seatStatus = { seat: activeSeat(), pending: null, exists: true };
+  incumbentStatus = incumbent();
+  const host = mount([{
+    ...orchestratorFile,
+    proc: "running",
+    pid: 4_242,
+    pendingQuestion: orchestratorQuestion,
+    durableLineage: { kind: "spawn", role: "orchestrator", parentConversationId: null, reviewsConversationId: null, memberships: [] },
+  } as FileEntry]);
+  await settle();
+  flushSync(() => undefined);
+
+  const badge = stateBadge(host);
+  expect(badge.getAttribute("data-orchestrator-badge")).toBe("needs-you");
+  expect(badge.textContent).toBe("needs you");
+  expect(badge.className).toContain("warning");
+  /* The SAME line the toast and the island popover carry — one derivation. */
+  expect(badge.getAttribute("title")).toBe("Rollout window · Orchestrator");
+});
+
+test("a quiet seat keeps the live badge, and claims no decision in its tooltip", async () => {
+  const host = await mountLive();
+
+  const badge = stateBadge(host);
+  expect(badge.getAttribute("data-orchestrator-badge")).toBe("live");
+  expect(badge.textContent).toBe("live");
+  expect(badge.hasAttribute("title")).toBeFalse();
+});
+
+test("the badge is localized with the rest of the dock", async () => {
+  setLocale("uk");
+  seatStatus = { seat: activeSeat(), pending: null, exists: true };
+  const host = mount([{ ...orchestratorFile, proc: "running", pid: 4_242, pendingQuestion: orchestratorQuestion } as FileEntry]);
+  await settle();
+  flushSync(() => undefined);
+
+  expect(stateBadge(host).getAttribute("data-orchestrator-badge")).toBe("needs-you");
+  expect(stateBadge(host).textContent).toBe("потребує тебе");
+});

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -876,9 +876,9 @@ const SEAT_BADGE: Record<SeatBadge, { tone: string; key: MessageKey }> = {
  * decision itself in its tooltip (issue #1167).
  *
  * The word comes from `seatBadgeOf`, which ranks a pending decision ahead of
- * the livenesses it can outrank; the line comes from the SAME `decisionLine`
- * the toast and the island popover read, so the dock can never name a wait
- * differently from the surfaces the operator reached it through.
+ * the liveness; the line comes from the SAME `decisionLine` the toast and the
+ * island popover read, so the dock can never name a wait differently from the
+ * surfaces the operator reached it through.
  */
 function StateBadge({ state, file }: { state: OrchestratorPanelState; file: FileEntry | null }) {
   const { t, locale } = useLocale();
@@ -900,9 +900,9 @@ function StateBadge({ state, file }: { state: OrchestratorPanelState; file: File
         : state.kind === "draft"
           ? "orchPanel.badgeNone"
           : "orchPanel.badgeReading");
-  /* Only a seat the badge calls «needs you» names a decision: a stale question
-     on a gone host is not one the operator can answer, and the badge already
-     says what that seat needs instead. */
+  /* The tooltip follows the badge: a seat the badge calls «needs you» carries
+     the decision behind it, and every other badge is already its own whole
+     answer. */
   const decision = seatBadge === "needs-you" && file ? decisionLine(t, locale, file) : null;
   return (
     <span

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -21,6 +21,7 @@ import {
 import type { OrchestratorSeat } from "@/lib/orchestrator/seats";
 import type { FileEntry } from "@/lib/types";
 
+import { decisionLine } from "../attention/decision";
 import { IncumbentHeader } from "./IncumbentHeader";
 import { incumbentHostLive, type OrchestratorIncumbent } from "./incumbent";
 import { OrchestratorConversation } from "./OrchestratorConversation";
@@ -30,13 +31,14 @@ import {
   orchestratorQuietBannerEligible,
   resolveSeatFile,
   SEAT_BIND_TIMEOUT_MS,
+  seatBadgeOf,
   seatBindPending,
   seatRequestSettled,
   type OrchestratorPanelState,
   type OrchestratorSeatStatus,
   type RotationHint,
+  type SeatBadge,
   type SeatBindFailure,
-  type SeatLiveness,
   type SeatTransition,
 } from "./seatState";
 import { useOrchestratorIncumbent } from "./useOrchestratorIncumbent";
@@ -331,7 +333,7 @@ export function OrchestratorPanel({
           <span className="truncate text-body font-semibold text-primary">{t("orchPanel.title")}</span>
           <span className="truncate text-caption text-muted" title={projectName}>{projectName}</span>
         </span>
-        <StateBadge state={state} />
+        <StateBadge state={state} file={file} />
         <button
           type="button"
           onClick={onClose}
@@ -855,29 +857,42 @@ function OrchestratorDraft({
 
 const QUIET_BADGE = "border-border bg-canvas text-muted";
 const DANGER_BADGE = "border-danger/40 bg-danger-soft text-danger";
+const WARNING_BADGE = "border-warning/45 bg-warning-soft text-warning";
 
-/** One row per liveness, so a tone can never drift from the word beside it —
-    and green is claimed ONLY by a conversation that is actually hosted. */
-const LIVENESS_BADGE: Record<SeatLiveness, { tone: string; key: MessageKey }> = {
+/** One row per badge, so a tone can never drift from the word beside it — green
+    is claimed ONLY by a conversation that is actually hosted, and the warning
+    tone the rest of the app spends on a wait is what «needs you» wears. */
+const SEAT_BADGE: Record<SeatBadge, { tone: string; key: MessageKey }> = {
+  "needs-you": { tone: WARNING_BADGE, key: "orchPanel.badgeNeedsYou" },
   live: { tone: "border-success/45 bg-success-soft text-success", key: "orchPanel.badgeLive" },
-  stalled: { tone: "border-warning/45 bg-warning-soft text-warning", key: "orchPanel.badgeStalled" },
+  stalled: { tone: WARNING_BADGE, key: "orchPanel.badgeStalled" },
   resumable: { tone: QUIET_BADGE, key: "orchPanel.badgeResumable" },
   dead: { tone: DANGER_BADGE, key: "orchPanel.badgeDead" },
   resolving: { tone: QUIET_BADGE, key: "orchPanel.badgeResolving" },
 };
 
-function StateBadge({ state }: { state: OrchestratorPanelState }) {
-  const { t } = useLocale();
-  const live = state.kind === "live" ? LIVENESS_BADGE[state.liveness] : null;
-  const tone = live
-    ? live.tone
+/**
+ * The badge, and — when the seat is holding a decision up at the operator — the
+ * decision itself in its tooltip (issue #1167).
+ *
+ * The word comes from `seatBadgeOf`, which ranks a pending decision ahead of
+ * the livenesses it can outrank; the line comes from the SAME `decisionLine`
+ * the toast and the island popover read, so the dock can never name a wait
+ * differently from the surfaces the operator reached it through.
+ */
+function StateBadge({ state, file }: { state: OrchestratorPanelState; file: FileEntry | null }) {
+  const { t, locale } = useLocale();
+  const seatBadge = state.kind === "live" ? seatBadgeOf(state) : null;
+  const badge = seatBadge ? SEAT_BADGE[seatBadge] : null;
+  const tone = badge
+    ? badge.tone
     : state.kind === "intent-error"
       ? DANGER_BADGE
       : state.kind === "creating"
         ? "border-accent/45 bg-accent-soft text-accent"
         : QUIET_BADGE;
-  const label = live
-    ? t(live.key)
+  const label = badge
+    ? t(badge.key)
     : t(state.kind === "creating"
       ? "orchPanel.badgeCreating"
       : state.kind === "intent-error"
@@ -885,8 +900,18 @@ function StateBadge({ state }: { state: OrchestratorPanelState }) {
         : state.kind === "draft"
           ? "orchPanel.badgeNone"
           : "orchPanel.badgeReading");
+  /* Only a seat the badge calls «needs you» names a decision: a stale question
+     on a gone host is not one the operator can answer, and the badge already
+     says what that seat needs instead. */
+  const decision = seatBadge === "needs-you" && file ? decisionLine(t, locale, file) : null;
   return (
-    <span className={`shrink-0 rounded-full border px-2 py-0.5 text-caption font-semibold ${tone}`}>{label}</span>
+    <span
+      data-orchestrator-badge={seatBadge ?? state.kind}
+      title={decision ?? undefined}
+      className={`shrink-0 rounded-full border px-2 py-0.5 text-caption font-semibold ${tone}`}
+    >
+      {label}
+    </span>
   );
 }
 

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -491,35 +491,49 @@ describe("a decision the operator owes outranks every word for «it is running»
     questions: [{ header: "Rollout window", question: "Approve the proposed rollout window", multiSelect: false, options: [] }],
   };
   const seated = { ...base, status: status({ seat: seat() }), now: NOW };
+  const badgeOf = (state: OrchestratorPanelState) => seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>);
+
+  /* EVERY liveness `livenessOf` can produce, with the surface and the file that
+     produce it — the badge is asserted over all five, both ways, so no state can
+     quietly opt out of naming a decision the island is already counting. */
+  const LIVENESSES = [
+    ["live-root", {}, "live"],
+    ["live-root", { activity: "stalled" }, "stalled"],
+    ["resume", {}, "resumable"],
+    ["dead", {}, "dead"],
+    ["unresolved", {}, "resolving"],
+  ] as const;
 
   test("a hosted seat with a question on screen carries the attention id and badges «needs you»", () => {
     const state = deriveOrchestratorPanelState({ ...seated, file: file({ pendingQuestion: asked }), surface: "live-root" });
     expect(state).toMatchObject({ kind: "live", liveness: "live", attention: "tool-use-orch" });
-    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("needs-you");
+    expect(badgeOf(state)).toBe("needs-you");
   });
 
-  test("a quiet seat is still the liveness word — nothing is owed", () => {
-    const state = deriveOrchestratorPanelState({ ...seated, file: file(), surface: "live-root" });
-    expect(state).toMatchObject({ kind: "live", liveness: "live", attention: null });
-    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("live");
+  test("a pending decision is the badge at every liveness, «finished» and «host gone» included", () => {
+    for (const [surface, overrides, liveness] of LIVENESSES) {
+      const state = deriveOrchestratorPanelState({ ...seated, file: file({ ...overrides, pendingQuestion: asked }), surface });
+      expect(state).toMatchObject({ liveness, attention: "tool-use-orch" });
+      expect(badgeOf(state)).toBe("needs-you");
+    }
   });
 
-  test("a stalled seat with a terminal prompt is «needs you» too: both livenesses it outranks are hosted", () => {
+  test("with nothing owed, every liveness keeps its own word", () => {
+    for (const [surface, overrides, liveness] of LIVENESSES) {
+      const state = deriveOrchestratorPanelState({ ...seated, file: file(overrides), surface });
+      expect(state).toMatchObject({ liveness, attention: null });
+      expect(badgeOf(state)).toBe(liveness);
+    }
+  });
+
+  test("a terminal prompt is a decision too — the badge follows the queue, not the signal's shape", () => {
     const waiting = file({
       activity: "stalled",
       waitingInput: { since: NOW - 120, screenTail: "> 1. Yes", target: "llv:0.0", menu: null },
     });
     const state = deriveOrchestratorPanelState({ ...seated, file: waiting, surface: "live-root" });
     expect(state).toMatchObject({ liveness: "stalled" });
-    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("needs-you");
-  });
-
-  test("a gone or resumable host keeps its own badge: a decision nobody can answer must not hide the recovery", () => {
-    for (const [surface, liveness] of [["dead", "dead"], ["resume", "resumable"], ["unresolved", "resolving"]] as const) {
-      const state = deriveOrchestratorPanelState({ ...seated, file: file({ pendingQuestion: asked }), surface });
-      expect(state).toMatchObject({ liveness, attention: "tool-use-orch" });
-      expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe(liveness);
-    }
+    expect(badgeOf(state)).toBe("needs-you");
   });
 
   test("the attention read is the QUEUE's: an abandoned open turn with no live process owes nothing", () => {

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -14,7 +14,9 @@ import {
   resolveSeatFile,
   ROTATION_CONTEXT_PERCENT,
   SEAT_BIND_TIMEOUT_MS,
+  seatBadgeOf,
   seatRequestSettled,
+  type OrchestratorPanelState,
   type OrchestratorSeatStatus,
 } from "./seatState";
 
@@ -64,6 +66,10 @@ function file(overrides: Partial<FileEntry> = {}): FileEntry {
 }
 
 const base = { statusFailed: false, submitting: false, submitFailure: null, file: null, surface: null };
+
+/** A fixed «now» for the one derivation that reads a clock: the attention
+    queue's stalled tier, which ages out (`STALLED_ATTENTION_TTL`). */
+const NOW = 1_760_000_100;
 
 describe("the panel names every state in the map (#977)", () => {
   test("no answer yet is loading, and a failed read says so instead of inviting a second orchestrator", () => {
@@ -471,5 +477,57 @@ describe("«opening» is bounded once the status read says the host is alive (#1
     /* Bound and classified — there is no wait to bound. */
     expect(deriveOrchestratorPanelState({ ...stuck, file: file(), surface: "live-root", unboundForMs: 10 * SEAT_BIND_TIMEOUT_MS }))
       .toMatchObject({ liveness: "live", bindFailure: null });
+  });
+});
+
+describe("a decision the operator owes outranks every word for «it is running» (#1167)", () => {
+  const asked = {
+    kind: "question" as const,
+    toolUseId: "tool-use-orch",
+    transcriptPath: "/transcripts/orchestrator.jsonl",
+    pid: 4242,
+    paneTarget: null,
+    askedAt: "2026-08-25T10:00:00.000Z",
+    questions: [{ header: "Rollout window", question: "Approve the proposed rollout window", multiSelect: false, options: [] }],
+  };
+  const seated = { ...base, status: status({ seat: seat() }), now: NOW };
+
+  test("a hosted seat with a question on screen carries the attention id and badges «needs you»", () => {
+    const state = deriveOrchestratorPanelState({ ...seated, file: file({ pendingQuestion: asked }), surface: "live-root" });
+    expect(state).toMatchObject({ kind: "live", liveness: "live", attention: "tool-use-orch" });
+    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("needs-you");
+  });
+
+  test("a quiet seat is still the liveness word — nothing is owed", () => {
+    const state = deriveOrchestratorPanelState({ ...seated, file: file(), surface: "live-root" });
+    expect(state).toMatchObject({ kind: "live", liveness: "live", attention: null });
+    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("live");
+  });
+
+  test("a stalled seat with a terminal prompt is «needs you» too: both livenesses it outranks are hosted", () => {
+    const waiting = file({
+      activity: "stalled",
+      waitingInput: { since: NOW - 120, screenTail: "> 1. Yes", target: "llv:0.0", menu: null },
+    });
+    const state = deriveOrchestratorPanelState({ ...seated, file: waiting, surface: "live-root" });
+    expect(state).toMatchObject({ liveness: "stalled" });
+    expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe("needs-you");
+  });
+
+  test("a gone or resumable host keeps its own badge: a decision nobody can answer must not hide the recovery", () => {
+    for (const [surface, liveness] of [["dead", "dead"], ["resume", "resumable"], ["unresolved", "resolving"]] as const) {
+      const state = deriveOrchestratorPanelState({ ...seated, file: file({ pendingQuestion: asked }), surface });
+      expect(state).toMatchObject({ liveness, attention: "tool-use-orch" });
+      expect(seatBadgeOf(state as Extract<OrchestratorPanelState, { kind: "live" }>)).toBe(liveness);
+    }
+  });
+
+  test("the attention read is the QUEUE's: an abandoned open turn with no live process owes nothing", () => {
+    const abandoned = file({ activity: "stalled", proc: "done", mtime: NOW - 60 });
+    expect(deriveOrchestratorPanelState({ ...seated, file: abandoned, surface: "live-root" })).toMatchObject({ attention: null });
+    const held = file({ activity: "stalled", proc: "running", mtime: NOW - 60 });
+    expect(deriveOrchestratorPanelState({ ...seated, file: held, surface: "live-root" })).toMatchObject({
+      attention: `/transcripts/orchestrator.jsonl:stalled:${NOW - 60}`,
+    });
   });
 });

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -3,6 +3,7 @@ import type { OrchestratorSeat } from "@/lib/orchestrator/seats";
 import type { FileEntry } from "@/lib/types";
 
 import type { StripSurface } from "../agentCapabilities";
+import { attentionId } from "../attention";
 import type { OrchestratorIncumbent } from "./incumbent";
 
 /*
@@ -131,6 +132,33 @@ export const ROTATION_CONTEXT_PERCENT = 50;
 export type SeatLiveness = "resolving" | "live" | "stalled" | "resumable" | "dead";
 
 /**
+ * What the dock's badge NAMES, which is not always the liveness (issue #1167).
+ *
+ * A seat that is running and a seat that is holding a question up at the
+ * operator both read «live», and the second one is the only one that needs
+ * anything. So a pending decision is ranked ahead of the livenesses it can
+ * outrank, and the badge says «needs you» in the warning tone the rest of the
+ * app already uses for a wait.
+ */
+export type SeatBadge = "needs-you" | SeatLiveness;
+
+/**
+ * The livenesses a pending decision outranks. Both are HOSTED, so the question
+ * on screen is one the operator can actually answer.
+ *
+ * `dead`, `resumable` and `resolving` keep their own word deliberately: a
+ * transcript whose host is gone can still carry the last question it asked, and
+ * badging that «needs you» would hide the recovery the badge exists to offer
+ * behind an answer nobody can deliver.
+ */
+const ATTENTION_OUTRANKS: readonly SeatLiveness[] = ["live", "stalled"];
+
+/** The badge a live seat wears: its decision, or its liveness. */
+export function seatBadgeOf(state: OrchestratorLiveState): SeatBadge {
+  return state.attention && ATTENTION_OUTRANKS.includes(state.liveness) ? "needs-you" : state.liveness;
+}
+
+/**
  * Why a seat the server calls LIVE has still not reached this panel, once the
  * wait has run past {@link SEAT_BIND_TIMEOUT_MS} (issue #1182).
  *
@@ -209,6 +237,10 @@ export interface OrchestratorLiveState {
   seat: OrchestratorSeat;
   conversationId: string;
   liveness: SeatLiveness;
+  /** The attention id of the seat's conversation (`attentionId`), or null when
+      it is waiting on nobody. The QUEUE's own reading, verbatim — the dock must
+      count as waiting exactly what the island counts (issue #1167). */
+  attention: string | null;
   /** Why a `resolving` seat the server calls live has not bound, once the wait
       is past its bound; null whenever «opening» is still an honest answer. */
   bindFailure: SeatBindFailure | null;
@@ -255,6 +287,9 @@ export function deriveOrchestratorPanelState(input: {
   /** How long the dock has been unable to bind this seat's conversation, or
       null while it is bound (issue #1182). */
   unboundForMs?: number | null;
+  /** Epoch SECONDS, for the one reading that ages: the attention queue's
+      stalled tier. Defaults to the wall clock, exactly as `attentionId` does. */
+  now?: number;
 }): OrchestratorPanelState {
   const { status } = input;
   const active = status?.seat && status.exists ? status.seat : null;
@@ -269,6 +304,7 @@ export function deriveOrchestratorPanelState(input: {
       seat: active,
       conversationId: active.conversationId,
       liveness,
+      attention: input.file ? attentionId(input.file, input.now) : null,
       bindFailure: bindFailureOf({
         liveness,
         hostLive: input.hostLive === true,

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -136,26 +136,30 @@ export type SeatLiveness = "resolving" | "live" | "stalled" | "resumable" | "dea
  *
  * A seat that is running and a seat that is holding a question up at the
  * operator both read «live», and the second one is the only one that needs
- * anything. So a pending decision is ranked ahead of the livenesses it can
- * outrank, and the badge says «needs you» in the warning tone the rest of the
- * app already uses for a wait.
+ * anything. So a pending decision is ranked ahead of the liveness, and the
+ * badge says «needs you» in the warning tone the rest of the app already uses
+ * for a wait.
  */
 export type SeatBadge = "needs-you" | SeatLiveness;
 
 /**
- * The livenesses a pending decision outranks. Both are HOSTED, so the question
- * on screen is one the operator can actually answer.
+ * The badge a live seat wears: the decision it owes the operator, or — with
+ * nothing owed — its liveness.
  *
- * `dead`, `resumable` and `resolving` keep their own word deliberately: a
- * transcript whose host is gone can still carry the last question it asked, and
- * badging that «needs you» would hide the recovery the badge exists to offer
- * behind an answer nobody can deliver.
+ * A non-null attention id outranks EVERY liveness word, `dead` and `resumable`
+ * included, because the queue counting a conversation and the dock badging it
+ * have to be the same reading: a seat the island lists as waiting and the dock
+ * calls «finished» is one signal described two ways, which is the whole defect
+ * this issue names.
+ *
+ * Nothing is hidden by that. The badge was never the carrier of recovery — the
+ * rotation advisory, the «finished, resume it here» notice and the re-bind each
+ * ride as their own banner directly under the header, one line below the badge,
+ * and they keep saying what the seat needs while the badge says what the
+ * OPERATOR owes it.
  */
-const ATTENTION_OUTRANKS: readonly SeatLiveness[] = ["live", "stalled"];
-
-/** The badge a live seat wears: its decision, or its liveness. */
 export function seatBadgeOf(state: OrchestratorLiveState): SeatBadge {
-  return state.attention && ATTENTION_OUTRANKS.includes(state.liveness) ? "needs-you" : state.liveness;
+  return state.attention ? "needs-you" : state.liveness;
 }
 
 /**

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1874,6 +1874,7 @@ export const en = {
   "orchPanel.rotationStrong": "Rotation strongly recommended",
   "orchPanel.rotationContext": "context is at {percent}% of the model's window",
   "orchPanel.rotationDead": "its host is gone",
+  "orchPanel.badgeNeedsYou": "needs you",
   "orchPanel.badgeLive": "live",
   "orchPanel.badgeStalled": "quiet",
   "orchPanel.badgeResumable": "finished",
@@ -2035,6 +2036,13 @@ export const en = {
   "attention.popoverTitle": "Waiting on you",
   "attention.filterOn": "Show only those waiting on you (F)",
   "attention.filterOff": "Show all nodes (F)",
+  /* The one decision line every attention surface shares (#1167): the toast
+     title, the island popover row and the orchestrator dock badge's tooltip.
+     Lower-case to sit beside `rateLimit.badgeUntil`, which names the same class
+     of wait and is reused verbatim. */
+  "attention.decisionQuestion": "a question",
+  "attention.decisionPlan": "plan approval",
+  "attention.decisionPermission": "permission prompt",
 
   // MobileFocusView
   "mobile.noConvos": "No conversations yet",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1830,6 +1830,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "orchPanel.rotationStrong": "Наполегливо рекомендовано ротацію",
   "orchPanel.rotationContext": "контекст на {percent}% вікна моделі",
   "orchPanel.rotationDead": "його хост зник",
+  "orchPanel.badgeNeedsYou": "потребує тебе",
   "orchPanel.badgeLive": "живий",
   "orchPanel.badgeStalled": "тиша",
   "orchPanel.badgeResumable": "завершив",
@@ -1980,6 +1981,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "attention.popoverTitle": "Чекають на тебе",
   "attention.filterOn": "Показати лише тих, хто чекає на тебе (F)",
   "attention.filterOff": "Показати всі вузли (F)",
+  "attention.decisionQuestion": "питання",
+  "attention.decisionPlan": "затвердження плану",
+  "attention.decisionPermission": "запит дозволу",
 
   "mobile.noConvos": "Розмов поки нема",
   "mobile.map": "Карта",


### PR DESCRIPTION
Closes #1167.

The dock badge knew five words — live, quiet, finished, host gone, opening — and none of them was "this seat is holding a question up at you". The toast said "Agent is waiting for a reply" over a plan, a permission prompt, a rate-limit wall and a five-option question alike, and the island popover derived a snippet of its own. Three parallel strings over one signal is how a badge and a toast start describing the same wait differently, so the decision is now derived once and every surface reads it.

## What changed

**`src/components/attention/decision.ts` (new)** — one exported function. `decisionLine` asks `attentionId` whether the conversation is waiting at all, and only then names the wait: the agent's own `questions[0].header`, or "plan approval" / "permission prompt" / the rate-limit badge's own `rateLimitText`, plus the conversation's role. The vocabulary is FIXED: nothing is lifted out of a question body or off a scraped screen, because a line assembled from whatever the terminal happened to be drawing names the options rather than the decision.

The queue is the eligibility authority and this module calls it rather than re-deciding. That gate is load-bearing for the stalled tier, whose signal needs a live process and a fresh mtime before it is anyone's to answer: without it, a toast left up over an exited agent announced "interrupted or awaiting permission" while the popover behind it held no such row. The attention-queue builder itself is consumed unchanged — #1168's lane owns it, and nothing here touches it.

The role suffix walks the same fail-open ladder the registry walks in `conversationAgentRole`: the conversation's own role (`durableLineage.role`, which already collapses the launch receipt's `agentRole` and the durable spawn edge), then its newest container membership. The read model routinely carries `role: null` beside a pipeline or flow seat — an adopted stage records the membership and no conversation role — and that agent was rendering as nobody. A role-less stage records the literal placeholder `"agent"`, which is the absence of a role spelled as a word, so it attributes nobody rather than printing itself.

**`orchestrator/seatState.ts`** — `OrchestratorLiveState.attention` carries the seat conversation's attention id verbatim, and `seatBadgeOf` ranks a pending decision ahead of the liveness — every liveness, `dead` and `resumable` included. Nothing is hidden by that: the badge was never the carrier of recovery. The rotation advisory, the "finished, resume it here" notice and the re-bind each ride as their own banner one line under the header, and they keep saying what the seat needs while the badge says what the operator owes it.

**`orchestrator/OrchestratorPanel.tsx`** — `LIVENESS_BADGE` became `SEAT_BADGE` with a `needs-you` row in the warning tone; the badge carries the shared decision line in its tooltip and a `data-orchestrator-badge` hook.

**`attention/AttentionToast.tsx` (new) and `AttentionQueueRow` in `attention/AttentionIsland.tsx`** — the toast and the popover row moved out of `Viewer.tsx` so the line they share is testable where it lives. `viewer.agentWaiting` survives only as the toast's fallback, for a toast still up after its own signal was answered or abandoned. Layout, tap targets and behaviour are unchanged in the move.

**`src/lib/i18n/{en,uk}.ts`** — four new keys, `attention.decision{Question,Plan,Permission}` and `orchPanel.badgeNeedsYou`.

## Acceptance → verification

| Acceptance | Verification |
| --- | --- |
| Dock StateBadge shows "needs you" (warning tone) when `attentionId(seatFile)` is non-null, ranked ahead of live | `seatState.test.ts` → "a decision the operator owes outranks every word for «it is running» (#1167)": a table of all five livenesses asserted both ways — every one badges `needs-you` with a decision pending, every one keeps its own word with nothing owed — plus the terminal-prompt source and the queue's own freshness gate. `OrchestratorPanel.dom.test.tsx` → "a seat holding a question badges «needs you» in the warning tone, and names the decision" asserts `data-orchestrator-badge="needs-you"`, the text, the `warning` tone class and the tooltip |
| Toast title becomes the decision (`questions[0].header` / "plan approval" / "permission prompt" / "rate-limited until …") plus the role label when known | `attention/decision.test.ts` covers every branch of the ladder, the header-less and blank-header fallbacks, that a terminal prompt is "permission prompt" whatever the screen holds, the role suffix (direct role, membership seat, seat precedence, the `"agent"` placeholder, unknown-id fallback, role-less — en and uk), and that the precedence matches `attentionId`'s. `AttentionToast.dom.test.tsx` asserts the rendered title for the header+role case and for each kind of wait |
| Island popover rows carry the same line | `AttentionToast.dom.test.tsx` → "the toast title and the island popover row are the SAME line, for every kind of wait" renders both surfaces over one file per attention kind and asserts string equality. `AttentionIsland.dom.test.tsx` → "a queue row carries the decision line, the title, the project and the age" and "a terminal prompt and a stalled agent each keep their own wording" |
| No surface names a wait the queue does not count | `decision.test.ts` → "only a wait the queue counts is a wait the line will name": proc-done and past-TTL interruptions return null on both sides of the `STALLED_ATTENTION_TTL` boundary, and every counted/uncounted file is asserted against `buildAttentionQueue` itself. `AttentionToast.dom.test.tsx` → "an interrupted turn nobody is behind names no decision, on the toast or in the queue" |
| `AttentionIsland.dom.test.tsx` and the Viewer toast tests updated | Island test extended with the two row tests above; `AttentionToast.dom.test.tsx` added (there were no toast tests before); `Viewer.attentionMount.test.ts` extended so the shell is proven to mount both components and to no longer inline `viewer.agentWaiting` or `attentionSnippet` — the same defect class that file already guards for the attention host |
| Pending-question demo capture re-run only if its fixture text changes | Not re-run, and the driver is unchanged: `scripts/capture-issue-963-attention.ts` writes only structured questions, all four with headers ("Hero frame", "Capture order", "Rollout window", "Deck template"), and waits on `[data-attention-*]` selectors and the `attention.popoverTitle` copy, none of which this change touches. Those headers are exactly what the new toast/row lines render, so the fixture text stays valid demo copy. No rasters committed |
| en/uk parity, uk typed against en | The four new keys exist in both; `bunx tsc --noEmit` is the enforcement (`Record<keyof typeof en, Message>`). `OrchestratorPanel.dom.test.tsx` → "the badge is localized with the rest of the dock" renders the uk badge, and `decision.test.ts` asserts the uk role suffix for both the direct and the membership-only path |
| Scope fence | Touched: `src/components/orchestrator/**`, `src/components/attention/**`, `src/components/Viewer.tsx` (+ its two attention tests), `src/lib/i18n/{en,uk}.ts`. One file outside it, listed below |

## Gates

- `bunx tsc --noEmit --incremental false` — clean.
- Touched tests, by path, under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: `attention/decision.test.ts`, `attention/AttentionToast.dom.test.tsx`, `attention/AttentionIsland.dom.test.tsx`, `attention.test.ts`, `Viewer.attentionMount.test.ts`, `orchestrator/seatState.test.ts`, `orchestrator/OrchestratorPanel.dom.test.tsx`, `orchestrator/OrchestratorDock.dom.test.tsx`, `mobile/MobileOrchestratorSheet.render.test.tsx` — all green. The two component directories were also swept whole: `src/components/attention/` 110 pass / 0 fail, `src/components/orchestrator/` 114 pass / 0 fail. Nothing under `src/lib/agent/` or `src/app/api/runtime/` was run, and the live registry was never touched.
- `bunx eslint` over every touched file — clean.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — **PASS**.

## One file outside the fence, and why

`src/components/mobile/MobileOrchestratorSheet.render.test.tsx` gains one line — `attention: null` in a hand-built `OrchestratorLiveState` fixture — because the new field is required. Type fallout only; no mobile behaviour changed. The phone's orchestrator sheet renders its own `ROW_STATE_LABEL[state.liveness]` row rather than the dock's badge, so it keeps the liveness word; naming the decision there is a separate surface (slice C) and not in this issue's acceptance.

## Not done, deliberately

The issue's problem statement notes that the N shortcut lives only in a tooltip. No acceptance bullet asks for that to change, so the island's Next control is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
