### PR TITLE
ci(release): pass the publish receipt through a file, not through argv

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,12 +246,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          publish_json="$(npm publish "${{ steps.package.outputs.tarball }}" --tag "$PUBLISH_TAG" --json)"
-          printf '%s\n' "$publish_json"
-          publish_integrity="$(node -e '
-            const value = JSON.parse(process.argv[1]);
-            const packageName = process.argv[2];
-            const packageVersion = process.argv[3];
+          # The publish receipt lists every packed entry, which for this package is
+          # over a megabyte. Passing it to node as an argument exceeded ARG_MAX and
+          # the step died with exit 126 after the publish had already run, so the
+          # receipt travels through a file instead.
+          publish_json_file="$(mktemp "${RUNNER_TEMP}/npm-publish.XXXXXX.json")"
+          npm publish "${{ steps.package.outputs.tarball }}" --tag "$PUBLISH_TAG" --json > "$publish_json_file"
+          publish_integrity="$(PUBLISH_JSON_FILE="$publish_json_file" node -e '
+            const value = JSON.parse(require("node:fs").readFileSync(process.env.PUBLISH_JSON_FILE, "utf8"));
+            const packageName = process.argv[1];
+            const packageVersion = process.argv[2];
             const candidates = value && typeof value === "object"
               ? [value, ...Object.values(value)]
               : [];
@@ -264,7 +268,7 @@ jobs:
               throw new Error("npm publish returned no tarball integrity");
             }
             process.stdout.write(published.integrity);
-          ' "$publish_json" "$PACKAGE_NAME" "$PACKAGE_VERSION")"
+          ' "$PACKAGE_NAME" "$PACKAGE_VERSION")"
           printf 'integrity=%s\n' "$publish_integrity" >> "$GITHUB_OUTPUT"
           printf 'tag=%s\n' "$PUBLISH_TAG" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Publishing to npm has failed on **every tagged release since 1.0.1** — v1.0.1, v1.0.2 and v1.0.3 all failed. The last successful publish run was 2026-08-01.

## The failure

The publish step does this:

```bash
publish_json="$(npm publish "$tarball" --tag "$PUBLISH_TAG" --json)"
printf '%s\n' "$publish_json"
publish_integrity="$(node -e '…' "$publish_json" "$PACKAGE_NAME" "$PACKAGE_VERSION")"
```

`npm publish --json` returns a receipt listing every packed entry. This package vendors enough that the list is over a megabyte — the step's log alone is 1.18 MB. Handing that to `node -e` as an argument exceeds `ARG_MAX`, the exec fails, and bash reports **exit 126** with no message of its own.

It is silent in the worst way. The failure lands *after* `npm publish` has already run, so the log shows a complete receipt followed by an unexplained 126, which reads as though the publish itself broke. It took reading the step's own script to see that the receipt had been printed by the line *after* the publish.

## The fix

The receipt travels through a file and node reads it from there. Nothing else changes — the same integrity check, the same failure message when the receipt has no integrity.

Dropping the megabyte dump from the log is a side effect worth having: it is what made the original diagnosis hard, since every filter returned packed-file entries.

The four other `node -e` calls in this workflow pass `npm view` output, which is small. Only the publish receipt is affected.

## After this merges

`v1.0.3` is tagged and its commit is on `main`, but the version is not in the registry — the direct registry read confirms `latest` is still 1.0.2 and 1.0.3 is absent. Publishing it needs a `workflow_dispatch` run of this workflow with `tag: v1.0.3`, dispatched from `main` so the fixed workflow file is the one that runs while the tag supplies the source.