### PR TITLE
feat(grok): treat Grok as a first-class viewer engine

### DIFF
--- a/scripts/demo-capture.ts
+++ b/scripts/demo-capture.ts
@@ -179,9 +179,10 @@ export const SHOTS: DemoShot[] = [
       "No projects yet",
       "~/.claude/projects",
       "~/.codex/sessions",
+      "~/.grok/sessions",
       "Create a project",
       "Create project",
-      "or run any claude / codex session inside a repo.",
+      "or run any claude / codex / grok session inside a repo.",
     ],
     frame: {
       visible: [

--- a/src/app/api/attach-command/route.ts
+++ b/src/app/api/attach-command/route.ts
@@ -7,6 +7,7 @@ import { deliveryFence } from "@/lib/accounts/migration/coordinator";
 import { accountIdFromPath } from "@/lib/accounts/badge";
 import { listClaudeAccounts } from "@/lib/accounts/claude";
 import { listCodexAccounts } from "@/lib/accounts/codex";
+import { grokHome } from "@/lib/accounts/grok";
 import { cachedFileScan } from "@/lib/scanner/scanCache";
 import { pathAllowed } from "@/lib/scanner/roots";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
@@ -22,11 +23,13 @@ function registryFirstAccountIdForPath(pathname: string): string {
   const registry = agentRegistry();
   return registry.transcriptAccountId("claude", pathname)
     ?? registry.transcriptAccountId("codex", pathname)
+    ?? registry.transcriptAccountId("grok", pathname)
     ?? accountIdFromPath(pathname);
 }
 
 /** Best-effort account id → human label; falls back to the id itself. */
 function accountLabelFor(engine: AgentEngine, accountId: string): string {
+  if (engine === "grok") return "Grok";
   try {
     const accounts = engine === "claude" ? listClaudeAccounts() : listCodexAccounts();
     return accounts.find((account) => account.id === accountId)?.label ?? accountId;
@@ -37,6 +40,7 @@ function accountLabelFor(engine: AgentEngine, accountId: string): string {
 
 /** Account id → managed home for composing a launch's resume command. */
 function homeForAccount(engine: AgentEngine, accountId: string): string | null {
+  if (engine === "grok") return grokHome();
   try {
     const accounts = engine === "claude" ? listClaudeAccounts() : listCodexAccounts();
     return accounts.find((account) => account.id === accountId)?.home ?? null;

--- a/src/app/api/grok/status/route.ts
+++ b/src/app/api/grok/status/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+import { grokAuthStatus } from "@/lib/accounts/grok";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Sign-in presence for the Grok footer row. Tokens never leave this process. */
+export async function GET() {
+  return NextResponse.json({ grok: grokAuthStatus() });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Agent Log Viewer",
-  description: "Agent Log Viewer for Codex and Claude agent logs",
+  description: "Agent Log Viewer for Codex, Claude, and Grok agent logs",
 };
 
 /* The on-screen keyboard shrinks the layout instead of covering it, so the

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -475,7 +475,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
                   the id is read from the live transcript path so a migrated
                   conversation reflects its current account. OpenClaw skips it
                   for the same reason: the Viewer owns no OpenClaw account. */}
-              {file.engine === "shell" || file.engine === "openclaw" ? null : (
+              {file.engine === "shell" || file.engine === "openclaw" || file.engine === "grok" ? null : (
                 <AccountBadge
                   engine={file.engine}
                   accountId={runtime?.session.accountId ?? file.spawn?.accountId ?? accountIdFromPath(file.path)}

--- a/src/components/GrokFooterRow.tsx
+++ b/src/components/GrokFooterRow.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Zap } from "./icons";
+
+import { useGrokAccount } from "@/hooks/useGrokAccount";
+import { useLocale } from "@/lib/i18n";
+
+import { engineTintOf } from "./utils";
+
+/** Sidebar footer: Grok has one CLI login, not Claude/Codex account homes. */
+export function GrokFooterRow() {
+  const { t } = useLocale();
+  const account = useGrokAccount();
+  const tint = engineTintOf("grok");
+  const signedIn = account.signedIn === true;
+  const loading = account.signedIn === null;
+  return (
+    <div
+      className="flex min-h-[44px] w-full items-center gap-2 px-3.5 py-1.5 sm:min-h-[36px]"
+      aria-label={t("grok.rowAria")}
+    >
+      <Zap className="h-3.5 w-3.5 shrink-0" style={{ color: tint.color }} aria-hidden />
+      <span className="text-[11.5px] font-bold" style={{ color: tint.color }}>{t("grok.title")}</span>
+      <span className="ml-auto flex shrink-0 items-center gap-1.5">
+        <span className="text-[10px] font-semibold text-muted">
+          {loading ? t("grok.statusLoading") : signedIn ? t("grok.signedIn") : t("grok.signedOut")}
+        </span>
+        <span
+          aria-hidden
+          className="h-2 w-2 rounded-full"
+          style={{
+            backgroundColor: loading ? "transparent" : signedIn ? "var(--color-success)" : "transparent",
+            boxShadow: signedIn || loading ? "none" : "inset 0 0 0 1.5px var(--color-border)",
+          }}
+        />
+      </span>
+    </div>
+  );
+}

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -10,6 +10,7 @@ import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type EngineL
 
 import { AccountsPanel } from "./AccountsPanel";
 import { BurndownPanel } from "./BurndownPanel";
+import { GrokFooterRow } from "./GrokFooterRow";
 import { TelegramFooterRow } from "./TelegramConnect";
 import { ChevronDown, Loader2 } from "./icons";
 import { formatQuotaAsOf, formatResetClock as fmtResetAt, formatResetEta as fmtEta, localeBcp47 as bcp47, windowLabel } from "./rateLimit";
@@ -393,6 +394,7 @@ export function LimitsFooter() {
     <div className="shrink-0 border-t border-border empty:hidden">
       <EngineLimitsBlock engine="claude" label="Claude" limits={snap?.data.claude ?? null} payloadAccountId={snap?.data.claudeAccountId ?? null} now={now} receivedAt={snap?.at ?? now} provenance={snap?.data.provenance.claude ?? { source: "unavailable", reason: null, staleSince: null }} onSwitched={invalidateLimits} />
       <EngineLimitsBlock engine="codex" label="Codex" limits={snap?.data.codex ?? null} payloadAccountId={snap?.data.codexAccountId ?? null} now={now} receivedAt={snap?.at ?? now} provenance={snap?.data.provenance.codex ?? { source: "unavailable", reason: null, staleSince: null }} onSwitched={invalidateLimits} />
+      <GrokFooterRow />
       {/* The personal Telegram connector row (issue #1059) sits beside the
           account controls; the entry point never disappears. */}
       <TelegramFooterRow />

--- a/src/components/draft/AgentLaunchControls.tsx
+++ b/src/components/draft/AgentLaunchControls.tsx
@@ -33,7 +33,7 @@ import { useLocale } from "@/lib/i18n";
  * its per-draft sessionStorage keys and a transient surface keeps nothing.
  */
 
-export type LaunchEngine = "claude" | "codex";
+export type LaunchEngine = "claude" | "codex" | "grok";
 export type { SpeedChoice };
 
 /** Secret-free slice of one stored account that a launch selector needs. */
@@ -48,6 +48,7 @@ export type LaunchAccountCatalog = Record<LaunchEngine, { active: string; accoun
 const ENGINES: { key: LaunchEngine; label: string }[] = [
   { key: "claude", label: "Claude" },
   { key: "codex", label: "Codex" },
+  { key: "grok", label: "Grok" },
 ];
 
 /** Crash-safe read of one engine section of `/api/accounts`: a malformed body
@@ -68,7 +69,11 @@ export function launchAccountSection(raw: unknown): LaunchAccountCatalog[LaunchE
 /** Both engine sections of one `/api/accounts` body. */
 export function launchAccountCatalogOf(body: unknown): LaunchAccountCatalog {
   const raw = body as { claude?: unknown; codex?: unknown } | null;
-  return { claude: launchAccountSection(raw?.claude), codex: launchAccountSection(raw?.codex) };
+  return {
+    claude: launchAccountSection(raw?.claude),
+    codex: launchAccountSection(raw?.codex),
+    grok: { active: "grok", accounts: [{ id: "grok", label: "Grok", authPresent: true }] },
+  };
 }
 
 /**
@@ -161,7 +166,7 @@ export function useAgentLaunchDraft(options: {
 
   const [engine, setEngineState] = useState<LaunchEngine>(() => {
     const stored = read("engine");
-    if (stored === "codex" || stored === "claude") return stored;
+    if (stored === "codex" || stored === "claude" || stored === "grok") return stored;
     return options.initialEngine ?? "claude";
   });
   const [model, setModelState] = useState(() => read("model") || options.initialModel || defaultModelFor(engine));

--- a/src/components/draftSpawn.ts
+++ b/src/components/draftSpawn.ts
@@ -14,7 +14,7 @@ import { derivedSpawnTitle, durableSemanticTitle, SPAWN_TITLE_REQUIRED_ERROR } f
  * without a DOM. */
 
 /** The engine a draft can launch — the transcript roots differ per engine. */
-export type DraftEngine = "claude" | "codex";
+export type DraftEngine = "claude" | "codex" | "grok";
 
 /** Display phase of a draft card, derived from the durable attempt + timers. */
 export type DraftPhase = "draft" | "launching" | "booting" | "booting-slow" | "confirming" | "confirming-slow" | "attention";

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -4,7 +4,7 @@ import { memo } from "react";
 
 import type { MandateDelivery } from "@/lib/runtime/messageOrigin";
 
-import { Brain, ChevronUp, Command, Check, Mail, MessageCircle, Mic, Sparkle, X } from "../icons";
+import { Brain, ChevronUp, Command, Check, Mail, MessageCircle, Mic, Sparkle, X, Zap } from "../icons";
 import { hhmm } from "../utils";
 import { MESSAGE_ACTION } from "./actionStyles";
 import { SelectedContextBadge } from "../SelectedContextBadge";
@@ -103,8 +103,8 @@ export const FeedItem = memo(function FeedItem({ item: sourceItem, speakText }: 
   if (item.kind === "record") return <RecordCard item={item} />;
   if (item.kind === "mem-citation") return <MemCitationCard item={item} />;
   if (item.kind === "prose") {
-    const cls = item.engine === "codex" ? "bg-codex" : item.engine === "openclaw" ? "bg-openclaw" : "bg-claude";
-    const AvatarIcon = item.engine === "codex" ? Command : item.engine === "openclaw" ? MessageCircle : Sparkle;
+    const cls = item.engine === "codex" ? "bg-codex" : item.engine === "openclaw" ? "bg-openclaw" : item.engine === "grok" ? "bg-grok" : "bg-claude";
+    const AvatarIcon = item.engine === "codex" ? Command : item.engine === "openclaw" ? MessageCircle : item.engine === "grok" ? Zap : Sparkle;
     return (
       <div className="group/msg my-3 flex gap-2.5">
         <div className={`mt-1 flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-full text-white ${cls}`}>

--- a/src/components/feed/grok.parse.test.ts
+++ b/src/components/feed/grok.parse.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { buildFeed } from "./parse";
+
+const grokFile = {
+  path: "/grok/sessions/project/session-alpha/chat_history.jsonl",
+  engine: "grok",
+  fmt: "grok",
+  activity: "recent",
+} as FileEntry;
+
+const line = (record: Record<string, unknown>) => JSON.stringify(record);
+
+test("Grok Build chat history renders messages and joins tool output", () => {
+  const items = buildFeed(grokFile, [
+    line({ type: "system", content: "ignored" }),
+    line({ type: "user", content: "Inspect the cobalt orchard" }),
+    line({ type: "reasoning", content: "checking   the   plan" }),
+    line({ type: "assistant", content: "I will inspect it.", model_id: "grok-demo", tool_calls: [
+      { id: "grok-call-1", name: "Bash", arguments: JSON.stringify({ command: "ls orchard" }) },
+    ] }),
+    line({ type: "tool_result", tool_call_id: "grok-call-1", content: "three files", is_error: false }),
+  ], false, "").items;
+
+  expect(items.map((item) => item.kind)).toEqual(["user", "think", "prose", "tool"]);
+  expect(items[0]).toMatchObject({ kind: "user", text: "Inspect the cobalt orchard" });
+  expect(items[1]).toMatchObject({ kind: "think", text: "checking the plan" });
+  expect(items[2]).toMatchObject({ kind: "prose", text: "I will inspect it.", engine: "grok" });
+  expect(items[3]).toMatchObject({ kind: "tool", id: "grok-call-1", status: "ok", outputPreview: expect.stringContaining("three files") });
+});

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -223,7 +223,7 @@ export type CmdGroupItem = {
     changes: this kind exists only between the resolver and the card. */
 export type MandateItem = { kind: "mandate"; ts: unknown; text: string; mandate: MandateDelivery };
 export type Item =
-  | { kind: "prose"; ts: unknown; text: string; engine: "codex" | "claude" | "openclaw"; sourceId?: string }
+  | { kind: "prose"; ts: unknown; text: string; engine: "codex" | "claude" | "openclaw" | "grok"; sourceId?: string }
   | { kind: "user"; ts: unknown; text: string; selectedContext?: SelectedContextRef }
   | MandateItem
   | VoiceTurnItem
@@ -367,6 +367,7 @@ const OPENCLAW_SYNTHETIC_PROVIDER = "openclaw";
 function feedEngine(engine: string): FeedEngine {
   if (engine === "codex") return "codex";
   if (engine === "openclaw") return "openclaw";
+  if (engine === "grok") return "grok";
   return "claude";
 }
 
@@ -1166,7 +1167,7 @@ function sameCodexTextAtTime(leftTs: unknown, leftText: unknown, rightTs: unknow
  */
 export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const { showSvc, lineFilter } = cfg;
-  const jsonl = cfg.fmt === "claude" || cfg.fmt === "codex" || cfg.fmt === "openclaw";
+  const jsonl = cfg.fmt === "claude" || cfg.fmt === "codex" || cfg.fmt === "openclaw" || cfg.fmt === "grok";
 
   const entries: StoredEntry[] = [];
   const calls = new Map<string, CallRec>();
@@ -2140,6 +2141,36 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       }
     }
   };
+  /* Grok Build persists a compact JSONL conversation format: user/assistant
+     content is top-level, tool calls sit on an assistant row, and results are
+     separate tool_result rows. It is read-only support: no viewer controls
+     attempt to write into a Grok session. */
+  const renderGrok = (obj: Record<string, unknown>) => {
+    const ts = obj.timestamp ?? obj.ts ?? null;
+    const contentText = (value: unknown): string => typeof value === "string"
+      ? value
+      : arr(value).map((part) => textPart(part.text) || textPart(part.content)).filter(Boolean).join("\n");
+    if (obj.type === "user") return void addUserText(ts, contentText(obj.content));
+    if (obj.type === "reasoning") {
+      const text = contentText(obj.content).trim();
+      if (text) push({ kind: "think", text: text.replace(/\s+/g, " ") });
+      return;
+    }
+    if (obj.type === "tool_result") {
+      return void addOutput(textPart(obj.tool_call_id), contentText(obj.content), obj.is_error === true || obj.error === true);
+    }
+    if (obj.type !== "assistant") return void addSvc(textPart(obj.type) || tr("render.record"));
+    const text = contentText(obj.content);
+    if (text.trim()) addProse(ts, text, textPart(obj.id) || undefined);
+    for (const call of arr(obj.tool_calls)) {
+      const name = textPart(call.name) || "tool";
+      let args: Record<string, unknown> = {};
+      try { args = rec(JSON.parse(textPart(call.arguments) || "{}")); } catch { /* malformed args stay readable as a generic tool */ }
+      const id = textPart(call.id) || "grok-" + pushSeq + "-" + String(ts ?? "");
+      const command = familyOf(name) === "shell" ? textPart(args.command ?? args.cmd) : undefined;
+      registerCall(newToolEvent({ ts, id, tool: name, args, engine: "grok", command }));
+    }
+  };
   /* Job .output logs echo the final review/citation block as bare lines after the
      [codex] stream ends; collect that run so it renders as one structured card
      instead of per-line raw rows. Falls back to the old raw rows when the block
@@ -2218,6 +2249,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         if (obj && typeof obj === "object" && !Array.isArray(obj)) {
           if (cfg.fmt === "claude") renderClaude(obj);
           else if (cfg.fmt === "openclaw") renderOpenclaw(obj);
+          else if (cfg.fmt === "grok") renderGrok(obj);
           else renderCodex(obj);
         } else addRecord(null, "malformed_record", { value: obj });
       } catch {

--- a/src/components/feed/tools.ts
+++ b/src/components/feed/tools.ts
@@ -13,8 +13,8 @@ import { normalizeEdit, type DiffModel } from "./diff";
 
 /** The engines a rendered row can be attributed to. Background-task job logs
     render Codex-shaped rows under the `shell` engine, so `shell` is not a
-    member: every row this taxonomy produces belongs to one of these three. */
-export type FeedEngine = "claude" | "codex" | "openclaw";
+    member: every row this taxonomy produces belongs to one of these four. */
+export type FeedEngine = "claude" | "codex" | "openclaw" | "grok";
 
 export type ToolFamily = "shell" | "read" | "write" | "edit" | "search" | "web" | "spawn" | "plan" | "mcp" | "other";
 

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -260,6 +260,12 @@ describe("buildBranchGroups", () => {
     expect(isSubagent(entry({ path: "/openclaw/oc-session-alpha.jsonl", ...openclaw }))).toBe(false);
   });
 
+  test("a Grok chat history is a conversation root of its own", () => {
+    const grok = { root: "grok-sessions" as const, engine: "grok" as const, fmt: "grok" as const };
+    expect(isConversation(entry({ path: "/grok/chat_history.jsonl", ...grok }))).toBe(true);
+    expect(isSubagent(entry({ path: "/grok/chat_history.jsonl", ...grok }))).toBe(false);
+  });
+
   test("a standalone viewer-spawned conversation stays a root despite its spawner parent", () => {
     const lineage = {
       kind: "spawn" as const,

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -79,7 +79,7 @@ export function isConversation(file: FileEntry): boolean {
      transcript in an agent's sessions directory is a conversation in its own
      right (#1207). Without this arm an OpenClaw card is scanned and attributed
      and then belongs to no board tree at all. */
-  if (file.root === "openclaw-sessions") return !file.parent;
+  if (file.root === "openclaw-sessions" || file.root === "grok-sessions") return !file.parent;
   return false;
 }
 

--- a/src/components/scheme/offscreenClusters.test.ts
+++ b/src/components/scheme/offscreenClusters.test.ts
@@ -48,6 +48,22 @@ describe("board clusters", () => {
       .toEqual(["var(--color-openclaw)"]);
   });
 
+  test("a Grok card keeps its own identity colour on the board", () => {
+    const live: FileEntry = {
+      path: "/grok/sessions/project/session-alpha/chat_history.jsonl",
+      root: "grok-sessions", name: "chat_history.jsonl", project: "project", title: "Live Grok agent",
+      engine: "grok", kind: "session", fmt: "grok", parent: null, mtime: 1, size: 1, activity: "live",
+      proc: null, pid: null, model: null, pendingQuestion: null, waitingInput: null,
+    };
+    const layout = {
+      groups: [],
+      nodes: [{ x: 0, y: 0, w: 600, h: 780, file: live, isRoot: true }],
+      stacks: [], decks: [], drafts: [], slots: [],
+    } as unknown as SchemeLayout;
+    expect(boardClusters(layout, new Set<string>()).map((cluster) => cluster.color))
+      .toEqual(["var(--color-grok)"]);
+  });
+
   test("keeps title text beyond the resting chip segment for progressive reveal", () => {
     const title = "Repair durable pipeline ownership while preserving every queued reviewer conversation title";
     const live: FileEntry = {

--- a/src/components/scheme/offscreenClusters.ts
+++ b/src/components/scheme/offscreenClusters.ts
@@ -381,7 +381,7 @@ export function boardClusters(
       label: cleanTitle(node.file.title),
       rect: node,
       priority: isCurrentWorkFile(node.file) ? 4 : 2,
-      color: `var(--color-${node.file.engine === "codex" ? "codex" : node.file.engine === "openclaw" ? "openclaw" : "claude"})`,
+      color: `var(--color-${node.file.engine === "codex" ? "codex" : node.file.engine === "openclaw" ? "openclaw" : node.file.engine === "grok" ? "grok" : "claude"})`,
     });
   }
   return clusters;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -47,6 +47,7 @@ const ENGINE_COLORS: Record<string, string> = {
   codex: "#2f6fd0",
   claude: "#d97757",
   openclaw: "#b3407a",
+  grok: "#3d5a80",
 };
 const NEUTRAL_COLOR = "#9a9aa4";
 const CLAUDE_MODEL_COLORS: [RegExp, string][] = [
@@ -94,7 +95,7 @@ function modelBaseHex(file: FileEntry): string {
   const model = (file.model ?? "").toLowerCase();
   /* OpenClaw runs other vendors' models through its own provider layer, so no
      model-family table applies: its cards keep the flat engine identity. */
-  if (file.engine === "openclaw") return base;
+  if (file.engine === "openclaw" || file.engine === "grok") return base;
   for (const [re, color] of file.engine === "codex" ? CODEX_MODEL_COLORS : CLAUDE_MODEL_COLORS) {
     if (re.test(model)) return color;
   }
@@ -183,7 +184,7 @@ export function engineEdge(file: FileEntry): { backgroundColor: string } {
 }
 
 export function engineBadgeFor(engine: string) {
-  const label = { codex: "Codex", claude: "Claude", shell: "Bash", openclaw: "OpenClaw" }[engine] ?? engine;
+  const label = { codex: "Codex", claude: "Claude", shell: "Bash", openclaw: "OpenClaw", grok: "Grok" }[engine] ?? engine;
   const tint = tintOf(ENGINE_COLORS[engine] ?? NEUTRAL_COLOR);
   return { label, style: { backgroundColor: tint.soft, color: tint.color } };
 }

--- a/src/hooks/useGrokAccount.ts
+++ b/src/hooks/useGrokAccount.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type GrokAccountState = {
+  signedIn: boolean | null;
+  source: "session" | "api_key" | null;
+};
+
+const POLL_MS = 60_000;
+
+export function useGrokAccount(): GrokAccountState {
+  const [state, setState] = useState<GrokAccountState>({ signedIn: null, source: null });
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        const response = await fetch("/api/grok/status");
+        const json = await response.json() as {
+          grok?: { signedIn?: boolean; source?: "session" | "api_key" | null };
+        };
+        if (!active) return;
+        setState({
+          signedIn: json.grok?.signedIn === true,
+          source: json.grok?.source === "session" || json.grok?.source === "api_key" ? json.grok.source : null,
+        });
+      } catch {
+        if (active) setState({ signedIn: false, source: null });
+      }
+    };
+    void load();
+    const timer = setInterval(load, POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/hooks/useSwitchboardData.ts
+++ b/src/hooks/useSwitchboardData.ts
@@ -70,7 +70,7 @@ export function isAwaitingUser(file: FileEntry, now = Date.now() / 1000): boolea
      counter. The attention queue owns that TTL judgement. */
   if (file.activity === "stalled") return attentionId(file, now) !== null;
   return file.activity === "recent"
-    && (file.engine === "claude" || file.engine === "codex" || file.engine === "openclaw")
+    && (file.engine === "claude" || file.engine === "codex" || file.engine === "openclaw" || file.engine === "grok")
     && isConversation(file)
     && !isSubagent(file);
 }

--- a/src/lib/accounts/contracts.ts
+++ b/src/lib/accounts/contracts.ts
@@ -42,7 +42,7 @@ export type LoginOperationSummary = {
 export type AccountCatalog = { claude: { active: string; accounts: AccountSummary[] }; codex: { active: string; accounts: AccountSummary[] } };
 
 export type AccountContext = {
-  engine: Extract<Engine, "claude" | "codex">;
+  engine: Extract<Engine, "claude" | "codex" | "grok">;
   accountId: string;
   kind: "legacy" | "managed";
   home: string;

--- a/src/lib/accounts/grok.test.ts
+++ b/src/lib/accounts/grok.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { grokAuthStatus, grokHome } from "./grok";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-grok-auth-"));
+const PREV_HOME = process.env.LLV_GROK_HOME;
+const PREV_KEY = process.env.XAI_API_KEY;
+
+function writeAuth(body: unknown) {
+  process.env.LLV_GROK_HOME = SANDBOX;
+  delete process.env.XAI_API_KEY;
+  fs.writeFileSync(path.join(SANDBOX, "auth.json"), JSON.stringify(body));
+}
+
+afterEach(() => {
+  if (PREV_HOME === undefined) delete process.env.LLV_GROK_HOME;
+  else process.env.LLV_GROK_HOME = PREV_HOME;
+  if (PREV_KEY === undefined) delete process.env.XAI_API_KEY;
+  else process.env.XAI_API_KEY = PREV_KEY;
+  fs.rmSync(path.join(SANDBOX, "auth.json"), { force: true });
+});
+
+test("grokHome honours LLV_GROK_HOME", () => {
+  process.env.LLV_GROK_HOME = SANDBOX;
+  expect(grokHome()).toBe(path.resolve(SANDBOX));
+});
+
+test("a future expires_at is signed in", () => {
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  writeAuth({
+    "https://auth.example.invalid::session-alpha": {
+      expires_at: expiresAt,
+      key: "session-token-fixture",
+    },
+  });
+  expect(grokAuthStatus()).toEqual({ signedIn: true, source: "session", expiresAt });
+});
+
+test("an expired session is signed out unless an API key is set", () => {
+  writeAuth({
+    "https://auth.example.invalid::session-alpha": {
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+      key: "session-token-fixture",
+    },
+  });
+  expect(grokAuthStatus().signedIn).toBe(false);
+  process.env.XAI_API_KEY = "xai-fixture";
+  expect(grokAuthStatus()).toEqual({ signedIn: true, source: "api_key", expiresAt: null });
+});
+
+test("missing auth.json is signed out", () => {
+  process.env.LLV_GROK_HOME = SANDBOX;
+  delete process.env.XAI_API_KEY;
+  expect(grokAuthStatus()).toEqual({ signedIn: false, source: null, expiresAt: null });
+});

--- a/src/lib/accounts/grok.ts
+++ b/src/lib/accounts/grok.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { recordValue, stringValue } from "@/lib/scanner/json";
+
+/** Same home the scanner uses for `grok-sessions`. */
+export function grokHome(): string {
+  const configured = process.env.LLV_GROK_HOME?.trim();
+  return configured ? path.resolve(configured) : path.join(os.homedir(), ".grok");
+}
+
+export type GrokAuthSource = "session" | "api_key";
+
+export interface GrokAuthStatus {
+  signedIn: boolean;
+  source: GrokAuthSource | null;
+  expiresAt: string | null;
+}
+
+function entryExpiry(entry: Record<string, unknown>): number | null {
+  const raw = stringValue(entry.expires_at);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sessionEntrySignedIn(entry: Record<string, unknown>, now: number): { signedIn: boolean; expiresAt: string | null } {
+  const expires = entryExpiry(entry);
+  if (expires !== null) {
+    return {
+      signedIn: expires > now,
+      expiresAt: new Date(expires).toISOString(),
+    };
+  }
+  const hasSecret = (typeof entry.key === "string" && entry.key.length > 0)
+    || (typeof entry.refresh_token === "string" && entry.refresh_token.length > 0);
+  return { signedIn: hasSecret, expiresAt: null };
+}
+
+/** Local Grok CLI sign-in. Never returns tokens, emails, or account ids. */
+export function grokAuthStatus(now = Date.now()): GrokAuthStatus {
+  const authPath = path.join(grokHome(), "auth.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(authPath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      /* Unreadable or malformed credentials are treated as signed out. */
+    }
+    parsed = null;
+  }
+  const file = recordValue(parsed);
+  if (file) {
+    let best: { signedIn: true; expiresAt: string | null } | null = null;
+    for (const value of Object.values(file)) {
+      const entry = recordValue(value);
+      if (!entry) continue;
+      const status = sessionEntrySignedIn(entry, now);
+      if (!status.signedIn) continue;
+      if (!best) {
+        best = { signedIn: true, expiresAt: status.expiresAt };
+        continue;
+      }
+      const previous = best.expiresAt ? Date.parse(best.expiresAt) : 0;
+      const next = status.expiresAt ? Date.parse(status.expiresAt) : 0;
+      if (next >= previous) best = { signedIn: true, expiresAt: status.expiresAt };
+    }
+    if (best) return { signedIn: true, source: "session", expiresAt: best.expiresAt };
+  }
+  if (process.env.XAI_API_KEY?.trim()) {
+    return { signedIn: true, source: "api_key", expiresAt: null };
+  }
+  return { signedIn: false, source: null, expiresAt: null };
+}

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+
+import { grokAuthStatus, grokHome } from "./grok";
 import { accountForSpawn, activeCodexAccountId, codexAccountsMutationLocked, codexHomeOwningSessionPath, CorruptCodexAccountsError, createManagedCodexAccount, listCodexAccounts, setActiveCodexAccount, UnknownAccountError, type CodexAccount } from "./codex";
 import { activeClaudeAccountId, claudeAccountForSpawn, claudeAccountsMutationLocked, claudeHomeOwningTranscript, claudeManagedEnvironment, CorruptClaudeAccountsError, createManagedClaudeAccount, listClaudeAccounts, setActiveClaudeAccount, UnknownClaudeAccountError } from "./claude";
 import { claudeLoginSupervisor, LIVE_CLAUDE_LOGIN_PHASES } from "./claudeLogin";
@@ -11,7 +14,20 @@ import { selectHealthyClaudeAccount } from "./spawnHealth";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 import { classifySpawnAccountAdmission, type SpawnAccountAdmission } from "@/lib/agent/accountLiveness";
 
-function contextForSpawn(engine: "claude" | "codex", requested?: string | null) {
+function grokSpawnContext(): AccountContext {
+  const home = grokHome();
+  return {
+    engine: "grok",
+    accountId: "grok",
+    kind: "legacy",
+    home,
+    transcriptRoot: path.join(home, "sessions"),
+    env: withoutWakatimeCredential(process.env),
+  };
+}
+
+function contextForSpawn(engine: "claude" | "codex" | "grok", requested?: string | null) {
+  if (engine === "grok") return grokSpawnContext();
   if (engine === "claude") { const item = claudeAccountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(item.home) : withoutWakatimeCredential(process.env) }; }
   const item = accountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.sessionsDir, env: { ...withoutWakatimeCredential(process.env), CODEX_HOME: item.home } };
 }
@@ -23,9 +39,13 @@ export type HealthySpawnAccountResolution = AccountContext & {
 };
 
 export async function resolveHealthySpawnAccount(
-  engine: "claude" | "codex",
+  engine: "claude" | "codex" | "grok",
   requested?: string | null,
 ): Promise<HealthySpawnAccountResolution> {
+  if (engine === "grok") {
+    if (!grokAuthStatus().signedIn) throw new AccountAuthenticationRequiredError("grok", "grok");
+    return grokSpawnContext();
+  }
   const active = agentRegistry().engineRouting(engine).activeAccountId ?? undefined;
   const routed = requested ?? active;
   const missingRequested = classifySpawnAccountAdmission({
@@ -70,7 +90,7 @@ function summary(engine: "claude" | "codex", id: string): AccountSummary {
 }
 
 export class AccountAuthenticationRequiredError extends Error {
-  constructor(readonly engine: "claude" | "codex", readonly accountId: string) {
+  constructor(readonly engine: "claude" | "codex" | "grok", readonly accountId: string) {
     super(`${engine} account requires authentication`);
     this.name = "AccountAuthenticationRequiredError";
   }

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -320,6 +320,62 @@ describe("OpenClaw turn state (#1207)", () => {
     expect(turnStateFromRecords([prompt(1), assistant(2, "toolUse"), toolResult(3, "call-one")], "openclaw"))
       .toEqual({ state: "busy", source: "assistant", terminalAt: null });
   });
+});
+
+describe("Grok turn state", () => {
+  const at = (second: number) => `2026-08-27T09:0${second}:00.000Z`;
+  test("an assistant reply with no tools ends the turn", () => {
+    expect(turnStateFromRecords([
+      { type: "user", content: "Inspect the orchard" },
+      { type: "assistant", content: "Looking.", timestamp: at(2) },
+    ], "grok")).toEqual({ state: "terminal", source: "assistant", terminalAt: at(2) });
+  });
+  test("a tool call stays busy until the assistant finishes", () => {
+    expect(turnStateFromRecords([
+      { type: "user", content: "Inspect the orchard" },
+      { type: "assistant", content: "Looking.", timestamp: at(2), tool_calls: [{ id: "call-1", name: "Bash" }] },
+    ], "grok")).toEqual({ state: "busy", source: "tool", terminalAt: null });
+    expect(turnStateFromRecords([
+      { type: "user", content: "Inspect the orchard" },
+      { type: "assistant", content: "Looking.", timestamp: at(2), tool_calls: [{ id: "call-1", name: "Bash" }] },
+      { type: "tool_result", tool_call_id: "call-1", content: "ok", timestamp: at(3) },
+    ], "grok")).toEqual({ state: "busy", source: "assistant", terminalAt: null });
+    expect(turnStateFromRecords([
+      { type: "user", content: "Inspect the orchard" },
+      { type: "assistant", content: "Looking.", timestamp: at(2), tool_calls: [{ id: "call-1", name: "Bash" }] },
+      { type: "tool_result", tool_call_id: "call-1", content: "ok", timestamp: at(3) },
+      { type: "assistant", content: "Three files.", timestamp: at(4) },
+    ], "grok")).toEqual({ state: "terminal", source: "assistant", terminalAt: at(4) });
+  });
+});
+
+describe("OpenClaw turn state (#1207)", () => {
+  const at = (second: number) => `2026-08-27T09:0${second}:00.000Z`;
+  const assistant = (
+    second: number,
+    stopReason: string,
+    provider = "openai",
+  ): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-assistant-${second}`,
+    parentId: `oc-parent-${second}`,
+    timestamp: at(second),
+    message: { role: "assistant", provider, model: "demo-model", api: "demo-api", stopReason, content: [] },
+  });
+  const prompt = (second: number): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-user-${second}`,
+    parentId: null,
+    timestamp: at(second),
+    message: { role: "user", content: "invented prompt", timestamp: at(second) },
+  });
+  const toolResult = (second: number, callId: string): Record<string, unknown> => ({
+    type: "message",
+    id: `oc-result-${second}`,
+    parentId: `oc-parent-${second}`,
+    timestamp: at(second),
+    message: { role: "toolResult", toolCallId: callId, toolName: "demo_tool", isError: false, content: [] },
+  });
 
   test("error and aborted end the turn", () => {
     expect(turnStateFromRecords([prompt(1), assistant(2, "error")], "openclaw"))

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -102,6 +102,42 @@ export function claudeRecoveryTailRelease(records: RecordLike[]): { terminalAt: 
  * `stopReason: "stop"`, and they land in the middle of real turns. Taking the
  * tail record unconditionally would report a session sitting inside a tool call
  * as finished and drop it out of busy grading. */
+/** Grok Build chat_history.jsonl: user / assistant / tool_result rows, with
+    optional tool_calls on the assistant record. Reasoning and system rows are
+    not turn evidence. */
+function grokTurnState(records: RecordLike[]): TurnState {
+  let state: TurnState = { state: "unknown", source: "empty", terminalAt: null };
+  const openTools = new Set<string>();
+  for (const record of records) {
+    const type = stringValue(record.type);
+    if (type === "system" || type === "reasoning") continue;
+    if (type === "user") {
+      openTools.clear();
+      state = { state: "busy", source: "lifecycle", terminalAt: null };
+      continue;
+    }
+    if (type === "assistant") {
+      openTools.clear();
+      for (const call of recordsValue(record.tool_calls)) {
+        const id = stringValue(call.id);
+        if (id) openTools.add(id);
+      }
+      state = openTools.size > 0
+        ? { state: "busy", source: "tool", terminalAt: null }
+        : { state: "terminal", source: "assistant", terminalAt: timestamp(record) };
+      continue;
+    }
+    if (type === "tool_result") {
+      const id = stringValue(record.tool_call_id);
+      if (id) openTools.delete(id);
+      state = openTools.size > 0
+        ? { state: "busy", source: "tool", terminalAt: null }
+        : { state: "busy", source: "assistant", terminalAt: null };
+    }
+  }
+  return state;
+}
+
 function openclawTurnState(records: RecordLike[]): TurnState {
   for (let index = records.length - 1; index >= 0; index -= 1) {
     const record = records[index]!;
@@ -123,6 +159,7 @@ function openclawTurnState(records: RecordLike[]): TurnState {
 /** The newest authoritative lifecycle or tool event wins. Assistant prose
     cannot close an active turn because it commonly precedes tool work. */
 export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEngine, authoritative = false): TurnState {
+  if (engine === "grok") return grokTurnState(records);
   if (engine === "openclaw") return openclawTurnState(records);
   if (engine === "codex") {
     let turnOpen = false;

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -14,7 +14,7 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
 process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
 
-const { freshSpecFor, resumeSpecFor, withSpawnCapability } = await import("./cli");
+const { freshSpecFor, resumeSpecFor, resumeSpecForSession, resumeEligibility, withSpawnCapability } = await import("./cli");
 const { createManagedCodexAccount } = await import("@/lib/accounts/codex");
 const { createManagedClaudeAccount } = await import("@/lib/accounts/claude");
 const { saveTelegramSession, telegramConnectorTokenPath, telegramSessionPath } = await import("@/lib/telegram/sessionStore");
@@ -35,6 +35,37 @@ function replaceCodexLaunch(command: string, replacement: string): string {
   const suffix = command.slice(start).match(/(?:\s+\))+\s*$/)?.[0] ?? "";
   return command.slice(0, start) + replacement + suffix;
 }
+
+test("fresh Grok commands pin GROK_HOME, a session id, and skip-permissions", () => {
+  const spec = freshSpecFor("grok", SANDBOX, { model: "grok-4.6", effort: "high" });
+  expect(spec.engine).toBe("grok");
+  expect(spec.windowName).toBe("grok-new");
+  expect(spec.command).toContain("GROK_HOME=");
+  expect(spec.command).toContain("'-s'");
+  expect(spec.command).toContain("'--permission-mode' 'bypassPermissions'");
+  expect(spec.command).toContain("'-m' 'grok-4.6'");
+  expect(spec.command).toContain("'--effort' 'high'");
+  expect(spec.transcript).toContain("chat_history.jsonl");
+});
+
+test("Grok resume reopens by session id", () => {
+  const sessionId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const spec = resumeSpecForSession("grok", sessionId, SANDBOX, path.join(SANDBOX, "grok-home"));
+  expect(spec?.engine).toBe("grok");
+  expect(spec?.command).toContain("'-r' '" + sessionId + "'");
+  expect(spec?.transcript).toContain(sessionId);
+});
+
+test("Grok chat_history.jsonl is eligible to resume", () => {
+  const sessionId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const cwd = path.join(SANDBOX, "grok-resume-cwd");
+  fs.mkdirSync(cwd, { recursive: true });
+  const transcript = path.join(SANDBOX, "sessions", encodeURIComponent(cwd), sessionId, "chat_history.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, "{}\n");
+  const eligibility = resumeEligibility("grok-sessions", transcript, { cwd });
+  expect(eligibility).toMatchObject({ ok: true, engine: "grok", sessionId, cwd });
+});
 
 test("fresh Codex commands fix CODEX_HOME in the typed shell command", () => {
   const home = path.join(SANDBOX, "account with space");

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { grokHome } from "@/lib/accounts/grok";
 import { accountForSpawn, codexHomeOwningSessionPath, isManagedCodexHome } from "@/lib/accounts/codex";
 import { claudeSettingsPath, claudeTranscriptOwnership, isManagedClaudeHome, legacyClaudeHome } from "@/lib/accounts/claude";
 import { isUnderClaudeSubagentsDir } from "@/lib/scanner/claudeNative";
@@ -26,11 +27,23 @@ export { ENGINE_EFFORTS, isEngineEffort } from "./efforts";
  * else.
  */
 
-export type AgentEngine = "claude" | "codex";
+export type AgentEngine = "claude" | "codex" | "grok";
 
 /** Absolute path of an agent CLI when we can find one; bare name otherwise. */
 export function resolveBinary(name: string): string {
   const home = os.homedir();
+  if (name === "grok") {
+    for (const candidate of grokBinaryCandidates()) {
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        try {
+          if (fs.existsSync(candidate)) return candidate;
+        } catch { /* keep looking */ }
+      }
+    }
+  }
   if (process.env.LLV_DOCKER_NSENTER_SHIMS === "1" && (name === "claude" || name === "codex")) {
     const shim = "/usr/local/bin/" + name;
     try {
@@ -70,6 +83,13 @@ export function resolveBinary(name: string): string {
     container-owned and untrustworthy. Outside a container the system paths are
     probed too. When nothing matches, the bare name defers to the user's PATH. */
 export function resolveHostBinary(name: string): string {
+  if (name === "grok") {
+    for (const candidate of grokBinaryCandidates()) {
+      try {
+        if (fs.existsSync(candidate)) return candidate;
+      } catch { /* keep looking */ }
+    }
+  }
   const home = os.homedir();
   const homeCandidates = [
     path.join(home, ".bun", "bin", name),
@@ -88,6 +108,29 @@ export function resolveHostBinary(name: string): string {
     }
   }
   return name;
+}
+
+function grokBinaryCandidates(): string[] {
+  const home = grokHome();
+  return [
+    path.join(home, "bin", process.platform === "win32" ? "grok.exe" : "grok"),
+    path.join(home, "bin", "grok.exe"),
+    path.join(home, "bin", "grok"),
+  ];
+}
+
+export function grokTranscriptPath(cwd: string, sessionId: string): string {
+  return path.join(grokHome(), "sessions", encodeURIComponent(cwd), sessionId, "chat_history.jsonl");
+}
+
+function grokEnvPrefix(): string {
+  return `env -u LLV_TOKEN GROK_HOME=${shellQuote(grokHome())}`;
+}
+
+export function grokSessionIdFromTranscript(pathname: string): string | null {
+  if (path.basename(pathname) !== "chat_history.jsonl") return null;
+  const sessionId = path.basename(path.dirname(pathname));
+  return /^[0-9a-f-]{36}$/i.test(sessionId) ? sessionId.toLowerCase() : null;
 }
 
 export function shellQuote(value: string): string {
@@ -325,6 +368,39 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
       },
     };
   }
+  if (engine === "grok") {
+    const sid = crypto.randomUUID();
+    const args = [resolveBinary("grok"), "--cwd", cwd, "-s", sid];
+    if (options.model) args.push("-m", options.model);
+    if (options.effort) args.push("--effort", options.effort);
+    if (options.readOnly) args.push("--sandbox", "read-only");
+    else args.push("--permission-mode", "bypassPermissions");
+    if (!options.allowSubagents) args.push("--disallowed-tools", "Agent");
+    return {
+      command: `( unset LLV_TELEGRAM_MCP_TOKEN; ${grokEnvPrefix()} ${args.map(shellQuote).join(" ")} )`,
+      cwd,
+      windowName: "grok-new",
+      engine: "grok",
+      transcript: grokTranscriptPath(cwd, sid),
+      launchProfile: {
+        cwd,
+        model: options.model ?? null,
+        effort: options.effort ?? null,
+        fast: null,
+        permissionMode: options.readOnly ? "default" : "bypassPermissions",
+        readOnly: options.readOnly ?? false,
+        allowSubagents: options.allowSubagents ?? false,
+        mcpServers: [],
+        plugins: [],
+        title: options.title?.trim() || null,
+        project: null,
+        parentConversationId: null,
+        role: "worker",
+        goal: null,
+        plan: null,
+      },
+    };
+  }
   const args = [resolveBinary("codex")];
   const home = options.codexHome ?? accountForSpawn().home;
   if (isManagedCodexHome(home)) args.push("-c", "cli_auth_credentials_store=file");
@@ -420,7 +496,7 @@ export function claudeSuccessorSpecFor(input: {
     happened reads {@link ResumeEligibility.reason}, so diagnosing a refusal
     never again means reading three files. */
 export type ResumeEligibility =
-  | { ok: true; engine: Extract<AgentEngine, "claude" | "codex">; sessionId: string; home: string; cwd: string }
+  | { ok: true; engine: AgentEngine; sessionId: string; home: string; cwd: string }
   | { ok: false; reason: string };
 
 /**
@@ -454,6 +530,11 @@ export function resumeEligibility(root: string, pathname: string, options: Resum
     const home = codexHomeOwningSessionPath(pathname);
     if (!home) return { ok: false, reason: "the transcript is outside every Codex account session root the viewer knows" };
     return { ok: true, engine: "codex", sessionId: id, home, cwd: cwd() };
+  }
+  if (root === "grok-sessions" && base === "chat_history.jsonl") {
+    const sid = grokSessionIdFromTranscript(pathname);
+    if (!sid) return { ok: false, reason: "the Grok session directory carries no session id" };
+    return { ok: true, engine: "grok", sessionId: sid, home: grokHome(), cwd: cwd() };
   }
   return { ok: false, reason: "this transcript belongs to no resumable agent session" };
 }
@@ -521,6 +602,7 @@ export function resumeSpecForSession(
       launchProfile: { ...emptyLaunchProfileForResume(cwd, launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false, mcpServers, plugins: grantedPlugins(options.plugins) },
     };
   }
+  if (engine === "codex") {
   let command = `${(options.hostTerminal ? resolveHostBinary : resolveBinary)("codex")}`;
   if (isManagedCodexHome(home)) command += " -c cli_auth_credentials_store=file";
   for (const override of codexMcpRuntimeOverrides(home, cwd, mcpServers)) command += ` -c ${shellQuote(override)}`;
@@ -540,6 +622,30 @@ export function resumeSpecForSession(
     engine: "codex",
     launchProfile: { ...emptyLaunchProfileForResume(cwd, options.model ?? null, options.effort ?? null), fast: options.fast ?? null, readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false, mcpServers, plugins: grantedPlugins(options.plugins) },
   };
+  }
+  if (engine === "grok") {
+    const args = [(options.hostTerminal ? resolveHostBinary : resolveBinary)("grok"), "--cwd", cwd, "-r", sessionId];
+    if (options.model) args.push("-m", options.model);
+    if (options.effort) args.push("--effort", options.effort);
+    if (options.readOnly) args.push("--sandbox", "read-only");
+    else args.push("--permission-mode", "bypassPermissions");
+    return {
+      command: `( unset LLV_TELEGRAM_MCP_TOKEN; ${grokEnvPrefix()} ${args.map(shellQuote).join(" ")} )`,
+      cwd,
+      windowName: "grok-resume",
+      engine: "grok",
+      transcript: grokTranscriptPath(cwd, sessionId),
+      launchProfile: {
+        ...emptyLaunchProfileForResume(cwd, options.model ?? null, options.effort ?? null),
+        permissionMode: options.readOnly ? "default" : "bypassPermissions",
+        readOnly: options.readOnly ?? false,
+        allowSubagents: options.allowSubagents ?? false,
+        mcpServers: [],
+        plugins: [],
+      },
+    };
+  }
+  return null;
 }
 
 function emptyLaunchProfileForResume(cwd: string, model: string | null, effort: string | null): LaunchProfile {

--- a/src/lib/agent/efforts.ts
+++ b/src/lib/agent/efforts.ts
@@ -7,11 +7,12 @@
  * codex: `-c model_reasoning_effort=<level>`; the tier list mirrors
  * `supported_reasoning_levels` in ~/.codex/models_cache.json for current models.
  */
-export type AgentEngineName = "claude" | "codex";
+export type AgentEngineName = "claude" | "codex" | "grok";
 
 export const ENGINE_EFFORTS: Record<AgentEngineName, readonly string[]> = {
   claude: ["low", "medium", "high", "xhigh", "max"],
   codex: ["low", "medium", "high", "xhigh"],
+  grok: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
 };
 
 export function isEngineEffort(engine: AgentEngineName, value: string): boolean {
@@ -19,7 +20,7 @@ export function isEngineEffort(engine: AgentEngineName, value: string): boolean 
 }
 
 /** Canonical low→high ordering across every tier either CLI has ever recorded. */
-const EFFORT_ORDER: readonly string[] = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+const EFFORT_ORDER: readonly string[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
 
 /** Whether a token belongs to the canonical CLI tier vocabulary at all —
     engine/model fit is the engine's own verdict (a per-model scale like
@@ -46,6 +47,7 @@ const CODEX_MODEL_SCALES: readonly (readonly [RegExp, readonly string[]])[] = [
    the chip tooltip. */
 const OPENCLAW_EFFORTS: readonly string[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
+
 /** Reasoning tiers a given engine+model pair can run at, lowest first; null
     for engines without a reasoning dial (shell). Model may be the viewer's
     display-shortened id — matching is prefix-based on the codex slug, and
@@ -53,6 +55,7 @@ const OPENCLAW_EFFORTS: readonly string[] = ["off", "minimal", "low", "medium", 
 export function effortScale(engine: string, model: string | null | undefined): readonly string[] | null {
   if (engine === "claude") return ENGINE_EFFORTS.claude;
   if (engine === "openclaw") return OPENCLAW_EFFORTS;
+  if (engine === "grok") return ENGINE_EFFORTS.grok;
   if (engine !== "codex") return null;
   const id = (model ?? "").trim().toLowerCase();
   for (const [re, scale] of CODEX_MODEL_SCALES) {

--- a/src/lib/agent/models.test.ts
+++ b/src/lib/agent/models.test.ts
@@ -20,6 +20,8 @@ test("the model catalog exposes Opus 5 as the Claude default", () => {
   ]);
   expect(defaultModelFor("codex")).toBe(CODEX_SOL_MODEL);
   expect(defaultModelFor("claude")).toBe("opus");
+  expect(defaultModelFor("grok")).toBe("grok-4.6");
+  expect(validateLaunchModel("grok", "grok-4.6")).toEqual({ model: "grok-4.6" });
 });
 
 test("spawn model validation accepts CLI ids and rejects control characters", () => {

--- a/src/lib/agent/models.ts
+++ b/src/lib/agent/models.ts
@@ -27,7 +27,9 @@ export function codexModelSupportsImages(model: string | null | undefined): bool
   return CODEX_IMAGE_INPUT_MODELS.has(model.trim());
 }
 
-export const ENGINE_MODELS: Record<"claude" | "codex", readonly AgentModelOption[]> = {
+export const GROK_BUILD_MODEL = "grok-4.6";
+
+export const ENGINE_MODELS: Record<"claude" | "codex" | "grok", readonly AgentModelOption[]> = {
   claude: [
     { id: "opus", label: "Opus 5", shortLabel: "Opus 5", use: "review" },
     { id: "fable", label: "Fable", shortLabel: "Fable", use: "general" },
@@ -39,13 +41,17 @@ export const ENGINE_MODELS: Record<"claude" | "codex", readonly AgentModelOption
     { id: CODEX_TERRA_MODEL, label: "GPT-5.6-Terra", shortLabel: "5.6-Terra", use: "implement" },
     { id: CODEX_LUNA_MODEL, label: "GPT-5.6-Luna", shortLabel: "5.6-Luna", use: "general" },
   ],
+  grok: [
+    { id: GROK_BUILD_MODEL, label: "Grok 4.6", shortLabel: "4.6", use: "implement" },
+    { id: "grok-4.5", label: "Grok 4.5", shortLabel: "4.5", use: "general" },
+  ],
 };
 
 export type LaunchModelValidation = { model: string } | { error: string };
 
 /** Validate a fresh-launch model against the catalog rendered by the Viewer.
     Resume and migration paths deliberately do not call this helper. */
-export function validateLaunchModel(engine: "claude" | "codex", model: string): LaunchModelValidation {
+export function validateLaunchModel(engine: "claude" | "codex" | "grok", model: string): LaunchModelValidation {
   const requested = model.trim();
   const validIds = ENGINE_MODELS[engine].map((option) => option.id);
   if (validIds.includes(requested)) return { model: requested };
@@ -55,8 +61,10 @@ export function validateLaunchModel(engine: "claude" | "codex", model: string): 
 }
 
 /** A fresh Codex conversation starts on the architecture/review profile. */
-export function defaultModelFor(engine: "claude" | "codex"): string {
-  return engine === "codex" ? CODEX_SOL_MODEL : "opus";
+export function defaultModelFor(engine: "claude" | "codex" | "grok"): string {
+  if (engine === "codex") return CODEX_SOL_MODEL;
+  if (engine === "grok") return GROK_BUILD_MODEL;
+  return "opus";
 }
 
 const CLAUDE_MODEL_FAMILIES = ["fable", "opus", "sonnet", "haiku"] as const;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -431,7 +431,7 @@ export class SupersedenceConflictError extends Error {
 
 export interface RegistryConversation {
   id: ViewerConversationId;
-  engine: Extract<AgentEngine, "claude" | "codex">;
+  engine: Extract<AgentEngine, "claude" | "codex" | "grok">;
   generations: NativeGeneration[];
   /** Provider-created transcript artifacts that retain this conversation's
       identity while the canonical generation path advances. */
@@ -505,9 +505,9 @@ export interface RegistryFile {
   /** Durable redirects for conversation IDs that escaped before scanner-owned
       provisional identities were adopted by their canonical owner. */
   conversationAliases: Record<string, ViewerConversationId>;
-  conversationRevision: Record<Extract<AgentEngine, "claude" | "codex">, number>;
+  conversationRevision: Record<Extract<AgentEngine, "claude" | "codex" | "grok">, number>;
   migrationIntents: Record<string, MigrationIntent>;
-  engineRouting: Record<Extract<AgentEngine, "claude" | "codex">, { activeAccountId: string | null; revision: number }>;
+  engineRouting: Record<Extract<AgentEngine, "claude" | "codex" | "grok">, { activeAccountId: string | null; revision: number }>;
   autoBalance: Record<Extract<AgentEngine, "claude" | "codex">, AutoBalancePolicy>;
   quotaObservations: Record<Extract<AgentEngine, "claude" | "codex">, Record<string, DurableQuotaObservation>>;
   heldDeliveries: Record<string, HeldDelivery>;
@@ -1079,9 +1079,9 @@ const EMPTY: RegistryFile = {
   legacyResumePanes: { serverPid: null, panes: {} },
   conversations: {},
   conversationAliases: {},
-  conversationRevision: { claude: 0, codex: 0 },
+  conversationRevision: { claude: 0, codex: 0, grok: 0 },
   migrationIntents: {},
-  engineRouting: { claude: { activeAccountId: null, revision: 0 }, codex: { activeAccountId: null, revision: 0 } },
+  engineRouting: { claude: { activeAccountId: null, revision: 0 }, codex: { activeAccountId: null, revision: 0 }, grok: { activeAccountId: null, revision: 0 } },
   autoBalance: { claude: emptyPolicy(), codex: emptyPolicy() },
   quotaObservations: { claude: {}, codex: {} },
   heldDeliveries: {},
@@ -2593,7 +2593,7 @@ function normalizeReceipt(value: SpawnReceipt, policy?: McpGrantPolicy): SpawnRe
     parentSource: value.parentSource === "explicit" || value.parentSource === "inferred-caller" ? value.parentSource : null,
     state,
     artifactLifecycle: value.artifactLifecycle === "materialized" ? "materialized" : "pending",
-    key: value.key && typeof value.key === "object" && (value.key.engine === "claude" || value.key.engine === "codex") && typeof value.key.sessionId === "string" ? value.key : null,
+    key: value.key && typeof value.key === "object" && (value.key.engine === "claude" || value.key.engine === "codex" || value.key.engine === "grok") && typeof value.key.sessionId === "string" ? value.key : null,
     pane,
     verifiedHost: value.verifiedHost && typeof value.verifiedHost === "object" && value.verifiedHost.kind === "tmux" ? value.verifiedHost : null,
     target: pane?.paneId ?? (typeof value.target === "string" && /^%\d+$/.test(value.target) ? value.target : null),
@@ -5120,7 +5120,7 @@ export class AgentRegistry {
 
   /** Allocates one Viewer-owned identity for every native generation. Paths
       remain an interoperability detail and can change on every account move. */
-  ensureConversation(engine: Extract<AgentEngine, "claude" | "codex">, artifactPath: string, accountId: string | null): RegistryConversation {
+  ensureConversation(engine: Extract<AgentEngine, "claude" | "codex" | "grok">, artifactPath: string, accountId: string | null): RegistryConversation {
     return this.mutate((file) => {
       const existing = Object.values(file.conversations).find((conversation) => conversation.engine === engine && conversationOwnsPath(conversation, artifactPath));
       if (existing) return clone(existing);
@@ -5524,7 +5524,7 @@ export class AgentRegistry {
       The generation record is the source of truth for which account owns a
       conversation; deriving the account from the path layout stays in the
       account manager only as recovery for artifacts the registry never saw. */
-  transcriptAccountId(engine: Extract<AgentEngine, "claude" | "codex">, artifactPath: string): string | null {
+  transcriptAccountId(engine: Extract<AgentEngine, "claude" | "codex" | "grok">, artifactPath: string): string | null {
     const snapshot = this.readOnlySnapshot();
     for (const conversation of Object.values(snapshot.conversations)) {
       if (conversation.engine !== engine) continue;
@@ -5646,7 +5646,7 @@ export class AgentRegistry {
     return conversation?.generations.at(-1)?.path ?? artifactPath;
   }
 
-  setEngineRouting(engine: Extract<AgentEngine, "claude" | "codex">, accountId: string): number {
+  setEngineRouting(engine: Extract<AgentEngine, "claude" | "codex" | "grok">, accountId: string): number {
     return withAccountMutationLock(() => this.mutate((file) => {
       const route = file.engineRouting[engine];
       route.activeAccountId = accountId;
@@ -5655,7 +5655,7 @@ export class AgentRegistry {
     }));
   }
 
-  engineRouting(engine: Extract<AgentEngine, "claude" | "codex">): { activeAccountId: string | null; revision: number } {
+  engineRouting(engine: Extract<AgentEngine, "claude" | "codex" | "grok">): { activeAccountId: string | null; revision: number } {
     return clone(this.readOnlySnapshot().engineRouting[engine]);
   }
 

--- a/src/lib/agent/sessionKey.ts
+++ b/src/lib/agent/sessionKey.ts
@@ -26,6 +26,10 @@ export function sessionKeyId(key: SessionKey): string {
 }
 
 export function sessionKeyFromTranscript(engine: AgentEngine, pathname: string): SessionKey | null {
+  if (engine === "grok") {
+    const sessionId = path.basename(path.dirname(pathname));
+    return sessionKey(engine, sessionId);
+  }
   const base = path.basename(pathname);
   const match = base.match(SESSION_ID);
   return match ? sessionKey(engine, match[0]) : null;

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -6,7 +6,7 @@ import { after, NextRequest, NextResponse } from "next/server";
 
 import { UnknownAccountError } from "@/lib/accounts/codex";
 import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } from "@/lib/accounts/claude";
-import { accountManager, resolveHealthySpawnAccount, type HealthySpawnAccountResolution } from "@/lib/accounts/manager";
+import { AccountAuthenticationRequiredError, accountManager, resolveHealthySpawnAccount, type HealthySpawnAccountResolution } from "@/lib/accounts/manager";
 import { emptyLaunchProfile, validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError, type SpawnRequest } from "@/lib/agent/registry";
@@ -226,10 +226,10 @@ export async function executeSpawnRequest(
   if (role.value && isSpawnDeniedRole(role.value.role) && body.allowSubagents === true) {
     return NextResponse.json({ error: `${role.value.role} launches cannot enable subagents: reviewer and verifier sessions run every check in-session` }, { status: 400 });
   }
-  const engine = body.engine === "claude" || body.engine === "codex"
+  const engine = body.engine === "claude" || body.engine === "codex" || body.engine === "grok"
     ? (body.engine as AgentEngine)
     : (role.value?.config.engine ?? null);
-  if (!engine) return NextResponse.json({ error: "engine must be claude or codex" }, { status: 400 });
+  if (!engine) return NextResponse.json({ error: "engine must be claude, codex, or grok" }, { status: 400 });
   if (body.accountId !== undefined && typeof body.accountId !== "string") return NextResponse.json({ error: "accountId must be a string" }, { status: 400 });
   if (body.clientAttemptId !== undefined && (typeof body.clientAttemptId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(body.clientAttemptId))) return NextResponse.json({ error: "clientAttemptId must be 8-128 URL-safe characters" }, { status: 400 });
 
@@ -263,7 +263,7 @@ export async function executeSpawnRequest(
     : null;
   let transport;
   try {
-    transport = spawnTransport();
+    transport = engine === "grok" ? "tmux" : spawnTransport();
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }
@@ -1024,6 +1024,7 @@ export async function executeSpawnRequest(
     if (error instanceof SpawnChildLimitError) return NextResponse.json({ error: error.message }, { status: 429 });
     if (error instanceof RuntimeImageStorageError) return NextResponse.json({ error: error.message }, { status: 503 });
     if (error instanceof UnknownAccountError || error instanceof UnknownClaudeAccountError) return NextResponse.json({ error: error.message }, { status: 400 });
+    if (error instanceof AccountAuthenticationRequiredError) return NextResponse.json({ error: error.message, retrySafe: true }, { status: 401 });
     const accountError = spawnAccountErrorResponse(error);
     if (accountError) return accountError;
     if (receipt?.pane) {

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -535,14 +535,14 @@ function spawnCard(
   );
   return {
     path: `spawn:${receipt.launchId}`,
-    root: receipt.engine === "codex" ? "codex-sessions" : "claude-projects",
+    root: receipt.engine === "codex" ? "codex-sessions" : receipt.engine === "grok" ? "grok-sessions" : "claude-projects",
     name: `spawn:${receipt.launchId}`,
     project: attribution.project ?? path.basename(receipt.cwd),
     ...(projectOwnership ? { projectOwnership } : {}),
     cwd: receipt.cwd,
     projectRoot: projectRootForCwd(receipt.cwd) ?? null,
     ...(attribution.worktree ? { worktree: attribution.worktree } : {}),
-    title: receipt.launchProfile.title ?? (receipt.engine === "codex" ? "Codex" : "Claude"),
+    title: receipt.launchProfile.title ?? (receipt.engine === "codex" ? "Codex" : receipt.engine === "grok" ? "Grok" : "Claude"),
     engine: receipt.engine,
     kind: "session",
     fmt: receipt.engine,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -712,6 +712,13 @@ export const en = {
   "qr.copy": "Copy link",
   "qr.scanHint": "scan from a phone on the same tailnet",
 
+  // Grok account (single sign-in; no Claude/Codex-style multi-account homes)
+  "grok.title": "Grok",
+  "grok.rowAria": "Grok account",
+  "grok.signedIn": "Signed in",
+  "grok.signedOut": "Signed out",
+  "grok.statusLoading": "Checking sign-in…",
+
   // Telegram connector (#1059)
   "telegram.title": "Telegram",
   "telegram.rowAria": "Telegram connection",
@@ -1856,9 +1863,9 @@ export const en = {
   "overview.moreLive": "{count} more live",
   "overview.quiet": "quiet · last activity {age}",
   "overview.firstRunTitle": "No projects yet",
-  "overview.firstRunBody": "Sessions from ~/.claude/projects and ~/.codex/sessions appear here as they happen",
+  "overview.firstRunBody": "Sessions from ~/.claude/projects, ~/.codex/sessions, and ~/.grok/sessions appear here as they happen",
   "overview.firstRunCreate": "Create a project",
-  "overview.firstRunElsewhere": "…or run any claude / codex session inside a repo.",
+  "overview.firstRunElsewhere": "…or run any claude / codex / grok session inside a repo.",
 
   // Catalog fetch failure (issue #696) — never the idle empty-state copy
   "catalog.unreachable": "catalog unavailable",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -697,6 +697,12 @@ export const uk: Record<keyof typeof en, Message> = {
   "qr.copy": "Копіювати посилання",
   "qr.scanHint": "скануй з телефона в тому ж tailnet",
 
+  "grok.title": "Grok",
+  "grok.rowAria": "Обліковий запис Grok",
+  "grok.signedIn": "Увійшов",
+  "grok.signedOut": "Не ввійшов",
+  "grok.statusLoading": "Перевіряю вхід…",
+
   "telegram.title": "Telegram",
   "telegram.rowAria": "Підключення Telegram",
   "telegram.close": "Закрити",
@@ -1806,9 +1812,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "overview.moreLive": "ще {count} live",
   "overview.quiet": "тихо · остання активність {age}",
   "overview.firstRunTitle": "Проєктів поки нема",
-  "overview.firstRunBody": "Сесії з ~/.claude/projects і ~/.codex/sessions з'являються тут одразу, як тільки стартують",
+  "overview.firstRunBody": "Сесії з ~/.claude/projects, ~/.codex/sessions і ~/.grok/sessions з'являються тут одразу, як тільки стартують",
   "overview.firstRunCreate": "Створити проєкт",
-  "overview.firstRunElsewhere": "…або просто запусти claude чи codex у будь-якому репозиторії.",
+  "overview.firstRunElsewhere": "…або просто запусти claude, codex чи grok у будь-якому репозиторії.",
 
   "catalog.unreachable": "каталог недоступний",
   "catalog.errorTitle": "Не вдалося завантажити каталог сесій",

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -50,7 +50,7 @@ function resourceFileObservation(value: unknown): value is ResourceWorkerFileObs
     && typeof value.project === "string"
     && (value.activity === "live" || value.activity === "recent" || value.activity === "stalled" || value.activity === "idle")
     && typeof value.mtime === "number" && Number.isFinite(value.mtime) && value.mtime >= 0
-    && (value.engine === "claude" || value.engine === "codex" || value.engine === "shell" || value.engine === "openclaw")
+    && (value.engine === "claude" || value.engine === "codex" || value.engine === "shell" || value.engine === "openclaw" || value.engine === "grok")
     && (value.pid === null || (Number.isSafeInteger(value.pid) && (value.pid as number) > 0))
     && (value.proc === "running" || value.proc === "done" || value.proc === "killed" || value.proc === null)
     && nullableString(value.conversationId);

--- a/src/lib/runtime/spawnTransport.ts
+++ b/src/lib/runtime/spawnTransport.ts
@@ -52,5 +52,8 @@ export function structuredSpawnGap(
   if (request.engine === "codex" && request.fast !== null) {
     return "structured Codex spawn does not support an explicit Codex service tier";
   }
+  if (request.engine === "grok") {
+    return "structured Grok spawn is not available; Grok launches through tmux";
+  }
   return null;
 }

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -157,6 +157,7 @@ function recoveryRelease(
 export function transcriptEngineForRoot(root: RootKey): TranscriptEngine {
   if (root === "codex-sessions") return "codex";
   if (root === "openclaw-sessions") return "openclaw";
+  if (root === "grok-sessions") return "grok";
   return "claude";
 }
 

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -705,3 +705,51 @@ test("a workspace directory outside any OpenClaw state directory is not recogniz
     projectInfoFromCwd(foreign, "openclaw-foreign"));
   expect(info).toMatchObject({ displayName: "workspace" });
 });
+
+function writeGrokSession(cwd: string, sessionId: string, lines: unknown[], summary?: Record<string, unknown>) {
+  const encoded = encodeURIComponent(cwd);
+  const dir = path.join(SANDBOX, "grok-sessions", encoded, sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const transcript = path.join(dir, "chat_history.jsonl");
+  fs.writeFileSync(transcript, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+  if (summary) fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify(summary));
+  return transcript;
+}
+
+test("a Grok chat history is its own engine and takes the generated title from summary.json", () => {
+  useStateDirectory("grok-summary-title");
+  const repo = path.join(SANDBOX, "grok-summary-repository");
+  const identity = createRepository(repo);
+  const transcript = writeGrokSession(repo, "session-alpha", [
+    { type: "user", content: [{ type: "text", text: "<user_query>\nInspect the orchard\n</user_query>" }] },
+  ], {
+    generated_title: "Orchard inspection",
+    created_at: "2026-08-27T09:00:00.000Z",
+    reasoning_effort: "high",
+  });
+  expect(describe("grok-sessions", path.join(SANDBOX, "grok-sessions"), transcript, fs.statSync(transcript))).toMatchObject({
+    engine: "grok",
+    fmt: "grok",
+    kind: "session",
+    title: "Orchard inspection",
+    sessionStartedAt: "2026-08-27T09:00:00.000Z",
+    project: identity.project,
+    projectName: identity.displayName,
+    cwd: repo,
+  });
+});
+
+test("a Grok session without summary.json titles from the operator user_query", () => {
+  useStateDirectory("grok-query-title");
+  const cwd = path.join(SANDBOX, "grok-query-cwd");
+  fs.mkdirSync(cwd, { recursive: true });
+  const transcript = writeGrokSession(cwd, "session-beta", [
+    { type: "user", content: [{ type: "text", text: "<user_info>\nskipped</user_info>" }], synthetic_reason: "system_reminder" },
+    { type: "user", content: [{ type: "text", text: "<user_query>\nPlant the cobalt orchard\n</user_query>" }] },
+  ]);
+  expect(describe("grok-sessions", path.join(SANDBOX, "grok-sessions"), transcript, fs.statSync(transcript))).toMatchObject({
+    engine: "grok",
+    title: "Plant the cobalt orchard",
+    cwd,
+  });
+});

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -133,12 +133,31 @@ function subagentSidecarPath(rootName: RootKey, pathname: string): string | null
   return pathname.slice(0, -".jsonl".length) + ".meta.json";
 }
 
+function grokSummaryPath(rootName: RootKey, pathname: string): string | null {
+  if (rootName !== "grok-sessions" || path.basename(pathname) !== "chat_history.jsonl") return null;
+  return path.join(path.dirname(pathname), "summary.json");
+}
+
+function descriptionSidecarPath(rootName: RootKey, pathname: string): string | null {
+  return subagentSidecarPath(rootName, pathname) ?? grokSummaryPath(rootName, pathname);
+}
+
+/** Grok Build records a Windows cwd even when the Viewer is scanning from
+    WSL. Translate `C:\…` onto `/mnt/<drive>/…` so project grouping can see
+    the same repository Claude/Codex sessions already live in. */
+function grokHostCwd(cwd: string): string {
+  if (path.sep !== "/") return cwd;
+  const match = /^([A-Za-z]):[\\/](.*)$/.exec(cwd);
+  if (!match) return cwd;
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replace(/\\/g, "/")}`;
+}
+
 export function fileDescriptionIdentity(
   rootName: RootKey,
   pathname: string,
   st: fs.Stats,
 ): FileDescriptionIdentity {
-  const sidecarPath = subagentSidecarPath(rootName, pathname);
+  const sidecarPath = descriptionSidecarPath(rootName, pathname);
   if (!sidecarPath) {
     return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null, complete: true };
   }
@@ -731,7 +750,23 @@ function goodTitle(text: unknown): string | null {
   return val && !skipTitlePrefixes.some((prefix) => val.startsWith(prefix)) ? val : null;
 }
 
+function grokUserPrompt(obj: Record<string, unknown>): string | null {
+  if (obj.type !== "user") return null;
+  if (typeof obj.synthetic_reason === "string") return null;
+  const content = obj.content;
+  const text = typeof content === "string"
+    ? content
+    : recordsValue(content).map((part) => stringValue(part.text) ?? "").join(" ");
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const query = trimmed.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+  if (query?.[1]) return query[1].trim();
+  if (trimmed.startsWith("<")) return null;
+  return trimmed;
+}
+
 function userPromptFromRecord(obj: Record<string, unknown>, engine: TranscriptEngine): string | null {
+  if (engine === "grok") return grokUserPrompt(obj);
   if (engine === "openclaw") {
     /* OpenClaw wraps every role, the operator's included, in a top-level
        `message` envelope, so the Claude arm's `type === "user"` never fires. */
@@ -795,6 +830,8 @@ function titleFromLines(lines: string[], engine: TranscriptEngine): string | nul
   }
   return null;
 }
+
+
 
 function conversationTextFromLines(lines: string[], engine: TranscriptEngine): ConversationSearchText {
   let title: string | null = null;
@@ -1064,6 +1101,31 @@ function deriveTranscriptMetadata(
       title = titleRead.value;
     }
     title ??= "OpenClaw session";
+  } else if (rootName === "grok-sessions") {
+    /* A Grok session directory is nested below a percent-encoded working
+       directory. It is the only durable cwd signal in its on-disk format. */
+    const encodedCwd = path.basename(path.dirname(path.dirname(pathname)));
+    try { cwd = decodeURIComponent(encodedCwd); } catch { cwd = undefined; }
+    if (cwd) cwd = grokHostCwd(cwd);
+    engine = "grok";
+    kind = "session";
+    fmt = "grok";
+    const sidecar = complete
+      ? identity.sidecarSize === null
+        ? { value: null, complete: identity.complete }
+        : readJsonResult(path.join(path.dirname(pathname), "summary.json"))
+      : { value: null, complete: false };
+    complete &&= sidecar.complete;
+    const meta = sidecar.value ?? {};
+    title = goodTitle(stringValue(meta.generated_title)) ?? goodTitle(stringValue(meta.session_summary));
+    const created = stringValue(meta.created_at);
+    if (created && Number.isFinite(Date.parse(created))) sessionStartedAt = new Date(created).toISOString();
+    if (!title && complete) {
+      const titleRead = scanJsonlTitle(pathname, st, "grok");
+      complete &&= titleRead.complete;
+      title = titleRead.value;
+    }
+    title ??= "Grok session";
   } else if (rootName === "claude-tasks") {
     engine = "shell";
     kind = "background";
@@ -1120,6 +1182,11 @@ function resolveProjectOverlay(
        OpenClaw session a stable project, and it only runs if this branch calls
        it: the overlay reaches `projectInfoFromCwd` from the Codex and Claude
        branches alone. */
+    info = (cwd ? projectInfoFromCwd(cwd, stateKey) : null) ?? projectInfoFromTranscript(pathname, stateKey);
+  } else if (rootName === "grok-sessions") {
+    /* Same recognizer Claude/Codex/OpenClaw use: a session running inside a
+       repository groups with that repository, including after a Windows cwd
+       has been mapped onto the host path. */
     info = (cwd ? projectInfoFromCwd(cwd, stateKey) : null) ?? projectInfoFromTranscript(pathname, stateKey);
   } else if (rootName === "claude-tasks") {
     const rel = path.relative(root, pathname);

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -108,6 +108,10 @@ async function walkPaths(rootName: RootKey, root: string, dir: string, limit: Li
        backups). Filtering here rather than at hydration keeps them out of the
        resource-scope inventory too, which only checks the `.jsonl` suffix. */
     if (rootName === "openclaw-sessions" && !isOpenclawTranscript(entry.name)) return { paths: [], complete: true };
+    /* Grok stores multiple JSONL sidecars per session. The chat history is the
+       only conversation transcript; events and rewind journals must not become
+       phantom cards. */
+    if (rootName === "grok-sessions" && entry.name !== "chat_history.jsonl") return { paths: [], complete: true };
     return { paths: [{ rootName, root, path: path.join(dir, entry.name) }], complete: true };
   }));
   return {
@@ -196,7 +200,7 @@ function transcriptIndexFeed(
        conversations stay searchable through the catalog's title and
        first-prompt text; full-text search over their bodies moves with the
        index's own schema migration. */
-    sources: catalog.flatMap((entry) => (entry.engine === "openclaw" ? [] : [{
+    sources: catalog.flatMap((entry) => (entry.engine === "openclaw" || entry.engine === "grok" ? [] : [{
       path: entry.path,
       project: projectByPath?.get(entry.path) ?? entry.project,
       engine: entry.engine,

--- a/src/lib/scanner/effort.test.ts
+++ b/src/lib/scanner/effort.test.ts
@@ -127,3 +127,14 @@ describe("entryEffort for OpenClaw", () => {
       .toBeNull();
   });
 });
+
+describe("entryEffort for Grok", () => {
+  test("reads reasoning_effort from summary.json", () => {
+    const dir = path.join(SANDBOX, "grok-session");
+    fs.mkdirSync(dir, { recursive: true });
+    const pathname = path.join(dir, "chat_history.jsonl");
+    fs.writeFileSync(pathname, JSON.stringify({ type: "user", content: "hello" }) + "\n");
+    fs.writeFileSync(path.join(dir, "summary.json"), JSON.stringify({ reasoning_effort: "high" }));
+    expect(entryEffort(entry(pathname, { root: "grok-sessions", engine: "grok", fmt: "grok" }))).toBe("high");
+  });
+});

--- a/src/lib/scanner/effort.ts
+++ b/src/lib/scanner/effort.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
+
 import type { FileEntry } from "../types";
 import { headRecordsResult, tailRecordsResult } from "./activity";
 import { globalCache } from "./caches";
-import { recordValue, recordsValue, stringValue } from "./json";
+import { readJson, recordValue, recordsValue, stringValue } from "./json";
 import { readArgv } from "./process";
 
 const effortCache = globalCache<[number, number, string | null]>("effort");
@@ -10,7 +12,7 @@ const effortCache = globalCache<[number, number, string | null]>("effort");
     OpenClaw's `--thinking`, which adds `off` at the bottom and `adaptive` —
     a request to let the model choose, which is a recorded setting rather than
     a rung on the ladder. */
-const TIERS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "adaptive"]);
+const TIERS = new Set(["none", "off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "adaptive"]);
 
 function normalizeEffort(value: string | null | undefined): string | null {
   const tier = value?.trim().toLowerCase() ?? "";
@@ -27,6 +29,9 @@ function pickEffort(entry: FileEntry, obj: Record<string, unknown>): string | nu
   }
   if (entry.root === "openclaw-sessions" && obj.type === "thinking_level_change") {
     return stringValue(obj.thinkingLevel);
+  }
+  if (entry.root === "grok-sessions") {
+    return stringValue(obj.reasoning_effort);
   }
   if (entry.root === "claude-projects" && obj.type === "assistant") {
     const message = recordValue(obj.message);
@@ -47,6 +52,7 @@ function argvEffort(entry: FileEntry): string | null {
       if (match) return match[1];
     }
     if (entry.engine === "claude" && argv[i] === "--effort") return argv[i + 1];
+    if (entry.engine === "grok" && (argv[i] === "--effort" || argv[i] === "--reasoning-effort")) return argv[i + 1];
   }
   return null;
 }
@@ -67,13 +73,18 @@ export interface EntryEffortResult {
 
 export function entryEffortResult(entry: FileEntry): EntryEffortResult {
   if (
-    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions")
+    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions" && entry.root !== "grok-sessions")
     || !entry.path.endsWith(".jsonl")
   ) {
     return { value: null, complete: true };
   }
   const argv = normalizeEffort(argvEffort(entry));
   if (entry.root === "claude-projects" && argv) return { value: argv, complete: true };
+  if (entry.root === "grok-sessions") {
+    const summary = readJson(path.join(path.dirname(entry.path), "summary.json"));
+    const fromSummary = normalizeEffort(stringValue(summary?.reasoning_effort));
+    if (fromSummary) return { value: fromSummary, complete: true };
+  }
   const mtimeMs = entry.mtime * 1000;
   const cached = effortCache.get(entry.path);
   if (cached?.[0] === entry.size && cached[1] === mtimeMs) return { value: cached[2] ?? argv, complete: true };

--- a/src/lib/scanner/fileScanWorker.ts
+++ b/src/lib/scanner/fileScanWorker.ts
@@ -233,7 +233,7 @@ export function collectFileScanInWorker(
             /* Same exclusion as `transcriptIndexFeed`: the full-text index has
                no OpenClaw record parser and its engine column admits two
                values. */
-            sources: completedConversationCatalog.flatMap((entry) => (entry.engine === "openclaw" ? [] : [{
+            sources: completedConversationCatalog.flatMap((entry) => (entry.engine === "openclaw" || entry.engine === "grok" ? [] : [{
               path: entry.path,
               project: entry.project,
               engine: entry.engine,

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -297,7 +297,7 @@ async function listFilesInternal(
     entry.activity = verdict.state;
     entry.activityReason = verdict.reason;
     entry.derivationComplete = verdict.complete;
-    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw")) {
+    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw" || entry.engine === "grok")) {
       const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine);
       entry.derivationComplete &&= authoritative.complete;
       if (authoritative.complete) entry.authoritativeTurn = authoritative.turn;

--- a/src/lib/scanner/model.ts
+++ b/src/lib/scanner/model.ts
@@ -34,6 +34,8 @@ function pickModel(entry: FileEntry, obj: Record<string, unknown>): string | nul
        no provider ever ran, and they are appended often enough to become the
        newest assistant record in an ordinary session. */
     return stringValue(openclawProviderAssistant(obj)?.model);
+  } else if (entry.root === "grok-sessions") {
+    return stringValue(obj.model_id);
   } else if (obj.type === "assistant") {
     const model = stringValue(recordValue(obj.message)?.model);
     if (model && model !== "<synthetic>") return model;
@@ -48,7 +50,7 @@ export function entryModelsResult(entry: FileEntry): EntryModelsResult {
     if (model) return { value: { display: shortModel(model), launch: model }, complete: true };
   }
   if (
-    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions")
+    (entry.root !== "claude-projects" && entry.root !== "codex-sessions" && entry.root !== "openclaw-sessions" && entry.root !== "grok-sessions")
     || !entry.path.endsWith(".jsonl")
   ) {
     return { value: { display: null, launch: null }, complete: true };

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -73,7 +73,7 @@ async function runObservation(signal?: AbortSignal): Promise<FileEntry[]> {
   await each(entries, (entry) => {
     const verdict = activityVerdict(entry.root, entry.path, entry.mtime, entry.size);
     entry.activity = verdict.state; entry.activityReason = verdict.reason; entry.derivationComplete = verdict.complete;
-    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw")) {
+    if (entry.path.endsWith(".jsonl") && (entry.engine === "claude" || entry.engine === "codex" || entry.engine === "openclaw" || entry.engine === "grok")) {
       const authoritative = transcriptTurnResult(entry.path, entry.size, entry.mtime * 1000, entry.engine);
       entry.derivationComplete &&= authoritative.complete;
       if (authoritative.complete) entry.authoritativeTurn = authoritative.turn;

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -133,8 +133,8 @@ function readState(): ProjectCatalogState {
       ) {
         continue;
       }
-      const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" || file.engine === "openclaw" ? file.engine : undefined;
-      const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" || file.fmt === "openclaw" ? file.fmt : undefined;
+      const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" || file.engine === "openclaw" || file.engine === "grok" ? file.engine : undefined;
+      const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" || file.fmt === "openclaw" || file.fmt === "grok" ? file.fmt : undefined;
       const cwd = typeof file.cwd === "string" ? file.cwd : file.cwd === null ? null : undefined;
       const sessionStartedAt = typeof file.sessionStartedAt === "string"
         ? file.sessionStartedAt

--- a/src/lib/scanner/roots.ts
+++ b/src/lib/scanner/roots.ts
@@ -70,6 +70,7 @@ export const ROOTS: Record<RootKey, string> = {
   /* Every OpenClaw scan root is a descendant of this one; the per-agent roots
      that discovery actually walks come from `openclawSessionRoots()`. */
   "openclaw-sessions": path.join(HOME, ".openclaw/agents"),
+  "grok-sessions": path.join(HOME, ".grok/sessions"),
 };
 
 /** Every scanner root, including all account homes, with real-path dedupe. */
@@ -79,6 +80,7 @@ export function scanRootEntries(): [RootKey, string][] {
     ...claudeProjectRoots().map((root): [RootKey, string] => ["claude-projects", root]),
     ["claude-tasks", ROOTS["claude-tasks"]],
     ...openclawSessionRoots().map((root): [RootKey, string] => ["openclaw-sessions", root]),
+    ["grok-sessions", path.resolve(process.env.LLV_GROK_HOME || path.join(os.homedir(), ".grok"), "sessions")],
   ];
   const seen = new Set<string>();
   return entries.filter(([, root]) => { const real = realpathSafe(root) ?? path.resolve(root); if (seen.has(real)) return false; seen.add(real); return true; });

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -106,13 +106,13 @@ function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
   const filesValid = value.files.every((candidate) => {
     if (!isRecord(candidate)) return false;
     return typeof candidate.path === "string"
-      && (candidate.root === "codex-sessions" || candidate.root === "claude-projects" || candidate.root === "claude-tasks" || candidate.root === "openclaw-sessions")
+      && (candidate.root === "codex-sessions" || candidate.root === "claude-projects" || candidate.root === "claude-tasks" || candidate.root === "openclaw-sessions" || candidate.root === "grok-sessions")
       && typeof candidate.name === "string"
       && typeof candidate.project === "string"
       && typeof candidate.title === "string"
-      && (candidate.engine === "codex" || candidate.engine === "claude" || candidate.engine === "shell" || candidate.engine === "openclaw")
+      && (candidate.engine === "codex" || candidate.engine === "claude" || candidate.engine === "shell" || candidate.engine === "openclaw" || candidate.engine === "grok")
       && typeof candidate.kind === "string"
-      && (candidate.fmt === "codex" || candidate.fmt === "claude" || candidate.fmt === "plain" || candidate.fmt === "openclaw")
+      && (candidate.fmt === "codex" || candidate.fmt === "claude" || candidate.fmt === "plain" || candidate.fmt === "openclaw" || candidate.fmt === "grok")
       && (candidate.parent === null || typeof candidate.parent === "string")
       && typeof candidate.mtime === "number" && Number.isFinite(candidate.mtime)
       && typeof candidate.size === "number" && Number.isFinite(candidate.size)
@@ -138,7 +138,7 @@ function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
 /* The primed evidence above is only meaningful for an engine whose transcript
    the turn reader parses; background-task output logs carry no turn. */
 function isTranscriptEngine(engine: Engine): engine is TranscriptEngine {
-  return engine === "claude" || engine === "codex" || engine === "openclaw";
+  return engine === "claude" || engine === "codex" || engine === "openclaw" || engine === "grok";
 }
 
 function persistedTurnState(entry: FileEntry): TurnState | undefined {

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -140,6 +140,32 @@ function openclawEvents(entry: FileEntry, actor: string, records: Record<string,
   return out;
 }
 
+function grokContent(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  return recs(value).map((part) => str(part.text)).join(" ").trim();
+}
+
+function grokEvents(entry: FileEntry, actor: string, records: Record<string, unknown>[]): ActionEvent[] {
+  const out: ActionEvent[] = [];
+  for (const obj of records) {
+    const ts = toTs(obj.timestamp);
+    if (ts === null) continue;
+    if (obj.type === "user") {
+      if (typeof obj.synthetic_reason === "string") continue;
+      const raw = grokContent(obj.content);
+      const query = raw.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+      const text = (query?.[1] ?? raw).trim();
+      if (text && !text.startsWith("<")) out.push({ ts, file: entry.path, actor, kind: "user", label: label(text) });
+      continue;
+    }
+    if (obj.type === "assistant") {
+      const text = grokContent(obj.content);
+      if (text) out.push({ ts, file: entry.path, actor, kind: "turn", label: label(text) });
+    }
+  }
+  return out;
+}
+
 function fileEvents(entry: FileEntry): ActionEvent[] {
   const mtimeMs = entry.mtime * 1000;
   const cached = eventCache.get(entry.path);
@@ -152,7 +178,9 @@ function fileEvents(entry: FileEntry): ActionEvent[] {
       ? codexEvents(entry, actor, tail.records)
       : entry.fmt === "openclaw"
         ? openclawEvents(entry, actor, tail.records)
-        : [];
+        : entry.fmt === "grok"
+          ? grokEvents(entry, actor, tail.records)
+          : [];
   if (tail.complete) eventCache.set(entry.path, [entry.size, mtimeMs, events]);
   return events;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,17 +9,18 @@ export type RootKey =
   | "codex-sessions"
   | "claude-projects"
   | "claude-tasks"
-  | "openclaw-sessions";
+  | "openclaw-sessions"
+  | "grok-sessions";
 
-export type Engine = "codex" | "claude" | "shell" | "openclaw";
+export type Engine = "codex" | "claude" | "shell" | "openclaw" | "grok";
 export type Activity = "live" | "recent" | "stalled" | "idle";
-export type Fmt = "codex" | "claude" | "plain" | "openclaw";
+export type Fmt = "codex" | "claude" | "plain" | "openclaw" | "grok";
 
 /** The engines that write a structured transcript the Viewer parses — every
     `Engine` except `"shell"`, whose background tasks are plain output logs.
     Named once so the readers that must switch on the dialect (title and search
     text, turn state, model, effort, the feed) all agree on the same set. */
-export type TranscriptEngine = Extract<Engine, "codex" | "claude" | "openclaw">;
+export type TranscriptEngine = Extract<Engine, "codex" | "claude" | "openclaw" | "grok">;
 
 declare const epochSecondsBrand: unique symbol;
 /**

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -58,7 +58,7 @@ function validateExplicitMembership(session: StoredViewSession, explicit: readon
     `SnapshotConversation` without a cast: a widened filter over a cast field is
     exactly how an OpenClaw entry would have been published as Claude. */
 function isTranscriptEntry(entry: FileEntry | undefined): entry is FileEntry & { engine: TranscriptEngine } {
-  return entry?.engine === "claude" || entry?.engine === "codex" || entry?.engine === "openclaw";
+  return entry?.engine === "claude" || entry?.engine === "codex" || entry?.engine === "openclaw" || entry?.engine === "grok";
 }
 
 function transcriptEntry(

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -110,6 +110,8 @@
   --color-claude-soft: #faeee9;
   --color-openclaw: #b3407a;
   --color-openclaw-soft: #fbeaf3;
+  --color-grok: #3d5a80;
+  --color-grok-soft: #e8eef4;
 
   /* ── §1.6 Motion ───────────────────────────────────────────────────────── */
   --motion-fast: 120ms; /* hover, press, chip state         */
@@ -191,6 +193,8 @@
     --color-claude-soft: #2b1c15;
     --color-openclaw: #e888b6;
     --color-openclaw-soft: #2e1622;
+    --color-grok: #8aa4c4;
+    --color-grok-soft: #1a2430;
 
     --color-user: #2a2a33;
 
@@ -248,6 +252,8 @@
   --color-claude-soft: #2b1c15;
   --color-openclaw: #e888b6;
   --color-openclaw-soft: #2e1622;
+  --color-grok: #8aa4c4;
+  --color-grok-soft: #1a2430;
 
   --color-user: #2a2a33;
 


### PR DESCRIPTION
Grok sessions were scanned as OpenClaw under a dummy project. This branch makes Grok a first-class Viewer engine:

- engine identity `grok` (not OpenClaw)
- group sessions by working directory
- titles from `summary.json`
- signed-in footer row
- `POST /api/spawn` with `engine: grok` (tmux; no structured host yet)

Fresh and resume launches use the Grok CLI. Structured composer/interrupt/kill is not included.