### PR TITLE
fix(deploy): give the runtime host a bootstrap path onto a new revision (#1216)

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -68,6 +68,55 @@ serializes the request, verifies the candidate, and switches its listener
 target. Inspect the owner with
 `docker compose --profile runtime-host logs -f runtime-host`.
 
+### Bootstrap the runtime host onto a new revision (#1216)
+
+`scripts/rebuild.sh` replaces the runtime-host generation only in the
+`host-handoff` phase, which is downstream of `promoting`. A defect in the
+promote path therefore pins the runtime host to the revision that carries the
+defect: every later deployment runs the old promote code, fails in the same
+place, rolls back, and never reaches the staging that would have installed the
+fix. `scripts/bootstrap-runtime-host.ts` is the way out. It stages the same
+#518 successor from a chosen revision without a deployment, so no promote has
+to have succeeded first.
+
+Run it on the host, from a checkout, with `bun`. The default mode renders the
+plan and changes nothing:
+
+```bash
+bun scripts/bootstrap-runtime-host.ts            # plan only
+bun scripts/bootstrap-runtime-host.ts <sha>      # plan a pinned revision
+```
+
+The plan names the target revision and image, the successor container it will
+create, the predecessor container it is replacing, and — for a hand-over — the
+one container it will stop. It also states what it never stops: Viewer release
+containers, the structured and engine hosts inside them, and every live agent
+session, pipeline, and orchestrator they own.
+
+Read the plan, then choose how far to go:
+
+```bash
+bun scripts/bootstrap-runtime-host.ts --stage      # build and stage; stop nothing
+bun scripts/bootstrap-runtime-host.ts --hand-over  # also stop the predecessor
+```
+
+`--stage` builds the image from a clean canonical worktree and creates the
+successor container. The successor waits on the singleton fence, the
+predecessor keeps serving, and the durable release record is repointed. Nothing
+is stopped, so this is safe to run ahead of the moment you want the switch.
+
+`--hand-over` performs the staging and then stops the predecessor runtime-host
+container so the successor acquires the fence. `127.0.0.1:8898` is unserved for
+the length of that exit; the run waits for the fence and names what it saw if
+it never arrives. The successor removes the stopped predecessor once it owns
+the fence.
+
+After a host-only bootstrap the runtime host runs a newer revision than the
+published Viewer release, so its boot-time MCP reconcile logs
+`runtime-host MCP revision differs from the active Viewer release` and leaves
+the published runtime unchanged. That is expected; the next successful
+`scripts/rebuild.sh` brings the Viewer release up to the same revision.
+
 The Compose `viewer` service exists only for the one-time listener migration. Its
 `legacy-viewer-migration` profile and `LLV_ALLOW_LEGACY_VIEWER=1` launch grant
 must both be present.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -101,9 +101,15 @@ bun scripts/bootstrap-runtime-host.ts --hand-over  # also stop the predecessor
 ```
 
 `--stage` builds the image from a clean canonical worktree and creates the
-successor container. The successor waits on the singleton fence, the
-predecessor keeps serving, and the durable release record is repointed. Nothing
-is stopped, so this is safe to run ahead of the moment you want the switch.
+successor container. The successor is *parked* on the singleton fence — it
+waits there with no deadline, so it neither times out nor restart-loops — while
+the predecessor keeps serving and the durable release record is repointed.
+Nothing is stopped and there is no window to beat: the hand-over can follow
+minutes or hours later and resumes that same container.
+
+A successor staged by a *deployment* keeps the bounded #518 wait instead. There
+the predecessor has already been asked to exit, so a bound on the wait is what
+makes a wedged hand-over visible.
 
 `--hand-over` performs the staging and then stops the predecessor runtime-host
 container so the successor acquires the fence. `127.0.0.1:8898` is unserved for

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:mcp": "bun scripts/build-mcp.ts",
     "demo:capture": "bun scripts/demo-capture.ts",
     "deploy:staging": "bun scripts/deploy-staging.ts",
+    "bootstrap:runtime-host": "bun scripts/bootstrap-runtime-host.ts",
     "demo:motion": "bun scripts/demo-motion.ts",
     "start": "bun --bun node_modules/.bin/next start",
     "lint": "eslint",

--- a/scripts/bootstrap-runtime-host.test.ts
+++ b/scripts/bootstrap-runtime-host.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+
+import { parseArguments } from "./bootstrap-runtime-host";
+
+const source = fs.readFileSync(new URL("./bootstrap-runtime-host.ts", import.meta.url), "utf8");
+
+test("issue 1216: the bootstrap plans by default and never mutates without an explicit mode", () => {
+  expect(parseArguments([])).toEqual({ revision: "origin/main", mode: "plan" });
+  expect(parseArguments(["a".repeat(40)])).toEqual({ revision: "a".repeat(40), mode: "plan" });
+  expect(parseArguments(["--stage"])).toEqual({ revision: "origin/main", mode: "stage" });
+  expect(parseArguments(["a".repeat(40), "--hand-over"])).toEqual({ revision: "a".repeat(40), mode: "hand-over" });
+});
+
+test("issue 1216: the bootstrap refuses arguments it does not understand", () => {
+  expect(() => parseArguments(["--force"])).toThrow("unsupported option --force");
+  expect(() => parseArguments(["main"])).toThrow("invalid revision: use origin/main or a full lowercase commit SHA");
+  expect(() => parseArguments(["a".repeat(40), "b".repeat(40)])).toThrow("only one revision may be given");
+});
+
+/* The machine this runs on owns live agent sessions, so the statement of what
+   will be stopped has to precede every mutation — the image build, the
+   staging, and the predecessor stop alike. */
+test("issue 1216: the plan is rendered before anything is built, staged, or stopped", () => {
+  const planAt = source.indexOf("console.log(renderRuntimeHostBootstrapPlan(plan))");
+  const buildAt = source.indexOf("await buildRuntimeHostImage(revision, image)");
+  const executeAt = source.indexOf("await executeRuntimeHostBootstrap(plan, candidate,");
+
+  expect(planAt).toBeGreaterThanOrEqual(0);
+  expect(buildAt).toBeGreaterThan(planAt);
+  expect(executeAt).toBeGreaterThan(buildAt);
+});
+
+/* The bootstrap replaces the runtime-host generation and nothing else. A
+   Viewer container stop or removal here would take down the promoted release
+   and the agent sessions inside it. */
+test("issue 1216: the bootstrap never stops or removes a Viewer release container", () => {
+  expect(source).not.toContain('"container", "rm"');
+  expect(source).not.toContain("retireRelease");
+  expect(source).not.toContain("switchTarget");
+  /* The single stop it performs is the predecessor runtime-host container,
+     reached only through the hand-over port. */
+  expect(source.match(/"container", "stop"/g)).toHaveLength(1);
+});

--- a/scripts/bootstrap-runtime-host.test.ts
+++ b/scripts/bootstrap-runtime-host.test.ts
@@ -31,6 +31,15 @@ test("issue 1216: the plan is rendered before anything is built, staged, or stop
   expect(executeAt).toBeGreaterThan(buildAt);
 });
 
+/* An operator stages now and hands over when they are ready, so the successor
+   this script creates has to wait without the #518 deadline — that bound
+   exists for a hand-over already in flight, and here there is none until the
+   operator starts one. */
+test("issue 1216: the bootstrap stages its successor parked rather than on the deployment fence budget", () => {
+  expect(source).toContain('fenceWait: "parked"');
+  expect(source).not.toContain("LLV_RUNTIME_HOST_FENCE_WAIT_MS");
+});
+
 /* The bootstrap replaces the runtime-host generation and nothing else. A
    Viewer container stop or removal here would take down the promoted release
    and the agent sessions inside it. */

--- a/scripts/bootstrap-runtime-host.ts
+++ b/scripts/bootstrap-runtime-host.ts
@@ -93,6 +93,18 @@ async function command(argv: string[], options: { cwd?: string } = {}): Promise<
   return stdout.trim();
 }
 
+/** The image build is the one step that runs for minutes, so its progress goes
+    to the operator's terminal instead of into a buffer they only see if it
+    fails. */
+async function streamedCommand(argv: string[]): Promise<void> {
+  const child = Bun.spawn(argv, {
+    stdout: "inherit",
+    stderr: "inherit",
+    env: withoutWakatimeCredential(process.env),
+  });
+  if (await child.exited !== 0) throw new Error(`${argv[0]} failed`);
+}
+
 function log(line: string): void {
   console.error(`[runtime-host bootstrap] ${line}`);
 }
@@ -145,7 +157,7 @@ async function buildRuntimeHostImage(revision: string, image: string): Promise<v
   await command(["git", "--git-dir", mirrorDir, "worktree", "add", "--detach", sourceDir, revision]);
   try {
     log(`building the runtime-host image for ${revision}; this takes several minutes`);
-    await command([
+    await streamedCommand([
       "docker", "build", "--pull",
       "--build-arg", `LLV_RUNTIME_HOME=${runtimeHome}`,
       "--label", `dev.live-log-viewer.revision=${revision}`,

--- a/scripts/bootstrap-runtime-host.ts
+++ b/scripts/bootstrap-runtime-host.ts
@@ -212,6 +212,12 @@ async function main(): Promise<number> {
       clearHandoffIntent: () => clearRuntimeHostHandoffIntent(runtimeHostHandoffIntentFile()),
       fenceOwnerPid,
       reportPhase: (phase) => log(phase),
+    }, {
+      /* #1216: the operator decides when the hand-over happens, and it may be
+         hours after the staging. A deployment's bounded fence wait would exit
+         this successor at its budget and let dockerd restart-loop the very
+         container the runbook calls idle. */
+      fenceWait: "parked",
     }),
     stopPredecessor: async (predecessorId) => {
       await docker(["container", "stop", "--time", String(PREDECESSOR_STOP_GRACE_SECONDS), predecessorId]);
@@ -222,7 +228,7 @@ async function main(): Promise<number> {
     log,
   });
   if (!outcome.handedOver) {
-    log(`successor ${outcome.successorContainer} is staged and idle; the predecessor still serves ${stableEndpoint}`);
+    log(`successor ${outcome.successorContainer} is staged and parked; the predecessor still serves ${stableEndpoint}`);
   }
   return 0;
 }

--- a/scripts/bootstrap-runtime-host.ts
+++ b/scripts/bootstrap-runtime-host.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env bun
+/* #1216 runtime-host bootstrap — the path onto a new revision that does NOT
+   require a promote to have already succeeded.
+ *
+ * A deployment only replaces the runtime host in its `host-handoff` phase,
+ * which is downstream of `promoting`. So a promote defect pins the host to the
+ * revision carrying that defect, and the repair cannot be delivered by the
+ * mechanism it repairs. This entry point runs on the HOST with `bun`, from a
+ * checkout of the revision being installed, and drives the same #518 staging
+ * the deployment would have driven.
+ *
+ * Modes, in ascending order of what they touch:
+ *   (default)     render the plan and exit; nothing on the machine changes
+ *   --stage       build the image and stage the successor; nothing is stopped
+ *   --hand-over   --stage, then stop the predecessor so the successor takes
+ *                 the singleton fence
+ *
+ * The plan is always rendered first, and it names the one container a
+ * hand-over stops and the containers it never touches. Viewer releases, the
+ * structured and engine hosts inside them, and every live agent session keep
+ * running across all three modes.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ViewerReleaseIdentity } from "../src/lib/runtime/contracts";
+import { ensureCanonicalMirror, resolveCanonicalRevision } from "../src/runtime-host/canonicalMirror";
+import {
+  executeRuntimeHostBootstrap,
+  planRuntimeHostBootstrap,
+  renderRuntimeHostBootstrapPlan,
+  runtimeHostBootstrapRefusal,
+  type RuntimeHostBootstrapMode,
+} from "../src/runtime-host/hostBootstrap";
+import {
+  clearRuntimeHostHandoffIntent,
+  readRuntimeHostHandoffIntent,
+  readRuntimeHostRelease,
+  runtimeHostHandoffIntentFile,
+  runtimeHostReleaseFile,
+  writeRuntimeHostHandoffIntent,
+  writeRuntimeHostRelease,
+} from "../src/runtime-host/hostRelease";
+import {
+  findRuntimeHostPredecessor,
+  stageRuntimeHostSuccessorContainer,
+} from "../src/runtime-host/hostSuccessor";
+import { withoutWakatimeCredential } from "../src/lib/wakatime/credential";
+
+const USAGE = "usage: bun scripts/bootstrap-runtime-host.ts [origin/main|<40-hex sha>] [--stage|--hand-over]";
+
+const defaultConfigDir = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || "", ".config");
+const stateDir = process.env.LLV_STATE_DIR || path.join(defaultConfigDir, "agent-log-viewer", "state");
+const deploymentDir = path.join(stateDir, "deployments");
+const mirrorDir = path.join(deploymentDir, "canonical.git");
+const canonicalRemote = process.env.LLV_VIEWER_CANONICAL_REMOTE || "https://github.com/Latand/live-log-viewer-next.git";
+const runtimeSocket = process.env.LLV_RUNTIME_HOST_SOCKET || path.join(stateDir, "runtime-host.sock");
+const runtimeHostImageTag = process.env.LLV_RUNTIME_HOST_IMAGE_TAG || "agent-log-viewer:node22";
+const stableEndpoint = `http://127.0.0.1:${Number(process.env.LLV_VIEWER_PORT || 8898)}`;
+const PREDECESSOR_STOP_GRACE_SECONDS = 40;
+
+export function parseArguments(argv: string[]): { revision: string; mode: RuntimeHostBootstrapMode } {
+  let revision: string | null = null;
+  let mode: RuntimeHostBootstrapMode = "plan";
+  for (const argument of argv) {
+    if (argument === "--stage") { mode = "stage"; continue; }
+    if (argument === "--hand-over") { mode = "hand-over"; continue; }
+    if (argument.startsWith("-")) throw new Error(`unsupported option ${argument}\n${USAGE}`);
+    if (revision !== null) throw new Error(`only one revision may be given\n${USAGE}`);
+    revision = argument;
+  }
+  const requested = revision ?? "origin/main";
+  if (requested !== "origin/main" && !/^[0-9a-f]{40}$/.test(requested)) {
+    throw new Error(`invalid revision: use origin/main or a full lowercase commit SHA\n${USAGE}`);
+  }
+  return { revision: requested, mode };
+}
+
+async function command(argv: string[], options: { cwd?: string } = {}): Promise<string> {
+  const child = Bun.spawn(argv, {
+    cwd: options.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: withoutWakatimeCredential(process.env),
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0) throw new Error((stderr.trim() || `${argv[0]} failed`).slice(0, 1000));
+  return stdout.trim();
+}
+
+function log(line: string): void {
+  console.error(`[runtime-host bootstrap] ${line}`);
+}
+
+async function docker(argv: string[]): Promise<string> {
+  return command(["docker", ...argv]);
+}
+
+async function containerPid(container: string): Promise<number | null> {
+  try {
+    const raw = await docker(["container", "inspect", "--format", "{{.State.Pid}}", container]);
+    const pid = Number(raw);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function fenceOwnerPid(): number | null {
+  try {
+    const owner = JSON.parse(fs.readFileSync(`${runtimeSocket}.lock`, "utf8")) as { pid?: unknown };
+    return Number.isInteger(owner.pid) && (owner.pid as number) > 0 ? owner.pid as number : null;
+  } catch {
+    return null;
+  }
+}
+
+async function imageExists(image: string): Promise<boolean> {
+  try { await docker(["image", "inspect", image]); return true; }
+  catch { return false; }
+}
+
+/** The same build a deployment runs, from a clean canonical worktree, minus
+    everything a Viewer candidate needs and a runtime-host generation does not:
+    no candidate container, no candidate port, no MCP runtime staging, and no
+    change to the Viewer release target. */
+async function buildRuntimeHostImage(revision: string, image: string): Promise<void> {
+  const runtimeHome = process.env.HOME?.trim();
+  if (!runtimeHome || !path.isAbsolute(runtimeHome)) {
+    throw new Error("HOME must be an absolute path before building a runtime-host image");
+  }
+  if (await imageExists(image)) {
+    log(`reusing the existing image for ${revision}`);
+    return;
+  }
+  const sourceDir = path.join(deploymentDir, `runtime-host-bootstrap-${revision}`, "source");
+  fs.rmSync(path.dirname(sourceDir), { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(sourceDir), { recursive: true, mode: 0o700 });
+  await command(["git", "--git-dir", mirrorDir, "worktree", "prune"]);
+  await command(["git", "--git-dir", mirrorDir, "worktree", "add", "--detach", sourceDir, revision]);
+  try {
+    log(`building the runtime-host image for ${revision}; this takes several minutes`);
+    await command([
+      "docker", "build", "--pull",
+      "--build-arg", `LLV_RUNTIME_HOME=${runtimeHome}`,
+      "--label", `dev.live-log-viewer.revision=${revision}`,
+      "-t", image, sourceDir,
+    ]);
+  } finally {
+    try { await command(["git", "--git-dir", mirrorDir, "worktree", "remove", "--force", sourceDir]); }
+    catch { fs.rmSync(sourceDir, { recursive: true, force: true }); }
+  }
+}
+
+async function main(): Promise<number> {
+  const { revision: requested, mode } = parseArguments(process.argv.slice(2));
+  const revision = await resolveCanonicalRevision(
+    requested,
+    { mirrorDir, remote: canonicalRemote },
+    {
+      run: command,
+      ensureMirror: () => ensureCanonicalMirror({ deploymentDir, mirrorDir, remote: canonicalRemote }, { run: command }),
+    },
+  );
+  const image = `agent-log-viewer:hostboot-${revision}`;
+  const predecessor = await findRuntimeHostPredecessor({ docker, fenceOwnerPid });
+  const plan = planRuntimeHostBootstrap({ mode, revision, image, predecessor, stableEndpoint });
+  console.log(renderRuntimeHostBootstrapPlan(plan));
+  const refusal = runtimeHostBootstrapRefusal(plan);
+  if (refusal) {
+    log(`refused: ${refusal}`);
+    return 1;
+  }
+  if (mode === "plan") {
+    log("plan only; nothing on this machine has changed");
+    log("re-run with --stage to create the successor, or --hand-over to also stop the predecessor");
+    return 0;
+  }
+  const currentRelease = readRuntimeHostRelease(runtimeHostReleaseFile());
+  log(`the durable runtime-host release record currently names ${currentRelease?.revision ?? "no staged generation"}`);
+  await buildRuntimeHostImage(revision, image);
+  const candidate: ViewerReleaseIdentity = {
+    revision,
+    image,
+    container: plan.successorContainer,
+    endpoint: stableEndpoint,
+  };
+  const outcome = await executeRuntimeHostBootstrap(plan, candidate, {
+    stageSuccessor: (target) => stageRuntimeHostSuccessorContainer(target, runtimeHostImageTag, {
+      docker,
+      writeRelease: (record) => writeRuntimeHostRelease(record, runtimeHostReleaseFile()),
+      readRelease: () => readRuntimeHostRelease(runtimeHostReleaseFile()),
+      readHandoffIntent: () => readRuntimeHostHandoffIntent(runtimeHostHandoffIntentFile()),
+      writeHandoffIntent: (intent) => writeRuntimeHostHandoffIntent(intent, runtimeHostHandoffIntentFile()),
+      clearHandoffIntent: () => clearRuntimeHostHandoffIntent(runtimeHostHandoffIntentFile()),
+      fenceOwnerPid,
+      reportPhase: (phase) => log(phase),
+    }),
+    stopPredecessor: async (predecessorId) => {
+      await docker(["container", "stop", "--time", String(PREDECESSOR_STOP_GRACE_SECONDS), predecessorId]);
+    },
+    successorPid: () => containerPid(plan.successorContainer),
+    fenceOwnerPid,
+    sleep: (milliseconds) => Bun.sleep(milliseconds),
+    log,
+  });
+  if (!outcome.handedOver) {
+    log(`successor ${outcome.successorContainer} is staged and idle; the predecessor still serves ${stableEndpoint}`);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  try {
+    process.exit(await main());
+  } catch (error) {
+    console.error(`[runtime-host bootstrap] ${error instanceof Error ? error.message : "bootstrap failed"}`);
+    process.exit(1);
+  }
+}

--- a/scripts/bun-spawn-credential-isolation.test.ts
+++ b/scripts/bun-spawn-credential-isolation.test.ts
@@ -50,6 +50,7 @@ test("production Bun child paths use the credential-isolated environment seam", 
 
   expect(uncovered).toEqual([]);
   expect(inventory).toEqual([
+    { file: "scripts/bootstrap-runtime-host.ts", method: "spawn" },
     { file: "scripts/deploy-staging.ts", method: "spawn" },
     ...Array.from({ length: 9 }, () => ({ file: "scripts/privacy-publication-gate.ts", method: "spawnSync" })),
     { file: "scripts/runtime-host-viewer-adapter.ts", method: "spawn" },

--- a/scripts/bun-spawn-credential-isolation.test.ts
+++ b/scripts/bun-spawn-credential-isolation.test.ts
@@ -50,7 +50,7 @@ test("production Bun child paths use the credential-isolated environment seam", 
 
   expect(uncovered).toEqual([]);
   expect(inventory).toEqual([
-    { file: "scripts/bootstrap-runtime-host.ts", method: "spawn" },
+    ...Array.from({ length: 2 }, () => ({ file: "scripts/bootstrap-runtime-host.ts", method: "spawn" })),
     { file: "scripts/deploy-staging.ts", method: "spawn" },
     ...Array.from({ length: 9 }, () => ({ file: "scripts/privacy-publication-gate.ts", method: "spawnSync" })),
     { file: "scripts/runtime-host-viewer-adapter.ts", method: "spawn" },

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -967,12 +967,19 @@ async function reconcileMcpRuntime(
     the predecessor generation is allowed to exit; this adapter process never
     needs to survive that exit. Only the runtime-host generation changes —
     Viewer containers and the engine processes they own are never signalled. */
-async function stageRuntimeHostSuccessor(candidate: ViewerReleaseIdentity): Promise<void> {
+async function stageRuntimeHostSuccessor(
+  candidate: ViewerReleaseIdentity,
+  phase: (value: string) => void = () => {},
+): Promise<void> {
   const registryBackendMode = viewerRegistryBackendMode(
     viewerComposeServiceFromConfig(fs.readFileSync(composeConfigFile(candidate.container), "utf8")),
   );
   await stageRuntimeHostSuccessorContainer(candidate, runtimeHostImageTag, {
     docker: (argv) => command(["docker", ...argv]),
+    /* #1216: the staging action has an eleven-second stability wait and half a
+       dozen Docker calls inside a sixty-second host budget. Without a phase it
+       reported "waiting for the adapter process" and named nothing. */
+    reportPhase: phase,
     writeRelease: (record) => writeRuntimeHostRelease(record, runtimeHostReleaseFile()),
     readRelease: () => readRuntimeHostRelease(runtimeHostReleaseFile()),
     readHandoffIntent: () => readRuntimeHostHandoffIntent(runtimeHostHandoffIntentFile()),
@@ -1117,7 +1124,7 @@ async function main(): Promise<unknown> {
   }
   if (action === "stage-host-successor") {
     const candidate = release(input.candidate);
-    await stageRuntimeHostSuccessor(candidate);
+    await stageRuntimeHostSuccessor(candidate, (phase) => reportAdapterPhase(action, phase));
     return {};
   }
   if (action === "complete-host-handoff") {

--- a/src/runtime-host/deployment.test.ts
+++ b/src/runtime-host/deployment.test.ts
@@ -68,6 +68,8 @@ class FakeDeploymentAdapter implements ViewerDeploymentAdapter {
   candidateHealth = healthy("http://127.0.0.1/candidate");
   promotedHealth = healthy("http://127.0.0.1:8898");
   stageHostFailure: Error | null = null;
+  promoteFailure: Error | null = null;
+  hotStateHandOver: string | null = null;
   calls: string[] = [];
 
   async reconcile(): Promise<void> { this.calls.push("reconcile"); }
@@ -125,6 +127,7 @@ class FakeDeploymentAdapter implements ViewerDeploymentAdapter {
   }
   async promote(candidate: ViewerReleaseIdentity): Promise<ViewerMcpRuntimePublicationEvidence> {
     this.calls.push(`promote:${candidate.container}`);
+    if (this.promoteFailure) throw this.promoteFailure;
     this.current = candidate;
     this.currentMcp = candidate.mcpRuntime!;
     return {
@@ -132,6 +135,7 @@ class FakeDeploymentAdapter implements ViewerDeploymentAdapter {
       ...candidate.mcpRuntime!,
       publishedAt: "2026-07-23T08:00:01.000Z",
       durable: true,
+      ...(this.hotStateHandOver ? { hotStateHandOver: this.hotStateHandOver } : {}),
     };
   }
   async verifyPromoted(candidate: ViewerReleaseIdentity): Promise<ViewerHealthEvidence> { this.calls.push(`verify-promoted:${candidate.container}`); return this.promotedHealth; }
@@ -448,6 +452,94 @@ test("issue 518: a succeeded exact-SHA deployment stages the candidate image as 
      Viewer processes keep running through the runtime-host replacement. */
   expect(adapter.calls.filter((call) => call.startsWith("rollback:"))).toEqual([]);
   expect(adapter.calls.filter((call) => call.startsWith("retire:"))).toEqual([]);
+  store.close();
+});
+
+/* #1216 reopened. The promote fix could not be delivered by the mechanism it
+   fixes, and this is the ordering that makes that true: runtime-host
+   succession lives in the `host-handoff` phase, which is downstream of
+   `promoting`. A promote that times out rolls back and never reaches it, so
+   the runtime host keeps executing the old promote path on the next attempt,
+   and the next, and the next. `scripts/bootstrap-runtime-host.ts` exists
+   because of this test. */
+test("issue 1216: a promote that times out never reaches runtime-host successor staging", async () => {
+  const store = journal("promote-timeout-host");
+  const adapter = new FakeDeploymentAdapter();
+  adapter.promoteFailure = new Error("deployment adapter promote timed out while waiting for hot-state activation");
+  const handoffs: string[] = [];
+  const lines: string[] = [];
+  const coordinator = new ViewerDeploymentCoordinator(store, adapter, { pid: 10, startIdentity: "10:1" }, {
+    hostGeneration: () => ({ image: "agent-log-viewer:node22", revision: null }),
+    onHostHandoff: (context) => { handoffs.push(context.deploymentId); },
+    log: (line) => { lines.push(line); },
+  });
+
+  const receipt = await coordinator.requestViewerDeployment({ idempotencyKey: "promote-timeout", revision: "b".repeat(40) });
+  if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
+  await coordinator.waitForDeployment(receipt.deploymentId);
+
+  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({
+    phase: "rolled-back",
+    terminal: true,
+    error: "deployment adapter promote timed out while waiting for hot-state activation",
+  });
+  /* The runtime host is left on whatever generation it was already running:
+     the deployment that carried the promote repair never staged a successor
+     that could execute it. */
+  expect(adapter.calls.filter((call) => call.startsWith("stage-host-successor:"))).toEqual([]);
+  expect(handoffs).toEqual([]);
+  expect(lines.some((line) => line.includes("host-handoff"))).toBe(false);
+  store.close();
+});
+
+/* Three deployments in a row left an operator unable to answer "did this even
+   try to replace the runtime host?" from the log. The step now says what it
+   decided and why. */
+test("issue 1216: the host-handoff step narrates the decision it made", async () => {
+  const store = journal("host-handoff-log");
+  const adapter = new FakeDeploymentAdapter();
+  adapter.hotStateHandOver = "incumbent released hot state after 4s; activation published after 12s";
+  const lines: string[] = [];
+  const coordinator = new ViewerDeploymentCoordinator(store, adapter, { pid: 10, startIdentity: "10:1" }, {
+    hostGeneration: () => ({ image: "agent-log-viewer:node22", revision: null }),
+    log: (line) => { lines.push(line); },
+  });
+
+  const receipt = await coordinator.requestViewerDeployment({ idempotencyKey: "host-handoff-log", revision: "b".repeat(40) });
+  if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
+  await coordinator.waitForDeployment(receipt.deploymentId);
+
+  const image = store.viewerDeployment(receipt.deploymentId)?.candidate?.image;
+  expect(lines).toEqual([
+    `[viewer deployment] ${receipt.deploymentId} promote hot-state hand-over: incumbent released hot state after 4s; activation published after 12s`,
+    `[viewer deployment] ${receipt.deploymentId} host-handoff staging a successor for ${"b".repeat(40)}; the running generation is untracked`,
+    `[viewer deployment] ${receipt.deploymentId} host-handoff staged; the successor waits for the singleton fence while this generation hands off ${"b".repeat(40)}`,
+  ]);
+  expect(image).toBe(`viewer:${"b".repeat(40)}`);
+  store.close();
+});
+
+/* A staging failure parks the deployment in a retryable `host-handoff` phase
+   and returns normally, so nothing printed it: the host stayed on the old
+   generation with no line in the log to say so. */
+test("issue 1216: a failed successor staging is printed, not only journalled", async () => {
+  const store = journal("host-handoff-failure-log");
+  const adapter = new FakeDeploymentAdapter();
+  adapter.stageHostFailure = new Error("runtime-host predecessor container is unavailable for successor staging");
+  const lines: string[] = [];
+  const coordinator = new ViewerDeploymentCoordinator(store, adapter, { pid: 10, startIdentity: "10:1" }, {
+    hostGeneration: () => ({ image: "agent-log-viewer:node22", revision: null }),
+    log: (line) => { lines.push(line); },
+  });
+
+  const receipt = await coordinator.requestViewerDeployment({ idempotencyKey: "host-handoff-failure", revision: "b".repeat(40) });
+  if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
+  await coordinator.waitForDeployment(receipt.deploymentId);
+
+  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({ phase: "host-handoff", terminal: false });
+  expect(lines).toContain(
+    `[viewer deployment] ${receipt.deploymentId} host-handoff failed and stays retryable: runtime-host predecessor container is unavailable for successor staging`,
+  );
   store.close();
 });
 

--- a/src/runtime-host/deployment.ts
+++ b/src/runtime-host/deployment.ts
@@ -75,6 +75,11 @@ export interface ViewerDeploymentCoordinatorOptions {
       succeeded deployment AND after the successor staging is durable — never
       as a same-image self-restart, which would boot the stale image again. */
   onHostHandoff?: (context: RuntimeHostHandoffContext) => void;
+  /** #1216: the deployment's own narration. Three deployments in a row left
+      no trace of whether a runtime-host successor was even attempted, because
+      the only step that stages one decided silently and parked its failures in
+      the journal without printing them. */
+  log?: (line: string) => void;
 }
 
 function validRequestedRevision(revision: string): boolean {
@@ -119,6 +124,7 @@ export class ViewerDeploymentCoordinator {
   private readonly ownerAlive: (owner: ViewerDeploymentOwner) => boolean;
   private readonly hostGeneration?: () => RuntimeHostGeneration;
   private readonly onHostHandoff?: (context: RuntimeHostHandoffContext) => void;
+  private readonly log: (line: string) => void;
 
   constructor(
     private readonly journal: RuntimeJournal,
@@ -132,6 +138,7 @@ export class ViewerDeploymentCoordinator {
       && (candidate.startIdentity === null || procBackend.processIdentity(candidate.pid) === candidate.startIdentity));
     this.hostGeneration = options.hostGeneration;
     this.onHostHandoff = options.onHostHandoff;
+    this.log = options.log ?? ((line) => console.error(line));
   }
 
   async requestViewerDeployment(request: ViewerDeploymentRequest): Promise<ViewerDeploymentReceipt> {
@@ -246,10 +253,19 @@ export class ViewerDeploymentCoordinator {
       host-handoff phase until staging succeeds. Only then does it become
       terminal and signal the predecessor to release the singleton fence. */
   private async stageDriftedHostSuccessor(status: ViewerDeploymentStatus): Promise<RuntimeHostHandoffContext | null> {
-    if (!this.hostGeneration || !status.candidate) return null;
+    const trace = (line: string) => this.log(`[viewer deployment] ${status.deploymentId} host-handoff ${line}`);
+    if (!this.hostGeneration || !status.candidate) {
+      trace("skipped: this runtime host does not track its own generation, so no successor can be staged");
+      return null;
+    }
     const running = this.hostGeneration();
-    if (running.revision === status.revision && running.image === status.candidate.image) return null;
+    if (running.revision === status.revision && running.image === status.candidate.image) {
+      trace(`not required: the runtime host already runs ${status.revision}`);
+      return null;
+    }
+    trace(`staging a successor for ${status.revision}; the running generation is ${running.revision ?? "untracked"}`);
     await this.adapter.stageRuntimeHostSuccessor(status.candidate);
+    trace(`staged; the successor waits for the singleton fence while this generation hands off ${status.revision}`);
     return {
       deploymentId: status.deploymentId,
       revision: status.revision,
@@ -261,7 +277,7 @@ export class ViewerDeploymentCoordinator {
   private start(status: ViewerDeploymentStatus): void {
     if (this.tasks.has(status.deploymentId) || status.terminal) return;
     const task = this.run(status)
-      .catch((error) => console.error(`[viewer deployment] ${safeError(error)}`))
+      .catch((error) => this.log(`[viewer deployment] ${safeError(error)}`))
       .finally(() => this.tasks.delete(status.deploymentId));
     this.tasks.set(status.deploymentId, task);
   }
@@ -322,6 +338,13 @@ export class ViewerDeploymentCoordinator {
         if (status.phase === "promoting") {
           if (!status.candidate) throw new Error("candidate identity is missing");
           const publication = await this.adapter.promote(status.candidate);
+          /* #1216: the promote's hot-state hand-over used to leave no trace in
+             the runtime-host log at all — the ordered steps and their waits
+             lived only in the adapter phase file, which is deleted the moment
+             the action returns. */
+          if (publication.hotStateHandOver) {
+            this.log(`[viewer deployment] ${status.deploymentId} promote hot-state hand-over: ${publication.hotStateHandOver}`);
+          }
           const runtime = mcpRuntimeStatus(status);
           status = this.journal.updateViewerDeployment(status.deploymentId, {
             phase: "post-promotion-health",
@@ -382,6 +405,7 @@ export class ViewerDeploymentCoordinator {
       const message = safeError(error);
       const latest = this.journal.viewerDeployment(status.deploymentId) ?? status;
       if (latest.phase === "host-handoff") {
+        this.log(`[viewer deployment] ${latest.deploymentId} host-handoff failed and stays retryable: ${message}`);
         this.journal.updateViewerDeployment(latest.deploymentId, {
           error: message,
           phase: "host-handoff",

--- a/src/runtime-host/fenceWait.test.ts
+++ b/src/runtime-host/fenceWait.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test";
+
+import {
+  acquireRuntimeHostFence,
+  RUNTIME_HOST_FENCE_PARK_ENV,
+  RUNTIME_HOST_FENCE_WAIT_ENV,
+  runtimeHostFenceWaitPlan,
+} from "./fenceWait";
+
+function heldFence(releaseAfterAttempts: number): { acquire(): void; attempts(): number } {
+  let attempts = 0;
+  return {
+    acquire() {
+      attempts += 1;
+      if (attempts <= releaseAfterAttempts) throw new Error("runtime host singleton fence is held");
+    },
+    attempts: () => attempts,
+  };
+}
+
+test("issue 518: a staged successor waits out its bounded budget for the predecessor's exit", async () => {
+  const plan = runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_WAIT_ENV]: "600000" });
+  const fence = heldFence(4);
+  let elapsedMs = 0;
+
+  expect(plan).toEqual({ parked: false, budgetMs: 600_000 });
+  const acquired = await acquireRuntimeHostFence({
+    acquire: () => fence.acquire(),
+    plan,
+    container: "llv-runtime-host-abcdef012345-0123456789ab",
+    now: () => elapsedMs,
+    sleep: async (milliseconds) => { elapsedMs += milliseconds; },
+    pollMs: 500,
+  });
+
+  expect(acquired).toEqual({ waitedMs: 2_000 });
+  expect(fence.attempts()).toBe(5);
+});
+
+test("issue 518: a bounded wait that expires names the generation and the budget it spent", async () => {
+  const plan = runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_WAIT_ENV]: "600000" });
+  let elapsedMs = 0;
+
+  await expect(acquireRuntimeHostFence({
+    acquire: () => { throw new Error("runtime host singleton fence is held"); },
+    plan,
+    container: "llv-runtime-host-abcdef012345-0123456789ab",
+    now: () => elapsedMs,
+    sleep: async (milliseconds) => { elapsedMs += milliseconds; },
+    pollMs: 60_000,
+  })).rejects.toThrow(
+    "runtime-host successor llv-runtime-host-abcdef012345-0123456789ab never acquired the singleton fence"
+    + "; waited 600s of 600s"
+    + "; the predecessor generation still holds it",
+  );
+});
+
+test("an ordinary boot carries no budget and still fails on the fence's own error", async () => {
+  const plan = runtimeHostFenceWaitPlan({});
+
+  expect(plan).toEqual({ parked: false, budgetMs: 0 });
+  await expect(acquireRuntimeHostFence({
+    acquire: () => { throw new Error("runtime host singleton fence is held"); },
+    plan,
+    sleep: async () => { throw new Error("an ordinary boot must not wait"); },
+  })).rejects.toThrow("runtime host singleton fence is held");
+});
+
+/* The reopened #1216 defect, one level down: `--stage` advertises an idle
+   successor that the operator hands over whenever they are ready, and the #518
+   budget turned that container into a ten-minute dockerd restart loop. A
+   parked generation has no hand-over in flight for a deadline to detect. */
+test("issue 1216: a parked successor never gives up on the fence and says why on a cadence", async () => {
+  const plan = runtimeHostFenceWaitPlan({
+    [RUNTIME_HOST_FENCE_PARK_ENV]: "1",
+    [RUNTIME_HOST_FENCE_WAIT_ENV]: "600000",
+  });
+  const fence = heldFence(7_200);
+  const reports: string[] = [];
+  let elapsedMs = 0;
+
+  /* The park outranks a bounded wait inherited from the same environment. */
+  expect(plan).toEqual({ parked: true, budgetMs: 0 });
+  const acquired = await acquireRuntimeHostFence({
+    acquire: () => fence.acquire(),
+    plan,
+    container: "llv-runtime-host-abcdef012345-0123456789ab",
+    now: () => elapsedMs,
+    sleep: async (milliseconds) => { elapsedMs += milliseconds; },
+    report: (line) => { reports.push(line); },
+    pollMs: 500,
+    reportEveryMs: 60_000,
+  });
+
+  /* An hour past the #518 budget, and the container is still the one the
+     operator staged rather than the sixth restart of it. */
+  expect(acquired).toEqual({ waitedMs: 3_600_000 });
+  expect(reports[0]).toBe(
+    "[runtime host] runtime-host successor llv-runtime-host-abcdef012345-0123456789ab"
+    + " is parked on the singleton fence with no deadline"
+    + "; waited 0s"
+    + "; the predecessor still serves and has not been asked to exit"
+    + "; run scripts/bootstrap-runtime-host.ts --hand-over to release it",
+  );
+  expect(reports).toHaveLength(60);
+  expect(reports[59]).toContain("; waited 3540s;");
+});
+
+test("issue 1216: a bounded wait reports what it is waiting for and how long it has waited", async () => {
+  const plan = runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_WAIT_ENV]: "600000" });
+  const fence = heldFence(2);
+  const reports: string[] = [];
+  let elapsedMs = 0;
+
+  await acquireRuntimeHostFence({
+    acquire: () => fence.acquire(),
+    plan,
+    container: "llv-runtime-host-abcdef012345-0123456789ab",
+    now: () => elapsedMs,
+    sleep: async (milliseconds) => { elapsedMs += milliseconds; },
+    report: (line) => { reports.push(line); },
+    pollMs: 60_000,
+    reportEveryMs: 60_000,
+  });
+
+  expect(reports).toEqual([
+    "[runtime host] runtime-host successor llv-runtime-host-abcdef012345-0123456789ab"
+    + " is waiting for the singleton fence; waited 0s of 600s; the predecessor has not released it yet",
+    "[runtime host] runtime-host successor llv-runtime-host-abcdef012345-0123456789ab"
+    + " is waiting for the singleton fence; waited 60s of 600s; the predecessor has not released it yet",
+  ]);
+});
+
+test("issue 1216: an unparsable fence budget is read as no budget rather than as an unbounded wait", () => {
+  expect(runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_WAIT_ENV]: "later" })).toEqual({ parked: false, budgetMs: 0 });
+  expect(runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_WAIT_ENV]: "-1" })).toEqual({ parked: false, budgetMs: 0 });
+  expect(runtimeHostFenceWaitPlan({ [RUNTIME_HOST_FENCE_PARK_ENV]: "0" })).toEqual({ parked: false, budgetMs: 0 });
+});

--- a/src/runtime-host/fenceWait.ts
+++ b/src/runtime-host/fenceWait.ts
@@ -1,0 +1,127 @@
+/* How a runtime-host generation waits for the singleton fence at boot.
+ *
+ * #518 gave a staged successor a bounded wait: it boots while the predecessor
+ * still holds the fence, waits for that predecessor's graceful exit, and fails
+ * its container if the exit never comes. The bound is the detector — a
+ * hand-over is in flight, and one that wedges has to become visible.
+ *
+ * #1216 added a second way a successor comes to exist: `--stage` from
+ * `scripts/bootstrap-runtime-host.ts`, where the predecessor has NOT been
+ * asked to exit and will not be until the operator runs the hand-over. There
+ * is no hand-over in flight for a deadline to detect, so a bounded wait there
+ * detects nothing and instead exits the container at the bound, which dockerd
+ * restart-loops on that period. A successor advertised as "staged and idle"
+ * was crash-looping. Such a generation is *parked* instead: no deadline, and
+ * the wait says so on a fixed cadence so `docker logs` shows a container that
+ * is deliberately waiting rather than one that is wedged.
+ */
+
+/** #518: the bounded successor wait, in milliseconds. */
+export const RUNTIME_HOST_FENCE_WAIT_ENV = "LLV_RUNTIME_HOST_FENCE_WAIT_MS";
+
+/** #1216: this generation was parked by an operator bootstrap. It outranks the
+    bounded wait, because a parked successor's predecessor is still serving on
+    purpose. */
+export const RUNTIME_HOST_FENCE_PARK_ENV = "LLV_RUNTIME_HOST_FENCE_PARK";
+
+/* Internal defaults. `hostBootstrap.ts` owns a separate, unrelated poll: this
+   one is how often a booting container retries the fence, that one is how
+   often the operator's hand-over run checks whether it took. */
+const FENCE_ACQUIRE_POLL_MS = 500;
+const FENCE_REPORT_EVERY_MS = 60_000;
+
+export interface RuntimeHostFenceWaitPlan {
+  /** No deadline: the predecessor has not been asked to exit. */
+  parked: boolean;
+  /** The bounded wait, or `0` for an ordinary boot that must fail immediately
+      when another generation already owns the fence. */
+  budgetMs: number;
+}
+
+export function runtimeHostFenceWaitPlan(
+  environment: Record<string, string | undefined>,
+): RuntimeHostFenceWaitPlan {
+  if (environment[RUNTIME_HOST_FENCE_PARK_ENV] === "1") return { parked: true, budgetMs: 0 };
+  const budgetMs = Number(environment[RUNTIME_HOST_FENCE_WAIT_ENV] || 0);
+  return { parked: false, budgetMs: Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : 0 };
+}
+
+function seconds(milliseconds: number): number {
+  return Math.max(0, Math.round(milliseconds / 1_000));
+}
+
+function generation(container: string | undefined): string {
+  return container ? `runtime-host successor ${container}` : "this runtime-host generation";
+}
+
+/** What the wait is waiting for and how long it has waited — the same
+    discipline the promote's hot-state waits carry (#1216). */
+export function runtimeHostFenceWaitLine(
+  plan: RuntimeHostFenceWaitPlan,
+  container: string | undefined,
+  elapsedMs: number,
+): string {
+  if (plan.parked) {
+    return `[runtime host] ${generation(container)} is parked on the singleton fence with no deadline`
+      + `; waited ${seconds(elapsedMs)}s`
+      + "; the predecessor still serves and has not been asked to exit"
+      + "; run scripts/bootstrap-runtime-host.ts --hand-over to release it";
+  }
+  return `[runtime host] ${generation(container)} is waiting for the singleton fence`
+    + `; waited ${seconds(elapsedMs)}s of ${seconds(plan.budgetMs)}s`
+    + "; the predecessor has not released it yet";
+}
+
+/** What it saw at give-up. A bounded wait that expires used to surface the
+    fence's own "singleton fence is held", which named neither the generation
+    nor the budget it had just spent (#1216). An ordinary boot carries no
+    budget, has nothing to report about waiting, and keeps that error verbatim. */
+export function runtimeHostFenceTimeoutLine(
+  plan: RuntimeHostFenceWaitPlan,
+  container: string | undefined,
+  elapsedMs: number,
+): string {
+  return `${generation(container)} never acquired the singleton fence`
+    + `; waited ${seconds(elapsedMs)}s of ${seconds(plan.budgetMs)}s`
+    + "; the predecessor generation still holds it";
+}
+
+/** Acquire the singleton fence the way this generation was staged to wait for
+    it. A parked wait never gives up; a bounded wait gives up at its budget
+    with a named message that keeps the fence's own error as its cause. */
+export async function acquireRuntimeHostFence(options: {
+  acquire(): void;
+  plan: RuntimeHostFenceWaitPlan;
+  container?: string;
+  now?(): number;
+  sleep?(milliseconds: number): Promise<void>;
+  report?(line: string): void;
+  pollMs?: number;
+  reportEveryMs?: number;
+}): Promise<{ waitedMs: number }> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep
+    ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  const pollMs = Math.max(1, options.pollMs ?? FENCE_ACQUIRE_POLL_MS);
+  const reportEveryMs = Math.max(1, options.reportEveryMs ?? FENCE_REPORT_EVERY_MS);
+  const started = now();
+  const deadline = started + options.plan.budgetMs;
+  let reportedAt: number | null = null;
+  for (;;) {
+    try {
+      options.acquire();
+      return { waitedMs: now() - started };
+    } catch (error) {
+      const elapsedMs = now() - started;
+      if (!options.plan.parked && now() >= deadline) {
+        if (options.plan.budgetMs <= 0) throw error;
+        throw new Error(runtimeHostFenceTimeoutLine(options.plan, options.container, elapsedMs), { cause: error });
+      }
+      if (reportedAt === null || elapsedMs - reportedAt >= reportEveryMs) {
+        reportedAt = elapsedMs;
+        options.report?.(runtimeHostFenceWaitLine(options.plan, options.container, elapsedMs));
+      }
+      await sleep(pollMs);
+    }
+  }
+}

--- a/src/runtime-host/hostBootstrap.test.ts
+++ b/src/runtime-host/hostBootstrap.test.ts
@@ -88,6 +88,21 @@ test("issue 1216: the plan names the one container a hand-over stops before anyt
   expect(rendered).toContain(`${stableEndpoint} is unserved between the predecessor exit and the successor acquiring the singleton fence`);
 });
 
+/* The runbook invites the operator to stage now and hand over later, so the
+   plan has to say what that staged successor does in between. Its predecessor
+   has not been asked to exit, so a bounded fence wait would detect nothing and
+   only crash-loop the container the plan calls staged. */
+test("issue 1216: the plan states that a staged successor waits with no deadline", () => {
+  for (const mode of ["plan", "stage", "hand-over"] as const) {
+    const rendered = renderRuntimeHostBootstrapPlan(plan(mode));
+
+    expect(rendered).toContain("while the successor is staged and the predecessor still serves:");
+    expect(rendered).toContain("the successor is parked on the singleton fence with no deadline; it never times out and never restart-loops");
+    expect(rendered).toContain("there is no window to beat — a hand-over run hours later resumes this same successor container");
+    expect(rendered).toContain(`${stableEndpoint} keeps being served by the predecessor throughout`);
+  }
+});
+
 test("issue 1216: the plan and stage modes both promise to stop nothing", () => {
   for (const mode of ["plan", "stage"] as const) {
     expect(renderRuntimeHostBootstrapPlan(plan(mode)))
@@ -133,6 +148,10 @@ test("issue 1216: stage mode creates the successor and leaves the predecessor se
   expect(outcome.handedOver).toBe(false);
   expect(recorded.calls).toEqual([`stage:${revision}`]);
   expect(recorded.lines.some((line) => line.startsWith("nothing was stopped;"))).toBe(true);
+  /* The completion line is what an operator reads before walking away, so it
+     carries the same promise the plan made. */
+  expect(recorded.lines).toContain(`staged runtime-host successor ${runtimeHostSuccessorName(revision, image)}; it is parked on the singleton fence with no deadline`);
+  expect(recorded.lines).toContain("there is no window to beat: the parked successor neither times out nor restart-loops, so the hand-over can run whenever you are ready");
 });
 
 test("issue 1216: a hand-over stops the predecessor only after the successor is staged", async () => {

--- a/src/runtime-host/hostBootstrap.test.ts
+++ b/src/runtime-host/hostBootstrap.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "bun:test";
+
+import type { ViewerReleaseIdentity } from "@/lib/runtime/contracts";
+
+import {
+  awaitRuntimeHostSuccessorFence,
+  executeRuntimeHostBootstrap,
+  planRuntimeHostBootstrap,
+  renderRuntimeHostBootstrapPlan,
+  runtimeHostBootstrapRefusal,
+  type RuntimeHostBootstrapMode,
+  type RuntimeHostBootstrapPorts,
+} from "./hostBootstrap";
+import { runtimeHostSuccessorName } from "./hostSuccessor";
+
+const revision = "c".repeat(40);
+const image = `agent-log-viewer:hostboot-${revision}`;
+const stableEndpoint = "http://127.0.0.1:8898";
+
+function predecessor(overrides: Partial<{ id: string; name: string; image: string }> = {}) {
+  return {
+    id: "f".repeat(64),
+    name: "llv-runtime-host-704ff4636294-0123456789ab",
+    image: "agent-log-viewer:deploy-704ff4636294",
+    ...overrides,
+  };
+}
+
+function plan(mode: RuntimeHostBootstrapMode, overrides: Partial<Parameters<typeof planRuntimeHostBootstrap>[0]> = {}) {
+  return planRuntimeHostBootstrap({
+    mode,
+    revision,
+    image,
+    predecessor: predecessor(),
+    stableEndpoint,
+    ...overrides,
+  });
+}
+
+function candidate(): ViewerReleaseIdentity {
+  return { revision, image, container: runtimeHostSuccessorName(revision, image), endpoint: stableEndpoint };
+}
+
+interface Recorded {
+  calls: string[];
+  lines: string[];
+  ports: RuntimeHostBootstrapPorts;
+}
+
+function recorder(options: { fenceOwner?: (calls: string[]) => number | null; successorPid?: number | null } = {}): Recorded {
+  const calls: string[] = [];
+  const lines: string[] = [];
+  const successorPid = options.successorPid === undefined ? 4242 : options.successorPid;
+  return {
+    calls,
+    lines,
+    ports: {
+      stageSuccessor: async (target) => {
+        calls.push(`stage:${target.revision}`);
+        return { successorContainer: runtimeHostSuccessorName(target.revision, target.image) };
+      },
+      stopPredecessor: async (id) => { calls.push(`stop:${id.slice(0, 6)}`); },
+      successorPid: async () => successorPid,
+      fenceOwnerPid: () => options.fenceOwner ? options.fenceOwner(calls) : successorPid,
+      sleep: async () => {},
+      log: (line) => { lines.push(line); },
+    },
+  };
+}
+
+/* The reopened half of #1216: a runtime host pinned to the revision that
+   carries the promote defect can only be replaced by a deployment that
+   reaches `host-handoff`, which is downstream of the promote that fails. The
+   bootstrap is the path that does not require a promote to have succeeded, so
+   the first thing it owes an operator whose host owns live agent sessions is a
+   statement of what it will stop. */
+test("issue 1216: the plan names the one container a hand-over stops before anything runs", () => {
+  const rendered = renderRuntimeHostBootstrapPlan(plan("hand-over"));
+
+  expect(rendered).toContain("mode         hand-over");
+  expect(rendered).toContain(`revision     ${revision}`);
+  expect(rendered).toContain(`successor    ${runtimeHostSuccessorName(revision, image)}`);
+  expect(rendered).toContain("predecessor  llv-runtime-host-704ff4636294-0123456789ab");
+  expect(rendered).toContain("the predecessor runtime-host container llv-runtime-host-704ff4636294-0123456789ab, and nothing else");
+  /* The sessions the operator is worried about are named as untouched, not
+     left to inference. */
+  expect(rendered).toContain("every live agent session, pipeline, and orchestrator they own");
+  expect(rendered).toContain(`${stableEndpoint} is unserved between the predecessor exit and the successor acquiring the singleton fence`);
+});
+
+test("issue 1216: the plan and stage modes both promise to stop nothing", () => {
+  for (const mode of ["plan", "stage"] as const) {
+    expect(renderRuntimeHostBootstrapPlan(plan(mode)))
+      .toContain("nothing — this mode never stops a container");
+  }
+});
+
+test("issue 1216: a bootstrap without a running runtime host is refused by name", () => {
+  expect(runtimeHostBootstrapRefusal(plan("hand-over", { predecessor: null })))
+    .toBe("no running runtime-host container owns the singleton fence; start the runtime-host service before bootstrapping a successor");
+});
+
+test("issue 1216: a runtime host already on the target generation is refused rather than restarted", () => {
+  const already = predecessor({ name: runtimeHostSuccessorName(revision, image) });
+
+  expect(runtimeHostBootstrapRefusal(plan("hand-over", { predecessor: already })))
+    .toBe(`the runtime host already runs ${revision} from ${image}`);
+});
+
+test("issue 1216: a bootstrap refuses a revision that is not a resolved commit", () => {
+  expect(runtimeHostBootstrapRefusal(plan("stage", { revision: "origin/main" })))
+    .toBe("runtime-host bootstrap needs a resolved 40-character commit SHA");
+});
+
+test("issue 1216: plan mode changes nothing at all", async () => {
+  const recorded = recorder();
+
+  const outcome = await executeRuntimeHostBootstrap(plan("plan"), candidate(), recorded.ports);
+
+  expect(outcome).toEqual({
+    successorContainer: runtimeHostSuccessorName(revision, image),
+    handedOver: false,
+    fenceWaitedMs: null,
+  });
+  expect(recorded.calls).toEqual([]);
+});
+
+test("issue 1216: stage mode creates the successor and leaves the predecessor serving", async () => {
+  const recorded = recorder();
+
+  const outcome = await executeRuntimeHostBootstrap(plan("stage"), candidate(), recorded.ports);
+
+  expect(outcome.handedOver).toBe(false);
+  expect(recorded.calls).toEqual([`stage:${revision}`]);
+  expect(recorded.lines.some((line) => line.startsWith("nothing was stopped;"))).toBe(true);
+});
+
+test("issue 1216: a hand-over stops the predecessor only after the successor is staged", async () => {
+  const recorded = recorder();
+
+  const outcome = await executeRuntimeHostBootstrap(plan("hand-over"), candidate(), recorded.ports);
+
+  expect(recorded.calls).toEqual([`stage:${revision}`, "stop:ffffff"]);
+  expect(outcome.handedOver).toBe(true);
+  expect(outcome.successorContainer).toBe(runtimeHostSuccessorName(revision, image));
+  expect(recorded.lines.some((line) => line.includes("owns the singleton fence"))).toBe(true);
+});
+
+/* The predecessor's exit is asynchronous — the successor only acquires the
+   fence once the predecessor has drained. #1216 is what a wait with no name
+   costs, so this one reports what it is waiting for and what it saw. */
+test("issue 1216: a fence that arrives late but inside the budget succeeds", async () => {
+  let elapsedMs = 0;
+  const reports: string[] = [];
+  let polls = 0;
+
+  const fence = await awaitRuntimeHostSuccessorFence({
+    successorContainer: "llv-runtime-host-abcdef012345-0123456789ab",
+    successorPid: async () => { polls += 1; return polls < 4 ? null : 4242; },
+    fenceOwnerPid: () => polls < 4 ? 99 : 4242,
+    sleep: async (delayMs) => { elapsedMs += delayMs; },
+    now: () => elapsedMs,
+    report: (line) => { reports.push(line); },
+    timeoutMs: 10_000,
+    pollMs: 1_000,
+  });
+
+  expect(fence).toEqual({ waitedMs: 3_000, pid: 4242 });
+  expect(reports[0]).toBe("waiting for the runtime-host successor to acquire the singleton fence - 0s of 10s - the successor container is not running");
+});
+
+test("issue 1216: a fence that never arrives fails with a named reason and what it saw", async () => {
+  let elapsedMs = 0;
+
+  await expect(awaitRuntimeHostSuccessorFence({
+    successorContainer: "llv-runtime-host-abcdef012345-0123456789ab",
+    successorPid: async () => 4242,
+    fenceOwnerPid: () => 99,
+    sleep: async (delayMs) => { elapsedMs += delayMs; },
+    now: () => elapsedMs,
+    timeoutMs: 3_000,
+    pollMs: 1_000,
+  })).rejects.toThrow(
+    "runtime-host successor llv-runtime-host-abcdef012345-0123456789ab never acquired the singleton fence"
+    + "; waited 3s of 3s"
+    + "; last observed successor pid 4242, fence owner pid 99",
+  );
+});
+
+test("issue 1216: an unreadable fence lock is named rather than read as success", async () => {
+  let elapsedMs = 0;
+
+  await expect(awaitRuntimeHostSuccessorFence({
+    successorContainer: "llv-runtime-host-abcdef012345-0123456789ab",
+    successorPid: async () => 4242,
+    fenceOwnerPid: () => null,
+    sleep: async (delayMs) => { elapsedMs += delayMs; },
+    now: () => elapsedMs,
+    timeoutMs: 1_000,
+    pollMs: 1_000,
+  })).rejects.toThrow("; last observed successor pid 4242, fence owner unreadable");
+});
+
+test("issue 1216: a refused plan never reaches the staging step", async () => {
+  const recorded = recorder();
+
+  await expect(executeRuntimeHostBootstrap(plan("hand-over", { predecessor: null }), candidate(), recorded.ports))
+    .rejects.toThrow("no running runtime-host container owns the singleton fence");
+  expect(recorded.calls).toEqual([]);
+});

--- a/src/runtime-host/hostBootstrap.ts
+++ b/src/runtime-host/hostBootstrap.ts
@@ -26,11 +26,15 @@ import {
  * live agent sessions on it.
  */
 
-/** The successor waits on the singleton fence for ten minutes (#518), but a
-    predecessor that is going to exit does so in seconds: it drains the socket
-    server, closes the journal and releases the fence. Two minutes is generous
-    for that and short enough that a predecessor which is NOT exiting is
-    reported while the operator is still watching. */
+/** How long THIS RUN waits for the successor to take the fence after it stops
+    the predecessor. It bounds the operator's wait, not the successor's: a
+    bootstrap-staged successor is parked and waits without a deadline
+    (`RuntimeHostSuccessorFenceWait`), so a give-up here reports a predecessor
+    that did not exit and leaves the successor still able to take over. A
+    predecessor that is going to exit does so in seconds — it drains the socket
+    server, closes the journal and releases the fence — so two minutes is
+    generous for that and short enough to be reported while the operator is
+    still watching. */
 export const RUNTIME_HOST_FENCE_TIMEOUT_MS = 120_000;
 export const RUNTIME_HOST_FENCE_POLL_MS = 1_000;
 
@@ -120,6 +124,13 @@ export function renderRuntimeHostBootstrapPlan(plan: RuntimeHostBootstrapPlan): 
       "the successor container is created and proven stable while the predecessor keeps serving",
       "the predecessor restart policy is set to no, so a predecessor that dies later will not come back",
       "the durable runtime-host release record is repointed at the successor",
+    ]),
+    "",
+    "while the successor is staged and the predecessor still serves:",
+    bullet([
+      "the successor is parked on the singleton fence with no deadline; it never times out and never restart-loops",
+      "there is no window to beat — a hand-over run hours later resumes this same successor container",
+      `${plan.stableEndpoint} keeps being served by the predecessor throughout`,
     ]),
     "",
     "during the hand-over:",
@@ -229,9 +240,10 @@ export async function executeRuntimeHostBootstrap(
   }
   ports.log(`staging runtime-host successor ${plan.successorContainer} for ${plan.revision}; ${predecessor.name} keeps serving`);
   const staged = await ports.stageSuccessor(candidate);
-  ports.log(`staged runtime-host successor ${staged.successorContainer}; it is waiting for the singleton fence`);
+  ports.log(`staged runtime-host successor ${staged.successorContainer}; it is parked on the singleton fence with no deadline`);
   if (plan.mode === "stage") {
     ports.log(`nothing was stopped; re-run with --hand-over to stop ${predecessor.name} and let the successor take over`);
+    ports.log("there is no window to beat: the parked successor neither times out nor restart-loops, so the hand-over can run whenever you are ready");
     return { successorContainer: staged.successorContainer, handedOver: false, fenceWaitedMs: null };
   }
   ports.log(`stopping the predecessor runtime-host container ${predecessor.name}; ${plan.stableEndpoint} is unserved until the successor acquires the fence`);

--- a/src/runtime-host/hostBootstrap.ts
+++ b/src/runtime-host/hostBootstrap.ts
@@ -1,0 +1,250 @@
+import type { ViewerReleaseIdentity } from "@/lib/runtime/contracts";
+
+import {
+  runtimeHostSuccessorName,
+  type RuntimeHostPredecessorIdentity,
+} from "./hostSuccessor";
+
+/* #1216 runtime-host bootstrap.
+ *
+ * The runtime host executes the promote, and it runs a baked image, so the
+ * only supported way onto a new revision used to be the #518 succession that
+ * a deployment stages in its `host-handoff` phase — strictly downstream of the
+ * promote. A promote defect therefore pinned the host to the revision that
+ * carried the defect: the repair could only be delivered by the mechanism it
+ * repaired.
+ *
+ * This module is the way out. It stages the same #518 successor from a chosen
+ * revision without a deployment, so a promote never has to have succeeded.
+ * The steps it drives are the deployment's own, in the same order, and it adds
+ * exactly one thing a deployment does not need: the predecessor's exit is a
+ * named, budgeted step here, because there is no `onHostHandoff` signal to
+ * carry it.
+ *
+ * Nothing runs before the plan is rendered. The plan names the one container
+ * this will stop and the ones it will not, because the machine it runs on has
+ * live agent sessions on it.
+ */
+
+/** The successor waits on the singleton fence for ten minutes (#518), but a
+    predecessor that is going to exit does so in seconds: it drains the socket
+    server, closes the journal and releases the fence. Two minutes is generous
+    for that and short enough that a predecessor which is NOT exiting is
+    reported while the operator is still watching. */
+export const RUNTIME_HOST_FENCE_TIMEOUT_MS = 120_000;
+export const RUNTIME_HOST_FENCE_POLL_MS = 1_000;
+
+export type RuntimeHostBootstrapMode = "plan" | "stage" | "hand-over";
+
+export interface RuntimeHostBootstrapPlan {
+  mode: RuntimeHostBootstrapMode;
+  revision: string;
+  image: string;
+  successorContainer: string;
+  predecessor: RuntimeHostPredecessorIdentity | null;
+  /** The listener the deployment proxy serves, which is unserved for the
+      length of the hand-over. */
+  stableEndpoint: string;
+  fenceTimeoutMs: number;
+}
+
+export function planRuntimeHostBootstrap(input: {
+  mode: RuntimeHostBootstrapMode;
+  revision: string;
+  image: string;
+  predecessor: RuntimeHostPredecessorIdentity | null;
+  stableEndpoint: string;
+  fenceTimeoutMs?: number;
+}): RuntimeHostBootstrapPlan {
+  return {
+    mode: input.mode,
+    revision: input.revision,
+    image: input.image,
+    successorContainer: runtimeHostSuccessorName(input.revision, input.image),
+    predecessor: input.predecessor,
+    stableEndpoint: input.stableEndpoint,
+    fenceTimeoutMs: input.fenceTimeoutMs ?? RUNTIME_HOST_FENCE_TIMEOUT_MS,
+  };
+}
+
+/** Why this bootstrap must not run, or `null`. Refusals are named so the
+    operator reads a reason rather than a Docker error from three steps in. */
+export function runtimeHostBootstrapRefusal(plan: RuntimeHostBootstrapPlan): string | null {
+  if (!/^[0-9a-f]{40}$/.test(plan.revision)) {
+    return "runtime-host bootstrap needs a resolved 40-character commit SHA";
+  }
+  if (!plan.predecessor) {
+    return "no running runtime-host container owns the singleton fence; start the runtime-host service before bootstrapping a successor";
+  }
+  if (plan.predecessor.name === plan.successorContainer) {
+    return `the runtime host already runs ${plan.revision} from ${plan.image}`;
+  }
+  return null;
+}
+
+function bullet(lines: string[]): string {
+  return lines.map((line) => `  - ${line}`).join("\n");
+}
+
+/** The statement the operator reads before anything on the machine changes. */
+export function renderRuntimeHostBootstrapPlan(plan: RuntimeHostBootstrapPlan): string {
+  const predecessor = plan.predecessor
+    ? `${plan.predecessor.name} (${plan.predecessor.id.slice(0, 12)}) running ${plan.predecessor.image || "an unnamed image"}`
+    : "none — no container owns the singleton fence";
+  const fenceSeconds = Math.round(plan.fenceTimeoutMs / 1_000);
+  const stops = plan.mode === "hand-over"
+    ? bullet([
+      `the predecessor runtime-host container ${plan.predecessor?.name ?? "(none)"}, and nothing else`,
+    ])
+    : bullet(["nothing — this mode never stops a container"]);
+  return [
+    "runtime-host bootstrap plan",
+    `  mode         ${plan.mode}`,
+    `  revision     ${plan.revision}`,
+    `  image        ${plan.image}`,
+    `  successor    ${plan.successorContainer}`,
+    `  predecessor  ${predecessor}`,
+    "",
+    "will stop:",
+    stops,
+    "",
+    "will NOT stop, signal, or restart:",
+    bullet([
+      "Viewer release containers, including the one serving production",
+      "the structured and engine hosts inside them",
+      "every live agent session, pipeline, and orchestrator they own",
+    ]),
+    "",
+    "before anything is stopped:",
+    bullet([
+      "the successor container is created and proven stable while the predecessor keeps serving",
+      "the predecessor restart policy is set to no, so a predecessor that dies later will not come back",
+      "the durable runtime-host release record is repointed at the successor",
+    ]),
+    "",
+    "during the hand-over:",
+    bullet([
+      `${plan.stableEndpoint} is unserved between the predecessor exit and the successor acquiring the singleton fence`,
+      `this run waits up to ${fenceSeconds}s for that fence and names what it saw if it never arrives`,
+      "the successor removes the stopped predecessor container once it owns the fence",
+    ]),
+  ].join("\n");
+}
+
+export interface RuntimeHostBootstrapPorts {
+  /** #518 staging, unchanged: creates the successor, proves it stable, and
+      publishes the release record without touching the predecessor process. */
+  stageSuccessor(candidate: ViewerReleaseIdentity): Promise<{ successorContainer: string }>;
+  /** Graceful stop of the predecessor container — the only thing this module
+      ever stops. */
+  stopPredecessor(predecessorId: string): Promise<void>;
+  /** The successor container's main pid, or `null` while it is not running. */
+  successorPid(): Promise<number | null>;
+  /** The singleton fence owner pid, or `null` when the lock is unreadable. */
+  fenceOwnerPid(): number | null;
+  sleep(milliseconds: number): Promise<void>;
+  now?(): number;
+  log(line: string): void;
+}
+
+export interface RuntimeHostBootstrapOutcome {
+  successorContainer: string;
+  handedOver: boolean;
+  fenceWaitedMs: number | null;
+}
+
+export function runtimeHostFenceObservation(successor: number | null, fenceOwner: number | null): string {
+  if (successor === null) return "the successor container is not running";
+  if (fenceOwner === null) return `successor pid ${successor}, fence owner unreadable`;
+  return `successor pid ${successor}, fence owner pid ${fenceOwner}`;
+}
+
+export function runtimeHostFenceTimeoutMessage(input: {
+  successorContainer: string;
+  waitedMs: number;
+  budgetMs: number;
+  observation: string;
+}): string {
+  const seconds = (value: number) => Math.max(0, Math.round(value / 1_000));
+  return [
+    `runtime-host successor ${input.successorContainer} never acquired the singleton fence`,
+    `waited ${seconds(input.waitedMs)}s of ${seconds(input.budgetMs)}s`,
+    `last observed ${input.observation}`,
+  ].join("; ");
+}
+
+/** The hand-over's own visible outcome. The predecessor's exit is asynchronous
+    — dockerd stops it, it drains, and only then does the successor's fence
+    wait return — so this step reports what it is waiting for, how long it has
+    waited, and what it saw at give-up, exactly like the promote's hot-state
+    waits do (#1216). */
+export async function awaitRuntimeHostSuccessorFence(options: {
+  successorContainer: string;
+  successorPid(): Promise<number | null>;
+  fenceOwnerPid(): number | null;
+  sleep(milliseconds: number): Promise<void>;
+  now?(): number;
+  report?(line: string): void;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<{ waitedMs: number; pid: number }> {
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.max(100, options.timeoutMs ?? RUNTIME_HOST_FENCE_TIMEOUT_MS);
+  const pollMs = Math.max(5, options.pollMs ?? RUNTIME_HOST_FENCE_POLL_MS);
+  const started = now();
+  let observation = runtimeHostFenceObservation(null, null);
+  for (;;) {
+    const successor = await options.successorPid();
+    const fenceOwner = options.fenceOwnerPid();
+    observation = runtimeHostFenceObservation(successor, fenceOwner);
+    if (successor !== null && fenceOwner === successor) return { waitedMs: now() - started, pid: successor };
+    const elapsedMs = now() - started;
+    options.report?.(`waiting for the runtime-host successor to acquire the singleton fence - ${Math.round(elapsedMs / 1_000)}s of ${Math.round(timeoutMs / 1_000)}s - ${observation}`);
+    if (elapsedMs >= timeoutMs) {
+      throw new Error(runtimeHostFenceTimeoutMessage({
+        successorContainer: options.successorContainer,
+        waitedMs: elapsedMs,
+        budgetMs: timeoutMs,
+        observation,
+      }));
+    }
+    await options.sleep(pollMs);
+  }
+}
+
+/** Ordered, and every step announces itself before it runs. `plan` returns
+    before anything mutates; `stage` leaves the predecessor serving; only
+    `hand-over` stops it, and only after the successor is durably staged. */
+export async function executeRuntimeHostBootstrap(
+  plan: RuntimeHostBootstrapPlan,
+  candidate: ViewerReleaseIdentity,
+  ports: RuntimeHostBootstrapPorts,
+): Promise<RuntimeHostBootstrapOutcome> {
+  const refusal = runtimeHostBootstrapRefusal(plan);
+  if (refusal) throw new Error(refusal);
+  const predecessor = plan.predecessor;
+  if (!predecessor) throw new Error("runtime-host bootstrap lost its predecessor between planning and staging");
+  if (plan.mode === "plan") {
+    return { successorContainer: plan.successorContainer, handedOver: false, fenceWaitedMs: null };
+  }
+  ports.log(`staging runtime-host successor ${plan.successorContainer} for ${plan.revision}; ${predecessor.name} keeps serving`);
+  const staged = await ports.stageSuccessor(candidate);
+  ports.log(`staged runtime-host successor ${staged.successorContainer}; it is waiting for the singleton fence`);
+  if (plan.mode === "stage") {
+    ports.log(`nothing was stopped; re-run with --hand-over to stop ${predecessor.name} and let the successor take over`);
+    return { successorContainer: staged.successorContainer, handedOver: false, fenceWaitedMs: null };
+  }
+  ports.log(`stopping the predecessor runtime-host container ${predecessor.name}; ${plan.stableEndpoint} is unserved until the successor acquires the fence`);
+  await ports.stopPredecessor(predecessor.id);
+  const fence = await awaitRuntimeHostSuccessorFence({
+    successorContainer: staged.successorContainer,
+    successorPid: ports.successorPid,
+    fenceOwnerPid: ports.fenceOwnerPid,
+    sleep: ports.sleep,
+    ...(ports.now ? { now: ports.now } : {}),
+    report: (line) => ports.log(line),
+    timeoutMs: plan.fenceTimeoutMs,
+  });
+  ports.log(`runtime-host successor ${staged.successorContainer} owns the singleton fence after ${Math.round(fence.waitedMs / 1_000)}s; the runtime host now runs ${plan.revision}`);
+  return { successorContainer: staged.successorContainer, handedOver: true, fenceWaitedMs: fence.waitedMs };
+}

--- a/src/runtime-host/hostBootstrap.ts
+++ b/src/runtime-host/hostBootstrap.ts
@@ -238,10 +238,10 @@ export async function executeRuntimeHostBootstrap(
   await ports.stopPredecessor(predecessor.id);
   const fence = await awaitRuntimeHostSuccessorFence({
     successorContainer: staged.successorContainer,
-    successorPid: ports.successorPid,
-    fenceOwnerPid: ports.fenceOwnerPid,
-    sleep: ports.sleep,
-    ...(ports.now ? { now: ports.now } : {}),
+    successorPid: () => ports.successorPid(),
+    fenceOwnerPid: () => ports.fenceOwnerPid(),
+    sleep: (milliseconds) => ports.sleep(milliseconds),
+    ...(ports.now ? { now: () => ports.now!() } : {}),
     report: (line) => ports.log(line),
     timeoutMs: plan.fenceTimeoutMs,
   });

--- a/src/runtime-host/hostSuccessor.test.ts
+++ b/src/runtime-host/hostSuccessor.test.ts
@@ -12,10 +12,12 @@ import {
 } from "./hostRelease";
 import {
   completeRuntimeHostHandoff,
+  findRuntimeHostPredecessor,
   RUNTIME_HOST_FENCE_WAIT_ENV,
   RUNTIME_HOST_PREDECESSOR_LABEL,
   RUNTIME_HOST_SUCCESSOR_LABEL,
   runtimeHostSuccessorName,
+  runtimeHostSuccessorObservation,
   stageRuntimeHostSuccessorContainer,
   type RuntimeHostSuccessorPorts,
 } from "./hostSuccessor";
@@ -103,8 +105,10 @@ test("issue 521 review: successor cleanup converges when the predecessor is alre
 const wakatimePlaceholderValue = "waka-credential-value-placeholder";
 
 const predecessorInspect = JSON.stringify([{
+  Name: "/llv-runtime-host-704ff4636294-0123456789ab",
   State: { Pid: 3970 },
   Config: {
+    Image: "agent-log-viewer:deploy-704ff4636294",
     Env: [
       "LLV_RUNTIME_EVENTS=1",
       "HOME=/home/user",
@@ -129,6 +133,7 @@ interface Harness {
   ports: RuntimeHostSuccessorPorts;
   calls: string[][];
   events: string[];
+  phases: string[];
   records: RuntimeHostReleaseRecord[];
   intents: RuntimeHostHandoffIntent[];
   storedIntent: () => RuntimeHostHandoffIntent | null;
@@ -151,6 +156,7 @@ function harness(overrides: {
 } = {}): Harness {
   const calls: string[][] = [];
   const events: string[] = [];
+  const phases: string[] = [];
   const records: RuntimeHostReleaseRecord[] = [];
   const intents: RuntimeHostHandoffIntent[] = [];
   let storedIntent: RuntimeHostHandoffIntent | null = overrides.handoffIntent ?? null;
@@ -229,8 +235,9 @@ function harness(overrides: {
     fenceOwnerPid: () => overrides.fenceOwnerPid === undefined ? 3970 : overrides.fenceOwnerPid,
     now: () => "2026-07-21T09:00:00.000Z",
     wait: overrides.wait ?? (async () => undefined),
+    reportPhase: (phase) => { phases.push(phase); },
   };
-  return { ports, calls, events, records, intents, storedIntent: () => storedIntent };
+  return { ports, calls, events, phases, records, intents, storedIntent: () => storedIntent };
 }
 
 /* A stateful Docker world that survives across staging attempts, for
@@ -859,4 +866,64 @@ test("issue 521: the predecessor's unsupported credential never reaches Docker c
   expect(JSON.stringify(intents)).not.toContain(wakatimePlaceholderValue);
   /* Supported predecessor environment entries still clone. */
   expect(calls.find((argv) => argv[0] === "run")?.join(" ")).toContain("-e LLV_RUNTIME_EVENTS=1");
+});
+
+/* #1216. The staging action runs under a sixty-second host budget with an
+   eleven-second stability wait inside it, and it used to report nothing at
+   all: a promote that never staged and a staging that wedged were the same
+   silence to an operator. */
+test("issue 1216: staging reports each ordered step in the host phase alphabet", async () => {
+  const harnessed = harness();
+
+  await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", harnessed.ports);
+
+  expect(harnessed.phases).toEqual([
+    "tagging the runtime-host successor image",
+    "locating the runtime-host predecessor container",
+    "creating the runtime-host successor container",
+    "observing runtime-host successor stability for 11s",
+    "recording the runtime-host handoff intent",
+    "disabling the runtime-host predecessor restart policy",
+    "publishing the runtime-host release record",
+  ]);
+  /* The host reads phases back through `/^[A-Za-z0-9 -]{1,160}$/` and drops
+     anything else, so a phase outside that alphabet is a phase nobody sees. */
+  for (const phase of harnessed.phases) expect(phase).toMatch(/^[A-Za-z0-9 -]{1,160}$/);
+});
+
+test("issue 1216: a successor that never settles names what the gate saw", async () => {
+  const harnessed = harness({ successorState: "restarting" });
+
+  await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", harnessed.ports))
+    .rejects.toThrow("runtime-host successor container failed its identity or running-state gate - generation matches, status restarting, restarting, 0 restarts");
+});
+
+test("issue 1216: a successor that crash-loops past the stability probe names its restarts", async () => {
+  const harnessed = harness({ stableRestartCount: 3 });
+
+  await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", harnessed.ports))
+    .rejects.toThrow("runtime-host successor container restarted between readiness probes - generation matches, status running, 3 restarts");
+});
+
+test("issue 1216: an unreadable inspection is named rather than thrown as a parse error", () => {
+  expect(runtimeHostSuccessorObservation("not json", "llv-runtime-host-aaaaaaaaaaaa-000000000000", candidate))
+    .toBe("container inspection is unreadable");
+});
+
+/* The bootstrap path states which container it will stop before it stops it,
+   and this is where that name comes from. */
+test("issue 1216: the fence owner is resolvable as a named predecessor container", async () => {
+  const harnessed = harness();
+
+  expect(await findRuntimeHostPredecessor(harnessed.ports)).toEqual({
+    id: "abc123",
+    name: "llv-runtime-host-704ff4636294-0123456789ab",
+    image: "agent-log-viewer:deploy-704ff4636294",
+  });
+});
+
+test("issue 1216: an unheld fence names no predecessor at all", async () => {
+  const harnessed = harness({ fenceOwnerPid: null });
+
+  expect(await findRuntimeHostPredecessor(harnessed.ports)).toBeNull();
 });

--- a/src/runtime-host/hostSuccessor.test.ts
+++ b/src/runtime-host/hostSuccessor.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   completeRuntimeHostHandoff,
   findRuntimeHostPredecessor,
+  RUNTIME_HOST_FENCE_PARK_ENV,
   RUNTIME_HOST_FENCE_WAIT_ENV,
   RUNTIME_HOST_PREDECESSOR_LABEL,
   RUNTIME_HOST_SUCCESSOR_LABEL,
@@ -152,6 +153,8 @@ function harness(overrides: {
   successorImage?: string;
   registryBackendMode?: string;
   updateFailure?: Error;
+  startFailure?: Error;
+  predecessorInspect?: string;
   wait?: (milliseconds: number) => Promise<void>;
 } = {}): Harness {
   const calls: string[][] = [];
@@ -195,7 +198,10 @@ function harness(overrides: {
       calls.push([...argv]);
       events.push(`docker:${argv.join(" ")}`);
       if (argv[0] === "container" && argv[1] === "ls") return "abc123\n";
-      if (argv[0] === "container" && argv[1] === "inspect" && argv[2] === "abc123") return predecessorInspect;
+      if (argv[0] === "container" && argv[1] === "inspect" && argv[2] === "abc123") {
+        return overrides.predecessorInspect ?? predecessorInspect;
+      }
+      if (argv[0] === "container" && argv[1] === "start" && overrides.startFailure) throw overrides.startFailure;
       if (argv[0] === "run") {
         if (overrides.runFailure) throw overrides.runFailure;
         if (overrides.runConflict) throw new Error(`docker: Error response from daemon: Conflict. The container name "/${argv[3]}" is already in use`);
@@ -601,6 +607,101 @@ test("issue 521 review: A to B to A stages each deployment generation and never 
   }
   expect(containers).toHaveLength(1);
   expect(intent).toBeNull();
+});
+
+/* The reopened #1216 defect, one level down. `--stage` advertises a successor
+   the operator hands over whenever they are ready; the #518 fence budget made
+   that container exit after ten minutes into a dockerd restart loop. The two
+   staging paths want opposite things from a bound, so the mode is threaded to
+   the container rather than picked once for both. */
+test("issue 1216: a bootstrap-staged successor is parked on the fence with no deadline", async () => {
+  const { ports, calls } = harness();
+
+  await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports, { fenceWait: "parked" });
+
+  const run = calls.find((argv) => argv[0] === "run");
+  expect(run).toContain(`${RUNTIME_HOST_FENCE_PARK_ENV}=1`);
+  expect(run?.some((entry) => entry.startsWith(`${RUNTIME_HOST_FENCE_WAIT_ENV}=`))).toBe(false);
+});
+
+test("issue 518: a deployment-staged successor keeps the bounded ten-minute fence wait", async () => {
+  for (const options of [undefined, { fenceWait: "handoff-budget" as const }]) {
+    const { ports, calls } = harness();
+
+    await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports, options);
+
+    const run = calls.find((argv) => argv[0] === "run");
+    expect(run).toContain(`${RUNTIME_HOST_FENCE_WAIT_ENV}=600000`);
+    expect(run?.some((entry) => entry.startsWith(`${RUNTIME_HOST_FENCE_PARK_ENV}=`))).toBe(false);
+  }
+});
+
+/* A parked generation that later becomes the predecessor must not hand its
+   park down: the next successor is staged by a deployment, whose predecessor
+   IS being asked to exit. */
+test("issue 1216: a parked predecessor never passes its park down to the next successor", async () => {
+  const parkedPredecessor = JSON.parse(predecessorInspect) as Array<Record<string, unknown>>;
+  const config = parkedPredecessor[0]!.Config as Record<string, unknown>;
+  config.Env = [...(config.Env as string[]), `${RUNTIME_HOST_FENCE_PARK_ENV}=1`];
+  const { ports, calls } = harness({ predecessorInspect: JSON.stringify(parkedPredecessor) });
+
+  await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports);
+
+  const run = calls.find((argv) => argv[0] === "run");
+  expect(run?.filter((entry) => entry.startsWith(`${RUNTIME_HOST_FENCE_PARK_ENV}=`))).toEqual([]);
+  expect(run).toContain(`${RUNTIME_HOST_FENCE_WAIT_ENV}=600000`);
+});
+
+/* The recovery tool is reached when production is already stuck, so a resume
+   dockerd refuses has to read as a runtime-host state rather than as a raw
+   daemon error from three steps in (#1216). */
+test("issue 1216: a successor that cannot be resumed is named with the state it was in", async () => {
+  const successorContainer = runtimeHostSuccessorName(revision, candidate.image);
+  const { ports, records, events } = harness({
+    successorState: "restarting",
+    startFailure: new Error(`Error response from daemon: container ${successorContainer} is restarting, wait until the container is running`),
+    handoffIntent: {
+      revision: candidate.revision,
+      image: candidate.image,
+      successorContainer,
+      predecessorId: "abc123",
+      recordedAt: "2026-07-21T08:00:00.000Z",
+    },
+  });
+
+  await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports))
+    .rejects.toThrow(`runtime-host successor container ${successorContainer} could not be resumed - generation matches, status restarting, restarting, 0 restarts`);
+
+  expect(records).toEqual([]);
+  expect(events.some((event) => event.startsWith("docker:container update --restart no"))).toBe(false);
+});
+
+test("issue 1216: a resume of a container that is gone reports the daemon's own reason by name", async () => {
+  const successorContainer = runtimeHostSuccessorName(revision, candidate.image);
+  const { ports } = harness({
+    startFailure: new Error(`Error: No such container: ${successorContainer}`),
+    handoffIntent: {
+      revision: candidate.revision,
+      image: candidate.image,
+      successorContainer,
+      predecessorId: "abc123",
+      recordedAt: "2026-07-21T08:00:00.000Z",
+    },
+  });
+  /* The inspect that would describe it fails too, so the daemon's sentence is
+     the observation rather than a swallowed one. */
+  const inspectFails: RuntimeHostSuccessorPorts = {
+    ...ports,
+    docker: async (argv) => {
+      if (argv[0] === "container" && argv[1] === "inspect" && argv[2] === successorContainer) {
+        throw new Error(`Error: No such container: ${successorContainer}`);
+      }
+      return ports.docker(argv);
+    },
+  };
+
+  await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", inspectFails))
+    .rejects.toThrow(`runtime-host successor container ${successorContainer} could not be resumed - Error: No such container: ${successorContainer}`);
 });
 
 test("issue 518: a successor that is not running never becomes the durable release", async () => {

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -4,6 +4,7 @@ import type { ViewerReleaseIdentity } from "@/lib/runtime/contracts";
 import { withoutWakatimeCredentialEntries } from "@/lib/wakatime/credential";
 
 import { AGENT_REGISTRY_SQLITE_ENV, type AgentRegistryBackendMode } from "./candidateContainer";
+import { RUNTIME_HOST_FENCE_PARK_ENV, RUNTIME_HOST_FENCE_WAIT_ENV } from "./fenceWait";
 
 import {
   RUNTIME_HOST_CONTAINER_ENV,
@@ -13,16 +14,15 @@ import {
   type RuntimeHostReleaseRecord,
 } from "./hostRelease";
 
-/** Environment variable read by main.ts: a successor boots while the
-    predecessor still holds the singleton fence and must wait for it instead
-    of failing its container. */
-export const RUNTIME_HOST_FENCE_WAIT_ENV = "LLV_RUNTIME_HOST_FENCE_WAIT_MS";
+export { RUNTIME_HOST_FENCE_PARK_ENV, RUNTIME_HOST_FENCE_WAIT_ENV };
+
 const SUCCESSOR_FENCE_WAIT_MS = 10 * 60_000;
 const DOCKER_RESTART_POLICY_STABILITY_MS = 11_000;
 export const RUNTIME_HOST_SUCCESSOR_LABEL = "dev.live-log-viewer.runtime-host-successor";
 export const RUNTIME_HOST_PREDECESSOR_LABEL = "dev.live-log-viewer.runtime-host-predecessor";
 const RUNTIME_HOST_GENERATION_ENV = [
   RUNTIME_HOST_FENCE_WAIT_ENV,
+  RUNTIME_HOST_FENCE_PARK_ENV,
   RUNTIME_HOST_IMAGE_ENV,
   RUNTIME_HOST_REVISION_ENV,
   RUNTIME_HOST_CONTAINER_ENV,
@@ -67,8 +67,18 @@ export interface RuntimeHostGenerationIdentity {
   container: string;
 }
 
+/** How the staged successor waits for the singleton fence at boot (#1216).
+    `handoff-budget` is the #518 deployment case: the predecessor has been
+    asked to exit, so a bound on the wait is the detector for a hand-over that
+    wedges. `parked` is the bootstrap `--stage` case: nothing has asked the
+    predecessor to exit and nothing will until the operator runs the
+    hand-over, so the bound detects nothing and only converts a deliberately
+    waiting container into a ten-minute dockerd restart loop. */
+export type RuntimeHostSuccessorFenceWait = "handoff-budget" | "parked";
+
 export interface RuntimeHostSuccessorOptions {
   registryBackendMode?: AgentRegistryBackendMode;
+  fenceWait?: RuntimeHostSuccessorFenceWait;
 }
 
 export interface RuntimeHostPredecessorIdentity {
@@ -216,7 +226,9 @@ function successorRunArgs(
     ...(options.registryBackendMode === undefined
       ? []
       : ["-e", `${AGENT_REGISTRY_SQLITE_ENV}=${options.registryBackendMode}`]),
-    "-e", `${RUNTIME_HOST_FENCE_WAIT_ENV}=${SUCCESSOR_FENCE_WAIT_MS}`,
+    ...(options.fenceWait === "parked"
+      ? ["-e", `${RUNTIME_HOST_FENCE_PARK_ENV}=1`]
+      : ["-e", `${RUNTIME_HOST_FENCE_WAIT_ENV}=${SUCCESSOR_FENCE_WAIT_MS}`]),
     "-e", `${RUNTIME_HOST_IMAGE_ENV}=${candidate.image}`,
     "-e", `${RUNTIME_HOST_REVISION_ENV}=${candidate.revision}`,
     "-e", `${RUNTIME_HOST_CONTAINER_ENV}=${name}`,
@@ -321,6 +333,40 @@ export function runtimeHostSuccessorObservation(
   const restarts = typeof container.RestartCount === "number" ? `, ${container.RestartCount} restarts` : "";
   const exitCode = typeof state.ExitCode === "number" && status !== "running" ? `, exit ${state.ExitCode}` : "";
   return `${generation}, status ${status}${restarting}${restarts}${exitCode}`;
+}
+
+/** A resume dockerd refuses reads as a runtime-host state, not as a daemon
+    error surfaced from three steps in (#1216). A staged successor that is
+    currently `restarting`, or that was removed between staging and a later
+    hand-over, is exactly the case an operator hits when they come back to a
+    successor they staged earlier, so it gets the same named vocabulary as
+    every other gate here. */
+async function resumeSuccessorContainer(
+  name: string,
+  candidate: ViewerReleaseIdentity,
+  ports: RuntimeHostSuccessorPorts,
+  options: RuntimeHostSuccessorOptions,
+): Promise<void> {
+  try {
+    await ports.docker(["container", "start", name]);
+  } catch (error) {
+    let observation: string;
+    try {
+      observation = runtimeHostSuccessorObservation(
+        await ports.docker(["container", "inspect", name]),
+        name,
+        candidate,
+        options,
+      );
+    } catch {
+      const message = error instanceof Error ? error.message.trim() : "";
+      observation = message ? message.slice(0, 200) : "the container is unreadable";
+    }
+    throw new Error(
+      `runtime-host successor container ${name} could not be resumed - ${observation}`,
+      { cause: error },
+    );
+  }
 }
 
 /** Two identity-aware observations: both must report the ready running state,
@@ -432,7 +478,7 @@ export async function stageRuntimeHostSuccessorContainer(
        predecessor discovery is forbidden here — it would select, disable,
        and exit the successor itself. Both identities come from the intent. */
     phase("resuming the recorded runtime-host successor container");
-    await ports.docker(["container", "start", name]);
+    await resumeSuccessorContainer(name, candidate, ports, options);
     await observeStableSuccessor(name, candidate, ports, options);
     phase("disabling the runtime-host predecessor restart policy");
     await disablePredecessorRestart(intent.predecessorId, ports);
@@ -461,7 +507,7 @@ export async function stageRuntimeHostSuccessorContainer(
     if (!encoded) throw new Error("runtime-host successor container lacks durable predecessor identity");
     predecessorId = encoded;
     phase("resuming a same-attempt runtime-host successor container");
-    await ports.docker(["container", "start", name]);
+    await resumeSuccessorContainer(name, candidate, ports, options);
   }
   await observeStableSuccessor(name, candidate, ports, options);
   phase("recording the runtime-host handoff intent");

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -460,6 +460,7 @@ export async function stageRuntimeHostSuccessorContainer(
     const encoded = encodedPredecessorId(collision, name);
     if (!encoded) throw new Error("runtime-host successor container lacks durable predecessor identity");
     predecessorId = encoded;
+    phase("resuming a same-attempt runtime-host successor container");
     await ports.docker(["container", "start", name]);
   }
   await observeStableSuccessor(name, candidate, ports, options);

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -49,6 +49,10 @@ export interface RuntimeHostSuccessorPorts {
   fenceOwnerPid(): number | null;
   now?(): string;
   wait?(milliseconds: number): Promise<void>;
+  /** #1216: the staging step is the one a deployment reaches last and the one
+      an operator can least observe. Every ordered step below names itself here,
+      so the host phase logger prints progress instead of a bare action name. */
+  reportPhase?(phase: string): void;
 }
 
 export interface RuntimeHostHandoffCleanupPorts {
@@ -65,6 +69,12 @@ export interface RuntimeHostGenerationIdentity {
 
 export interface RuntimeHostSuccessorOptions {
   registryBackendMode?: AgentRegistryBackendMode;
+}
+
+export interface RuntimeHostPredecessorIdentity {
+  id: string;
+  name: string;
+  image: string;
 }
 
 export function runtimeHostSuccessorName(revision: string, image: string): string {
@@ -101,6 +111,8 @@ export async function completeRuntimeHostHandoff(
 
 interface PredecessorTopology {
   id: string;
+  name: string;
+  image: string;
   env: string[];
   cmd: string[];
   containerUser: string;
@@ -127,8 +139,11 @@ function parseTopology(id: string, raw: string): PredecessorTopology {
   const hostConfig = (container.HostConfig ?? {}) as Record<string, unknown>;
   const cmd = stringArray(config.Cmd);
   if (cmd.length === 0) throw new Error("predecessor runtime-host command is unavailable");
+  const name = typeof container.Name === "string" ? container.Name.replace(/^\//, "") : "";
   return {
     id,
+    name: name || id,
+    image: typeof config.Image === "string" ? config.Image : "",
     /* PR #521: keep unsupported credentials and predecessor-owned generation
        markers outside the cloned environment. The successor appends one
        authoritative value for every reserved generation key below. */
@@ -145,7 +160,9 @@ function parseTopology(id: string, raw: string): PredecessorTopology {
   };
 }
 
-async function findPredecessor(ports: RuntimeHostSuccessorPorts): Promise<PredecessorTopology | null> {
+type PredecessorDiscoveryPorts = Pick<RuntimeHostSuccessorPorts, "docker" | "fenceOwnerPid">;
+
+async function findPredecessor(ports: PredecessorDiscoveryPorts): Promise<PredecessorTopology | null> {
   const ownerPid = ports.fenceOwnerPid();
   if (!ownerPid) return null;
   const listed = await ports.docker(["container", "ls", "--format", "{{.ID}}"]);
@@ -156,6 +173,18 @@ async function findPredecessor(ports: RuntimeHostSuccessorPorts): Promise<Predec
     if (state.Pid === ownerPid) return parseTopology(id, raw);
   }
   return null;
+}
+
+/** The runtime-host generation that currently owns the singleton fence, named
+    so a bootstrap can state exactly which container it is about to stop
+    (#1216). `null` means no running generation holds the fence. */
+export async function findRuntimeHostPredecessor(
+  ports: PredecessorDiscoveryPorts,
+): Promise<RuntimeHostPredecessorIdentity | null> {
+  const predecessor = await findPredecessor(ports);
+  return predecessor === null
+    ? null
+    : { id: predecessor.id, name: predecessor.name, image: predecessor.image };
 }
 
 function successorRunArgs(
@@ -265,6 +294,35 @@ function successorIsReady(
     && state.Restarting !== true;
 }
 
+/** What the stability gate actually saw, appended to every gate failure so a
+    successor that never settles is diagnosable from the message alone (#1216).
+    A bare "failed its gate" named neither the state nor the mismatch. */
+export function runtimeHostSuccessorObservation(
+  raw: string,
+  name: string,
+  candidate: ViewerReleaseIdentity,
+  options: RuntimeHostSuccessorOptions = {},
+): string {
+  let container: Record<string, unknown>;
+  try {
+    container = ((JSON.parse(raw) as Array<Record<string, unknown>>)[0] ?? {}) as Record<string, unknown>;
+  } catch {
+    return "container inspection is unreadable";
+  }
+  const state = (container.State ?? {}) as Record<string, unknown>;
+  const status = typeof state.Status === "string" ? state.Status : "unknown";
+  let generation: string;
+  try {
+    generation = successorMatchesGeneration(raw, name, candidate, options) ? "generation matches" : "generation differs";
+  } catch {
+    generation = "generation is unreadable";
+  }
+  const restarting = state.Restarting === true ? ", restarting" : "";
+  const restarts = typeof container.RestartCount === "number" ? `, ${container.RestartCount} restarts` : "";
+  const exitCode = typeof state.ExitCode === "number" && status !== "running" ? `, exit ${state.ExitCode}` : "";
+  return `${generation}, status ${status}${restarting}${restarts}${exitCode}`;
+}
+
 /** Two identity-aware observations: both must report the ready running state,
     and the successor's start identity must stay unchanged beyond Docker's
     10-second restart-policy activation threshold. The additional second is a
@@ -278,17 +336,18 @@ async function observeStableSuccessor(
 ): Promise<void> {
   const firstEvidence = await ports.docker(["container", "inspect", name]);
   if (!successorIsReady(firstEvidence, name, candidate, options)) {
-    throw new Error("runtime-host successor container failed its identity or running-state gate");
+    throw new Error(`runtime-host successor container failed its identity or running-state gate - ${runtimeHostSuccessorObservation(firstEvidence, name, candidate, options)}`);
   }
+  ports.reportPhase?.(`observing runtime-host successor stability for ${Math.round(DOCKER_RESTART_POLICY_STABILITY_MS / 1_000)}s`);
   await (ports.wait ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))))(DOCKER_RESTART_POLICY_STABILITY_MS);
   const stableEvidence = await ports.docker(["container", "inspect", name]);
   if (!successorIsReady(stableEvidence, name, candidate, options)) {
-    throw new Error("runtime-host successor container did not remain stably ready");
+    throw new Error(`runtime-host successor container did not remain stably ready - ${runtimeHostSuccessorObservation(stableEvidence, name, candidate, options)}`);
   }
   const first = successorStartIdentity(firstEvidence);
   const stable = successorStartIdentity(stableEvidence);
   if (first.id !== stable.id || first.restartCount !== stable.restartCount || first.startedAt !== stable.startedAt) {
-    throw new Error("runtime-host successor container restarted between readiness probes");
+    throw new Error(`runtime-host successor container restarted between readiness probes - ${runtimeHostSuccessorObservation(stableEvidence, name, candidate, options)}`);
   }
 }
 
@@ -354,6 +413,7 @@ export async function stageRuntimeHostSuccessorContainer(
   options: RuntimeHostSuccessorOptions = {},
 ): Promise<{ successorContainer: string }> {
   const name = runtimeHostSuccessorName(candidate.revision, candidate.image);
+  const phase = ports.reportPhase ?? (() => {});
   const intent = ports.readHandoffIntent();
   const exactIntent = intent
     && intent.revision === candidate.revision
@@ -362,6 +422,7 @@ export async function stageRuntimeHostSuccessorContainer(
   if (intent && !exactIntent) {
     throw new Error("runtime-host handoff intent is owned by another generation");
   }
+  phase("tagging the runtime-host successor image");
   await ports.docker(["image", "inspect", candidate.image]);
   await ports.docker(["tag", candidate.image, runtimeHostImageTag]);
   if (exactIntent) {
@@ -370,16 +431,21 @@ export async function stageRuntimeHostSuccessorContainer(
        successor may already own the singleton fence, so fence-owner
        predecessor discovery is forbidden here — it would select, disable,
        and exit the successor itself. Both identities come from the intent. */
+    phase("resuming the recorded runtime-host successor container");
     await ports.docker(["container", "start", name]);
     await observeStableSuccessor(name, candidate, ports, options);
+    phase("disabling the runtime-host predecessor restart policy");
     await disablePredecessorRestart(intent.predecessorId, ports);
+    phase("publishing the runtime-host release record");
     publishReleaseOnce(name, candidate, ports);
     return { successorContainer: name };
   }
+  phase("locating the runtime-host predecessor container");
   const predecessor = await findPredecessor(ports);
   if (!predecessor) throw new Error("runtime-host predecessor container is unavailable for successor staging");
   let predecessorId = predecessor.id;
   try {
+    phase("creating the runtime-host successor container");
     await ports.docker(successorRunArgs(name, candidate, predecessor, options));
   } catch (error) {
     const message = error instanceof Error ? error.message : "";
@@ -397,6 +463,7 @@ export async function stageRuntimeHostSuccessorContainer(
     await ports.docker(["container", "start", name]);
   }
   await observeStableSuccessor(name, candidate, ports, options);
+  phase("recording the runtime-host handoff intent");
   ports.writeHandoffIntent({
     revision: candidate.revision,
     image: candidate.image,
@@ -404,7 +471,9 @@ export async function stageRuntimeHostSuccessorContainer(
     predecessorId,
     recordedAt: (ports.now ?? (() => new Date().toISOString()))(),
   });
+  phase("disabling the runtime-host predecessor restart policy");
   await disablePredecessorRestart(predecessorId, ports);
+  phase("publishing the runtime-host release record");
   publishReleaseOnce(name, candidate, ports);
   return { successorContainer: name };
 }

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -19,6 +19,7 @@ const {
   currentRuntimeHostGeneration,
   RUNTIME_HOST_CONTAINER_ENV,
 } = await import("./hostRelease");
+const { acquireRuntimeHostFence, runtimeHostFenceWaitPlan } = await import("./fenceWait");
 
 const { runtimeHostActivationRefusal } = await import("@/lib/runtime/flags");
 
@@ -35,18 +36,16 @@ if (process.env.LLV_RUNTIME_LEGACY_SCHEDULER === "1" && process.env.LLV_ACCOUNT_
 const fence = new RuntimeHostFence(`${socketPath}.lock`);
 /* #518: a staged successor generation boots while its predecessor still holds
    the singleton fence, and must wait for the predecessor's graceful exit
-   instead of failing its container. Ordinary boots keep the immediate throw. */
-const fenceWaitMs = Number(process.env.LLV_RUNTIME_HOST_FENCE_WAIT_MS || 0);
-const fenceDeadline = Date.now() + (Number.isFinite(fenceWaitMs) && fenceWaitMs > 0 ? fenceWaitMs : 0);
-for (;;) {
-  try {
-    fence.acquire();
-    break;
-  } catch (error) {
-    if (Date.now() >= fenceDeadline) throw error;
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-}
+   instead of failing its container. Ordinary boots keep the immediate throw.
+   #1216: a successor parked by an operator bootstrap waits without a deadline,
+   because nothing has asked its predecessor to exit yet. Either wait names
+   what it is waiting for and how long it has waited. */
+await acquireRuntimeHostFence({
+  acquire: () => fence.acquire(),
+  plan: runtimeHostFenceWaitPlan(process.env),
+  container: process.env[RUNTIME_HOST_CONTAINER_ENV],
+  report: (line) => console.error(line),
+});
 const journal = new RuntimeJournal(process.env.LLV_RUNTIME_JOURNAL || statePath("runtime-events.sqlite"));
 if (journal.isWritable()) journal.claimHostEpoch();
 const deploymentsEnabled = process.env.LLV_VIEWER_DEPLOYMENTS === "1";


### PR DESCRIPTION
Closes #1216

## Diagnosis first — the three questions the reopened issue turns on

### 1. Does a deployment stage a runtime-host successor at all?

It does, but only in a phase the failing deployments never reached. The phase
machine in `src/runtime-host/deployment.ts` runs
`promoting` (`deployment.ts:338`) → `post-promotion-health` (`deployment.ts:355`)
→ `host-handoff` (`deployment.ts:378`), and `host-handoff` is the *only* caller
of `stageDriftedHostSuccessor` (`deployment.ts:380`), which is the only caller of
`adapter.stageRuntimeHostSuccessor` (`deployment.ts:267`) →
`stage-host-successor` (`scripts/runtime-host-viewer-adapter.ts:1125`) →
`stageRuntimeHostSuccessorContainer` (`src/runtime-host/hostSuccessor.ts:409`).

Both failing attempts died at `promoting`. The catch path routes a `promoting`
failure straight to `rolling-back` (`deployment.ts:416`), which is terminal.
`host-handoff` is never entered, so **the hand-off is skipped, not attempted and
not what timed out**. `completeRuntimeHostHandoff` is likewise unreachable: it
runs at the *successor's* boot (`src/runtime-host/main.ts:70`) and there is no
successor.

The mechanism itself is not broken. The running container is named
`llv-runtime-host-704ff4636294-…`, which is exactly the output of
`runtimeHostSuccessorName(revision, image)` (`hostSuccessor.ts:80`) — the current
host *is* a successor, staged by the last deployment that reached
`host-handoff`. Succession works; it is simply downstream of the step that
fails.

### 2. Is "hot-state activation" the name of that hand-over?

No. It names a different hand-over entirely: the **promoted Viewer container
publishing its hot-state authority**. Nothing about the runtime host.

- **Signal**: `hot-state-authority.json` reaching `mode: "sqlite"` with
  `releaseRevision === candidate.revision` and a string `activationReadyAt` —
  the predicate is `hotStateActivationSatisfied` (`deploymentHotState.ts:105`).
- **Emitter**: `markHotStateActivationReady` (`src/lib/state/hotStateAuthority.ts:292`),
  called from the `publishHotStateActivation` step of
  `completeViewerRuntimeActivation` (`src/lib/viewerInstrumentation.ts:535`,
  wired at `viewerInstrumentation.ts:570`) inside the newly promoted Viewer
  process.
- **Awaiter**: `awaitHotStateActivation` (`deploymentHotState.ts:282`), driven by
  `handOverHotState` (`scripts/runtime-host-viewer-adapter.ts:851`, call at
  `:879`) inside `promoteTarget` (`:903`), which is the adapter's `promote`
  action (`:1091`).

### 3. Why the fix could not reach the code that fails

The adapter executable is baked into the runtime-host image
(`Dockerfile:228`, default path `src/runtime-host/main.ts:54`), so the promote
that runs is the one from the image the container was built from. On the pinned
revision:

- host-side kill deadline: `promote: 30_000`
  (`git show 704ff463:src/runtime-host/deploymentAdapter.ts`, line 36)
- adapter-side wait budget: `LLV_HOT_STATE_ACTIVATION_TIMEOUT_MS || 30_000`
  (`git show 704ff463:scripts/runtime-host-viewer-adapter.ts`, line 809)

A tie. The host kills the adapter's process group at its own deadline while the
adapter is still inside its wait, then reports
`deployment adapter ${action} timed out while ${phase}`
(`deploymentAdapter.ts:423`) with `phase` = `"waiting for hot-state activation"`
(old adapter, line 835). That is the operator's message, verbatim. The adapter's
*own* error on that path reads `timed out waiting for the promoted Viewer to
activate hot state` (old adapter, line 821) — a different string, which never
appeared, proving the adapter lost the race every time and never got to report
what it saw.

So the reviewer's LOW on #1219 — "the new budgets cannot take effect on the
deployment that carries them" — was the whole defect: #1219's 180s activation
budget, 255s host deadline and named waits live in an image that only starts
running *after* a successful promote.

## What this PR changes

### 4. The bootstrap path — the part that makes it fixable

`scripts/bootstrap-runtime-host.ts` brings the runtime host onto a new revision
**without requiring a promote to have succeeded**. It runs on the host with
`bun`, from a checkout, and drives the same #518 staging a deployment would
have driven — no `switchTarget`, no Viewer release change, no promote.

Three modes, in ascending order of what they touch:

| mode | builds | stages | stops |
| --- | --- | --- | --- |
| *(default)* | no | no | nothing |
| `--stage` | yes | yes | nothing |
| `--hand-over` | yes | yes | the predecessor runtime-host container |

The plan is rendered before anything is built, staged or stopped — asserted as a
source-order test, because this runs on a machine with live agent sessions on
it. It names the target revision and image, the successor container, the
predecessor it replaces, and:

```
will stop:
  - the predecessor runtime-host container llv-runtime-host-…, and nothing else

will NOT stop, signal, or restart:
  - Viewer release containers, including the one serving production
  - the structured and engine hosts inside them
  - every live agent session, pipeline, and orchestrator they own
```

…plus what changes before the stop (successor proven stable while the
predecessor still serves; predecessor restart policy set to `no`; release record
repointed) and what the hand-over costs (`127.0.0.1:8898` unserved between the
predecessor's exit and the successor acquiring the singleton fence, with a
budgeted, named wait for that fence).

`awaitRuntimeHostSuccessorFence` gives that last step the same discipline #1219
gave the promote's waits: what it is waiting for, how long it has waited, and
what it saw at give-up —
`runtime-host successor <name> never acquired the singleton fence; waited 120s of 120s; last observed successor pid 4242, fence owner pid 99`.

Documented in `docs/docker.md` under "Bootstrap the runtime host onto a new
revision".

### 3b. The succession step is now observable

The reopening comment's "from outside there is no way to tell" is addressed at
each place it was silent:

- `host-handoff` says which of the three things it did — staged, not required,
  or skipped because the host does not track its own generation.
- A staging failure is **printed**, not only parked in the retryable journal
  phase; that branch returned normally, so nothing ever logged it.
- The promote's hot-state hand-over summary is logged; it previously existed
  only in the adapter phase file, which is deleted the moment the action
  returns.
- `stage-host-successor` reports each ordered step through the adapter phase
  file (tag → locate predecessor → create → observe stability for 11s → record
  intent → disable restart → publish). It had an 11-second stability wait and
  half a dozen Docker calls inside a 60-second host budget and reported nothing,
  so a wedge read as `waiting for the adapter process`.
- Every successor readiness-gate failure now names the container state it saw:
  `… failed its identity or running-state gate - generation matches, status restarting, restarting, 0 restarts`.

`ViewerDeploymentCoordinator` takes an injectable `log`, so all of this is
asserted rather than eyeballed.

## Tests

New, and red before this change:

- `src/runtime-host/hostBootstrap.test.ts` — the plan names the one container a
  hand-over stops and the sessions it does not; plan mode mutates nothing; stage
  mode leaves the predecessor serving; a hand-over stops the predecessor only
  after staging; the fence wait succeeds late-but-inside-budget and fails with a
  named reason and observation when it never arrives; refusals (no predecessor,
  already on the target generation, unresolved revision) fire before staging.
- `scripts/bootstrap-runtime-host.test.ts` — argument parsing defaults to
  plan-only; the plan is rendered before the build and the execution; the script
  never removes a container or touches a Viewer release.
- `src/runtime-host/deployment.test.ts` — **a promote that times out never
  reaches runtime-host successor staging** (the reopened defect, pinned as a
  regression); the host-handoff step narrates its decision; a failed staging is
  printed.
- `src/runtime-host/hostSuccessor.test.ts` — staging reports each ordered step
  and every phase fits the host phase alphabet; gate failures name what they
  saw; the fence owner resolves to a named predecessor container.

Already covered by #1219 and still green: activation that never arrives fails
with a named reason, and activation that arrives late but inside budget
succeeds (`src/runtime-host/deploymentHotState.test.ts`).

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test` by path under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`:
  `src/runtime-host/hostBootstrap.test.ts`, `src/runtime-host/hostSuccessor.test.ts`,
  `src/runtime-host/deployment.test.ts`, `src/runtime-host/deploymentHotState.test.ts`,
  `scripts/bootstrap-runtime-host.test.ts`, `scripts/bun-spawn-credential-isolation.test.ts`
  → 85 pass, 0 fail; `scripts/runtime-host-viewer-adapter.test.ts` → 24 pass, 0 fail
  (needs `bun run build:mcp` first for the successor-package fixture).
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` → PASS.
- No deployment, promote, rollback or restart was run against any machine. Every
  Docker interaction in these tests is an injected port or a fake `docker` on
  `PATH`.


## Review round 2 — `--stage` promised an idle successor and staged a crash loop

The reviewer's one blocker was real, and it is the same class of defect as the
one this PR exists to fix: a statement about what a mechanism does that the
mechanism does not do.

`docs/docker.md` and the runbook posted on the issue told the operator that a
`--stage`d successor "waits on the singleton fence", that this is "safe to run
ahead of the moment you want the switch", and that it is "the point of no
cost". The successor was started with `LLV_RUNTIME_HOST_FENCE_WAIT_MS=600000`
(`hostSuccessor.ts`, `SUCCESSOR_FENCE_WAIT_MS`) and `--restart unless-stopped`.
The acquire loop in `src/runtime-host/main.ts` threw out of the wait at that
deadline, the top-level throw exited the process, and dockerd restarted the
container. Ten minutes after staging, the "idle container" was a restart loop
on a ten-minute period — and staging has already set the predecessor's restart
policy to `no`, so the machine sat with a non-recovering predecessor beside it.
An operator returning an hour later hit the exact-intent branch, where
`docker container start` against a `restarting` container returns a raw daemon
error instead of one of the tool's named refusals.

### The mechanism, not a longer number

The bound is not wrong; it is being applied to the wrong case. It exists as a
*detector*: a deployment has asked its predecessor to exit, and a hand-over
that wedges has to become visible rather than wait forever. A bootstrap
`--stage` has asked nothing to exit and will not until the operator runs
`--hand-over`, so there is no hand-over in flight for a deadline to detect. The
bound detects nothing there and only ends the container.

So the staging mode is threaded to the container rather than picked once for
both, through `RuntimeHostSuccessorOptions.fenceWait`
(`"handoff-budget" | "parked"`, `src/runtime-host/hostSuccessor.ts`):

- a **deployment**-staged successor is unchanged — `LLV_RUNTIME_HOST_FENCE_WAIT_MS=600000`,
  and a wedged hand-off still surfaces at ten minutes;
- a **bootstrap**-staged successor is started with `LLV_RUNTIME_HOST_FENCE_PARK=1`
  and no `…_WAIT_MS` at all. `src/runtime-host/fenceWait.ts` reads the park
  ahead of any inherited budget and waits without a deadline, so the container
  neither times out nor restart-loops.

No timeout was widened. The parked path has no timeout to widen, and the
bounded path kept its number.

### The wait says what it is doing, in both modes

The inline acquire loop moved into `acquireRuntimeHostFence`
(`src/runtime-host/fenceWait.ts`), which is where the behaviour became
assertable. Both modes report on a cadence:

```
[runtime host] runtime-host successor llv-runtime-host-… is parked on the singleton fence with no deadline; waited 3540s; the predecessor still serves and has not been asked to exit; run scripts/bootstrap-runtime-host.ts --hand-over to release it
[runtime host] runtime-host successor llv-runtime-host-… is waiting for the singleton fence; waited 60s of 600s; the predecessor has not released it yet
```

A bounded wait that expires now names the generation and the budget it spent
instead of surfacing the fence's own `singleton fence is held`, keeping that
error as the `cause`. An ordinary boot carries no budget, has nothing to report
about waiting, and keeps today's immediate throw verbatim.

### The rest of the finding

- **Named resume.** `resumeSuccessorContainer` wraps both `docker container start`
  call sites, so a refusal reads
  `runtime-host successor container llv-runtime-host-… could not be resumed - generation matches, status restarting, restarting, 0 restarts`,
  falling back to the daemon's own sentence when the container cannot even be
  inspected. Kept as defence: the park removes the periodic restarts, not every
  way a container can be unhealthy when the operator comes back to it.
- **The park does not propagate.** `LLV_RUNTIME_HOST_FENCE_PARK` joined
  `RUNTIME_HOST_GENERATION_ENV`, so a parked generation that later becomes a
  predecessor never hands its park down to the successor a deployment stages
  from it.
- **The claim matches the code now**, in all three places the finding named:
  the rendered plan grew a `while the successor is staged and the predecessor
  still serves:` block, the `--stage` completion lines say there is no window to
  beat, and `docs/docker.md` states the park and why a deployment-staged
  successor keeps the bound instead.

### Tests for this round

Red before the change, green after — verified by mutating the three call sites
back and re-running: 6 fail → 0 fail.

- `src/runtime-host/fenceWait.test.ts` (new) — a parked wait is still holding
  the same container an hour past the #518 budget and has reported 60 times;
  the same fence under the bounded plan gives up at 600s with the named
  message; an ordinary boot keeps the fence's own error and never sleeps; both
  modes' report lines; the park outranks an inherited budget; an unparsable
  budget reads as no budget rather than as an unbounded wait.
- `src/runtime-host/hostSuccessor.test.ts` — the bootstrap stages
  `…_FENCE_PARK=1` and no `…_WAIT_MS`; the deployment path stages
  `…_WAIT_MS=600000` and no park, with and without an explicit mode; a parked
  predecessor never passes its park down; a refused resume is named with the
  state it saw, and with the daemon's reason when the container is gone.
- `src/runtime-host/hostBootstrap.test.ts` — the plan states the deadline-free
  park in every mode; the `--stage` completion lines carry the same promise.
- `scripts/bootstrap-runtime-host.test.ts` — the script stages parked and
  mentions no fence budget at all.

### Verification

- `bunx tsc --noEmit --incremental false` — clean.
- By path under an isolated `HOME`/`XDG_CONFIG_HOME`/`XDG_CACHE_HOME`/`LLV_STATE_DIR`/`TMPDIR`:
  `fenceWait`, `hostSuccessor`, `hostBootstrap`, `bootstrap-runtime-host`,
  `deployment`, `deploymentHotState`, `runtimeHostFence`,
  `bootstrapMcpHealthProbeAdmission`, `stagingContainer`, `bin/server-runtime`
  → **138 pass, 0 fail**; `scripts/runtime-host-viewer-adapter.test.ts` → **24 pass, 0 fail**.
- `bun scripts/privacy-publication-gate.ts --base 0cd121f4 --check-commits` → **PASS**.
- No deployment, promote, rollback or restart was run against any machine.
