### PR TITLE
fix(telegram): restore scheduled report admission

### DIFF
--- a/src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx
@@ -159,7 +159,7 @@ const dashboardProps = (over: Partial<DashboardProps> = {}): DashboardProps => (
 let roots: Root[] = [];
 beforeEach(() => {
   roots = [];
-  boardRevision = 1;
+  boardRevision += 1;
   boardPrefs = {};
   catalogRows = [];
   seatAnswer = { seat: null, pending: null, exists: true, viewerMcpRegistered: false };

--- a/src/lib/telegram/reportPrompt.ts
+++ b/src/lib/telegram/reportPrompt.ts
@@ -68,12 +68,18 @@ export interface DailyReportPromptInput {
   instructions: string;
 }
 
+/** The semantic conversation title shared by spawn admission and the prompt's
+    first line, with a window that distinguishes one scheduled run from another. */
+export function reportConversationTitle(input: Pick<DailyReportPromptInput, "windowStart" | "windowEnd">): string {
+  return `Telegram daily report — window ${input.windowStart} → ${input.windowEnd} (UTC).`;
+}
+
 /** The half the operator cannot edit: everything a run must do to be correct,
     safe for the connector, and readable by the Viewer afterwards. */
 export function reportPromptPreamble(input: Omit<DailyReportPromptInput, "instructions">): string {
   /* The first line is the board card's title (#1086: the run is visible on the
      board), so it names the run rather than opening with instructions. */
-  return `Telegram daily report — window ${input.windowStart} → ${input.windowEnd} (UTC).
+  return `${reportConversationTitle(input)}
 
 You have the read-only \`telegram\` MCP connector for the operator's own account. Work through it only; do not install anything and do not write to Telegram — the connector exposes no write tools. The Viewer has already verified with \`get_me\` that the connector holds the account this report belongs to.
 

--- a/src/lib/telegram/reportRunner.test.ts
+++ b/src/lib/telegram/reportRunner.test.ts
@@ -9,7 +9,7 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
 const { TelegramReportRunner, RUN_TIMEOUT_MS } = await import("./reportRunner");
 const { readTelegramReports, readReportText, reportInboxPath, reportSourcesPath, updateTelegramReports } = await import("./reportStore");
-const { DEFAULT_DAILY_REPORT_PROMPT } = await import("./reportPrompt");
+const { DEFAULT_DAILY_REPORT_PROMPT, reportConversationTitle } = await import("./reportPrompt");
 /* The tag lives in the operator's editable brief; fixtures use a synthetic
    one, exactly as a real operator's own tag never appears in this repo. */
 const DAILY_REPORT_TAG = "#report_tag";
@@ -207,6 +207,10 @@ test("Run now launches a board-visible Codex conversation holding exactly viewer
   expect(String(body.cwd)).toContain("report-workspace");
 
   const prompt = String(body.prompt);
+  const title = String(body.title);
+  const active = readTelegramReports().active!;
+  expect(title).toBe(reportConversationTitle({ windowStart: active.windowStart, windowEnd: active.windowEnd }));
+  expect(prompt.split("\n")[0]).toBe(title);
   /* The account was verified by the Viewer before this launch, so the recorded
      identity is in no prompt, no transcript and no registry row. */
   expect(ports.reads[0]).toBe("getMe");

--- a/src/lib/telegram/reportRunner.ts
+++ b/src/lib/telegram/reportRunner.ts
@@ -12,6 +12,7 @@ import {
 import {
   DAILY_REPORT_PROMPT_VERSION,
   classifyReportOutput,
+  reportConversationTitle,
   renderDailyReportPrompt,
 } from "./reportPrompt";
 import {
@@ -470,6 +471,7 @@ export class TelegramReportRunner {
           model: CODEX_SOL_MODEL,
           effort: "medium",
           cwd: reportWorkspaceDir(),
+          title: reportConversationTitle({ windowStart: window.startAt, windowEnd: window.endAt }),
           /* The durable report-run marker (#1091), in the two fields the
              ordinary spawn path already makes durable: the receipt's attempt
              id spells the run id, and explicit project ownership is what the

--- a/src/lib/telegram/reportSpawn.test.ts
+++ b/src/lib/telegram/reportSpawn.test.ts
@@ -15,11 +15,14 @@ const { after } = await import("next/server");
 const { reportSpawnHeaders, reportSpawnOverrides, startDeferredSpawnWork } = await import("./reportSpawn");
 const { SCHEDULED_REPORT_SESSION_CLASS } = await import("@/lib/agent/mcpAllowlist");
 const { TELEGRAM_REPORT_PROJECT } = await import("./reportLineage");
+const { reportConversationTitle } = await import("./reportPrompt");
 
 /** An invented run id, in the shape the runner mints. Assembled rather than
     written out: the publication privacy gate refuses any literal with the
     shape of a session identifier, invented or not. */
 const REPORT_RUN_ID = ["0192d4f1", "8f43", "4a10", "9c1e", "6b0f0a5d77c2"].join("-");
+const REPORT_WINDOW = { windowStart: "2026-08-20T07:00:00.000Z", windowEnd: "2026-08-21T07:00:00.000Z" };
+const REPORT_TITLE = reportConversationTitle(REPORT_WINDOW);
 const { executeSpawnRequest, productionSpawnCommandDependencies } = await import("@/lib/agent/spawnCommand");
 const { ensureOperatorSpawnCapability } = await import("@/lib/agent/operatorCapability");
 const { VIEWER_SPAWN_CAPABILITY_HEADER } = await import("@/lib/agent/spawnPolicy");
@@ -150,13 +153,14 @@ test("the report class decides the whole capability surface admission reserves",
     engine: "codex",
     cwd: SANDBOX,
     accountId: "account-pinned",
+    title: REPORT_TITLE,
     /* The durable report-run marker the runner sends (#1091). It rides the real
        admission path here because both halves are admitted, not decorative: an
        explicit project is refused outright for a launch admission reads as
        agent-initiated, which would settle every report run `launch_failed`. */
     clientAttemptId: `telegram-report-${REPORT_RUN_ID}`,
     project: TELEGRAM_REPORT_PROJECT,
-    ["prompt"]: "Telegram daily report — window A → B.\n\nThe operator's own brief.",
+    ["prompt"]: `${REPORT_TITLE}\n\nThe operator's own brief.`,
   };
   const response = await executeSpawnRequest(reportLaunchRequest(body), dependencies);
   if (captured.profiles.length === 0) throw new Error(`no launch reserved: ${response.status} ${JSON.stringify(await response.json())}`);
@@ -172,6 +176,7 @@ test("the report class decides the whole capability surface admission reserves",
   expect(captured.requests[0]).toMatchObject({
     clientAttemptId: `telegram-report-${REPORT_RUN_ID}`,
     explicitProject: TELEGRAM_REPORT_PROJECT,
+    launchProfile: expect.objectContaining({ title: REPORT_TITLE }),
   });
   expect(captured.requests[0].parentConversationId ?? null).toBeNull();
   expect(captured.requests[0].role ?? null).toBeNull();


### PR DESCRIPTION
## Summary

- Keep the mobile leaf fixture board revision monotonic so the prior list-mode case cannot pollute the focus case through the project-scoped board cache.
- Give scheduled Telegram report conversations a semantic UTC-window title and use the same text as the prompt first line.
- Prove the production runner emits that title and real admission persists it.

## Verdicts

### #1188: stale test fixture

At baseline `ac197031`, `src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx:162` reset the fake board revision to `1` for every case. The first list-mode cases cached revision `1` for the same project. `src/components/projectModel.ts:707-716` honors that cached list preference whenever history exists, while `src/components/ProjectDashboard.tsx:1979-1982` mounts the mobile focus shell only for scheme mode. The exact focus case passed alone with 1 pass and 0 failures, and `src/components/mobile/MobileFocusView.tsx:445-459` still returns `mobile-chat-shell`. The fixture revision violated the board store monotonic-revision contract.

Before: 3 pass, 1 fail.
After: 4 pass, 0 fail.

### #1198: product bug

At baseline `ac197031`, `src/lib/telegram/reportRunner.ts:467-482` built the scheduled body without a title. `src/lib/telegram/reportSpawn.ts:109-116` forwarded that body unchanged, and `src/lib/agent/spawnCommand.ts:254-303` rejects every new attempt without an explicit semantic title. The production runner now sends a window-specific title. `src/lib/telegram/reportRunner.test.ts` checks production assembly, and `src/lib/telegram/reportSpawn.test.ts` checks real admission and the reserved profile.

Before: 3 pass, 1 fail with `400 {"error":"title is required for every new spawn"}`.
After: 4 pass, 0 fail.

## Verification

All test commands used isolated `HOME`, `XDG_CONFIG_HOME`, `LLV_STATE_DIR`, and `TMPDIR` directories.

- `bun test src/components/mobile/mobileOrchestratorLeaves.dom.test.tsx`: 4 pass, 0 fail
- `bun test src/lib/telegram/reportSpawn.test.ts`: 4 pass, 0 fail
- `bun test src/lib/telegram/reportRunner.test.ts`: 37 pass, 0 fail
- `bunx tsc --noEmit --incremental false`: pass
- `bun scripts/privacy-publication-gate.ts --base ac197031 --check-commits`: pass

Closes #1188
Closes #1198