### PR TITLE
fix(privacy): a forge no-reply identity passes the merge boundary (#1251)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ address reads as a no-reply address and is an account handle with a number in
 front of it, and the same address written into prose is not attribution, so
 both are still violations.
 
+The identity git records on a commit is read by a separate rule. A squash merge
+composes those identities into a `Co-authored-by:` trailer on the default
+branch, and there an address on the `users.noreply` host of the forge passes:
+the forge issues it so an account's own address is not what its commits carry.
+That reading is the merge boundary only — it changes nothing about what you may
+write into a message, a doc or a fixture, where the paragraph above still holds.
+
 `privacy-publication` on CI enforces this with a fingerprint list the repo does
 not carry, so it fails **after** you have pushed. Scrub before the push:
 `bun scripts/privacy-publication-gate.ts --base <merge-base>` locally catches the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Outside pull requests are welcome. This page covers the one thing that is
+easier to get right before you commit than after: the identity your commits
+carry.
+
+## Your commit identity reaches the default branch
+
+Git records an author and a committer on every commit, and a squash merge lifts
+both into a `Co-authored-by:` trailer on the commit that lands on `main`. This
+repository is public, so that trailer is published — and the
+`privacy-publication` check reads it before the merge composes it.
+
+An identity passes when its address is on the forge's
+`users.noreply.github.com` host, which GitHub issues for exactly this reason,
+or when it is a machine-attribution mailbox. A personal address is reported as
+`email_address` with a `merge_boundary:` line naming the commit, and the merge
+is blocked until the branch is re-authored.
+
+To use your no-reply address, turn on **Keep my email addresses private** under
+GitHub's email settings, then point the checkout at the address it shows you:
+
+```sh
+git config user.email '<the no-reply address GitHub shows you>'
+git config user.name '<your name or handle>'
+```
+
+Commits already written can be re-authored with `git rebase --exec`, or with
+`git commit --amend --reset-author` for a single one.
+
+## Everything else the check reads
+
+The same check reads the files you changed and the commit messages you wrote.
+Keep account handles, addresses, tokens, absolute home paths, and transcript
+excerpts out of both — [docs/privacy-publication.md](docs/privacy-publication.md)
+describes what it looks for and why. Run it before you open the pull request:
+
+```sh
+bun run privacy:check
+```
+
+Findings name a class and a count, never the value that matched, so a failing
+run tells you where to look without republishing what it found.

--- a/docs/privacy-publication.md
+++ b/docs/privacy-publication.md
@@ -53,13 +53,22 @@ committer into a `Co-authored-by:` trailer of its own, so an address on no
 message at all can reach the public history. The check runs on the pull request,
 before the merge composes that commit.
 
-An identity publishes nobody when it is the account the repository belongs to on
-the forge — read from the origin remote of the checkout under inspection, never
-written down — or one of the machine-attribution mailboxes the trailer rule
-already exempts. Every other identity is a person and produces `email_address`,
-exactly as an address in a file does, with a `merge_boundary:` line naming the
-commit, the field and the trailer. The address stays suppressed there like every
-other matched value: `git show -s <commit>` names it to whoever is fixing it.
+An identity publishes nobody when its address sits on the forge's
+`users.noreply.github.com` host, or when it is one of the machine-attribution
+mailboxes the trailer rule already exempts. The forge issues a no-reply address
+so that an account's own address is not what its commits carry, and the handle
+on it is already public on the pull request, so the composed trailer discloses
+nothing the contribution has not. Every other identity is a person and produces
+`email_address`, exactly as an address in a file does, with a `merge_boundary:`
+line naming the commit, the field and the trailer. The address stays suppressed
+there like every other matched value: `git show -s <commit>` names it to whoever
+is fixing it.
+
+That reading of the no-reply host belongs to the identity path alone. An address
+on it written into a commit message — as a trailer by hand, or anywhere in the
+body — is an account handle in text and stays reportable, because the exemption
+for written trailers is the local part being exactly `noreply` or `no-reply`,
+plus the forge's own `support` role mailbox.
 
 ## Known-value fingerprints
 

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -3217,13 +3217,31 @@ describe("mergeBoundaryReview", () => {
     expect(review.notices).toEqual([]);
   });
 
-  test("another account's forge address is not the repository's identity", () => {
+  test("a contributor's forge account identity composes nothing attributable", () => {
+    /* The forge issues this address so the contributor's own one is not what
+       their commits carry, and the handle in front of it is already public on
+       the pull request. Reporting it blocked every outside contribution while
+       exempting the repository's own identity, which has the same shape. */
     const repo = gitRepo();
-    const stranger = ["77+privacy-gate-fixture-stranger", forgeAccountDomain].join("@");
-    commit(repo, "feat: something", { email: stranger, name: "Someone Else" });
+    const contributor = ["77+privacy-gate-fixture-contributor", forgeAccountDomain].join("@");
+    commit(repo, "feat: something", { email: contributor, name: "Some Contributor" });
     const review = mergeBoundaryReview(repo, "main");
 
-    expect(review.findings.get("email_address")).toBe(1);
+    expect(review.findings.size).toBe(0);
+    expect(review.notices).toEqual([]);
+  });
+
+  test("the exemption is the identity path, never the message", () => {
+    /* One address, two surfaces. Composed from an identity it publishes an
+       account; written into a trailer by hand it is still an account handle
+       with a number in front of it, and the trailer rule still reads it that
+       way. This change moves the merge boundary and nothing else. */
+    const repo = gitRepo();
+    const contributor = ["77+privacy-gate-fixture-contributor", forgeAccountDomain].join("@");
+    commit(repo, `feat: something\n\nCo-Authored-By: Some Contributor <${contributor}>`, canonicalIdentity);
+
+    expect(mergeBoundaryReview(repo, "main").findings.size).toBe(0);
+    expect(commitMessageFindings(repo, "main").get("email_address")).toBe(1);
   });
 
   test("a vendor no-reply identity stays machine attribution", () => {
@@ -3247,12 +3265,18 @@ describe("mergeBoundaryReview", () => {
     expect(review.findings.size).toBe(0);
   });
 
-  test("an identity is attributable when no repository account can be resolved", () => {
-    const repo = gitRepo("");
-    commit(repo, "feat: something", canonicalIdentity);
-    const review = mergeBoundaryReview(repo, "main");
+  test("the rule reads the address, not the checkout's remote", () => {
+    /* A fork's checkout, a mirror, a bare clone with no origin at all: which
+       account the repository belongs to no longer decides anything here, so a
+       missing remote neither exempts a person nor reports an account. */
+    const withoutRemote = gitRepo("");
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(withoutRemote, "feat: something", { email: personal, name: "Someone" });
+    expect(mergeBoundaryReview(withoutRemote, "main").findings.get("email_address")).toBe(1);
 
-    expect(review.findings.get("email_address")).toBe(1);
+    const forgeAccounts = gitRepo("");
+    commit(forgeAccounts, "feat: something", canonicalIdentity);
+    expect(mergeBoundaryReview(forgeAccounts, "main").findings.size).toBe(0);
   });
 
   test("the committer identity publishes too", () => {

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1420,36 +1420,20 @@ export type MergeBoundaryReview = { findings: Map<FindingClass, number>; notices
 type CommitIdentity = { address: string; commit: string; field: "author" | "committer"; name: string };
 
 /* The forge's account namespace, `<id>+<handle>` or `<handle>` at the no-reply
-   host of its own domain. The handle names the account, and the account the
-   repository belongs to is the one its origin remote names — so the canonical
-   identity is read from the checkout rather than written down here, where
-   writing it down would publish it. */
+   host of its own domain. The forge issues that address for one purpose: so a
+   contributor's own address stays unpublished when their commits are. An
+   identity on this host therefore names an account, and the account is already
+   public on the pull request the moment it is opened — the composed trailer
+   discloses nothing the contribution has not disclosed. Which account it is
+   does not matter here, so no account is written down and none is read from
+   the checkout. */
 const FORGE_ACCOUNT_DOMAIN = `users.noreply.${FORGE_DOMAIN}`;
 const COMPOSED_ATTRIBUTION_TRAILER = "Co-authored-by";
 
-function forgeAccountHandle(address: string): string | undefined {
+function isForgeAccountAddress(address: string): boolean {
   const separator = address.lastIndexOf("@");
-  if (separator === -1) return undefined;
-  if (address.slice(separator + 1).toLowerCase() !== FORGE_ACCOUNT_DOMAIN) return undefined;
-  const localPart = address.slice(0, separator).toLowerCase();
-  const identifier = localPart.indexOf("+");
-  return identifier === -1 ? localPart : localPart.slice(identifier + 1);
-}
-
-/* `<host>/<owner>/<repository>` in the HTTPS form, `<host>:<owner>/<repository>`
-   in the SSH one. The remote is written by whoever created the checkout — the
-   workflow, or the operator — never by the branch under inspection. */
-function forgeOwner(repository: string): string | undefined {
-  const result = Bun.spawnSync({
-    cmd: ["git", "-C", repository, "config", "--get", "remote.origin.url"],
-    env: withoutWakatimeCredential(process.env),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  if (result.exitCode !== 0) return undefined;
-  const owner = new RegExp(`${FORGE_DOMAIN.replaceAll(".", String.raw`\.`)}[/:]([A-Za-z0-9._-]+)/`, "i")
-    .exec(result.stdout.toString().trim());
-  return owner?.[1].toLowerCase();
+  if (separator === -1) return false;
+  return address.slice(separator + 1).toLowerCase() === FORGE_ACCOUNT_DOMAIN;
 }
 
 /** Every identity git recorded on the commits the merge will squash. */
@@ -1493,11 +1477,16 @@ function composedAttributionMessage(identity: CommitIdentity): string {
  *
  * Git records an author and a committer on every commit and a commit cannot be
  * made without them, so the question is never whether an identity publishes but
- * whose. Two answers publish nobody: the account the repository belongs to on
- * the forge, and the machine-attribution mailboxes the trailer rule already
+ * whose. Two answers publish nobody: an account on the forge's no-reply host,
+ * which the forge issues so that the account's own address is not what its
+ * commits carry, and the machine-attribution mailboxes the trailer rule already
  * names. Every other identity is a person, and is reported exactly as an
- * address in a file is — the carve-out for written trailers is not widened,
- * it is read here as it is read there.
+ * address in a file is.
+ *
+ * The no-reply host is read only here, on the identities the merge composes.
+ * A commit message that writes such an address into a trailer by hand, or into
+ * its body, keeps the narrow reading the trailer rule gives it — this is the
+ * merge-boundary identity path, and it widens nothing else.
  */
 export function mergeBoundaryReview(repository: string, base: string): MergeBoundaryReview {
   const findings = new Map<FindingClass, number>();
@@ -1507,10 +1496,9 @@ export function mergeBoundaryReview(repository: string, base: string): MergeBoun
     addFinding(findings, "inspection_error");
     return { findings, notices };
   }
-  const owner = forgeOwner(repository);
   for (const identity of identities) {
     const { attributable } = commitMessageAddressReview(composedAttributionMessage(identity));
-    const publishes = attributable.some((address) => owner === undefined || forgeAccountHandle(address) !== owner);
+    const publishes = attributable.some((address) => !isForgeAccountAddress(address));
     if (!publishes) continue;
     addFinding(findings, "email_address");
     /* The notice names the commit, the field and the trailer, and never the


### PR DESCRIPTION
## What changed

The merge-boundary identity check exempted one address: the account the origin
remote named. That address is on the forge's `users.noreply.github.com` host,
issued so an account's own address is not what its commits carry — so the gate
exempted one address of that shape and reported every other one. Every outside
contribution failed on that, for no principle.

The identity path now reads the host, not the account. An identity on the
forge's no-reply host publishes an account handle that opening a pull request
has already published, so the trailer a squash merge composes from it discloses
nothing new. The origin-remote lookup is gone along with the comparison it
existed for.

## What did not change

- A personal address as a branch identity is still `email_address`, at the same
  weight, with the same exit code and the same `merge_boundary:` notice.
- A personal address in a commit **body** is still caught by the message path.
- The written-trailer carve-out from #1195, #1209 and #1220 keeps its shape: the
  local part being exactly `noreply`/`no-reply`, plus the forge's `support` role
  mailbox. An account-form no-reply address written into a message is still a
  handle with a number in front of it, and is still reported.

The no-reply host is read on composed identities only. A test pins both
readings of one address, so the two paths cannot drift together.

## Verification

`bunx tsc --noEmit --incremental false` — clean.

`scripts/privacy-publication-gate.test.ts` under an isolated
HOME/XDG_CONFIG_HOME/LLV_STATE_DIR/TMPDIR: 148 pass, 0 fail. The two new
assertions were confirmed RED against the previous scanner.

Covered at the merge boundary: a contributor identity on the no-reply host
passes; a personal branch identity is reported; a personal address in a commit
body is reported; the repository's own identity, a vendor no-reply mailbox and
a forge role account stay exempt as before.

The gate on this branch: `PRIVACY GATE: PASS`.

The gate against the open outside contribution (#1250), run read-only from a
detached checkout of its head — nothing on that pull request was touched:

| scanner | result |
| --- | --- |
| before this change | `email_address: 1` + `merge_boundary:` notice, `transcript_content: 1` |
| after this change | `transcript_content: 1` |

The identity block clears. That branch **still fails the gate** on a
`transcript_content` finding in a changed file, which is a separate problem
belonging to that contribution and is deliberately left reported.

`CONTRIBUTING.md` states the identity rule where a contributor meets it before
opening a pull request; `docs/privacy-publication.md` and `AGENTS.md` record the
boundary between the identity path and the message path.

Local `eslint` could not run in this worktree: `eslint-plugin-react` fails to
load `react/display-name` under this ESLint. It fails identically on files this
branch does not touch, so it is not this change.

Closes #1251

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>