### PR TITLE
ci(privacy): scan the identities a squash merge composes into trailers

### DIFF
--- a/.github/workflows/privacy-publication.yml
+++ b/.github/workflows/privacy-publication.yml
@@ -63,7 +63,13 @@ jobs:
       # Commit messages are published the moment the branch is pushed, and the
       # gate is the only thing that reads them before that happens. Scanning
       # only the files left the one surface nobody re-reads unguarded.
-      - name: Scan changed publication surfaces and commit messages
+      #
+      # The commit that lands is not one of them: a squash merge composes a new
+      # message and lifts the identities git recorded on the branch commits into
+      # `Co-authored-by:` trailers. So the same step reads the merge boundary,
+      # here, on the pull request, while the composed commit can still be
+      # prevented rather than found afterwards in the public history.
+      - name: Scan changed publication surfaces, commit messages and the merge boundary
         env:
           LLV_PRIVACY_KNOWN_VALUE_FINGERPRINTS_FILE: ${{ github.workspace }}/trusted/scripts/privacy-known-value-fingerprints.json
           LLV_PRIVACY_OCR_LANGUAGES: eng+ukr

--- a/docs/privacy-publication.md
+++ b/docs/privacy-publication.md
@@ -43,6 +43,24 @@ video stream. Frame-count sampling keeps that coverage when duration metadata
 is unavailable. Missing duration and frame count, malformed stream inventories,
 and excessive stream counts produce `inspection_error`.
 
+## Commit surface and merge boundary
+
+`--check-commits` reads the branch commit messages, which publish the moment
+the branch is pushed, and the identities git recorded on those commits. The
+second is what a squash merge publishes: the forge writes a new message for the
+commit that lands on the default branch and lifts every branch author and
+committer into a `Co-authored-by:` trailer of its own, so an address on no
+message at all can reach the public history. The check runs on the pull request,
+before the merge composes that commit.
+
+An identity publishes nobody when it is the account the repository belongs to on
+the forge — read from the origin remote of the checkout under inspection, never
+written down — or one of the machine-attribution mailboxes the trailer rule
+already exempts. Every other identity is a person and produces `email_address`,
+exactly as an address in a file does, with a `merge_boundary:` line naming the
+commit, the field and the trailer. The address stays suppressed there like every
+other matched value: `git show -s <commit>` names it to whoever is fixing it.
+
 ## Known-value fingerprints
 
 CI reads the committed

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -21,6 +21,7 @@ import {
   commitMessageAddressReview,
   commitMessageFindings,
   formatPrivacyReport,
+  mergeBoundaryReview,
   TRUSTED_TELEGRAM_VENDOR_EXEMPT_FINDING_CLASSES,
   TRUSTED_TELEGRAM_VENDOR_ROOT_DIGEST,
   trustedVendorRootDigest,
@@ -3151,5 +3152,167 @@ describe("commitMessageFindings", () => {
     commit(repo, `fix: handle ${uuid} correctly`);
     const findings = commitMessageFindings(repo, "main");
     expect(findings.has("resource_identifier")).toBe(false);
+  });
+});
+
+describe("mergeBoundaryReview", () => {
+  /* Every address here is invented. The change is about an address that
+     reached the public history, and a fixture that quotes a real one would
+     publish it again. */
+  const forgeAccountDomain = ["users.noreply", "github.com"].join(".");
+  const owner = "privacy-gate-fixture-owner";
+  const canonicalIdentity = { email: [`4242+${owner}`, forgeAccountDomain].join("@"), name: "Fixture Maintainer" };
+  let fixtureFile = 0;
+
+  function gitRepo(remote = `https://github.com/${owner}/fixture-repository.git`): string {
+    const repo = mkdtempSync(join(tmpdir(), "llv-privacy-merge-"));
+    temporaryDirectories.push(repo);
+    runGit(repo, ["init", "--quiet", "-b", "main", "."]);
+    if (remote) runGit(repo, ["remote", "add", "origin", remote]);
+    commit(repo, "chore: baseline", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "-b", "feature"]);
+    return repo;
+  }
+
+  function commit(repo: string, message: string, identity: { email: string; name: string }): void {
+    fixtureFile += 1;
+    writeFileSync(join(repo, `fixture-${fixtureFile}.txt`), "x");
+    runGit(repo, ["add", "."]);
+    runGit(repo, [
+      "-c", `user.name=${identity.name}`,
+      "-c", `user.email=${identity.email}`,
+      "commit", "--quiet", "-m", message,
+    ]);
+  }
+
+  function head(repo: string): string {
+    const result = Bun.spawnSync({ cmd: ["git", "-C", repo, "rev-parse", "HEAD"], stderr: "pipe", stdout: "pipe" });
+    return result.stdout.toString().trim();
+  }
+
+  test("a non-canonical author becomes an attributable trailer at the merge boundary", () => {
+    /* Nothing in the message carries this address — git recorded it as the
+       author, and the squash merge is what turns it into a trailer. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: something", { email: personal, name: "Someone" });
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(commitMessageFindings(repo, "main").size).toBe(0);
+    expect(review.findings.get("email_address")).toBe(1);
+    expect(review.notices).toHaveLength(1);
+    expect(review.notices[0]).toContain(head(repo).slice(0, 12));
+    expect(review.notices[0]).toContain("author");
+    expect(review.notices[0]).toContain("Co-authored-by");
+    expect(review.notices[0]).not.toContain(personal);
+  });
+
+  test("a canonically authored branch composes nothing attributable", () => {
+    const repo = gitRepo();
+    commit(repo, "feat: something", canonicalIdentity);
+    commit(repo, "fix: something else", canonicalIdentity);
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.size).toBe(0);
+    expect(review.notices).toEqual([]);
+  });
+
+  test("another account's forge address is not the repository's identity", () => {
+    const repo = gitRepo();
+    const stranger = ["77+privacy-gate-fixture-stranger", forgeAccountDomain].join("@");
+    commit(repo, "feat: something", { email: stranger, name: "Someone Else" });
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+  });
+
+  test("a vendor no-reply identity stays machine attribution", () => {
+    const repo = gitRepo();
+    const vendor = ["noreply", "vendor.example.com"].join("@");
+    commit(repo, "feat: something", { email: vendor, name: "Some Model" });
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.size).toBe(0);
+  });
+
+  test("a forge role account identity stays exempt", () => {
+    /* The forge merges its own automation's branches — a dependency bump, a
+       lockfile refresh — and those commits are authored by an app account on
+       the forge's own domain. Flagging one would freeze those merges. */
+    const repo = gitRepo();
+    const roleAccount = ["4242+fixture-tool[bot]", forgeAccountDomain].join("@");
+    commit(repo, "chore: refresh", { email: roleAccount, name: "fixture-tool[bot]" });
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.size).toBe(0);
+  });
+
+  test("an identity is attributable when no repository account can be resolved", () => {
+    const repo = gitRepo("");
+    commit(repo, "feat: something", canonicalIdentity);
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+  });
+
+  test("the committer identity publishes too", () => {
+    /* A rebase or an amend rewrites the committer and leaves the author
+       alone, so the two fields can name different people on one commit. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: something", canonicalIdentity);
+    runGit(repo, [
+      "-c", "user.name=Someone",
+      "-c", `user.email=${personal}`,
+      "commit", "--quiet", "--amend", "--no-edit",
+    ]);
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+    expect(review.notices).toHaveLength(1);
+    expect(review.notices[0]).toContain("committer");
+  });
+
+  test("reports one finding for a commit whose author and committer are the same person", () => {
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: something", { email: personal, name: "Someone" });
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+  });
+
+  test("reports an unreadable range rather than passing it", () => {
+    const repo = gitRepo();
+    const review = mergeBoundaryReview(repo, "no-such-base");
+
+    expect(review.findings.get("inspection_error")).toBe(1);
+  });
+
+  test("the gate reads the merge boundary under --check-commits and withholds the address", () => {
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: something", { email: personal, name: "Someone" });
+
+    const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
+    const output = result.stdout.toString();
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toContain("PRIVACY GATE: FAIL\nemail_address: 1\n");
+    expect(output).toContain("merge_boundary: ");
+    expect(output).toContain(head(repo).slice(0, 12));
+    expect(output).not.toContain(personal);
+  });
+
+  test("an address in the commit body is still flagged, and named as a message finding", () => {
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, `feat: write to ${personal} about it`, canonicalIdentity);
+
+    const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
+    const output = result.stdout.toString();
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toBe("PRIVACY GATE: FAIL\nemail_address: 1\n");
   });
 });

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1219,7 +1219,7 @@ export function inspectPaths(
   return findings;
 }
 
-export function formatPrivacyReport(findings: Map<FindingClass, number>): string {
+export function formatPrivacyReport(findings: Map<FindingClass, number>, notices: string[] = []): string {
   if (findings.size === 0) {
     return "PRIVACY GATE: PASS\n";
   }
@@ -1227,6 +1227,9 @@ export function formatPrivacyReport(findings: Map<FindingClass, number>): string
   for (const [finding, count] of [...findings].sort(([left], [right]) => left.localeCompare(right))) {
     lines.push(`${finding}: ${count}`);
   }
+  /* A count says a class was found; a notice says where, for the findings
+     whose location is a commit nobody can grep for. */
+  lines.push(...notices);
   return `${lines.join("\n")}\n`;
 }
 
@@ -1412,8 +1415,118 @@ export function commitMessageFindings(repository: string, base: string): Map<Fin
   return findings;
 }
 
-export function reportPrivacyFindings(findings: Map<FindingClass, number>): void {
-  process.stdout.write(formatPrivacyReport(findings));
+export type MergeBoundaryReview = { findings: Map<FindingClass, number>; notices: string[] };
+
+type CommitIdentity = { address: string; commit: string; field: "author" | "committer"; name: string };
+
+/* The forge's account namespace, `<id>+<handle>` or `<handle>` at the no-reply
+   host of its own domain. The handle names the account, and the account the
+   repository belongs to is the one its origin remote names — so the canonical
+   identity is read from the checkout rather than written down here, where
+   writing it down would publish it. */
+const FORGE_ACCOUNT_DOMAIN = `users.noreply.${FORGE_DOMAIN}`;
+const COMPOSED_ATTRIBUTION_TRAILER = "Co-authored-by";
+
+function forgeAccountHandle(address: string): string | undefined {
+  const separator = address.lastIndexOf("@");
+  if (separator === -1) return undefined;
+  if (address.slice(separator + 1).toLowerCase() !== FORGE_ACCOUNT_DOMAIN) return undefined;
+  const localPart = address.slice(0, separator).toLowerCase();
+  const identifier = localPart.indexOf("+");
+  return identifier === -1 ? localPart : localPart.slice(identifier + 1);
+}
+
+/* `<host>/<owner>/<repository>` in the HTTPS form, `<host>:<owner>/<repository>`
+   in the SSH one. The remote is written by whoever created the checkout — the
+   workflow, or the operator — never by the branch under inspection. */
+function forgeOwner(repository: string): string | undefined {
+  const result = Bun.spawnSync({
+    cmd: ["git", "-C", repository, "config", "--get", "remote.origin.url"],
+    env: withoutWakatimeCredential(process.env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (result.exitCode !== 0) return undefined;
+  const owner = new RegExp(`${FORGE_DOMAIN.replaceAll(".", String.raw`\.`)}[/:]([A-Za-z0-9._-]+)/`, "i")
+    .exec(result.stdout.toString().trim());
+  return owner?.[1].toLowerCase();
+}
+
+/** Every identity git recorded on the commits the merge will squash. */
+function branchIdentities(repository: string, base: string): CommitIdentity[] | undefined {
+  const result = Bun.spawnSync({
+    cmd: ["git", "-C", repository, "log", "--format=%H%x00%an%x00%ae%x00%cn%x00%ce", `${base}..HEAD`],
+    env: withoutWakatimeCredential(process.env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (result.exitCode !== 0) return undefined;
+  const identities: CommitIdentity[] = [];
+  /* An identity carries no newline — git refuses to record one — so a commit
+     is a line and its five fields are NUL-separated within it. */
+  for (const line of result.stdout.toString().split("\n")) {
+    if (line === "") continue;
+    const [commit, authorName, authorAddress, committerName, committerAddress] = line.split("\0");
+    if (committerAddress === undefined) return undefined;
+    identities.push({ address: authorAddress, commit, field: "author", name: authorName });
+    if (committerName === authorName && committerAddress === authorAddress) continue;
+    identities.push({ address: committerAddress, commit, field: "committer", name: committerName });
+  }
+  return identities;
+}
+
+/* One identity in the shape the forge composes it: a message whose last
+   paragraph is the attribution trailer, so the trailer rules read a composed
+   trailer exactly as they read a written one. */
+function composedAttributionMessage(identity: CommitIdentity): string {
+  return `squash merge\n\n${COMPOSED_ATTRIBUTION_TRAILER}: ${identity.name} <${identity.address}>\n`;
+}
+
+/**
+ * The identities the forge will publish in the commit it composes at merge.
+ *
+ * `--check-commits` reads the messages the branch carries, and the commit that
+ * lands on the default branch is none of them: a squash merge writes a new
+ * message and lifts every identity git recorded on the branch commits into a
+ * `Co-authored-by:` trailer of its own. Nothing had ever read those identities,
+ * so an address on no message at all reached the public history as a trailer.
+ *
+ * Git records an author and a committer on every commit and a commit cannot be
+ * made without them, so the question is never whether an identity publishes but
+ * whose. Two answers publish nobody: the account the repository belongs to on
+ * the forge, and the machine-attribution mailboxes the trailer rule already
+ * names. Every other identity is a person, and is reported exactly as an
+ * address in a file is — the carve-out for written trailers is not widened,
+ * it is read here as it is read there.
+ */
+export function mergeBoundaryReview(repository: string, base: string): MergeBoundaryReview {
+  const findings = new Map<FindingClass, number>();
+  const notices: string[] = [];
+  const identities = branchIdentities(repository, base);
+  if (identities === undefined) {
+    addFinding(findings, "inspection_error");
+    return { findings, notices };
+  }
+  const owner = forgeOwner(repository);
+  for (const identity of identities) {
+    const { attributable } = commitMessageAddressReview(composedAttributionMessage(identity));
+    const publishes = attributable.some((address) => owner === undefined || forgeAccountHandle(address) !== owner);
+    if (!publishes) continue;
+    addFinding(findings, "email_address");
+    /* The notice names the commit, the field and the trailer, and never the
+       address: this report is itself published — a check run's log on a public
+       repository — and a report that quotes the address to prove it leaked,
+       leaks it. `git show -s <commit>` names it to whoever is fixing it. */
+    notices.push(
+      `merge_boundary: ${identity.commit.slice(0, 12)} ${identity.field} identity`
+      + ` composes an attributable ${COMPOSED_ATTRIBUTION_TRAILER} trailer (address withheld)`,
+    );
+  }
+  return { findings, notices };
+}
+
+export function reportPrivacyFindings(findings: Map<FindingClass, number>, notices: string[] = []): void {
+  process.stdout.write(formatPrivacyReport(findings, notices));
   if (findings.size === 0) return;
   process.exitCode = 1;
 }
@@ -1439,10 +1552,19 @@ if (import.meta.main) {
     inspectionRoot,
     trustedBase,
   );
+  const notices: string[] = [];
   if (arguments_.includes("--check-commits")) {
     for (const [finding, count] of commitMessageFindings(inspectionRoot, trustedBase)) {
       pathFindings.set(finding, (pathFindings.get(finding) ?? 0) + count);
     }
+    /* The branch commits publish their messages when they are pushed; the merge
+       publishes a commit composed from their identities. Both are the commit
+       surface, so one flag reads both. */
+    const boundary = mergeBoundaryReview(inspectionRoot, trustedBase);
+    for (const [finding, count] of boundary.findings) {
+      pathFindings.set(finding, (pathFindings.get(finding) ?? 0) + count);
+    }
+    notices.push(...boundary.notices);
   }
-  reportPrivacyFindings(pathFindings);
+  reportPrivacyFindings(pathFindings, notices);
 }


### PR DESCRIPTION
Closes #1239.

## The gap, and where the scanned range was computed

`--check-commits` scans `<base>...HEAD` and reads the messages the branch
commits carry. The commit that lands on the default branch is none of them: a
squash merge composes a new message and lifts every identity git recorded on
the branch commits into a `Co-authored-by:` trailer of its own. Those
identities are on no message, so nothing had ever read them — and one reached
the public history exactly that way.

The other components of the composed commit were already covered: its subject
is the pull-request title, which `privacy-tracker-audit` reads on `opened`,
`edited` and `synchronize`, and its body is the branch messages, which
`--check-commits` reads. The identities were the one component nothing read.

## What changed

`--check-commits` now also reviews the merge boundary: every author and
committer git recorded on `<base>..HEAD`, each read in the shape the forge
composes it — a message whose last paragraph is the attribution trailer — so
the existing trailer rules read a composed trailer exactly as they read a
written one. The machine-attribution carve-out (#1195, #1209, #1220) is
untouched and not widened.

Git records an author and a committer on every commit and a commit cannot be
made without them, so the question is never whether an identity publishes but
whose. Two answers publish nobody:

- the account the repository belongs to on the forge, resolved from the origin
  remote of the checkout under inspection — the canonical identity is read from
  the checkout rather than written down in the repository, where writing it down
  would publish it; and
- the machine-attribution mailboxes the trailer rule already exempts.

Every other identity is a person and produces `email_address` — the same class,
the same weight and the same exit code as an address in a file — plus a
`merge_boundary:` line naming the commit, the field (`author` or `committer`)
and the trailer.

The notice withholds the address itself. A check run's log on a public
repository is a publication surface, and a report that quotes an address to
prove it leaked, leaks it; the report hands over the commit instead, and
`git show -s <commit>` names it locally to whoever is fixing it. That matches
how every other finding class reports — matched values stay suppressed.

## Timing: before the merge completes, on the pull request

The issue allows either a pre-merge scan or a default-branch check that fires
once such a commit lands. This is the pre-merge one, because the two differ in
exactly the thing the issue cares about:

- publication happens at the merge, so a default-branch check reports a fact
  that is already permanent and public, and the only remedy left is rewriting
  the default branch;
- an after-the-fact signal already exists incidentally — the message range is
  symmetric, so a bad commit that lands surfaces on every later branch that
  does not contain it, loudly and too late. The missing control was the read
  before publication, and that is what this adds;
- and the pre-merge run costs nothing extra: the boundary is composed inside
  the job that already reads the commit surface.

The bound worth stating: the gate predicts the message the forge composes from
the branch. Someone who hand-edits the squash message in the merge dialog can
still type an address into it, and no gate reads that box.

## Tests

- a branch whose commits carry a non-canonical author produces a finding at the
  merge boundary, while its messages produce none — the finding exists only at
  the boundary;
- a canonically authored branch produces nothing;
- another account's forge address is not the repository's identity;
- the vendor no-reply exemption and a forge role account still pass, so
  automation merges do not freeze;
- an unresolvable repository account fails closed;
- a committer identity that differs from the author publishes too, and one
  commit whose author and committer are the same person reports once;
- an unreadable range reports `inspection_error` instead of passing;
- end to end through `--check-commits`: the report names the commit and the
  trailer and does not contain the address;
- an address in the message body rather than a trailer is still flagged as
  before.

Every address in the fixtures is invented. This change is about an address that
reached the public history, and a fixture that quoted a real one would publish
it again.

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test scripts/privacy-publication-gate.test.ts` — 147 pass, 0 fail
  (136 before this branch, baselined against the merge base).
- Both new rules were mutation-checked: dropping the canonical exemption fails
  the negative tests, and exempting everything fails the positive ones.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits`
  — PASS, and PASS again with `--require-known-values` and the fingerprint
  catalog, the way CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
