### PR TITLE
fix(monitor): a wake names what is owed now (#1285, #1289)

### DIFF
--- a/src/lib/monitor/githubEvidence.test.ts
+++ b/src/lib/monitor/githubEvidence.test.ts
@@ -131,6 +131,16 @@ describe("open issues for the proactive slot", () => {
       .toEqual({ ok: false, unavailable: "malformed-output" });
   });
 
+  /* The other edge of the same rule, so refusing the unusable row does not
+     grow into refusing a usable one: the number and the head branch are what
+     attribute a pull request to a lane, and a row carrying both is read even
+     with the two decorative fields missing. A read that failed over a missing
+     title would be a `gh` outage invented out of a complete answer. */
+  test("a row with a number and a head branch is read even with no title and no timestamp", async () => {
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => JSON.stringify([{ number: 1289, headRefName: "topic" }]) }))
+      .toEqual({ ok: true, pullRequests: [{ number: 1289, title: "", headRefName: "topic", updatedAt: null }] });
+  });
+
   /* The distinction the whole reason rests on: a repository with everything
      merged answers, and answering is what makes the tick's silence mean
      something. An empty ANSWER is still an answer. */

--- a/src/lib/monitor/githubEvidence.test.ts
+++ b/src/lib/monitor/githubEvidence.test.ts
@@ -107,12 +107,28 @@ describe("open issues for the proactive slot", () => {
     expect(calls.flat()).not.toContain("merge");
   });
 
-  test("a pull request with no head branch is dropped, because nothing could attribute it to a lane", async () => {
-    const pullRequests = await openPullRequestsForRepo({
-      cwd: "/srv/repo",
-      run: async () => JSON.stringify([{ number: 5, title: "no head" }, { number: 6, title: "kept", headRefName: "topic" }]),
-    });
-    expect(pullRequests).toEqual({ ok: true, pullRequests: [{ number: 6, title: "kept", headRefName: "topic", updatedAt: null }] });
+  /* Dropping the unusable row was the same collapse by a shorter route: one
+     row nobody can attribute to a lane turned a nonempty answer into an empty
+     one, and an empty one is the claim that everything merged. */
+  test("a single row with no head branch is malformed output, never a repository with nothing open", async () => {
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => JSON.stringify([{ number: 1289 }]) }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => JSON.stringify([{ title: "no number", headRefName: "topic" }]) }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => JSON.stringify(["a string"]) }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
+  });
+
+  /* And the mixed array, which is the case the skip hid best: the valid rows
+     make the answer look like a real one while the dropped row is exactly the
+     pull request that might still be open. */
+  test("one unusable row among valid ones fails the whole read rather than shortening it", async () => {
+    const mixed = JSON.stringify([
+      { number: 1289, title: "kept", headRefName: "topic-merge-queue" },
+      { number: 1290, title: "no head" },
+    ]);
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => mixed }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
   });
 
   /* The distinction the whole reason rests on: a repository with everything

--- a/src/lib/monitor/githubEvidence.test.ts
+++ b/src/lib/monitor/githubEvidence.test.ts
@@ -11,7 +11,7 @@ process.env.XDG_CONFIG_HOME = path.join(SANDBOX, "config");
 process.env.TMPDIR = path.join(SANDBOX, "tmp");
 fs.mkdirSync(process.env.TMPDIR, { recursive: true });
 
-const { githubEvidenceSource, openIssuesForProposal } = await import("./githubEvidence");
+const { githubEvidenceSource, openIssuesForProposal, openPullRequestsForRepo } = await import("./githubEvidence");
 const { evidenceFromGithub } = await import("./evidence");
 
 afterAll(() => {
@@ -81,6 +81,41 @@ describe("open issues for the proactive slot", () => {
     expect(await openIssuesForProposal({ cwd: "/srv/repo", run: async () => { throw new Error("gh: command not found"); } })).toEqual([]);
     expect(await openIssuesForProposal({ cwd: "/srv/repo", run: async () => "not json" })).toEqual([]);
     expect(await openIssuesForProposal({ cwd: "/srv/repo", run: async () => "{}" })).toEqual([]);
+  });
+
+  test("open pull requests are read with the head branch that ties one to a lane (#1289)", async () => {
+    const calls: string[][] = [];
+    const pullRequests = await openPullRequestsForRepo({
+      cwd: "/srv/repo",
+      run: async (args) => {
+        calls.push(args);
+        return JSON.stringify([
+          { number: 1289, title: "wake on a merge that is waiting", headRefName: "topic-merge-queue", updatedAt: "2026-08-29T10:00:00Z" },
+          { number: 1285, title: "stop replaying closed lanes", headRefName: "topic-closed-lanes", updatedAt: null },
+        ]);
+      },
+    });
+    expect(calls[0]).toEqual(["pr", "list", "--state", "open", "--limit", "60", "--json", "number,title,headRefName,updatedAt"]);
+    expect(pullRequests).toEqual([
+      { number: 1289, title: "wake on a merge that is waiting", headRefName: "topic-merge-queue", updatedAt: "2026-08-29T10:00:00Z" },
+      { number: 1285, title: "stop replaying closed lanes", headRefName: "topic-closed-lanes", updatedAt: null },
+    ]);
+    /* Read-only, like every other question asked of this seam. */
+    expect(calls.flat()).not.toContain("merge");
+  });
+
+  test("a pull request with no head branch is dropped, because nothing could attribute it to a lane", async () => {
+    const pullRequests = await openPullRequestsForRepo({
+      cwd: "/srv/repo",
+      run: async () => JSON.stringify([{ number: 5, title: "no head" }, { number: 6, title: "kept", headRefName: "topic" }]),
+    });
+    expect(pullRequests).toEqual([{ number: 6, title: "kept", headRefName: "topic", updatedAt: null }]);
+  });
+
+  test("a gh that cannot answer costs the tick the reason, never the check", async () => {
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => { throw new Error("gh: command not found"); } })).toEqual([]);
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "not json" })).toEqual([]);
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "{}" })).toEqual([]);
   });
 
   test("a row without a usable number is dropped rather than ranked as issue zero", async () => {

--- a/src/lib/monitor/githubEvidence.test.ts
+++ b/src/lib/monitor/githubEvidence.test.ts
@@ -96,10 +96,13 @@ describe("open issues for the proactive slot", () => {
       },
     });
     expect(calls[0]).toEqual(["pr", "list", "--state", "open", "--limit", "60", "--json", "number,title,headRefName,updatedAt"]);
-    expect(pullRequests).toEqual([
-      { number: 1289, title: "wake on a merge that is waiting", headRefName: "topic-merge-queue", updatedAt: "2026-08-29T10:00:00Z" },
-      { number: 1285, title: "stop replaying closed lanes", headRefName: "topic-closed-lanes", updatedAt: null },
-    ]);
+    expect(pullRequests).toEqual({
+      ok: true,
+      pullRequests: [
+        { number: 1289, title: "wake on a merge that is waiting", headRefName: "topic-merge-queue", updatedAt: "2026-08-29T10:00:00Z" },
+        { number: 1285, title: "stop replaying closed lanes", headRefName: "topic-closed-lanes", updatedAt: null },
+      ],
+    });
     /* Read-only, like every other question asked of this seam. */
     expect(calls.flat()).not.toContain("merge");
   });
@@ -109,13 +112,36 @@ describe("open issues for the proactive slot", () => {
       cwd: "/srv/repo",
       run: async () => JSON.stringify([{ number: 5, title: "no head" }, { number: 6, title: "kept", headRefName: "topic" }]),
     });
-    expect(pullRequests).toEqual([{ number: 6, title: "kept", headRefName: "topic", updatedAt: null }]);
+    expect(pullRequests).toEqual({ ok: true, pullRequests: [{ number: 6, title: "kept", headRefName: "topic", updatedAt: null }] });
   });
 
-  test("a gh that cannot answer costs the tick the reason, never the check", async () => {
-    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => { throw new Error("gh: command not found"); } })).toEqual([]);
-    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "not json" })).toEqual([]);
-    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "{}" })).toEqual([]);
+  /* The distinction the whole reason rests on: a repository with everything
+     merged answers, and answering is what makes the tick's silence mean
+     something. An empty ANSWER is still an answer. */
+  test("a repository with nothing open answers, rather than failing to answer", async () => {
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "[]" })).toEqual({ ok: true, pullRequests: [] });
+  });
+
+  /* And its mirror image: none of these establishes that a pull request
+     merged, so none of them may be handed on as the empty list that says so. */
+  test("a gh that cannot answer is carried as a failure, never as an empty list", async () => {
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => { throw new Error("gh: command not found"); } }))
+      .toEqual({ ok: false, unavailable: "command-failed" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "not json" }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => "{}" }))
+      .toEqual({ ok: false, unavailable: "malformed-output" });
+  });
+
+  /* `execFile` reports the timeout it enforces as a killed child, and an
+     outage reads differently from a misconfiguration to whoever is holding the
+     journal line. */
+  test("a gh killed at its timeout is named as a timeout", async () => {
+    const killed = Object.assign(new Error("Command failed"), { killed: true, signal: "SIGTERM" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => { throw killed; } }))
+      .toEqual({ ok: false, unavailable: "timed-out" });
+    expect(await openPullRequestsForRepo({ cwd: "/srv/repo", run: async () => { throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }); } }))
+      .toEqual({ ok: false, unavailable: "timed-out" });
   });
 
   test("a row without a usable number is dropped rather than ranked as issue zero", async () => {

--- a/src/lib/monitor/githubEvidence.ts
+++ b/src/lib/monitor/githubEvidence.ts
@@ -136,12 +136,13 @@ function parseProposalIssues(raw: string): ProposalIssue[] {
  * Unlike the two questions above, this one does NOT degrade to an empty list.
  * An empty list here is a claim — every pull request those lanes opened has
  * since been merged or closed — and a `gh` that is missing, unauthenticated,
- * rate-limited, killed at the timeout or answering with something that is not
- * a JSON array has established no such thing. Collapsing the two made a failed
- * read indistinguishable from a finished merge, and the tick then reported
- * `nothing owed` on the strength of it, which is the twelve-hour silence #1289
- * exists to end returning by a slower route. So the failure is carried out as
- * a failure and the caller decides what it costs.
+ * rate-limited, killed at the timeout, or answering with anything but a JSON
+ * array of rows that can be attributed to a branch has established no such
+ * thing. Collapsing the two made a failed read indistinguishable from a
+ * finished merge, and the tick then reported `nothing owed` on the strength of
+ * it, which is the twelve-hour silence #1289 exists to end returning by a
+ * slower route. So the failure is carried out as a failure and the caller
+ * decides what it costs.
  *
  * Read-only. Nothing here merges, closes, comments on or opens a pull request.
  * ------------------------------------------------------------------------- */
@@ -173,13 +174,19 @@ export type OpenPullRequestsResult =
 const PULL_REQUEST_TITLE_LIMIT = 200;
 
 /**
- * Null means the output was not a JSON array at all, which is a read that
- * failed rather than a repository with nothing open.
+ * Null means the read failed rather than answered, and there are two ways.
  *
- * A row INSIDE a well-formed array that names no number or no head branch is
- * still skipped rather than failing the read: that one row cannot be
- * attributed to a lane, and `gh` answering the question it was asked is not
- * put in doubt by it.
+ * Output that is not a JSON array at all is the obvious one. The other is a
+ * well-formed array carrying a row that names no number or no head branch:
+ * dropping that row quietly turns a nonempty answer into an empty one, and an
+ * empty one here is a claim — every pull request those lanes opened has since
+ * merged or closed. A single unusable row was therefore enough to buy the
+ * quiet verdict this result type exists to make earnable, which is the
+ * collapse the type was introduced to end taking a shorter route.
+ *
+ * `gh` asked for these four fields answers with them; an array whose rows do
+ * not carry them is output nobody can attribute, so it is reported as what it
+ * is. Exactly the empty array stays the answer that nothing is open.
  */
 function parseOpenPullRequests(raw: string): OpenPullRequest[] | null {
   let parsed: unknown;
@@ -191,12 +198,12 @@ function parseOpenPullRequests(raw: string): OpenPullRequest[] | null {
   if (!Array.isArray(parsed)) return null;
   const rows: OpenPullRequest[] = [];
   for (const entry of parsed) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
     const row = entry as { number?: unknown; title?: unknown; headRefName?: unknown; updatedAt?: unknown };
-    if (typeof row.number !== "number" || !Number.isSafeInteger(row.number)) continue;
-    /* A row with no head branch cannot be attributed to a lane, and an
-       unattributable pull request is not what the reason is about. */
-    if (typeof row.headRefName !== "string" || !row.headRefName) continue;
+    if (typeof row.number !== "number" || !Number.isSafeInteger(row.number)) return null;
+    /* A row with no head branch cannot be attributed to a lane, and a pull
+       request nobody can name is not evidence that nothing is open. */
+    if (typeof row.headRefName !== "string" || !row.headRefName) return null;
     rows.push({
       number: row.number,
       title: typeof row.title === "string" ? row.title.slice(0, PULL_REQUEST_TITLE_LIMIT) : "",

--- a/src/lib/monitor/githubEvidence.ts
+++ b/src/lib/monitor/githubEvidence.ts
@@ -133,10 +133,15 @@ function parseProposalIssues(raw: string): ProposalIssue[] {
  * produced it, so a lane that finished with its work unmerged can be named
  * rather than merely counted.
  *
- * Degradable exactly like the two above: a `gh` that is missing,
- * unauthenticated or rate-limited returns nothing and the tick simply has no
- * unmerged pull request to report, because a check that failed outright over an
- * optional evidence source would take the whole seat tick down with it.
+ * Unlike the two questions above, this one does NOT degrade to an empty list.
+ * An empty list here is a claim — every pull request those lanes opened has
+ * since been merged or closed — and a `gh` that is missing, unauthenticated,
+ * rate-limited, killed at the timeout or answering with something that is not
+ * a JSON array has established no such thing. Collapsing the two made a failed
+ * read indistinguishable from a finished merge, and the tick then reported
+ * `nothing owed` on the strength of it, which is the twelve-hour silence #1289
+ * exists to end returning by a slower route. So the failure is carried out as
+ * a failure and the caller decides what it costs.
  *
  * Read-only. Nothing here merges, closes, comments on or opens a pull request.
  * ------------------------------------------------------------------------- */
@@ -150,16 +155,40 @@ export interface OpenPullRequest {
   updatedAt: string | null;
 }
 
+/**
+ * Why the question could not be answered.
+ *
+ * Coarse on purpose: this token travels into a published journal line, so it
+ * names the class of the failure and never the command, the repository, the
+ * account or `gh`'s own stderr.
+ */
+export type OpenPullRequestsUnavailable = "timed-out" | "command-failed" | "malformed-output";
+
+/** Either the answer or the reason there is none — never both, and never an
+    empty list standing in for the second. */
+export type OpenPullRequestsResult =
+  | { ok: true; pullRequests: OpenPullRequest[] }
+  | { ok: false; unavailable: OpenPullRequestsUnavailable };
+
 const PULL_REQUEST_TITLE_LIMIT = 200;
 
-function parseOpenPullRequests(raw: string): OpenPullRequest[] {
+/**
+ * Null means the output was not a JSON array at all, which is a read that
+ * failed rather than a repository with nothing open.
+ *
+ * A row INSIDE a well-formed array that names no number or no head branch is
+ * still skipped rather than failing the read: that one row cannot be
+ * attributed to a lane, and `gh` answering the question it was asked is not
+ * put in doubt by it.
+ */
+function parseOpenPullRequests(raw: string): OpenPullRequest[] | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw) as unknown;
   } catch {
-    return [];
+    return null;
   }
-  if (!Array.isArray(parsed)) return [];
+  if (!Array.isArray(parsed)) return null;
   const rows: OpenPullRequest[] = [];
   for (const entry of parsed) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
@@ -178,19 +207,31 @@ function parseOpenPullRequests(raw: string): OpenPullRequest[] {
   return rows;
 }
 
+/** A command that failed and a command that was killed at the timeout are
+    different facts about the machine, and whoever reads the journal line is
+    telling an outage from a misconfiguration. `execFile` reports its own
+    timeout as a killed child. */
+function unavailableFromError(error: unknown): OpenPullRequestsUnavailable {
+  const detail = error as { killed?: unknown; code?: unknown; name?: unknown } | null | undefined;
+  if (detail?.killed === true || detail?.code === "ETIMEDOUT" || detail?.name === "TimeoutError") return "timed-out";
+  return "command-failed";
+}
+
 export async function openPullRequestsForRepo(options: {
   cwd: string;
   limit?: number;
   run?: GithubRunner;
   timeoutMs?: number;
-}): Promise<OpenPullRequest[]> {
+}): Promise<OpenPullRequestsResult> {
   const run = options.run ?? githubRunner(options.cwd, options.timeoutMs ?? 20_000);
+  let raw: string;
   try {
-    const raw = await run(["pr", "list", "--state", "open", "--limit", String(options.limit ?? 60), "--json", "number,title,headRefName,updatedAt"]);
-    return parseOpenPullRequests(raw);
-  } catch {
-    return [];
+    raw = await run(["pr", "list", "--state", "open", "--limit", String(options.limit ?? 60), "--json", "number,title,headRefName,updatedAt"]);
+  } catch (error) {
+    return { ok: false, unavailable: unavailableFromError(error) };
   }
+  const pullRequests = parseOpenPullRequests(raw);
+  return pullRequests ? { ok: true, pullRequests } : { ok: false, unavailable: "malformed-output" };
 }
 
 export async function openIssuesForProposal(options: {

--- a/src/lib/monitor/githubEvidence.ts
+++ b/src/lib/monitor/githubEvidence.ts
@@ -184,9 +184,13 @@ const PULL_REQUEST_TITLE_LIMIT = 200;
  * quiet verdict this result type exists to make earnable, which is the
  * collapse the type was introduced to end taking a shorter route.
  *
- * `gh` asked for these four fields answers with them; an array whose rows do
- * not carry them is output nobody can attribute, so it is reported as what it
- * is. Exactly the empty array stays the answer that nothing is open.
+ * The two fields that make a row usable are the number and the head branch:
+ * one names the pull request, the other ties it to the lane that opened it, and
+ * a `gh` answering the question it was asked carries both on every row. An
+ * array whose rows do not is output nobody can attribute, so it is reported as
+ * what it is. A missing title or timestamp is a different matter — neither is
+ * load-bearing for the reason, so a row is still attributable without them.
+ * Exactly the empty array stays the answer that nothing is open.
  */
 function parseOpenPullRequests(raw: string): OpenPullRequest[] | null {
   let parsed: unknown;

--- a/src/lib/monitor/githubEvidence.ts
+++ b/src/lib/monitor/githubEvidence.ts
@@ -124,6 +124,75 @@ function parseProposalIssues(raw: string): ProposalIssue[] {
   return issues;
 }
 
+/* ------------------------------------------------------------------------- *
+ * Open pull requests as the seat tick's unmerged-merge evidence (#1289).
+ *
+ * The third question asked of the same `gh` seam, and the narrowest: which pull
+ * requests are still open, and what branch each one is the head of. The branch
+ * is the whole point — it is what ties a pull request back to the lane that
+ * produced it, so a lane that finished with its work unmerged can be named
+ * rather than merely counted.
+ *
+ * Degradable exactly like the two above: a `gh` that is missing,
+ * unauthenticated or rate-limited returns nothing and the tick simply has no
+ * unmerged pull request to report, because a check that failed outright over an
+ * optional evidence source would take the whole seat tick down with it.
+ *
+ * Read-only. Nothing here merges, closes, comments on or opens a pull request.
+ * ------------------------------------------------------------------------- */
+
+export interface OpenPullRequest {
+  number: number;
+  title: string;
+  /** The branch the pull request is the head of, which is what a lane's own
+      branch is matched against. */
+  headRefName: string;
+  updatedAt: string | null;
+}
+
+const PULL_REQUEST_TITLE_LIMIT = 200;
+
+function parseOpenPullRequests(raw: string): OpenPullRequest[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const rows: OpenPullRequest[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const row = entry as { number?: unknown; title?: unknown; headRefName?: unknown; updatedAt?: unknown };
+    if (typeof row.number !== "number" || !Number.isSafeInteger(row.number)) continue;
+    /* A row with no head branch cannot be attributed to a lane, and an
+       unattributable pull request is not what the reason is about. */
+    if (typeof row.headRefName !== "string" || !row.headRefName) continue;
+    rows.push({
+      number: row.number,
+      title: typeof row.title === "string" ? row.title.slice(0, PULL_REQUEST_TITLE_LIMIT) : "",
+      headRefName: row.headRefName,
+      updatedAt: typeof row.updatedAt === "string" ? row.updatedAt : null,
+    });
+  }
+  return rows;
+}
+
+export async function openPullRequestsForRepo(options: {
+  cwd: string;
+  limit?: number;
+  run?: GithubRunner;
+  timeoutMs?: number;
+}): Promise<OpenPullRequest[]> {
+  const run = options.run ?? githubRunner(options.cwd, options.timeoutMs ?? 20_000);
+  try {
+    const raw = await run(["pr", "list", "--state", "open", "--limit", String(options.limit ?? 60), "--json", "number,title,headRefName,updatedAt"]);
+    return parseOpenPullRequests(raw);
+  } catch {
+    return [];
+  }
+}
+
 export async function openIssuesForProposal(options: {
   cwd: string;
   limit?: number;

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -18,6 +18,7 @@ import {
   type SeatTickEventInput,
   type SeatTickPipelineInput,
   type SeatTickProjectState,
+  type SeatTickPullRequestInput,
   type SeatTickSeatInput,
   type SeatTickTaskInput,
   type SeatTickVerdict,
@@ -59,7 +60,27 @@ function card(over: Partial<SeatTickTaskInput> = {}): SeatTickTaskInput {
 }
 
 function event(over: Partial<SeatTickEventInput> = {}): SeatTickEventInput {
-  return { seq: 42, at: new Date(NOW - MINUTE).toISOString(), type: "stage_blocked", summary: "the review round is parked", pipelineId: "pipeline_a1", ...over };
+  return {
+    seq: 42,
+    at: new Date(NOW - MINUTE).toISOString(),
+    type: "stage_blocked",
+    summary: "the review round is parked",
+    pipelineId: "pipeline_a1",
+    pipelineTerminal: false,
+    ...over,
+  };
+}
+
+/** A pull request a finished lane left open (#1289). */
+function pullRequest(over: Partial<SeatTickPullRequestInput> = {}): SeatTickPullRequestInput {
+  return {
+    number: 1289,
+    title: "wake on a merge that is waiting",
+    pipelineId: "pipeline_a1",
+    pipelineTitle: "ship the exporter",
+    updatedAt: new Date(NOW - 30 * MINUTE).toISOString(),
+    ...over,
+  };
 }
 
 function input(over: Partial<SeatTickCheckInput> = {}): SeatTickCheckInput {
@@ -70,7 +91,7 @@ function input(over: Partial<SeatTickCheckInput> = {}): SeatTickCheckInput {
     pipelines: [],
     tasks: [],
     events: [],
-    terminalPending: false,
+    pullRequests: [],
     signals: [],
     changeFingerprint: "fp-1",
     state: emptySeatTickState(),
@@ -238,7 +259,7 @@ test("a lane with no activity verdict at all is never called stalled", () => {
    hourly bound has no exempt reason kind, because a reason allowed to jump it
    would make the ADR's cost argument describe a different system. */
 test("a terminal lane event leads the next wake rather than raising one early", () => {
-  const args = { events: [event()], terminalPending: true, pipelines: [lane()] };
+  const args = { events: [event()], pipelines: [lane()] };
   const early = seatTickDecision(input({ ...args, state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }) }));
   expect(early.verdict.kind).toBe("quiet");
 
@@ -250,25 +271,195 @@ test("a terminal lane event leads the next wake rather than raising one early", 
 test("routine lane events do not wake on their own", () => {
   const decision = seatTickDecision(input({
     events: [event({ type: "stage_started", summary: "builder started" })],
-    terminalPending: false,
     pipelines: [lane()],
     state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }),
   }));
   expect(decision.verdict.kind).toBe("quiet");
 });
 
-/* A verdict at pending position 401 is as decision-blocking as one at position
-   one, so the pending question is asked over the whole range rather than the
-   page this check happened to read. */
-test("a terminal event buried past the page still wakes, naming that it is further down", () => {
+/* #1285, the first direction. Three consecutive wakes were spent listing events
+   whose pipelines had reached a terminal state the day before — two of them
+   closed by the seat itself earlier in the same session. A lane that is over
+   owes nothing, so an event about it is history and never an agenda. */
+test("events whose lanes have finished are history, and a project holding only those is quiet", () => {
   const decision = seatTickDecision(input({
-    events: [event({ type: "stage_started", summary: "builder started" })],
-    terminalPending: true,
+    events: [
+      event({ seq: 60, type: "stage_completed", summary: "the builder finished", pipelineTerminal: true }),
+      event({ seq: 61, type: "review_verdict", summary: "the round passed", pipelineId: "pipeline_c3", pipelineTerminal: true }),
+    ],
+    /* Open work, so the answer under test is "nothing owed" rather than "the
+       board is done" — and an inbox card is deliberately not an agenda of its
+       own, which leaves the events as the only thing that could wake anyone. */
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+});
+
+/* And the count beside the reason says how much of it is live. "18 more" over a
+   page that was almost entirely closed lanes described a queue of eighteen
+   things to do that did not exist. */
+test("the lane-event count names only the events that are still owed", () => {
+  const decision = seatTickDecision(input({
+    events: [
+      event({ seq: 60, type: "stage_completed", summary: "yesterday's lane finished", pipelineTerminal: true }),
+      event({ seq: 61, type: "review_verdict", summary: "the round passed" }),
+      event({ seq: 62, type: "stage_failed", summary: "the verifier failed", pipelineTerminal: true }),
+      event({ seq: 63, type: "stage_blocked", summary: "the round is parked" }),
+    ],
     pipelines: [lane()],
-    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+    state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
   }));
   expect(reasonsOf(decision.verdict)).toEqual(["lane-event"]);
-  expect(decision.verdict.kind === "wake" && decision.verdict.reasons[0]!.detail).toContain("further down the journal");
+  expect(decision.verdict.kind === "wake" && decision.verdict.reasons[0]!.detail)
+    .toBe("review_verdict since the last delivered wake and 1 more");
+  expect(decision.verdict.kind === "wake" && decision.verdict.items.filter((item) => item.kind === "event"))
+    .toHaveLength(2);
+});
+
+/* The second half of #1285, and the expensive one. A backlog drained at
+   `itemsPerWake` per hourly wake is ten resumed hosts and ten paid turns for
+   fifty events that were history. One look establishes that nothing in front of
+   the cursor is owed, and the cursor moves on that look alone. */
+test("a page of history is discharged by the check that read it, with no wake at all", () => {
+  const history = Array.from({ length: 50 }, (_, index) => event({
+    seq: 100 + index,
+    type: "stage_completed",
+    summary: "a lane that closed yesterday finished",
+    pipelineTerminal: true,
+  }));
+  const decision = seatTickDecision(input({
+    events: history,
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ eventsThrough: 99, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict.kind).toBe("quiet");
+  expect(decision.state.eventsThrough).toBe(149);
+});
+
+/* The seal is not a licence to acknowledge. It stops dead at the first event
+   that is still owed, so the history in front of one is discharged and the
+   event itself waits for a wake that actually lands. */
+test("the seal stops at the first event that is still owed", () => {
+  const decision = seatTickDecision(input({
+    events: [
+      event({ seq: 60, type: "stage_started", summary: "builder started" }),
+      event({ seq: 61, type: "stage_completed", summary: "a closed lane's stage", pipelineTerminal: true }),
+      event({ seq: 62, type: "review_verdict", summary: "the round passed" }),
+      event({ seq: 63, type: "stage_completed", summary: "another closed lane's stage", pipelineTerminal: true }),
+    ],
+    pipelines: [lane()],
+    state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.state.eventsThrough).toBe(61);
+  expect(reasonsOf(decision.verdict)).toEqual(["lane-event"]);
+  /* And only a landing takes the cursor past the live one. */
+  expect(seatTickWakeCommit(decision.state, plan(decision.verdict, "fp-1", 63), NOW).eventsThrough).toBe(63);
+});
+
+/* A skipped check remembers nothing — including this. The turn it landed behind
+   has already superseded the evidence it read. */
+test("a skipped check seals nothing", () => {
+  const decision = seatTickDecision(input({
+    seat: seat({ turn: "busy", activity: { lifecycle: "running", reason: "host_alive_turn_active" } }),
+    events: [event({ seq: 60, type: "stage_completed", summary: "a closed lane's stage", pipelineTerminal: true })],
+    state: stateWith({ eventsThrough: 59 }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "skipped", reason: "seat-busy" });
+  expect(decision.state.eventsThrough).toBe(59);
+});
+
+/* A live event further down the journal than this check reads is NOT announced
+   as "something is waiting". That wake carried no item naming it, so the seat
+   paid a resume to be told to look again — and the pages of history in front of
+   it are now sealed away for free, so the check that reaches it names it. */
+test("a live event past the page waits for the check that can name it, rather than raising an empty wake", () => {
+  const decision = seatTickDecision(input({
+    events: [event({ seq: 60, type: "stage_completed", summary: "a closed lane's stage", pipelineTerminal: true })],
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+  expect(decision.state.eventsThrough).toBe(60);
+});
+
+/* #1289, the mirror image, and it cost twelve hours. Two lanes finished with
+   clean approvals, three pull requests sat approved and unmerged, and the tick
+   answered "quiet — nothing owed" every five minutes because `hasOpenWork`
+   counts open lanes and board cards and a finished lane is neither. */
+test("a finished lane whose pull request is still open is a wake reason of its own, naming the pull request", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [pullRequest()],
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(reasonsOf(decision.verdict)).toEqual(["unmerged-pr"]);
+  expect(decision.verdict.kind === "wake" && decision.verdict.reasons[0]!.detail)
+    .toBe("pull request #1289 left open by a lane that finished");
+  expect(decision.verdict.kind === "wake" && decision.verdict.items[0]).toEqual({
+    kind: "pull-request",
+    id: "#1289",
+    label: "wake on a merge that is waiting — open pull request from ship the exporter, unmerged since that lane finished",
+  });
+});
+
+/* The merge is the discharge, and the only one. The source reads OPEN pull
+   requests, so a merged or closed one is simply absent and the same project
+   goes quiet with no second mechanism silencing anything. */
+test("a merged batch goes quiet on its own", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [],
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+});
+
+/* It is a reason, never a route around the bound: the hourly interval applies
+   to it exactly as it applies to a terminal lane event. */
+test("an unmerged pull request waits out the wake interval like every other reason", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [pullRequest()],
+    state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict.kind).toBe("quiet");
+});
+
+/* And the retry guard applies to it too, so a pull request nobody merges stops
+   costing an hourly wake and becomes one card instead. */
+test("an unmerged pull request that has stopped producing change is held by the retry guard", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [pullRequest()],
+    state: stateWith({
+      lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString(),
+      lastWakeFingerprint: "fp-1",
+      wakesWithoutChange: { "unmerged-pr": 2 },
+    }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "every wake reason is held by the retry guard" });
+  expect(decision.cards.map((card) => card.ref)).toContain("seat-tick-stuck-unmerged-pr");
+});
+
+/* Several at once name the first and count the rest, and every one of them is
+   carried as an item — the seat acts on the list without rediscovering it. */
+test("several unmerged pull requests are counted in the reason and named one by one", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [pullRequest(), pullRequest({ number: 1290, title: "stop replaying closed lanes" })],
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict.kind === "wake" && decision.verdict.reasons[0]!.detail)
+    .toBe("pull request #1289 and 1 more left open by a lane that finished");
+  expect(decision.verdict.kind === "wake" && decision.verdict.items.map((item) => item.id)).toEqual(["#1289", "#1290"]);
+});
+
+/* An unmerged pull request is open work, so a board with nothing else on it
+   does not read as idle and the proposal slot does not open under it. */
+test("a finished lane with an open pull request is not an idle board", () => {
+  const decision = seatTickDecision(input({
+    pullRequests: [pullRequest()],
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString(), lastProposalAt: null }),
+  }));
+  expect(reasonsOf(decision.verdict)).toEqual(["unmerged-pr"]);
+  expect(decision.state.idleSince).toBeNull();
 });
 
 test("an assigned task nothing has started wakes the seat once the wake interval has elapsed", () => {
@@ -426,7 +617,6 @@ test("the wake commit records the wake, and only the commit advances lastWakeAt"
 test("no commit means no cursor: the event cursor moves only with a delivered wake", () => {
   const decision = seatTickDecision(input({
     events: [event({ seq: 44 })],
-    terminalPending: true,
     pipelines: [lane()],
     state: stateWith({ eventsThrough: 12, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
   }));

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -533,11 +533,17 @@ test("no candidate reason lets a failed read spend the stamp or the guard", () =
   const candidates = {
     "lane-event": { events: [event({ seq: 60 })] },
     "unstarted-task": { tasks: [card({ updatedAt: new Date(NOW - 90 * MINUTE).toISOString() })] },
+    /* Carrying its own row, because a stall is only a reason once the memory of
+       the previous check says it survived one. */
+    stalled: {
+      pipelines: [lane({ stageActivity: { lifecycle: "stalled", reason: "host_alive_transcript_silent" } })],
+      state: { ...before, stalledSeen: ["pipeline_a1"] },
+    },
     interval: { pipelines: [lane()] },
   } satisfies Record<string, Partial<SeatTickCheckInput>>;
   for (const gap of ["command-failed", "timed-out", "malformed-output"] as const) {
     for (const [name, candidate] of Object.entries(candidates)) {
-      const decision = seatTickDecision(input({ ...candidate, pullRequestsUnavailable: gap, state: before }));
+      const decision = seatTickDecision(input({ state: before, ...candidate, pullRequestsUnavailable: gap }));
       expect(`${name}/${gap}: ${decision.verdict.kind}`).toBe(`${name}/${gap}: error`);
       expect(decision.state.lastWakeAt).toBe(before.lastWakeAt);
       expect(decision.state.lastWakeFingerprint).toBe(before.lastWakeFingerprint);
@@ -547,6 +553,23 @@ test("no candidate reason lets a failed read spend the stamp or the guard", () =
       expect(decision.state.quietSince).toBeNull();
     }
   }
+});
+
+/* The proposal is the fourth thing a check can spend, and it is spent on the
+   strength of an idle board — which is the very reading a failed pull-request
+   read leaves unestablished. So it waits with the rest, and its 24-hour slot
+   stays unstamped for the check that can see what the finished lanes left. */
+test("an idle board with the proposal slot due proposes nothing while GitHub is unreadable", () => {
+  const decision = seatTickDecision(input({
+    tasks: [card({ status: "done" })],
+    pullRequestsUnavailable: "lanes-unreadable",
+  }));
+  expect(decision.verdict.kind).toBe("error");
+  expect(decision.state.lastProposalAt).toBeNull();
+  /* And the board is not recorded as idle since now either: an idle board is
+     the same claim about the same evidence. */
+  expect(decision.state.idleSince).toBeNull();
+  expect(decision.state.quietSince).toBeNull();
 });
 
 /* And the interval still bounds it from the other side: a check that was never

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -505,16 +505,48 @@ test("a failed read spends neither the wake stamp nor the retry guard", () => {
   expect(decision.state.quietSince).toBeNull();
 });
 
-/* The failure costs this one reason, never the check: a lane event that IS
-   established still wakes the seat while `gh` is down, because a `gh` outage
-   silencing the tick is the failure this whole issue is about. */
-test("a wake reason that stands on its own still wakes while GitHub is unreadable", () => {
+/* The failed read is refused ahead of the wake, not only ahead of the quiet.
+   A wake delivered here would advance the wake stamp and the retry guard, so
+   the reason that stood on its own would have paid the hour on behalf of the
+   read that answered nothing. It waits for the next check instead — one check
+   interval, not one wake interval — and the gap is journaled meanwhile. */
+test("a wake reason that stands on its own is held rather than spent while GitHub is unreadable", () => {
   const decision = seatTickDecision(input({
     pullRequestsUnavailable: "command-failed",
     events: [event({ seq: 60, type: "stage_blocked", summary: "the review round is parked" })],
     state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
   }));
-  expect(reasonsOf(decision.verdict)).toEqual(["lane-event"]);
+  expect(decision.verdict.kind).toBe("error");
+  expect(reasonsOf(decision.verdict)).toEqual([]);
+});
+
+/* Every way the read can fail, against every other reason that could have
+   carried a wake past it. None of them may move the stamp or the counter. */
+test("no candidate reason lets a failed read spend the stamp or the guard", () => {
+  const before = stateWith({
+    eventsThrough: 59,
+    lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString(),
+    lastWakeFingerprint: "fp-0",
+    wakesWithoutChange: { "lane-event": 1 },
+    quietSince: null,
+  });
+  const candidates = {
+    "lane-event": { events: [event({ seq: 60 })] },
+    "unstarted-task": { tasks: [card({ updatedAt: new Date(NOW - 90 * MINUTE).toISOString() })] },
+    interval: { pipelines: [lane()] },
+  } satisfies Record<string, Partial<SeatTickCheckInput>>;
+  for (const gap of ["command-failed", "timed-out", "malformed-output"] as const) {
+    for (const [name, candidate] of Object.entries(candidates)) {
+      const decision = seatTickDecision(input({ ...candidate, pullRequestsUnavailable: gap, state: before }));
+      expect(`${name}/${gap}: ${decision.verdict.kind}`).toBe(`${name}/${gap}: error`);
+      expect(decision.state.lastWakeAt).toBe(before.lastWakeAt);
+      expect(decision.state.lastWakeFingerprint).toBe(before.lastWakeFingerprint);
+      expect(decision.state.wakesWithoutChange).toEqual({ "lane-event": 1 });
+      /* And no claim of quiet in the row either, so the next check is due
+         exactly as this one was. */
+      expect(decision.state.quietSince).toBeNull();
+    }
+  }
 });
 
 /* And the interval still bounds it from the other side: a check that was never

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -92,6 +92,7 @@ function input(over: Partial<SeatTickCheckInput> = {}): SeatTickCheckInput {
     tasks: [],
     events: [],
     pullRequests: [],
+    pullRequestsUnavailable: null,
     signals: [],
     changeFingerprint: "fp-1",
     state: emptySeatTickState(),
@@ -449,6 +450,92 @@ test("several unmerged pull requests are counted in the reason and named one by 
   expect(decision.verdict.kind === "wake" && decision.verdict.reasons[0]!.detail)
     .toBe("pull request #1289 and 1 more left open by a lane that finished");
   expect(decision.verdict.kind === "wake" && decision.verdict.items.map((item) => item.id)).toEqual(["#1289", "#1290"]);
+});
+
+/* ------------------------------------------------------------------------- *
+ * A read that failed may not be spent as a silence.
+ *
+ * The empty list a failed `gh` used to return was indistinguishable from every
+ * pull request having merged, and the decision published `quiet — nothing
+ * owed` on the strength of it. Quiet is a conclusion; this is what happens
+ * when the evidence for it could not be read.
+ * ------------------------------------------------------------------------- */
+
+test("a check that could not read the open pull requests reports an error instead of quiet", () => {
+  const decision = seatTickDecision(input({
+    pullRequestsUnavailable: "command-failed",
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict).toEqual({
+    kind: "error",
+    detail: "the open pull requests of this project's finished lanes could not be read (command-failed), so nothing owed is not established",
+  });
+});
+
+/* Every way the read can fail, and none of them is a merge. */
+test("a timeout and a malformed answer are refused as quiet exactly like a failed command", () => {
+  for (const gap of ["timed-out", "malformed-output", "lanes-unreadable"] as const) {
+    const decision = seatTickDecision(input({
+      pullRequestsUnavailable: gap,
+      tasks: [card({ status: "inbox" })],
+      state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+    }));
+    expect(decision.verdict.kind).toBe("error");
+  }
+});
+
+/* The bound the fix must not become a way around: the error raises no wake, so
+   there is nothing for the stamp or the guard to record, and an hour of `gh`
+   failures leaves the next real wake exactly as due as it was. */
+test("a failed read spends neither the wake stamp nor the retry guard", () => {
+  const before = stateWith({
+    lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString(),
+    lastWakeFingerprint: "fp-1",
+    wakesWithoutChange: { "unmerged-pr": 1 },
+    quietSince: null,
+  });
+  const decision = seatTickDecision(input({ pullRequestsUnavailable: "timed-out", state: before }));
+  expect(decision.state.lastWakeAt).toBe(before.lastWakeAt);
+  expect(decision.state.wakesWithoutChange).toEqual({ "unmerged-pr": 1 });
+  expect(decision.state.lastWakeReasons).toEqual(before.lastWakeReasons);
+  /* And it does not record the project as having been quiet since now, which
+     is the same claim in the state row that the verdict just declined to
+     make. */
+  expect(decision.state.quietSince).toBeNull();
+});
+
+/* The failure costs this one reason, never the check: a lane event that IS
+   established still wakes the seat while `gh` is down, because a `gh` outage
+   silencing the tick is the failure this whole issue is about. */
+test("a wake reason that stands on its own still wakes while GitHub is unreadable", () => {
+  const decision = seatTickDecision(input({
+    pullRequestsUnavailable: "command-failed",
+    events: [event({ seq: 60, type: "stage_blocked", summary: "the review round is parked" })],
+    state: stateWith({ eventsThrough: 59, lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(reasonsOf(decision.verdict)).toEqual(["lane-event"]);
+});
+
+/* And the interval still bounds it from the other side: a check that was never
+   going to ask GitHub carries no gap, so it goes quiet as it always did. */
+test("a check inside the interval is quiet rather than an error", () => {
+  const decision = seatTickDecision(input({
+    tasks: [card({ status: "inbox" })],
+    state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+});
+
+/* A tick that is off is off; nothing was read, so there is nothing to report
+   as unreadable. */
+test("a project whose tick is off stays quiet rather than reporting an error", () => {
+  const decision = seatTickDecision(input({
+    pullRequestsUnavailable: "command-failed",
+    settings: settings({ enabled: false, reason: "nothing here for me" }),
+    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
+  }));
+  expect(decision.verdict.kind).toBe("quiet");
 });
 
 /* An unmerged pull request is open work, so a board with nothing else on it

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -498,6 +498,28 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     };
   }
 
+  /* Nothing left to wake on — and every outcome below this line is a statement
+     that nothing is owed. One of them rests on the pull requests this project's
+     finished lanes left open, and a `gh` that could not be reached establishes
+     none of it. So the check reports what happened and is retried at the next
+     one, rather than reporting a silence it never earned.
+
+     It is an error rather than a wake precisely so it stays incapable of
+     costing anything: no delivery, no wake stamp, no retry-guard count. The
+     hourly bound belongs to wakes that were actually sent, and a failed read
+     cannot spend it. The cards the guard raised above still travel — they
+     describe the board, not this check's conclusion about it. */
+  if (input.pullRequestsUnavailable) {
+    return {
+      verdict: {
+        kind: "error",
+        detail: `the open pull requests of this project's finished lanes could not be read (${input.pullRequestsUnavailable}), so nothing owed is not established`,
+      },
+      state,
+      cards,
+    };
+  }
+
   if (cards.length > 0) {
     return { verdict: { kind: "quiet", detail: "every wake reason is held by the retry guard" }, state: quiet(state, at), cards };
   }

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -28,7 +28,7 @@ import {
  * seat, the open lanes, the board, the lifecycle events past the seat's own
  * cursor and the Viewer's own signals, and answers one of five things.
  *
- * Four rules are load-bearing and easy to lose:
+ * Five rules are load-bearing and easy to lose:
  *
  * - **A stale tick is dropped, never queued.** A seat whose turn is genuinely
  *   progressing is `skipped`, and a skipped check remembers nothing: the stall
@@ -49,9 +49,17 @@ import {
  *   settings (#1275, and the ADR amendment it carries): the seat governs its
  *   own tick, deliberately and with the reason on the record, and a project
  *   nobody configured runs on the default hour exactly as before.
- * - **Nothing here creates, wakes or acknowledges anything.** The decision names
- *   what is owed; the controller sends it, re-reads the seat epoch before it
- *   does, and only a delivered send advances a stamp or a cursor.
+ * - **Nothing here creates or wakes anything.** The decision names what is
+ *   owed; the controller sends it, re-reads the seat epoch before it does, and
+ *   only a delivered send advances a stamp. The one thing a check may settle on
+ *   its own is the history in front of the cursor: an event nothing is owed on
+ *   is discharged by the look that established that, never by a wake (#1285).
+ * - **A wake names what is owed NOW, and silence means nothing is.** Both
+ *   directions of that are here. An event about a lane that has itself finished
+ *   is not an obligation, however far the cursor has fallen behind; a lane that
+ *   finished and left its pull request unmerged IS one, however quiet the board
+ *   otherwise looks (#1289). Where the two pull against each other the rarer,
+ *   truer wake wins over the earlier one.
  */
 
 const MINUTE_MS = 60_000;
@@ -142,11 +150,61 @@ function isUnstarted(task: SeatTickTaskInput, now: number, backlogAfterMs: numbe
   return Number.isFinite(movedAt) && now - movedAt < backlogAfterMs;
 }
 
-/** Work the seat could still carry: an open lane, or a board card that is
-    neither blocked (a recorded stop) nor done. */
+/**
+ * Work the seat could still carry: an open lane, a board card that is neither
+ * blocked (a recorded stop) nor done, or a pull request a finished lane left
+ * open.
+ *
+ * The third clause is #1289. Counting only lanes and cards made "the work
+ * finished" and "the work finished and left three approved pull requests
+ * unmerged" the same answer, and the tick said `quiet — nothing owed` to the
+ * second one every five minutes for twelve hours. A finished lane's open pull
+ * request is the obligation that finishing created, so it is open work.
+ */
 function hasOpenWork(input: SeatTickCheckInput): boolean {
   return input.pipelines.some(isOpenLane)
-    || input.tasks.some((task) => task.status === "inbox" || task.status === "assigned");
+    || input.tasks.some((task) => task.status === "inbox" || task.status === "assigned")
+    || input.pullRequests.length > 0;
+}
+
+/**
+ * A pending event that is still a present obligation.
+ *
+ * Two filters, and the second is the one #1285 adds: the event has to be
+ * terminal and high-signal (routine progress has never woken anyone on its
+ * own), and the lane it names must not have reached a terminal state itself.
+ * A `stage_completed` for a pipeline that closed yesterday is a fact about the
+ * past — nothing is owed on it, and a wake that carries it spends a resumed
+ * host and a paid turn establishing exactly that.
+ */
+function isOwedEvent(event: SeatTickEventInput): boolean {
+  return isTerminalHighSignalEvent(event.type) && !event.pipelineTerminal;
+}
+
+/**
+ * How far this check may move the cursor with no wake at all.
+ *
+ * The page is walked oldest-first and stops at the first event that is still
+ * owed, so the seal covers exactly the history in front of it: routine progress
+ * and terminal events whose lanes have finished. Null means the very first
+ * pending event is owed and the cursor stays where it is.
+ *
+ * This is what stops a backlog from costing one resume per page. The bound that
+ * makes a wake cheap — {@link SeatTickPolicy.itemsPerWake} items, once per
+ * project per interval — turned into a ten-hour tail the moment the cursor fell
+ * behind, because every page of history had to be carried to a seat before the
+ * next one could be read. A page of history is discharged by one look instead,
+ * and a check costs nothing.
+ */
+function dischargedThrough(events: readonly SeatTickEventInput[], cursor: number | null): number | null {
+  let sealed = cursor;
+  for (const event of events) {
+    if (isOwedEvent(event)) break;
+    /* A floor, never a subtraction: the cursor may only ever move forwards,
+       whatever order a page reaches this. */
+    sealed = Math.max(sealed ?? event.seq, event.seq);
+  }
+  return sealed;
 }
 
 /**
@@ -214,6 +272,19 @@ function elapsed(since: string | null, now: number, window: number): boolean {
   if (!since) return true;
   const at = Date.parse(since);
   return !Number.isFinite(at) || now - at >= window;
+}
+
+/**
+ * The one gate every wake passes, exported so the gather can apply the SAME
+ * clause rather than a second copy of it.
+ *
+ * It reads `lastWakeAt`, which the project keeps across a rotation, so an
+ * incoming seat inherits the bound rather than a clean slate the predecessor's
+ * wake is missing from — and the interval is the project's own (#1275), which
+ * is the default hour until someone records something else.
+ */
+export function seatTickWakeDue(lastWakeAt: string | null, now: number, wakeIntervalMs: number): boolean {
+  return elapsed(lastWakeAt, now, wakeIntervalMs);
 }
 
 /** The retry-guard count that applies right now: a fingerprint that moved since
@@ -300,7 +371,16 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     return { verdict: { kind: "skipped", reason: "seat-busy" }, state: unchanged, cards: [] };
   }
 
-  const base: SeatTickProjectState = { ...unchanged, seatEpoch: input.seat.seatEpoch };
+  /* The seal (#1285) rides on every verdict from here down, a skipped check
+     excepted — that one returns above and remembers nothing, deliberately. It
+     is not a record of anything having been sent: it says this check looked at
+     the history in front of the cursor and found nothing owed in it, which is
+     a conclusion a quiet check is as entitled to as a wake. */
+  const base: SeatTickProjectState = {
+    ...unchanged,
+    seatEpoch: input.seat.seatEpoch,
+    eventsThrough: dischargedThrough(input.events, unchanged.eventsThrough),
+  };
   const stalled = stalledLanes(input);
   const stalledNow = stalled.map((entry) => entry.pipeline.id);
   /* A stall is only reported once it survived a second check, so a lane between
@@ -309,12 +389,7 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
   const unstarted = input.tasks.filter((task) => isUnstarted(task, input.now, input.policy.backlogAfterMs));
   const backlog = input.tasks.filter((task) => task.status === "assigned" && !task.owned).length - unstarted.length;
   const openWork = hasOpenWork(input);
-  /* The one gate every wake passes. It reads `lastWakeAt`, which the project
-     keeps across a rotation, so an incoming seat inherits the bound rather than
-     a clean slate the predecessor's wake is missing from — and the interval is
-     the project's own (#1275), which is the default hour until someone records
-     something else. */
-  const wakeDue = elapsed(input.state.lastWakeAt, input.now, input.settings.wakeIntervalMs);
+  const wakeDue = seatTickWakeDue(input.state.lastWakeAt, input.now, input.settings.wakeIntervalMs);
 
   const state: SeatTickProjectState = { ...base, stalledSeen: stalledNow };
 
@@ -338,22 +413,37 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     };
   }
 
-  const laneEvents = input.events.filter((event) => isTerminalHighSignalEvent(event.type));
+  const laneEvents = input.events.filter(isOwedEvent);
   const candidates: SeatTickWakeReason[] = [];
   if (wakeDue) {
-    /* Terminal events are counted over the WHOLE pending range, not just the
-       page this check carries: a verdict sitting behind a backlog is as
-       decision-blocking as one at the front, and a page-sized answer is how it
-       gets buried. It leads the wake for that reason — and it waits for the
-       wake like everything else. Routine progress never wakes on its own. */
-    if (input.terminalPending) {
-      const first = laneEvents[0];
+    /* A verdict the seat cannot decide without leads the wake — and waits for
+       the wake like everything else. Routine progress never wakes on its own,
+       and neither does an event whose lane has finished.
+
+       The count beside it is what the seat reads as "how much is there", so it
+       counts what is owed and nothing else (#1285): "and 18 more" over a page
+       that was almost entirely closed lanes described a queue that did not
+       exist. A live event further down the journal than this check reads is
+       NOT announced here; the pages of history in front of it are sealed away
+       by the check itself at no cost, and the check that reaches it names it.
+       A wake that says only "something is waiting further down" is the empty
+       agenda this whole mechanism exists to stop sending. */
+    if (laneEvents.length > 0) {
+      const first = laneEvents[0]!;
       const more = laneEvents.length > 1 ? ` and ${laneEvents.length - 1} more` : "";
+      candidates.push({ kind: "lane-event", detail: `${first.type} since the last delivered wake${more}` });
+    }
+    /* The mirror image (#1289), and it is a wake reason rather than a silence
+       for one reason: a lane that finished with its pull request unmerged is
+       the seat's next obligation, and the tick could not see one. It takes no
+       shortcut around the bound — same interval above, same retry guard below —
+       and it clears itself when the pull request merges or closes. */
+    if (input.pullRequests.length > 0) {
+      const first = input.pullRequests[0]!;
+      const more = input.pullRequests.length > 1 ? ` and ${input.pullRequests.length - 1} more` : "";
       candidates.push({
-        kind: "lane-event",
-        detail: first
-          ? `${first.type} since the last delivered wake${more}`
-          : "a terminal lane event is waiting further down the journal than this check reads",
+        kind: "unmerged-pr",
+        detail: `pull request #${first.number}${more} left open by a lane that finished`,
       });
     }
     if (persistedStalls.length > 0) {
@@ -443,6 +533,17 @@ function wakeItems(context: {
   const items: SeatTickItem[] = [];
   for (const event of context.laneEvents) {
     items.push({ kind: "event", id: event.pipelineId ?? event.type, label: `${event.type}: ${event.summary}` });
+  }
+  /* Named, not merely counted (#1289). The twelve hours were spent because the
+     seat had no way to know a pull request was waiting; a wake that says one is
+     and leaves the seat to rediscover which would have cost most of the same
+     turn. The lane that produced it travels with it for the same reason. */
+  for (const pullRequest of input.pullRequests) {
+    items.push({
+      kind: "pull-request",
+      id: `#${pullRequest.number}`,
+      label: `${pullRequest.title} — open pull request from ${pullRequest.pipelineTitle}, unmerged since that lane finished`,
+    });
   }
   for (const entry of context.stalled) {
     items.push({ kind: "pipeline", id: entry.pipeline.id, label: `${entry.pipeline.title} — ${entry.reason}` });

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -484,25 +484,18 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     reasons.push(reason);
   }
 
-  if (reasons.length > 0) {
-    const all = wakeItems({ input, stalled: persistedStalls, laneEvents, unstarted });
-    return {
-      verdict: {
-        kind: "wake",
-        reasons,
-        items: all.slice(0, input.policy.itemsPerWake),
-        deferred: Math.max(0, all.length - input.policy.itemsPerWake),
-      },
-      state,
-      cards,
-    };
-  }
+  /* Ahead of the wake, because the wake is what would pay for the gap.
+     Delivering one advances the wake stamp and the retry-guard count, so a
+     `gh` that answered nothing would buy the next hour of silence on the
+     strength of a read that established nothing — the same trade the error
+     below refuses, arriving by the one route that still charged for it.
 
-  /* Nothing left to wake on — and every outcome below this line is a statement
-     that nothing is owed. One of them rests on the pull requests this project's
-     finished lanes left open, and a `gh` that could not be reached establishes
-     none of it. So the check reports what happened and is retried at the next
-     one, rather than reporting a silence it never earned.
+     The reason that DID stand on its own is not dropped by this; it is held
+     until the next check, five minutes away rather than the hour a delivered
+     wake would have spent, and that check wakes with everything owed by then.
+     Meanwhile the error is journaled every check, so a `gh` outage is loud for
+     as long as it lasts instead of being quietly absorbed into a wake that
+     could not name what it was hiding.
 
      It is an error rather than a wake precisely so it stays incapable of
      costing anything: no delivery, no wake stamp, no retry-guard count. The
@@ -520,6 +513,23 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     };
   }
 
+  if (reasons.length > 0) {
+    const all = wakeItems({ input, stalled: persistedStalls, laneEvents, unstarted });
+    return {
+      verdict: {
+        kind: "wake",
+        reasons,
+        items: all.slice(0, input.policy.itemsPerWake),
+        deferred: Math.max(0, all.length - input.policy.itemsPerWake),
+      },
+      state,
+      cards,
+    };
+  }
+
+  /* Nothing left to wake on, and every outcome below this line is a statement
+     that nothing is owed — each of them resting on evidence the check above
+     has already shown it could read. */
   if (cards.length > 0) {
     return { verdict: { kind: "quiet", detail: "every wake reason is held by the retry guard" }, state: quiet(state, at), cards };
   }

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -16,7 +16,7 @@ const { DEFAULT_SEAT_TICK_POLICY } = await import("./seatTick");
 const { defaultSeatTickSettings } = await import("./seatTickSettings");
 import type { SeatTickSettings } from "./seatTickSettings";
 import type { SeatTickControllerDependencies } from "./seatTickController";
-import type { OpenPullRequest } from "./githubEvidence";
+import type { OpenPullRequest, OpenPullRequestsUnavailable } from "./githubEvidence";
 import type { SeatTickWakeState, SeatTickWithdrawal } from "./seatTickSources";
 import {
   emptySeatTickState,
@@ -54,39 +54,10 @@ interface Harness {
   seat: { conversationId: string; seatEpoch: number; path: string | null } | null;
 }
 
-function harness(options: {
-  seat?: { conversationId: string; seatEpoch: number; path: string | null } | null;
-  turn?: "busy" | "idle";
-  seatActivity?: Partial<AgentLivenessRecord> | null;
-  pipelines?: { id: string; state: string; createdAt: string; movedAt: string | null; branch?: string; closedAt?: string | null }[];
-  tasks?: { id: string; status: "inbox" | "assigned" | "blocked" | "done" }[];
-  events?: LifecycleEvent[];
-  state?: Partial<SeatTickProjectState>;
-  delivery?: DeliveryOutcome;
-  deliveryThrows?: boolean;
-  /** Swaps the seat after the decision, the way a rotation lands mid-check. */
-  rotateBeforeSend?: { conversationId: string; seatEpoch: number; path: string | null } | null;
-  /** What the layer holding a retained wake says has become of it. */
-  wakeState?: SeatTickWakeState;
-  /** What taking that wake back out of the holder's queue achieves. */
-  withdrawal?: SeatTickWithdrawal;
-  /** The holder cannot be reached at all, for either question. */
-  holderThrows?: boolean;
-  /** The project's own tick settings (#1275); the default is the tick as it
-      shipped. */
-  settings?: SeatTickSettings;
-  /** What `gh` reports open in the project's repository (#1289). */
-  openPullRequests?: OpenPullRequest[];
-}): Harness {
-  const sent: ConversationMessage[] = [];
-  const journal: SeatTickRunRecord[] = [];
-  const cards: { project: string; card: SeatTickCard }[] = [];
-  const written: SeatTickProjectState[] = [];
-  const withdrawn: { wake: SeatTickOutstandingWake; reason: string }[] = [];
-  const result: Harness = { deps: {}, sent, journal, cards, written, withdrawn, seat: options.seat === undefined ? { conversationId: CONVERSATION, seatEpoch: 7, path: null } : options.seat };
-  let reads = 0;
+type PipelineFixture = { id: string; state: string; createdAt: string; movedAt: string | null; branch?: string; closedAt?: string | null };
 
-  const pipelines = (options.pipelines ?? []).map((entry) => ({
+function pipelineRecord(entry: PipelineFixture) {
+  return {
     id: entry.id,
     task: `lane ${entry.id}`,
     taskIds: [],
@@ -107,7 +78,49 @@ function harness(options: {
     srcConversationId: null,
     createdAt: entry.createdAt,
     closedAt: entry.closedAt ?? null,
-  }));
+  };
+}
+
+function harness(options: {
+  seat?: { conversationId: string; seatEpoch: number; path: string | null } | null;
+  turn?: "busy" | "idle";
+  seatActivity?: Partial<AgentLivenessRecord> | null;
+  pipelines?: PipelineFixture[];
+  tasks?: { id: string; status: "inbox" | "assigned" | "blocked" | "done" }[];
+  events?: LifecycleEvent[];
+  state?: Partial<SeatTickProjectState>;
+  delivery?: DeliveryOutcome;
+  deliveryThrows?: boolean;
+  /** Swaps the seat after the decision, the way a rotation lands mid-check. */
+  rotateBeforeSend?: { conversationId: string; seatEpoch: number; path: string | null } | null;
+  /** What the layer holding a retained wake says has become of it. */
+  wakeState?: SeatTickWakeState;
+  /** What taking that wake back out of the holder's queue achieves. */
+  withdrawal?: SeatTickWithdrawal;
+  /** The holder cannot be reached at all, for either question. */
+  holderThrows?: boolean;
+  /** The project's own tick settings (#1275); the default is the tick as it
+      shipped. */
+  settings?: SeatTickSettings;
+  /** What `gh` reports open in the project's repository (#1289). */
+  openPullRequests?: OpenPullRequest[];
+  /** The `gh` read failing rather than answering (#1289). Distinct from an
+      empty answer on purpose: that is what the check may go quiet on. */
+  pullRequestsUnavailable?: OpenPullRequestsUnavailable;
+  archivedPipelines?: PipelineFixture[];
+}): Harness {
+  const sent: ConversationMessage[] = [];
+  const journal: SeatTickRunRecord[] = [];
+  const cards: { project: string; card: SeatTickCard }[] = [];
+  const written: SeatTickProjectState[] = [];
+  const withdrawn: { wake: SeatTickOutstandingWake; reason: string }[] = [];
+  const result: Harness = { deps: {}, sent, journal, cards, written, withdrawn, seat: options.seat === undefined ? { conversationId: CONVERSATION, seatEpoch: 7, path: null } : options.seat };
+  let reads = 0;
+
+  const pipelines = (options.pipelines ?? []).map(pipelineRecord);
+  /* Lanes the hot store has already let go of: a settled record leaves after
+     three days and the pull request it left open does not (#1289). */
+  const archived = (options.archivedPipelines ?? []).map(pipelineRecord);
 
   const tasks = (options.tasks ?? []).map((entry) => ({
     id: entry.id,
@@ -143,6 +156,7 @@ function harness(options: {
       },
       activeSeats: () => [PROJECT],
       pipelines: () => pipelines as never,
+      archivedPipelines: () => archived as never,
       tasks: () => tasks as never,
       registry: () => ({
         conversation: () => ({ turn: { state: options.turn ?? "idle" } }),
@@ -155,7 +169,9 @@ function harness(options: {
       latestDeployment: () => ({ state: "unreadable", error: "no ledger" }) as never,
       retirementReport: () => null,
       settings: () => options.settings ?? defaultSeatTickSettings(PROJECT),
-      openPullRequests: async () => options.openPullRequests ?? [],
+      openPullRequests: async () => (options.pullRequestsUnavailable
+        ? { ok: false, unavailable: options.pullRequestsUnavailable }
+        : { ok: true, pullRequests: options.openPullRequests ?? [] }),
       wakeState: async () => {
         if (options.holderThrows) throw new Error("the layer holding the wake cannot be read");
         return options.wakeState ?? "retained";
@@ -734,6 +750,104 @@ test("once the pull request is merged the same project owes nothing again", asyn
   });
   expect(await runSeatTickCheck(PROJECT, bare.deps)).toMatchObject({ verdict: "quiet" });
   expect(bare.sent).toEqual([]);
+});
+
+/* The same lane five days on: out of the hot store, into the archive, and the
+   pull request it left open is still the seat's next obligation. Every route
+   into this case is a tick that was not able to say so earlier — ticking off,
+   a seat busy for days, a `gh` nobody could reach — so the first check that
+   CAN must not be the one that reports quiet. */
+const ARCHIVED_LANE = [{
+  id: "pipeline_z9",
+  state: "completed",
+  createdAt: "2026-08-22T09:00:00.000Z",
+  movedAt: "2026-08-22T22:00:00.000Z",
+  branch: "topic-merge-queue",
+  closedAt: "2026-08-22T22:00:00.000Z",
+}];
+
+test("a lane the archive has taken still wakes the seat over its open pull request", async () => {
+  const rig = harness({
+    pipelines: [],
+    archivedPipelines: ARCHIVED_LANE,
+    state: OVERDUE,
+    openPullRequests: [{
+      number: 1289,
+      title: "wake on a merge that is waiting",
+      headRefName: "topic-merge-queue",
+      updatedAt: "2026-08-28T11:30:00.000Z",
+    }],
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "wake", reasons: ["unmerged-pr"], items: 1 });
+  expect(rig.sent[0]!.text).toContain("pull request #1289 left open by a lane that finished");
+});
+
+test("and once that pull request merges the same project goes quiet", async () => {
+  const rig = harness({
+    pipelines: [],
+    archivedPipelines: ARCHIVED_LANE,
+    state: { ...OVERDUE, lastProposalAt: new Date(NOW - MINUTE).toISOString() },
+    openPullRequests: [],
+  });
+  expect(await runSeatTickCheck(PROJECT, rig.deps)).toMatchObject({ verdict: "quiet" });
+  expect(rig.sent).toEqual([]);
+});
+
+/* ------------------------------------------------------------------------- *
+ * A `gh` that could not answer is journaled and retried, never spent.
+ * ------------------------------------------------------------------------- */
+
+test("a GitHub failure is journaled as an error rather than published as quiet", async () => {
+  const rig = harness({
+    pipelines: FINISHED_LANE,
+    tasks: [{ id: "task_b2", status: "inbox" }],
+    state: OVERDUE,
+    pullRequestsUnavailable: "command-failed",
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "error", reasons: [], items: 0 });
+  expect(record!.detail).toContain("command-failed");
+  expect(rig.sent).toEqual([]);
+  /* The stamp and the guard are exactly where the previous check left them, so
+     the hourly budget is intact and the next check asks again. */
+  expect(rig.written[0]!.lastWakeAt).toBe(OVERDUE.lastWakeAt);
+  expect(rig.written[0]!.wakesWithoutChange).toEqual({});
+  expect(rig.written[0]!.quietSince).toBeNull();
+});
+
+test("the check after the failure asks again, and wakes as soon as GitHub answers", async () => {
+  const failed = harness({ pipelines: FINISHED_LANE, state: OVERDUE, pullRequestsUnavailable: "timed-out" });
+  expect(await runSeatTickCheck(PROJECT, failed.deps)).toMatchObject({ verdict: "error" });
+
+  /* The next check reads the row the failed one wrote — the wake stamp it did
+     not move — and the wake is still due. */
+  const recovered = harness({
+    pipelines: FINISHED_LANE,
+    state: failed.written[0]!,
+    openPullRequests: [{
+      number: 1289,
+      title: "wake on a merge that is waiting",
+      headRefName: "topic-merge-queue",
+      updatedAt: "2026-08-28T11:30:00.000Z",
+    }],
+  });
+  expect(await runSeatTickCheck(PROJECT, recovered.deps)).toMatchObject({ verdict: "wake", reasons: ["unmerged-pr"] });
+});
+
+/* The failure costs this one reason and not the check: while `gh` is down a
+   lane event that IS established still reaches the seat, because a GitHub
+   outage silencing the tick is the failure this all exists to prevent. */
+test("a lane event still wakes the seat while GitHub is unreadable", async () => {
+  const rig = harness({
+    pipelines: [...OPEN_LANE, ...FINISHED_LANE],
+    state: { ...OVERDUE, eventsThrough: 12 },
+    events: [terminalEvent(44)],
+    pullRequestsUnavailable: "malformed-output",
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "wake", reasons: ["lane-event"] });
+  expect(rig.sent).toHaveLength(1);
 });
 
 test("a failed delivery leaves the wake stamp where it was, so the next check retries", async () => {

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -14,9 +14,10 @@ fs.mkdirSync(process.env.TMPDIR, { recursive: true });
 const { reconcileSeatTick, runSeatTickCheck, startSeatTick, stopSeatTick, wakeReached } = await import("./seatTickController");
 const { DEFAULT_SEAT_TICK_POLICY } = await import("./seatTick");
 const { defaultSeatTickSettings } = await import("./seatTickSettings");
+const { openPullRequestsForRepo } = await import("./githubEvidence");
 import type { SeatTickSettings } from "./seatTickSettings";
 import type { SeatTickControllerDependencies } from "./seatTickController";
-import type { OpenPullRequest, OpenPullRequestsUnavailable } from "./githubEvidence";
+import type { GithubRunner, OpenPullRequest, OpenPullRequestsUnavailable } from "./githubEvidence";
 import type { SeatTickWakeState, SeatTickWithdrawal } from "./seatTickSources";
 import {
   emptySeatTickState,
@@ -107,6 +108,11 @@ function harness(options: {
   /** The `gh` read failing rather than answering (#1289). Distinct from an
       empty answer on purpose: that is what the check may go quiet on. */
   pullRequestsUnavailable?: OpenPullRequestsUnavailable;
+  /** The `gh` seam itself, one level below the option above, so a command that
+      throws, a child killed at its timeout and output nobody can attribute
+      reach the check the way they reach it in production — through the real
+      parse — rather than as a verdict the test picked for it. */
+  githubRun?: GithubRunner;
   archivedPipelines?: PipelineFixture[];
 }): Harness {
   const sent: ConversationMessage[] = [];
@@ -169,9 +175,12 @@ function harness(options: {
       latestDeployment: () => ({ state: "unreadable", error: "no ledger" }) as never,
       retirementReport: () => null,
       settings: () => options.settings ?? defaultSeatTickSettings(PROJECT),
-      openPullRequests: async () => (options.pullRequestsUnavailable
-        ? { ok: false, unavailable: options.pullRequestsUnavailable }
-        : { ok: true, pullRequests: options.openPullRequests ?? [] }),
+      openPullRequests: async (request) => {
+        if (options.githubRun) return openPullRequestsForRepo({ ...request, run: options.githubRun });
+        return options.pullRequestsUnavailable
+          ? { ok: false, unavailable: options.pullRequestsUnavailable }
+          : { ok: true, pullRequests: options.openPullRequests ?? [] };
+      },
       wakeState: async () => {
         if (options.holderThrows) throw new Error("the layer holding the wake cannot be read");
         return options.wakeState ?? "retained";
@@ -835,10 +844,12 @@ test("the check after the failure asks again, and wakes as soon as GitHub answer
   expect(await runSeatTickCheck(PROJECT, recovered.deps)).toMatchObject({ verdict: "wake", reasons: ["unmerged-pr"] });
 });
 
-/* The failure costs this one reason and not the check: while `gh` is down a
-   lane event that IS established still reaches the seat, because a GitHub
-   outage silencing the tick is the failure this all exists to prevent. */
-test("a lane event still wakes the seat while GitHub is unreadable", async () => {
+/* The wake that WOULD have gone out is where the failure used to be paid for.
+   Delivering it stamps `lastWakeAt` and the retry accounting, so the hour it
+   bought was bought by a read that answered nothing. The lane event is held
+   for the next check instead — five minutes, not an hour — and the gap is
+   journaled for as long as it lasts. */
+test("a lane event is held rather than spent while GitHub is unreadable", async () => {
   const rig = harness({
     pipelines: [...OPEN_LANE, ...FINISHED_LANE],
     state: { ...OVERDUE, eventsThrough: 12 },
@@ -846,8 +857,62 @@ test("a lane event still wakes the seat while GitHub is unreadable", async () =>
     pullRequestsUnavailable: "malformed-output",
   });
   const record = await runSeatTickCheck(PROJECT, rig.deps);
-  expect(record).toMatchObject({ verdict: "wake", reasons: ["lane-event"] });
-  expect(rig.sent).toHaveLength(1);
+  expect(record).toMatchObject({ verdict: "error", reasons: [], items: 0 });
+  expect(record!.detail).toContain("malformed-output");
+  expect(rig.sent).toEqual([]);
+  expect(rig.written[0]!.lastWakeAt).toBe(OVERDUE.lastWakeAt);
+  expect(rig.written[0]!.wakesWithoutChange).toEqual({});
+  /* And the event cursor stays put too, so the check that can answer still has
+     the event to name. */
+  expect(rig.written[0]!.eventsThrough).toBe(12);
+});
+
+/* The three ways `gh` itself fails, each carried through the real seam and the
+   real parse, each alongside a lane event that would otherwise have woken the
+   seat. None of them may move the stamp, the guard or the cursor, and each
+   must still be asked on the next check. */
+test("a thrown command, a timeout and unusable output each cost nothing and are asked again", async () => {
+  const killed = Object.assign(new Error("Command failed"), { killed: true, signal: "SIGTERM" });
+  const failures: { name: string; gap: string; run: GithubRunner }[] = [
+    { name: "thrown command", gap: "command-failed", run: async () => { throw new Error("gh: command not found"); } },
+    { name: "timeout", gap: "timed-out", run: async () => { throw killed; } },
+    /* A nonempty answer whose only row names no head branch: the shape that
+       used to arrive as a successful empty list. */
+    { name: "unusable output", gap: "malformed-output", run: async () => JSON.stringify([{ number: 1289, title: "no head" }]) },
+  ];
+
+  for (const failure of failures) {
+    let asked = 0;
+    const run: GithubRunner = async (args) => {
+      asked += 1;
+      return failure.run(args);
+    };
+    const rig = harness({
+      pipelines: [...OPEN_LANE, ...FINISHED_LANE],
+      state: { ...OVERDUE, eventsThrough: 12, wakesWithoutChange: { "lane-event": 1 }, lastWakeFingerprint: "fp-0" },
+      events: [terminalEvent(44)],
+      githubRun: run,
+    });
+
+    const record = await runSeatTickCheck(PROJECT, rig.deps);
+    expect(`${failure.name}: ${record!.verdict}`).toBe(`${failure.name}: error`);
+    expect(record!.detail).toContain(failure.gap);
+    expect(rig.sent).toEqual([]);
+    expect(rig.written[0]!.lastWakeAt).toBe(OVERDUE.lastWakeAt);
+    expect(rig.written[0]!.wakesWithoutChange).toEqual({ "lane-event": 1 });
+    expect(rig.written[0]!.quietSince).toBeNull();
+    expect(asked).toBe(1);
+
+    /* The next check reads the row the failed one wrote and asks `gh` again,
+       rather than waiting out an hour it never spent. */
+    await runSeatTickCheck(PROJECT, harness({
+      pipelines: [...OPEN_LANE, ...FINISHED_LANE],
+      state: rig.written[0]!,
+      events: [terminalEvent(44)],
+      githubRun: run,
+    }).deps);
+    expect(`${failure.name}: asked ${asked}`).toBe(`${failure.name}: asked 2`);
+  }
 });
 
 test("a failed delivery leaves the wake stamp where it was, so the next check retries", async () => {

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -16,6 +16,7 @@ const { DEFAULT_SEAT_TICK_POLICY } = await import("./seatTick");
 const { defaultSeatTickSettings } = await import("./seatTickSettings");
 import type { SeatTickSettings } from "./seatTickSettings";
 import type { SeatTickControllerDependencies } from "./seatTickController";
+import type { OpenPullRequest } from "./githubEvidence";
 import type { SeatTickWakeState, SeatTickWithdrawal } from "./seatTickSources";
 import {
   emptySeatTickState,
@@ -57,7 +58,7 @@ function harness(options: {
   seat?: { conversationId: string; seatEpoch: number; path: string | null } | null;
   turn?: "busy" | "idle";
   seatActivity?: Partial<AgentLivenessRecord> | null;
-  pipelines?: { id: string; state: string; createdAt: string; movedAt: string | null }[];
+  pipelines?: { id: string; state: string; createdAt: string; movedAt: string | null; branch?: string; closedAt?: string | null }[];
   tasks?: { id: string; status: "inbox" | "assigned" | "blocked" | "done" }[];
   events?: LifecycleEvent[];
   state?: Partial<SeatTickProjectState>;
@@ -74,6 +75,8 @@ function harness(options: {
   /** The project's own tick settings (#1275); the default is the tick as it
       shipped. */
   settings?: SeatTickSettings;
+  /** What `gh` reports open in the project's repository (#1289). */
+  openPullRequests?: OpenPullRequest[];
 }): Harness {
   const sent: ConversationMessage[] = [];
   const journal: SeatTickRunRecord[] = [];
@@ -90,7 +93,7 @@ function harness(options: {
     project: PROJECT,
     repoDir: "/srv/repo",
     worktreeDir: "/srv/worktree",
-    branch: "topic",
+    branch: entry.branch ?? "topic",
     baseBranch: "main",
     baseRef: "main",
     lastPassedCommit: "",
@@ -103,7 +106,7 @@ function harness(options: {
     srcPath: null,
     srcConversationId: null,
     createdAt: entry.createdAt,
-    closedAt: null,
+    closedAt: entry.closedAt ?? null,
   }));
 
   const tasks = (options.tasks ?? []).map((entry) => ({
@@ -152,6 +155,7 @@ function harness(options: {
       latestDeployment: () => ({ state: "unreadable", error: "no ledger" }) as never,
       retirementReport: () => null,
       settings: () => options.settings ?? defaultSeatTickSettings(PROJECT),
+      openPullRequests: async () => options.openPullRequests ?? [],
       wakeState: async () => {
         if (options.holderThrows) throw new Error("the layer holding the wake cannot be read");
         return options.wakeState ?? "retained";
@@ -652,6 +656,84 @@ test("the check after the seal carries the events that arrived since it", async 
   const record = await runSeatTickCheck(PROJECT, next.deps);
   expect(record!.reasons).toEqual(["lane-event"]);
   expect(record!.eventsThrough).toBe(9854);
+});
+
+/* ------------------------------------------------------------------------- *
+ * #1285 / #1289, end to end: a wake names what is owed now, and silence means
+ * nothing is.
+ * ------------------------------------------------------------------------- */
+
+/** A lane that ran and finished, with the branch its pull request is the head
+    of. Whether it is still open is the whole question both halves turn on. */
+const FINISHED_LANE = [{
+  id: "pipeline_z9",
+  state: "completed",
+  createdAt: "2026-08-27T09:00:00.000Z",
+  movedAt: "2026-08-27T22:00:00.000Z",
+  branch: "topic-merge-queue",
+  closedAt: "2026-08-27T22:00:00.000Z",
+}];
+
+/* The report: three consecutive wakes whose every item named a pipeline that
+   had reached a terminal state the day before. Nothing was owed on any of them,
+   and establishing that was the entire cost of the wake. */
+test("events belonging to a lane that has finished send nothing, and the check that read them discharges them", async () => {
+  const rig = harness({
+    pipelines: FINISHED_LANE,
+    tasks: [{ id: "task_b2", status: "inbox" }],
+    events: [terminalEvent(44), terminalEvent(45), terminalEvent(46)].map((event) => ({ ...event, pipelineId: "pipeline_z9" })),
+    state: { ...OVERDUE, eventsThrough: 12 },
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "quiet", delivery: null, detail: "nothing owed" });
+  expect(rig.sent).toEqual([]);
+  /* And the backlog does not come back for a second, third and fourth wake:
+     one look moved the cursor past all of it. */
+  expect(rig.written[0]!.eventsThrough).toBe(46);
+  expect(record!.eventsThrough).toBe(46);
+});
+
+/* Twelve hours of `quiet — nothing owed` while three approved pull requests sat
+   unmerged, because the tick counts open lanes and board cards and a finished
+   lane is neither. */
+test("a completed lane whose pull request is still open wakes the seat, naming the pull request", async () => {
+  const rig = harness({
+    pipelines: FINISHED_LANE,
+    state: OVERDUE,
+    openPullRequests: [{
+      number: 1289,
+      title: "wake on a merge that is waiting",
+      headRefName: "topic-merge-queue",
+      updatedAt: "2026-08-28T11:30:00.000Z",
+    }],
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "wake", reasons: ["unmerged-pr"], items: 1 });
+  expect(rig.sent[0]!.text).toContain("pull request #1289 left open by a lane that finished");
+  expect(rig.sent[0]!.text).toContain("[pull-request] #1289 — wake on a merge that is waiting");
+});
+
+/* And the merge is what silences it, with nothing else to turn off. */
+test("once the pull request is merged the same project owes nothing again", async () => {
+  const rig = harness({
+    pipelines: FINISHED_LANE,
+    tasks: [{ id: "task_b2", status: "inbox" }],
+    state: OVERDUE,
+    openPullRequests: [],
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "quiet", detail: "nothing owed" });
+  expect(rig.sent).toEqual([]);
+
+  /* And with the board empty behind it too — one finished lane and nothing
+     else — the same merge leaves a project with no wake owed at all. */
+  const bare = harness({
+    pipelines: FINISHED_LANE,
+    state: { ...OVERDUE, lastProposalAt: new Date(NOW - MINUTE).toISOString() },
+    openPullRequests: [],
+  });
+  expect(await runSeatTickCheck(PROJECT, bare.deps)).toMatchObject({ verdict: "quiet" });
+  expect(bare.sent).toEqual([]);
 });
 
 test("a failed delivery leaves the wake stamp where it was, so the next check retries", async () => {

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -915,6 +915,40 @@ test("a thrown command, a timeout and unusable output each cost nothing and are 
   }
 });
 
+/* The other edge of that table, through the same seam. Exactly the empty array
+   is the answer a check may go quiet on, so the refusal above must not grow
+   into refusing it: a parse that read `[]` as output nobody can attribute
+   would leave every project whose pull requests have all merged in a permanent
+   error, which is the same confusion of an answer with a failure, running the
+   other way. */
+test("the empty array is the one gh answer that still earns quiet", async () => {
+  const rig = harness({
+    pipelines: FINISHED_LANE,
+    tasks: [{ id: "task_b2", status: "inbox" }],
+    state: OVERDUE,
+    githubRun: async () => "[]",
+  });
+  const record = await runSeatTickCheck(PROJECT, rig.deps);
+  expect(record).toMatchObject({ verdict: "quiet", detail: "nothing owed" });
+  expect(rig.sent).toEqual([]);
+  /* And the row records the quiet, which is the claim an error never makes. */
+  expect(rig.written[0]!.quietSince).toBe(new Date(NOW).toISOString());
+
+  /* One usable row beside it, off the same seam and the same parse: the answer
+     that is not empty wakes, so the quiet above came from the answer and not
+     from a seam that had stopped reporting anything. */
+  const open = harness({
+    pipelines: FINISHED_LANE,
+    tasks: [{ id: "task_b2", status: "inbox" }],
+    state: OVERDUE,
+    githubRun: async () => JSON.stringify([
+      { number: 1289, title: "wake on a merge that is waiting", headRefName: "topic-merge-queue", updatedAt: "2026-08-28T11:30:00.000Z" },
+    ]),
+  });
+  expect(await runSeatTickCheck(PROJECT, open.deps)).toMatchObject({ verdict: "wake", reasons: ["unmerged-pr"] });
+  expect(open.sent[0]!.text).toContain("pull request #1289 left open by a lane that finished");
+});
+
 test("a failed delivery leaves the wake stamp where it was, so the next check retries", async () => {
   const rig = harness({
     pipelines: OPEN_LANE,

--- a/src/lib/monitor/seatTickSources.test.ts
+++ b/src/lib/monitor/seatTickSources.test.ts
@@ -16,6 +16,7 @@ import type { SeatTickSources } from "./seatTickSources";
 const { DEFAULT_SEAT_TICK_POLICY, seatTickDecision } = await import("./seatTick");
 const { defaultSeatTickSettings } = await import("./seatTickSettings");
 import type { AgentLivenessRecord } from "@/lib/lifecycle/liveness";
+import type { OpenPullRequest } from "./githubEvidence";
 import type { LifecycleEvent, LifecycleJournalFile } from "@/lib/lifecycle/journal";
 import { emptySeatTickState, type SeatTickProjectState } from "./types";
 
@@ -133,6 +134,9 @@ function sources(over: {
   latestDeployment?: ReturnType<SeatTickSources["latestDeployment"]>;
   settings?: ReturnType<SeatTickSources["settings"]>;
   livenessCalls?: { project?: string; conversationId?: string; stallAfterMs: number }[];
+  openPullRequests?: OpenPullRequest[];
+  pullRequestCalls?: { cwd: string; limit: number }[];
+  pullRequestsThrow?: boolean;
 }): SeatTickSources {
   return {
     seatFor: () => ({ active: { conversationId: CONVERSATION, seatEpoch: 7, path: null } as never, pending: null, history: [] }),
@@ -156,6 +160,11 @@ function sources(over: {
     latestDeployment: () => over.latestDeployment ?? ({ state: "unreadable", error: "no ledger" }) as never,
     retirementReport: () => null,
     settings: () => over.settings ?? defaultSeatTickSettings(PROJECT),
+    openPullRequests: async (options) => {
+      over.pullRequestCalls?.push(options);
+      if (over.pullRequestsThrow) throw new Error("gh is not authenticated");
+      return over.openPullRequests ?? [];
+    },
     wakeState: async () => "retained",
     withdrawWake: async () => "withdrawn",
     now: () => NOW,
@@ -353,7 +362,7 @@ test("events are read past the tick's own cursor, and reading acknowledges nothi
   const events = [event(10), event(11, { type: "review_verdict", summary: "the round passed" }), event(12)];
   const input = await gather({ events }, withCursor(10));
   expect(input.events.map((entry) => entry.seq)).toEqual([11, 12]);
-  expect(input.terminalPending).toBe(true);
+  expect(input.events.some((entry) => entry.type === "review_verdict")).toBe(true);
   /* Same cursor, same answer: a second read of the same state re-offers them. */
   const again = await gather({ events }, withCursor(10));
   expect(again.events.map((entry) => entry.seq)).toEqual([11, 12]);
@@ -379,7 +388,6 @@ test("a seat with no cursor yet starts at the present, so its first check carrie
   ];
   const input = await gather({ events: history });
   expect(input.events).toEqual([]);
-  expect(input.terminalPending).toBe(false);
   /* And the seal is written down, so the next check pages from it rather than
      re-deciding where the present was. */
   expect(input.state.eventsThrough).toBe(9853);
@@ -391,7 +399,6 @@ test("the seal is the journal head, so everything after the tick began is still 
   const later = [...history, event(9849, { type: "stage_blocked", summary: "the review round is parked" })];
   const second = await gather({ events: later }, first.state);
   expect(second.events.map((entry) => entry.seq)).toEqual([9849]);
-  expect(second.terminalPending).toBe(true);
 });
 
 /* The over-correction the fix must not make. A cursor a previous wake earned is
@@ -446,7 +453,6 @@ test("under a journal the cursor has already passed, only a card that recently m
   /* The journal is full and the check carries none of it, which is the whole
      point of the fixture: what wakes the seat here can only be the board. */
   expect(input.events).toEqual([]);
-  expect(input.terminalPending).toBe(false);
 
   const decision = seatTickDecision(input);
   expect(reasonsOf(decision)).toEqual(["unstarted-task"]);
@@ -514,16 +520,189 @@ test("the deployment signal reports the latest deployment, and stays silent when
   expect(running.signals).toEqual([]);
 });
 
-test("only terminal high-signal events count as pending; routine progress does not", async () => {
-  const input = await gather({ events: [event(10), event(11)] }, withCursor(0));
-  expect(input.events).toHaveLength(2);
-  expect(input.terminalPending).toBe(false);
+/* ------------------------------------------------------------------------- *
+ * #1285: an event whose lane is over, and a backlog of them.
+ * ------------------------------------------------------------------------- */
+
+/** A lane that ran and reached the end, which is what the tick's own store no
+    longer lists as open. */
+function finishedLane(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return lane({
+    id: "pipeline_z9",
+    task: "publish the merge queue",
+    branch: "topic-merge-queue",
+    state: "completed",
+    cursor: null,
+    runs: [],
+    closedAt: new Date(NOW - 14 * 60 * 60_000).toISOString(),
+    ...over,
+  });
+}
+
+test("an event is marked history exactly when its own lane is no longer open", async () => {
+  const input = await gather({
+    pipelines: [lane(), finishedLane()],
+    events: [
+      event(10, { type: "stage_completed", pipelineId: "pipeline_a1", summary: "the builder finished" }),
+      event(11, { type: "stage_completed", pipelineId: "pipeline_z9", summary: "the builder finished" }),
+      /* Archived out of the hot store, which only ever takes settled records. */
+      event(12, { type: "review_verdict", pipelineId: "pipeline_gone", summary: "the round passed" }),
+      /* A deploy outcome names no pipeline, and nothing about it has finished. */
+      event(13, { type: "deploy_failed", pipelineId: null, summary: "the release rolled back" }),
+    ],
+  }, withCursor(9));
+  expect(input.events.map((entry) => entry.pipelineTerminal)).toEqual([false, true, true, false]);
+});
+
+/* The report, end to end: a wake whose every item named a pipeline that had
+   reached a terminal state the day before, and whose entire cost was
+   establishing that nothing was owed on any of them. */
+test("a project whose only pending events belong to finished lanes is quiet, and the look discharges them", async () => {
+  const history = Array.from({ length: 50 }, (_, index) => event(9900 + index, {
+    type: "stage_completed",
+    pipelineId: "pipeline_z9",
+    summary: "the builder finished",
+  }));
+  const input = await gather(
+    { pipelines: [finishedLane()], tasks: [boardCard({ status: "inbox" })], events: history },
+    withCursor(9899, OVERDUE),
+  );
+  expect(input.events).toHaveLength(50);
+
+  const decision = seatTickDecision(input);
+  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+  /* And no second wake is owed for the same backlog: the cursor is past all
+     fifty on the strength of the one look that read them. */
+  expect(decision.state.eventsThrough).toBe(9949);
+});
+
+/* ------------------------------------------------------------------------- *
+ * #1289: a lane that finished and left its pull request open.
+ * ------------------------------------------------------------------------- */
+
+function openPullRequest(over: Partial<OpenPullRequest> = {}): OpenPullRequest {
+  return {
+    number: 1289,
+    title: "wake on a merge that is waiting",
+    headRefName: "topic-merge-queue",
+    updatedAt: new Date(NOW - 30 * 60_000).toISOString(),
+    ...over,
+  };
+}
+
+test("a finished lane whose branch still has an open pull request is carried, named by its lane", async () => {
+  const input = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest()] },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([{
+    number: 1289,
+    title: "wake on a merge that is waiting",
+    pipelineId: "pipeline_z9",
+    pipelineTitle: "publish the merge queue",
+    updatedAt: new Date(NOW - 30 * 60_000).toISOString(),
+  }]);
+  expect(reasonsOf(seatTickDecision(input))).toEqual(["unmerged-pr"]);
+});
+
+test("a pull request no finished lane produced is not this seat's obligation", async () => {
+  const input = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest({ headRefName: "someone-elses-branch" })] },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([]);
+});
+
+/* An open lane's pull request is the lane's business; the lane is already open
+   work and the tick already carries it. The reason is about FINISHING. */
+test("an open lane's pull request raises nothing", async () => {
+  const input = await gather(
+    { pipelines: [lane({ branch: "topic-merge-queue" })], openPullRequests: [openPullRequest()] },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([]);
+});
+
+/* A discarded draft never ran, so it published nothing and left nothing behind
+   (#1274 draws the same line for open lanes). */
+test("a hidden lane leaves no pull request behind it", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const input = await gather(
+    {
+      pipelines: [finishedLane({ hiddenAt: new Date(NOW - 60_000).toISOString(), state: "closed" })],
+      openPullRequests: [openPullRequest()],
+      pullRequestCalls: calls,
+    },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([]);
+  expect(calls).toEqual([]);
+});
+
+/* The read is a subprocess, so it happens only where a wake could come of it. */
+test("the pull request read is skipped entirely until the wake interval has elapsed", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const early = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls },
+    withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
+  );
+  expect(calls).toEqual([]);
+  expect(early.pullRequests).toEqual([]);
+
+  await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls },
+    withCursor(0, OVERDUE),
+  );
+  expect(calls).toEqual([{ cwd: "/srv/repo", limit: 60 }]);
+});
+
+test("a project whose tick is off asks GitHub nothing", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const input = await gather(
+    {
+      pipelines: [finishedLane()],
+      openPullRequests: [openPullRequest()],
+      pullRequestCalls: calls,
+      settings: { ...defaultSeatTickSettings(PROJECT), enabled: false, configured: true } as never,
+    },
+    withCursor(0, OVERDUE),
+  );
+  expect(calls).toEqual([]);
+  expect(input.pullRequests).toEqual([]);
+});
+
+/* Degradable like every other `gh` read here: a missing, unauthenticated or
+   rate-limited CLI costs the tick this one reason, never the check. */
+test("a gh that cannot answer leaves the check standing with no pull request reason", async () => {
+  const input = await gather(
+    { pipelines: [finishedLane()], pullRequestsThrow: true },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([]);
+  expect(input.tasks).toEqual([]);
+});
+
+/* The guard half, the same shape #1262 established for a card's movement: the
+   fingerprint has to carry what the reason is decided from, or a guard keyed on
+   it goes on suppressing the reason while a second pull request piles up. */
+test("a second unmerged pull request moves the fingerprint", async () => {
+  const one = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest()] },
+    withCursor(0, OVERDUE),
+  );
+  const two = await gather(
+    {
+      pipelines: [finishedLane()],
+      openPullRequests: [openPullRequest(), openPullRequest({ number: 1290, headRefName: "topic-merge-queue" })],
+    },
+    withCursor(0, OVERDUE),
+  );
+  expect(two.changeFingerprint).not.toBe(one.changeFingerprint);
 });
 
 test("another project's events are not this project's", async () => {
   const input = await gather({ events: [event(10, { project: "other", type: "review_verdict" })] }, withCursor(0));
   expect(input.events).toEqual([]);
-  expect(input.terminalPending).toBe(false);
 });
 
 test("the projects worth checking are the seated ones plus anything with work and nobody on it", async () => {

--- a/src/lib/monitor/seatTickSources.test.ts
+++ b/src/lib/monitor/seatTickSources.test.ts
@@ -137,9 +137,14 @@ function sources(over: {
   openPullRequests?: OpenPullRequest[];
   pullRequestCalls?: { cwd: string; limit: number }[];
   pullRequestsThrow?: boolean;
+  noSeat?: boolean;
 }): SeatTickSources {
   return {
-    seatFor: () => ({ active: { conversationId: CONVERSATION, seatEpoch: 7, path: null } as never, pending: null, history: [] }),
+    seatFor: () => ({
+      active: over.noSeat ? null : { conversationId: CONVERSATION, seatEpoch: 7, path: null } as never,
+      pending: null,
+      history: [],
+    }),
     activeSeats: () => [PROJECT],
     pipelines: () => (over.pipelines ?? [lane()]) as never,
     tasks: () => (over.tasks ?? []) as never,
@@ -654,6 +659,36 @@ test("the pull request read is skipped entirely until the wake interval has elap
     withCursor(0, OVERDUE),
   );
   expect(calls).toEqual([{ cwd: "/srv/repo", limit: 60 }]);
+});
+
+/* The same rule as the clause above, applied to the other two ways a check
+   ends before any wake reason is composed. A seat mid-turn is the expensive
+   one: a turn that runs for hours would otherwise pay a subprocess at every
+   five-minute check for its whole length. */
+test("a check whose seat is already mid-turn asks GitHub nothing", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const input = await gather(
+    {
+      pipelines: [finishedLane()],
+      openPullRequests: [openPullRequest()],
+      pullRequestCalls: calls,
+      seatTurn: "busy",
+      seatRows: [livenessRow({ lifecycle: "running", reason: "host_alive_turn_active" })],
+    },
+    withCursor(0, OVERDUE),
+  );
+  expect(calls).toEqual([]);
+  expect(input.pullRequests).toEqual([]);
+});
+
+test("a project with no seat to wake asks GitHub nothing", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const input = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls, noSeat: true },
+    withCursor(0, OVERDUE),
+  );
+  expect(calls).toEqual([]);
+  expect(input.pullRequests).toEqual([]);
 });
 
 test("a project whose tick is off asks GitHub nothing", async () => {

--- a/src/lib/monitor/seatTickSources.test.ts
+++ b/src/lib/monitor/seatTickSources.test.ts
@@ -16,7 +16,7 @@ import type { SeatTickSources } from "./seatTickSources";
 const { DEFAULT_SEAT_TICK_POLICY, seatTickDecision } = await import("./seatTick");
 const { defaultSeatTickSettings } = await import("./seatTickSettings");
 import type { AgentLivenessRecord } from "@/lib/lifecycle/liveness";
-import type { OpenPullRequest } from "./githubEvidence";
+import type { OpenPullRequest, OpenPullRequestsUnavailable } from "./githubEvidence";
 import type { LifecycleEvent, LifecycleJournalFile } from "@/lib/lifecycle/journal";
 import { emptySeatTickState, type SeatTickProjectState } from "./types";
 
@@ -137,6 +137,10 @@ function sources(over: {
   openPullRequests?: OpenPullRequest[];
   pullRequestCalls?: { cwd: string; limit: number }[];
   pullRequestsThrow?: boolean;
+  pullRequestsUnavailable?: OpenPullRequestsUnavailable;
+  archivedPipelines?: Record<string, unknown>[];
+  archiveCalls?: number[];
+  archiveThrows?: boolean;
   noSeat?: boolean;
 }): SeatTickSources {
   return {
@@ -147,6 +151,11 @@ function sources(over: {
     }),
     activeSeats: () => [PROJECT],
     pipelines: () => (over.pipelines ?? [lane()]) as never,
+    archivedPipelines: () => {
+      over.archiveCalls?.push(1);
+      if (over.archiveThrows) throw new Error("the archive is unreadable");
+      return (over.archivedPipelines ?? []) as never;
+    },
     tasks: () => (over.tasks ?? []) as never,
     registry: () => ({
       conversation: () => ({ turn: { state: over.seatTurn ?? "idle" } }),
@@ -168,7 +177,8 @@ function sources(over: {
     openPullRequests: async (options) => {
       over.pullRequestCalls?.push(options);
       if (over.pullRequestsThrow) throw new Error("gh is not authenticated");
-      return over.openPullRequests ?? [];
+      if (over.pullRequestsUnavailable) return { ok: false, unavailable: over.pullRequestsUnavailable };
+      return { ok: true, pullRequests: over.openPullRequests ?? [] };
     },
     wakeState: async () => "retained",
     withdrawWake: async () => "withdrawn",
@@ -706,15 +716,158 @@ test("a project whose tick is off asks GitHub nothing", async () => {
   expect(input.pullRequests).toEqual([]);
 });
 
-/* Degradable like every other `gh` read here: a missing, unauthenticated or
-   rate-limited CLI costs the tick this one reason, never the check. */
-test("a gh that cannot answer leaves the check standing with no pull request reason", async () => {
+/* ------------------------------------------------------------------------- *
+ * The obligation outlives the lane's residence in the hot store.
+ *
+ * Settled lanes are archived after three days. Reading only the hot store put
+ * the reason on a timer nothing about the pull request knows: a tick switched
+ * off, a seat busy for days, or a `gh` unreachable until archival all reach
+ * their first eligible check with no lane to attribute anything to, and go
+ * quiet over a pull request still sitting open.
+ * ------------------------------------------------------------------------- */
+
+/** The same lane, three days later: out of the hot store, into cold storage,
+    and its pull request still unmerged. */
+function archivedLane(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return finishedLane({ closedAt: new Date(NOW - 5 * DAY_MS).toISOString(), ...over });
+}
+
+test("a lane that has been archived still owes its open pull request", async () => {
+  const input = await gather(
+    { pipelines: [], archivedPipelines: [archivedLane()], openPullRequests: [openPullRequest()] },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([{
+    number: 1289,
+    title: "wake on a merge that is waiting",
+    pipelineId: "pipeline_z9",
+    pipelineTitle: "publish the merge queue",
+    updatedAt: new Date(NOW - 30 * 60_000).toISOString(),
+  }]);
+  expect(reasonsOf(seatTickDecision(input))).toEqual(["unmerged-pr"]);
+});
+
+/* The repository is asked for in the archived record too, because a project
+   whose every lane has settled out still has one — and a `gh` never run is the
+   same silence read off a different shelf. */
+test("an archived lane names the repository the pull requests are read from", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  await gather(
+    { pipelines: [], archivedPipelines: [archivedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls },
+    withCursor(0, OVERDUE),
+  );
+  expect(calls).toEqual([{ cwd: "/srv/repo", limit: 60 }]);
+});
+
+/* And it discharges itself the same way a hot lane's does: the source reads
+   OPEN pull requests, so a merge or a close simply stops returning the row. */
+test("once that pull request merges the same project is quiet again", async () => {
+  const input = await gather(
+    { pipelines: [], archivedPipelines: [archivedLane()], openPullRequests: [] },
+    withCursor(0, { ...OVERDUE, lastProposalAt: new Date(NOW - 60_000).toISOString() }),
+  );
+  expect(input.pullRequests).toEqual([]);
+  expect(input.pullRequestsUnavailable).toBeNull();
+  expect(seatTickDecision(input).verdict).toEqual({
+    kind: "quiet",
+    detail: "the board is done and the proposal slot is not due",
+  });
+});
+
+/* Cold storage is read only where the check has already committed to a
+   subprocess, so the gates that skip `gh` skip the archive with it. */
+test("the archive is not read by a check that could raise no wake from it", async () => {
+  const early: number[] = [];
+  await gather(
+    { pipelines: [finishedLane()], archiveCalls: early },
+    withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
+  );
+  expect(early).toEqual([]);
+
+  const seated: number[] = [];
+  await gather({ pipelines: [finishedLane()], archiveCalls: seated, noSeat: true }, withCursor(0, OVERDUE));
+  expect(seated).toEqual([]);
+
+  const off: number[] = [];
+  await gather(
+    {
+      pipelines: [finishedLane()],
+      archiveCalls: off,
+      settings: { ...defaultSeatTickSettings(PROJECT), enabled: false, configured: true } as never,
+    },
+    withCursor(0, OVERDUE),
+  );
+  expect(off).toEqual([]);
+
+  const due: number[] = [];
+  await gather({ pipelines: [finishedLane()], archiveCalls: due }, withCursor(0, OVERDUE));
+  expect(due).toEqual([1]);
+});
+
+/* ------------------------------------------------------------------------- *
+ * A read that failed is not a pull request that merged.
+ *
+ * Every failure below used to arrive as an empty list, which the decision then
+ * read as "nothing open" — `quiet — nothing owed` published on the strength of
+ * a `gh` nobody could run. The gap travels out of the gather instead.
+ * ------------------------------------------------------------------------- */
+
+test("a gh that throws is carried out of the gather as a gap, not as no pull requests", async () => {
   const input = await gather(
     { pipelines: [finishedLane()], pullRequestsThrow: true },
     withCursor(0, OVERDUE),
   );
   expect(input.pullRequests).toEqual([]);
+  expect(input.pullRequestsUnavailable).toBe("command-failed");
+  /* The rest of the check is untouched: one unreadable evidence source is not
+     a failed check. */
   expect(input.tasks).toEqual([]);
+});
+
+test("each way gh can fail keeps its own name", async () => {
+  for (const unavailable of ["command-failed", "timed-out", "malformed-output"] as const) {
+    const input = await gather(
+      { pipelines: [finishedLane()], pullRequestsUnavailable: unavailable },
+      withCursor(0, OVERDUE),
+    );
+    expect(input.pullRequestsUnavailable).toBe(unavailable);
+    expect(input.pullRequests).toEqual([]);
+  }
+});
+
+/* The lanes are half of the correlation, so lanes that cannot be read leave
+   the same question unanswered — and asking `gh` about lanes nobody could
+   enumerate would answer it wrongly rather than not at all. */
+test("lanes that cannot be read are a gap of their own, and gh is not asked", async () => {
+  const calls: { cwd: string; limit: number }[] = [];
+  const input = await gather(
+    { pipelines: [finishedLane()], archiveThrows: true, openPullRequests: [openPullRequest()], pullRequestCalls: calls },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequestsUnavailable).toBe("lanes-unreadable");
+  expect(input.pullRequests).toEqual([]);
+  expect(calls).toEqual([]);
+});
+
+/* The successful empty answer is what a gap must stay distinguishable from:
+   here GitHub was asked and said nothing is open, and quiet is earned. */
+test("a successful empty answer leaves no gap behind it", async () => {
+  const input = await gather(
+    { pipelines: [finishedLane()], openPullRequests: [] },
+    withCursor(0, OVERDUE),
+  );
+  expect(input.pullRequests).toEqual([]);
+  expect(input.pullRequestsUnavailable).toBeNull();
+});
+
+/* A check that was never going to ask has no gap either — it reports nothing
+   because nothing was owed from this reason, not because something failed. */
+test("a check that asks GitHub nothing reports no gap", async () => {
+  const input = await gather(
+    { pipelines: [finishedLane()], pullRequestsThrow: true },
+    withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
+  );
+  expect(input.pullRequestsUnavailable).toBeNull();
 });
 
 /* The guard half, the same shape #1262 established for a card's movement: the

--- a/src/lib/monitor/seatTickSources.ts
+++ b/src/lib/monitor/seatTickSources.ts
@@ -6,7 +6,7 @@ import { statePath } from "@/lib/configDir";
 import { pageFromEvents, readLifecycleJournal } from "@/lib/lifecycle/journal";
 import { agentLivenessSnapshot, productionLivenessSources, type AgentLivenessRecord } from "@/lib/lifecycle/liveness";
 import { canonicalOrchestratorProject, activeOrchestratorSeats, orchestratorSeatFor } from "@/lib/orchestrator/seats";
-import { loadPipelinesForList } from "@/lib/pipelines/store";
+import { loadArchivedPipelines, loadPipelinesForList } from "@/lib/pipelines/store";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
@@ -16,7 +16,7 @@ import { loadTasks } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 
 import { evidenceFromPipelines, evidenceFromTasks } from "./evidence";
-import { openPullRequestsForRepo, type OpenPullRequest } from "./githubEvidence";
+import { openPullRequestsForRepo, type OpenPullRequestsResult } from "./githubEvidence";
 import { redactBounded } from "./redact";
 import { SEAT_TICK_WAKE_INTERVAL_MS, seatTickWakeDue, seatTurnProgressing } from "./seatTick";
 import { effectiveSeatTickSettings, readSeatTickSettings, type SeatTickSettings } from "./seatTickSettings";
@@ -29,6 +29,7 @@ import {
   type SeatTickPipelineInput,
   type SeatTickPolicy,
   type SeatTickProjectState,
+  type SeatTickPullRequestGap,
   type SeatTickPullRequestInput,
   type SeatTickSeatInput,
   type SeatTickSignalInput,
@@ -156,6 +157,11 @@ export interface SeatTickSources {
   /** Projects that currently hold an active seat. */
   activeSeats: () => string[];
   pipelines: () => readonly Pipeline[];
+  /** Settled lanes the hot store has already let go of (#1289). Cold storage,
+      so it is read only once a check has decided it would pay for a `gh`
+      subprocess anyway — and it has to be read at all because the obligation a
+      finished lane leaves behind outlives the lane's three days of residence. */
+  archivedPipelines: () => readonly Pipeline[];
   tasks: () => BoardTask[];
   registry: () => ReturnType<typeof agentRegistry>;
   /** The registry's own activity verdict — `agent_activity`'s answer, which is
@@ -177,8 +183,10 @@ export interface SeatTickSources {
       `gh` seam as the proposal source. Read at most once per wake interval, and
       only for a project that has a finished lane to attribute one to: a
       subprocess per project per five-minute check would be a cost the tick's
-      whole design is arranged to avoid. */
-  openPullRequests: (options: { cwd: string; limit: number }) => Promise<OpenPullRequest[]>;
+      whole design is arranged to avoid. Answers with a result rather than a
+      list, because "no pull request is open" and "nobody could be asked" are
+      the two facts this reason must never confuse. */
+  openPullRequests: (options: { cwd: string; limit: number }) => Promise<OpenPullRequestsResult>;
   /** Whether the layer holding a retained wake still has it, and whether the
       seat ever got it. The tick's stamps move on this answer and nothing else. */
   wakeState: (wake: SeatTickOutstandingWake) => Promise<SeatTickWakeState>;
@@ -193,6 +201,7 @@ export function defaultSeatTickSources(): SeatTickSources {
     seatFor: orchestratorSeatFor,
     activeSeats: () => activeOrchestratorSeats().map((seat) => seat.project),
     pipelines: () => loadPipelinesForList(),
+    archivedPipelines: () => loadArchivedPipelines(),
     tasks: () => loadTasks(),
     registry: () => agentRegistry(),
     liveness: async (request) => {
@@ -418,9 +427,18 @@ function seatStalled(activity: SeatTickActivity): boolean {
 
 /** The repository a project's `gh` reads run in: the newest pipeline that named
     one. Null when nothing ever did, and the proposal then ranks the board alone. */
-export function repoDirForProject(project: string, sources: SeatTickSources): string | null {
+export function repoDirForProject(
+  project: string,
+  sources: SeatTickSources,
+  /** Lanes the caller has already read out of cold storage. A project whose
+      every lane has been archived still has a repository, and asking `gh`
+      nothing because the hot store happens to be empty is the same silence
+      read off a different shelf (#1289). Never read here on its own: the
+      caller pays for the archive when it has already decided to. */
+  archived: readonly Pipeline[] = [],
+): string | null {
   const canonical = canonicalOrchestratorProject(project);
-  const named = sources.pipelines()
+  const named = [...sources.pipelines(), ...archived]
     .filter((pipeline) => pipeline.repoDir && canonicalOrchestratorProject(pipeline.project) === canonical)
     .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt));
   return named[0]?.repoDir ?? null;
@@ -534,44 +552,76 @@ function eventsSince(
  * is on for this project, the interval has elapsed, there is a seat to wake and
  * its turn is not already moving — only when the project has a finished lane to
  * attribute one to, and only when some pipeline named a repository to ask in.
- * Everything else answers with no pull requests at all, which is the same
- * answer a `gh` that cannot be reached gives.
+ * Each of those is an answer: this check would raise no wake from this reason
+ * whatever GitHub said. A read that FAILED is not an answer, and leaves with
+ * {@link SeatTickPullRequestGap} rather than an empty list.
  *
- * The lanes come from the hot store, so the reason decays with it: a lane
- * settled long enough to have been archived stops attributing a pull request.
- * That is deliberate rather than incidental. The reason is about the obligation
- * FINISHING created, and by then the retry guard has long since stopped
- * re-sending it anyway — a pull request nobody merged carried two fruitless
- * wakes and became one board card. A cold-storage read on every check to keep
- * naming it would buy nothing the guard has not already settled.
+ * The lanes come from the hot store AND the archive, because the obligation is
+ * the pull request still being open and that outlives the lane's three days of
+ * residence. Reading only the hot store made the reason decay on a timer: a
+ * tick switched off, a seat busy for days, or a `gh` unreachable until the lane
+ * settled out all arrive at the first eligible check with nothing to attribute
+ * a pull request to, and report quiet over one still sitting open — the same
+ * twelve-hour silence #1289 exists to end, taken slowly. The retry guard does
+ * not cover the gap either: it counts wakes that changed nothing, and a wake
+ * that was never sent has nothing to count. The archive is cold storage, so it
+ * is read only after every cheap gate above has passed, at which point the
+ * check has already committed to a `gh` subprocess and a snapshot read is the
+ * cheaper half of the pair.
  */
+interface PullRequestEvidence {
+  pullRequests: SeatTickPullRequestInput[];
+  /** Null means the question was answered — including answered with nothing
+      open, which is what the tick is entitled to go quiet on. */
+  unavailable: SeatTickPullRequestGap | null;
+}
+
+/** Asked, and nothing came back that is owed. A fresh row each time: this one
+    travels out on the check input and is never shared between two of them. */
+function none(): PullRequestEvidence {
+  return { pullRequests: [], unavailable: null };
+}
+
 async function unmergedPullRequests(context: {
   project: string;
   seat: SeatTickSeatInput | null;
   wakeDue: boolean;
   enabled: boolean;
   sources: SeatTickSources;
-}): Promise<SeatTickPullRequestInput[]> {
-  if (!context.wakeDue || !context.enabled) return [];
+}): Promise<PullRequestEvidence> {
+  if (!context.wakeDue || !context.enabled) return none();
   /* The other two ways a check can be unable to raise any reason at all: a
      project with nobody to wake ends in `no-seat`, and a seat whose turn is
      genuinely moving ends in `skipped`, both before a wake reason is composed.
      Without this clause a seat that stays busy for hours pays a `gh` subprocess
      every five minutes for the whole turn, to answer a question that check was
      never going to ask. */
-  if (!context.seat || seatTurnProgressing(context.seat)) return [];
-  const finished = context.sources.pipelines()
-    .filter((pipeline) => canonicalOrchestratorProject(pipeline.project) === context.project && isFinished(pipeline));
-  if (finished.length === 0) return [];
-  const cwd = repoDirForProject(context.project, context.sources);
-  if (!cwd) return [];
+  if (!context.seat || seatTurnProgressing(context.seat)) return none();
 
-  let open: OpenPullRequest[];
+  let archived: readonly Pipeline[];
   try {
-    open = await context.sources.openPullRequests({ cwd, limit: PULL_REQUEST_LIMIT });
+    archived = context.sources.archivedPipelines();
   } catch {
-    return [];
+    /* Lanes half-read are obligations half-seen, and an obligation that cannot
+       be seen is exactly what gets reported as quiet. */
+    return { pullRequests: [], unavailable: "lanes-unreadable" };
   }
+  const finished = [...context.sources.pipelines(), ...archived]
+    .filter((pipeline) => canonicalOrchestratorProject(pipeline.project) === context.project && isFinished(pipeline));
+  if (finished.length === 0) return none();
+  const cwd = repoDirForProject(context.project, context.sources, archived);
+  if (!cwd) return none();
+
+  let result: OpenPullRequestsResult;
+  try {
+    /* The seam answers with a result; a seam that throws instead is the same
+       fact arriving by exception, and neither is an empty list. */
+    result = await context.sources.openPullRequests({ cwd, limit: PULL_REQUEST_LIMIT });
+  } catch {
+    result = { ok: false, unavailable: "command-failed" };
+  }
+  if (!result.ok) return { pullRequests: [], unavailable: result.unavailable };
+  const open = result.pullRequests;
   const byBranch = new Map<string, Pipeline>();
   for (const pipeline of finished) {
     if (!pipeline.branch) continue;
@@ -592,7 +642,7 @@ async function unmergedPullRequests(context: {
       updatedAt: pullRequest.updatedAt,
     });
   }
-  return found.sort((left, right) => left.number - right.number);
+  return { pullRequests: found.sort((left, right) => left.number - right.number), unavailable: null };
 }
 
 export async function gatherSeatTickInput(
@@ -637,7 +687,7 @@ export async function gatherSeatTickInput(
      made about the wrong pipeline. */
   const openPipelineIds = new Set(sources.pipelines().filter(isOpen).map((pipeline) => pipeline.id));
   const { events, cursor } = eventsSince(canonical, state.eventsThrough, openPipelineIds, sources);
-  const pullRequests = await unmergedPullRequests({
+  const { pullRequests, unavailable: pullRequestsUnavailable } = await unmergedPullRequests({
     project: canonical,
     seat,
     /* The same clause the decision applies, asked here because the read behind
@@ -657,6 +707,7 @@ export async function gatherSeatTickInput(
     tasks,
     events,
     pullRequests,
+    pullRequestsUnavailable,
     signals: signals(canonical, seat, sources),
     changeFingerprint: changeFingerprint(pipelines, tasks, pullRequests),
     /* The sealed cursor travels on the state the decision carries forward, so a

--- a/src/lib/monitor/seatTickSources.ts
+++ b/src/lib/monitor/seatTickSources.ts
@@ -18,7 +18,7 @@ import type { BoardTask } from "@/lib/tasks/types";
 import { evidenceFromPipelines, evidenceFromTasks } from "./evidence";
 import { openPullRequestsForRepo, type OpenPullRequest } from "./githubEvidence";
 import { redactBounded } from "./redact";
-import { SEAT_TICK_WAKE_INTERVAL_MS, seatTickWakeDue } from "./seatTick";
+import { SEAT_TICK_WAKE_INTERVAL_MS, seatTickWakeDue, seatTurnProgressing } from "./seatTick";
 import { effectiveSeatTickSettings, readSeatTickSettings, type SeatTickSettings } from "./seatTickSettings";
 import type { PipelineSummary, TaskSummary } from "./viewerApi";
 import {
@@ -529,12 +529,13 @@ function eventsSince(
  * ref — durable on both sides, and the only tie that survives the lane being
  * closed, its worktree being removed and its host being reaped.
  *
- * Three bounds keep it cheap and keep it from becoming a route around the
- * hourly wake. It is read only when a wake could actually be raised from it —
- * the tick is on for this project and the interval has elapsed — only when the
- * project has a finished lane to attribute one to, and only when some pipeline
- * named a repository to ask in. Everything else answers with no pull requests
- * at all, which is the same answer a `gh` that cannot be reached gives.
+ * The bounds keep it cheap and keep it from becoming a route around the hourly
+ * wake. It is read only when a wake could actually be raised from it — the tick
+ * is on for this project, the interval has elapsed, there is a seat to wake and
+ * its turn is not already moving — only when the project has a finished lane to
+ * attribute one to, and only when some pipeline named a repository to ask in.
+ * Everything else answers with no pull requests at all, which is the same
+ * answer a `gh` that cannot be reached gives.
  *
  * The lanes come from the hot store, so the reason decays with it: a lane
  * settled long enough to have been archived stops attributing a pull request.
@@ -546,11 +547,19 @@ function eventsSince(
  */
 async function unmergedPullRequests(context: {
   project: string;
+  seat: SeatTickSeatInput | null;
   wakeDue: boolean;
   enabled: boolean;
   sources: SeatTickSources;
 }): Promise<SeatTickPullRequestInput[]> {
   if (!context.wakeDue || !context.enabled) return [];
+  /* The other two ways a check can be unable to raise any reason at all: a
+     project with nobody to wake ends in `no-seat`, and a seat whose turn is
+     genuinely moving ends in `skipped`, both before a wake reason is composed.
+     Without this clause a seat that stays busy for hours pays a `gh` subprocess
+     every five minutes for the whole turn, to answer a question that check was
+     never going to ask. */
+  if (!context.seat || seatTurnProgressing(context.seat)) return [];
   const finished = context.sources.pipelines()
     .filter((pipeline) => canonicalOrchestratorProject(pipeline.project) === context.project && isFinished(pipeline));
   if (finished.length === 0) return [];
@@ -630,6 +639,7 @@ export async function gatherSeatTickInput(
   const { events, cursor } = eventsSince(canonical, state.eventsThrough, openPipelineIds, sources);
   const pullRequests = await unmergedPullRequests({
     project: canonical,
+    seat,
     /* The same clause the decision applies, asked here because the read behind
        it is a subprocess: a reason that cannot be raised this check is a reason
        whose evidence is not worth fetching. The decision applies the bound

--- a/src/lib/monitor/seatTickSources.ts
+++ b/src/lib/monitor/seatTickSources.ts
@@ -3,9 +3,8 @@ import fs from "node:fs";
 
 import { agentRegistry } from "@/lib/agent/registry";
 import { statePath } from "@/lib/configDir";
-import { pageFromEvents, readLifecycleJournal, someMatchingEvent } from "@/lib/lifecycle/journal";
+import { pageFromEvents, readLifecycleJournal } from "@/lib/lifecycle/journal";
 import { agentLivenessSnapshot, productionLivenessSources, type AgentLivenessRecord } from "@/lib/lifecycle/liveness";
-import { isTerminalHighSignalEvent } from "@/lib/lifecycle/vocabulary";
 import { canonicalOrchestratorProject, activeOrchestratorSeats, orchestratorSeatFor } from "@/lib/orchestrator/seats";
 import { loadPipelinesForList } from "@/lib/pipelines/store";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
@@ -17,7 +16,9 @@ import { loadTasks } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 
 import { evidenceFromPipelines, evidenceFromTasks } from "./evidence";
-import { SEAT_TICK_WAKE_INTERVAL_MS } from "./seatTick";
+import { openPullRequestsForRepo, type OpenPullRequest } from "./githubEvidence";
+import { redactBounded } from "./redact";
+import { SEAT_TICK_WAKE_INTERVAL_MS, seatTickWakeDue } from "./seatTick";
 import { effectiveSeatTickSettings, readSeatTickSettings, type SeatTickSettings } from "./seatTickSettings";
 import type { PipelineSummary, TaskSummary } from "./viewerApi";
 import {
@@ -28,6 +29,7 @@ import {
   type SeatTickPipelineInput,
   type SeatTickPolicy,
   type SeatTickProjectState,
+  type SeatTickPullRequestInput,
   type SeatTickSeatInput,
   type SeatTickSignalInput,
   type SeatTickTaskInput,
@@ -44,10 +46,16 @@ import {
  * which is where the answer to "is this turn still moving?" already lives.
  */
 
-/** How much of the lifecycle journal one check carries. The reason a terminal
-    event is never buried by a backlog is {@link SeatTickCheckInput.terminalPending},
-    which is asked over the whole pending range rather than this page. */
+/** How much of the lifecycle journal one check carries. A backlog can no longer
+    bury a live event behind this bound: the history in front of it is sealed
+    away by the check that read it (#1285), so the pages advance at the check
+    interval and cost nothing, rather than at one paid wake apiece. */
 const EVENT_PAGE = 200;
+/** Open pull requests one check reads. Bounds the `gh` answer, not the lanes:
+    a project with more open pull requests than this has other problems. */
+const PULL_REQUEST_LIMIT = 60;
+/** Bounded pull request title carried into a wake item. */
+const PULL_REQUEST_TITLE_LIMIT = 120;
 /** Liveness rows one project's check asks for. */
 const LIVENESS_LIMIT = 60;
 
@@ -165,6 +173,12 @@ export interface SeatTickSources {
       an agent just recorded takes effect at the very next check rather than at
       the next deploy. A project nobody configured reads the defaults. */
   settings: (project: string) => SeatTickSettings;
+  /** Open pull requests in the project's repository (#1289), through the same
+      `gh` seam as the proposal source. Read at most once per wake interval, and
+      only for a project that has a finished lane to attribute one to: a
+      subprocess per project per five-minute check would be a cost the tick's
+      whole design is arranged to avoid. */
+  openPullRequests: (options: { cwd: string; limit: number }) => Promise<OpenPullRequest[]>;
   /** Whether the layer holding a retained wake still has it, and whether the
       seat ever got it. The tick's stamps move on this answer and nothing else. */
   wakeState: (wake: SeatTickOutstandingWake) => Promise<SeatTickWakeState>;
@@ -200,6 +214,7 @@ export function defaultSeatTickSources(): SeatTickSources {
       }
     },
     settings: (project) => readSeatTickSettings(project),
+    openPullRequests: (options) => openPullRequestsForRepo(options),
     /* One rule for both halves: ask, and act on, the layer that is actually
        holding the payload. A send the runtime host queued belongs to the runtime
        host — the registry row beside it is a mirror, and settling a mirror stops
@@ -249,6 +264,18 @@ export function defaultSeatTickSources(): SeatTickSources {
  */
 function isOpen(pipeline: Pipeline): boolean {
   return !pipeline.closedAt && !pipeline.hiddenAt && pipeline.state !== "completed" && pipeline.state !== "closed";
+}
+
+/**
+ * A lane that RAN and reached the end, which is the only kind whose pull
+ * request is an obligation (#1289).
+ *
+ * A hidden record is excluded on the same reasoning as {@link isOpen}: a
+ * discarded draft never ran, so nothing it names was ever published and there
+ * is nothing for it to have left behind.
+ */
+function isFinished(pipeline: Pipeline): boolean {
+  return !pipeline.hiddenAt && (!!pipeline.closedAt || pipeline.state === "completed" || pipeline.state === "closed");
 }
 
 /** The projection `evidence.ts` correlates on, built in-process rather than
@@ -411,10 +438,20 @@ export function repoDirForProject(project: string, sources: SeatTickSources): st
  * reason back, and while it was missing from here the guard held the reason
  * suppressed with the card's movement invisible to it.
  */
-function changeFingerprint(pipelines: readonly SeatTickPipelineInput[], tasks: readonly SeatTickTaskInput[]): string {
+function changeFingerprint(
+  pipelines: readonly SeatTickPipelineInput[],
+  tasks: readonly SeatTickTaskInput[],
+  pullRequests: readonly SeatTickPullRequestInput[],
+): string {
   const parts = [
     ...pipelines.map((pipeline) => `p:${pipeline.id}:${pipeline.state}:${pipeline.updatedAt ?? ""}`),
     ...tasks.map((task) => `t:${task.id}:${task.status}:${task.owned}:${task.updatedAt ?? ""}`),
+    /* The set of unmerged pull requests, for the same reason the card's
+       movement instant is here: it decides a wake reason, so a guard keyed on
+       less than it would hold the reason suppressed while a SECOND pull request
+       went unmerged behind the first. A merge or a close removes the row, which
+       is what lets the guard reset the moment the seat acts. */
+    ...pullRequests.map((pullRequest) => `pr:${pullRequest.number}:${pullRequest.pipelineId}`),
   ].sort();
   return crypto.createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 32);
 }
@@ -449,8 +486,9 @@ export function seatTickProjects(sources: SeatTickSources): string[] {
 function eventsSince(
   project: string,
   cursor: number | null,
+  openPipelineIds: ReadonlySet<string>,
   sources: SeatTickSources,
-): { events: SeatTickEventInput[]; terminalPending: boolean; cursor: number } {
+): { events: SeatTickEventInput[]; cursor: number } {
   const journal = sources.lifecycleJournal();
   /* `lastSeq` is the head the journal maintains; the newest event's seq is the
      same number written a second way, and taking the larger keeps a head that
@@ -463,9 +501,8 @@ function eventsSince(
      records — four-day-old merges listed as work, with ninety-three more items
      held back. The seal is written once and only once; from then on the cursor
      is the seat's, and it moves only when a wake lands. */
-  if (cursor === null) return { events: [], terminalPending: false, cursor: head };
-  const query = { project, afterSeq: cursor };
-  const page = pageFromEvents(journal, { ...query, limit: EVENT_PAGE });
+  if (cursor === null) return { events: [], cursor: head };
+  const page = pageFromEvents(journal, { project, afterSeq: cursor, limit: EVENT_PAGE });
   return {
     events: page.events.map((event) => ({
       seq: event.seq,
@@ -473,10 +510,80 @@ function eventsSince(
       type: event.type,
       summary: event.summary,
       pipelineId: event.pipelineId,
+      /* An open lane is always in the hot store; the archive only ever takes
+         SETTLED records. So a pipeline id the store no longer lists names a
+         lane that ended long enough ago to have been archived, and reading it
+         as terminal is the same answer arrived at from the other side. An event
+         that names no pipeline is never terminal here — nothing about a deploy
+         outcome or a held delivery has finished (#1285). */
+      pipelineTerminal: event.pipelineId !== null && !openPipelineIds.has(event.pipelineId),
     })),
-    terminalPending: someMatchingEvent(journal, query, (event) => isTerminalHighSignalEvent(event.type)),
     cursor,
   };
+}
+
+/**
+ * Pull requests the project's finished lanes left open (#1289).
+ *
+ * The correlation is the lane's own branch against the pull request's head
+ * ref — durable on both sides, and the only tie that survives the lane being
+ * closed, its worktree being removed and its host being reaped.
+ *
+ * Three bounds keep it cheap and keep it from becoming a route around the
+ * hourly wake. It is read only when a wake could actually be raised from it —
+ * the tick is on for this project and the interval has elapsed — only when the
+ * project has a finished lane to attribute one to, and only when some pipeline
+ * named a repository to ask in. Everything else answers with no pull requests
+ * at all, which is the same answer a `gh` that cannot be reached gives.
+ *
+ * The lanes come from the hot store, so the reason decays with it: a lane
+ * settled long enough to have been archived stops attributing a pull request.
+ * That is deliberate rather than incidental. The reason is about the obligation
+ * FINISHING created, and by then the retry guard has long since stopped
+ * re-sending it anyway — a pull request nobody merged carried two fruitless
+ * wakes and became one board card. A cold-storage read on every check to keep
+ * naming it would buy nothing the guard has not already settled.
+ */
+async function unmergedPullRequests(context: {
+  project: string;
+  wakeDue: boolean;
+  enabled: boolean;
+  sources: SeatTickSources;
+}): Promise<SeatTickPullRequestInput[]> {
+  if (!context.wakeDue || !context.enabled) return [];
+  const finished = context.sources.pipelines()
+    .filter((pipeline) => canonicalOrchestratorProject(pipeline.project) === context.project && isFinished(pipeline));
+  if (finished.length === 0) return [];
+  const cwd = repoDirForProject(context.project, context.sources);
+  if (!cwd) return [];
+
+  let open: OpenPullRequest[];
+  try {
+    open = await context.sources.openPullRequests({ cwd, limit: PULL_REQUEST_LIMIT });
+  } catch {
+    return [];
+  }
+  const byBranch = new Map<string, Pipeline>();
+  for (const pipeline of finished) {
+    if (!pipeline.branch) continue;
+    /* Two lanes on one branch is a relaunch: the newest is the one whose
+       finishing left the pull request open. */
+    const held = byBranch.get(pipeline.branch);
+    if (!held || Date.parse(pipeline.createdAt) > Date.parse(held.createdAt)) byBranch.set(pipeline.branch, pipeline);
+  }
+  const found: SeatTickPullRequestInput[] = [];
+  for (const pullRequest of open) {
+    const lane = byBranch.get(pullRequest.headRefName);
+    if (!lane) continue;
+    found.push({
+      number: pullRequest.number,
+      title: redactBounded(pullRequest.title, PULL_REQUEST_TITLE_LIMIT),
+      pipelineId: lane.id,
+      pipelineTitle: redactBounded(lane.task.split("\n")[0] ?? "", PULL_REQUEST_TITLE_LIMIT),
+      updatedAt: pullRequest.updatedAt,
+    });
+  }
+  return found.sort((left, right) => left.number - right.number);
 }
 
 export async function gatherSeatTickInput(
@@ -487,6 +594,7 @@ export async function gatherSeatTickInput(
 ): Promise<SeatTickCheckInput> {
   const now = sources.now();
   const canonical = canonicalOrchestratorProject(project);
+  const settings = effectiveSeatTickSettings(sources.settings(canonical), now, SEAT_TICK_WAKE_INTERVAL_MS);
   const seat = await seatInput(canonical, policy, sources);
 
   const openLanes = sources.pipelines().filter((pipeline) => isOpen(pipeline) && canonicalOrchestratorProject(pipeline.project) === canonical);
@@ -514,8 +622,22 @@ export async function gatherSeatTickInput(
     updatedAt: task.updatedAt ?? null,
   }));
 
-  const { events, terminalPending, cursor } = eventsSince(canonical, state.eventsThrough, sources);
-  const settings = effectiveSeatTickSettings(sources.settings(canonical), now, SEAT_TICK_WAKE_INTERVAL_MS);
+  /* The open set spans EVERY project, not this one's lanes: an event is history
+     because its own lane finished, and reading a lane from another project as
+     terminal because it is not in this project's slice would be the same claim
+     made about the wrong pipeline. */
+  const openPipelineIds = new Set(sources.pipelines().filter(isOpen).map((pipeline) => pipeline.id));
+  const { events, cursor } = eventsSince(canonical, state.eventsThrough, openPipelineIds, sources);
+  const pullRequests = await unmergedPullRequests({
+    project: canonical,
+    /* The same clause the decision applies, asked here because the read behind
+       it is a subprocess: a reason that cannot be raised this check is a reason
+       whose evidence is not worth fetching. The decision applies the bound
+       again on its own terms — this is a cost gate, never the bound itself. */
+    wakeDue: seatTickWakeDue(state.lastWakeAt, now, settings.wakeIntervalMs),
+    enabled: settings.enabled,
+    sources,
+  });
 
   return {
     project: canonical,
@@ -524,9 +646,9 @@ export async function gatherSeatTickInput(
     pipelines,
     tasks,
     events,
-    terminalPending,
+    pullRequests,
     signals: signals(canonical, seat, sources),
-    changeFingerprint: changeFingerprint(pipelines, tasks),
+    changeFingerprint: changeFingerprint(pipelines, tasks, pullRequests),
     /* The sealed cursor travels on the state the decision carries forward, so a
        check of any verdict — a skip included, which remembers nothing else —
        persists where the journal stood when the tick first saw this project. */

--- a/src/lib/monitor/types.ts
+++ b/src/lib/monitor/types.ts
@@ -224,7 +224,18 @@ export type SeatTickVerdict =
   | { kind: "quiet"; detail: string }
   | { kind: "wake"; reasons: SeatTickWakeReason[]; items: SeatTickItem[]; deferred: number }
   /** No work, and the proposal slot is due. */
-  | { kind: "proactive"; detail: string };
+  | { kind: "proactive"; detail: string }
+  /**
+   * The check could not establish that nothing is owed.
+   *
+   * Quiet is a conclusion, and a conclusion drawn from evidence that could not
+   * be read is the failure this whole mechanism exists to prevent, so the
+   * check says so instead. It moves no stamp and holds no reason back: the
+   * wake interval and the retry guard are exactly where the previous check
+   * left them, and the next check asks again. A failure cannot spend the
+   * hourly budget.
+   */
+  | { kind: "error"; detail: string };
 
 /**
  * The registry's own answer about a turn: the durable activity verdict
@@ -344,6 +355,21 @@ export interface SeatTickPullRequestInput {
   pipelineTitle: string;
   updatedAt: string | null;
 }
+
+/**
+ * Why a check could not establish what this project's finished lanes left open.
+ *
+ * Machine tokens only, because the journal line carrying one is published:
+ * `gh` could not be run or exited non-zero (`command-failed`), was killed at
+ * its timeout (`timed-out`), answered with something that is not a JSON array
+ * (`malformed-output`), or the lane records the pull requests are correlated
+ * against could not be read (`lanes-unreadable`).
+ */
+export type SeatTickPullRequestGap =
+  | "timed-out"
+  | "command-failed"
+  | "malformed-output"
+  | "lanes-unreadable";
 
 /** A durable log line the Viewer already writes: a deploy outcome, the host
     retirement report, a seat whose own turn stopped progressing. */
@@ -487,9 +513,21 @@ export interface SeatTickCheckInput {
   /** Events after {@link SeatTickProjectState.eventsThrough}, oldest first. */
   events: readonly SeatTickEventInput[];
   /** Pull requests that finished lanes left open (#1289). Empty whenever the
-      project has no finished lane, no repository to ask, or `gh` could not
-      answer — the reason is degradable, never a failed check. */
+      project has no finished lane, no repository to ask, or the check could
+      not raise a wake at all — all of which are answers. A read that FAILED is
+      not one of them; it arrives below. */
   pullRequests: readonly SeatTickPullRequestInput[];
+  /**
+   * Set when the list above could not be established.
+   *
+   * A check that cannot see what its finished lanes left open has not shown
+   * that nothing is owed, so this turns an otherwise-quiet verdict into an
+   * `error` the controller journals and retries. Deliberately incapable of
+   * doing anything else: it raises no wake, so it can neither advance the wake
+   * stamp nor spend a retry-guard count, and a `gh` outage is therefore unable
+   * to buy the very silence it would otherwise be mistaken for.
+   */
+  pullRequestsUnavailable: SeatTickPullRequestGap | null;
   signals: readonly SeatTickSignalInput[];
   /** Digest of everything a wake could change. Compared against the previous
       wake's, never interpreted. */
@@ -533,14 +571,17 @@ export interface SeatTickDecision {
   cards: SeatTickCard[];
 }
 
-/** What one check recorded. Five kinds are journal-only: `error` is a check
-    that threw, `refused` a sweep or a second clock refused for want of
-    authority, and the other three are what became of a retained wake — it was
-    taken back from a seat that had already been replaced (`revoked`), the
-    layer holding it delivered it after all (`landed`), or that layer settled it
-    without ever delivering it (`dropped`). */
+/** What one check recorded. Four kinds are journal-only: `refused` is a sweep
+    or a second clock refused for want of authority, and the other three are
+    what became of a retained wake — it was taken back from a seat that had
+    already been replaced (`revoked`), the layer holding it delivered it after
+    all (`landed`), or that layer settled it without ever delivering it
+    (`dropped`). */
 export type SeatTickVerdictKind =
   | SeatTickVerdict["kind"]
+  /** A check that threw outright, which the decision never gets to see. The
+      decision has its own `error` above, for a check that ran and could not
+      establish what is owed; both are read the same way off the journal. */
   | "error"
   | "refused"
   | "revoked"

--- a/src/lib/monitor/types.ts
+++ b/src/lib/monitor/types.ts
@@ -180,8 +180,11 @@ export interface MonitorRunReport {
 /** Why a wake is owed. Kinds are stable strings: they are journaled, counted
     against the retry guard, and named in the message the seat receives. */
 export type SeatTickWakeReasonKind =
-  /** A terminal, high-signal lane event since the last delivered wake (#1105). */
+  /** A terminal, high-signal lane event since the last delivered wake (#1105),
+      belonging to a lane that has NOT itself reached a terminal state. */
   | "lane-event"
+  /** A lane that finished and left a pull request open behind it (#1289). */
+  | "unmerged-pr"
   /** A parked or non-progressing lane that persisted across two checks. */
   | "stalled"
   /** A board task the operator assigned that nothing has started. */
@@ -191,6 +194,7 @@ export type SeatTickWakeReasonKind =
 
 export const SEAT_TICK_WAKE_REASON_KINDS: readonly SeatTickWakeReasonKind[] = [
   "lane-event",
+  "unmerged-pr",
   "stalled",
   "unstarted-task",
   "interval",
@@ -204,7 +208,7 @@ export interface SeatTickWakeReason {
 
 /** One line of the wake's body. Bounded and structural — never transcript text. */
 export interface SeatTickItem {
-  kind: "pipeline" | "task" | "event" | "signal";
+  kind: "pipeline" | "task" | "event" | "signal" | "pull-request";
   id: string;
   label: string;
 }
@@ -295,13 +299,50 @@ export interface SeatTickTaskInput {
 }
 
 export interface SeatTickEventInput {
-  /** Journal seq — the cursor the tick advances only on a delivered wake. */
+  /** Journal seq — the cursor the tick advances only on a delivered wake, or
+      seals past when this check established that nothing here is owed. */
   seq: number;
   at: string;
   type: LifecycleEventType;
   /** Bounded summary the journal already stored; never raw transcript text. */
   summary: string;
   pipelineId: string | null;
+  /**
+   * Whether the lane this event names has since reached a terminal state
+   * (#1285), which is the difference between work waiting to start and history.
+   *
+   * A wake exists to name what is owed NOW. An event about a pipeline that
+   * closed yesterday cannot be that: the lane is over, and establishing so was
+   * the entire cost of three consecutive wakes — two of them naming lanes the
+   * seat had closed itself earlier in the same session. Events that name no
+   * pipeline at all (a deploy outcome, a held delivery) are never terminal by
+   * this field: nothing about them has finished.
+   */
+  pipelineTerminal: boolean;
+}
+
+/**
+ * A pull request a finished lane left open (#1289).
+ *
+ * The mirror of the field above, and the same property read from the other
+ * side. `hasOpenWork` counts open lanes and board cards, so a lane that
+ * COMPLETED with its pull request still unmerged was indistinguishable from
+ * finished work: the tick answered `quiet — nothing owed` every five minutes
+ * for twelve hours while three approved pull requests sat there. Finishing is
+ * exactly what creates the seat's next obligation, so the finished lane's open
+ * pull request is carried here and named in its own wake reason.
+ *
+ * It discharges itself: the source reads OPEN pull requests, so a merge or a
+ * close removes the row and the reason goes quiet with no second mechanism.
+ */
+export interface SeatTickPullRequestInput {
+  number: number;
+  /** Bounded, already redacted by the source. */
+  title: string;
+  /** The finished lane whose branch is this pull request's head. */
+  pipelineId: string;
+  pipelineTitle: string;
+  updatedAt: string | null;
 }
 
 /** A durable log line the Viewer already writes: a deploy outcome, the host
@@ -405,11 +446,23 @@ export interface SeatTickProjectState {
       otherwise a guard keyed on it outlives its own condition (#1262). */
   lastWakeFingerprint: string | null;
   /**
-   * Lifecycle journal seq the seat has actually been TOLD about.
+   * Lifecycle journal seq the seat has actually been told about, or that this
+   * check established nothing is owed on.
    *
-   * Advanced only by a delivered wake. Acknowledging at read time is how a
-   * lane event gets lost across a rotation or a refused send: the cursor moves,
-   * the message never arrives, and nothing offers the event again.
+   * A wake is what advances it past anything a seat still has to act on.
+   * Acknowledging THAT at read time is how a lane event gets lost across a
+   * rotation or a refused send: the cursor moves, the message never arrives,
+   * and nothing offers the event again.
+   *
+   * The other half is #1285. Everything in front of the first event that is
+   * still owed — routine progress, and terminal events belonging to lanes that
+   * have themselves finished — is history a single look discharges, so a check
+   * seals the cursor past it with no wake at all. Without that, a cursor that
+   * fell behind drained at `itemsPerWake` per hourly wake: a burst of fifty
+   * historical events became a ten-hour tail of resumed hosts and paid turns,
+   * and the seat could not tell it from real work without reading every item.
+   * The seal never crosses a live event, so nothing that is owed is discharged
+   * by it.
    *
    * Null means the tick has never established where the journal stood for this
    * project, which is not the same as zero. Zero is a real cursor with the
@@ -433,11 +486,10 @@ export interface SeatTickCheckInput {
   tasks: readonly SeatTickTaskInput[];
   /** Events after {@link SeatTickProjectState.eventsThrough}, oldest first. */
   events: readonly SeatTickEventInput[];
-  /** Whether a terminal high-signal event is pending anywhere past the cursor,
-      including beyond the page `events` carries. Asking this over the whole
-      pending range is what stops a backlog from burying the one class of event
-      the seat cannot decide without. */
-  terminalPending: boolean;
+  /** Pull requests that finished lanes left open (#1289). Empty whenever the
+      project has no finished lane, no repository to ask, or `gh` could not
+      answer — the reason is degradable, never a failed check. */
+  pullRequests: readonly SeatTickPullRequestInput[];
   signals: readonly SeatTickSignalInput[];
   /** Digest of everything a wake could change. Compared against the previous
       wake's, never interpreted. */

--- a/src/lib/monitor/types.ts
+++ b/src/lib/monitor/types.ts
@@ -361,9 +361,10 @@ export interface SeatTickPullRequestInput {
  *
  * Machine tokens only, because the journal line carrying one is published:
  * `gh` could not be run or exited non-zero (`command-failed`), was killed at
- * its timeout (`timed-out`), answered with something that is not a JSON array
- * (`malformed-output`), or the lane records the pull requests are correlated
- * against could not be read (`lanes-unreadable`).
+ * its timeout (`timed-out`), answered with anything but a JSON array of rows
+ * that can be attributed to a branch (`malformed-output`), or the lane records
+ * the pull requests are correlated against could not be read
+ * (`lanes-unreadable`).
  */
 export type SeatTickPullRequestGap =
   | "timed-out"
@@ -521,11 +522,13 @@ export interface SeatTickCheckInput {
    * Set when the list above could not be established.
    *
    * A check that cannot see what its finished lanes left open has not shown
-   * that nothing is owed, so this turns an otherwise-quiet verdict into an
-   * `error` the controller journals and retries. Deliberately incapable of
-   * doing anything else: it raises no wake, so it can neither advance the wake
-   * stamp nor spend a retry-guard count, and a `gh` outage is therefore unable
-   * to buy the very silence it would otherwise be mistaken for.
+   * that nothing is owed, so this ends the check as an `error` the controller
+   * journals and retries — ahead of any wake, because a delivered wake is what
+   * would advance the wake stamp and spend a retry-guard count on a read that
+   * established nothing. Deliberately incapable of costing anything, so a `gh`
+   * outage cannot buy the very silence it would otherwise be mistaken for.
+   * Whatever reason stood on its own waits for the next check instead, which
+   * is one check interval away rather than one wake interval.
    */
   pullRequestsUnavailable: SeatTickPullRequestGap | null;
   signals: readonly SeatTickSignalInput[];


### PR DESCRIPTION
Closes #1285. Closes #1289.

Two issues, one property seen from two sides: **a wake names what is owed now, and silence means nothing is.** The monitor had it wrong in both directions — it woke a seat for work that was over, and stayed silent about the one thing that was owed. They share files, so they ship together.

## #1285 — a wake replayed lane events from pipelines that closed the day before

A wake arrived with a reason like `lane-event: stage_completed since the last delivered wake and 18 more`, listed five items and held the rest back. Every item named a pipeline that had already reached a terminal state — two of them closed by the seat itself earlier in the same session. Establishing that nothing was owed was the entire cost of the wake, three wakes running.

Two changes, and the second is the expensive one:

**An event whose own lane has finished is not a present obligation.** Each pending event now carries whether the pipeline it names is still open, and only live ones can raise the `lane-event` reason, appear as items, or be counted in the reason's `and N more`. So the number the seat reads is how much is actually live.

**A backlog discharged by one look does not cost one wake per page.** The cursor moved only on a delivered wake, so a cursor that fell behind could only catch up one paid wake at a time: fifty historical events at five items per hourly wake is ten resumed hosts and ten paid turns. A check now seals the cursor past every pending event that is not owed — routine progress, and terminal events whose lanes have finished — stopping dead at the first one that is, with no send and no resume. A page of backlog costs one five-minute check instead of one hour and one host, and nothing that is owed is ever discharged by it.

That also retires the wake whose reason was `a terminal lane event is waiting further down the journal than this check reads`. It carried no item naming the event, so the seat paid a resume to be told to look again; the pages of history in front of that event are now sealed away for free and the check that reaches it names it. Where the two rules pull against each other, the rarer and truer wake wins over the earlier one.

## #1289 — a finished lane with an unmerged pull request read as nothing owed

The mirror image, and it cost twelve hours. Two lanes finished with clean approvals; three pull requests then sat approved, green and unmerged, and the seat was never woken again. The tick was applying its rules correctly — `hasOpenWork` counts open lanes and board cards, and a finished lane is neither — so the answer was `quiet — nothing owed` every five minutes until the operator asked why nothing was happening.

A lane that reached a terminal state whose branch still has an open pull request is now open work, and a wake reason of its own: `unmerged-pr`, naming the pull request and the lane that produced it so the seat can act without rediscovering either. The correlation is the lane's own branch against the pull request's head ref — durable on both sides, and the only tie that survives the lane being closed and its worktree removed.

It takes no shortcut around anything: same wake interval, same retry guard, and the change fingerprint now carries the set of unmerged pull requests, so a second one appearing behind the first cannot be suppressed by a guard that could not see it. It clears itself when the pull request merges or closes, because the source reads *open* pull requests and a merged one is simply absent.

The read is a `gh` subprocess, so it happens only where a wake could come of it — the tick is on for the project, the wake interval has elapsed, there is a seat to wake and its turn is not already moving, the project has a finished lane to attribute one to, and some lane named a repository to ask in. The seat clauses are the second commit: a project with nobody holding the seat ends in `no-seat` and a seat mid-turn ends in `skipped`, both above the point where a reason is composed, and the busy one is expensive — the tick checks every five minutes and a turn runs for hours, so each of those checks was paying a subprocess to answer a question it was never going to ask. Both read the seat the gather has already resolved, so the gate costs nothing it was not already holding, and a turn that settles is followed by a check that reads normally. A `gh` that cannot answer costs the tick this one reason and never the check — and, as of the third commit below, is no longer allowed to buy a silence with it.

## The third commit — quiet is established, not assumed

Review found the same failure wearing two coats: the tick could still report `nothing owed` without having shown it. Both are closed here, and neither is a route around the hourly bound.

**An unmerged pull request stopped being an obligation once its lane was archived.** The correlation read only the hot pipeline store, and settled records leave it after three days. So a tick that was switched off, a seat that stayed busy, or a `gh` nobody could reach until archival all met their first eligible check with no lane to attribute anything to — and reported quiet over a pull request still sitting open. That is the twelve-hour silence #1289 exists to end, arriving by a slower route.

The lanes now come from the hot store **and** the archive. Persisting the obligation instead was the other option on the table and it does not cover the case: the monitor would have to observe the lane finishing in order to record anything, and the scenario that produced the report is precisely a tick that observed nothing until the record had already settled out. The archive is cold storage, so it is read only after every gate that already fences the `gh` subprocess — ticking on, interval elapsed, a seat to wake, its turn not moving — at which point the check has committed to a subprocess anyway and a snapshot read is the cheaper half of the pair. The repository is taken from an archived record too, because a project whose every lane has settled out still has one.

**A `gh` failure was indistinguishable from a merged pull request.** Malformed output, timeouts, authentication failures and command failures all became `[]`, an empty list read as "nothing open", and the wake went quiet on the strength of a question nobody could ask. The read now answers with a result that carries the failure class, the gather keeps it distinct, and a check that cannot see what its finished lanes left open journals an `error` and asks again at the next check instead of publishing a silence it never earned. An empty *answer* is still an answer, and still earns quiet.

The bound is untouched by both. The error raises no wake, so it advances neither the wake stamp nor the retry guard, and an hour of failures leaves the next real wake exactly as due as it was. A reason that stands on its own — a terminal lane event — still wakes the seat while `gh` is unreadable, because an outage silencing the tick is the failure being fixed, not a remedy for it.

One consequence worth naming: while `gh` is unreadable, a project with finished lanes cannot reach the proactive proposal slot either, because "the board is done" is exactly the claim the failed read did not establish. It resumes on the first check that gets an answer.

## The fourth and fifth commits — a failed read pays for nothing

The third commit stopped a failed read from buying a *silence*. Review then found the two routes by which it could still buy something, and both are closed here.

**A wake was still returned before the failure was consulted.** The refusal sat below the wake branch, so a check that had a reason of its own — a terminal lane event, a persisted stall, an unstarted task, the interval itself — composed that wake, delivered it, and the delivery advanced `lastWakeAt` and the retry accounting. The next hour of silence was then bought by a check whose pull-request read had established nothing. The refusal now sits **above** the wake branch: the reason that stood on its own is held for the next check five minutes away instead of the hour a delivered wake would have spent, and the outage is journaled every check rather than absorbed into a wake that could not name what it was hiding. The proposal is the fourth thing a check can spend and it is spent on the strength of an idle board, which is exactly the reading a failed read leaves unestablished — so it waits too, and its 24-hour slot stays unstamped.

**A nonempty malformed answer still read as "nothing open".** A row inside a well-formed array that names no number or no head branch was skipped while the read still reported success, so one unusable row turned a nonempty answer into an empty one — and an empty one here is the claim that every pull request those lanes opened has since merged or closed. A single bad row therefore bought the quiet verdict the result type exists to make earnable. Such an array is now `malformed-output`, like any other output nobody can attribute.

The boundary is pinned from both sides, because refusing the unusable row is one edit away from refusing the empty row set as well, which would leave every project whose pull requests have all merged in a permanent error. The two load-bearing fields are the number and the head branch — one names the pull request, the other ties it to the lane — and a row carrying both is read even with no title and no timestamp; a read that failed over a missing title would be an outage invented out of a complete answer. Exactly the empty array stays the answer that nothing is open.

## Scope

Everything is inside `src/lib/monitor/**`. No behaviour outside the seat tick changes; the wake message, the journal record and the durable row all carry the new reason kind through the constants they already read.

One boundary left deliberately where it was: the set of projects a check runs for is unchanged (a seat, an open lane, or an inbox/assigned card). A project whose seat has gone away entirely is still not checked, and enumerating projects by their unmerged pull requests would mean a `gh` call to decide whether to make a `gh` call. The incident's project had a seat throughout.

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- Every `src/lib/monitor/*.test.ts` file, by path, under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`: **320 pass, 0 fail** across 14 files. `src/lib/lifecycle/journal.test.ts` and `digest.test.ts` too, since the journal read changed shape: 21 pass, 0 fail.
- Each new clause was checked red as well as green, so no assertion here is green for a reason nobody has seen. Removing the seal, the terminal-event filter or either seat gate fails the regressions that claim them; removing the `error` verdict fails 5, dropping the archive out of the correlation fails 3, and letting the `gh` seam degrade to an empty list again fails 2. For the last two commits, each edge was re-checked red against the current branch: moving the refusal back below the wake branch fails 4, skipping the unusable row instead of refusing it fails 3, and treating the empty array as unattributable output fails 2.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS.

New regressions cover each acceptance criterion:

- a project whose only pending events belong to finished lanes answers `nothing owed`, not a wake (decision, gather and controller);
- fifty historical events are discharged by the one check that read them, cursor advanced, nothing sent;
- the seal stops at the first event that is still owed, and a skipped check seals nothing;
- the `and N more` count names only what is live;
- a completed lane with an open pull request wakes the seat with the pull request named in the item, and the same project goes quiet once it is merged;
- the new reason waits out the wake interval and is held by the retry guard like every other;
- a lane the archive has taken still wakes the seat over its open pull request, names the repository the read runs in, and goes quiet once that pull request merges;
- the archive is not read by a check that could raise no wake from it;
- a thrown command, a timeout, a malformed answer and lanes that cannot be enumerated each keep their own name, become an `error` in the journal, send nothing, and leave the wake stamp, the retry guard and `quietSince` where the previous check left them;
- the check after a failure asks again and wakes as soon as GitHub answers, while a successful empty answer still earns quiet;
- every candidate reason a check can raise — lane event, unmerged pull request, persisted stall, unstarted task, interval — yields to the failure rather than being delivered ahead of it, for each failure class, leaving the wake stamp, the retry guard and the event cursor untouched;
- an idle board with the proposal slot due proposes nothing while GitHub is unreadable, and records neither the slot nor the idle stamp;
- one unusable row among valid ones fails the whole read rather than shortening it, while a row with a number and a head branch is read with no title and no timestamp on it;
- exactly the empty array goes quiet and records the quiet, and one usable row off the same seam wakes and names the pull request;
- the pull request read is skipped entirely before the interval elapses, for a tick that is off, for a hidden lane, when there is no seat to wake, and when the seat is already mid-turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



