### PR TITLE
fix(accounts): give the Claude login identity fence a darwin implementation (#1256)

### DIFF
--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -1,0 +1,57 @@
+name: macOS process identity
+
+# The Claude login fence proves a spawned pid's identity before adopting it.
+# On Linux it reads /proc; on macOS it reads the kernel through libproc and
+# sysctl, and no maintainer here has a Mac. Issue #1256 shipped precisely
+# because that half was never executed anywhere — this job is where it runs.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  darwin-identity:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The darwin-only tests below skip themselves off darwin, and a silent
+      # skip would leave this job green while proving nothing. This step fails
+      # loudly instead when the runner is not a Mac or the FFI readers cannot
+      # reach the kernel at all.
+      - name: Require live kernel readers on this runner
+        run: |
+          bun -e '
+          const { darwinProcessArgv } = await import("./src/lib/proc/darwinArgv.ts");
+          const { darwinProcessIdentity } = await import("./src/lib/proc/darwinIdentity.ts");
+
+          if (process.platform !== "darwin") throw new Error(`expected a darwin runner, got ${process.platform}`);
+          const argv = darwinProcessArgv(process.pid);
+          const token = darwinProcessIdentity(process.pid);
+          if (!argv || argv.length === 0) throw new Error("KERN_PROCARGS2 argv reader returned nothing for this process");
+          if (!token) throw new Error("proc_pidinfo identity reader returned nothing for this process");
+          console.log(`argv entries: ${argv.length}, identity token fields: ${token.split(":").length}`);
+          '
+
+      - name: Verify the identity fence against the real macOS kernel
+        run: >
+          bun test
+          src/lib/proc/darwinArgv.test.ts
+          src/lib/proc/darwinIdentity.test.ts
+          src/lib/proc/portable.test.ts
+          src/lib/accounts/claudeLogin.test.ts
+          src/lib/accounts/claudeLoginIdentity.test.ts

--- a/src/lib/accounts/claudeLogin.ts
+++ b/src/lib/accounts/claudeLogin.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 
 import { resolveBinary } from "@/lib/agent/cli";
 import { statePath } from "@/lib/configDir";
+import { darwinProcessArgv } from "@/lib/proc/darwinArgv";
+import { darwinProcessIdentity } from "@/lib/proc/darwinIdentity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 import { AccountMutationBusyError, withAccountMutationLock, withAccountMutationLockAsync } from "./accountMutation";
 
@@ -69,14 +71,23 @@ function procStartToken(pid: number): string | null {
   try { return fs.readFileSync(`/proc/${pid}/stat`, "utf8").split(" ")[21] ?? null; } catch { return null; }
 }
 
-async function waitForProcessExit(pid: number, startToken: string): Promise<void> {
-  while (procStartToken(pid) === startToken) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 25));
-  }
+function exitPoller(startTokenOf: (pid: number) => string | null) {
+  return async function waitForProcessExit(pid: number, startToken: string): Promise<void> {
+    while (startTokenOf(pid) === startToken) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    }
+  };
 }
 
 export function isExpectedClaudeLoginCommand(commandLine: string): boolean {
-  const args = commandLine.split("\0").filter(Boolean);
+  return isExpectedClaudeLoginArgv(commandLine.split("\0"));
+}
+
+/** The command half of the fence, over an argument vector: Linux splits
+    /proc/<pid>/cmdline on NUL to get one, macOS reads the kernel's exec-time
+    copy. Both platforms match the same three shapes here. */
+export function isExpectedClaudeLoginArgv(argv: readonly string[]): boolean {
+  const args = argv.filter(Boolean);
   const direct = /(?:^|\/)claude$/.test(args[0] ?? "") && args.length === 4;
   const wrapped = /(?:^|\/)(?:node|bun)$/.test(args[0] ?? "") && /claude/i.test(args[1] ?? "") && args.length === 5;
   /* Inside the Docker runtime `claude` is the nsenter shim — a /bin/sh script —
@@ -90,6 +101,87 @@ export function isExpectedClaudeLoginCommand(commandLine: string): boolean {
 
 function expectedClaude(pid: number): boolean {
   try { return isExpectedClaudeLoginCommand(fs.readFileSync(`/proc/${pid}/cmdline`, "utf8")); } catch { return false; }
+}
+
+/** The two facts the fence needs about a pid: the kernel start token that
+    pins this exact process instance, and the command it is running. */
+export interface ProcessIdentityReaders {
+  startToken(pid: number): string | null;
+  argv(pid: number): readonly string[] | null;
+}
+
+type IdentityPorts = Pick<ClaudeLoginPorts, "pidStartToken" | "isExpectedClaude" | "waitForExit">;
+
+/* macOS has no /proc, so the same two facts come from the kernel directly:
+   proc_pidinfo(PROC_PIDTBSDINFO) for a pid-plus-start-time token, and
+   sysctl(KERN_PROCARGS2) for the exec-time argv. Neither is a relaxation —
+   an unproven pid is still refused adoption and is still never signalled by
+   number. Both readers need the FFI available under Bun, which
+   assertDarwinStructuredRuntime already requires of a macOS server. */
+const darwinIdentityReaders: ProcessIdentityReaders = {
+  startToken: darwinProcessIdentity,
+  argv: darwinProcessArgv,
+};
+
+/* posix_spawn hands back a pid before the child's exec has completed, so a
+   macOS fence read can land while that pid is still the forking viewer — argv
+   reads back as this process's own command line, or briefly not at all while
+   the kernel swaps the image. Reading through that window is not a
+   relaxation: adoption still requires seeing the login command, and every
+   other answer (a stranger's argv, a pid that is gone) is returned at once.
+   Linux never lands here — the spawn returns only after the exec status pipe
+   reports success — which is why the /proc reads never needed this. */
+/* One second is far past any observed exec latency and is only ever spent on
+   a pid that is alive but has not shown its command; a busy machine must not
+   turn that into a refused login. */
+const EXEC_WINDOW_MS = 1_000;
+const EXEC_POLL_MS = 2;
+
+const execWindowLatch = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepThrough(ms: number): void {
+  try { Atomics.wait(execWindowLatch, 0, 0, ms); }
+  catch { const until = Date.now() + ms; while (Date.now() < until) { /* runtime forbids a blocking wait here */ } }
+}
+
+function sameArguments(left: readonly string[], right: readonly string[] | null): boolean {
+  return right !== null && left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+/** The command of `pid` once that pid is running its own image: this process
+    is never the login it spawned, a command that is neither absent nor ours
+    is already the child's, and a pid with no start token has exited. */
+function executedArgv(pid: number, readers: ProcessIdentityReaders): readonly string[] | null {
+  if (pid === process.pid) return readers.argv(pid);
+  const forking = readers.argv(process.pid);
+  const deadline = Date.now() + EXEC_WINDOW_MS;
+  for (;;) {
+    const argv = readers.argv(pid);
+    if (argv !== null && !sameArguments(argv, forking)) return argv;
+    if (argv === null && readers.startToken(pid) === null) return null;
+    if (Date.now() >= deadline) return argv;
+    sleepThrough(EXEC_POLL_MS);
+  }
+}
+
+function identityPortsFrom(readers: ProcessIdentityReaders): IdentityPorts {
+  return {
+    pidStartToken: readers.startToken,
+    isExpectedClaude: (pid) => {
+      const argv = executedArgv(pid, readers);
+      return argv !== null && isExpectedClaudeLoginArgv(argv);
+    },
+    waitForExit: exitPoller(readers.startToken),
+  };
+}
+
+/** Linux keeps its /proc reads verbatim; darwin gets the kernel-backed pair.
+    `darwin` is injectable so the macOS branch can be exercised from a host
+    that has no macOS kernel to read. */
+export function processIdentityPorts(platform: NodeJS.Platform = process.platform, darwin: ProcessIdentityReaders = darwinIdentityReaders): IdentityPorts {
+  return platform === "darwin"
+    ? identityPortsFrom(darwin)
+    : { pidStartToken: procStartToken, isExpectedClaude: expectedClaude, waitForExit: exitPoller(procStartToken) };
 }
 
 /** A recognized Claude home is either a safe managed home or the exact legacy
@@ -129,9 +221,7 @@ async function structuredStatus(home: string): Promise<{ loggedIn: boolean; meth
 export const realClaudeLoginPorts: ClaudeLoginPorts = {
   spawn: (command, args, options) => spawn(command, args, options) as LoginChild,
   kill: (pid, signal) => { try { process.kill(-pid, signal); } catch { try { process.kill(pid, signal); } catch { /* process already exited */ } } },
-  pidStartToken: procStartToken,
-  isExpectedClaude: expectedClaude,
-  waitForExit: waitForProcessExit,
+  ...processIdentityPorts(),
   status: structuredStatus,
   now: Date.now,
   setTimeout,

--- a/src/lib/accounts/claudeLoginIdentity.test.ts
+++ b/src/lib/accounts/claudeLoginIdentity.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-login-identity-test-"));
+const OLD_STATE = process.env.LLV_STATE_DIR; const OLD_HOME = process.env.LLV_CLAUDE_HOME;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state"); process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy");
+const { createManagedClaudeAccount } = await import("./claude");
+const { ClaudeLoginSupervisor, isExpectedClaudeLoginArgv, processIdentityPorts } = await import("./claudeLogin");
+type ClaudeLoginPorts = import("./claudeLogin").ClaudeLoginPorts;
+type LoginChild = import("./claudeLogin").LoginChild;
+type ProcessIdentityReaders = import("./claudeLogin").ProcessIdentityReaders;
+
+const LOGIN_PID = 4242;
+/* What the macOS kernel reports for a login the supervisor just spawned: the
+   Homebrew `claude` is a shell wrapper, so argv[0] is the interpreter. */
+const LOGIN_ARGV = ["/bin/sh", "/opt/homebrew/bin/claude", "auth", "login", "--claudeai"];
+const LOGIN_TOKEN = `${LOGIN_PID}:1721234567:012345`;
+
+class FakeChild extends EventEmitter {
+  pid = LOGIN_PID;
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  writes: string[] = [];
+  handleSignals: string[] = [];
+  stdin = { write: (text: string) => { this.writes.push(text); return true; }, end: () => undefined };
+  kill(signal?: string) { this.handleSignals.push(signal ?? "SIGTERM"); return true; }
+}
+
+let child: FakeChild; let signals: string[];
+
+/** Every port except the identity trio, which each test supplies. */
+function ports(): Omit<ClaudeLoginPorts, "pidStartToken" | "isExpectedClaude" | "waitForExit"> {
+  return {
+    spawn: () => child as never,
+    kill: (_pid, signal) => { signals.push(signal); },
+    status: async () => ({ loggedIn: true, method: "oauth", email: "person@example.com", plan: "max" }),
+    now: () => 1_000,
+    setTimeout: (fn, ms) => { if (ms <= 2_000) fn(); return {} as NodeJS.Timeout; },
+    clearTimeout: () => undefined,
+  };
+}
+
+/** A macOS host as the fence sees it: pid → kernel start token and argv. */
+function darwinKernel(table: Map<number, { token: string | null; argv: string[] | null }>): ProcessIdentityReaders {
+  return {
+    startToken: (pid) => table.get(pid)?.token ?? null,
+    argv: (pid) => table.get(pid)?.argv ?? null,
+  };
+}
+
+function loginTable(): Map<number, { token: string | null; argv: string[] | null }> {
+  return new Map([[LOGIN_PID, { token: LOGIN_TOKEN, argv: LOGIN_ARGV }]]);
+}
+
+beforeEach(() => {
+  fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+  child = new FakeChild();
+  signals = [];
+});
+
+afterAll(() => {
+  if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE;
+  if (OLD_HOME === undefined) delete process.env.LLV_CLAUDE_HOME; else process.env.LLV_CLAUDE_HOME = OLD_HOME;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+test("every macOS argv shape reaches the same command matcher the Linux command line uses", () => {
+  expect(isExpectedClaudeLoginArgv(["/opt/homebrew/bin/claude", "auth", "login", "--claudeai"])).toBe(true);
+  expect(isExpectedClaudeLoginArgv(["/opt/homebrew/bin/node", "/opt/claude/cli.js", "auth", "login", "--claudeai"])).toBe(true);
+  expect(isExpectedClaudeLoginArgv(LOGIN_ARGV)).toBe(true);
+  expect(isExpectedClaudeLoginArgv(["/opt/homebrew/bin/claude", "auth", "status", "--json"])).toBe(false);
+  expect(isExpectedClaudeLoginArgv(["/bin/sh", "-c", "claude auth login --claudeai"])).toBe(false);
+  expect(isExpectedClaudeLoginArgv(["/usr/bin/vim", "notes.txt"])).toBe(false);
+  expect(isExpectedClaudeLoginArgv([])).toBe(false);
+});
+
+test("on macOS the kernel readers fence a real login child in, where /proc rejected it (issue #1256)", () => {
+  const account = createManagedClaudeAccount("Darwin adopted");
+  const identity = processIdentityPorts("darwin", darwinKernel(loginTable()));
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...identity });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+  expect(identity.pidStartToken(LOGIN_PID)).toBe(LOGIN_TOKEN);
+  expect(child.handleSignals).toEqual([]);
+});
+
+test("on macOS a pid running something else is refused and never signalled by number", () => {
+  const account = createManagedClaudeAccount("Darwin recycled pid");
+  const recycled = new Map([[LOGIN_PID, { token: LOGIN_TOKEN, argv: ["/usr/bin/vim", "notes.txt"] }]]);
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...processIdentityPorts("darwin", darwinKernel(recycled)) });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "failed", result: expect.objectContaining({ code: "launch_unfenced" }) }));
+  expect(child.writes).toEqual([]);
+  // The stranger's pid is killed through the child handle only: signalling it
+  // by number is exactly what the fence exists to prevent.
+  expect(child.handleSignals).toEqual(["SIGKILL"]);
+  expect(signals).toEqual([]);
+});
+
+test("on macOS a pid the kernel does not attribute to this login is refused", () => {
+  const account = createManagedClaudeAccount("Darwin unattributed");
+  // proc_pidinfo answered for a different pid, or the process was already gone.
+  const unknown = new Map([[LOGIN_PID, { token: null, argv: LOGIN_ARGV }]]);
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...processIdentityPorts("darwin", darwinKernel(unknown)) });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "failed", result: expect.objectContaining({ code: "launch_unfenced" }) }));
+  expect(signals).toEqual([]);
+});
+
+test("on macOS a login pid recycled after adoption is never signalled", async () => {
+  const account = createManagedClaudeAccount("Darwin recycled after adoption");
+  const table = loginTable();
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...processIdentityPorts("darwin", darwinKernel(table)) });
+  const operation = supervisor.start(account.id);
+  expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+
+  // The login exited and the kernel handed its number to an unrelated process:
+  // same pid, different start token, different command.
+  table.set(LOGIN_PID, { token: `${LOGIN_PID}:1721299999:000001`, argv: ["/usr/bin/vim", "notes.txt"] });
+  const canceled = await supervisor.cancel(operation.operationId);
+
+  expect(canceled).toEqual(expect.objectContaining({ phase: "canceled" }));
+  expect(signals).toEqual([]);
+});
+
+test("on macOS a child read before its exec completes is adopted once the login appears", () => {
+  const account = createManagedClaudeAccount("Darwin pre-exec");
+  // posix_spawn returned the pid while it was still a fork of this process:
+  // the first reads answer with the viewer's own argv, then the exec lands.
+  const viewerArgv = ["/opt/homebrew/bin/bun", "server.js"];
+  let reads = 0;
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...processIdentityPorts("darwin", {
+    startToken: (pid) => (pid === LOGIN_PID ? LOGIN_TOKEN : null),
+    argv: (pid) => (pid !== LOGIN_PID ? viewerArgv : (reads++ < 3 ? viewerArgv : LOGIN_ARGV)),
+  }) });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+  expect(reads).toBeGreaterThan(3);
+});
+
+test("on macOS a pid whose command never becomes the login is refused when the window closes", () => {
+  const account = createManagedClaudeAccount("Darwin never execs");
+  const viewerArgv = ["/opt/homebrew/bin/bun", "server.js"];
+  const supervisor = new ClaudeLoginSupervisor({ ...ports(), ...processIdentityPorts("darwin", {
+    startToken: (pid) => (pid === LOGIN_PID ? LOGIN_TOKEN : null),
+    argv: () => viewerArgv,
+  }) });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "failed", result: expect.objectContaining({ code: "launch_unfenced" }) }));
+  expect(signals).toEqual([]);
+});
+
+test("on macOS a live pid with an unreadable command is refused, and a dead one immediately", () => {
+  const unreadable = processIdentityPorts("darwin", { startToken: () => LOGIN_TOKEN, argv: () => null });
+  const gone = processIdentityPorts("darwin", { startToken: () => null, argv: () => null });
+
+  const startedAt = Date.now();
+  expect(gone.isExpectedClaude(LOGIN_PID)).toBe(false);
+  const goneTook = Date.now() - startedAt;
+  expect(unreadable.isExpectedClaude(LOGIN_PID)).toBe(false);
+
+  // A pid the kernel no longer knows is decided at once; only a live process
+  // whose command has not appeared yet is worth waiting for.
+  expect(goneTook).toBeLessThan(50);
+});
+
+test.skipIf(process.platform === "darwin")("the darwin branch reads the kernel and never falls back to /proc", () => {
+  const identity = processIdentityPorts("darwin");
+
+  // This host has a live pid and a /proc to read it from; the darwin readers
+  // must still answer "unidentified" rather than borrowing the Linux source.
+  expect(identity.pidStartToken(process.pid)).toBeNull();
+  expect(identity.isExpectedClaude(process.pid)).toBe(false);
+});
+
+test.skipIf(process.platform !== "linux")("the Linux branch keeps reading /proc exactly as before", () => {
+  const identity = processIdentityPorts("linux");
+  const stat = fs.readFileSync(`/proc/${process.pid}/stat`, "utf8").split(" ")[21];
+
+  expect(identity.pidStartToken(process.pid)).toBe(stat!);
+  expect(identity.isExpectedClaude(process.pid)).toBe(false);
+  expect(identity.pidStartToken(2 ** 31 - 1)).toBeNull();
+});
+
+test.skipIf(process.platform !== "darwin")("on macOS a real spawned login clears the real fence and a foreign pid does not", async () => {
+  const account = createManagedClaudeAccount("Darwin real login");
+  const directory = fs.mkdtempSync(path.join(SANDBOX, "shim-"));
+  const shim = path.join(directory, "claude");
+  // A wrapper script, like every macOS `claude` install: reads stdin forever,
+  // so the fence sees a live child exactly as the real login would be.
+  fs.writeFileSync(shim, "#!/bin/sh\nwhile read -r _line; do :; done\n", { mode: 0o755 });
+  const identity = processIdentityPorts();
+  const spawned: Array<{ pid?: number; kill(signal?: NodeJS.Signals): boolean }> = [];
+  const supervisor = new ClaudeLoginSupervisor({
+    ...ports(),
+    ...identity,
+    kill: (pid, signal) => { signals.push(signal); try { process.kill(-pid, signal); } catch { /* already gone */ } },
+    spawn: (_command, args, options) => {
+      const real = spawn(shim, args, options);
+      spawned.push(real);
+      return real as unknown as LoginChild;
+    },
+  });
+
+  const operation = supervisor.start(account.id);
+  const pid = spawned[0]?.pid ?? 0;
+  try {
+    expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+    expect(pid).toBeGreaterThan(0);
+    const token = identity.pidStartToken(pid) ?? "";
+    expect(token).toMatch(new RegExp(`^${pid}:\\d+:\\d{6}$`));
+    expect(identity.isExpectedClaude(pid)).toBe(true);
+    // Still a fence: this test process is alive and is not that login.
+    expect(identity.isExpectedClaude(process.pid)).toBe(false);
+    expect(identity.pidStartToken(process.pid)).not.toBe(token);
+
+    const canceled = await supervisor.cancel(operation.operationId);
+    expect(canceled).toEqual(expect.objectContaining({ phase: "canceled" }));
+    expect(signals).toContain("SIGTERM");
+    await identity.waitForExit(pid, token);
+    expect(identity.isExpectedClaude(pid)).toBe(false);
+  } finally {
+    for (const real of spawned) { try { real.kill("SIGKILL"); } catch { /* already gone */ } }
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/proc/darwinArgv.test.ts
+++ b/src/lib/proc/darwinArgv.test.ts
@@ -1,0 +1,100 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+import { darwinProcessArgv, parseDarwinProcArgs2 } from "./darwinArgv";
+
+/** One KERN_PROCARGS2 record as the macOS kernel lays it out: argc, the
+    executable path, NUL padding to alignment, then the argument strings and
+    the environment behind them. */
+function procArgs2Record(argc: number, execPath: string, args: string[], environment: string[] = [], padding = 3): Buffer {
+  const head = Buffer.alloc(4);
+  head.writeInt32LE(argc, 0);
+  return Buffer.concat([
+    head,
+    Buffer.from(`${execPath}\0`, "utf8"),
+    Buffer.alloc(padding),
+    ...[...args, ...environment].map((entry) => Buffer.from(`${entry}\0`, "utf8")),
+  ]);
+}
+
+test("a kernel argument record yields argv alone, past the executable path and short of the environment", () => {
+  const record = procArgs2Record(5, "/bin/sh", ["/opt/homebrew/bin/claude", "auth", "login", "--claudeai", "extra-because-argc-says-so"], ["HOME=/Users/user", "PATH=/usr/bin"]);
+
+  expect(parseDarwinProcArgs2(record, record.byteLength))
+    .toEqual(["/opt/homebrew/bin/claude", "auth", "login", "--claudeai", "extra-because-argc-says-so"]);
+});
+
+test("an argument containing spaces survives the read that `ps` output cannot express", () => {
+  const record = procArgs2Record(2, "/usr/bin/env", ["/Users/user/Application Support/claude", "auth login"]);
+
+  expect(parseDarwinProcArgs2(record, record.byteLength))
+    .toEqual(["/Users/user/Application Support/claude", "auth login"]);
+});
+
+test("a record the kernel could not write in full is refused rather than half-read", () => {
+  const record = procArgs2Record(4, "/usr/local/bin/claude", ["/usr/local/bin/claude", "auth", "login", "--claudeai"]);
+
+  // Whole record: four arguments. Cut short: no argv at all, never a prefix.
+  expect(parseDarwinProcArgs2(record, record.byteLength)).toHaveLength(4);
+  expect(parseDarwinProcArgs2(record, record.byteLength - 3)).toBeNull();
+  expect(parseDarwinProcArgs2(record, 4)).toBeNull();
+  expect(parseDarwinProcArgs2(record, 2)).toBeNull();
+  expect(parseDarwinProcArgs2(record, record.byteLength + 1)).toBeNull();
+});
+
+test("a record with an impossible argument count is refused", () => {
+  const args = ["/usr/local/bin/claude", "auth", "login", "--claudeai"];
+  const withCount = (argc: number) => {
+    const record = procArgs2Record(argc, "/usr/local/bin/claude", args);
+    return parseDarwinProcArgs2(record, record.byteLength);
+  };
+
+  expect(withCount(0)).toBeNull();
+  expect(withCount(-1)).toBeNull();
+  expect(withCount(9_999)).toBeNull();
+
+  // argc promises more arguments than the record carries.
+  const short = procArgs2Record(6, "/usr/local/bin/claude", args);
+  expect(parseDarwinProcArgs2(short, short.byteLength)).toBeNull();
+});
+
+test("a record without a terminated executable path is refused", () => {
+  const head = Buffer.alloc(4);
+  head.writeInt32LE(1, 0);
+  const record = Buffer.concat([head, Buffer.from("/usr/local/bin/claude", "utf8")]);
+
+  expect(parseDarwinProcArgs2(record, record.byteLength)).toBeNull();
+});
+
+test("the reader answers null for a pid it cannot identify, and never guesses", () => {
+  expect(darwinProcessArgv(0)).toBeNull();
+  expect(darwinProcessArgv(-1)).toBeNull();
+  expect(darwinProcessArgv(1.5)).toBeNull();
+  // Off darwin there is no kernel record to read: the reader stays closed
+  // rather than reaching for /proc or `ps`.
+  if (process.platform !== "darwin") expect(darwinProcessArgv(process.pid)).toBeNull();
+});
+
+test.skipIf(process.platform !== "darwin")("on macOS the reader returns the exec-time argv of a live child", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-darwin-argv-"));
+  const script = path.join(directory, "sleeper");
+  fs.writeFileSync(script, "#!/bin/sh\nwhile read -r _line; do :; done\n", { mode: 0o755 });
+  const child = spawn(script, ["first argument", "second"], { stdio: ["pipe", "ignore", "ignore"] });
+  const pid = child.pid ?? 0;
+  try {
+    expect(pid).toBeGreaterThan(0);
+    // A #! script execs its interpreter, so argv[0] is the shell and argv[1]
+    // the script — the same rewriting the Linux fence already matches.
+    expect(darwinProcessArgv(pid)).toEqual(["/bin/sh", script, "first argument", "second"]);
+    expect(darwinProcessArgv(process.pid)).not.toEqual(darwinProcessArgv(pid));
+  } finally {
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+
+  expect(darwinProcessArgv(pid)).toBeNull();
+});

--- a/src/lib/proc/darwinArgv.ts
+++ b/src/lib/proc/darwinArgv.ts
@@ -1,0 +1,144 @@
+import { createRequire } from "node:module";
+
+/**
+ * macOS counterpart of `/proc/<pid>/cmdline`. The kernel keeps the exec-time
+ * argument vector of every process and hands it back through
+ * `sysctl(KERN_PROCARGS2)`, in this layout:
+ *
+ *   int argc | executable path (NUL-terminated) | NUL padding |
+ *   argc NUL-terminated argv strings | environment strings
+ *
+ * so the argv this returns is NUL-exact, exactly like the Linux read it
+ * mirrors. It deliberately does not go through `ps`: that column is argv
+ * already joined by spaces, which cannot be split back without guessing, and
+ * the portable backend's `ps` snapshot is up to 5s stale — useless for a pid
+ * that was spawned milliseconds ago.
+ *
+ * Reading another process's arguments this way requires the same real uid,
+ * which holds for the children this viewer spawns itself.
+ */
+
+const CTL_KERN = 1;
+const KERN_ARGMAX = 8;
+const KERN_PROCARGS2 = 49;
+const ARGC_SIZE = 4;
+/** Fallback when `kern.argmax` cannot be read; it has been 1 MiB on macOS for
+    as long as the sysctl has existed. */
+const DEFAULT_ARG_MAX = 1024 * 1024;
+/* A host that lowered `kern.argmax` must be believed, not rounded up: the
+   kernel refuses a request larger than the value it reports. */
+const MIN_ARG_MAX = 4 * 1024;
+const MAX_ARG_MAX = 32 * 1024 * 1024;
+/** The fence matches argv of four or five entries; the cap only keeps a
+    corrupt argc from driving a long parse loop. */
+const MAX_ARGC = 4096;
+
+type ProcArgsReader = (pid: number, buffer: Buffer) => number;
+
+interface BunFfiModule {
+  FFIType: { i32: number; u32: number; u64: number; ptr: number };
+  ptr(buffer: Buffer): unknown;
+  dlopen(path: string, symbols: Record<string, unknown>): {
+    symbols: { sysctl: (...args: unknown[]) => number };
+  };
+}
+
+let cachedReader: ProcArgsReader | null | undefined;
+let cachedBuffer: Buffer | null = null;
+
+/** Splits one KERN_PROCARGS2 record into its argv. `bytesRead` is what the
+    kernel actually wrote: everything past it is stale or absent, so a record
+    that ends early yields null rather than a half-read command line. */
+export function parseDarwinProcArgs2(buffer: Buffer, bytesRead: number): string[] | null {
+  if (bytesRead < ARGC_SIZE || bytesRead > buffer.byteLength) return null;
+  const argc = buffer.readInt32LE(0);
+  if (argc <= 0 || argc > MAX_ARGC) return null;
+
+  let cursor = buffer.indexOf(0, ARGC_SIZE);
+  if (cursor < 0 || cursor >= bytesRead) return null;
+  while (cursor < bytesRead && buffer[cursor] === 0) cursor += 1;
+
+  const argv: string[] = [];
+  while (argv.length < argc) {
+    const end = buffer.indexOf(0, cursor);
+    if (end < 0 || end >= bytesRead) return null;
+    argv.push(buffer.toString("utf8", cursor, end));
+    cursor = end + 1;
+  }
+  return argv;
+}
+
+function loadReader(): ProcArgsReader | null {
+  if (cachedReader !== undefined) return cachedReader;
+  if (process.platform !== "darwin") {
+    cachedReader = null;
+    return cachedReader;
+  }
+  try {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const library = ffi.dlopen("/usr/lib/libSystem.B.dylib", {
+      sysctl: {
+        args: [ffi.FFIType.ptr, ffi.FFIType.u32, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.u64],
+        returns: ffi.FFIType.i32,
+      },
+    });
+    /* `newp` is ignored while `newlen` is 0, and passing a real (unused)
+       buffer keeps every pointer argument a valid one. */
+    const unusedNew = Buffer.alloc(8);
+    const call = (mib: Buffer, out: Buffer, outLength: Buffer): number => Number(library.symbols.sysctl(
+      ffi.ptr(mib),
+      mib.byteLength / 4,
+      ffi.ptr(out),
+      ffi.ptr(outLength),
+      ffi.ptr(unusedNew),
+      BigInt(0),
+    ));
+    cachedReader = (pid, buffer) => {
+      const mib = Buffer.alloc(12);
+      mib.writeInt32LE(CTL_KERN, 0);
+      mib.writeInt32LE(KERN_PROCARGS2, 4);
+      mib.writeInt32LE(pid, 8);
+      const length = Buffer.alloc(8);
+      length.writeBigUInt64LE(BigInt(buffer.byteLength));
+      if (call(mib, buffer, length) !== 0) return -1;
+      const written = Number(length.readBigUInt64LE());
+      return Number.isSafeInteger(written) ? written : -1;
+    };
+    cachedBuffer = Buffer.alloc(readArgMax(call));
+  } catch {
+    cachedReader = null;
+  }
+  return cachedReader;
+}
+
+/** The buffer has to be exactly `kern.argmax`, which is both the most the
+    record can need (it bounds argv and environment at exec time) and the most
+    the kernel will accept: asking KERN_PROCARGS2 for more bytes than that
+    fails outright, which the fence would read as an unidentifiable process.
+    Reading the live value keeps both halves true on a host that changed it. */
+function readArgMax(call: (mib: Buffer, out: Buffer, outLength: Buffer) => number): number {
+  const mib = Buffer.alloc(8);
+  mib.writeInt32LE(CTL_KERN, 0);
+  mib.writeInt32LE(KERN_ARGMAX, 4);
+  const value = Buffer.alloc(4);
+  const length = Buffer.alloc(8);
+  length.writeBigUInt64LE(BigInt(value.byteLength));
+  if (call(mib, value, length) !== 0) return DEFAULT_ARG_MAX;
+  const argMax = value.readInt32LE(0);
+  return argMax >= MIN_ARG_MAX && argMax <= MAX_ARG_MAX ? argMax : DEFAULT_ARG_MAX;
+}
+
+/** Exec-time argv of a live process, or null when it cannot be read — a gone
+    or foreign pid, a non-darwin host, or a runtime without the FFI reader. */
+export function darwinProcessArgv(pid: number): string[] | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const reader = loadReader();
+  const buffer = cachedBuffer;
+  if (!reader || !buffer) return null;
+  try {
+    return parseDarwinProcArgs2(buffer, reader(pid, buffer));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #1256

## The defect

`POST /api/accounts/claude` answered `503 launch_unfenced` on every macOS attempt: the account was removed again and the `claude auth login --claudeai` child that had just been spawned was SIGKILLed. Both ports behind the fence read `/proc` and fail closed —

- `procStartToken(pid)` reads `/proc/<pid>/stat`, `null` on any throw;
- `expectedClaude(pid)` reads `/proc/<pid>/cmdline`, `false` on any throw —

so on a platform with no `/proc` a correct child was refused every time.

## The fix, and what it does not do

The fence exists so a reused pid can never be signalled by number, and it is not relaxed anywhere here. macOS proves the same two facts about the pid, read from the kernel instead of `/proc`:

- **start token** — the existing `darwinIdentity` reader (`proc_pidinfo` / `PROC_PIDTBSDINFO`, `pid:seconds:microseconds`), which already refuses a record whose pid does not match the one asked for. It was written for this and simply was not wired in.
- **command** — a new `sysctl(KERN_PROCARGS2)` reader (`src/lib/proc/darwinArgv.ts`), the macOS counterpart of `/proc/<pid>/cmdline`. The record is `argc | executable path | NUL padding | argv | environment`, so the argv it returns is NUL-exact, and a record the kernel could not write in full yields nothing rather than a prefix.

The argv goes through `isExpectedClaudeLoginCommand`'s own matcher rather than a second parse: that function now delegates to `isExpectedClaudeLoginArgv(argv)`, and the NUL-split command-line form is one caller of it. The three shapes it already knows (direct, `node`/`bun`-wrapped, `#!` shim) are exactly the shapes macOS produces, since a `#!` exec rewrites argv the same way there.

`ps` is deliberately not the source: its `args` column is argv already joined by spaces and cannot be split back without guessing, and the portable backend's snapshot of it is up to 5s stale — it says nothing about a pid spawned milliseconds ago.

A pid that fails either half is still refused adoption and still killed through the child handle only, never `ports.kill(pid)`.

## Two things only a real kernel could say

Both were found by the CI job below, after the code looked right:

1. **`KERN_PROCARGS2` refuses a request larger than `kern.argmax`.** The first version allocated `argmax + 8 KiB` of slack and every read failed. The buffer is now sized to exactly the value the kernel reports (`1048576` on the runner), and a host that lowered `kern.argmax` is believed rather than rounded up.
2. **`posix_spawn` returns a pid before that child has finished exec'ing.** A fence read can land while the pid is still a fork of the viewer: argv reads back as this process's own command line, or briefly not at all while the kernel swaps the image. The darwin read waits out that window — bounded at one second, polling — and still adopts only after it has seen the login command; a stranger's argv or a pid that is gone is answered at once, so no rejection path pays for it. Linux never lands here: its spawn returns only once the exec status pipe reports success, which is why the `/proc` reads never needed this.

The second one is why this fix could not have been finished without a Mac in the loop. It failed intermittently in exactly the way the original bug did.

## Scope

- The Linux reads are untouched, and a test pins `processIdentityPorts("linux")` to the exact `/proc/<pid>/stat` field it read before.
- The exit poller is now built from whichever start-token reader the platform selected. Without that, `waitForExit` on macOS compared a darwin token against a `/proc` read that is always `null`, returned instantly, and let restart recovery escalate to SIGKILL without ever waiting.
- The limits/Keychain defect from the same report is left alone; it is a separate issue.

## Verification

- Unit tests drive the darwin branch of `processIdentityPorts` through injected kernel readers: a login child adopted, **a pid running something else refused**, a pid the kernel does not attribute to us refused, a pid recycled after adoption never signalled, a child observed before its exec adopted once the login appears, and a pid whose command never becomes the login refused when the window closes. `signals` stays empty in every rejection.
- `src/lib/proc/darwinArgv.test.ts` covers the record parser against synthesized kernel records — truncation, impossible `argc`, an unterminated executable path, an argument containing spaces — on any platform.
- The `macos-latest` job runs the parser, both FFI readers, the portable backend and the whole fence against a live kernel, including a test that spawns a real wrapper script named `claude`, clears the fence with the real ports, refuses the test process's own pid, then cancels and waits for the exit. A guard step fails the job if the runner is not darwin or the readers return nothing, so the `skipIf` cases cannot skip themselves into a green run. Result on this branch: **50 pass, 0 fail** (2 skips are the two Linux-only cases).

Local gates on Linux (`bun 1.3.3`):

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test` over the five touched/adjacent files plus `src/app/api/accounts/claude/route.test.ts` and `src/lib/accounts/credentialIsolation.test.ts` — 67 pass, 2 skip (the darwin-only cases), 0 fail.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS.

`eslint` cannot run in this checkout at all — `eslint-plugin-react` throws on rule load under ESLint 10, on untouched files too. Filed as #1259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)