### PR TITLE
fix(ci): bound the commit trailer block the way git does

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -2822,6 +2822,19 @@ describe("commitMessageFindings", () => {
     Bun.spawnSync({ cmd: ["git", "-C", repo, "commit", "-m", message], stderr: "pipe", stdout: "pipe" });
   }
 
+  function git(repo: string, ...arguments_: string[]): string {
+    const result = Bun.spawnSync({
+      cmd: ["git", "-C", repo, ...arguments_],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    return result.stdout.toString();
+  }
+
+  /* The footer `git cherry-pick -x` appends, spelled out where a test needs the
+     shape without performing the pick. */
+  const cherryPickLine = `(cherry picked from commit ${"0123456789abcdef".repeat(2) + "01234567"})`;
+
   test("flags a personal email in a Co-Authored-By trailer", () => {
     const repo = gitRepo();
     const localPart = "someone";
@@ -3025,6 +3038,92 @@ describe("commitMessageFindings", () => {
     commit(
       repo,
       `chore: refresh dependencies\n\nSigned-Off-By: Dependency Tool\n <${forgeRole}>`,
+    );
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.has("email_address")).toBe(true);
+  });
+
+  test("a cherry-picked attribution trailer is still inside the trailer block", () => {
+    /* `git cherry-pick -x` writes its own line into the trailer block it
+       copies, and git keeps reading that block as one. Requiring every line of
+       the final paragraph to be `Token: value` discarded the whole block
+       instead, so the standing agent trailer became a finding and a branch
+       carrying a cherry-pick could only clear a required check by removing a
+       trailer AGENTS.md forbids removing. */
+    const repo = gitRepo();
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    git(repo, "checkout", "-b", "source");
+    commit(repo, `feat: something\n\nCo-Authored-By: Some Model <${vendor}>`);
+    const picked = git(repo, "rev-parse", "HEAD").trim();
+    git(repo, "checkout", "feature");
+    git(repo, "cherry-pick", "-x", picked);
+
+    const message = git(repo, "log", "--format=%B", "-1", "HEAD");
+    expect(message).toContain("(cherry picked from commit ");
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.has("email_address")).toBe(false);
+  });
+
+  test("a cherry-pick line does not turn body prose into a trailer block", () => {
+    const repo = gitRepo();
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    commit(
+      repo,
+      `fix: quote the report\n\nThe report reads:\nCo-Authored-By: Some Model <${vendor}>\n${cherryPickLine}`,
+    );
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.has("email_address")).toBe(true);
+  });
+
+  test("the forge's own co-author paragraph does not demote the trailer above it", () => {
+    /* A squash merge writes the pull request's commits into one message and
+       appends its own co-author paragraph behind a horizontal rule. Reading
+       only the message's last paragraph left every trailer the forge wrote
+       above that rule outside the block. */
+    const repo = gitRepo();
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    commit(
+      repo,
+      `feat: something (#1)\n\nA body paragraph.\n\nCo-Authored-By: Some Model <${vendor}>\n\n---------\n\nCo-authored-by: Some Model <${vendor}>`,
+    );
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.has("email_address")).toBe(false);
+  });
+
+  test("a squashed pull request keeps the trailer block of every commit in it", () => {
+    const repo = gitRepo();
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    commit(
+      repo,
+      `feat: two things (#2)\n\n* feat: the first thing\n\nFirst body.\n\nCo-Authored-By: Some Model <${vendor}>\n\n* feat: the second thing\n\nSecond body.\n\nCo-Authored-By: Some Model <${vendor}>\n\n---------\n\nCo-authored-by: Some Model <${vendor}>`,
+    );
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.has("email_address")).toBe(false);
+  });
+
+  test("neither concatenation shape launders a person", () => {
+    const repo = gitRepo();
+    const person = ["someone", "personal.dev"].join("@");
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    commit(repo, `feat: something\n\nCo-Authored-By: Someone <${person}>\n${cherryPickLine}`);
+    commit(
+      repo,
+      `feat: something (#3)\n\n* feat: the first thing\n\nCo-Authored-By: Someone <${person}>\n\n---------\n\nCo-authored-by: Some Model <${vendor}>`,
+    );
+    const findings = commitMessageFindings(repo, "main");
+    expect(findings.get("email_address")).toBe(2);
+  });
+
+  test("a bullet after a trailer paragraph is not a squashed message", () => {
+    /* The bullets only mark embedded messages when the text is the forge's
+       concatenation, which it marks by bulleting the paragraph right after the
+       title. A body that merely holds a list is one message with one trailer
+       block, and this address is not in it. */
+    const repo = gitRepo();
+    const forgeRole = ["support", "github.com"].join("@");
+    commit(
+      repo,
+      `fix: document the dependency report\n\nSigned-Off-By: Dependency Tool <${forgeRole}>\n\n* the line above came from the report body`,
     );
     const findings = commitMessageFindings(repo, "main");
     expect(findings.has("email_address")).toBe(true);

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -580,7 +580,7 @@ const emailAddressSource =
 function domainNamesNobody(domain: string): boolean {
   const lowered = domain.toLowerCase();
   return lowered === "example.com" || lowered === "example.net" || lowered === "example.org"
-    || lowered.endsWith(".invalid") || lowered === "test" || lowered.endsWith(".test");
+    || lowered.endsWith(".invalid") || lowered.endsWith(".test");
 }
 
 /** Every mailbox in the text that reaches a person, in the order they appear. */
@@ -1269,20 +1269,76 @@ function isMachineAttributionAddress(occurrence: EmailOccurrence): boolean {
   return localPart === FORGE_ROLE_LOCAL_PART && occurrence.domain.toLowerCase() === FORGE_DOMAIN;
 }
 
-/* Git reads a trailer block as the message's last paragraph: a run of
+/* Git reads a trailer block as a message's last paragraph: a run of
    `Token: value` lines that a blank line separates from everything before it,
    each token starting the line. A line anywhere else with the same shape is
    body prose, and prose is where people quote other people's addresses. */
 const COMMIT_TRAILER_LINE = /^[A-Za-z0-9][A-Za-z0-9-]*[ \t]*:[ \t]*\S/;
 
-function trailerBlockRange(lines: string[]): { end: number; start: number } | undefined {
-  let end = lines.length;
-  while (end > 0 && lines[end - 1].trim() === "") end -= 1;
-  let start = end;
-  while (start > 0 && lines[start - 1].trim() !== "") start -= 1;
-  if (start === 0 || start === end) return undefined;
-  if (!lines.slice(start, end).every((line) => COMMIT_TRAILER_LINE.test(line))) return undefined;
-  return { end, start };
+/* `git cherry-pick -x` writes this line into the trailer block it copies, and
+   git still reads that block as one — it is a prefix git generates itself. A
+   block does not stop being a block because git annotated it. */
+const CHERRY_PICK_TRAILER_LINE = /^\(cherry picked from commit [0-9a-f]{7,64}\)[ \t]*$/;
+
+function isTrailerLine(line: string): boolean {
+  return COMMIT_TRAILER_LINE.test(line) || CHERRY_PICK_TRAILER_LINE.test(line);
+}
+
+/* One commit message can carry several. A squash merge writes every commit of
+   a pull request into one message — each behind a `* <subject>` bullet, the
+   forge's own co-author paragraph behind a horizontal rule — and each of those
+   messages keeps the trailer block it was written with. So git's rule reads
+   every message the text concatenates, not only the last one. The bullets
+   count only when the text IS that concatenation, which the forge marks by
+   bulleting the paragraph right after the title; a body that merely holds a
+   list is one message and keeps one trailer block. */
+const EMBEDDED_MESSAGE_BULLET = /^\*[ \t]\S/;
+const EMBEDDED_MESSAGE_RULE = /^-{3,}[ \t]*$/;
+
+type MessageParagraph = { end: number; start: number };
+
+function messageParagraphs(lines: string[]): MessageParagraph[] {
+  const found: MessageParagraph[] = [];
+  let start: number | undefined;
+  for (let index = 0; index <= lines.length; index += 1) {
+    if (index < lines.length && lines[index].trim() !== "") {
+      if (start === undefined) start = index;
+      continue;
+    }
+    if (start !== undefined) found.push({ end: index, start });
+    start = undefined;
+  }
+  return found;
+}
+
+/** The line numbers that sit inside a trailer block, of any embedded message. */
+function trailerBlockLines(lines: string[]): Set<number> {
+  const paragraphs = messageParagraphs(lines);
+  const concatenated = paragraphs.length > 1
+    && EMBEDDED_MESSAGE_BULLET.test(lines[paragraphs[1].start]);
+  const block = new Set<number>();
+  let segment: MessageParagraph[] = [];
+  const closeSegment = (): void => {
+    const last = segment.at(-1);
+    /* A message's first paragraph is its subject, never its trailers. */
+    if (last === undefined || segment.length < 2) return;
+    for (let index = last.start; index < last.end; index += 1) {
+      if (!isTrailerLine(lines[index])) return;
+    }
+    for (let index = last.start; index < last.end; index += 1) block.add(index);
+  };
+  for (const paragraph of paragraphs) {
+    const rule = paragraph.end - paragraph.start === 1
+      && EMBEDDED_MESSAGE_RULE.test(lines[paragraph.start]);
+    const bullet = concatenated && EMBEDDED_MESSAGE_BULLET.test(lines[paragraph.start]);
+    if (segment.length > 0 && (rule || bullet)) {
+      closeSegment();
+      segment = [];
+    }
+    segment.push(paragraph);
+  }
+  closeSegment();
+  return block;
 }
 
 /* Occurrences arrive in ascending order, so one cursor walks the line starts
@@ -1319,11 +1375,9 @@ export function commitMessageAddressReview(message: string): CommitAddressReview
   const exempt = new Set<string>();
   for (const view of sensitiveTextViews(message).views) {
     const lines = view.split("\n");
-    const trailer = trailerBlockRange(lines);
+    const block = trailerBlockLines(lines);
     for (const { line, occurrence } of addressLines(view, lines)) {
-      const attributed = trailer === undefined
-        || line < trailer.start
-        || line >= trailer.end
+      const attributed = !block.has(line)
         || !MACHINE_ATTRIBUTION_TRAILER.test(lines[line])
         || !isMachineAttributionAddress(occurrence);
       (attributed ? attributable : exempt).add(occurrence.address);


### PR DESCRIPTION
## What this repairs

#1209 shipped the #1195 rule inverted the right way round: the commit message is scanned whole and the machine-attribution exemption drops an address detection already reported. The bound it drew around the trailer block is stricter than git's own, and that is a defect in shipped code — pointing the opposite way from a leak. A legitimate machine trailer stops being recognised as one, the exemption never applies, and the address becomes an `email_address` finding.

## What breaks without it

`privacy-publication` is a required check and it resolves its base to the tip of the default branch, so every commit on `main` that a branch is behind enters that branch's scanned range. Two shapes this repository writes constantly fall outside the shipped bound:

- **`git cherry-pick -x`** appends `(cherry picked from commit <sha>)` inside the trailer block it copies. Requiring every line of the final paragraph to be `Token: value` discards the whole block along with it, so the standing agent attribution trailer on the line above becomes a finding — and the only way to clear the check would be removing a trailer AGENTS.md forbids removing.
- **A squash merge** writes the pull request's commits into one message, each behind a `* <subject>` bullet, with the forge's own co-author paragraph behind a horizontal rule. Every trailer above that rule sits outside the message's last paragraph.

Replaying the shipped implementation over all 1998 commits of `main` reports `email_address` on 100 of them. 99 carry nothing but a vendor no-reply attribution trailer. After this change the same replay reports 1 — a genuine personal address on a squash co-author line, which is the gate working. Among the 99 are the dependency pull requests #1195 exists to unblock.

## What changed, and what did not

Only the bound moves. Nothing is removed from the text before scanning, detection is untouched, and the exemption is the same one: a role mailbox, on a `Co-authored-by`/`Signed-off-by` line, subtracted from what detection reported.

- Git's cherry-pick prefix counts as a line of the block it sits in, because git generates it there.
- Git's rule — the final paragraph of `Token: value` lines — reads every message the text concatenates, not only the last one. Bullets mark embedded messages solely when the text is that concatenation, which the forge marks by bulleting the paragraph right after the title, so a body that merely holds a list keeps one trailer block.
- `domainNamesNobody` also compared against a bare `test` domain, which the address pattern cannot produce (it requires a dot and a two-letter TLD). Dead reasoning in a security-relevant predicate, removed.

## Evidence

Each shape driven through the real CLI over a synthetic commit range, against the implementation on `main` and against this branch. `FAIL` is `PRIVACY GATE: FAIL` with `email_address: 1`.

| Commit message shape | on `main` | this branch |
| --- | --- | --- |
| `git cherry-pick -x` of an attribution trailer | `FAIL` | `PASS` |
| squash merge, forge rule paragraph | `FAIL` | `PASS` |
| squash merge, bulleted concatenation | `FAIL` | `PASS` |
| the dependency bot sign-off trailer (#1195) | `PASS` | `PASS` |
| cherry-pick shape, personal address | `FAIL` | `FAIL` |
| squash shape, personal address | `FAIL` | `FAIL` |
| role address in body prose (#1209 round 1) | `FAIL` | `FAIL` |
| second address on the exempt line (round 2) | `FAIL` | `FAIL` |
| quoted local part in the body (round 3) | `FAIL` | `FAIL` |
| cherry-pick line inside body prose | `FAIL` | `FAIL` |

The first three rows are the repair. The rest must not move, and do not.

## Verification

- `bun test scripts/privacy-publication-gate.test.ts` — 136 pass, 0 fail, under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`. All 130 existing cases are green unchanged; none were edited.
- The six new cases run against `main`'s implementation in a throwaway worktree: 3 fail — the cherry-pick block, the forge rule paragraph, the bulleted concatenation. The other 3 pin that the wider bound launders nobody and pass in both, which is what guards it.
- `bunx tsc --noEmit --incremental false` — clean.
- `bunx eslint` on both files — clean.
- `bun scripts/privacy-publication-gate.ts --require-known-values --check-commits --base <default-branch tip>` — `PRIVACY GATE: PASS`, and the same run driven from `main`'s trusted implementation against this branch, the way the workflow performs it — `PRIVACY GATE: PASS`.
- Full-history replay above, run from this worktree over `origin/main`.

The workflow runs the test file from a trusted checkout of the default branch, so the new cases prove themselves on CI only after this merges; the runs above are local plus the trusted-implementation simulation.

Repairs the trailer-block bound shipped in #1209 for #1195.
