### PR TITLE
fix(delivery): an accepted send settles, and its receipt says what became of it (#1131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ do not render as Viewer cards.
 The MCP surface includes:
 
 - conversations and the board: `board_snapshot`, `list_conversations`,
-  `get_conversation`, `send_message`, and `conversation_action` for
+  `get_conversation`, `send_message`, `message_receipt` (what became of an
+  accepted send, by its operation id), and `conversation_action` for
   `interrupt`, `kill`, `resume`, `compact`, and `dialog-key`;
 - review flows: `list_flows`, `get_flow`, and `flow_action`;
 - pipelines: `create_pipeline`, `list_pipelines`, `get_pipeline`,

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -515,6 +515,36 @@ test("automatic host retirement starts with the release that owns traffic, not w
   expect(started).toEqual(["pipelines", "host-retirement"]);
 });
 
+test("send settlement starts with the release that owns traffic, and a failure to start it costs only itself", async () => {
+  /* #1131: the sweep fences operations in the runtime journal that THIS
+     process's delivery queue would otherwise still execute, so it belongs to
+     the process that owns traffic — and, like every controller here, it must
+     not take the rest of the boot down when it cannot start. */
+  const started: string[] = [];
+  await startCurrentReleaseControllers(
+    { LLV_ACCOUNT_CONTROLLER_DISABLED: "1" },
+    {
+      loadFlowPipelineController: async () => ({ startFlowPipelineController: () => { started.push("pipelines"); } }),
+      loadAccountMigrationController: async () => ({ startAccountMigrationController: async () => { started.push("account"); } }),
+      loadSendSettlement: async () => ({ startSendSettlement: () => { started.push("send-settlement"); } }),
+      loadSeatTick: async () => ({ startSeatTick: () => { started.push("seat-tick"); return true; } }),
+    },
+  );
+  expect(started).toEqual(["pipelines", "send-settlement", "seat-tick"]);
+
+  const withoutSettlement: string[] = [];
+  await startCurrentReleaseControllers(
+    { LLV_ACCOUNT_CONTROLLER_DISABLED: "1" },
+    {
+      loadFlowPipelineController: async () => ({ startFlowPipelineController: () => { withoutSettlement.push("pipelines"); } }),
+      loadAccountMigrationController: async () => ({ startAccountMigrationController: async () => { withoutSettlement.push("account"); } }),
+      loadSendSettlement: async () => { throw new Error("runtime state unavailable"); },
+      loadSeatTick: async () => ({ startSeatTick: () => { withoutSettlement.push("seat-tick"); return true; } }),
+    },
+  );
+  expect(withoutSettlement).toEqual(["pipelines", "seat-tick"]);
+});
+
 test("the seat tick starts with the release that owns traffic — one clock, one process", async () => {
   /* #1245: the thing that drove orchestrator sessions was a prompt an agent
      scheduled for itself, so it died with the session and every rotation

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { SEND_LOST_REASON } from "@/lib/runtime/sendSettlement";
 import { VIEWER_SPAWN_CAPABILITY_ENV, VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { applyBoardCommand } from "@/lib/board/command";
 import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
@@ -2296,4 +2298,80 @@ test("seat_tick_settings is callable by a session that holds no seat at all", as
   });
   expect(applied).toMatchObject({ changed: true });
   expect(store.get("viewer")).toMatchObject({ setBy: { kind: "agent", conversationId: TICK_SEAT } });
+});
+
+test("send_message reports acceptance as unsettled, and message_receipt answers what became of it", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-send-receipt-"));
+  sandboxes.push(sandbox);
+  const registry = new AgentRegistry(
+    path.join(sandbox, "agent-registry.json"),
+    undefined,
+    undefined,
+    { sqliteMode: "off" },
+  );
+  setAgentRegistryForTests(registry);
+  const transcriptPath = path.join(sandbox, "recipient.jsonl");
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: transcriptPath,
+    accountId: "receipt-fixture-account",
+    launchProfile: emptyLaunchProfile({ cwd: sandbox }),
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-08-30T10:00:00.000Z",
+  }]);
+  const conversation = Object.values(registry.snapshot().conversations)[0]!;
+  const generationId = conversation.generations.at(-1)!.id;
+  const operationId = "op_receipt_fixture";
+
+  const bindings = viewerMcpBindings(undefined, {
+    post: async () => ({ outcome: "queued", operationId, receipt: { operationId, status: "queued" } }),
+  });
+  const accepted = await bindings.send_message({
+    clientRequestId: "receipt-fixture-send",
+    conversationId: conversation.id,
+    text: "hold the cutover",
+  });
+  /* #1131: the answer says acceptance, and says that acceptance is not the end
+     of the story. A caller that read `queued` as terminal is what cost forty
+     idle minutes. */
+  expect(accepted).toMatchObject({ operationId, outcome: "queued", settled: false });
+
+  const reservation = registry.holdDelivery(
+    conversation.id,
+    "hold the cutover",
+    "receipt-fixture-send",
+    "text",
+    [],
+    null,
+    { operationId, kind: "send", policy: "queue" },
+  );
+  registry.beginDeliveryAttempt(reservation.id, generationId);
+  expect(await bindings.message_receipt({ clientRequestId: "receipt-read-1", operationId }))
+    .toMatchObject({ operationId, state: "in-flight", resend: null, evidence: "delivery-journal" });
+
+  registry.recordDeliveryOutcome(reservation.id, "failed", SEND_LOST_REASON);
+  expect(await bindings.message_receipt({ clientRequestId: "receipt-read-2", operationId })).toMatchObject({
+    operationId,
+    conversationId: conversation.id,
+    state: "failed",
+    reason: SEND_LOST_REASON,
+    duplicateRisk: false,
+    resend: "safe",
+  });
+});
+
+test("message_receipt refuses an operation id nothing ever admitted", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-send-receipt-unknown-"));
+  sandboxes.push(sandbox);
+  setAgentRegistryForTests(new AgentRegistry(
+    path.join(sandbox, "agent-registry.json"),
+    undefined,
+    undefined,
+    { sqliteMode: "off" },
+  ));
+  const refusal = await viewerMcpBindings()
+    .message_receipt({ clientRequestId: "receipt-unknown", operationId: "op_never_admitted" })
+    .then(() => null, (error: unknown) => error as Error & { details?: { code?: string } });
+  expect(refusal?.name).toBe("McpToolRefusal");
+  expect(refusal?.details?.code).toBe("OPERATION_UNKNOWN");
 });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -85,6 +85,7 @@ import type { RoleDefinition, RoleParameter } from "@/lib/roles/types";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { messageOriginRole, type MessageOrigin } from "@/lib/runtime/messageOrigin";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
+import { sendReceiptFor } from "@/lib/runtime/sendSettlement";
 import {
   SELECTED_TAIL_MAX_BYTES,
   SELECTED_TAIL_MAX_LINES,
@@ -819,12 +820,41 @@ async function sendMessage(
   const conversation = conversationId
     ? lookup.conversation(conversationId as `conversation_${string}`)
     : lookup.conversationForPath(transcriptPath);
+  const settledOutcome = outcome.outcome ?? "delivered";
   return {
     conversationId: (conversation?.id ?? conversationId) || null,
     transcriptPath: (conversation?.generations.at(-1)?.path ?? transcriptPath) || null,
     operationId: outcome.operationId ?? (outcome.receipt as { operationId?: unknown } | undefined)?.operationId ?? null,
-    outcome: outcome.outcome ?? "delivered",
+    outcome: settledOutcome,
+    /* #1131: acceptance is not arrival. A `queued` send is admitted and not yet
+       settled, and saying so on the answer itself is what stops a caller from
+       reading the send-time guess as the end of the story — `message_receipt`
+       over the operation id is where the end of the story lives. */
+    settled: settledOutcome === "delivered",
   };
+}
+
+/**
+ * What became of one accepted send (#1131).
+ *
+ * The answer is read from the durable delivery record, so it survives the
+ * process that made the send, the runtime host that took it, and the
+ * reservation itself once compaction has retired it. An id nothing ever
+ * admitted is refused rather than answered with an invented in-flight state.
+ */
+async function messageReceipt(
+  args: McpToolArgs,
+  dependencies: Pick<ViewerMcpDomainDependencies, "registrySnapshot">,
+): Promise<McpToolPayload> {
+  const operationId = required(args, "operationId");
+  const receipt = sendReceiptFor(dependencies.registrySnapshot(), operationId);
+  if (!receipt) {
+    throw new McpToolRefusal(
+      "no accepted send is recorded under that operationId",
+      { code: "OPERATION_UNKNOWN" },
+    );
+  }
+  return { ...receipt };
 }
 
 async function createBoardTask(args: McpToolArgs): Promise<McpToolPayload> {
@@ -1939,6 +1969,10 @@ async function sendMessageToOrchestrator(
     predecessorConversationId: seat.predecessorConversationId,
     operationId: outcome.operationId ?? (outcome.receipt as { operationId?: unknown } | undefined)?.operationId ?? null,
     outcome: outcome.outcome ?? "delivered",
+    /* #1131: the same control path as `send_message`, so the same contract —
+       acceptance is not arrival, and `message_receipt` over the operation id is
+       what says which. */
+    settled: (outcome.outcome ?? "delivered") === "delivered",
   });
 }
 
@@ -3152,6 +3186,7 @@ export function viewerMcpBindings(
   return {
     spawn_agent: (args, context) => spawnAgent(args, viewerControlForCall(controlDependencies, context)),
     send_message: (args, context) => sendMessage(args, viewerControlForCall(controlDependencies, context), domainDependencies),
+    message_receipt: (args) => messageReceipt(args, domainDependencies),
     create_task: createBoardTask,
     update_task: updateBoardTask,
     create_pipeline: createPipeline,

--- a/src/lib/mcp/presentation.ts
+++ b/src/lib/mcp/presentation.ts
@@ -100,6 +100,21 @@ export function describeMcpCall(
     };
   }
 
+  if (toolName === "message_receipt") {
+    const operationId = string(result.operationId) || string(args.operationId);
+    const state = string(result.state) || "unknown";
+    const conversationId = string(result.conversationId);
+    return {
+      icon: "message",
+      verb: "Checking",
+      title: `Checking delivery of ${operationId || "a send"}: ${state}`,
+      subtitle: string(result.reason),
+      links: conversationId
+        ? [{ kind: "conversation", id: conversationId, label: "Open conversation", href: `#c=${encodeURIComponent(conversationId)}` }]
+        : [],
+    };
+  }
+
   if (toolName === "create_task") {
     const id = entityId(result, "task");
     return {

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1569,6 +1569,7 @@ describe("MCP tool service", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual([
         "spawn_agent",
         "send_message",
+        "message_receipt",
         "create_task",
         "update_task",
         "create_pipeline",

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1652,6 +1652,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
     "Answer what became of one accepted send, by the `operationId` `send_message` returned.",
     "`state` is `delivered`, `failed` or `in-flight`, read from the durable delivery record rather than from what the send call reported at the time. Every accepted send reaches `delivered` or `failed`; a send that was dropped ends as `failed`.",
     "`resend` says what is safe to do next: `not-needed` (it arrived), `safe` (it provably never executed and is fenced, so the same instruction may be sent again), or `verify-first` (`duplicateRisk` is true — delivery was started and never settled, so check the recipient before sending again).",
+    "A resend is a NEW `send_message` under a NEW `clientRequestId`: the settled operation is fenced, so repeating the original `clientRequestId` replays that settled answer instead of delivering anything.",
   ].join(" "),
   create_task: "Create a durable board task.",
   update_task: "Update a durable board task.",

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -39,6 +39,7 @@ export const MCP_SERVER_NAME = "viewer";
 export const MCP_TOOL_NAMES = [
   "spawn_agent",
   "send_message",
+  "message_receipt",
   "create_task",
   "update_task",
   "create_pipeline",
@@ -1643,7 +1644,15 @@ export function createMcpToolService(
 
 const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   spawn_agent: "Create a Viewer-managed agent conversation and return its durable conversation and launch ids.",
-  send_message: "Deliver a message to a Viewer conversation through its registered runtime host.",
+  send_message: [
+    "Deliver a message to a Viewer conversation through its registered runtime host.",
+    "The answer reports acceptance, not arrival: `outcome` is `queued` or `delivering` until the delivery record settles, and `settled` says which. Hold `operationId` and ask `message_receipt` what became of it — never treat `queued` as a terminal answer, and never re-send an unsettled operation, because a send whose fate is unknown can be delivered twice.",
+  ].join(" "),
+  message_receipt: [
+    "Answer what became of one accepted send, by the `operationId` `send_message` returned.",
+    "`state` is `delivered`, `failed` or `in-flight`, read from the durable delivery record rather than from what the send call reported at the time. Every accepted send reaches `delivered` or `failed`; a send that was dropped ends as `failed`.",
+    "`resend` says what is safe to do next: `not-needed` (it arrived), `safe` (it provably never executed and is fenced, so the same instruction may be sent again), or `verify-first` (`duplicateRisk` is true — delivery was started and never settled, so check the recipient before sending again).",
+  ].join(" "),
   create_task: "Create a durable board task.",
   update_task: "Update a durable board task.",
   create_pipeline: [
@@ -1692,7 +1701,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   bridge_directive: "Relay the user's intent to the designated manager. The recipient and the delivery id are derived server-side, so a retry of the same root turn is one instruction, never two.",
   get_orchestrator: "Read a project's designated orchestrator: designation, health and activity, model and prompt version, transcript size, message/tool/compaction counts, context usage against its model's configured window (clearly labelled when estimated), predecessor lineage, and a bounded rotation recommendation — STRONGLY_RECOMMEND_ROTATION once usage reaches the configured threshold. Words only: it never rotates, creates, or interrupts anything itself.",
   create_orchestrator: "Create a project's orchestrator or adopt one eligible registered conversation: designate it as the project's selected orchestrator and deliver the approved versioned mandate (editable). Idempotent by clientRequestId.",
-  send_message_to_orchestrator: "Deliver a message to the project's selected orchestrator, resolved server-side. A dead selected conversation is resumed; with none designated, one is created first and then delivered to. Idempotent by clientRequestId.",
+  send_message_to_orchestrator: "Deliver a message to the project's selected orchestrator, resolved server-side. A dead selected conversation is resumed; with none designated, one is created first and then delivered to. Idempotent by clientRequestId. Like send_message, the answer reports acceptance rather than arrival: ask message_receipt what became of the operationId.",
   seat_tick_settings: [
     "Read — and change — one project's seat tick: whether the Viewer wakes that project's seat at all, how often, and what your own monitor prompt tells the wake to look at.",
     "Called with no change fields it is a read. `project` defaults to your own, and naming another project's is allowed rather than refused; the answer says which of the two you did, and the record, the board card and the tick's journal all carry who changed whose tick.",
@@ -1880,6 +1889,10 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     conversationId: z.string().optional(),
     transcriptPath: z.string().optional(),
     text: z.string().min(1),
+  }).passthrough(),
+  message_receipt: z.object({
+    clientRequestId: clientRequestIdSchema,
+    operationId: z.string().min(1).describe("The operationId a send_message call returned."),
   }).passthrough(),
   create_task: z.object({
     clientRequestId: clientRequestIdSchema,

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -1,0 +1,526 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+/* Isolated state only: this suite writes real registry files and a real runtime
+   journal, neither of which may be the operator's. Nothing here addresses a
+   real conversation — every send is built in a fixture. */
+const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-send-settlement-"));
+const isolatedEnvironment = {
+  HOME: path.join(isolated, "home"),
+  XDG_CONFIG_HOME: path.join(isolated, "config"),
+  LLV_STATE_DIR: path.join(isolated, "state"),
+  TMPDIR: path.join(isolated, "tmp"),
+};
+/* Restored in afterAll: a bun run that carries several test files shares one
+   process, so an isolated TMPDIR this file then deletes would strand every
+   later file's mkdtemp. */
+const ambientEnvironment = Object.fromEntries(
+  Object.keys(isolatedEnvironment).map((name) => [name, process.env[name]]),
+);
+for (const [name, directory] of Object.entries(isolatedEnvironment)) {
+  fs.mkdirSync(directory, { recursive: true });
+  process.env[name] = directory;
+}
+
+const { AgentRegistry } = await import("@/lib/agent/registry");
+const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+const { RuntimeJournal } = await import("@/runtime-host/journal");
+const { projectDeliveryEvents } = await import("@/lib/lifecycle/projector");
+const { StructuredDeliveryQueue } = await import("./structuredDeliveryQueue");
+const {
+  SEND_LOST_REASON,
+  SEND_UNVERIFIED_REASON,
+  sendReceiptFor,
+  settleUnsettledSends,
+  unsettledSends,
+} = await import("./sendSettlement");
+type AgentRegistry = InstanceType<typeof AgentRegistry>;
+type RuntimeJournal = InstanceType<typeof RuntimeJournal>;
+type RuntimeHostClient = import("./client").RuntimeHostClient;
+type StructuredDeliveryQueuePort = import("./structuredDeliveryQueue").StructuredDeliveryQueuePort;
+type EngineHost = import("./engineHost").EngineHost;
+type HostState = import("./engineHost").HostState;
+type QueueEntry = import("./engineHost").QueueEntry;
+type DeliveryReceipt = import("./engineHost").DeliveryReceipt;
+type ViewerConversationId = `conversation_${string}`;
+
+afterAll(() => {
+  for (const [name, value] of Object.entries(ambientEnvironment)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  fs.rmSync(isolated, { recursive: true, force: true });
+});
+
+const SETTLEMENT_WINDOW_MS = 10 * 60_000;
+/** Every fixture send is accepted "now"; the sweep is driven from a clock past
+    the window instead of sleeping through it. */
+const AFTER_THE_WINDOW = () => Date.now() + SETTLEMENT_WINDOW_MS + 60_000;
+
+function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
+  return {
+    snapshot: async () => journal.snapshot(),
+    events: async (after: number) => journal.replay(after),
+    waitEvents: async (after: number) => journal.replay(after),
+    append: async (event) => journal.append(event),
+    operation: async (event) => journal.append(event),
+    command: async (command) => journal.executeOperation(command),
+    operationStatus: async (operationId: string, options?: { currentRetryLeaf?: boolean }) =>
+      (options?.currentRetryLeaf ? journal.currentRetryResult(operationId) : journal.operationResult(operationId)),
+    producerCursor: async (producerKind: string, eventKeyPrefix: string) =>
+      journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
+    transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
+    retryOperation: async (operationId, nextIdempotencyKey) => journal.retryOperation(operationId, nextIdempotencyKey),
+  } as RuntimeHostClient;
+}
+
+function idleState(sessionKey: string): HostState {
+  return {
+    status: "idle",
+    sessionKey,
+    endpoint: "fixture:host",
+    pid: 1,
+    processStartIdentity: "1",
+    eventCursor: 0,
+    protocolVersion: "fixture",
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+    account: null,
+  };
+}
+
+/** A host that records everything handed to it, so "was never delivered" is an
+    assertion about the recipient rather than about a receipt. */
+function recordingHost(sessionKey: string): { host: EngineHost; received: string[] } {
+  const received: string[] = [];
+  return {
+    received,
+    host: {
+      attach: () => ({ async *[Symbol.asyncIterator]() {} }),
+      send: async (entry: QueueEntry): Promise<DeliveryReceipt> => {
+        received.push(entry.text ?? "");
+        return { outcome: "turn-started", turnId: `turn-${entry.id}` };
+      },
+      interrupt: async () => {},
+      answer: async () => {},
+      health: async () => idleState(sessionKey),
+      release: async () => {},
+    },
+  };
+}
+
+interface Fixture {
+  registry: AgentRegistry;
+  journal: RuntimeJournal;
+  client: RuntimeHostClient;
+  conversationId: ViewerConversationId;
+  generationId: string;
+  transcriptPath: string;
+  close(): void;
+}
+
+function fixture(name: string): Fixture {
+  const directory = fs.mkdtempSync(path.join(isolated, `${name}-`));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const transcriptPath = path.join(directory, `${name}.jsonl`);
+  const launchProfile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: transcriptPath,
+    accountId: "settlement-fixture-account",
+    launchProfile,
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-08-30T10:00:00.000Z",
+  }]);
+  const conversation = Object.values(registry.snapshot().conversations)[0];
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) throw new Error("fixture conversation is missing");
+  registry.upsert({
+    key: { engine: "codex", sessionId: generation.id },
+    artifactPath: transcriptPath,
+    cwd: directory,
+    accountId: "settlement-fixture-account",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fixture:settlement-host",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "fixture-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  /* The runtime journal only admits a send for a hosted session, so the fixture
+     publishes the same host state a live structured host would. */
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId: generation.id },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath: transcriptPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  return {
+    registry,
+    journal,
+    client: runtimeClient(journal),
+    conversationId: conversation.id,
+    generationId: generation.id,
+    transcriptPath,
+    close: () => journal.close(),
+  };
+}
+
+/**
+ * Admits one send exactly the way the structured send path does: a durable
+ * reservation, a claimed attempt, then the runtime-journal operation. What
+ * comes back is the operation id an MCP caller would have been handed with
+ * `outcome: "queued"`.
+ */
+function acceptSend(
+  active: Fixture,
+  options: { text?: string; clientMessageId?: string; operationId?: string } = {},
+): { operationId: string; deliveryId: string } {
+  const clientMessageId = options.clientMessageId ?? "fixture-message-key";
+  const operationId = options.operationId ?? `op_${clientMessageId}`;
+  const text = options.text ?? "hold the cutover until I say go";
+  const reservation = active.registry.holdDelivery(
+    active.conversationId,
+    text,
+    clientMessageId,
+    "text",
+    [],
+    null,
+    { operationId, kind: "send", policy: "queue" },
+  );
+  if (reservation.state !== "assigned") throw new Error(`fixture reservation is ${reservation.state}`);
+  const claimed = active.registry.beginDeliveryAttempt(reservation.id, active.generationId);
+  if (!claimed) throw new Error("fixture reservation could not claim its attempt");
+  const admitted = active.journal.executeOperation({
+    kind: "send",
+    operationId,
+    conversationId: active.conversationId,
+    idempotencyKey: clientMessageId,
+    text,
+    policy: "queue",
+  });
+  expect(admitted.receipt.status).toBe("queued");
+  return { operationId, deliveryId: reservation.id };
+}
+
+/** An executor that had already batched this effect before anything settled it
+    — the exact race a fence has to survive. */
+function stalePortFor(
+  active: Fixture,
+  operationId: string,
+  clientMessageId: string,
+  text: string,
+): StructuredDeliveryQueuePort {
+  return {
+    effects: async () => [{
+      id: `effect:${operationId}`,
+      kind: "runtime.send",
+      eventSeq: 1,
+      payload: {
+        kind: "send",
+        operationId,
+        conversationId: active.conversationId,
+        text,
+        idempotencyKey: clientMessageId,
+        policy: "queue",
+      },
+    }],
+    transition: async (id, status, details) => {
+      await active.client.transitionOperation(id, status, details);
+    },
+  };
+}
+
+function receiptOf(active: Fixture, operationId: string) {
+  return sendReceiptFor(active.registry.readOnlySnapshot(), operationId);
+}
+
+test("an accepted send that the journal delivered reconciles rather than being reported lost", async () => {
+  const active = fixture("delivered");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, { clientMessageId: "delivered-key" });
+    /* The executor did its job; only the projection onto the reservation was
+       missed, which must never be mistaken for a loss. */
+    active.journal.transitionOperation(operationId, "delivering");
+    active.journal.transitionOperation(operationId, "delivered", { turnId: "turn-1" });
+    expect(receiptOf(active, operationId)?.state).toBe("in-flight");
+
+    const report = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+
+    expect(report.settled).toEqual([{
+      operationId,
+      deliveryId,
+      conversationId: active.conversationId,
+      state: "delivered",
+      disposition: "reconciled",
+      duplicateRisk: false,
+    }]);
+    const receipt = receiptOf(active, operationId);
+    expect(receipt?.state).toBe("delivered");
+    expect(receipt?.resend).toBe("not-needed");
+    expect(receipt?.duplicateRisk).toBe(false);
+    expect(receipt?.evidence).toBe("delivery-journal");
+  } finally {
+    active.close();
+  }
+});
+
+test("a dropped send settles as failed, and the fence stops the queue from delivering it afterwards", async () => {
+  const active = fixture("dropped");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, {
+      clientMessageId: "dropped-key",
+      text: "resume the cutover",
+    });
+    /* Nothing else happens to it: this is the incident's shape — accepted,
+       answered `queued`, and then silence. */
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("queued");
+    expect(unsettledSends(active.registry.readOnlySnapshot(), { now: AFTER_THE_WINDOW() })).toMatchObject([
+      { operationId, deliveryId, awaitingTurn: false },
+    ]);
+
+    const report = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+
+    expect(report.settled).toEqual([{
+      operationId,
+      deliveryId,
+      conversationId: active.conversationId,
+      state: "failed",
+      disposition: "lost",
+      duplicateRisk: false,
+    }]);
+    const receipt = receiptOf(active, operationId);
+    expect(receipt?.state).toBe("failed");
+    expect(receipt?.reason).toBe(SEND_LOST_REASON);
+    expect(receipt?.duplicateRisk).toBe(false);
+    expect(receipt?.resend).toBe("safe");
+
+    /* The fence, proved against the real queue rather than asserted: the effect
+       is gone from the outbox, and an executor that had already batched it is
+       refused at the `delivering` transition — before `host.send` is reached. */
+    expect(await active.journal.effectBatch(100, ["runtime.send"])).toEqual([]);
+    const { host, received } = recordingHost(active.generationId);
+    const stalePort = stalePortFor(active, operationId, "dropped-key", "resume the cutover");
+    await new StructuredDeliveryQueue(stalePort, () => host).drain().catch(() => undefined);
+    expect(received).toEqual([]);
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("failed");
+  } finally {
+    active.close();
+  }
+});
+
+test("the same queue pass delivers a send the settlement has not fenced", async () => {
+  /* The control for the fence above: with the operation left open, this exact
+     port, queue and host do deliver, so the empty recipient in that test is the
+     fence's doing and not the harness's. */
+  const active = fixture("unfenced");
+  try {
+    const { operationId } = acceptSend(active, { clientMessageId: "unfenced-key", text: "resume the cutover" });
+    const { host, received } = recordingHost(active.generationId);
+    await new StructuredDeliveryQueue(stalePortFor(active, operationId, "unfenced-key", "resume the cutover"), () => host).drain();
+    expect(received).toEqual(["resume the cutover"]);
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("delivered");
+  } finally {
+    active.close();
+  }
+});
+
+test("a send whose first attempt is uncertain settles as failed and refuses to call a resend safe", async () => {
+  const active = fixture("uncertain");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, { clientMessageId: "uncertain-key" });
+    /* The executor took it and never came back. Nothing can prove the recipient
+       did not receive it, so nothing here may pretend otherwise. */
+    active.journal.transitionOperation(operationId, "delivering", { turnId: "turn-7" });
+
+    const report = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+
+    expect(report.settled).toEqual([{
+      operationId,
+      deliveryId,
+      conversationId: active.conversationId,
+      state: "failed",
+      disposition: "unverified",
+      duplicateRisk: true,
+    }]);
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("uncertain");
+    const receipt = receiptOf(active, operationId);
+    expect(receipt?.state).toBe("failed");
+    expect(receipt?.reason).toBe(SEND_UNVERIFIED_REASON);
+    expect(receipt?.duplicateRisk).toBe(true);
+    expect(receipt?.resend).toBe("verify-first");
+    /* Terminal either way: an unverified send is still fenced against being
+       executed a second time by the queue. */
+    expect(await active.journal.effectBatch(100, ["runtime.send"])).toEqual([]);
+  } finally {
+    active.close();
+  }
+});
+
+test("a send queued behind the recipient's own turn waits, and stops being exempt at the ceiling", async () => {
+  const active = fixture("in-turn");
+  try {
+    const { operationId } = acceptSend(active, { clientMessageId: "in-turn-key" });
+    active.registry.setStructuredHost({ engine: "codex", sessionId: active.generationId }, {
+      kind: "codex-app-server",
+      endpoint: "fixture:settlement-host",
+      process: null,
+      eventCursor: 1,
+      protocolVersion: "fixture-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: "turn-in-progress",
+      pendingAttention: [],
+      activeFlags: [],
+    });
+
+    const inTurn = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+    expect(inTurn).toMatchObject({ examined: 0, settled: [], deferred: [] });
+    expect(receiptOf(active, operationId)?.state).toBe("in-flight");
+
+    /* A host wedged mid-turn must not make `queued` permanent again. */
+    const pastCeiling = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: () => Date.now() + 61 * 60_000,
+    });
+    expect(pastCeiling.settled).toMatchObject([{ operationId, state: "failed", disposition: "lost" }]);
+    expect(receiptOf(active, operationId)?.state).toBe("failed");
+  } finally {
+    active.close();
+  }
+});
+
+test("a retried send is judged by its current attempt, not by the ancestor it replaced", async () => {
+  const active = fixture("retried");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, { clientMessageId: "retried-key" });
+    /* The first attempt died with the host; a fresh attempt was admitted under a
+       new idempotency key and delivered. The reservation still names the
+       ancestor, so reading the ancestor would report a delivered message as a
+       loss — and would then try to fence an operation already terminal. */
+    active.journal.transitionOperation(operationId, "failed", { reason: "dead-host" });
+    const retry = active.journal.retryOperation(operationId, "retried-key-second");
+    expect(retry.operationId).not.toBe(operationId);
+    active.journal.transitionOperation(retry.operationId, "delivering");
+    active.journal.transitionOperation(retry.operationId, "delivered", { turnId: "turn-9" });
+
+    const report = await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+
+    expect(report.settled).toMatchObject([{ operationId, deliveryId, state: "delivered", disposition: "reconciled" }]);
+    expect(receiptOf(active, operationId)?.state).toBe("delivered");
+  } finally {
+    active.close();
+  }
+});
+
+test("an unreadable delivery journal defers the send instead of declaring it lost", async () => {
+  const active = fixture("deferred");
+  try {
+    const { operationId } = acceptSend(active, { clientMessageId: "deferred-key" });
+
+    const withoutHost = await settleUnsettledSends({
+      registry: active.registry,
+      client: null,
+      now: AFTER_THE_WINDOW,
+    });
+    expect(withoutHost.settled).toEqual([]);
+    expect(withoutHost.deferred).toEqual([{ operationId, reason: "runtime host is unavailable" }]);
+
+    const unreachable = await settleUnsettledSends({
+      registry: active.registry,
+      client: {
+        ...active.client,
+        operationStatus: async () => { throw new Error("runtime host request timed out"); },
+      } as RuntimeHostClient,
+      now: AFTER_THE_WINDOW,
+    });
+    expect(unreachable.settled).toEqual([]);
+    expect(unreachable.deferred).toEqual([{ operationId, reason: "runtime host request timed out" }]);
+    /* Still open, still unfenced: knowing less is never a licence to declare a
+       message lost while it may be sitting in a live outbox. */
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("queued");
+    expect(receiptOf(active, operationId)?.state).toBe("in-flight");
+  } finally {
+    active.close();
+  }
+});
+
+test("a settled loss is journaled as it is declared, so nobody has to run a silence monitor", async () => {
+  const active = fixture("visible");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, { clientMessageId: "visible-key" });
+    const journaled: unknown[] = [];
+    await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+      /* The shared lifecycle file is not this fixture's to write; what matters
+         is that the loss is handed to it inside the settlement rather than left
+         for whichever poll happens next. */
+      journalLifecycle: (deliveries) => journaled.push(...projectDeliveryEvents([...deliveries])),
+    });
+
+    expect(active.registry.readOnlySnapshot().heldDeliveries[deliveryId]?.state).toBe("failed");
+    expect(journaled).toMatchObject([{
+      key: `delivery:${deliveryId}:failed`,
+      type: "delivery_expired",
+      conversationId: active.conversationId,
+    }]);
+    expect(receiptOf(active, operationId)?.state).toBe("failed");
+  } finally {
+    active.close();
+  }
+});
+
+test("an operation id nothing ever admitted is answered with nothing, not an invented in-flight state", () => {
+  const active = fixture("unknown");
+  try {
+    expect(receiptOf(active, "op_never_admitted")).toBeNull();
+  } finally {
+    active.close();
+  }
+});

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -524,3 +524,48 @@ test("an operation id nothing ever admitted is answered with nothing, not an inv
     active.close();
   }
 });
+
+test("the caller's own replay of a settled loss is answered with the settlement, never with a second delivery", async () => {
+  /* The fence proved against the OTHER way the same instruction could arrive
+     twice: not a stale executor, but the sender deciding to send it again. The
+     settled operation still owns its idempotency key, so an identical send is
+     answered with the settled receipt and admits no new effect — which is why
+     `resend: "safe"` means a NEW request id rather than a repeat of this one. */
+  const active = fixture("replayed");
+  try {
+    const { operationId } = acceptSend(active, {
+      clientMessageId: "replayed-key",
+      text: "resume the cutover",
+    });
+    await settleUnsettledSends({
+      registry: active.registry,
+      client: active.client,
+      now: AFTER_THE_WINDOW,
+    });
+    expect(receiptOf(active, operationId)?.resend).toBe("safe");
+
+    const replay = active.journal.executeOperation({
+      kind: "send",
+      operationId,
+      conversationId: active.conversationId,
+      idempotencyKey: "replayed-key",
+      text: "resume the cutover",
+      policy: "queue",
+    });
+
+    expect(replay).toMatchObject({ operationId, replayed: true });
+    expect(replay.receipt.status).toBe("failed");
+    expect(replay.receipt.reason).toBe(SEND_LOST_REASON);
+    /* Nothing new to execute, and the queue that would execute it delivers
+       nothing when it is asked. */
+    expect(await active.journal.effectBatch(100, ["runtime.send"])).toEqual([]);
+    const { host, received } = recordingHost(active.generationId);
+    await new StructuredDeliveryQueue(
+      stalePortFor(active, operationId, "replayed-key", "resume the cutover"),
+      () => host,
+    ).drain().catch(() => undefined);
+    expect(received).toEqual([]);
+  } finally {
+    active.close();
+  }
+});

--- a/src/lib/runtime/sendSettlement.ts
+++ b/src/lib/runtime/sendSettlement.ts
@@ -1,0 +1,535 @@
+import {
+  agentRegistry,
+  readOnlyConversationLookupFromSnapshot,
+  type AgentRegistry,
+  type RegistryFile,
+} from "@/lib/agent/registry";
+import { sessionKeyId } from "@/lib/agent/sessionKey";
+import type { HeldDelivery, ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { appendLifecycleEvents } from "@/lib/lifecycle/journal";
+import { projectDeliveryEvents } from "@/lib/lifecycle/projector";
+
+import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import type { RuntimeReceiptStatus } from "./contracts";
+
+/**
+ * Settlement of accepted sends (#1131).
+ *
+ * `send_message` answers `queued` the moment the runtime host admits the
+ * operation, and until now that could be the LAST thing anyone ever said about
+ * it. A delivery that the drain never executed — because the host it was
+ * addressed to went away, or because the effect was simply never picked up —
+ * rested at `queued` forever: the reservation stayed `delivery-uncertain`, the
+ * receipt stayed non-terminal, and nothing anywhere turned that into an answer.
+ * A production deployer holding a paused cutover sat idle for forty minutes on
+ * exactly this, and the only thing that noticed was the sender's own suspicion.
+ *
+ * Three things are needed, and this module owns all three:
+ *
+ * - **Every accepted send settles.** {@link settleUnsettledSends} sweeps the
+ *   reservations that have not reached a terminal state and ends each one as
+ *   `delivered` or `failed`, from the delivery journal's own answer.
+ * - **The settlement is queryable by operation id.** {@link sendReceiptFor} is
+ *   a pure read over the registry's durable delivery index, so a caller holding
+ *   the id `send_message` returned learns what became of it — from the record,
+ *   never from what the send call guessed at the time.
+ * - **A loss surfaces without a watchdog.** A settled-as-failed reservation is
+ *   rendered as a failed send on the recipient's card, and the settlement
+ *   journals its `delivery_expired` event as it declares the loss rather than
+ *   leaving it for whoever next polls — so it is in the lifecycle digest, which
+ *   orchestrators already read, before anyone asks. No new surface, and nothing
+ *   for the sender to watch.
+ *
+ * ── WHY THIS CANNOT DELIVER THE SAME INSTRUCTION TWICE ────────────────────
+ *
+ * Declaring a send failed is only honest if the send can no longer happen, so
+ * the settlement never merely relabels a reservation: it terminalizes the
+ * OPERATION in the runtime journal first, and only writes `failed` on the
+ * reservation once that succeeded. Two properties of the journal make that a
+ * real fence rather than a hopeful one:
+ *
+ * - terminalizing an operation marks its outbox row completed inside the same
+ *   `BEGIN IMMEDIATE` transaction, so the effect is gone from every later
+ *   effect batch; and
+ * - the delivery queue must move an effect to `delivering` BEFORE it calls
+ *   `host.send`, and the journal refuses that transition out of a terminal
+ *   state — so an executor that had already batched the effect is stopped at
+ *   the transition rather than at the send.
+ *
+ * That fence exists only for a send the journal still shows as unexecuted. A
+ * send the executor already took (`delivering`) may have reached the recipient,
+ * and nothing here can prove it did not, so it is terminalized as `uncertain`
+ * and its receipt says so: the caller is told the fate is unknown and that
+ * re-sending it may duplicate. This module never retries anything on its own —
+ * a resend is the caller's decision, made against a receipt that states whether
+ * it is safe.
+ */
+
+/** The two failure reasons this module writes, and the only two the receipt
+    reads back. `sendReceiptFor` derives duplicate risk from them, so they are a
+    contract between the sweep and the query rather than log prose. */
+export const SEND_LOST_REASON =
+  "accepted for delivery but never executed; the delivery journal has fenced it, so it cannot arrive and may be sent again";
+export const SEND_UNVERIFIED_REASON =
+  "delivery was started and never settled; whether it reached the recipient is unknown, so sending it again may deliver it twice";
+
+/**
+ * How long an accepted send may rest unsettled before it is declared lost.
+ *
+ * This is a settlement deadline, not a delivery timeout: nothing waits on it,
+ * and widening it would only make a lost send take longer to become an answer.
+ * It is generous enough that an ordinary drain, host recovery or reconnection
+ * finishes well inside it.
+ */
+export const SEND_SETTLEMENT_WINDOW_MS = 10 * 60_000;
+
+/**
+ * The ceiling on the in-turn exemption below.
+ *
+ * A send queued behind the recipient's active turn is progressing, not lost, so
+ * it is exempt from the window. A host wedged mid-turn would otherwise make
+ * that exemption permanent and put `queued` right back where this issue found
+ * it, so the exemption ends here.
+ */
+export const SEND_SETTLEMENT_IN_TURN_CEILING_MS = 60 * 60_000;
+
+/** How often the release that owns traffic sweeps. */
+export const SEND_SETTLEMENT_INTERVAL_MS = 60_000;
+
+/** Settlements attempted per sweep. Each costs one journal round trip; the rest
+    wait for the next tick rather than holding the event loop. */
+const SETTLEMENT_BATCH_CEILING = 20;
+
+/** Receipt statuses that mean the recipient has the message. */
+const DELIVERED_RECEIPT_STATUSES: ReadonlySet<RuntimeReceiptStatus> = new Set<RuntimeReceiptStatus>([
+  "delivered",
+  "turn-started",
+  "steered",
+]);
+
+/** Receipt statuses the journal will still act on. */
+const OPEN_RECEIPT_STATUSES: ReadonlySet<RuntimeReceiptStatus> = new Set<RuntimeReceiptStatus>([
+  "pending",
+  "queued",
+]);
+
+export type SendReceiptState = "delivered" | "failed" | "in-flight";
+
+/** What a caller may do with a settled send without risking a second delivery. */
+export type SendResendGuidance =
+  /** It arrived. Sending it again would be a second instruction, not a retry. */
+  | "not-needed"
+  /** It provably never executed and is fenced; the same instruction may be sent again. */
+  | "safe"
+  /** Its fate is unknown; verify the recipient before sending it again. */
+  | "verify-first";
+
+export interface SendReceipt {
+  operationId: string;
+  conversationId: string | null;
+  /** The idempotency key the send was admitted under, when the record kept it. */
+  clientMessageId: string | null;
+  state: SendReceiptState;
+  /** Why it failed, or what it is still waiting on. */
+  reason: string | null;
+  acceptedAt: string | null;
+  settledAt: string | null;
+  /** True when re-sending this instruction could deliver it a second time. */
+  duplicateRisk: boolean;
+  resend: SendResendGuidance | null;
+  /** The record this answer was read from, never the send call's own guess. */
+  evidence: "delivery-journal";
+}
+
+/** An accepted send the delivery record has not settled. */
+export interface UnsettledSend {
+  operationId: string;
+  deliveryId: string;
+  conversationId: ViewerConversationId;
+  clientMessageId: string | null;
+  acceptedAt: string;
+  unsettledForMs: number;
+  /** Set while the recipient's own turn is what the send is waiting on. */
+  awaitingTurn: boolean;
+}
+
+export interface SendSettlementOutcome {
+  operationId: string;
+  deliveryId: string;
+  conversationId: ViewerConversationId;
+  state: "delivered" | "failed";
+  /** `lost` fenced an unexecuted send; `unverified` terminalized a started one;
+      `reconciled` copied a terminal journal answer the projection had missed. */
+  disposition: "lost" | "unverified" | "reconciled";
+  duplicateRisk: boolean;
+}
+
+export interface SendSettlementReport {
+  /** Accepted sends past the settlement window this pass considered. */
+  examined: number;
+  settled: SendSettlementOutcome[];
+  /** Sends left alone because the journal could not be asked or answered. */
+  deferred: { operationId: string; reason: string }[];
+}
+
+export interface SendSettlementPorts {
+  registry?: AgentRegistry;
+  client?: RuntimeHostClient | null;
+  now?: () => number;
+  windowMs?: number;
+  inTurnCeilingMs?: number;
+  batchCeiling?: number;
+  /** Where the declared loss is journaled. Swapped only by tests that assert
+      the event without writing a shared lifecycle file. */
+  journalLifecycle?: (deliveries: readonly HeldDelivery[]) => void;
+}
+
+function parseTime(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** The moment the send was accepted for delivery. */
+function acceptedAtOf(delivery: HeldDelivery): string {
+  return delivery.assignedAt ?? delivery.createdAt;
+}
+
+/** The turn reference the recipient's current generation is publishing, or null
+    when it publishes none — including when it has no live structured host at
+    all, which is the case a lost send most often sits in. The lookup is built
+    once per pass: it indexes every conversation, so building one per delivery
+    would make a sweep quadratic in a registry that has thousands. */
+function activeTurnOf(
+  file: RegistryFile,
+  lookup: ReturnType<typeof readOnlyConversationLookupFromSnapshot>,
+  conversationId: ViewerConversationId,
+): string | null {
+  const conversation = lookup.conversation(conversationId);
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) return null;
+  const entry = file.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
+  return entry?.structuredHost?.activeTurnRef ?? null;
+}
+
+/**
+ * The accepted sends this snapshot has not settled, oldest first.
+ *
+ * `delivery-uncertain` is the state a reservation holds from the moment the
+ * send path claims its attempt until a terminal transition projects an outcome
+ * onto it, so it is exactly "accepted, not settled". `held` is excluded: a
+ * parked delivery is waiting on an account migration by design, and settling it
+ * here would fight the coordinator that owns it.
+ */
+export function unsettledSends(
+  file: RegistryFile,
+  options: { now?: number; windowMs?: number; inTurnCeilingMs?: number } = {},
+): UnsettledSend[] {
+  const now = options.now ?? Date.now();
+  const windowMs = options.windowMs ?? SEND_SETTLEMENT_WINDOW_MS;
+  const ceilingMs = options.inTurnCeilingMs ?? SEND_SETTLEMENT_IN_TURN_CEILING_MS;
+  const unsettled: UnsettledSend[] = [];
+  let lookup: ReturnType<typeof readOnlyConversationLookupFromSnapshot> | null = null;
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.state !== "delivery-uncertain") continue;
+    const acceptedAt = parseTime(acceptedAtOf(delivery));
+    if (acceptedAt === null) continue;
+    const unsettledForMs = now - acceptedAt;
+    if (unsettledForMs < windowMs) continue;
+    lookup ??= readOnlyConversationLookupFromSnapshot(file);
+    const awaitingTurn = activeTurnOf(file, lookup, delivery.conversationId) !== null;
+    if (awaitingTurn && unsettledForMs < ceilingMs) continue;
+    unsettled.push({
+      operationId: delivery.command.operationId,
+      deliveryId: delivery.id,
+      conversationId: delivery.conversationId,
+      clientMessageId: delivery.clientMessageId,
+      acceptedAt: acceptedAtOf(delivery),
+      unsettledForMs,
+      awaitingTurn,
+    });
+  }
+  return unsettled.sort((left, right) => right.unsettledForMs - left.unsettledForMs);
+}
+
+/**
+ * What became of one operation id, from the durable delivery record.
+ *
+ * The answer is read from `deliveryOperationOwners` first, which is the index
+ * that survives reservation compaction, and falls back to the reservation
+ * itself for records that predate an owner row. A caller that asks about an id
+ * nothing ever admitted gets `null` rather than an invented in-flight answer.
+ */
+export function sendReceiptFor(file: RegistryFile, operationId: string): SendReceipt | null {
+  const owner = file.deliveryOperationOwners[operationId];
+  const delivery = owner
+    ? file.heldDeliveries[owner.deliveryId]
+    : Object.values(file.heldDeliveries).find((candidate) => candidate.command.operationId === operationId);
+  if (!owner && !delivery) return null;
+  const conversationId = (delivery?.conversationId ?? owner?.conversationId) ?? null;
+  const clientMessageId = (delivery?.clientMessageId ?? owner?.clientMessageId) ?? null;
+  const acceptedAt = delivery ? acceptedAtOf(delivery) : owner?.createdAt ?? null;
+  /* The reservation wins when it is still present — it carries the reason and
+     the settlement time — and the owner row answers once it has been compacted
+     away. The two never disagree: the owner's terminal state is synchronized
+     from the reservation every time one settles. */
+  const terminalState = delivery && (delivery.state === "delivered" || delivery.state === "failed")
+    ? delivery.state
+    : owner?.terminalState ?? null;
+  if (terminalState === "delivered") {
+    return {
+      operationId,
+      conversationId,
+      clientMessageId,
+      state: "delivered",
+      reason: null,
+      acceptedAt,
+      settledAt: delivery?.deliveredAt ?? null,
+      duplicateRisk: false,
+      resend: "not-needed",
+      evidence: "delivery-journal",
+    };
+  }
+  if (terminalState === "failed") {
+    const reason = delivery?.error ?? null;
+    const duplicateRisk = reason === SEND_UNVERIFIED_REASON;
+    return {
+      operationId,
+      conversationId,
+      clientMessageId,
+      state: "failed",
+      reason,
+      acceptedAt,
+      settledAt: null,
+      duplicateRisk,
+      resend: duplicateRisk ? "verify-first" : "safe",
+      evidence: "delivery-journal",
+    };
+  }
+  return {
+    operationId,
+    conversationId,
+    clientMessageId,
+    state: "in-flight",
+    reason: delivery?.state === "held"
+      ? "held behind an account migration"
+      : "accepted for delivery and not settled yet",
+    acceptedAt,
+    settledAt: null,
+    duplicateRisk: false,
+    resend: null,
+    evidence: "delivery-journal",
+  };
+}
+
+/** The same read against the live registry. */
+export function sendReceipt(operationId: string, registry: AgentRegistry = agentRegistry()): SendReceipt | null {
+  return sendReceiptFor(registry.readOnlySnapshot(), operationId);
+}
+
+/**
+ * Terminalizes the journal operation, and answers whether the send can still
+ * reach the recipient afterwards.
+ *
+ * An unexecuted send is failed outright: that clears its outbox row in the same
+ * transaction and makes the later `delivering` transition illegal, so the send
+ * is fenced. A started one is terminalized as `uncertain`, which fences it just
+ * as firmly against a SECOND execution but says nothing about the first — which
+ * is the truth, and is what the receipt then reports.
+ */
+async function fenceOperation(
+  client: RuntimeHostClient,
+  operationId: string,
+  status: RuntimeReceiptStatus,
+): Promise<{ disposition: "lost" | "unverified"; duplicateRisk: boolean }> {
+  if (OPEN_RECEIPT_STATUSES.has(status)) {
+    await client.transitionOperation(operationId, "failed", { reason: SEND_LOST_REASON });
+    return { disposition: "lost", duplicateRisk: false };
+  }
+  /* `uncertain` is a newer transition than the rest of this channel; a runtime
+     host from before it rejects the word. The operation must still stop being
+     open either way, so the fallback keeps the fence and the receipt keeps the
+     unverified reason it is read back by. */
+  try {
+    await client.transitionOperation(operationId, "uncertain", { reason: SEND_UNVERIFIED_REASON });
+  } catch {
+    await client.transitionOperation(operationId, "failed", { reason: SEND_UNVERIFIED_REASON });
+  }
+  return { disposition: "unverified", duplicateRisk: true };
+}
+
+/**
+ * Settles one accepted send against the delivery journal.
+ *
+ * The journal is asked first and always wins: a send it already delivered is
+ * reconciled rather than failed, which is what keeps a merely-missed projection
+ * from being reported as a loss.
+ */
+async function settleOne(
+  send: UnsettledSend,
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+): Promise<SendSettlementOutcome> {
+  /* The CURRENT attempt, not the one the reservation was born with. A retried
+     operation leaves its ancestor terminal and carries on under a fresh id, so
+     reading the ancestor would report a live attempt as a settled loss — and
+     would then try to fence an operation that is already terminal. */
+  const current = await client.operationStatus(send.operationId, { currentRetryLeaf: true });
+  const operationId = current?.operationId ?? send.operationId;
+  const status = current?.receipt.status ?? null;
+  if (status !== null && DELIVERED_RECEIPT_STATUSES.has(status)) {
+    registry.recordDeliveryOutcome(send.deliveryId, "delivered");
+    return {
+      operationId: send.operationId,
+      deliveryId: send.deliveryId,
+      conversationId: send.conversationId,
+      state: "delivered",
+      disposition: "reconciled",
+      duplicateRisk: false,
+    };
+  }
+  if (status === "failed" || status === "rejected") {
+    registry.recordDeliveryOutcome(send.deliveryId, "failed", SEND_LOST_REASON);
+    return {
+      operationId: send.operationId,
+      deliveryId: send.deliveryId,
+      conversationId: send.conversationId,
+      state: "failed",
+      disposition: "reconciled",
+      duplicateRisk: false,
+    };
+  }
+  if (status === "uncertain") {
+    registry.recordDeliveryOutcome(send.deliveryId, "failed", SEND_UNVERIFIED_REASON);
+    return {
+      operationId: send.operationId,
+      deliveryId: send.deliveryId,
+      conversationId: send.conversationId,
+      state: "failed",
+      disposition: "reconciled",
+      duplicateRisk: true,
+    };
+  }
+  /* No journal record at all means the send never reached admission, so nothing
+     can execute it and there is nothing to fence — the same terminal answer as
+     a fenced one, reached without a transition. */
+  const fenced = status === null
+    ? { disposition: "lost" as const, duplicateRisk: false }
+    : await fenceOperation(client, operationId, status);
+  registry.recordDeliveryOutcome(
+    send.deliveryId,
+    "failed",
+    fenced.duplicateRisk ? SEND_UNVERIFIED_REASON : SEND_LOST_REASON,
+  );
+  return {
+    operationId: send.operationId,
+    deliveryId: send.deliveryId,
+    conversationId: send.conversationId,
+    state: "failed",
+    disposition: fenced.disposition,
+    duplicateRisk: fenced.duplicateRisk,
+  };
+}
+
+/**
+ * Journals the loss the moment it is declared.
+ *
+ * `delivery_expired` is the event a failed reservation already projects; what
+ * changes here is WHEN, and that is the whole difference between a loss the
+ * lifecycle digest carries and one that waits for a poll that may never come.
+ * A journal that cannot be written must not undo a settlement that already
+ * happened, so this reports and moves on.
+ */
+function journalSettledLosses(
+  registry: AgentRegistry,
+  deliveryIds: readonly string[],
+  journal: (deliveries: readonly HeldDelivery[]) => void,
+): void {
+  if (deliveryIds.length === 0) return;
+  const snapshot = registry.readOnlySnapshot();
+  const settled = deliveryIds
+    .map((id) => snapshot.heldDeliveries[id])
+    .filter((delivery): delivery is HeldDelivery => delivery?.state === "failed");
+  if (settled.length === 0) return;
+  try {
+    journal(settled);
+  } catch (error) {
+    console.error("[send settlement] journaling a settled loss failed", error instanceof Error ? error.message : "unknown");
+  }
+}
+
+/**
+ * One settlement pass.
+ *
+ * A send whose journal answer cannot be read is DEFERRED, never settled: an
+ * unreachable runtime host is a reason to know less, not a licence to declare a
+ * message lost while it may still be sitting in a live outbox.
+ */
+export async function settleUnsettledSends(ports: SendSettlementPorts = {}): Promise<SendSettlementReport> {
+  const registry = ports.registry ?? agentRegistry();
+  const client = ports.client === undefined ? runtimeHostClient() : ports.client;
+  const now = ports.now ?? Date.now;
+  const candidates = unsettledSends(registry.readOnlySnapshot(), {
+    now: now(),
+    ...(ports.windowMs !== undefined ? { windowMs: ports.windowMs } : {}),
+    ...(ports.inTurnCeilingMs !== undefined ? { inTurnCeilingMs: ports.inTurnCeilingMs } : {}),
+  });
+  const report: SendSettlementReport = { examined: candidates.length, settled: [], deferred: [] };
+  if (!client) {
+    for (const send of candidates) report.deferred.push({ operationId: send.operationId, reason: "runtime host is unavailable" });
+    return report;
+  }
+  for (const send of candidates.slice(0, ports.batchCeiling ?? SETTLEMENT_BATCH_CEILING)) {
+    try {
+      report.settled.push(await settleOne(send, registry, client));
+    } catch (error) {
+      report.deferred.push({
+        operationId: send.operationId,
+        reason: error instanceof Error ? error.message : "settlement failed",
+      });
+    }
+  }
+  journalSettledLosses(
+    registry,
+    report.settled.filter((outcome) => outcome.state === "failed").map((outcome) => outcome.deliveryId),
+    ports.journalLifecycle
+      ?? ((deliveries) => { appendLifecycleEvents(projectDeliveryEvents([...deliveries])); }),
+  );
+  return report;
+}
+
+const settlementHost = globalThis as typeof globalThis & {
+  __llvSendSettlementTimer?: ReturnType<typeof setInterval>;
+};
+
+/**
+ * Starts the sweep in the release that owns traffic.
+ *
+ * Idempotent per process, and unref'd so it never holds a Viewer open. The
+ * sweep is what makes terminality a property of the system rather than of
+ * whoever happens to ask; `message_receipt` reads the same record it writes.
+ */
+export function startSendSettlement(ports: {
+  scheduleInterval?: (callback: () => void, delayMs: number) => ReturnType<typeof setInterval>;
+  sweep?: () => Promise<unknown>;
+  intervalMs?: number;
+} = {}): void {
+  if (settlementHost.__llvSendSettlementTimer) return;
+  const schedule = ports.scheduleInterval ?? ((callback, delayMs) => setInterval(callback, delayMs));
+  const sweep = ports.sweep ?? (() => settleUnsettledSends());
+  const timer = schedule(() => {
+    void sweep().catch((error) => {
+      console.error("[send settlement] sweep failed", error instanceof Error ? error.message : "unknown");
+    });
+  }, ports.intervalMs ?? SEND_SETTLEMENT_INTERVAL_MS);
+  timer.unref?.();
+  settlementHost.__llvSendSettlementTimer = timer;
+}
+
+/** Test seam: the timer is process-global, so a suite must be able to start
+    from an unstarted one without reaching into module internals. */
+export function stopSendSettlement(): void {
+  const timer = settlementHost.__llvSendSettlementTimer;
+  if (timer) clearInterval(timer);
+  settlementHost.__llvSendSettlementTimer = undefined;
+}

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -89,6 +89,8 @@ interface CurrentReleaseControllerLoaders {
   /** Optional for the same reason. */
   loadStructuredHostRetirement?: () => Promise<{ startStructuredHostRetirement: () => void }>;
   /** Optional for the same reason. */
+  loadSendSettlement?: () => Promise<{ startSendSettlement: () => void }>;
+  /** Optional for the same reason. */
   loadSeatTick?: () => Promise<{ startSeatTick: () => boolean }>;
 }
 
@@ -335,6 +337,7 @@ export async function startCurrentReleaseControllers(
     loadTelegramReportScheduler: () => import("@/lib/telegram/reportRunner"),
     loadTelegramConnectorBoot: () => import("@/lib/telegram/connectorBoot"),
     loadStructuredHostRetirement: () => import("@/lib/runtime/structuredHostRetirement"),
+    loadSendSettlement: () => import("@/lib/runtime/sendSettlement"),
     loadSeatTick: () => import("@/lib/monitor/seatTickController"),
   },
 ): Promise<void> {
@@ -379,6 +382,19 @@ export async function startCurrentReleaseControllers(
     retirement?.startStructuredHostRetirement();
   } catch (error) {
     console.error("[host retirement] sweep start failed", error instanceof Error ? error.name : "unknown");
+  }
+  /* Send settlement (#1131). An accepted send that the delivery queue never
+     executed used to rest at `queued` forever, with nothing anywhere turning
+     that into an answer; this sweep is what makes every accepted send reach
+     `delivered` or `failed`. It belongs to the release that owns traffic for
+     the reason retirement does — it fences operations in the runtime journal
+     that the delivery queue of THIS process would otherwise still execute — and
+     it must not take the controllers below down if it fails to start. */
+  try {
+    const settlement = await loaders.loadSendSettlement?.();
+    settlement?.startSendSettlement();
+  } catch (error) {
+    console.error("[send settlement] sweep start failed", error instanceof Error ? error.name : "unknown");
   }
   /* The seat tick (#1245). It belongs here for the reason every controller
      above does — one clock, in the release that owns traffic. Starting here


### PR DESCRIPTION
Closes #1131

## The failure

`send_message` answers `queued` the moment the runtime host admits the operation, and until now that could be the last thing anyone ever said about it. A delivery the drain never executed rested there forever: the reservation stayed `delivery-uncertain`, the receipt stayed non-terminal, and nothing anywhere turned that into an answer. A deployer holding a paused cutover sat idle for forty minutes on exactly this, and the only thing that noticed was the sender's own suspicion.

## What changed

**Every accepted send settles.** `src/lib/runtime/sendSettlement.ts` sweeps the reservations that have not reached a terminal state, asks the delivery journal what became of each, and ends it as `delivered` or `failed`. A send the journal already delivered is reconciled rather than reported lost; an unexecuted one is declared lost. The sweep runs in the release that owns traffic, beside host retirement, because it fences operations that this process's own delivery queue would otherwise still execute.

A send queued behind the recipient's active turn is progressing, not lost, so it is exempt from the settlement window — with a ceiling, so a host wedged mid-turn cannot make `queued` permanent again. A send whose journal answer cannot be read is deferred, never settled: an unreachable runtime host is a reason to know less, not a licence to declare a message lost while it may still be sitting in a live outbox.

**A receipt is queryable.** A new `message_receipt` tool answers what became of one operation id — `delivered`, `failed` or `in-flight` — read from the durable delivery record rather than from what the send call guessed at the time. It also says what is safe to do next: `not-needed`, `safe`, or `verify-first` when `duplicateRisk` is set — and that a resend is a NEW `send_message` under a NEW `clientRequestId`, because the settled operation still owns the old key and repeating it replays the settled answer instead of delivering. `send_message` and `send_message_to_orchestrator` now report `settled` on their own answers, so acceptance is not mistaken for arrival, and both tool descriptions say so.

**A loss is visible without a watchdog.** The settlement journals the `delivery_expired` lifecycle event as it declares the loss, rather than leaving it for whichever poll happens next — so it is in the lifecycle digest, which orchestrators already read, and on the recipient's card as a failed send. No new surface, nothing for the sender to watch.

## Why this cannot deliver the same instruction twice

Declaring a send failed is only honest if the send can no longer happen, so the settlement terminalizes the **operation in the runtime journal first**, and writes `failed` on the reservation only once that succeeded. Two properties of the journal make that a real fence:

- terminalizing an operation marks its outbox row completed inside the same `BEGIN IMMEDIATE` transaction, so the effect is gone from every later effect batch; and
- the delivery queue must move an effect to `delivering` **before** it calls `host.send`, and the journal refuses that transition out of a terminal state — so an executor that had already batched the effect is stopped at the transition rather than at the send.

A send the executor already took (`delivering`) may have reached the recipient, and nothing here can prove it did not, so it is terminalized as `uncertain` and the receipt says the fate is unknown and a resend may duplicate. **Nothing is retried automatically** — a resend is the caller's decision, made against a receipt that states whether it is safe. Nothing widens a timeout: the settlement deadline is a deadline for producing an answer, not a wait anything sits in.

A retried send is judged by its current attempt, not by the ancestor it replaced: reading the ancestor would report a delivered message as a loss and would then try to fence an operation that is already terminal.

## Verification

All fixture-built; nothing was sent into a real conversation, and every suite ran by path under an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`.

- `bunx tsc --noEmit --incremental false` — clean.
- `src/lib/runtime/sendSettlement.test.ts` — 10 pass. Real `AgentRegistry` and real `RuntimeJournal` per fixture: a delivered send reconciles; a dropped send settles failed and the real `StructuredDeliveryQueue` then delivers nothing (with a control test proving the same port, queue and host **do** deliver an unfenced send, so the empty recipient is the fence's doing and not the harness's); an uncertain first attempt settles failed and refuses to call a resend safe; a retried send is judged by its leaf; an in-turn send waits and stops being exempt at the ceiling; an unreadable journal defers; the loss is journaled as it is declared. The caller's own replay of a settled loss is answered with the settlement rather than a second delivery — admission replays the terminal receipt, no effect is admitted, and the queue delivers nothing; a scratch control run confirmed each of those three assertions turns on the settlement (without it the replay is `queued`, the effect batch holds the send, and the queue delivers the text).
- `src/lib/mcp/bindings.test.ts` — 47 pass, including `settled: false` on an accepted send, `message_receipt` answering in-flight then failed, and a refusal for an id nothing admitted.
- `src/lib/mcp/server.test.ts` 33 pass · `schemaParity.test.ts` 18 pass · `presentation.test.ts` 3 pass · `src/instrumentation.test.ts` 40 pass.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS.

Pre-existing and not from this branch: `src/lib/delivery.test.ts` fails 2 ("title is required for every new spawn") — 34 pass / 2 fail on this branch and the identical 34/2 at the merge base in a throwaway worktree. `bunx eslint` cannot run in this checkout at all — `eslint-plugin-react` throws loading `react/display-name` under the installed ESLint — which is also unrelated to this change.

Nothing was deployed, promoted, restarted, or rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

