### PR TITLE
feat(runtime): send /compact on the Claude structured path with an honest receipt

### DIFF
--- a/src/components/AgentControlStrip.action.test.tsx
+++ b/src/components/AgentControlStrip.action.test.tsx
@@ -109,6 +109,27 @@ afterEach(() => {
   localStorage.clear();
 });
 
+/** The bus's own endpoints — never a control anyone asserts on. */
+const RUNTIME_BUS_URLS = ["/api/runtime/snapshot", "/api/runtime/stream"];
+
+/**
+ * Every test's fetch stub, with the runtime bus's own traffic kept out of it.
+ * The first strip mount starts the tab-wide bus, which fetches
+ * `/api/runtime/snapshot` on its own schedule — landing in whichever test's
+ * recorder happens to be installed when it resolves and adding a request nobody
+ * made (it made the whole file order-dependent). The guard answers the bus
+ * itself so each test only ever records the controls it asked about; every
+ * other URL, `/api/runtime/interrupt` included, reaches the test's handler.
+ */
+function stubFetch(handler: (url: string, init?: RequestInit) => Promise<Response>): void {
+  globalThis.fetch = ((url: string, init?: RequestInit) => {
+    if (RUNTIME_BUS_URLS.some((busUrl) => String(url).startsWith(busUrl))) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) } as unknown as Response);
+    }
+    return handler(String(url), init);
+  }) as typeof fetch;
+}
+
 const stopButton = (host: HTMLElement) =>
   host.querySelector(`button[aria-label^="${translate("en", "composer.interruptAria")}"]`) as HTMLButtonElement | null;
 
@@ -157,10 +178,10 @@ test("the width observer attaches when the strip mounts late (gated → live roo
 
 test("Stop on a structured-root subagent relays to the root's structured interrupt — zero /api/tmux, /api/proc", async () => {
   const calls: { url: string; body: unknown }[] = [];
-  globalThis.fetch = ((url: string, init?: RequestInit) => {
+  stubFetch((url: string, init?: RequestInit) => {
     calls.push({ url: String(url), body: init?.body ? JSON.parse(String(init.body)) : undefined });
     return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, operationId: "op-1" }) } as unknown as Response);
-  }) as typeof fetch;
+  });
 
   const { host, root } = await mount(subagent);
   const stop = stopButton(host)!;
@@ -182,10 +203,10 @@ test("Stop on a structured-root subagent relays to the root's structured interru
 test("Stop on a live TMUX-root subagent keeps the canonical /api/tmux child path", async () => {
   rootKind = "tmux-legacy";
   const calls: { url: string; body: unknown }[] = [];
-  globalThis.fetch = ((url: string, init?: RequestInit) => {
+  stubFetch((url: string, init?: RequestInit) => {
     calls.push({ url: String(url), body: init?.body ? JSON.parse(String(init.body)) : undefined });
     return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, target: "root:%1" }) } as unknown as Response);
-  }) as typeof fetch;
+  });
 
   const { host, root } = await mount(subagent);
   expect(host.querySelector('[data-strip-surface="live-subagent"]')).not.toBeNull();
@@ -244,7 +265,7 @@ const statusText = (host: HTMLElement) =>
 test("a rejected compaction is reported as the refusal, not as a started compaction", async () => {
   sessionView = structuredCodexView();
   const bodies: Array<Record<string, unknown>> = [];
-  globalThis.fetch = ((url: string, init?: RequestInit) => {
+  stubFetch((url: string, init?: RequestInit) => {
     bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
     /* Structured controls answer 202 `ok` for a receipt the journal REFUSED,
        so the receipt decides what the operator is told. */
@@ -258,7 +279,7 @@ test("a rejected compaction is reported as the refusal, not as a started compact
         receipt: { operationId: String(bodies.at(-1)!.operationId), status: "rejected", reason: "busy-turn" },
       }),
     } as unknown as Response);
-  }) as typeof fetch;
+  });
 
   const { host, root } = await mount(structuredRoot);
   expect(host.querySelector('[data-strip-surface="structured"]')).not.toBeNull();
@@ -283,19 +304,19 @@ test("a rejected compaction is reported as the refusal, not as a started compact
 test("a typed capability refusal is localized from its code, not echoed in English", async () => {
   sessionView = structuredCodexView();
   const calls: string[] = [];
-  globalThis.fetch = ((url: string) => {
+  stubFetch((url: string) => {
     calls.push(String(url));
     return Promise.resolve({
     ok: false,
     json: () => Promise.resolve({
       /* `dispatchStructuredControl`'s capability body: the sentence is a
          server-side English string, so the code is what the operator reads. */
-      error: "The Claude stream-json protocol has no client-originated compact control; only interrupt is exposed.",
+      error: "the codex structured host does not expose a compact control",
       code: "unsupported-capability",
-      capability: { control: "compact", engine: "claude", supported: false },
+      capability: { control: "compact", engine: "codex", supported: false },
     }),
     } as unknown as Response);
-  }) as typeof fetch;
+  });
 
   const { host, root } = await mount(structuredRoot);
   await confirmCompact(host);
@@ -309,7 +330,7 @@ test("a typed capability refusal is localized from its code, not echoed in Engli
 test("an ambiguous transport failure keeps the gesture on one operation", async () => {
   sessionView = structuredCodexView();
   const bodies: Array<Record<string, unknown>> = [];
-  globalThis.fetch = ((url: string, init?: RequestInit) => {
+  stubFetch((url: string, init?: RequestInit) => {
     bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
     /* The runtime-host socket failed and no receipt came back: the compaction
        may or may not have been admitted, so the retry must name the same
@@ -318,7 +339,7 @@ test("an ambiguous transport failure keeps the gesture on one operation", async 
       ok: false,
       json: () => Promise.resolve({ error: "runtime host request timed out" }),
     } as unknown as Response);
-  }) as typeof fetch;
+  });
 
   const { host, root } = await mount(structuredRoot);
   await confirmCompact(host);
@@ -330,16 +351,108 @@ test("an ambiguous transport failure keeps the gesture on one operation", async 
   await act(async () => root.unmount());
 });
 
+/* --------------------- #1214 the Claude compact path --------------------- */
+
+const structuredClaudeRoot: FileEntry = {
+  path: "/claude-root.jsonl", root: "claude-projects", name: "claude-root.jsonl", project: "viewer", title: "root",
+  engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1, size: 1,
+  activity: "live", proc: "running", pid: null, model: "opus", effort: "high", fast: false,
+  pendingQuestion: null, waitingInput: null,
+} as FileEntry;
+
+function structuredClaudeView(receipts: RuntimeSessionView["receipts"] = []): RuntimeSessionView {
+  return {
+    session: {
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "idle",
+      sessionKey: { engine: "claude", sessionId: "session-claude" },
+      conversationId: "conv-claude",
+      capabilities: { steer: true, structuredAttention: true },
+    } as unknown as RuntimeSessionView["session"],
+    uiState: {} as RuntimeSessionView["uiState"],
+    attentions: [],
+    receipts,
+    legacy: false,
+    structuredControlsEnabled: true,
+  };
+}
+
+test("the Claude compact control is offered, sends the command, and reports what was witnessed", async () => {
+  sessionView = structuredClaudeView();
+  const bodies: Array<Record<string, unknown>> = [];
+  stubFetch((url: string, init?: RequestInit) => {
+    bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        structured: true,
+        target: "conv-claude",
+        operationId: String(bodies.at(-1)!.operationId),
+        receipt: { operationId: String(bodies.at(-1)!.operationId), status: "pending" },
+      }),
+    } as unknown as Response);
+  });
+
+  const { host, root } = await mount(structuredClaudeRoot);
+  /* The control is there and live — not a disabled cell explaining that the
+     engine the operator uses daily has no /compact. */
+  expect(compactButton(host)!.disabled).toBe(false);
+  await confirmCompact(host);
+
+  expect(bodies).toHaveLength(1);
+  expect(bodies[0]!.action).toBe("compact");
+  /* The admitted line promises a sent command, not a finished compaction. */
+  expect(statusText(host)).toBe(translate("en", "composer.compactSentClaude"));
+
+  /* The durable receipt then replaces it with the outcome that was actually
+     witnessed — here, none. */
+  const operationId = String(bodies[0]!.operationId);
+  sessionView = structuredClaudeView([{
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: "conv-claude",
+    kind: "compact",
+    status: "uncertain",
+    reason: "compact-sent-unobserved",
+    at: "2026-08-27T00:00:00.000Z",
+    revision: 2,
+  }]);
+  await act(async () => root.render(<AgentControlStrip file={structuredClaudeRoot} />));
+  expect(statusText(host)).toBe(translate("en", "receipt.human.compactSentUnobserved"));
+
+  /* And a compaction that WAS witnessed says so. */
+  sessionView = structuredClaudeView([{
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: "conv-claude",
+    kind: "compact",
+    status: "delivered",
+    reason: "compaction:boundary-one",
+    at: "2026-08-27T00:01:00.000Z",
+    revision: 3,
+  }]);
+  await act(async () => root.render(<AgentControlStrip file={structuredClaudeRoot} />));
+  expect(statusText(host)).toBe(translate("en", "composer.compactObserved"));
+
+  /* A settled compaction is a note about one action, not a permanent line: the
+     next action starts from a clean status, or its own note would never show. */
+  await act(async () => stopButton(host)!.click());
+  expect(statusText(host)).not.toBe(translate("en", "composer.compactObserved"));
+  await act(async () => root.unmount());
+});
+
 test("compact still mints an operation id without a secure context", async () => {
   sessionView = structuredCodexView();
   const bodies: Array<Record<string, unknown>> = [];
-  globalThis.fetch = ((url: string, init?: RequestInit) => {
+  stubFetch((url: string, init?: RequestInit) => {
     bodies.push(init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {});
     return Promise.resolve({
       ok: true,
       json: () => Promise.resolve({ ok: true, structured: true, target: "conv-root", receipt: { status: "pending" } }),
     } as unknown as Response);
-  }) as typeof fetch;
+  });
   /* Plain-http LAN access has no `crypto.randomUUID`. Reaching for it directly
      would throw outside the try, leaving the button permanently busy. */
   const cryptoObject = globalThis.crypto as { randomUUID?: unknown };

--- a/src/components/AgentControlStrip.action.test.tsx
+++ b/src/components/AgentControlStrip.action.test.tsx
@@ -422,6 +422,22 @@ test("the Claude compact control is offered, sends the command, and reports what
   await act(async () => root.render(<AgentControlStrip file={structuredClaudeRoot} />));
   expect(statusText(host)).toBe(translate("en", "receipt.human.compactSentUnobserved"));
 
+  /* A compaction the engine declined is its own visible ending — the command
+     went and nothing was compacted — instead of the generic failure line. */
+  sessionView = structuredClaudeView([{
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: "conv-claude",
+    kind: "compact",
+    status: "failed",
+    reason: "compact-declined",
+    at: "2026-08-27T00:00:30.000Z",
+    revision: 3,
+  }]);
+  await act(async () => root.render(<AgentControlStrip file={structuredClaudeRoot} />));
+  expect(statusText(host)).toBe(translate("en", "receipt.human.compactDeclined"));
+  expect(statusText(host)).not.toBe(translate("en", "composer.failedCompact"));
+
   /* And a compaction that WAS witnessed says so. */
   sessionView = structuredClaudeView([{
     operationId,
@@ -431,7 +447,7 @@ test("the Claude compact control is offered, sends the command, and reports what
     status: "delivered",
     reason: "compaction:boundary-one",
     at: "2026-08-27T00:01:00.000Z",
-    revision: 3,
+    revision: 4,
   }]);
   await act(async () => root.render(<AgentControlStrip file={structuredClaudeRoot} />));
   expect(statusText(host)).toBe(translate("en", "composer.compactObserved"));

--- a/src/components/AgentControlStrip.dom.test.tsx
+++ b/src/components/AgentControlStrip.dom.test.tsx
@@ -78,11 +78,11 @@ test("hidden controls never reach the DOM (resume hides stop/compact/kill)", () 
 });
 
 test("a disabled control keeps aria-disabled and appends the reason to its aria-label", () => {
-  // A structured Claude host has no compact control in its protocol (#862), so
-  // that cell is the disabled one and names the engine gap.
-  const html = render(file({ proc: "running" }), rv("claude-broker", "hosted"));
-  expect(html).toContain('data-strip-surface="structured"');
-  const reason = translate("en", "strip.compactEngineUnsupported");
+  /* A subagent cannot be compacted on its own — the control belongs to the root
+     conversation — so that cell is the disabled one and names the surface. */
+  const html = render(file({ proc: "running", parent: "/root.jsonl" }), null);
+  expect(html).toContain('data-strip-surface="live-subagent"');
+  const reason = translate("en", "strip.compactSubagent");
   expect(html).toContain('aria-disabled="true"');
   expect(html).toContain(`context (/compact) — ${reason}`);
 });
@@ -91,7 +91,23 @@ test("a structured Codex host renders Compact as a real, enabled control (#862)"
   const html = render(file({ proc: "running" }), rv("codex-app-server", "hosted"));
   expect(html).toContain('data-strip-surface="structured"');
   expect(html).toContain('aria-label="Compact the agent&#x27;s context (/compact)"');
-  expect(html).not.toContain(`context (/compact) — ${translate("en", "strip.compactEngineUnsupported")}`);
+});
+
+test("a structured Claude host renders Compact enabled, noting what the Viewer can confirm (#1214)", () => {
+  for (const locale of ["en", "uk"] as const) {
+    const localized = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) =>
+      translate(locale, key, params);
+    const html = render(file({ proc: "running" }), rv("claude-broker", "hosted"), { t: localized });
+    expect(html).toContain('data-strip-surface="structured"');
+    /* Enabled: the operator asked for the command to be sent, and it is. */
+    expect(html).not.toContain('aria-disabled="true"');
+    /* The note is about what the Viewer can confirm, in both languages — the
+       strip never again tells the operator the engine lacks /compact. */
+    const note = translate(locale, "strip.compactClaudeMessage");
+    expect(note).toContain("/compact");
+    const label = `${translate(locale, "composer.compactAria")} \u2014 ${note}`.replace(/'/g, "&#x27;");
+    expect(html).toContain(`aria-label="${label}"`);
+  }
 });
 
 test("the structured surface renders no mode chip — the «structured» badge is gone (issue #390)", () => {

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -12,7 +12,7 @@ import { interruptRuntime, refreshRuntime } from "@/hooks/useRuntime";
 import { useLocale, type MessageKey, type TFunction } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
-import { humanReceiptReasonKey, mintIdempotencyKey } from "@/components/runtime/runtimeModel";
+import { humanReceiptReasonKey, mintIdempotencyKey, type RuntimeReceipt } from "@/components/runtime/runtimeModel";
 import { turnIsRunning } from "./turnDuration";
 import { useAgentCapabilities } from "./useAgentCapabilities";
 import {
@@ -189,6 +189,34 @@ function compactFailureText(
 }
 
 /**
+ * What the durable compact receipt turned out to be (#1214). The strip's own
+ * "sent" line is optimistic by necessity — it is written the moment the journal
+ * admits the operation — so the receipt replaces it as soon as the operation
+ * terminalizes. `uncertain` is the Claude path's honest ending: the command was
+ * typed into the conversation and no compaction boundary was ever witnessed,
+ * which the operator is told in those words rather than left to guess.
+ */
+function compactReceiptStatus(
+  t: TFunction,
+  receipt: RuntimeReceipt | undefined,
+): { kind: "ok" | "info" | "err"; text: string } | null {
+  if (!receipt) return null;
+  if (receipt.status === "delivered") return { kind: "ok", text: t("composer.compactObserved") };
+  if (receipt.status === "uncertain") {
+    return {
+      kind: "info",
+      text: humanReceiptReasonKey(receipt.reason)
+        ? t(humanReceiptReasonKey(receipt.reason)!)
+        : t("receipt.human.compactSentUnobserved"),
+    };
+  }
+  if (receipt.status === "rejected" || receipt.status === "failed") {
+    return { kind: "err", text: compactFailureText(t, receipt.reason, undefined, undefined) };
+  }
+  return null;
+}
+
+/**
  * Presentational unified control strip (issue #241). Pure — its control set,
  * disabled-with-tooltip vs. hidden treatment, 44px mobile targets, and busy
  * states are DOM-tested against capability fixtures. Mounted once by
@@ -359,8 +387,19 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
   const [compactArmed, setCompactArmed] = useState(false);
   /** The durable operation a confirmed compact gesture owns until it lands. */
   const compactOperationRef = useRef<string | null>(null);
+  /** The admitted compact operation whose durable receipt the strip is still
+      waiting on, so its real outcome replaces the optimistic line (#1214). */
+  const [compactWatch, setCompactWatch] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [status, setStatus] = useState<StripStatus | null>(null);
+
+  /** Every action starts from a clean line — including a settled compaction
+      outcome, which would otherwise sit on the status line forever and hide the
+      note the NEXT action wants to show (#1214). */
+  const clearStatus = () => {
+    setStatus(null);
+    setCompactWatch(null);
+  };
 
   /* One click, one command (operator request): the terminal button copies the
      COMPLETE resume command (cd + env + CLI) straight to the clipboard and
@@ -373,7 +412,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
       setAttachOpen(true);
       return;
     }
-    setStatus(null);
+    clearStatus();
     try {
       const response = await fetch(`/api/attach-command?path=${encodeURIComponent(file.path)}`);
       const body = (await response.json()) as { fullCommand?: string; error?: string };
@@ -413,12 +452,24 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
     return () => window.clearTimeout(id);
   }, [compactArmed]);
 
+  /* A claude-broker host has no compact subtype in its transport, so its
+     compaction is a typed `/compact` whose completion the Viewer can only
+     witness in the transcript (#1214). The strip's wording follows. */
+  const claudeCompact = structuredSession?.session.hostKind === "claude-broker";
+  const compactOutcome = compactReceiptStatus(
+    t,
+    compactWatch
+      ? structuredSession?.receipts.find((receipt) =>
+          receipt.kind === "compact" && receipt.operationId === compactWatch)
+      : undefined,
+  );
+
   if (!stripHasVisibleControls(caps)) return null;
 
   const stop = async () => {
     if (stopBusy) return;
     setStopBusy(true);
-    setStatus(null);
+    clearStatus();
     try {
       const result = structuredSession
         ? await interruptRuntime(structuredSession.session.conversationId, mintIdempotencyKey())
@@ -445,7 +496,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
   const recheck = async () => {
     if (recheckBusy) return;
     setRecheckBusy(true);
-    setStatus(null);
+    clearStatus();
     try {
       const ok = await refreshRuntime();
       if (!ok) setStatus({ kind: "err", text: t("deadHost.recheckFailed") });
@@ -462,7 +513,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
     setCompactArmed(false);
     if (compactBusy) return;
     setCompactBusy(true);
-    setStatus(null);
+    clearStatus();
     /* #862: one durable operation per confirmed gesture. On a structured host
        this admits a real compaction, so a retry after a timeout or a failed
        response must replay that same operation — the id is only released once
@@ -497,8 +548,12 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
          compact this conversation again. It is held only while the outcome is
          genuinely unknown: a transport failure, or a throw below. */
       if (accepted || settled) compactOperationRef.current = null;
+      setCompactWatch(accepted ? operationId : null);
       setStatus(accepted
-        ? { kind: "ok", text: t("composer.compactSent") }
+        /* The Claude path reaches compaction by typing `/compact` into the
+           conversation, so the admitted line promises a sent command and
+           nothing more; the durable receipt says how it ended. */
+        ? { kind: "ok", text: t(claudeCompact ? "composer.compactSentClaude" : "composer.compactSent") }
         : { kind: "err", text: compactFailureText(t, body.receipt?.reason, body.error, body.code) });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
@@ -524,7 +579,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
         onRecheck={() => void recheck()}
         onTerminal={() => void copyAttachCommand()}
         onToggleOverflow={() => setOverflowOpen((open) => !open)}
-        status={resolvedStatus(status, file, t)}
+        status={compactOutcome ?? resolvedStatus(status, file, t)}
       />
       {attachOpen ? <AttachTerminalDialog file={file} mode={attachMode} onClose={() => setAttachOpen(false)} /> : null}
     </div>

--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -192,9 +192,11 @@ function compactFailureText(
  * What the durable compact receipt turned out to be (#1214). The strip's own
  * "sent" line is optimistic by necessity — it is written the moment the journal
  * admits the operation — so the receipt replaces it as soon as the operation
- * terminalizes. `uncertain` is the Claude path's honest ending: the command was
- * typed into the conversation and no compaction boundary was ever witnessed,
- * which the operator is told in those words rather than left to guess.
+ * terminalizes. The Claude path has two endings of its own, and the operator is
+ * told both in words rather than left to guess: `uncertain` means the command
+ * was typed and no boundary was ever witnessed, while a `failed`
+ * `compact-declined` means the engine answered the command and compacted
+ * nothing.
  */
 function compactReceiptStatus(
   t: TFunction,

--- a/src/components/agentCapabilities.test.ts
+++ b/src/components/agentCapabilities.test.ts
@@ -275,12 +275,17 @@ test("structured: stop+terminal+kill+runtime enabled, compact follows the engine
   expect(state("kill", f, view)).toBe("enabled");
   // Compact is a real durable control on codex-app-server (#862)...
   expect(state("compact", f, view)).toBe("enabled");
-  // ...and a genuine protocol gap on claude-broker, which names the engine.
-  expect(reason("compact", f, rv("claude-broker", "hosted"))).toBe("strip.compactEngineUnsupported");
-  // The cell gates on exactly what the server gates on: host kind as well as
-  // engine. A session view whose sessionKey never arrived defaults its engine to
-  // codex, so the host kind is what keeps a claude-broker cell honest...
-  expect(reason("compact", f, rvWithoutSessionKey("claude-broker"))).toBe("strip.compactEngineUnsupported");
+  /* ...and on claude-broker it is enabled too (#1214): the host types
+     `/compact` into the conversation, which is the only mechanism the
+     stream-json transport offers. The note is the caveat, and it is about what
+     the Viewer can confirm — never about what Claude can do. */
+  expect(state("compact", f, rv("claude-broker", "hosted"))).toBe("enabled");
+  expect(note("compact", f, rv("claude-broker", "hosted"))).toBe("strip.compactClaudeMessage");
+  /* The cell gates on exactly what the server gates on: host kind as well as
+     engine. A session view whose sessionKey never arrived defaults its engine to
+     codex, so the host kind decides the mechanism... */
+  expect(note("compact", f, rvWithoutSessionKey("claude-broker"))).toBe("strip.compactClaudeMessage");
+  expect(reason("compact", f, rvWithoutSessionKey("codex-app-server"))).toBe("strip.compactHostUnsupported");
   // ...and the turn, because admission rejects a compaction that races one.
   expect(reason("compact", f, rvTurn("running"))).toBe("strip.compactBusyTurn");
   expect(reason("compact", f, rvTurn("interrupt_requested"))).toBe("strip.compactBusyTurn");

--- a/src/components/agentCapabilities.ts
+++ b/src/components/agentCapabilities.ts
@@ -145,29 +145,37 @@ const structuredImages = (imageInput: RuntimeImageCapability | null | undefined)
   imageInput?.supported ? ENABLED : disabled("composer.structuredImagesProtocol");
 
 /**
- * Compact on a pane-less structured host (#862). Three facts decide the cell,
- * and they are exactly the three the server gates on, so a click can only be
- * refused for a reason that arrived after the render:
+ * Compact on a pane-less structured host (#862, reopened by #1214). Both
+ * structured host kinds can compact; what differs is what the Viewer can
+ * promise afterwards, and the cell says which:
  *
- * - the engine: codex-app-server exposes `thread/compact/start` and reports
- *   completion through the `contextCompaction` item, while the Claude
- *   stream-json protocol has no client-originated compact control at all;
- * - the host kind, which `dispatchStructuredControl` and journal admission both
- *   require to be codex-app-server (a session view missing `sessionKey`
- *   defaults its engine to codex, so the engine alone is not enough);
- * - the turn, because admission rejects a compaction that would race a live one
- *   — an enabled button there promises something the journal refuses. Both
- *   halves of that rejection are read: the turn axis AND a non-null
- *   `activeTurnId`, which a session can project while its axis still says idle.
+ * - codex-app-server sends `thread/compact/start` and reports completion
+ *   through the `contextCompaction` item, so the control is plainly enabled;
+ * - claude-broker has no compact subtype in its transport, so its host types
+ *   `/compact` into the conversation and can only witness the outcome if a
+ *   compaction boundary appears. The cell is enabled with a note saying that —
+ *   a caveat about what the Viewer can confirm, never about what Claude can do.
+ *
+ * The other two facts are exactly the ones the server gates on, so a click can
+ * only be refused for a reason that arrived after the render: the host kind,
+ * which `dispatchStructuredControl` and journal admission both require to be
+ * one of those two, and the turn, because admission rejects a compaction that
+ * would race a live one. Both halves of that rejection are read: the turn axis
+ * AND a non-null `activeTurnId`, which a session can project while its axis
+ * still says idle.
  */
 const structuredCompact = (session: RuntimeSessionView["session"] | undefined): Capability => {
-  if (session?.hostKind !== "codex-app-server" || session.sessionKey?.engine !== "codex") {
-    return disabled("strip.compactEngineUnsupported");
-  }
-  if (session.turn === "running" || session.turn === "interrupt_requested" || session.activeTurnId) {
+  /* A session view whose `sessionKey` payload never arrived defaults its engine
+     to codex, so the host kind decides the mechanism and the engine only has to
+     not contradict it. */
+  const mechanism = session?.hostKind === "codex-app-server" && session.sessionKey?.engine === "codex" ? "control"
+    : session?.hostKind === "claude-broker" && session.sessionKey?.engine !== "codex" ? "message"
+    : null;
+  if (!mechanism) return disabled("strip.compactHostUnsupported");
+  if (session!.turn === "running" || session!.turn === "interrupt_requested" || session!.activeTurnId) {
     return disabled("strip.compactBusyTurn");
   }
-  return ENABLED;
+  return mechanism === "message" ? enabledWithNote("strip.compactClaudeMessage") : ENABLED;
 };
 
 /** A structured (pane-less) host that is currently alive. Gated by the
@@ -311,8 +319,8 @@ export function capabilitiesFor(file: FileEntry, rv: RuntimeSessionView | null, 
         surface,
         controls: {
           stop: ENABLED,
-          // Compact is a real durable control on a Codex structured host and a
-          // genuine protocol gap on a Claude one (#862).
+          // Compact is a durable control on both structured host kinds; the
+          // cell's note says what the Viewer can confirm (#862, #1214).
           compact: structuredCompact(rv?.session),
           // The composer runtime pill owns selection here (issue #390): the cell
           // is enabled, and per-turn honesty comes from the session's negotiated

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import { translate } from "@/lib/i18n";
+
 import type { Flow } from "@/lib/flows/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { streamingVoiceDelivery } from "@/lib/runtime/voiceDelivery";
@@ -602,5 +604,16 @@ describe("humanReceiptReasonKey", () => {
     expect(humanReceiptReasonKey(" unhosted ")).toBe("receipt.human.deadHost"); // trimmed
     expect(humanReceiptReasonKey("quota-exceeded")).toBeNull();
     expect(humanReceiptReasonKey(null)).toBeNull();
+  });
+
+  test("a compaction that was sent and never witnessed has words of its own (#1214)", () => {
+    expect(humanReceiptReasonKey("compact-sent-unobserved")).toBe("receipt.human.compactSentUnobserved");
+    for (const locale of ["en", "uk"] as const) {
+      const sentence = translate(locale, "receipt.human.compactSentUnobserved");
+      expect(sentence.length).toBeGreaterThan(0);
+      /* The sentence is about what the Viewer could confirm, never about a
+         capability Claude is missing. */
+      expect(sentence.toLowerCase()).not.toContain("engine");
+    }
   });
 });

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -616,4 +616,15 @@ describe("humanReceiptReasonKey", () => {
       expect(sentence.toLowerCase()).not.toContain("engine");
     }
   });
+
+  test("a compaction the engine declined has words of its own (#1214)", () => {
+    expect(humanReceiptReasonKey("compact-declined")).toBe("receipt.human.compactDeclined");
+    for (const locale of ["en", "uk"] as const) {
+      const sentence = translate(locale, "receipt.human.compactDeclined");
+      /* Both halves, in both languages: the command went, and nothing was
+         compacted. Neither one alone is the truth. */
+      expect(sentence).toContain("/compact");
+      expect(sentence.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -794,6 +794,11 @@ export const RECEIPT_REASON_KEYS: Record<string, MessageKey> = {
   "stale-generation": "receipt.human.staleKey",
   "stale-turn": "receipt.human.staleKey",
   "unsupported-capability": "receipt.human.unsupportedCapability",
+  /* #1214: the Claude compact control typed `/compact` into the conversation
+     and no compaction boundary was ever observed. An outcome, not a refusal —
+     the command went, and this says exactly how far the Viewer can vouch for
+     it. */
+  "compact-sent-unobserved": "receipt.human.compactSentUnobserved",
 };
 
 /** The human sentence key for a receipt's reason, or null for an unknown one. */

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -799,6 +799,9 @@ export const RECEIPT_REASON_KEYS: Record<string, MessageKey> = {
      the command went, and this says exactly how far the Viewer can vouch for
      it. */
   "compact-sent-unobserved": "receipt.human.compactSentUnobserved",
+  /* #1214: the engine answered the `/compact` this control typed and compacted
+     nothing. The command still went, so the sentence says both halves. */
+  "compact-declined": "receipt.human.compactDeclined",
 };
 
 /** The human sentence key for a receipt's reason, or null for an unknown one. */

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -470,6 +470,7 @@ export const en = {
   "receipt.human.noTurn": "there is no active turn",
   "receipt.human.unsupportedCapability": "the Viewer has no channel for this control here",
   "receipt.human.compactSentUnobserved": "sent — the Viewer couldn’t confirm the compaction finished",
+  "receipt.human.compactDeclined": "sent — the agent finished /compact without compacting",
   "receipt.human.verbatim": "not delivered: {reason}",
 
   // DraftAgentPane

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -399,6 +399,8 @@ export const en = {
   "composer.compactConfirm": "Compact?",
   "composer.compactConfirmTitle": "Click again to send /compact",
   "composer.compactSent": "compaction started — the band will appear in the feed once it's done",
+  "composer.compactSentClaude": "/compact sent — the band appears in the feed if the agent compacts",
+  "composer.compactObserved": "context compacted",
   "composer.failedCompact": "couldn't start compaction",
   "composer.addImages": "Add images",
   "composer.moreTools": "More actions",
@@ -420,7 +422,8 @@ export const en = {
   "strip.stopSubagent": "interrupts the root agent",
   "strip.compactSubagent": "not available for subagents",
   "strip.structuredUnsupported": "the structured host does not support this action yet",
-  "strip.compactEngineUnsupported": "this engine has no compact control",
+  "strip.compactHostUnsupported": "the Viewer has no compact channel to this host",
+  "strip.compactClaudeMessage": "sends /compact into the conversation; the Viewer confirms it only if the compaction band appears",
   "strip.compactBusyTurn": "not while a turn is running",
   "strip.resolving": "resolving the agent host…",
 
@@ -465,7 +468,8 @@ export const en = {
   "receipt.human.duplicate": "already delivered",
   "receipt.human.turnActive": "the agent is mid-turn",
   "receipt.human.noTurn": "there is no active turn",
-  "receipt.human.unsupportedCapability": "this engine has no such control",
+  "receipt.human.unsupportedCapability": "the Viewer has no channel for this control here",
+  "receipt.human.compactSentUnobserved": "sent — the Viewer couldn’t confirm the compaction finished",
   "receipt.human.verbatim": "not delivered: {reason}",
 
   // DraftAgentPane

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -498,6 +498,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "receipt.human.noTurn": "немає активного ходу",
   "receipt.human.unsupportedCapability": "Viewer не має каналу для цієї команди тут",
   "receipt.human.compactSentUnobserved": "надіслано — Viewer не зміг підтвердити завершення стискання",
+  "receipt.human.compactDeclined": "надіслано — агент завершив /compact, нічого не стиснувши",
   "receipt.human.verbatim": "не доставлено: {reason}",
 
   "draft.readPrompt": "Прочитай розмову агента у файлі {src} і продовж роботу звідти: ",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -388,6 +388,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.compactConfirm": "Точно?",
   "composer.compactConfirmTitle": "Натисни ще раз, щоб надіслати /compact",
   "composer.compactSent": "стискання почалось — позначка з'явиться у стрічці, щойно завершиться",
+  "composer.compactSentClaude": "/compact надіслано — позначка з'явиться у стрічці, якщо агент стисне контекст",
+  "composer.compactObserved": "контекст стиснуто",
   "composer.failedCompact": "не вдалося запустити стискання",
   "composer.addImages": "Додати картинки",
   "composer.moreTools": "Додаткові дії",
@@ -448,7 +450,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "strip.stopSubagent": "перериває кореневого агента",
   "strip.compactSubagent": "недоступно для субагентів",
   "strip.structuredUnsupported": "структурований хост поки не підтримує цю дію",
-  "strip.compactEngineUnsupported": "цей двигун не має команди стиснення",
+  "strip.compactHostUnsupported": "Viewer не має каналу стиснення до цього хоста",
+  "strip.compactClaudeMessage": "надсилає /compact у розмову; Viewer підтвердить, лише якщо з'явиться позначка стискання",
   "strip.compactBusyTurn": "недоступно, поки триває хід",
   "strip.resolving": "визначаємо середовище агента…",
 
@@ -493,7 +496,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "receipt.human.duplicate": "вже доставлено",
   "receipt.human.turnActive": "агент посеред ходу",
   "receipt.human.noTurn": "немає активного ходу",
-  "receipt.human.unsupportedCapability": "цей двигун не має такої команди",
+  "receipt.human.unsupportedCapability": "Viewer не має каналу для цієї команди тут",
+  "receipt.human.compactSentUnobserved": "надіслано — Viewer не зміг підтвердити завершення стискання",
   "receipt.human.verbatim": "не доставлено: {reason}",
 
   "draft.readPrompt": "Прочитай розмову агента у файлі {src} і продовж роботу звідти: ",

--- a/src/lib/runtime/claudeStreamBrokerHost.compact.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.compact.test.ts
@@ -1,0 +1,313 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+
+import { afterAll, expect, test } from "bun:test";
+
+import { claudeTranscriptPath } from "@/lib/agent/transcript";
+
+import {
+  CLAUDE_COMPACT_COMMAND,
+  CLAUDE_COMPACT_UNOBSERVED_REASON,
+  ClaudeStreamBrokerHost,
+  fileClaudeCompactionEvidence,
+  type ClaudeCompactionEvidenceSource,
+  type ClaudeDeliveryLedger,
+  type ClaudeDeliveryState,
+} from "./claudeStreamBrokerHost";
+import { StructuredCompactError, type QueueEntry, type RuntimeEvent } from "./engineHost";
+import type { RuntimeEventStore } from "./eventStore";
+
+/**
+ * The Claude compact control (#1214). The stream-json transport has no compact
+ * subtype — `interrupt` and `can_use_tool` are the whole control channel — so
+ * the host reaches compaction the only way the transport allows: it types
+ * `/compact` into the conversation, then watches the session transcript for the
+ * compaction boundary. Every assertion here is about the two things that decide
+ * the control: the command is really sent (exactly once), and the outcome the
+ * receipt carries is the one that was actually witnessed.
+ */
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-compact-"));
+afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+
+class MemoryEventStore implements RuntimeEventStore {
+  private readonly events = new Map<string, RuntimeEvent[]>();
+
+  load(sessionId: string): RuntimeEvent[] {
+    return structuredClone(this.events.get(sessionId) ?? []);
+  }
+
+  append(sessionId: string, event: RuntimeEvent): void {
+    const events = this.events.get(sessionId) ?? [];
+    events.push(structuredClone(event));
+    this.events.set(sessionId, events);
+  }
+}
+
+class MemoryDeliveryLedger implements ClaudeDeliveryLedger {
+  readonly records: string[] = [];
+  private readonly states = new Map<string, ClaudeDeliveryState[]>();
+
+  load(sessionId: string): ClaudeDeliveryState[] {
+    return structuredClone(this.states.get(sessionId) ?? []);
+  }
+
+  recordQueued(sessionId: string, entry: QueueEntry, disposition: ClaudeDeliveryState["disposition"]): void {
+    this.records.push(`queued:${entry.id}`);
+    const states = this.states.get(sessionId) ?? [];
+    states.push({ entry: structuredClone(entry) as ClaudeDeliveryState["entry"], disposition, delivered: false });
+    this.states.set(sessionId, states);
+  }
+
+  confirmDelivered(sessionId: string, entryId: string): void {
+    this.records.push(`delivered:${entryId}`);
+  }
+}
+
+class FakeClaude extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 4242;
+  readonly inputs: Array<Record<string, unknown>> = [];
+
+  constructor() {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += String(chunk);
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line) this.inputs.push(JSON.parse(line) as Record<string, unknown>);
+        newline = buffer.indexOf("\n");
+      }
+    });
+  }
+
+  emitJson(value: unknown): void {
+    this.stdout.write(`${JSON.stringify(value)}\n`);
+  }
+
+  kill(): boolean {
+    queueMicrotask(() => this.emit("close", 0, "SIGTERM"));
+    return true;
+  }
+}
+
+/** Waits for a fixture condition without pinning the test to a stream tick. */
+async function waitFor(check: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (check()) return;
+    await Bun.sleep(2);
+  }
+  throw new Error(label);
+}
+
+/** Every `/compact` frame the child was actually handed. */
+function compactFrames(child: FakeClaude): Array<Record<string, unknown>> {
+  return child.inputs.filter((input) => {
+    if (input.type !== "user") return false;
+    const message = input.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
+    return (message?.content ?? []).some((block) => block.type === "text" && block.text === CLAUDE_COMPACT_COMMAND);
+  });
+}
+
+/** A scripted evidence channel: the test decides when a boundary appears. */
+function scriptedEvidence(): ClaudeCompactionEvidenceSource & { announce(uuid: string | null): void } {
+  let pending: Array<{ uuid: string | null; trigger: string | null }> = [];
+  return {
+    cursor: () => 128,
+    read: ({ fromByte }) => {
+      const boundaries = pending;
+      pending = [];
+      return { boundaries, cursor: fromByte };
+    },
+    announce(uuid) { pending = [{ uuid, trigger: "manual" }]; },
+  };
+}
+
+function startHost(options: {
+  child: FakeClaude;
+  compactionEvidence?: ClaudeCompactionEvidenceSource;
+  compactEvidenceTimeoutMs?: number;
+  compactEvidencePollMs?: number;
+} ): Promise<ClaudeStreamBrokerHost> {
+  return ClaudeStreamBrokerHost.start({
+    cwd: sandbox,
+    eventStore: new MemoryEventStore(),
+    deliveryLedger: new MemoryDeliveryLedger(),
+    readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+    readTranscript: () => [],
+    compactEvidencePollMs: options.compactEvidencePollMs ?? 2,
+    compactEvidenceTimeoutMs: options.compactEvidenceTimeoutMs ?? 2_000,
+    ...(options.compactionEvidence ? { compactionEvidence: options.compactionEvidence } : {}),
+    /* A fixture never signals a real process group: the fake child's own
+       `kill` is the fallback, and no pid on this machine is touched. */
+    signalProcess: () => { throw new Error("fixture has no process group"); },
+    processIdentity: () => "fixture-identity",
+    spawnProcess: ((_command: string, _args: string[], _spawnOptions: SpawnOptionsWithoutStdio) =>
+      options.child as unknown as ChildProcessWithoutNullStreams),
+  });
+}
+
+test("the compact control types /compact once and terminalizes on the observed transcript boundary", async () => {
+  const child = new FakeClaude();
+  const evidence = scriptedEvidence();
+  const host = await startHost({ child, compactionEvidence: evidence });
+  try {
+    const compaction = host.compact({ operationId: "op-compact", threadId: host.identity.sessionId });
+
+    /* The command reaches the conversation as a message — the transport offers
+       no other way — and it carries nothing but the command itself. */
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+    expect(compactFrames(child)[0]).toMatchObject({
+      type: "user",
+      session_id: host.identity.sessionId,
+      message: { role: "user", content: [{ type: "text", text: "/compact" }] },
+    });
+
+    evidence.announce("boundary-one");
+    expect(await compaction).toEqual({ compactionId: "boundary-one" });
+  } finally {
+    await host.release();
+  }
+});
+
+test("a compaction nobody witnessed terminalizes as sent-but-unobservable, never as success", async () => {
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 25 });
+  try {
+    const outcome = await host.compact({ operationId: "op-silent", threadId: host.identity.sessionId })
+      .then(() => "resolved", (error: unknown) => error);
+
+    expect(outcome).toBeInstanceOf(StructuredCompactError);
+    expect((outcome as StructuredCompactError).phase).toBe("unverified");
+    expect((outcome as StructuredCompactError).message).toBe(CLAUDE_COMPACT_UNOBSERVED_REASON);
+    /* The command was still sent: the operator asked for it, and the receipt
+       says exactly what is known about the outcome. */
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+  } finally {
+    await host.release();
+  }
+});
+
+test("a retry on the same operation replays the outcome instead of typing /compact twice", async () => {
+  const child = new FakeClaude();
+  const evidence = scriptedEvidence();
+  const host = await startHost({ child, compactionEvidence: evidence });
+  try {
+    const first = host.compact({ operationId: "op-once", threadId: host.identity.sessionId });
+    const concurrent = host.compact({ operationId: "op-once", threadId: host.identity.sessionId });
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+
+    evidence.announce("boundary-once");
+    expect(await first).toEqual({ compactionId: "boundary-once" });
+    expect(await concurrent).toEqual({ compactionId: "boundary-once" });
+
+    /* A caller that gave up and retried after the outcome landed replays it. */
+    expect(await host.compact({ operationId: "op-once", threadId: host.identity.sessionId }))
+      .toEqual({ compactionId: "boundary-once" });
+    expect(compactFrames(child)).toHaveLength(1);
+  } finally {
+    await host.release();
+  }
+});
+
+test("a compaction refused before the command is written sends nothing", async () => {
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactionEvidence: scriptedEvidence() });
+  try {
+    /* Someone else's session. */
+    await expect(host.compact({ operationId: "op-foreign", threadId: "another-session" }))
+      .rejects.toMatchObject({ phase: "refused" });
+
+    /* A live turn: compaction underneath a running turn is the race this
+       control must not run, and admission already fenced it once. The delivery
+       stays in flight — its echo never arrives in this fixture. */
+    const delivery = host.send({ id: "entry-one", text: "hello" });
+    void delivery.catch(() => undefined);
+    await expect(host.compact({ operationId: "op-busy", threadId: host.identity.sessionId }))
+      .rejects.toMatchObject({ phase: "refused" });
+
+    await Bun.sleep(10);
+    expect(compactFrames(child)).toHaveLength(0);
+  } finally {
+    await host.release();
+  }
+});
+
+test("a host that dies mid-compaction terminalizes unverified rather than hanging", async () => {
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 60_000 });
+  const compaction = host.compact({ operationId: "op-dead", threadId: host.identity.sessionId })
+    .then(() => "resolved", (error: unknown) => error);
+  child.emitJson({ type: "system", subtype: "init", apiKeySource: "oops" });
+
+  const outcome = await compaction;
+  expect(outcome).toBeInstanceOf(StructuredCompactError);
+  expect((outcome as StructuredCompactError).phase).toBe("unverified");
+});
+
+test("a compaction boundary announced on the stream settles the control immediately", async () => {
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 60_000 });
+  try {
+    const compaction = host.compact({ operationId: "op-stream", threadId: host.identity.sessionId });
+    child.emitJson({
+      type: "system",
+      subtype: "compact_boundary",
+      session_id: host.identity.sessionId,
+      uuid: "boundary-stream",
+      compactMetadata: { trigger: "manual", preTokens: 900_000 },
+    });
+
+    expect(await compaction).toEqual({ compactionId: "boundary-stream" });
+  } finally {
+    await host.release();
+  }
+});
+
+test("the transcript evidence source reports only boundaries appended after the fence", () => {
+  const projectsRoot = fs.mkdtempSync(path.join(sandbox, "projects-"));
+  const cwd = path.join(sandbox, "repo");
+  const sessionId = "session-compact-evidence";
+  const transcript = claudeTranscriptPath(cwd, sessionId, projectsRoot);
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  /* The record shape the CLI writes: only `uuid` and the trigger are read, so
+     the fixture carries no identifier of any real conversation. */
+  const boundary = (uuid: string, trigger: string) => JSON.stringify({
+    type: "system",
+    subtype: "compact_boundary",
+    uuid,
+    compactMetadata: { trigger, preTokens: 850_932, postTokens: 11_926 },
+  });
+  fs.writeFileSync(transcript, `${boundary("older-boundary", "auto")}\n`);
+
+  const fence = fileClaudeCompactionEvidence.cursor({ cwd, sessionId, projectsRoot });
+  expect(fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: fence }).boundaries).toEqual([]);
+
+  /* A record still being written is not evidence until its newline lands. */
+  fs.appendFileSync(transcript, `${JSON.stringify({ type: "assistant" })}\n${boundary("fresh-boundary", "manual")}`);
+  const partial = fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: fence });
+  expect(partial.boundaries).toEqual([]);
+
+  fs.appendFileSync(transcript, "\n");
+  const observed = fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: partial.cursor });
+  expect(observed.boundaries).toEqual([{ uuid: "fresh-boundary", trigger: "manual" }]);
+  /* The cursor advances, so the same boundary is never counted twice. */
+  expect(fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: observed.cursor }).boundaries)
+    .toEqual([]);
+});
+
+test("a missing transcript is not evidence of anything", () => {
+  const projectsRoot = fs.mkdtempSync(path.join(sandbox, "empty-projects-"));
+  const input = { cwd: path.join(sandbox, "gone"), sessionId: "absent", projectsRoot };
+  expect(fileClaudeCompactionEvidence.cursor(input)).toBe(0);
+  expect(fileClaudeCompactionEvidence.read({ ...input, fromByte: 0 })).toEqual({ boundaries: [], cursor: 0 });
+});

--- a/src/lib/runtime/claudeStreamBrokerHost.compact.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.compact.test.ts
@@ -7,14 +7,11 @@ import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "n
 
 import { afterAll, expect, test } from "bun:test";
 
-import { claudeTranscriptPath } from "@/lib/agent/transcript";
-
 import {
   CLAUDE_COMPACT_COMMAND,
+  CLAUDE_COMPACT_DECLINED_REASON,
   CLAUDE_COMPACT_UNOBSERVED_REASON,
   ClaudeStreamBrokerHost,
-  fileClaudeCompactionEvidence,
-  type ClaudeCompactionEvidenceSource,
   type ClaudeDeliveryLedger,
   type ClaudeDeliveryState,
 } from "./claudeStreamBrokerHost";
@@ -25,10 +22,12 @@ import type { RuntimeEventStore } from "./eventStore";
  * The Claude compact control (#1214). The stream-json transport has no compact
  * subtype — `interrupt` and `can_use_tool` are the whole control channel — so
  * the host reaches compaction the only way the transport allows: it types
- * `/compact` into the conversation, then watches the session transcript for the
- * compaction boundary. Every assertion here is about the two things that decide
- * the control: the command is really sent (exactly once), and the outcome the
- * receipt carries is the one that was actually witnessed.
+ * `/compact` into the conversation and reads the outcome off the stream it
+ * already consumes: `system/compact_boundary` when the engine compacted, and
+ * the command's own boundary-less `result` when it declined. Every assertion
+ * here is about the two things that decide the control: the command is really
+ * sent (exactly once), and the outcome the receipt carries is the one that was
+ * actually witnessed.
  */
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-compact-"));
@@ -101,9 +100,9 @@ class FakeClaude extends EventEmitter {
 }
 
 /** Waits for a fixture condition without pinning the test to a stream tick. */
-async function waitFor(check: () => boolean, label: string): Promise<void> {
+async function waitFor(check: () => boolean | Promise<boolean>, label: string): Promise<void> {
   for (let attempt = 0; attempt < 300; attempt += 1) {
-    if (check()) return;
+    if (await check()) return;
     await Bun.sleep(2);
   }
   throw new Error(label);
@@ -118,25 +117,32 @@ function compactFrames(child: FakeClaude): Array<Record<string, unknown>> {
   });
 }
 
-/** A scripted evidence channel: the test decides when a boundary appears. */
-function scriptedEvidence(): ClaudeCompactionEvidenceSource & { announce(uuid: string | null): void } {
-  let pending: Array<{ uuid: string | null; trigger: string | null }> = [];
-  return {
-    cursor: () => 128,
-    read: ({ fromByte }) => {
-      const boundaries = pending;
-      pending = [];
-      return { boundaries, cursor: fromByte };
-    },
-    announce(uuid) { pending = [{ uuid, trigger: "manual" }]; },
-  };
+/** The boundary frame the CLI announces on stdout when it compacted. */
+function announceBoundary(child: FakeClaude, host: ClaudeStreamBrokerHost, uuid: string): void {
+  child.emitJson({
+    type: "system",
+    subtype: "compact_boundary",
+    session_id: host.identity.sessionId,
+    uuid,
+    compact_metadata: { trigger: "manual", pre_tokens: 850_932, post_tokens: 11_926 },
+  });
+}
+
+/** The frame the CLI answers `/compact` with once it is done with the command;
+    it belongs to no turn, because the compaction never took a turn slot. */
+function announceResult(child: FakeClaude, host: ClaudeStreamBrokerHost): void {
+  child.emitJson({
+    type: "result",
+    subtype: "success",
+    session_id: host.identity.sessionId,
+    is_error: false,
+    num_turns: 0,
+  });
 }
 
 function startHost(options: {
   child: FakeClaude;
-  compactionEvidence?: ClaudeCompactionEvidenceSource;
   compactEvidenceTimeoutMs?: number;
-  compactEvidencePollMs?: number;
 } ): Promise<ClaudeStreamBrokerHost> {
   return ClaudeStreamBrokerHost.start({
     cwd: sandbox,
@@ -144,9 +150,7 @@ function startHost(options: {
     deliveryLedger: new MemoryDeliveryLedger(),
     readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
     readTranscript: () => [],
-    compactEvidencePollMs: options.compactEvidencePollMs ?? 2,
     compactEvidenceTimeoutMs: options.compactEvidenceTimeoutMs ?? 2_000,
-    ...(options.compactionEvidence ? { compactionEvidence: options.compactionEvidence } : {}),
     /* A fixture never signals a real process group: the fake child's own
        `kill` is the fallback, and no pid on this machine is touched. */
     signalProcess: () => { throw new Error("fixture has no process group"); },
@@ -156,10 +160,9 @@ function startHost(options: {
   });
 }
 
-test("the compact control types /compact once and terminalizes on the observed transcript boundary", async () => {
+test("the compact control types /compact once and terminalizes on the boundary the CLI announces", async () => {
   const child = new FakeClaude();
-  const evidence = scriptedEvidence();
-  const host = await startHost({ child, compactionEvidence: evidence });
+  const host = await startHost({ child });
   try {
     const compaction = host.compact({ operationId: "op-compact", threadId: host.identity.sessionId });
 
@@ -172,8 +175,83 @@ test("the compact control types /compact once and terminalizes on the observed t
       message: { role: "user", content: [{ type: "text", text: "/compact" }] },
     });
 
-    evidence.announce("boundary-one");
+    announceBoundary(child, host, "boundary-one");
     expect(await compaction).toEqual({ compactionId: "boundary-one" });
+  } finally {
+    await host.release();
+  }
+});
+
+test("the boundary settles the control before the command's own result can call it declined", async () => {
+  /* The CLI emits the boundary and then closes the command with a `result`,
+     which is what makes a boundary-less `result` legible as a decline. */
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactEvidenceTimeoutMs: 60_000 });
+  try {
+    const compaction = host.compact({ operationId: "op-order", threadId: host.identity.sessionId });
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+
+    announceBoundary(child, host, "boundary-then-result");
+    announceResult(child, host);
+
+    expect(await compaction).toEqual({ compactionId: "boundary-then-result" });
+  } finally {
+    await host.release();
+  }
+});
+
+test("a /compact the engine declines terminalizes at once instead of waiting out the budget", async () => {
+  /* "Error: No messages to compact" is the everyday shape: the CLI answers the
+     command, emits no boundary, and closes it with a `result` that belongs to
+     no turn. Sitting out five minutes for evidence the engine already declined
+     to produce would be an honest verdict reached silently and far too late. */
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactEvidenceTimeoutMs: 60_000 });
+  try {
+    const compaction = host.compact({ operationId: "op-declined", threadId: host.identity.sessionId })
+      .then(() => "resolved", (error: unknown) => error);
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+
+    child.emitJson({
+      type: "assistant",
+      session_id: host.identity.sessionId,
+      message: { role: "assistant", model: "<synthetic>", content: [{ type: "text", text: "Error: No messages to compact" }] },
+    });
+    announceResult(child, host);
+
+    const outcome = await compaction;
+    expect(outcome).toBeInstanceOf(StructuredCompactError);
+    /* `refused` is the phase the queue turns into a visible failed receipt: the
+       engine did not compact, and the reason says so without claiming one. */
+    expect((outcome as StructuredCompactError).phase).toBe("refused");
+    expect((outcome as StructuredCompactError).message).toBe(CLAUDE_COMPACT_DECLINED_REASON);
+  } finally {
+    await host.release();
+  }
+});
+
+test("a result that belongs to a live turn is not a compaction decline", async () => {
+  /* Only the compaction runs off the turn plane, so only a result no turn
+     claims can be the `/compact` command's. A turn's own result must never
+     terminalize a compaction that is still running. */
+  const child = new FakeClaude();
+  const host = await startHost({ child, compactEvidenceTimeoutMs: 60_000 });
+  try {
+    const compaction = host.compact({ operationId: "op-turn-result", threadId: host.identity.sessionId });
+    await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
+
+    /* A delivery the queue's barrier would normally hold back; its echo opens a
+       turn, so the result that follows is that turn's. */
+    void host.send({ id: "entry-turn", text: "hello" }).catch(() => undefined);
+    await waitFor(async () => (await host.health()).activeTurnRef !== null, "the delivery never opened a turn");
+    announceResult(child, host);
+
+    /* Still running: nothing declined it. */
+    expect(await Promise.race([compaction.then(() => "settled", () => "settled"), Bun.sleep(30).then(() => "pending")]))
+      .toBe("pending");
+
+    announceBoundary(child, host, "boundary-after-turn");
+    expect(await compaction).toEqual({ compactionId: "boundary-after-turn" });
   } finally {
     await host.release();
   }
@@ -181,7 +259,7 @@ test("the compact control types /compact once and terminalizes on the observed t
 
 test("a compaction nobody witnessed terminalizes as sent-but-unobservable, never as success", async () => {
   const child = new FakeClaude();
-  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 25 });
+  const host = await startHost({ child, compactEvidenceTimeoutMs: 25 });
   try {
     const outcome = await host.compact({ operationId: "op-silent", threadId: host.identity.sessionId })
       .then(() => "resolved", (error: unknown) => error);
@@ -199,14 +277,13 @@ test("a compaction nobody witnessed terminalizes as sent-but-unobservable, never
 
 test("a retry on the same operation replays the outcome instead of typing /compact twice", async () => {
   const child = new FakeClaude();
-  const evidence = scriptedEvidence();
-  const host = await startHost({ child, compactionEvidence: evidence });
+  const host = await startHost({ child });
   try {
     const first = host.compact({ operationId: "op-once", threadId: host.identity.sessionId });
     const concurrent = host.compact({ operationId: "op-once", threadId: host.identity.sessionId });
     await waitFor(() => compactFrames(child).length === 1, "the /compact frame never reached the child");
 
-    evidence.announce("boundary-once");
+    announceBoundary(child, host, "boundary-once");
     expect(await first).toEqual({ compactionId: "boundary-once" });
     expect(await concurrent).toEqual({ compactionId: "boundary-once" });
 
@@ -221,7 +298,7 @@ test("a retry on the same operation replays the outcome instead of typing /compa
 
 test("a compaction refused before the command is written sends nothing", async () => {
   const child = new FakeClaude();
-  const host = await startHost({ child, compactionEvidence: scriptedEvidence() });
+  const host = await startHost({ child });
   try {
     /* Someone else's session. */
     await expect(host.compact({ operationId: "op-foreign", threadId: "another-session" }))
@@ -244,7 +321,7 @@ test("a compaction refused before the command is written sends nothing", async (
 
 test("a host that dies mid-compaction terminalizes unverified rather than hanging", async () => {
   const child = new FakeClaude();
-  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 60_000 });
+  const host = await startHost({ child, compactEvidenceTimeoutMs: 60_000 });
   const compaction = host.compact({ operationId: "op-dead", threadId: host.identity.sessionId })
     .then(() => "resolved", (error: unknown) => error);
   child.emitJson({ type: "system", subtype: "init", apiKeySource: "oops" });
@@ -252,62 +329,4 @@ test("a host that dies mid-compaction terminalizes unverified rather than hangin
   const outcome = await compaction;
   expect(outcome).toBeInstanceOf(StructuredCompactError);
   expect((outcome as StructuredCompactError).phase).toBe("unverified");
-});
-
-test("a compaction boundary announced on the stream settles the control immediately", async () => {
-  const child = new FakeClaude();
-  const host = await startHost({ child, compactionEvidence: scriptedEvidence(), compactEvidenceTimeoutMs: 60_000 });
-  try {
-    const compaction = host.compact({ operationId: "op-stream", threadId: host.identity.sessionId });
-    child.emitJson({
-      type: "system",
-      subtype: "compact_boundary",
-      session_id: host.identity.sessionId,
-      uuid: "boundary-stream",
-      compactMetadata: { trigger: "manual", preTokens: 900_000 },
-    });
-
-    expect(await compaction).toEqual({ compactionId: "boundary-stream" });
-  } finally {
-    await host.release();
-  }
-});
-
-test("the transcript evidence source reports only boundaries appended after the fence", () => {
-  const projectsRoot = fs.mkdtempSync(path.join(sandbox, "projects-"));
-  const cwd = path.join(sandbox, "repo");
-  const sessionId = "session-compact-evidence";
-  const transcript = claudeTranscriptPath(cwd, sessionId, projectsRoot);
-  fs.mkdirSync(path.dirname(transcript), { recursive: true });
-  /* The record shape the CLI writes: only `uuid` and the trigger are read, so
-     the fixture carries no identifier of any real conversation. */
-  const boundary = (uuid: string, trigger: string) => JSON.stringify({
-    type: "system",
-    subtype: "compact_boundary",
-    uuid,
-    compactMetadata: { trigger, preTokens: 850_932, postTokens: 11_926 },
-  });
-  fs.writeFileSync(transcript, `${boundary("older-boundary", "auto")}\n`);
-
-  const fence = fileClaudeCompactionEvidence.cursor({ cwd, sessionId, projectsRoot });
-  expect(fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: fence }).boundaries).toEqual([]);
-
-  /* A record still being written is not evidence until its newline lands. */
-  fs.appendFileSync(transcript, `${JSON.stringify({ type: "assistant" })}\n${boundary("fresh-boundary", "manual")}`);
-  const partial = fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: fence });
-  expect(partial.boundaries).toEqual([]);
-
-  fs.appendFileSync(transcript, "\n");
-  const observed = fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: partial.cursor });
-  expect(observed.boundaries).toEqual([{ uuid: "fresh-boundary", trigger: "manual" }]);
-  /* The cursor advances, so the same boundary is never counted twice. */
-  expect(fileClaudeCompactionEvidence.read({ cwd, sessionId, projectsRoot, fromByte: observed.cursor }).boundaries)
-    .toEqual([]);
-});
-
-test("a missing transcript is not evidence of anything", () => {
-  const projectsRoot = fs.mkdtempSync(path.join(sandbox, "empty-projects-"));
-  const input = { cwd: path.join(sandbox, "gone"), sessionId: "absent", projectsRoot };
-  expect(fileClaudeCompactionEvidence.cursor(input)).toBe(0);
-  expect(fileClaudeCompactionEvidence.read({ ...input, fromByte: 0 })).toEqual({ boundaries: [], cursor: 0 });
 });

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -75,7 +75,6 @@ type PendingCompaction = {
   reject(error: StructuredCompactError): void;
   settled: boolean;
   timer: ReturnType<typeof setTimeout> | null;
-  poll: ReturnType<typeof setInterval> | null;
 };
 
 export interface ClaudeDeliveryState {
@@ -225,11 +224,7 @@ export interface ClaudeStreamBrokerHostOptions {
   processIdentity?: (pid: number) => string | null;
   readAuthStatus?: () => ClaudeAuthStatus | Promise<ClaudeAuthStatus>;
   readTranscript?: (cwd: string, sessionId: string) => ClaudeTranscriptUser[];
-  /** Where a compaction can be witnessed (#1214); defaults to the session
-      transcript. */
-  compactionEvidence?: ClaudeCompactionEvidenceSource;
   compactEvidenceTimeoutMs?: number;
-  compactEvidencePollMs?: number;
   eventStore?: RuntimeEventStore;
   deliveryLedger?: ClaudeDeliveryLedger;
   readImage?: (ref: StructuredImageRef) => Buffer;
@@ -242,96 +237,6 @@ export interface ClaudeTranscriptUser {
   uuid: string | null;
   timestamp: string | null;
 }
-
-/** One compaction boundary the session transcript recorded. `uuid` names the
-    record when it carries one, so the durable receipt can say which compaction
-    closed the operation. */
-export interface ClaudeCompactionBoundary {
-  uuid: string | null;
-  trigger: string | null;
-}
-
-export interface ClaudeCompactionEvidence {
-  boundaries: ClaudeCompactionBoundary[];
-  /** Byte offset the next read resumes from; only complete records are ever
-      consumed, so a half-written line is re-read rather than missed. */
-  cursor: number;
-}
-
-export interface ClaudeCompactionEvidenceInput {
-  cwd: string;
-  sessionId: string;
-  projectsRoot?: string;
-}
-
-/**
- * Where a Claude compaction can be *witnessed*. The stream-json transport has
- * no compact control and reports no compaction outcome, so the only durable
- * evidence is the `compact_boundary` record the CLI writes into the session
- * transcript. The seam is injectable for the same reason `readTranscript` is:
- * a test must never depend on the operator's `~/.claude` tree.
- */
-export interface ClaudeCompactionEvidenceSource {
-  /** The fence a compaction's evidence must appear after — the transcript's
-      current end. Boundaries already in the file belong to earlier
-      compactions and can never close this operation. */
-  cursor(input: ClaudeCompactionEvidenceInput): number;
-  /** Boundary records appended since `fromByte`. */
-  read(input: ClaudeCompactionEvidenceInput & { fromByte: number }): ClaudeCompactionEvidence;
-}
-
-/** Marker every boundary record carries, cheap enough to test every line on. */
-const COMPACT_BOUNDARY_MARKER = '"compact_boundary"';
-/** Upper bound on one evidence pass. Polls read only what was appended since
-    the previous pass, so this only caps a transcript that grew explosively
-    between two reads — the next pass picks up where this one stopped. */
-const MAX_COMPACT_EVIDENCE_READ_BYTES = 4 * 1024 * 1024;
-
-function transcriptSize(filename: string): number {
-  try { return fs.statSync(filename).size; } catch { return 0; }
-}
-
-/** The session transcript read as a compaction evidence channel. */
-export const fileClaudeCompactionEvidence: ClaudeCompactionEvidenceSource = {
-  cursor: (input) => transcriptSize(claudeTranscriptPath(input.cwd, input.sessionId, input.projectsRoot)),
-  read: (input) => {
-    const filename = claudeTranscriptPath(input.cwd, input.sessionId, input.projectsRoot);
-    const size = transcriptSize(filename);
-    /* A transcript that shrank was rotated or rewritten under us; the old
-       offset names nothing, so evidence is read from the new head. */
-    const from = size < input.fromByte ? 0 : input.fromByte;
-    if (size <= from) return { boundaries: [], cursor: from };
-    let text: string;
-    try {
-      const fd = fs.openSync(filename, "r");
-      try {
-        const length = Math.min(size - from, MAX_COMPACT_EVIDENCE_READ_BYTES);
-        const buffer = Buffer.alloc(length);
-        const read = fs.readSync(fd, buffer, 0, length, from);
-        text = buffer.toString("utf8", 0, read);
-      } finally {
-        fs.closeSync(fd);
-      }
-    } catch {
-      return { boundaries: [], cursor: input.fromByte };
-    }
-    const lastNewline = text.lastIndexOf("\n");
-    if (lastNewline < 0) return { boundaries: [], cursor: from };
-    const complete = text.slice(0, lastNewline);
-    const boundaries: ClaudeCompactionBoundary[] = [];
-    for (const line of complete.split("\n")) {
-      if (!line.includes(COMPACT_BOUNDARY_MARKER)) continue;
-      let value: JsonObject | null = null;
-      try { value = record(JSON.parse(line)); } catch { continue; }
-      if (value?.type !== "system" || value.subtype !== "compact_boundary") continue;
-      boundaries.push({
-        uuid: stringField(value, "uuid"),
-        trigger: stringField(record(value.compactMetadata), "trigger"),
-      });
-    }
-    return { boundaries, cursor: from + Buffer.byteLength(complete) + 1 };
-  },
-};
 
 const CHILD_ENV_ALLOWLIST = [
   "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TMP", "TEMP", "LANG",
@@ -355,12 +260,22 @@ export const CLAUDE_COMPACT_COMMAND = "/compact";
  */
 export const CLAUDE_COMPACT_UNOBSERVED_REASON = "compact-sent-unobserved";
 
+/**
+ * The durable receipt reason for a `/compact` the engine handled and declined.
+ * The CLI answers the command with a `result` frame once it is done with it,
+ * and that frame belongs to no turn — the compaction takes no turn slot. A
+ * boundary always precedes it when there was one to emit, so a `result` with
+ * no boundary behind it is the engine saying it compacted nothing ("Error: No
+ * messages to compact" is the everyday case). Waiting out the evidence budget
+ * for a boundary the engine already declined to write would be a silent wait,
+ * so this terminalizes at once.
+ */
+export const CLAUDE_COMPACT_DECLINED_REASON = "compact-declined";
+
 /** How long a compaction may run before its outcome counts as unobservable.
     Compaction re-reads the whole thread through the model — a manual one
     observed locally took ~2.5 minutes — so the budget is generous. */
 const DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS = 5 * 60_000;
-/** How often the transcript is re-read for a boundary while one is pending. */
-const DEFAULT_COMPACT_EVIDENCE_POLL_MS = 1_000;
 
 /** Durable launch evidence: hosts that launched with the native multi-agent
     denial advertise the effective denied-tool set so registry snapshots and
@@ -637,11 +552,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly eventStore: RuntimeEventStore;
   private readonly deliveryLedger: ClaudeDeliveryLedger;
   private readonly readImage: (ref: StructuredImageRef) => Buffer;
-  private readonly cwd: string;
-  private readonly projectsRoot: string | undefined;
-  private readonly compactionEvidence: ClaudeCompactionEvidenceSource;
   private readonly compactEvidenceTimeoutMs: number;
-  private readonly compactEvidencePollMs: number;
   private readonly requestTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
@@ -697,11 +608,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.deliveryLedger = options.deliveryLedger ?? new FileClaudeDeliveryLedger();
     this.readImage = options.readImage ?? ((ref) => runtimeImageStore().read(ref));
-    this.cwd = options.cwd;
-    this.projectsRoot = options.claudeProjectsDir;
-    this.compactionEvidence = options.compactionEvidence ?? fileClaudeCompactionEvidence;
     this.compactEvidenceTimeoutMs = options.compactEvidenceTimeoutMs ?? DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS;
-    this.compactEvidencePollMs = options.compactEvidencePollMs ?? DEFAULT_COMPACT_EVIDENCE_POLL_MS;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
@@ -968,19 +875,22 @@ export class ClaudeStreamBrokerHost implements EngineHost {
    * conversation, exactly as the operator would in the terminal.
    *
    * That mechanism buys no knowledge of the outcome, so none is claimed. The
-   * promise settles only on a *witnessed* compaction: a `compact_boundary`
-   * record appended to the session transcript after the command went (or the
-   * same boundary announced on the stream). Nothing arriving inside the
-   * evidence budget terminalizes `unverified` with
+   * promise settles only on a *witnessed* compaction: the `compact_boundary`
+   * frame the CLI announces on this host's own stream, which is the same
+   * boundary it writes to the transcript and arrives without anyone tailing a
+   * file for it. An engine that declines the command answers it with a
+   * boundary-less `result` and terminalizes `CLAUDE_COMPACT_DECLINED_REASON`
+   * on the spot. Only a compaction that neither finished nor was declined
+   * inside the evidence budget terminalizes `unverified` with
    * `CLAUDE_COMPACT_UNOBSERVED_REASON` — "sent, completion not observable" —
    * which is the honest verdict and an acceptable outcome. It is never
    * reported as success, and it never spins forever.
    *
    * The compaction is deliberately left out of the turn plane: it is not a
-   * delivery, so it takes no ledger row and no turn slot, and the `result` the
-   * CLI answers with lands on an empty turn queue and is ignored. The delivery
-   * queue holds messages behind an unfinished compaction, so the turn queue is
-   * empty for the duration.
+   * delivery, so it takes no ledger row and no turn slot, which is exactly why
+   * the `result` the CLI answers with is legible as this command's. The
+   * delivery queue holds messages behind an unfinished compaction, so the turn
+   * queue is empty for the duration.
    */
   async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
     /* One durable operation, one `/compact`. A caller that timed out and
@@ -1015,26 +925,16 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       reject: (error) => rejectOutcome(error),
       settled: false,
       timer: null,
-      poll: null,
     };
     /* A retry that arrives while the command is being written finds the entry
        here, so the registration happens before the frame. */
     this.compactions.set(request.operationId, compaction);
     void promise.catch(() => undefined);
-    /* Only boundaries appended after this offset can belong to this request;
-       the ones already in the transcript closed earlier compactions. */
-    let cursor = this.readCompactionCursor();
     this.write({
       type: "user",
       session_id: this.identity.sessionId,
       message: { role: "user", content: [{ type: "text", text: CLAUDE_COMPACT_COMMAND }] },
     });
-    compaction.poll = setInterval(() => {
-      const evidence = this.readCompactionEvidence(cursor);
-      cursor = evidence.cursor;
-      const boundary = evidence.boundaries.at(-1);
-      if (boundary) this.settleCompaction(compaction, { compactionId: boundary.uuid });
-    }, this.compactEvidencePollMs);
     compaction.timer = setTimeout(() => {
       this.settleCompaction(
         compaction,
@@ -1044,44 +944,15 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     return promise;
   }
 
-  private readCompactionCursor(): number {
-    try {
-      return this.compactionEvidence.cursor({
-        cwd: this.cwd,
-        sessionId: this.identity.sessionId,
-        ...(this.projectsRoot ? { projectsRoot: this.projectsRoot } : {}),
-      });
-    } catch {
-      /* An unreadable transcript is not evidence of anything: start at the
-         head and let the boundary check decide. */
-      return 0;
-    }
-  }
-
-  private readCompactionEvidence(fromByte: number): ClaudeCompactionEvidence {
-    try {
-      return this.compactionEvidence.read({
-        cwd: this.cwd,
-        sessionId: this.identity.sessionId,
-        ...(this.projectsRoot ? { projectsRoot: this.projectsRoot } : {}),
-        fromByte,
-      });
-    } catch {
-      return { boundaries: [], cursor: fromByte };
-    }
-  }
-
-  /** Settles one compaction exactly once and stops watching for its evidence.
-      The entry stays in the map so a later retry replays this outcome. */
+  /** Settles one compaction exactly once and drops its evidence budget. The
+      entry stays in the map so a later retry replays this outcome. */
   private settleCompaction(
     compaction: PendingCompaction,
     outcome: RuntimeCompactOutcome | StructuredCompactError,
   ): void {
     if (compaction.settled) return;
     compaction.settled = true;
-    if (compaction.poll) clearInterval(compaction.poll);
     if (compaction.timer) clearTimeout(compaction.timer);
-    compaction.poll = null;
     compaction.timer = null;
     if (outcome instanceof StructuredCompactError) compaction.reject(outcome);
     else compaction.resolve(outcome);
@@ -1306,9 +1177,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       if (message.apiKeySource !== "none") return this.fail(new Error("Claude stream process did not use subscription OAuth"));
       return;
     }
-    /* The second compaction evidence channel (#1214). The transcript is the
-       durable one; a boundary announced on the stream says the same thing
-       sooner, so whichever arrives first settles the control. */
+    /* Where a compaction is witnessed (#1214). The CLI announces the same
+       boundary it writes to the transcript on this stream, so the evidence is
+       already here: nothing tails the transcript for a second copy of it. */
     if (type === "system" && message.subtype === "compact_boundary") {
       this.settlePendingCompactions({ compactionId: stringField(message, "uuid") });
       return;
@@ -1415,7 +1286,17 @@ export class ClaudeStreamBrokerHost implements EngineHost {
 
   private acceptResult(message: JsonObject): void {
     const turnId = this.turnQueue.shift() ?? this.activeTurnId;
-    if (!turnId) return;
+    if (!turnId) {
+      /* No turn owns this result, so it closes the `/compact` this host typed
+         into the conversation (#1214) — the only thing running off the turn
+         plane. A boundary would have come first, so reaching here means the
+         engine handled the command and compacted nothing. Say that now
+         instead of sitting out the evidence budget in silence. */
+      this.settlePendingCompactions(
+        new StructuredCompactError(CLAUDE_COMPACT_DECLINED_REASON, "refused"),
+      );
+      return;
+    }
     this.partialTurns.delete(turnId);
     const interrupted = this.interruptedTurns.delete(turnId);
     const status = interrupted || message.subtype === "interrupted"

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -15,8 +15,22 @@ import { signalDetachedProcessGroup, type ProcessSignal } from "@/lib/processGro
 import { STRUCTURED_HOST_STAMP_ENV, structuredHostStamp } from "@/lib/scanner/process";
 import { hardenedRedact } from "@/lib/view/compactText";
 
-import type { DeliveryReceipt, EngineHost, HostState, NormalizedQueueEntry, QueueEntry, RuntimeEvent } from "./engineHost";
-import { normalizeQueueEntry, RuntimeReplayGapError, StructuredHostAdoptionCleanupError } from "./engineHost";
+import type {
+  DeliveryReceipt,
+  EngineHost,
+  HostState,
+  NormalizedQueueEntry,
+  QueueEntry,
+  RuntimeCompactOutcome,
+  RuntimeCompactRequest,
+  RuntimeEvent,
+} from "./engineHost";
+import {
+  normalizeQueueEntry,
+  RuntimeReplayGapError,
+  StructuredCompactError,
+  StructuredHostAdoptionCleanupError,
+} from "./engineHost";
 import {
   FileRuntimeEventStore,
   nextRuntimeEventSequence,
@@ -54,6 +68,14 @@ type PendingAnswer = {
   resolve(): void;
   reject(error: Error): void;
   timer: ReturnType<typeof setTimeout>;
+};
+type PendingCompaction = {
+  promise: Promise<RuntimeCompactOutcome>;
+  resolve(outcome: RuntimeCompactOutcome): void;
+  reject(error: StructuredCompactError): void;
+  settled: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+  poll: ReturnType<typeof setInterval> | null;
 };
 
 export interface ClaudeDeliveryState {
@@ -203,6 +225,11 @@ export interface ClaudeStreamBrokerHostOptions {
   processIdentity?: (pid: number) => string | null;
   readAuthStatus?: () => ClaudeAuthStatus | Promise<ClaudeAuthStatus>;
   readTranscript?: (cwd: string, sessionId: string) => ClaudeTranscriptUser[];
+  /** Where a compaction can be witnessed (#1214); defaults to the session
+      transcript. */
+  compactionEvidence?: ClaudeCompactionEvidenceSource;
+  compactEvidenceTimeoutMs?: number;
+  compactEvidencePollMs?: number;
   eventStore?: RuntimeEventStore;
   deliveryLedger?: ClaudeDeliveryLedger;
   readImage?: (ref: StructuredImageRef) => Buffer;
@@ -216,6 +243,96 @@ export interface ClaudeTranscriptUser {
   timestamp: string | null;
 }
 
+/** One compaction boundary the session transcript recorded. `uuid` names the
+    record when it carries one, so the durable receipt can say which compaction
+    closed the operation. */
+export interface ClaudeCompactionBoundary {
+  uuid: string | null;
+  trigger: string | null;
+}
+
+export interface ClaudeCompactionEvidence {
+  boundaries: ClaudeCompactionBoundary[];
+  /** Byte offset the next read resumes from; only complete records are ever
+      consumed, so a half-written line is re-read rather than missed. */
+  cursor: number;
+}
+
+export interface ClaudeCompactionEvidenceInput {
+  cwd: string;
+  sessionId: string;
+  projectsRoot?: string;
+}
+
+/**
+ * Where a Claude compaction can be *witnessed*. The stream-json transport has
+ * no compact control and reports no compaction outcome, so the only durable
+ * evidence is the `compact_boundary` record the CLI writes into the session
+ * transcript. The seam is injectable for the same reason `readTranscript` is:
+ * a test must never depend on the operator's `~/.claude` tree.
+ */
+export interface ClaudeCompactionEvidenceSource {
+  /** The fence a compaction's evidence must appear after — the transcript's
+      current end. Boundaries already in the file belong to earlier
+      compactions and can never close this operation. */
+  cursor(input: ClaudeCompactionEvidenceInput): number;
+  /** Boundary records appended since `fromByte`. */
+  read(input: ClaudeCompactionEvidenceInput & { fromByte: number }): ClaudeCompactionEvidence;
+}
+
+/** Marker every boundary record carries, cheap enough to test every line on. */
+const COMPACT_BOUNDARY_MARKER = '"compact_boundary"';
+/** Upper bound on one evidence pass. Polls read only what was appended since
+    the previous pass, so this only caps a transcript that grew explosively
+    between two reads — the next pass picks up where this one stopped. */
+const MAX_COMPACT_EVIDENCE_READ_BYTES = 4 * 1024 * 1024;
+
+function transcriptSize(filename: string): number {
+  try { return fs.statSync(filename).size; } catch { return 0; }
+}
+
+/** The session transcript read as a compaction evidence channel. */
+export const fileClaudeCompactionEvidence: ClaudeCompactionEvidenceSource = {
+  cursor: (input) => transcriptSize(claudeTranscriptPath(input.cwd, input.sessionId, input.projectsRoot)),
+  read: (input) => {
+    const filename = claudeTranscriptPath(input.cwd, input.sessionId, input.projectsRoot);
+    const size = transcriptSize(filename);
+    /* A transcript that shrank was rotated or rewritten under us; the old
+       offset names nothing, so evidence is read from the new head. */
+    const from = size < input.fromByte ? 0 : input.fromByte;
+    if (size <= from) return { boundaries: [], cursor: from };
+    let text: string;
+    try {
+      const fd = fs.openSync(filename, "r");
+      try {
+        const length = Math.min(size - from, MAX_COMPACT_EVIDENCE_READ_BYTES);
+        const buffer = Buffer.alloc(length);
+        const read = fs.readSync(fd, buffer, 0, length, from);
+        text = buffer.toString("utf8", 0, read);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      return { boundaries: [], cursor: input.fromByte };
+    }
+    const lastNewline = text.lastIndexOf("\n");
+    if (lastNewline < 0) return { boundaries: [], cursor: from };
+    const complete = text.slice(0, lastNewline);
+    const boundaries: ClaudeCompactionBoundary[] = [];
+    for (const line of complete.split("\n")) {
+      if (!line.includes(COMPACT_BOUNDARY_MARKER)) continue;
+      let value: JsonObject | null = null;
+      try { value = record(JSON.parse(line)); } catch { continue; }
+      if (value?.type !== "system" || value.subtype !== "compact_boundary") continue;
+      boundaries.push({
+        uuid: stringField(value, "uuid"),
+        trigger: stringField(record(value.compactMetadata), "trigger"),
+      });
+    }
+    return { boundaries, cursor: from + Buffer.byteLength(complete) + 1 };
+  },
+};
+
 const CHILD_ENV_ALLOWLIST = [
   "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TMP", "TEMP", "LANG",
   "LC_ALL", "LC_CTYPE", "TERM", "COLORTERM", "NO_COLOR", "XDG_CONFIG_HOME",
@@ -225,6 +342,25 @@ const CHILD_ENV_ALLOWLIST = [
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
+
+/** The command this control types into the conversation (#1214). */
+export const CLAUDE_COMPACT_COMMAND = "/compact";
+
+/**
+ * The durable receipt reason for a compaction that was sent and never
+ * witnessed. It is a machine token like every other receipt reason
+ * (`busy-turn`, `stale-generation`, …) so the strip can say it in both
+ * languages: "sent — completion could not be confirmed". It is an outcome, not
+ * a failure to act: the operator asked for the command and the command went.
+ */
+export const CLAUDE_COMPACT_UNOBSERVED_REASON = "compact-sent-unobserved";
+
+/** How long a compaction may run before its outcome counts as unobservable.
+    Compaction re-reads the whole thread through the model — a manual one
+    observed locally took ~2.5 minutes — so the budget is generous. */
+const DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS = 5 * 60_000;
+/** How often the transcript is re-read for a boundary while one is pending. */
+const DEFAULT_COMPACT_EVIDENCE_POLL_MS = 1_000;
 
 /** Durable launch evidence: hosts that launched with the native multi-agent
     denial advertise the effective denied-tool set so registry snapshots and
@@ -501,6 +637,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly eventStore: RuntimeEventStore;
   private readonly deliveryLedger: ClaudeDeliveryLedger;
   private readonly readImage: (ref: StructuredImageRef) => Buffer;
+  private readonly cwd: string;
+  private readonly projectsRoot: string | undefined;
+  private readonly compactionEvidence: ClaudeCompactionEvidenceSource;
+  private readonly compactEvidenceTimeoutMs: number;
+  private readonly compactEvidencePollMs: number;
   private readonly requestTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
@@ -514,6 +655,10 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly attentions = new Map<string, JsonObject>();
   private readonly pendingControls = new Map<string, PendingControl>();
   private readonly pendingAnswers = new Map<string, PendingAnswer>();
+  /** Compactions this host issued, keyed by durable operation and kept after
+      they settle: a retry replays the outcome instead of typing `/compact` a
+      second time into the conversation (#1214). */
+  private readonly compactions = new Map<string, PendingCompaction>();
   private readonly interruptedTurns = new Set<string>();
   private readonly partialTurns = new Set<string>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
@@ -552,6 +697,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.deliveryLedger = options.deliveryLedger ?? new FileClaudeDeliveryLedger();
     this.readImage = options.readImage ?? ((ref) => runtimeImageStore().read(ref));
+    this.cwd = options.cwd;
+    this.projectsRoot = options.claudeProjectsDir;
+    this.compactionEvidence = options.compactionEvidence ?? fileClaudeCompactionEvidence;
+    this.compactEvidenceTimeoutMs = options.compactEvidenceTimeoutMs ?? DEFAULT_COMPACT_EVIDENCE_TIMEOUT_MS;
+    this.compactEvidencePollMs = options.compactEvidencePollMs ?? DEFAULT_COMPACT_EVIDENCE_POLL_MS;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
@@ -810,6 +960,142 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     });
   }
 
+  /**
+   * Manual context compaction (#1214). The stream-json transport exposes
+   * `interrupt` and `can_use_tool` as its whole client-originated control
+   * channel — there is no compact subtype to send — so this control reaches
+   * compaction the one way the transport allows: it types `/compact` into the
+   * conversation, exactly as the operator would in the terminal.
+   *
+   * That mechanism buys no knowledge of the outcome, so none is claimed. The
+   * promise settles only on a *witnessed* compaction: a `compact_boundary`
+   * record appended to the session transcript after the command went (or the
+   * same boundary announced on the stream). Nothing arriving inside the
+   * evidence budget terminalizes `unverified` with
+   * `CLAUDE_COMPACT_UNOBSERVED_REASON` — "sent, completion not observable" —
+   * which is the honest verdict and an acceptable outcome. It is never
+   * reported as success, and it never spins forever.
+   *
+   * The compaction is deliberately left out of the turn plane: it is not a
+   * delivery, so it takes no ledger row and no turn slot, and the `result` the
+   * CLI answers with lands on an empty turn queue and is ignored. The delivery
+   * queue holds messages behind an unfinished compaction, so the turn queue is
+   * empty for the duration.
+   */
+  async compact(request: RuntimeCompactRequest): Promise<RuntimeCompactOutcome> {
+    /* One durable operation, one `/compact`. A caller that timed out and
+       retried — or a queue pass that re-read the same effect — joins the
+       in-flight control or replays the settled outcome; it never types the
+       command into the conversation a second time. */
+    const existing = this.compactions.get(request.operationId);
+    if (existing) return existing.promise;
+    if (this.unavailable()) throw new StructuredCompactError("Claude stream host is unavailable", "refused");
+    if (request.threadId && request.threadId !== this.identity.sessionId) {
+      throw new StructuredCompactError("compact target session is not the session this host owns", "refused");
+    }
+    /* Admission fenced the durable turn axis, but a turn can start in between,
+       and a `/compact` typed underneath a running turn is queued behind it
+       instead of compacting anything the operator is looking at. */
+    if (this.activeTurnId) {
+      throw new StructuredCompactError("a turn is active; compaction would race it", "refused");
+    }
+    if ([...this.compactions.values()].some((compaction) => !compaction.settled)) {
+      throw new StructuredCompactError("a compaction is already running on this conversation", "refused");
+    }
+
+    let resolveOutcome!: PendingCompaction["resolve"];
+    let rejectOutcome!: PendingCompaction["reject"];
+    const promise = new Promise<RuntimeCompactOutcome>((resolve, reject) => {
+      resolveOutcome = resolve;
+      rejectOutcome = reject;
+    });
+    const compaction: PendingCompaction = {
+      promise,
+      resolve: (outcome) => resolveOutcome(outcome),
+      reject: (error) => rejectOutcome(error),
+      settled: false,
+      timer: null,
+      poll: null,
+    };
+    /* A retry that arrives while the command is being written finds the entry
+       here, so the registration happens before the frame. */
+    this.compactions.set(request.operationId, compaction);
+    void promise.catch(() => undefined);
+    /* Only boundaries appended after this offset can belong to this request;
+       the ones already in the transcript closed earlier compactions. */
+    let cursor = this.readCompactionCursor();
+    this.write({
+      type: "user",
+      session_id: this.identity.sessionId,
+      message: { role: "user", content: [{ type: "text", text: CLAUDE_COMPACT_COMMAND }] },
+    });
+    compaction.poll = setInterval(() => {
+      const evidence = this.readCompactionEvidence(cursor);
+      cursor = evidence.cursor;
+      const boundary = evidence.boundaries.at(-1);
+      if (boundary) this.settleCompaction(compaction, { compactionId: boundary.uuid });
+    }, this.compactEvidencePollMs);
+    compaction.timer = setTimeout(() => {
+      this.settleCompaction(
+        compaction,
+        new StructuredCompactError(CLAUDE_COMPACT_UNOBSERVED_REASON, "unverified"),
+      );
+    }, this.compactEvidenceTimeoutMs);
+    return promise;
+  }
+
+  private readCompactionCursor(): number {
+    try {
+      return this.compactionEvidence.cursor({
+        cwd: this.cwd,
+        sessionId: this.identity.sessionId,
+        ...(this.projectsRoot ? { projectsRoot: this.projectsRoot } : {}),
+      });
+    } catch {
+      /* An unreadable transcript is not evidence of anything: start at the
+         head and let the boundary check decide. */
+      return 0;
+    }
+  }
+
+  private readCompactionEvidence(fromByte: number): ClaudeCompactionEvidence {
+    try {
+      return this.compactionEvidence.read({
+        cwd: this.cwd,
+        sessionId: this.identity.sessionId,
+        ...(this.projectsRoot ? { projectsRoot: this.projectsRoot } : {}),
+        fromByte,
+      });
+    } catch {
+      return { boundaries: [], cursor: fromByte };
+    }
+  }
+
+  /** Settles one compaction exactly once and stops watching for its evidence.
+      The entry stays in the map so a later retry replays this outcome. */
+  private settleCompaction(
+    compaction: PendingCompaction,
+    outcome: RuntimeCompactOutcome | StructuredCompactError,
+  ): void {
+    if (compaction.settled) return;
+    compaction.settled = true;
+    if (compaction.poll) clearInterval(compaction.poll);
+    if (compaction.timer) clearTimeout(compaction.timer);
+    compaction.poll = null;
+    compaction.timer = null;
+    if (outcome instanceof StructuredCompactError) compaction.reject(outcome);
+    else compaction.resolve(outcome);
+  }
+
+  /** Every compaction still awaiting evidence, settled with one verdict. A
+      host that dies or is released mid-compaction leaves the engine outcome
+      unknown, which is `unverified`, never a failure to have acted. */
+  private settlePendingCompactions(outcome: RuntimeCompactOutcome | StructuredCompactError): void {
+    for (const compaction of this.compactions.values()) {
+      if (!compaction.settled) this.settleCompaction(compaction, outcome);
+    }
+  }
+
   async answer(attentionRef: string, value: unknown): Promise<void> {
     if (this.unavailable()) throw new Error("Claude stream host is unavailable");
     if (!this.attentions.has(attentionRef)) throw new Error("attention request is missing or already answered");
@@ -1018,6 +1304,13 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     if (sessionId && sessionId !== this.identity.sessionId) return this.fail(new Error("Claude emitted a different session id"));
     if (type === "system" && message.subtype === "init") {
       if (message.apiKeySource !== "none") return this.fail(new Error("Claude stream process did not use subscription OAuth"));
+      return;
+    }
+    /* The second compaction evidence channel (#1214). The transcript is the
+       durable one; a boundary announced on the stream says the same thing
+       sooner, so whichever arrives first settles the control. */
+    if (type === "system" && message.subtype === "compact_boundary") {
+      this.settlePendingCompactions({ compactionId: stringField(message, "uuid") });
       return;
     }
     if (type === "user") {
@@ -1294,6 +1587,12 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       pending.reject(new Error(safeError(error)));
     }
     this.pendingAnswers.clear();
+    /* A `/compact` that was already typed into the conversation cannot be
+       taken back, and a host that goes away mid-compaction proves nothing
+       about what became of it — which is exactly the unobserved outcome. */
+    this.settlePendingCompactions(
+      new StructuredCompactError(CLAUDE_COMPACT_UNOBSERVED_REASON, "unverified"),
+    );
   }
 
   private closeSubscribers(): void {

--- a/src/lib/runtime/compactControl.test.ts
+++ b/src/lib/runtime/compactControl.test.ts
@@ -62,16 +62,24 @@ test("a compact command without an owned session key is refused", () => {
   })).toThrow("sessionKey is invalid");
 });
 
-test("compact capability is engine-specific and truthful", () => {
+test("compact capability is supported on both engines and truthful about confirmation", () => {
+  /* Codex reports completion on its own channel, so the receipt terminalizes
+     on the engine's evidence. */
   expect(runtimeCompactCapability("codex")).toEqual({
     control: "compact",
     engine: "codex",
     supported: true,
+    confirmation: "observed",
   });
-  const claude = runtimeCompactCapability("claude");
-  expect(claude.supported).toBe(false);
-  expect(claude.engine).toBe("claude");
-  expect(claude.reason).toContain("compact");
+  /* Claude has no compact subtype in its transport, so its host types
+     `/compact` into the conversation (#1214). The control is supported; what
+     is qualified is the confirmation, never the engine's ability. */
+  expect(runtimeCompactCapability("claude")).toEqual({
+    control: "compact",
+    engine: "claude",
+    supported: true,
+    confirmation: "best-effort",
+  });
 });
 
 test("a host without a compact control is detected structurally", () => {

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -296,42 +296,56 @@ export type RuntimePendingReconfigure = Omit<RuntimeReconfigureCommand, "kind" |
 
 /**
  * A manual context compaction requested against one owned structured
- * generation (issue #862). It is a control, never a message: the command
- * carries no text and no images, so no path through the runtime can replay it
- * as a user prompt. `sessionKey` fences the compaction to the exact generation
- * the caller was looking at. There is deliberately no turn fence: a compaction
- * is only ever admitted against an idle generation, so any turn a caller could
- * name would already have made the request a `busy-turn` rejection.
+ * generation (issue #862, extended by #1214). The command itself carries no
+ * text and no images: it names a generation to compact and nothing else, so no
+ * caller can smuggle a prompt through this channel. How the compaction then
+ * reaches the engine is the host's business — the Codex host sends
+ * `thread/compact/start`, the Claude host types `/compact` into the
+ * conversation because its transport offers no control subtype.
+ * `sessionKey` fences the compaction to the exact generation the caller was
+ * looking at. There is deliberately no turn fence: a compaction is only ever
+ * admitted against an idle generation, so any turn a caller could name would
+ * already have made the request a `busy-turn` rejection.
  */
 export interface RuntimeCompactCommand extends RuntimeCommandBase {
   kind: "compact";
   sessionKey: { engine: RuntimeEngine; sessionId: string };
 }
 
-/** An engine's truthful support for one client-originated engine control. */
+/**
+ * An engine's truthful support for one client-originated engine control, and
+ * how far its outcome can be trusted. `confirmation` is the honest half:
+ * `observed` means the engine reports completion on its own channel, while
+ * `best-effort` means the control reaches the engine but its completion can
+ * only be witnessed indirectly — and may not be witnessed at all.
+ */
 export interface RuntimeControlCapability {
   control: "compact";
   engine: RuntimeEngine;
   supported: boolean;
+  confirmation?: "observed" | "best-effort";
   reason?: string;
 }
 
 /**
- * Codex app-server 0.146 exposes `thread/compact/start` and reports completion
- * through the `contextCompaction` item lifecycle. The Claude stream-json
- * transport exposes interrupt as its only client-originated control and has no
- * manual compact subtype, so the capability reports false with the reason
- * rather than degrading into a `/compact` prompt.
+ * Both engines can compact; they differ in what the Viewer can promise about
+ * the outcome (#1214).
+ *
+ * Codex app-server exposes `thread/compact/start` and reports completion
+ * through the `contextCompaction` item lifecycle, so the receipt terminalizes
+ * on the engine's own evidence. The Claude stream-json transport has no
+ * compact subtype at all — `interrupt` and `can_use_tool` are the whole
+ * control channel — so the host types `/compact` into the conversation, the
+ * way the operator does in the terminal, and witnesses the outcome only if a
+ * compaction boundary appears in the transcript. That is best-effort
+ * confirmation, and it is stated rather than hidden: the alternative, refusing
+ * to compact at all, leaves the operator with a full context window and a
+ * button that lies about the engine.
  */
 export function runtimeCompactCapability(engine: RuntimeEngine): RuntimeControlCapability {
   return engine === "codex"
-    ? { control: "compact", engine, supported: true }
-    : {
-        control: "compact",
-        engine,
-        supported: false,
-        reason: "The Claude stream-json protocol has no client-originated compact control; only interrupt is exposed.",
-      };
+    ? { control: "compact", engine, supported: true, confirmation: "observed" }
+    : { control: "compact", engine, supported: true, confirmation: "best-effort" };
 }
 
 export interface RuntimeAnswerCommand extends RuntimeCommandBase {

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -9,6 +9,7 @@ import {
   type QueueEntry,
   type RuntimeEvent,
 } from "./engineHost";
+import { CLAUDE_COMPACT_UNOBSERVED_REASON } from "./claudeStreamBrokerHost";
 import {
   StructuredDeliveryQueue,
   type StructuredDeliveryEffect,
@@ -438,6 +439,28 @@ test("a rejected compact request terminalizes as failed and an unverified one as
     "uncertain",
     "Codex app-server host was lost",
   ]);
+});
+
+test("a Claude compaction nobody witnessed terminalizes uncertain with its own reason (#1214)", async () => {
+  const sent: QueueEntry[] = [];
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => {
+      throw new StructuredCompactError(CLAUDE_COMPACT_UNOBSERVED_REASON, "unverified");
+    },
+  });
+  const { port, transitions, settled } = recorder([
+    compactEffect({ sessionKey: { engine: "claude", sessionId: "thread-one" } }),
+  ]);
+
+  await new StructuredDeliveryQueue(port, () => host).drain();
+  await settled;
+
+  /* The durable receipt says what happened — the command went and nothing
+     witnessed the compaction — instead of claiming success or spinning. */
+  expect(transitions.at(-1)).toEqual(["op-one", "uncertain", CLAUDE_COMPACT_UNOBSERVED_REASON]);
+  /* Even on the path whose mechanism IS a message, the queue never turns the
+     control into a delivery: the `/compact` belongs to the host. */
+  expect(sent).toEqual([]);
 });
 
 test("a recovered host lets a queued compaction reach the engine on the next pass", async () => {

--- a/src/lib/runtime/structuredCompactDelivery.test.ts
+++ b/src/lib/runtime/structuredCompactDelivery.test.ts
@@ -9,7 +9,7 @@ import {
   type QueueEntry,
   type RuntimeEvent,
 } from "./engineHost";
-import { CLAUDE_COMPACT_UNOBSERVED_REASON } from "./claudeStreamBrokerHost";
+import { CLAUDE_COMPACT_DECLINED_REASON, CLAUDE_COMPACT_UNOBSERVED_REASON } from "./claudeStreamBrokerHost";
 import {
   StructuredDeliveryQueue,
   type StructuredDeliveryEffect,
@@ -460,6 +460,26 @@ test("a Claude compaction nobody witnessed terminalizes uncertain with its own r
   expect(transitions.at(-1)).toEqual(["op-one", "uncertain", CLAUDE_COMPACT_UNOBSERVED_REASON]);
   /* Even on the path whose mechanism IS a message, the queue never turns the
      control into a delivery: the `/compact` belongs to the host. */
+  expect(sent).toEqual([]);
+});
+
+test("a Claude compaction the engine declined terminalizes failed with its own reason (#1214)", async () => {
+  const sent: QueueEntry[] = [];
+  const host: CompactCapableHost = Object.assign(baseHost(sent), {
+    compact: async () => {
+      throw new StructuredCompactError(CLAUDE_COMPACT_DECLINED_REASON, "refused");
+    },
+  });
+  const { port, transitions, settled } = recorder([
+    compactEffect({ sessionKey: { engine: "claude", sessionId: "thread-one" } }),
+  ]);
+
+  await new StructuredDeliveryQueue(port, () => host).drain();
+  await settled;
+
+  /* A decline is a visible failure, not an uncertainty: the engine answered
+     and compacted nothing, so nothing about the outcome is unknown. */
+  expect(transitions.at(-1)).toEqual(["op-one", "failed", CLAUDE_COMPACT_DECLINED_REASON]);
   expect(sent).toEqual([]);
 });
 

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -156,30 +156,38 @@ test("a compact transport failure answers from the durable receipt instead of re
   });
 });
 
-test("a structured claude conversation answers compact with a typed capability error", async () => {
+test("a structured claude conversation enters the same durable command channel (#1214)", async () => {
   const fixture = structuredConversation({ engine: "claude" });
   const commands: unknown[] = [];
   const client = {
     command: async (command: unknown) => {
       commands.push(command);
-      throw new Error("an unsupported compact reached the runtime host");
+      return { operationId: "compact-claude", receipt: { operationId: "compact-claude", status: "pending" }, replayed: false };
     },
   } as unknown as RuntimeHostClient;
 
   const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "compact" }, {
     registry: fixture.registry,
     client,
+    operationId: () => "compact-claude",
     enabled: () => true,
   });
 
-  expect(commands).toEqual([]);
-  expect(result).toMatchObject({
-    status: 409,
-    body: {
-      code: "unsupported-capability",
-      capability: { control: "compact", engine: "claude", supported: false },
+  /* The dispatcher no longer refuses the Claude path. The command it sends is
+     the same control every engine gets — a generation fence and nothing else;
+     the `/compact` text is the host's own, and never travels from here. */
+  expect(result).toMatchObject({ status: 202, body: { operationId: "compact-claude", receipt: { status: "pending" } } });
+  expect(commands).toEqual([{
+    kind: "compact",
+    operationId: "compact-claude",
+    idempotencyKey: "compact-claude",
+    conversationId: fixture.conversationId,
+    sessionKey: {
+      engine: "claude",
+      sessionId: fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!.generations.at(-1)!.id,
     },
-  });
+  }]);
+  expect(commands[0]).not.toHaveProperty("text");
 });
 
 test("structured reconfigure validates and enters the runtime command channel", async () => {

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -124,8 +124,12 @@ export async function dispatchStructuredControl(
   }
 
   if (request.action === "compact") {
+    /* #1214: both structured host kinds can compact — codex-app-server through
+       `thread/compact/start`, claude-broker by typing `/compact` into the
+       conversation. The 409 is left for a host kind that has neither. */
     const capability = runtimeCompactCapability(conversation.engine);
-    if (!capability.supported || entry.structuredHost?.kind !== "codex-app-server") {
+    const hostKind = entry.structuredHost?.kind;
+    if (!capability.supported || (hostKind !== "codex-app-server" && hostKind !== "claude-broker")) {
       return {
         status: 409,
         body: {
@@ -168,8 +172,9 @@ export async function dispatchStructuredControl(
     const command: RuntimeOperationCommand = request.action === "kill"
       ? { kind: "kill", operationId, idempotencyKey: operationId, conversationId: conversation.id, sessionKey }
       /* #862: a compact command carries a generation fence and nothing else.
-         There is no text field to fill, so this control cannot degrade into a
-         `/compact` user turn on any path. */
+         There is no text field to fill, so no caller's text can ride this
+         control into the conversation — the Claude host's `/compact` is the
+         host's own fixed command, not anything that travelled from here. */
       : request.action === "compact"
         ? { kind: "compact", operationId, idempotencyKey: operationId, conversationId: conversation.id, sessionKey }
         : request.action === "reconfigure"

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1428,7 +1428,12 @@ export class RuntimeJournal {
       if (!session || session.host !== "hosted") {
         status = "rejected";
         reason = session?.host === "dead" || session?.host === "unhosted" ? "dead-host" : "no-claim";
-      } else if (!capability.supported || session.hostKind !== "codex-app-server") {
+      } else if (!capability.supported
+        || (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker")) {
+        /* #1214: claude-broker admits compaction too — its host types
+           `/compact` into the conversation, the only mechanism the stream-json
+           transport offers. A host kind with neither path is still refused
+           here rather than left to the delivery queue. */
         status = "rejected";
         reason = "unsupported-capability";
       } else if (session.sessionKey.engine !== command.sessionKey.engine

--- a/src/runtime-host/journalCompact.test.ts
+++ b/src/runtime-host/journalCompact.test.ts
@@ -121,15 +121,15 @@ test("a caller-supplied turn fence cannot smuggle a compaction past the busy-tur
   journal.close();
 });
 
-test("compact admission refuses a lost host, a stale generation, and an unsupported engine", () => {
+test("compact admission refuses a lost host, a stale generation, and a host with no compact path", () => {
   const journal = new RuntimeJournal(path.join(sandbox("refusals"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
   hostedCodexSession(journal, { conversationId: "conv-dead", host: "dead" });
   hostedCodexSession(journal, { conversationId: "conv-stale", sessionId: "thread-current" });
   hostedCodexSession(journal, {
-    conversationId: "conv-claude",
+    conversationId: "conv-paned",
     engine: "claude",
-    hostKind: "claude-broker",
-    sessionId: "session-claude",
+    hostKind: "tmux-pane",
+    sessionId: "session-paned",
   });
 
   const dead = journal.executeOperation({
@@ -146,7 +146,31 @@ test("compact admission refuses a lost host, a stale generation, and an unsuppor
     conversationId: "conv-stale",
     sessionKey: { engine: "codex", sessionId: "thread-previous" },
   });
-  const claude = journal.executeOperation({
+  const paned = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-paned",
+    idempotencyKey: "op-paned",
+    conversationId: "conv-paned",
+    sessionKey: { engine: "claude", sessionId: "session-paned" },
+  });
+
+  expect(dead.receipt).toMatchObject({ status: "rejected", reason: "dead-host" });
+  expect(stale.receipt).toMatchObject({ status: "rejected", reason: "stale-generation" });
+  expect(paned.receipt).toMatchObject({ status: "rejected", reason: "unsupported-capability" });
+  expect(journal.effectBatch()).toHaveLength(0);
+  journal.close();
+});
+
+test("an idle owned claude-broker conversation admits its compaction like any other (#1214)", () => {
+  const journal = new RuntimeJournal(path.join(sandbox("claude"), "events.sqlite"), { structuredHosts: true, now: () => 100 });
+  hostedCodexSession(journal, {
+    conversationId: "conv-claude",
+    engine: "claude",
+    hostKind: "claude-broker",
+    sessionId: "session-claude",
+  });
+
+  const result = journal.executeOperation({
     kind: "compact",
     operationId: "op-claude",
     idempotencyKey: "op-claude",
@@ -154,10 +178,31 @@ test("compact admission refuses a lost host, a stale generation, and an unsuppor
     sessionKey: { engine: "claude", sessionId: "session-claude" },
   });
 
-  expect(dead.receipt).toMatchObject({ status: "rejected", reason: "dead-host" });
-  expect(stale.receipt).toMatchObject({ status: "rejected", reason: "stale-generation" });
-  expect(claude.receipt).toMatchObject({ status: "rejected", reason: "unsupported-capability" });
-  expect(journal.effectBatch()).toHaveLength(0);
+  expect(result.receipt).toMatchObject({ kind: "compact", status: "pending", turnId: null });
+  const effects = journal.effectBatch();
+  expect(effects).toHaveLength(1);
+  expect(effects[0]!.kind).toBe("runtime.compact");
+  expect(effects[0]!.payload).toMatchObject({
+    kind: "compact",
+    operationId: "op-claude",
+    conversationId: "conv-claude",
+    sessionKey: { engine: "claude", sessionId: "session-claude" },
+  });
+  /* Nothing on the effect can be replayed as user input: the `/compact` the
+     Claude host types is its own fixed command, not payload from a caller. */
+  expect(effects[0]!.payload).not.toHaveProperty("text");
+
+  /* A retry of the same operation replays the admitted receipt rather than
+     admitting a second compaction into the same conversation. */
+  const retry = journal.executeOperation({
+    kind: "compact",
+    operationId: "op-claude",
+    idempotencyKey: "op-claude",
+    conversationId: "conv-claude",
+    sessionKey: { engine: "claude", sessionId: "session-claude" },
+  });
+  expect(retry.receipt.operationId).toBe(result.receipt.operationId);
+  expect(journal.effectBatch()).toHaveLength(1);
   journal.close();
 });
 


### PR DESCRIPTION
Closes #1214

The compact control refused on a Viewer-owned structured Claude conversation and told the operator "this engine has no compact control" — true of the stream-json control channel, false to someone who types `/compact` daily. The operator's decision on the issue overrules #862's refusal to translate compact into a message: **if there is no other way, send the command**, provided the receipt tells the truth about the outcome.

## The mechanism

`ClaudeStreamBrokerHost.compact()` types `/compact` into the conversation — the transport exposes `interrupt` and `can_use_tool` and nothing else — and then watches for evidence that compaction actually happened:

- **primary:** a `compact_boundary` record appended to the session transcript *after* the command went (byte-fenced, so boundaries already in the file can never close this operation);
- **corroborating:** the same boundary announced on the stream.

Whichever arrives first settles the durable receipt as `delivered`, naming the boundary. Nothing inside the evidence budget terminalizes `uncertain` with reason `compact-sent-unobserved` — "sent, completion not observable". A host that dies mid-compaction reads the same way, because it proves nothing either.

The compaction stays out of the turn plane: no ledger row, no turn slot. The delivery queue's existing barrier already holds messages behind an unfinished compaction.

## Required outcome → test

| Outcome | Test |
|---|---|
| 1. Claude structured compact **sends** `/compact` as a message | `claudeStreamBrokerHost.compact.test.ts` — "types /compact once and terminalizes on the observed transcript boundary" asserts the exact frame handed to the child; `structuredControls.test.ts` — "a structured claude conversation enters the same durable command channel" (dispatcher no longer 409s); `runtime-host/journalCompact.test.ts` — "an idle owned claude-broker conversation admits its compaction like any other" |
| 2a. Terminalizes on **observed** compaction | same host test (resolves `{ compactionId: "boundary-one" }`); "a compaction boundary announced on the stream settles the control immediately"; `fileClaudeCompactionEvidence` unit tests: only boundaries after the fence, partial lines ignored, cursor advances, missing transcript is not evidence |
| 2b. **"Sent, completion not observable"** as its own terminal outcome | host test "a compaction nobody witnessed terminalizes as sent-but-unobservable, never as success"; "a host that dies mid-compaction terminalizes unverified rather than hanging"; `structuredCompactDelivery.test.ts` — "a Claude compaction nobody witnessed terminalizes uncertain with its own reason" pins the durable transition `["op-one", "uncertain", "compact-sent-unobserved"]`; `runtimeModel.test.ts` maps that token to a sentence in both locales |
| 3. Strip copy stops naming a missing engine capability; en/uk parity | `agentCapabilities.test.ts` — claude-broker compact is `enabled` with note `strip.compactClaudeMessage`; `AgentControlStrip.dom.test.tsx` — "renders Compact enabled, noting what the Viewer can confirm" runs over `en` and `uk`; `AgentControlStrip.action.test.tsx` — the admitted line is `composer.compactSentClaude`, then the durable receipt replaces it with the witnessed outcome |
| 4. **Codex untouched** | `codexAppServerHost.compact.test.ts` and the rest of `structuredCompactDelivery.test.ts` unchanged and green — `thread/compact/start` and observed-completion semantics as before; `compactControl.test.ts` pins codex `confirmation: "observed"` vs claude `"best-effort"` |
| 5. **Idempotency** — one receipt, never two commands | host test "a retry on the same operation replays the outcome instead of typing /compact twice" (concurrent, and after settlement); journal test asserts a retry replays the admitted receipt with no second effect; the queue's existing `delivering` → `uncertain` restart path is unchanged |

Refusals that write nothing are covered too ("a compaction refused before the command is written sends nothing": foreign session, live turn).

## What moved

- `claudeStreamBrokerHost.ts` — `compact()`, the transcript evidence source, the stream evidence channel, and unverified settlement on host loss/release.
- `contracts.ts` — the capability reports both engines supported and states `confirmation`.
- `structuredControls.ts` + `runtime-host/journal.ts` — admission gates on the host *kind* having a compact path, not on the engine.
- `agentCapabilities.ts`, `AgentControlStrip.tsx`, `i18n/en.ts`, `i18n/uk.ts` — the enabled cell, its note, the sent line, and the receipt sentence.

`strip.compactEngineUnsupported` is gone; the residual disabled reason (`strip.compactHostUnsupported`) and `receipt.human.unsupportedCapability` now speak about the Viewer's channel rather than the engine's abilities.

## Also in here

A pre-existing order dependence in `AgentControlStrip.action.test.tsx`: the runtime bus's own `/api/runtime/snapshot` request landed in whichever test's fetch recorder was installed when it resolved. It fails on the base branch too when the file is run with a `-t` filter. The stubs now answer the bus's endpoints themselves, so the file is deterministic full-file and in isolation.

## Verification

- `bunx tsc --noEmit --incremental false` — clean
- 202 tests across the 11 touched files, run by path under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`; the strip action file run 5× full and 3× filtered for flakiness
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS (also with `--require-known-values` and the fingerprint catalog)
- No compact was ever sent into a live conversation: every path is exercised against a fake child process, and the fixtures never signal a real process group

🤖 Generated with [Claude Code](https://claude.com/claude-code)
