### PR TITLE
fix(pipelines): close retires an attempt whose turn a provider limit ended

### DIFF
--- a/src/lib/pipelines/durableEvidence.test.ts
+++ b/src/lib/pipelines/durableEvidence.test.ts
@@ -140,3 +140,137 @@ test("a missing or torn artifact yields no durable evidence", async () => {
   fs.writeFileSync(torn, '{"type":"assistant","message":{"stop_reason":"end_turn"\n', "utf8");
   expect(await durableStageTurnEvidence("claude", torn)).toBeNull();
 });
+
+/* #1141 — a provider limit cuts the turn off mid-flight, so the transcript's
+   last record is the CLI's own notice and there is no verdict to read. The
+   invented notices below are the two shapes the CLIs write; never copy a real
+   transcript into a fixture. */
+const CLAUDE_SESSION_LIMIT = "You've hit your session limit. Try again once the window resets.";
+
+function claudeLimitRecord(timestamp: string, text = CLAUDE_SESSION_LIMIT): Record<string, unknown> {
+  return {
+    type: "assistant",
+    timestamp,
+    isApiErrorMessage: true,
+    error: "rate_limit",
+    message: { role: "assistant", model: "<synthetic>", stop_reason: "stop_sequence", content: [{ type: "text", text }] },
+  };
+}
+
+test("a Claude turn cut off by a session limit reports the provider's notice as terminal evidence (#1141)", async () => {
+  const file = writeTranscript("claude-session-limit.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:20:00.000Z",
+      message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "halfway through the fix" }] },
+    },
+    claudeLimitRecord("2026-08-27T09:41:00.000Z"),
+  ]);
+
+  const evidence = await durableStageTurnEvidence("claude", file);
+  expect(evidence).toMatchObject({
+    turn: "terminal",
+    terminalProviderMessage: { text: CLAUDE_SESSION_LIMIT },
+  });
+  expect(evidence!.terminalProviderMessage!.ts).toBe(Date.parse("2026-08-27T09:41:00.000Z"));
+});
+
+test("a limit notice under trailing bookkeeping records still closes the turn (#1141)", async () => {
+  const file = writeTranscript("claude-session-limit-bookkeeping.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    claudeLimitRecord("2026-08-27T09:41:00.000Z"),
+    { type: "file-history-snapshot", timestamp: "2026-08-27T09:41:01.000Z", snapshot: { trackedFileBackups: {} } },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({
+    turn: "terminal",
+    terminalProviderMessage: { text: CLAUDE_SESSION_LIMIT },
+  });
+});
+
+test("a turn that ended on its own verdict carries no provider notice (#1141)", async () => {
+  const file = writeTranscript("claude-verdict-no-notice.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:05:00.000Z",
+      message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: PASS_TEXT }] },
+    },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({
+    turn: "terminal",
+    message: { text: PASS_TEXT },
+    terminalProviderMessage: null,
+  });
+});
+
+test("a silent mid-work transcript carries no provider notice (#1141)", async () => {
+  const file = writeTranscript("claude-silent-midwork.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:02:00.000Z",
+      message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "reading the failing test" }] },
+    },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({ turn: "busy", terminalProviderMessage: null });
+});
+
+test("prose that merely quotes a limit notice is not one (#1141)", async () => {
+  const file = writeTranscript("claude-quoted-limit.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:05:00.000Z",
+      message: {
+        role: "assistant",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: `The stage agent stopped on "${CLAUDE_SESSION_LIMIT}" last night.` }],
+      },
+    },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({ turn: "terminal", terminalProviderMessage: null });
+});
+
+test("a prompt after the limit notice reopens the turn and withdraws the evidence (#1141)", async () => {
+  const file = writeTranscript("claude-limit-then-prompt.jsonl", [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "prompt" } },
+    claudeLimitRecord("2026-08-27T09:41:00.000Z"),
+    { type: "user", timestamp: "2026-08-27T13:00:00.000Z", message: { role: "user", content: "carry on now that the window reset" } },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({ turn: "busy", terminalProviderMessage: null });
+});
+
+test("a Codex turn refused for usage carries the provider's notice (#1141)", async () => {
+  const file = writeTranscript("codex-usage-limit.jsonl", [
+    { timestamp: "2026-08-27T10:00:00.000Z", payload: { type: "task_started" } },
+    { timestamp: "2026-08-27T10:04:00.000Z", payload: { type: "agent_message", message: "starting on the stage" } },
+    {
+      timestamp: "2026-08-27T10:05:00.000Z",
+      payload: {
+        type: "task_complete",
+        error: { message: "You've hit your usage limit. Try again after reset.", codex_error_info: "usage_limit_exceeded" },
+      },
+    },
+  ]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({
+    turn: "terminal",
+    terminalProviderMessage: { text: "You've hit your usage limit. Try again after reset." },
+  });
+});
+
+test("a Codex turn that completed normally carries no provider notice (#1141)", async () => {
+  const file = writeTranscript("codex-clean-complete.jsonl", [
+    { timestamp: "2026-08-27T10:00:00.000Z", payload: { type: "task_started" } },
+    { timestamp: "2026-08-27T10:04:00.000Z", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-08-27T10:05:00.000Z", payload: { type: "task_complete", last_agent_message: PASS_TEXT } },
+  ]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({ turn: "terminal", terminalProviderMessage: null });
+});

--- a/src/lib/pipelines/durableEvidence.ts
+++ b/src/lib/pipelines/durableEvidence.ts
@@ -4,6 +4,9 @@ import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
 import type { FlowEngine } from "@/lib/flows/types";
 import { lastAssistantMessageFromRecords } from "@/lib/flows/findings";
 import { readStableTailRecords } from "@/lib/scanner/activity";
+import { recordValue, recordsValue, stringValue } from "@/lib/scanner/json";
+
+type RecordLike = Record<string, unknown>;
 
 /**
  * Turn evidence read straight from the stage transcript artifact — the durable
@@ -17,7 +20,74 @@ import { readStableTailRecords } from "@/lib/scanner/activity";
 export type StageTurnEvidence = {
   turn: "terminal" | "busy" | "unknown";
   message: { text: string; ts: number } | null;
+  /** The provider's own end-of-turn notice, when the record that closed the
+      turn is one: a session or model limit, an expired credential, a refusal —
+      a message the CLI writes *instead of* the agent's answer, so the turn
+      ended with nothing to parse (#1141). Null whenever the turn ended on the
+      agent's own message, and null while the turn is still open, so silence
+      can never present as one. */
+  terminalProviderMessage?: { text: string; ts: number } | null;
 };
+
+function recordTs(record: RecordLike, fallbackTs: number): number {
+  return Date.parse(String(record.timestamp ?? "")) || fallbackTs;
+}
+
+function claudeAssistantText(record: RecordLike): string {
+  return recordsValue(recordValue(record.message)?.content)
+    .filter((part) => part.type === "text")
+    .map((part) => stringValue(part.text) ?? "")
+    .join("\n")
+    .trim();
+}
+
+/** Codex turn-end records that carry a provider failure instead of a result.
+    A clean completion has no error field at all, so it yields nothing here. */
+function codexTurnEndFailure(payload: RecordLike): string | null {
+  const error = recordValue(payload.error);
+  const info = stringValue(payload.codex_error_info) ?? stringValue(error?.codex_error_info);
+  const message = stringValue(error?.message)
+    ?? stringValue(payload.error)
+    ?? (info ? stringValue(payload.message) : null);
+  return message ?? info;
+}
+
+const CODEX_TURN_END_TYPES = new Set(["task_complete", "turn_complete", "turn_completed", "turn_aborted"]);
+const CODEX_TURN_START_TYPES = new Set(["task_started", "turn_started", "user_message"]);
+
+/**
+ * The notice the provider wrote when it ended the turn, read from the record
+ * that CLOSED it — the assistant record Claude flags `isApiErrorMessage`, or
+ * the Codex turn-end record carrying a failure. Everything after that record
+ * on Claude's side is bookkeeping the CLI appends once the turn is over.
+ *
+ * Read from the closing record rather than from prose, so an agent that merely
+ * quotes a limit notice in its answer is not mistaken for one, and a later
+ * prompt that reopened the turn withdraws the evidence.
+ */
+function terminalProviderMessageFromRecords(
+  records: RecordLike[],
+  codex: boolean,
+  fallbackTs: number,
+): { text: string; ts: number } | null {
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    if (codex) {
+      const payload = recordValue(record.payload) ?? {};
+      const type = stringValue(payload.type) ?? "";
+      if (CODEX_TURN_START_TYPES.has(type)) return null;
+      if (!CODEX_TURN_END_TYPES.has(type)) continue;
+      const failure = codexTurnEndFailure(payload);
+      return failure ? { text: failure, ts: recordTs(record, fallbackTs) } : null;
+    }
+    if (record.type === "user") return null;
+    if (record.type !== "assistant") continue;
+    if (record.isApiErrorMessage !== true) return null;
+    const text = claudeAssistantText(record);
+    return text ? { text, ts: recordTs(record, fallbackTs) } : null;
+  }
+  return null;
+}
 
 export async function durableStageTurnEvidence(
   engine: FlowEngine,
@@ -38,5 +108,11 @@ export async function durableStageTurnEvidence(
   return {
     turn: turn.state === "terminal" ? "terminal" : turn.state === "busy" ? "busy" : "unknown",
     message,
+    /* Gated on the same turn reading the rest of the engine trusts: a provider
+       error the CLI may still retry inside an open turn keeps the busy
+       projection (#516), and so never reads as the end of the turn here. */
+    terminalProviderMessage: turn.state === "terminal"
+      ? terminalProviderMessageFromRecords(read.records, codex, fallbackTs)
+      : null,
   };
 }

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -23,6 +23,7 @@ const createPipelineFromRequest: typeof rawCreatePipelineFromRequest = async (re
   await rawCreatePipelineFromRequest({ src: "/codex/creator.jsonl", ...request }, ports, options);
 const { registerPipelineTick } = await import("./controllerSignal");
 const { loadPipelines, savePipelines } = await import("./store");
+const { durableStageTurnEvidence } = await import("./durableEvidence");
 const { saveTasks } = await import("@/lib/tasks/store");
 type PipelinePorts = import("./engine").PipelinePorts;
 type PipelineStageStopResult = import("./engine").PipelineStageStopResult;
@@ -5498,6 +5499,196 @@ test("close terminalizes host-unavailable attempts from durable evidence and rec
     expect(terminal.runs[0]!.attempts[0]!.completedAt).toBeTruthy();
     expect(terminal.stateDetail).toContain(stopError);
   }
+});
+
+/* #1141 — the sibling case of transcript terminalization. A provider limit cuts
+   the stage turn off mid-flight, so the transcript's last record is the CLI's
+   own notice and there is no verdict to read; the close then had no terminal
+   reading at all and refused, parking the lane on the board forever. The
+   fixtures below are written here, never lifted from a live transcript. */
+const PROVIDER_LIMIT_NOTICE = "You've hit your session limit. Try again once the window resets.";
+
+function stageTranscript(name: string, records: Record<string, unknown>[]): string {
+  const file = path.join(process.env.LLV_STATE_DIR!, `${name}.jsonl`);
+  fs.writeFileSync(file, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
+  return file;
+}
+
+function limitInterruptedTranscript(name: string): string {
+  return stageTranscript(name, [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "run the stage" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:20:00.000Z",
+      message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "opening the failing test" }] },
+    },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:41:00.000Z",
+      isApiErrorMessage: true,
+      error: "rate_limit",
+      message: {
+        role: "assistant",
+        model: "<synthetic>",
+        stop_reason: "stop_sequence",
+        content: [{ type: "text", text: PROVIDER_LIMIT_NOTICE }],
+      },
+    },
+  ]);
+}
+
+function verdictTranscript(name: string, status: "pass" | "needs_decision" = "pass"): string {
+  return stageTranscript(name, [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "run the stage" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:30:00.000Z",
+      message: {
+        role: "assistant",
+        stop_reason: "end_turn",
+        content: [{
+          type: "text",
+          text: `done\n\n\`\`\`json\n${JSON.stringify({ status, findings: [], confidence: 0.9 })}\n\`\`\``,
+        }],
+      },
+    },
+  ]);
+}
+
+function silentTranscript(name: string): string {
+  return stageTranscript(name, [
+    { type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { role: "user", content: "run the stage" } },
+    {
+      type: "assistant",
+      timestamp: "2026-08-27T09:20:00.000Z",
+      message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "opening the failing test" }] },
+    },
+  ]);
+}
+
+/** Read the stage's durable evidence out of a fixture transcript through the
+    same reader production uses, so the close is exercised against real records
+    rather than a hand-shaped evidence object. */
+function readFixtures(h: ReturnType<typeof harness>, fixtures: Record<string, string>): void {
+  h.ports.durableTurnEvidence = async (engine, transcriptPath) => {
+    const fixture = fixtures[transcriptPath];
+    return fixture ? await durableStageTurnEvidence(engine, fixture) : null;
+  };
+}
+
+test("close retires an attempt whose turn a provider limit cut off, naming the notice (#1141)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setHostsResident(true);
+  h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+  readFixtures(h, { "/codex/stage-1.jsonl": limitInterruptedTranscript("close-limit-interrupted") });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.stillRunning).toEqual([]);
+  expect(closed.close?.alreadyStopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+  const stored = loadPipelines()[0]!;
+  expect(stored.state).toBe("closed");
+  /* Retired as failed, with the provider's own words as the reason — on the
+     attempt and on the lane, so nothing reads as a stage that produced one. */
+  const attempt = stored.runs[0]!.attempts[0]!;
+  expect(attempt.state).toBe("failed");
+  expect(attempt.completedAt).toBeTruthy();
+  expect(attempt.error).toContain("terminal provider message");
+  expect(attempt.error).toContain(PROVIDER_LIMIT_NOTICE);
+  expect(stored.stateDetail).toContain(PROVIDER_LIMIT_NOTICE);
+});
+
+test("a transcript that ends on a valid fenced verdict still closes on the verdict path (#1141)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setHostsResident(true);
+  h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+  readFixtures(h, { "/codex/stage-1.jsonl": verdictTranscript("close-verdict") });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  const detail = closed.close?.notes[0]?.detail ?? "";
+  expect(detail).toContain("valid fenced verdict");
+  /* A lane closed on a real verdict stays distinguishable from one closed on a
+     provider notice — the two reasons never collapse into one. */
+  expect(detail).not.toContain("terminal provider message");
+  expect(loadPipelines()[0]!.state).toBe("closed");
+});
+
+test("a transcript silent under a live host is not terminalized by the provider-message rule (#1141)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setHostsResident(true);
+  h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured runtime host is unavailable" });
+  readFixtures(h, { "/codex/stage-1.jsonl": silentTranscript("close-silent") });
+
+  const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  /* Silence is not evidence that the turn ended: the stall path keeps it. */
+  expect(refused.status).toBe(409);
+  expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+  const stored = loadPipelines()[0]!;
+  expect(stored.state).toBe("running");
+  expect(stored.runs[0]!.attempts[0]!.state).toBe("running");
+});
+
+test("a pipeline blocked only by a limit-interrupted attempt closes end to end (#1141)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* The board shape from the issue: earlier attempts of the same stage ended on
+     verdicts and terminalize from their transcripts; the parked one was cut off
+     by the limit and is the whole reason the close was refused. */
+  const stored = loadPipelines()[0]!;
+  const run = stored.runs[0]!;
+  const parked = run.attempts[0]!;
+  const settled = structuredClone(parked);
+  settled.n = 1;
+  settled.state = "failed";
+  settled.conversationId = "conversation_stage_2";
+  settled.agentPath = "/codex/stage-2.jsonl";
+  settled.paneId = "%2";
+  parked.n = 2;
+  parked.state = "needs_decision";
+  parked.error = "stage verdict recovery exhausted after 3 checks";
+  run.attempts = [settled, parked];
+  stored.state = "needs_decision";
+  stored.stateDetail = parked.error;
+  savePipelines([stored]);
+  h.setHostsResident(true);
+  for (const conversationId of ["conversation_stage_1", "conversation_stage_2"]) {
+    h.setStageHost(conversationId, { outcome: "failed", error: "structured runtime host is unavailable" });
+  }
+  readFixtures(h, {
+    "/codex/stage-1.jsonl": limitInterruptedTranscript("close-blocker-limit"),
+    "/codex/stage-2.jsonl": verdictTranscript("close-blocker-verdict", "needs_decision"),
+  });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.stillRunning).toEqual([]);
+  expect(closed.close?.alreadyStopped).toHaveLength(2);
+  const terminal = loadPipelines()[0]!;
+  expect(terminal.state).toBe("closed");
+  expect(terminal.closedAt).toBeTruthy();
+  /* Nothing unconfirmed is left, so the lane leaves the board. */
+  expect(terminal.hiddenAt).toBe(terminal.closedAt);
+  expect(terminal.runs[0]!.attempts.map((item) => item.completedAt).every(Boolean)).toBeTrue();
+  /* The parking attempt keeps the reason it parked with; the close reason it
+     was retired on rides the lane's own detail. */
+  expect(terminal.runs[0]!.attempts[1]!.error).toBe("stage verdict recovery exhausted after 3 checks");
+  expect(terminal.stateDetail).toContain(PROVIDER_LIMIT_NOTICE);
 });
 
 test("closing preserves uncommitted stage work and names what it left behind (#670)", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -3250,6 +3250,26 @@ function verdictRecoveryResetRefusal(
   return refusal(`the worktree HEAD ${local.sha} differs from the last-passed commit ${pipeline.lastPassedCommit}`);
 }
 
+/** One line of the provider's own words, for the close report and the board. */
+function providerNoticeSummary(text: string): string {
+  const line = text.split("\n").map((part) => part.trim()).find(Boolean) ?? text.trim();
+  return line.length > 160 ? `${line.slice(0, 159)}\u2026` : line;
+}
+
+/**
+ * What a transcript can prove about an attempt whose host refused to stop — the
+ * only thing standing between a superseded lane and the board it cannot leave.
+ *
+ * Two shapes count, and they are siblings. A completed turn carrying a valid
+ * fenced verdict says the stage finished (#1047, #988). A turn the provider cut
+ * off — a session or model limit, an expired credential — says the stage ended
+ * without producing one (#1141): the message that ended it is right there in the
+ * final record, so the attempt is terminal by evidence and retires as failed.
+ *
+ * Silence is neither. A transcript that simply stops mid-turn proves nothing
+ * about a host that may still be working, so it falls through to null and keeps
+ * refusing the close, exactly as before.
+ */
 async function closeStopFailureEvidence(
   candidate: StageHostCandidate,
   ports: PipelinePorts,
@@ -3261,11 +3281,17 @@ async function closeStopFailureEvidence(
   }
   if (!candidate.target.agentPath) return null;
   const durable = await ports.durableTurnEvidence(candidate.attempt.effectiveRole.engine, candidate.target.agentPath);
-  if (durable?.turn !== "terminal" || !durable.message) return null;
-  if (durable.message.ts <= unixMs(candidate.attempt.startedAt)) return null;
-  const parsed = parsePipelineStageVerdict(durable.message.text);
-  if (!parsed || "failureReason" in parsed) return null;
-  return "the attempt transcript holds a completed final assistant turn with a valid fenced verdict";
+  if (durable?.turn !== "terminal") return null;
+  const startedAt = unixMs(candidate.attempt.startedAt);
+  if (durable.message && durable.message.ts > startedAt) {
+    const parsed = parsePipelineStageVerdict(durable.message.text);
+    if (parsed && !("failureReason" in parsed)) {
+      return "the attempt transcript holds a completed final assistant turn with a valid fenced verdict";
+    }
+  }
+  const interrupted = durable.terminalProviderMessage;
+  if (!interrupted || interrupted.ts <= startedAt) return null;
+  return `the attempt transcript ending on a terminal provider message with no fenced verdict: ${providerNoticeSummary(interrupted.text)}`;
 }
 
 function terminalizeAttemptForClose(candidate: StageHostCandidate, note: string, ports: PipelinePorts): void {


### PR DESCRIPTION
Closes #1141

## The defect

`close` already terminalizes an attempt from its transcript when that transcript ends in a completed assistant turn carrying a valid fenced verdict — it says so in its own per-attempt note, and six pipelines on the operator's board closed on exactly that path, several of them with hosts long dead. A dead host was never the problem.

The problem is an attempt the provider cut off mid-flight. A session or model limit ends the turn, so the transcript's final record is the CLI's own notice and there is no verdict to read. That attempt satisfied neither exit — no live host to stop, no verdict to terminalize from — so the whole close failed with `structured runtime host is unavailable`, the lane stayed parked on the board, and its worktree could not be reclaimed. Killing the host processes by hand did not help, which is what proved the blocker was the missing verdict rather than the live process.

## The fix

One predicate plus one branch, as the issue expected.

- `durableStageTurnEvidence` (`src/lib/pipelines/durableEvidence.ts`) now also reports `terminalProviderMessage`: the notice on the record that **closed** the turn, when that record is one the provider wrote instead of the agent's answer — Claude's flagged api-error assistant record, or a Codex turn-end record carrying a failure.
- `closeStopFailureEvidence` (`src/lib/pipelines/engine.ts`) reads it as the sibling of the verdict case. The attempt retires as `failed`, with the provider's own line as the reason.

Two guards keep it from swallowing a live turn:

- the notice is read from the closing **record**, never from prose, so an agent that quotes a limit notice in its answer is not mistaken for one, and a prompt appended after the notice withdraws the evidence;
- it is gated on the same terminal turn reading the rest of the engine already trusts, so a provider error the CLI may retry inside an open turn keeps the busy projection (#516).

Silence is untouched. A transcript that simply stops mid-turn still yields no evidence, still refuses the close, and still flows to the existing `host_alive_transcript_silent` stall path. Nothing in the runtime host lifecycle, verdict recovery, or any store was changed.

## The reason surfaces honestly

`terminalizeAttemptForClose` writes the note to `attempt.error` (for an attempt not already in a terminal state) and `closeSummary` carries it into `pipeline.stateDetail`. A lane retired this way reads `terminalized from the attempt transcript ending on a terminal provider message with no fenced verdict: <the notice>`, which never collapses into the verdict path's wording. The board's verdict popover already renders `attempt.error ?? pipeline.stateDetail` for a verdict-less attempt, so it shows the notice with no UI change.

## Required outcome → test

All transcripts are fixtures written by the tests themselves; no test reads live state.

| Required outcome | Test |
| --- | --- |
| A limit-interrupted attempt closes and is marked failed with the reason | `engine.test.ts` — "close retires an attempt whose turn a provider limit cut off, naming the notice (#1141)" |
| A valid fenced verdict still closes on the existing path, distinguishably | `engine.test.ts` — "a transcript that ends on a valid fenced verdict still closes on the verdict path (#1141)" |
| Silence under a live host is NOT terminalized by this rule | `engine.test.ts` — "a transcript silent under a live host is not terminalized by the provider-message rule (#1141)" |
| A pipeline blocked only by such an attempt closes end to end | `engine.test.ts` — "a pipeline blocked only by a limit-interrupted attempt closes end to end (#1141)" |
| The predicate itself: notice / verdict / silence / quoted prose / reopened turn / Codex usage refusal / Codex clean completion | `durableEvidence.test.ts` — eight `(#1141)` cases over fixture transcripts |

The three engine tests that had to go RED did, each refusing the close with `structured runtime host is unavailable` before the branch existed; the silence test passed before and after, which is the point of it.

## Verification

- `bunx tsc --noEmit --incremental false` — clean
- `bun test src/lib/pipelines/durableEvidence.test.ts src/lib/pipelines/engine.test.ts src/lib/pipelines/terminalReap.test.ts` — 230 pass, 0 fail
- `bun test "src/app/api/pipelines/[id]/route.test.ts"` — 7 pass, 0 fail
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS

Every run used an isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR` / `TMPDIR`, by path, never a directory sweep and never the live state dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
