### PR TITLE
fix(runtime-host): a failed socket write ends the connection, not the host (#1254)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,12 +124,16 @@ bun scripts/verify-runtime-host.ts --runtime <the bun binary being pinned>
 It starts two runtime-host generations under that interpreter, drives one
 singleton-fence succession, and holds both endpoints the succession handed
 over while peers come and go — in a private state directory on an ephemeral
-port, never the stable one. The same rehearsal runs inside a container built
-from the candidate image during `verify-candidate`, so a candidate whose host
-cannot boot, cannot take the fence, or cannot hold what it took is refused
-before promotion rather than after.
+port, never the stable one. Half the callers walk away mid-answer without
+reading a byte of a snapshot-sized reply, which is the write that took
+production down: run against the host as it was, the rehearsal kills it
+within a second under 1.4.0 and passes under 1.3.3, exactly as the incident
+did. The same rehearsal runs inside a container built from the candidate image
+during `verify-candidate`, so a candidate whose host cannot boot, cannot take
+the fence, or cannot hold what it took is refused before promotion rather than
+after.
 
-Two consequences worth keeping:
+Three consequences worth keeping:
 
 - **A failing socket write is a connection event, never a process event.**
   Every long-lived listener in the runtime host attaches its `error` handler
@@ -142,4 +146,10 @@ Two consequences worth keeping:
 - **Verification has to name the process it exercised.** "Loaded every built
   server module and requested real routes" is a statement about the Viewer. Say
   which process, or the gap comes back.
+- **Inside the image, the interpreter is `bun-container`.** `bun` there is an
+  nsenter shim onto the operator's own bun, for the agent CLIs; in a container
+  without the host PID namespace it cannot run at all, and it is never the
+  interpreter being promoted. Anything that starts a first-party process inside
+  the image names `bun-container`, and the rehearsal passes that name down to
+  the generations it starts.
 <!-- END:runtime-host-verification -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,43 @@ not carry, so it fails **after** you have pushed. Scrub before the push:
 `bun scripts/privacy-publication-gate.ts --base <merge-base>` locally catches the
 generic classes, and re-read every table and quote you lifted out of logs.
 <!-- END:live-state-and-publication -->
+
+<!-- BEGIN:runtime-host-verification -->
+# Two processes run under Bun here, and only one of them was ever checked
+
+The Viewer and the **runtime host** (`src/runtime-host/`) both run under the
+Bun pinned in the `Dockerfile`. The runtime host owns the stable listener and
+performs the release succession, so when it crash-loops, that is an outage no
+Viewer health check can see. Moving the pin to 1.4.0 was verified thoroughly
+and only on the Viewer; the host had never been started under the new runtime
+when it was promoted, and it died on its first failing socket write (#1254).
+
+**A change to a Bun pin is not verified until the runtime host has run under
+it.** Before such a change is proposed for promotion, run:
+
+```
+bun scripts/verify-runtime-host.ts --runtime <the bun binary being pinned>
+```
+
+It starts two runtime-host generations under that interpreter, drives one
+singleton-fence succession, and holds both endpoints the succession handed
+over while peers come and go — in a private state directory on an ephemeral
+port, never the stable one. The same rehearsal runs inside a container built
+from the candidate image during `verify-candidate`, so a candidate whose host
+cannot boot, cannot take the fence, or cannot hold what it took is refused
+before promotion rather than after.
+
+Two consequences worth keeping:
+
+- **A failing socket write is a connection event, never a process event.**
+  Every long-lived listener in the runtime host attaches its `error` handler
+  to a connection before the first byte can be written to it. Bun 1.3.3 dropped
+  failed writes silently, which is why the missing handlers survived so long;
+  1.4.0 reports them, and an unhandled `error` on a connection kills the
+  process that owns 8898. Tests must not paper over this: a test harness that
+  attaches its own listener to each accepted connection hides exactly the
+  defect the production server has.
+- **Verification has to name the process it exercised.** "Loaded every built
+  server module and requested real routes" is a statement about the Viewer. Say
+  which process, or the gap comes back.
+<!-- END:runtime-host-verification -->

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -11,6 +11,7 @@ import type {
   ViewerMcpRuntimePublicationEvidence,
   ViewerMcpRuntimeReconciliation,
   ViewerReleaseIdentity,
+  ViewerRuntimeHostHealthEvidence,
 } from "../src/lib/runtime/contracts";
 import { admittedMcpHealthProbe } from "../src/lib/mcp/healthProbeAdmission";
 import {
@@ -37,6 +38,10 @@ import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandi
 import { withBootstrapMcpHealthProbeAdmission } from "../src/runtime-host/bootstrapMcpHealthProbeAdmission";
 import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
 import { bootstrapViewerRelease } from "../src/runtime-host/deploymentBootstrap";
+import {
+  parseRuntimeHostRehearsalReport,
+  runtimeHostRehearsalDockerArgs,
+} from "../src/runtime-host/hostRehearsal";
 import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
 import type { McpHealthProbeAdmissionConsumer } from "../src/runtime-host/mcpHealthProbeAdmissionChannel";
 import { probeControlUrl, probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
@@ -131,7 +136,7 @@ function reportAdapterPhase(action: string, phase: string): void {
   writeDurableJson(adapterPhaseFile, { action, phase, updatedAt: new Date().toISOString() });
 }
 
-async function command(argv: string[], options: { cwd?: string } = {}): Promise<string> {
+async function commandResult(argv: string[], options: { cwd?: string } = {}): Promise<{ code: number; stdout: string; stderr: string }> {
   const child = Bun.spawn(["/usr/bin/setpriv", "--pdeathsig", "KILL", "--", ...argv], {
     cwd: options.cwd,
     stdout: "pipe",
@@ -139,8 +144,13 @@ async function command(argv: string[], options: { cwd?: string } = {}): Promise<
     env: withoutWakatimeCredential(process.env),
   });
   const [stdout, stderr, code] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
-  if (code !== 0) throw new Error((stderr.trim() || `${argv[0]} failed`).slice(0, 1000));
-  return stdout.trim();
+  return { code, stdout: stdout.trim(), stderr: stderr.trim() };
+}
+
+async function command(argv: string[], options: { cwd?: string } = {}): Promise<string> {
+  const { code, stdout, stderr } = await commandResult(argv, options);
+  if (code !== 0) throw new Error((stderr || `${argv[0]} failed`).slice(0, 1000));
+  return stdout;
 }
 
 async function ensureMirror(): Promise<void> {
@@ -562,6 +572,40 @@ export function mcpProbeEnvironment(
   };
 }
 
+/**
+ * #1254: the candidate image's runtime host, exercised before promotion.
+ *
+ * The runtime host runs under the same Bun as the Viewer, owns the stable
+ * listener, and performs the release succession. Verifying only the Viewer is
+ * what let a runtime the host could not survive reach production. The
+ * rehearsal runs inside a throwaway container from the candidate image, so it
+ * exercises exactly the interpreter that would be promoted and can reach
+ * neither the live state directory nor the live listener.
+ *
+ * A rehearsal that cannot run at all is a failed gate, not a skipped one.
+ */
+async function rehearseCandidateRuntimeHost(
+  candidate: ViewerReleaseIdentity,
+  reportPhase?: (phase: string) => void,
+): Promise<ViewerRuntimeHostHealthEvidence> {
+  reportPhase?.("rehearsing the candidate runtime host");
+  const { stdout, stderr } = await commandResult(runtimeHostRehearsalDockerArgs(candidate.image));
+  try {
+    return parseRuntimeHostRehearsalReport(`${stdout}\n${stderr}`);
+  } catch (error) {
+    return {
+      checkedAt: new Date().toISOString(),
+      runtime: "unknown",
+      succession: { predecessorReadyMs: 0, successorTookOverMs: 0, completed: false },
+      listener: { windowMs: 0, polls: 0, answered: 0, abandoned: 0 },
+      socket: { polls: 0, answered: 0, abandoned: 0 },
+      ok: false,
+      detail: `the candidate runtime-host rehearsal did not report: ${error instanceof Error ? error.message : String(error)}`,
+      log: stderr.split("\n").filter(Boolean).slice(-20),
+    };
+  }
+}
+
 async function verify(
   candidate: ViewerReleaseIdentity,
   endpoint: string,
@@ -597,11 +641,19 @@ async function verify(
     const state = fs.openSync(stateDir, "r");
     try { fs.fsyncSync(state); } finally { fs.closeSync(state); }
   }
+  if (!mcpRuntime.ok) {
+    return { ...viewer, mcpRuntime, ok: false, detail: mcpRuntime.detail ?? "MCP runtime health gate failed" };
+  }
+  /* The promoted check reads the release that is already serving; the host
+     rehearsal belongs to the candidate, before anything is switched. */
+  if (promoted) return { ...viewer, mcpRuntime, ok: true };
+  const runtimeHost = await rehearseCandidateRuntimeHost(candidate, options.reportPhase);
   return {
     ...viewer,
     mcpRuntime,
-    ok: mcpRuntime.ok,
-    ...(mcpRuntime.ok ? {} : { detail: mcpRuntime.detail ?? "MCP runtime health gate failed" }),
+    runtimeHost,
+    ok: runtimeHost.ok,
+    ...(runtimeHost.ok ? {} : { detail: runtimeHost.detail ?? "candidate runtime-host gate failed" }),
   };
 }
 
@@ -1179,6 +1231,7 @@ async function main(): Promise<unknown> {
     const candidate = release(input.candidate);
     const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
     return verify(candidate, candidate.endpoint, {
+      reportPhase: (phase) => reportAdapterPhase(action, phase),
       ...(healthProbe ?? {}),
     });
   }

--- a/scripts/verify-runtime-host.ts
+++ b/scripts/verify-runtime-host.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+/* #1254: verify the runtime host under a runtime, before that runtime ships.
+ *
+ * The Bun pin moved and only the Viewer was exercised. The runtime host runs
+ * under the same Bun, owns the stable listener, and performs the release
+ * succession; nobody started it under the new runtime until production did.
+ *
+ *   bun scripts/verify-runtime-host.ts                    # this checkout's bun
+ *   bun scripts/verify-runtime-host.ts --runtime /path/to/bun
+ *
+ * It starts two runtime-host generations under that interpreter, drives one
+ * singleton-fence succession, and holds both endpoints the succession handed
+ * over. Nothing it touches is shared: a private state directory removed on
+ * exit, a private socket, an ephemeral loopback port. It never binds the
+ * stable port and never reads the operator's state directory. The deployment
+ * gate runs the same rehearsal inside the candidate image.
+ *
+ * Exit status is the verdict; the evidence is printed as JSON.
+ */
+
+import { runRuntimeHostRehearsal } from "../src/runtime-host/hostRehearsalRun";
+
+const USAGE = "usage: bun scripts/verify-runtime-host.ts [--runtime <bun binary>] [--hold-ms <milliseconds>]";
+
+function option(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  if (index < 0) return undefined;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value\n${USAGE}`);
+  return value;
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes("--help") || argv.includes("-h")) {
+  console.log(USAGE);
+  process.exit(0);
+}
+
+const runtimeBin = option(argv, "--runtime");
+const holdMs = option(argv, "--hold-ms");
+const report = await runRuntimeHostRehearsal({
+  ...(runtimeBin ? { runtimeBin } : {}),
+  ...(holdMs ? { holdWindowMs: Number(holdMs) } : {}),
+});
+
+console.log(JSON.stringify(report, null, 2));
+if (!report.ok) {
+  console.error(`runtime-host verification failed under ${report.runtime}: ${report.detail ?? "no detail"}`);
+  process.exit(1);
+}
+console.error(
+  `runtime-host verified under ${report.runtime}:`
+  + ` succession completed in ${report.succession.successorTookOverMs}ms,`
+  + ` stable listener answered ${report.listener.answered}/${report.listener.polls}`
+  + ` and the runtime socket ${report.socket.answered}/${report.socket.polls}`
+  + ` over ${Math.round(report.listener.windowMs / 1_000)}s`,
+);

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -538,6 +538,45 @@ export interface ViewerMcpRuntimeReconciliation {
   health: ViewerMcpRuntimeHealthEvidence;
 }
 
+/** What one runtime-host rehearsal saw (#1254). The Viewer and the runtime
+    host run under the same Bun, and only the Viewer was ever verified before a
+    runtime change was promoted; this is the host's half of that answer. */
+export interface ViewerRuntimeHostSuccessionEvidence {
+  /** How long the first generation took to hold the stable listener. */
+  predecessorReadyMs: number;
+  /** How long the successor took to hold it after the predecessor exited. */
+  successorTookOverMs: number;
+  completed: boolean;
+}
+
+/** How one endpoint answered while it was held under observation. */
+export interface ViewerRuntimeHostProbeEvidence {
+  polls: number;
+  answered: number;
+  /** Polls whose caller vanished mid-answer, the write that took #1254 down. */
+  abandoned: number;
+}
+
+/** The bounded observation window the handed-over endpoints were held under. */
+export interface ViewerRuntimeHostListenerEvidence extends ViewerRuntimeHostProbeEvidence {
+  windowMs: number;
+}
+
+export interface ViewerRuntimeHostHealthEvidence {
+  checkedAt: string;
+  /** The interpreter that was exercised, as it reported itself. */
+  runtime: string;
+  succession: ViewerRuntimeHostSuccessionEvidence;
+  /** The stable endpoint the succession handed over. */
+  listener: ViewerRuntimeHostListenerEvidence;
+  /** The runtime socket, whose answers are the large ones. */
+  socket: ViewerRuntimeHostProbeEvidence;
+  ok: boolean;
+  detail?: string;
+  /** Bounded tail of the failing generation's own output. */
+  log?: string[];
+}
+
 export type ViewerHealthProbeName = "root" | "authenticated" | "unauthorized" | "capability";
 
 /** One readiness request, kept with what the gate asked for. A failed candidate
@@ -582,6 +621,8 @@ export interface ViewerHealthEvidence {
   /** Bounded tail of the candidate's own output, read before it is retired. */
   containerLog?: string[];
   mcpRuntime?: ViewerMcpRuntimeHealthEvidence;
+  /** The candidate image's runtime host, rehearsed before promotion (#1254). */
+  runtimeHost?: ViewerRuntimeHostHealthEvidence;
   ok: boolean;
   detail?: string;
 }

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -253,6 +253,108 @@ test("health evidence with an unusable observation is refused rather than record
   expect(adapter.verifyCandidate(candidate)).rejects.toThrow("deployment adapter returned invalid health evidence");
 });
 
+/* #1254 exists because a runtime reached production after a verification that
+   only covered the Viewer. The rehearsal now covers the host too, and the proof
+   is worth nothing if it stops here: a record with no runtime-host evidence
+   cannot be told apart from one where the host was never exercised. */
+test("the candidate runtime-host rehearsal reaches the record with the runtime it exercised", async () => {
+  const verified: ViewerHealthEvidence = {
+    checkedAt: "2026-08-28T18:04:11.000Z",
+    endpoint: "http://127.0.0.1:19310",
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [],
+    runtimeHost: {
+      checkedAt: "2026-08-28T18:05:02.000Z",
+      runtime: "bun 1.4.0",
+      succession: { predecessorReadyMs: 1_480, successorTookOverMs: 2_140, completed: true },
+      listener: { windowMs: 15_000, polls: 30, answered: 30, abandoned: 15 },
+      socket: { polls: 30, answered: 30, abandoned: 15 },
+      ok: true,
+    },
+    ok: true,
+  };
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:19310",
+    revision: "a".repeat(40),
+  };
+  const adapter = new HostCommandViewerDeploymentAdapter(async (action) => (
+    action === "verify-candidate" ? verified : {}
+  ));
+
+  expect(await adapter.verifyCandidate(candidate)).toEqual(verified);
+});
+
+/* The generation that died is gone by the time anyone reads the deployment, so
+   its reason and its own last words only exist if they cross here (#1254). */
+test("a refused runtime-host rehearsal carries its reason and the failing generation's output", async () => {
+  const failing: ViewerHealthEvidence = {
+    checkedAt: "2026-08-28T18:11:40.000Z",
+    endpoint: "http://127.0.0.1:19311",
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [],
+    runtimeHost: {
+      checkedAt: "2026-08-28T18:12:31.000Z",
+      runtime: "bun 1.4.0",
+      succession: { predecessorReadyMs: 1_390, successorTookOverMs: 0, completed: false },
+      listener: { windowMs: 15_000, polls: 24, answered: 12, abandoned: 12 },
+      socket: { polls: 0, answered: 0, abandoned: 0 },
+      ok: false,
+      detail: "the stable listener stopped answering 6.0s into the hold window",
+      log: ["error: write EPIPE", "      at failWrite (node:net)"],
+    },
+    ok: false,
+    detail: "the stable listener stopped answering 6.0s into the hold window",
+  };
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:19311",
+    revision: "a".repeat(40),
+  };
+  const adapter = new HostCommandViewerDeploymentAdapter(async (action) => (
+    action === "verify-candidate" ? failing : {}
+  ));
+
+  expect(await adapter.verifyCandidate(candidate)).toEqual(failing);
+});
+
+test("runtime-host evidence missing its poll counts is refused rather than recorded half-read", async () => {
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:19312",
+    revision: "a".repeat(40),
+  };
+  const adapter = new HostCommandViewerDeploymentAdapter(async () => ({
+    checkedAt: "2026-08-28T18:20:00.000Z",
+    endpoint: "http://127.0.0.1:19312",
+    processReady: true,
+    rootStatus: 200,
+    authenticatedStatus: 200,
+    unauthorizedStatus: 403,
+    assets: [],
+    runtimeHost: {
+      checkedAt: "2026-08-28T18:20:51.000Z",
+      runtime: "bun 1.4.0",
+      succession: { predecessorReadyMs: 1_480, successorTookOverMs: 2_140, completed: true },
+      listener: { windowMs: 15_000, polls: 30, answered: 30 },
+      socket: { polls: 30, answered: 30, abandoned: 15 },
+      ok: true,
+    },
+    ok: true,
+  }));
+
+  expect(adapter.verifyCandidate(candidate)).rejects.toThrow("invalid runtime-host health evidence");
+});
+
 test("the host injects and revokes health authority only around probe-bearing adapter actions", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-adapter-health-authority-"));
   sandboxes.push(directory);

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -36,7 +36,10 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
   "current-release": 90_000,
   "current-mcp-runtime": 90_000,
   "reconcile-mcp-runtime": 10 * 60_000,
-  "verify-candidate": 90_000,
+  /* #1254: the candidate's runtime host is rehearsed inside a container from
+     its own image — one succession plus a bounded hold — on top of the Viewer
+     and MCP probes this action already ran. */
+  "verify-candidate": 240_000,
   /* #1216: strictly larger than the adapter-side hand-over budgets it
      contains, so the adapter reports its own named reason instead of being
      killed mid-wait and leaving the operator a bare phase string. */

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -15,6 +15,8 @@ import type {
   ViewerMcpRuntimePublicationEvidence,
   ViewerMcpRuntimeReconciliation,
   ViewerReleaseIdentity,
+  ViewerRuntimeHostHealthEvidence,
+  ViewerRuntimeHostProbeEvidence,
 } from "@/lib/runtime/contracts";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
@@ -307,6 +309,7 @@ function evidence(value: unknown): ViewerHealthEvidence {
     ...(item.readiness === undefined ? {} : { readiness: readinessRecord(item.readiness) }),
     ...(item.containerLog === undefined ? {} : { containerLog: item.containerLog as string[] }),
     ...(item.mcpRuntime === undefined ? {} : { mcpRuntime: mcpHealthEvidence(item.mcpRuntime) }),
+    ...(item.runtimeHost === undefined ? {} : { runtimeHost: runtimeHostEvidence(item.runtimeHost) }),
     ok: item.ok,
     ...(typeof item.detail === "string" ? { detail: item.detail } : {}),
   };
@@ -364,6 +367,55 @@ function mcpCallFailures(value: unknown): ViewerMcpRuntimeCallFailure[] {
       error: failure.error,
     };
   });
+}
+
+/** How one endpoint answered while it was held. Counts are the whole substance
+    of the rehearsal, so a set that arrives half-read is refused. */
+function runtimeHostProbeCounts(value: unknown): ViewerRuntimeHostProbeEvidence {
+  const item = object(value);
+  if (typeof item.polls !== "number"
+    || typeof item.answered !== "number"
+    || typeof item.abandoned !== "number") {
+    throw new Error("deployment adapter returned invalid runtime-host health evidence");
+  }
+  return { polls: item.polls, answered: item.answered, abandoned: item.abandoned };
+}
+
+/** The host's half of a candidate verification, carried into the durable record
+    (#1254). A Bun pin reached production because everything that ran before
+    promotion exercised the Viewer; the rehearsal exercises the host as well,
+    and evidence dropped at this boundary leaves the record unable to say which
+    runtime the host was started under, whether the succession completed, or how
+    the handed-over endpoints answered — which reads exactly like the check that
+    was never run. */
+function runtimeHostEvidence(value: unknown): ViewerRuntimeHostHealthEvidence {
+  const item = object(value);
+  const succession = object(item.succession);
+  const listener = object(item.listener);
+  if (typeof item.checkedAt !== "string"
+    || typeof item.runtime !== "string"
+    || typeof succession.predecessorReadyMs !== "number"
+    || typeof succession.successorTookOverMs !== "number"
+    || typeof succession.completed !== "boolean"
+    || typeof listener.windowMs !== "number"
+    || typeof item.ok !== "boolean"
+    || (item.log !== undefined && (!Array.isArray(item.log) || item.log.some((line) => typeof line !== "string")))) {
+    throw new Error("deployment adapter returned invalid runtime-host health evidence");
+  }
+  return {
+    checkedAt: item.checkedAt,
+    runtime: item.runtime,
+    succession: {
+      predecessorReadyMs: succession.predecessorReadyMs,
+      successorTookOverMs: succession.successorTookOverMs,
+      completed: succession.completed,
+    },
+    listener: { windowMs: listener.windowMs, ...runtimeHostProbeCounts(item.listener) },
+    socket: runtimeHostProbeCounts(item.socket),
+    ok: item.ok,
+    ...(typeof item.detail === "string" ? { detail: item.detail } : {}),
+    ...(item.log === undefined ? {} : { log: item.log as string[] }),
+  };
 }
 
 /** `null` is the adapter's "the published runtime already matches" answer. */

--- a/src/runtime-host/deploymentProxy.test.ts
+++ b/src/runtime-host/deploymentProxy.test.ts
@@ -69,3 +69,31 @@ test("deployment proxy forwards an immediate request through a real TCP connecti
     await fs.rm(directory, { recursive: true, force: true });
   }
 });
+
+test("a failed write on the stable listener ends the connection, not the runtime host", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "llv-deployment-proxy-"));
+  // No release target: the connection is answered with a raw 503 write, the
+  // path that carried no error handling at all before #1254.
+  const proxy = serveViewerDeploymentProxy(path.join(directory, "viewer-release.json"), 0);
+  await once(proxy, "listening");
+  const address = proxy.address();
+  if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
+
+  try {
+    const accepted = once(proxy, "connection") as Promise<[net.Socket]>;
+    const client = net.createConnection(address.port, "127.0.0.1");
+    client.on("error", () => undefined);
+    const [downstream] = await accepted;
+
+    const epipe = Object.assign(new Error("write EPIPE"), { errno: -32, code: "EPIPE", syscall: "write" });
+    expect(() => downstream.emit("error", epipe)).not.toThrow();
+    expect(downstream.destroyed).toBe(true);
+    // A socket can fail more than once; the second report must stay handled.
+    expect(() => downstream.emit("error", epipe)).not.toThrow();
+
+    client.destroy();
+  } finally {
+    await close(proxy);
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/runtime-host/deploymentProxy.ts
+++ b/src/runtime-host/deploymentProxy.ts
@@ -19,6 +19,18 @@ function readTarget(filename: string): ViewerReleaseIdentity | null {
 /** Each accepted connection reads one atomically replaced release target. */
 export function serveViewerDeploymentProxy(targetFile: string, port = 8898, host = "127.0.0.1"): net.Server {
   const server = net.createServer({ pauseOnConnect: true }, (downstream) => {
+    /* #1254: this listener is the stable endpoint, so a connection failure
+       here must never reach the process. Bun 1.3.3 dropped a failed socket
+       write; 1.4.0 reports it by destroying the socket with the EPIPE, and an
+       unhandled `error` event is an uncaught exception. The handler is
+       attached before the first byte is written — including the 503 answers
+       below, which used to write to a raw connection with no handler at all —
+       and it stays attached, because a socket can fail more than once. */
+    let upstream: net.Socket | null = null;
+    downstream.on("error", () => {
+      downstream.destroy();
+      upstream?.destroy();
+    });
     const target = readTarget(targetFile);
     if (!target) {
       downstream.end("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
@@ -29,13 +41,15 @@ export function serveViewerDeploymentProxy(targetFile: string, port = 8898, host
       downstream.end("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
       return;
     }
-    const upstream = net.createConnection({ host: endpoint.hostname, port: Number(endpoint.port) });
+    upstream = net.createConnection({ host: endpoint.hostname, port: Number(endpoint.port) });
+    upstream.on("error", () => {
+      upstream?.destroy();
+      downstream.destroy();
+    });
     downstream.pipe(upstream);
     upstream.pipe(downstream);
     downstream.resume();
-    upstream.once("error", () => downstream.destroy());
-    downstream.once("error", () => upstream.destroy());
-    downstream.once("close", () => upstream.destroy());
+    downstream.once("close", () => upstream?.destroy());
   });
   server.listen(port, host);
   return server;

--- a/src/runtime-host/hostRehearsal.test.ts
+++ b/src/runtime-host/hostRehearsal.test.ts
@@ -1,0 +1,176 @@
+import { expect, test } from "bun:test";
+
+import {
+  parseRuntimeHostRehearsalReport,
+  rehearseRuntimeHost,
+  runtimeHostRehearsalDockerArgs,
+  RUNTIME_HOST_REHEARSAL_REPORT_PREFIX,
+  type RuntimeHostRehearsalGeneration,
+  type RuntimeHostRehearsalPorts,
+} from "./hostRehearsal";
+
+interface Script {
+  /** Answers for the stable listener, consumed in order; the last repeats. */
+  listener: boolean[];
+  /** Answers for the runtime socket, consumed the same way. */
+  socket?: boolean[];
+  /** Which poll the successor process dies on, counted from one. */
+  diesAtPoll?: number;
+}
+
+interface Recorded {
+  started: string[];
+  stopped: string[];
+  seeded: number;
+  abandonedListener: number;
+  abandonedSocket: number;
+}
+
+function harness(script: Script): { ports: RuntimeHostRehearsalPorts; recorded: Recorded } {
+  const recorded: Recorded = { started: [], stopped: [], seeded: 0, abandonedListener: 0, abandonedSocket: 0 };
+  let clock = 0;
+  let listenerPolls = 0;
+  let socketPolls = 0;
+  let successorExited = false;
+  const answer = (answers: boolean[], index: number): boolean => answers[Math.min(index, answers.length - 1)] ?? true;
+  const generation = (role: string): RuntimeHostRehearsalGeneration => ({
+    stop: async () => { recorded.stopped.push(role); },
+    exited: () => role === "successor" && successorExited,
+    log: () => [`${role}: line one`],
+  });
+  return {
+    recorded,
+    ports: {
+      start: async (role) => { recorded.started.push(role); return generation(role); },
+      seed: async () => { recorded.seeded += 1; },
+      probeListener: async ({ abandon }) => {
+        if (abandon) recorded.abandonedListener += 1;
+        return answer(script.listener, listenerPolls++);
+      },
+      probeSocket: async ({ abandon }) => {
+        if (abandon) recorded.abandonedSocket += 1;
+        socketPolls += 1;
+        if (script.diesAtPoll !== undefined && socketPolls >= script.diesAtPoll) successorExited = true;
+        return answer(script.socket ?? [true], socketPolls - 1);
+      },
+      now: () => clock,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    },
+  };
+}
+
+const options = { runtime: "bun 1.4.0", holdWindowMs: 2_000, holdPollMs: 500 };
+
+test("a runtime that boots, succeeds the fence and holds both endpoints passes", async () => {
+  const { ports, recorded } = harness({ listener: [true] });
+
+  const report = await rehearseRuntimeHost(ports, options);
+
+  expect(report.ok).toBe(true);
+  expect(report.runtime).toBe("bun 1.4.0");
+  expect(report.succession.completed).toBe(true);
+  expect(report.listener.polls).toBeGreaterThan(0);
+  expect(report.listener.answered).toBe(report.listener.polls);
+  expect(report.socket.answered).toBe(report.socket.polls);
+  // Both generations ran, in order, and the journal was filled before the
+  // succession so the socket answers are large ones.
+  expect(recorded.started).toEqual(["predecessor", "successor"]);
+  expect(recorded.seeded).toBe(1);
+  // Half the callers left mid-answer on each endpoint.
+  expect(report.listener.abandoned).toBeGreaterThan(0);
+  expect(report.socket.abandoned).toBe(report.listener.abandoned);
+});
+
+test("a host that never holds the listener fails before a successor is started", async () => {
+  const { ports, recorded } = harness({ listener: [false] });
+
+  const report = await rehearseRuntimeHost(ports, { ...options, readyBudgetMs: 1_000 });
+
+  expect(report.ok).toBe(false);
+  expect(report.detail).toContain("did not hold the stable listener");
+  expect(report.detail).toContain("bun 1.4.0");
+  expect(report.succession.completed).toBe(false);
+  expect(recorded.started).toEqual(["predecessor"]);
+  expect(report.log).toEqual(["predecessor: line one"]);
+});
+
+test("a successor that never takes the fence fails the rehearsal", async () => {
+  // The predecessor answers once, then nothing answers after it is stopped.
+  const { ports } = harness({ listener: [true, false] });
+
+  const report = await rehearseRuntimeHost(ports, { ...options, successionBudgetMs: 1_000 });
+
+  expect(report.ok).toBe(false);
+  expect(report.detail).toContain("never took the singleton fence");
+  expect(report.succession.completed).toBe(false);
+  expect(report.log).toEqual(["successor: line one"]);
+});
+
+test("a listener that stops answering inside the hold window fails the rehearsal", async () => {
+  const { ports } = harness({ listener: [true, true, true, false] });
+
+  const report = await rehearseRuntimeHost(ports, options);
+
+  expect(report.ok).toBe(false);
+  expect(report.detail).toContain("stable listener stopped answering");
+  // The succession itself completed; what failed is holding what it handed over.
+  expect(report.succession.completed).toBe(true);
+});
+
+test("a runtime socket that stops answering inside the hold window fails the rehearsal", async () => {
+  const { ports } = harness({ listener: [true], socket: [true, false] });
+
+  const report = await rehearseRuntimeHost(ports, options);
+
+  expect(report.ok).toBe(false);
+  expect(report.detail).toContain("runtime socket stopped answering");
+  expect(report.succession.completed).toBe(true);
+});
+
+test("a host that exits mid-hold fails even while its endpoints still answer", async () => {
+  const { ports } = harness({ listener: [true], diesAtPoll: 2 });
+
+  const report = await rehearseRuntimeHost(ports, options);
+
+  expect(report.ok).toBe(false);
+  expect(report.detail).toContain("exited during the");
+});
+
+test("every generation is stopped even when the rehearsal fails", async () => {
+  const { ports, recorded } = harness({ listener: [true, true, true, false] });
+
+  await rehearseRuntimeHost(ports, options);
+
+  expect(recorded.stopped).toContain("predecessor");
+  expect(recorded.stopped).toContain("successor");
+});
+
+test("the image rehearsal runs in a throwaway container that cannot reach live state", () => {
+  const args = runtimeHostRehearsalDockerArgs("agent-log-viewer:candidate-abc");
+
+  expect(args.slice(0, 4)).toEqual(["docker", "run", "--rm", "--network"]);
+  expect(args).toContain("none");
+  expect(args.slice(-3)).toEqual(["agent-log-viewer:candidate-abc", "run", "src/runtime-host/hostRehearsalRun.ts"]);
+  // No bind mount can carry the operator's state directory into the rehearsal.
+  expect(args).not.toContain("-v");
+  expect(args).not.toContain("--volume");
+});
+
+test("the rehearsal report is read back out of a stream of host output", () => {
+  const output = [
+    "[runtime host] some unrelated line",
+    `${RUNTIME_HOST_REHEARSAL_REPORT_PREFIX}${JSON.stringify({
+      checkedAt: "2026-08-28T00:00:00.000Z",
+      runtime: "bun 1.4.0",
+      succession: { predecessorReadyMs: 1, successorTookOverMs: 2, completed: true },
+      listener: { windowMs: 15_000, polls: 30, answered: 30, abandoned: 15 },
+      socket: { polls: 30, answered: 30, abandoned: 15 },
+      ok: true,
+    })}`,
+    "",
+  ].join("\n");
+
+  expect(parseRuntimeHostRehearsalReport(output).ok).toBe(true);
+  expect(parseRuntimeHostRehearsalReport(output).runtime).toBe("bun 1.4.0");
+  expect(() => parseRuntimeHostRehearsalReport("nothing here")).toThrow("produced no report");
+});

--- a/src/runtime-host/hostRehearsal.test.ts
+++ b/src/runtime-host/hostRehearsal.test.ts
@@ -4,6 +4,7 @@ import {
   parseRuntimeHostRehearsalReport,
   rehearseRuntimeHost,
   runtimeHostRehearsalDockerArgs,
+  RUNTIME_HOST_REHEARSAL_IMAGE_BIN,
   RUNTIME_HOST_REHEARSAL_REPORT_PREFIX,
   type RuntimeHostRehearsalGeneration,
   type RuntimeHostRehearsalPorts,
@@ -154,6 +155,19 @@ test("the image rehearsal runs in a throwaway container that cannot reach live s
   // No bind mount can carry the operator's state directory into the rehearsal.
   expect(args).not.toContain("-v");
   expect(args).not.toContain("--volume");
+});
+
+test("the image rehearsal names the image's own interpreter for every generation it starts", () => {
+  const args = runtimeHostRehearsalDockerArgs("agent-log-viewer:candidate-abc");
+
+  /* `bun` in the image is an nsenter shim to the operator's bun on the host:
+     it is not the interpreter being promoted, and inside a container without
+     the host PID namespace it cannot run at all. The rehearsal itself and the
+     generations it starts must both be the image's real Bun, or the gate fails
+     every candidate without ever having reached a runtime host. */
+  expect(args[args.indexOf("--entrypoint") + 1]).toBe(RUNTIME_HOST_REHEARSAL_IMAGE_BIN);
+  expect(args).toContain(`LLV_RUNTIME_HOST_REHEARSAL_BIN=${RUNTIME_HOST_REHEARSAL_IMAGE_BIN}`);
+  expect(RUNTIME_HOST_REHEARSAL_IMAGE_BIN.endsWith("/bun")).toBe(false);
 });
 
 test("the rehearsal report is read back out of a stream of host output", () => {

--- a/src/runtime-host/hostRehearsal.ts
+++ b/src/runtime-host/hostRehearsal.ts
@@ -1,0 +1,230 @@
+/* #1254: what it means to have verified a runtime change.
+ *
+ * The Bun pin moved to 1.4.0 for the framework bump. Every check that ran
+ * before promotion exercised the Viewer, and the Viewer was fine. The runtime
+ * host runs under the same Bun, owns the stable listener, and performs the
+ * release succession — and it was never started under 1.4.0 until it was
+ * production. It crash-looped there, on a socket write to a peer that had
+ * already gone.
+ *
+ * A runtime is verified for this repository when the runtime host has actually
+ * done its job under it: booted, taken the singleton fence from a predecessor
+ * generation, and then held both of its endpoints while real peers came and
+ * went — including peers that leave in the middle of an answer, which is the
+ * write that took production down. This is a gate, not a report: a candidate
+ * whose host cannot do this is refused before promotion.
+ *
+ * The rehearsal never touches a live listener. Both generations run against a
+ * private state directory on an ephemeral port; the concrete ports in
+ * `hostRehearsalRun.ts` own that isolation, and the deployment gate runs the
+ * whole thing inside a throwaway container from the candidate image.
+ */
+
+import type {
+  ViewerRuntimeHostHealthEvidence,
+  ViewerRuntimeHostListenerEvidence,
+  ViewerRuntimeHostProbeEvidence,
+} from "@/lib/runtime/contracts";
+
+/** The predecessor's listener must answer within this after it is started. */
+const DEFAULT_READY_BUDGET_MS = 60_000;
+/** The successor must take the fence and answer within this after the
+    predecessor is asked to exit. */
+const DEFAULT_SUCCESSION_BUDGET_MS = 30_000;
+/** How long the successor's endpoints are held under observation, and how
+    often they are asked. The incident's listener answered 12 of 24 polls, so a
+    window of this size with every poll required sees it several times over. */
+const DEFAULT_HOLD_WINDOW_MS = 15_000;
+const DEFAULT_HOLD_POLL_MS = 500;
+/** Bounded tail of a generation's own output, kept with a failure. */
+export const RUNTIME_HOST_REHEARSAL_LOG_LINES = 40;
+/** How the rehearsal names its report inside a stream of host output. */
+export const RUNTIME_HOST_REHEARSAL_REPORT_PREFIX = "[runtime host rehearsal] report ";
+
+export interface RuntimeHostRehearsalGeneration {
+  /** Ask this generation to exit the way a hand-over does. */
+  stop(): Promise<void>;
+  /** Whether the process is gone, however it went. */
+  exited(): boolean;
+  /** Bounded tail of what it wrote. */
+  log(): string[];
+}
+
+export interface RuntimeHostRehearsalPorts {
+  /** Start one runtime-host generation. The successor boots while the
+      predecessor still owns the fence, exactly as a staged one does. */
+  start(role: "predecessor" | "successor"): Promise<RuntimeHostRehearsalGeneration>;
+  /**
+   * Put enough in the journal that one replay is a large answer rather than a
+   * single small write, so an abandoning peer has something to leave behind.
+   */
+  seed(): Promise<void>;
+  /**
+   * Ask the stable listener for an answer. `abandon` makes the caller vanish
+   * part-way through — the write that took production down, produced on
+   * purpose rather than waited for.
+   */
+  probeListener(options: { abandon: boolean }): Promise<boolean>;
+  /** The same question of the runtime socket, whose answers are the large ones. */
+  probeSocket(options: { abandon: boolean }): Promise<boolean>;
+  now(): number;
+  sleep(milliseconds: number): Promise<void>;
+}
+
+export interface RuntimeHostRehearsalOptions {
+  /** What was exercised, for the record: `bun 1.4.0`. */
+  runtime: string;
+  readyBudgetMs?: number;
+  successionBudgetMs?: number;
+  holdWindowMs?: number;
+  holdPollMs?: number;
+}
+
+function evidence(
+  options: RuntimeHostRehearsalOptions,
+  checkedAt: string,
+  succession: ViewerRuntimeHostHealthEvidence["succession"],
+  listener: ViewerRuntimeHostListenerEvidence,
+  socket: ViewerRuntimeHostProbeEvidence,
+  failure: { detail: string; log: string[] } | null,
+): ViewerRuntimeHostHealthEvidence {
+  return {
+    checkedAt,
+    runtime: options.runtime,
+    succession,
+    listener,
+    socket,
+    ok: failure === null,
+    ...(failure ? { detail: failure.detail } : {}),
+    ...(failure && failure.log.length > 0 ? { log: failure.log } : {}),
+  };
+}
+
+/** Wait until the stable listener answers, or give up at the budget. */
+async function awaitListener(
+  ports: RuntimeHostRehearsalPorts,
+  budgetMs: number,
+  pollMs: number,
+): Promise<number | null> {
+  const started = ports.now();
+  for (;;) {
+    if (await ports.probeListener({ abandon: false })) return ports.now() - started;
+    if (ports.now() - started >= budgetMs) return null;
+    await ports.sleep(pollMs);
+  }
+}
+
+/**
+ * Drive one runtime-host succession under a runtime and hold the endpoints it
+ * hands over. The returned evidence is the whole account: a caller that gets
+ * `ok: false` has a named reason and the generation's own output.
+ */
+export async function rehearseRuntimeHost(
+  ports: RuntimeHostRehearsalPorts,
+  options: RuntimeHostRehearsalOptions,
+): Promise<ViewerRuntimeHostHealthEvidence> {
+  const readyBudgetMs = options.readyBudgetMs ?? DEFAULT_READY_BUDGET_MS;
+  const successionBudgetMs = options.successionBudgetMs ?? DEFAULT_SUCCESSION_BUDGET_MS;
+  const holdWindowMs = options.holdWindowMs ?? DEFAULT_HOLD_WINDOW_MS;
+  const holdPollMs = Math.max(1, options.holdPollMs ?? DEFAULT_HOLD_POLL_MS);
+  const checkedAt = new Date().toISOString();
+  const listener: ViewerRuntimeHostListenerEvidence = { windowMs: holdWindowMs, polls: 0, answered: 0, abandoned: 0 };
+  const socket: ViewerRuntimeHostProbeEvidence = { polls: 0, answered: 0, abandoned: 0 };
+
+  let predecessor: RuntimeHostRehearsalGeneration | null = null;
+  let successor: RuntimeHostRehearsalGeneration | null = null;
+  // A failure keeps the output of whichever generation was meant to be serving.
+  const fail = (
+    detail: string,
+    succession: ViewerRuntimeHostHealthEvidence["succession"],
+  ): ViewerRuntimeHostHealthEvidence => evidence(options, checkedAt, succession, listener, socket, {
+    detail,
+    log: (successor ?? predecessor)?.log() ?? [],
+  });
+
+  try {
+    predecessor = await ports.start("predecessor");
+    const predecessorReadyMs = await awaitListener(ports, readyBudgetMs, holdPollMs);
+    if (predecessorReadyMs === null) {
+      return fail(
+        `the runtime host did not hold the stable listener within ${Math.round(readyBudgetMs / 1_000)}s of starting under ${options.runtime}`,
+        { predecessorReadyMs: readyBudgetMs, successorTookOverMs: 0, completed: false },
+      );
+    }
+    await ports.seed();
+
+    successor = await ports.start("successor");
+    const started = { predecessorReadyMs, successorTookOverMs: 0, completed: false };
+    await predecessor.stop();
+    const successorTookOverMs = await awaitListener(ports, successionBudgetMs, holdPollMs);
+    if (successorTookOverMs === null) {
+      return fail(
+        `the successor generation never took the singleton fence and the stable listener within ${Math.round(successionBudgetMs / 1_000)}s under ${options.runtime}`,
+        { ...started, successorTookOverMs: successionBudgetMs },
+      );
+    }
+    const succession = { predecessorReadyMs, successorTookOverMs, completed: true };
+
+    /* The hold. Every poll on both endpoints must answer: whoever asked a
+       listener that missed one saw an outage, and a host that dies on a peer's
+       disconnect misses them in runs. Half the callers leave mid-answer. */
+    const holdStarted = ports.now();
+    const elapsed = () => Math.round((ports.now() - holdStarted) / 1_000);
+    const window = Math.round(holdWindowMs / 1_000);
+    while (ports.now() - holdStarted < holdWindowMs) {
+      const abandon = listener.polls % 2 === 1;
+      listener.polls += 1;
+      if (abandon) listener.abandoned += 1;
+      if (!await ports.probeListener({ abandon })) {
+        return fail(`the stable listener stopped answering ${elapsed()}s into a ${window}s hold under ${options.runtime}`, succession);
+      }
+      listener.answered += 1;
+      socket.polls += 1;
+      if (abandon) socket.abandoned += 1;
+      if (!await ports.probeSocket({ abandon })) {
+        return fail(`the runtime socket stopped answering ${elapsed()}s into a ${window}s hold under ${options.runtime}`, succession);
+      }
+      socket.answered += 1;
+      if (successor.exited()) {
+        return fail(`the runtime host exited during the ${window}s hold under ${options.runtime}`, succession);
+      }
+      await ports.sleep(holdPollMs);
+    }
+    if (listener.polls === 0) return fail("the hold window observed nothing", succession);
+    return evidence(options, checkedAt, succession, listener, socket, null);
+  } finally {
+    await successor?.stop().catch(() => undefined);
+    await predecessor?.stop().catch(() => undefined);
+  }
+}
+
+/**
+ * Rehearse the runtime host of a candidate image, inside a container built
+ * from that image. `--rm` and no mounts: the rehearsal writes only inside a
+ * container that is discarded, so it can reach neither the live state
+ * directory nor the live listener.
+ */
+export function runtimeHostRehearsalDockerArgs(image: string, stateDir = "/tmp/llv-host-rehearsal"): string[] {
+  return [
+    "docker", "run", "--rm",
+    // Loopback only: the rehearsal's ephemeral ports are the container's own.
+    "--network", "none",
+    "--label", "dev.live-log-viewer.runtime-host-rehearsal=1",
+    "-e", `LLV_RUNTIME_HOST_REHEARSAL_STATE_DIR=${stateDir}`,
+    "--entrypoint", "bun-container",
+    image,
+    "run", "src/runtime-host/hostRehearsalRun.ts",
+  ];
+}
+
+/** Read the rehearsal's own report out of the container's output. */
+export function parseRuntimeHostRehearsalReport(output: string): ViewerRuntimeHostHealthEvidence {
+  const marker = output.lastIndexOf(RUNTIME_HOST_REHEARSAL_REPORT_PREFIX);
+  if (marker < 0) throw new Error("the runtime-host rehearsal produced no report");
+  const line = output.slice(marker + RUNTIME_HOST_REHEARSAL_REPORT_PREFIX.length).split("\n")[0] ?? "";
+  const report = JSON.parse(line) as ViewerRuntimeHostHealthEvidence;
+  if (typeof report.ok !== "boolean" || typeof report.runtime !== "string") {
+    throw new Error("the runtime-host rehearsal report is malformed");
+  }
+  return report;
+}

--- a/src/runtime-host/hostRehearsal.ts
+++ b/src/runtime-host/hostRehearsal.ts
@@ -55,8 +55,8 @@ export interface RuntimeHostRehearsalPorts {
       predecessor still owns the fence, exactly as a staged one does. */
   start(role: "predecessor" | "successor"): Promise<RuntimeHostRehearsalGeneration>;
   /**
-   * Put enough in the journal that one replay is a large answer rather than a
-   * single small write, so an abandoning peer has something to leave behind.
+   * Put enough in the journal that one answer is a large one rather than a
+   * single small write, so an abandoning peer leaves bytes still pending.
    */
   seed(): Promise<void>;
   /**
@@ -199,6 +199,17 @@ export async function rehearseRuntimeHost(
 }
 
 /**
+ * The interpreter the rehearsal must exercise inside the image, named in full.
+ *
+ * `bun` in the image is an nsenter shim that redirects to the operator's bun
+ * on the host — it is for the agent CLIs, it needs the host PID namespace this
+ * container deliberately does not have, and it is not the interpreter being
+ * promoted. `bun-container` is the real in-container Bun the runtime host runs
+ * under in production, which is the whole point of the rehearsal.
+ */
+export const RUNTIME_HOST_REHEARSAL_IMAGE_BIN = "/usr/local/bin/bun-container";
+
+/**
  * Rehearse the runtime host of a candidate image, inside a container built
  * from that image. `--rm` and no mounts: the rehearsal writes only inside a
  * container that is discarded, so it can reach neither the live state
@@ -211,7 +222,11 @@ export function runtimeHostRehearsalDockerArgs(image: string, stateDir = "/tmp/l
     "--network", "none",
     "--label", "dev.live-log-viewer.runtime-host-rehearsal=1",
     "-e", `LLV_RUNTIME_HOST_REHEARSAL_STATE_DIR=${stateDir}`,
-    "--entrypoint", "bun-container",
+    // Both the rehearsal itself and the generations it starts run under the
+    // image's own Bun. Without the second one the generations inherit `bun`,
+    // the shim, and every candidate fails a gate that never reached a host.
+    "-e", `LLV_RUNTIME_HOST_REHEARSAL_BIN=${RUNTIME_HOST_REHEARSAL_IMAGE_BIN}`,
+    "--entrypoint", RUNTIME_HOST_REHEARSAL_IMAGE_BIN,
     image,
     "run", "src/runtime-host/hostRehearsalRun.ts",
   ];

--- a/src/runtime-host/hostRehearsalRun.test.ts
+++ b/src/runtime-host/hostRehearsalRun.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { probeRuntimeSocket } from "./hostRehearsalRun";
+
+/** A newline-framed stand-in for the runtime socket, driven per connection. */
+async function serve(answer: (socket: net.Socket) => void): Promise<{ socketPath: string; close: () => Promise<void> }> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "llv-rehearsal-probe-"));
+  const socketPath = path.join(directory, "runtime-host.sock");
+  const server = net.createServer((socket) => {
+    socket.on("error", () => socket.destroy());
+    socket.once("data", () => answer(socket));
+  });
+  server.listen(socketPath);
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  return {
+    socketPath,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+test("a caller that reads the answer needs a complete frame to count the poll", async () => {
+  const answered = await serve((socket) => socket.end('{"id":"probe","ok":true,"result":{}}\n'));
+  try {
+    expect(await probeRuntimeSocket(answered.socketPath, { id: "probe", method: "snapshot" }, { abandon: false })).toBe(true);
+  } finally {
+    await answered.close();
+  }
+
+  const silent = await serve((socket) => socket.destroy());
+  try {
+    expect(await probeRuntimeSocket(silent.socketPath, { id: "probe", method: "snapshot" }, { abandon: false })).toBe(false);
+  } finally {
+    await silent.close();
+  }
+});
+
+test("an abandoning caller counts the poll once its request is taken, however the host then ends the connection", async () => {
+  /* The point of an abandoning caller is to leave the answer pending, so the
+     endpoint is asked only to accept the request. Under Bun 1.3.3 a host drops
+     the write it cannot finish and closes the connection itself; that is the
+     runtime behaving as it always did, and reading it as a listener that
+     stopped answering would fail the gate on the runtime it was written for. */
+  const closes = await serve((socket) => socket.destroy());
+  try {
+    expect(await probeRuntimeSocket(closes.socketPath, { id: "probe", method: "snapshot" }, { abandon: true })).toBe(true);
+  } finally {
+    await closes.close();
+  }
+});
+
+test("a socket nobody is listening on fails the poll either way", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "llv-rehearsal-probe-"));
+  const socketPath = path.join(directory, "absent.sock");
+  try {
+    expect(await probeRuntimeSocket(socketPath, { id: "probe", method: "snapshot" }, { abandon: false })).toBe(false);
+    expect(await probeRuntimeSocket(socketPath, { id: "probe", method: "snapshot" }, { abandon: true })).toBe(false);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/runtime-host/hostRehearsalRun.ts
+++ b/src/runtime-host/hostRehearsalRun.ts
@@ -33,15 +33,23 @@ const REHEARSAL_FENCE_WAIT_MS = 120_000;
 /** A probe that waits longer than this against a local endpoint is a failure,
     not a slow answer. */
 const PROBE_TIMEOUT_MS = 5_000;
-/* The seed. `replay` returns at most 128 events and the journal caps a payload
-   at 16 KiB, so this asks the host for the largest answer a rehearsal can make
-   it produce — roughly a quarter of a megabyte, several socket writes wide.
-   A production snapshot is larger still; this is the biggest stand-in a fresh
-   journal can offer, and it is what the abandoning peers below leave behind. */
-const SEED_EVENTS = 128;
-const SEED_EVENT_BYTES = 15_000;
+/* The seed, sized by what actually makes a write fail. A write only fails once
+   the peer has gone while bytes are still pending in the host: an answer the
+   kernel swallows whole is written before anyone can leave. Measured under Bun
+   1.4.0 on a Unix socket, an answer of ~400 KB leaves nothing pending and one
+   of ~600 KB does, so the seed builds a snapshot several times past that.
+   The journal caps an event payload at 16 KiB, and a session's live turn is
+   kept per session, so the size comes from the number of sessions. Sixty-four
+   of them project to roughly two megabytes — the shape of a real snapshot,
+   which is what `PreserializedJson` exists for. */
+const SEED_SESSIONS = 64;
+const SEED_LIVE_TURN_BYTES = 15_000;
 /** A frame beyond this is a runaway answer, not a large one. */
 const MAX_PROBE_FRAME_BYTES = 64 * 1024 * 1024;
+/** How long an abandoning caller lets the answer accumulate unread before it
+    vanishes. Long enough for the host to fill the socket buffer and still be
+    writing; short enough that a hold window is made of real polls. */
+const ABANDON_DELAY_MS = 150;
 
 export interface RuntimeHostRehearsalRunOptions {
   /** The interpreter under test; `bun-container` inside the image. */
@@ -144,11 +152,12 @@ export function probeStableListener(port: number, options: { abandon: boolean })
 }
 
 /**
- * One request on the runtime socket. `abandon` reads the first bytes of the
- * answer and then vanishes, leaving the host writing the rest of a multi-
- * megabyte frame into a socket whose peer is gone. That is the production
- * write: Bun 1.3.3 dropped its failure, 1.4.0 reports it, and a host without a
- * handler on that connection dies of it.
+ * One request on the runtime socket. `abandon` never reads a byte and then
+ * vanishes, leaving the host with the rest of a multi-megabyte frame still
+ * pending for a peer that is gone. That is the production write: Bun 1.3.3
+ * dropped its failure, 1.4.0 reports it, and a host without a handler on that
+ * connection dies of it — which this rehearsal, run against the host as it
+ * was, reproduces.
  */
 export function probeRuntimeSocket(socketPath: string, request: unknown, options: { abandon: boolean }): Promise<boolean> {
   return new Promise((resolve) => {
@@ -157,30 +166,52 @@ export function probeRuntimeSocket(socketPath: string, request: unknown, options
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      clearTimeout(abandonment);
       socket.destroy();
       resolve(answered);
     };
     const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    let abandonment: ReturnType<typeof setTimeout> | undefined;
     const socket = net.createConnection(socketPath);
     let frame = "";
-    socket.on("error", () => finish(false));
-    socket.on("close", () => finish(false));
-    socket.on("data", (chunk) => {
-      if (options.abandon) return finish(true);
-      // Reading to the frame delimiter is what a complete answer means here.
-      frame += String(chunk);
-      const newline = frame.indexOf("\n");
-      if (newline >= 0) finish(frame.slice(0, newline).includes('"ok":true'));
-      else if (frame.length > MAX_PROBE_FRAME_BYTES) finish(false);
+    /* What an abandoning caller asks of the endpoint is that it take the
+       request; the answer is what it deliberately walks away from. Once the
+       request is on the wire the poll is answered however the connection then
+       ends — under 1.3.3 the host drops the failing write and closes it
+       itself, and that is the runtime behaving as it always did, not a
+       listener that stopped answering. A host that is actually gone fails the
+       next poll, which reads its answer in full. */
+    let requested = false;
+    socket.on("error", () => finish(requested));
+    socket.on("close", () => finish(requested));
+    if (!options.abandon) {
+      socket.on("data", (chunk) => {
+        // Reading to the frame delimiter is what a complete answer means here.
+        frame += String(chunk);
+        const newline = frame.indexOf("\n");
+        if (newline >= 0) finish(frame.slice(0, newline).includes('"ok":true'));
+        else if (frame.length > MAX_PROBE_FRAME_BYTES) finish(false);
+      });
+    }
+    socket.once("connect", () => {
+      socket.write(JSON.stringify(request) + "\n");
+      if (!options.abandon) return;
+      requested = true;
+      /* An abandoning caller never reads a byte: with no `data` listener the
+         socket stays paused, so the answer fills the socket buffer and the
+         rest of it is still pending in the host when this caller vanishes.
+         That pending remainder is the production write, and leaving one
+         behind is why the seed above is sized the way it is. */
+      abandonment = setTimeout(() => finish(true), ABANDON_DELAY_MS);
     });
-    socket.once("connect", () => socket.write(JSON.stringify(request) + "\n"));
   });
 }
 
-/** Fill the journal so one `events` replay is a multi-megabyte answer. */
+/** Fill the journal so one snapshot is a multi-megabyte answer. */
 async function seedJournal(socketPath: string): Promise<void> {
-  const filler = "x".repeat(SEED_EVENT_BYTES);
-  for (let index = 0; index < SEED_EVENTS; index += 1) {
+  const text = "x".repeat(SEED_LIVE_TURN_BYTES);
+  for (let index = 0; index < SEED_SESSIONS; index += 1) {
+    const turnId = `rehearsal-turn-${index}`;
     const appended = await probeRuntimeSocket(socketPath, {
       id: `rehearsal-seed-${index}`,
       method: "append",
@@ -188,7 +219,8 @@ async function seedJournal(socketPath: string): Promise<void> {
         event: {
           scope: `session:rehearsal-${index}`,
           kind: "session-status",
-          payload: { hostAxis: "hosted", filler },
+          // A running turn is what keeps live text in the snapshot projection.
+          payload: { host: "hosted", turn: "running", activeTurnId: turnId, liveTurn: { turnId, text } },
         },
       },
     }, { abandon: false });
@@ -202,7 +234,9 @@ export function runtimeHostRehearsalPorts(options: RuntimeHostRehearsalRunOption
     start: async (role) => startGeneration(options, role),
     seed: () => seedJournal(socketPath),
     probeListener: (probe) => probeStableListener(options.port, probe),
-    probeSocket: (probe) => probeRuntimeSocket(socketPath, { id: "rehearsal-events", method: "events", params: { after: 0 } }, probe),
+    /* The snapshot, because it is the large answer: a peer that leaves during
+       one of these is the write that took production down. */
+    probeSocket: (probe) => probeRuntimeSocket(socketPath, { id: "rehearsal-snapshot", method: "snapshot", params: {} }, probe),
     now: () => Date.now(),
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
   };

--- a/src/runtime-host/hostRehearsalRun.ts
+++ b/src/runtime-host/hostRehearsalRun.ts
@@ -1,0 +1,269 @@
+/* #1254: the concrete ports for the runtime-host rehearsal, and its entry
+   point. Run directly, this file is the rehearsal:
+
+     bun run src/runtime-host/hostRehearsalRun.ts
+
+   It starts two real runtime-host generations under a chosen Bun, drives one
+   singleton-fence succession between them, and holds the stable listener the
+   succession handed over. Everything it touches is created here and removed
+   here: a private state directory, a private socket, an ephemeral loopback
+   port. It never reads the operator's state directory and never binds 8898. */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import type { ViewerRuntimeHostHealthEvidence } from "@/lib/runtime/contracts";
+
+import {
+  RUNTIME_HOST_REHEARSAL_LOG_LINES,
+  RUNTIME_HOST_REHEARSAL_REPORT_PREFIX,
+  rehearseRuntimeHost,
+  type RuntimeHostRehearsalGeneration,
+  type RuntimeHostRehearsalPorts,
+} from "./hostRehearsal";
+import { RUNTIME_HOST_FENCE_WAIT_ENV } from "./fenceWait";
+import { RUNTIME_HOST_CONTAINER_ENV } from "./hostRelease";
+
+/** The successor's own fence wait has to outlast the succession budget, or it
+    fails its container before the predecessor has finished releasing. */
+const REHEARSAL_FENCE_WAIT_MS = 120_000;
+/** A probe that waits longer than this against a local endpoint is a failure,
+    not a slow answer. */
+const PROBE_TIMEOUT_MS = 5_000;
+/* The seed. `replay` returns at most 128 events and the journal caps a payload
+   at 16 KiB, so this asks the host for the largest answer a rehearsal can make
+   it produce — roughly a quarter of a megabyte, several socket writes wide.
+   A production snapshot is larger still; this is the biggest stand-in a fresh
+   journal can offer, and it is what the abandoning peers below leave behind. */
+const SEED_EVENTS = 128;
+const SEED_EVENT_BYTES = 15_000;
+/** A frame beyond this is a runaway answer, not a large one. */
+const MAX_PROBE_FRAME_BYTES = 64 * 1024 * 1024;
+
+export interface RuntimeHostRehearsalRunOptions {
+  /** The interpreter under test; `bun-container` inside the image. */
+  runtimeBin: string;
+  /** Repository (or `/app`) root that owns `src/runtime-host/main.ts`. */
+  root: string;
+  stateDir: string;
+  port: number;
+  holdWindowMs?: number;
+}
+
+function rehearsalEnvironment(options: RuntimeHostRehearsalRunOptions, role: "predecessor" | "successor"): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+    // The environment is built rather than inherited, so the rehearsal cannot
+    // pick up a live socket, journal or state dir from whoever started it.
+    // The image pins production, and the host under test must see the same.
+    NODE_ENV: process.env.NODE_ENV ?? "production",
+    HOME: options.stateDir,
+    XDG_CONFIG_HOME: path.join(options.stateDir, "config"),
+    TMPDIR: path.join(options.stateDir, "tmp"),
+    LLV_STATE_DIR: options.stateDir,
+    LLV_RUNTIME_HOST_SOCKET: path.join(options.stateDir, "runtime-host.sock"),
+    LLV_RUNTIME_JOURNAL: path.join(options.stateDir, "runtime-events.sqlite"),
+    /* The stable listener exists only when deployments are enabled, and the
+       listener is the point. The adapter is never invoked: no deployment is
+       requested, and the release target file is deliberately absent, so the
+       proxy answers its own 503 — which is the raw-write path that took the
+       host down, exercised on every probe. */
+    LLV_VIEWER_DEPLOYMENTS: "1",
+    LLV_VIEWER_DEPLOY_ADAPTER: path.join(options.root, "scripts", "runtime-host-viewer-adapter.ts"),
+    LLV_VIEWER_DEPLOY_TARGET: path.join(options.stateDir, "viewer-release.json"),
+    LLV_VIEWER_PORT: String(options.port),
+    [RUNTIME_HOST_CONTAINER_ENV]: `rehearsal-${role}`,
+    ...(role === "successor" ? { [RUNTIME_HOST_FENCE_WAIT_ENV]: String(REHEARSAL_FENCE_WAIT_MS) } : {}),
+  };
+}
+
+function startGeneration(options: RuntimeHostRehearsalRunOptions, role: "predecessor" | "successor"): RuntimeHostRehearsalGeneration {
+  const child: ChildProcess = spawn(options.runtimeBin, ["run", "src/runtime-host/main.ts"], {
+    cwd: options.root,
+    env: rehearsalEnvironment(options, role),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const lines: string[] = [];
+  const collect = (chunk: unknown) => {
+    for (const line of String(chunk).split("\n")) {
+      if (!line.trim()) continue;
+      lines.push(`${role}: ${line}`);
+      if (lines.length > RUNTIME_HOST_REHEARSAL_LOG_LINES) lines.shift();
+    }
+  };
+  child.stdout?.on("data", collect);
+  child.stderr?.on("data", collect);
+  child.on("error", (error) => collect(`failed to start: ${error.message}`));
+  let exited = false;
+  const gone = new Promise<void>((resolve) => child.once("exit", () => { exited = true; resolve(); }));
+  return {
+    exited: () => exited,
+    log: () => [...lines],
+    stop: async () => {
+      if (exited) return;
+      child.kill("SIGTERM");
+      const forced = setTimeout(() => child.kill("SIGKILL"), 10_000);
+      try { await gone; } finally { clearTimeout(forced); }
+    },
+  };
+}
+
+/**
+ * One request against the stable listener. `abandon` drops the caller as soon
+ * as the connection exists, leaving the host to write its answer into a socket
+ * whose peer is gone — the production failure, produced on purpose rather than
+ * waited for. Any HTTP status counts: the rehearsal asks whether the listener
+ * is held, not what is behind it.
+ */
+export function probeStableListener(port: number, options: { abandon: boolean }): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (answered: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(answered);
+    };
+    const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    const socket = net.createConnection(port, "127.0.0.1");
+    socket.on("error", () => finish(false));
+    socket.on("close", () => finish(false));
+    socket.on("data", (chunk) => finish(String(chunk).startsWith("HTTP/1.")));
+    socket.once("connect", () => {
+      /* An abandoning caller vanishes the moment the connection exists — the
+         listener is already composing its answer into a peer that is gone.
+         Reaching `connect` is itself the evidence that the listener is held. */
+      if (options.abandon) return finish(true);
+      socket.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    });
+  });
+}
+
+/**
+ * One request on the runtime socket. `abandon` reads the first bytes of the
+ * answer and then vanishes, leaving the host writing the rest of a multi-
+ * megabyte frame into a socket whose peer is gone. That is the production
+ * write: Bun 1.3.3 dropped its failure, 1.4.0 reports it, and a host without a
+ * handler on that connection dies of it.
+ */
+export function probeRuntimeSocket(socketPath: string, request: unknown, options: { abandon: boolean }): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (answered: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(answered);
+    };
+    const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    const socket = net.createConnection(socketPath);
+    let frame = "";
+    socket.on("error", () => finish(false));
+    socket.on("close", () => finish(false));
+    socket.on("data", (chunk) => {
+      if (options.abandon) return finish(true);
+      // Reading to the frame delimiter is what a complete answer means here.
+      frame += String(chunk);
+      const newline = frame.indexOf("\n");
+      if (newline >= 0) finish(frame.slice(0, newline).includes('"ok":true'));
+      else if (frame.length > MAX_PROBE_FRAME_BYTES) finish(false);
+    });
+    socket.once("connect", () => socket.write(JSON.stringify(request) + "\n"));
+  });
+}
+
+/** Fill the journal so one `events` replay is a multi-megabyte answer. */
+async function seedJournal(socketPath: string): Promise<void> {
+  const filler = "x".repeat(SEED_EVENT_BYTES);
+  for (let index = 0; index < SEED_EVENTS; index += 1) {
+    const appended = await probeRuntimeSocket(socketPath, {
+      id: `rehearsal-seed-${index}`,
+      method: "append",
+      params: {
+        event: {
+          scope: `session:rehearsal-${index}`,
+          kind: "session-status",
+          payload: { hostAxis: "hosted", filler },
+        },
+      },
+    }, { abandon: false });
+    if (!appended) throw new Error("the runtime host refused the rehearsal seed");
+  }
+}
+
+export function runtimeHostRehearsalPorts(options: RuntimeHostRehearsalRunOptions): RuntimeHostRehearsalPorts {
+  const socketPath = path.join(options.stateDir, "runtime-host.sock");
+  return {
+    start: async (role) => startGeneration(options, role),
+    seed: () => seedJournal(socketPath),
+    probeListener: (probe) => probeStableListener(options.port, probe),
+    probeSocket: (probe) => probeRuntimeSocket(socketPath, { id: "rehearsal-events", method: "events", params: { after: 0 } }, probe),
+    now: () => Date.now(),
+    sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  };
+}
+
+/** An unused loopback port, claimed and released so the host can bind it. */
+export function ephemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") return reject(new Error("no ephemeral port was assigned"));
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function runtimeVersion(runtimeBin: string): Promise<string> {
+  const child = spawn(runtimeBin, ["--version"], { stdio: ["ignore", "pipe", "ignore"] });
+  let output = "";
+  child.stdout?.on("data", (chunk) => { output += String(chunk); });
+  const code = await new Promise<number | null>((resolve) => child.once("exit", resolve));
+  const version = output.trim();
+  return code === 0 && version ? `bun ${version}` : `${path.basename(runtimeBin)} (version unavailable)`;
+}
+
+/**
+ * Rehearse the runtime host once, under `runtimeBin`, in a state directory
+ * created for this run and removed after it.
+ */
+export async function runRuntimeHostRehearsal(options: {
+  runtimeBin?: string;
+  root?: string;
+  stateDir?: string;
+  holdWindowMs?: number;
+}): Promise<ViewerRuntimeHostHealthEvidence> {
+  const runtimeBin = options.runtimeBin ?? process.env.LLV_RUNTIME_HOST_REHEARSAL_BIN ?? "bun";
+  const root = options.root ?? process.cwd();
+  const stateDir = options.stateDir
+    ?? process.env.LLV_RUNTIME_HOST_REHEARSAL_STATE_DIR
+    ?? fs.mkdtempSync(path.join(os.tmpdir(), "llv-host-rehearsal-"));
+  fs.mkdirSync(path.join(stateDir, "tmp"), { recursive: true, mode: 0o700 });
+  const owned = options.stateDir === undefined && process.env.LLV_RUNTIME_HOST_REHEARSAL_STATE_DIR === undefined;
+  try {
+    return await rehearseRuntimeHost(
+      runtimeHostRehearsalPorts({ runtimeBin, root, stateDir, port: await ephemeralPort() }),
+      {
+        runtime: await runtimeVersion(runtimeBin),
+        ...(options.holdWindowMs === undefined ? {} : { holdWindowMs: options.holdWindowMs }),
+      },
+    );
+  } finally {
+    if (owned) fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  const report = await runRuntimeHostRehearsal({
+    ...(process.env.LLV_RUNTIME_HOST_REHEARSAL_ROOT ? { root: process.env.LLV_RUNTIME_HOST_REHEARSAL_ROOT } : {}),
+  });
+  console.log(RUNTIME_HOST_REHEARSAL_REPORT_PREFIX + JSON.stringify(report));
+  process.exit(report.ok ? 0 : 1);
+}

--- a/src/runtime-host/socket.test.ts
+++ b/src/runtime-host/socket.test.ts
@@ -131,3 +131,25 @@ test("a timed-out socket destroyed by the server produces zero late writes", asy
   expect(socketErrors).toEqual([]);
   client.destroy();
 });
+
+test("a write that fails after the peer vanished ends the connection, not the host", async () => {
+  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const server = serveRuntimeHost(socketPath, stubHost(async (request) => ({ id: request.id, ok: true, result: {} })));
+  servers.push(server);
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+
+  const accepted = new Promise<net.Socket>((resolve) => server.once("connection", resolve));
+  const client = net.createConnection(socketPath);
+  client.on("error", () => undefined);
+  const connection = await accepted;
+
+  /* Bun 1.4.0 reports a write whose peer is gone by destroying the socket with
+     the EPIPE; 1.3.3 dropped it silently. Nothing but a listener on this
+     connection stands between that report and an uncaught exception in the
+     process that owns the stable listener (#1254). */
+  const epipe = Object.assign(new Error("write EPIPE"), { errno: -32, code: "EPIPE", syscall: "write" });
+  expect(() => connection.emit("error", epipe)).not.toThrow();
+  expect(connection.destroyed).toBe(true);
+
+  client.destroy();
+});

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -38,6 +38,13 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHand
   try { fs.unlinkSync(socketPath); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
   let activeWaitConnections = 0;
   const server = net.createServer((socket) => {
+    /* #1254: a peer that goes away mid-frame is a connection event, and the
+       write that discovers it must end this connection and nothing else. Bun
+       1.3.3 dropped a failed socket write on the floor; 1.4.0 reports it by
+       destroying the socket with the EPIPE, so an unhandled `error` here is an
+       uncaught exception that kills the process owning the stable listener.
+       This listener is attached before anything can be written. */
+    socket.on("error", () => socket.destroy());
     const abort = new AbortController();
     socket.once("close", () => abort.abort());
     socket.setTimeout(defaultTimeoutMs, () => socket.destroy());


### PR DESCRIPTION
Closes #1254.

## What broke, exactly

Both halves of the issue are true and they reconcile: Bun 1.4.0 is genuinely required for the framework bump, and 1.4.0 is genuinely what the runtime host could not survive — because **1.3.3 dropped failed socket writes on the floor and 1.4.0 reports them.**

Bun 1.4.0's `node:net` handles a write that returns a negative errno like this:

```js
function failWrite(self, negErrno, callback) {
  let er = new ErrnoException(negErrno, "write");
  ...
  if (self._pendingData = null, self[kwriteCallback] = null, callback) {
    if (callback(er), !self.destroyed && !self._hadError)
      self._hadError = !0, self.destroy(er);      // ← emits 'error' on the socket
  } else if (!self.destroyed)
    if (self.listenerCount("error") > 0) ... else self.destroy();
}
```

reached from `process.nextTick(failWrite, this, res, callback)` — which is the `failWrite (node:net)` / `processTicksAndRejections` pair in the issue's stack. The same region in 1.3.3 has no `failWrite` at all: the drain handler ignores a failing write entirely.

Neither of the runtime host's two listeners had an `error` listener on its accepted connections:

- `src/runtime-host/socket.ts` — `serveRuntimeHost` writes the response with `socket.end(frame)` and attached no handler anywhere. Snapshot frames are multi-megabyte (that is what `PreserializedJson` exists for), so a caller that goes away mid-frame is routine.
- `src/runtime-host/deploymentProxy.ts` — the stable 8898 listener. Its two 503 answers wrote to a raw connection with no handling at all, and the proxying path used `once("error")`, which is removed after the first error and leaves a second one uncaught.

With no listener, `destroy(er)` raises an uncaught exception, and the process that owns 8898 dies. That is the crash loop.

## Reproduced outside production

A standalone driver: `serveRuntimeHost` on a private Unix socket answering with a snapshot-sized frame, and one client that vanishes while bytes are still pending.

| runtime | pre-fix source | with this change |
| --- | --- | --- |
| bun 1.3.3 | survives | survives |
| bun 1.4.0 | connection error kills the process | survives |

The full runtime host, under the gate below, dies the same way — the table further down is the same experiment run against `main`'s `src/runtime-host/main.ts` inside a container from the image.

On the error code, precisely: production reported `write EPIPE` from `failWrite (node:net)`. The driver and the in-image rehearsal both report `ECONNRESET, read` on the same accepted connection under 1.4.0. Those are two reports of one thing — a peer that went away while the host still owed it bytes — and the defect is that neither had a listener, so either one destroys the socket with an unhandled `error` and takes the process with it. The fix is the same for both, and the tests pin the invariant rather than a code.

The Bun 1.4.0 binary was fetched into a scratch directory and never installed; every run used a private `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR` and ephemeral ports. No deployment, promote, rollback or restart was run, and the operator's viewer and runtime host were not touched.

## The fix

Both listeners attach their connection `error` handler **before the first byte can be written**, and keep it attached because a socket can fail more than once. A peer disappearing ends that connection and nothing else — which is the correct contract for a server, not a suppressed write: the write genuinely cannot succeed, and the only question is whether its failure is scoped to the connection or to the process.

Two tests pin the invariant, and both are RED against the pre-fix source under the current pin:

```
(fail) a write that fails after the peer vanished ends the connection, not the host
  error: expect(received).not.toThrow()  Error message: "write EPIPE"
(fail) a failed write on the stable listener ends the connection, not the runtime host
```

They emit the EPIPE on the accepted connection directly, so they hold under every Bun version rather than only the one that reports it. Note the existing `socket.test.ts` harness attaches its *own* error listener to each accepted connection — which is exactly how the production server's missing one stayed invisible; the new tests deliberately do not.

## Making the runtime host part of runtime verification

This is the actual defect. The runtime host runs under the same Bun as the Viewer, owns the stable listener, and performs the release succession, and it had never been started under 1.4.0 before promotion.

`scripts/verify-runtime-host.ts` starts two runtime-host generations under a chosen interpreter, drives one **singleton-fence succession** (predecessor serving → successor parked on the fence → predecessor exits → successor takes the fence and the listener), and then **holds both endpoints under observation** for a bounded window, half the callers leaving mid-answer without reading a byte. Everything is private: its own state directory, its own socket, an ephemeral loopback port. It never binds the stable port and never reads the operator's state directory.

The same rehearsal runs inside a throwaway container built from the candidate image (`docker run --rm --network none`, no mounts) during `verify-candidate`, so a candidate whose host cannot boot, cannot take the fence, or cannot hold what it took is refused **before** promotion instead of after. `verify-candidate`'s adapter budget moves 90s → 240s to cover it; one rehearsal takes 17s.

### Two things the first version of this gate got wrong, found by running it in a container

**It ran the wrong interpreter, and would have refused every candidate.** `bun` inside the image is an nsenter shim onto the operator's own bun — it exists for the agent CLIs, and in a container without the host PID namespace it cannot run at all. The rehearsal passed that name to the generations it started:

```
the runtime host did not hold the stable listener within 60s of starting under bun (version unavailable)
log: predecessor: nsenter: reassociate to namespace 'ns/pid' failed: Operation not permitted
```

Both the rehearsal and the generations it starts now name `bun-container`, the real in-container interpreter the runtime host runs under in production — which is also the only one worth verifying.

**It had no teeth.** With the right interpreter it ran, and passed against the *pre-fix* host under 1.4.0. A failing write needs bytes still pending when the peer leaves, and the `events` answer it asked for is capped at 240 KiB — small enough that the kernel takes all of it before anyone can go. Measured under 1.4.0 on a Unix socket: an answer of ~400 KB leaves nothing pending, ~600 KB does. The seed now builds a snapshot-shaped answer instead — 64 sessions with live turns, about two megabytes, which is what `PreserializedJson` exists for — and the abandoning caller reads none of it.

## What the gate now says, run inside containers built from the image

Four images, identical but for the two variables. Each ran the same `verify-candidate` rehearsal, `docker run --rm --network none`, no mounts:

| in-image Bun | runtime host as it was | runtime host with this change |
| --- | --- | --- |
| 1.3.3 | pass — listener 30/30, socket 30/30 | pass — 30/30, 30/30 |
| 1.4.0 | **FAIL — dead 1s into the hold** | pass — 26/26, 26/26 |

The failing cell reports the incident's own error, read out of the generation's output:

```json
{"runtime":"bun 1.4.0",
 "succession":{"predecessorReadyMs":509,"successorTookOverMs":502,"completed":true},
 "listener":{"windowMs":15000,"polls":3,"answered":2,"abandoned":1},
 "ok":false,
 "detail":"the stable listener stopped answering 1s into a 15s hold under bun 1.4.0",
 "log":["successor: ECONNRESET: connection reset by peer, read","successor:  syscall: \"read\",","successor:    errno: -104,","successor: Bun v1.4.0 (Linux x64)"]}
```

So the gate reproduces #1254 and would have refused the promoted candidate. The 1.3.3 row is the other half of the incident: that runtime drops the failed write, which is why the missing handlers survived so long — and why an abandoning poll counts as answered once its request is taken, however the host then ends the connection.

Repeatability: the passing cell ran 3/3 with identical counts at 17s each, the failing cell 3/3.

## Runtime verification performed, and on which process

**On the runtime host** (`src/runtime-host/main.ts`) — not the Viewer — under **bun 1.4.0**:

- inside a container built from the image, through the exact `verify-candidate` gate path: succession completed in 503ms, stable listener 26/26, runtime socket 26/26 over a 15s hold, half the callers abandoning.
- on this machine, out of the checkout, with a 1.4.0 binary fetched into a scratch directory and never installed: succession completed, both endpoints held for the full window.

Re-run from scratch on a fresh pass, out of the checkout under both real interpreters, the same 2x2 the container table reports — the pre-fix column produced by reverting only `socket.ts` and `deploymentProxy.ts` to the merge base in a throwaway worktree:

| runtime | runtime host as it was | runtime host with this change |
| --- | --- | --- |
| bun 1.3.3 | pass — listener 30/30, socket 30/30 | pass — 30/30, 30/30 |
| bun 1.4.0 | **FAIL — `the stable listener stopped answering 1s into a 15s hold`**, log `successor: ECONNRESET ... Bun v1.4.0 (Linux x64)` | pass — 26/26, 26/26 |

Succession completed in every cell (`predecessorReadyMs` ~510, `successorTookOverMs` ~503), so the failing cell is the hold and not the hand-over. The two new unit tests are RED against that same reverted source — `(fail) a write that fails after the peer vanished ends the connection, not the host`, `(fail) a failed write on the stable listener ends the connection, not the runtime host` — and green at HEAD.

Every run used a private `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR` and an ephemeral port. No deployment, promote, rollback or restart was run; the operator's viewer and runtime host were not touched, and no container of theirs was stopped or started.

## The two gaps this does not close, filed rather than left

The deployment reported `succeeded` while the listener it had handed over was already failing, and the obvious repair does not work. `post-promotion-health` probes the stable endpoint while the **predecessor** still serves it; the successor only starts serving in `host-handoff`, and `host-handoff` writes `succeeded` *before* calling `onHostHandoff`, which drains this process and exits. `stageRuntimeHostSuccessorContainer`'s stability gate observes the successor while it is still parked on the fence, so a generation that dies once it is actually serving passes it every time.

Holding the stable listener after promotion would therefore have watched the healthy predecessor for the whole window. The real fix needs an observer that outlives both generations — the coordinator cannot be it, because it is the process that exits. #1268 has the phase walk-through and three candidate designs.

The incident's operational note — a rollback that has to reach the very listener that is failing has no way through — is #1270. A permanently red guard test found while running the touched files is #1271.

## Gates

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test` on the touched files by path, under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: `socket.test.ts`, `deploymentProxy.test.ts`, `hostRehearsal.test.ts`, `hostRehearsalRun.test.ts`, `deploymentAdapter.test.ts`, `deployment.test.ts`, `deploymentHealth.test.ts` — **70 pass, 0 fail**.
- `scripts/runtime-host-viewer-adapter.test.ts` — **27 pass, 0 fail**. Its one failure is only ever a missing `dist/mcp-server.mjs`; run `bun scripts/build-mcp.ts` first and it is green.
- `scripts/bun-spawn-credential-isolation.test.ts` fails **byte-for-byte identically at the merge base** in a throwaway worktree, and is not attributable to this branch: its hardcoded spawn-site inventory is stale by one entry in each of two files, and the spawn-site counts are the same at HEAD and at the merge base (`privacy-publication-gate.ts` 10, `runtime-host-viewer-adapter.ts` 2). Its security half — `uncovered` — passes. Filed as #1271.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — **PASS**.

## Round 4: the host's verification evidence reaches the record

The remaining review finding, and it defeats the point of everything above. `evidence()` in `src/runtime-host/deploymentAdapter.ts` rebuilds the health document field by field on its way out of the adapter, and `runtimeHost` was not one of the fields. So the gate rehearsed the host, decided, and then the durable deployment record kept the Viewer probes and the MCP call failures and lost the entire answer: which runtime the host was started under, whether the succession completed, how each handed-over endpoint answered across the hold, and the failing generation's own last lines.

That is this issue one layer along. An unrecorded check cannot be told apart from a check that never ran, which is precisely what nobody could answer about the host after the pin moved.

The evidence now crosses the boundary the way `containerLog` and the MCP call failures already do, and is **validated there**: a set of poll counts that arrives half-read is refused with `deployment adapter returned invalid runtime-host health evidence` rather than written into a durable record as a partial truth.

Both shapes the adapter script can emit were replayed through the boundary rather than assumed:

- a **real rehearsal report**, produced by running `bun scripts/verify-runtime-host.ts` in this checkout, survives it byte for byte:

  ```json
  {"checkedAt":"...","runtime":"bun 1.3.3",
   "succession":{"predecessorReadyMs":509,"successorTookOverMs":502,"completed":true},
   "listener":{"windowMs":15000,"polls":30,"answered":30,"abandoned":15},
   "socket":{"polls":30,"answered":30,"abandoned":15},"ok":true}
  ```

- the **no-report fallback** the script builds when the rehearsal produces nothing at all (`runtime: "unknown"`, zeroed counts, a named detail, the stderr tail) survives it unchanged, so a rehearsal that cannot report still reaches the record as a stated failure.

Three tests pin it, all three RED against the pre-fix parser (3 fail / 13 pass) and green at HEAD (16 pass): the passing rehearsal reaching the record, a refused rehearsal keeping its reason and the generation's output, and half-formed counts being refused.

Scope held to that one finding. #1268 (a deployment reporting `succeeded` before the hand-over it scheduled has happened, which needs an observer outliving both generations) and #1270 (rollback has no path when the failing process is the one performing it) stay separate and untouched.

## What ran in this round's sandbox, and what did not

Stated as an inventory rather than a checklist, because earlier rounds of this lane reported environmental blocks that did **not** apply here — network, DNS, GitHub, Unix and TCP listeners and the Docker socket were all reachable this round, so the socket-bound tests were actually executed rather than deferred.

| check | this round | note |
| --- | --- | --- |
| `bunx tsc --noEmit` | **ran — clean** | exit 0 |
| `deploymentAdapter.test.ts` | **ran — 16 pass, 0 fail** | 13 before this round; the count in the Gates section above predates it |
| `socket.test.ts` | **ran — 5 pass, 0 fail** | binds real Unix sockets; deferred in earlier rounds, executed here |
| `deploymentProxy.test.ts` | **ran — 2 pass, 0 fail** | binds real TCP listeners on `127.0.0.1:0` |
| `hostRehearsal.test.ts`, `hostRehearsalRun.test.ts` | **ran — 13 pass, 0 fail** | |
| `deployment.test.ts`, `deploymentBootstrap.test.ts`, `deploymentFailureReport.test.ts`, `deploymentHealth.test.ts`, `deploymentLedger.test.ts` | **ran — 51 pass, 0 fail** | the record's consumers |
| `scripts/runtime-host-viewer-adapter.test.ts` | **ran — 27 pass, 0 fail** | after `bun scripts/build-mcp.ts`, as noted above |
| `bun scripts/verify-runtime-host.ts` | **ran — pass under bun 1.3.3** | two real generations, one succession (502ms), both endpoints 30/30 over a 15s hold, half the callers abandoning; private state dir, ephemeral port |
| privacy publication gate | **ran — PASS** | `--require-known-values --check-commits`, against both the merge base and the `origin/main` tip |
| PR metadata | **confirmed** | head branch and `headRefOid` read back from the forge; earlier rounds could not |
| `bun run lint` | **could not run** | #1259, already open: `eslint-plugin-react` fails to load rule `react/display-name` under ESLint 10.9.1. Reconfirmed here on **every** file including ones this branch does not touch, under both bun and node 26, so it is independent of this branch |
| the candidate-image rehearsal through `verify-candidate` | **not re-run** | Docker was available; it needs a candidate image built for it, and this round changes neither the rehearsal nor the image. The in-container 2×2 table above is that evidence, from the round that produced it |
| anything under bun 1.4.0 | **not re-run** | same reason: unchanged this round |
| the full suite | **deliberately not run** | AGENTS.md forbids sweeping this repo's runtime and registry directories against live state; every run above was by path under a private `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR` |

Two of those rest on nothing but a local run, and should be read that way: **this repository's CI does not run the test suite or the linter** (#279 is open for exactly that). The workflows are the privacy gate, the privacy tracker audit, the supply-chain audit, npm publish, and a macOS identity job that runs five named `src/lib/proc` and `src/lib/accounts` files. Nothing on CI will execute `socket.test.ts`, `deploymentProxy.test.ts`, the rehearsal, or the adapter tests. Where the table says a check ran, it ran on this machine, once, at `f7cb2f189792ad64f9677ef43112a19e1782bbbe`.

No deployment, promote, rollback, restart or container start was performed in this round, and the operator's viewer and runtime host were not touched. The rehearsal's generations ran against their own state directory on an ephemeral loopback port and were reaped on exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



