### PR TITLE
feat(engines): scan, attribute and render OpenClaw conversations (#1207)

### DIFF
--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -147,7 +147,7 @@ The root-specific viewing work is bounded:
 | Concern | Current gate at `dbfa3753` | Phase-1 change |
 |---|---|---|
 | Discovery | `src/lib/scanner/roots.ts:33-47`; `discover.ts:347` | Add the root and an explicit third branch. |
-| Metadata and search text | `describe.ts:883,889-999` | Parse OpenClaw cwd, start time, title, and first prompt. |
+| Metadata and search text | `describe.ts:883,889-999` | Parse OpenClaw cwd, start time, and first prompt, which is also the title. |
 | Project overlay | `describe.ts:1001-1035` | Route OpenClaw cwd through `projectInfoFromCwd`. |
 | Turn state | `turnState.ts:92`; `activity.ts:156-194,428` | Replace the `codex: boolean` parameter and cache key with an engine discriminator. |
 | Model | `scanner/model.ts:25-45` | Admit the root and read the latest real assistant model. |
@@ -216,13 +216,26 @@ Inner `message` objects, on the assistant records:
   must not assume the key set is invariant across OpenClaw versions.
 - `stopReason` ∈ `{toolUse, stop, error, aborted}`.
 
-`stopReason` is the turn-state signal. The last assistant record ending in
-`stop` is a completed turn. `toolUse` keeps the turn busy, and `error` or
-`aborted` ends it.
+`stopReason` is the turn-state signal, read off the newest assistant record
+whose provider is a real provider — any value other than the synthetic
+`openclaw`. `stop` is a completed turn, `toolUse` keeps the turn busy, and
+`error` or `aborted` end it.
 
-Two measured records use the synthetic provider value `openclaw`. Real model
-outputs name an external provider. Synthetic records do not count as model
-usage and cannot set the displayed model.
+Why the qualifier: re-measured over the same install (55 transcripts; one
+session was written after the counts above), 55 assistant records in 14 of
+those files carry the synthetic provider value `openclaw`, under three distinct
+synthetic model labels. All 55 have `stopReason: "stop"`; 7 sit directly after
+a real assistant record that stopped on `toolUse`, and 3 files end with one as
+their trailing assistant record. Taking the tail record unconditionally would
+report a session sitting inside a tool call as finished, drop it out of busy
+grading at `src/lib/scanner/activity.ts:428`, and land a mid-turn conversation
+in the waiting bucket and the attention counter through
+`src/hooks/useSwitchboardData.ts:72`.
+
+One predicate keyed on the provider value serves model display and turn state
+alike; the synthetic model labels vary, and these records are frequent enough
+to reach ordinary sessions. A record whose provider is `openclaw` is excluded
+from model usage and cannot end a turn.
 
 `model_change` and `thinking_level_change` records carry `{modelId, provider}`
 and `{thinkingLevel}` respectively, which is where mid-conversation model and
@@ -390,10 +403,15 @@ function projectInfoFromOpenclawWorkspace(cwd: string): ProjectInfo | null
 
 It fires only when the normalized cwd equals `<stateDir>/workspace` for the
 default state directory, `OPENCLAW_STATE_DIR`, or a
-`~/.openclaw-<profile>/workspace` path. It returns the existing directory
-identity computed from `path.resolve(workspace)`, with display name
-`OpenClaw`. It never calls `realpathSync`, so the identity is identical before
-and after deletion.
+`~/.openclaw-<profile>/workspace` path. It mints the existing directory
+identity shape — `dir-` plus the `sha256("dir:" + p)` digest
+`projectIdentityFromDirectory` uses at `src/lib/projects/identity.ts:39-48` —
+over `p = path.resolve(workspace)`, with display name `OpenClaw`. It cannot
+delegate to that helper: the helper resolves through `fs.realpathSync.native`
+and reaches `path.resolve` only once the path is gone, which is the
+before/after-deletion split this recognizer exists to remove. Computing the
+digest directly keeps `realpathSync` out of the path, so the identity is
+identical before and after deletion.
 
 Three properties this buys, each of which the alternatives lose:
 
@@ -543,8 +561,10 @@ files before ranking. Add explicit OpenClaw engine, format, and title fallbacks
 at the resource-scope mapping around `:342-378`.
 
 **3. Metadata, search, and attribution.** In
-`src/lib/scanner/describe.ts`, parse cwd, timestamp, the first user prompt, and
-the OpenClaw title. Generalize the search helper at
+`src/lib/scanner/describe.ts`, parse cwd, timestamp, and the first user prompt.
+No OpenClaw record carries a title — there is no `summary` or `ai-title`
+analogue on disk — so the title is the first prompt through the existing
+`goodTitle` path. Generalize the search helper at
 `:883-886` to an engine discriminator. Add the exact-workspace recognizer after
 `:539` and the OpenClaw project overlay after `:1030`.
 
@@ -552,7 +572,10 @@ the OpenClaw title. Generalize the search helper at
 `src/lib/accounts/migration/turnState.ts` and
 `src/lib/scanner/activity.ts`. Add explicit OpenClaw arms in
 `src/lib/scanner/index.ts:300`, `src/lib/scanner/observe.ts:76`, and the
-persisted-evidence path in `src/lib/scanner/scanCache.ts:173`.
+persisted-evidence path in `src/lib/scanner/scanCache.ts:173`. The OpenClaw arm
+reads `stopReason` from the newest assistant record whose provider is real —
+the same predicate item 5 applies to the model — so a synthetic record appended
+mid-turn cannot end the turn.
 
 **5. Model and effort display.** In `src/lib/scanner/model.ts`, admit the root
 and read the newest assistant record whose provider is a real provider. A
@@ -591,7 +614,8 @@ describes a spawn and phase 1 creates none.
 `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run by path:
 
 - `src/lib/scanner/describe.test.ts` covers title/search text, the same
-  workspace identity before and after deletion, the workspace's
+  workspace identity before and after deletion through a symlinked fixture path
+  so a `realpathSync` regression fails the case, the workspace's
   remote-less `.git`, the OpenClaw overlay, and a genuine nested checkout that
   retains repository attribution.
 - `src/lib/scanner/discover.test.ts`: a fixture agent tree yields one entry
@@ -599,10 +623,12 @@ describes a spawn and phase 1 creates none.
   `.acp-stream.jsonl`, `.trajectory-path.json`, `sessions.json` and `.bak`
   siblings.
 - `src/lib/accounts/migration/turnState.test.ts`: `stopReason` of `stop`
-  reads terminal, `toolUse` reads busy, `error`/`aborted` read terminal.
+  reads terminal, `toolUse` reads busy, `error`/`aborted` read terminal, and a
+  synthetic-provider `stop` record appended after a real `toolUse` record
+  leaves the state busy.
 - `src/lib/scanner/model.test.ts` and `effort.test.ts` cover real model display,
-  synthetic-provider exclusion, model changes, `off`, `adaptive`, and an
-  unknown effort.
+  exclusion of a synthetic-provider record that is the newest assistant record
+  in the file, model changes, `off`, `adaptive`, and an unknown effort.
 - `src/lib/scanner/conversationCatalog.test.ts` proves complete list and search
   inclusion, including first-prompt search.
 - `src/app/api/files/scanCache.real.test.ts` and

--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -544,7 +544,9 @@ that remain unproven, so it is a separate design gated on section (d).
 Phase 1 delivers Expected 1 and 2 in one PR. An OpenClaw card enters the full
 catalog, receives stable project attribution, displays its real model and
 effort, reports turn state, and opens through `renderOpenclaw`. The PR has no
-plain-text fallback.
+plain-text fallback. Catalog search matches its title and first prompt; search
+inside message bodies waits on the transcript index's own schema migration
+(**Deferred — not currently justified**).
 
 Work plan against `origin/main` at `a3f9c2e2`:
 
@@ -610,6 +612,12 @@ engine; `SnapshotConversation["engine"]` at
 `launch.engine` at `src/lib/view/types.ts:103` stays two-membered, because it
 describes a spawn and phase 1 creates none.
 
+**9. Project timeline.** `fileEvents` in `src/lib/timeline.ts` dispatches on
+`fmt` and returns no events for anything it does not recognize, so the
+Switchboard's recent-actions list would stay empty for an OpenClaw project.
+A third arm reads the prompts and assistant prose out of the `message`
+envelope, the same pair the Codex arm contributes.
+
 **Tests**, all against invented fixtures under an isolated
 `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run by path:
 
@@ -645,6 +653,8 @@ describes a spawn and phase 1 creates none.
 - `src/lib/view/view.test.ts`: a selected OpenClaw path appears in the snapshot
   as `engine: "openclaw"` rather than being omitted or reported as Claude, and
   a path with no scan entry is still omitted.
+- `src/lib/timeline.test.ts`: an OpenClaw transcript contributes its prompt and
+  its assistant prose to the project timeline, newest first.
 
 **Gates:** `bunx tsc --noEmit --incremental false`; the touched test files by
 path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
@@ -704,6 +714,17 @@ the join would be machinery heavier than the problem.
 
 **`sessions.json` as a metadata source.** Indexes only recent sessions (21 of
 54 on the machine inspected); using it would silently hide the rest.
+
+**Full-text body search over OpenClaw transcripts.** The transcript index
+(`src/lib/search/transcriptSearch.ts`) parses per-engine record shapes and
+constrains its `engine` column to `('claude','codex')` in SQL, so feeding it an
+OpenClaw source would fail the insert rather than index anything. Phase 1
+excludes OpenClaw entries from the index feed instead. OpenClaw conversations
+stay reachable in the complete list and in list search, which match on the
+title and the first prompt the catalog already carries; only matches inside
+message bodies are unavailable. Closing the gap is a schema migration of that
+index — a new engine value, a record parser, and a reindex of existing rows —
+which is its own change.
 
 **Process-based liveness for OpenClaw.** One Gateway process writes every
 session; pid attribution would map every conversation to the same pid.

--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -1,0 +1,951 @@
+# OpenClaw as a third engine (issue #1207)
+
+## The originating requirement
+
+Verbatim, from the operator's request line in GitHub issue #1207 (opened
+2026-08-27, `gh issue view 1207`):
+
+> Support OpenClaw as a third engine, at the same level Claude and Codex
+> already are: the Viewer scans and renders OpenClaw conversations, and the
+> Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
+> message, stream the turn, resume, kill).
+
+Everything below is validated against that sentence. Scope that the sentence
+does not demand is preserved in **Deferred — not currently justified**.
+
+## Evidence discipline
+
+Two sources: this repository at `ac19703`, and read-only inspection of the
+OpenClaw 2026.6.10 install on the development machine. No OpenClaw state was
+written, and the operator's running Gateway was not started, stopped or
+reconfigured.
+
+The real session files hold the operator's private messaging history. Nothing
+from them is reproduced here. Every shape below is described abstractly, every
+identifier is invented (`agent:demo:local:main`, agent id `demo`), and every
+count is an aggregate over files whose contents are not quoted.
+
+Where the issue's starting facts turned out to be wrong, this document says so
+and cites what was measured instead.
+
+---
+
+## Summary of decisions
+
+| # | Question | Decision |
+|---|----------|----------|
+| a | Engine surface | A third union member on `Engine`/`Fmt`, **not** an engine-descriptor registry. The seam is `Fmt` for rendering plus a named `hostable` predicate for lifecycle. |
+| b | Viewing | The session file alone is authoritative for the message chain **and** for model/provider. The trajectory supplies only `sessionKey`. Checkpoints are excluded from discovery. |
+| c | Project attribution | A pure path recognizer for the OpenClaw workspace, minting one stable directory identity, inserted ahead of every disk-dependent resolver. |
+| d | Hosting transport | The ACP bridge (`openclaw acp`), spawned through an explicit real-Node interpreter, with a preflight that names the failure. |
+| e | Phasing | Viewing (phase 1) / hosting (phase 2). The boundary is drawn so phase 1 also avoids both contended lanes' files except one. |
+
+---
+
+## Corrections to the issue's starting facts
+
+The issue asked for these to be re-verified rather than assumed. Four of them
+did not survive.
+
+**1. Model and provider do not come from the trajectory file.** The issue says
+"The trajectory file supplies model/provider/run metadata; the session file
+supplies the message chain." Measured over the 54 session files (2 940 message
+records): every `"assistant"` record carries `model`, `provider`, `api`,
+`usage` and `stopReason` on the inner message object. All 1 452 of them. The
+trajectory is not needed for any of it.
+
+**2. The trajectory is not reliably a sibling of the session file.** Of 54
+session-file basenames and 58 trajectory basenames, 40 pair by name; 14 session
+files have no trajectory and 18 trajectories have no session file. Any join
+must go through the `session.started` event's `sessionFile` field, which points
+at the transcript explicitly, and must tolerate both halves being absent.
+
+**3. The filename is not the session id.** 17 of 54 session files are named
+`<sessionId>-topic-<n>.jsonl`, and their header `id` is the bare session id
+without the `-topic-<n>` suffix. Header ids are bare v4-shaped ids in 52 of 54
+cases and are unique across all files and across both agent ids. The header is
+the identity; the filename is not.
+
+**4. Checkpoints are not fragments to merge.** The one checkpoint file present
+is a *complete* transcript in its own right — its own `"session"` header, then
+its own `parentId`-chained message records — and the session file it is named
+after does not exist. A checkpoint is an alternative branch of a conversation,
+not a continuation of one. Merging it into the base conversation would
+duplicate the whole history. Phase 1 excludes `*.checkpoint.*.jsonl` from
+discovery.
+
+The `-topic-<n>` naming and the checkpoint-as-fork shape are inferences from
+file structure; OpenClaw's own semantics for them were not read out of its
+source and remain **uncertain**. The design only relies on the measured shape
+(self-contained transcript, header id, no base file), which is enough to decide
+exclusion.
+
+---
+
+## (a) Engine surface
+
+### What is actually there
+
+There are already **three** engine unions with three different memberships:
+
+- `src/lib/types.ts:13` — `export type Engine = "codex" | "claude" | "shell"`
+- `src/lib/types.ts:15` — `export type Fmt = "codex" | "claude" | "plain"`
+- `src/lib/scanner/process.ts:13` — `export type AgentEngine = "claude" | "codex"`
+
+plus 38 inline `"claude" | "codex"` type literals spread over 18 non-test
+component files — the "~15 component files" the issue counted — and more in
+`src/lib`: `src/components/AccountBadge.tsx:31`,
+`src/components/draftSpawn.ts:17`, `src/components/DraftAgentPane.tsx:54`,
+`src/components/RuntimePill.tsx:548`, `src/lib/events.ts:65` and `:88`,
+`src/lib/limits.ts:38`, `src/lib/limitsHistoryStore.ts:21`,
+`src/lib/types.ts:680`, `src/lib/lifecycle/inventorySelection.ts:43`.
+
+`Engine` already carries a third member. `"shell"` — background tasks under the
+`claude-tasks` root — is referenced in 18 non-test files and the codebase
+handles it without incident. **That is the empirical answer to "how much does a
+third member cost": the widening itself is nearly free, and it has been paid
+once already.**
+
+### The branches, classified
+
+308 engine comparisons across 124 non-test files
+(`engine === "codex"`, `=== "claude"`, and their negations). They fall into
+four classes, and only two of them matter.
+
+**Class A — narrowing predicates, in 32 non-test files. Safe. Do not touch in
+phase 1.**
+
+The idiom `entry.engine === "claude" || entry.engine === "codex"` is the single
+most repeated engine expression in the codebase. Representative sites:
+`src/lib/scanner/index.ts:300`, `src/lib/scanner/observe.ts:76`,
+`src/lib/scanner/scanCache.ts:173`,
+`src/lib/lifecycle/inventorySelection.ts:98`,
+`src/lib/lifecycle/liveness.ts:532` and `:681`,
+`src/lib/session/titleTarget.ts:68`, `src/lib/session/titleStore.ts:163`,
+`src/lib/accounts/migration/coordinator.ts:87`,
+`src/lib/workflows/store.ts:218`, `src/lib/wakatime/operatorActivity.ts:84`,
+`src/app/api/tasks/[id]/send/route.ts:80`,
+`src/app/api/tasks/[id]/spawn/route.ts:221`, `src/lib/agent/registry.ts`
+(2), `src/lib/runtime/commands.ts` (2), `src/lib/mcp/bindings.ts` (4),
+`src/lib/tasks/store.ts`, `src/lib/pipelines/store.ts`,
+`src/lib/view/snapshot.ts`, `src/hooks/useSwitchboardData.ts`. Reproduce the
+full list with (add `-l` for the file list, which is the unit that matters —
+several lines carry two matches, so an occurrence count lands anywhere between
+35 and 39 depending on how you count):
+
+```
+grep -rnE 'engine === "(claude|codex)" \|\| [^)]*engine === "(codex|claude)"' \
+  src/ --include='*.ts' --include='*.tsx' | grep -v '\.test\.'
+```
+
+Every one of them is asking *"is this an engine I can host, rename, hydrate or
+spawn?"* — and under a widened union each one keeps answering **no** for
+OpenClaw, which is exactly right for phase 1. The codebase already has a safe
+default for a third engine, and it spread the definition across 32 files
+without naming it. That spread is the argument for naming it before phase 2,
+and it is twice what a first pass over this surface suggests — the idiom
+appears in both operand orders and in files that have nothing else
+engine-shaped in them.
+
+**Class B — erasure coercions (8 sites). Actively wrong. Must be fixed.**
+
+`src/components/DraftAgentPane.tsx:396`,
+`src/components/flows/directReviewGroups.ts:134` and `:146`,
+`src/components/feed/parse.ts:1311` and `:1486`,
+`src/app/api/tasks/[id]/send/route.ts:94`,
+`src/lib/runtime/liveTurn.ts:374`,
+`src/lib/tasks/inboxScanner.ts:144`.
+
+These read `engine === "codex" ? "codex" : "claude"` and *relabel* anything
+that is not Codex as Claude. TypeScript approves: the expression is total over
+any union. An OpenClaw conversation flowing through
+`src/lib/tasks/inboxScanner.ts:144` becomes a Claude conversation in the task
+inbox, and nothing anywhere reports it.
+
+**Class C — presentation ternaries (~99 sites). Cosmetic. Long tail.**
+
+Colours, labels, avatars: `src/components/utils.ts:95`,
+`src/components/feed/FeedItem.tsx:106-107`,
+`src/components/scheme/offscreenClusters.ts:384`. A third engine renders in
+Claude's colour with Claude's icon. Wrong, visible, harmless, and fixable
+incrementally.
+
+**Class D — genuinely engine-specific machinery. This is the real work.**
+
+Eight places, all of them keyed on the transcript **root** rather than on a
+free-floating engine string:
+
+| Concern | Site | Shape |
+|---|---|---|
+| Root inventory | `src/lib/scanner/roots.ts:33-47` | `Record<RootKey, string>` + `scanRootEntries()` |
+| Root → engine | `src/lib/scanner/discover.ts:347` | `rootName === "codex-sessions" ? "codex" : "claude"` |
+| Metadata derivation | `src/lib/scanner/describe.ts:918-983` | `if (rootName === …) else if … else if …` |
+| Turn state | `src/lib/scanner/activity.ts:428` → `src/lib/accounts/migration/turnState.ts:92` | a **boolean** `codex: boolean` |
+| Effort extraction | `src/lib/scanner/effort.ts:19-30` | `entry.root === "codex-sessions"` / `"claude-projects"` |
+| Feed rendering | `src/components/feed/parse.ts:2127` | `cfg.fmt === "claude" ? renderClaude : renderCodex` |
+| Host construction | `src/lib/runtime/structuredSpawn.ts:1312`, `:1372` | `engine === "codex" ? … : …` |
+| Persisted-cache validators | `src/lib/scanner/scanCache.ts:105,109,111`; `src/lib/scanner/projectCatalog.ts:136-137`; `src/lib/resourceCollector.worker.ts:45` | literal enum echoes |
+
+Of these, only two are structurally hostile.
+
+`turnStateFromRecords(records, codex: boolean, authoritative)` at
+`src/lib/accounts/migration/turnState.ts:92` cannot express a third engine at
+all — the parameter is a boolean, fed from `root.startsWith("codex")` at
+`src/lib/scanner/activity.ts:428`. A new root falls into the `false` arm and
+gets Claude's parser, which keys on `record.type === "assistant"` and
+`message.stop_reason` (`turnState.ts:166-173`). No OpenClaw record has
+`type: "assistant"` — they are all `type: "message"` — so every branch misses
+and the function returns `{ state: "unknown", source: "empty" }` forever. The
+failure is quiet and degrades to mtime-only activity rather than lying, but the
+boolean must become a discriminator before OpenClaw can report turn state.
+
+The three persisted-cache validators echo the enums as literals. Widen one and
+not the others and entries are silently dropped:
+`src/lib/resourceCollector.worker.ts:45` discards the whole entry;
+`src/lib/scanner/projectCatalog.ts:136-137` blanks `engine` and `fmt` to
+`undefined`. **They move together, in the same commit, with
+`FILE_SCAN_CACHE_SCHEMA_VERSION` (`src/lib/scanner/scanCache.ts:75`) bumped from
+9 to 10** so an older build rejects a newer snapshot wholesale and rescans
+instead of reading it through a narrower enum.
+
+### Registry of engine descriptors, or a third union member?
+
+**A third union member.** A descriptor registry is over-built here, and the
+evidence for that is specific rather than aesthetic:
+
+1. The widening is already proven cheap — `"shell"` did it.
+2. A descriptor cannot help Class B or Class C at all. Those 107 ternaries are
+   binary expressions that are *total* over any union; no amount of descriptor
+   indirection makes `x === "codex" ? a : b` stop compiling. They have to be
+   read and fixed by hand either way.
+3. The facts that genuinely vary are few, they all live in the scanner, and
+   they are already keyed on `RootKey` — which is a descriptor key in all but
+   name.
+
+What is worth building is far smaller than a registry: **one root descriptor**,
+declared next to `ROOTS`, carrying exactly the five facts the scanner branches
+on.
+
+```ts
+interface TranscriptRootDescriptor {
+  root: RootKey;
+  engine: Engine;          // discover.ts:347 reads this instead of branching
+  fmt: Fmt;                // selects the feed renderer
+  dir: () => string[];     // account homes / profile dirs
+  isTranscript(basename: string): boolean;  // excludes .trajectory/.checkpoint/.bak
+}
+```
+
+That is the whole descriptor. It does **not** carry launch arguments, model
+catalogues, account shapes or UI labels — those either do not exist for
+OpenClaw in phase 1 or are better expressed as the capability predicate below.
+Proposing a descriptor that carries them would be building the abstraction for
+a fourth engine that nobody has asked for.
+
+### The seam
+
+Three named things, and they are what keep the third engine off 300 call sites.
+
+1. **`Fmt` is the rendering seam.** `src/components/feed/parse.ts:2127`
+   dispatches on `cfg.fmt`, and `renderClaude`
+   (`src/components/feed/parse.ts:1943`) is a pure record→primitive emitter: it
+   calls `addUserText`, `addProse`, `push({kind:"think"})`,
+   `registerCall(newToolEvent(…))`, `addOutput`, `addCompact`, `pushImage`, and
+   returns. A third renderer calling the same primitives is the entire feed
+   change. No card, no tool summariser, no timeline consumer learns a third
+   engine.
+
+2. **A named capability predicate is the lifecycle seam.** The 32 Class-A
+   files already implement it; give it a name and a single definition —
+
+   ```ts
+   /** Engines the Viewer can host, resume, rename and hydrate. */
+   export function isHostableEngine(engine: Engine | null | undefined): engine is AgentEngine
+   ```
+
+   — and adopt it at those sites. This is the precedent
+   the codebase already set for capability probing:
+   `hostSupportsCompact(host)` at `src/lib/runtime/engineHost.ts:126`. Phase 1
+   defines it to exclude OpenClaw; phase 2 changes it in one place and every
+   call site follows. Without the name, phase 2 is a 32-file audit that a
+   reviewer cannot check.
+
+3. **`EngineHost` is the hosting seam** (`src/lib/runtime/engineHost.ts:100`).
+   Six methods. `src/lib/runtime/structuredSpawn.ts:1312` and `:1372` are the
+   only two construction sites, and both are `if/else` — turning them into a
+   three-way switch is a phase-2 edit of two functions.
+
+**What the seam does not protect.** Class B's eight erasure sites and Class C's
+ninety-nine presentation ternaries sit outside all three seams, and no seam can
+pull them in, because they are expressions over the union rather than
+dispatches through it. TypeScript will not flag a single one. They must be
+enumerated by grep and fixed by reading. This document's Class B list is that
+enumeration for the eight that produce wrong data.
+
+---
+
+## (b) Viewing
+
+### Which file is authoritative
+
+**The session file, `<sessionId>[-topic-<n>].jsonl`, is authoritative for the
+message chain and for model/provider/turn-state.** The trajectory is
+authoritative for one thing only: `sessionKey`. Checkpoints are excluded.
+
+Measured shape, over 54 files:
+
+- Record 1 of every file, without exception: `{"type":"session","version":3,
+  "id","timestamp","cwd"}`. `version` was 3 in all 55 headers read.
+- Record types thereafter: `"message"` (2 940), `"custom"` (33),
+  `"model_change"` (23), `"thinking_level_change"` (23).
+- Every `"message"` record has exactly `{id, parentId, timestamp, type,
+  message}` — a `parentId` chain, structurally the same idea as Claude's
+  `uuid`/`parentUuid`.
+- `message.role` is one of `"user"` (205), `"assistant"` (1 452) or
+  `"toolResult"` (1 283).
+
+### Where model, provider and turn state come from
+
+Inner `message` objects, on the assistant records:
+
+- `model`, `provider`, `api` on all 1 452 assistant records.
+- `usage` as `{input, output, cacheRead, cacheWrite, cost, totalTokens}` on
+  1 451 of them. One record carries an OpenAI-native key set
+  (`prompt_tokens`/`completion_tokens`/`total_tokens`) instead, so the reader
+  must not assume the key set is invariant across OpenClaw versions.
+- `stopReason` ∈ `{toolUse, stop, error, aborted}`.
+
+`stopReason` is the turn-state signal, and it is cleaner than either engine's
+current one: the last assistant record ending in `stop` is a completed turn;
+`toolUse` is a turn still running; `error`/`aborted` are terminal. That is the
+third branch of `turnStateFromRecords` in about five lines.
+
+Two provider values are synthetic — records OpenClaw injected rather than
+model output, distinguishable because `provider` is `openclaw` rather than a
+real provider name. They must not be counted as model usage and must not set
+the conversation's displayed model.
+
+`model_change` and `thinking_level_change` records carry `{modelId, provider}`
+and `{thinkingLevel}` respectively, which is where mid-conversation model and
+effort changes come from.
+
+### What the trajectory is for
+
+`<base>.trajectory.jsonl` records share one flat key set across all 1 507
+events measured: `{traceSchema, schemaVersion, seq, ts, type, source,
+sourceSeq, traceId, sessionId, sessionKey, runId, workspaceDir, provider,
+modelId, modelApi, data}`. Event types: `session.started`, `context.compiled`,
+`prompt.submitted`, `tool.call`, `tool.result`, `model.completed`,
+`session.ended`, `trace.metadata`, `trace.artifacts`, `turn.client_closed`.
+
+Everything there except `sessionKey` duplicates the session file. `sessionKey`
+does not appear in the session file at all, and it is what phase 2 needs to
+resume a session (`openclaw acp --session <key>`). Phase 1 reads it — from the
+first `session.started` event, whose `data.sessionFile` is also the reliable
+back-pointer to the transcript — and stores it, doing nothing else with it.
+
+"session" in the trajectory names a *run*. There were 143
+`session.started` events across 58 files, one per submitted prompt.
+
+### How a live session is detected
+
+Two independent signals, and one of them does not work here.
+
+**Signal 1 — mtime and turn state. Works.** `resourceActivity` at
+`src/lib/scanner/discover.ts:337-340` grades by transcript age (`< 20 s` live,
+`< 900 s` recent, else idle) and is engine-agnostic. Layered on it,
+`src/lib/scanner/activity.ts:428` reads the transcript tail for turn state.
+Once the OpenClaw branch of `turnStateFromRecords` exists, a trailing assistant
+record with `stopReason: "toolUse"` reads as busy and one with `"stop"` reads
+as done, matching the fidelity Claude and Codex have.
+
+**Signal 2 — process attribution. Does not work, and phase 1 must not pretend
+it does.** `argvEngine` at `src/lib/scanner/process.ts:122` maps a live process
+to an engine by binary basename, and `agentProcesses()` at `:155` pairs one pid
+to one transcript by cwd. OpenClaw has no per-session process. One long-lived
+Gateway process writes every session file for every agent id and every channel
+— observed on this machine as a single `node … openclaw/dist/index.js gateway
+--port <port>`. Mapping it to a conversation would attribute every OpenClaw
+session to the same pid.
+
+Phase 1 therefore leaves `pid`/`proc` null for OpenClaw entries. This costs
+nothing that matters: `argvEngine` returns `AgentEngine`, which phase 1 does
+not widen, so `src/lib/scanner/process.ts` — a file the #1199 lane owns — is
+not touched at all.
+
+### How the scanner discovers sessions across agent ids
+
+The layout is `<stateDir>/agents/<agentId>/sessions/<sessionId>.jsonl`, where
+`<stateDir>` is `~/.openclaw` by default, `~/.openclaw-dev` under `--dev`, and
+`~/.openclaw-<name>` under `--profile <name>` (per `openclaw --help`), and is
+overridable by `OPENCLAW_STATE_DIR`. There is no sessions-directory key in
+`openclaw.json`; the path is derived from the state dir.
+
+Discovery is therefore a two-level walk: enumerate `<stateDir>/agents/*/`, then
+`sessions/*.jsonl` inside each. `scanRootEntries()`
+(`src/lib/scanner/roots.ts:39`) already returns `[RootKey, string][]` and
+already fans out over multiple account homes for both existing engines, so
+OpenClaw contributes one entry per agent id and the existing realpath dedupe
+applies unchanged.
+
+The sessions directory is not clean, and the filter is the load-bearing part.
+Beside real transcripts it holds `.trajectory.jsonl`, `.trajectory-path.json`,
+`.codex-app-server.json`, `.acp-stream.jsonl`, `.checkpoint.<id>.jsonl`,
+`sessions.json`, and dated `.bak` / `.deleted.<timestamp>` files from past
+repairs — in the agent inspected, 58 trajectories, 58 `trajectory-path`
+sidecars and 36 app-server sidecars against 54 transcripts, plus a long tail of
+backups. `isTranscript(basename)`
+admits `*.jsonl` and rejects any basename containing `.trajectory.`,
+`.checkpoint.`, `.acp-stream.`, or a `.bak`/`.deleted.` segment. A rescan of
+this shape without the filter would roughly triple the board's OpenClaw card
+count with sidecars and dead backups.
+
+`sessions.json` deserves a note because it looks tempting and should not be
+used. It is a live index keyed by session key carrying `sessionFile`,
+`sessionId`, `label`, `model`, `modelProvider`, token counts, `chatType`,
+`lastInteractionAt` and `sessionStartedAt` — a ready-made metadata source. It
+covered 21 entries against the 54 transcripts on disk, so it indexes only
+recent sessions and would silently hide the rest. Phase 1 reads the transcripts.
+
+### Rendering
+
+`renderOpenclaw` calls the same primitives `renderClaude` does. The mapping:
+
+| OpenClaw | Feed primitive |
+|---|---|
+| `role: "user"`, content string or `text` blocks | `addUserText` |
+| `role: "assistant"`, `text` block | `addProse` |
+| `role: "assistant"`, `thinking` block | `push({kind:"think"})` |
+| `role: "assistant"`, `toolCall` block (`{id, name, arguments}`) | `registerCall(newToolEvent(…))` |
+| `role: "toolResult"` record (`{toolCallId, toolName, isError, content}`) | `addOutput(toolCallId, text, isError)` |
+| `custom` / `model_change` / `thinking_level_change` | `addSvc` |
+
+The one shape difference worth calling out is why this is a third renderer
+rather than a record-shape adapter. In Claude's format a tool result is a
+`tool_result` content block inside a `"user"` record; in OpenClaw it is a
+top-level record with its own role. Translating OpenClaw into Claude's shape
+would mean synthesising fake `"user"` records to carry results the operator
+never sent — inventing records to satisfy a parser. The third renderer calls
+`addOutput` directly and invents nothing. Roughly 80 lines against a translator
+that would be shorter to write and permanently harder to reason about.
+
+Content-block key sets to code against: `toolCall` is `{type, id, name,
+arguments}` and sometimes carries `partialJson` or `input`; `thinking` is
+`{type, thinking, thinkingSignature}`; assistant `text` sometimes carries
+`textSignature`; the `toolResult` role's blocks are either `text` or a
+`toolResult` block carrying both camelCase and snake_case id aliases. Read
+`toolCallId` off the record itself; the block's copies are aliases.
+
+---
+
+## (c) Project attribution
+
+### The measured problem
+
+52 of 54 session headers carry the same `cwd`: the OpenClaw workspace,
+`<stateDir>/workspace`. All 1 507 trajectory events carry the same
+`workspaceDir`. The remaining two sessions' cwd is the home directory. Session keys
+are channel-bound — `agent:<id>:<channel>:<kind>:<peer>…`, `agent:<id>:cron:…`,
+`agent:<id>:main` — and name no repository.
+
+So the question is not "which of many projects" but "what is the one project
+these all belong to, and does that answer survive the workspace being gone".
+
+### Why the default answer fails the AGENTS.md invariant
+
+The OpenClaw workspace **is itself a git repository** — it has a real `.git`
+directory — with no `origin` remote. Trace it through
+`projectInfoFromCwd` (`src/lib/scanner/describe.ts:530`):
+
+*While the directory exists:* no path recognizer matches, `hasGitMarker(cwd)`
+is true so the persisted-map fallback at `:549-557` is skipped,
+`repositoryRootForPath(cwd)` at `:568` returns the workspace, and
+`projectIdentityFromRepositoryRoot` (`src/lib/projects/identity.ts:153`) finds
+no remote and falls to `canonical = "local:" + realpath(root)`, minting
+`repo-<digest>` with display name `workspace`.
+
+*After the directory is deleted:* `gitDirectory(root)` at
+`src/lib/projects/identity.ts:154` does `fs.lstatSync` on a path that is gone
+and returns `null`. `repositoryRootForPath` returns `null`. `hasGitMarker` is
+now false, so `:549` reaches `worktreeFromMemory` and then `persistedProjects`
+— which is populated from `flows`/`workflows` rows in `state.sqlite`
+(`src/lib/scanner/describe.ts:492`), so a channel-bound session that never
+joined a flow has no entry. Execution falls to `directoryProjectInfo()` at
+`:562`, minting `dir-<digest>`.
+
+`repo-<digest>` alive, `dir-<digest>` dead. Two different projects for the same
+conversations, and every OpenClaw session that runs in the workspace fragments at once, because
+they all share the one cwd. This is precisely the failure AGENTS.md describes: *"a
+worktree's grouping must survive the checkout being deleted… Any mapping that
+finds the parent repo only by reading on-disk git metadata silently fails
+afterward."*
+
+It is worth being honest that this hazard is not OpenClaw's. Any transcript
+whose cwd is a remote-less git repository has it today. OpenClaw makes it
+systemic by putting 52 of 54 sessions in one such directory.
+
+### The decision
+
+**Add a pure path recognizer for the OpenClaw workspace, and place it in the
+pure-path group so it precedes every disk-dependent resolver.** This is exactly
+the instruction AGENTS.md gives for a new agent layout: *"prefer a pure path
+recognizer beside #1–#4 and wire it into `projectInfoFromCwd`."*
+
+```ts
+/** Recognizer 1.5, immediately after the scratchpad early-return at
+    describe.ts:539 — ahead of every resolver that reads the disk. */
+function projectInfoFromOpenclawWorkspace(cwd: string): ProjectInfo | null
+```
+
+It fires when `cwd` is, or is under, `<stateDir>/workspace` for the default
+state dir, `OPENCLAW_STATE_DIR`, or any `~/.openclaw-<profile>` sibling. It
+returns a `DirectoryProjectIdentity` computed from `path.resolve(workspace)`
+— never `fs.realpathSync` — so the identity is byte-identical whether or not
+the directory exists.
+
+Three properties this buys, each of which the alternatives lose:
+
+- **Stable across deletion**, because nothing on disk is consulted.
+- **Ahead of the repo resolver**, so the workspace's incidental `.git` never
+  mints a competing `repo-` identity.
+- **Inside the existing id namespace** (`dir-<32 hex>`, which
+  `isCanonicalProjectId` at `src/lib/projects/identity.ts:22` already accepts),
+  so no second naming scheme is invented — the other thing AGENTS.md warns
+  against.
+
+The display name is set explicitly rather than taken from the basename:
+`projectIdentityFromDirectory` would name this project **workspace**, which
+reads like a repository and would collide in the sidebar with any real
+checkout of that name.
+
+Sessions whose cwd is a genuine git checkout are untouched — the recognizer is
+scoped to the workspace subtree and everything else falls through to the
+existing chain. The one home-directory session resolves to the existing
+`home-<user>` directory identity, as it would today.
+
+### One project for the whole workspace
+
+Rejected: a project per OpenClaw agent id. It would need the transcript path
+rather than the cwd (`projectInfoFromCwd` only receives a cwd), which means
+hooking `resolveProjectOverlay` (`src/lib/scanner/describe.ts:1001`) and
+minting ids from a source other than a directory — a second naming scheme, for
+a distinction that is presentational. The agent id is already in the transcript
+path and can drive a card title or a subtitle without touching project
+identity. If the operator later wants per-agent lanes, that is a sidebar
+grouping change that leaves identity alone, and this decision does not block it.
+
+---
+
+## (d) Hosting transport
+
+### What the transport has to do
+
+From `EngineHost` (`src/lib/runtime/engineHost.ts:100-107`) and what
+`CodexAppServerHost` needs to satisfy it:
+
+| Requirement | `EngineHost` member |
+|---|---|
+| Deliver a message | `send(entry): Promise<DeliveryReceipt>` — and the receipt must discriminate `steered` / `turn-started` / `queued-next-turn` / `rejected` |
+| Stream a turn | `attach(afterSeq): AsyncIterable<RuntimeEvent>` |
+| Observe turn state | `health(): Promise<HostState>` with `status`, `activeTurnRef`, `eventCursor` |
+| Resume | construction via `adopt(id, options)` (`codexAppServerHost.ts:750`) |
+| Kill | `release()` |
+| Survive a viewer restart | `HostState.pid` + `processStartIdentity`, re-adoption, and a durable event store |
+
+### The three candidates
+
+**1. ACP bridge — `openclaw acp`.** JSON-RPC over stdio, structurally identical
+to `codex app-server`, which `CodexAppServerHost` already drives over the same
+substrate (`spawn(…, {stdio: ["pipe","pipe","pipe"], detached: true})` at
+`codexAppServerHost.ts:757` and `:773`). The installed bundle contains
+`initialize`, `session/new`, `session/prompt`, `session/cancel`,
+`session/update`, `session/resume`, `session/status`, `session/list`,
+`session/set_model`, `session/set_mode`, `session/set_config_option`, plus
+client-side `fs/*` and `terminal/*` callbacks. The CLI exposes `--session <key>`,
+`--session-label`, `--require-existing`, `--reset-session`, `--provenance`, and
+gateway `--url/--token/--token-file`.
+
+Maps to all six members: `session/prompt` → `send`, `session/update`
+notifications → `attach`, `session/cancel` → `interrupt`,
+`session/request_permission` → `answer`, `session/status` → `health`,
+child termination → `release`, `--session <key> --require-existing` → resume.
+
+**2. Gateway WebSocket.** No child process to own, so `release()` has no
+meaning — you cannot kill a shared service. Requires speaking OpenClaw's
+internal Gateway RPC, which is not a published stable protocol, plus token or
+password auth. Decisively: it is the operator's live Gateway, carrying their
+personal messaging channels, and a Viewer defect on that socket is a defect in
+the operator's messaging. Rejected.
+
+**3. `openclaw agent --json` per turn.** One process per turn. `--json` emits a
+single terminal result with no streaming, so `attach` degrades to "nothing until the turn ends";
+there is no `interrupt`, no attention channel, and turn state is a process exit
+code. Four of six members unsatisfied. Rejected for hosting; it remains a
+reasonable fallback for a fire-and-forget send, and is noted as such under
+Deferred.
+
+**Choice: the ACP bridge.**
+
+### What the ACP bridge cannot do
+
+The bridge is a *client* of the Gateway — `openclaw acp --help` describes it as
+"Run an ACP bridge backed by the Gateway", and it takes a gateway URL and
+token. The Gateway owns the agent; the bridge does not. Four consequences, and
+they are not small:
+
+1. **`release()` detaches; it does not stop the agent.** A turn in flight keeps
+   running inside the Gateway and keeps writing the session file after the
+   Viewer's host is gone. "Kill" means "stop watching". For Codex, killing the
+   app-server child stops the work; here it does not. The Viewer must not
+   display this as a kill.
+2. **No hosting without the Gateway, and the Viewer must not manage it.** The
+   Gateway is the operator's own long-running service. If it is down, hosting
+   is unavailable and must say so; starting it is out of bounds.
+3. **No exclusive claim on a session.** The operator's Telegram channel, a cron
+   job and the Viewer can all drive the same session key concurrently. The
+   `expectedTurnId` fence on `QueueEntry` (`engineHost.ts:22`) rejects a stale
+   Viewer-side write, but nothing prevents an operator message arriving
+   mid-turn from another channel. Codex's single-owner assumption does not
+   hold, and the registry's claim model should treat an OpenClaw host as
+   advisory rather than exclusive.
+4. **Cancellation is likely advisory.** `session/cancel` exists, but the
+   trajectory records `turn.client_closed` events (3 observed) that sit
+   alongside `session.ended`, which reads as "the client went away" being
+   logged rather than aborting the run. **Uncertain** — the bridge was not
+   exercised, because doing so would have opened a session against the
+   operator's live Gateway. Phase 2 must measure this before claiming
+   interrupt works.
+
+One thing the bridge does *better* than Codex: because the Gateway holds the
+session, surviving a Viewer restart needs no process adoption. Re-attaching is
+launching a new bridge with `--session <key> --require-existing`. But the
+`RuntimeEvent` `seq` cursor is per-bridge-process, so `attach(afterSeq)` cannot
+be served by a fresh bridge. Replay stays a Viewer-side responsibility through
+the existing `FileRuntimeEventStore`
+(`codexAppServerHost.ts:709`: `options.eventStore ?? new FileRuntimeEventStore()`),
+with the session file as canonical transcript — the same division Codex
+already uses.
+
+### The `node:sqlite` obstacle: root cause, fix, diagnosis
+
+**The cause is `PATH`.** OpenClaw is fine and Bun is fine; the resolution of
+the name `node` is what breaks.
+
+Reproduced on this machine:
+
+- `openclaw` is a shim whose first line is `#!/usr/bin/env node`.
+- `which node` resolves to `/tmp/bun-node-<hash>/node` — a shim directory Bun
+  prepends to `PATH` for its child processes. `node --version` there answers
+  with a Bun error in place of a version.
+- `bun -e 'require("node:sqlite")'` on Bun 1.3.3 fails: *No such built-in
+  module: node:sqlite*.
+- `openclaw --help` under that `node` terminates with
+  `error: Registry URL must be http:// or https:// Received: "node:sqlite"`.
+- The same command run as `/usr/bin/node <openclaw-dist-entry> --help` exits
+  clean, with no error. `/usr/bin/node` (v26) imports `node:sqlite`
+  successfully; so does a v22 runtime.
+
+And the mechanism by which the Viewer would inherit this: `PATH` is the first
+entry of `CHILD_ENV_ALLOWLIST` at `src/lib/runtime/codexAppServerHost.ts:226`,
+and `subscriptionEnv` (`:396-400`) forwards every allowlisted variable
+verbatim. A Viewer running under Bun hands its Bun-shimmed `PATH` to any child
+it spawns. An `openclaw` child would resolve `node` to Bun and die at startup,
+every time.
+
+Note also that the operator's own running Gateway is launched with an explicit
+absolute path to a bundled Node runtime rather than through the shim — the same
+workaround, arrived at independently.
+
+**The fix.** Never spawn the `openclaw` shim and never depend on inherited
+`PATH`. Spawn the interpreter directly on OpenClaw's entry script:
+
+```
+<node> <openclaw-dist-entry> acp --session <key> [--require-existing] ...
+```
+
+resolved from `LLV_OPENCLAW_NODE` and `LLV_OPENCLAW_ENTRY`, mirroring the
+`options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex"` precedent at
+`src/lib/runtime/codexAppServerHost.ts:771`. The child's `PATH` is rebuilt with
+any `/tmp/bun-node-*` segment removed, so a nested `node` lookup inside
+OpenClaw cannot fall back into the shim.
+
+**The named diagnosis.** `stderrExitDiagnostic`
+(`src/lib/runtime/codexAppServerHost.ts:378`) relays the last four stderr lines
+verbatim — useful, but what it produces is prose, and the observed
+failure string talks about a registry URL. Scraping it is the wrong primary
+mechanism. The host runs a **preflight before spawn**, each check with its own
+code, and a launch failure surfaces as that code rather than as a dead host:
+
+| Code | Check | Operator-facing meaning |
+|---|---|---|
+| `openclaw_runtime_missing` | configured interpreter is absent or not executable | "Set `LLV_OPENCLAW_NODE` to a Node runtime." |
+| `openclaw_runtime_lacks_sqlite` | `<node> -e 'require("node:sqlite")'` exits non-zero | "That runtime has no `node:sqlite`. Bun cannot run OpenClaw; point at Node 22+." |
+| `openclaw_entry_missing` | entry script is absent | "OpenClaw is not installed where the Viewer expects." |
+| `openclaw_gateway_unreachable` | no Gateway backing the bridge | "Start the OpenClaw Gateway; the Viewer will not start it for you." |
+
+The preflight costs two `statSync` calls, one short subprocess and one gateway
+reachability probe, cached per host launch. As a backstop, a post-spawn stderr matcher for `node:sqlite` maps
+into `openclaw_runtime_lacks_sqlite`, since the observed message does contain
+that token even though its prose is about something else.
+
+The preflight is the only place this belongs. `detectLaunchFailure`
+(`src/lib/status.ts:261`) is the other named-failure surface in the codebase,
+but it reads a tmux screen, and the tmux transport is being removed (#1161).
+Adding an OpenClaw case there would be building on a floor that is coming out.
+
+---
+
+## (e) Phasing
+
+### The boundary
+
+**Phase 1: viewing. Phase 2: hosting.** The issue expected this split; three
+things confirm it, and the third is the one that actually decides it.
+
+1. Viewing is additive and root-keyed. Every phase-1 edit is a new branch in an
+   existing `rootName` switch, a new member on a union that already has three,
+   or a new file. Nothing changes behaviour for Claude or Codex.
+2. Viewing has no external dependency. Hosting depends on a service the Viewer
+   does not own (the Gateway), a runtime it does not run (real Node), and a
+   claim model that does not exist (no exclusive session ownership). Two of
+   those three still carry open uncertainties — see (d). Bundling them with
+   viewing would hold a shippable increment hostage to them.
+3. **Hosting's data model rides on viewing's.** `SessionKey`
+   (`src/lib/agent/sessionKey.ts:7`) is `{engine, sessionId}`, and
+   `normalizeSessionId` (`:14`) requires the whole value to be a bare
+   v4-shaped id. OpenClaw header ids satisfy that — but the *filename* does
+   not, for the 17 of 54 files named `-topic-<n>`. Phase 1 is what establishes
+   that the registry's `sessionId` comes from the header rather than the
+   filename, and proves the registry↔transcript join with fixtures. Phase 2
+   adopts and resumes against that join. Doing them together means designing
+   the join and the host lifecycle at once, against a shape that phase 1's own
+   evidence only just corrected.
+
+There is a fourth reason, opportunistic but real: the boundary drawn here keeps
+phase 1 out of `src/lib/scanner/process.ts`, which the #1199 lane owns.
+`AgentEngine` is the *hostable*-engine union, and phase 1 deliberately does not
+make OpenClaw hostable, so it does not widen it.
+
+### What phase 1 ships
+
+Board and feed parity for OpenClaw conversations — Expected 1 and 2 — with
+OpenClaw explicitly **not** hostable and every Class-A predicate still
+answering "no".
+
+Work plan, in dependency order. None of these files are owned by another lane
+except where flagged.
+
+**1. `src/lib/types.ts`** — `RootKey` gains `"openclaw-sessions"` (`:8-11`);
+`Engine` gains `"openclaw"` (`:13`); `Fmt` gains `"openclaw"` (`:15`).
+Compile and read every error: they are the exhaustive-position call sites, and
+they are the only ones the compiler will ever hand you.
+
+**2. `src/lib/scanner/roots.ts`** — add the OpenClaw root to `ROOTS` (`:33`)
+resolved from `OPENCLAW_STATE_DIR` with `~/.openclaw` default; extend
+`scanRootEntries()` (`:39`) to fan out one entry per `<stateDir>/agents/*/
+sessions` directory. Add `openclawSessionRootFor(candidate)` beside
+`codexSessionRootFor` (`:83`) so `/api/log` path allowlisting covers the new
+root. Declare the `TranscriptRootDescriptor` here.
+
+**3. `src/lib/scanner/discover.ts:347`** — replace the two-way root ternary
+with a descriptor lookup, and fix the title fallback at `:365` alongside it.
+
+**4. `src/lib/scanner/describe.ts`** — add an `else if (rootName ===
+"openclaw-sessions")` branch to `deriveTranscriptMetadata` (after `:983`)
+setting `engine`/`fmt`/`kind`, reading `cwd` and `sessionStartedAt` from the
+header record, and taking the title from the first `"user"` message. Add the
+`projectInfoFromOpenclawWorkspace` early-return after `:539`.
+
+**5. `src/lib/accounts/migration/turnState.ts:92`** — change the `codex:
+boolean` parameter to a discriminator, add the OpenClaw arm keyed on the last
+assistant record's `stopReason`, and update the two call sites
+(`src/lib/scanner/activity.ts:175` and `:428`) plus the `cached.codex ===
+codex` cache-key comparisons at `:165`, `:184`, `:212`, `:256`.
+
+**6. The three persisted-cache validators, in one commit** —
+`src/lib/scanner/scanCache.ts:105,109,111` plus bumping
+`FILE_SCAN_CACHE_SCHEMA_VERSION` at `:75` from 9 to 10;
+`src/lib/scanner/projectCatalog.ts:136-137`;
+`src/lib/resourceCollector.worker.ts:45`.
+
+**7. `src/components/feed/parse.ts`** — `renderOpenclaw`, and the dispatch at
+`:2127`. **This file is owned by the #1202 lane.** See Conflicts below.
+
+**8. `src/lib/scanner/effort.ts`** — add `"off"` and `"adaptive"` to `TIERS`
+(`:10`); add an `entry.root === "openclaw-sessions"` arm to `pickEffort`
+(`:18`) reading `thinkingLevel` from `thinking_level_change` records. Do
+**not** touch `argvEffort` (`:34`) — there is no per-session process to read
+argv from.
+
+**9. The capability predicate** — define `isHostableEngine` (suggested home:
+`src/lib/agentCapabilities.ts` or beside `Engine` in `src/lib/types.ts`) and
+adopt it at the Class-A sites. Behaviour-preserving by construction; the value
+is that phase 2 becomes a one-line change with a test instead of a 32-file
+audit.
+
+Exactly three of those 32 files sit in fenced lanes —
+`src/lib/mcp/bindings.ts` and `src/components/LogFeed.tsx` under #1202,
+`src/lib/resources.ts` under #1199. Phase 1 adopts the predicate in the other
+29 and leaves those three copies in place. Since the predicate is
+defined to exclude OpenClaw, the mixed state behaves identically either way,
+and the leftovers are a mechanical follow-up once those lanes merge.
+
+**10. Class B, the eight erasure sites** — `parse.ts:1311` and `:1486` are
+inside the fenced feed directory and ride with item 7. The other six take an
+explicit third arm. `src/lib/runtime/liveTurn.ts:374` and
+`RuntimeLiveTurnToolEngine` (`:22`) can wait for phase 2, since nothing
+produces live-turn rows for a non-hosted engine; note it in the phase-2 issue
+rather than widening a hosting type in a viewing PR.
+
+**Tests**, all against invented fixtures under an isolated
+`HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run **by path**:
+
+- `src/lib/scanner/describe.test.ts` — the case AGENTS.md requires: an OpenClaw
+  workspace cwd resolves to the same project whether or not the directory
+  exists, and a workspace carrying a remote-less `.git` still resolves to the
+  directory identity rather than a `repo-` identity.
+- `src/lib/scanner/discover.test.ts` — a fixture agent tree yields one entry
+  per transcript, and zero for `.trajectory.jsonl`, `.checkpoint.<id>.jsonl`,
+  `.acp-stream.jsonl`, `.trajectory-path.json`, `sessions.json` and `.bak`
+  siblings.
+- `src/lib/accounts/migration/turnState.test.ts` — `stopReason` of `stop`
+  reads terminal, `toolUse` reads busy, `error`/`aborted` read terminal.
+- a new `src/components/feed/openclaw.test.ts` — the six-row mapping table
+  above, plus a synthetic-provider record not setting the displayed model.
+- `src/lib/scanner/effort.test.ts` — `off` and `adaptive` normalise; an
+  unknown tier still returns null.
+
+**Gates:** `bunx tsc --noEmit --incremental false`; the touched test files by
+path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
+--check-commits`; a non-draft PR against `main` with an identity-free body.
+
+### What phase 1 explicitly does not ship
+
+`AgentEngine` stays two-membered. `isHostableEngine` returns false for
+OpenClaw. `SessionKey` cannot name an OpenClaw session. No spawn path, no
+registry entry, no delivery controller. Model and effort **controls** — Expected
+5 — are phase 2, because they configure a launch and phase 1 does not launch
+anything; phase 1 gets read-only model/provider display for free from the
+assistant records.
+
+### Phase 2, sketched
+
+`AgentEngine` widening; `isHostableEngine` flipped; an `OpenclawAcpHost`
+implementing `EngineHost`; the preflight and its four diagnosis codes; third
+arms at `structuredSpawn.ts:1312` and `:1372`; the advisory-claim change to the
+registry; `--model` and `--thinking` wired to the existing model/effort
+controls. Its own PR, its own tests, its own issue. The open uncertainties from
+(d) — whether `session/cancel` aborts a run, and whether
+`session/request_permission` reaches the attention queue — get measured at the
+start of phase 2, before anything is built on them.
+
+---
+
+## Conflicts with live lanes
+
+Reported rather than worked around, per the assignment's file-ownership fence.
+
+**`src/components/feed/parse.ts` — owned by the #1202 lane.** Phase 1 needs
+`renderOpenclaw` and the one-line dispatch at `:2127`, and both Class-B sites
+at `:1311` and `:1486` are in the same file. There is no way to add a third
+`Fmt` renderer without touching it; putting `renderOpenclaw` in a new file
+under `src/components/feed/` does not help, because that directory is fenced
+too.
+
+Recommended sequencing, for the next stage to confirm with the operator:
+land phase-1 items 1–6, 8, 9 and the six non-feed Class-B sites of item 10
+first — all outside both fences, and together they give scanning, attribution,
+turn state and effort — then land the feed renderer plus the two Class-B sites
+inside `parse.ts` as a follow-up PR once #1202 merges. Until then OpenClaw conversations appear on the
+board with correct titles, projects, models and activity, and open in the feed
+through the `"plain"` fallback rather than a structured render. That is a
+visible gap and should be stated in the phase-1 PR rather than hidden.
+
+**Not in conflict, and deliberately so:** `src/lib/scanner/process.ts`,
+`src/lib/resources.ts`, `src/lib/runtime/structuredDeliveryController.ts`,
+`src/components/ResourcesFooter.tsx` (#1199) and `src/lib/mcp/**`,
+`src/lib/orchestrator/prompt.ts`, `src/components/LogFeed.tsx` (#1202) are all
+untouched by phase 1. Three of them hold Class-A narrowing predicates
+(`src/lib/resources.ts:793`, `src/lib/mcp/bindings.ts`,
+`src/components/LogFeed.tsx`) and `src/components/ResourcesFooter.tsx:474`
+holds a Class-C label expression. All four degrade safely under a widened
+union: the predicates keep answering "no" for OpenClaw, which is the phase-1
+answer anyway, and the footer renders `?` for an unknown engine, which is
+honest. None of them needs an edit to ship phase 1; they are the leftovers item
+9 deliberately skips.
+
+---
+
+## Deferred — not currently justified
+
+Cut from this design, with the reason. None of it is discarded.
+
+**An engine-descriptor registry spanning the UI.** Would not fix the 107 binary
+ternaries, which are the actual cost, and would abstract for a fourth engine
+nobody has asked for. Revisit if a fourth engine appears. See (a).
+
+**Merging trajectory and checkpoint files into the conversation.** The issue's
+Expected 1 assumes a three-file join. The evidence says the session file is
+self-sufficient, the trajectory adds only `sessionKey`, and a checkpoint is a
+complete alternative transcript whose merge would duplicate history. Building
+the join would be machinery heavier than the problem.
+
+**`sessions.json` as a metadata source.** Indexes only recent sessions (21 of
+54 on the machine inspected); using it would silently hide the rest.
+
+**Process-based liveness for OpenClaw.** One Gateway process writes every
+session; pid attribution would map every conversation to the same pid.
+Reconsider only if OpenClaw grows per-session processes.
+
+**Model registry entries for OpenClaw's models.** `MODEL_REGISTRY`
+(`src/lib/scanner/modelRegistry.ts:13`) is an Anthropic context-window
+snapshot. OpenClaw runs OpenAI-family models through an OpenAI response API, so
+`normalizeModelKey` finds no entry and `registryWindow` returns null — an
+unknown context window, which is the correct answer here. Adding OpenAI
+model windows is a separate decision with its own maintenance burden and is not
+required by the requirement.
+
+**Account and limits integration.** `LimitsCache`
+(`src/lib/limits.ts:38,50`) is `Record<EngineName, …>` behind `version: 2`;
+adding a third key is a persisted-shape migration. But OpenClaw does not have
+its own subscription — it routes to an OpenAI provider whose quota is already
+accounted elsewhere — so a third limits engine would report a window that does
+not exist. Out of scope until OpenClaw's account model is understood.
+
+**`openclaw agent --json` as a fallback transport.** Genuinely unsuitable for
+hosting, but it is the simplest possible "send one message and read the reply".
+If phase 2's ACP work stalls on the Gateway dependency, it is a viable reduced
+mode — send only, no streaming, no interrupt — and should be reconsidered then
+rather than built now.
+
+**Per-agent-id project grouping.** Presentational; can ride on card titles
+without a second project-id namespace. See (c).
+
+---
+
+## Validation against the requirement
+
+Read back against the quote at the top.
+
+*"the Viewer scans and renders OpenClaw conversations"* — phase 1, items 1–8.
+Scanning is complete on merge of items 1–6; rendering is complete on merge of
+item 7, which is gated on the #1202 lane and flagged above rather than assumed.
+
+*"the Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
+message, stream the turn, resume, kill)"* — phase 2, over the ACP bridge, with
+one honest deviation the operator should see now rather than at delivery:
+**"kill" cannot mean what it means for Claude and Codex.** The Gateway owns the
+agent, so releasing the host stops the Viewer watching while the agent keeps working.
+Every other verb in the sentence maps cleanly.
+
+*"at the same level Claude and Codex already are"* — reached for scanning,
+rendering, project attribution, turn state and model display. Not reached, and
+not proposed, for accounts, limits and process-level liveness — because for
+those three OpenClaw has no equivalent to be at the same level as. Claiming
+parity there would mean inventing a subscription and a per-session process that
+do not exist.
+
+Nothing in this design exists because it was interesting. The one place the
+design deliberately spends more than the minimum is the named capability
+predicate, which is behaviour-preserving in phase 1 and buys a checkable
+one-line change in phase 2 instead of a 32-file audit.

--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -10,15 +10,15 @@ Verbatim, from the operator's request line in GitHub issue #1207 (opened
 > Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
 > message, stream the turn, resume, kill).
 
-Everything below is validated against that sentence. Scope that the sentence
-does not demand is preserved in **Deferred — not currently justified**.
+Everything below is validated against that sentence. Scope beyond the sentence
+is preserved in **Deferred — not currently justified**.
 
 ## Evidence discipline
 
 Two sources: this repository, and read-only inspection of the OpenClaw
-2026.6.10 install on the development machine. Source evidence was first read at
-`ac197031` and re-verified against `main` at `e61c1ce4`, which is the baseline
-phase 1 is cut from — see *Baseline and lane ownership*. No OpenClaw state was
+2026.6.10 install on the development machine. Source evidence was re-verified
+against `origin/main` at `dbfa3753` on 2026-08-27. That commit includes the
+structured-host inventory and kill work from #1203. No OpenClaw state was
 written, and the operator's running Gateway was not started, stopped or
 reconfigured.
 
@@ -36,18 +36,17 @@ and cites what was measured instead.
 
 | # | Question | Decision |
 |---|----------|----------|
-| a | Engine surface | A third union member on `Engine`/`Fmt`, in preference to an engine-descriptor registry. The seam is `Fmt` for rendering plus a named `hostable` predicate for lifecycle. |
+| a | Engine surface | Add `openclaw` to `Engine` and `Fmt`. Use explicit third arms at the viewing call sites. Defer the repository-wide hostability predicate and root-descriptor abstraction. |
 | b | Viewing | The session file alone is authoritative for the message chain **and** for model/provider. The trajectory supplies only `sessionKey`. Checkpoints are excluded from discovery. |
-| c | Project attribution | A pure path recognizer for the OpenClaw workspace, minting one stable directory identity, inserted ahead of every disk-dependent resolver. |
-| d | Hosting transport | The ACP bridge (`openclaw acp`), spawned through an explicit real-Node interpreter, behind a four-check preflight whose every message names the interpreter it resolved. |
-| e | Phasing | Viewing (phase 1) / hosting (phase 2). Phase 1 is one PR — scanning, attribution, turn state and structured rendering together — cut against `main` at `e61c1ce4`. |
+| c | Project attribution | Add an exact-workspace pure path recognizer before disk-dependent resolution, and call the existing overlay for OpenClaw roots. Descendant repositories retain normal repository attribution. |
+| d | Hosting transport | Keep ACP as the leading candidate. Do not select it for implementation until an isolated Gateway proves cancellation and kill parity. The installed bridge lacks status and model methods and hides `chat.abort` failures. |
+| e | Phasing | Phase 1 ships viewing in one PR: discovery, stable attribution, list/search, model and effort display, turn state, and structured feed rendering. Hosting remains phase 2 after its transport gates pass. |
 
 ---
 
 ## Corrections to the issue's starting facts
 
-The issue asked for these to be re-verified rather than assumed. Four of them
-did not survive.
+Verification changed four of the issue's starting facts.
 
 **1. Model and provider do not come from the trajectory file.** The issue says
 "The trajectory file supplies model/provider/run metadata; the session file
@@ -68,13 +67,11 @@ without the `-topic-<n>` suffix. Header ids are bare v4-shaped ids in 52 of 54
 cases and are unique across all files and across both agent ids. The header is
 the identity; the filename is not.
 
-**4. Checkpoints are not fragments to merge.** The one checkpoint file present
-is a *complete* transcript in its own right — its own `"session"` header, then
-its own `parentId`-chained message records — and the session file it is named
-after does not exist. A checkpoint is an alternative branch of a conversation,
-not a continuation of one. Merging it into the base conversation would
-duplicate the whole history. Phase 1 excludes `*.checkpoint.*.jsonl` from
-discovery.
+**4. Each checkpoint is a self-contained transcript.** The one checkpoint file
+present has its own `"session"` header and `parentId`-chained message records.
+The session file named by that checkpoint does not exist. Merging the checkpoint
+would duplicate its complete history. Phase 1 excludes
+`*.checkpoint.*.jsonl` from discovery.
 
 The `-topic-<n>` naming and the checkpoint-as-fork shape are inferences from
 file structure; OpenClaw's own semantics for them were not read out of its
@@ -88,209 +85,85 @@ exclusion.
 
 ### What is actually there
 
-There are already **three** engine unions with three different memberships:
+There are already **four** engine unions with three different memberships:
 
-- `src/lib/types.ts:13` — `export type Engine = "codex" | "claude" | "shell"`
-- `src/lib/types.ts:15` — `export type Fmt = "codex" | "claude" | "plain"`
-- `src/lib/scanner/process.ts:13` — `export type AgentEngine = "claude" | "codex"`
+- `src/lib/types.ts:13`: `export type Engine = "codex" | "claude" | "shell"`
+- `src/lib/types.ts:15`: `export type Fmt = "codex" | "claude" | "plain"`
+- `src/lib/agent/cli.ts:29`: `export type AgentEngine = "claude" | "codex"`
+- `src/lib/scanner/process.ts:14`: a second `AgentEngine` with the same members
 
-plus 38 inline `"claude" | "codex"` type literals spread over 18 non-test
-component files — the "~15 component files" the issue counted — and more in
-`src/lib`: `src/components/AccountBadge.tsx:31`,
-`src/components/draftSpawn.ts:17`, `src/components/DraftAgentPane.tsx:54`,
-`src/components/RuntimePill.tsx:548`, `src/lib/events.ts:65` and `:88`,
-`src/lib/limits.ts:38`, `src/lib/limitsHistoryStore.ts:21`,
-`src/lib/types.ts:680`, `src/lib/lifecycle/inventorySelection.ts:43`.
+Inline two-engine unions also appear across components, launch controls,
+accounts, limits, registry, and runtime code. Most describe hostable engines or
+engine-specific products. Phase 1 widens only the viewing types identified
+below.
 
-`Engine` already carries a third member. `"shell"` — background tasks under the
-`claude-tasks` root — is referenced in 18 non-test files and the codebase
-handles it without incident. **That is the empirical answer to "how much does a
-third member cost": the widening itself is nearly free, and it has been paid
-once already.**
+`Engine` already carries a third member. `"shell"` represents background tasks
+under the `claude-tasks` root and appears in 18 non-test files. The existing
+member shows that union widening has low direct cost; engine-specific behavior
+creates the work.
 
 ### The branches, classified
 
-308 engine comparisons across 124 non-test files
-(`engine === "codex"`, `=== "claude"`, and their negations). They fall into
-four classes, and only two of them matter.
+At `origin/main` `dbfa3753`, the repeated
+`engine === "claude" || engine === "codex"` idiom appears in 33 non-test
+files. A repository-wide replacement would dominate phase 1 while preserving
+its current behavior. Phase 1 changes only the viewing call sites that must
+accept OpenClaw:
 
-**Class A — narrowing predicates, in 32 non-test files. Safe. Do not touch in
-phase 1.**
+- `src/lib/scanner/index.ts:300` and `src/lib/scanner/observe.ts:76` decide
+  whether to derive authoritative turn state.
+- `src/lib/scanner/scanCache.ts:173` primes persisted turn evidence.
+- `src/lib/scanner/projectCatalog.ts:582` decides whether a transcript enters
+  the complete list/search catalog.
 
-The idiom `entry.engine === "claude" || entry.engine === "codex"` is the single
-most repeated engine expression in the codebase. Representative sites:
-`src/lib/scanner/index.ts:300`, `src/lib/scanner/observe.ts:76`,
-`src/lib/scanner/scanCache.ts:173`,
-`src/lib/lifecycle/inventorySelection.ts:98`,
-`src/lib/lifecycle/liveness.ts:532` and `:681`,
-`src/lib/session/titleTarget.ts:68`, `src/lib/session/titleStore.ts:163`,
-`src/lib/accounts/migration/coordinator.ts:87`,
-`src/lib/workflows/store.ts:218`, `src/lib/wakatime/operatorActivity.ts:84`,
-`src/app/api/tasks/[id]/send/route.ts:80`,
-`src/app/api/tasks/[id]/spawn/route.ts:221`, `src/lib/agent/registry.ts`
-(2), `src/lib/runtime/commands.ts` (2), `src/lib/mcp/bindings.ts` (4),
-`src/lib/tasks/store.ts`, `src/lib/pipelines/store.ts`,
-`src/lib/view/snapshot.ts`, `src/hooks/useSwitchboardData.ts`. Reproduce the
-full list with (add `-l` for the file list, which is the unit that matters —
-several lines carry two matches, so an occurrence count lands anywhere between
-35 and 39 depending on how you count):
+The other narrowing predicates govern host lifecycle, launch, account
+migration, tasks, workflows, and runtime controls. They keep excluding
+OpenClaw during phase 1.
 
-```
-grep -rnE 'engine === "(claude|codex)" \|\| [^)]*engine === "(codex|claude)"' \
-  src/ --include='*.ts' --include='*.tsx' | grep -v '\.test\.'
-```
+Eight erasure coercions use `engine === "codex" ? "codex" : "claude"`.
+Phase 1 fixes the two feed coercions at
+`src/components/feed/parse.ts:1311,1486`, because OpenClaw prose and tool rows
+reach them. The launch, review-flow, task-send, inbox, and live-turn coercions
+remain unreachable for a view-only engine and move to phase 2.
 
-Every one of them is asking *"is this an engine I can host, rename, hydrate or
-spawn?"* — and under a widened union each one keeps answering **no** for
-OpenClaw, which is exactly right for phase 1. The codebase already has a safe
-default for a third engine, and it spread the definition across 32 files
-without naming it. That spread is the argument for naming it before phase 2.
+The root-specific viewing work is bounded:
 
-**This count was wrong in an earlier draft of this document, and the correction
-is worth keeping visible: the first pass found 15 files, and the real figure is
-32.** Two reasons, both of which will bite anyone who re-derives this with a
-quick grep. The idiom appears in *both operand orders* — `claude || codex` and
-`codex || claude` — and a pattern anchored on one order silently halves the
-result. And it turns up in files with nothing else engine-shaped in them
-(`src/lib/view/snapshot.ts`, `src/hooks/useSwitchboardData.ts`,
-`src/lib/pipelines/store.ts`), so a search scoped to the files that *look*
-engine-related misses them too. Anyone sizing item 9 from a single-order grep
-will plan half the work.
-
-**Class B — erasure coercions (8 sites). Actively wrong. Must be fixed.**
-
-`src/components/DraftAgentPane.tsx:396`,
-`src/components/flows/directReviewGroups.ts:134` and `:146`,
-`src/components/feed/parse.ts:1311` and `:1486`,
-`src/app/api/tasks/[id]/send/route.ts:94`,
-`src/lib/runtime/liveTurn.ts:374`,
-`src/lib/tasks/inboxScanner.ts:144`.
-
-These read `engine === "codex" ? "codex" : "claude"` and *relabel* anything
-that is not Codex as Claude. TypeScript approves: the expression is total over
-any union. An OpenClaw conversation flowing through
-`src/lib/tasks/inboxScanner.ts:144` becomes a Claude conversation in the task
-inbox, and nothing anywhere reports it.
-
-**Class C — presentation ternaries (~99 sites). Cosmetic. Long tail.**
-
-Colours, labels, avatars: `src/components/utils.ts:95`,
-`src/components/feed/FeedItem.tsx:106-107`,
-`src/components/scheme/offscreenClusters.ts:384`. A third engine renders in
-Claude's colour with Claude's icon. Wrong, visible, harmless, and fixable
-incrementally.
-
-**Class D — genuinely engine-specific machinery. This is the real work.**
-
-Eight places, all of them keyed on the transcript **root** rather than on a
-free-floating engine string:
-
-| Concern | Site | Shape |
+| Concern | Current gate at `dbfa3753` | Phase-1 change |
 |---|---|---|
-| Root inventory | `src/lib/scanner/roots.ts:33-47` | `Record<RootKey, string>` + `scanRootEntries()` |
-| Root → engine | `src/lib/scanner/discover.ts:347` | `rootName === "codex-sessions" ? "codex" : "claude"` |
-| Metadata derivation | `src/lib/scanner/describe.ts:918-983` | `if (rootName === …) else if … else if …` |
-| Turn state | `src/lib/scanner/activity.ts:428` → `src/lib/accounts/migration/turnState.ts:92` | a **boolean** `codex: boolean` |
-| Effort extraction | `src/lib/scanner/effort.ts:19-30` | `entry.root === "codex-sessions"` / `"claude-projects"` |
-| Feed rendering | `src/components/feed/parse.ts:2127` | `cfg.fmt === "claude" ? renderClaude : renderCodex` |
-| Host construction | `src/lib/runtime/structuredSpawn.ts:1312`, `:1372` | `engine === "codex" ? … : …` |
-| Persisted-cache validators | `src/lib/scanner/scanCache.ts:105,109,111`; `src/lib/scanner/projectCatalog.ts:136-137`; `src/lib/resourceCollector.worker.ts:45` | literal enum echoes |
+| Discovery | `src/lib/scanner/roots.ts:33-47`; `discover.ts:347` | Add the root and an explicit third branch. |
+| Metadata and search text | `describe.ts:883,889-999` | Parse OpenClaw cwd, start time, title, and first prompt. |
+| Project overlay | `describe.ts:1001-1035` | Route OpenClaw cwd through `projectInfoFromCwd`. |
+| Turn state | `turnState.ts:92`; `activity.ts:156-194,428` | Replace the `codex: boolean` parameter and cache key with an engine discriminator. |
+| Model | `scanner/model.ts:25-45` | Admit the root and read the latest real assistant model. |
+| Effort | `scanner/effort.ts:10,17-30,62-64` | Admit the root and read `thinking_level_change`. |
+| Complete catalog | `conversationCatalog.ts:15`; `projectCatalog.ts:582` | Add OpenClaw to the catalog type and filter. |
+| Feed | `feed/parse.ts:226,1374,2127`; `feed/tools.ts:184-188` | Add a structured renderer and carry the engine through prose and tool rows. |
+| Persisted shapes | `scanCache.ts:105,109,111`; `projectCatalog.ts:124,136-137`; `resourceCollector.worker.ts:53` | Widen validators together and bump the scan schema from 9 to 10. |
 
-Of these, only two are structurally hostile.
-
-`turnStateFromRecords(records, codex: boolean, authoritative)` at
-`src/lib/accounts/migration/turnState.ts:92` cannot express a third engine at
-all — the parameter is a boolean, fed from `root.startsWith("codex")` at
-`src/lib/scanner/activity.ts:428`. A new root falls into the `false` arm and
-gets Claude's parser, which keys on `record.type === "assistant"` and
-`message.stop_reason` (`turnState.ts:166-173`). No OpenClaw record has
-`type: "assistant"` — they are all `type: "message"` — so every branch misses
-and the function returns `{ state: "unknown", source: "empty" }` forever. The
-failure is quiet and degrades to mtime-only activity rather than lying, but the
-boolean must become a discriminator before OpenClaw can report turn state.
-
-The three persisted-cache validators echo the enums as literals. Widen one and
-not the others and entries are silently dropped:
-`src/lib/resourceCollector.worker.ts:45` discards the whole entry;
-`src/lib/scanner/projectCatalog.ts:136-137` blanks `engine` and `fmt` to
-`undefined`. **They move together, in the same commit, with
-`FILE_SCAN_CACHE_SCHEMA_VERSION` (`src/lib/scanner/scanCache.ts:75`) bumped from
-9 to 10** so an older build rejects a newer snapshot wholesale and rescans
-instead of reading it through a narrower enum.
-
-### Registry of engine descriptors, or a third union member?
-
-**A third union member.** A descriptor registry is over-built here, and the
-evidence for that is specific rather than aesthetic:
-
-1. The widening is already proven cheap — `"shell"` did it.
-2. A descriptor cannot help Class B or Class C at all. Those 107 ternaries are
-   binary expressions that are *total* over any union; no amount of descriptor
-   indirection makes `x === "codex" ? a : b` stop compiling. They have to be
-   read and fixed by hand either way.
-3. The facts that genuinely vary are few, they all live in the scanner, and
-   they are already keyed on `RootKey` — which is a descriptor key in all but
-   name.
-
-What is worth building is far smaller than a registry: **one root descriptor**,
-declared next to `ROOTS`, carrying exactly the five facts the scanner branches
-on.
-
-```ts
-interface TranscriptRootDescriptor {
-  root: RootKey;
-  engine: Engine;          // discover.ts:347 reads this instead of branching
-  fmt: Fmt;                // selects the feed renderer
-  dir: () => string[];     // account homes / profile dirs
-  isTranscript(basename: string): boolean;  // excludes .trajectory/.checkpoint/.bak
-}
-```
-
-That is the whole descriptor. It does **not** carry launch arguments, model
-catalogues, account shapes or UI labels — those either do not exist for
-OpenClaw in phase 1 or are better expressed as the capability predicate below.
-Proposing a descriptor that carries them would be building the abstraction for
-a fourth engine that nobody has asked for.
+`turnStateFromRecords(records, codex: boolean, authoritative)` cannot express
+OpenClaw. The false arm expects Claude records whose top-level type is
+`assistant`; OpenClaw wraps assistant messages in a top-level `message` record.
+The replacement parameter is `engine: "codex" | "claude" | "openclaw"`.
+`activity.ts`, `scanner/index.ts`, `scanner/observe.ts`, and the persisted cache
+pass that value without another boolean conversion.
 
 ### The seam
 
-Three named things, and they are what keep the third engine off 300 call sites.
+Phase 1 uses the seams already present:
 
-1. **`Fmt` is the rendering seam.** `src/components/feed/parse.ts:2127`
-   dispatches on `cfg.fmt`, and `renderClaude`
-   (`src/components/feed/parse.ts:1943`) is a pure record→primitive emitter: it
-   calls `addUserText`, `addProse`, `push({kind:"think"})`,
-   `registerCall(newToolEvent(…))`, `addOutput`, `addCompact`, `pushImage`, and
-   returns. A third renderer calling the same primitives is the entire feed
-   change. No card, no tool summariser, no timeline consumer learns a third
-   engine.
+1. `Fmt` selects `renderOpenclaw` beside the existing renderers in
+   `src/components/feed/parse.ts`.
+2. `RootKey` selects the explicit scanner branch in discovery, metadata, model,
+   effort, and turn-state code.
+3. `EngineHost` remains the phase-2 host boundary at
+   `src/lib/runtime/engineHost.ts:100-108`.
 
-2. **A named capability predicate is the lifecycle seam.** The 32 Class-A
-   files already implement it; give it a name and a single definition —
-
-   ```ts
-   /** Engines the Viewer can host, resume, rename and hydrate. */
-   export function isHostableEngine(engine: Engine | null | undefined): engine is AgentEngine
-   ```
-
-   — and adopt it at those sites. This is the precedent
-   the codebase already set for capability probing:
-   `hostSupportsCompact(host)` at `src/lib/runtime/engineHost.ts:126`. Phase 1
-   defines it to exclude OpenClaw; phase 2 changes it in one place and every
-   call site follows. Without the name, phase 2 is a 32-file audit that a
-   reviewer cannot check.
-
-3. **`EngineHost` is the hosting seam** (`src/lib/runtime/engineHost.ts:100`).
-   Six methods. `src/lib/runtime/structuredSpawn.ts:1312` and `:1372` are the
-   only two construction sites, and both are `if/else` — turning them into a
-   three-way switch is a phase-2 edit of two functions.
-
-**What the seam does not protect.** Class B's eight erasure sites and Class C's
-ninety-nine presentation ternaries sit outside all three seams, and no seam can
-pull them in, because they are expressions over the union rather than
-dispatches through it. TypeScript will not flag a single one. They must be
-enumerated by grep and fixed by reading. This document's Class B list is that
-enumeration for the eight that produce wrong data.
+A root descriptor adds an abstraction around three transcript roots and does
+not reduce the phase-1 edits above. A global `isHostableEngine` migration adds
+changes across 33 files before OpenClaw is hostable. Both move to
+**Deferred — not currently justified**. Phase 2 can introduce one narrow
+hostability helper after its transport is proven and its real call sites are
+known.
 
 ---
 
@@ -309,7 +182,7 @@ Measured shape, over 54 files:
 - Record types thereafter: `"message"` (2 940), `"custom"` (33),
   `"model_change"` (23), `"thinking_level_change"` (23).
 - Every `"message"` record has exactly `{id, parentId, timestamp, type,
-  message}` — a `parentId` chain, structurally the same idea as Claude's
+  message}`, a `parentId` chain with the same structural role as Claude's
   `uuid`/`parentUuid`.
 - `message.role` is one of `"user"` (205), `"assistant"` (1 452) or
   `"toolResult"` (1 283).
@@ -325,15 +198,13 @@ Inner `message` objects, on the assistant records:
   must not assume the key set is invariant across OpenClaw versions.
 - `stopReason` ∈ `{toolUse, stop, error, aborted}`.
 
-`stopReason` is the turn-state signal, and it is cleaner than either engine's
-current one: the last assistant record ending in `stop` is a completed turn;
-`toolUse` is a turn still running; `error`/`aborted` are terminal. That is the
-third branch of `turnStateFromRecords` in about five lines.
+`stopReason` is the turn-state signal. The last assistant record ending in
+`stop` is a completed turn. `toolUse` keeps the turn busy, and `error` or
+`aborted` ends it.
 
-Two provider values are synthetic — records OpenClaw injected rather than
-model output, distinguishable because `provider` is `openclaw` rather than a
-real provider name. They must not be counted as model usage and must not set
-the conversation's displayed model.
+Two measured records use the synthetic provider value `openclaw`. Real model
+outputs name an external provider. Synthetic records do not count as model
+usage and cannot set the displayed model.
 
 `model_change` and `thinking_level_change` records carry `{modelId, provider}`
 and `{thinkingLevel}` respectively, which is where mid-conversation model and
@@ -349,10 +220,9 @@ modelId, modelApi, data}`. Event types: `session.started`, `context.compiled`,
 `session.ended`, `trace.metadata`, `trace.artifacts`, `turn.client_closed`.
 
 Everything there except `sessionKey` duplicates the session file. `sessionKey`
-does not appear in the session file at all, and it is what phase 2 needs to
-resume a session (`openclaw acp --session <key>`). Phase 1 reads it — from the
-first `session.started` event, whose `data.sessionFile` is also the reliable
-back-pointer to the transcript — and stores it, doing nothing else with it.
+does not appear in the session file and is needed only for hosting. Phase 1
+excludes trajectories. Phase 2 reads the first `session.started` event and uses
+its `data.sessionFile` back-pointer to join the key to the transcript.
 
 "session" in the trajectory names a *run*. There were 143
 `session.started` events across 58 files, one per submitted prompt.
@@ -361,7 +231,7 @@ back-pointer to the transcript — and stores it, doing nothing else with it.
 
 Two independent signals, and one of them does not work here.
 
-**Signal 1 — mtime and turn state. Works.** `resourceActivity` at
+**Signal 1: mtime and turn state.** `resourceActivity` at
 `src/lib/scanner/discover.ts:337-340` grades by transcript age (`< 20 s` live,
 `< 900 s` recent, else idle) and is engine-agnostic. Layered on it,
 `src/lib/scanner/activity.ts:428` reads the transcript tail for turn state.
@@ -369,19 +239,17 @@ Once the OpenClaw branch of `turnStateFromRecords` exists, a trailing assistant
 record with `stopReason: "toolUse"` reads as busy and one with `"stop"` reads
 as done, matching the fidelity Claude and Codex have.
 
-**Signal 2 — process attribution. Does not work, and phase 1 must not pretend
-it does.** `argvEngine` at `src/lib/scanner/process.ts:122` maps a live process
+**Signal 2: process attribution is unavailable.** `argvEngine` at
+`src/lib/scanner/process.ts:122` maps a live process
 to an engine by binary basename, and `agentProcesses()` at `:155` pairs one pid
 to one transcript by cwd. OpenClaw has no per-session process. One long-lived
-Gateway process writes every session file for every agent id and every channel
-— observed on this machine as a single `node … openclaw/dist/index.js gateway
---port <port>`. Mapping it to a conversation would attribute every OpenClaw
+Gateway process writes every session file for every agent id and every channel.
+It was observed as one `node … openclaw/dist/index.js gateway --port <port>`
+process. Mapping it to a conversation would attribute every OpenClaw
 session to the same pid.
 
-Phase 1 therefore leaves `pid`/`proc` null for OpenClaw entries. This costs
-nothing that matters: `argvEngine` returns `AgentEngine`, which phase 1 does
-not widen, so `src/lib/scanner/process.ts` — a file the #1199 lane owns — is
-not touched at all.
+Phase 1 leaves `pid` and `proc` null for OpenClaw entries. `AgentEngine` stays
+two-membered, so `src/lib/scanner/process.ts` remains unchanged.
 
 ### How the scanner discovers sessions across agent ids
 
@@ -402,7 +270,7 @@ The sessions directory is not clean, and the filter is the load-bearing part.
 Beside real transcripts it holds `.trajectory.jsonl`, `.trajectory-path.json`,
 `.codex-app-server.json`, `.acp-stream.jsonl`, `.checkpoint.<id>.jsonl`,
 `sessions.json`, and dated `.bak` / `.deleted.<timestamp>` files from past
-repairs — in the agent inspected, 58 trajectories, 58 `trajectory-path`
+repairs. In the agent inspected, 58 trajectories, 58 `trajectory-path`
 sidecars and 36 app-server sidecars against 54 transcripts, plus a long tail of
 backups. `isTranscript(basename)`
 admits `*.jsonl` and rejects any basename containing `.trajectory.`,
@@ -413,7 +281,7 @@ count with sidecars and dead backups.
 `sessions.json` deserves a note because it looks tempting and should not be
 used. It is a live index keyed by session key carrying `sessionFile`,
 `sessionId`, `label`, `model`, `modelProvider`, token counts, `chatType`,
-`lastInteractionAt` and `sessionStartedAt` — a ready-made metadata source. It
+`lastInteractionAt` and `sessionStartedAt` (a ready-made metadata source). It
 covered 21 entries against the 54 transcripts on disk, so it indexes only
 recent sessions and would silently hide the rest. Phase 1 reads the transcripts.
 
@@ -430,14 +298,11 @@ recent sessions and would silently hide the rest. Phase 1 reads the transcripts.
 | `role: "toolResult"` record (`{toolCallId, toolName, isError, content}`) | `addOutput(toolCallId, text, isError)` |
 | `custom` / `model_change` / `thinking_level_change` | `addSvc` |
 
-The one shape difference worth calling out is why this is a third renderer
-rather than a record-shape adapter. In Claude's format a tool result is a
+This needs a third renderer because Claude stores a tool result as a
 `tool_result` content block inside a `"user"` record; in OpenClaw it is a
 top-level record with its own role. Translating OpenClaw into Claude's shape
-would mean synthesising fake `"user"` records to carry results the operator
-never sent — inventing records to satisfy a parser. The third renderer calls
-`addOutput` directly and invents nothing. Roughly 80 lines against a translator
-that would be shorter to write and permanently harder to reason about.
+would synthesize `"user"` records that the operator never sent. The third
+renderer calls `addOutput` directly.
 
 Content-block key sets to code against: `toolCall` is `{type, id, name,
 arguments}` and sometimes carries `partialJson` or `input`; `thinking` is
@@ -455,16 +320,16 @@ arguments}` and sometimes carries `partialJson` or `input`; `thinking` is
 52 of 54 session headers carry the same `cwd`: the OpenClaw workspace,
 `<stateDir>/workspace`. All 1 507 trajectory events carry the same
 `workspaceDir`. The remaining two sessions' cwd is the home directory. Session keys
-are channel-bound — `agent:<id>:<channel>:<kind>:<peer>…`, `agent:<id>:cron:…`,
-`agent:<id>:main` — and name no repository.
+are channel-bound (`agent:<id>:<channel>:<kind>:<peer>…`,
+`agent:<id>:cron:…`, `agent:<id>:main`) and name no repository.
 
-So the question is not "which of many projects" but "what is the one project
-these all belong to, and does that answer survive the workspace being gone".
+The attribution decision must assign this shared workspace one stable project
+that survives workspace deletion.
 
 ### Why the default answer fails the AGENTS.md invariant
 
-The OpenClaw workspace **is itself a git repository** — it has a real `.git`
-directory — with no `origin` remote. Trace it through
+The OpenClaw workspace **is itself a git repository**. It has a real `.git`
+directory and no `origin` remote. Trace it through
 `projectInfoFromCwd` (`src/lib/scanner/describe.ts:530`):
 
 *While the directory exists:* no path recognizer matches, `hasGitMarker(cwd)`
@@ -478,7 +343,7 @@ no remote and falls to `canonical = "local:" + realpath(root)`, minting
 `src/lib/projects/identity.ts:154` does `fs.lstatSync` on a path that is gone
 and returns `null`. `repositoryRootForPath` returns `null`. `hasGitMarker` is
 now false, so `:549` reaches `worktreeFromMemory` and then `persistedProjects`
-— which is populated from `flows`/`workflows` rows in `state.sqlite`
+which is populated from `flows` and `workflows` rows in `state.sqlite`
 (`src/lib/scanner/describe.ts:492`), so a channel-bound session that never
 joined a flow has no entry. Execution falls to `directoryProjectInfo()` at
 `:562`, minting `dir-<digest>`.
@@ -490,28 +355,26 @@ worktree's grouping must survive the checkout being deleted… Any mapping that
 finds the parent repo only by reading on-disk git metadata silently fails
 afterward."*
 
-It is worth being honest that this hazard is not OpenClaw's. Any transcript
-whose cwd is a remote-less git repository has it today. OpenClaw makes it
-systemic by putting 52 of 54 sessions in one such directory.
+Any transcript whose cwd is a remote-less git repository has this hazard.
+OpenClaw makes it systemic by putting 52 of 54 sessions in one such directory.
 
 ### The decision
 
-**Add a pure path recognizer for the OpenClaw workspace, and place it in the
-pure-path group so it precedes every disk-dependent resolver.** This is exactly
-the instruction AGENTS.md gives for a new agent layout: *"prefer a pure path
-recognizer beside #1–#4 and wire it into `projectInfoFromCwd`."*
+**Add a pure path recognizer for the exact OpenClaw workspace directory, and
+place it before every disk-dependent resolver.** AGENTS.md requires a path
+recognizer when the path itself identifies the parent project.
 
 ```ts
-/** Recognizer 1.5, immediately after the scratchpad early-return at
-    describe.ts:539 — ahead of every resolver that reads the disk. */
+/** Immediately after the scratchpad early-return at describe.ts:539. */
 function projectInfoFromOpenclawWorkspace(cwd: string): ProjectInfo | null
 ```
 
-It fires when `cwd` is, or is under, `<stateDir>/workspace` for the default
-state dir, `OPENCLAW_STATE_DIR`, or any `~/.openclaw-<profile>` sibling. It
-returns a `DirectoryProjectIdentity` computed from `path.resolve(workspace)`
-— never `fs.realpathSync` — so the identity is byte-identical whether or not
-the directory exists.
+It fires only when the normalized cwd equals `<stateDir>/workspace` for the
+default state directory, `OPENCLAW_STATE_DIR`, or a
+`~/.openclaw-<profile>/workspace` path. It returns the existing directory
+identity computed from `path.resolve(workspace)`, with display name
+`OpenClaw`. It never calls `realpathSync`, so the identity is identical before
+and after deletion.
 
 Three properties this buys, each of which the alternatives lose:
 
@@ -520,29 +383,26 @@ Three properties this buys, each of which the alternatives lose:
   mints a competing `repo-` identity.
 - **Inside the existing id namespace** (`dir-<32 hex>`, which
   `isCanonicalProjectId` at `src/lib/projects/identity.ts:22` already accepts),
-  so no second naming scheme is invented — the other thing AGENTS.md warns
-  against.
+  so the implementation keeps the naming scheme required by AGENTS.md.
 
-The display name is set explicitly rather than taken from the basename:
-`projectIdentityFromDirectory` would name this project **workspace**, which
-reads like a repository and would collide in the sidebar with any real
-checkout of that name.
+The exact-match boundary preserves a repository nested under the workspace.
+That descendant falls through to `worktreeFromGitFile` and repository
+resolution while it exists, then to the existing persisted worktree map after
+deletion. The one measured home-directory session keeps the existing home
+directory identity.
 
-Sessions whose cwd is a genuine git checkout are untouched — the recognizer is
-scoped to the workspace subtree and everything else falls through to the
-existing chain. The one home-directory session resolves to the existing
-`home-<user>` directory identity, as it would today.
+`resolveProjectOverlay` at `src/lib/scanner/describe.ts:1001-1035` also needs an
+`openclaw-sessions` branch. It uses `projectInfoFromCwd(cwd, stateKey)` first
+and `projectInfoFromTranscript(pathname, stateKey)` as the persisted fallback.
+The recognizer alone would never run for an OpenClaw root because the current
+overlay calls `projectInfoFromCwd` only from the Codex and Claude branches.
 
 ### One project for the whole workspace
 
-Rejected: a project per OpenClaw agent id. It would need the transcript path
-rather than the cwd (`projectInfoFromCwd` only receives a cwd), which means
-hooking `resolveProjectOverlay` (`src/lib/scanner/describe.ts:1001`) and
-minting ids from a source other than a directory — a second naming scheme, for
-a distinction that is presentational. The agent id is already in the transcript
-path and can drive a card title or a subtitle without touching project
-identity. If the operator later wants per-agent lanes, that is a sidebar
-grouping change that leaves identity alone, and this decision does not block it.
+Rejected: a project per OpenClaw agent id. `projectInfoFromCwd` receives no
+agent id, so this option would mint project ids from transcript paths and add a
+second identity scheme. The transcript path already carries the agent id for a
+future card subtitle or sidebar grouping.
 
 ---
 
@@ -550,176 +410,119 @@ grouping change that leaves identity alone, and this decision does not block it.
 
 ### What the transport has to do
 
-From `EngineHost` (`src/lib/runtime/engineHost.ts:100-107`) and what
-`CodexAppServerHost` needs to satisfy it:
+`EngineHost` at `src/lib/runtime/engineHost.ts:100-108` has six methods. Current
+`origin/main` adds lifecycle requirements around that interface:
 
-| Requirement | `EngineHost` member |
+| Requirement | Current contract |
 |---|---|
-| Deliver a message | `send(entry): Promise<DeliveryReceipt>` — and the receipt must discriminate `steered` / `turn-started` / `queued-next-turn` / `rejected` |
+| Deliver a message | `send(entry): Promise<DeliveryReceipt>` with a truthful delivery outcome |
 | Stream a turn | `attach(afterSeq): AsyncIterable<RuntimeEvent>` |
-| Observe turn state | `health(): Promise<HostState>` with `status`, `activeTurnRef`, `eventCursor` |
-| Resume | construction via `adopt(id, options)` (`codexAppServerHost.ts:750`) |
-| Kill | `release()` |
-| Survive a viewer restart | `HostState.pid` + `processStartIdentity`, re-adoption, and a durable event store |
+| Observe turn state | `health()` with status, active turn, event cursor, pid, and process start identity |
+| Resume | Reconstruct a host for the same session and replay durable events |
+| Interrupt | `interrupt(turnRef)` must fail when the engine does not confirm the abort |
+| Release and resource kill | `release()` plus identity-bound `releaseIfOwned` in the concrete host |
+| Inventory | The registry row must pass `structuredHostControl.ts:23-67` and the structured resource types at `resources.ts:163-207` |
+| Process safety | `structuredHostControl.ts:268-451` fences termination by pid and start identity and verifies that the process tree is gone |
 
 ### The three candidates
 
-**1. ACP bridge — `openclaw acp`.** JSON-RPC over stdio, structurally identical
-to `codex app-server`, which `CodexAppServerHost` already drives over the same
-substrate (`spawn(…, {stdio: ["pipe","pipe","pipe"], detached: true})` at
-`codexAppServerHost.ts:757` and `:773`). The installed bundle contains
-`initialize`, `session/new`, `session/prompt`, `session/cancel`,
-`session/update`, `session/resume`, `session/status`, `session/list`,
-`session/set_model`, `session/set_mode`, `session/set_config_option`, plus
-client-side `fs/*` and `terminal/*` callbacks. The CLI exposes `--session <key>`,
-`--session-label`, `--require-existing`, `--reset-session`, `--provenance`, and
-gateway `--url/--token/--token-file`.
+**1. ACP bridge, `openclaw acp`.** This is the closest transport shape to the
+existing Codex stdio host. Read-only inspection of OpenClaw 2026.6.10 found
+handlers for initialization, session create/load/list/resume/close,
+prompt/cancel, mode, and config-option changes. It emits `session/update` and
+calls the client for permission decisions.
 
-Maps to all six members: `session/prompt` → `send`, `session/update`
-notifications → `attach`, `session/cancel` → `interrupt`,
-`session/request_permission` → `answer`, `session/status` → `health`,
-child termination → `release`, `--session <key> --require-existing` → resume.
+The installed server has no `session/status` handler and advertises no status
+capability. It also has no `session/set_model` handler or model capability.
+Its config options cover thinking level and several session behaviors; model
+selection is absent. Generic methods found in the bundled ACP client and SDK
+are not evidence that this bridge server implements them.
 
-**2. Gateway WebSocket.** No child process to own, so `release()` has no
-meaning — you cannot kill a shared service. Requires speaking OpenClaw's
-internal Gateway RPC, which is not a published stable protocol, plus token or
-password auth. Decisively: it is the operator's live Gateway, carrying their
-personal messaging channels, and a Viewer defect on that socket is a defect in
-the operator's messaging. Rejected.
+Health can be derived locally without a status RPC: child exit means dead,
+release means unhosted, a pending prompt means active, a permission callback
+means attention, and prompt completion means idle. The host must test this
+state machine against protocol fixtures.
 
-**3. `openclaw agent --json` per turn.** One process per turn. `--json` emits a
-single terminal result with no streaming, so `attach` degrades to "nothing until the turn ends";
-there is no `interrupt`, no attention channel, and turn state is a process exit
-code. Four of six members unsatisfied. Rejected for hosting; it remains a
-reasonable fallback for a fire-and-forget send, and is noted as such under
-Deferred.
+Cancellation remains a blocker. The bridge's cancel handler sends
+`chat.abort`, catches and logs any failure, clears its local pending prompt,
+and resolves it as cancelled. A failed Gateway abort therefore looks
+successful to an ACP client. Killing the bridge process only closes the client;
+the Gateway may continue the run.
 
-**Choice: the ACP bridge.**
+**2. Gateway WebSocket.** A direct client could call `chat.abort` and preserve
+its result, which gives it a possible route to real interruption. The cost is a
+private Gateway protocol and a direct connection to the operator's messaging
+service. This option stays behind the same isolated proof gate and needs a
+separate security review before selection.
 
-### What the ACP bridge cannot do
+**3. `openclaw agent --json` per turn.** The command returns one terminal JSON
+result. It provides no streamed deltas, permission channel, or proven remote
+abort. It cannot meet the structured-host requirement.
 
-The bridge is a *client* of the Gateway — `openclaw acp --help` describes it as
-"Run an ACP bridge backed by the Gateway", and it takes a gateway URL and
-token. The Gateway owns the agent; the bridge does not. Four consequences, and
-they are not small:
+### Transport decision gate
 
-1. **`release()` detaches; it does not stop the agent.** A turn in flight keeps
-   running inside the Gateway and keeps writing the session file after the
-   Viewer's host is gone. "Kill" means "stop watching". For Codex, killing the
-   app-server child stops the work; here it does not. The Viewer must not
-   display this as a kill.
-2. **No hosting without the Gateway, and the Viewer must not manage it.** The
-   Gateway is the operator's own long-running service. If it is down, hosting
-   is unavailable and must say so; starting it is out of bounds.
-3. **No exclusive claim on a session.** The operator's Telegram channel, a cron
-   job and the Viewer can all drive the same session key concurrently. The
-   `expectedTurnId` fence on `QueueEntry` (`engineHost.ts:22`) rejects a stale
-   Viewer-side write, but nothing prevents an operator message arriving
-   mid-turn from another channel. Codex's single-owner assumption does not
-   hold, and the registry's claim model should treat an OpenClaw host as
-   advisory rather than exclusive.
-4. **Cancellation is likely advisory.** `session/cancel` exists, but the
-   trajectory records `turn.client_closed` events (3 observed) that sit
-   alongside `session.ended`, which reads as "the client went away" being
-   logged rather than aborting the run. **Uncertain** — the bridge was not
-   exercised, because doing so would have opened a session against the
-   operator's live Gateway. Phase 2 must measure this before claiming
-   interrupt works.
+ACP is the leading candidate because it already provides session lifecycle,
+stream updates, and permission callbacks over stdio. Implementation is blocked
+until an isolated Gateway test proves all of these properties:
 
-One thing the bridge does *better* than Codex: because the Gateway holds the
-session, surviving a Viewer restart needs no process adoption. Re-attaching is
-launching a new bridge with `--session <key> --require-existing`. But the
-`RuntimeEvent` `seq` cursor is per-bridge-process, so `attach(afterSeq)` cannot
-be served by a fresh bridge. Replay stays a Viewer-side responsibility through
-the existing `FileRuntimeEventStore`
-(`codexAppServerHost.ts:709`: `options.eventStore ?? new FileRuntimeEventStore()`),
-with the session file as canonical transcript — the same division Codex
-already uses.
+1. Start a synthetic session and a deliberately long turn.
+2. Send `session/cancel` and verify the Gateway run terminates, transcript
+   growth stops, and the client receives a failure when `chat.abort` fails.
+3. Release the host during an active turn and verify the same termination
+   outcome through the runtime and resource kill surfaces.
+4. Resume the session through a fresh bridge and prove replay plus new streamed
+   events without duplication.
+
+The test uses an isolated `HOME`, `XDG_CONFIG_HOME`, `OPENCLAW_STATE_DIR`,
+`LLV_STATE_DIR`, and `TMPDIR`. It must never connect to the operator's Gateway.
+If stock ACP fails step 2, phase 2 must either add an upstream bridge fix that
+propagates abort failure or select the direct Gateway transport after its own
+proof. A detach-only release cannot ship under a control labelled kill.
+
+Expected 5 has a separate gate. Effort maps to `session/set_mode` or the
+advertised thought-level config option. Model control has no route in this ACP
+server. Phase 2 must demonstrate a supported model method before enabling the
+Viewer's model selector. Until then, OpenClaw model selection stays disabled
+with an explicit unsupported reason.
+
+Once the transport passes, replay remains Viewer-owned through a durable event
+store. The session transcript is canonical across bridge restarts, while each
+bridge process has its own runtime event cursor.
 
 ### The `node:sqlite` obstacle: root cause, fix, diagnosis
 
-**The cause is `PATH`.** OpenClaw is fine and Bun is fine; the resolution of
-the name `node` is what breaks.
+The observed failure comes from resolving `node` through a Bun child-process
+shim. `openclaw` uses `#!/usr/bin/env node`, and the Viewer forwards `PATH`
+through `CHILD_ENV_ALLOWLIST` and `subscriptionEnv` at
+`src/lib/runtime/codexAppServerHost.ts:226,396-400`.
 
-Reproduced on this machine:
+Bun 1.3.3 exposes a sharper trap: `require("node:sqlite")` can exit zero without
+returning `DatabaseSync`. An ESM named import fails under that shim. The earlier
+CommonJS exit-code probe therefore accepted the broken runtime.
 
-- `openclaw` is a shim whose first line is `#!/usr/bin/env node`.
-- `which node` resolves to `/tmp/bun-node-<hash>/node` — a shim directory Bun
-  prepends to `PATH` for its child processes. `node --version` there answers
-  with a Bun error in place of a version.
-- `bun -e 'require("node:sqlite")'` on Bun 1.3.3 fails: *No such built-in
-  module: node:sqlite*.
-- `openclaw --help` under that `node` terminates with
-  `error: Registry URL must be http:// or https:// Received: "node:sqlite"`.
-- The same command run as `/usr/bin/node <openclaw-dist-entry> --help` exits
-  clean, with no error. `/usr/bin/node` (v26) imports `node:sqlite`
-  successfully; so does a v22 runtime.
-
-And the mechanism by which the Viewer would inherit this: `PATH` is the first
-entry of `CHILD_ENV_ALLOWLIST` at `src/lib/runtime/codexAppServerHost.ts:226`,
-and `subscriptionEnv` (`:396-400`) forwards every allowlisted variable
-verbatim. A Viewer running under Bun hands its Bun-shimmed `PATH` to any child
-it spawns. An `openclaw` child would resolve `node` to Bun and die at startup,
-every time.
-
-Note also that the operator's own running Gateway is launched with an explicit
-absolute path to a bundled Node runtime rather than through the shim — the same
-workaround, arrived at independently.
-
-**The fix.** Never spawn the `openclaw` shim and never depend on inherited
-`PATH`. Spawn the interpreter directly on OpenClaw's entry script:
+The host resolves a Node interpreter and the OpenClaw entry script explicitly,
+then spawns:
 
 ```
 <node> <openclaw-dist-entry> acp --session <key> [--require-existing] ...
 ```
 
-resolved from `LLV_OPENCLAW_NODE` and `LLV_OPENCLAW_ENTRY`, mirroring the
-`options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex"` precedent at
-`src/lib/runtime/codexAppServerHost.ts:771`. The child's `PATH` is rebuilt with
-any `/tmp/bun-node-*` segment removed, so a nested `node` lookup inside
-OpenClaw cannot fall back into the shim.
+`LLV_OPENCLAW_NODE` and `LLV_OPENCLAW_ENTRY` provide explicit overrides. The
+default resolver must reject Bun shim directories and include the selected
+interpreter in any launch diagnostic.
 
-**The named diagnosis.** `stderrExitDiagnostic`
-(`src/lib/runtime/codexAppServerHost.ts:378`) relays the last four stderr lines
-verbatim — useful, but what it produces is prose, and the observed
-failure string talks about a registry URL. Scraping it is the wrong primary
-mechanism. The host runs a **preflight before spawn**, each check with its own
-code, and a launch failure surfaces as that code rather than as a dead host:
+The preflight stays small:
 
 | Code | Check | Message must name |
 |---|---|---|
-| `openclaw_runtime_missing` | configured interpreter is absent or not executable | the path that was resolved, and where it came from (`LLV_OPENCLAW_NODE`, or `PATH` lookup) |
-| `openclaw_runtime_lacks_sqlite` | `<node> -e 'require("node:sqlite")'` exits non-zero | the resolved interpreter path and its `--version` output |
+| `openclaw_runtime_missing` | configured interpreter is absent or not executable | the resolved path and configuration source |
+| `openclaw_runtime_lacks_sqlite` | `<node> --input-type=module -e 'import { DatabaseSync } from "node:sqlite"; if (typeof DatabaseSync !== "function") process.exit(1)'` fails | the resolved interpreter and its version |
 | `openclaw_entry_missing` | entry script is absent | the path that was probed |
-| `openclaw_gateway_unreachable` | no Gateway backing the bridge | the gateway URL that was tried |
 
-**Every message names the interpreter it resolved.** This is the whole value of
-the diagnosis, because the underlying fault is a name resolving to the wrong
-binary. "SQLite support is unavailable in this Node runtime" sends the operator
-to install a Node they already have. The same failure reported as —
-
-```
-openclaw_runtime_lacks_sqlite: resolved node -> /tmp/bun-node-<hash>/node
-  (from PATH); that runtime has no node:sqlite. Set LLV_OPENCLAW_NODE to a
-  real Node 22+ binary.
-```
-
-— shows a `/tmp/bun-node-*` path, and the operator is done reading. A
-diagnosis that reports only the symptom hides the one fact that identifies the
-cause.
-
-Keep it at these four checks. The preflight costs two `statSync` calls, one
-short subprocess and one gateway reachability probe, cached per host launch,
-and it earns that by turning a dead host into a sentence. Anything more
-belongs in `doctor`, and OpenClaw already has one. As a backstop, a post-spawn
-stderr matcher for `node:sqlite` maps into `openclaw_runtime_lacks_sqlite` with
-the same resolved-path line attached, since the observed message does contain
-that token even though its prose is about something else.
-
-The preflight is the only place this belongs. `detectLaunchFailure`
-(`src/lib/status.ts:261`) is the other named-failure surface in the codebase,
-but it reads a tmux screen, and the tmux transport is being removed (#1161).
-Adding an OpenClaw case there would be building on a floor that is coming out.
+Gateway reachability is part of ACP initialization and should surface the
+bridge's own failure. A separate probe would duplicate the connection and auth
+path. Tests prove that the Bun shim produces
+`openclaw_runtime_lacks_sqlite`, while supported Node 22 and 26 runtimes pass.
 
 ---
 
@@ -727,132 +530,94 @@ Adding an OpenClaw case there would be building on a floor that is coming out.
 
 ### The boundary
 
-**Phase 1: viewing. Phase 2: hosting.** The issue expected this split; three
-things confirm it, and the third is the one that actually decides it.
+**Phase 1: viewing. Phase 2: hosting.** Viewing depends only on transcript
+files and existing feed primitives. Hosting depends on a Gateway, a real Node
+runtime, and remote-run termination semantics that remain unproven.
 
-1. Viewing is additive and root-keyed. Every phase-1 edit is a new branch in an
-   existing `rootName` switch, a new member on a union that already has three,
-   or a new file. Nothing changes behaviour for Claude or Codex.
-2. Viewing has no external dependency. Hosting depends on a service the Viewer
-   does not own (the Gateway), a runtime it does not run (real Node), and a
-   claim model that does not exist (no exclusive session ownership). Two of
-   those three still carry open uncertainties — see (d). Bundling them with
-   viewing would hold a shippable increment hostage to them.
-3. **Hosting's data model rides on viewing's.** `SessionKey`
-   (`src/lib/agent/sessionKey.ts:7`) is `{engine, sessionId}`, and
-   `normalizeSessionId` (`:14`) requires the whole value to be a bare
-   v4-shaped id. OpenClaw header ids satisfy that — but the *filename* does
-   not, for the 17 of 54 files named `-topic-<n>`. Phase 1 is what establishes
-   that the registry's `sessionId` comes from the header rather than the
-   filename, and proves the registry↔transcript join with fixtures. Phase 2
-   adopts and resumes against that join. Doing them together means designing
-   the join and the host lifecycle at once, against a shape that phase 1's own
-   evidence only just corrected.
-
-There is a fourth reason, opportunistic but real: the boundary drawn here keeps
-phase 1 out of `src/lib/scanner/process.ts`, which the #1199 lane owns.
-`AgentEngine` is the *hostable*-engine union, and phase 1 deliberately does not
-make OpenClaw hostable, so it does not widen it.
+Phase 2 must build `SessionKey` from the transcript header id and the trajectory
+session key. `src/lib/agent/sessionKey.ts:7-19` accepts a bare v4-shaped id;
+OpenClaw topic filenames carry a suffix and cannot supply that value.
 
 ### What phase 1 ships
 
-Board and feed parity for OpenClaw conversations — Expected 1 and 2 — in a
-single PR, with OpenClaw explicitly **not** hostable and every Class-A
-predicate still answering "no". Scanning, project attribution, turn state,
-effort and structured rendering ship together; there is no interim state in
-which an OpenClaw conversation appears on the board but opens as unstructured
-text.
+Phase 1 delivers Expected 1 and 2 in one PR. An OpenClaw card enters the full
+catalog, receives stable project attribution, displays its real model and
+effort, reports turn state, and opens through `renderOpenclaw`. The PR has no
+plain-text fallback.
 
-Work plan, in dependency order, against `main` at `e61c1ce4`. One file
-(`src/lib/resources.ts`) is owned by the #1199 lane and is deliberately skipped
-at item 9; everything else here is free.
+Work plan against `origin/main` at `dbfa3753`:
 
-**1. `src/lib/types.ts`** — `RootKey` gains `"openclaw-sessions"` (`:8-11`);
-`Engine` gains `"openclaw"` (`:13`); `Fmt` gains `"openclaw"` (`:15`).
-Compile and read every error: they are the exhaustive-position call sites, and
-they are the only ones the compiler will ever hand you.
+**1. Core unions.** In `src/lib/types.ts`, add `openclaw-sessions` to
+`RootKey` and `openclaw` to `Engine` and `Fmt`. Keep both `AgentEngine` unions,
+`StructuredHostRecord`, and `StructuredHostKillRef` two-membered because phase
+1 creates no host.
 
-**2. `src/lib/scanner/roots.ts`** — add the OpenClaw root to `ROOTS` (`:33`)
-resolved from `OPENCLAW_STATE_DIR` with `~/.openclaw` default; extend
-`scanRootEntries()` (`:39`) to fan out one entry per `<stateDir>/agents/*/
-sessions` directory. Add `openclawSessionRootFor(candidate)` beside
-`codexSessionRootFor` (`:83`) so `/api/log` path allowlisting covers the new
-root. Declare the `TranscriptRootDescriptor` here.
+**2. Discovery.** In `src/lib/scanner/roots.ts`, resolve
+`OPENCLAW_STATE_DIR` with a `~/.openclaw` default and return one scan root per
+`agents/<agentId>/sessions` directory. In `src/lib/scanner/discover.ts`, exclude
+trajectory, checkpoint, ACP stream, sidecar, index, backup, and zero-length
+files before ranking. Add explicit OpenClaw engine, format, and title fallbacks
+at the resource-scope mapping around `:342-378`.
 
-**3. `src/lib/scanner/discover.ts:347`** — replace the two-way root ternary
-with a descriptor lookup, and fix the title fallback at `:365` alongside it.
+**3. Metadata, search, and attribution.** In
+`src/lib/scanner/describe.ts`, parse cwd, timestamp, the first user prompt, and
+the OpenClaw title. Generalize the search helper at
+`:883-886` to an engine discriminator. Add the exact-workspace recognizer after
+`:539` and the OpenClaw project overlay after `:1030`.
 
-**4. `src/lib/scanner/describe.ts`** — add an `else if (rootName ===
-"openclaw-sessions")` branch to `deriveTranscriptMetadata` (after `:983`)
-setting `engine`/`fmt`/`kind`, reading `cwd` and `sessionStartedAt` from the
-header record, and taking the title from the first `"user"` message. Add the
-`projectInfoFromOpenclawWorkspace` early-return after `:539`.
+**4. Turn state.** Replace the boolean discriminator and cache field in
+`src/lib/accounts/migration/turnState.ts` and
+`src/lib/scanner/activity.ts`. Add explicit OpenClaw arms in
+`src/lib/scanner/index.ts:300`, `src/lib/scanner/observe.ts:76`, and the
+persisted-evidence path in `src/lib/scanner/scanCache.ts:173`.
 
-**5. `src/lib/accounts/migration/turnState.ts:92`** — change the `codex:
-boolean` parameter to a discriminator, add the OpenClaw arm keyed on the last
-assistant record's `stopReason`, and update the two call sites
-(`src/lib/scanner/activity.ts:175` and `:428`) plus the `cached.codex ===
-codex` cache-key comparisons at `:165`, `:184`, `:212`, `:256`.
+**5. Model and effort display.** In `src/lib/scanner/model.ts`, admit the root
+and read the newest assistant record whose provider is a real provider. A
+record with provider `openclaw` cannot replace the displayed model. In
+`src/lib/scanner/effort.ts`, admit the root and read the latest
+`thinking_level_change`; add `off` and `adaptive` to the accepted scale.
 
-**6. The three persisted-cache validators, in one commit** —
-`src/lib/scanner/scanCache.ts:105,109,111` plus bumping
-`FILE_SCAN_CACHE_SCHEMA_VERSION` at `:75` from 9 to 10;
-`src/lib/scanner/projectCatalog.ts:136-137`;
-`src/lib/resourceCollector.worker.ts:45`.
+**6. Catalog and persisted shapes.** Add OpenClaw to
+`src/lib/scanner/conversationCatalog.ts:15`, the catalog inclusion at
+`src/lib/scanner/projectCatalog.ts:582`, and the validators in
+`projectCatalog.ts:124,136-137`, `scanCache.ts:105,109,111`, and
+`resourceCollector.worker.ts:53`. Bump `FILE_SCAN_CACHE_SCHEMA_VERSION` from 9
+to 10 in the same change.
 
-**7. `src/components/feed/parse.ts`** — add `renderOpenclaw` beside
-`renderClaude` (`:1943`) and extend the dispatch at `:2127` from a two-way
-`fmt` test to a three-way one. The mapping table under *(b) Rendering* is the
-specification; the renderer emits only primitives that already exist.
-
-**8. `src/lib/scanner/effort.ts`** — add `"off"` and `"adaptive"` to `TIERS`
-(`:10`); add an `entry.root === "openclaw-sessions"` arm to `pickEffort`
-(`:18`) reading `thinkingLevel` from `thinking_level_change` records. Do
-**not** touch `argvEffort` (`:34`) — there is no per-session process to read
-argv from.
-
-**9. The capability predicate** — define `isHostableEngine` (suggested home:
-`src/lib/agentCapabilities.ts` or beside `Engine` in `src/lib/types.ts`) and
-adopt it at the Class-A sites. Behaviour-preserving by construction; the value
-is that phase 2 becomes a one-line change with a test instead of a 32-file
-audit.
-
-One of those 32 files is still owned elsewhere: `src/lib/resources.ts`, under
-the #1199 lane. Phase 1 adopts the predicate in the other 31 and leaves that
-copy in place. Since the predicate is defined to exclude OpenClaw, the mixed
-state behaves identically either way, and the leftover is a mechanical
-follow-up once #1199 merges.
-
-**10. Class B, the eight erasure sites** — seven take an explicit third arm in
-phase 1: `src/components/feed/parse.ts:1311` and `:1486`,
-`src/components/DraftAgentPane.tsx:396`,
-`src/components/flows/directReviewGroups.ts:134` and `:146`,
-`src/app/api/tasks/[id]/send/route.ts:94`,
-`src/lib/tasks/inboxScanner.ts:144`.
-
-The eighth, `src/lib/runtime/liveTurn.ts:374` with
-`RuntimeLiveTurnToolEngine` (`:22`), waits for phase 2. Nothing produces
-live-turn rows for an engine the Viewer does not host, so widening a hosting
-type inside a viewing PR would add an unreachable branch. Carry it on the
-phase-2 issue.
+**7. Structured feed.** Add `renderOpenclaw` and a three-way `Fmt` dispatch in
+`src/components/feed/parse.ts`. Widen its prose and tool-summary engine types,
+plus `src/components/feed/tools.ts`, to carry `openclaw`. Emit one service row
+when the real provider/model changes. Update `FeedItem.tsx`, `utils.ts`, and
+`scheme/offscreenClusters.ts` so OpenClaw uses its own label, icon, and color on
+the board and in the feed. The mapping table in section (b) defines the record
+behavior.
 
 **Tests**, all against invented fixtures under an isolated
-`HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run **by path**:
+`HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run by path:
 
-- `src/lib/scanner/describe.test.ts` — the case AGENTS.md requires: an OpenClaw
-  workspace cwd resolves to the same project whether or not the directory
-  exists, and a workspace carrying a remote-less `.git` still resolves to the
-  directory identity rather than a `repo-` identity.
-- `src/lib/scanner/discover.test.ts` — a fixture agent tree yields one entry
+- `src/lib/scanner/describe.test.ts` covers title/search text, the same
+  workspace identity before and after deletion, the workspace's
+  remote-less `.git`, the OpenClaw overlay, and a genuine nested checkout that
+  retains repository attribution.
+- `src/lib/scanner/discover.test.ts`: a fixture agent tree yields one entry
   per transcript, and zero for `.trajectory.jsonl`, `.checkpoint.<id>.jsonl`,
   `.acp-stream.jsonl`, `.trajectory-path.json`, `sessions.json` and `.bak`
   siblings.
-- `src/lib/accounts/migration/turnState.test.ts` — `stopReason` of `stop`
+- `src/lib/accounts/migration/turnState.test.ts`: `stopReason` of `stop`
   reads terminal, `toolUse` reads busy, `error`/`aborted` read terminal.
-- a new `src/components/feed/openclaw.test.ts` — the six-row mapping table
-  above, plus a synthetic-provider record not setting the displayed model.
-- `src/lib/scanner/effort.test.ts` — `off` and `adaptive` normalise; an
-  unknown tier still returns null.
+- `src/lib/scanner/model.test.ts` and `effort.test.ts` cover real model display,
+  synthetic-provider exclusion, model changes, `off`, `adaptive`, and an
+  unknown effort.
+- `src/lib/scanner/conversationCatalog.test.ts` proves complete list and search
+  inclusion, including first-prompt search.
+- `src/app/api/files/scanCache.real.test.ts` and
+  `src/lib/resourceCollector.test.ts` prove persisted OpenClaw entries survive
+  validation.
+- a new `src/components/feed/openclaw.parse.test.ts` covers the six-row mapping,
+  provider/model service rows, tool-result attachment, and OpenClaw prose
+  identity.
+- `src/components/scheme/offscreenClusters.test.ts` covers the OpenClaw board
+  color.
 
 **Gates:** `bunx tsc --noEmit --incremental false`; the touched test files by
 path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
@@ -860,72 +625,55 @@ path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
 
 ### What phase 1 explicitly does not ship
 
-`AgentEngine` stays two-membered. `isHostableEngine` returns false for
-OpenClaw. `SessionKey` cannot name an OpenClaw session. No spawn path, no
-registry entry, no delivery controller. Model and effort **controls** — Expected
-5 — are phase 2, because they configure a launch and phase 1 does not launch
-anything; phase 1 gets read-only model/provider display for free from the
-assistant records.
+`AgentEngine` and `SessionKey` stay two-engine. Phase 1 adds no process
+recognition, spawn path, registry entry, delivery controller, model selector,
+or effort selector. It displays recorded model, provider, and effort values.
+The repository-wide hostability predicate also stays out of phase 1.
 
 ### Phase 2, sketched
 
-`AgentEngine` widening; `isHostableEngine` flipped; an `OpenclawAcpHost`
-implementing `EngineHost`; the preflight and its four diagnosis codes; third
-arms at `structuredSpawn.ts:1312` and `:1372`; the advisory-claim change to the
-registry; `--model` and `--thinking` wired to the existing model/effort
-controls. Its own PR, its own tests, its own issue. The open uncertainties from
-(d) — whether `session/cancel` aborts a run, and whether
-`session/request_permission` reaches the attention queue — get measured at the
-start of phase 2, before anything is built on them.
+Phase 2 starts with the isolated transport proof in section (d). After that
+gate passes, its implementation map follows current `origin/main`:
+
+1. Parse the bare session id from the transcript header, join the trajectory
+   session key through `data.sessionFile`, widen `AgentEngine` in
+   `src/lib/agent/cli.ts` and `SessionKey`, then add the two structured-spawn
+   construction arms.
+2. Implement the selected host with all six `EngineHost` methods,
+   identity-bound `releaseIfOwned`, process start identity in `health()`, and a
+   writer fence. `releaseIfOwned` must abort and verify the Gateway run before
+   it reaps the bridge child.
+3. Publish the host through `structuredDeliveryController.ts`, including state
+   projection, generation rebind, owned termination, and registry retirement.
+4. Extend `structuredHostControl.ts:23-67`, `resources.ts:163-207`, the resource
+   validators, and the runtime-host API so OpenClaw appears in inventory and
+   the resource kill path carries the same pid/start-identity fence. An orphan
+   bridge cannot report kill success unless a fresh control path verifies the
+   Gateway run ended.
+5. Extend `scanner/process.ts` so the bridge process carries the structured-host
+   stamp and is attributable without matching the shared Gateway process.
+6. Wire effort control through the proven ACP mode/config method. Enable model
+   control only after the transport proof demonstrates a supported model
+   method.
+
+This is a separate PR and issue. It includes protocol fixtures plus isolated
+Gateway tests for prompt streaming, attention, resume, runtime kill, resource
+kill, abort failure, process-identity mismatch, controller rebind, and replay.
 
 ---
 
-## Baseline and lane ownership
+## Baseline and file ownership
 
-**Phase 1 is cut against `main` at `e61c1ce4`**, which already contains PR
-#1206 (the #1202 `suggest_replies` lane, merged 2026-08-27). The implementer
-rebases on current `main`. This document's evidence was originally read at
-`ac197031`; both commits are recorded here because the difference is what
-decides whether the file:line citations below still hold.
+The evidence and line references in this revision use `origin/main` at
+`dbfa3753` (2026-08-27). That baseline includes the merged structured-host
+inventory, process-stamp, identity-fenced release, and resource-kill work from
+#1203, plus the feed and orchestration work named in the task.
 
-Every line this document cites was re-read at `e61c1ce4` and is unchanged.
-`src/components/feed/parse.ts` is byte-identical between the two commits, so
-`:1311`, `:1486`, `:1943` and `:2127` all still point at what the text says
-they do; so are `src/lib/types.ts`, all six cited `src/lib/scanner/` files,
-`src/lib/accounts/migration/turnState.ts`,
-`src/lib/resourceCollector.worker.ts`, `src/lib/projects/identity.ts`,
-`src/lib/agent/sessionKey.ts`, `src/lib/status.ts` and the three cited
-`src/lib/runtime/` files. The one cited file #1206 did touch is
-`src/lib/mcp/bindings.ts`, which this document cites only at file level as a
-Class-A site; re-counted at `e61c1ce4`, the Class-A surface is still 32 files.
-
-**Fences lifted.** `src/components/feed/**` (including `parse.ts`),
-`src/components/LogFeed.tsx`, `src/lib/mcp/**` and
-`src/lib/orchestrator/prompt.ts` have no other owner. Phase 1 takes the feed
-renderer directly, so there is no `"plain"` fallback state and no split
-delivery: scanning, attribution, turn state and structured rendering ship
-together in one PR.
-
-**Still owned — the #1199 lane, in final review.** `src/lib/resources.ts`,
-`src/lib/scanner/process.ts`, `src/lib/runtime/structuredHostControl.ts`,
-`src/lib/runtime/structuredDeliveryController.ts` and
-`src/components/ResourcesFooter.tsx`. Phase 1 touches none of them, and needs
-none of them:
-
-- `src/lib/scanner/process.ts` holds `AgentEngine` (`:13`) and `argvEngine`
-  (`:122`). Phase 1 deliberately does not make OpenClaw hostable and does not
-  do process attribution, so neither needs to change. The phase boundary was
-  drawn partly for this reason and it still holds.
-- `src/lib/resources.ts:793` is a Class-A narrowing predicate. It keeps
-  answering "no" for OpenClaw, which is the phase-1 answer anyway. It is the
-  single Class-A copy item 9 skips.
-- `src/components/ResourcesFooter.tsx:474` is a Class-C label expression that
-  renders `?` for an unrecognised engine — honest, and correct until someone
-  gives OpenClaw a label.
-
-Phase 2 will need `src/lib/scanner/process.ts` and
-`src/lib/runtime/structuredDeliveryController.ts`, so it should not start until
-#1199 has merged.
+No file fence remains. The implementer rebases this branch on current main
+before editing, records the new merge base, and rechecks every cited branch
+whose line moved. Phase 1 may edit the feed renderer directly and ships its
+scanner, catalog, attribution, model, effort, cache, and presentation changes
+in the same PR.
 
 ---
 
@@ -936,6 +684,19 @@ Cut from this design, with the reason. None of it is discarded.
 **An engine-descriptor registry spanning the UI.** Would not fix the 107 binary
 ternaries, which are the actual cost, and would abstract for a fourth engine
 nobody has asked for. Revisit if a fourth engine appears. See (a).
+
+**A transcript-root descriptor in phase 1.** Three transcript roots do not need
+a registry around their existing switches. Explicit OpenClaw branches are
+shorter and keep each parser beside the shape it understands.
+
+**The 33-file hostability-predicate migration.** Most of those predicates
+guard launch, lifecycle, tasks, workflows, or account behavior. OpenClaw cannot
+reach them during phase 1. Phase 2 may introduce a helper for the smaller set
+its proven transport actually needs.
+
+**Host-only erasure coercions.** Draft launch, direct reviews, task send, inbox,
+and live-turn rows have no OpenClaw producer in phase 1. They move with the
+hosting work so each third arm has a real behavior and test.
 
 **Merging trajectory and checkpoint files into the conversation.** The issue's
 Expected 1 assumes a three-file join. The evidence says the session file is
@@ -953,23 +714,23 @@ Reconsider only if OpenClaw grows per-session processes.
 **Model registry entries for OpenClaw's models.** `MODEL_REGISTRY`
 (`src/lib/scanner/modelRegistry.ts:13`) is an Anthropic context-window
 snapshot. OpenClaw runs OpenAI-family models through an OpenAI response API, so
-`normalizeModelKey` finds no entry and `registryWindow` returns null — an
-unknown context window, which is the correct answer here. Adding OpenAI
-model windows is a separate decision with its own maintenance burden and is not
-required by the requirement.
+`normalizeModelKey` finds no entry and `registryWindow` returns null. An unknown
+context window is accurate. Adding OpenAI model windows creates a separate
+maintenance surface.
+
+**OpenClaw model control.** The installed ACP server exposes no model method or
+model config option. Keep the selector disabled until the phase-2 transport
+proof identifies a supported route.
 
 **Account and limits integration.** `LimitsCache`
 (`src/lib/limits.ts:38,50`) is `Record<EngineName, …>` behind `version: 2`;
-adding a third key is a persisted-shape migration. But OpenClaw does not have
-its own subscription — it routes to an OpenAI provider whose quota is already
-accounted elsewhere — so a third limits engine would report a window that does
-not exist. Out of scope until OpenClaw's account model is understood.
+adding a third key is a persisted-shape migration. OpenClaw has no Viewer-owned
+subscription window to display. This stays out of scope until OpenClaw's
+account model is understood.
 
-**`openclaw agent --json` as a fallback transport.** Genuinely unsuitable for
-hosting, but it is the simplest possible "send one message and read the reply".
-If phase 2's ACP work stalls on the Gateway dependency, it is a viable reduced
-mode — send only, no streaming, no interrupt — and should be reconsidered then
-rather than built now.
+**`openclaw agent --json` as a reduced send mode.** It can send one message and
+return one terminal result. Streaming, attention, resume, and verified abort
+remain unavailable, so it cannot satisfy the originating host requirement.
 
 **Per-agent-id project grouping.** Presentational; can ride on card titles
 without a second project-id namespace. See (c).
@@ -980,26 +741,18 @@ without a second project-id namespace. See (c).
 
 Read back against the quote at the top.
 
-*"the Viewer scans and renders OpenClaw conversations"* — phase 1, items 1–10,
-in one PR. Both halves of the clause land together: scanning and attribution
-from items 1–6, structured rendering from item 7. No fallback state, no partial
-delivery.
+*"the Viewer scans and renders OpenClaw conversations"* is phase 1, items 1-7,
+in one PR. Discovery, complete catalog/search, attribution, turn state,
+model/provider/effort display, and the structured renderer ship together.
 
 *"the Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
-message, stream the turn, resume, kill)"* — phase 2, over the ACP bridge, with
-one honest deviation the operator should see now rather than at delivery:
-**"kill" cannot mean what it means for Claude and Codex.** The Gateway owns the
-agent, so releasing the host stops the Viewer watching while the agent keeps working.
-Every other verb in the sentence maps cleanly.
+message, stream the turn, resume, kill)"* remains phase 2. ACP is eligible only
+after the isolated proof shows real run termination and propagated abort
+failure. A transport that only detaches the Viewer fails this requirement and
+does not ship.
 
-*"at the same level Claude and Codex already are"* — reached for scanning,
-rendering, project attribution, turn state and model display. Not reached, and
-not proposed, for accounts, limits and process-level liveness — because for
-those three OpenClaw has no equivalent to be at the same level as. Claiming
-parity there would mean inventing a subscription and a per-session process that
-do not exist.
-
-Nothing in this design exists because it was interesting. The one place the
-design deliberately spends more than the minimum is the named capability
-predicate, which is behaviour-preserving in phase 1 and buys a checkable
-one-line change in phase 2 instead of a 32-file audit.
+*"at the same level Claude and Codex already are"* is met for the phase-1
+viewing surface. Hosting reaches that bar only after runtime and resource kill,
+resume, delivery, streaming, attention, inventory, and process identity pass
+the phase-2 gates. Accounts, subscription limits, and shared-Gateway process
+liveness have no equivalent OpenClaw concept and remain outside the request.

--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -10,14 +10,17 @@ Verbatim, from the operator's request line in GitHub issue #1207 (opened
 > Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
 > message, stream the turn, resume, kill).
 
-Everything below is validated against that sentence. Scope beyond the sentence
-is preserved in **Deferred — not currently justified**.
+This document designs the first half of that sentence — scanning and rendering.
+Hosting is deferred with its open requirements in **(d) Deferred — hosting**;
+other out-of-scope work is preserved in **Deferred — not currently justified**.
 
 ## Evidence discipline
 
 Two sources: this repository, and read-only inspection of the OpenClaw
 2026.6.10 install on the development machine. Source evidence was re-verified
-against `origin/main` at `dbfa3753` on 2026-08-27. That commit includes the
+against `origin/main` at `a3f9c2e2` on 2026-08-27. Every file cited below is
+byte-identical between that commit and `dbfa3753`, the baseline of the previous
+revision, so every line reference still resolves. `dbfa3753` carries the
 structured-host inventory and kill work from #1203. No OpenClaw state was
 written, and the operator's running Gateway was not started, stopped or
 reconfigured.
@@ -39,8 +42,8 @@ and cites what was measured instead.
 | a | Engine surface | Add `openclaw` to `Engine` and `Fmt`. Use explicit third arms at the viewing call sites. Defer the repository-wide hostability predicate and root-descriptor abstraction. |
 | b | Viewing | The session file alone is authoritative for the message chain **and** for model/provider. The trajectory supplies only `sessionKey`. Checkpoints are excluded from discovery. |
 | c | Project attribution | Add an exact-workspace pure path recognizer before disk-dependent resolution, and call the existing overlay for OpenClaw roots. Descendant repositories retain normal repository attribution. |
-| d | Hosting transport | Keep ACP as the leading candidate. Do not select it for implementation until an isolated Gateway proves cancellation and kill parity. The installed bridge lacks status and model methods and hides `chat.abort` failures. |
-| e | Phasing | Phase 1 ships viewing in one PR: discovery, stable attribution, list/search, model and effort display, turn state, and structured feed rendering. Hosting remains phase 2 after its transport gates pass. |
+| d | Hosting | **Not designed here.** No transport is selected, so there is nothing to build a lifecycle on. **(d) Deferred — hosting** records the measured candidates, the termination gate that has to be passed before one is chosen, and the ownership, concurrency and lifecycle questions a hosting design must answer. |
+| e | Phasing | Phase 1 ships viewing in one PR: discovery, stable attribution, list/search, model and effort display, turn state, structured feed rendering, awaiting-user state, and Viewer snapshots. Hosting is a separate design that does not start until the termination gate passes. |
 
 ---
 
@@ -104,7 +107,7 @@ creates the work.
 
 ### The branches, classified
 
-At `origin/main` `dbfa3753`, the repeated
+At `origin/main` `a3f9c2e2`, the repeated
 `engine === "claude" || engine === "codex"` idiom appears in 33 non-test
 files. A repository-wide replacement would dominate phase 1 while preserving
 its current behavior. Phase 1 changes only the viewing call sites that must
@@ -115,6 +118,15 @@ accept OpenClaw:
 - `src/lib/scanner/scanCache.ts:173` primes persisted turn evidence.
 - `src/lib/scanner/projectCatalog.ts:582` decides whether a transcript enters
   the complete list/search catalog.
+- `src/hooks/useSwitchboardData.ts:72` decides whether a recent conversation
+  counts as awaiting the user, which drives the waiting bucket and the
+  attention counter.
+- `src/lib/view/snapshot.ts:58` decides whether a focused or selected path
+  resolves to a conversation the Viewer snapshot reports at all.
+
+The last two are viewing surfaces outside the scanner. Without them an OpenClaw
+card is scanned, attributed and rendered, then vanishes from the waiting bucket
+and from every snapshot an agent reads, which is not the parity phase 1 claims.
 
 The other narrowing predicates govern host lifecycle, launch, account
 migration, tasks, workflows, and runtime controls. They keep excluding
@@ -123,8 +135,12 @@ OpenClaw during phase 1.
 Eight erasure coercions use `engine === "codex" ? "codex" : "claude"`.
 Phase 1 fixes the two feed coercions at
 `src/components/feed/parse.ts:1311,1486`, because OpenClaw prose and tool rows
-reach them. The launch, review-flow, task-send, inbox, and live-turn coercions
-remain unreachable for a view-only engine and move to phase 2.
+reach them. A ninth erasure of the same kind, the
+`entry.engine as "claude" | "codex"` cast at `src/lib/view/snapshot.ts:63`, is
+fixed together with the snapshot filter above it, since a widened filter that
+kept the cast would report OpenClaw entries as Claude. The launch,
+review-flow, task-send, inbox, and live-turn coercions remain unreachable for
+a view-only engine and move with the hosting work.
 
 The root-specific viewing work is bounded:
 
@@ -138,6 +154,8 @@ The root-specific viewing work is bounded:
 | Effort | `scanner/effort.ts:10,17-30,62-64` | Admit the root and read `thinking_level_change`. |
 | Complete catalog | `conversationCatalog.ts:15`; `projectCatalog.ts:582` | Add OpenClaw to the catalog type and filter. |
 | Feed | `feed/parse.ts:226,1374,2127`; `feed/tools.ts:184-188` | Add a structured renderer and carry the engine through prose and tool rows. |
+| Awaiting-user state | `src/hooks/useSwitchboardData.ts:72` | Admit `openclaw`, so a finished OpenClaw turn reaches the waiting bucket. |
+| Viewer snapshot | `src/lib/view/snapshot.ts:58,63`; `src/lib/view/types.ts:81` | Admit `openclaw` in the transcript filter, the reported engine, and `SnapshotConversation`. |
 | Persisted shapes | `scanCache.ts:105,109,111`; `projectCatalog.ts:124,136-137`; `resourceCollector.worker.ts:53` | Widen validators together and bump the scan schema from 9 to 10. |
 
 `turnStateFromRecords(records, codex: boolean, authoritative)` cannot express
@@ -155,15 +173,15 @@ Phase 1 uses the seams already present:
    `src/components/feed/parse.ts`.
 2. `RootKey` selects the explicit scanner branch in discovery, metadata, model,
    effort, and turn-state code.
-3. `EngineHost` remains the phase-2 host boundary at
-   `src/lib/runtime/engineHost.ts:100-108`.
+3. `EngineHost` at `src/lib/runtime/engineHost.ts:100-108` remains the
+   boundary any hosting design has to satisfy. Phase 1 does not touch it.
 
 A root descriptor adds an abstraction around three transcript roots and does
 not reduce the phase-1 edits above. A global `isHostableEngine` migration adds
 changes across 33 files before OpenClaw is hostable. Both move to
-**Deferred — not currently justified**. Phase 2 can introduce one narrow
-hostability helper after its transport is proven and its real call sites are
-known.
+**Deferred — not currently justified**. A hosting design can introduce one
+narrow hostability helper once its transport is proven and its real call sites
+are known.
 
 ---
 
@@ -221,8 +239,9 @@ modelId, modelApi, data}`. Event types: `session.started`, `context.compiled`,
 
 Everything there except `sessionKey` duplicates the session file. `sessionKey`
 does not appear in the session file and is needed only for hosting. Phase 1
-excludes trajectories. Phase 2 reads the first `session.started` event and uses
-its `data.sessionFile` back-pointer to join the key to the transcript.
+excludes trajectories; the `data.sessionFile` back-pointer that would join the
+key to a transcript is recorded in **(d) Deferred — hosting** as the one join a
+hosting design will have to make.
 
 "session" in the trajectory names a *run*. There were 143
 `session.started` events across 58 files, one per submitted prompt.
@@ -406,112 +425,81 @@ future card subtitle or sidebar grouping.
 
 ---
 
-## (d) Hosting transport
+## (d) Deferred — hosting
 
-### What the transport has to do
+**Hosting is not designed in this document.** The candidate transports were
+measured and none can be selected yet, so this is a requirement list for a
+hosting design carrying its own issue. **Nothing in it is answered here.**
 
-`EngineHost` at `src/lib/runtime/engineHost.ts:100-108` has six methods. Current
-`origin/main` adds lifecycle requirements around that interface:
+### The candidates, and the gate that picks one
 
-| Requirement | Current contract |
-|---|---|
-| Deliver a message | `send(entry): Promise<DeliveryReceipt>` with a truthful delivery outcome |
-| Stream a turn | `attach(afterSeq): AsyncIterable<RuntimeEvent>` |
-| Observe turn state | `health()` with status, active turn, event cursor, pid, and process start identity |
-| Resume | Reconstruct a host for the same session and replay durable events |
-| Interrupt | `interrupt(turnRef)` must fail when the engine does not confirm the abort |
-| Release and resource kill | `release()` plus identity-bound `releaseIfOwned` in the concrete host |
-| Inventory | The registry row must pass `structuredHostControl.ts:23-67` and the structured resource types at `resources.ts:163-207` |
-| Process safety | `structuredHostControl.ts:268-451` fences termination by pid and start identity and verifies that the process tree is gone |
+From read-only inspection of OpenClaw 2026.6.10 on the development machine:
 
-### The three candidates
+- **ACP bridge, `openclaw acp`** — leading, closest to the existing Codex stdio
+  host. The installed server advertises no status and no model capability, and
+  its cancel handler swallows a failed `chat.abort` and resolves as cancelled,
+  so a failed Gateway abort looks successful and killing the bridge only closes
+  the client.
+- **Gateway WebSocket** — a direct client keeps the `chat.abort` result, at the
+  cost of a private protocol, a direct connection to the operator's messaging
+  service, and its own security review.
+- **`openclaw agent --json`** — rejected: one terminal result, no streamed
+  deltas, no permission channel, no proven remote abort.
 
-**1. ACP bridge, `openclaw acp`.** This is the closest transport shape to the
-existing Codex stdio host. Read-only inspection of OpenClaw 2026.6.10 found
-handlers for initialization, session create/load/list/resume/close,
-prompt/cancel, mode, and config-option changes. It emits `session/update` and
-calls the client for permission decisions.
+**No transport is selected and no hosting work starts until one passes this
+gate against an isolated Gateway:** cancel a deliberately long turn and verify
+the Gateway run terminates, transcript growth stops, and the client sees a
+**failure** when `chat.abort` fails; release the host mid-turn and verify the
+same outcome through the runtime and resource kill surfaces; resume through a
+fresh bridge and prove replay plus new events without duplication. The gate runs
+under an isolated `HOME`, `XDG_CONFIG_HOME`, `OPENCLAW_STATE_DIR`,
+`LLV_STATE_DIR` and `TMPDIR` and never touches the operator's Gateway. If stock
+ACP fails the cancel step, hosting carries an upstream bridge fix or selects the
+Gateway transport after its own proof. A detach-only release cannot ship under a
+control labelled kill.
 
-The installed server has no `session/status` handler and advertises no status
-capability. It also has no `session/set_model` handler or model capability.
-Its config options cover thinking level and several session behaviors; model
-selection is absent. Generic methods found in the bundled ACP client and SDK
-are not evidence that this bridge server implements them.
+### Requirements a hosting design must answer
 
-Health can be derived locally without a status RPC: child exit means dead,
-release means unhosted, a pending prompt means active, a permission callback
-means attention, and prompt completion means idle. The host must test this
-state machine against protocol fixtures.
+**1. Ownership and concurrency for sessions that also receive Gateway turns.**
+Session keys are channel-bound: a session a Viewer-owned bridge holds can also
+receive turns from a messaging channel or from cron, with no Viewer
+involvement. Bridge-local health inference — child exit means dead, a pending
+prompt means active, prompt completion means idle — describes only the turns
+the bridge itself issued, so a Gateway-originated turn leaves an idle-looking
+host that is busy and an abort aimed at the wrong run. The design must say who
+owns a session, what happens when a second writer takes a turn (refuse, observe
+or serialise), what `health()` reports and `send()` promises while a foreign
+turn runs, and how a writer fence behaves when the Viewer is not the only
+writer.
 
-Cancellation remains a blocker. The bridge's cancel handler sends
-`chat.abort`, catches and logs any failure, clears its local pending prompt,
-and resolves it as cancelled. A failed Gateway abort therefore looks
-successful to an ACP client. Killing the bridge process only closes the client;
-the Gateway may continue the run.
+**2. The lifecycle surfaces.** Beyond the six `EngineHost` methods, at minimum:
+**startup re-adoption** of hosts that outlived the Viewer process; **persistence
+binding** between the registry row, the durable event store and the transcript;
+**registry host-kind validation** for a third kind, through
+`structuredHostControl.ts:23-67` and `resources.ts:163-207`; **successor
+publication** when a host is replaced, rebound or generation-bumped; and
+**restart failure handling** — what the board shows when re-adoption fails, and
+how a half-adopted host retires without reporting a kill it never performed.
 
-**2. Gateway WebSocket.** A direct client could call `chat.abort` and preserve
-its result, which gives it a possible route to real interruption. The cost is a
-private Gateway protocol and a direct connection to the operator's messaging
-service. This option stays behind the same isolated proof gate and needs a
-separate security review before selection.
+**3. Identity, model and effort.** `src/lib/agent/sessionKey.ts:7-19` accepts a
+bare v4-shaped id, which a `-topic-<n>` filename cannot supply; the bare id is
+in the transcript header and the trajectory's first `session.started` event
+joins `sessionKey` to it through `data.sessionFile`. That join is the whole cost
+of phase 1's trajectory exclusion. For Expected 5, effort may map to
+`session/set_mode` or the advertised thought-level option, while model control
+has no route in the installed ACP server — the selector stays disabled with an
+explicit unsupported reason until one is demonstrated.
 
-**3. `openclaw agent --json` per turn.** The command returns one terminal JSON
-result. It provides no streamed deltas, permission channel, or proven remote
-abort. It cannot meet the structured-host requirement.
+### The `node:sqlite` preflight, retained
 
-### Transport decision gate
-
-ACP is the leading candidate because it already provides session lifecycle,
-stream updates, and permission callbacks over stdio. Implementation is blocked
-until an isolated Gateway test proves all of these properties:
-
-1. Start a synthetic session and a deliberately long turn.
-2. Send `session/cancel` and verify the Gateway run terminates, transcript
-   growth stops, and the client receives a failure when `chat.abort` fails.
-3. Release the host during an active turn and verify the same termination
-   outcome through the runtime and resource kill surfaces.
-4. Resume the session through a fresh bridge and prove replay plus new streamed
-   events without duplication.
-
-The test uses an isolated `HOME`, `XDG_CONFIG_HOME`, `OPENCLAW_STATE_DIR`,
-`LLV_STATE_DIR`, and `TMPDIR`. It must never connect to the operator's Gateway.
-If stock ACP fails step 2, phase 2 must either add an upstream bridge fix that
-propagates abort failure or select the direct Gateway transport after its own
-proof. A detach-only release cannot ship under a control labelled kill.
-
-Expected 5 has a separate gate. Effort maps to `session/set_mode` or the
-advertised thought-level config option. Model control has no route in this ACP
-server. Phase 2 must demonstrate a supported model method before enabling the
-Viewer's model selector. Until then, OpenClaw model selection stays disabled
-with an explicit unsupported reason.
-
-Once the transport passes, replay remains Viewer-owned through a durable event
-store. The session transcript is canonical across bridge restarts, while each
-bridge process has its own runtime event cursor.
-
-### The `node:sqlite` obstacle: root cause, fix, diagnosis
-
-The observed failure comes from resolving `node` through a Bun child-process
-shim. `openclaw` uses `#!/usr/bin/env node`, and the Viewer forwards `PATH`
-through `CHILD_ENV_ALLOWLIST` and `subscriptionEnv` at
-`src/lib/runtime/codexAppServerHost.ts:226,396-400`.
-
-Bun 1.3.3 exposes a sharper trap: `require("node:sqlite")` can exit zero without
-returning `DatabaseSync`. An ESM named import fails under that shim. The earlier
-CommonJS exit-code probe therefore accepted the broken runtime.
-
-The host resolves a Node interpreter and the OpenClaw entry script explicitly,
-then spawns:
-
-```
-<node> <openclaw-dist-entry> acp --session <key> [--require-existing] ...
-```
-
-`LLV_OPENCLAW_NODE` and `LLV_OPENCLAW_ENTRY` provide explicit overrides. The
-default resolver must reject Bun shim directories and include the selected
-interpreter in any launch diagnostic.
-
-The preflight stays small:
+Kept because it is diagnosed and should not be rediscovered. `openclaw` uses
+`#!/usr/bin/env node` and the Viewer forwards `PATH`
+(`src/lib/runtime/codexAppServerHost.ts:226,396-400`), so `node` can resolve to
+a Bun 1.3.3 shim where `require("node:sqlite")` exits zero without returning
+`DatabaseSync` — which is why an exit-code probe accepted a broken runtime. A
+host resolves interpreter and entry script explicitly (`LLV_OPENCLAW_NODE`,
+`LLV_OPENCLAW_ENTRY`), rejects Bun shim directories, names the interpreter in
+every launch diagnostic, and preflights three codes:
 
 | Code | Check | Message must name |
 |---|---|---|
@@ -519,10 +507,8 @@ The preflight stays small:
 | `openclaw_runtime_lacks_sqlite` | `<node> --input-type=module -e 'import { DatabaseSync } from "node:sqlite"; if (typeof DatabaseSync !== "function") process.exit(1)'` fails | the resolved interpreter and its version |
 | `openclaw_entry_missing` | entry script is absent | the path that was probed |
 
-Gateway reachability is part of ACP initialization and should surface the
-bridge's own failure. A separate probe would duplicate the connection and auth
-path. Tests prove that the Bun shim produces
-`openclaw_runtime_lacks_sqlite`, while supported Node 22 and 26 runtimes pass.
+Gateway reachability is part of ACP initialization and surfaces as the bridge's
+own failure, so it needs no separate probe.
 
 ---
 
@@ -530,13 +516,10 @@ path. Tests prove that the Bun shim produces
 
 ### The boundary
 
-**Phase 1: viewing. Phase 2: hosting.** Viewing depends only on transcript
-files and existing feed primitives. Hosting depends on a Gateway, a real Node
-runtime, and remote-run termination semantics that remain unproven.
-
-Phase 2 must build `SessionKey` from the transcript header id and the trajectory
-session key. `src/lib/agent/sessionKey.ts:7-19` accepts a bare v4-shaped id;
-OpenClaw topic filenames carry a suffix and cannot supply that value.
+**Phase 1 is viewing, and it is the only phase this document designs.**
+Viewing depends only on transcript files and existing feed primitives. Hosting
+depends on a Gateway, a real Node runtime, and remote-run termination semantics
+that remain unproven, so it is a separate design gated on section (d).
 
 ### What phase 1 ships
 
@@ -545,7 +528,7 @@ catalog, receives stable project attribution, displays its real model and
 effort, reports turn state, and opens through `renderOpenclaw`. The PR has no
 plain-text fallback.
 
-Work plan against `origin/main` at `dbfa3753`:
+Work plan against `origin/main` at `a3f9c2e2`:
 
 **1. Core unions.** In `src/lib/types.ts`, add `openclaw-sessions` to
 `RootKey` and `openclaw` to `Engine` and `Fmt`. Keep both `AgentEngine` unions,
@@ -592,6 +575,18 @@ when the real provider/model changes. Update `FeedItem.tsx`, `utils.ts`, and
 the board and in the feed. The mapping table in section (b) defines the record
 behavior.
 
+**8. Awaiting-user state and Viewer snapshots.** `isAwaitingUser` at
+`src/hooks/useSwitchboardData.ts:72` admits `openclaw`, so a recent OpenClaw
+conversation that finished its turn reaches the waiting bucket and the attention
+counter instead of sinking into the recency buckets. In
+`src/lib/view/snapshot.ts`, `transcriptEntry` at `:58` admits `openclaw` so a
+focused or selected OpenClaw path resolves instead of being dropped, and
+`conversation` at `:63` drops the `"claude" | "codex"` cast and reports the real
+engine; `SnapshotConversation["engine"]` at
+`src/lib/view/types.ts:81` widens to match. `SnapshotSpawnStub`'s
+`launch.engine` at `src/lib/view/types.ts:103` stays two-membered, because it
+describes a spawn and phase 1 creates none.
+
 **Tests**, all against invented fixtures under an isolated
 `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run by path:
 
@@ -618,6 +613,12 @@ behavior.
   identity.
 - `src/components/scheme/offscreenClusters.test.ts` covers the OpenClaw board
   color.
+- `src/hooks/useSwitchboardData.dom.test.tsx`: a recent OpenClaw conversation
+  lands in the waiting bucket, while an OpenClaw subagent and a non-recent
+  OpenClaw entry still do not.
+- `src/lib/view/view.test.ts`: a selected OpenClaw path appears in the snapshot
+  as `engine: "openclaw"` rather than being omitted or reported as Claude, and
+  a path with no scan entry is still omitted.
 
 **Gates:** `bunx tsc --noEmit --incremental false`; the touched test files by
 path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
@@ -630,56 +631,27 @@ recognition, spawn path, registry entry, delivery controller, model selector,
 or effort selector. It displays recorded model, provider, and effort values.
 The repository-wide hostability predicate also stays out of phase 1.
 
-### Phase 2, sketched
-
-Phase 2 starts with the isolated transport proof in section (d). After that
-gate passes, its implementation map follows current `origin/main`:
-
-1. Parse the bare session id from the transcript header, join the trajectory
-   session key through `data.sessionFile`, widen `AgentEngine` in
-   `src/lib/agent/cli.ts` and `SessionKey`, then add the two structured-spawn
-   construction arms.
-2. Implement the selected host with all six `EngineHost` methods,
-   identity-bound `releaseIfOwned`, process start identity in `health()`, and a
-   writer fence. `releaseIfOwned` must abort and verify the Gateway run before
-   it reaps the bridge child.
-3. Publish the host through `structuredDeliveryController.ts`, including state
-   projection, generation rebind, owned termination, and registry retirement.
-4. Extend `structuredHostControl.ts:23-67`, `resources.ts:163-207`, the resource
-   validators, and the runtime-host API so OpenClaw appears in inventory and
-   the resource kill path carries the same pid/start-identity fence. An orphan
-   bridge cannot report kill success unless a fresh control path verifies the
-   Gateway run ended.
-5. Extend `scanner/process.ts` so the bridge process carries the structured-host
-   stamp and is attributable without matching the shared Gateway process.
-6. Wire effort control through the proven ACP mode/config method. Enable model
-   control only after the transport proof demonstrates a supported model
-   method.
-
-This is a separate PR and issue. It includes protocol fixtures plus isolated
-Gateway tests for prompt streaming, attention, resume, runtime kill, resource
-kill, abort failure, process-identity mismatch, controller rebind, and replay.
-
 ---
 
 ## Baseline and file ownership
 
 The evidence and line references in this revision use `origin/main` at
-`dbfa3753` (2026-08-27). That baseline includes the merged structured-host
-inventory, process-stamp, identity-fenced release, and resource-kill work from
-#1203, plus the feed and orchestration work named in the task.
+`a3f9c2e2` (2026-08-27); every cited file is unchanged since `dbfa3753`, which
+carries the merged structured-host inventory, process-stamp, identity-fenced
+release, and resource-kill work from #1203, plus the feed and orchestration work
+named in the task.
 
 No file fence remains. The implementer rebases this branch on current main
 before editing, records the new merge base, and rechecks every cited branch
-whose line moved. Phase 1 may edit the feed renderer directly and ships its
-scanner, catalog, attribution, model, effort, cache, and presentation changes
-in the same PR.
+whose line moved. Phase 1 ships its scanner, catalog, attribution, model,
+effort, cache, feed, awaiting-user and snapshot changes in one PR.
 
 ---
 
 ## Deferred — not currently justified
 
-Cut from this design, with the reason. None of it is discarded.
+Cut from this design, with the reason. None of it is discarded. Hosting has its
+own list in section (d).
 
 **An engine-descriptor registry spanning the UI.** Would not fix the 107 binary
 ternaries, which are the actual cost, and would abstract for a fourth engine
@@ -691,8 +663,8 @@ shorter and keep each parser beside the shape it understands.
 
 **The 33-file hostability-predicate migration.** Most of those predicates
 guard launch, lifecycle, tasks, workflows, or account behavior. OpenClaw cannot
-reach them during phase 1. Phase 2 may introduce a helper for the smaller set
-its proven transport actually needs.
+reach them during phase 1. A hosting design may introduce a helper for the
+smaller set its proven transport actually needs.
 
 **Host-only erasure coercions.** Draft launch, direct reviews, task send, inbox,
 and live-turn rows have no OpenClaw producer in phase 1. They move with the
@@ -718,19 +690,11 @@ snapshot. OpenClaw runs OpenAI-family models through an OpenAI response API, so
 context window is accurate. Adding OpenAI model windows creates a separate
 maintenance surface.
 
-**OpenClaw model control.** The installed ACP server exposes no model method or
-model config option. Keep the selector disabled until the phase-2 transport
-proof identifies a supported route.
-
 **Account and limits integration.** `LimitsCache`
 (`src/lib/limits.ts:38,50`) is `Record<EngineName, …>` behind `version: 2`;
 adding a third key is a persisted-shape migration. OpenClaw has no Viewer-owned
 subscription window to display. This stays out of scope until OpenClaw's
 account model is understood.
-
-**`openclaw agent --json` as a reduced send mode.** It can send one message and
-return one terminal result. Streaming, attention, resume, and verified abort
-remain unavailable, so it cannot satisfy the originating host requirement.
 
 **Per-agent-id project grouping.** Presentational; can ride on card titles
 without a second project-id namespace. See (c).
@@ -746,13 +710,15 @@ in one PR. Discovery, complete catalog/search, attribution, turn state,
 model/provider/effort display, and the structured renderer ship together.
 
 *"the Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
-message, stream the turn, resume, kill)"* remains phase 2. ACP is eligible only
-after the isolated proof shows real run termination and propagated abort
-failure. A transport that only detaches the Viewer fails this requirement and
-does not ship.
+message, stream the turn, resume, kill)"* is **not answered here**, and is not
+claimed to be. No transport has passed the termination gate, so there is nothing
+to design a lifecycle against; section (d) carries the open questions to the
+design that will.
 
 *"at the same level Claude and Codex already are"* is met for the phase-1
-viewing surface. Hosting reaches that bar only after runtime and resource kill,
-resume, delivery, streaming, attention, inventory, and process identity pass
-the phase-2 gates. Accounts, subscription limits, and shared-Gateway process
-liveness have no equivalent OpenClaw concept and remain outside the request.
+viewing surface: discovery, attribution, catalog and search, turn state,
+model/effort display, feed rendering, the awaiting-user bucket, and Viewer
+snapshots. Hosting reaches that bar only after section (d)'s gate and
+requirements are both answered. Accounts, subscription limits, and
+shared-Gateway process liveness have no equivalent OpenClaw concept and remain
+outside the request.

--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -15,8 +15,10 @@ does not demand is preserved in **Deferred — not currently justified**.
 
 ## Evidence discipline
 
-Two sources: this repository at `ac19703`, and read-only inspection of the
-OpenClaw 2026.6.10 install on the development machine. No OpenClaw state was
+Two sources: this repository, and read-only inspection of the OpenClaw
+2026.6.10 install on the development machine. Source evidence was first read at
+`ac197031` and re-verified against `main` at `e61c1ce4`, which is the baseline
+phase 1 is cut from — see *Baseline and lane ownership*. No OpenClaw state was
 written, and the operator's running Gateway was not started, stopped or
 reconfigured.
 
@@ -34,11 +36,11 @@ and cites what was measured instead.
 
 | # | Question | Decision |
 |---|----------|----------|
-| a | Engine surface | A third union member on `Engine`/`Fmt`, **not** an engine-descriptor registry. The seam is `Fmt` for rendering plus a named `hostable` predicate for lifecycle. |
+| a | Engine surface | A third union member on `Engine`/`Fmt`, in preference to an engine-descriptor registry. The seam is `Fmt` for rendering plus a named `hostable` predicate for lifecycle. |
 | b | Viewing | The session file alone is authoritative for the message chain **and** for model/provider. The trajectory supplies only `sessionKey`. Checkpoints are excluded from discovery. |
 | c | Project attribution | A pure path recognizer for the OpenClaw workspace, minting one stable directory identity, inserted ahead of every disk-dependent resolver. |
-| d | Hosting transport | The ACP bridge (`openclaw acp`), spawned through an explicit real-Node interpreter, with a preflight that names the failure. |
-| e | Phasing | Viewing (phase 1) / hosting (phase 2). The boundary is drawn so phase 1 also avoids both contended lanes' files except one. |
+| d | Hosting transport | The ACP bridge (`openclaw acp`), spawned through an explicit real-Node interpreter, behind a four-check preflight whose every message names the interpreter it resolved. |
+| e | Phasing | Viewing (phase 1) / hosting (phase 2). Phase 1 is one PR — scanning, attribution, turn state and structured rendering together — cut against `main` at `e61c1ce4`. |
 
 ---
 
@@ -142,10 +144,18 @@ Every one of them is asking *"is this an engine I can host, rename, hydrate or
 spawn?"* — and under a widened union each one keeps answering **no** for
 OpenClaw, which is exactly right for phase 1. The codebase already has a safe
 default for a third engine, and it spread the definition across 32 files
-without naming it. That spread is the argument for naming it before phase 2,
-and it is twice what a first pass over this surface suggests — the idiom
-appears in both operand orders and in files that have nothing else
-engine-shaped in them.
+without naming it. That spread is the argument for naming it before phase 2.
+
+**This count was wrong in an earlier draft of this document, and the correction
+is worth keeping visible: the first pass found 15 files, and the real figure is
+32.** Two reasons, both of which will bite anyone who re-derives this with a
+quick grep. The idiom appears in *both operand orders* — `claude || codex` and
+`codex || claude` — and a pattern anchored on one order silently halves the
+result. And it turns up in files with nothing else engine-shaped in them
+(`src/lib/view/snapshot.ts`, `src/hooks/useSwitchboardData.ts`,
+`src/lib/pipelines/store.ts`), so a search scoped to the files that *look*
+engine-related misses them too. Anyone sizing item 9 from a single-order grep
+will plan half the work.
 
 **Class B — erasure coercions (8 sites). Actively wrong. Must be fixed.**
 
@@ -676,16 +686,34 @@ failure string talks about a registry URL. Scraping it is the wrong primary
 mechanism. The host runs a **preflight before spawn**, each check with its own
 code, and a launch failure surfaces as that code rather than as a dead host:
 
-| Code | Check | Operator-facing meaning |
+| Code | Check | Message must name |
 |---|---|---|
-| `openclaw_runtime_missing` | configured interpreter is absent or not executable | "Set `LLV_OPENCLAW_NODE` to a Node runtime." |
-| `openclaw_runtime_lacks_sqlite` | `<node> -e 'require("node:sqlite")'` exits non-zero | "That runtime has no `node:sqlite`. Bun cannot run OpenClaw; point at Node 22+." |
-| `openclaw_entry_missing` | entry script is absent | "OpenClaw is not installed where the Viewer expects." |
-| `openclaw_gateway_unreachable` | no Gateway backing the bridge | "Start the OpenClaw Gateway; the Viewer will not start it for you." |
+| `openclaw_runtime_missing` | configured interpreter is absent or not executable | the path that was resolved, and where it came from (`LLV_OPENCLAW_NODE`, or `PATH` lookup) |
+| `openclaw_runtime_lacks_sqlite` | `<node> -e 'require("node:sqlite")'` exits non-zero | the resolved interpreter path and its `--version` output |
+| `openclaw_entry_missing` | entry script is absent | the path that was probed |
+| `openclaw_gateway_unreachable` | no Gateway backing the bridge | the gateway URL that was tried |
 
-The preflight costs two `statSync` calls, one short subprocess and one gateway
-reachability probe, cached per host launch. As a backstop, a post-spawn stderr matcher for `node:sqlite` maps
-into `openclaw_runtime_lacks_sqlite`, since the observed message does contain
+**Every message names the interpreter it resolved.** This is the whole value of
+the diagnosis, because the underlying fault is a name resolving to the wrong
+binary. "SQLite support is unavailable in this Node runtime" sends the operator
+to install a Node they already have. The same failure reported as —
+
+```
+openclaw_runtime_lacks_sqlite: resolved node -> /tmp/bun-node-<hash>/node
+  (from PATH); that runtime has no node:sqlite. Set LLV_OPENCLAW_NODE to a
+  real Node 22+ binary.
+```
+
+— shows a `/tmp/bun-node-*` path, and the operator is done reading. A
+diagnosis that reports only the symptom hides the one fact that identifies the
+cause.
+
+Keep it at these four checks. The preflight costs two `statSync` calls, one
+short subprocess and one gateway reachability probe, cached per host launch,
+and it earns that by turning a dead host into a sentence. Anything more
+belongs in `doctor`, and OpenClaw already has one. As a backstop, a post-spawn
+stderr matcher for `node:sqlite` maps into `openclaw_runtime_lacks_sqlite` with
+the same resolved-path line attached, since the observed message does contain
 that token even though its prose is about something else.
 
 The preflight is the only place this belongs. `detectLaunchFailure`
@@ -728,12 +756,16 @@ make OpenClaw hostable, so it does not widen it.
 
 ### What phase 1 ships
 
-Board and feed parity for OpenClaw conversations — Expected 1 and 2 — with
-OpenClaw explicitly **not** hostable and every Class-A predicate still
-answering "no".
+Board and feed parity for OpenClaw conversations — Expected 1 and 2 — in a
+single PR, with OpenClaw explicitly **not** hostable and every Class-A
+predicate still answering "no". Scanning, project attribution, turn state,
+effort and structured rendering ship together; there is no interim state in
+which an OpenClaw conversation appears on the board but opens as unstructured
+text.
 
-Work plan, in dependency order. None of these files are owned by another lane
-except where flagged.
+Work plan, in dependency order, against `main` at `e61c1ce4`. One file
+(`src/lib/resources.ts`) is owned by the #1199 lane and is deliberately skipped
+at item 9; everything else here is free.
 
 **1. `src/lib/types.ts`** — `RootKey` gains `"openclaw-sessions"` (`:8-11`);
 `Engine` gains `"openclaw"` (`:13`); `Fmt` gains `"openclaw"` (`:15`).
@@ -768,8 +800,10 @@ codex` cache-key comparisons at `:165`, `:184`, `:212`, `:256`.
 `src/lib/scanner/projectCatalog.ts:136-137`;
 `src/lib/resourceCollector.worker.ts:45`.
 
-**7. `src/components/feed/parse.ts`** — `renderOpenclaw`, and the dispatch at
-`:2127`. **This file is owned by the #1202 lane.** See Conflicts below.
+**7. `src/components/feed/parse.ts`** — add `renderOpenclaw` beside
+`renderClaude` (`:1943`) and extend the dispatch at `:2127` from a two-way
+`fmt` test to a three-way one. The mapping table under *(b) Rendering* is the
+specification; the renderer emits only primitives that already exist.
 
 **8. `src/lib/scanner/effort.ts`** — add `"off"` and `"adaptive"` to `TIERS`
 (`:10`); add an `entry.root === "openclaw-sessions"` arm to `pickEffort`
@@ -783,19 +817,24 @@ adopt it at the Class-A sites. Behaviour-preserving by construction; the value
 is that phase 2 becomes a one-line change with a test instead of a 32-file
 audit.
 
-Exactly three of those 32 files sit in fenced lanes —
-`src/lib/mcp/bindings.ts` and `src/components/LogFeed.tsx` under #1202,
-`src/lib/resources.ts` under #1199. Phase 1 adopts the predicate in the other
-29 and leaves those three copies in place. Since the predicate is
-defined to exclude OpenClaw, the mixed state behaves identically either way,
-and the leftovers are a mechanical follow-up once those lanes merge.
+One of those 32 files is still owned elsewhere: `src/lib/resources.ts`, under
+the #1199 lane. Phase 1 adopts the predicate in the other 31 and leaves that
+copy in place. Since the predicate is defined to exclude OpenClaw, the mixed
+state behaves identically either way, and the leftover is a mechanical
+follow-up once #1199 merges.
 
-**10. Class B, the eight erasure sites** — `parse.ts:1311` and `:1486` are
-inside the fenced feed directory and ride with item 7. The other six take an
-explicit third arm. `src/lib/runtime/liveTurn.ts:374` and
-`RuntimeLiveTurnToolEngine` (`:22`) can wait for phase 2, since nothing
-produces live-turn rows for a non-hosted engine; note it in the phase-2 issue
-rather than widening a hosting type in a viewing PR.
+**10. Class B, the eight erasure sites** — seven take an explicit third arm in
+phase 1: `src/components/feed/parse.ts:1311` and `:1486`,
+`src/components/DraftAgentPane.tsx:396`,
+`src/components/flows/directReviewGroups.ts:134` and `:146`,
+`src/app/api/tasks/[id]/send/route.ts:94`,
+`src/lib/tasks/inboxScanner.ts:144`.
+
+The eighth, `src/lib/runtime/liveTurn.ts:374` with
+`RuntimeLiveTurnToolEngine` (`:22`), waits for phase 2. Nothing produces
+live-turn rows for an engine the Viewer does not host, so widening a hosting
+type inside a viewing PR would add an unreachable branch. Carry it on the
+phase-2 issue.
 
 **Tests**, all against invented fixtures under an isolated
 `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, run **by path**:
@@ -841,38 +880,52 @@ start of phase 2, before anything is built on them.
 
 ---
 
-## Conflicts with live lanes
+## Baseline and lane ownership
 
-Reported rather than worked around, per the assignment's file-ownership fence.
+**Phase 1 is cut against `main` at `e61c1ce4`**, which already contains PR
+#1206 (the #1202 `suggest_replies` lane, merged 2026-08-27). The implementer
+rebases on current `main`. This document's evidence was originally read at
+`ac197031`; both commits are recorded here because the difference is what
+decides whether the file:line citations below still hold.
 
-**`src/components/feed/parse.ts` — owned by the #1202 lane.** Phase 1 needs
-`renderOpenclaw` and the one-line dispatch at `:2127`, and both Class-B sites
-at `:1311` and `:1486` are in the same file. There is no way to add a third
-`Fmt` renderer without touching it; putting `renderOpenclaw` in a new file
-under `src/components/feed/` does not help, because that directory is fenced
-too.
+Every line this document cites was re-read at `e61c1ce4` and is unchanged.
+`src/components/feed/parse.ts` is byte-identical between the two commits, so
+`:1311`, `:1486`, `:1943` and `:2127` all still point at what the text says
+they do; so are `src/lib/types.ts`, all six cited `src/lib/scanner/` files,
+`src/lib/accounts/migration/turnState.ts`,
+`src/lib/resourceCollector.worker.ts`, `src/lib/projects/identity.ts`,
+`src/lib/agent/sessionKey.ts`, `src/lib/status.ts` and the three cited
+`src/lib/runtime/` files. The one cited file #1206 did touch is
+`src/lib/mcp/bindings.ts`, which this document cites only at file level as a
+Class-A site; re-counted at `e61c1ce4`, the Class-A surface is still 32 files.
 
-Recommended sequencing, for the next stage to confirm with the operator:
-land phase-1 items 1–6, 8, 9 and the six non-feed Class-B sites of item 10
-first — all outside both fences, and together they give scanning, attribution,
-turn state and effort — then land the feed renderer plus the two Class-B sites
-inside `parse.ts` as a follow-up PR once #1202 merges. Until then OpenClaw conversations appear on the
-board with correct titles, projects, models and activity, and open in the feed
-through the `"plain"` fallback rather than a structured render. That is a
-visible gap and should be stated in the phase-1 PR rather than hidden.
+**Fences lifted.** `src/components/feed/**` (including `parse.ts`),
+`src/components/LogFeed.tsx`, `src/lib/mcp/**` and
+`src/lib/orchestrator/prompt.ts` have no other owner. Phase 1 takes the feed
+renderer directly, so there is no `"plain"` fallback state and no split
+delivery: scanning, attribution, turn state and structured rendering ship
+together in one PR.
 
-**Not in conflict, and deliberately so:** `src/lib/scanner/process.ts`,
-`src/lib/resources.ts`, `src/lib/runtime/structuredDeliveryController.ts`,
-`src/components/ResourcesFooter.tsx` (#1199) and `src/lib/mcp/**`,
-`src/lib/orchestrator/prompt.ts`, `src/components/LogFeed.tsx` (#1202) are all
-untouched by phase 1. Three of them hold Class-A narrowing predicates
-(`src/lib/resources.ts:793`, `src/lib/mcp/bindings.ts`,
-`src/components/LogFeed.tsx`) and `src/components/ResourcesFooter.tsx:474`
-holds a Class-C label expression. All four degrade safely under a widened
-union: the predicates keep answering "no" for OpenClaw, which is the phase-1
-answer anyway, and the footer renders `?` for an unknown engine, which is
-honest. None of them needs an edit to ship phase 1; they are the leftovers item
-9 deliberately skips.
+**Still owned — the #1199 lane, in final review.** `src/lib/resources.ts`,
+`src/lib/scanner/process.ts`, `src/lib/runtime/structuredHostControl.ts`,
+`src/lib/runtime/structuredDeliveryController.ts` and
+`src/components/ResourcesFooter.tsx`. Phase 1 touches none of them, and needs
+none of them:
+
+- `src/lib/scanner/process.ts` holds `AgentEngine` (`:13`) and `argvEngine`
+  (`:122`). Phase 1 deliberately does not make OpenClaw hostable and does not
+  do process attribution, so neither needs to change. The phase boundary was
+  drawn partly for this reason and it still holds.
+- `src/lib/resources.ts:793` is a Class-A narrowing predicate. It keeps
+  answering "no" for OpenClaw, which is the phase-1 answer anyway. It is the
+  single Class-A copy item 9 skips.
+- `src/components/ResourcesFooter.tsx:474` is a Class-C label expression that
+  renders `?` for an unrecognised engine — honest, and correct until someone
+  gives OpenClaw a label.
+
+Phase 2 will need `src/lib/scanner/process.ts` and
+`src/lib/runtime/structuredDeliveryController.ts`, so it should not start until
+#1199 has merged.
 
 ---
 
@@ -927,9 +980,10 @@ without a second project-id namespace. See (c).
 
 Read back against the quote at the top.
 
-*"the Viewer scans and renders OpenClaw conversations"* — phase 1, items 1–8.
-Scanning is complete on merge of items 1–6; rendering is complete on merge of
-item 7, which is gated on the #1202 lane and flagged above rather than assumed.
+*"the Viewer scans and renders OpenClaw conversations"* — phase 1, items 1–10,
+in one PR. Both halves of the clause land together: scanning and attribution
+from items 1–6, structured rendering from item 7. No fallback state, no partial
+delivery.
 
 *"the Viewer can host an OpenClaw agent as a structured host (spawn, deliver a
 message, stream the turn, resume, kill)"* — phase 2, over the ACP bridge, with

--- a/src/app/api/agent/snapshot/standalone.integration.test.ts
+++ b/src/app/api/agent/snapshot/standalone.integration.test.ts
@@ -116,7 +116,7 @@ function seedCompletedFiles(sandbox: string, stateDir: string): FileEntry[] {
   fs.mkdirSync(stateDir, { recursive: true });
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), `${JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: { files, projectCatalog, complete: true },
   })}\n`);
   return files;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -775,7 +775,7 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   };
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: persistedSnapshot,
   }));
   resetFilesRouteCacheForTests();
@@ -795,7 +795,7 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
 test("the pipeline controller warm-starts from the persisted completed snapshot while revalidating", async () => {
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: {
       files: [file("/sessions/persisted-controller.jsonl")],
       projectCatalog: [],
@@ -822,7 +822,7 @@ test("the pipeline controller warm-starts from the persisted completed snapshot 
 test("a current scan joins restart revalidation before publishing transcript metadata", async () => {
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: {
       files: [file("/sessions/persisted-resource.jsonl")],
       projectCatalog: [],
@@ -1264,7 +1264,7 @@ test("a fresh resource snapshot replaces stale process and pane observations bef
 test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: {
       files: [file("/sessions/persisted-client.jsonl")],
       projectCatalog: [],
@@ -1302,7 +1302,7 @@ test("a restart hydrates a persisted 7700-row snapshot within two seconds", asyn
   const files = Array.from({ length: 7_700 }, (_, index) => file(`/sessions/persisted-${index}.jsonl`));
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: { files, projectCatalog: [], complete: true },
   }));
   resetFilesRouteCacheForTests();
@@ -1326,7 +1326,7 @@ test("a corrupt completed snapshot falls back to a cold scan and repairs persist
   expect(scans).toBe(1);
   const persisted = JSON.parse(fs.readFileSync(path.join(stateDir, "files-scan-snapshot.json"), "utf8"));
   expect(persisted.version).toBe(1);
-  expect(persisted.schemaVersion).toBe(9);
+  expect(persisted.schemaVersion).toBe(10);
 });
 
 test("repeated first-ever incomplete scans stay unpublished until recovery", async () => {
@@ -1391,7 +1391,7 @@ test("snapshot publication failures preserve the canonical file, clean temps, st
   const snapshotPath = path.join(stateDir, "files-scan-snapshot.json");
   const canonical = JSON.stringify({
     version: 1,
-    schemaVersion: 9,
+    schemaVersion: 10,
     snapshot: {
       files: [file("/sessions/canonical.jsonl")],
       projectCatalog: [],

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -26,7 +26,7 @@ fs.mkdirSync(sessions, { recursive: true });
 
 const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
 const { ROOTS } = await import("@/lib/scanner/roots");
-const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { cachedFileScan, currentFileScan, persistedFileScanSnapshot, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
 const { linkEntries } = await import("@/lib/scanner/links");
 const { activityVerdict, transcriptTurnResult } = await import("@/lib/scanner/activity");
 const { entryEffort } = await import("@/lib/scanner/effort");
@@ -151,10 +151,10 @@ test("a persisted completed generation avoids cold tail rereads for unchanged tr
     expect(persisted).toBeDefined();
     const mtimeMs = persisted!.mtime * 1000;
     const caches = cacheStore.__llvCaches ?? {};
-    expect(caches["turn-evidence-v2"]?.get(`authoritative:${transcript}`)).toMatchObject({
+    expect(caches["turn-evidence-v3"]?.get(`authoritative:${transcript}`)).toMatchObject({
       size: persisted!.size,
       mtimeMs,
-      codex: true,
+      engine: "codex",
       authoritative: true,
       turn: { state: "terminal", source: "lifecycle" },
       composerReleased: false,
@@ -342,7 +342,7 @@ test("a persisted completed generation primes permanent lineage facts", async ()
     fs.mkdirSync(testStateDir, { recursive: true });
     fs.writeFileSync(path.join(testStateDir, "files-scan-snapshot.json"), JSON.stringify({
       version: 1,
-      schemaVersion: 9,
+      schemaVersion: 10,
       snapshot: {
         complete: true,
         files: [sourceEntry, taskEntry, predecessorEntry, successorEntry],
@@ -591,12 +591,12 @@ test("a persisted Claude result rebuilds recovery evidence while a busy assistan
     const restarted = await cachedFileScan(undefined, undefined, 0);
     const restartedResult = restarted.snapshot.files.find((entry) => entry.path === resultPath)!;
     const restartedAssistant = restarted.snapshot.files.find((entry) => entry.path === assistantPath)!;
-    expect(transcriptTurnResult(resultPath, restartedResult.size, restartedResult.mtime * 1000, false)).toMatchObject({
+    expect(transcriptTurnResult(resultPath, restartedResult.size, restartedResult.mtime * 1000, "claude")).toMatchObject({
       complete: true,
       turn: { state: "terminal", source: "lifecycle" },
     });
     expect(transcriptReads).toBe(1);
-    expect(transcriptTurnResult(assistantPath, restartedAssistant.size, restartedAssistant.mtime * 1000, false)).toMatchObject({
+    expect(transcriptTurnResult(assistantPath, restartedAssistant.size, restartedAssistant.mtime * 1000, "claude")).toMatchObject({
       complete: true,
       turn: { state: "busy", source: "assistant" },
     });
@@ -605,9 +605,9 @@ test("a persisted Claude result rebuilds recovery evidence while a busy assistan
     fs.appendFileSync(resultPath, "\n");
     const changed = fs.statSync(resultPath);
     failPath = resultPath;
-    expect(transcriptTurnResult(resultPath, changed.size, changed.mtimeMs, false).complete).toBe(false);
+    expect(transcriptTurnResult(resultPath, changed.size, changed.mtimeMs, "claude").complete).toBe(false);
     failPath = null;
-    expect(transcriptTurnResult(resultPath, changed.size, changed.mtimeMs, false)).toMatchObject({
+    expect(transcriptTurnResult(resultPath, changed.size, changed.mtimeMs, "claude")).toMatchObject({
       complete: true,
       turn: { state: "terminal", source: "lifecycle" },
     });
@@ -665,7 +665,7 @@ test("a cold restart after upgrade rejects pre-#406 persisted lastTurn boundarie
       schemaVersion?: number;
       snapshot: { files: FileEntry[] };
     };
-    expect(persisted.schemaVersion).toBe(9);
+    expect(persisted.schemaVersion).toBe(10);
     delete persisted.schemaVersion;
     const persistedEntry = persisted.snapshot.files.find((entry) => entry.path === transcript)!;
     persistedEntry.lastTurn = { startedAt: echoStartedAt, endedAt };
@@ -683,7 +683,7 @@ test("a cold restart after upgrade rejects pre-#406 persisted lastTurn boundarie
     /* The recovery scan re-stamps the snapshot with the current schema, so
        the next restart warm-starts on the repaired boundary. */
     const restamped = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as { schemaVersion?: number };
-    expect(restamped.schemaVersion).toBe(9);
+    expect(restamped.schemaVersion).toBe(10);
     for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
     resetFilesRouteCacheForTests();
     const warm = await cachedFileScan(undefined, undefined, 0);
@@ -1341,6 +1341,76 @@ test("a restart served from the persisted scan cache adopts a Codex fork without
     fs.readSync = originalRead;
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+/* Issue #1207: a persisted scan snapshot carrying OpenClaw entries must survive
+   validation on restart, and its turn evidence must be primed under the OpenClaw
+   discriminator. Every identifier below is invented. */
+test("a persisted snapshot keeps its OpenClaw entries and primes their turn evidence", async () => {
+  const testStateDir = path.join(sandbox, "openclaw-persisted-state");
+  const stateDirBefore = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = testStateDir;
+  const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+  try {
+    const sessionsDir = path.join(sandbox, "openclaw", "agents", "primary", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const transcript = path.join(sessionsDir, "oc-session-alpha.jsonl");
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "session", version: 3, id: "oc-header", timestamp: "2026-08-27T09:00:00.000Z", cwd: sandbox }),
+      JSON.stringify({
+        type: "message",
+        id: "oc-assistant-1",
+        parentId: "oc-parent",
+        timestamp: "2026-08-27T09:00:01.000Z",
+        message: { role: "assistant", provider: "demo-provider", model: "demo-model", api: "demo-api", stopReason: "toolUse", content: [] },
+      }),
+    ].join("\n") + "\n");
+    const stat = fs.statSync(transcript);
+    const entry: FileEntry = {
+      path: transcript,
+      root: "openclaw-sessions",
+      name: "oc-session-alpha.jsonl",
+      project: "openclaw",
+      title: "Invented OpenClaw prompt",
+      engine: "openclaw",
+      kind: "session",
+      fmt: "openclaw",
+      parent: null,
+      mtime: stat.mtimeMs / 1000,
+      size: stat.size,
+      activity: "live",
+      activityReason: "jsonl_turn_open",
+      derivationComplete: true,
+      proc: null,
+      pid: null,
+      model: "demo-model",
+      pendingQuestion: null,
+      waitingInput: null,
+    };
+    fs.mkdirSync(testStateDir, { recursive: true });
+    fs.writeFileSync(path.join(testStateDir, "files-scan-snapshot.json"), JSON.stringify({
+      version: 1,
+      schemaVersion: 10,
+      snapshot: { complete: true, files: [entry], projectCatalog: [] },
+    }));
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    resetFilesRouteCacheForTests();
+
+    /* Reading the persisted snapshot is what runs the validator; a rejected
+       entry leaves no primed evidence at all. */
+    expect(persistedFileScanSnapshot()?.files.map((file) => file.path)).toEqual([transcript]);
+    await cachedFileScan(undefined, undefined, 0);
+    expect(transcriptTurnResult(transcript, entry.size, stat.mtimeMs, "openclaw").turn)
+      .toMatchObject({ state: "busy" });
+    expect(cacheStore.__llvCaches?.model?.get(transcript))
+      .toEqual([entry.size, stat.mtimeMs, { display: "demo-model", launch: null }]);
+  } finally {
+    if (stateDirBefore === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = stateDirBefore;
     resetFilesRouteCacheForTests();
     for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
     fs.rmSync(testStateDir, { recursive: true, force: true });

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -473,8 +473,9 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
               {/* Account badge (issue #229): the third meta-chip, after ctx and
                   the branch chip. Shell tasks carry no account, so they skip it;
                   the id is read from the live transcript path so a migrated
-                  conversation reflects its current account. */}
-              {file.engine === "shell" ? null : (
+                  conversation reflects its current account. OpenClaw skips it
+                  for the same reason: the Viewer owns no OpenClaw account. */}
+              {file.engine === "shell" || file.engine === "openclaw" ? null : (
                 <AccountBadge
                   engine={file.engine}
                   accountId={runtime?.session.accountId ?? file.spawn?.accountId ?? accountIdFromPath(file.path)}

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -4,7 +4,7 @@ import { memo } from "react";
 
 import type { MandateDelivery } from "@/lib/runtime/messageOrigin";
 
-import { Brain, ChevronUp, Command, Check, Mail, Mic, Sparkle, X } from "../icons";
+import { Brain, ChevronUp, Command, Check, Mail, MessageCircle, Mic, Sparkle, X } from "../icons";
 import { hhmm } from "../utils";
 import { MESSAGE_ACTION } from "./actionStyles";
 import { SelectedContextBadge } from "../SelectedContextBadge";
@@ -103,8 +103,8 @@ export const FeedItem = memo(function FeedItem({ item: sourceItem, speakText }: 
   if (item.kind === "record") return <RecordCard item={item} />;
   if (item.kind === "mem-citation") return <MemCitationCard item={item} />;
   if (item.kind === "prose") {
-    const cls = item.engine === "codex" ? "bg-codex" : "bg-claude";
-    const AvatarIcon = item.engine === "codex" ? Command : Sparkle;
+    const cls = item.engine === "codex" ? "bg-codex" : item.engine === "openclaw" ? "bg-openclaw" : "bg-claude";
+    const AvatarIcon = item.engine === "codex" ? Command : item.engine === "openclaw" ? MessageCircle : Sparkle;
     return (
       <div className="group/msg my-3 flex gap-2.5">
         <div className={`mt-1 flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-full text-white ${cls}`}>

--- a/src/components/feed/openclaw.parse.test.ts
+++ b/src/components/feed/openclaw.parse.test.ts
@@ -1,0 +1,213 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { buildFeed, createFeedSession, type Item } from "./parse";
+
+/*
+ * The OpenClaw feed renderer (#1207). OpenClaw needs a third renderer rather
+ * than a translation into Claude's shape: it stores a tool result as a
+ * top-level record carrying its own `toolResult` role, where Claude nests one
+ * as a `tool_result` block inside a "user" record. Translating would synthesize
+ * user records the operator never sent.
+ *
+ * Every id, model, provider, tool name and message body below is invented. No
+ * OpenClaw record was copied.
+ */
+
+const openclawFile = {
+  path: "/openclaw/agents/primary/sessions/oc-session-alpha.jsonl",
+  engine: "openclaw",
+  fmt: "openclaw",
+  activity: "recent",
+} as FileEntry;
+
+const AT = "2026-08-27T09:00:00.000Z";
+
+function line(record: Record<string, unknown>): string {
+  return JSON.stringify(record);
+}
+
+function message(id: string, message: Record<string, unknown>): string {
+  return line({ type: "message", id, parentId: "oc-parent", timestamp: AT, message });
+}
+
+function assistant(id: string, content: unknown[], overrides: Record<string, unknown> = {}): string {
+  return message(id, {
+    role: "assistant",
+    provider: "demo-provider",
+    model: "demo-model",
+    api: "demo-api",
+    stopReason: "stop",
+    content,
+    ...overrides,
+  });
+}
+
+/* `srcCall`/`srcResult` are absolute stream indices, so a windowed parse and a
+   start-0 one-shot number them differently for the same logical line. Both are
+   opaque provenance tokens; normalize them out before structural comparison. */
+function normalize(items: Item[]): unknown {
+  return JSON.parse(JSON.stringify(items, (key, value) => (key === "srcCall" || key === "srcResult" ? 0 : value)));
+}
+
+function render(lines: string[], showSvc = false): Item[] {
+  return buildFeed(openclawFile, lines, showSvc, "").items;
+}
+
+test("every OpenClaw record shape maps onto its feed primitive", () => {
+  const items = render([
+    line({ type: "session", version: 3, id: "oc-header", timestamp: AT, cwd: "/openclaw/workspace" }),
+    message("oc-user-1", { role: "user", content: "Plant the cobalt orchard", timestamp: AT }),
+    message("oc-user-2", { role: "user", content: [{ type: "text", text: "and water it" }], timestamp: AT }),
+    assistant("oc-assistant-1", [
+      { type: "thinking", thinking: "weighing   the   options", thinkingSignature: "invented-signature" },
+      { type: "text", text: "Planting now.", textSignature: "invented-signature" },
+      { type: "toolCall", id: "oc-call-1", name: "Bash", arguments: { command: "plant --orchard cobalt" } },
+    ], { stopReason: "toolUse" }),
+    message("oc-result-1", {
+      role: "toolResult",
+      toolCallId: "oc-call-1",
+      toolName: "Bash",
+      isError: false,
+      content: [{ type: "toolResult", toolCallId: "oc-call-1", tool_use_id: "oc-call-1", content: "planted 3 rows" }],
+    }),
+  ]);
+
+  expect(items.map((item) => item.kind)).toEqual(["user", "user", "think", "prose", "tool"]);
+  expect(items[0]).toMatchObject({ kind: "user", text: "Plant the cobalt orchard" });
+  expect(items[1]).toMatchObject({ kind: "user", text: "and water it" });
+  expect(items[2]).toMatchObject({ kind: "think", text: "weighing the options" });
+  /* Prose carries the OpenClaw identity, which is what picks the feed avatar. */
+  expect(items[3]).toMatchObject({ kind: "prose", text: "Planting now.", engine: "openclaw", sourceId: "oc-assistant-1" });
+  expect(items[4]).toMatchObject({
+    kind: "tool",
+    id: "oc-call-1",
+    tool: "Bash",
+    family: "shell",
+    command: "plant --orchard cobalt",
+    status: "ok",
+    outputPreview: expect.stringContaining("planted 3 rows"),
+  });
+});
+
+test("a tool result attaches by the call id the record itself carries", () => {
+  const items = render([
+    assistant("oc-assistant-1", [
+      { type: "toolCall", id: "oc-call-1", name: "Read", arguments: { file_path: "/invented/notes.md" } },
+    ], { stopReason: "toolUse" }),
+    message("oc-result-1", {
+      role: "toolResult",
+      toolCallId: "oc-call-1",
+      toolName: "Read",
+      isError: true,
+      content: [{ type: "text", text: "no such file" }],
+    }),
+  ]);
+
+  expect(items).toHaveLength(1);
+  expect(items[0]).toMatchObject({ kind: "tool", id: "oc-call-1", tool: "Read", status: "err" });
+});
+
+test("a tool result whose call is absent does not invent a user bubble", () => {
+  const items = render([
+    message("oc-result-orphan", {
+      role: "toolResult",
+      toolCallId: "oc-call-missing",
+      toolName: "Read",
+      isError: false,
+      content: [{ type: "text", text: "orphaned output" }],
+    }),
+  ]);
+
+  expect(items.some((item) => item.kind === "user")).toBe(false);
+});
+
+test("a provider or model switch emits exactly one service row", () => {
+  const items = render([
+    assistant("oc-assistant-1", [{ type: "text", text: "first" }]),
+    assistant("oc-assistant-2", [{ type: "text", text: "second" }]),
+    assistant("oc-assistant-3", [{ type: "text", text: "third" }], { model: "demo-model-2" }),
+  ], true);
+
+  const svc = items.filter((item) => item.kind === "svc");
+  expect(svc).toEqual([{ kind: "svc", text: "demo-provider · demo-model-2" }]);
+});
+
+/* The synthetic records OpenClaw writes for itself carry model labels no
+   provider ever ran; they must not announce a model switch. */
+test("a synthetic-provider record never announces a model switch", () => {
+  const items = render([
+    assistant("oc-assistant-1", [{ type: "text", text: "first" }]),
+    assistant("oc-assistant-2", [{ type: "text", text: "mirrored" }], { provider: "openclaw", model: "delivery-mirror" }),
+    assistant("oc-assistant-3", [{ type: "text", text: "third" }]),
+  ], true);
+
+  expect(items.filter((item) => item.kind === "svc")).toEqual([]);
+  /* The mirrored record still renders — it is real content OpenClaw injected. */
+  expect(items.filter((item) => item.kind === "prose").map((item) => (item as { text: string }).text))
+    .toEqual(["first", "mirrored", "third"]);
+});
+
+test("model and thinking level changes render as service rows", () => {
+  const items = render([
+    line({ type: "model_change", id: "oc-change-1", parentId: "oc-parent", timestamp: AT, provider: "demo-provider", modelId: "demo-model-2" }),
+    line({ type: "thinking_level_change", id: "oc-change-2", parentId: "oc-parent", timestamp: AT, thinkingLevel: "high" }),
+    line({ type: "custom", id: "oc-change-3", parentId: "oc-parent", timestamp: AT, customType: "demo:snapshot", data: {} }),
+  ], true);
+
+  expect(items).toEqual([
+    { kind: "svc", text: "demo-provider · demo-model-2" },
+    { kind: "svc", text: "thinking · high" },
+    { kind: "svc", text: "demo:snapshot" },
+  ]);
+});
+
+test("an OpenClaw transcript never falls back to raw plain-text rows", () => {
+  const items = render([
+    line({ type: "session", version: 3, id: "oc-header", timestamp: AT, cwd: "/openclaw/workspace" }),
+    message("oc-user-1", { role: "user", content: "Plant the cobalt orchard", timestamp: AT }),
+  ], true);
+
+  expect(items.some((item) => item.kind === "raw")).toBe(false);
+});
+
+/* The feed is an incremental window parser: a sliding window must render the
+   same rows a fresh parse of that window would. The model-switch service row is
+   the only cross-record state the OpenClaw arm holds, so its baseline has to
+   clear when the line that set it slides out. */
+test("a sliding window renders the same rows as a fresh parse of that window", () => {
+  const lines = [
+    line({ type: "session", version: 3, id: "oc-header", timestamp: AT, cwd: "/openclaw/workspace" }),
+    message("oc-user-1", { role: "user", content: "Plant the cobalt orchard", timestamp: AT }),
+    assistant("oc-assistant-1", [{ type: "text", text: "first" }]),
+    assistant("oc-assistant-2", [{ type: "text", text: "second" }], { model: "demo-model-2" }),
+    assistant("oc-assistant-3", [
+      { type: "toolCall", id: "oc-call-1", name: "Bash", arguments: { command: "plant --orchard cobalt" } },
+    ], { stopReason: "toolUse", model: "demo-model-2" }),
+    message("oc-result-1", {
+      role: "toolResult",
+      toolCallId: "oc-call-1",
+      toolName: "Bash",
+      isError: false,
+      content: [{ type: "text", text: "planted 3 rows" }],
+    }),
+    assistant("oc-assistant-4", [{ type: "text", text: "done" }], { model: "demo-model-3" }),
+  ];
+
+  const session = createFeedSession({ engine: "openclaw", fmt: "openclaw", showSvc: true, lineFilter: "" });
+  const cap = 4;
+  let window: string[] = [];
+  let start = 0;
+  for (const next of lines) {
+    window = window.concat(next);
+    if (window.length > cap) {
+      start += window.length - cap;
+      window = window.slice(-cap);
+    }
+    const incremental = session.feed(window, start, false);
+    const oneShot = buildFeed(openclawFile, window, true, "");
+    expect(normalize(incremental.items.map((row) => row.item))).toEqual(normalize(oneShot.items));
+    expect(incremental.hiddenServiceCount).toBe(oneShot.hiddenServiceCount);
+  }
+});

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -20,7 +20,7 @@ import type { GlyphName } from "../icons";
 import { hhmm } from "../utils";
 import { decodeTerminalText } from "./ansi";
 import { diffFromApplyPatch, normalizeEdit, type DiffModel, type FileDiff } from "./diff";
-import { familyOf, summarizeTool, type ArgChip, type ToolFamily } from "./tools";
+import { familyOf, summarizeTool, type ArgChip, type FeedEngine, type ToolFamily } from "./tools";
 
 /* Feed labels resolve against the active locale at build/render time; a locale
    flip rebuilds the feed (see LogFeed's memo), so cached items re-localize. */
@@ -223,7 +223,7 @@ export type CmdGroupItem = {
     changes: this kind exists only between the resolver and the card. */
 export type MandateItem = { kind: "mandate"; ts: unknown; text: string; mandate: MandateDelivery };
 export type Item =
-  | { kind: "prose"; ts: unknown; text: string; engine: "codex" | "claude"; sourceId?: string }
+  | { kind: "prose"; ts: unknown; text: string; engine: "codex" | "claude" | "openclaw"; sourceId?: string }
   | { kind: "user"; ts: unknown; text: string; selectedContext?: SelectedContextRef }
   | MandateItem
   | VoiceTurnItem
@@ -354,6 +354,20 @@ function tmsgAttr(attrs: string, name: string): string {
 
 function textPart(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+/** The provider value OpenClaw stamps on assistant records it synthesised
+    itself (a channel delivery mirrored back, a Gateway injection) rather than
+    on a model's answer. Repeated from `@/lib/scanner/openclawNative`, which
+    reads files and so cannot be imported into a client bundle; both definitions
+    describe the same on-disk value. */
+const OPENCLAW_SYNTHETIC_PROVIDER = "openclaw";
+
+/** Narrow a session's configured engine to the set the rows carry. */
+function feedEngine(engine: string): FeedEngine {
+  if (engine === "codex") return "codex";
+  if (engine === "openclaw") return "openclaw";
+  return "claude";
 }
 
 function rec(value: unknown): Record<string, unknown> {
@@ -1152,7 +1166,7 @@ function sameCodexTextAtTime(leftTs: unknown, leftText: unknown, rightTs: unknow
  */
 export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const { showSvc, lineFilter } = cfg;
-  const jsonl = cfg.fmt === "claude" || cfg.fmt === "codex";
+  const jsonl = cfg.fmt === "claude" || cfg.fmt === "codex" || cfg.fmt === "openclaw";
 
   const entries: StoredEntry[] = [];
   const calls = new Map<string, CallRec>();
@@ -1192,6 +1206,15 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
      provisional record keeps a live tail visible until its echo arrives. */
   let pendingCodexUsers: PendingCodexUser[] = [];
   let codexCompacted: { src: number } | null = null;
+  /* The provider·model pair the last real OpenClaw assistant record ran on,
+     with the source line it came from. A change emits one service row; the
+     first pair a window sees is its baseline and announces nothing. */
+  let openclawModel: { pair: string; src: number } | null = null;
+  /* For each emitted model-change row, the line that established the pair it
+     changed FROM. Once that line slides out of the window, a fresh parse of the
+     shortened window would read the new pair as its baseline and emit no row,
+     so the window is re-parsed whole instead of keeping a row nothing justifies. */
+  let openclawModelBoundaries: number[] = [];
   let plainBlock: { lines: string[]; src: number } | null = null;
   let lastPlainCall: CallRec | null = null;
   /* Every ScheduleWakeup call, in transcript order. The active wakeup is the
@@ -1308,7 +1331,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (!text.trim()) return null;
     const firstSeq = pushSeq;
     if (pushBlobIfHuge(text, sourceId)) return { firstSeq, lastSeq: pushSeq - 1 };
-    const engine = cfg.engine === "codex" ? "codex" : "claude";
+    const engine = feedEngine(cfg.engine);
     if (pushStructured(ts, text, (segment) => push({
       kind: "prose",
       ts,
@@ -1371,7 +1394,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     id: string;
     tool: string;
     args?: Record<string, unknown>;
-    engine: "claude" | "codex";
+    engine: FeedEngine;
     command?: string;
     diff?: DiffModel;
     lang?: string | null;
@@ -1483,7 +1506,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
      a synthetic id keeps the row addressable (and the last one attachable). */
   const addShell = (ts: unknown, command: string, callId?: string, tool = "Bash", extraArgs?: Record<string, unknown>): ToolEvent => {
     const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
-    const engine = cfg.engine === "codex" ? "codex" : "claude";
+    const engine = feedEngine(cfg.engine);
     const event = newToolEvent({ ts, id, tool, args: { ...extraArgs, command }, engine, command });
     const rec = registerCall(event);
     if (!callId) lastPlainCall = rec;
@@ -2048,6 +2071,75 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     }
     addSvc(textPart(obj.type) || tr("render.record"));
   };
+  /* OpenClaw needs its own renderer rather than a translation into Claude's
+     shape: it stores a tool result as a TOP-LEVEL record with its own
+     `toolResult` role, where Claude nests one as a `tool_result` content block
+     inside a "user" record. Translating would synthesize user records the
+     operator never sent, so this arm calls `addOutput` directly. */
+  const renderOpenclaw = (obj: Record<string, unknown>) => {
+    const ts = obj.timestamp;
+    if (obj.type !== "message") {
+      if (obj.type === "model_change") {
+        const label = [textPart(obj.provider), textPart(obj.modelId)].filter(Boolean).join(" · ");
+        return addSvc(label || "model_change");
+      }
+      if (obj.type === "thinking_level_change") {
+        return addSvc(`thinking · ${textPart(obj.thinkingLevel) || tr("render.record")}`);
+      }
+      if (obj.type === "custom") return addSvc(textPart(obj.customType) || "custom");
+      return addSvc(textPart(obj.type) || tr("render.record"));
+    }
+    const message = rec(obj.message);
+    const content = message.content;
+    const role = textPart(message.role);
+    if (role === "user") {
+      if (typeof content === "string") return addUserText(ts, content);
+      for (const part of arr(content)) {
+        if (part.type === "text") addUserText(ts, textPart(part.text));
+      }
+      return;
+    }
+    if (role === "toolResult") {
+      /* The record itself owns the call id; the blocks carry camelCase and
+         snake_case aliases of it, which are copies rather than a second id. */
+      const callId = textPart(message.toolCallId);
+      const isError = message.isError === true;
+      const text = arr(content)
+        .map((part) => (part.type === "toolResult" ? textPart(part.content) || textPart(part.text) : textPart(part.text)))
+        .filter(Boolean)
+        .join("\n");
+      return addOutput(callId, text, isError);
+    }
+    if (role !== "assistant") return void addSvc(role || tr("render.record"));
+    /* A record a real provider served may announce a model switch; the
+       synthetic ones OpenClaw writes for itself carry labels no provider ran,
+       so they never move the displayed pair. */
+    if (textPart(message.provider) !== OPENCLAW_SYNTHETIC_PROVIDER) {
+      const pair = `${textPart(message.provider)} · ${textPart(message.model)}`;
+      if (pair !== openclawModel?.pair) {
+        if (openclawModel !== null) {
+          openclawModelBoundaries.push(openclawModel.src);
+          addSvc(pair);
+        }
+        openclawModel = { pair, src: curSrc };
+      }
+    }
+    const sourceId = textPart(obj.id) || undefined;
+    for (const part of arr(content)) {
+      if (part.type === "text" && textPart(part.text).trim()) {
+        addProse(ts, textPart(part.text), sourceId);
+      } else if (part.type === "thinking" && textPart(part.thinking).trim()) {
+        push({ kind: "think", text: textPart(part.thinking).replace(/\s+/g, " ").trim() });
+      } else if (part.type === "toolCall") {
+        const name = textPart(part.name) || "tool";
+        const args = rec(part.arguments ?? part.input);
+        const id = textPart(part.id) || "plain-" + pushSeq + "-" + String(ts ?? "");
+        const command = familyOf(name) === "shell" ? textPart(args.command ?? args.cmd) : undefined;
+        const lang = familyOf(name) === "read" ? extLang(textPart(args.file_path ?? args.path)) : undefined;
+        registerCall(newToolEvent({ ts, id, tool: name, args, engine: "openclaw", command, lang }));
+      }
+    }
+  };
   /* Job .output logs echo the final review/citation block as bare lines after the
      [codex] stream ends; collect that run so it renders as one structured card
      instead of per-line raw rows. Falls back to the old raw rows when the block
@@ -2125,6 +2217,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         const obj = JSON.parse(line);
         if (obj && typeof obj === "object" && !Array.isArray(obj)) {
           if (cfg.fmt === "claude") renderClaude(obj);
+          else if (cfg.fmt === "openclaw") renderOpenclaw(obj);
           else renderCodex(obj);
         } else addRecord(null, "malformed_record", { value: obj });
       } catch {
@@ -2144,6 +2237,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     codexAssistantRecord = null;
     pendingCodexUsers = [];
     codexCompacted = null;
+    openclawModel = null;
+    openclawModelBoundaries = [];
     plainBlock = null;
     lastPlainCall = null;
     wakeupCalls.length = 0;
@@ -2181,6 +2276,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (codexAssistantRecord && codexAssistantRecord.src < start) codexAssistantRecord = null;
     pendingCodexUsers = pendingCodexUsers.filter((pending) => pending.src >= start);
     if (codexCompacted && codexCompacted.src < start) codexCompacted = null;
+    if (openclawModel && openclawModel.src < start) openclawModel = null;
+    const openclawBoundaryEvicted = openclawModelBoundaries.some((src) => src < start);
+    openclawModelBoundaries = openclawModelBoundaries.filter((src) => src >= start);
     if (lastPlainCall && entryIndex(lastPlainCall.seq) < 0) lastPlainCall = null;
     /* Drop wakeup calls whose entry slid out of the window; recompute so the
        active/superseded assignment matches a fresh parse of the shortened
@@ -2190,7 +2288,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       if (entryIndex(wakeupCalls[i].seq) < 0) { wakeupCalls.splice(i, 1); wakeupsEvicted = true; }
     }
     if (wakeupsEvicted) recomputeWakeupStates();
-    return crossedEchoSeam || (plainBlock !== null && plainBlock.src < start);
+    return crossedEchoSeam || openclawBoundaryEvicted || (plainBlock !== null && plainBlock.src < start);
   };
 
   /* Collapses a run of >=2 consecutive foldable tool entries into one cmd-group

--- a/src/components/feed/tools.ts
+++ b/src/components/feed/tools.ts
@@ -11,6 +11,11 @@ import { normalizeEdit, type DiffModel } from "./diff";
    language-neutral summary, and a small set of redacted argument chips. It is
    total: any `Record<string, unknown>` yields a valid result and never throws. */
 
+/** The engines a rendered row can be attributed to. Background-task job logs
+    render Codex-shaped rows under the `shell` engine, so `shell` is not a
+    member: every row this taxonomy produces belongs to one of these three. */
+export type FeedEngine = "claude" | "codex" | "openclaw";
+
 export type ToolFamily = "shell" | "read" | "write" | "edit" | "search" | "web" | "spawn" | "plan" | "mcp" | "other";
 
 export const TOOL_FAMILIES: readonly ToolFamily[] = ["shell", "read", "write", "edit", "search", "web", "spawn", "plan", "mcp", "other"];
@@ -184,7 +189,7 @@ function shortUrl(url: string): string {
 export function summarizeTool(
   tool: string,
   args: Record<string, unknown>,
-  engine: "claude" | "codex",
+  engine: FeedEngine,
   precomputedDiff?: DiffModel,
 ): ToolSummary {
   const family = familyOf(tool);

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -10,6 +10,7 @@ import {
   draftWorkingDirectory,
   descendantCounts,
   isConversation,
+  isSubagent,
   kidsIndex,
   quietHistoryRows,
   quietRootsWithActiveDescendants,
@@ -251,6 +252,12 @@ describe("buildBranchGroups", () => {
   test("a compaction-chain predecessor is no conversation root", () => {
     expect(isConversation(entry({ path: "/root" }))).toBe(true);
     expect(isConversation(entry({ path: "/root", parent: "/older" }))).toBe(false);
+  });
+
+  test("an OpenClaw transcript is a conversation root of its own (#1207)", () => {
+    const openclaw = { root: "openclaw-sessions" as const, engine: "openclaw" as const, fmt: "openclaw" as const };
+    expect(isConversation(entry({ path: "/openclaw/oc-session-alpha.jsonl", ...openclaw }))).toBe(true);
+    expect(isSubagent(entry({ path: "/openclaw/oc-session-alpha.jsonl", ...openclaw }))).toBe(false);
   });
 
   test("a standalone viewer-spawned conversation stays a root despite its spawner parent", () => {

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -75,6 +75,11 @@ export function isConversation(file: FileEntry): boolean {
     return lineage?.kind === "spawn" && !lineage.memberships.length && !file.handoff;
   }
   if (file.root === "codex-sessions") return !file.parent;
+  /* OpenClaw has no subagent or compaction-successor shape on disk: every
+     transcript in an agent's sessions directory is a conversation in its own
+     right (#1207). Without this arm an OpenClaw card is scanned and attributed
+     and then belongs to no board tree at all. */
+  if (file.root === "openclaw-sessions") return !file.parent;
   return false;
 }
 

--- a/src/components/scheme/offscreenClusters.test.ts
+++ b/src/components/scheme/offscreenClusters.test.ts
@@ -32,6 +32,22 @@ describe("board clusters", () => {
     expect(clusters.some((cluster) => cluster.key.startsWith("task::"))).toBe(false);
   });
 
+  test("an OpenClaw card keeps its own identity colour on the board (#1207)", () => {
+    const live: FileEntry = {
+      path: "/openclaw/agents/primary/sessions/oc-session-alpha.jsonl",
+      root: "openclaw-sessions", name: "oc-session-alpha.jsonl", project: "project", title: "Live OpenClaw agent",
+      engine: "openclaw", kind: "session", fmt: "openclaw", parent: null, mtime: 1, size: 1, activity: "live",
+      proc: null, pid: null, model: null, pendingQuestion: null, waitingInput: null,
+    };
+    const layout = {
+      groups: [],
+      nodes: [{ x: 0, y: 0, w: 600, h: 780, file: live, isRoot: true }],
+      stacks: [], decks: [], drafts: [], slots: [],
+    } as unknown as SchemeLayout;
+    expect(boardClusters(layout, new Set<string>()).map((cluster) => cluster.color))
+      .toEqual(["var(--color-openclaw)"]);
+  });
+
   test("keeps title text beyond the resting chip segment for progressive reveal", () => {
     const title = "Repair durable pipeline ownership while preserving every queued reviewer conversation title";
     const live: FileEntry = {

--- a/src/components/scheme/offscreenClusters.ts
+++ b/src/components/scheme/offscreenClusters.ts
@@ -381,7 +381,7 @@ export function boardClusters(
       label: cleanTitle(node.file.title),
       rect: node,
       priority: isCurrentWorkFile(node.file) ? 4 : 2,
-      color: node.file.engine === "codex" ? "var(--color-codex)" : "var(--color-claude)",
+      color: `var(--color-${node.file.engine === "codex" ? "codex" : node.file.engine === "openclaw" ? "openclaw" : "claude"})`,
     });
   }
   return clusters;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,7 +1,6 @@
 import { effortMeter as meterOf } from "@/lib/agent/efforts";
 import { getLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
-import { cleanTitle } from "@/lib/title";
 
 export { cleanTitle, shortTitle } from "@/lib/title";
 
@@ -191,42 +190,4 @@ export function engineBadgeFor(engine: string) {
 
 export function engineBadge(file: FileEntry) {
   return engineBadgeFor(file.engine);
-}
-
-const OPENCLAW_TRANSCRIPT_PATH = /\/\.openclaw[^/]*\/agents\/[^/]+\/sessions\//;
-
-export function syntheticFile(pathname: string): FileEntry {
-  const root = pathname.includes("/.claude/projects/")
-    ? "claude-projects"
-    : /\/tmp\/claude-\d+\//.test(pathname)
-      ? "claude-tasks"
-      : OPENCLAW_TRANSCRIPT_PATH.test(pathname)
-        ? "openclaw-sessions"
-        : "codex-sessions";
-  const fmt = pathname.endsWith(".jsonl")
-    ? (root === "claude-projects" ? "claude" : root === "openclaw-sessions" ? "openclaw" : "codex")
-    : "plain";
-  const engine = root === "codex-sessions"
-    ? "codex"
-    : root === "claude-tasks" ? "shell" : root === "openclaw-sessions" ? "openclaw" : "claude";
-  return {
-    path: pathname,
-    root,
-    fmt,
-    engine,
-    kind: "",
-    title: cleanTitle(pathname.split("/").pop() || pathname, 120),
-    project: "",
-    worktree: undefined,
-    mtime: Date.now() / 1000,
-    size: 0,
-    activity: "idle",
-    proc: null,
-    pid: null,
-    model: null,
-    pendingQuestion: null,
-    waitingInput: null,
-    parent: null,
-    name: pathname,
-  };
 }

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -35,7 +35,7 @@ export function activityDot(activity: FileEntry["activity"]): string {
 
 export type ModelTint = { color: string; soft: string };
 
-/* Engine base identity: Codex blue, Claude orange. Model families shift the
+/* Engine base identity: Codex blue, Claude orange, OpenClaw magenta. Model families shift the
    hue so sibling agents on different models are tellable apart at a glance.
 
    Only the identity `color` is stored — a saturated hue that reads on any
@@ -47,6 +47,7 @@ export type ModelTint = { color: string; soft: string };
 const ENGINE_COLORS: Record<string, string> = {
   codex: "#2f6fd0",
   claude: "#d97757",
+  openclaw: "#b3407a",
 };
 const NEUTRAL_COLOR = "#9a9aa4";
 const CLAUDE_MODEL_COLORS: [RegExp, string][] = [
@@ -92,6 +93,9 @@ function modelBaseHex(file: FileEntry): string {
   const base = ENGINE_COLORS[file.engine];
   if (!base) return NEUTRAL_COLOR;
   const model = (file.model ?? "").toLowerCase();
+  /* OpenClaw runs other vendors' models through its own provider layer, so no
+     model-family table applies: its cards keep the flat engine identity. */
+  if (file.engine === "openclaw") return base;
   for (const [re, color] of file.engine === "codex" ? CODEX_MODEL_COLORS : CLAUDE_MODEL_COLORS) {
     if (re.test(model)) return color;
   }
@@ -180,7 +184,7 @@ export function engineEdge(file: FileEntry): { backgroundColor: string } {
 }
 
 export function engineBadgeFor(engine: string) {
-  const label = { codex: "Codex", claude: "Claude", shell: "Bash" }[engine] ?? engine;
+  const label = { codex: "Codex", claude: "Claude", shell: "Bash", openclaw: "OpenClaw" }[engine] ?? engine;
   const tint = tintOf(ENGINE_COLORS[engine] ?? NEUTRAL_COLOR);
   return { label, style: { backgroundColor: tint.soft, color: tint.color } };
 }
@@ -189,14 +193,22 @@ export function engineBadge(file: FileEntry) {
   return engineBadgeFor(file.engine);
 }
 
+const OPENCLAW_TRANSCRIPT_PATH = /\/\.openclaw[^/]*\/agents\/[^/]+\/sessions\//;
+
 export function syntheticFile(pathname: string): FileEntry {
   const root = pathname.includes("/.claude/projects/")
     ? "claude-projects"
     : /\/tmp\/claude-\d+\//.test(pathname)
       ? "claude-tasks"
-      : "codex-sessions";
-  const fmt = pathname.endsWith(".jsonl") ? (root === "claude-projects" ? "claude" : "codex") : "plain";
-  const engine = root.startsWith("codex") ? "codex" : root === "claude-tasks" ? "shell" : "claude";
+      : OPENCLAW_TRANSCRIPT_PATH.test(pathname)
+        ? "openclaw-sessions"
+        : "codex-sessions";
+  const fmt = pathname.endsWith(".jsonl")
+    ? (root === "claude-projects" ? "claude" : root === "openclaw-sessions" ? "openclaw" : "codex")
+    : "plain";
+  const engine = root === "codex-sessions"
+    ? "codex"
+    : root === "claude-tasks" ? "shell" : root === "openclaw-sessions" ? "openclaw" : "claude";
   return {
     path: pathname,
     root,

--- a/src/hooks/useSwitchboardData.dom.test.tsx
+++ b/src/hooks/useSwitchboardData.dom.test.tsx
@@ -7,7 +7,7 @@ import { reviewerBindingTargetsForRound } from "@/components/flows/flowModel";
 import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
-import { type SwitchboardData, useSwitchboardData } from "./useSwitchboardData";
+import { isAwaitingUser, type SwitchboardData, useSwitchboardData } from "./useSwitchboardData";
 
 const dom = new Window({ url: "http://localhost/" });
 const globals = globalThis as Record<string, unknown>;
@@ -152,6 +152,39 @@ test("keeps every durable same-round reviewer binding out of standalone switchbo
   const standalonePaths = [data!.waiting, data!.working, data!.recent, data!.older]
     .flatMap((items) => items.map((item) => item.file.path));
   expect(standalonePaths).toEqual([builder.path]);
+
+  await act(async () => { root.unmount(); });
+  host.remove();
+});
+
+/* Issue #1207: a finished OpenClaw turn is the operator's to answer, so it must
+   reach the waiting bucket and the attention counter instead of sinking into
+   the recency buckets. Every path below is invented. */
+test("a recent OpenClaw conversation lands in the waiting bucket", async () => {
+  const openclaw = {
+    root: "openclaw-sessions" as const,
+    engine: "openclaw" as const,
+    fmt: "openclaw" as const,
+  };
+  const waiting = entry({ path: "/openclaw/sessions/oc-session-alpha.jsonl", ...openclaw });
+  const idle = entry({ path: "/openclaw/sessions/oc-session-beta.jsonl", ...openclaw, activity: "idle" });
+  /* An OpenClaw transcript whose card belongs to a tree is not a standalone
+     root, so it is not the operator's to answer on its own. */
+  const nested = entry({ path: "/openclaw/sessions/oc-session-gamma.jsonl", ...openclaw, parent: "/openclaw/sessions/oc-session-alpha.jsonl" });
+
+  expect(isAwaitingUser(waiting, 1_100)).toBe(true);
+  expect(isAwaitingUser(idle, 1_100)).toBe(false);
+  expect(isAwaitingUser(nested, 1_100)).toBe(false);
+
+  let data: SwitchboardData | null = null;
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(<Probe files={[waiting, idle, nested]} flows={[]} onData={(next) => { data = next; }} />);
+  });
+
+  expect(data!.waiting.map((item) => item.file.path)).toEqual([waiting.path]);
 
   await act(async () => { root.unmount(); });
   host.remove();

--- a/src/hooks/useSwitchboardData.ts
+++ b/src/hooks/useSwitchboardData.ts
@@ -69,7 +69,10 @@ export function isAwaitingUser(file: FileEntry, now = Date.now() / 1000): boolea
      entries sink into the recency buckets instead of inflating the waiting
      counter. The attention queue owns that TTL judgement. */
   if (file.activity === "stalled") return attentionId(file, now) !== null;
-  return file.activity === "recent" && (file.engine === "claude" || file.engine === "codex") && isConversation(file) && !isSubagent(file);
+  return file.activity === "recent"
+    && (file.engine === "claude" || file.engine === "codex" || file.engine === "openclaw")
+    && isConversation(file)
+    && !isSubagent(file);
 }
 
 export function useSwitchboardData(

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -240,7 +240,7 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
     const parentConversation = entry.parent ? conversationByPath.get(entry.parent) ?? null : null;
     const owner = accountManager.resolveTranscriptOwner(engine, entry.path);
     const mtimeMs = entry.mtime * 1000;
-    const observedTurn = transcriptTurnResult(entry.path, entry.size, mtimeMs, engine === "codex");
+    const observedTurn = transcriptTurnResult(entry.path, entry.size, mtimeMs, engine);
     const hostedPath = hostedPaths.has(entry.path);
     const parsed = observedTurn.complete ? hostFencedTurn(observedTurn, hostedPath) : null;
     const releasedDeadTurn = deadStalledTurn(entry, existing, hostedPath);
@@ -249,7 +249,7 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
       || currentPaneWall(entry)
       || releasedDeadTurn
     )) {
-      recordTranscriptComposerRelease(entry.path, entry.size, mtimeMs, engine === "codex");
+      recordTranscriptComposerRelease(entry.path, entry.size, mtimeMs, engine);
     }
     const turn = projectedInventoryTurn(entry, parsed, existing, hostedPath);
     const currentProfile = launchProfileByPath.get(entry.path)
@@ -504,7 +504,7 @@ function completeProviderTurnObservation(
   } catch (error) {
     return virtualSource && (error as NodeJS.ErrnoException).code === "ENOENT";
   }
-  const observed = transcriptTurnResult(source.path, before.size, before.mtimeMs, conversation.engine === "codex");
+  const observed = transcriptTurnResult(source.path, before.size, before.mtimeMs, conversation.engine);
   if (!observed.complete) return false;
   let after: fs.Stats;
   try {

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -20,12 +20,12 @@ test("issue 51 keeps a Codex turn busy through interim assistant text and tool w
     { payload: { type: "custom_tool_call", id: "tool-1" } },
     { payload: { type: "agent_message" } },
   ];
-  expect(turnStateFromRecords(records, true)).toMatchObject({ state: "busy", source: "tool" });
+  expect(turnStateFromRecords(records, "codex")).toMatchObject({ state: "busy", source: "tool" });
   expect(turnStateFromRecords([
     ...records,
     { payload: { type: "custom_tool_call_output", call_id: "tool-1" } },
     { timestamp: "2026-07-10T12:00:00.000Z", payload: { type: "turn_complete" } },
-  ], true)).toEqual({ state: "terminal", source: "lifecycle", terminalAt: "2026-07-10T12:00:00.000Z" });
+  ], "codex")).toEqual({ state: "terminal", source: "lifecycle", terminalAt: "2026-07-10T12:00:00.000Z" });
 });
 
 test("issue 51 requires the matching terminal event after every open tool closes", () => {
@@ -34,28 +34,28 @@ test("issue 51 requires the matching terminal event after every open tool closes
     { type: "event_msg", timestamp: "2026-07-10T00:00:01Z", payload: { type: "agent_message", message: "I am checking" } },
     { type: "response_item", timestamp: "2026-07-10T00:00:02Z", payload: { type: "custom_tool_call", id: "tool-1" } },
   ];
-  expect(turnStateFromRecords(open, true).state).toBe("busy");
+  expect(turnStateFromRecords(open, "codex").state).toBe("busy");
 
   const closedTool = [...open, {
     type: "response_item",
     timestamp: "2026-07-10T00:00:03Z",
     payload: { type: "custom_tool_call_output", call_id: "tool-1", output: "ok" },
   }];
-  expect(turnStateFromRecords(closedTool, true).state).toBe("busy");
+  expect(turnStateFromRecords(closedTool, "codex").state).toBe("busy");
 
   const prematureTerminal = [...open, {
     type: "event_msg",
     timestamp: "2026-07-10T00:00:02.500Z",
     payload: { type: "task_complete", turn_id: "turn-1" },
   }];
-  expect(turnStateFromRecords(prematureTerminal, true).state).toBe("busy");
+  expect(turnStateFromRecords(prematureTerminal, "codex").state).toBe("busy");
 
   const terminal = [...closedTool, {
     type: "event_msg",
     timestamp: "2026-07-10T00:00:04Z",
     payload: { type: "task_complete", turn_id: "turn-1" },
   }];
-  expect(turnStateFromRecords(terminal, true)).toMatchObject({
+  expect(turnStateFromRecords(terminal, "codex")).toMatchObject({
     state: "terminal",
     source: "lifecycle",
     terminalAt: "2026-07-10T00:00:04Z",
@@ -68,7 +68,7 @@ test("later work after a terminal event reopens the Codex turn", () => {
     { type: "event_msg", timestamp: "2026-07-10T00:00:01Z", payload: { type: "task_complete", turn_id: "turn-1" } },
     { type: "response_item", timestamp: "2026-07-10T00:00:02Z", payload: { type: "function_call", call_id: "late-tool" } },
   ];
-  expect(turnStateFromRecords(records, true).state).toBe("busy");
+  expect(turnStateFromRecords(records, "codex").state).toBe("busy");
 });
 
 test("Claude migration waits for a top-level result event", () => {
@@ -77,7 +77,7 @@ test("Claude migration waits for a top-level result event", () => {
     timestamp: "2026-07-10T00:00:01Z",
     message: { stop_reason: "end_turn" },
   };
-  expect(turnStateFromRecords([assistant], false, true)).toEqual({
+  expect(turnStateFromRecords([assistant], "claude", true)).toEqual({
     state: "busy",
     source: "assistant",
     terminalAt: null,
@@ -85,7 +85,7 @@ test("Claude migration waits for a top-level result event", () => {
   expect(turnStateFromRecords([
     assistant,
     { type: "result", timestamp: "2026-07-10T00:00:02Z", subtype: "success" },
-  ], false, true)).toEqual({
+  ], "claude", true)).toEqual({
     state: "terminal",
     source: "lifecycle",
     terminalAt: "2026-07-10T00:00:02Z",
@@ -173,13 +173,13 @@ describe("issue 516 — structured Claude API-error records project the terminal
 
   for (const { name, records, expected } of authoritativeCases) {
     test(`authoritative: ${name}`, () => {
-      expect(turnStateFromRecords(records, false, true)).toEqual(expected as ReturnType<typeof turnStateFromRecords>);
+      expect(turnStateFromRecords(records, "claude", true)).toEqual(expected as ReturnType<typeof turnStateFromRecords>);
     });
   }
 
   test("activity: a terminal API error without a stop reason closes the turn", () => {
     const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "authentication_failed", true, null)];
-    expect(turnStateFromRecords(records, false)).toEqual({
+    expect(turnStateFromRecords(records, "claude")).toEqual({
       state: "terminal",
       source: "lifecycle",
       terminalAt: "2026-07-17T15:00:01Z",
@@ -188,12 +188,12 @@ describe("issue 516 — structured Claude API-error records project the terminal
 
   test("activity: an unknown API error without a stop reason keeps the busy-assistant projection", () => {
     const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "model_not_found", true, null)];
-    expect(turnStateFromRecords(records, false)).toEqual({ state: "busy", source: "assistant", terminalAt: null });
+    expect(turnStateFromRecords(records, "claude")).toEqual({ state: "busy", source: "assistant", terminalAt: null });
   });
 
   test("activity: an ordinary stop_sequence assistant record keeps its terminal projection", () => {
     const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", null, false)];
-    expect(turnStateFromRecords(records, false)).toEqual({
+    expect(turnStateFromRecords(records, "claude")).toEqual({
       state: "terminal",
       source: "lifecycle",
       terminalAt: "2026-07-17T15:00:01Z",
@@ -202,7 +202,7 @@ describe("issue 516 — structured Claude API-error records project the terminal
 });
 
 describe("issue 516 — recovery records must not reopen a released turn", () => {
-  const authoritative = (records: Record<string, unknown>[]) => turnStateFromRecords(records, false, true);
+  const authoritative = (records: Record<string, unknown>[]) => turnStateFromRecords(records, "claude", true);
   const released = { state: "terminal", source: "lifecycle", terminalAt: OAUTH_FAILURE_AT } as const;
 
   test("the production recovery tail after a terminal OAuth failure projects a released turn", () => {
@@ -270,10 +270,82 @@ describe("issue 516 — recovery records must not reopen a released turn", () =>
   });
 
   test("the activity projection keeps its own live semantics for the same tail", () => {
-    expect(turnStateFromRecords(oauthFailureWithRecoveryTail(), false)).toEqual({
+    expect(turnStateFromRecords(oauthFailureWithRecoveryTail(), "claude")).toEqual({
       state: "busy",
       source: "lifecycle",
       terminalAt: null,
     });
+  });
+});
+
+describe("OpenClaw turn state (#1207)", () => {
+  const at = (second: number) => `2026-08-27T09:0${second}:00.000Z`;
+  const assistant = (
+    second: number,
+    stopReason: string,
+    provider = "openai",
+  ): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-assistant-${second}`,
+    parentId: `oc-parent-${second}`,
+    timestamp: at(second),
+    message: { role: "assistant", provider, model: "demo-model", api: "demo-api", stopReason, content: [] },
+  });
+  const prompt = (second: number): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-user-${second}`,
+    parentId: null,
+    timestamp: at(second),
+    message: { role: "user", content: "invented prompt", timestamp: at(second) },
+  });
+  const toolResult = (second: number, callId: string): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-result-${second}`,
+    parentId: `oc-parent-${second}`,
+    timestamp: at(second),
+    message: { role: "toolResult", toolCallId: callId, toolName: "demo_tool", isError: false, content: [] },
+  });
+
+  test("a completed turn ends on the assistant record that stopped", () => {
+    expect(turnStateFromRecords([prompt(1), assistant(2, "stop")], "openclaw")).toEqual({
+      state: "terminal",
+      source: "lifecycle",
+      terminalAt: at(2),
+    });
+  });
+
+  test("a tool call keeps the turn busy, through its own result record", () => {
+    expect(turnStateFromRecords([prompt(1), assistant(2, "toolUse")], "openclaw"))
+      .toEqual({ state: "busy", source: "assistant", terminalAt: null });
+    expect(turnStateFromRecords([prompt(1), assistant(2, "toolUse"), toolResult(3, "call-one")], "openclaw"))
+      .toEqual({ state: "busy", source: "assistant", terminalAt: null });
+  });
+
+  test("error and aborted end the turn", () => {
+    expect(turnStateFromRecords([prompt(1), assistant(2, "error")], "openclaw"))
+      .toEqual({ state: "terminal", source: "lifecycle", terminalAt: at(2) });
+    expect(turnStateFromRecords([prompt(1), assistant(2, "aborted")], "openclaw"))
+      .toEqual({ state: "terminal", source: "lifecycle", terminalAt: at(2) });
+  });
+
+  test("a prompt with no answer yet is busy, and an empty tail is unknown", () => {
+    expect(turnStateFromRecords([prompt(1)], "openclaw"))
+      .toEqual({ state: "busy", source: "lifecycle", terminalAt: null });
+    expect(turnStateFromRecords([{ type: "session", version: 3, id: "oc-session-alpha" }], "openclaw"))
+      .toEqual({ state: "unknown", source: "empty", terminalAt: null });
+  });
+
+  /* The whole reason the reader keys on the provider: OpenClaw appends
+     assistant records of its own mid-turn, always stopping on "stop". */
+  test("a synthetic-provider record appended after a tool call cannot end the turn", () => {
+    const records = [prompt(1), assistant(2, "toolUse"), assistant(3, "stop", "openclaw")];
+    expect(turnStateFromRecords(records, "openclaw"))
+      .toEqual({ state: "busy", source: "assistant", terminalAt: null });
+  });
+
+  test("a synthetic-provider record trailing a finished turn keeps the real terminal time", () => {
+    const records = [prompt(1), assistant(2, "stop"), assistant(3, "stop", "openclaw")];
+    expect(turnStateFromRecords(records, "openclaw"))
+      .toEqual({ state: "terminal", source: "lifecycle", terminalAt: at(2) });
   });
 });

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -1,4 +1,6 @@
+import { openclawMessage, openclawProviderAssistant } from "@/lib/scanner/openclawNative";
 import { recordValue, recordsValue, stringValue } from "@/lib/scanner/json";
+import type { TranscriptEngine } from "@/lib/types";
 
 import type { TurnState } from "./contracts";
 
@@ -87,10 +89,42 @@ export function claudeRecoveryTailRelease(records: RecordLike[]): { terminalAt: 
   return null;
 }
 
+/** OpenClaw's turn evidence, read backwards from the newest record.
+ *
+ * `stopReason` on an assistant record is the whole signal: `toolUse` means the
+ * model asked for a tool and the turn continues, while `stop`, `error` and
+ * `aborted` all end it. Tool-result records are skipped so the assistant record
+ * that requested the tool decides, and a user record reached before any
+ * assistant record is a prompt still waiting for its first answer.
+ *
+ * The provider qualifier is load-bearing. OpenClaw appends assistant records of
+ * its own — a channel delivery mirrored back, a Gateway injection — always with
+ * `stopReason: "stop"`, and they land in the middle of real turns. Taking the
+ * tail record unconditionally would report a session sitting inside a tool call
+ * as finished and drop it out of busy grading. */
+function openclawTurnState(records: RecordLike[]): TurnState {
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    const message = openclawMessage(record);
+    if (!message) continue;
+    if (message.role === "assistant") {
+      if (!openclawProviderAssistant(record)) continue;
+      const stop = stringValue(message.stopReason);
+      if (stop === "stop" || stop === "error" || stop === "aborted") {
+        return { state: "terminal", source: "lifecycle", terminalAt: timestamp(record) };
+      }
+      return { state: "busy", source: "assistant", terminalAt: null };
+    }
+    if (message.role === "user") return { state: "busy", source: "lifecycle", terminalAt: null };
+  }
+  return { state: "unknown", source: "empty", terminalAt: null };
+}
+
 /** The newest authoritative lifecycle or tool event wins. Assistant prose
     cannot close an active turn because it commonly precedes tool work. */
-export function turnStateFromRecords(records: RecordLike[], codex: boolean, authoritative = false): TurnState {
-  if (codex) {
+export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEngine, authoritative = false): TurnState {
+  if (engine === "openclaw") return openclawTurnState(records);
+  if (engine === "codex") {
     let turnOpen = false;
     let terminalAt: string | null = null;
     let terminalSeen = false;

--- a/src/lib/agent/efforts.ts
+++ b/src/lib/agent/efforts.ts
@@ -38,12 +38,21 @@ const CODEX_MODEL_SCALES: readonly (readonly [RegExp, readonly string[]])[] = [
   [/^gpt-5\.6\b/, ["low", "medium", "high", "xhigh", "max"]],
 ];
 
+/* OpenClaw's `--thinking` ladder, kept out of ENGINE_EFFORTS because it is a
+   display scale: the Viewer reads a recorded tier off the transcript and
+   offers no OpenClaw selector. `off` is the bottom rung; `adaptive` hands the
+   choice to the model and so is not a rung at all — it stays out of the scale
+   and reads as an unranked tier, which hides the meter and leaves the value in
+   the chip tooltip. */
+const OPENCLAW_EFFORTS: readonly string[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+
 /** Reasoning tiers a given engine+model pair can run at, lowest first; null
     for engines without a reasoning dial (shell). Model may be the viewer's
     display-shortened id — matching is prefix-based on the codex slug, and
     claude models all share one CLI scale. */
 export function effortScale(engine: string, model: string | null | undefined): readonly string[] | null {
   if (engine === "claude") return ENGINE_EFFORTS.claude;
+  if (engine === "openclaw") return OPENCLAW_EFFORTS;
   if (engine !== "codex") return null;
   const id = (model ?? "").trim().toLowerCase();
   for (const [re, scale] of CODEX_MODEL_SCALES) {

--- a/src/lib/lifecycle/transcript.ts
+++ b/src/lib/lifecycle/transcript.ts
@@ -81,7 +81,7 @@ export async function readLivenessTranscriptEvidence(
 ): Promise<LivenessTranscriptEvidence | null> {
   const read = await readStableTailRecords(transcriptPath);
   if (read.integrity !== "complete") return null;
-  const turn = turnStateFromRecords(read.records, engine === "codex");
+  const turn = turnStateFromRecords(read.records, engine);
   return {
     turn: turn.state === "terminal" ? "idle" : turn.state === "busy" ? "busy" : "unknown",
     lastRecordTs: newestRecordTimestamp(read.records),

--- a/src/lib/pipelines/durableEvidence.ts
+++ b/src/lib/pipelines/durableEvidence.ts
@@ -96,7 +96,7 @@ export async function durableStageTurnEvidence(
   const read = await readStableTailRecords(transcriptPath);
   if (read.integrity !== "complete") return null;
   const codex = engine === "codex";
-  const turn = turnStateFromRecords(read.records, codex);
+  const turn = turnStateFromRecords(read.records, codex ? "codex" : "claude");
   let fallbackTs = 0;
   try {
     fallbackTs = fs.statSync(transcriptPath).mtimeMs;

--- a/src/lib/projects/identity.ts
+++ b/src/lib/projects/identity.ts
@@ -43,8 +43,18 @@ export function projectIdentityFromDirectory(cwd: string): DirectoryProjectIdent
   const base = path.basename(resolved);
   if (!base || resolved === path.sep) return null;
   const displayName = resolved === os.homedir() ? `home-${base}` : base;
-  const digest = crypto.createHash("sha256").update(`dir:${resolved}`).digest("hex").slice(0, 32);
-  return { project: `dir-${digest}`, displayName };
+  return { project: directoryProjectId(resolved), displayName };
+}
+
+/** The durable id of a directory identity, over an already-resolved path.
+    Exported because a recognizer whose whole purpose is surviving the
+    directory's deletion cannot go through {@link projectIdentityFromDirectory}:
+    that one resolves symlinks while the path exists and stops resolving once it
+    is gone, so the same directory would mint two different ids across the
+    deletion boundary. Such a caller resolves the path itself, once, and asks
+    for the digest — which keeps the id shape defined in exactly one place. */
+export function directoryProjectId(resolvedPath: string): string {
+  return `dir-${crypto.createHash("sha256").update(`dir:${resolvedPath}`).digest("hex").slice(0, 32)}`;
 }
 
 export function displayNameFromProjectIdentity(project: string): string {

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -50,7 +50,7 @@ function resourceFileObservation(value: unknown): value is ResourceWorkerFileObs
     && typeof value.project === "string"
     && (value.activity === "live" || value.activity === "recent" || value.activity === "stalled" || value.activity === "idle")
     && typeof value.mtime === "number" && Number.isFinite(value.mtime) && value.mtime >= 0
-    && (value.engine === "claude" || value.engine === "codex" || value.engine === "shell")
+    && (value.engine === "claude" || value.engine === "codex" || value.engine === "shell" || value.engine === "openclaw")
     && (value.pid === null || (Number.isSafeInteger(value.pid) && (value.pid as number) > 0))
     && (value.proc === "running" || value.proc === "done" || value.proc === "killed" || value.proc === null)
     && nullableString(value.conversationId);

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -2845,7 +2845,7 @@ describe("resource recurring reads", () => {
       mkdirSync(state, { recursive: true });
       writeFileSync(path.join(state, "files-scan-snapshot.json"), JSON.stringify({
         version: 1,
-        schemaVersion: 9,
+        schemaVersion: 10,
         snapshot: { complete: true, files: [], projectCatalog: [] },
       }));
       process.env.HOME = home;

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -2326,7 +2326,7 @@ test("startup keeps a Codex host eligible when the bounded tail cuts off an unma
     },
     { timestamp: "2026-07-15T10:00:02.000Z", payload: { type: "task_complete", turn_id: "turn-1" } },
   ];
-  expect(turnStateFromRecords(transcriptRecords, true)).toBe("busy");
+  expect(turnStateFromRecords(transcriptRecords, "codex")).toBe("busy");
   addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -342,8 +342,8 @@ function persistedTurnState(
   engine: "codex" | "claude",
   prefixTruncated: boolean,
 ) {
-  if (engine === "claude") return turnStateFromRecords(records, false);
-  if (!prefixTruncated) return turnStateFromRecords(records, true, true);
+  if (engine === "claude") return turnStateFromRecords(records, "claude");
+  if (!prefixTruncated) return turnStateFromRecords(records, "codex", true);
 
   const turnStartIndex = records.findLastIndex((record) => {
     const payload = record.payload;
@@ -352,12 +352,12 @@ function persistedTurnState(
     return type === "task_started" || type === "turn_started" || type === "user_message";
   });
   if (turnStartIndex < 0) {
-    const turn = turnStateFromRecords(records, true, true);
+    const turn = turnStateFromRecords(records, "codex", true);
     return turn.state === "terminal"
       ? { state: "unknown" as const, source: "empty" as const, terminalAt: null }
       : turn;
   }
-  return turnStateFromRecords(records.slice(turnStartIndex), true, true);
+  return turnStateFromRecords(records.slice(turnStartIndex), "codex", true);
 }
 
 async function refreshStructuredTranscriptState(registry: AgentRegistry): Promise<void> {

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -54,48 +54,48 @@ describe("turnStateFromRecords (claude)", () => {
     const unknown = { state: "unknown" as const, source: "empty" as const, terminalAt: null };
     const evidenceCacheCapacity = 4_096;
     for (let index = 0; index < evidenceCacheCapacity + 904; index += 1) {
-      primeTranscriptTurnEvidence(`/cache-primer-${index}.jsonl`, 1, 1, false, unknown);
+      primeTranscriptTurnEvidence(`/cache-primer-${index}.jsonl`, 1, 1, "claude", unknown);
     }
-    transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false, false);
-    recordTranscriptComposerRelease(pathname, stat.size, stat.mtimeMs, false);
+    transcriptTurnResult(pathname, stat.size, stat.mtimeMs, "claude", false);
+    recordTranscriptComposerRelease(pathname, stat.size, stat.mtimeMs, "claude");
     for (let index = 0; index < evidenceCacheCapacity - 2; index += 1) {
-      primeTranscriptTurnEvidence(`/cache-churn-${index}.jsonl`, 1, 1, false, unknown);
+      primeTranscriptTurnEvidence(`/cache-churn-${index}.jsonl`, 1, 1, "claude", unknown);
     }
-    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false).composerReleased).toBe(true);
-    primeTranscriptTurnEvidence("/cache-churn-final.jsonl", 1, 1, false, unknown);
+    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, "claude").composerReleased).toBe(true);
+    primeTranscriptTurnEvidence("/cache-churn-final.jsonl", 1, 1, "claude", unknown);
 
-    transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false, false);
+    transcriptTurnResult(pathname, stat.size, stat.mtimeMs, "claude", false);
 
-    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false).composerReleased).toBe(true);
+    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, "claude").composerReleased).toBe(true);
   });
 
   test("mid-turn narration — text record before its tool_use lands — keeps the turn open", () => {
     /* The exact window that mislabeled working subagents as «returned with
        result»: Claude appends the narration record first, then the tool_use. */
     const records = [{ type: "user" }, assistant(null, "thinking"), assistant(null, "text")];
-    expect(turnStateFromRecords(records, false)).toBe("busy");
+    expect(turnStateFromRecords(records, "claude")).toBe("busy");
   });
 
   test("end_turn closes the turn", () => {
     const records = [{ type: "user" }, assistant("end_turn", "text")];
-    expect(turnStateFromRecords(records, false)).toBe("done");
+    expect(turnStateFromRecords(records, "claude")).toBe("done");
   });
 
   test("stop_sequence closes the turn", () => {
-    expect(turnStateFromRecords([assistant("stop_sequence", "text")], false)).toBe("done");
+    expect(turnStateFromRecords([assistant("stop_sequence", "text")], "claude")).toBe("done");
   });
 
   test("tool_use stop_reason keeps the turn open", () => {
-    expect(turnStateFromRecords([assistant("tool_use", "tool_use")], false)).toBe("busy");
+    expect(turnStateFromRecords([assistant("tool_use", "tool_use")], "claude")).toBe("busy");
   });
 
   test("trailing user record (tool result pending) keeps the turn open", () => {
     const records = [assistant("tool_use", "tool_use"), { type: "user" }];
-    expect(turnStateFromRecords(records, false)).toBe("busy");
+    expect(turnStateFromRecords(records, "claude")).toBe("busy");
   });
 
   test("no assistant/user records yields no verdict", () => {
-    expect(turnStateFromRecords([{ type: "summary" }], false)).toBeNull();
+    expect(turnStateFromRecords([{ type: "summary" }], "claude")).toBeNull();
   });
 
   test("a restart prime cannot disable the recovery-release host fence", () => {
@@ -106,9 +106,9 @@ describe("turnStateFromRecords (claude)", () => {
     );
     const stat = fs.statSync(pathname);
     const terminal = { state: "terminal" as const, source: "lifecycle" as const, terminalAt: OAUTH_FAILURE_AT };
-    primeTranscriptTurnEvidence(pathname, stat.size, stat.mtimeMs, false, terminal);
+    primeTranscriptTurnEvidence(pathname, stat.size, stat.mtimeMs, "claude", terminal);
 
-    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false).recoveryReleased).toBe(true);
+    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, "claude").recoveryReleased).toBe(true);
   });
 });
 
@@ -116,18 +116,18 @@ describe("turnStateFromRecords (codex)", () => {
   const payload = (type: string, extra: Record<string, unknown> = {}) => ({ type: "event_msg", payload: { type, ...extra } });
 
   test("lifecycle events are authoritative", () => {
-    expect(turnStateFromRecords([payload("task_started")], true)).toBe("busy");
-    expect(turnStateFromRecords([payload("task_started"), payload("task_complete")], true)).toBe("done");
+    expect(turnStateFromRecords([payload("task_started")], "codex")).toBe("busy");
+    expect(turnStateFromRecords([payload("task_started"), payload("task_complete")], "codex")).toBe("done");
   });
 
   test("interim agent_message after tool activity falls back to done only without newer lifecycle", () => {
     const records = [payload("task_started"), payload("function_call"), payload("agent_message")];
-    expect(turnStateFromRecords(records, true)).toBe("busy");
+    expect(turnStateFromRecords(records, "codex")).toBe("busy");
   });
 
   test("token_count and reasoning records are ignored", () => {
     const records = [payload("task_complete"), payload("token_count"), payload("reasoning")];
-    expect(turnStateFromRecords(records, true)).toBe("done");
+    expect(turnStateFromRecords(records, "codex")).toBe("done");
   });
 });
 

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 import type { TurnState } from "@/lib/accounts/migration/contracts";
-import type { Activity, RootKey } from "../types";
+import type { Activity, RootKey, TranscriptEngine } from "../types";
 import { globalCache } from "./caches";
 import { readHead } from "./head";
 import { outputHolders } from "./process";
@@ -10,7 +10,7 @@ import { claudeRecoveryTailRelease, turnStateFromRecords as structuredTurnStateF
 type CachedTurnEvidence = {
   size: number;
   mtimeMs: number;
-  codex: boolean;
+  engine: TranscriptEngine;
   authoritative: boolean;
   turn: TurnState;
   composerReleased: boolean;
@@ -19,7 +19,10 @@ type CachedTurnEvidence = {
 
 globalCache<unknown>("turn").clear();
 globalCache<unknown>("turn-evidence-v1").clear();
-const turnEvidenceCache = globalCache<CachedTurnEvidence>("turn-evidence-v2");
+/* v3 replaces the entry's `codex: boolean` discriminator with the engine, so a
+   v2 entry surviving a hot reload can no longer be matched by identity. */
+globalCache<unknown>("turn-evidence-v2").clear();
+const turnEvidenceCache = globalCache<CachedTurnEvidence>("turn-evidence-v3");
 const TURN_EVIDENCE_CACHE_CAP = 4_096;
 
 /** Shared tail read+parse, keyed by path and file identity. Within one
@@ -143,11 +146,18 @@ export interface TranscriptTurnResult {
 function recoveryRelease(
   turn: TurnState,
   records: Record<string, unknown>[],
-  codex: boolean,
+  engine: TranscriptEngine,
   authoritative: boolean,
 ): boolean {
-  if (codex || !authoritative || turn.state !== "terminal") return false;
+  if (engine !== "claude" || !authoritative || turn.state !== "terminal") return false;
   return claudeRecoveryTailRelease(records) !== null;
+}
+
+/** The transcript dialect a scanner root's files are written in. */
+export function transcriptEngineForRoot(root: RootKey): TranscriptEngine {
+  if (root === "codex-sessions") return "codex";
+  if (root === "openclaw-sessions") return "openclaw";
+  return "claude";
 }
 
 /** Complete, identity-bound turn evidence shared by scanner and migration
@@ -157,12 +167,12 @@ export function transcriptTurnResult(
   pathname: string,
   size: number,
   mtimeMs: number,
-  codex: boolean,
+  engine: TranscriptEngine,
   authoritative = true,
 ): TranscriptTurnResult {
   const key = `${authoritative ? "authoritative" : "activity"}:${pathname}`;
   const cached = turnEvidenceCache.get(key);
-  if (cached && cached.size === size && cached.mtimeMs === mtimeMs && cached.codex === codex) {
+  if (cached && cached.size === size && cached.mtimeMs === mtimeMs && cached.engine === engine) {
     storeTurnEvidence(pathname, cached);
     return {
       turn: { ...cached.turn },
@@ -172,26 +182,26 @@ export function transcriptTurnResult(
     };
   }
   const tail = tailRecordsResult(pathname, size, mtimeMs);
-  const turn = structuredTurnStateFromRecords(tail.records, codex, authoritative);
-  const recoveryReleased = tail.complete && recoveryRelease(turn, tail.records, codex, authoritative);
+  const turn = structuredTurnStateFromRecords(tail.records, engine, authoritative);
+  const recoveryReleased = tail.complete && recoveryRelease(turn, tail.records, engine, authoritative);
   if (tail.complete) {
-    storeTurnEvidence(pathname, { size, mtimeMs, codex, authoritative, turn, composerReleased: false, recoveryReleased });
+    storeTurnEvidence(pathname, { size, mtimeMs, engine, authoritative, turn, composerReleased: false, recoveryReleased });
     const companionAuthoritative = !authoritative;
     const companionKey = `${companionAuthoritative ? "authoritative" : "activity"}:${pathname}`;
     const cachedCompanion = turnEvidenceCache.get(companionKey);
     const companionComposerReleased = cachedCompanion?.size === size
       && cachedCompanion.mtimeMs === mtimeMs
-      && cachedCompanion.codex === codex
+      && cachedCompanion.engine === engine
       && cachedCompanion.composerReleased;
-    const companionTurn = structuredTurnStateFromRecords(tail.records, codex, companionAuthoritative);
+    const companionTurn = structuredTurnStateFromRecords(tail.records, engine, companionAuthoritative);
     storeTurnEvidence(pathname, {
       size,
       mtimeMs,
-      codex,
+      engine,
       authoritative: companionAuthoritative,
       turn: companionTurn,
       composerReleased: companionComposerReleased,
-      recoveryReleased: recoveryRelease(companionTurn, tail.records, codex, companionAuthoritative),
+      recoveryReleased: recoveryRelease(companionTurn, tail.records, engine, companionAuthoritative),
     });
   }
   return { turn, complete: tail.complete, composerReleased: false, recoveryReleased };
@@ -205,11 +215,11 @@ export function cachedTranscriptTurn(
   pathname: string,
   size: number,
   mtimeMs: number,
-  codex: boolean,
+  engine: TranscriptEngine,
 ): TurnState | null {
   for (const key of [`activity:${pathname}`, `authoritative:${pathname}`]) {
     const cached = turnEvidenceCache.get(key);
-    if (cached && cached.size === size && cached.mtimeMs === mtimeMs && cached.codex === codex) {
+    if (cached && cached.size === size && cached.mtimeMs === mtimeMs && cached.engine === engine) {
       return { ...cached.turn };
     }
   }
@@ -227,17 +237,17 @@ export function primeTranscriptTurnEvidence(
   pathname: string,
   size: number,
   mtimeMs: number,
-  codex: boolean,
+  engine: TranscriptEngine,
   turn: TurnState,
   options: { authoritative?: boolean; composerReleased?: boolean } = {},
 ): void {
   const authoritative = options.authoritative ?? true;
   const composerReleased = options.composerReleased ?? false;
-  if (!codex && authoritative && turn.state === "terminal") return;
+  if (engine === "claude" && authoritative && turn.state === "terminal") return;
   storeTurnEvidence(pathname, {
     size,
     mtimeMs,
-    codex,
+    engine,
     authoritative,
     turn: { ...turn },
     composerReleased,
@@ -249,11 +259,11 @@ export function recordTranscriptComposerRelease(
   pathname: string,
   size: number,
   mtimeMs: number,
-  codex: boolean,
+  engine: TranscriptEngine,
 ): void {
   const key = `authoritative:${pathname}`;
   const cached = turnEvidenceCache.get(key);
-  if (!cached || cached.size !== size || cached.mtimeMs !== mtimeMs || cached.codex !== codex) return;
+  if (!cached || cached.size !== size || cached.mtimeMs !== mtimeMs || cached.engine !== engine) return;
   storeTurnEvidence(pathname, { ...cached, composerReleased: true });
 }
 
@@ -397,8 +407,8 @@ function readTail(pathname: string, size: number, nbytes: number): TailRecordsRe
 }
 
 /** Compatibility projection retained for scanner callers. */
-export function turnStateFromRecords(records: Record<string, unknown>[], codex: boolean): "done" | "busy" | null {
-  const state = structuredTurnStateFromRecords(records, codex).state;
+export function turnStateFromRecords(records: Record<string, unknown>[], engine: TranscriptEngine): "done" | "busy" | null {
+  const state = structuredTurnStateFromRecords(records, engine).state;
   return state === "terminal" ? "done" : state === "busy" ? "busy" : null;
 }
 
@@ -425,7 +435,7 @@ export function activityVerdict(
   let complete = true;
   if (pathname.endsWith(".jsonl")) {
     const mtimeMs = mtime * 1000;
-    const turn = transcriptTurnResult(pathname, size, mtimeMs, root.startsWith("codex"), false);
+    const turn = transcriptTurnResult(pathname, size, mtimeMs, transcriptEngineForRoot(root), false);
     const state = turn.turn.state === "terminal" ? "done" : turn.turn.state === "busy" ? "busy" : null;
     complete = turn.complete;
     if (state === "busy") {

--- a/src/lib/scanner/claudeNative.integration.test.ts
+++ b/src/lib/scanner/claudeNative.integration.test.ts
@@ -71,7 +71,7 @@ test("the sidechain yields real messages, tool activity, and an open turn state"
 
   const st = fs.statSync(child);
   // Trailing tool_use with no result → the subagent is mid-turn.
-  expect(transcriptTurnResult(child, st.size, st.mtimeMs, false).turn.state).toBe("busy");
+  expect(transcriptTurnResult(child, st.size, st.mtimeMs, "claude").turn.state).toBe("busy");
   const verdict = activityVerdict("claude-projects", child, st.mtimeMs / 1000, st.size);
   expect(verdict.reason).toBe("jsonl_turn_open");
 });
@@ -83,6 +83,7 @@ test("discovery surfaces the Workflow subagent but never its journal bookkeeping
     "codex-sessions": path.join(SANDBOX, "codex-sessions"),
     "claude-projects": ROOT,
     "claude-tasks": path.join(SANDBOX, "claude-tasks"),
+    "openclaw-sessions": path.join(SANDBOX, "openclaw"),
   };
   fs.mkdirSync(roots["codex-sessions"], { recursive: true });
   fs.mkdirSync(roots["claude-tasks"], { recursive: true });

--- a/src/lib/scanner/conversationCatalog.test.ts
+++ b/src/lib/scanner/conversationCatalog.test.ts
@@ -131,3 +131,36 @@ test("a fresh transcript never reads idle in list rows — activity carries the 
   expect(fresh.activity).toBe("recent");
   expect(aged.activity).toBe("idle");
 });
+
+/* Issue #1207: an OpenClaw conversation must be a first-class row in the
+   complete list, reachable by both title and first-prompt search. */
+test("an OpenClaw conversation lists and searches beside Claude and Codex rows", () => {
+  const openclaw: ConversationCatalogEntry = {
+    path: "/openclaw/agents/primary/sessions/oc-session-alpha.jsonl",
+    root: "openclaw-sessions",
+    name: "oc-session-alpha.jsonl",
+    project: "viewer",
+    title: "Draft the cobalt orchard note",
+    firstPrompt: "Draft the cobalt orchard note about seedlings",
+    engine: "openclaw",
+    kind: "session",
+    fmt: "openclaw",
+    mtime: 9,
+    size: 512,
+  };
+  const catalog = [entry(1), openclaw, entry(2)];
+
+  expect(paginateConversationCatalog(catalog, { project: "viewer" }).items.map((item) => item.path))
+    .toContain(openclaw.path);
+  expect(paginateConversationCatalog(catalog, { query: "cobalt orchard" }).items.map((item) => item.path))
+    .toEqual([openclaw.path]);
+  /* Only the first prompt carries this phrase, so the match proves the
+     first-prompt column is searched and not just the title. */
+  expect(paginateConversationCatalog(catalog, { query: "seedlings" }).items.map((item) => item.path))
+    .toEqual([openclaw.path]);
+  expect(catalogEntryToFileEntry(openclaw)).toMatchObject({
+    engine: "openclaw",
+    fmt: "openclaw",
+    root: "openclaw-sessions",
+  });
+});

--- a/src/lib/scanner/conversationCatalog.ts
+++ b/src/lib/scanner/conversationCatalog.ts
@@ -1,6 +1,6 @@
 import { stat } from "node:fs/promises";
 
-import type { FileEntry, Fmt, RootKey } from "../types";
+import type { FileEntry, Fmt, RootKey, TranscriptEngine } from "../types";
 
 export interface ConversationCatalogEntry {
   path: string;
@@ -12,7 +12,7 @@ export interface ConversationCatalogEntry {
   worktree?: string;
   title: string;
   firstPrompt: string;
-  engine: "codex" | "claude";
+  engine: TranscriptEngine;
   kind: string;
   fmt: Fmt;
   /** Unix seconds. */

--- a/src/lib/scanner/conversationSearchIndex.ts
+++ b/src/lib/scanner/conversationSearchIndex.ts
@@ -4,7 +4,7 @@ import { cleanTitle } from "@/lib/title";
 import { searchTextForTranscript } from "./describe";
 
 type TranscriptSearchText = ReturnType<typeof searchTextForTranscript>;
-type SearchTextReader = (pathname: string, size: number, engine: "codex" | "claude") => TranscriptSearchText;
+type SearchTextReader = (pathname: string, size: number, engine: ConversationCatalogEntry["engine"]) => TranscriptSearchText;
 type YieldControl = () => Promise<void>;
 
 interface SearchTextCacheEntry extends TranscriptSearchText {

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -572,3 +572,136 @@ test("a Codex description carries the provider-fork source from the first sessio
      consumer distinguishes "read, no fork" from "nobody has read this yet". */
   expect(describe("codex-sessions", root, plain, fs.statSync(plain)).nativeForkSourceThreadId).toBeNull();
 });
+
+/* ── OpenClaw (#1207) ──────────────────────────────────────────────────────
+   Every identifier below is invented; no OpenClaw record was copied. */
+
+const OPENCLAW_STATE = path.join(SANDBOX, "openclaw-state");
+
+function openclawTranscript(name: string, cwd: string, prompt: string): string {
+  const sessions = path.join(OPENCLAW_STATE, "agents", "primary", "sessions");
+  const transcript = path.join(sessions, name);
+  fs.mkdirSync(sessions, { recursive: true });
+  fs.writeFileSync(transcript, [
+    JSON.stringify({ type: "session", version: 3, id: "oc-header-" + name, timestamp: "2026-08-27T09:00:00.000Z", cwd }),
+    JSON.stringify({
+      type: "message",
+      id: "oc-user-1",
+      parentId: null,
+      timestamp: "2026-08-27T09:00:01.000Z",
+      message: { role: "user", content: prompt, timestamp: "2026-08-27T09:00:01.000Z" },
+    }),
+  ].join("\n") + "\n");
+  return transcript;
+}
+
+function withOpenclawStateDir<T>(state: string, run: () => T): T {
+  const previous = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = state;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = previous;
+  }
+}
+
+test("an OpenClaw transcript is titled and searched by its first prompt", () => {
+  const workspace = path.join(OPENCLAW_STATE, "workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  const transcript = openclawTranscript("oc-session-title.jsonl", workspace, "Draft the cobalt orchard note");
+  const root = path.dirname(transcript);
+  const stat = fs.statSync(transcript);
+
+  withOpenclawStateDir(OPENCLAW_STATE, () => {
+    expect(describe("openclaw-sessions", root, transcript, stat)).toMatchObject({
+      title: "Draft the cobalt orchard note",
+      engine: "openclaw",
+      fmt: "openclaw",
+      kind: "session",
+      cwd: workspace,
+      sessionStartedAt: "2026-08-27T09:00:00.000Z",
+    });
+  });
+  expect(searchTextForTranscript(transcript, stat.size, "openclaw")).toEqual({
+    title: "Draft the cobalt orchard note",
+    firstPrompt: "Draft the cobalt orchard note",
+  });
+});
+
+/* The invariant AGENTS.md names: the workspace is itself a remote-less git
+   repository, so the ordinary resolvers would mint `repo-…` while it exists and
+   `dir-…` once it is gone, fragmenting every channel-bound session at once. The
+   fixture is reached through a symlink so a `realpathSync` regression — which
+   resolves while the path exists and stops once it does not — fails the case. */
+test("the OpenClaw workspace keeps one project identity before and after deletion", () => {
+  useStateDirectory("openclaw-workspace-identity");
+  const state = path.join(SANDBOX, "openclaw-deletion", "real-state");
+  const link = path.join(SANDBOX, "openclaw-deletion", "linked-state");
+  const workspace = path.join(link, "workspace");
+  fs.mkdirSync(path.join(state, "workspace", ".git"), { recursive: true });
+  fs.symlinkSync(state, link);
+  /* The measured workspace is a real git repository with no `origin`, which is
+     exactly the shape that mints `repo-…` alive and `dir-…` once deleted. */
+  fs.writeFileSync(path.join(state, "workspace", ".git", "HEAD"), "ref: refs/heads/main\n");
+  fs.writeFileSync(path.join(state, "workspace", ".git", "config"), "[core]\n\tbare = false\n");
+
+  const alive = withOpenclawStateDir(link, () => projectInfoFromCwd(workspace, "openclaw-alive"));
+  expect(alive).toEqual({ project: expect.stringMatching(/^dir-[0-9a-f]{32}$/), displayName: "OpenClaw" });
+  expect(withOpenclawStateDir(link, () => projectRootForCwd(workspace))).toBeUndefined();
+
+  fs.rmSync(state, { recursive: true, force: true });
+  fs.rmSync(link, { force: true });
+  expect(fs.existsSync(workspace)).toBe(false);
+
+  const dead = withOpenclawStateDir(link, () => projectInfoFromCwd(workspace, "openclaw-dead"));
+  expect(dead).toEqual(alive!);
+});
+
+test("a repository nested under the OpenClaw workspace keeps repository attribution", () => {
+  useStateDirectory("openclaw-nested-repository");
+  const state = path.join(SANDBOX, "openclaw-nested", "state");
+  const workspace = path.join(state, "workspace");
+  const nested = path.join(workspace, "checkout");
+  fs.mkdirSync(nested, { recursive: true });
+  const identity = createRepository(nested, "ssh://git@example.invalid/team/openclaw-nested.git");
+
+  withOpenclawStateDir(state, () => {
+    expect(projectInfoFromCwd(nested, "openclaw-nested")).toMatchObject({ project: identity.project });
+    expect(projectForCwd(workspace)).toMatch(/^dir-[0-9a-f]{32}$/);
+  });
+});
+
+test("the OpenClaw overlay routes a transcript's workspace cwd through the recognizer", () => {
+  useStateDirectory("openclaw-overlay");
+  const state = path.join(SANDBOX, "openclaw-overlay-state");
+  const workspace = path.join(state, "workspace");
+  const sessions = path.join(state, "agents", "primary", "sessions");
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(sessions, { recursive: true });
+  const transcript = path.join(sessions, "oc-session-overlay.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({
+    type: "session",
+    version: 3,
+    id: "oc-header-overlay",
+    timestamp: "2026-08-27T09:00:00.000Z",
+    cwd: workspace,
+  }) + "\n");
+
+  withOpenclawStateDir(state, () => {
+    expect(describe("openclaw-sessions", sessions, transcript, fs.statSync(transcript), "openclaw-overlay")).toMatchObject({
+      project: projectForCwd(workspace)!,
+      projectName: "OpenClaw",
+      projectRoot: null,
+    });
+  });
+});
+
+test("a workspace directory outside any OpenClaw state directory is not recognized", () => {
+  useStateDirectory("openclaw-foreign-workspace");
+  const foreign = path.join(SANDBOX, "not-openclaw", "workspace");
+  fs.mkdirSync(foreign, { recursive: true });
+  const info = withOpenclawStateDir(path.join(SANDBOX, "openclaw-elsewhere"), () =>
+    projectInfoFromCwd(foreign, "openclaw-foreign"));
+  expect(info).toMatchObject({ displayName: "workspace" });
+});

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { stateDir } from "@/lib/configDir";
 import { canonicalProject, projectAliasSnapshot } from "@/lib/projects/aliases";
 import { readStateCollectionsRows } from "@/lib/state/sqliteStateStore";
 import {
+  directoryProjectId,
   displayNameFromProjectIdentity,
   isCanonicalProjectId,
   projectIdentityFromDirectory,
@@ -14,12 +16,13 @@ import {
   UNRESOLVED_PROJECT_NAME,
 } from "@/lib/projects/identity";
 
-import type { Engine, Fmt, RootKey } from "../types";
+import type { Engine, Fmt, RootKey, TranscriptEngine } from "../types";
 import { cleanTitle } from "../title";
 import { globalCache } from "./caches";
 import { nativeCodexSessionMetaResult } from "./codexNative";
 import { HEAD_READ_CHUNK_BYTES, headFingerprint, readHead, type HeadReadResult } from "./head";
 import { readJsonResult, recordValue, recordsValue, stringValue } from "./json";
+import { openclawMessage } from "./openclawNative";
 import { projectResolutionStateKey } from "./projectState";
 
 export interface FileDescription {
@@ -524,7 +527,42 @@ function persistedProjects(stateKey = projectResolutionStateKey()): {
   return maps;
 }
 
-/** Project identity for a real cwd, shared by both engines: resolve a
+/* `~/.openclaw`, plus the `~/.openclaw-dev` and `~/.openclaw-<profile>`
+   siblings the `--dev` and `--profile` flags create. */
+const OPENCLAW_STATE_DIRECTORY = /^\.openclaw(?:-[A-Za-z0-9._-]+)?$/;
+
+/**
+ * The OpenClaw workspace directory, recognized by path alone.
+ *
+ * Nearly every OpenClaw session runs in one shared directory — its sessions are
+ * bound to messaging channels, not to repositories — and that directory happens
+ * to be a git repository with no remote. Left to the ordinary resolution order
+ * it would mint a `repo-` identity from its own `.git` while it exists and a
+ * `dir-` identity once it is deleted, splitting every OpenClaw conversation
+ * across two projects at once. AGENTS.md requires a pure path recognizer
+ * wherever the path itself names the project, and this is that recognizer: it
+ * runs before every disk-dependent resolver and reads nothing off disk, so the
+ * identity is the same before and after the workspace is gone.
+ *
+ * The match is exact. A repository nested *under* the workspace keeps ordinary
+ * repository attribution, and a session running somewhere else entirely keeps
+ * whatever the normal resolvers give it.
+ */
+function projectInfoFromOpenclawWorkspace(cwd: string): ProjectInfo | null {
+  const resolved = path.resolve(cwd);
+  if (path.basename(resolved) !== "workspace") return null;
+  const state = path.dirname(resolved);
+  const configured = process.env.OPENCLAW_STATE_DIR?.trim();
+  const recognized = (configured !== undefined && configured !== "" && path.resolve(configured) === state)
+    || (path.dirname(state) === os.homedir() && OPENCLAW_STATE_DIRECTORY.test(path.basename(state)));
+  if (!recognized) return null;
+  /* Deliberately not `projectIdentityFromDirectory`: that helper resolves
+     symlinks through the live filesystem, which is exactly the before/after
+     deletion split this recognizer exists to remove. */
+  return { project: directoryProjectId(resolved), displayName: "OpenClaw" };
+}
+
+/** Project identity for a real cwd, shared by every engine: resolve a
     worktree checkout to its main repository, then derive the stable key and
     human label from that repository's canonical remote. */
 export function projectInfoFromCwd(cwd: string, requestedState?: string): ProjectInfo | null {
@@ -536,6 +574,11 @@ export function projectInfoFromCwd(cwd: string, requestedState?: string): Projec
   if (scratchpad) {
     projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolutionState, scratchpad]);
     return scratchpad;
+  }
+  const openclawWorkspace = projectInfoFromOpenclawWorkspace(cwd);
+  if (openclawWorkspace) {
+    projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolutionState, openclawWorkspace]);
+    return openclawWorkspace;
   }
   const codexWorktree = worktreeFromCodexPath(cwd);
   let worktree =
@@ -592,6 +635,10 @@ export function projectForCwd(cwd: string): string | null {
 export function projectRootForCwd(cwd: string): string | undefined {
   const scratchpad = projectInfoFromClaudeTaskCwd(cwd);
   if (scratchpad) return scratchpad.repo;
+  /* The workspace's own remote-less `.git` would answer here while the
+     directory exists and vanish with it, reintroducing across `projectRoot`
+     the very before/after split the recognizer removes from `project`. */
+  if (projectInfoFromOpenclawWorkspace(cwd)) return undefined;
   const worktree =
     worktreeFromPath(cwd) ??
     worktreeFromNested(cwd) ??
@@ -684,8 +731,22 @@ function goodTitle(text: unknown): string | null {
   return val && !skipTitlePrefixes.some((prefix) => val.startsWith(prefix)) ? val : null;
 }
 
-function userPromptFromRecord(obj: Record<string, unknown>, wantCodex: boolean): string | null {
-  if (wantCodex) {
+function userPromptFromRecord(obj: Record<string, unknown>, engine: TranscriptEngine): string | null {
+  if (engine === "openclaw") {
+    /* OpenClaw wraps every role, the operator's included, in a top-level
+       `message` envelope, so the Claude arm's `type === "user"` never fires. */
+    const message = openclawMessage(obj);
+    if (!message || message.role !== "user") return null;
+    const content = message.content;
+    if (typeof content === "string") return content.trim() || null;
+    const text = recordsValue(content)
+      .filter((part) => part.type === "text")
+      .map((part) => stringValue(part.text) ?? "")
+      .join(" ")
+      .trim();
+    return text || null;
+  }
+  if (engine === "codex") {
     const payload = recordValue(obj.payload) ?? {};
     if (payload.type === "user_message") {
       const prompt = typeof payload.message === "string" ? payload.message.trim() : "";
@@ -711,7 +772,7 @@ function userPromptFromRecord(obj: Record<string, unknown>, wantCodex: boolean):
   return null;
 }
 
-function titleFromLines(lines: string[], wantCodex: boolean): string | null {
+function titleFromLines(lines: string[], engine: TranscriptEngine): string | null {
   for (const line of lines) {
     let obj: Record<string, unknown>;
     try {
@@ -729,13 +790,13 @@ function titleFromLines(lines: string[], wantCodex: boolean): string | null {
       const title = goodTitle(obj.aiTitle);
       if (title) return title;
     }
-    const title = goodTitle(userPromptFromRecord(obj, wantCodex));
+    const title = goodTitle(userPromptFromRecord(obj, engine));
     if (title) return title;
   }
   return null;
 }
 
-function conversationTextFromLines(lines: string[], wantCodex: boolean): ConversationSearchText {
+function conversationTextFromLines(lines: string[], engine: TranscriptEngine): ConversationSearchText {
   let title: string | null = null;
   let firstPrompt: string | null = null;
   for (const line of lines) {
@@ -755,7 +816,7 @@ function conversationTextFromLines(lines: string[], wantCodex: boolean): Convers
     if (obj.type === "ai-title") {
       title ??= goodTitle(obj.aiTitle);
     }
-    const prompt = userPromptFromRecord(obj, wantCodex);
+    const prompt = userPromptFromRecord(obj, engine);
     if (!prompt) continue;
     firstPrompt ??= prompt;
     title ??= goodTitle(prompt);
@@ -860,7 +921,7 @@ function projectInfoFromSlug(slug: string, stateKey?: string): ProjectInfo | nul
   return persisted ? aliasedProjectInfo(persisted.project, persisted.worktree, persisted.repo) : null;
 }
 
-function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): MetadataReadResult<string | null> {
+function scanJsonlTitle(pathname: string, st: fs.Stats, engine: TranscriptEngine): MetadataReadResult<string | null> {
   const cached = titleCache.get(pathname);
   if (cached?.size === st.size && cached.mtimeMs === st.mtimeMs) {
     return { value: cached.value, complete: true, headPreserved: true };
@@ -874,16 +935,16 @@ function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): Met
       return { value: reused.value, complete: true, headPreserved: true };
     }
   }
-  const title = titleFromLines(head.value.text.split("\n").slice(0, 151), wantCodex);
+  const title = titleFromLines(head.value.text.split("\n").slice(0, 151), engine);
   titleCache.set(pathname, cacheHeadMetadata(st, head.value, title));
   return { value: title, complete: true, headPreserved: false };
 }
 
 /** Title and first-prompt hydration owned entirely by list/search requests. */
-export function searchTextForTranscript(pathname: string, size: number, engine: "codex" | "claude"): ConversationSearchText {
+export function searchTextForTranscript(pathname: string, size: number, engine: TranscriptEngine): ConversationSearchText {
   const head = readSearchHead(pathname, size);
   if (!head) return { title: null, firstPrompt: null };
-  return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine === "codex");
+  return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine);
 }
 
 function deriveTranscriptMetadata(
@@ -931,7 +992,7 @@ function deriveTranscriptMetadata(
     kind = "session";
     fmt = "codex";
     if (complete) {
-      const titleRead = scanJsonlTitle(pathname, st, true);
+      const titleRead = scanJsonlTitle(pathname, st, "codex");
       complete &&= titleRead.complete;
       title = titleRead.value;
     }
@@ -963,7 +1024,7 @@ function deriveTranscriptMetadata(
          transcript still carries the delegated sidechain prompt, so the first
          real user message names the card instead of a generic «Subagent …». */
       if (!title && complete) {
-        const titleRead = scanJsonlTitle(pathname, st, false);
+        const titleRead = scanJsonlTitle(pathname, st, "claude");
         complete &&= titleRead.complete;
         title = titleRead.value;
       }
@@ -971,12 +1032,38 @@ function deriveTranscriptMetadata(
     } else {
       kind = "session";
       if (complete) {
-        const titleRead = scanJsonlTitle(pathname, st, false);
+        const titleRead = scanJsonlTitle(pathname, st, "claude");
         complete &&= titleRead.complete;
         title = titleRead.value;
       }
       title ??= "Claude session";
     }
+  } else if (rootName === "openclaw-sessions") {
+    /* The header record carries `cwd` and `timestamp` at the top level, the
+       same place `transcriptCwd`/`transcriptStartedAt` already look, so both
+       readers work unchanged. No OpenClaw record carries a title — there is no
+       `summary` or `ai-title` analogue on disk — so the first user prompt
+       names the card, through the same `goodTitle` path the other engines use. */
+    const cwdRead = complete
+      ? transcriptCwd(pathname, st)
+      : { value: null, complete: false, headPreserved: false };
+    complete &&= cwdRead.complete;
+    cwdComplete = cwdRead.complete;
+    cwd = cwdRead.value ?? undefined;
+    if (complete) {
+      const startedAtRead = transcriptStartedAt(pathname, st);
+      complete &&= startedAtRead.complete;
+      sessionStartedAt = startedAtRead.value;
+    }
+    engine = "openclaw";
+    kind = "session";
+    fmt = "openclaw";
+    if (complete) {
+      const titleRead = scanJsonlTitle(pathname, st, "openclaw");
+      complete &&= titleRead.complete;
+      title = titleRead.value;
+    }
+    title ??= "OpenClaw session";
   } else if (rootName === "claude-tasks") {
     engine = "shell";
     kind = "background";
@@ -1028,6 +1115,12 @@ function resolveProjectOverlay(
       ?? (worktreeInfo
         ? aliasedProjectInfo(worktreeInfo.project, worktreeInfo.worktree, worktreeInfo.repo)
         : aliasedProjectInfo(projectFromSlug(slug)));
+  } else if (rootName === "openclaw-sessions") {
+    /* The workspace recognizer inside `projectInfoFromCwd` is what gives an
+       OpenClaw session a stable project, and it only runs if this branch calls
+       it: the overlay reaches `projectInfoFromCwd` from the Codex and Claude
+       branches alone. */
+    info = (cwd ? projectInfoFromCwd(cwd, stateKey) : null) ?? projectInfoFromTranscript(pathname, stateKey);
   } else if (rootName === "claude-tasks") {
     const rel = path.relative(root, pathname);
     const slug = rel.split(path.sep)[0] ?? "";

--- a/src/lib/scanner/discover.performance.test.ts
+++ b/src/lib/scanner/discover.performance.test.ts
@@ -43,6 +43,7 @@ test("large-catalog reconciliation keeps event-loop lag below the controller bud
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const padding = "x".repeat(1_900);
@@ -85,6 +86,7 @@ test("pipeline status churn keeps a 100 MB growing transcript scan incremental a
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
     const flowPath = path.join(stateDir, "flows.json");

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -13,7 +13,7 @@ import { discoverFiles, discoverFilesWithProjectCatalog, type RawEntry } from ".
 import { projectForCwd } from "./describe";
 import { projectCatalogSnapshotFromRaw } from "./projectCatalog";
 import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./projectState";
-import { FILE_CAP } from "./roots";
+import { FILE_CAP, openclawSessionRoots } from "./roots";
 import { DEFAULT_SCHEME_CARDS_PER_PROJECT } from "./schemeWindow";
 
 async function writeFixture(pathname: string, content: string, mtimeSeconds: number): Promise<void> {
@@ -67,6 +67,7 @@ test("pure project-catalog discovery leaves the state directory unchanged", asyn
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
@@ -87,6 +88,7 @@ test("request refreshes persist the per-file scanner index", async () => {
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["codex-sessions"], "indexed.jsonl");
@@ -117,6 +119,7 @@ test("a poisoned durable alias source defers only itself in the persist scan", a
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     await mkdir(process.env.LLV_STATE_DIR, { recursive: true });
@@ -162,6 +165,7 @@ test("project catalog persistence repairs private modes and atomically replaces 
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["codex-sessions"], "private.jsonl");
@@ -209,6 +213,7 @@ test("a non-ENOENT directory failure leaves the completed catalog index authorit
     "codex-sessions": path.join(base, "codex-sessions"),
     "claude-projects": path.join(base, "claude-projects"),
     "claude-tasks": path.join(base, "claude-tasks"),
+    "openclaw-sessions": path.join(base, "openclaw"),
   };
   try {
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
@@ -251,6 +256,7 @@ test("project index publication failures preserve the canonical file, clean temp
     "codex-sessions": path.join(base, "codex-sessions"),
     "claude-projects": path.join(base, "claude-projects"),
     "claude-tasks": path.join(base, "claude-tasks"),
+    "openclaw-sessions": path.join(base, "openclaw"),
   };
   try {
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
@@ -332,6 +338,7 @@ test("an append reparses its file and reuses unchanged persisted summaries", asy
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const unchanged = path.join(roots["claude-projects"], "incremental", "session", "subagents", "agent-unchanged.jsonl");
@@ -380,6 +387,7 @@ test("a same-size transcript rewrite with a newer mtime reparses cwd and project
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["codex-sessions"], "rewritten.jsonl");
@@ -417,6 +425,7 @@ test("larger Codex and Claude rewrites replace cached head metadata", async () =
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const codex = path.join(roots["codex-sessions"], "rewritten.jsonl");
@@ -474,6 +483,7 @@ test("Codex and Claude true appends retain head metadata through repeated EIO an
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const codex = path.join(roots["codex-sessions"], "append-recovery.jsonl");
@@ -557,6 +567,7 @@ test("a one-shot transcript read failure stays incomplete and recovers in memory
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["codex-sessions"], "rewritten.jsonl");
@@ -622,6 +633,7 @@ test("first-ever repeated transcript read failures publish and persist only afte
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["codex-sessions"], "first.jsonl");
@@ -678,6 +690,7 @@ test("a same-size subagent sidecar rewrite with a newer mtime reparses its title
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["claude-projects"], "sidecar", "session", "subagents", "agent-rewritten.jsonl");
@@ -711,6 +724,7 @@ test("a one-shot sidecar read failure stays incomplete and recovers in memory an
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["claude-projects"], "sidecar", "session", "subagents", "agent-x.jsonl");
@@ -767,6 +781,7 @@ test("a corrupt per-file scanner index falls back to a full parse and repairs it
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcript = path.join(roots["claude-projects"], "recovered", "session", "subagents", "agent-child.jsonl");
@@ -794,6 +809,7 @@ test("a pinned discovery identifies only rows outside the global scheme window",
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const transcripts: string[] = [];
@@ -953,6 +969,7 @@ test("project catalog carries the canonical root for projects outside the capped
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const repo = path.join(base, "catalog-project");
@@ -996,6 +1013,7 @@ test("archived migration predecessors cannot outvote the current project root", 
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const archivedPaths = [
@@ -1061,6 +1079,7 @@ test("persisted scheme metadata excludes unbounded first-prompt text", async () 
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const marker = "PROMPT_TAIL_MUST_STAY_OUT_OF_SCHEME_STATE";
@@ -1106,6 +1125,7 @@ test("a legacy cached Claude subagent is migrated into the conversation catalog"
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const subagent = path.join(roots["claude-projects"], "legacy-project", "session", "subagents", "agent-child.jsonl");
@@ -1156,6 +1176,7 @@ test("project catalog omits task-only residue from a clean state", async () => {
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const taskPath = path.join(roots["claude-tasks"], "orphan-project", "missing-session", "tasks", "task.output");
@@ -1184,6 +1205,7 @@ test("a Claude transcript appearing in a previously sessionless project director
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const repository = path.join(base, "late-session-repository");
@@ -1227,6 +1249,7 @@ test("first-ever EIO and EACCES task twin lookups publish only after recovery", 
         "codex-sessions": path.join(base, "codex-sessions"),
         "claude-projects": path.join(base, "claude-projects"),
         "claude-tasks": path.join(base, "claude-tasks"),
+        "openclaw-sessions": path.join(base, "openclaw"),
       };
       await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
       const taskPath = path.join(roots["claude-tasks"], "project-a", "session-a", "tasks", "task-a.output");
@@ -1270,6 +1293,7 @@ test("a first-ever ENOTDIR task twin lookup stays incomplete and publishes no du
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const taskPath = path.join(roots["claude-tasks"], "project-a", "session-a", "tasks", "task-a.output");
@@ -1300,6 +1324,7 @@ test("project and conversation catalogs retain a project whose only transcript i
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const subagent = path.join(roots["claude-projects"], "project-only-child", "session", "subagents", "agent-child.jsonl");
@@ -1326,6 +1351,7 @@ test("discoverFiles preserves scanner filters, mtime ordering, and the per-proje
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const repository = path.join(base, "recent-project");
@@ -1398,6 +1424,7 @@ test("discoverFiles applies the card cap independently to each visible project",
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const projectA = path.join(base, "project-a");
@@ -1519,6 +1546,7 @@ test("discoverFiles keeps native Codex spawn parents outside the recent cap", as
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
@@ -1557,6 +1585,7 @@ test("discoverFilesWithProjectCatalog keeps quiet projects in the recent cap", a
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
@@ -1605,6 +1634,7 @@ test("registry launch cwd governs scheme caps and the uncapped project catalog",
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const paths: string[] = [];
@@ -1651,6 +1681,7 @@ test("discoverFilesWithProjectCatalog keeps a selected project inside the scheme
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
@@ -1706,6 +1737,7 @@ test("discoverFilesWithProjectCatalog refreshes cached projects when flow state 
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
@@ -1770,6 +1802,7 @@ test("current-production catalog records converge two legacy buckets for one rep
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
 
@@ -1889,6 +1922,7 @@ test("an ambiguous legacy project key defers catalog and board migration", async
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
 
@@ -1974,6 +2008,7 @@ test("demoted archived predecessors rank below live transcripts for the recency 
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
@@ -2027,6 +2062,7 @@ test("a live conversation keeps its card past the per-project card cap", async (
       "codex-sessions": path.join(base, "codex-sessions"),
       "claude-projects": path.join(base, "claude-projects"),
       "claude-tasks": path.join(base, "claude-tasks"),
+      "openclaw-sessions": path.join(base, "openclaw"),
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const slug = path.join(roots["claude-projects"], "-repo");
@@ -2110,5 +2146,121 @@ test("a transcript reached through a symlinked account home has one identity in 
     if (previousClaudeHome === undefined) delete process.env.LLV_CLAUDE_HOME;
     else process.env.LLV_CLAUDE_HOME = previousClaudeHome;
     await rm(base, { recursive: true, force: true });
+  }
+});
+
+/* Issue #1207. An OpenClaw sessions directory holds several sidecar formats
+   beside the transcripts, and a scan that admitted them would multiply the
+   board's OpenClaw cards. Every identifier in the fixture is invented. */
+test("an OpenClaw agent tree yields one card per transcript and none for its sidecars", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-openclaw-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  const previousOpenclawStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  process.env.OPENCLAW_STATE_DIR = path.join(base, "openclaw");
+  try {
+    const workspace = path.join(base, "openclaw", "workspace");
+    await mkdir(workspace, { recursive: true });
+    const header = (id: string) => JSON.stringify({
+      type: "session",
+      version: 3,
+      id,
+      timestamp: "2026-08-27T09:00:00.000Z",
+      cwd: workspace,
+    });
+    const prompt = (text: string) => JSON.stringify({
+      type: "message",
+      id: "oc-user-1",
+      parentId: null,
+      timestamp: "2026-08-27T09:00:01.000Z",
+      message: { role: "user", content: text, timestamp: "2026-08-27T09:00:01.000Z" },
+    });
+
+    const mainSessions = path.join(base, "openclaw", "agents", "primary", "sessions");
+    const otherSessions = path.join(base, "openclaw", "agents", "secondary", "sessions");
+    const transcripts = [
+      path.join(mainSessions, "oc-session-alpha.jsonl"),
+      path.join(mainSessions, "oc-session-beta-topic-7.jsonl"),
+      path.join(otherSessions, "oc-session-gamma.jsonl"),
+    ];
+    for (const [index, transcript] of transcripts.entries()) {
+      await writeFixture(
+        transcript,
+        header(`oc-header-${index}`) + "\n" + prompt(`Invented prompt ${index}`) + "\n",
+        1_700_060_000 + index,
+      );
+    }
+    /* Everything the sessions directory holds that is NOT a conversation. */
+    const sidecars = [
+      path.join(mainSessions, "oc-session-alpha.trajectory.jsonl"),
+      path.join(mainSessions, "oc-session-alpha.checkpoint.oc-checkpoint-1.jsonl"),
+      path.join(mainSessions, "oc-session-alpha.acp-stream.jsonl"),
+      path.join(mainSessions, "oc-session-alpha.trajectory-path.json"),
+      path.join(mainSessions, "sessions.json"),
+      path.join(mainSessions, "oc-session-alpha.jsonl.pre-doctor-repair-2026-08-01T00-00-00.bak"),
+      path.join(mainSessions, "oc-session-alpha.jsonl.deleted.2026-08-01T00-00-00"),
+      path.join(mainSessions, "skills-prompts", "sha256", "aa", "invented-digest.txt"),
+    ];
+    for (const sidecar of sidecars) {
+      await writeFixture(sidecar, header("oc-header-sidecar") + "\n", 1_700_060_100);
+    }
+
+    const scan = await discoverFilesWithProjectCatalog(
+      [
+        ["openclaw-sessions", mainSessions],
+        ["openclaw-sessions", otherSessions],
+      ],
+      undefined,
+      { persist: false },
+    );
+    expect(scan.files.map((entry) => entry.path).sort()).toEqual([...transcripts].sort());
+    for (const entry of scan.files) {
+      expect(entry.engine).toBe("openclaw");
+      expect(entry.fmt).toBe("openclaw");
+      expect(entry.kind).toBe("session");
+      expect(entry.pid).toBeNull();
+    }
+    /* The title is the first prompt: OpenClaw writes no summary record. */
+    expect(scan.files.find((entry) => entry.path === transcripts[0])?.title).toBe("Invented prompt 0");
+    /* And the same transcripts enter the complete list/search catalog. */
+    const catalog = conversationCatalogSnapshot();
+    expect(catalog.map((item) => item.path).sort()).toEqual([...transcripts].sort());
+    expect(catalog.every((item) => item.engine === "openclaw" && item.fmt === "openclaw")).toBe(true);
+    expect(catalog.find((item) => item.path === transcripts[0])?.title).toBe("Invented prompt 0");
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    if (previousOpenclawStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = previousOpenclawStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("openclawSessionRoots returns one root per agent id under the configured state dir", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-openclaw-roots-"));
+  const previousOpenclawStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = path.join(base, "state-dir");
+  try {
+    await mkdir(path.join(base, "state-dir", "agents", "primary", "sessions"), { recursive: true });
+    await mkdir(path.join(base, "state-dir", "agents", "secondary", "sessions"), { recursive: true });
+    expect(openclawSessionRoots()).toEqual([
+      path.join(base, "state-dir", "agents", "primary", "sessions"),
+      path.join(base, "state-dir", "agents", "secondary", "sessions"),
+    ]);
+  } finally {
+    if (previousOpenclawStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = previousOpenclawStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("openclawSessionRoots is empty when the state directory does not exist", () => {
+  const previousOpenclawStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = path.join(os.tmpdir(), "llv-openclaw-absent", "state");
+  try {
+    expect(openclawSessionRoots()).toEqual([]);
+  } finally {
+    if (previousOpenclawStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = previousOpenclawStateDir;
   }
 });

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -8,6 +8,7 @@ import { sessionProjectProjection } from "../session/titleProjection";
 import { scheduleTranscriptIndex, type TranscriptIndexFeed } from "../search/transcriptFeed";
 import { isClaudeWorkflowBookkeeping } from "./claudeNative";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
+import { isOpenclawTranscript } from "./openclawNative";
 import { describe } from "./describe";
 import type { ConversationCatalogEntry } from "./conversationCatalog";
 import {
@@ -20,7 +21,7 @@ import {
 import { projectResolutionStateKey } from "./projectState";
 import { EXTS, ROOTS, scanRootEntries } from "./roots";
 import { selectSchemeWindow } from "./schemeWindow";
-import { cachedTranscriptTurn, transcriptTurnResult } from "./activity";
+import { cachedTranscriptTurn, transcriptEngineForRoot, transcriptTurnResult } from "./activity";
 import {
   canonicalizeTranscriptPaths,
   createTranscriptPathCanonicalizer,
@@ -102,6 +103,11 @@ async function walkPaths(rootName: RootKey, root: string, dir: string, limit: Li
       return walkPaths(rootName, root, path.join(dir, entry.name), limit);
     }
     if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return { paths: [], complete: true };
+    /* An OpenClaw sessions directory holds far more sidecars than transcripts
+       (trajectories, ACP streams, checkpoint forks, prompt caches, dated
+       backups). Filtering here rather than at hydration keeps them out of the
+       resource-scope inventory too, which only checks the `.jsonl` suffix. */
+    if (rootName === "openclaw-sessions" && !isOpenclawTranscript(entry.name)) return { paths: [], complete: true };
     return { paths: [{ rootName, root, path: path.join(dir, entry.name) }], complete: true };
   }));
   return {
@@ -184,13 +190,19 @@ function transcriptIndexFeed(
 ): TranscriptIndexFeed {
   return {
     complete,
-    sources: catalog.map((entry) => ({
+    /* The full-text transcript index parses per-engine record shapes and pins
+       its engine column to the two it can parse, so an OpenClaw transcript is
+       excluded from it rather than inserted as an unparseable row. OpenClaw
+       conversations stay searchable through the catalog's title and
+       first-prompt text; full-text search over their bodies moves with the
+       index's own schema migration. */
+    sources: catalog.flatMap((entry) => (entry.engine === "openclaw" ? [] : [{
       path: entry.path,
       project: projectByPath?.get(entry.path) ?? entry.project,
       engine: entry.engine,
       size: entry.size,
       mtimeMs: entry.mtime * 1_000,
-    })),
+    }])),
   };
 }
 
@@ -274,7 +286,7 @@ function schemeBucket(entry: RawEntry, projectByPath: ReadonlyMap<string, string
 function isLiveEntry(entry: RawEntry, hosted: ReadonlySet<string> | undefined): boolean {
   if (hosted?.has(entry.path)) return true;
   if (!entry.path.endsWith(".jsonl")) return false;
-  const turn = cachedTranscriptTurn(entry.path, entry.st.size, entry.st.mtimeMs, entry.rootName === "codex-sessions");
+  const turn = cachedTranscriptTurn(entry.path, entry.st.size, entry.st.mtimeMs, transcriptEngineForRoot(entry.rootName));
   return turn?.state === "busy";
 }
 
@@ -290,8 +302,8 @@ async function primeElidedOpenTurns(ranked: readonly RawEntry[], selected: Reado
   for (const entry of ranked) {
     if (candidates.length >= OPEN_TURN_PROBE_LIMIT) break;
     if (selected.has(entry.path) || !entry.path.endsWith(".jsonl") || entry.st.mtimeMs <= horizon) continue;
-    const codex = entry.rootName === "codex-sessions";
-    if (!cachedTranscriptTurn(entry.path, entry.st.size, entry.st.mtimeMs, codex)) candidates.push(entry);
+    const engine = transcriptEngineForRoot(entry.rootName);
+    if (!cachedTranscriptTurn(entry.path, entry.st.size, entry.st.mtimeMs, engine)) candidates.push(entry);
   }
   let open = false;
   await forEachCooperatively(candidates, (entry) => {
@@ -299,7 +311,7 @@ async function primeElidedOpenTurns(ranked: readonly RawEntry[], selected: Reado
       entry.path,
       entry.st.size,
       entry.st.mtimeMs,
-      entry.rootName === "codex-sessions",
+      transcriptEngineForRoot(entry.rootName),
       false,
     );
     open ||= turn.turn.state === "busy";
@@ -339,12 +351,18 @@ function resourceActivity(previous: FileEntry | undefined, mtime: number, size: 
   return { activity: "idle", activityReason: "mtime_old" };
 }
 
+/** Placeholder card labels for the resource scope, which names a transcript
+    before any of its bytes have been read. */
+const ENGINE_LABEL = { codex: "Codex", claude: "Claude", openclaw: "OpenClaw" } as const;
+
 function resourceScopeFromPaths(raw: RawPath[], baseline?: ResourceScopeSnapshot): ResourceScopeSnapshot {
   const previousByPath = new Map((baseline?.files ?? []).map((entry) => [entry.path, entry] as const));
   const conversations = raw.filter((entry) => entry.rootName !== "claude-tasks" && entry.path.endsWith(".jsonl"));
   const files = conversations.map((entry): FileEntry => {
     const previous = previousByPath.get(entry.path);
-    const engine = entry.rootName === "codex-sessions" ? "codex" as const : "claude" as const;
+    const engine = entry.rootName === "codex-sessions"
+      ? "codex" as const
+      : entry.rootName === "openclaw-sessions" ? "openclaw" as const : "claude" as const;
     const mtime = previous?.mtime ?? Date.now() / 1000;
     const size = previous?.size ?? 1;
     const activity = resourceActivity(previous, mtime, size);
@@ -362,7 +380,7 @@ function resourceScopeFromPaths(raw: RawPath[], baseline?: ResourceScopeSnapshot
       nativeForkSourceThreadId: previous?.nativeForkSourceThreadId,
       projectRoot: previous?.projectRoot,
       worktree: previous?.worktree,
-      title: previous?.title ?? (filename.startsWith("agent-") ? `Subagent ${filename.slice(6).split(".")[0]}` : `${engine === "codex" ? "Codex" : "Claude"} session`),
+      title: previous?.title ?? (filename.startsWith("agent-") ? `Subagent ${filename.slice(6).split(".")[0]}` : `${ENGINE_LABEL[engine]} session`),
       engine,
       kind: previous?.kind ?? (filename.startsWith("agent-") ? "subagent" : "session"),
       fmt: engine,

--- a/src/lib/scanner/effort.test.ts
+++ b/src/lib/scanner/effort.test.ts
@@ -93,3 +93,37 @@ describe("entryEffort", () => {
     expect(entryEffort(entry(pathname, { pid: 42 }))).toBe("max");
   });
 });
+
+/* OpenClaw fixtures (#1207). Every id and level below is invented. */
+describe("entryEffort for OpenClaw", () => {
+  function openclawEntry(name: string, rows: unknown[]): FileEntry {
+    const pathname = writeJsonl(name, rows);
+    return entry(pathname, { root: "openclaw-sessions", engine: "openclaw", fmt: "openclaw" });
+  }
+  const thinkingLevel = (level: string, id: string) => ({
+    type: "thinking_level_change",
+    id,
+    parentId: "oc-parent",
+    timestamp: "2026-08-27T09:00:00.000Z",
+    thinkingLevel: level,
+  });
+
+  test("reads the latest thinking_level_change", () => {
+    expect(entryEffort(openclawEntry("openclaw-effort.jsonl", [
+      { type: "session", version: 3, id: "oc-session-alpha", timestamp: "2026-08-27T08:59:00.000Z", cwd: SANDBOX },
+      thinkingLevel("low", "oc-level-1"),
+      thinkingLevel("high", "oc-level-2"),
+    ]))).toBe("high");
+  });
+
+  test("accepts the two tiers only OpenClaw has", () => {
+    expect(entryEffort(openclawEntry("openclaw-off.jsonl", [thinkingLevel("off", "oc-level-off")]))).toBe("off");
+    expect(entryEffort(openclawEntry("openclaw-adaptive.jsonl", [thinkingLevel("adaptive", "oc-level-adaptive")])))
+      .toBe("adaptive");
+  });
+
+  test("an unrecognised level reports no effort", () => {
+    expect(entryEffort(openclawEntry("openclaw-unknown.jsonl", [thinkingLevel("turbo", "oc-level-unknown")])))
+      .toBeNull();
+  });
+});

--- a/src/lib/scanner/effort.ts
+++ b/src/lib/scanner/effort.ts
@@ -6,8 +6,11 @@ import { readArgv } from "./process";
 
 const effortCache = globalCache<[number, number, string | null]>("effort");
 
-/** Union of both CLI scales: codex minimal…ultra, claude low…max. */
-const TIERS = new Set(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+/** Union of all three CLI scales: codex minimal…ultra, claude low…max, and
+    OpenClaw's `--thinking`, which adds `off` at the bottom and `adaptive` —
+    a request to let the model choose, which is a recorded setting rather than
+    a rung on the ladder. */
+const TIERS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "adaptive"]);
 
 function normalizeEffort(value: string | null | undefined): string | null {
   const tier = value?.trim().toLowerCase() ?? "";
@@ -21,6 +24,9 @@ function pickEffort(entry: FileEntry, obj: Record<string, unknown>): string | nu
     if (direct) return direct;
     const settings = recordValue(recordValue(payload?.collaboration_mode)?.settings);
     return stringValue(settings?.reasoning_effort);
+  }
+  if (entry.root === "openclaw-sessions" && obj.type === "thinking_level_change") {
+    return stringValue(obj.thinkingLevel);
   }
   if (entry.root === "claude-projects" && obj.type === "assistant") {
     const message = recordValue(obj.message);
@@ -60,7 +66,10 @@ export interface EntryEffortResult {
 }
 
 export function entryEffortResult(entry: FileEntry): EntryEffortResult {
-  if ((entry.root !== "claude-projects" && entry.root !== "codex-sessions") || !entry.path.endsWith(".jsonl")) {
+  if (
+    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions")
+    || !entry.path.endsWith(".jsonl")
+  ) {
     return { value: null, complete: true };
   }
   const argv = normalizeEffort(argvEffort(entry));

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -208,13 +208,16 @@ export function collectFileScanInWorker(
         if (currentScan) {
           (runtime.transcriptIndexScheduler ?? scheduleTranscriptIndex)({
             complete: completed.complete,
-            sources: completedConversationCatalog.map((entry) => ({
+            /* Same exclusion as `transcriptIndexFeed`: the full-text index has
+               no OpenClaw record parser and its engine column admits two
+               values. */
+            sources: completedConversationCatalog.flatMap((entry) => (entry.engine === "openclaw" ? [] : [{
               path: entry.path,
               project: entry.project,
               engine: entry.engine,
               size: entry.size,
               mtimeMs: entry.mtime * 1_000,
-            })),
+            }])),
           });
         }
       }

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -297,8 +297,8 @@ async function listFilesInternal(
     entry.activity = verdict.state;
     entry.activityReason = verdict.reason;
     entry.derivationComplete = verdict.complete;
-    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex")) {
-      const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine === "codex");
+    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw")) {
+      const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine);
       entry.derivationComplete &&= authoritative.complete;
       if (authoritative.complete) entry.authoritativeTurn = authoritative.turn;
     }

--- a/src/lib/scanner/model.test.ts
+++ b/src/lib/scanner/model.test.ts
@@ -36,3 +36,64 @@ test("keeps Claude's raw dated model id for resume while presenting its short la
 
   expect(entryModels(entry)).toEqual({ display: "opus-4-1", launch: "claude-opus-4-1-20250805" });
 });
+
+/* OpenClaw fixtures (#1207). Every id, model and provider below is invented. */
+function openclawEntry(pathname: string, lines: unknown[]): FileEntry {
+  fs.writeFileSync(pathname, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+  const stat = fs.statSync(pathname);
+  return {
+    path: pathname,
+    root: "openclaw-sessions",
+    name: path.basename(pathname),
+    project: "proj",
+    title: "session",
+    engine: "openclaw",
+    kind: "session",
+    fmt: "openclaw",
+    parent: null,
+    mtime: stat.mtimeMs / 1000,
+    size: stat.size,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+function openclawAssistant(model: string, provider: string): Record<string, unknown> {
+  return {
+    type: "message",
+    id: `oc-assistant-${model}-${provider}`,
+    parentId: "oc-parent",
+    timestamp: "2026-08-27T09:00:00.000Z",
+    message: { role: "assistant", provider, model, api: "demo-api", stopReason: "stop", content: [] },
+  };
+}
+
+test("an OpenClaw card shows the model the newest real provider record ran on", () => {
+  const entry = openclawEntry(path.join(SANDBOX, "openclaw-model.jsonl"), [
+    { type: "session", version: 3, id: "oc-session-alpha", timestamp: "2026-08-27T08:59:00.000Z", cwd: SANDBOX },
+    openclawAssistant("demo-model-1", "demo-provider"),
+    openclawAssistant("demo-model-2", "demo-provider"),
+  ]);
+  expect(entryModels(entry)).toEqual({ display: "demo-model-2", launch: "demo-model-2" });
+});
+
+test("a synthetic-provider record cannot replace the displayed OpenClaw model", () => {
+  const entry = openclawEntry(path.join(SANDBOX, "openclaw-synthetic-model.jsonl"), [
+    { type: "session", version: 3, id: "oc-session-beta", timestamp: "2026-08-27T08:59:00.000Z", cwd: SANDBOX },
+    openclawAssistant("demo-model-1", "demo-provider"),
+    openclawAssistant("delivery-mirror", "openclaw"),
+  ]);
+  expect(entryModels(entry)).toEqual({ display: "demo-model-1", launch: "demo-model-1" });
+});
+
+test("an OpenClaw session with only synthetic records reports no model", () => {
+  const entry = openclawEntry(path.join(SANDBOX, "openclaw-only-synthetic.jsonl"), [
+    { type: "session", version: 3, id: "oc-session-gamma", timestamp: "2026-08-27T08:59:00.000Z", cwd: SANDBOX },
+    openclawAssistant("gateway-injected", "openclaw"),
+  ]);
+  expect(entryModels(entry)).toEqual({ display: null, launch: null });
+});

--- a/src/lib/scanner/model.ts
+++ b/src/lib/scanner/model.ts
@@ -4,6 +4,7 @@ import type { FileEntry } from "../types";
 import { headRecordsResult, tailRecordsResult } from "./activity";
 import { globalCache } from "./caches";
 import { readJson, recordValue, stringValue } from "./json";
+import { openclawProviderAssistant } from "./openclawNative";
 
 export interface EntryModels {
   display: string | null;
@@ -27,6 +28,12 @@ function pickModel(entry: FileEntry, obj: Record<string, unknown>): string | nul
     if (obj.type === "turn_context" || obj.type === "session_meta") {
       return stringValue(recordValue(obj.payload)?.model);
     }
+  } else if (entry.root === "openclaw-sessions") {
+    /* Only a record a real provider served may name the displayed model. The
+       synthetic assistant records OpenClaw writes for itself carry model labels
+       no provider ever ran, and they are appended often enough to become the
+       newest assistant record in an ordinary session. */
+    return stringValue(openclawProviderAssistant(obj)?.model);
   } else if (obj.type === "assistant") {
     const model = stringValue(recordValue(obj.message)?.model);
     if (model && model !== "<synthetic>") return model;
@@ -40,7 +47,10 @@ export function entryModelsResult(entry: FileEntry): EntryModelsResult {
     const model = stringValue(meta.model);
     if (model) return { value: { display: shortModel(model), launch: model }, complete: true };
   }
-  if ((entry.root !== "claude-projects" && entry.root !== "codex-sessions") || !entry.path.endsWith(".jsonl")) {
+  if (
+    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions")
+    || !entry.path.endsWith(".jsonl")
+  ) {
     return { value: { display: null, launch: null }, complete: true };
   }
   const mtimeMs = entry.mtime * 1000;

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -73,8 +73,8 @@ async function runObservation(signal?: AbortSignal): Promise<FileEntry[]> {
   await each(entries, (entry) => {
     const verdict = activityVerdict(entry.root, entry.path, entry.mtime, entry.size);
     entry.activity = verdict.state; entry.activityReason = verdict.reason; entry.derivationComplete = verdict.complete;
-    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex")) {
-      const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine === "codex");
+    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw")) {
+      const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine);
       entry.derivationComplete &&= authoritative.complete;
       if (authoritative.complete) entry.authoritativeTurn = authoritative.turn;
     }

--- a/src/lib/scanner/openclawNative.ts
+++ b/src/lib/scanner/openclawNative.ts
@@ -1,0 +1,61 @@
+import { recordValue, stringValue } from "./json";
+
+/**
+ * OpenClaw's own record shapes, in one place: the sessions directory is shared
+ * with several sidecar formats, and its assistant records are not all provider
+ * work. Every reader that has to tell one from the other — discovery, model,
+ * effort, turn state, the feed — goes through here so a single definition
+ * decides what an OpenClaw transcript is and which of its records count.
+ */
+
+/**
+ * The provider value OpenClaw stamps on assistant records it synthesised
+ * itself — a channel delivery mirrored back into the transcript, a Gateway
+ * injection — rather than on a model's answer. They always carry
+ * `stopReason: "stop"`, so a synthetic record appended in the middle of a tool
+ * call would read as a finished turn and would replace the displayed model
+ * with a label no provider ever served. The model labels vary between
+ * versions; the provider value is what identifies them.
+ */
+export const OPENCLAW_SYNTHETIC_PROVIDER = "openclaw";
+
+/** Basenames that are not the sessions directory's own sidecars or wreckage. */
+const NON_TRANSCRIPT_SEGMENTS = [".trajectory.", ".checkpoint.", ".acp-stream.", ".deleted.", ".bak"];
+
+/**
+ * Whether a basename inside an OpenClaw sessions directory is a conversation.
+ *
+ * Beside the transcripts that directory holds runtime traces
+ * (`<id>.trajectory.jsonl`), ACP stream logs, self-contained checkpoint forks,
+ * JSON sidecars, a `sessions.json` index and dated repair backups. Admitting
+ * them would multiply the board's OpenClaw cards by the number of sidecar
+ * formats and surface dead backups as live conversations.
+ *
+ * Checkpoints are excluded rather than merged: each carries its own `session`
+ * header and a complete `parentId` chain, so folding one into the session it
+ * names would duplicate that whole history.
+ */
+export function isOpenclawTranscript(basename: string): boolean {
+  if (!basename.endsWith(".jsonl")) return false;
+  return !NON_TRANSCRIPT_SEGMENTS.some((segment) => basename.includes(segment));
+}
+
+/**
+ * The inner message of an OpenClaw `message` record, or null for anything else.
+ * The transcript wraps every role — including tool results — in a top-level
+ * `{type:"message", message:{role,…}}` envelope.
+ */
+export function openclawMessage(record: Record<string, unknown>): Record<string, unknown> | null {
+  return record.type === "message" ? recordValue(record.message) : null;
+}
+
+/**
+ * The inner message of an assistant record that a real provider produced, or
+ * null. Both the model display and the turn state read the newest such record,
+ * so a synthetic delivery mirror can neither rename the model nor end a turn.
+ */
+export function openclawProviderAssistant(record: Record<string, unknown>): Record<string, unknown> | null {
+  const message = openclawMessage(record);
+  if (!message || message.role !== "assistant") return null;
+  return stringValue(message.provider) === OPENCLAW_SYNTHETIC_PROVIDER ? null : message;
+}

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -13,7 +13,7 @@ import {
 } from "@/lib/projects/aliases";
 import { displayNameFromProjectIdentity } from "@/lib/projects/identity";
 
-import type { ProjectCatalogEntry } from "../types";
+import type { Engine, Fmt, ProjectCatalogEntry } from "../types";
 import { replaceConversationCatalog, type ConversationCatalogEntry } from "./conversationCatalog";
 import {
   describeFile,
@@ -50,8 +50,8 @@ type CachedProjectFile = {
   nativeParentThreadId?: string | null;
   nativeForkSourceThreadId?: string | null;
   title?: string;
-  engine?: "codex" | "claude" | "shell";
-  fmt?: "codex" | "claude" | "plain";
+  engine?: Engine;
+  fmt?: Fmt;
 };
 
 export type ParsedFileSummary = FileDescription;
@@ -60,8 +60,8 @@ type ProjectCatalogFile = CachedProjectFile & {
   path: string;
   title: string;
   titleCached: boolean;
-  engine: "codex" | "claude" | "shell";
-  fmt: "codex" | "claude" | "plain";
+  engine: Engine;
+  fmt: Fmt;
 };
 
 type ProjectCatalogState = {
@@ -121,7 +121,7 @@ function readState(): ProjectCatalogState {
       if (!value || typeof value !== "object" || Array.isArray(value)) continue;
       const file = value as Partial<CachedProjectFile>;
       if (
-        (file.rootName !== "codex-sessions" && file.rootName !== "claude-projects" && file.rootName !== "claude-tasks") ||
+        (file.rootName !== "codex-sessions" && file.rootName !== "claude-projects" && file.rootName !== "claude-tasks" && file.rootName !== "openclaw-sessions") ||
         typeof file.size !== "number" ||
         typeof file.mtimeMs !== "number" ||
         typeof file.stateKey !== "string" ||
@@ -133,8 +133,8 @@ function readState(): ProjectCatalogState {
       ) {
         continue;
       }
-      const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" ? file.engine : undefined;
-      const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" ? file.fmt : undefined;
+      const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" || file.engine === "openclaw" ? file.engine : undefined;
+      const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" || file.fmt === "openclaw" ? file.fmt : undefined;
       const cwd = typeof file.cwd === "string" ? file.cwd : file.cwd === null ? null : undefined;
       const sessionStartedAt = typeof file.sessionStartedAt === "string"
         ? file.sessionStartedAt
@@ -235,18 +235,22 @@ function writeState(state: ProjectCatalogState): void {
 }
 
 function isConversation(rootName: RawEntry["rootName"], kind: string): boolean {
-  return rootName === "codex-sessions" || (rootName === "claude-projects" && (kind === "session" || kind === "subagent"));
+  return rootName === "codex-sessions"
+    || rootName === "openclaw-sessions"
+    || (rootName === "claude-projects" && (kind === "session" || kind === "subagent"));
 }
 
 function engineForRoot(rootName: RawEntry["rootName"]): ProjectCatalogFile["engine"] {
   if (rootName === "codex-sessions") return "codex";
   if (rootName === "claude-projects") return "claude";
+  if (rootName === "openclaw-sessions") return "openclaw";
   return "shell";
 }
 
 function fmtForRoot(rootName: RawEntry["rootName"]): ProjectCatalogFile["fmt"] {
   if (rootName === "codex-sessions") return "codex";
   if (rootName === "claude-projects") return "claude";
+  if (rootName === "openclaw-sessions") return "openclaw";
   return "plain";
 }
 
@@ -255,6 +259,7 @@ function fallbackTitle(raw: RawEntry, kind: string): string {
   if (kind === "subagent") return "Subagent " + filename.slice("agent-".length).split(".")[0];
   if (raw.rootName === "codex-sessions") return "Codex session";
   if (raw.rootName === "claude-projects") return "Claude session";
+  if (raw.rootName === "openclaw-sessions") return "OpenClaw session";
   return "Background task " + filename.split(".")[0];
 }
 
@@ -579,7 +584,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
       kind: file.kind,
       fmt: file.fmt,
     });
-    if (!file.session || (file.engine !== "codex" && file.engine !== "claude")) return;
+    if (!file.session || (file.engine !== "codex" && file.engine !== "claude" && file.engine !== "openclaw")) return;
     conversationCatalog.push({
       path: file.path,
       root: file.rootName,

--- a/src/lib/scanner/roots.ts
+++ b/src/lib/scanner/roots.ts
@@ -30,10 +30,46 @@ function claudeTasksRoot(): string {
   return tmpdirCandidate;
 }
 
+/**
+ * OpenClaw keeps its whole state under one directory: `~/.openclaw` by default,
+ * `~/.openclaw-dev` under `--dev` and `~/.openclaw-<name>` under
+ * `--profile <name>`. Both flags work by pointing `OPENCLAW_STATE_DIR` at the
+ * profile directory, so honouring that variable covers every profile without
+ * the scanner learning the flag vocabulary. Resolved per call rather than at
+ * import so a relocated state directory takes effect without a restart.
+ */
+export function openclawStateDir(): string {
+  const configured = process.env.OPENCLAW_STATE_DIR?.trim();
+  return configured ? path.resolve(configured) : path.join(os.homedir(), ".openclaw");
+}
+
+/**
+ * The transcript directories under an OpenClaw state dir — one per agent id,
+ * at `<stateDir>/agents/<agentId>/sessions`. Each is its own scan root so a
+ * transcript's `name` stays the bare filename, the way a Codex rollout's does,
+ * and so an agent directory holding no sessions costs nothing.
+ */
+export function openclawSessionRoots(): string[] {
+  const agents = path.join(openclawStateDir(), "agents");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(agents, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => (entry.isDirectory() || entry.isSymbolicLink()) && !entry.name.startsWith("."))
+    .map((entry) => path.join(agents, entry.name, "sessions"))
+    .sort();
+}
+
 export const ROOTS: Record<RootKey, string> = {
   "codex-sessions": path.join(HOME, ".codex/sessions"),
   "claude-projects": path.join(HOME, ".claude/projects"),
   "claude-tasks": claudeTasksRoot(),
+  /* Every OpenClaw scan root is a descendant of this one; the per-agent roots
+     that discovery actually walks come from `openclawSessionRoots()`. */
+  "openclaw-sessions": path.join(HOME, ".openclaw/agents"),
 };
 
 /** Every scanner root, including all account homes, with real-path dedupe. */
@@ -42,6 +78,7 @@ export function scanRootEntries(): [RootKey, string][] {
     ...codexSessionRoots().map((root): [RootKey, string] => ["codex-sessions", root]),
     ...claudeProjectRoots().map((root): [RootKey, string] => ["claude-projects", root]),
     ["claude-tasks", ROOTS["claude-tasks"]],
+    ...openclawSessionRoots().map((root): [RootKey, string] => ["openclaw-sessions", root]),
   ];
   const seen = new Set<string>();
   return entries.filter(([, root]) => { const real = realpathSafe(root) ?? path.resolve(root); if (seen.has(real)) return false; seen.add(real); return true; });

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -9,7 +9,7 @@ import { globalCache } from "@/lib/scanner/caches";
 import { primePersistedLineageFacts } from "@/lib/scanner/links";
 import { QUESTION_CACHE_NAME } from "@/lib/scanner/questions";
 import { coordinatedFileScan, resetFileScanCoordinatorForTests, runFileCatalogScan } from "@/lib/scanner/scanCoordinator";
-import type { FileEntry, PendingQuestion } from "@/lib/types";
+import type { Engine, FileEntry, PendingQuestion, TranscriptEngine } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
 export type FileScanSnapshot = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
@@ -72,7 +72,7 @@ const FILE_SCAN_PIN_CACHE_MAX = 8;
 // and must be recomputed.
 // Bumped to 9 for issue #339: engine-native subagent titles/lineage and the
 // `spawnOrigin` provenance marker must not replay from a pre-#339 snapshot.
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 9 as const;
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 10 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
@@ -102,13 +102,13 @@ function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
   const filesValid = value.files.every((candidate) => {
     if (!isRecord(candidate)) return false;
     return typeof candidate.path === "string"
-      && (candidate.root === "codex-sessions" || candidate.root === "claude-projects" || candidate.root === "claude-tasks")
+      && (candidate.root === "codex-sessions" || candidate.root === "claude-projects" || candidate.root === "claude-tasks" || candidate.root === "openclaw-sessions")
       && typeof candidate.name === "string"
       && typeof candidate.project === "string"
       && typeof candidate.title === "string"
-      && (candidate.engine === "codex" || candidate.engine === "claude" || candidate.engine === "shell")
+      && (candidate.engine === "codex" || candidate.engine === "claude" || candidate.engine === "shell" || candidate.engine === "openclaw")
       && typeof candidate.kind === "string"
-      && (candidate.fmt === "codex" || candidate.fmt === "claude" || candidate.fmt === "plain")
+      && (candidate.fmt === "codex" || candidate.fmt === "claude" || candidate.fmt === "plain" || candidate.fmt === "openclaw")
       && (candidate.parent === null || typeof candidate.parent === "string")
       && typeof candidate.mtime === "number" && Number.isFinite(candidate.mtime)
       && typeof candidate.size === "number" && Number.isFinite(candidate.size)
@@ -129,6 +129,12 @@ function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
     && typeof candidate.conversations === "number" && Number.isSafeInteger(candidate.conversations)
     && (candidate.projectRoot === undefined || typeof candidate.projectRoot === "string"));
   return filesValid && catalogValid;
+}
+
+/* The primed evidence above is only meaningful for an engine whose transcript
+   the turn reader parses; background-task output logs carry no turn. */
+function isTranscriptEngine(engine: Engine): engine is TranscriptEngine {
+  return engine === "claude" || engine === "codex" || engine === "openclaw";
 }
 
 function persistedTurnState(entry: FileEntry): TurnState | undefined {
@@ -170,12 +176,13 @@ function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
     if (current.size !== entry.size || current.mtimeMs / 1000 !== entry.mtime) continue;
     const mtimeMs = entry.mtime * 1000;
     const turnState = persistedTurnState(entry);
-    if (turnState !== undefined && entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex")) {
+    if (turnState !== undefined && entry.path.endsWith(".jsonl") && isTranscriptEngine(entry.engine)) {
+      const engine = entry.engine;
       primeTranscriptTurnEvidence(
         entry.path,
         entry.size,
         mtimeMs,
-        entry.engine === "codex",
+        engine,
         turnState,
         {
           authoritative: false,
@@ -187,16 +194,16 @@ function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
           entry.path,
           entry.size,
           mtimeMs,
-          entry.engine === "codex",
+          engine,
           entry.authoritativeTurn,
           { composerReleased: entry.activityReason === "pane_at_composer" },
         );
-      } else if (entry.engine === "codex" || turnState.state !== "terminal") {
+      } else if (engine !== "claude" || turnState.state !== "terminal") {
         primeTranscriptTurnEvidence(
           entry.path,
           entry.size,
           mtimeMs,
-          entry.engine === "codex",
+          engine,
           turnState,
           { composerReleased: entry.activityReason === "pane_at_composer" },
         );

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -72,6 +72,10 @@ const FILE_SCAN_PIN_CACHE_MAX = 8;
 // and must be recomputed.
 // Bumped to 9 for issue #339: engine-native subagent titles/lineage and the
 // `spawnOrigin` provenance marker must not replay from a pre-#339 snapshot.
+// Bumped to 10 for issue #1207: entries carry the `openclaw-sessions` root and
+// the `openclaw` engine/format, which a pre-#1207 validator rejects — and a
+// pre-#1207 snapshot has no OpenClaw rows at all, so it must be rescanned
+// rather than served as a complete inventory.
 const FILE_SCAN_CACHE_SCHEMA_VERSION = 10 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";

--- a/src/lib/timeline.test.ts
+++ b/src/lib/timeline.test.ts
@@ -10,7 +10,7 @@ const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-timeline-cache-test-"
 
 afterAll(() => fs.rmSync(SANDBOX, { recursive: true, force: true }));
 
-function entry(pathname: string): FileEntry {
+function entry(pathname: string, overrides: Partial<FileEntry> = {}): FileEntry {
   const stat = fs.statSync(pathname);
   return {
     path: pathname,
@@ -30,6 +30,7 @@ function entry(pathname: string): FileEntry {
     model: null,
     pendingQuestion: null,
     waitingInput: null,
+    ...overrides,
   };
 }
 
@@ -74,4 +75,40 @@ test("an incomplete timeline read stays retryable for the same identity", () => 
   } finally {
     fs.openSync = originalOpenSync;
   }
+});
+
+/* Issue #1207: an OpenClaw conversation reaches a project's recent-actions
+   timeline like any other. Its records wrap every role in a top-level
+   `message` envelope, so neither the Claude nor the Codex arm sees one and the
+   card would otherwise be scanned, attributed, rendered — and then contribute
+   nothing here. Every identifier below is invented. */
+test("an OpenClaw conversation contributes its prompts and answers to the timeline", () => {
+  const pathname = path.join(SANDBOX, "oc-session-alpha.jsonl");
+  const started = Date.now() - 60_000;
+  const at = (offset: number) => new Date(started + offset).toISOString();
+  const message = (id: string, offset: number, message: Record<string, unknown>) =>
+    JSON.stringify({ type: "message", id, parentId: "oc-parent", timestamp: at(offset), message }) + "\n";
+  fs.writeFileSync(pathname, [
+    JSON.stringify({ type: "session", version: 3, id: "oc-header", timestamp: at(0), cwd: SANDBOX }) + "\n",
+    message("oc-user-1", 1_000, { role: "user", content: "Plant the cobalt orchard", timestamp: at(1_000) }),
+    message("oc-assistant-1", 2_000, {
+      role: "assistant",
+      provider: "demo-provider",
+      model: "demo-model",
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "oc-call-1", name: "Bash", arguments: { command: "plant" } }],
+    }),
+    message("oc-result-1", 3_000, { role: "toolResult", toolCallId: "oc-call-1", isError: false, content: [{ type: "text", text: "planted" }] }),
+    message("oc-assistant-2", 4_000, {
+      role: "assistant",
+      provider: "demo-provider",
+      model: "demo-model",
+      stopReason: "stop",
+      content: [{ type: "thinking", thinking: "not an action" }, { type: "text", text: "Three rows are in." }],
+    }),
+  ].join(""));
+  const file = entry(pathname, { root: "openclaw-sessions", engine: "openclaw", fmt: "openclaw" });
+
+  expect(projectTimeline([file], file.project, 10).map((event) => [event.kind, event.label]))
+    .toEqual([["turn", "Three rows are in."], ["user", "Plant the cobalt orchard"]]);
 });

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,5 +1,6 @@
 import { tailRecordsResult } from "./scanner/activity";
 import { globalCache } from "./scanner/caches";
+import { openclawMessage } from "./scanner/openclawNative";
 import type { ActionEvent, FileEntry } from "./types";
 import { cleanTitle } from "./title";
 
@@ -108,6 +109,37 @@ function codexEvents(entry: FileEntry, actor: string, records: Record<string, un
   return out;
 }
 
+/* OpenClaw wraps every role — the operator's included — in a top-level
+   `message` envelope, so neither engine arm above fires on one of its records
+   and an OpenClaw conversation would contribute nothing to its project's
+   recent actions. Assistant records OpenClaw synthesised itself are kept: the
+   feed renders them as prose too, and they are content the conversation
+   really carries. */
+function openclawEvents(entry: FileEntry, actor: string, records: Record<string, unknown>[]): ActionEvent[] {
+  const out: ActionEvent[] = [];
+  for (const obj of records) {
+    const ts = toTs(obj.timestamp);
+    if (ts === null) continue;
+    const message = openclawMessage(obj);
+    if (!message) continue;
+    const content = message.content;
+    if (message.role === "user") {
+      const text = typeof content === "string"
+        ? content.trim()
+        : recs(content).filter((part) => part.type === "text").map((part) => str(part.text)).join(" ").trim();
+      if (text) out.push({ ts, file: entry.path, actor, kind: "user", label: label(text) });
+      continue;
+    }
+    if (message.role !== "assistant") continue;
+    for (const part of recs(content)) {
+      if (part.type === "text" && str(part.text).trim()) {
+        out.push({ ts, file: entry.path, actor, kind: "turn", label: label(str(part.text)) });
+      }
+    }
+  }
+  return out;
+}
+
 function fileEvents(entry: FileEntry): ActionEvent[] {
   const mtimeMs = entry.mtime * 1000;
   const cached = eventCache.get(entry.path);
@@ -118,7 +150,9 @@ function fileEvents(entry: FileEntry): ActionEvent[] {
     ? claudeEvents(entry, actor, tail.records)
     : entry.fmt === "codex"
       ? codexEvents(entry, actor, tail.records)
-      : [];
+      : entry.fmt === "openclaw"
+        ? openclawEvents(entry, actor, tail.records)
+        : [];
   if (tail.complete) eventCache.set(entry.path, [entry.size, mtimeMs, events]);
   return events;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,11 +8,18 @@ import type { TurnState } from "@/lib/accounts/migration/contracts";
 export type RootKey =
   | "codex-sessions"
   | "claude-projects"
-  | "claude-tasks";
+  | "claude-tasks"
+  | "openclaw-sessions";
 
-export type Engine = "codex" | "claude" | "shell";
+export type Engine = "codex" | "claude" | "shell" | "openclaw";
 export type Activity = "live" | "recent" | "stalled" | "idle";
-export type Fmt = "codex" | "claude" | "plain";
+export type Fmt = "codex" | "claude" | "plain" | "openclaw";
+
+/** The engines that write a structured transcript the Viewer parses — every
+    `Engine` except `"shell"`, whose background tasks are plain output logs.
+    Named once so the readers that must switch on the dialect (title and search
+    text, turn state, model, effort, the feed) all agree on the same set. */
+export type TranscriptEngine = Extract<Engine, "codex" | "claude" | "openclaw">;
 
 declare const epochSecondsBrand: unique symbol;
 /**

--- a/src/lib/view/snapshot.openclaw.test.ts
+++ b/src/lib/view/snapshot.openclaw.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect, test } from "bun:test";
+import path from "node:path";
+
+import type { FileEntry } from "@/lib/types";
+
+import { resetPresenceForTest, upsertPresence } from "./presenceStore";
+import { composeSnapshot } from "./snapshot";
+import type { PresencePayloadV1 } from "./types";
+
+/*
+ * Issue #1207. Without the widened transcript filter a focused or selected
+ * OpenClaw path is silently dropped from every snapshot an agent reads, and
+ * without dropping the `"claude" | "codex"` cast beside it the entry would be
+ * reported as Claude. Both are viewing surfaces outside the scanner, and
+ * without them an OpenClaw card is scanned, attributed and rendered and then
+ * vanishes from the agent-facing view.
+ *
+ * A sibling of `view.test.ts` rather than a section inside it: that file
+ * carries redaction fixtures whose literal shapes the publication gate reads
+ * as credentials, so editing it would fail the gate on content this change
+ * does not own. Every path below is invented.
+ */
+
+afterEach(() => resetPresenceForTest());
+
+const OPENCLAW_PATH = "/openclaw/agents/primary/sessions/oc-session-alpha.jsonl";
+
+function presence(overrides: Partial<PresencePayloadV1> = {}): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "view-openclaw",
+    deviceId: "desktop",
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "viewer",
+    mode: "scheme",
+    viewport: { width: 100, height: 100, dpr: 1 },
+    camera: null,
+    focusedPath: OPENCLAW_PATH,
+    selectedPaths: [],
+    visiblePaths: [OPENCLAW_PATH],
+    board: { renderedRevision: 1, durableRevision: 1, sync: "current" },
+    ...overrides,
+  };
+}
+
+function file(pathname: string, overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: pathname,
+    root: "openclaw-sessions",
+    name: path.basename(pathname),
+    project: "viewer",
+    title: "Invented OpenClaw prompt",
+    engine: "openclaw",
+    kind: "session",
+    fmt: "openclaw",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: "demo-model",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+test("a focused OpenClaw path is reported under its own engine", async () => {
+  upsertPresence(presence(), 1000);
+  const result = await composeSnapshot({
+    request: { schemaVersion: 1, text: { include: false } },
+    files: [file(OPENCLAW_PATH)],
+    siblings: { selfResolution: "omitted", agents: [] },
+    scannerDurationMs: 0,
+    now: 2000,
+  });
+
+  expect(result.conversations.map((item) => item.path)).toEqual([OPENCLAW_PATH]);
+  expect(result.conversations[0]).toMatchObject({ engine: "openclaw", model: "demo-model", title: "Invented OpenClaw prompt" });
+});
+
+test("an OpenClaw path with no scan entry is still omitted", async () => {
+  const absent = "/openclaw/agents/primary/sessions/oc-session-absent.jsonl";
+  upsertPresence(presence({ focusedPath: absent, visiblePaths: [absent] }), 1000);
+  const result = await composeSnapshot({
+    request: { schemaVersion: 1, text: { include: false } },
+    files: [],
+    siblings: { selfResolution: "omitted", agents: [] },
+    scannerDurationMs: 0,
+    now: 2000,
+  });
+
+  expect(result.conversations).toEqual([]);
+  expect(result.scope).toMatchObject({ omittedCount: 1, truncated: true });
+});

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -1,5 +1,5 @@
 import { snapshotSpawnsFromRegistry, type RegistryFile, type SnapshotSpawnProjection } from "@/lib/agent/registry";
-import type { FileEntry } from "@/lib/types";
+import type { FileEntry, TranscriptEngine } from "@/lib/types";
 
 import { compactText } from "./compactText";
 import { freshness, listPresence, sessionSummary } from "./presenceStore";
@@ -53,14 +53,25 @@ function validateExplicitMembership(session: StoredViewSession, explicit: readon
   if (explicit.some((pathname) => !currentView.has(pathname))) throw new SnapshotError("PATH_OUTSIDE_CURRENT_VIEW", 422, "path is outside current view");
 }
 
-function transcriptEntry(byPath: ReadonlyMap<string, FileEntry>, pathname: string): FileEntry | undefined {
-  const entry = byPath.get(pathname);
-  return entry?.engine === "claude" || entry?.engine === "codex" || entry?.engine === "openclaw" ? entry : undefined;
+/** The scan entry behind a path, when that path names a transcript the snapshot
+    reports. The return type carries the narrowing so the engine reaches
+    `SnapshotConversation` without a cast: a widened filter over a cast field is
+    exactly how an OpenClaw entry would have been published as Claude. */
+function isTranscriptEntry(entry: FileEntry | undefined): entry is FileEntry & { engine: TranscriptEngine } {
+  return entry?.engine === "claude" || entry?.engine === "codex" || entry?.engine === "openclaw";
 }
 
-function conversation(entry: FileEntry): SnapshotConversation {
+function transcriptEntry(
+  byPath: ReadonlyMap<string, FileEntry>,
+  pathname: string,
+): (FileEntry & { engine: TranscriptEngine }) | undefined {
+  const entry = byPath.get(pathname);
+  return isTranscriptEntry(entry) ? entry : undefined;
+}
+
+function conversation(entry: FileEntry & { engine: TranscriptEngine }): SnapshotConversation {
   const attention = entry.pendingQuestion ? { state: "question" as const, since: entry.pendingQuestion.askedAt } : entry.waitingInput ? { state: "terminal" as const, since: new Date(entry.waitingInput.since * 1000).toISOString() } : entry.activity === "stalled" ? { state: "stalled" as const, since: new Date(entry.mtime * 1000).toISOString() } : null;
-  return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as SnapshotConversation["engine"], model: entry.model, activity: entry.activity, proc: entry.proc, attention };
+  return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine, model: entry.model, activity: entry.activity, proc: entry.proc, attention };
 }
 
 export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; scannerScannedAt?: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; snapshotSpawns?: (launchIds: readonly string[]) => SnapshotSpawnProjection; now?: number }): Promise<ViewerSnapshotV1> {
@@ -84,7 +95,7 @@ export async function composeSnapshot(input: { request: SnapshotRequestV1; files
       ? snapshotSpawnsFromRegistry(input.registry, launchIds)
       : input.snapshotSpawns?.(launchIds) ?? {};
   const stubs: SnapshotSpawnStub[] = [];
-  const resolvedEntries: Array<{ entry: FileEntry; resolvedFrom?: string }> = [];
+  const resolvedEntries: Array<{ entry: FileEntry & { engine: TranscriptEngine }; resolvedFrom?: string }> = [];
   const seenPaths = new Set<string>();
   for (const pathname of scope.all) {
     if (resolvedEntries.length + stubs.length >= MAX_SCOPE_PATHS) break;

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -55,12 +55,12 @@ function validateExplicitMembership(session: StoredViewSession, explicit: readon
 
 function transcriptEntry(byPath: ReadonlyMap<string, FileEntry>, pathname: string): FileEntry | undefined {
   const entry = byPath.get(pathname);
-  return entry?.engine === "claude" || entry?.engine === "codex" ? entry : undefined;
+  return entry?.engine === "claude" || entry?.engine === "codex" || entry?.engine === "openclaw" ? entry : undefined;
 }
 
 function conversation(entry: FileEntry): SnapshotConversation {
   const attention = entry.pendingQuestion ? { state: "question" as const, since: entry.pendingQuestion.askedAt } : entry.waitingInput ? { state: "terminal" as const, since: new Date(entry.waitingInput.since * 1000).toISOString() } : entry.activity === "stalled" ? { state: "stalled" as const, since: new Date(entry.mtime * 1000).toISOString() } : null;
-  return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as "claude" | "codex", model: entry.model, activity: entry.activity, proc: entry.proc, attention };
+  return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as SnapshotConversation["engine"], model: entry.model, activity: entry.activity, proc: entry.proc, attention };
 }
 
 export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; scannerScannedAt?: number; siblings: ViewerSnapshotV1["siblings"]; registry?: RegistryFile; snapshotSpawns?: (launchIds: readonly string[]) => SnapshotSpawnProjection; now?: number }): Promise<ViewerSnapshotV1> {

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -1,4 +1,4 @@
-import type { Activity, Engine, FileEntry } from "@/lib/types";
+import type { Activity, Engine, FileEntry, TranscriptEngine } from "@/lib/types";
 
 export const VIEW_SCHEMA_VERSION = 1 as const;
 export const MAX_PRESENCE_BYTES = 32 * 1024;
@@ -78,7 +78,7 @@ export interface SnapshotConversation {
   path: string;
   project: string;
   title: string;
-  engine: Extract<Engine, "claude" | "codex">;
+  engine: TranscriptEngine;
   model: string | null;
   activity: Activity;
   proc: FileEntry["proc"];

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -108,6 +108,8 @@
   --color-codex-soft: #e8f0fb;
   --color-claude: #d97757;
   --color-claude-soft: #faeee9;
+  --color-openclaw: #b3407a;
+  --color-openclaw-soft: #fbeaf3;
 
   /* ── §1.6 Motion ───────────────────────────────────────────────────────── */
   --motion-fast: 120ms; /* hover, press, chip state         */
@@ -187,6 +189,8 @@
     --color-codex-soft: #152238;
     --color-claude: #e08a6d;
     --color-claude-soft: #2b1c15;
+    --color-openclaw: #e888b6;
+    --color-openclaw-soft: #2e1622;
 
     --color-user: #2a2a33;
 
@@ -242,6 +246,8 @@
   --color-codex-soft: #152238;
   --color-claude: #e08a6d;
   --color-claude-soft: #2b1c15;
+  --color-openclaw: #e888b6;
+  --color-openclaw-soft: #2e1622;
 
   --color-user: #2a2a33;
 


### PR DESCRIPTION
Phase 1 of #1207 — the viewing slice. Hosting is deliberately not here; `docs/design/openclaw-engine.md` on this branch carries it as **Deferred — hosting**, holding the transport candidates, the termination gate that must be passed before one is chosen, the ownership question for sessions that also receive Gateway turns from channels or cron, and the lifecycle surfaces a hosting design must cover — as requirements, not answers.

## What phase 1 delivers

OpenClaw conversations are scanned, attributed to a project, and rendered — not through the `"plain"` fallback, but as the engine's own transcript shape. 54 files, +2299/−180.

## How this PR reached you

Opened by the orchestrator rather than by the implementing agent. The implementation is entirely the agent's: it landed as `2ff564e2` with the worktree clean. Its stage then died at the verdict boundary before it could push or open a PR — the same failure that killed three earlier stages on this issue, always after the work was committed, never during it. Nothing here was written by hand; only the push and this description were.

Because of that, the implementer's own summary of decisions and evidence is not available in the usual place. The design document on this branch is the specification it worked from, and its file-level phase-1 plan is what the diff should be read against.

## Review anchor

The design has had three review rounds and one structural cut; every finding raised against it is committed, including the last one — the turn-state rule now keys on the real provider instead of taking `stopReason` off the last assistant record (`3634a6fd`).

What still deserves a reviewer's attention, since no review stage survived to give it:

- project attribution must be stable and survive the session directory being gone, per `AGENTS.md`;
- the engine seam must not have degenerated into a third branch at every call site;
- the two viewing gates the earlier review found missing — `src/hooks/useSwitchboardData.ts` and `src/lib/view/snapshot.ts` — must actually be covered;
- no fixture may carry real OpenClaw content: the sessions on this machine hold personal messaging history, and this repository is public.