### PR TITLE
fix(deploy): name the refused candidate MCP read, and give the sidecar a scan it can run

### DIFF
--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -504,6 +504,18 @@ export interface ViewerReleaseIdentity {
   mcpRuntime?: ViewerMcpRuntimeIdentity;
 }
 
+/** What one refused probe read actually answered. `calls` says which read
+    failed; without this the deployment record cannot say why, and the tool's
+    own account of the refusal dies with the candidate (#790). Bounded and
+    redacted at the point of capture, like `containerLog`. */
+export interface ViewerMcpRuntimeCallFailure {
+  tool: string;
+  /** The MCP failure envelope's code, when the refusal carried one. */
+  code?: string;
+  /** The refusal text, single-line, redacted and length-bounded. */
+  error: string;
+}
+
 export interface ViewerMcpRuntimeHealthEvidence {
   checkedAt: string;
   revision: string;
@@ -514,6 +526,9 @@ export interface ViewerMcpRuntimeHealthEvidence {
     deploymentStatus: boolean;
     boardSnapshot: boolean;
   };
+  /** Every read that did not answer `ok`, in call order. Absent when they all
+      passed. */
+  callFailures?: ViewerMcpRuntimeCallFailure[];
   ok: boolean;
   detail?: string;
 }

--- a/src/lib/scanner/fileScanWorker.test.ts
+++ b/src/lib/scanner/fileScanWorker.test.ts
@@ -7,7 +7,7 @@ import { scheduleTranscriptIndex, waitForTranscriptIndexIdleForTests } from "@/l
 import { searchTranscripts } from "@/lib/search/transcriptSearch";
 
 import { conversationCatalogSnapshot, replaceConversationCatalog } from "./conversationCatalog";
-import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
+import { collectFileScanInWorker, fileScanWorkerEnabled, fileScanWorkerLaunch } from "./fileScanWorker";
 
 const directories: string[] = [];
 
@@ -369,4 +369,43 @@ test("aborting a worker scan kills the child and releases its timer and listener
   expect(() => process.kill(pid, 0)).toThrow();
   expect(timers).toBe(0);
   expect(listeners).toBe(0);
+});
+
+
+/* #790: the published MCP runtime release root is `dist/`, `node_modules/` and
+   a manifest. The launcher used to answer with the source path it had just
+   found missing, so every corpus read in that process died on a module that was
+   never there - and took the deployment gate's `board_snapshot` with it. */
+test("a root with no worker artifact reports none instead of naming one that is not there", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-root-"));
+  directories.push(root);
+  fs.mkdirSync(path.join(root, "dist"));
+  fs.mkdirSync(path.join(root, "node_modules"));
+
+  expect(fileScanWorkerLaunch(root)).toBeNull();
+
+  fs.mkdirSync(path.join(root, ".next", "server"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".next", "server", "file-scanner-worker.js"), "");
+  expect(fileScanWorkerLaunch(root)).toMatchObject({
+    workerPath: path.join(root, ".next", "server", "file-scanner-worker.js"),
+  });
+});
+
+test("a checkout root still launches its source worker", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-checkout-"));
+  directories.push(root);
+  fs.mkdirSync(path.join(root, "src", "lib"), { recursive: true });
+  fs.writeFileSync(path.join(root, "src", "lib", "fileScanner.worker.ts"), "");
+
+  expect(fileScanWorkerLaunch(root)).toMatchObject({
+    workerPath: path.join(root, "src", "lib", "fileScanner.worker.ts"),
+  });
+});
+
+test("a worker scan asked for from a root without one is refused, never spawned", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-file-scan-empty-"));
+  directories.push(root);
+
+  await expect(collectFileScanInWorker({ persist: false, persistIndex: false }, undefined, { cwd: root }))
+    .rejects.toThrow("no file scanner worker artifact");
 });

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -24,7 +24,7 @@ type FileScanWorkerMessage =
   | { type: "complete"; snapshot: FileCatalogScan };
 
 export interface FileScanWorkerRuntime {
-  launch?: { executable: string; workerPath: string };
+  launch?: FileScanWorkerLaunch;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -57,7 +57,25 @@ function workerMessage(value: unknown): FileScanWorkerMessage | null {
   return value as unknown as FileScanWorkerMessage;
 }
 
-function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: string } {
+export interface FileScanWorkerLaunch {
+  executable: string;
+  workerPath: string;
+}
+
+/**
+ * The worker artifact THIS process can run, or `null` when its root carries
+ * none.
+ *
+ * Both artifacts are resolved against the process root: the container's
+ * checkout, or a built Next server. The published MCP runtime release is
+ * neither — its root holds `dist/`, `node_modules/` and a manifest — and the
+ * final branch used to return the source path it had just found missing and
+ * spawn it anyway. Every corpus read in that process then died with
+ * `Module not found`, which is how a candidate whose whole HTTP surface was
+ * healthy failed its `board_snapshot` gate (#790). Naming the absence lets the
+ * caller scan in-process instead of launching nothing.
+ */
+export function fileScanWorkerLaunch(cwd = process.cwd()): FileScanWorkerLaunch | null {
   const source = path.join(cwd, "src/lib/fileScanner.worker.ts");
   const bundled = path.join(cwd, ".next/server/file-scanner-worker.js");
   if (fs.existsSync(source) && fs.existsSync("/usr/local/bin/bun-container")) {
@@ -67,7 +85,8 @@ function workerLaunch(cwd = process.cwd()): { executable: string; workerPath: st
     const bun = process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun");
     return { executable: bun, workerPath: bundled };
   }
-  return { executable: process.execPath, workerPath: source };
+  if (fs.existsSync(source)) return { executable: process.execPath, workerPath: source };
+  return null;
 }
 
 export function fileScanWorkerEnabled(
@@ -84,8 +103,11 @@ export function collectFileScanInWorker(
   runtime: FileScanWorkerRuntime = {},
 ): Promise<FileCatalogScan> {
   if (runtime.signal?.aborted) return Promise.reject(abortError());
+  const launch = runtime.launch ?? fileScanWorkerLaunch(runtime.cwd);
+  /* Callers choose the in-process scan when no artifact is present; reaching
+     here without one would spawn a path this process does not have. */
+  if (!launch) return Promise.reject(new Error("this process has no file scanner worker artifact"));
   const catalogScanToken = beginProjectCatalogScan(false);
-  const launch = runtime.launch ?? workerLaunch(runtime.cwd);
   /* Full-corpus scans are background freshness work. Keep the interactive
      Next process ahead of their CPU demand on a busy operator host. Explicit
      test/runtime launch seams retain their exact command. */

--- a/src/lib/scanner/scanCoordinator.test.ts
+++ b/src/lib/scanner/scanCoordinator.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import type { FileEntry } from "@/lib/types";
 
 import type { FileCatalogScan } from "./index";
-import { coordinatedFileScan, fileScanCoordinatorStatus, resetFileScanCoordinatorForTests, type CoordinatedScanRunner } from "./scanCoordinator";
+import {
+  coordinatedFileScan,
+  fileScanCoordinatorStatus,
+  resetFileScanCoordinatorForTests,
+  runFileCatalogScan,
+  type CoordinatedScanRunner,
+} from "./scanCoordinator";
 
 beforeEach(() => {
   resetFileScanCoordinatorForTests();
@@ -251,4 +260,51 @@ test("aborting every subscriber stops the shared refresh and releases its genera
 
   expect(underlyingAborts).toBe(1);
   expect(fileScanCoordinatorStatus()).toEqual({ inFlight: false, queued: 0, subscribers: 0 });
+});
+
+
+/* #790: the MCP runtime sidecar runs from the published release root, which
+   carries no worker artifact of either kind. Every corpus read it served died
+   with `Module not found` on the worker the launcher named anyway, so the
+   deployment gate's `board_snapshot` failed on a candidate whose whole HTTP
+   surface was healthy. The scan still has to happen - here, in this process. */
+test("a process root with no worker artifact scans in-process rather than spawning one it lacks", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-scan-release-root-"));
+  const corpus = fs.mkdtempSync(path.join(os.tmpdir(), "llv-scan-corpus-"));
+  const previous = {
+    cwd: process.cwd(),
+    nodeEnv: process.env.NODE_ENV,
+    claudeHome: process.env.LLV_CLAUDE_HOME,
+    codexHome: process.env.LLV_CODEX_HOME,
+  };
+  fs.mkdirSync(path.join(root, "dist"));
+  fs.mkdirSync(path.join(corpus, "claude"));
+  fs.mkdirSync(path.join(corpus, "codex"));
+  try {
+    /* NODE_ENV is assigned the way the test preload assigns it: the worker
+       boundary is only live outside the test runtime, and this is the branch it
+       takes there. */
+    Object.assign(process.env, {
+      LLV_CLAUDE_HOME: path.join(corpus, "claude"),
+      LLV_CODEX_HOME: path.join(corpus, "codex"),
+      NODE_ENV: "production",
+    });
+    process.chdir(root);
+
+    const snapshot = await runFileCatalogScan({ persist: false, fresh: false });
+
+    expect(snapshot.complete).toBe(true);
+  } finally {
+    process.chdir(previous.cwd);
+    for (const [key, value] of Object.entries({
+      NODE_ENV: previous.nodeEnv,
+      LLV_CLAUDE_HOME: previous.claudeHome,
+      LLV_CODEX_HOME: previous.codexHome,
+    })) {
+      if (value === undefined) Reflect.deleteProperty(process.env, key);
+      else Object.assign(process.env, { [key]: value });
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(corpus, { recursive: true, force: true });
+  }
 });

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -1,6 +1,6 @@
 import { listFilesWithProjectCatalog, type FileCatalogScan, type FileScanOptions } from "@/lib/scanner";
 
-import { collectFileScanInWorker, fileScanWorkerEnabled } from "./fileScanWorker";
+import { collectFileScanInWorker, fileScanWorkerEnabled, fileScanWorkerLaunch } from "./fileScanWorker";
 
 /**
  * Process-wide filesystem scan coordination (#287).
@@ -98,12 +98,19 @@ export function runFileCatalogScan(
     ...(intent.fresh ? { fresh: true } : {}),
   };
   if (signal.aborted) return Promise.reject(abortError(signal.reason));
-  if (!fileScanWorkerEnabled()) {
-    return listFilesWithProjectCatalog(undefined, { ...scanOptions, signal }).then((snapshot) => {
+  const inProcess = (): Promise<FileCatalogScan> =>
+    listFilesWithProjectCatalog(undefined, { ...scanOptions, signal }).then((snapshot) => {
       if (signal.aborted) throw abortError(signal.reason);
       return snapshot;
     });
-  }
+  if (!fileScanWorkerEnabled()) return inProcess();
+  /* A process whose root carries no worker artifact scans here instead. The
+     published MCP runtime release is one such root, and the sidecar running
+     from it still has to be able to read the corpus: spawning the absent
+     artifact failed every read it served, which is what took the deployment
+     gate's `board_snapshot` down with it (#790). Slower than the child, and
+     the whole difference between a read that answers and one that cannot. */
+  if (fileScanWorkerLaunch() === null) return inProcess();
   const { onResourceSnapshot, ...serializable } = scanOptions;
   return collectFileScanInWorker(serializable, onResourceSnapshot, { signal });
 }

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -158,6 +158,79 @@ test("candidate health evidence carries its probe observations, readiness budget
   expect(await adapter.verifyCandidate(candidate)).toEqual(failing);
 });
 
+/* The boolean pair in `calls` cannot explain a failed read, and the candidate
+   that produced the refusal is retired seconds later (#790). */
+test("the MCP probe's refused reads cross the boundary with the reason each one gave", async () => {
+  const failing: ViewerHealthEvidence = {
+    checkedAt: "2026-08-28T01:31:13.231Z",
+    endpoint: "http://127.0.0.1:19250",
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [],
+    mcpRuntime: {
+      checkedAt: "2026-08-28T01:31:13.238Z",
+      revision: "a".repeat(40),
+      artifactDigest: "b".repeat(64),
+      processReady: true,
+      tools: ["board_snapshot", "deployment_status"],
+      calls: { deploymentStatus: true, boardSnapshot: false },
+      callFailures: [{
+        tool: "board_snapshot",
+        code: "tool_failed",
+        error: "file scanner worker exited before completion (1)",
+      }],
+      ok: false,
+      detail: "MCP runtime read probes failed against http://127.0.0.1:19250 - board_snapshot: file scanner worker exited before completion (1)",
+    },
+    ok: false,
+    detail: "MCP runtime read probes failed",
+  };
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:19250",
+    revision: "a".repeat(40),
+  };
+  const adapter = new HostCommandViewerDeploymentAdapter(async (action) => (
+    action === "verify-candidate" ? failing : {}
+  ));
+
+  expect(await adapter.verifyCandidate(candidate)).toEqual(failing);
+});
+
+test("an MCP call failure missing its reason is refused rather than recorded half-read", async () => {
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:19250",
+    revision: "a".repeat(40),
+  };
+  const adapter = new HostCommandViewerDeploymentAdapter(async () => ({
+    checkedAt: "2026-08-28T01:31:13.231Z",
+    endpoint: "http://127.0.0.1:19250",
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [],
+    mcpRuntime: {
+      checkedAt: "2026-08-28T01:31:13.238Z",
+      revision: "a".repeat(40),
+      artifactDigest: "b".repeat(64),
+      processReady: true,
+      tools: [],
+      calls: { deploymentStatus: true, boardSnapshot: false },
+      callFailures: [{ tool: "board_snapshot" }],
+      ok: false,
+    },
+    ok: false,
+  }));
+
+  expect(adapter.verifyCandidate(candidate)).rejects.toThrow("invalid MCP runtime call failures");
+});
+
 test("health evidence with an unusable observation is refused rather than recorded half-read", async () => {
   const candidate = {
     image: "viewer:test",

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -9,6 +9,7 @@ import type {
   ViewerHealthEvidence,
   ViewerHealthProbeObservation,
   ViewerHealthReadiness,
+  ViewerMcpRuntimeCallFailure,
   ViewerMcpRuntimeHealthEvidence,
   ViewerMcpRuntimeIdentity,
   ViewerMcpRuntimePublicationEvidence,
@@ -324,6 +325,7 @@ function mcpHealthEvidence(value: unknown): ViewerMcpRuntimeHealthEvidence {
     || typeof item.ok !== "boolean") {
     throw new Error("deployment adapter returned invalid MCP runtime health evidence");
   }
+  const callFailures = mcpCallFailures(item.callFailures);
   return {
     checkedAt: item.checkedAt,
     revision: item.revision,
@@ -334,9 +336,31 @@ function mcpHealthEvidence(value: unknown): ViewerMcpRuntimeHealthEvidence {
       deploymentStatus: calls.deploymentStatus,
       boardSnapshot: calls.boardSnapshot,
     },
+    ...(callFailures.length ? { callFailures } : {}),
     ok: item.ok,
     ...(typeof item.detail === "string" ? { detail: item.detail } : {}),
   };
+}
+
+/** Why each refused read failed, carried across the adapter boundary. Dropping
+    it here would return the deployment record to a pair of booleans, which is
+    the defect the probe evidence exists to end (#790). */
+function mcpCallFailures(value: unknown): ViewerMcpRuntimeCallFailure[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error("deployment adapter returned invalid MCP runtime call failures");
+  return value.map((entry) => {
+    const failure = object(entry);
+    if (typeof failure.tool !== "string"
+      || typeof failure.error !== "string"
+      || (failure.code !== undefined && typeof failure.code !== "string")) {
+      throw new Error("deployment adapter returned invalid MCP runtime call failures");
+    }
+    return {
+      tool: failure.tool,
+      ...(failure.code === undefined ? {} : { code: failure.code as string }),
+      error: failure.error,
+    };
+  });
 }
 
 /** `null` is the adapter's "the published runtime already matches" answer. */

--- a/src/runtime-host/deploymentFailureReport.test.ts
+++ b/src/runtime-host/deploymentFailureReport.test.ts
@@ -102,3 +102,39 @@ test("a deployment that failed before any health check says so instead of render
   ]);
   expect(deploymentFailureReport(null)).toEqual([]);
 });
+
+
+/* Three deploys failed on this gate and the printed report named no cause. */
+test("a refused MCP read is printed with the reason the candidate's own runtime gave", () => {
+  const report = deploymentFailureReport(status([{
+    checkedAt: "2026-08-28T01:31:13.231Z",
+    endpoint: CANDIDATE,
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [{ path: "/_next/static/chunks/main.js", status: 200 }],
+    mcpRuntime: {
+      checkedAt: "2026-08-28T01:31:13.238Z",
+      revision: "b".repeat(40),
+      artifactDigest: "c".repeat(64),
+      processReady: true,
+      tools: ["board_snapshot", "deployment_status"],
+      calls: { deploymentStatus: true, boardSnapshot: false },
+      callFailures: [{
+        tool: "board_snapshot",
+        code: "tool_failed",
+        error: "file scanner worker exited before completion (1): Module not found ~/release/fileScanner.worker.ts",
+      }],
+      ok: false,
+      detail: "MCP runtime read probes failed",
+    },
+    ok: false,
+    detail: "MCP runtime read probes failed",
+  }]));
+
+  expect(report).toContain(
+    "  mcp board_snapshot refused (tool_failed): file scanner worker exited before completion (1):"
+    + " Module not found ~/release/fileScanner.worker.ts",
+  );
+});

--- a/src/runtime-host/deploymentFailureReport.ts
+++ b/src/runtime-host/deploymentFailureReport.ts
@@ -35,6 +35,11 @@ export function deploymentFailureReport(status: unknown): string[] {
   const mcp = last.mcpRuntime;
   if (mcp) {
     lines.push(`  mcp runtime: process ${mcp.processReady ? "ready" : "not ready"}, deployment_status ${mcp.calls.deploymentStatus}, board_snapshot ${mcp.calls.boardSnapshot}${mcp.detail ? ` - ${mcp.detail}` : ""}`);
+    /* One line per refused read, so the tool's own reason is printed even when
+       the composed detail was clamped before reaching it. */
+    for (const failure of mcp.callFailures ?? []) {
+      lines.push(`  mcp ${failure.tool} refused${failure.code ? ` (${failure.code})` : ""}: ${failure.error}`);
+    }
   }
   const log = last.containerLog ?? [];
   if (log.length > 0) {

--- a/src/runtime-host/mcpRuntimeProbe.test.ts
+++ b/src/runtime-host/mcpRuntimeProbe.test.ts
@@ -8,7 +8,7 @@ import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
 import { RuntimeHost } from "./host";
 import { RuntimeJournal } from "./journal";
 import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
-import { mcpProbeFailureDetail, probeControlUrl, probeMcpRuntime, VIEWER_CONTROL_URL_ENV } from "./mcpRuntimeProbe";
+import { mcpProbeCallFailures, mcpProbeFailureDetail, probeControlUrl, probeMcpRuntime, VIEWER_CONTROL_URL_ENV } from "./mcpRuntimeProbe";
 import { serveRuntimeHost } from "./socket";
 
 /* The probed runtime reads through the control endpoint it is handed. Unset, it
@@ -81,6 +81,7 @@ test("host-admitted managed MCP probes discover the complete surface, call requi
       expect(evidence.tools).toHaveLength(MCP_TOOL_NAMES.length);
       expect(evidence.tools).toContain("deployment_status");
       expect(evidence.tools).toContain("board_snapshot");
+      expect(evidence.callFailures).toBeUndefined();
       expect(processId).not.toBeNull();
       expect(() => process.kill(processId!, 0)).toThrow();
     }
@@ -344,4 +345,65 @@ test("a probe keeps the control endpoint it was handed", () => {
   expect(probeControlUrl("https://viewer.invalid/base")).toBe("https://viewer.invalid/base");
   expect(probeControlUrl("ftp://viewer.invalid")).toBeNull();
   expect(probeControlUrl(undefined)).toBeNull();
+});
+
+
+/* Three deploys failed on `boardSnapshot: false` and a sentence that named no
+   reason. The refusal the candidate's own runtime produced is the only account
+   of it there will ever be - the candidate is retired seconds later. */
+test("every refused read is kept with the tool's own reason and its failure code", () => {
+  expect(mcpProbeCallFailures([
+    { name: "deployment_status", ok: true, result: { structuredContent: { ok: true } } },
+    {
+      name: "board_snapshot",
+      ok: false,
+      result: {
+        isError: true,
+        structuredContent: {
+          ok: false,
+          code: "tool_failed",
+          error: "file scanner worker exited before completion (1)",
+        },
+      },
+    },
+  ])).toEqual([{
+    tool: "board_snapshot",
+    code: "tool_failed",
+    error: "file scanner worker exited before completion (1)",
+  }]);
+});
+
+test("a refusal with no code, and one that answered nothing at all, are both still kept", () => {
+  expect(mcpProbeCallFailures([
+    {
+      name: "board_snapshot",
+      ok: false,
+      result: { isError: true, content: [{ type: "text", text: "the corpus could not be read" }] },
+    },
+    { name: "deployment_status", ok: false, result: undefined },
+  ])).toEqual([
+    { tool: "board_snapshot", error: "the corpus could not be read" },
+    { tool: "deployment_status", error: "no result" },
+  ]);
+});
+
+/* The record is durable and the operator pastes it into issues, so the capture
+   redacts and clamps exactly where `containerLog` does. The refusal that
+   blocked these deploys named a filesystem path, which is precisely the shape
+   that must not survive into a published artifact. */
+test("a refusal naming a home path is redacted and clamped before it is recorded", () => {
+  const refusal = `Module not found ${["", "home", "someone", "checkout", "fileScanner.worker.ts"].join("/")}\n`
+    + `${"scan detail. ".repeat(60)}`;
+  const [failure] = mcpProbeCallFailures([{
+    name: "board_snapshot",
+    ok: false,
+    result: { isError: true, structuredContent: { ok: false, code: "tool_failed", error: refusal } },
+  }]);
+
+  expect(failure!.error).not.toContain(["", "home", "someone"].join("/"));
+  expect(failure!.error).toContain("Module not found");
+  expect(failure!.error).toContain("fileScanner.worker.ts");
+  expect(failure!.error).not.toContain("\n");
+  expect(failure!.error.endsWith("...")).toBe(true);
+  expect(failure!.error.length).toBeLessThan(refusal.length / 2);
 });

--- a/src/runtime-host/mcpRuntimeProbe.ts
+++ b/src/runtime-host/mcpRuntimeProbe.ts
@@ -4,8 +4,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 import { MCP_HEALTH_PROBE_CAPABILITY_ENV } from "@/lib/mcp/healthProbeAdmission";
 import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
-import type { ViewerMcpRuntimeHealthEvidence, ViewerMcpRuntimeIdentity } from "@/lib/runtime/contracts";
+import { redactMonitorText } from "@/lib/monitor/redact";
+import type {
+  ViewerMcpRuntimeCallFailure,
+  ViewerMcpRuntimeHealthEvidence,
+  ViewerMcpRuntimeIdentity,
+} from "@/lib/runtime/contracts";
 
+import { probeExcerpt } from "./deploymentHealth";
 import { McpProbeStdioTransport } from "./mcpProbeStdioTransport";
 import type { McpHealthProbeAdmissionConsumer } from "./mcpHealthProbeAdmissionChannel";
 
@@ -55,6 +61,46 @@ export function mcpToolCallRefusal(value: unknown): string {
   return `${reason}${status}`;
 }
 
+/** The MCP failure envelope's own code (`tool_failed`, `tool_not_permitted`,
+    `call_interrupted`, …), which classes a refusal without parsing its prose. */
+export function mcpToolCallRefusalCode(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const structured = (value as { structuredContent?: unknown }).structuredContent;
+  if (!structured || typeof structured !== "object") return null;
+  const code = (structured as { code?: unknown }).code;
+  return typeof code === "string" && code.trim() ? code.trim().slice(0, 64) : null;
+}
+
+/* How much of a refusal the durable record keeps. The record outlives the
+   candidate and the operator pastes it into issues, so the text is redacted,
+   collapsed to one printable line and clamped where it is captured, exactly
+   like `containerLog`. Redaction runs before the clamp so a truncation can
+   never leave half of what it removed. */
+const CALL_FAILURE_CHARS = 300;
+
+function recordedRefusal(value: unknown): string {
+  return probeExcerpt(redactMonitorText(mcpToolCallRefusal(value)), CALL_FAILURE_CHARS);
+}
+
+/** The failing reads, each with the tool's own account of why it failed.
+    `calls` already says WHICH read failed, and that boolean was the entire
+    record for three deploys — it can explain none of them (#790). Empty when
+    every read answered. */
+export function mcpProbeCallFailures(
+  calls: Array<{ name: string; ok: boolean; result: unknown }>,
+): ViewerMcpRuntimeCallFailure[] {
+  return calls
+    .filter((call) => !call.ok)
+    .map((call) => {
+      const code = mcpToolCallRefusalCode(call.result);
+      return {
+        tool: call.name,
+        ...(code ? { code } : {}),
+        error: recordedRefusal(call.result),
+      };
+    });
+}
+
 /** Names the failed read, its refusal and the control surface the probe was
     pointed at, so a failure can be told apart from a probe aimed at the wrong
     Viewer without re-reading the adapter (#790). */
@@ -62,9 +108,8 @@ export function mcpProbeFailureDetail(input: {
   controlUrl: string | undefined;
   calls: Array<{ name: string; ok: boolean; result: unknown }>;
 }): string {
-  const failures = input.calls
-    .filter((call) => !call.ok)
-    .map((call) => `${call.name}: ${mcpToolCallRefusal(call.result)}`);
+  const failures = mcpProbeCallFailures(input.calls)
+    .map((failure) => `${failure.tool}: ${failure.error}`);
   const target = input.controlUrl ? ` against ${input.controlUrl}` : "";
   return `MCP runtime read probes failed${target} - ${failures.join("; ") || "no read reported a reason"}`
     .replace(/[\r\n]+/g, " ")
@@ -138,6 +183,14 @@ export async function probeMcpRuntime(options: McpRuntimeProbeOptions): Promise<
     boardSnapshot = successfulToolCall(board);
     const missing = REQUIRED_TOOLS.filter((tool) => !tools.includes(tool));
     const ok = missing.length === 0 && deploymentStatus && boardSnapshot;
+    const reads = [
+      { name: "deployment_status", ok: deploymentStatus, result: deployment },
+      { name: "board_snapshot", ok: boardSnapshot, result: board },
+    ];
+    /* Kept whenever a read was refused, including when a missing tool decides
+       the verdict: the refusal is the only account of the candidate's own
+       runtime that survives, and the candidate is retired seconds later. */
+    const callFailures = mcpProbeCallFailures(reads);
     return {
       checkedAt,
       revision: options.runtime.revision,
@@ -145,17 +198,12 @@ export async function probeMcpRuntime(options: McpRuntimeProbeOptions): Promise<
       processReady,
       tools,
       calls: { deploymentStatus, boardSnapshot },
+      ...(callFailures.length ? { callFailures } : {}),
       ok,
       ...(ok ? {} : {
         detail: missing.length
           ? `MCP runtime is missing tools: ${missing.join(", ")}`
-          : mcpProbeFailureDetail({
-            controlUrl,
-            calls: [
-              { name: "deployment_status", ok: deploymentStatus, result: deployment },
-              { name: "board_snapshot", ok: boardSnapshot, result: board },
-            ],
-          }),
+          : mcpProbeFailureDetail({ controlUrl, calls: reads }),
       }),
     };
   } catch (error) {


### PR DESCRIPTION
## The blocker

The candidate was healthy on every surface except one read:

```
root 200, authenticated 200, unauthorized 403, assets 8
mcpRuntime: processReady true, tools 34
calls: { deploymentStatus: true, boardSnapshot: false }
detail: "MCP runtime read probes failed"
```

Two fixes, in the order they had to happen.

## 1. The probe now keeps the reason

`calls` is two booleans, and a boolean explains nothing. The candidate that
produced the refusal is retired seconds later, so the tool's own account of it
was the only evidence that would ever exist — and the probe reduced it to
`false` and threw it away. Three deploys failed this way.

Health evidence now carries `callFailures`: the tool, the MCP failure
envelope's `code`, and the refusal text — redacted, collapsed to one printable
line and clamped at capture, the way `containerLog` is (the record outlives the
candidate and gets pasted into issues). It crosses the adapter boundary with
the rest of the health record, and the deploy driver prints one line per
refused read, so a clamped `detail` can no longer cost the reason.

## 2. What the reason said, and the root fix

With the reason in hand:

```
board_snapshot refused (tool_failed): file scanner worker exited before
completion (1): error: Module not found ".../fileScanner.worker.ts"
```

`workerLaunch` resolves the file-scan worker against the process root — the
container's checkout, or a built Next server — and, finding neither, returned
the source path it had **just proven missing** and spawned it anyway. The
published MCP runtime release root is exactly that case: `dist/`,
`node_modules/` and a manifest, no checkout and no `.next`. So every corpus
read the MCP sidecar serves dies with `Module not found` the moment it needs a
scan.

The persisted catalog normally spares it that scan — and cannot when the
candidate's file-scan cache schema differs from the generation that wrote the
snapshot. That is guaranteed on the deploy that introduces a bump: the serving
generation's `files-scan-snapshot.json` is `schemaVersion 9`, the candidate is
`10`, the warm start is refused by design, and the cold path lands on the
worker that is not there.

The launcher now reports the absence and the coordinator scans in this process
instead. Where an artifact exists nothing changes: the container still spawns
its worker, still under `nice` (`next.config.ts` builds
`.next/server/file-scanner-worker.js` and the image carries
`/usr/local/bin/bun-container`). No timeout was touched, and a candidate whose
board read genuinely fails still fails the gate — the read really runs.

This is not only a deploy-gate defect: the same sidecar serves every agent's
`board_snapshot`, and any cold read from a managed release root failed the same
way.

## Verification

Against a candidate-shaped process — `node bin/mcp-server.mjs` into a staged
managed release root (`dist/` + `node_modules/` + manifest, digest-checked),
the real corpus (~5,000 transcripts), an isolated state dir carrying a copy of
the registry and no persisted snapshot, a real `McpHealthProbeAdmissions`
capability and a control stub. No deployment was run and nothing of the
operator's was restarted.

Pre-fix bundle — reproduces production exactly, and now says why:

```json
{"elapsedMs": 1238, "ok": false, "calls": {"deploymentStatus": true, "boardSnapshot": false},
 "callFailures": [{"tool": "board_snapshot", "code": "tool_failed",
   "error": "file scanner worker exited before completion (1): error: Module not found \"…/fileScanner.worker.ts\""}]}
```

Fixed bundle:

```json
{"elapsedMs": 13774, "ok": true, "processReady": true, "tools": 34,
 "calls": {"deploymentStatus": true, "boardSnapshot": true}, "callFailures": null}
```

Worth the operator knowing: that 13.8 s is the whole probe (spawn, `listTools`,
both reads) and the cold in-process corpus scan is ~11 s of it, against the
probe's unchanged 15 s per-call budget. That cost is only paid when the warm
start is refused — a cache-schema bump — and it is the honest cost of the read.
Narrowing it further means changing what `board_snapshot` reads, which would
weaken the gate.

Gates: `bunx tsc --noEmit --incremental false` clean; touched suites by path
under an isolated HOME/XDG_CONFIG_HOME/LLV_STATE_DIR/TMPDIR — 87 pass, 2 fail,
both the pre-existing `mcpRuntimeProbe.test.ts` admission assertions of #1242,
verified failing identically on the merge base; privacy publication gate PASS
with `--check-commits`.

Refs #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)
