### PR TITLE
ci(privacy): let the base-ref assertion accept the dispatch fallback

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -1491,7 +1491,9 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     const workflow = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "privacy-publication.yml"), "utf8");
 
     expect(workflow).not.toContain("github.event.pull_request.base.sha");
-    expect(workflow).toContain("PRIVACY_BASE_REF: ${{ github.event.pull_request.base.ref }}");
+    expect(workflow).toMatch(
+      /PRIVACY_BASE_REF: \$\{\{[^}]*github\.event\.pull_request\.base\.ref[^}]*\}\}/,
+    );
     expect(workflow).toContain(
       'git fetch --no-tags --force origin "+refs/heads/${PRIVACY_BASE_REF}:refs/remotes/origin/${PRIVACY_BASE_REF}"',
     );


### PR DESCRIPTION
## Problem

`privacy-publication` is failing on every open pull request (#1203, #1204, #1205, #1206), so nothing can merge. The failure is not a privacy hit — it is the gate's own test suite:

```
(fail) privacy publication gate > resolves the current protected base tip for long-lived pull requests
1494 | expect(workflow).toContain("PRIVACY_BASE_REF: ${{ github.event.pull_request.base.ref }}");
```

## Cause

`ac197031` (PR #1196) gave the workflow a `workflow_dispatch` default:

```yaml
PRIVACY_BASE_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.repository.default_branch || github.event.pull_request.base.ref }}
```

The behaviour the test guards is unchanged — the base ref still comes from the pull request's base branch and is still resolved to that branch's current tip — but the assertion pinned the whole env line as an exact substring, so it went stale the moment the fallback landed.

## Change

Assert the guarantee instead of the literal line: `PRIVACY_BASE_REF` must be an expression that reads `github.event.pull_request.base.ref`. The `base.sha` prohibition, the fetch line and the `rev-parse` line are untouched, so the "current tip, never the frozen base sha" contract still fails loudly if it regresses.

## Verification

`bun test scripts/privacy-publication-gate.test.ts` under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: **116 pass, 0 fail** (was 115 pass / 1 fail).