### PR TITLE
fix(codex): keep a sibling thread's turn out of the parent conversation (#1284)

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -15,6 +15,7 @@ import { CodexAppServerHost, redactCodexHostDiagnostic } from "./codexAppServerH
 import { encodeCodexStructuredUserText } from "./codexStructuredUserText";
 import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 import type { HostState, RuntimeEvent } from "./engineHost";
+import { appendRuntimeLiveTurnDelta, runtimeLiveTurnItems, type RuntimeLiveTurn } from "./liveTurn";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContent, type StructuredImageRef } from "./structuredContent";
 import { materializeStructuredHostAccess, READ_ONLY_STAGE_PERMISSION_PROFILE } from "./structuredSpawn";
@@ -2351,6 +2352,145 @@ describe("CodexAppServerHost", () => {
       { kind: "session-status", status: "active", activeFlags: ["running"], seq: 5 },
     ]);
     expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: activeTurnId });
+    await host.release();
+  });
+
+  /* #1284: one app-server connection carries every thread of a session tree, so
+     a native sub-agent's turn streams down the same pipe as its parent's. Left
+     unfiltered, the two turn ids alternate in the parent's ledger and the live
+     projection opens a fresh item on every switch — the parent's answer rendered
+     as a column of mid-sentence fragments. */
+  test("keeps a sibling thread's interleaved turn out of the parent's stream", async () => {
+    const parentThreadId = "parent-thread-stream";
+    const childThreadId = "child-thread-stream";
+    const parentTurnId = "turn-parent-stream";
+    const childTurnId = "turn-child-stream";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(parentThreadId);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    server.notify("turn/started", { threadId: parentThreadId, turn: { id: parentTurnId } });
+    server.notify("item/agentMessage/delta", {
+      threadId: parentThreadId,
+      turnId: parentTurnId,
+      itemId: "parent-item",
+      delta: "The parent answer ",
+    });
+    /* The sub-agent's whole lifecycle, interleaved delta by delta. */
+    server.notify("turn/started", { threadId: childThreadId, turn: { id: childTurnId } });
+    server.notify("item/agentMessage/delta", {
+      threadId: childThreadId,
+      turnId: childTurnId,
+      itemId: "child-item",
+      delta: "VERDICT",
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId: parentThreadId,
+      turnId: parentTurnId,
+      itemId: "parent-item",
+      delta: "stays one ",
+    });
+    server.notify("item/agentMessage/delta", {
+      threadId: childThreadId,
+      turnId: childTurnId,
+      itemId: "child-item",
+      delta: "_HELD",
+    });
+    server.notify("item/completed", {
+      threadId: childThreadId,
+      turnId: childTurnId,
+      item: { type: "agentMessage", id: "child-item", text: "VERDICT_HELD" },
+    });
+    server.notify("turn/completed", {
+      threadId: childThreadId,
+      turn: { id: childTurnId, status: "completed" },
+    });
+    server.notify("thread/status/changed", { threadId: childThreadId, status: { type: "idle" } });
+    server.notify("item/agentMessage/delta", {
+      threadId: parentThreadId,
+      turnId: parentTurnId,
+      itemId: "parent-item",
+      delta: "continuous stream.",
+    });
+    await Bun.sleep(0);
+
+    const events = eventStore.load(parentThreadId);
+    expect(events.filter((event) => event.kind !== "session-status")).toEqual([
+      { kind: "turn-started", turnId: parentTurnId, seq: 2 },
+      { kind: "delta", turnId: parentTurnId, text: "The parent answer ", seq: 3 },
+      { kind: "delta", turnId: parentTurnId, text: "stays one ", seq: 4 },
+      { kind: "delta", turnId: parentTurnId, text: "continuous stream.", seq: 5 },
+    ]);
+    /* The parent's own record of the delegation is untouched, and the child's
+       turn neither idles the parent's session nor steals its active turn. */
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: parentTurnId });
+
+    const live = events.reduce<RuntimeLiveTurn | null>(
+      (turn, event) => event.kind === "delta"
+        ? appendRuntimeLiveTurnDelta(turn, event.turnId, event.text)
+        : turn,
+      null,
+    );
+    expect(runtimeLiveTurnItems(live).map((item) => item.text))
+      .toEqual(["The parent answer stays one continuous stream."]);
+
+    server.notify("item/completed", {
+      threadId: parentThreadId,
+      turnId: parentTurnId,
+      item: {
+        type: "collabAgentToolCall",
+        id: "collab-1",
+        tool: "spawnAgent",
+        senderThreadId: parentThreadId,
+        receiverThreadIds: [childThreadId],
+        status: "completed",
+        agentsStates: {},
+      },
+    });
+    await Bun.sleep(0);
+    expect(eventStore.load(parentThreadId).findLast((event) => event.kind === "item"))
+      .toMatchObject({ turnId: parentTurnId, item: { type: "collabAgentToolCall" } });
+    await host.release();
+  });
+
+  test("skips a sibling thread's buffered frames when replaying a crash prefix", async () => {
+    const threadId = "buffered-sibling-thread";
+    const siblingThreadId = "buffered-sibling-child";
+    const turnId = "buffered-sibling-turn";
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 1 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: "durable fragment", seq: 2 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, [
+      {
+        method: "item/agentMessage/delta",
+        params: { threadId: siblingThreadId, turnId: "buffered-sibling-child-turn", delta: "sibling fragment" },
+      },
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "durable fragment" } },
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "replayed fragment" } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 2,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    /* The sibling frame is neither replayed nor counted: counting it would put a
+       key at the head of the buffered prefix that replay never emits, breaking
+       the overlap match and re-emitting the durable fragment as a duplicate. */
+    expect(eventStore.load(threadId).filter((event) => event.kind === "delta")).toEqual([
+      { kind: "delta", turnId, text: "durable fragment", seq: 2 },
+      { kind: "delta", turnId, text: "replayed fragment", seq: 3 },
+    ]);
     await host.release();
   });
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -2269,6 +2269,11 @@ export class CodexAppServerHost implements EngineHost {
         if (key) bufferedKeys.push(key);
         continue;
       }
+      /* The overlap is matched against what replay will actually emit, so a
+         sibling thread's buffered frames are skipped here for the same reason
+         `acceptNotification` rejects them — counting a key that never arrives
+         would break the prefix match and replay the whole buffer (#1284). */
+      if (this.foreignThreadNotification(params)) continue;
       const turnId = turnIdFromParams(params);
       if (method === "turn/started" && turnId) activeTurnId = turnId;
       if (method === "item/agentMessage/delta") {
@@ -2597,6 +2602,38 @@ export class CodexAppServerHost implements EngineHost {
     this.acceptNotification(method, params, reconcileBufferedLifecycle);
   }
 
+  /**
+   * True when a thread-scoped notification names a thread this host does not
+   * own (issue #1284).
+   *
+   * One app-server connection serves a whole tree of threads, not just the one
+   * this host started. A native sub-agent — `AgentControl` spawn, and the
+   * `review` / `compact` / `memory_consolidation` sources beside it — runs as a
+   * real child thread (`Thread.parentThreadId`) on this same stdio pipe, and
+   * every `turn/*` and `item/*` notification it produces carries the child's own
+   * `threadId`. Accepted here, those frames enter the parent's ledger with the
+   * child's turn id, so the live projection alternates between two turn ids and
+   * opens a fresh live item on every switch — the column of mid-sentence
+   * fragments the operator saw, and a `turn/completed` that idles the parent's
+   * session while its own answer is still streaming.
+   *
+   * Nothing the parent produced is lost by the rejection: the child's stream was
+   * never part of the parent's transcript, the parent's own record of the
+   * delegation arrives as its own `collabAgentToolCall` / `subAgentActivity`
+   * items on this thread, and the child's rollout is a transcript in its own
+   * right, so the child's stream still has the child's own view to render in.
+   *
+   * A frame carrying no `threadId` belongs to the owned thread by default. The
+   * field is required on every thread-scoped notification handled here, so its
+   * absence means a protocol shape older than the schema this was read from —
+   * and silently dropping the parent's own stream is a far worse failure than
+   * admitting a stray frame.
+   */
+  private foreignThreadNotification(params: JsonObject): boolean {
+    const threadId = stringField(params, "threadId");
+    return threadId !== null && threadId !== this.identity.threadId;
+  }
+
   private acceptNotification(method: string, params: JsonObject, reconcileBufferedLifecycle = false): void {
     if (method === "thread/realtime/started") {
       const pending = this.pendingRealtimeStart;
@@ -2651,6 +2688,13 @@ export class CodexAppServerHost implements EngineHost {
       this.emit({ kind: "attention-resolved", id: resolved[0], resolution: answer ? "answered" : "server-resolved" });
       return;
     }
+    /* Everything below this line projects into the owned thread's conversation,
+       so a frame belonging to another thread on this connection stops here.
+       The approval surface above is deliberately outside the gate: a child's
+       request arrives on this connection and has no other answerer, so refusing
+       it — or refusing only its `serverRequest/resolved` and stranding the
+       attention it opened — would strand work the parent delegated. */
+    if (this.foreignThreadNotification(params)) return;
     if (method === "turn/started" && turnId) {
       if (reconcileBufferedLifecycle) {
         const historicalStart = this.events.some((event) => event.kind === "turn-started" && event.turnId === turnId);


### PR DESCRIPTION
Closes #1284.

## What was wrong

A Codex conversation streamed into the pane as a column of mid-sentence
fragments, one per line, unreadable while it generated.

One Codex app-server connection carries **every thread of a session tree**, not
only the thread the host started. A native sub-agent — an `AgentControl` spawn,
and the `review` / `compact` / `memory_consolidation` sub-agent sources beside
it — runs as a real child thread (`Thread.parentThreadId` in the app-server
schema) on that same stdio pipe, and every `turn/*` and `item/*` notification it
produces carries the **child's** `threadId`.

`CodexAppServerHost.acceptNotification` compared `threadId` on the realtime and
`thread/compacted` paths and nowhere else, so it accepted the child's frames as
its own. Two consequences:

- The parent's event ledger interleaved two turn ids. `appendRuntimeLiveTurnDelta`
  closes the current live item whenever the turn id changes, so every switch
  opened a fresh item — the parent's answer chopped into spaced blocks.
- The child's `turn/completed` and `thread/status/changed` idled the parent's
  session while the parent's own answer was still streaming.

## The fix

Thread-scoped notifications are rejected when their `threadId` names a thread
this host does not own, at the one seam where the frames enter the parent's
ledger. Confirmed against the installed app-server schema: `threadId` is a
required field on every notification this host handles that has one, and the two
it handles without one (`account/rateLimits/updated`, `thread/started`) are
connection-scoped and must keep flowing.

Two deliberate boundaries:

- **The approval surface stays outside the gate.** A child's approval request
  arrives on this connection and has no other answerer; dropping it — or dropping
  only its `serverRequest/resolved` and stranding the attention it opened — would
  strand work the parent delegated.
- **A frame with no `threadId` is treated as the owned thread's.** The field is
  required today, so its absence would mean an older protocol shape, and silently
  dropping the parent's own stream is far worse than admitting a stray frame.

The buffered-replay scan (`beginBufferedNotificationReconciliation`) applies the
same filter, because it matches its overlap prefix against what replay will
actually emit: a counted key that never arrives broke the prefix match and
re-emitted a durable fragment as a duplicate. That case is covered by its own
test, which is red without the filter.

## What is not lost

- Nothing the parent produced is dropped — the child's stream was never part of
  the parent's transcript.
- The parent keeps its own record of the delegation: `collabAgentToolCall` and
  `subAgentActivity` items are emitted **on the parent thread** with the parent's
  `threadId`, and they name the child's thread id.
- A child's stream still renders in the child's own view: the sub-agent thread
  writes its own rollout, which the scanner discovers as a transcript in its own
  right.
- No fragments are stitched back together after the fact; they are separate live
  items, and this stops them being created in the parent at all.

## Tests

`keeps a sibling thread's interleaved turn out of the parent's stream`
interleaves a full child turn (started → deltas → completed item → completed
turn → status change) delta-by-delta with the parent's, then asserts the parent's
ledger holds only the parent's frames, that the parent's session stays active on
its own turn, and — folding the ledger through `appendRuntimeLiveTurnDelta`, the
projection the pane renders — that the parent's answer is **one** continuous live
item. It then completes a `collabAgentToolCall` item on the parent thread and
asserts it still lands.

`skips a sibling thread's buffered frames when replaying a crash prefix` covers
the replay path.

Both were verified red against `main`'s `codexAppServerHost.ts`: without the fix
the first sees the child's `turn-started`, deltas, item and `turn-ended` in the
parent's ledger, and the second re-emits the durable fragment as a duplicate.

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test src/lib/runtime/codexAppServerHost.test.ts` — 115 pass, 0 fail.
- `bun test src/lib/runtime/codexAppServerHost.compact.test.ts` — 16 pass;
  `…pluginGrant.test.ts` — 6 pass; `…integration.test.ts` — 3 skip;
  `src/lib/runtime/liveTurn.test.ts` — 15 pass.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS.

Nothing was deployed, promoted or restarted; every suite ran by path under an
isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR` / `TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
