### PR TITLE
fix(deploy): name and budget the promote hot-state hand-over (#1216)

### DIFF
--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -511,11 +511,14 @@ test("promote that never sees hot-state activation fails with a named reason", a
     action: "promote",
     input: { candidate },
     setupState: (state) => { initializeHotStateFixture(state, sqliteIncumbent); },
+    /* The release budget has to outlast a real `docker inspect` spawn, or the
+       step reports the daemon as unobservable rather than the incumbent as
+       retained — which is the honest outcome, but not the one under test. */
     environment: {
       LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS: "400",
       LLV_HOT_STATE_ACTIVATION_POLL_MS: "10",
-      LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS: "150",
-      LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS: "10",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS: "3000",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS: "300",
     },
     dockerScript: liveIncumbentDocker,
   });
@@ -574,8 +577,38 @@ test("promote succeeds when hot-state activation arrives late but inside the bud
   });
   expect(phases.some((phase) => phase.startsWith("releasing incumbent hot state"))).toBe(true);
   expect(phases.some((phase) => /^waiting for hot-state activation - \d+s of \d+s - /.test(phase))).toBe(true);
+  /* The phase file is deleted when the action ends, so the hand-over outcome
+     rides the publication evidence into the deployment journal instead. */
+  expect((JSON.parse(result.stdout) as { hotStateHandOver?: string }).hotStateHandOver)
+    .toMatch(/^incumbent (released hot state|still|state unobservable|release not required).*activation published after \d+s$/);
   fs.rmSync(path.dirname(phaseFile), { recursive: true, force: true });
 });
+
+/* A configured budget above the deadline the host will enforce puts the two
+   back in the inversion this fix removes: the host would kill the adapter
+   mid-wait and the operator would read the bare phase string again. Without
+   the clamp this promote waits ten minutes and the test times out. */
+test("hand-over budgets configured past the host deadline still expire inside it", async () => {
+  const candidate = sqliteCandidate("6".repeat(40), "deploy-1216-clamped");
+  const startedAt = Date.now();
+  const result = await runAction({
+    action: "promote",
+    input: { candidate },
+    setupState: (state) => { initializeHotStateFixture(state, sqliteIncumbent); },
+    environment: {
+      LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS: "3000",
+      LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS: "600000",
+      LLV_HOT_STATE_ACTIVATION_POLL_MS: "20",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS: "600000",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS: "20",
+    },
+    dockerScript: liveIncumbentDocker,
+  });
+
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toContain("promoted Viewer never published hot-state activation");
+  expect(Date.now() - startedAt).toBeLessThan(20_000);
+}, 30_000);
 
 test("promotion from SQLite to a legacy release checkpoints rollback mirrors first", async () => {
   const current = { ...release, hotStateBackend: HOT_STATE_BACKEND };

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -477,6 +477,106 @@ test("SQLite promotion waits for completed runtime activation", async () => {
   });
 });
 
+/* #1216 regression pair. The promote deadline and the adapter-side activation
+   budget used to be the same 30s, so the host killed the adapter before its own
+   wait could name anything, and the operator only ever saw the phase string. */
+const sqliteIncumbent = { ...release, hotStateBackend: HOT_STATE_BACKEND };
+
+const liveIncumbentDocker = `#!/bin/sh
+if [ "$1" = "container" ] && [ "$2" = "inspect" ]; then exit 0; fi
+if [ "$1" = "inspect" ] && [ "$2" = "--format" ]; then printf 'running\\n'; exit 0; fi
+exit 1
+`;
+
+function sqliteCandidate(revision: string, releaseId: string) {
+  return {
+    ...release,
+    revision,
+    container: "viewer-candidate-1216",
+    image: "viewer:candidate-1216",
+    hotStateBackend: HOT_STATE_BACKEND,
+    mcpRuntime: {
+      source: "managed" as const,
+      revision,
+      releaseId,
+      artifactDigest: revision.slice(0, 1).repeat(64),
+      stagedAt: "2026-08-27T00:00:00.000Z",
+    },
+  };
+}
+
+test("promote that never sees hot-state activation fails with a named reason", async () => {
+  const candidate = sqliteCandidate("5".repeat(40), "deploy-1216-never");
+  const result = await runAction({
+    action: "promote",
+    input: { candidate },
+    setupState: (state) => { initializeHotStateFixture(state, sqliteIncumbent); },
+    environment: {
+      LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS: "400",
+      LLV_HOT_STATE_ACTIVATION_POLL_MS: "10",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS: "150",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS: "10",
+    },
+    dockerScript: liveIncumbentDocker,
+  });
+
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toContain(candidate.revision);
+  expect(result.stderr).toContain("waited");
+  expect(result.stderr).toContain("authority mode sqlite");
+  expect(result.stderr).toContain("activation pending");
+  expect(result.stderr).toContain("candidate container is running");
+  expect(result.stderr).toContain("incumbent still running");
+});
+
+test("promote succeeds when hot-state activation arrives late but inside the budget", async () => {
+  const candidate = sqliteCandidate("4".repeat(40), "deploy-1216-late");
+  const phaseFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-1216-phase-")), "phase.json");
+  const phases: string[] = [];
+  const result = await runAction({
+    action: "promote",
+    input: { candidate },
+    setupState: (state) => { initializeHotStateFixture(state, sqliteIncumbent); },
+    environment: {
+      LLV_DEPLOYMENT_ADAPTER_PHASE_FILE: phaseFile,
+      LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS: "5000",
+      LLV_HOT_STATE_ACTIVATION_POLL_MS: "10",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS: "150",
+      LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS: "10",
+    },
+    observe: async (state, child) => {
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        try {
+          const phase = (JSON.parse(fs.readFileSync(phaseFile, "utf8")) as { phase?: string }).phase;
+          if (phase && phases[phases.length - 1] !== phase) phases.push(phase);
+        } catch { /* the adapter rewrites the phase file atomically */ }
+        const authority = readHotStateAuthority(state);
+        if (authority?.mode === "sqlite"
+          && authority.releaseRevision === candidate.revision
+          && !authority.activationReadyAt
+          && phases.some((phase) => phase.startsWith("waiting for hot-state activation"))) {
+          markHotStateActivationReady(state, authority);
+          break;
+        }
+        await Bun.sleep(10);
+      }
+      await child.exited;
+    },
+    dockerScript: liveIncumbentDocker,
+  });
+
+  expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 0, stderr: "" });
+  expect(result.authority).toMatchObject({
+    mode: "sqlite",
+    releaseRevision: candidate.revision,
+    activationReadyAt: expect.any(String),
+  });
+  expect(phases.some((phase) => phase.startsWith("releasing incumbent hot state"))).toBe(true);
+  expect(phases.some((phase) => /^waiting for hot-state activation - \d+s of \d+s - /.test(phase))).toBe(true);
+  fs.rmSync(path.dirname(phaseFile), { recursive: true, force: true });
+});
+
 test("promotion from SQLite to a legacy release checkpoints rollback mirrors first", async () => {
   const current = { ...release, hotStateBackend: HOT_STATE_BACKEND };
   const candidate = {

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -51,6 +51,20 @@ import {
 } from "../src/runtime-host/hostRelease";
 import { completeRuntimeHostHandoff, stageRuntimeHostSuccessorContainer } from "../src/runtime-host/hostSuccessor";
 import {
+  awaitHotStateActivation,
+  awaitIncumbentHotStateRelease,
+  hotStateActivationApplies,
+  hotStateActivationObservation,
+  hotStateActivationPhase,
+  hotStateActivationSatisfied,
+  HOT_STATE_ACTIVATION_POLL_MS,
+  HOT_STATE_ACTIVATION_TIMEOUT_MS,
+  incumbentHotStateReleasePhase,
+  INCUMBENT_RELEASE_NOT_REQUIRED,
+  INCUMBENT_RELEASE_POLL_MS,
+  INCUMBENT_RELEASE_TIMEOUT_MS,
+} from "../src/runtime-host/deploymentHotState";
+import {
   hasViewerDeploymentCapability,
   promotedViewerReadinessPhase,
   viewerDeploymentRegistryBackendMode,
@@ -100,8 +114,13 @@ function removeDurableFile(filename: string): void {
   try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
 }
 
+let reportedAdapterPhase: string | null = null;
+
 function reportAdapterPhase(action: string, phase: string): void {
   if (!adapterPhaseFile) return;
+  const reported = `${action} :: ${phase}`;
+  if (reported === reportedAdapterPhase) return;
+  reportedAdapterPhase = reported;
   writeDurableJson(adapterPhaseFile, { action, phase, updatedAt: new Date().toISOString() });
 }
 
@@ -804,21 +823,54 @@ async function fenceCurrentSqliteRelease(
   }
 }
 
-async function waitForHotStateActivation(candidate: ViewerReleaseIdentity): Promise<void> {
-  if (candidate.hotStateBackend !== HOT_STATE_BACKEND) return;
-  const requestedTimeoutMs = Number(process.env.LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS || 30_000);
-  const requestedPollMs = Number(process.env.LLV_HOT_STATE_ACTIVATION_POLL_MS || 50);
-  const timeoutMs = Number.isFinite(requestedTimeoutMs) ? Math.max(100, requestedTimeoutMs) : 30_000;
-  const pollMs = Number.isFinite(requestedPollMs) ? Math.max(5, requestedPollMs) : 50;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const authority = readHotStateAuthority(stateDir);
-    if (authority?.mode === "sqlite"
-      && authority.releaseRevision === candidate.revision
-      && authority.activationReadyAt) return;
-    await Bun.sleep(pollMs);
-  }
-  throw new Error("timed out waiting for the promoted Viewer to activate hot state");
+function budgetMs(name: string, fallback: number, floor: number): number {
+  const requested = Number(process.env[name] || fallback);
+  return Number.isFinite(requested) ? Math.max(floor, requested) : fallback;
+}
+
+/* #1216. An SQLite promote hands hot state from a live incumbent to the
+   candidate in two ordered steps, each with its own budget and its own visible
+   outcome. Step one waits for the incumbent to let go; the durable target flip
+   already fenced it out of SQLite writes, so a lingering incumbent is reported
+   rather than fatal. Step two waits for the candidate to publish activation and
+   names what it saw when it gives up. Both budgets sit inside the host-side
+   promote deadline (PROMOTE_ACTION_TIMEOUT_MS), so the adapter always outlives
+   its own waits and the operator reads a reason instead of a bare timeout. */
+async function handOverHotState(
+  candidate: ViewerReleaseIdentity,
+  current: ViewerReleaseIdentity | null,
+  phase: (value: string) => void,
+): Promise<void> {
+  if (!hotStateActivationApplies(candidate.hotStateBackend)) return;
+  const releaseTimeoutMs = budgetMs("LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS", INCUMBENT_RELEASE_TIMEOUT_MS, 0);
+  const releasePollMs = budgetMs("LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS", INCUMBENT_RELEASE_POLL_MS, 5);
+  const activationTimeoutMs = budgetMs("LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS", HOT_STATE_ACTIVATION_TIMEOUT_MS, 100);
+  const activationPollMs = budgetMs("LLV_HOT_STATE_ACTIVATION_POLL_MS", HOT_STATE_ACTIVATION_POLL_MS, 5);
+  const authority = () => readHotStateAuthority(stateDir);
+  const activated = () => hotStateActivationSatisfied(authority(), candidate.revision);
+  const incumbent = current && current.container !== candidate.container ? current.container : null;
+  phase(incumbentHotStateReleasePhase("unknown", 0, releaseTimeoutMs));
+  const release = incumbent === null
+    ? INCUMBENT_RELEASE_NOT_REQUIRED
+    : await awaitIncumbentHotStateRelease({
+      inspect: () => containerState(incumbent),
+      activated,
+      sleep: (delayMs) => Bun.sleep(delayMs),
+      reportPhase: phase,
+      timeoutMs: releaseTimeoutMs,
+      pollMs: releasePollMs,
+    });
+  phase(hotStateActivationPhase(hotStateActivationObservation(authority(), candidate.revision), 0, activationTimeoutMs));
+  await awaitHotStateActivation({
+    revision: candidate.revision,
+    readAuthority: authority,
+    release,
+    inspectCandidate: () => containerState(candidate.container),
+    sleep: (delayMs) => Bun.sleep(delayMs),
+    reportPhase: phase,
+    timeoutMs: activationTimeoutMs,
+    pollMs: activationPollMs,
+  });
 }
 
 async function promoteTarget(
@@ -832,8 +884,7 @@ async function promoteTarget(
     ? await fenceCurrentSqliteRelease(current.revision, candidate)
     : null;
   const publication = switchTarget(candidate, "activate", undefined, fence, phase);
-  phase("waiting for hot-state activation");
-  await waitForHotStateActivation(candidate);
+  await handOverHotState(candidate, current, phase);
   return publication;
 }
 

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -53,16 +53,19 @@ import { completeRuntimeHostHandoff, stageRuntimeHostSuccessorContainer } from "
 import {
   awaitHotStateActivation,
   awaitIncumbentHotStateRelease,
+  fitHandOverBudgets,
   hotStateActivationApplies,
   hotStateActivationObservation,
   hotStateActivationPhase,
   hotStateActivationSatisfied,
+  hotStateHandOverSummary,
   HOT_STATE_ACTIVATION_POLL_MS,
   HOT_STATE_ACTIVATION_TIMEOUT_MS,
   incumbentHotStateReleasePhase,
   INCUMBENT_RELEASE_NOT_REQUIRED,
   INCUMBENT_RELEASE_POLL_MS,
   INCUMBENT_RELEASE_TIMEOUT_MS,
+  PROMOTE_ACTION_TIMEOUT_MS,
 } from "../src/runtime-host/deploymentHotState";
 import {
   hasViewerDeploymentCapability,
@@ -828,49 +831,62 @@ function budgetMs(name: string, fallback: number, floor: number): number {
   return Number.isFinite(requested) ? Math.max(floor, requested) : fallback;
 }
 
+/** The host publishes the deadline it will enforce for this action, and it
+    kills the process group on expiry. Every hand-over budget is fitted inside
+    that number, so a configured budget cannot restore the inversion of #1216
+    where the host killed the adapter before the adapter could report. */
+function hostActionDeadlineMs(): number {
+  const published = Number(process.env.LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS || PROMOTE_ACTION_TIMEOUT_MS);
+  return Number.isFinite(published) && published > 0 ? published : PROMOTE_ACTION_TIMEOUT_MS;
+}
+
 /* #1216. An SQLite promote hands hot state from a live incumbent to the
    candidate in two ordered steps, each with its own budget and its own visible
    outcome. Step one waits for the incumbent to let go; the durable target flip
    already fenced it out of SQLite writes, so a lingering incumbent is reported
    rather than fatal. Step two waits for the candidate to publish activation and
    names what it saw when it gives up. Both budgets sit inside the host-side
-   promote deadline (PROMOTE_ACTION_TIMEOUT_MS), so the adapter always outlives
-   its own waits and the operator reads a reason instead of a bare timeout. */
+   promote deadline, so the adapter always outlives its own waits and the
+   operator reads a reason instead of a bare timeout. */
 async function handOverHotState(
   candidate: ViewerReleaseIdentity,
   current: ViewerReleaseIdentity | null,
   phase: (value: string) => void,
-): Promise<void> {
-  if (!hotStateActivationApplies(candidate.hotStateBackend)) return;
-  const releaseTimeoutMs = budgetMs("LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS", INCUMBENT_RELEASE_TIMEOUT_MS, 0);
+): Promise<string | null> {
+  if (!hotStateActivationApplies(candidate.hotStateBackend)) return null;
+  const budgets = fitHandOverBudgets({
+    releaseMs: budgetMs("LLV_INCUMBENT_HOT_STATE_RELEASE_TIMEOUT_MS", INCUMBENT_RELEASE_TIMEOUT_MS, 0),
+    activationMs: budgetMs("LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS", HOT_STATE_ACTIVATION_TIMEOUT_MS, 100),
+  }, hostActionDeadlineMs());
   const releasePollMs = budgetMs("LLV_INCUMBENT_HOT_STATE_RELEASE_POLL_MS", INCUMBENT_RELEASE_POLL_MS, 5);
-  const activationTimeoutMs = budgetMs("LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS", HOT_STATE_ACTIVATION_TIMEOUT_MS, 100);
   const activationPollMs = budgetMs("LLV_HOT_STATE_ACTIVATION_POLL_MS", HOT_STATE_ACTIVATION_POLL_MS, 5);
   const authority = () => readHotStateAuthority(stateDir);
   const activated = () => hotStateActivationSatisfied(authority(), candidate.revision);
   const incumbent = current && current.container !== candidate.container ? current.container : null;
-  phase(incumbentHotStateReleasePhase("unknown", 0, releaseTimeoutMs));
-  const release = incumbent === null
-    ? INCUMBENT_RELEASE_NOT_REQUIRED
-    : await awaitIncumbentHotStateRelease({
+  let release = INCUMBENT_RELEASE_NOT_REQUIRED;
+  if (incumbent !== null) {
+    phase(incumbentHotStateReleasePhase("unknown", 0, budgets.releaseMs));
+    release = await awaitIncumbentHotStateRelease({
       inspect: () => containerState(incumbent),
       activated,
       sleep: (delayMs) => Bun.sleep(delayMs),
       reportPhase: phase,
-      timeoutMs: releaseTimeoutMs,
+      timeoutMs: budgets.releaseMs,
       pollMs: releasePollMs,
     });
-  phase(hotStateActivationPhase(hotStateActivationObservation(authority(), candidate.revision), 0, activationTimeoutMs));
-  await awaitHotStateActivation({
+  }
+  phase(hotStateActivationPhase(hotStateActivationObservation(authority(), candidate.revision), 0, budgets.activationMs));
+  const activation = await awaitHotStateActivation({
     revision: candidate.revision,
     readAuthority: authority,
     release,
     inspectCandidate: () => containerState(candidate.container),
     sleep: (delayMs) => Bun.sleep(delayMs),
     reportPhase: phase,
-    timeoutMs: activationTimeoutMs,
+    timeoutMs: budgets.activationMs,
     pollMs: activationPollMs,
   });
+  return hotStateHandOverSummary(release, activation.waitedMs);
 }
 
 async function promoteTarget(
@@ -884,8 +900,11 @@ async function promoteTarget(
     ? await fenceCurrentSqliteRelease(current.revision, candidate)
     : null;
   const publication = switchTarget(candidate, "activate", undefined, fence, phase);
-  await handOverHotState(candidate, current, phase);
-  return publication;
+  const hotStateHandOver = await handOverHotState(candidate, current, phase);
+  /* The hand-over outcome travels with the publication evidence so the
+     deployment journal keeps it even when the promote finishes between two
+     samples of the adapter phase file (#1216). */
+  return hotStateHandOver === null ? publication : { ...publication, hotStateHandOver };
 }
 
 async function currentMcpRuntime(): Promise<ViewerMcpRuntimeIdentity> {

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -462,6 +462,10 @@ export interface ViewerMcpRuntimePublicationEvidence extends ViewerMcpRuntimeIde
   action: "activate" | "restore";
   publishedAt: string;
   durable: true;
+  /** What the SQLite hot-state hand-over did during an activate promote: the
+      incumbent's release outcome and how long activation took (#1216). Absent
+      on releases that never ran one. */
+  hotStateHandOver?: string;
 }
 
 export interface ViewerDeploymentMcpRuntimeStatus {

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -202,6 +202,28 @@ test("adapter action deadline terminates the process tree and clears durable own
   expect(fs.existsSync(fixture.stateFile)).toBe(false);
 });
 
+/* #1216: the runtime-host log carried nothing about a running deployment, so a
+   promote that stalled was invisible next to the journal maintenance chatter. */
+test("a running adapter action reports its phase transitions to the host log", async () => {
+  const phase = "waiting for hot-state activation - 3s of 180s - authority mode preparing revision matches epoch 9 activation pending";
+  const fixture = sleepingAdapter(phase);
+  const lines: string[] = [];
+  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, {
+    stateFile: fixture.stateFile,
+    timeouts: { promote: 200 },
+    phaseLogIntervalMs: 5,
+    log: (...args) => { lines.push(args.map(String).join(" ")); },
+  });
+
+  await expect(adapter.promote({
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:18001",
+    revision: "a".repeat(40),
+  })).rejects.toThrow(`deployment adapter promote timed out while ${phase}`);
+  expect(new Set(lines)).toEqual(new Set([`[viewer deployment] promote ${phase}`]));
+});
+
 test("promotion deadline reports the active handoff phase", async () => {
   const candidate = {
     image: "viewer:test",

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 
 import { HostCommandViewerDeploymentAdapter } from "./deploymentAdapter";
 import { promotedViewerReadinessPhase } from "./deploymentHealth";
+import { PROMOTE_ACTION_TIMEOUT_MS } from "./deploymentHotState";
 
 const sandboxes: string[] = [];
 afterEach(() => {
@@ -222,6 +223,31 @@ test("a running adapter action reports its phase transitions to the host log", a
     revision: "a".repeat(40),
   })).rejects.toThrow(`deployment adapter promote timed out while ${phase}`);
   expect(new Set(lines)).toEqual(new Set([`[viewer deployment] promote ${phase}`]));
+});
+
+/* #1216: the adapter cannot fit its waits inside a deadline it cannot see, and
+   the hand-over outcome is lost unless it survives publication normalization. */
+test("the host publishes its promote deadline and keeps the hand-over the adapter reports", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-adapter-handover-"));
+  sandboxes.push(directory);
+  const executable = path.join(directory, "adapter.sh");
+  fs.writeFileSync(executable, `#!/bin/sh
+printf '{"action":"activate","source":"legacy","revision":"${"a".repeat(40)}","releaseId":null,"artifactDigest":"${"b".repeat(64)}","stagedAt":null,"publishedAt":"2026-08-27T00:00:01.000Z","durable":true,"hotStateHandOver":"incumbent released hot state after 4s; activation published after 12s; deadline %s"}\n' "$LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS"
+`, { mode: 0o700 });
+  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(executable, {
+    stateFile: path.join(directory, "adapter-process.json"),
+  });
+
+  const publication = await adapter.promote({
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:18001",
+    revision: "a".repeat(40),
+    hotStateBackend: "sqlite-v1",
+  });
+
+  expect(publication.hotStateHandOver)
+    .toBe(`incumbent released hot state after 4s; activation published after 12s; deadline ${PROMOTE_ACTION_TIMEOUT_MS}`);
 });
 
 test("promotion deadline reports the active handoff phase", async () => {

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -16,6 +16,7 @@ import type {
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { ViewerDeploymentAdapter } from "./deployment";
+import { PROMOTE_ACTION_TIMEOUT_MS } from "./deploymentHotState";
 import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 import {
   createMcpHealthProbeAdmissionChannel,
@@ -33,7 +34,10 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
   "current-mcp-runtime": 90_000,
   "reconcile-mcp-runtime": 10 * 60_000,
   "verify-candidate": 90_000,
-  promote: 30_000,
+  /* #1216: strictly larger than the adapter-side hand-over budgets it
+     contains, so the adapter reports its own named reason instead of being
+     killed mid-wait and leaving the operator a bare phase string. */
+  promote: PROMOTE_ACTION_TIMEOUT_MS,
   "verify-promoted": 120_000,
   rollback: 90_000,
   retire: 60_000,
@@ -59,8 +63,14 @@ interface AdapterPhaseRecord {
   phase: string;
 }
 
+/** Slow enough to stay quiet through a long build, fast enough that a stalled
+    promote names its wait while it is still stalling. */
+const PHASE_LOG_INTERVAL_MS = 5_000;
+
 export interface HostCommandViewerDeploymentAdapterOptions {
   stateFile?: string;
+  log?(...args: unknown[]): void;
+  phaseLogIntervalMs?: number;
   timeouts?: Partial<Record<AdapterAction, number>>;
   proc?: ProcBackend;
   mcpHealthProbeAdmissions?: Pick<McpHealthProbeAdmissions, "issue" | "consume" | "revoke">;
@@ -290,6 +300,8 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
     const stateFile = options.stateFile ?? statePath("viewer-deployment-adapter-process.json");
     const phaseFile = `${stateFile}.phase`;
     const proc = options.proc ?? procBackend;
+    const log = options.log ?? console.error;
+    const phaseLogIntervalMs = Math.max(1, options.phaseLogIntervalMs ?? PHASE_LOG_INTERVAL_MS);
     const timeouts = { ...ACTION_TIMEOUTS, ...options.timeouts };
     const reconcile = async () => {
       const previous = readProcessRecord(stateFile);
@@ -372,6 +384,17 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       const stdoutPromise = readStream(child.stdout);
       const stderrPromise = readStream(child.stderr);
       let timer: ReturnType<typeof setTimeout> | null = null;
+      /* #1216: a deployment used to leave no trace in the runtime-host log, so
+         a promote that stalled was invisible next to the journal maintenance
+         chatter. Phase transitions are the adapter's own progress report. */
+      let reportedPhase: string | null = null;
+      const phaseLog = setInterval(() => {
+        const phase = readAdapterPhase(phaseFile, action);
+        if (phase === null || phase === reportedPhase) return;
+        reportedPhase = phase;
+        log(`[viewer deployment] ${action} ${phase}`);
+      }, phaseLogIntervalMs);
+      phaseLog.unref?.();
       try {
         const timeoutMs = Math.max(1, timeouts[action]);
         const outcome = await Promise.race([
@@ -391,6 +414,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
         catch { throw new Error(`deployment adapter ${action} returned invalid JSON`); }
       } finally {
         if (timer) clearTimeout(timer);
+        clearInterval(phaseLog);
         closeHealthAdmission?.();
         clearProcessRecord(stateFile, record);
         fs.rmSync(phaseFile, { force: true });

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -216,7 +216,18 @@ function publication(value: unknown): ViewerMcpRuntimePublicationEvidence {
     || item.durable !== true) {
     throw new Error("deployment adapter returned invalid MCP runtime publication evidence");
   }
-  return { ...runtime, action: item.action, publishedAt: item.publishedAt, durable: true };
+  /* #1216: the hand-over summary is what the journal keeps about the promote's
+     ordered hot-state steps, so it survives normalization here. */
+  const hotStateHandOver = typeof item.hotStateHandOver === "string"
+    ? item.hotStateHandOver.slice(0, 200)
+    : null;
+  return {
+    ...runtime,
+    action: item.action,
+    publishedAt: item.publishedAt,
+    durable: true,
+    ...(hotStateHandOver ? { hotStateHandOver } : {}),
+  };
 }
 
 function evidence(value: unknown): ViewerHealthEvidence {
@@ -319,6 +330,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       input: Record<string, unknown>,
       healthAdmissions?: Pick<McpHealthProbeAdmissions, "consume">,
     ): Promise<unknown> => {
+      const timeoutMs = Math.max(1, timeouts[action]);
       const admissionChannel = healthAdmissions
         ? await createMcpHealthProbeAdmissionChannel()
         : null;
@@ -334,6 +346,9 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
             ...withoutWakatimeCredential(process.env),
             LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1",
             LLV_DEPLOYMENT_ADAPTER_PHASE_FILE: phaseFile,
+            /* #1216: the deadline this host will enforce, so the adapter can
+               fit its own waits inside it instead of being killed mid-wait. */
+            LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS: String(timeoutMs),
           },
           detached: true,
         });
@@ -396,7 +411,6 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       }, phaseLogIntervalMs);
       phaseLog.unref?.();
       try {
-        const timeoutMs = Math.max(1, timeouts[action]);
         const outcome = await Promise.race([
           exitPromise.then((exitCode) => ({ type: "exit" as const, exitCode })),
           new Promise<{ type: "timeout" }>((resolve) => { timer = setTimeout(() => resolve({ type: "timeout" }), timeoutMs); }),

--- a/src/runtime-host/deploymentHotState.test.ts
+++ b/src/runtime-host/deploymentHotState.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "bun:test";
+
+import type { HotStateAuthority } from "@/lib/state/hotStateAuthority";
+
+import {
+  awaitHotStateActivation,
+  awaitIncumbentHotStateRelease,
+  hotStateActivationObservation,
+  hotStateActivationPhase,
+  HOT_STATE_ACTIVATION_TIMEOUT_MS,
+  incumbentHotStateReleasePhase,
+  INCUMBENT_RELEASE_TIMEOUT_MS,
+  PROMOTE_ACTION_TIMEOUT_MS,
+} from "./deploymentHotState";
+import type { ViewerCandidateContainerState } from "./deploymentHealth";
+
+const revision = "9".repeat(40);
+const PHASE_ALPHABET = /^[A-Za-z0-9 -]{1,160}$/;
+
+function authority(overrides: Partial<HotStateAuthority> = {}): HotStateAuthority {
+  return {
+    schemaVersion: 1,
+    epoch: 4,
+    mode: "sqlite",
+    releaseRevision: revision,
+    updatedAt: "2026-08-27T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Time advances only when the wait sleeps, so every elapsed value in these
+    assertions is the budget the wait actually spent. */
+function clock() {
+  let elapsedMs = 0;
+  return {
+    now: () => elapsedMs,
+    sleep: async (delayMs: number) => { elapsedMs += delayMs; },
+  };
+}
+
+/* The promote deadline used to equal the activation budget it contains, so the
+   host killed the adapter before the adapter could report anything. */
+test("the promote deadline outlives every hand-over budget it contains", () => {
+  expect(PROMOTE_ACTION_TIMEOUT_MS).toBeGreaterThan(
+    HOT_STATE_ACTIVATION_TIMEOUT_MS + INCUMBENT_RELEASE_TIMEOUT_MS,
+  );
+});
+
+test("activation observations name the authority the promote can actually see", () => {
+  expect(hotStateActivationObservation(null, revision)).toBe("no hot-state authority is published");
+  expect(hotStateActivationObservation(authority({ mode: "preparing" }), revision))
+    .toBe("authority mode preparing revision matches epoch 4 activation pending");
+  expect(hotStateActivationObservation(authority({ releaseRevision: "1".repeat(40) }), revision))
+    .toBe("authority mode sqlite revision differs epoch 4 activation pending");
+  expect(hotStateActivationObservation(authority({ activationReadyAt: "2026-08-27T00:00:01.000Z" }), revision))
+    .toBe("authority mode sqlite revision matches epoch 4 activation ready");
+});
+
+test("every reported phase survives the host phase-file alphabet", () => {
+  const phases = [
+    incumbentHotStateReleasePhase("running", 12_400, 60_000),
+    incumbentHotStateReleasePhase("unknown", 0, 60_000),
+    hotStateActivationPhase(hotStateActivationObservation(authority({ mode: "fencing" }), revision), 91_000, 180_000),
+    hotStateActivationPhase("x".repeat(400), 1_000, 180_000),
+  ];
+  for (const phase of phases) expect(phase).toMatch(PHASE_ALPHABET);
+  expect(phases[0]).toBe("releasing incumbent hot state - 12s of 60s - incumbent running");
+  expect(phases[2]).toBe("waiting for hot-state activation - 91s of 180s - authority mode fencing revision matches epoch 4 activation pending");
+});
+
+test("activation that never arrives fails with a named reason", async () => {
+  const phases: string[] = [];
+  await expect(awaitHotStateActivation({
+    revision,
+    readAuthority: () => authority({ mode: "preparing" }),
+    release: { outcome: "retained", state: "running", waitedMs: 60_000 },
+    ...clock(),
+    reportPhase: (phase) => { phases.push(phase); },
+    timeoutMs: 200,
+    pollMs: 100,
+  })).rejects.toThrow(
+    `promoted Viewer never published hot-state activation for revision ${revision}`
+    + "; waited 0s of 0s"
+    + "; last observed authority mode preparing revision matches epoch 4 activation pending"
+    + "; candidate container state is unobservable"
+    + "; incumbent still running after 60s",
+  );
+  expect(phases[0]).toBe("waiting for hot-state activation - 0s of 0s - authority mode preparing revision matches epoch 4 activation pending");
+});
+
+test("a candidate that died during its own activation is named separately", async () => {
+  await expect(awaitHotStateActivation({
+    revision,
+    readAuthority: () => authority({ mode: "preparing" }),
+    inspectCandidate: async () => "exited",
+    ...clock(),
+    timeoutMs: 200,
+    pollMs: 100,
+  })).rejects.toThrow("; candidate container is exited; incumbent release not required");
+});
+
+test("activation that arrives late but inside the budget succeeds", async () => {
+  let reads = 0;
+  const phases: string[] = [];
+  await awaitHotStateActivation({
+    revision,
+    readAuthority: () => {
+      reads += 1;
+      return reads < 4 ? authority({ mode: "preparing" }) : authority({ activationReadyAt: "2026-08-27T00:00:09.000Z" });
+    },
+    ...clock(),
+    reportPhase: (phase) => { phases.push(phase); },
+    timeoutMs: 5_000,
+    pollMs: 1_000,
+  });
+
+  expect(reads).toBe(4);
+  expect(phases).toHaveLength(3);
+});
+
+test("the incumbent release step reports the hand-over it observed", async () => {
+  const states: ViewerCandidateContainerState[] = ["running", "running", "exited"];
+  const phases: string[] = [];
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: async () => states.shift() ?? "missing",
+    activated: () => false,
+    ...clock(),
+    reportPhase: (phase) => { phases.push(phase); },
+    timeoutMs: 60_000,
+    pollMs: 1_000,
+  });
+
+  expect(release).toEqual({ outcome: "released", state: "exited", waitedMs: 2_000 });
+  expect(phases[0]).toBe("releasing incumbent hot state - 0s of 60s - incumbent running");
+});
+
+test("an incumbent that never lets go is reported rather than fatal", async () => {
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: async () => "running",
+    activated: () => false,
+    ...clock(),
+    timeoutMs: 60_000,
+    pollMs: 1_000,
+  });
+
+  expect(release).toEqual({ outcome: "retained", state: "running", waitedMs: 60_000 });
+});
+
+test("an unobservable incumbent does not stall the promote", async () => {
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: async () => { throw new Error("docker daemon is unreachable"); },
+    activated: () => false,
+    ...clock(),
+    timeoutMs: 60_000,
+    pollMs: 1_000,
+  });
+
+  expect(release).toEqual({ outcome: "unobservable", state: "unknown", waitedMs: 60_000 });
+});
+
+test("activation that already landed retires the incumbent release step immediately", async () => {
+  let inspected = 0;
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: async () => { inspected += 1; return "running"; },
+    activated: () => true,
+    ...clock(),
+    timeoutMs: 60_000,
+    pollMs: 1_000,
+  });
+
+  expect({ release, inspected }).toEqual({
+    release: { outcome: "not required", state: "unknown", waitedMs: 0 },
+    inspected: 0,
+  });
+});

--- a/src/runtime-host/deploymentHotState.test.ts
+++ b/src/runtime-host/deploymentHotState.test.ts
@@ -5,8 +5,10 @@ import type { HotStateAuthority } from "@/lib/state/hotStateAuthority";
 import {
   awaitHotStateActivation,
   awaitIncumbentHotStateRelease,
+  fitHandOverBudgets,
   hotStateActivationObservation,
   hotStateActivationPhase,
+  hotStateHandOverSummary,
   HOT_STATE_ACTIVATION_TIMEOUT_MS,
   incumbentHotStateReleasePhase,
   INCUMBENT_RELEASE_TIMEOUT_MS,
@@ -28,13 +30,26 @@ function authority(overrides: Partial<HotStateAuthority> = {}): HotStateAuthorit
   };
 }
 
-/** Time advances only when the wait sleeps, so every elapsed value in these
-    assertions is the budget the wait actually spent. */
+/** Time advances only when the wait sleeps or when a bound it set actually
+    fires, so every elapsed value in these assertions is the budget the wait
+    really spent — a bound abandoned because the work finished costs nothing,
+    exactly as a cleared timer does on a wall clock. */
 function clock() {
   let elapsedMs = 0;
   return {
     now: () => elapsedMs,
     sleep: async (delayMs: number) => { elapsedMs += delayMs; },
+    timer: (delayMs: number) => {
+      let cancelled = false;
+      const expired = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          if (cancelled) return;
+          elapsedMs += delayMs;
+          resolve();
+        }, 0);
+      });
+      return { expired, cancel: () => { cancelled = true; } };
+    },
   };
 }
 
@@ -64,8 +79,26 @@ test("every reported phase survives the host phase-file alphabet", () => {
     hotStateActivationPhase("x".repeat(400), 1_000, 180_000),
   ];
   for (const phase of phases) expect(phase).toMatch(PHASE_ALPHABET);
-  expect(phases[0]).toBe("releasing incumbent hot state - 12s of 60s - incumbent running");
-  expect(phases[2]).toBe("waiting for hot-state activation - 91s of 180s - authority mode fencing revision matches epoch 4 activation pending");
+  /* Elapsed is reported in 5s steps: the phase file costs two fsyncs on the
+     state directory the hand-over contends on, and its consumer samples every
+     few seconds, so a per-second value would defeat the dedupe upstream. */
+  expect(phases[0]).toBe("releasing incumbent hot state - 10s of 60s - incumbent running");
+  expect(phases[2]).toBe("waiting for hot-state activation - 90s of 180s - authority mode fencing revision matches epoch 4 activation pending");
+});
+
+/* A budget configured past the host deadline restores exactly the inversion
+   this fix removes, so the adapter fits what it was given instead of it. */
+test("configured hand-over budgets are fitted inside the host deadline", () => {
+  const fitted = fitHandOverBudgets({ releaseMs: 10 * 60_000, activationMs: 30 * 60_000 });
+
+  expect(fitted.releaseMs + fitted.activationMs).toBeLessThan(PROMOTE_ACTION_TIMEOUT_MS);
+  expect(fitted.releaseMs).toBeGreaterThan(0);
+  expect(fitted.activationMs).toBeGreaterThan(0);
+  expect(fitHandOverBudgets({ releaseMs: 150, activationMs: 400 }))
+    .toEqual({ releaseMs: 150, activationMs: 400 });
+  expect(fitHandOverBudgets({ releaseMs: 4_000, activationMs: 4_000 }, 2_000).releaseMs
+    + fitHandOverBudgets({ releaseMs: 4_000, activationMs: 4_000 }, 2_000).activationMs)
+    .toBeLessThan(2_000);
 });
 
 test("activation that never arrives fails with a named reason", async () => {
@@ -144,6 +177,62 @@ test("an incumbent that never lets go is reported rather than fatal", async () =
   });
 
   expect(release).toEqual({ outcome: "retained", state: "running", waitedMs: 60_000 });
+});
+
+/* A wedged dockerd used to freeze the release loop on an unbounded inspect:
+   it never re-read the activation signal, never expired, and the host killed a
+   promote whose activation had landed normally. */
+test("a container inspection that never settles does not freeze the release step", async () => {
+  let activationChecks = 0;
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: () => new Promise<never>(() => {}),
+    activated: () => { activationChecks += 1; return false; },
+    ...clock(),
+    timeoutMs: 15_000,
+    pollMs: 5_000,
+    inspectionTimeoutMs: 5_000,
+  });
+
+  expect(release).toEqual({ outcome: "unobservable", state: "unknown", waitedMs: 15_000 });
+  expect(activationChecks).toBeGreaterThan(1);
+});
+
+test("a wedged inspection cannot outrun the budget of the step that started it", async () => {
+  const release = await awaitIncumbentHotStateRelease({
+    inspect: () => new Promise<never>(() => {}),
+    activated: () => false,
+    ...clock(),
+    timeoutMs: 300,
+    pollMs: 100,
+    inspectionTimeoutMs: 5_000,
+  });
+
+  expect(release).toEqual({ outcome: "unobservable", state: "unknown", waitedMs: 300 });
+});
+
+test("a candidate inspection that never settles still names the activation timeout", async () => {
+  await expect(awaitHotStateActivation({
+    revision,
+    readAuthority: () => authority({ mode: "preparing" }),
+    inspectCandidate: () => new Promise<never>(() => {}),
+    ...clock(),
+    timeoutMs: 200,
+    pollMs: 100,
+    inspectionTimeoutMs: 5_000,
+  })).rejects.toThrow(
+    `promoted Viewer never published hot-state activation for revision ${revision}`
+    + "; waited 0s of 0s"
+    + "; last observed authority mode preparing revision matches epoch 4 activation pending"
+    + "; candidate container state is unobservable"
+    + "; incumbent release not required",
+  );
+});
+
+test("a hand-over that completed reports both ordered steps to the journal", () => {
+  expect(hotStateHandOverSummary({ outcome: "released", state: "exited", waitedMs: 4_000 }, 12_000))
+    .toBe("incumbent released hot state after 4s; activation published after 12s");
+  expect(hotStateHandOverSummary({ outcome: "not required", state: "unknown", waitedMs: 0 }, 1_400))
+    .toBe("incumbent release not required; activation published after 1s");
 });
 
 test("an unobservable incumbent does not stall the promote", async () => {

--- a/src/runtime-host/deploymentHotState.ts
+++ b/src/runtime-host/deploymentHotState.ts
@@ -1,0 +1,216 @@
+import { HOT_STATE_BACKEND, type HotStateAuthority } from "@/lib/state/hotStateAuthority";
+
+import type { ViewerCandidateContainerState } from "./deploymentHealth";
+
+/* #1216 promote hand-over budgets.
+ *
+ * The activation signal a promote waits for is `hot-state-authority.json`
+ * gaining `mode: "sqlite"`, the candidate's revision and `activationReadyAt`.
+ * Only the promoted Viewer container writes it (markHotStateActivationReady),
+ * and it does so several startup steps after the durable target flips, while
+ * the incumbent is still running and still writing the same SQLite state.
+ * Every one of those steps can block on a contended lock for up to 30s
+ * (LOCK_ATTEMPTS * LOCK_WAIT_MS in sqliteStateStore.ts and fileTransaction.ts),
+ * so the hand-over legitimately outlives a 30s promote.
+ *
+ * The host-side promote deadline must therefore stay strictly larger than the
+ * adapter-side budgets it contains, or the host kills the adapter before the
+ * adapter can report what it saw. Both sides read these constants so the two
+ * budgets cannot drift back into a tie. */
+export const HOT_STATE_ACTIVATION_TIMEOUT_MS = 180_000;
+export const HOT_STATE_ACTIVATION_POLL_MS = 250;
+export const INCUMBENT_RELEASE_TIMEOUT_MS = 60_000;
+export const INCUMBENT_RELEASE_POLL_MS = 1_000;
+/** Fencing, the switch intent, the authority publication and the durable
+    target publication all run before the waits start, and every one of them
+    fsyncs. */
+export const PROMOTE_PUBLICATION_BUDGET_MS = 60_000;
+export const PROMOTE_ACTION_TIMEOUT_MS =
+  HOT_STATE_ACTIVATION_TIMEOUT_MS + INCUMBENT_RELEASE_TIMEOUT_MS + PROMOTE_PUBLICATION_BUDGET_MS;
+
+/** Adapter phases are validated against `/^[A-Za-z0-9 -]{1,160}$/` before the
+    host will read them back, so every phase fragment stays in that alphabet. */
+const PHASE_LIMIT = 160;
+
+export type IncumbentHotStateReleaseOutcome = "released" | "retained" | "unobservable" | "not required";
+
+export interface IncumbentHotStateRelease {
+  outcome: IncumbentHotStateReleaseOutcome;
+  state: ViewerCandidateContainerState | "unknown";
+  waitedMs: number;
+}
+
+export const INCUMBENT_RELEASE_NOT_REQUIRED: IncumbentHotStateRelease = {
+  outcome: "not required",
+  state: "unknown",
+  waitedMs: 0,
+};
+
+function seconds(durationMs: number): number {
+  return Math.max(0, Math.round(durationMs / 1_000));
+}
+
+function clip(phase: string): string {
+  return phase.length <= PHASE_LIMIT ? phase : phase.slice(0, PHASE_LIMIT).trimEnd();
+}
+
+export function hotStateActivationSatisfied(
+  authority: HotStateAuthority | null,
+  revision: string,
+): boolean {
+  return authority?.mode === "sqlite"
+    && authority.releaseRevision === revision
+    && typeof authority.activationReadyAt === "string";
+}
+
+/** What the promote can actually see about the signal it is waiting for. */
+export function hotStateActivationObservation(
+  authority: HotStateAuthority | null,
+  revision: string,
+): string {
+  if (!authority) return "no hot-state authority is published";
+  const match = authority.releaseRevision === null
+    ? "revision unset"
+    : authority.releaseRevision === revision ? "revision matches" : "revision differs";
+  const activation = typeof authority.activationReadyAt === "string" ? "activation ready" : "activation pending";
+  return `authority mode ${authority.mode} ${match} epoch ${authority.epoch} ${activation}`;
+}
+
+export function incumbentHotStateReleaseSummary(release: IncumbentHotStateRelease): string {
+  if (release.outcome === "not required") return "incumbent release not required";
+  if (release.outcome === "released") return `incumbent released hot state after ${seconds(release.waitedMs)}s`;
+  if (release.outcome === "unobservable") return `incumbent state unobservable after ${seconds(release.waitedMs)}s`;
+  return `incumbent still ${release.state} after ${seconds(release.waitedMs)}s`;
+}
+
+export function incumbentHotStateReleasePhase(
+  state: ViewerCandidateContainerState | "unknown",
+  elapsedMs: number,
+  budgetMs: number,
+): string {
+  return clip(`releasing incumbent hot state - ${seconds(elapsedMs)}s of ${seconds(budgetMs)}s - incumbent ${state}`);
+}
+
+export function hotStateActivationPhase(
+  observation: string,
+  elapsedMs: number,
+  budgetMs: number,
+): string {
+  return clip(`waiting for hot-state activation - ${seconds(elapsedMs)}s of ${seconds(budgetMs)}s - ${observation}`);
+}
+
+export const CANDIDATE_STATE_UNOBSERVABLE = "candidate container state is unobservable";
+
+export function candidateContainerSummary(state: ViewerCandidateContainerState): string {
+  return `candidate container is ${state}`;
+}
+
+/** The named reason the operator reads when the signal never arrives. */
+export function hotStateActivationTimeoutMessage(input: {
+  revision: string;
+  waitedMs: number;
+  budgetMs: number;
+  observation: string;
+  release: IncumbentHotStateRelease;
+  candidate: string;
+}): string {
+  return [
+    `promoted Viewer never published hot-state activation for revision ${input.revision}`,
+    `waited ${seconds(input.waitedMs)}s of ${seconds(input.budgetMs)}s`,
+    `last observed ${input.observation}`,
+    input.candidate,
+    incumbentHotStateReleaseSummary(input.release),
+  ].join("; ");
+}
+
+interface WaitClock {
+  sleep(delayMs: number): Promise<void>;
+  now?(): number;
+  reportPhase?(phase: string): void;
+}
+
+/** Ordered step one of an SQLite promote: the incumbent hands its hot state
+    back. It is bounded and non-fatal — the durable target flip already fences
+    the incumbent out of SQLite writes (hotStateSqliteWriterReady), so a
+    lingering incumbent cannot block activation. Its outcome is reported and
+    carried into the activation diagnosis instead of being raced silently. */
+export async function awaitIncumbentHotStateRelease(options: WaitClock & {
+  inspect(): Promise<ViewerCandidateContainerState>;
+  activated(): boolean;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<IncumbentHotStateRelease> {
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.max(0, options.timeoutMs ?? INCUMBENT_RELEASE_TIMEOUT_MS);
+  const pollMs = Math.max(5, options.pollMs ?? INCUMBENT_RELEASE_POLL_MS);
+  const started = now();
+  for (;;) {
+    /* Activation already landing means the incumbent is out of the way as far
+       as the promote is concerned; a real release returns from the branch
+       below instead. */
+    if (options.activated()) return { outcome: "not required", state: "unknown", waitedMs: now() - started };
+    let observed: ViewerCandidateContainerState | null = null;
+    try { observed = await options.inspect(); }
+    catch { observed = null; }
+    const state = observed ?? "unknown";
+    options.reportPhase?.(incumbentHotStateReleasePhase(state, now() - started, timeoutMs));
+    if (observed !== null && observed !== "running") {
+      return { outcome: "released", state: observed, waitedMs: now() - started };
+    }
+    if (now() - started >= timeoutMs) {
+      return {
+        outcome: observed === null ? "unobservable" : "retained",
+        state,
+        waitedMs: now() - started,
+      };
+    }
+    await options.sleep(pollMs);
+  }
+}
+
+/** Ordered step two: the promoted Viewer publishes hot-state activation. */
+export async function awaitHotStateActivation(options: WaitClock & {
+  revision: string;
+  readAuthority(): HotStateAuthority | null;
+  release?: IncumbentHotStateRelease;
+  /** Inspected once, on the failure path: a candidate that died during its own
+      activation and one that is up but never published look identical in the
+      authority file, and they are different bugs. */
+  inspectCandidate?(): Promise<ViewerCandidateContainerState>;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<void> {
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.max(100, options.timeoutMs ?? HOT_STATE_ACTIVATION_TIMEOUT_MS);
+  const pollMs = Math.max(5, options.pollMs ?? HOT_STATE_ACTIVATION_POLL_MS);
+  const release = options.release ?? INCUMBENT_RELEASE_NOT_REQUIRED;
+  const started = now();
+  let observation = hotStateActivationObservation(null, options.revision);
+  for (;;) {
+    const authority = options.readAuthority();
+    observation = hotStateActivationObservation(authority, options.revision);
+    if (hotStateActivationSatisfied(authority, options.revision)) return;
+    const elapsedMs = now() - started;
+    options.reportPhase?.(hotStateActivationPhase(observation, elapsedMs, timeoutMs));
+    if (elapsedMs >= timeoutMs) {
+      let candidate = CANDIDATE_STATE_UNOBSERVABLE;
+      if (options.inspectCandidate) {
+        try { candidate = candidateContainerSummary(await options.inspectCandidate()); }
+        catch { /* the failure message keeps the unobservable default */ }
+      }
+      throw new Error(hotStateActivationTimeoutMessage({
+        revision: options.revision,
+        waitedMs: elapsedMs,
+        budgetMs: timeoutMs,
+        observation,
+        release,
+        candidate,
+      }));
+    }
+    await options.sleep(pollMs);
+  }
+}
+
+export function hotStateActivationApplies(hotStateBackend: string | undefined): boolean {
+  return hotStateBackend === HOT_STATE_BACKEND;
+}

--- a/src/runtime-host/deploymentHotState.ts
+++ b/src/runtime-host/deploymentHotState.ts
@@ -16,21 +16,44 @@ import type { ViewerCandidateContainerState } from "./deploymentHealth";
  * The host-side promote deadline must therefore stay strictly larger than the
  * adapter-side budgets it contains, or the host kills the adapter before the
  * adapter can report what it saw. Both sides read these constants so the two
- * budgets cannot drift back into a tie. */
+ * budgets cannot drift back into a tie, and a configured budget is fitted to
+ * the deadline it runs under (fitHandOverBudgets) rather than trusted. */
 export const HOT_STATE_ACTIVATION_TIMEOUT_MS = 180_000;
 export const HOT_STATE_ACTIVATION_POLL_MS = 250;
-export const INCUMBENT_RELEASE_TIMEOUT_MS = 60_000;
-export const INCUMBENT_RELEASE_POLL_MS = 1_000;
+/** The demoted incumbent sees the flipped target on its own 250ms poll,
+    checkpoints its rollback mirrors and exits, so a release that has not
+    happened within this budget is not going to happen inside the promote — and
+    does not have to, because the flip already fenced the incumbent out of
+    SQLite writes. */
+export const INCUMBENT_RELEASE_TIMEOUT_MS = 15_000;
+export const INCUMBENT_RELEASE_POLL_MS = 5_000;
+/** Every container inspection here is a diagnostic and dockerd can wedge, so
+    each one is bounded: a wait keeps its own schedule instead of hanging on
+    the daemon, and an inspection that does not settle reads as unobservable.
+    Inside a wait this ceiling is further clamped to the wait's own remaining
+    budget; only the one diagnostic inspection on the failure path, which runs
+    after that budget is spent, costs the full ceiling. */
+export const CONTAINER_INSPECTION_TIMEOUT_MS = 5_000;
 /** Fencing, the switch intent, the authority publication and the durable
     target publication all run before the waits start, and every one of them
     fsyncs. */
 export const PROMOTE_PUBLICATION_BUDGET_MS = 60_000;
-export const PROMOTE_ACTION_TIMEOUT_MS =
-  HOT_STATE_ACTIVATION_TIMEOUT_MS + INCUMBENT_RELEASE_TIMEOUT_MS + PROMOTE_PUBLICATION_BUDGET_MS;
+export const HAND_OVER_BUDGET_MS = INCUMBENT_RELEASE_TIMEOUT_MS + HOT_STATE_ACTIVATION_TIMEOUT_MS;
+/** Both waits, the publication that precedes them, and the one bounded
+    inspection each wait can overshoot by. */
+export const PROMOTE_ACTION_TIMEOUT_MS = HAND_OVER_BUDGET_MS
+  + PROMOTE_PUBLICATION_BUDGET_MS
+  + 2 * CONTAINER_INSPECTION_TIMEOUT_MS;
 
 /** Adapter phases are validated against `/^[A-Za-z0-9 -]{1,160}$/` before the
     host will read them back, so every phase fragment stays in that alphabet. */
 const PHASE_LIMIT = 160;
+
+/** A phase costs two fsyncs on the same state directory the hand-over contends
+    on, and its only consumer samples every few seconds, so elapsed time is
+    reported in steps: the dedupe upstream then collapses a whole step into a
+    single write instead of one per poll. */
+const PHASE_ELAPSED_STEP_MS = 5_000;
 
 export type IncumbentHotStateReleaseOutcome = "released" | "retained" | "unobservable" | "not required";
 
@@ -50,8 +73,33 @@ function seconds(durationMs: number): number {
   return Math.max(0, Math.round(durationMs / 1_000));
 }
 
+function reportedSeconds(elapsedMs: number): number {
+  return Math.max(0, Math.floor(elapsedMs / PHASE_ELAPSED_STEP_MS) * (PHASE_ELAPSED_STEP_MS / 1_000));
+}
+
 function clip(phase: string): string {
   return phase.length <= PHASE_LIMIT ? phase : phase.slice(0, PHASE_LIMIT).trimEnd();
+}
+
+/** The host kills the adapter's process group at its own action deadline, so
+    the budgets the adapter waits on have to fit inside that deadline with the
+    publication and inspection allowances still intact. Configured budgets are
+    scaled down to fit rather than trusted: a budget that outruns the deadline
+    silently restores the inversion #1216 was. */
+export function fitHandOverBudgets(
+  requested: { releaseMs: number; activationMs: number },
+  hostDeadlineMs: number = PROMOTE_ACTION_TIMEOUT_MS,
+): { releaseMs: number; activationMs: number } {
+  const releaseMs = Math.max(0, Math.floor(requested.releaseMs));
+  const activationMs = Math.max(0, Math.floor(requested.activationMs));
+  const available = Math.max(
+    0,
+    Math.floor(Math.max(0, hostDeadlineMs) * HAND_OVER_BUDGET_MS / PROMOTE_ACTION_TIMEOUT_MS),
+  );
+  const requestedTotal = releaseMs + activationMs;
+  if (requestedTotal <= available || requestedTotal === 0) return { releaseMs, activationMs };
+  const fittedRelease = Math.floor(available * releaseMs / requestedTotal);
+  return { releaseMs: fittedRelease, activationMs: available - fittedRelease };
 }
 
 export function hotStateActivationSatisfied(
@@ -83,12 +131,22 @@ export function incumbentHotStateReleaseSummary(release: IncumbentHotStateReleas
   return `incumbent still ${release.state} after ${seconds(release.waitedMs)}s`;
 }
 
+/** The hand-over as the deployment journal keeps it, so a promote that
+    succeeded inside one log sampling window still records what each ordered
+    step did. */
+export function hotStateHandOverSummary(
+  release: IncumbentHotStateRelease,
+  activationWaitedMs: number,
+): string {
+  return `${incumbentHotStateReleaseSummary(release)}; activation published after ${seconds(activationWaitedMs)}s`;
+}
+
 export function incumbentHotStateReleasePhase(
   state: ViewerCandidateContainerState | "unknown",
   elapsedMs: number,
   budgetMs: number,
 ): string {
-  return clip(`releasing incumbent hot state - ${seconds(elapsedMs)}s of ${seconds(budgetMs)}s - incumbent ${state}`);
+  return clip(`releasing incumbent hot state - ${reportedSeconds(elapsedMs)}s of ${seconds(budgetMs)}s - incumbent ${state}`);
 }
 
 export function hotStateActivationPhase(
@@ -96,7 +154,7 @@ export function hotStateActivationPhase(
   elapsedMs: number,
   budgetMs: number,
 ): string {
-  return clip(`waiting for hot-state activation - ${seconds(elapsedMs)}s of ${seconds(budgetMs)}s - ${observation}`);
+  return clip(`waiting for hot-state activation - ${reportedSeconds(elapsedMs)}s of ${seconds(budgetMs)}s - ${observation}`);
 }
 
 export const CANDIDATE_STATE_UNOBSERVABLE = "candidate container state is unobservable";
@@ -123,10 +181,50 @@ export function hotStateActivationTimeoutMessage(input: {
   ].join("; ");
 }
 
+export interface AbandonableTimer {
+  expired: Promise<void>;
+  cancel(): void;
+}
+
 interface WaitClock {
   sleep(delayMs: number): Promise<void>;
   now?(): number;
   reportPhase?(phase: string): void;
+  /** Bounds work that may never finish. Abandoned as soon as that work does,
+      so bounding a fast inspection costs nothing. */
+  timer?(delayMs: number): AbandonableTimer;
+}
+
+function wallClockTimer(delayMs: number): AbandonableTimer {
+  let handle: ReturnType<typeof setTimeout> | null = null;
+  const expired = new Promise<void>((resolve) => { handle = setTimeout(resolve, delayMs); });
+  return { expired, cancel: () => { if (handle !== null) clearTimeout(handle); } };
+}
+
+const INSPECTION_EXPIRED: unique symbol = Symbol("container inspection expired");
+
+/** A container inspection that outlives its bound reads as unobservable
+    instead of holding the caller: a wedged dockerd froze the whole release
+    loop, which then never re-read the activation signal and never expired. */
+async function inspectWithin(
+  inspect: () => Promise<ViewerCandidateContainerState>,
+  timeoutMs: number,
+  timer: (delayMs: number) => AbandonableTimer,
+): Promise<ViewerCandidateContainerState | null> {
+  const attempt = (async () => {
+    try { return await inspect(); }
+    catch { return null; }
+  })();
+  const bound = timer(Math.max(1, timeoutMs));
+  try {
+    const observed = await Promise.race([
+      attempt,
+      bound.expired.then((): typeof INSPECTION_EXPIRED => INSPECTION_EXPIRED),
+    ]);
+    return observed === INSPECTION_EXPIRED ? null : observed;
+  } finally {
+    bound.cancel();
+  }
 }
 
 /** Ordered step one of an SQLite promote: the incumbent hands its hot state
@@ -139,72 +237,86 @@ export async function awaitIncumbentHotStateRelease(options: WaitClock & {
   activated(): boolean;
   timeoutMs?: number;
   pollMs?: number;
+  inspectionTimeoutMs?: number;
 }): Promise<IncumbentHotStateRelease> {
   const now = options.now ?? Date.now;
   const timeoutMs = Math.max(0, options.timeoutMs ?? INCUMBENT_RELEASE_TIMEOUT_MS);
   const pollMs = Math.max(5, options.pollMs ?? INCUMBENT_RELEASE_POLL_MS);
+  const inspectionMs = Math.max(1, options.inspectionTimeoutMs ?? CONTAINER_INSPECTION_TIMEOUT_MS);
+  const timer = options.timer ?? wallClockTimer;
   const started = now();
+  /* What the step actually managed to see. The last inspection before the
+     deadline is the one most likely to be cut short by the clamp below, so the
+     outcome is decided by every observation the step made, not by that one. */
+  let seen: ViewerCandidateContainerState | null = null;
   for (;;) {
     /* Activation already landing means the incumbent is out of the way as far
        as the promote is concerned; a real release returns from the branch
        below instead. */
     if (options.activated()) return { outcome: "not required", state: "unknown", waitedMs: now() - started };
-    let observed: ViewerCandidateContainerState | null = null;
-    try { observed = await options.inspect(); }
-    catch { observed = null; }
-    const state = observed ?? "unknown";
-    options.reportPhase?.(incumbentHotStateReleasePhase(state, now() - started, timeoutMs));
+    /* The inspection is bounded by whatever is left of the step's own budget as
+       well as by its own ceiling, so a wedged daemon cannot make a bounded step
+       overrun the deadline that contains it. */
+    const observed = await inspectWithin(
+      options.inspect,
+      Math.min(inspectionMs, Math.max(1, timeoutMs - (now() - started))),
+      timer,
+    );
+    if (observed !== null) seen = observed;
+    options.reportPhase?.(incumbentHotStateReleasePhase(observed ?? "unknown", now() - started, timeoutMs));
     if (observed !== null && observed !== "running") {
       return { outcome: "released", state: observed, waitedMs: now() - started };
     }
     if (now() - started >= timeoutMs) {
-      return {
-        outcome: observed === null ? "unobservable" : "retained",
-        state,
-        waitedMs: now() - started,
-      };
+      return seen === null
+        ? { outcome: "unobservable", state: "unknown", waitedMs: now() - started }
+        : { outcome: "retained", state: seen, waitedMs: now() - started };
     }
     await options.sleep(pollMs);
   }
 }
 
-/** Ordered step two: the promoted Viewer publishes hot-state activation. */
+/** Ordered step two: the promoted Viewer publishes hot-state activation.
+    Resolves with how long the signal took, which is the step's own visible
+    outcome on the success path. */
 export async function awaitHotStateActivation(options: WaitClock & {
   revision: string;
   readAuthority(): HotStateAuthority | null;
   release?: IncumbentHotStateRelease;
   /** Inspected once, on the failure path: a candidate that died during its own
       activation and one that is up but never published look identical in the
-      authority file, and they are different bugs. */
+      authority file, and they are different bugs. Bounded like every other
+      inspection, so a wedged daemon cannot swallow the named error. */
   inspectCandidate?(): Promise<ViewerCandidateContainerState>;
   timeoutMs?: number;
   pollMs?: number;
-}): Promise<void> {
+  inspectionTimeoutMs?: number;
+}): Promise<{ waitedMs: number }> {
   const now = options.now ?? Date.now;
   const timeoutMs = Math.max(100, options.timeoutMs ?? HOT_STATE_ACTIVATION_TIMEOUT_MS);
   const pollMs = Math.max(5, options.pollMs ?? HOT_STATE_ACTIVATION_POLL_MS);
+  const inspectionMs = Math.max(1, options.inspectionTimeoutMs ?? CONTAINER_INSPECTION_TIMEOUT_MS);
   const release = options.release ?? INCUMBENT_RELEASE_NOT_REQUIRED;
+  const timer = options.timer ?? wallClockTimer;
   const started = now();
   let observation = hotStateActivationObservation(null, options.revision);
   for (;;) {
     const authority = options.readAuthority();
     observation = hotStateActivationObservation(authority, options.revision);
-    if (hotStateActivationSatisfied(authority, options.revision)) return;
+    if (hotStateActivationSatisfied(authority, options.revision)) return { waitedMs: now() - started };
     const elapsedMs = now() - started;
     options.reportPhase?.(hotStateActivationPhase(observation, elapsedMs, timeoutMs));
     if (elapsedMs >= timeoutMs) {
-      let candidate = CANDIDATE_STATE_UNOBSERVABLE;
-      if (options.inspectCandidate) {
-        try { candidate = candidateContainerSummary(await options.inspectCandidate()); }
-        catch { /* the failure message keeps the unobservable default */ }
-      }
+      const inspected = options.inspectCandidate
+        ? await inspectWithin(options.inspectCandidate, inspectionMs, timer)
+        : null;
       throw new Error(hotStateActivationTimeoutMessage({
         revision: options.revision,
         waitedMs: elapsedMs,
         budgetMs: timeoutMs,
         observation,
         release,
-        candidate,
+        candidate: inspected === null ? CANDIDATE_STATE_UNOBSERVABLE : candidateContainerSummary(inspected),
       }));
     }
     await options.sleep(pollMs);

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -14,6 +14,7 @@ const { serveRuntimeHost } = await import("./socket");
 const { ViewerDeploymentCoordinator } = await import("./deployment");
 const { HostCommandViewerDeploymentAdapter } = await import("./deploymentAdapter");
 const { serveViewerDeploymentProxy } = await import("./deploymentProxy");
+const { ReceiptSweepReporter, receiptSweepDebugEnabled } = await import("./receiptSweep");
 const {
   currentRuntimeHostGeneration,
   RUNTIME_HOST_CONTAINER_ENV,
@@ -107,17 +108,14 @@ const legacyTimer = legacyScheduler ? setInterval(() => {
 /* Producer-receipt retention runs on wall clock, not on append traffic, so a
    quiet journal still drains its backlog. Each tick is bounded inside
    maintainProducerReceipts; the multi-week legacy accumulation drains across
-   ticks while the sweep itself never blocks the socket loop noticeably. */
-let receiptSweepDeleted = 0;
+   ticks while the sweep itself never blocks the socket loop noticeably. The
+   reporter keeps the ten-second cadence out of the log stream (#1216). */
+const receiptSweepReporter = new ReceiptSweepReporter({ debug: receiptSweepDebugEnabled() });
 const receiptSweepTimer = journal.isWritable() ? setInterval(() => {
   if (!journal.isWritable()) return;
   try {
-    const pass = journal.maintainProducerReceipts();
-    receiptSweepDeleted += pass.deleted;
-    if (pass.cycled && receiptSweepDeleted > 0) {
-      console.error(`[runtime journal] receipt sweep cycle removed ${receiptSweepDeleted} stale producer receipts`);
-      receiptSweepDeleted = 0;
-    }
+    const line = receiptSweepReporter.record(journal.maintainProducerReceipts(), Date.now());
+    if (line) console.error(line);
   } catch (error) {
     console.error(`[runtime journal] receipt sweep failed; next tick will retry: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/runtime-host/receiptSweep.test.ts
+++ b/src/runtime-host/receiptSweep.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+
+import {
+  ReceiptSweepReporter,
+  receiptSweepDebugEnabled,
+  RECEIPT_SWEEP_SUMMARY_INTERVAL_MS,
+} from "./receiptSweep";
+
+const SWEEP_TICK_MS = 10_000;
+const TICKS_PER_WINDOW = RECEIPT_SWEEP_SUMMARY_INTERVAL_MS / SWEEP_TICK_MS;
+
+function sweep(
+  reporter: ReceiptSweepReporter,
+  ticks: readonly number[],
+  deleted: (tick: number) => number,
+): string[] {
+  const lines: string[] = [];
+  for (const tick of ticks) {
+    const line = reporter.record(
+      { scanned: 4_096, deleted: deleted(tick), cycled: true },
+      tick * SWEEP_TICK_MS,
+    );
+    if (line) lines.push(line);
+  }
+  return lines;
+}
+
+function ticks(from: number, to: number): number[] {
+  return Array.from({ length: to - from + 1 }, (_unused, index) => from + index);
+}
+
+/* The sweep ticks every 10s. One line per cycle buried a whole deployment in
+   the runtime-host log, which is why #1216 could not be diagnosed from it. */
+test("a continuously deleting sweep logs one aggregated line per window", () => {
+  const reporter = new ReceiptSweepReporter();
+  const lines = sweep(reporter, ticks(1, TICKS_PER_WINDOW * 2 + 1), () => 7);
+
+  expect(lines).toEqual([
+    `[runtime journal] receipt sweep removed ${7 * (TICKS_PER_WINDOW + 1)} stale producer receipts across ${TICKS_PER_WINDOW + 1} cycles in the last 15m`,
+    `[runtime journal] receipt sweep removed ${7 * TICKS_PER_WINDOW} stale producer receipts across ${TICKS_PER_WINDOW} cycles in the last 15m`,
+  ]);
+});
+
+test("a sweep with nothing to remove stays silent", () => {
+  const reporter = new ReceiptSweepReporter();
+  expect(sweep(reporter, ticks(1, TICKS_PER_WINDOW * 3), () => 0)).toEqual([]);
+});
+
+test("the per-cycle line survives only under the journal debug flag", () => {
+  const reporter = new ReceiptSweepReporter({ debug: true });
+  expect(sweep(reporter, ticks(1, 3), () => 5)).toEqual([
+    "[runtime journal] receipt sweep cycle removed 5 stale producer receipts",
+    "[runtime journal] receipt sweep cycle removed 5 stale producer receipts",
+    "[runtime journal] receipt sweep cycle removed 5 stale producer receipts",
+  ]);
+  expect(receiptSweepDebugEnabled({ LLV_RUNTIME_JOURNAL_DEBUG: "1" })).toBe(true);
+  expect(receiptSweepDebugEnabled({})).toBe(false);
+});
+
+test("an idle stretch does not carry a stale window into the next deletion", () => {
+  const reporter = new ReceiptSweepReporter();
+  const idle = TICKS_PER_WINDOW * 4;
+  const lines = sweep(
+    reporter,
+    ticks(1, idle + TICKS_PER_WINDOW + 1),
+    (tick) => tick > idle ? 3 : 0,
+  );
+
+  expect(lines).toEqual([
+    `[runtime journal] receipt sweep removed ${3 * TICKS_PER_WINDOW} stale producer receipts across ${TICKS_PER_WINDOW} cycles in the last 15m`,
+  ]);
+});

--- a/src/runtime-host/receiptSweep.ts
+++ b/src/runtime-host/receiptSweep.ts
@@ -1,0 +1,62 @@
+/* #1216. The producer-receipt sweep runs every 10s and used to print a line on
+   every cycle that removed anything, which on a busy journal is a line every
+   ten seconds forever — enough to bury a whole deployment in the same stream.
+   The per-cycle detail is now debug-only, and the default stream carries one
+   aggregated line per window so the sweep stays observable without drowning
+   anything else. */
+export const RECEIPT_SWEEP_SUMMARY_INTERVAL_MS = 15 * 60_000;
+
+export interface ReceiptSweepPass {
+  scanned: number;
+  deleted: number;
+  cycled: boolean;
+}
+
+export interface ReceiptSweepReporterOptions {
+  debug?: boolean;
+  summaryIntervalMs?: number;
+}
+
+export function receiptSweepDebugEnabled(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.LLV_RUNTIME_JOURNAL_DEBUG === "1";
+}
+
+export class ReceiptSweepReporter {
+  private deleted = 0;
+  private cycles = 0;
+  private windowStartedAt: number | null = null;
+  private readonly debug: boolean;
+  private readonly summaryIntervalMs: number;
+
+  constructor(options: ReceiptSweepReporterOptions = {}) {
+    this.debug = options.debug ?? false;
+    this.summaryIntervalMs = Math.max(0, options.summaryIntervalMs ?? RECEIPT_SWEEP_SUMMARY_INTERVAL_MS);
+  }
+
+  /** The line to log for this pass, or `null` to stay quiet. */
+  record(pass: ReceiptSweepPass, nowMs: number): string | null {
+    if (this.debug) {
+      return pass.deleted > 0
+        ? `[runtime journal] receipt sweep cycle removed ${pass.deleted} stale producer receipts`
+        : null;
+    }
+    this.windowStartedAt ??= nowMs;
+    if (pass.deleted > 0) {
+      this.deleted += pass.deleted;
+      this.cycles += 1;
+    }
+    if (this.deleted === 0) {
+      this.windowStartedAt = nowMs;
+      return null;
+    }
+    if (nowMs - this.windowStartedAt < this.summaryIntervalMs) return null;
+    const minutes = Math.max(1, Math.round((nowMs - this.windowStartedAt) / 60_000));
+    const line = `[runtime journal] receipt sweep removed ${this.deleted} stale producer receipts across ${this.cycles} cycles in the last ${minutes}m`;
+    this.deleted = 0;
+    this.cycles = 0;
+    this.windowStartedAt = nowMs;
+    return line;
+  }
+}


### PR DESCRIPTION
Closes #1216

## Diagnosis — what hot-state activation waits for, and why it did not arrive

**The signal.** `promoteTarget` waits for the file `<state>/hot-state-authority.json` to reach `mode: "sqlite"` with `releaseRevision === candidate.revision` and `activationReadyAt` set — `scripts/runtime-host-viewer-adapter.ts:807-822` (pre-change), matching the predicate at `src/lib/state/hotStateAuthority.ts:292-306`.

**Who emits it.** Only the *promoted Viewer container*, from `markHotStateActivationReady` at `src/lib/viewerInstrumentation.ts:553`. It runs inside `completeViewerRuntimeActivation` (`src/lib/viewerInstrumentation.ts:508-518`), which the candidate reaches only after its 250ms poll notices the durable target now names it (`src/lib/viewerInstrumentation.ts:186-246`), then `establishHotStateCutoverBoundary`, `initializeHotStateStoresAtStartup`, operator-capability init, the identity-wave kick and Wakatime startup. Nothing in the runtime host emits it, and nothing in the runtime host can see why it is late.

**Why it did not arrive while the incumbent was live — the primary cause is a budget inversion, not the incumbent.** Tested first, as the issue asked:

| Budget | Value at `150d338b` | Evidence |
| --- | --- | --- |
| Host-side `promote` action deadline | `30_000` | `src/runtime-host/deploymentAdapter.ts:36` |
| Adapter-side activation wait | `30_000` | `scripts/runtime-host-viewer-adapter.ts:809` |

The two are equal, and they do not start at the same moment. The host timer starts when the adapter process is spawned (`src/runtime-host/deploymentAdapter.ts:377-395`). The adapter's own wait starts only after `recoverInterruptedReleaseSwitch`, `readCurrentRelease`, the optional SQLite fence and the whole of `switchTarget` — the switch-intent write, the hot-state authority publication and the durable target publication, each of which fsyncs the file *and* its directory. So the host deadline **always** expires first. On expiry the host kills the process group and raises `deployment adapter ${action} timed out while ${phase}` from the last phase file value (`src/runtime-host/deploymentAdapter.ts:404-408`), which is exactly the string the operator saw. The adapter's own message, `timed out waiting for the promoted Viewer to activate hot state` (`scripts/runtime-host-viewer-adapter.ts:821`), was unreachable in production — and it named nothing either.

Verified there is no environment override raising the adapter budget: neither the runtime-host container nor the running deploy container sets `LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS` or `LLV_HOT_STATE_ACTIVATION_POLL_MS` (`docker inspect` env grep, 0 matches each), and the repository sets them only in tests. Both failing deployments therefore ran 30s against 30s.

**Why 30s is not enough for the real hand-over, with the incumbent live.** Between the target flip and `markHotStateActivationReady`, the candidate opens the same SQLite database the incumbent is still writing and takes the same durable-file locks. Both retry paths are bounded at `LOCK_ATTEMPTS = 6_000` × `LOCK_WAIT_MS = 5` — **30 seconds each**, and the SQLite one blocks the candidate's event loop synchronously via `Atomics.wait`:

- `src/lib/state/sqliteStateStore.ts:18-19` and `:338-393` — `initializeStateCollections` opens with `busy_timeout = 0`, runs `BEGIN IMMEDIATE`, and retries busy for up to 30s.
- `src/lib/state/fileTransaction.ts:7-8` and `:123-142` — every hot-state authority write, including `markHotStateActivationReady` itself, is a FIFO file-lock acquisition with the same 30s budget.

So one contended acquisition can consume the entire old promote budget on its own. This is the sense in which "the incumbent still holds that state" is true: it does not *block* the hand-over — the target flip already fences it out of SQLite writes (`hotStateSqliteWriterReady`, `src/lib/state/hotStateAuthority.ts:200-224`) — it makes the hand-over slow, and the promote had no room for slow.

**The hand-over was also an unordered race.** In an sqlite→sqlite promote no fence is taken at all: the fence branch requires `current.hotStateBackend === "sqlite-v1" && candidate.hotStateBackend !== "sqlite-v1"` (`scripts/runtime-host-viewer-adapter.ts:830-833`), i.e. sqlite→legacy only. The incumbent is never told to release anything; it discovers its own demotion on its 250ms poll (`src/lib/viewerInstrumentation.ts:206-211`), checkpoints its rollback mirrors and exits — concurrently with the candidate's activation, on the same database, with nobody observing either outcome.

**The remaining blind spot, named rather than closed.** If the candidate's activation *fails* — `markHotStateActivationReady` losing its compare-and-set, or a `FileTransactionBusyError` from either lock — the error is swallowed into `void start().catch((error) => log(...))` at `src/lib/viewerInstrumentation.ts:243` and logged **inside the candidate container**. The authority file simply never gains `activationReadyAt`, so from the promote's side a crashed activation and a slow one are indistinguishable in that file. This change makes the promote inspect the candidate container on the failure path so the two are told apart in the message; routing the candidate's activation error itself to the host is left as follow-up work.

## Expected → verification

| # | Expected | What changed | Verified by |
| --- | --- | --- | --- |
| 1 | Find what activation waits for and why it does not arrive | The diagnosis above, with file:line evidence, plus the `docker inspect` check that no env override existed | Section above; `HOT_STATE_ACTIVATION_*` constants now carry the mechanism as a comment in `src/runtime-host/deploymentHotState.ts:5-29` |
| 2 | The promote logs what it waits on, how long, and what it saw when it gave up | Both steps report a phase carrying elapsed/budget seconds and the live observation (`hotStateActivationPhase`, `incumbentHotStateReleasePhase`); the failure message names the revision, the waited/budget seconds, the authority observation, the candidate container state and the incumbent outcome; the host now logs adapter phase transitions to its own stream | `src/runtime-host/deploymentHotState.test.ts` — "activation that never arrives fails with a named reason", "a candidate that died during its own activation is named separately", "every reported phase survives the host phase-file alphabet"; `src/runtime-host/deploymentAdapter.test.ts` — "a running adapter action reports its phase transitions to the host log"; end-to-end in `scripts/runtime-host-viewer-adapter.test.ts` — "promote that never sees hot-state activation fails with a named reason" |
| 3 | Timeout long enough, or hand-over made deterministic; an explicit ordered release step with a visible outcome | Both: the budgets are now `HOT_STATE_ACTIVATION_TIMEOUT_MS = 180_000` and `INCUMBENT_RELEASE_TIMEOUT_MS = 60_000`, and the host `promote` deadline is derived as their sum plus a publication allowance, so it cannot tie again. The hand-over is two ordered steps — the incumbent releases hot state (bounded, reported, non-fatal because the target flip already fenced it), then activation is awaited — instead of one implicit race | `src/runtime-host/deploymentHotState.test.ts` — "the promote deadline outlives every hand-over budget it contains", "the incumbent release step reports the hand-over it observed", "an incumbent that never lets go is reported rather than fatal", "an unobservable incumbent does not stall the promote", "activation that already landed retires the incumbent release step immediately" |
| 4 | Receipt-sweep line stops drowning the log | The per-cycle line is now debug-only (`LLV_RUNTIME_JOURNAL_DEBUG=1`); the default stream carries one aggregated line per 15-minute window, and stays silent when nothing is being removed | `src/runtime-host/receiptSweep.test.ts` — all four cases |
| 5 | Regression test that fails on today's behaviour | Two end-to-end tests drive the real adapter script: activation that never arrives must fail with a named reason, and activation that arrives late but inside the budget must succeed and must show both ordered phases | Both failed at `150d338b` — the first with `Received: "timed out waiting for the promoted Viewer to activate hot state\n"`, the second because no `releasing incumbent hot state` phase existed — and pass here |

## Gates

- `bunx tsc --noEmit --incremental false` — clean
- `bunx eslint` on all touched files — clean
- `bun test` by path, under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: `scripts/runtime-host-viewer-adapter.test.ts`, `src/runtime-host/deploymentHotState.test.ts`, `src/runtime-host/receiptSweep.test.ts`, `src/runtime-host/deploymentAdapter.test.ts`, `src/runtime-host/deployment.test.ts`, `src/instrumentation.test.ts`, `src/lib/state/hotStateStores.sqlite.test.ts` — 122 pass, 0 fail
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS

No deployment, restart, promote or rollback was run against the live machine; the adapter was exercised only against sandboxed state directories and injected signals. The next real deployment is the first end-to-end proof, and it is the operator's to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round — the five findings, at their root

| Finding | Root fix | Verified by |
| --- | --- | --- |
| MEDIUM correctness — unbounded container inspections (`deploymentHotState.ts:153`, `:198`) freeze the release loop on a wedged dockerd and swallow the named activation error | Every inspection runs under an abandonable timer bounded by `CONTAINER_INSPECTION_TIMEOUT_MS` **and** by the remaining budget of the step that started it; an inspection that does not settle reads as unobservable and the loop keeps its schedule. Abandoning a bound costs nothing, so a fast inspection is unaffected. The release outcome is decided by every observation the step made, not by the last one, which is the one the clamp can cut short | `deploymentHotState.test.ts` — "a container inspection that never settles does not freeze the release step", "a wedged inspection cannot outrun the budget of the step that started it", "a candidate inspection that never settles still names the activation timeout". RED at the previous head: the same two cases hang there — `await options.inspect()` on a promise that never settles cannot expire, which is the SIGKILL the finding describes |
| LOW correctness — env budgets clamped only from below can sum past the fixed host deadline and restore the 30s-vs-30s inversion | The host publishes the deadline it will enforce (`LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS`, set from the same `timeouts[action]` the timer uses), and the adapter fits both budgets inside it with `fitHandOverBudgets`, scaling proportionally when they do not fit | `deploymentHotState.test.ts` — "configured hand-over budgets are fitted inside the host deadline"; end to end in `runtime-host-viewer-adapter.test.ts` — "hand-over budgets configured past the host deadline still expire inside it" (ten-minute budgets under a 3s deadline). RED at the previous head: that test times out at 30s because the adapter honours the configured ten minutes |
| LOW efficiency/over-built — per-second elapsed defeats the phase dedupe, two fsyncs a second on the contended state dir, docker spawned twice a second for 60s | Phases report elapsed in 5s steps, matching the 5s sampling of their only consumer, so the dedupe collapses a whole step into one write. `INCUMBENT_RELEASE_TIMEOUT_MS` is 15s polled every 5s | `deploymentHotState.test.ts` — "every reported phase survives the host phase-file alphabet" now pins the 5s steps; the budget constants carry the exit-latency reasoning |
| LOW correctness — the release phase is reported before the `incumbent === null` branch, naming a step that never ran | The phase is reported inside the waiting branch | `runtime-host-viewer-adapter.ts` `handOverHotState`; the sqlite→legacy and no-incumbent promotes in the adapter suite no longer emit it |
| LOW observability — the hand-over leaves no record on the success path | `hotStateHandOverSummary(release, activationWaitedMs)` rides the promote's publication evidence (`ViewerMcpRuntimePublicationEvidence.hotStateHandOver`) through the host's publication normalizer into the deployment journal | `deploymentAdapter.test.ts` — "the host publishes its promote deadline and keeps the hand-over the adapter reports"; the successful late-activation end-to-end test asserts the summary on the promote's stdout. RED at the previous head: the field is `undefined` there, and the deadline env is unset |

`PROMOTE_ACTION_TIMEOUT_MS` is now `INCUMBENT_RELEASE_TIMEOUT_MS + HOT_STATE_ACTIVATION_TIMEOUT_MS + PROMOTE_PUBLICATION_BUDGET_MS + 2 × CONTAINER_INSPECTION_TIMEOUT_MS` = 265s, so the host deadline still contains every budget the adapter can spend, including the one diagnostic inspection each wait may end on.

### Gates for this round

- `bunx tsc --noEmit --incremental false` — clean
- `bunx eslint` on every touched file — clean
- `bun test` by path under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: `scripts/runtime-host-viewer-adapter.test.ts`, `src/runtime-host/deploymentHotState.test.ts`, `src/runtime-host/deploymentAdapter.test.ts`, `src/runtime-host/receiptSweep.test.ts`, `src/runtime-host/deployment.test.ts`, `src/instrumentation.test.ts`, `src/lib/state/hotStateStores.sqlite.test.ts` — 129 pass, 0 fail
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS

Still no deployment, restart, promote or rollback against the live machine: the adapter was exercised only against sandboxed state directories, a fake docker on `PATH` and injected signals. The next real deployment remains the first end-to-end proof, and it is the operator's to run.
