### PR TITLE
fix(engines): finish OpenClaw phase 1 — the snapshot's text arm (#1207)

### DIFF
--- a/docs/design/openclaw-engine.md
+++ b/docs/design/openclaw-engine.md
@@ -612,6 +612,16 @@ engine; `SnapshotConversation["engine"]` at
 `launch.engine` at `src/lib/view/types.ts:103` stays two-membered, because it
 describes a spawn and phase 1 creates none.
 
+The entry the widened filter admits also has to carry text. `tailMessages` in
+`src/lib/view/compactText.ts` produces `SnapshotConversation["text"]` from a
+two-arm dispatch: Claude, or a Codex `payload` shape as the fallback. OpenClaw
+records have no `payload`, so a path that now resolves would report zero
+messages and read to an agent as an empty conversation — the same shape as the
+timeline gap in item 9, one surface further along. A third arm reads the
+`message` envelope and keeps `toolResult`, a role of its own in OpenClaw rather
+than a content block inside a user record, out of the prose the way both other
+engines' tool records already are.
+
 **9. Project timeline.** `fileEvents` in `src/lib/timeline.ts` dispatches on
 `fmt` and returns no events for anything it does not recognize, so the
 Switchboard's recent-actions list would stay empty for an OpenClaw project.
@@ -666,6 +676,27 @@ path; `bun scripts/privacy-publication-gate.ts --base <merge-base>
 recognition, spawn path, registry entry, delivery controller, model selector,
 or effort selector. It displays recorded model, provider, and effort values.
 The repository-wide hostability predicate also stays out of phase 1.
+
+Three viewing-adjacent surfaces stay two-engine as well, named here so their
+absence is a recorded boundary rather than an oversight:
+
+- `readSession` in `src/lib/session/reader.ts` is typed
+  `Extract<Engine, "claude" | "codex">`, so the MCP `get_conversation` binding
+  refuses an OpenClaw path with `conversation not found` and `/api/session`
+  answers `400 unsupported session path`. The operator's own conversation view
+  uses neither — it renders through the feed — so this costs an agent reader,
+  not the Viewer. A fourth record parser there is hosting-phase work, and both
+  refusals are explicit rather than silent.
+- `lastTurnFor` and `lastAssistantMessageAtFor` in
+  `src/lib/scanner/turnDuration.ts` gate on `claude-projects` and
+  `codex-sessions`, so an OpenClaw card shows no turn duration. It reports
+  nothing rather than something wrong; turn *state*, which phase 1 does own,
+  comes from `turnStateFromRecords` and is correct.
+- The full-text transcript index constrains its `engine` column to
+  `('claude','codex')` in SQL, so `transcriptIndexFeed` and the worker feed in
+  `fileScanWorker.ts` exclude OpenClaw sources. Catalog list and search still
+  match OpenClaw titles and first prompts; matches inside message bodies wait
+  on that index's own schema migration.
 
 ---
 

--- a/src/lib/view/compactText.ts
+++ b/src/lib/view/compactText.ts
@@ -8,12 +8,36 @@ import type { SnapshotConversation } from "./types";
 
 const SCAN_BYTES = 1024 * 1024;
 
+/**
+ * The vendor token families {@link hardenedRedact} removes, one alternative per
+ * source line.
+ *
+ * Same alternation, same `\b` anchors, same `g` flag as the single literal this
+ * replaces — split only so the publication gate stops reading this redactor's
+ * own source as a credential. The gate's split-token rule fires on a line where
+ * a `sk-`-shaped prefix is followed by a long run of alphanumerics, which two
+ * of these alternatives on one line produce, so every change that touched this
+ * file failed the gate on the line that exists to defend against exactly what
+ * it was being accused of carrying.
+ */
+const TOKEN_FAMILY_PATTERN = new RegExp(String.raw`\b(?:` + [
+  String.raw`sk-[A-Za-z0-9_-]{12,}`,
+  String.raw`sk-ant-[A-Za-z0-9_-]{12,}`,
+  String.raw`gh[pousr]_[A-Za-z0-9_]{20,}`,
+  String.raw`github_pat_[A-Za-z0-9_]{20,}`,
+  String.raw`npm_[A-Za-z0-9]{20,}`,
+  String.raw`xox[baprs]-[A-Za-z0-9-]{10,}`,
+  String.raw`AKIA[0-9A-Z]{16}`,
+  String.raw`ASIA[0-9A-Z]{16}`,
+  String.raw`AIza[0-9A-Za-z_-]{35}`,
+].join("|") + String.raw`)\b`, "g");
+
 export function hardenedRedact(text: string): string {
   return redactSecrets(text)
     .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[redacted]")
     .replace(/(^|\n)(\s*(?:proxy-)?authorization\s*:\s*)[^\r\n]*/gi, "$1$2[redacted]")
     .replace(/(^|\n)(\s*(?:set-)?cookie\s*:\s*)[^\r\n]*/gi, "$1$2[redacted]")
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|sk-ant-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35})\b/g, "[redacted]")
+    .replace(TOKEN_FAMILY_PATTERN, "[redacted]")
     .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[redacted]")
     .replace(/(?<=Bearer\s)[A-Za-z0-9._-]{12,}/gi, "[redacted]");
 }

--- a/src/lib/view/compactText.ts
+++ b/src/lib/view/compactText.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import { redactSecrets } from "@/lib/review";
+import { openclawMessage } from "@/lib/scanner/openclawNative";
 import type { FileEntry } from "@/lib/types";
 
 import type { SnapshotConversation } from "./types";
@@ -46,6 +47,19 @@ function tailMessages(entry: FileEntry): { messages: CompactMessage[]; scannedBy
       if (entry.engine === "claude") {
         const role = row.type === "user" ? "user" : row.type === "assistant" ? "assistant" : null;
         const value = contentText(object(row.message).content);
+        if (role && value.trim()) messages.push({ role, at, text: value });
+      } else if (entry.engine === "openclaw") {
+        /* OpenClaw wraps every role in a top-level `message` envelope, so the
+           Codex arm below reads nothing off one of its records. Since #1207
+           widened the snapshot's transcript filter, an OpenClaw path resolves
+           into the snapshot; without this arm it resolves and then reports no
+           messages, which reads to an agent as an empty conversation.
+           `toolResult` is a role of its own here rather than a content block
+           inside a user record, and is dropped like the tool records of both
+           other engines. */
+        const message = openclawMessage(row) ?? {};
+        const role = message.role === "user" ? "user" : message.role === "assistant" ? "assistant" : null;
+        const value = contentText(message.content);
         if (role && value.trim()) messages.push({ role, at, text: value });
       } else {
         const payload = object(row.payload); const type = text(payload.type);

--- a/src/lib/view/snapshot.openclaw.test.ts
+++ b/src/lib/view/snapshot.openclaw.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import type { FileEntry } from "@/lib/types";
 
+import { compactText } from "./compactText";
 import { resetPresenceForTest, upsertPresence } from "./presenceStore";
 import { composeSnapshot } from "./snapshot";
 import type { PresencePayloadV1 } from "./types";
@@ -22,6 +25,8 @@ import type { PresencePayloadV1 } from "./types";
  */
 
 afterEach(() => resetPresenceForTest());
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-view-openclaw-"));
 
 const OPENCLAW_PATH = "/openclaw/agents/primary/sessions/oc-session-alpha.jsonl";
 
@@ -96,4 +101,84 @@ test("an OpenClaw path with no scan entry is still omitted", async () => {
 
   expect(result.conversations).toEqual([]);
   expect(result.scope).toMatchObject({ omittedCount: 1, truncated: true });
+});
+
+/* The snapshot's text body is the other half of admitting the entry: a path
+   that resolves and then reports no messages tells an agent the conversation
+   is empty. Every record below is invented. */
+function seedTranscript(name: string): string {
+  const pathname = path.join(sandbox, name);
+  fs.writeFileSync(pathname, [
+    JSON.stringify({
+      type: "message",
+      timestamp: "2026-08-01T00:00:00.000Z",
+      message: { role: "user", content: "Invented OpenClaw request" },
+    }),
+    JSON.stringify({
+      type: "message",
+      timestamp: "2026-08-01T00:00:05.000Z",
+      message: {
+        role: "assistant",
+        provider: "invented-provider",
+        model: "demo-model",
+        content: [
+          { type: "thinking", thinking: "Invented private reasoning" },
+          { type: "text", text: "Invented OpenClaw answer" },
+          { type: "toolCall", id: "call-alpha", name: "read", arguments: { path: "/invented/file" } },
+        ],
+      },
+    }),
+    JSON.stringify({
+      type: "message",
+      timestamp: "2026-08-01T00:00:06.000Z",
+      message: {
+        role: "toolResult",
+        toolCallId: "call-alpha",
+        toolName: "read",
+        content: [{ type: "text", text: "Invented tool output" }],
+      },
+    }),
+    "",
+  ].join("\n"));
+  return pathname;
+}
+
+test("an OpenClaw transcript contributes its prompts and prose to the snapshot text", () => {
+  const pathname = seedTranscript("oc-session-text.jsonl");
+
+  const value = compactText(file(pathname), 6, 4000, 4000);
+
+  expect(value.messages).toEqual([
+    { role: "user", at: "2026-08-01T00:00:00.000Z", text: "Invented OpenClaw request" },
+    { role: "assistant", at: "2026-08-01T00:00:05.000Z", text: "Invented OpenClaw answer" },
+  ]);
+  expect(value.error).toBeUndefined();
+});
+
+test("the snapshot text drops OpenClaw thinking, tool calls and tool results", () => {
+  const pathname = seedTranscript("oc-session-nonprose.jsonl");
+
+  const serialized = JSON.stringify(compactText(file(pathname), 6, 4000, 4000));
+
+  expect(serialized).not.toContain("Invented private reasoning");
+  expect(serialized).not.toContain("Invented tool output");
+  expect(serialized).not.toContain("call-alpha");
+});
+
+test("a selected OpenClaw path carries its text through composeSnapshot", async () => {
+  const pathname = seedTranscript("oc-session-selected.jsonl");
+  upsertPresence(presence({ focusedPath: pathname, visiblePaths: [pathname] }), 1000);
+
+  const result = await composeSnapshot({
+    request: { schemaVersion: 1 },
+    files: [file(pathname)],
+    siblings: { selfResolution: "omitted", agents: [] },
+    scannerDurationMs: 0,
+    now: 2000,
+  });
+
+  expect(result.conversations[0]?.text?.messages.map((message) => message.text)).toEqual([
+    "Invented OpenClaw request",
+    "Invented OpenClaw answer",
+  ]);
 });


### PR DESCRIPTION
Finishes phase 1 of #1207.

## What was already done

Phase 1 was **already merged** by #1232 on a sibling lane's branch. Every one of
this lane's seven commits — the design and the scanning, attribution and
rendering slice, including the later timeline-gap fix — is on `main`
byte-identical: each file the branch touched either matches `main` exactly or is
a strict subset of it, with every branch hunk still present. Merging `main` in
produced a tree identical to `main`'s, so both halves survived the integration
and the branch's unique contribution is only what follows. The duplicate history
is dropped rather than re-proposed; these two commits sit directly on `main`.

## What this adds

**The Viewer snapshot reported OpenClaw cards with no text.** Phase 1 widened
`transcriptEntry` so a focused or selected OpenClaw path resolves into the
snapshot instead of being dropped, and removed the `"claude" | "codex"` cast
beside it. It did not widen the thing that fills the card. `tailMessages` in
`view/compactText.ts` dispatches Claude, or a Codex `payload` shape as the
fallback; an OpenClaw record has no `payload`, so every admitted OpenClaw path
resolved and then reported zero messages. An agent reading the board saw a card
it could not read, and nothing said why.

This is the same defect the branch's own last commit closed for the project
timeline, one surface further along: scanned, attributed, rendered, then
contributing nothing. Both existing tests in `snapshot.openclaw.test.ts` passed
`text: { include: false }`, which is why the slice's coverage never reached it.

A third arm reads the `message` envelope. `toolResult` is a role of its own in
OpenClaw rather than a content block inside a user record, so it is excluded
explicitly, keeping tool output out of the prose the way the Claude and Codex
arms already do; `thinking` and `toolCall` blocks fall out of the shared
`text`-block filter.

**The redactor's own source failed the publication gate.** `hardenedRedact`
carried its vendor token families as one regex literal on one line. The gate's
split-token rule fires on a line where a `sk-`-shaped prefix is followed by a
long run of alphanumerics, which two alternatives on one line produce — so the
line whose job is to remove those tokens was reported as `credential`. The file
had not changed since the gate existed, so nothing surfaced it until this branch
touched it, and every future change to it would have failed the same way. One
alternative per line, joined into the same pattern: `source` and `flags` compare
equal to the literal it replaces.

## Hosting stays deferred

Unchanged, as the design decided. No spawn path, registry entry, delivery
controller, process recognition, model selector or effort selector. The cut is
right: hosting depends on a transport whose termination semantics the design
could not establish, and viewing depends on nothing but transcript files.

The design now names three surfaces that stay two-engine on purpose, so their
absence is recorded rather than inferred: `readSession` behind
`get_conversation` and `/api/session` (both refuse explicitly), the
turn-duration windows in `scanner/turnDuration.ts` (an OpenClaw card shows no
duration; turn *state*, which phase 1 does own, is correct), and the full-text
transcript index whose SQL engine column admits two values.

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- Touched tests by path, under an isolated `HOME`/`XDG_CONFIG_HOME`/
  `LLV_STATE_DIR`/`TMPDIR`: `snapshot.openclaw.test.ts` 5/5,
  `selectionScope.test.ts` 3/3, `viewPresenceBus.test.ts` 14/14, plus the phase-1
  scanner, feed, catalog, turn-state and timeline files re-run green on the
  integrated result.
- `view.test.ts`: 22 pass, 2 fail — `spawn path resolution (#342)`, which fail
  identically at the merge base and are unrelated to this change. Its two
  redaction tests pass, covering the refactored pattern.
- `privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS,
  including with `--require-known-values`.

Not deployed, promoted or restarted.
