### PR TITLE
fix(orchestrator,feed): retry unbound dock re-resolution (#1189) and honour historical mandate versions (#1190)

### DIFF
--- a/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.dom.test.tsx
@@ -93,7 +93,7 @@ mock.module("@/hooks/useLogTail", () => ({
   }),
 }));
 
-const { OrchestratorPanel } = await import("./OrchestratorPanel");
+const { OrchestratorPanel, UNBOUND_STATUS_RETRY_MS } = await import("./OrchestratorPanel");
 const { SEAT_BIND_TIMEOUT_MS } = await import("./seatState");
 const { resetMessageProvenanceCacheForTests } = await import("../feed/messageProvenance");
 const { SEAT_POLL_MS, resetOrchestratorSeatCacheForTests } = await import("./useOrchestratorSeat");
@@ -741,6 +741,49 @@ test("a re-hosted seat binds to its successor transcript through the status read
   /* Nothing was rotated to get here. */
   expect(rotatePosts).toHaveLength(0);
 });
+
+test("a restart-time status read that fails is retried, and the dock binds itself inside the bound (#1189)", async () => {
+  seatStatus = { seat: activeSeat(), pending: null, exists: true };
+  /* The re-host replaced the transcript the seat recorded: only the successor
+     is in the catalog, under its own native id, so the status read's
+     `transcriptPath` is the only thing that can bind the two (#1182). */
+  incumbentStatus = incumbent({ transcriptPath: "/transcripts/orch.successor.jsonl", liveness: { lifecycle: "running", hostState: "alive", silentForMs: 0 } });
+  const successor = { ...orchestratorFile, path: "/transcripts/orch.successor.jsonl", name: "orch.successor.jsonl", conversationId: "conversation_orch_successor" } as FileEntry;
+  /* And the viewer has not finished coming back, so that read FAILS. */
+  incumbentReadDown = true;
+
+  const opened = Date.now();
+  const host = mount([successor]);
+  await settle();
+  flushSync(() => undefined);
+
+  /* Nothing is bound and nothing can be: with no answer there is no live-host
+     evidence, so the panel is not even offering the Re-bind that would let the
+     operator do this by hand. */
+  expect(panelState(host)).toBe("live");
+  expect(host.textContent).toContain("Opening the conversation");
+  expect(bindReason(host)).toBeNull();
+  expect(host.querySelector("[data-orchestrator-rebind]")).toBeNull();
+  const failed = incumbentReads;
+  expect(failed).toBeGreaterThan(0);
+
+  /* The endpoint recovers — and no one touches the panel. */
+  incumbentReadDown = false;
+  await new Promise((resolve) => setTimeout(resolve, UNBOUND_STATUS_RETRY_MS + 500));
+  await settle();
+  flushSync(() => undefined);
+
+  /* The panel asked again on its own and bound to the successor, well inside
+     the bound «opening…» is held to. */
+  expect(incumbentReads).toBeGreaterThan(failed);
+  expect(host.querySelector('[data-orchestrator-conversation="conversation_orch_successor"]')).not.toBeNull();
+  expect(host.textContent).not.toContain("Opening the conversation");
+  expect(Date.now() - opened).toBeLessThan(SEAT_BIND_TIMEOUT_MS);
+  /* Resolution is all it was: no rotation, no second designation, no spawn. */
+  expect(rotatePosts).toHaveLength(0);
+  expect(seatPosts).toHaveLength(0);
+  expect(spawnPosts).toBe(0);
+}, SEAT_BIND_TIMEOUT_MS + 20_000);
 
 test("a bind that never lands stops spinning: the panel names the reason and Re-bind CLEARS it (#1182)", async () => {
   seatStatus = { seat: activeSeat(), pending: null, exists: true };

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -46,6 +46,18 @@ import { useOrchestratorSeat } from "./useOrchestratorSeat";
 import { useSeatConfirm, type SeatConfirmFlow } from "./useSeatConfirm";
 import { useSeatSurface } from "./useSeatSurface";
 
+/**
+ * How often an UNBOUND seat re-asks the status read while its attempts are
+ * failing (issue #1189).
+ *
+ * The incumbent poll's own cadence answers «how full is the context window»,
+ * which moves over tens of minutes. This one answers «where does the seat's
+ * conversation live now», during the seconds a restarting viewer is unable to
+ * say — so it is set by the bound the dock is held to
+ * ({@link SEAT_BIND_TIMEOUT_MS}), with room for several attempts inside it.
+ */
+export const UNBOUND_STATUS_RETRY_MS = 2_000;
+
 /** Create and rotate keep SEPARATE drafts: they are different decisions about
     different orchestrators, and a half-written rotation must never overwrite the
     create draft the operator would need if the seat were vacated. */
@@ -192,6 +204,22 @@ export function OrchestratorPanel({
   useEffect(() => {
     if (unboundWithReading) void refreshIncumbent();
   }, [unboundWithReading, refreshIncumbent]);
+  /* One ask is not enough while the answer is the thing that is missing. A
+     status read that FAILS — the restart this panel is waiting out is exactly
+     when it does — leaves the retained reading stale with the trigger above
+     already spent, so nothing asks again until the 60 s wear poll: the bound
+     passes with no live-host evidence, which is also the evidence a Re-bind
+     control needs before it may be offered (issue #1189). So while the seat is
+     unbound and no attempt has answered, the SAME read is taken again on a
+     bounded cadence. It stops the moment one lands — a fresh reading either
+     binds the seat or lets the bound name what is missing — and it designates,
+     rotates and spawns nothing on the way. */
+  const unboundWithoutFreshReading = bindPending && readStale;
+  useEffect(() => {
+    if (!unboundWithoutFreshReading) return;
+    const timer = setInterval(() => void refreshIncumbent(), UNBOUND_STATUS_RETRY_MS);
+    return () => clearInterval(timer);
+  }, [unboundWithoutFreshReading, refreshIncumbent]);
   /* Liveness is only evidence while someone is still answering for it. The
      header may keep a cached reading — an engine and a context percent from a
      minute ago beat a row of dashes — but a cached «alive» carried across the

--- a/src/components/orchestrator/useOrchestratorIncumbent.ts
+++ b/src/components/orchestrator/useOrchestratorIncumbent.ts
@@ -15,8 +15,10 @@ import { parseIncumbent, type OrchestratorIncumbent } from "./incumbent";
  * That parse is the expensive thing on the panel's account, so the cadence is
  * set by what the answer is FOR: context pressure and a rotation recommendation
  * both move over tens of minutes, and nothing here is ever acted on
- * automatically. The moments that do matter — the seat changing, and opening
- * the rotate draft — refresh on their own instead of waiting for a tick.
+ * automatically. The moments that do matter — the seat changing, opening the
+ * rotate draft, and a seat the dock has not bound yet, whose resolution the
+ * panel re-asks for on its own much faster cadence (`UNBOUND_STATUS_RETRY_MS`,
+ * issue #1189) — refresh on their own instead of waiting for a tick.
  */
 export const INCUMBENT_POLL_MS = 60_000;
 

--- a/src/lib/runtime/deliveredMessageOccurrences.test.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.test.ts
@@ -328,13 +328,25 @@ test("an unedited rotation is still the approved default the incumbent held", ()
   expect(mandates.get(ADOPTION_MANDATE_ID)).toEqual(APPROVED);
 });
 
-test("a seat based on a default this checkout no longer carries claims no version at all", () => {
-  /* Its text cannot be checked against the one approved default that ships
-     here, so the card names it a mandate and stops there. */
+test("a seat based on a default this checkout no longer carries is still that version (#1190)", () => {
+  /* v8's text does not ship here, so there is nothing to compare the stored
+     mandate against — and having nothing to compare is no reason to drop what
+     the seat itself recorded. The current default's text decides the CURRENT
+     version and nothing else, so a historical number stands on its own. */
   const mandates = orchestratorMandateDeliveries(seatFile([
-    seat({ mandate: BESPOKE_MANDATE, promptVersion: ORCHESTRATOR_PROMPT_VERSION - 1, intent: { clientRequestId: ADOPTION_REQUEST_ID, mode: "existing", launchId: null, error: null } }),
+    seat({ mandate: BESPOKE_MANDATE, promptVersion: 8, intent: { clientRequestId: ADOPTION_REQUEST_ID, mode: "existing", launchId: null, error: null } }),
   ]));
-  expect(mandates.get(ADOPTION_MANDATE_ID)).toEqual({ kind: "unqualified" });
+  expect(ORCHESTRATOR_PROMPT_VERSION).toBeGreaterThan(8);
+  expect(mandates.get(ADOPTION_MANDATE_ID)).toEqual({ kind: "version", version: 8 });
+});
+
+test("a seat with no recorded version at all is the operator's own text (#1190)", () => {
+  /* `custom` is what an absent number means; `unqualified` is reserved for a
+     delivery whose seat record is gone entirely (the case below). */
+  const mandates = orchestratorMandateDeliveries(seatFile([
+    seat({ mandate: BESPOKE_MANDATE, promptVersion: null, intent: { clientRequestId: ADOPTION_REQUEST_ID, mode: "existing", launchId: null, error: null } }),
+  ]));
+  expect(mandates.get(ADOPTION_MANDATE_ID)).toEqual({ kind: "custom" });
 });
 
 test("identical bytes delivered under any other identity are not the seat's mandate", () => {

--- a/src/lib/runtime/deliveredMessageOccurrences.ts
+++ b/src/lib/runtime/deliveredMessageOccurrences.ts
@@ -63,25 +63,34 @@ const APPROVED_DEFAULT_MANDATE = ORCHESTRATOR_SYSTEM_PROMPT.trim();
 /**
  * WHICH mandate one seat holds, as far as its own record proves it.
  *
- * `promptVersion` records the default the mandate was BASED ON, and a rotation
- * — or an MCP creation carrying the caller's own text — keeps the incumbent's
- * number regardless of what was actually delivered, so the number alone can
- * never say the text IS that default. The seat also stores the mandate itself,
- * and this checkout holds exactly one approved default: the current one. That
- * is the whole of the evidence, and it answers three ways:
+ * `promptVersion` is what the seat recorded its mandate as being based on, and
+ * it IS the answer whenever it names a default: a seat carrying v8 says v8,
+ * whether or not this checkout still ships v8's text to compare it against
+ * (#1190). Dropping the number because the text is unavailable told the
+ * operator less than the seat itself knows.
  *
- *  - the stored mandate opens with the current approved default → that version;
- *  - it does not, and the seat recorded the current version or none at all →
- *    the text is somebody's own edit: `custom`;
- *  - it does not, and the seat recorded an OLDER version whose text this
- *    checkout no longer carries → nothing is proven, so nothing is claimed.
+ * The stored mandate decides exactly one case — the CURRENT version, the one
+ * default this checkout does carry, and therefore the only one whose text can
+ * be checked. A rotation composing the caller's own words, or an MCP creation
+ * carrying them, passes the incumbent's number through unchanged, so there the
+ * number alone cannot say the text IS that default. So:
+ *
+ *  - no version recorded at all → the text is somebody's own: `custom`;
+ *  - an older version → that version, on the seat's own record;
+ *  - the current version → that version when the stored mandate opens with the
+ *    approved default (a rotation appends its handoff, so the default is a
+ *    PREFIX of what the seat kept), and `custom` when it does not.
+ *
+ * `unqualified` is never an answer here. A seat record IS the metadata, so it
+ * always names one of the three; the unqualified card belongs to the delivery
+ * whose seat record is gone (see `mandateForDelivery`).
  */
 function seatMandate(seat: OrchestratorSeat): MandateDelivery {
-  if (seat.mandate.trimStart().startsWith(APPROVED_DEFAULT_MANDATE)) {
-    return { kind: "version", version: ORCHESTRATOR_PROMPT_VERSION };
-  }
-  if (seat.promptVersion === null || seat.promptVersion === ORCHESTRATOR_PROMPT_VERSION) return { kind: "custom" };
-  return { kind: "unqualified" };
+  if (seat.promptVersion === null) return { kind: "custom" };
+  if (seat.promptVersion !== ORCHESTRATOR_PROMPT_VERSION) return { kind: "version", version: seat.promptVersion };
+  return seat.mandate.trimStart().startsWith(APPROVED_DEFAULT_MANDATE)
+    ? { kind: "version", version: ORCHESTRATOR_PROMPT_VERSION }
+    : { kind: "custom" };
 }
 
 /**


### PR DESCRIPTION
Two merge-bar follow-ups, each implementing its reviewer's finding verbatim.

Closes #1189
Closes #1190

## #1189 — the unbound re-resolution retries while binding is pending

`OrchestratorPanel.tsx` hung the unbound-triggered status refresh on an edge, so
it fired once. When that read fails — which is what a restarting viewer answers —
`useOrchestratorIncumbent.ts` marks the retained reading stale while the trigger
stays true, so no further effect run happens and resolution waits for the 60 s
wear cadence. Past the ~10 s bind bound the dock is still saying «opening…» and
cannot even offer Re-bind, because that control needs live-host evidence no read
has answered for.

While the seat is unbound **and no attempt has answered** (`bindPending &&
readStale`), the panel now takes the same status read again every
`UNBOUND_STATUS_RETRY_MS` (2 s). It stops the moment one lands: a fresh reading
either binds the seat through the successor path, or lets the bound name what is
actually missing. No store, no bus, no rotation, no designation, no spawn were
added, and the stale-liveness guard is untouched — staleness is now what *arms*
the retry, so `hostLive = !readStale && …` still refuses to accuse a seat on a
cached «alive».

**Acceptance — "Add a DOM regression where the first restart-time status request
fails, the endpoint recovers with the successor path, and the dock binds
automatically by the next poll within ~10 seconds."**

`OrchestratorPanel.dom.test.tsx` → `a restart-time status read that fails is
retried, and the dock binds itself inside the bound (#1189)`:

| acceptance clause | how the test verifies it |
| --- | --- |
| the first restart-time status request fails | `incumbentReadDown = true` at mount; the panel asserts «Opening the conversation», `bindReason` null and **no** `[data-orchestrator-rebind]` |
| the endpoint recovers with the successor path | `incumbentReadDown = false` and the status answer carries `transcriptPath: …successor.jsonl`, which is the only key that names the catalog's entry |
| the dock binds automatically | nothing on screen is touched between the two phases; `incumbentReads` is asserted to have grown past the failed count, and `[data-orchestrator-conversation="conversation_orch_successor"]` is on screen |
| within ~10 seconds | `expect(Date.now() - opened).toBeLessThan(SEAT_BIND_TIMEOUT_MS)` |
| nothing else was spent to get there | `rotatePosts`, `seatPosts`, `spawnPosts` all asserted empty |

RED verified against the same test with the retry effect removed: 2 status reads
total, both at mount, and the dock never binds.

## #1190 — the mandate card honours a stored historical promptVersion

`deliveredMessageOccurrences.ts` emitted vN only when the stored text still
matched the current built-in prompt, so a seat carrying promptVersion 8 rendered
unqualified — the acceptance criterion the card was filed against.

The recorded version is now the answer whenever there is one. The stored text
decides exactly one case: the current version, the one default this checkout
carries and therefore the only one whose text can be checked, where an edited
rotation that passed the incumbent's number through still reads as custom.

**Acceptance — "v8 renders 'Mandate v8'; bespoke renders 'Mandate custom';
missing seat metadata omits the qualifier."**

| acceptance clause | how it is verified |
| --- | --- |
| v8 renders "Mandate v8" | `deliveredMessageOccurrences.test.ts` → `a seat based on a default this checkout no longer carries is still that version (#1190)` asserts `{ kind: "version", version: 8 }`; `MandateCard` renders `mandateCard.version` from that number |
| bespoke renders "Mandate custom" | `a seat with no recorded version at all is the operator's own text (#1190)` (null → custom) and the retained `a bespoke mandate reads as custom even when the seat kept the incumbent's version number` (current version + edited text → custom) |
| missing seat metadata omits the qualifier | the retained `the reserved adoption identity is a mandate on its own, with no seat record behind it` — unqualified now comes only from `mandateForDelivery`, never from a seat record |

The test that codified the divergence (`…claims no version at all`) is corrected
rather than preserved. RED verified: it returns `{ kind: "unqualified" }` against
the previous rule.

### The P2 on #1190 was deliberately not acted on

The reviewer also asked to delete the `SPAWN_CLIENT_MESSAGE_PREFIX` branch. A
seat created in spawn mode delivers its mandate as the spawn's first prompt
(`spawn_<launchId>`), which is the common case in production, while
`orchmandate_` exists only on the adoption path — removing the branch would send
most real mandates back to the 8 KB raw bubble the original issue was filed
about. The branch stays; scope here is the P1 label rule.

## Verification

- `bunx tsc --noEmit --incremental false` — clean
- `bun test src/components/orchestrator/OrchestratorPanel.dom.test.tsx` — 46 pass
- `bun test src/lib/runtime/deliveredMessageOccurrences.test.ts` — 17 pass
- `bun test` on the adjacent paths: `OrchestratorDock.dom.test.tsx`,
  `dockOpenState.dom.test.tsx`, `orchestratorAnswerCache.dom.test.tsx` (19 pass);
  `seatState.test.ts`, `incumbent.test.ts`, `mandateMessage.test.ts`,
  `MandateCard.dom.test.tsx`, `messageProvenance.parse.test.tsx`,
  `deliveredOccurrences.test.ts`, `MobileOrchestratorSheet.render.test.tsx`,
  `orchestratorRowState.test.ts` (all pass)
- `eslint` on the five touched files — clean
- privacy publication gate against the merge base with `--check-commits` — PASS
- Pre-existing, unrelated: `src/lib/delivery.test.ts` has 2 failures on `main`
  too (`title is required for every new spawn`), reproduced with this branch's
  source swapped back to HEAD.

All test runs used an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`
and named files by path — no directory sweeps, no live state dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
