### PR TITLE
feat(platform): native Windows — process backend, paths, termination and CLI, proven by a windows-latest job (#1201)

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1,0 +1,148 @@
+name: Platform tests
+
+# Nobody working on this repository has a Windows machine, so every claim about
+# Windows behaviour has to be something CI can refuse. This workflow is that
+# refusal. It follows the precedent set by `macos-identity.yml`, which exists
+# for the same reason on the macOS side: a job that fails when the behaviour
+# does not hold, not a paragraph saying it was tried.
+#
+# Two legs run the same explicit list of files. The Ubuntu leg is what makes
+# "Linux is unchanged" a witnessed claim rather than an assertion — no other
+# workflow here runs the suite at all. The Windows leg is the only place the
+# Windows process backend, the named-pipe endpoint, the LockFileEx fence and
+# the tree-kill termination ever execute.
+#
+# Files are named one by one. A directory sweep is forbidden by AGENTS.md
+# because sweeping `src/lib/agent/` or `src/app/api/runtime/` drives host
+# lifecycle code against whatever registry the runtime resolves; on a runner
+# that state is empty, but the rule is the rule and the list is also what keeps
+# these jobs short.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux-platform:
+    name: Linux (unchanged)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prepare an isolated state, config and temp root
+        shell: bash
+        run: mkdir -p "${RUNNER_TEMP}/llv-home" "${RUNNER_TEMP}/llv-config" "${RUNNER_TEMP}/llv-state" "${RUNNER_TEMP}/llv-tmp"
+
+      - name: Require the live backend this platform selects
+        env:
+          HOME: ${{ runner.temp }}/llv-home
+          XDG_CONFIG_HOME: ${{ runner.temp }}/llv-config
+          LLV_STATE_DIR: ${{ runner.temp }}/llv-state
+          TMPDIR: ${{ runner.temp }}/llv-tmp
+        run: bun scripts/verify-platform-backend.ts --expect linux
+
+      - name: Platform tests
+        env:
+          HOME: ${{ runner.temp }}/llv-home
+          XDG_CONFIG_HOME: ${{ runner.temp }}/llv-config
+          LLV_STATE_DIR: ${{ runner.temp }}/llv-state
+          TMPDIR: ${{ runner.temp }}/llv-tmp
+        run: >
+          bun test
+          src/lib/proc/memory.test.ts
+          src/lib/proc/portable.test.ts
+          src/lib/proc/darwinIdentity.test.ts
+          src/lib/proc/index.test.ts
+          src/lib/proc/windowsSnapshot.test.ts
+          src/lib/proc/windowsIdentity.test.ts
+          src/lib/proc/windowsCwd.test.ts
+          src/lib/proc/windows.test.ts
+          src/lib/processGroup.test.ts
+          src/lib/platformHome.test.ts
+          src/lib/runtime/localEndpoint.test.ts
+          src/lib/scanner/describe.test.ts
+          src/runtime-host/socket.test.ts
+          src/runtime-host/runtimeHostFence.test.ts
+          bin/server-runtime.test.ts
+
+  windows-platform:
+    name: Windows (native)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Refuse to install where the package says it cannot run
+        # The originating report: `"os": ["linux", "darwin"]` makes an install on
+        # Windows fail with EBADPLATFORM before anything else can be tried. This
+        # reads the field the resolver reads.
+        run: |
+          $manifest = Get-Content package.json -Raw | ConvertFrom-Json
+          if ($manifest.os -notcontains 'win32') { throw "package.json still refuses win32: $($manifest.os -join ', ')" }
+          Write-Output "package os field: $($manifest.os -join ', ')"
+
+      - name: Prepare an isolated profile, state and temp root
+        run: |
+          foreach ($leaf in @('llv-home', 'llv-config', 'llv-state', 'llv-tmp')) {
+            New-Item -ItemType Directory -Force -Path (Join-Path $env:RUNNER_TEMP $leaf) | Out-Null
+          }
+
+      # The Windows-only cases below skip themselves off win32, and a silent skip
+      # would leave this job green having executed nothing. This step fails
+      # instead when the runner is not Windows, when the backend selection is
+      # wrong, or when any kernel reader the backend depends on returns nothing.
+      - name: Require the live Windows kernel readers on this runner
+        env:
+          USERPROFILE: ${{ runner.temp }}\llv-home
+          XDG_CONFIG_HOME: ${{ runner.temp }}\llv-config
+          LLV_STATE_DIR: ${{ runner.temp }}\llv-state
+          TMP: ${{ runner.temp }}\llv-tmp
+          TEMP: ${{ runner.temp }}\llv-tmp
+        run: bun scripts/verify-platform-backend.ts --expect win32
+
+      - name: Platform tests
+        env:
+          USERPROFILE: ${{ runner.temp }}\llv-home
+          XDG_CONFIG_HOME: ${{ runner.temp }}\llv-config
+          LLV_STATE_DIR: ${{ runner.temp }}\llv-state
+          TMP: ${{ runner.temp }}\llv-tmp
+          TEMP: ${{ runner.temp }}\llv-tmp
+        run: >
+          bun test
+          src/lib/proc/memory.test.ts
+          src/lib/proc/portable.test.ts
+          src/lib/proc/darwinIdentity.test.ts
+          src/lib/proc/index.test.ts
+          src/lib/proc/windowsSnapshot.test.ts
+          src/lib/proc/windowsIdentity.test.ts
+          src/lib/proc/windowsCwd.test.ts
+          src/lib/proc/windows.test.ts
+          src/lib/processGroup.test.ts
+          src/lib/platformHome.test.ts
+          src/lib/runtime/localEndpoint.test.ts
+          src/lib/scanner/describe.test.ts
+          src/runtime-host/socket.test.ts
+          src/runtime-host/runtimeHostFence.test.ts
+          bin/server-runtime.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ guarantees for the 1.x series.
 ## [Unreleased]
 
 ### Added
+- The Viewer installs and runs on native Windows, with the process backend,
+  paths, termination and CLI that requires (#1201, phase 1 of the merged
+  `docs/design/windows-support.md`). The `os` field no longer refuses a Windows
+  install. Process discovery gets a third backend beside `/proc` and
+  `ps`/`lsof`: one `Get-CimInstance Win32_Process` snapshot per five seconds for
+  pids, lineage, command lines and working set, and two values read from the
+  kernel through FFI — the process creation time, which is the identity token,
+  and each agent's working directory, read out of its own process parameters
+  because Windows has no other route to it and a process with no known working
+  directory is not shown at all. Identity is what pid reuse makes load-bearing
+  here, and Windows reuses a pid within seconds, so it comes from
+  `GetProcessTimes` rather than from anything that merely differs between two
+  processes. Termination replaces the process-group signal with a walk of the
+  parent tree, descendants first, each member's identity re-checked immediately
+  before it is killed; a parent link whose parent started after its own child is
+  dropped as the stale link it is. The runtime host listens on a named pipe
+  instead of a Unix socket, and its singleton fence keeps its file and its
+  kernel-released lock by way of `LockFileEx`. `HOME` is ignored on Windows,
+  where it is not a Windows variable and a Git Bash value resolves to nothing.
+  The CLI opens a browser through `rundll32` with no shell in the way.
+
+  Nobody working on this repository has a Windows machine, so none of the above
+  is a claim: a new `platform-tests.yml` runs the process backend, the endpoint,
+  the fence, the tree kill, the path handling and the launcher on
+  `windows-latest`, refuses a runner that is not Windows, and fails when any
+  kernel reader returns nothing — the same shape as the `macos-identity` job
+  that exists because nobody here has a Mac. Its Ubuntu leg runs the identical
+  file list, which is what makes "Linux is unchanged" witnessed rather than
+  asserted. What Windows does not get in this phase is written down in the
+  README, including the two grouping recognisers that stop resolving a
+  repository there and what they resolve to instead. The job earned its keep
+  immediately: it caught the fence refusing to create its own file on a fresh
+  machine, a process identity that outlived the process it named, and a CLI that
+  could not find its own server from a checkout.
 - The Viewer ticks the orchestrator seat, so a rotation stops dropping the
   monitor (#1245). The monitor that had been driving orchestrator sessions was
   never a feature: it was a schedule an agent armed inside its own session, so

--- a/README.md
+++ b/README.md
@@ -311,19 +311,69 @@ agent-log-viewer [options]
 
 Linux is the native target: process discovery reads `/proc` directly. macOS is
 supported through a portable backend that shells out to `ps` and `lsof`
-instead — same live-process detection, tmux composer targeting, agent
-spawn/kill and background-task discovery, just a bit more subprocess overhead
-per scan. The backend is chosen automatically by `process.platform` (see
-`src/lib/proc/`); `VIEWER_PROC_BACKEND=portable` forces the portable path on
-Linux too, for testing.
+instead — same live-process detection, composer targeting, agent spawn/kill and
+background-task discovery, just a bit more subprocess overhead per scan.
+Windows has its own backend: one `Get-CimInstance Win32_Process` snapshot per
+five seconds for pids, lineage, command lines and memory, plus two values read
+from the kernel — the process creation time that makes up the identity token,
+and each agent's working directory. The backend is chosen automatically by
+`process.platform` (see `src/lib/proc/`); `VIEWER_PROC_BACKEND` forces one of
+`linux`, `portable` or `windows`, for testing.
 
-The package supports Linux and macOS. The package's `os` field blocks Windows
-installs with `EBADPLATFORM`. WSL works as Linux.
+### Windows
+
+The package installs on Windows. Install Claude Code with its **native
+installer**, or put a `claude.exe` on `PATH`: an npm-only install exposes
+`claude.cmd`, and a shim is not something the Viewer will run without a shell.
+State lives under `%USERPROFILE%\.config\agent-log-viewer`, transcripts under
+`%USERPROFILE%\.claude\projects`. Run the Viewer where the agents run — a
+Claude installed inside WSL writes into the WSL filesystem, and a native Viewer
+does not see those transcripts (or the reverse).
+
+These stay WSL routes on Windows, and WSL still works exactly as Linux:
+
+- **Codex** — hosting, review flows, and everything Codex-side. Upstream calls
+  native Windows experimental and recommends WSL 2.
+- **The Telegram connector** and **local dictation** (cloud dictation backends
+  are unaffected).
+- **Workflow setup commands**, which are `sh -c`.
+- **Docker deployments and staging**, which are Linux by nature.
+- **The MCP server** for orchestrator agents, and **`--tailscale`**.
+
+These work natively but narrower than on Linux:
+
+- **No open-handle scan.** A transcript reads as live from mtime recency, and
+  its owning process from the `--session-id` in its argv or from its working
+  directory — never from a live writer holding the file open. Background-task
+  `.output` files cannot be mapped back to a pid.
+- **Termination is immediate.** Windows has no signals; every stop is
+  `TerminateProcess` after the child's stdin is closed, and the "force" step in
+  the task header is a second immediate kill. A host's process tree is walked
+  and killed descendants-first, each member's identity checked, in place of the
+  process-group signal Linux sends.
+- **A process the Viewer cannot open stays invisible.** Reading an agent's
+  working directory needs a handle on it, so an elevated console's `claude`, or
+  one running as another user, is not listed.
+- **Memory shows the working set only**, with no swap figure.
+- **Managed (multi) Claude accounts, the in-app login supervisor and composer
+  image attachments** are not available; log in from a terminal with `claude`,
+  and use the Main account.
+- **Claude background tasks and scratchpad sessions** have no project. The
+  background-task root depends on a Windows directory layout nobody has
+  observed, so it is simply absent. A scratchpad session is still recognised as
+  one, but the walk that turns the encoded path in its container back into a
+  repository starts at the filesystem root and a Windows path starts at a drive
+  letter, so no repository is found and the session lands in "Unresolved
+  project" along with every other one. Sessions started from an ordinary
+  directory are unaffected — they group by that directory.
+- **A session whose recorded path differs from a root only by drive-letter
+  case** forms its own project.
 
 `tmux` is optional. Without it, log viewing, the parentage tree, live activity
 and deep links all work; the composer, agent spawn/kill and resume-into-pane
 features need tmux (`brew install tmux` on macOS, or your distro's package on
-Linux).
+Linux). The structured transport the CLI pins needs no tmux at all, which is
+why none of it is required on Windows.
 
 ## Language
 
@@ -412,7 +462,7 @@ All optional. Transcription variables are documented in full in
 
 | Variable | Effect |
 | --- | --- |
-| `VIEWER_PROC_BACKEND` | `portable` or `linux` — force the process-discovery backend (auto-selected by default). |
+| `VIEWER_PROC_BACKEND` | `portable`, `linux` or `windows` — force the process-discovery backend (auto-selected by default). |
 | `LLV_LANG` | `uk` or `en` — force the CLI message language. |
 | `LLV_TRANSCRIBE_BACKEND` | `local`, `chatgpt`, or `elevenlabs` — pick the dictation backend (default `local`). |
 | `LLV_WHISPER_MODEL` | faster-whisper model size (default `small`). |

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 
 import { detectTailscale, getToken, readStatus, serve as serveTailscale, TailscaleError } from "./tailscale.mjs";
 import {
+  browserOpenCommand,
   cliRuntimeHostConfig,
   cliRuntimeHostEnvironment,
   discardWakatimeEnvironmentCredential,
@@ -264,8 +265,16 @@ function resolveServer(packageRoot) {
     };
   }
 
-  const nextBin = join(packageRoot, "node_modules", ".bin", "next");
-  if (!existsSync(nextBin)) {
+  /* `node_modules/.bin/next` is a shell shim, and on Windows the installer
+     writes `next.cmd` / `next.ps1` / `next.exe` instead of an extension-less
+     file — so this probe found nothing there and a checkout could not start at
+     all. Next's own entry point is an ordinary JavaScript file on every
+     platform, and it is what the Bun runtime below actually runs. */
+  const nextBin = [
+    join(packageRoot, "node_modules", ".bin", "next"),
+    join(packageRoot, "node_modules", "next", "dist", "bin", "next"),
+  ].find((candidate) => existsSync(candidate));
+  if (!nextBin) {
     fail(m.noServer());
   }
 
@@ -411,9 +420,9 @@ function probeRuntimeHost(socketPath) {
   });
 }
 
-function runtimeHostFenceOwner(socketPath) {
+function runtimeHostFenceOwner(fencePath) {
   try {
-    const owner = JSON.parse(readFileSync(`${socketPath}.lock`, "utf8"));
+    const owner = JSON.parse(readFileSync(fencePath, "utf8"));
     if (!Number.isSafeInteger(owner?.pid) || owner.pid <= 1) return null;
     if (typeof owner.startIdentity !== "string" || !owner.startIdentity.startsWith(`${owner.pid}:`)) return null;
     if (typeof owner.acquisitionId !== "string" || owner.acquisitionId.length < 16) return null;
@@ -440,7 +449,9 @@ function runtimeHostExitDetail(processHandle) {
   return stderr ? `${outcome}: ${stderr}` : outcome;
 }
 
-async function waitForRuntimeHost(socketPath, processHandle = null) {
+/* The fence is a separate name from the endpoint because a Windows endpoint is
+   a named pipe with no file to sit beside — see `cliRuntimeHostEndpoint`. */
+async function waitForRuntimeHost(socketPath, fencePath, processHandle = null) {
   const deadline = Date.now() + RUNTIME_HOST_READINESS_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (processHandle?.state.spawnError) {
@@ -450,7 +461,7 @@ async function waitForRuntimeHost(socketPath, processHandle = null) {
       throw new Error(m.runtimeHostExited(runtimeHostExitDetail(processHandle)));
     }
     if (await probeRuntimeHost(socketPath)) {
-      const owner = runtimeHostFenceOwner(socketPath);
+      const owner = runtimeHostFenceOwner(fencePath);
       if (!processHandle) return;
       if (owner?.pid === processHandle.child.pid) return;
       if (owner) throw new Error(m.runtimeHostOwnerMismatch(owner.pid, processHandle.child.pid));
@@ -517,7 +528,7 @@ function createRuntimeHostSupervisor(config, bunRuntime, environment, packageRoo
   const launch = async (initial) => {
     const processHandle = spawnHost();
     try {
-      await waitForRuntimeHost(config.socketPath, processHandle);
+      await waitForRuntimeHost(config.socketPath, config.fencePath, processHandle);
       processHandle.state.readyAt = Date.now();
       if (processHandle.child.exitCode !== null || processHandle.child.signalCode !== null) {
         throw new Error(m.runtimeHostExited(runtimeHostExitDetail(processHandle)));
@@ -613,16 +624,17 @@ async function printTailscaleBanner(runtime) {
 }
 
 function openBrowser(url) {
-  const opener =
-    process.platform === "linux" ? "xdg-open" : process.platform === "darwin" ? "open" : null;
-
+  const opener = browserOpenCommand(url);
   if (!opener) {
     return;
   }
 
-  const child = spawn(opener, [url], viewerChildProcessOptions({
+  /* `windowsHide` keeps the console rundll32 would otherwise flash on the
+     desktop; it is inert on every other platform. */
+  const child = spawn(opener.command, opener.args, viewerChildProcessOptions({
     stdio: "ignore",
     detached: true,
+    windowsHide: true,
   }));
   child.unref();
 }

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, fstatSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -18,7 +19,10 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 let selectedReleaseRevision = null;
 
 function deployedPackageRoot() {
-  const configRoot = process.env.XDG_CONFIG_HOME || join(process.env.HOME || "/home/user", ".config");
+  /* `os.homedir()` rather than `$HOME` with a Linux-shaped default: on Windows
+     HOME is not a Windows variable at all, and the fallback named a directory
+     that exists on no machine running this. */
+  const configRoot = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   const stateDir = process.env.LLV_STATE_DIR || join(configRoot, "agent-log-viewer", "state");
   const targetFile = process.env.LLV_VIEWER_DEPLOY_TARGET || join(stateDir, "viewer-release.json");
   let target;

--- a/bin/server-runtime.mjs
+++ b/bin/server-runtime.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, posix, resolve, win32 } from "node:path";
 
 export const WAKATIME_CREDENTIAL_ENV = "WAKATIME_API_KEY";
 
@@ -64,21 +64,72 @@ export function viewerServerBunRuntime(options = {}) {
  * crosses this CLI ownership boundary.
  *
  * @param {string} packageRoot
- * @param {{ env?: Readonly<Record<string, string | undefined>>, home?: string }} [options]
+ * @param {{ env?: Readonly<Record<string, string | undefined>>, home?: string, platform?: NodeJS.Platform }} [options]
  */
 export function cliRuntimeHostConfig(packageRoot, options = {}) {
   const env = options.env ?? process.env;
   const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
   const stateDirectory = env.LLV_STATE_DIR?.trim()
     || join(env.XDG_CONFIG_HOME?.trim() || join(home, ".config"), "agent-log-viewer", "state");
   const installId = createHash("sha256").update(resolve(packageRoot)).digest("hex").slice(0, 16);
   const bundled = join(packageRoot, "dist", "runtime-host.mjs");
   const source = join(packageRoot, "src", "runtime-host", "main.ts");
   return {
-    socketPath: join(stateDirectory, `runtime-host-${installId}.sock`),
+    ...cliRuntimeHostEndpoint(stateDirectory, installId, platform),
     journalPath: join(stateDirectory, `runtime-events-${installId}.sqlite`),
     entrypoint: existsSync(bundled) ? bundled : source,
   };
+}
+
+/**
+ * Where the supervised host listens and where its singleton fence lives.
+ *
+ * Windows has no filesystem Unix socket, so the endpoint is a named pipe in the
+ * kernel's pipe namespace; `net.createServer().listen` and
+ * `net.createConnection` take that name unchanged, which is why nothing else in
+ * the CLI's readiness probe or the Viewer's client changes. The fence stays a
+ * real file either way, and a pipe name has nothing to sit beside, so the fence
+ * gets its own name in the state directory rather than `${socketPath}.lock`.
+ *
+ * This is a deliberate duplicate of `runtimeHostEndpoint` in
+ * `src/lib/runtime/localEndpoint.ts` — this file is loaded by Node as plain
+ * `.mjs` and cannot import TypeScript. `server-runtime.test.ts` imports both
+ * and fails when they disagree.
+ *
+ * @param {string} stateDirectory
+ * @param {string} installId
+ * @param {NodeJS.Platform} platform
+ */
+export function cliRuntimeHostEndpoint(stateDirectory, installId, platform = process.platform) {
+  if (platform === "win32") {
+    return {
+      socketPath: `\\\\.\\pipe\\agent-log-viewer-${installId}`,
+      fencePath: win32.join(stateDirectory, `runtime-host-${installId}.lock`),
+    };
+  }
+  const socketPath = posix.join(stateDirectory, `runtime-host-${installId}.sock`);
+  return { socketPath, fencePath: `${socketPath}.lock` };
+}
+
+/**
+ * The command that hands a URL to the desktop's default browser.
+ *
+ * Windows has no `xdg-open`. `rundll32 url.dll,FileProtocolHandler <url>` is
+ * the shell-free route: `cmd /c start` would put the URL through `cmd`'s own
+ * parsing, where the `&` between the viewer's query parameters ends the
+ * command. Any other platform keeps the existing "do nothing" degrade, which is
+ * what made the CLI runnable on Windows before this ever worked.
+ *
+ * @param {string} url
+ * @param {NodeJS.Platform} platform
+ * @returns {{ command: string, args: string[] } | null}
+ */
+export function browserOpenCommand(url, platform = process.platform) {
+  if (platform === "linux") return { command: "xdg-open", args: [url] };
+  if (platform === "darwin") return { command: "open", args: [url] };
+  if (platform === "win32") return { command: "rundll32.exe", args: ["url.dll,FileProtocolHandler", url] };
+  return null;
 }
 
 /**
@@ -89,12 +140,13 @@ export function cliRuntimeHostConfig(packageRoot, options = {}) {
  * claim an ambient deployment's host epoch through the shared state directory.
  *
  * @param {Readonly<Record<string, string | undefined>>} base
- * @param {{ socketPath: string, journalPath: string }} config
+ * @param {{ socketPath: string, fencePath: string, journalPath: string }} config
  */
 export function cliRuntimeHostEnvironment(base, config) {
   return {
     ...withoutWakatimeCredential(base),
     LLV_RUNTIME_HOST_SOCKET: config.socketPath,
+    LLV_RUNTIME_HOST_FENCE: config.fencePath,
     LLV_RUNTIME_JOURNAL: config.journalPath,
     LLV_STRUCTURED_HOSTS: "1",
     LLV_RUNTIME_EVENTS: "1",

--- a/bin/server-runtime.test.ts
+++ b/bin/server-runtime.test.ts
@@ -11,10 +11,13 @@ import { loadFlows } from "@/lib/flows/store";
 import { loadArchivedPipelines, loadPipelines } from "@/lib/pipelines/store";
 import { structuredHostsEnabled as structuredHostsEnabledInApp } from "@/lib/runtime/flags";
 import { loadWorkflows } from "@/lib/workflows/store";
+import { runtimeHostEndpoint } from "@/lib/runtime/localEndpoint";
 import { RuntimeHostFence } from "@/runtime-host/runtimeHostFence";
 
 import {
+  browserOpenCommand,
   cliRuntimeHostConfig,
+  cliRuntimeHostEndpoint,
   cliRuntimeHostEnvironment,
   structuredHostsEnabled as structuredHostsEnabledInLauncher,
   viewerServerBunRuntime,
@@ -22,6 +25,20 @@ import {
   WAKATIME_CREDENTIAL_ENV,
   withoutWakatimeCredential,
 } from "./server-runtime.mjs";
+
+/**
+ * Removing a scratch directory is teardown, not an assertion. Windows keeps a
+ * directory busy while any handle into it is open — the hot SQLite store this
+ * file opens through `loadFlows()` stays open for the life of the process by
+ * design — and the runner discards its temp root with the job either way.
+ */
+function removeSandbox(directory: string): void {
+  try {
+    fs.rmSync(directory, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  } catch {
+    /* the temp root goes with the job */
+  }
+}
 
 async function availablePort(): Promise<number> {
   const server = net.createServer();
@@ -62,10 +79,20 @@ test("the CLI derives a distinct managed runtime host for each install", () => {
 
     expect(first.entrypoint).toBe(firstBundle);
     expect(second.entrypoint).toBe(secondBundle);
-    expect(path.dirname(first.socketPath)).toBe(stateDirectory);
-    expect(path.dirname(second.socketPath)).toBe(stateDirectory);
-    expect(path.basename(first.socketPath)).toMatch(/^runtime-host-[a-f0-9]{16}\.sock$/);
-    expect(path.basename(second.socketPath)).toMatch(/^runtime-host-[a-f0-9]{16}\.sock$/);
+    /* On Windows the endpoint is a named pipe rather than a file in the state
+       directory; the fence is the file that stays there. */
+    for (const config of [first, second]) {
+      if (process.platform === "win32") {
+        expect(config.socketPath).toMatch(/^\\\\\.\\pipe\\agent-log-viewer-[a-f0-9]{16}$/);
+        expect(path.dirname(config.fencePath)).toBe(stateDirectory);
+        expect(path.basename(config.fencePath)).toMatch(/^runtime-host-[a-f0-9]{16}\.lock$/);
+      } else {
+        expect(path.dirname(config.socketPath)).toBe(stateDirectory);
+        expect(path.basename(config.socketPath)).toMatch(/^runtime-host-[a-f0-9]{16}\.sock$/);
+        expect(config.fencePath).toBe(`${config.socketPath}.lock`);
+      }
+    }
+    expect(first.fencePath).not.toBe(second.fencePath);
     expect(path.dirname(first.journalPath)).toBe(stateDirectory);
     expect(path.dirname(second.journalPath)).toBe(stateDirectory);
     expect(path.basename(first.journalPath)).toMatch(/^runtime-events-[a-f0-9]{16}\.sqlite$/);
@@ -77,7 +104,7 @@ test("the CLI derives a distinct managed runtime host for each install", () => {
     expect(first.journalPath).not.toBe(ambientJournal);
     expect(second.journalPath).not.toBe(ambientJournal);
   } finally {
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    removeSandbox(sandbox);
   }
 });
 
@@ -93,30 +120,33 @@ test("the CLI uses the source runtime host in a checkout", () => {
       home: path.join(packageRoot, "home"),
     });
     expect(config.entrypoint).toBe(source);
-    expect(path.dirname(config.socketPath)).toBe(stateDirectory);
+    expect(path.dirname(process.platform === "win32" ? config.fencePath : config.socketPath)).toBe(stateDirectory);
     expect(path.dirname(config.journalPath)).toBe(stateDirectory);
   } finally {
-    fs.rmSync(packageRoot, { recursive: true, force: true });
+    removeSandbox(packageRoot);
   }
 });
 
-test("the CLI runtime environment owns its socket and journal and strips ambient WakaTime credentials", () => {
+test("the CLI runtime environment owns its socket, fence and journal and strips ambient WakaTime credentials", () => {
   const socketPath = "/runtime/viewer.sock";
+  const fencePath = "/runtime/viewer.sock.lock";
   const journalPath = "/runtime/viewer.sqlite";
   const env: Record<string, string | undefined> = cliRuntimeHostEnvironment({
     PATH: "/usr/bin",
     LLV_RUNTIME_HOST_SOCKET: "/runtime/operator.sock",
+    LLV_RUNTIME_HOST_FENCE: "/runtime/operator.sock.lock",
     LLV_RUNTIME_JOURNAL: "/runtime/operator.sqlite",
     LLV_STRUCTURED_HOSTS: "off",
     LLV_RUNTIME_EVENTS: "0",
     LLV_SPAWN_TRANSPORT: "tmux",
     NEXT_PUBLIC_RUNTIME_UI: "0",
     [WAKATIME_CREDENTIAL_ENV]: "fixture-value",
-  }, { socketPath, journalPath });
+  }, { socketPath, fencePath, journalPath });
 
   expect(env).toMatchObject({
     PATH: "/usr/bin",
     LLV_RUNTIME_HOST_SOCKET: socketPath,
+    LLV_RUNTIME_HOST_FENCE: fencePath,
     LLV_RUNTIME_JOURNAL: journalPath,
     LLV_STRUCTURED_HOSTS: "1",
     LLV_RUNTIME_EVENTS: "1",
@@ -139,8 +169,9 @@ test("the CLI rejects a ready runtime socket owned by another process", async ()
     LLV_LANG: "en",
     LLV_RUNTIME_HOST_FENCE_WAIT_MS: "0",
   };
-  const socketPath = cliRuntimeHostConfig(packageRoot, { env: environment, home: environment.HOME }).socketPath;
-  const fence = new RuntimeHostFence(`${socketPath}.lock`);
+  const incumbent = cliRuntimeHostConfig(packageRoot, { env: environment, home: environment.HOME });
+  const socketPath = incumbent.socketPath;
+  const fence = new RuntimeHostFence(incumbent.fencePath);
   const listener = net.createServer((socket) => socket.end());
   fs.mkdirSync(environment.HOME!, { recursive: true });
   fs.mkdirSync(environment.XDG_CONFIG_HOME!, { recursive: true });
@@ -169,7 +200,7 @@ test("the CLI rejects a ready runtime socket owned by another process", async ()
     if (!child.killed) child.kill();
     await new Promise<void>((resolve, reject) => listener.close((error) => error ? reject(error) : resolve()));
     fence.release();
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    removeSandbox(sandbox);
   }
 }, 10_000);
 
@@ -205,7 +236,7 @@ test("the CLI names a missing Bun prerequisite before starting the Viewer", asyn
     expect(stderr).toContain("Bun executable");
     expect(stderr).toContain("is unavailable");
   } finally {
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    removeSandbox(sandbox);
   }
 }, 10_000);
 
@@ -311,7 +342,7 @@ test("documented development and production scripts pin Bun and open every hot c
   } finally {
     if (previous === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previous;
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    removeSandbox(sandbox);
   }
 });
 
@@ -348,4 +379,54 @@ test("published launcher child options capture no ambient WakaTime key material"
   expect(options.env.KEEP_ME).toBe("kept");
   expect(options.env[WAKATIME_CREDENTIAL_ENV]).toBeUndefined();
   expect(JSON.stringify(options)).not.toContain(placeholder);
+});
+
+test("the launcher's endpoint rule is the same rule the runtime host compiles", () => {
+  /* `bin/server-runtime.mjs` is loaded by Node as plain `.mjs` and cannot
+     import the TypeScript module the host and the socket server use, so the
+     rule exists twice. A disagreement would put the CLI's readiness probe on
+     one endpoint and the host's listener on another, and the CLI would report a
+     host that never bound. */
+  for (const platform of ["linux", "darwin", "win32"] as const) {
+    const stateDirectory = platform === "win32"
+      ? "C:\\profile\\.config\\agent-log-viewer\\state"
+      : "/home/user/.config/agent-log-viewer/state";
+    expect(cliRuntimeHostEndpoint(stateDirectory, "0123456789abcdef", platform))
+      .toEqual(runtimeHostEndpoint(stateDirectory, "0123456789abcdef", platform));
+  }
+});
+
+test("a Windows install supervises a named-pipe host with a file fence beside its journal", () => {
+  const config = cliRuntimeHostConfig("/opt/agent-log-viewer", {
+    env: { LLV_STATE_DIR: "C:\\state" },
+    home: "C:\\profile",
+    platform: "win32",
+  });
+  expect(config.socketPath.startsWith("\\\\.\\pipe\\agent-log-viewer-")).toBe(true);
+  expect(config.fencePath.startsWith("C:\\state")).toBe(true);
+  expect(config.fencePath.endsWith(".lock")).toBe(true);
+  /* The fence cannot be `${socketPath}.lock` on Windows: that names a file
+     inside the kernel's pipe namespace, which is not a filesystem. */
+  expect(config.fencePath).not.toBe(`${config.socketPath}.lock`);
+});
+
+test("the browser opener never puts a URL through a shell", () => {
+  /* The viewer's URL carries `?k=<token>`; `cmd /c start` would parse `&`
+     between query parameters as a command separator, and `start` would treat a
+     quoted first argument as a window title. */
+  expect(browserOpenCommand("http://127.0.0.1:8899/?k=t", "linux")).toEqual({
+    command: "xdg-open",
+    args: ["http://127.0.0.1:8899/?k=t"],
+  });
+  expect(browserOpenCommand("http://127.0.0.1:8899/?k=t", "darwin")).toEqual({
+    command: "open",
+    args: ["http://127.0.0.1:8899/?k=t"],
+  });
+  expect(browserOpenCommand("http://127.0.0.1:8899/?k=t", "win32")).toEqual({
+    command: "rundll32.exe",
+    args: ["url.dll,FileProtocolHandler", "http://127.0.0.1:8899/?k=t"],
+  });
+  // Anything else keeps the pre-existing "the CLI still runs, it just does not
+  // open a browser" degrade.
+  expect(browserOpenCommand("http://127.0.0.1:8899/", "freebsd")).toBeNull();
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "os": [
     "linux",
-    "darwin"
+    "darwin",
+    "win32"
   ],
   "scripts": {
     "dev": "NODE_ENV=development bun --bun node_modules/.bin/next dev --webpack --hostname 127.0.0.1",

--- a/scripts/verify-platform-backend.ts
+++ b/scripts/verify-platform-backend.ts
@@ -1,0 +1,218 @@
+/**
+ * Proves the process backend this platform selects can actually read the
+ * kernel, and fails loudly when it cannot.
+ *
+ * The Windows cases in `src/lib/proc/windows.test.ts`,
+ * `windowsIdentity.test.ts` and `processGroup.test.ts` skip themselves off
+ * win32. A silent skip leaves a green job that executed nothing — the exact
+ * shape of #1256, where the macOS half of the login fence had never run
+ * anywhere and shipped broken. This script runs before those files on each leg
+ * of `platform-tests.yml` and refuses a runner that is not what the leg claims,
+ * or a backend whose readers return nothing.
+ *
+ *   bun scripts/verify-platform-backend.ts --expect win32
+ *
+ * Every stage announces itself and every failure is printed on **stdout**
+ * before a nonzero exit: a runner that reports "exit code 1" and nothing else
+ * is not a diagnosis, and this script is the first thing a Windows change has
+ * to get past. It prints shapes and counts, never paths — the runner's own
+ * directories are not interesting and this repository is public.
+ */
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+import { selectProcBackend } from "@/lib/proc";
+import { windowsProcessCwd } from "@/lib/proc/windowsCwd";
+import { windowsProcessIdentity } from "@/lib/proc/windowsIdentity";
+import { tryLockFenceExclusive } from "@/runtime-host/fenceLock";
+import { RuntimeHostFence } from "@/runtime-host/runtimeHostFence";
+
+const EXPECTED_BACKEND: Partial<Record<NodeJS.Platform, string>> = {
+  linux: "linux",
+  darwin: "portable",
+  win32: "windows",
+};
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function stage(name: string): void {
+  console.log(`--- ${name}`);
+}
+
+function requireRunner(): NodeJS.Platform {
+  const index = process.argv.indexOf("--expect");
+  const expected = index >= 0 ? process.argv[index + 1] : undefined;
+  if (!expected) fail("usage: verify-platform-backend.ts --expect <platform>");
+  if (process.platform !== expected) fail(`expected a ${expected} runner, got ${process.platform}`);
+  return process.platform;
+}
+
+/**
+ * That `bun:ffi` loads and can call into the platform's own C library at all.
+ * Both the identity token and the fence lock go through it, and a Bun that
+ * cannot reach the kernel here would otherwise surface as three unrelated
+ * failures further down.
+ */
+function verifyForeignFunctionInterface(platform: NodeJS.Platform): void {
+  stage("bun:ffi reaches the platform C library");
+  const runtimeRequire = createRequire(import.meta.url);
+  const ffi = runtimeRequire(`bun:${"ffi"}`) as {
+    FFIType: { i32: number; u32: number };
+    dlopen(library: string, symbols: Record<string, unknown>): { symbols: Record<string, () => number> };
+  };
+  const library = platform === "win32"
+    ? "kernel32.dll"
+    : platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6";
+  const symbol = platform === "win32" ? "GetCurrentProcessId" : "getpid";
+  const returns = platform === "win32" ? ffi.FFIType.u32 : ffi.FFIType.i32;
+  const opened = ffi.dlopen(library, { [symbol]: { args: [], returns } });
+  const reported = Number(opened.symbols[symbol]!());
+  if (reported !== process.pid) fail(`${symbol} returned ${reported}, this process is ${process.pid}`);
+  console.log(`bun:ffi: ${library} loaded and ${symbol} agrees with process.pid`);
+}
+
+/**
+ * The fence's exclusivity, exercised on the primitive rather than through a
+ * host boot. `flock` is advisory and `LockFileEx` is mandatory, so this also
+ * checks the thing that difference threatens: the owner record must stay
+ * readable while the lock is held, because the fence reads it before locking
+ * and the CLI's readiness probe reads it on every poll.
+ */
+function verifyFenceLock(): void {
+  stage("the runtime-host fence lock");
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-platform-lock-"));
+  const filename = path.join(directory, "fence");
+  fs.writeFileSync(filename, '{"pid":1}');
+  const first = fs.openSync(filename, "r+");
+  const second = fs.openSync(filename, "r+");
+  try {
+    const held = tryLockFenceExclusive({ fd: first, filename });
+    if (!held) fail("the fence lock could not be taken at all");
+    if (tryLockFenceExclusive({ fd: second, filename })) fail("a second holder took a lock that is supposed to be exclusive");
+    if (fs.readFileSync(filename, "utf8") !== '{"pid":1}') fail("the owner record is unreadable while the fence is held");
+    held.release();
+    const again = tryLockFenceExclusive({ fd: second, filename });
+    if (!again) fail("the lock was not released");
+    again.release();
+  } finally {
+    fs.closeSync(first);
+    fs.closeSync(second);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+  console.log("fence lock: exclusive, releasable, and does not block reads of the owner record");
+}
+
+/**
+ * The fence a viewer creates on a machine it has never run on: the state
+ * directory does not exist yet, the record does not exist yet, and the very
+ * first boot has to make both. This is what a Windows install does the first
+ * time it starts, and it is where a wrong open-flag mask shows up — as ENOENT
+ * for a directory that plainly exists, or as EPERM at the first write.
+ */
+function verifyFenceBootstrap(): void {
+  stage("a fence created from nothing, as a first boot does");
+  /* Printed because the numbers behind these names are the reason the fence
+     asks for its two openings by name on Windows rather than by mask. */
+  const flags = Object.entries({
+    O_RDWR: fs.constants.O_RDWR,
+    O_CREAT: fs.constants.O_CREAT,
+    O_EXCL: fs.constants.O_EXCL,
+    O_NOFOLLOW: fs.constants.O_NOFOLLOW,
+  }).map(([name, value]) => `${name}=${value === undefined ? "absent" : `0x${value.toString(16)}`}`);
+  console.log(`open flags this platform reports: ${flags.join(" ")}`);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-platform-fence-"));
+  const filename = path.join(root, "state", "runtime-host.lock");
+  const fence = new RuntimeHostFence(filename);
+  try {
+    fence.acquire();
+    const owner = JSON.parse(fs.readFileSync(filename, "utf8")) as { pid?: number; startIdentity?: unknown };
+    if (owner.pid !== process.pid) fail(`the fence recorded pid ${String(owner.pid)}, this process is ${process.pid}`);
+    if (typeof owner.startIdentity !== "string" || !owner.startIdentity.startsWith(`${process.pid}:`)) {
+      fail("the fence recorded no usable start identity, so the CLI would never accept its own host");
+    }
+    /* A second holder must be refused while the first holds it, and admitted
+       once it lets go — through the whole fence, not just the lock primitive. */
+    let refused = false;
+    try {
+      new RuntimeHostFence(filename, () => true).acquire();
+    } catch {
+      refused = true;
+    }
+    if (!refused) fail("a second fence acquired a record the first one holds");
+    fence.release();
+    const successor = new RuntimeHostFence(filename, () => false);
+    successor.acquire();
+    successor.release();
+  } finally {
+    fence.release();
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  }
+  console.log("fence bootstrap: created its own directory and record, refused a rival, and handed over");
+}
+
+function verifyWindowsReaders(): void {
+  const backend = selectProcBackend();
+
+  stage("the process-identity token");
+  const identity = windowsProcessIdentity(process.pid);
+  if (!identity || !identity.startsWith(`${process.pid}:`)) {
+    fail("GetProcessTimes reported no creation time for this process; the identity token would be unavailable");
+  }
+  const creation = identity.slice(identity.indexOf(":") + 1);
+  if (!/^\d+$/.test(creation)) fail(`the identity token carries no FILETIME: ${creation.length} characters`);
+  console.log(`identity token: pid + a ${creation.length}-digit kernel FILETIME`);
+
+  stage("the working-directory read");
+  const cwd = windowsProcessCwd(process.pid);
+  if (!cwd) fail("the process-parameters read returned no working directory for this process");
+  if (path.resolve(cwd).toLowerCase() !== path.resolve(process.cwd()).toLowerCase()) {
+    fail("the process-parameters read returned a working directory that is not this process's own");
+  }
+  console.log(`working directory: read from the process parameters, ${cwd.length} characters, matches this process`);
+
+  stage("the Win32_Process snapshot");
+  const listed = backend.listProcesses();
+  if (listed.length < 5) fail(`the Win32_Process snapshot listed ${listed.length} processes; PowerShell or the CSV parse is broken`);
+  const self = listed.find((entry) => entry.pid === process.pid);
+  if (!self) fail("the Win32_Process snapshot does not contain this process");
+  if (!self.argv[0]) fail("the command line of this process did not survive argv splitting");
+  console.log(`snapshot: ${listed.length} processes, this one has ${self.argv.length} argv tokens`);
+
+  const parents = backend.ppidMap();
+  if (parents.size < 3) fail(`the parent map has ${parents.size} links; the stale-link filter dropped too much`);
+  console.log(`parent map: ${parents.size} links after the stale-parent filter`);
+
+  const memory = backend.processMemory([process.pid]).get(process.pid);
+  if (!memory || memory.rssBytes <= 0) fail("the snapshot reported no working set for this process");
+  if (backend.processCpuMs(process.pid) === null) fail("the snapshot reported no CPU time for this process");
+  const system = backend.systemMemory();
+  if (!system || system.ramTotal <= 0 || system.ramAvailable <= 0) fail("host memory is unreadable");
+  console.log("memory: working set and CPU for this pid, and host totals, all readable");
+}
+
+try {
+  const platform = requireRunner();
+  stage("backend selection");
+  const expectedBackend = EXPECTED_BACKEND[platform];
+  const selected = selectProcBackend(platform, undefined).name;
+  if (selected !== expectedBackend) fail(`${platform} selected the "${selected}" backend, expected "${expectedBackend}"`);
+  console.log(`backend: ${platform} selects "${selected}"`);
+
+  verifyForeignFunctionInterface(platform);
+  verifyFenceLock();
+  verifyFenceBootstrap();
+  if (platform === "win32") verifyWindowsReaders();
+  console.log("platform readers verified");
+} catch (error) {
+  /* stdout, not stderr: a Windows runner that reported "exit code 1" and no
+     other line is what this whole script exists to stop happening. */
+  console.log(`PLATFORM VERIFICATION FAILED: ${error instanceof Error ? error.message : String(error)}`);
+  if (error instanceof Error && error.stack) console.log(error.stack);
+  process.exitCode = 1;
+}

--- a/src/app/api/artifact/route.ts
+++ b/src/app/api/artifact/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { classifyArtifact } from "@/lib/artifact/classify";
 import { artifactEtag, artifactLimits, dispositionFilename, parseByteRange, sniffAgrees } from "@/lib/artifact/serve";
+import { homeDirectory } from "@/lib/platformHome";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
@@ -59,9 +60,11 @@ function fail(code: FailCode, error: string): NextResponse<FailBody> {
 }
 
 /* $HOME first: it is what the isolated demo/evidence runtimes (and tests)
-   repoint, and Bun's os.homedir() ignores the env override. */
+   repoint, and Bun's os.homedir() ignores the env override. On Windows HOME is
+   not a Windows variable and a Git Bash value would resolve to nothing — see
+   `homeDirectory`. */
 function homeRoot(): string {
-  return path.resolve(process.env.HOME || os.homedir());
+  return homeDirectory();
 }
 
 function resolveLocal(raw: string): string {

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import { accountForSpawn, codexHomeOwningSessionPath, isManagedCodexHome } from "@/lib/accounts/codex";
 import { claudeSettingsPath, claudeTranscriptOwnership, isManagedClaudeHome, legacyClaudeHome } from "@/lib/accounts/claude";
+import { homeDirectory } from "@/lib/platformHome";
 import { isUnderClaudeSubagentsDir } from "@/lib/scanner/claudeNative";
 import { telegramSessionReaderPath } from "@/lib/telegram/packaging";
 import { TELEGRAM_CONNECTOR_TOKEN_ENV, telegramSessionPath } from "@/lib/telegram/sessionStore";
@@ -28,8 +29,39 @@ export { ENGINE_EFFORTS, isEngineEffort } from "./efforts";
 
 export type AgentEngine = "claude" | "codex";
 
+/**
+ * Candidate absolute paths for an agent CLI on Windows, in probe order.
+ *
+ * The native Claude Code installer puts `claude.exe` under
+ * `%USERPROFILE%\.local\bin`; a Bun global install puts it under
+ * `%USERPROFILE%\.bun\bin`. Only `.exe` is probed. An npm install of Claude
+ * Code exposes `claude.cmd`, and `spawn` without a shell cannot run a `.cmd`
+ * (Node raises EINVAL), so finding one and returning it would produce a spawn
+ * failure instead of a clean "not installed" — the README says to use the
+ * native installer. `CreateProcess` searching PATH appends `.exe` and `.com`
+ * and never `.cmd`, so the bare-name fallback has the same property.
+ *
+ * Pure over `home`, so the order is asserted without a Windows filesystem.
+ */
+export function windowsBinaryCandidates(home: string, name: string): string[] {
+  return [
+    path.join(home, ".local", "bin", `${name}.exe`),
+    path.join(home, ".bun", "bin", `${name}.exe`),
+    path.join(home, "AppData", "Local", "Programs", name, `${name}.exe`),
+  ];
+}
+
 /** Absolute path of an agent CLI when we can find one; bare name otherwise. */
 export function resolveBinary(name: string): string {
+  if (process.platform === "win32") {
+    /* `X_OK` is meaningless on Windows — `fs.access` there answers existence —
+       so the probe says what it means. `homeDirectory()` rather than
+       `os.homedir()` so an isolated `USERPROFILE` is honoured under Bun. */
+    for (const candidate of windowsBinaryCandidates(homeDirectory(), name)) {
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    return name;
+  }
   const home = os.homedir();
   if (process.env.LLV_DOCKER_NSENTER_SHIMS === "1" && (name === "claude" || name === "codex")) {
     const shim = "/usr/local/bin/" + name;

--- a/src/lib/platformHome.test.ts
+++ b/src/lib/platformHome.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import { homeDirectory, isWindowsAbsolute } from "./platformHome";
+
+const FALLBACK_POSIX = "/home/user/fallback";
+const FALLBACK_WIN = "D:\\Users\\user\\fallback";
+
+test("POSIX keeps $HOME first so an isolated runtime is not read past", () => {
+  /* Bun's os.homedir() ignores the env override, so dropping $HOME here would
+     make an evidence run, a demo capture or a test read the real home. */
+  expect(homeDirectory({ HOME: "/tmp/isolated" }, "linux", () => FALLBACK_POSIX)).toBe("/tmp/isolated");
+  expect(homeDirectory({ HOME: "  " }, "darwin", () => FALLBACK_POSIX)).toBe(FALLBACK_POSIX);
+  expect(homeDirectory({}, "linux", () => FALLBACK_POSIX)).toBe(FALLBACK_POSIX);
+});
+
+test("Windows ignores HOME entirely, however it was set", () => {
+  /* Git Bash and MSYS export a POSIX HOME on Windows. Resolving `/c/Users/user`
+     there yields a path on the current drive that names nothing, so every
+     transcript root, the config dir and the state dir would point at an empty
+     directory the viewer would then create. */
+  expect(homeDirectory({ HOME: "/c/Users/user" }, "win32", () => FALLBACK_WIN)).toBe(FALLBACK_WIN);
+  expect(homeDirectory({ HOME: "C:\\Users\\user" }, "win32", () => FALLBACK_WIN)).toBe(FALLBACK_WIN);
+});
+
+test("Windows takes USERPROFILE when it is a Windows path, keeping the override", () => {
+  expect(homeDirectory({ USERPROFILE: "C:\\Users\\user\\isolated" }, "win32", () => FALLBACK_WIN))
+    .toBe("C:\\Users\\user\\isolated");
+  expect(homeDirectory({ USERPROFILE: "\\\\share\\profiles\\user" }, "win32", () => FALLBACK_WIN))
+    .toBe("\\\\share\\profiles\\user");
+  // A POSIX-shaped USERPROFILE is refused the same way HOME is.
+  expect(homeDirectory({ USERPROFILE: "/c/Users/user" }, "win32", () => FALLBACK_WIN)).toBe(FALLBACK_WIN);
+  expect(homeDirectory({ USERPROFILE: "   " }, "win32", () => FALLBACK_WIN)).toBe(FALLBACK_WIN);
+});
+
+test("only a drive-rooted or UNC path counts as absolute on Windows", () => {
+  /* `path.isAbsolute` would not do: on win32 it calls `/c/Users/user` absolute,
+     because a leading slash is rooted on the current drive. */
+  expect(isWindowsAbsolute("C:\\Users\\user")).toBe(true);
+  expect(isWindowsAbsolute("c:/Users/user")).toBe(true);
+  expect(isWindowsAbsolute("\\\\server\\share")).toBe(true);
+  expect(isWindowsAbsolute("/c/Users/user")).toBe(false);
+  expect(isWindowsAbsolute("C:")).toBe(false);
+  expect(isWindowsAbsolute("Users\\user")).toBe(false);
+});
+
+test("the resolved home is what the running platform would use", () => {
+  expect(homeDirectory()).toBe(path.resolve(homeDirectory()));
+});

--- a/src/lib/platformHome.ts
+++ b/src/lib/platformHome.ts
@@ -1,0 +1,37 @@
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * The home directory the Viewer reads transcripts, config and state under.
+ *
+ * On POSIX this is `$HOME` first and `os.homedir()` only as a fallback, which
+ * is deliberate and load-bearing: Bun's `os.homedir()` ignores an env override,
+ * so the isolated demo, evidence and test runtimes — which repoint `HOME` and
+ * nothing else — would otherwise read the machine's real home.
+ *
+ * On Windows `HOME` is ignored. It is not a Windows variable; the shells that
+ * set it there (Git Bash, MSYS) set it to a POSIX-shaped value such as
+ * `/c/Users/<name>`, which `path.resolve` turns into a path on the current
+ * drive that names nothing. `USERPROFILE` is the variable Windows itself sets
+ * and the one `os.homedir()` consults, so it keeps the same override property
+ * the POSIX branch has — but only when it actually looks like a Windows
+ * absolute path, so a shell that exports a POSIX value into it is refused too.
+ */
+export function homeDirectory(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  platform: NodeJS.Platform = process.platform,
+  fallback: () => string = os.homedir,
+): string {
+  /* The `platform` argument governs the path semantics too, so the Windows rule
+     is assertable from a Linux runner and not only from the Windows leg. */
+  if (platform === "win32") {
+    const profile = env.USERPROFILE?.trim();
+    return path.win32.resolve(profile && isWindowsAbsolute(profile) ? profile : fallback());
+  }
+  return path.posix.resolve(env.HOME?.trim() || fallback());
+}
+
+/** A drive-rooted (`C:\…`) or UNC (`\\server\share`) path. Pure. */
+export function isWindowsAbsolute(pathname: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(pathname) || /^\\\\[^\\]/.test(pathname);
+}

--- a/src/lib/proc/index.test.ts
+++ b/src/lib/proc/index.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+
+import { linuxBackend } from "./linux";
+import { portableBackend } from "./portable";
+import { selectProcBackend } from "./index";
+import { windowsBackend } from "./windows";
+
+/*
+ * Which backend a platform gets. This mattered enough to be worth its own file:
+ * before the Windows backend existed, win32 fell through to `portableBackend`,
+ * which shells out to `ps`, `lsof`, `vm_stat` and `sysctl` — so every scan
+ * returned empty and every process was invisible, with nothing to say so.
+ */
+
+test("each platform selects the backend that can actually read it", () => {
+  expect(selectProcBackend("linux", undefined).name).toBe("linux");
+  expect(selectProcBackend("darwin", undefined).name).toBe("portable");
+  expect(selectProcBackend("win32", undefined).name).toBe("windows");
+  expect(selectProcBackend("freebsd", undefined).name).toBe("portable");
+});
+
+test("VIEWER_PROC_BACKEND forces one of the three, literally", () => {
+  expect(selectProcBackend("linux", "portable")).toBe(portableBackend);
+  expect(selectProcBackend("darwin", "linux")).toBe(linuxBackend);
+  expect(selectProcBackend("linux", "windows")).toBe(windowsBackend);
+  expect(selectProcBackend("win32", "portable")).toBe(portableBackend);
+});
+
+test("an unrecognised override falls back to the platform default", () => {
+  expect(selectProcBackend("win32", "wmic").name).toBe("windows");
+  expect(selectProcBackend("linux", "").name).toBe("linux");
+});
+
+test("every backend answers the whole contract", () => {
+  /* A backend that silently lacks a method would throw deep inside a scan. */
+  const methods = Object.keys(linuxBackend).sort();
+  expect(Object.keys(windowsBackend).sort()).toEqual(methods);
+  expect(Object.keys(portableBackend).sort()).toEqual(methods);
+});

--- a/src/lib/proc/index.ts
+++ b/src/lib/proc/index.ts
@@ -1,20 +1,28 @@
 import { linuxBackend } from "./linux";
 import { portableBackend } from "./portable";
 import type { ProcBackend } from "./types";
+import { windowsBackend } from "./windows";
 
 export type { ProcBackend, ProcSnapshotEntry } from "./types";
 
 /**
- * Backend selection: Linux reads `/proc` directly; everything else (macOS)
- * shells out to `ps`/`lsof`. `VIEWER_PROC_BACKEND=portable` forces the
- * portable path on Linux too, so it can be exercised and parity-tested on a
- * machine that also has the fast native backend to compare against.
+ * Backend selection: Linux reads `/proc` directly, Windows reads a
+ * `Win32_Process` snapshot, and everything else (macOS) shells out to
+ * `ps`/`lsof`. The `VIEWER_PROC_BACKEND` override forces one of the three, so
+ * a backend can be exercised and parity-tested on a machine that also has the
+ * fast native one to compare against. Forcing `portable` on win32 is a way to
+ * get an empty scan and nothing else — `ps` and `lsof` are not there — but the
+ * override is deliberately literal rather than clever about it.
  */
-function selectBackend(): ProcBackend {
-  const override = process.env.VIEWER_PROC_BACKEND;
+export function selectProcBackend(
+  platform: NodeJS.Platform = process.platform,
+  override: string | undefined = process.env.VIEWER_PROC_BACKEND,
+): ProcBackend {
   if (override === "portable") return portableBackend;
   if (override === "linux") return linuxBackend;
-  return process.platform === "linux" ? linuxBackend : portableBackend;
+  if (override === "windows") return windowsBackend;
+  if (platform === "linux") return linuxBackend;
+  return platform === "win32" ? windowsBackend : portableBackend;
 }
 
-export const procBackend: ProcBackend = selectBackend();
+export const procBackend: ProcBackend = selectProcBackend();

--- a/src/lib/proc/types.ts
+++ b/src/lib/proc/types.ts
@@ -1,6 +1,8 @@
 /**
  * Process-introspection backend contract. Linux reads `/proc` directly
- * (`linux.ts`); every other platform shells out to `ps`/`lsof` (`portable.ts`).
+ * (`linux.ts`); Windows reads one `Win32_Process` snapshot plus two kernel
+ * values through FFI (`windows.ts`); every other platform shells out to
+ * `ps`/`lsof` (`portable.ts`).
  * Callers never depend on which backend is active — see `scanner/process.ts`
  * and `tmux.ts`, which hold the platform-independent logic (engine matching,
  * memoization, ppid-chain walks) on top of these primitives.
@@ -39,7 +41,7 @@ export interface ProcSnapshotEntry {
 }
 
 export interface ProcBackend {
-  readonly name: "linux" | "portable";
+  readonly name: "linux" | "portable" | "windows";
 
   pidAlive(pid: number): boolean;
 

--- a/src/lib/proc/windows.test.ts
+++ b/src/lib/proc/windows.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { encodedPowerShellCommand, resetWindowsSnapshotForTests, windowsBackend, WINDOWS_PROCESS_SNAPSHOT_SCRIPT } from "./windows";
+import { windowsProcessCwd } from "./windowsCwd";
+import { normalizeWindowsCwd } from "./windowsSnapshot";
+import { windowsProcessIdentity } from "./windowsIdentity";
+
+/*
+ * The live half of the Windows backend. Everything here talks to the running
+ * operating system, so off win32 the cases skip and prove nothing — which is
+ * why `platform-tests.yml` runs a step that fails when the runner is not
+ * Windows before it runs this file. A silent skip would leave the job green and
+ * the backend unexecuted, which is the failure mode issue #1256 shipped on the
+ * macOS side.
+ */
+
+const windows = process.platform === "win32";
+const SANDBOX = windows ? fs.mkdtempSync(path.join(os.tmpdir(), "llv-windows-proc-")) : "";
+const children: Array<{ kill(): void; exited: Promise<unknown> }> = [];
+
+afterAll(async () => {
+  for (const child of children) {
+    try {
+      child.kill();
+    } catch {
+      /* already gone */
+    }
+  }
+  /* Windows will not remove a directory that is still some process's working
+     directory, and a terminated child releases it only once it is reaped. */
+  await Promise.all(children.map((child) => child.exited.catch(() => undefined)));
+  try {
+    if (SANDBOX) fs.rmSync(SANDBOX, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  } catch {
+    /* teardown, not an assertion: the runner's temp root goes with the job */
+  }
+});
+
+/** A Bun child that idles in `cwd` until it is killed, with a known pid. */
+function idleChild(cwd: string, extra: string[] = []): { pid: number; kill(): void; exited: Promise<unknown> } {
+  fs.mkdirSync(cwd, { recursive: true });
+  const child = Bun.spawn(
+    [process.execPath, "-e", "setInterval(() => {}, 1000)", ...extra],
+    { cwd, stdout: "ignore", stderr: "ignore", stdin: "ignore" },
+  );
+  const handle = { pid: child.pid, kill: () => child.kill(), exited: child.exited };
+  children.push(handle);
+  return handle;
+}
+
+async function untilVisible(pid: number, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    resetWindowsSnapshotForTests();
+    if (windowsBackend.readArgv(pid).length > 0) return;
+    await Bun.sleep(250);
+  }
+  throw new Error(`the Win32_Process snapshot never listed pid ${pid}`);
+}
+
+test("the PowerShell script is handed over as an encoded command, not as quoting", () => {
+  /* Pure: no layer between here and PowerShell — Node's Windows argument
+     quoting, CreateProcess, PowerShell's own re-parse — can reinterpret the
+     script when it travels as base64 UTF-16LE. */
+  const encoded = encodedPowerShellCommand(WINDOWS_PROCESS_SNAPSHOT_SCRIPT);
+  expect(Buffer.from(encoded, "base64").toString("utf16le")).toBe(WINDOWS_PROCESS_SNAPSHOT_SCRIPT);
+  expect(WINDOWS_PROCESS_SNAPSHOT_SCRIPT).toContain("Get-CimInstance Win32_Process");
+  expect(WINDOWS_PROCESS_SNAPSHOT_SCRIPT).toContain("ToFileTimeUtc()");
+});
+
+test("the backend reports no open-handle holders instead of guessing", () => {
+  /* Windows has no shipped handle enumeration here. What degrades is stated in
+     the README: liveness comes from mtime and attribution from argv. */
+  const visits: string[] = [];
+  windowsBackend.scanFdTargetsUnder("C:\\anything", (target) => visits.push(target));
+  windowsBackend.scanFdTargetsFor(["C:\\anything"], (target) => visits.push(target));
+  expect(visits).toEqual([]);
+  expect(windowsBackend.pidHoldsPath(1, "C:\\anything")).toBe(false);
+  expect(windowsBackend.pidWritesPath(1, "C:\\anything")).toBe(false);
+  expect(windowsBackend.readEnvVar(1, "PATH")).toBeNull();
+});
+
+test.if(windows)("the snapshot lists this process with a parsed argv", async () => {
+  await untilVisible(process.pid);
+  const listed = windowsBackend.listProcesses().find((entry) => entry.pid === process.pid);
+  expect(listed).toBeDefined();
+  expect(path.basename(listed!.argv[0] ?? "").toLowerCase()).toContain("bun");
+  expect(listed!.tty).not.toBe(0);
+}, 30_000);
+
+test.if(windows)("identity is stable for a live pid, differs between two children, and vanishes with them", async () => {
+  const first = idleChild(path.join(SANDBOX, "identity-a"));
+  const second = idleChild(path.join(SANDBOX, "identity-b"));
+
+  const firstIdentity = windowsProcessIdentity(first.pid);
+  const secondIdentity = windowsProcessIdentity(second.pid);
+  expect(firstIdentity).toBeString();
+  expect(secondIdentity).toBeString();
+  expect(windowsProcessIdentity(first.pid)).toBe(firstIdentity!);
+  /* Two processes started moments apart must not share a token, or the fence
+     and every kill path would accept one in place of the other. */
+  expect(firstIdentity).not.toBe(secondIdentity!);
+  expect(windowsBackend.pidAlive(first.pid)).toBe(true);
+
+  first.kill();
+  await first.exited;
+  /* `pidAlive` is `process.kill(pid, 0)`; on Windows libuv answers the
+     existence question without terminating anything, and this is the assertion
+     that proves it — the process must read as gone, and this test process must
+     still be running afterwards. */
+  const deadline = Date.now() + 10_000;
+  while (windowsBackend.pidAlive(first.pid) && Date.now() < deadline) await Bun.sleep(100);
+  expect(windowsBackend.pidAlive(first.pid)).toBe(false);
+  expect(windowsProcessIdentity(first.pid)).toBeNull();
+
+  second.kill();
+}, 30_000);
+
+test.if(windows)("a child's working directory is read out of its own process parameters", async () => {
+  /* `agentProcesses` drops every process whose cwd is null, so this read is
+     what makes a running `claude` visible on Windows at all. The directory name
+     carries a space, which is the shape a real profile path has. */
+  const requested = path.join(SANDBOX, "cwd probe");
+  fs.mkdirSync(requested, { recursive: true });
+  const cwd = fs.realpathSync.native(requested);
+  const child = idleChild(cwd);
+  await untilVisible(child.pid);
+
+  /* The raw DosPath carries a trailing separator the rest of the codebase never
+     writes, which is what `normalizeWindowsCwd` exists to strip. Compared
+     case-insensitively too: NTFS preserves case but does not distinguish it, so
+     the path the kernel reports need not match the case it was created with. */
+  const raw = windowsProcessCwd(child.pid);
+  expect(raw).toBeString();
+  expect(normalizeWindowsCwd(raw!)?.toLowerCase()).toBe(cwd.toLowerCase());
+  expect(windowsBackend.readCwd(child.pid)?.toLowerCase()).toBe(cwd.toLowerCase());
+  child.kill();
+}, 40_000);
+
+test.if(windows)("the parent map links a child to this process", async () => {
+  const child = idleChild(path.join(SANDBOX, "lineage"));
+  await untilVisible(child.pid);
+
+  expect(windowsBackend.ppidMap().get(child.pid)).toBe(process.pid);
+  expect(windowsBackend.readPpid(child.pid)).toBe(process.pid);
+  child.kill();
+}, 40_000);
+
+test.if(windows)("memory and CPU are reported for a live pid, and memory for the host", async () => {
+  await untilVisible(process.pid);
+  const memory = windowsBackend.processMemory([process.pid]).get(process.pid);
+  expect(memory?.rssBytes ?? 0).toBeGreaterThan(0);
+  expect(memory?.swapBytes).toBe(0);
+
+  /* Unlike macOS, Windows counts per-process CPU in the snapshot already taken,
+     so the liveness verdict gets a reading rather than "no evidence". */
+  const cpuMs = windowsBackend.processCpuMs(process.pid);
+  expect(cpuMs).not.toBeNull();
+  expect(cpuMs!).toBeGreaterThanOrEqual(0);
+  expect(windowsBackend.processCpuMs(-1)).toBeNull();
+
+  const system = windowsBackend.systemMemory();
+  expect(system?.ramTotal ?? 0).toBeGreaterThan(0);
+  expect(system!.ramAvailable).toBeGreaterThan(0);
+  expect(system!.ramAvailable).toBeLessThanOrEqual(system!.ramTotal);
+}, 30_000);

--- a/src/lib/proc/windows.ts
+++ b/src/lib/proc/windows.ts
@@ -1,0 +1,240 @@
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+
+import type { ProcBackend, ProcessMemory, ProcSnapshotEntry, SystemMemory } from "./types";
+import { windowsProcessCwd } from "./windowsCwd";
+import { windowsProcessIdentity } from "./windowsIdentity";
+import {
+  normalizeWindowsCwd,
+  parseWindowsProcessSnapshot,
+  snapshotEntries,
+  type WindowsSnapshot,
+} from "./windowsSnapshot";
+
+/**
+ * The Windows process backend: the third one, beside Linux's `/proc` reader and
+ * the POSIX `ps`/`lsof` portable backend. It exists because `portableBackend`
+ * is not merely slower on Windows, it is empty there — it shells out to `ps`,
+ * `lsof`, `vm_stat` and `sysctl`, none of which exist, and its identity token
+ * is Darwin-only. Selecting it on win32 would make every scan return nothing.
+ *
+ * One Windows PowerShell call per TTL supplies pid, parent pid, command line,
+ * working set and creation time for every process; `Get-CimInstance
+ * Win32_Process` is the only always-present source with all five columns
+ * (`tasklist` has no lineage, `wmic` is gone from Windows 11 24H2, and
+ * `Get-Process` on Windows PowerShell 5.1 has no command line). The parsing of
+ * that output lives in `windowsSnapshot.ts` and is pure. The two things
+ * PowerShell cannot supply come from the kernel through `bun:ffi`: the identity
+ * token (`windowsIdentity.ts`) and the working directory (`windowsCwd.ts`).
+ *
+ * Nobody working on this repository has a Windows machine. Everything here
+ * that touches the OS is exercised by the `windows-latest` leg of
+ * `.github/workflows/platform-tests.yml`, and everything that is a rule about
+ * bytes is a pure function with a test that runs on every platform.
+ */
+
+const SNAPSHOT_TTL_MS = 5_000;
+const RUN_TIMEOUT_MS = 15_000;
+const MAX_BUFFER = 32 * 1024 * 1024;
+
+/**
+ * Windows has no cheap "does this process have a console" probe, and the field
+ * is only ever compared against 0 (see `types.ts`). Zero means headless, which
+ * both makes a process a reaper candidate and *blocks* the cwd-fallback
+ * transcript attribution. Reporting a constant nonzero keeps interactive Claude
+ * sessions attributable and keeps the (opt-in, unported) reaper from ever
+ * selecting a Windows process.
+ */
+const CONSTANT_TTY = 1;
+
+/**
+ * CSV, not JSON: Windows PowerShell 5.1 serialises a DateTime into JSON as
+ * `/Date(ms)/` and drops everything below the millisecond, and the whole point
+ * of the `Created` column is ordering a parent against its child. The
+ * `ToFileTimeUtc()` projection carries the value as an integer instead.
+ *
+ * The script is handed over as `-EncodedCommand` (UTF-16LE base64) so that no
+ * layer between here and PowerShell — Node's Windows argument quoting,
+ * `CreateProcess`, PowerShell's own re-parse — can reinterpret a quote or a
+ * dollar sign in it.
+ */
+export const WINDOWS_PROCESS_SNAPSHOT_SCRIPT = [
+  "$ErrorActionPreference='SilentlyContinue'",
+  /* UTF-8 so a non-ASCII path survives the console encoding, and explicitly
+     *without* a byte-order mark: `[System.Text.Encoding]::UTF8` carries a BOM
+     preamble, and a BOM in front of the header turns the first column name into
+     something `indexOf` does not find — a silently empty process table. The
+     parser strips one anyway; this keeps it from being written. */
+  "[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false",
+  "Get-CimInstance Win32_Process |",
+  " Select-Object ProcessId,ParentProcessId,CommandLine,WorkingSetSize,UserModeTime,KernelModeTime,",
+  "  @{n='Created';e={if ($_.CreationDate) { $_.CreationDate.ToFileTimeUtc() }}} |",
+  " ConvertTo-Csv -NoTypeInformation",
+].join("\n");
+
+/** PowerShell's `-EncodedCommand` argument for `script`. Pure. */
+export function encodedPowerShellCommand(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function runSnapshotCommand(): string {
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-EncodedCommand", encodedPowerShellCommand(WINDOWS_PROCESS_SNAPSHOT_SCRIPT)],
+    { encoding: "utf8", maxBuffer: MAX_BUFFER, timeout: RUN_TIMEOUT_MS, windowsHide: true },
+  );
+  /* A missing or refused PowerShell degrades to "nothing found", the same way
+     the portable backend treats a missing `ps`. It is not silent in practice:
+     zero rows means zero agents on the board, and `platform-tests.yml` fails
+     when the call stops working on a supported runner. */
+  if (result.error || typeof result.stdout !== "string") return "";
+  return result.stdout;
+}
+
+interface Snapshot {
+  at: number;
+  data: WindowsSnapshot;
+  /** cwd reads are the expensive part; one attempt per pid per snapshot. */
+  cwds: Map<number, string | null>;
+}
+
+let snapshotMemo: Snapshot | null = null;
+
+/** Test seam: forces the next read to take a fresh snapshot rather than one up
+    to five seconds old, so a test that just spawned a child can see it. */
+export function resetWindowsSnapshotForTests(): void {
+  snapshotMemo = null;
+}
+
+function snapshot(): Snapshot {
+  const now = Date.now();
+  if (snapshotMemo && now - snapshotMemo.at < SNAPSHOT_TTL_MS) return snapshotMemo;
+  snapshotMemo = { at: now, data: parseWindowsProcessSnapshot(runSnapshotCommand()), cwds: new Map() };
+  return snapshotMemo;
+}
+
+function cwdFor(pid: number): string | null {
+  const current = snapshot();
+  const cached = current.cwds.get(pid);
+  if (cached !== undefined) return cached;
+  const raw = windowsProcessCwd(pid);
+  const resolved = raw === null ? null : normalizeWindowsCwd(raw);
+  current.cwds.set(pid, resolved);
+  return resolved;
+}
+
+function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    /* Signal 0 is an existence probe on Windows too: libuv's uv_kill short
+       circuits before TerminateProcess when signum is 0. Every other signal
+       number would kill the process, so nothing else may be passed here. */
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readArgv(pid: number): string[] {
+  return snapshot().data.rows.get(pid)?.argv ?? [];
+}
+
+function readCwd(pid: number): string | null {
+  return cwdFor(pid);
+}
+
+function readPpid(pid: number): number | null {
+  return snapshot().data.ppids.get(pid) ?? null;
+}
+
+function processIdentity(pid: number): string | null {
+  return windowsProcessIdentity(pid);
+}
+
+/**
+ * `Win32_Process` already counts user and kernel time per process, so the CPU
+ * reading the liveness verdict wants costs nothing beyond the snapshot that was
+ * taken anyway — unlike macOS, which answers null here. It is snapshot-fresh,
+ * so two reads inside one TTL report the same number.
+ */
+function processCpuMs(pid: number): number | null {
+  return snapshot().data.rows.get(pid)?.cpuMs ?? null;
+}
+
+/**
+ * Reading another process's environment on Windows needs the same
+ * ReadProcessMemory walk the cwd read does, plus a whole-block parse, for a
+ * value only the Codex hook-path lineage fallback consults. Null here matches
+ * macOS, and `scanner/process.ts` already tolerates it.
+ */
+function readEnvVar(): string | null {
+  return null;
+}
+
+function listProcesses(): ProcSnapshotEntry[] {
+  return snapshotEntries(snapshot().data, cwdFor, CONSTANT_TTY);
+}
+
+/**
+ * `os.freemem()` on Windows is `GlobalMemoryStatusEx().ullAvailPhys`, which is
+ * already the reclaim-aware headroom `ramAvailable` wants; there is no second
+ * PowerShell call here. Swap is reported as absent rather than guessed: the
+ * page file is not a Unix swap device and the rail only displays the number.
+ */
+function systemMemory(): SystemMemory | null {
+  const ramTotal = os.totalmem();
+  if (!ramTotal) return null;
+  return { ramTotal, ramAvailable: Math.min(os.freemem(), ramTotal), swapTotal: 0, swapUsed: 0 };
+}
+
+function processMemory(pids: Iterable<number>): Map<number, ProcessMemory> {
+  const rows = snapshot().data.rows;
+  const map = new Map<number, ProcessMemory>();
+  for (const pid of pids) {
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    const row = rows.get(pid);
+    if (row) map.set(pid, { rssBytes: row.workingSetBytes, swapBytes: 0 });
+  }
+  return map;
+}
+
+function ppidMap(): Map<number, number> {
+  return new Map(snapshot().data.ppids);
+}
+
+/**
+ * No open-handle enumeration. Restoring it would mean walking
+ * `NtQuerySystemInformation`'s handle table and resolving each device path,
+ * which is large, undocumented and fragile. What degrades is named in the
+ * README: a transcript's liveness comes from mtime recency and its owning pid
+ * from `--session-id` argv or cwd, never from a live writer's open handle, and
+ * background-task `.output` files cannot be mapped to a pid.
+ */
+function scanFdTargetsUnder(): void {}
+function scanFdTargetsFor(): void {}
+function pidWritesPath(): boolean {
+  return false;
+}
+function pidHoldsPath(): boolean {
+  return false;
+}
+
+export const windowsBackend: ProcBackend = {
+  name: "windows",
+  pidAlive,
+  readArgv,
+  readCwd,
+  readPpid,
+  processIdentity,
+  processCpuMs,
+  readEnvVar,
+  listProcesses,
+  systemMemory,
+  processMemory,
+  ppidMap,
+  scanFdTargetsUnder,
+  scanFdTargetsFor,
+  pidWritesPath,
+  pidHoldsPath,
+};

--- a/src/lib/proc/windowsCwd.test.ts
+++ b/src/lib/proc/windowsCwd.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+
+import { parseWindowsProcessParametersCwd } from "./windowsCwd";
+
+/*
+ * The offsets into another process's `RTL_USER_PROCESS_PARAMETERS`, asserted
+ * against a hand-built block. The live read is `windows.test.ts` on the
+ * `windows-latest` leg; this file is what says which byte means what, on every
+ * platform.
+ */
+
+/** x64: `CurrentDirectory.DosPath` is a UNICODE_STRING at 0x38 (Buffer at 0x40). */
+const DOSPATH_AT = 0x38;
+const HEAD_BYTES = 0x50;
+
+function parametersBlock(path: string | null, address = BigInt("0x7ff000001000")): Buffer {
+  const block = Buffer.alloc(HEAD_BYTES);
+  const bytes = path === null ? 0 : Buffer.from(path, "utf16le").byteLength;
+  block.writeUInt16LE(bytes, DOSPATH_AT);
+  block.writeUInt16LE(bytes + 2, DOSPATH_AT + 2);
+  block.writeBigUInt64LE(path === null ? BigInt(0) : address, DOSPATH_AT + 8);
+  return block;
+}
+
+test("the DosPath is read from its own UNICODE_STRING, at the length it declares", () => {
+  const cwd = "C:\\work\\project";
+  const block = parametersBlock(cwd);
+  const reads: Array<{ address: bigint; size: number }> = [];
+
+  const resolved = parseWindowsProcessParametersCwd(block, (address, size) => {
+    reads.push({ address, size });
+    /* The path is not NUL-terminated in the target, and the buffer around it is
+       arbitrary memory — reading past `Length` would append garbage. */
+    return Buffer.concat([Buffer.from(cwd, "utf16le"), Buffer.from("\u0000junk", "utf16le")]).subarray(0, size);
+  });
+
+  expect(resolved).toBe(cwd);
+  expect(reads).toEqual([{ address: BigInt("0x7ff000001000"), size: Buffer.from(cwd, "utf16le").byteLength }]);
+});
+
+test("a block that says nothing readable resolves to nothing", () => {
+  const never = (): Buffer | null => {
+    throw new Error("must not read the target's memory");
+  };
+  expect(parseWindowsProcessParametersCwd(parametersBlock(null), never)).toBeNull();
+  expect(parseWindowsProcessParametersCwd(Buffer.alloc(8), never)).toBeNull();
+
+  // A declared length that is not a whole number of UTF-16 units is a torn read.
+  const odd = parametersBlock("C:\\x");
+  odd.writeUInt16LE(7, DOSPATH_AT);
+  expect(parseWindowsProcessParametersCwd(odd, never)).toBeNull();
+
+  // So is one longer than a Windows path can be.
+  const huge = parametersBlock("C:\\x");
+  huge.writeUInt16LE(0xfffe, DOSPATH_AT);
+  expect(parseWindowsProcessParametersCwd(huge, never)).toBeNull();
+});
+
+test("a refused or short memory read is not a partial path", () => {
+  const cwd = "C:\\work";
+  expect(parseWindowsProcessParametersCwd(parametersBlock(cwd), () => null)).toBeNull();
+  expect(parseWindowsProcessParametersCwd(parametersBlock(cwd), () => Buffer.alloc(4))).toBeNull();
+});

--- a/src/lib/proc/windowsCwd.ts
+++ b/src/lib/proc/windowsCwd.ts
@@ -1,0 +1,214 @@
+import { createRequire } from "node:module";
+
+/**
+ * Another process's working directory on Windows.
+ *
+ * `agentProcesses` drops every process whose cwd is null
+ * (`src/lib/scanner/process.ts`), so a backend that never resolved one would
+ * show zero agents on Windows — the acceptance sentence of issue #1201 fails
+ * on that alone. Windows has no `/proc/<pid>/cwd` and no `lsof -d cwd`: the
+ * only route is to read the target's own process parameters out of its
+ * address space, which is what this module does.
+ *
+ *   OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ)
+ *     -> NtQueryInformationProcess(ProcessBasicInformation)  -> PEB address
+ *     -> ReadProcessMemory(PEB + 0x20)                       -> RTL_USER_PROCESS_PARAMETERS
+ *     -> ReadProcessMemory(params + 0x38)                    -> CurrentDirectory.DosPath
+ *     -> ReadProcessMemory(DosPath.Buffer, DosPath.Length)   -> the UTF-16 path
+ *
+ * Every offset above is the x64 layout and only the x64 layout, so a 32-bit
+ * (WOW64) target is refused rather than read at the wrong offsets — checked
+ * with `IsWow64Process`. Claude Code's native binary is 64-bit.
+ *
+ * Failure is always `null`, never a throw: an elevated process, a process
+ * owned by another account, one that exited between the snapshot and the read,
+ * or a Viewer running under Node instead of Bun (no `bun:ffi`) all degrade to
+ * "cwd unknown", which is exactly what the portable backend reports on macOS
+ * when `lsof` has no cwd row. Such a process stays invisible to
+ * `agentProcesses`; a Viewer-spawned host is still attributed through its
+ * `--session-id` argv.
+ *
+ * The `windows-latest` leg of `platform-tests.yml` is where this executes:
+ * `windows.test.ts` spawns a child in a known directory and requires the read
+ * to return that directory.
+ */
+
+const PROCESS_QUERY_INFORMATION = 0x0400;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+const PROCESS_VM_READ = 0x0010;
+
+/** sizeof(PROCESS_BASIC_INFORMATION) on x64, PebBaseAddress at offset 8. */
+const PBI_SIZE = 48;
+const PBI_PEB_OFFSET = 8;
+/** PEB.ProcessParameters (x64). */
+const PEB_PARAMETERS_OFFSET = 0x20;
+/** RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath (x64): a UNICODE_STRING. */
+const PARAMETERS_HEAD_BYTES = 0x50;
+const CURDIR_DOSPATH_OFFSET = 0x38;
+const UNICODE_STRING_LENGTH_OFFSET = 0;
+const UNICODE_STRING_BUFFER_OFFSET = 8;
+/** A DosPath longer than this is a torn read, not a path. */
+const MAX_DOSPATH_BYTES = 0x7ffe;
+
+interface BunFfiModule {
+  FFIType: { i32: number; u32: number; u64: number; ptr: number };
+  ptr(buffer: NodeJS.TypedArray): number | bigint;
+  dlopen(path: string, symbols: Record<string, unknown>): { symbols: Record<string, (...args: never[]) => unknown> };
+}
+
+/*
+ * A HANDLE and a remote address cross the boundary as `u64`, never as `ptr`.
+ * A pointer-typed argument makes Bun marshal the value through its own pointer
+ * objects, and that path crashes the process on a bare integer; `u64` is the
+ * same eight bytes in the same register with none of the marshalling. Only the
+ * buffers this process owns stay `ptr`, passed through `ffi.ptr`.
+ */
+const NULL_HANDLE = BigInt(0);
+
+interface WindowsMemoryReader {
+  /** The target's process-parameters block address, or null when unreadable. */
+  parametersAddress(pid: number): bigint | null;
+  /** `size` bytes at `address` in `pid`'s address space, or null. */
+  read(pid: number, address: bigint, size: number): Buffer | null;
+  /** Releases whatever handle the two calls above opened for `pid`. */
+  close(pid: number): void;
+}
+
+let cachedReader: WindowsMemoryReader | null | undefined;
+
+/**
+ * Recovers the DosPath out of the two raw reads. Pure, so the offsets and the
+ * rejection rules are asserted on every platform rather than only where the
+ * FFI can run.
+ */
+export function parseWindowsProcessParametersCwd(
+  parameters: Buffer,
+  readBuffer: (address: bigint, size: number) => Buffer | null,
+): string | null {
+  if (parameters.byteLength < PARAMETERS_HEAD_BYTES) return null;
+  const dosPath = CURDIR_DOSPATH_OFFSET;
+  const length = parameters.readUInt16LE(dosPath + UNICODE_STRING_LENGTH_OFFSET);
+  const address = parameters.readBigUInt64LE(dosPath + UNICODE_STRING_BUFFER_OFFSET);
+  if (length === 0 || length % 2 !== 0 || length > MAX_DOSPATH_BYTES) return null;
+  if (address === BigInt(0)) return null;
+  const raw = readBuffer(address, length);
+  if (!raw || raw.byteLength < length) return null;
+  const text = raw.subarray(0, length).toString("utf16le");
+  return text.length === 0 ? null : text;
+}
+
+function loadReader(): WindowsMemoryReader | null {
+  if (cachedReader !== undefined) return cachedReader;
+  if (process.platform !== "win32") {
+    cachedReader = null;
+    return cachedReader;
+  }
+  try {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const { i32, u32, u64, ptr } = ffi.FFIType;
+    const kernel32 = ffi.dlopen("kernel32.dll", {
+      OpenProcess: { args: [u32, i32, u32], returns: u64 },
+      CloseHandle: { args: [u64], returns: i32 },
+      ReadProcessMemory: { args: [u64, u64, ptr, u64, ptr], returns: i32 },
+      IsWow64Process: { args: [u64, ptr], returns: i32 },
+    });
+    const ntdll = ffi.dlopen("ntdll.dll", {
+      NtQueryInformationProcess: { args: [u64, i32, ptr, u32, ptr], returns: i32 },
+    });
+
+    const handles = new Map<number, bigint>();
+    const open = (pid: number): bigint | null => {
+      const existing = handles.get(pid);
+      if (existing !== undefined) return existing;
+      for (const access of [
+        PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+        PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ,
+      ]) {
+        const handle = BigInt(kernel32.symbols.OpenProcess!(access as never, 0 as never, pid as never) as bigint | number);
+        if (handle !== NULL_HANDLE) {
+          handles.set(pid, handle);
+          return handle;
+        }
+      }
+      return null;
+    };
+
+    const readInto = (handle: bigint, address: bigint, out: Buffer): boolean => {
+      const transferred = Buffer.alloc(8);
+      const ok = kernel32.symbols.ReadProcessMemory!(
+        handle as never,
+        address as never,
+        ffi.ptr(out) as never,
+        BigInt(out.byteLength) as never,
+        ffi.ptr(transferred) as never,
+      ) as number;
+      return ok !== 0 && transferred.readBigUInt64LE(0) === BigInt(out.byteLength);
+    };
+
+    cachedReader = {
+      parametersAddress(pid) {
+        const handle = open(pid);
+        if (handle === null) return null;
+        /* A WOW64 target's parameters block uses the 32-bit layout, and every
+           offset here is x64. Refuse it instead of reading garbage. */
+        const wow64 = Buffer.alloc(4);
+        if ((kernel32.symbols.IsWow64Process!(handle as never, ffi.ptr(wow64) as never) as number) !== 0
+          && wow64.readInt32LE(0) !== 0) return null;
+        const pbi = Buffer.alloc(PBI_SIZE);
+        const returned = Buffer.alloc(8);
+        const status = ntdll.symbols.NtQueryInformationProcess!(
+          handle as never,
+          0 as never,
+          ffi.ptr(pbi) as never,
+          PBI_SIZE as never,
+          ffi.ptr(returned) as never,
+        ) as number;
+        if (status !== 0) return null;
+        const peb = pbi.readBigUInt64LE(PBI_PEB_OFFSET);
+        if (peb === BigInt(0)) return null;
+        const parametersPointer = Buffer.alloc(8);
+        if (!readInto(handle, peb + BigInt(PEB_PARAMETERS_OFFSET), parametersPointer)) return null;
+        const parameters = parametersPointer.readBigUInt64LE(0);
+        return parameters === BigInt(0) ? null : parameters;
+      },
+      read(pid, address, size) {
+        const handle = open(pid);
+        if (handle === null || size <= 0) return null;
+        const out = Buffer.alloc(size);
+        return readInto(handle, address, out) ? out : null;
+      },
+      close(pid) {
+        const handle = handles.get(pid);
+        if (handle === undefined) return;
+        handles.delete(pid);
+        try {
+          kernel32.symbols.CloseHandle!(handle as never);
+        } catch {
+          /* the handle is going away with the process either way */
+        }
+      },
+    };
+  } catch {
+    cachedReader = null;
+  }
+  return cachedReader;
+}
+
+/** The process's own working directory, or null when Windows will not say. */
+export function windowsProcessCwd(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const reader = loadReader();
+  if (!reader) return null;
+  try {
+    const parametersAddress = reader.parametersAddress(pid);
+    if (parametersAddress === null) return null;
+    const parameters = reader.read(pid, parametersAddress, PARAMETERS_HEAD_BYTES);
+    if (!parameters) return null;
+    return parseWindowsProcessParametersCwd(parameters, (address, size) => reader.read(pid, address, size));
+  } catch {
+    return null;
+  } finally {
+    reader.close(pid);
+  }
+}

--- a/src/lib/proc/windowsIdentity.test.ts
+++ b/src/lib/proc/windowsIdentity.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+
+import { parseWindowsCreationIdentity, windowsProcessIdentity } from "./windowsIdentity";
+
+/** FILETIME of 2026-01-01T00:00:00Z — a plausible creation time. */
+const PLAUSIBLE = BigInt("133776864000000000");
+
+function filetime(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(value);
+  return buffer;
+}
+
+test("the token is the pid and the kernel's creation FILETIME", () => {
+  expect(parseWindowsCreationIdentity(4321, filetime(PLAUSIBLE), true)).toBe(`4321:${PLAUSIBLE}`);
+});
+
+test("a failed read is no identity, never a token built from a zeroed buffer", () => {
+  /* This is the whole point of the token: a caller that cannot read the
+     creation time must learn nothing rather than learn something reusable. A
+     zeroed buffer would otherwise mint `pid:0`, which every process that fails
+     the same way would share, and the fence would treat two different processes
+     as the same owner. */
+  expect(parseWindowsCreationIdentity(4321, filetime(PLAUSIBLE), false)).toBeNull();
+  expect(parseWindowsCreationIdentity(4321, filetime(BigInt(0)), true)).toBeNull();
+  expect(parseWindowsCreationIdentity(4321, Buffer.alloc(4), true)).toBeNull();
+});
+
+test("a creation time before 2000 is not a creation time", () => {
+  expect(parseWindowsCreationIdentity(4321, filetime(BigInt("125911583999999999")), true)).toBeNull();
+  expect(parseWindowsCreationIdentity(4321, filetime(BigInt("125911584000000000")), true))
+    .toBe("4321:125911584000000000");
+});
+
+test("a pid that cannot be signalled cannot have an identity", () => {
+  expect(parseWindowsCreationIdentity(0, filetime(PLAUSIBLE), true)).toBeNull();
+  expect(parseWindowsCreationIdentity(-1, filetime(PLAUSIBLE), true)).toBeNull();
+  expect(windowsProcessIdentity(0)).toBeNull();
+  expect(windowsProcessIdentity(-7)).toBeNull();
+});
+
+test("the token carries the pid prefix the CLI's fence-owner check requires", () => {
+  const token = parseWindowsCreationIdentity(908, filetime(PLAUSIBLE), true)!;
+  expect(token.startsWith("908:")).toBe(true);
+});
+
+test.if(process.platform === "win32")("the kernel reader answers for this process, stably", () => {
+  const mine = windowsProcessIdentity(process.pid);
+  expect(mine).toBeString();
+  expect(mine!.startsWith(`${process.pid}:`)).toBe(true);
+  // Fixed for the life of the process: two reads cannot disagree.
+  expect(windowsProcessIdentity(process.pid)).toBe(mine!);
+});
+
+test.if(process.platform !== "win32")("the reader is inert off Windows rather than throwing", () => {
+  expect(windowsProcessIdentity(process.pid)).toBeNull();
+});

--- a/src/lib/proc/windowsIdentity.ts
+++ b/src/lib/proc/windowsIdentity.ts
@@ -1,0 +1,120 @@
+import { createRequire } from "node:module";
+
+/**
+ * The Windows process-identity token, read from the kernel.
+ *
+ * Identity exists to survive pid reuse, and Windows reuses a pid harder than
+ * any other platform this repository runs on: pids are handed out in multiples
+ * of four from a small table and a freed one comes back within seconds. Every
+ * kill path here (`structuredHostControl`, `structuredSpawn`, the agent
+ * registry, `signalProcessGroup`) and the runtime-host singleton fence
+ * re-reads the identity of a pid before acting on it, so the token has to be a
+ * value the OS supplies about *that* process — a counter, a hash of the
+ * command line or anything else that merely differs between two processes
+ * would be reused along with the pid.
+ *
+ * `GetProcessTimes`' creation FILETIME is that value: 100 ns ticks since
+ * 1601-01-01 UTC, fixed for the life of the process, and the same quantity
+ * `/proc/<pid>/stat` field 22 supplies on Linux and `proc_pidinfo`'s
+ * `pbi_start_tv{sec,usec}` supplies on macOS. The token is `${pid}:${filetime}`,
+ * matching the `pid:` prefix `bin/cli.mjs` already validates on the fence owner
+ * record.
+ *
+ * Deliberately NOT the snapshot's `Win32_Process.CreationDate`: that is a
+ * CIM_DATETIME truncated to whole microseconds, so it disagrees with the
+ * kernel value in its last digit, and it is up to a TTL old — the exact window
+ * a reused pid lives in. The snapshot column orders parents against children
+ * (`windowsSnapshot.ts`) and nothing else.
+ *
+ * When the reader cannot load (the Viewer running under Node instead of Bun,
+ * so `bun:ffi` is absent) this returns null, and null propagates as "identity
+ * unknown", which every caller treats conservatively — the fence refuses to
+ * reclaim an owner it cannot disprove. That is safe but not silent: the CLI's
+ * readiness probe requires a string identity in the fence owner record, so a
+ * host whose identity reader is dead fails to start rather than running
+ * unfenced. `platform-tests.yml` exercises the reader on `windows-latest`.
+ */
+
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+/** FILETIME of 2000-01-01T00:00:00Z. A creation time below it is not a real one. */
+const MIN_PLAUSIBLE_FILETIME = BigInt("125911584000000000");
+
+type ProcessTimesReader = (pid: number, creation: Buffer) => boolean;
+
+interface BunFfiModule {
+  FFIType: { i32: number; u32: number; ptr: number };
+  ptr(buffer: Buffer): unknown;
+  dlopen(path: string, symbols: Record<string, unknown>): {
+    symbols: {
+      OpenProcess: (...args: unknown[]) => unknown;
+      CloseHandle: (...args: unknown[]) => number;
+      GetProcessTimes: (...args: unknown[]) => number;
+    };
+  };
+}
+
+let cachedReader: ProcessTimesReader | null | undefined;
+
+/**
+ * Formats a creation FILETIME read into `creation` as an identity token. Pure,
+ * so the token's shape and its rejection rules are proven on every platform.
+ */
+export function parseWindowsCreationIdentity(pid: number, creation: Buffer, ok: boolean): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (!ok || creation.byteLength < 8) return null;
+  const filetime = creation.readBigUInt64LE(0);
+  if (filetime < MIN_PLAUSIBLE_FILETIME) return null;
+  return `${pid}:${filetime}`;
+}
+
+function loadReader(): ProcessTimesReader | null {
+  if (cachedReader !== undefined) return cachedReader;
+  if (process.platform !== "win32") {
+    cachedReader = null;
+    return cachedReader;
+  }
+  try {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const library = ffi.dlopen("kernel32.dll", {
+      OpenProcess: { args: [ffi.FFIType.u32, ffi.FFIType.i32, ffi.FFIType.u32], returns: ffi.FFIType.ptr },
+      CloseHandle: { args: [ffi.FFIType.ptr], returns: ffi.FFIType.i32 },
+      GetProcessTimes: {
+        args: [ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr],
+        returns: ffi.FFIType.i32,
+      },
+    });
+    cachedReader = (pid, creation) => {
+      const handle = library.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+      if (!handle) return false;
+      const scratch = [Buffer.alloc(8), Buffer.alloc(8), Buffer.alloc(8)];
+      try {
+        return library.symbols.GetProcessTimes(
+          handle,
+          ffi.ptr(creation),
+          ffi.ptr(scratch[0]!),
+          ffi.ptr(scratch[1]!),
+          ffi.ptr(scratch[2]!),
+        ) !== 0;
+      } finally {
+        library.symbols.CloseHandle(handle);
+      }
+    };
+  } catch {
+    cachedReader = null;
+  }
+  return cachedReader;
+}
+
+/** `${pid}:${creationFiletime}`, or null when the kernel would not say. */
+export function windowsProcessIdentity(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const reader = loadReader();
+  if (!reader) return null;
+  const creation = Buffer.alloc(8);
+  try {
+    return parseWindowsCreationIdentity(pid, creation, reader(pid, creation));
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/proc/windowsIdentity.ts
+++ b/src/lib/proc/windowsIdentity.ts
@@ -36,22 +36,41 @@ import { createRequire } from "node:module";
  */
 
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+/**
+ * `GetExitCodeProcess` reports this while a process is running. A Windows
+ * process object outlives the process itself for as long as anyone holds a
+ * handle to it — the spawning parent always does — and `GetProcessTimes` keeps
+ * answering for that corpse. An identity that outlives its process is the one
+ * thing this token must not do: `pidAlive` would say gone while the identity
+ * said present, and a caller comparing only identities would treat a dead host
+ * as a live one. (A process that genuinely exits with 259 reads as alive here.
+ * That is the documented ambiguity of this call, and it errs toward refusing to
+ * reclaim rather than toward reclaiming something live.)
+ */
+const STILL_ACTIVE = 259;
 /** FILETIME of 2000-01-01T00:00:00Z. A creation time below it is not a real one. */
 const MIN_PLAUSIBLE_FILETIME = BigInt("125911584000000000");
 
 type ProcessTimesReader = (pid: number, creation: Buffer) => boolean;
 
 interface BunFfiModule {
-  FFIType: { i32: number; u32: number; ptr: number };
+  FFIType: { i32: number; u32: number; u64: number; ptr: number };
   ptr(buffer: Buffer): unknown;
   dlopen(path: string, symbols: Record<string, unknown>): {
     symbols: {
-      OpenProcess: (...args: unknown[]) => unknown;
+      OpenProcess: (...args: unknown[]) => bigint | number;
       CloseHandle: (...args: unknown[]) => number;
       GetProcessTimes: (...args: unknown[]) => number;
+      GetExitCodeProcess: (...args: unknown[]) => number;
     };
   };
 }
+
+/* A HANDLE crosses the boundary as `u64`, never as `ptr`: a pointer-typed
+   argument makes Bun marshal the value through its own pointer objects, and
+   that path crashes the process on a bare integer. `u64` is the same eight
+   bytes in the same register. Only real buffers stay `ptr`. */
+const NULL_HANDLE = BigInt(0);
 
 let cachedReader: ProcessTimesReader | null | undefined;
 
@@ -76,19 +95,21 @@ function loadReader(): ProcessTimesReader | null {
   try {
     const runtimeRequire = createRequire(import.meta.url);
     const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const { i32, u32, u64, ptr } = ffi.FFIType;
     const library = ffi.dlopen("kernel32.dll", {
-      OpenProcess: { args: [ffi.FFIType.u32, ffi.FFIType.i32, ffi.FFIType.u32], returns: ffi.FFIType.ptr },
-      CloseHandle: { args: [ffi.FFIType.ptr], returns: ffi.FFIType.i32 },
-      GetProcessTimes: {
-        args: [ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr, ffi.FFIType.ptr],
-        returns: ffi.FFIType.i32,
-      },
+      OpenProcess: { args: [u32, i32, u32], returns: u64 },
+      CloseHandle: { args: [u64], returns: i32 },
+      GetProcessTimes: { args: [u64, ptr, ptr, ptr, ptr], returns: i32 },
+      GetExitCodeProcess: { args: [u64, ptr], returns: i32 },
     });
     cachedReader = (pid, creation) => {
-      const handle = library.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
-      if (!handle) return false;
+      const handle = BigInt(library.symbols.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid));
+      if (handle === NULL_HANDLE) return false;
       const scratch = [Buffer.alloc(8), Buffer.alloc(8), Buffer.alloc(8)];
       try {
+        const exitCode = Buffer.alloc(4);
+        if (library.symbols.GetExitCodeProcess(handle, ffi.ptr(exitCode)) !== 0
+          && exitCode.readUInt32LE(0) !== STILL_ACTIVE) return false;
         return library.symbols.GetProcessTimes(
           handle,
           ffi.ptr(creation),

--- a/src/lib/proc/windowsSnapshot.test.ts
+++ b/src/lib/proc/windowsSnapshot.test.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "bun:test";
+
+import {
+  looksLikeAgentArgv,
+  normalizeWindowsCwd,
+  parseCsvRows,
+  parseWindowsCommandLine,
+  parseWindowsProcessSnapshot,
+  snapshotEntries,
+  windowsParentLinks,
+  type WindowsProcessRow,
+} from "./windowsSnapshot";
+
+/*
+ * Every rule the Windows backend applies to bytes is a pure function, and this
+ * file runs on every platform. What it cannot prove is that a real
+ * `Get-CimInstance Win32_Process` produces these bytes — that is the
+ * `windows-latest` leg of `platform-tests.yml`, which runs the real call and
+ * requires this parser to find the runner's own process in the result.
+ */
+
+function csv(rows: string[][]): string {
+  return rows.map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(",")).join("\r\n") + "\r\n";
+}
+
+const HEADER = [
+  "ProcessId",
+  "ParentProcessId",
+  "CommandLine",
+  "WorkingSetSize",
+  "UserModeTime",
+  "KernelModeTime",
+  "Created",
+];
+
+test("argv[0] keeps a quoted program path with spaces as one token", () => {
+  expect(parseWindowsCommandLine('"C:\\Program Files\\nodejs\\claude.exe" -p "hello world"')).toEqual([
+    "C:\\Program Files\\nodejs\\claude.exe",
+    "-p",
+    "hello world",
+  ]);
+});
+
+test("argv[0] never treats a backslash as an escape", () => {
+  /* CommandLineToArgvW's documented exception: in the program name a backslash
+     is a separator, never an escape, so a bare Windows path survives whole. */
+  expect(parseWindowsCommandLine("C:\\tools\\claude.exe --version")).toEqual([
+    "C:\\tools\\claude.exe",
+    "--version",
+  ]);
+});
+
+test("backslash runs before a quote follow the 2n / 2n+1 rule", () => {
+  expect(parseWindowsCommandLine('claude.exe a\\\\"b c" d')).toEqual(["claude.exe", "a\\b c", "d"]);
+  expect(parseWindowsCommandLine('claude.exe a\\\\\\"b')).toEqual(["claude.exe", 'a\\"b']);
+  expect(parseWindowsCommandLine("claude.exe a\\\\b")).toEqual(["claude.exe", "a\\\\b"]);
+});
+
+test("a doubled quote inside a quoted argument is one literal quote", () => {
+  expect(parseWindowsCommandLine('claude.exe "say ""hi"" now"')).toEqual(["claude.exe", 'say "hi" now']);
+});
+
+test("an empty command line yields no argv rather than one empty token", () => {
+  expect(parseWindowsCommandLine("")).toEqual([]);
+  expect(parseWindowsCommandLine("   ")).toEqual([]);
+});
+
+test("the CSV reader handles quoted commas, doubled quotes, CRLF and unquoted cells", () => {
+  expect(parseCsvRows('"a","b,c","d""e"\r\n"1","2","3"\r\n')).toEqual([
+    ["a", "b,c", 'd"e'],
+    ["1", "2", "3"],
+  ]);
+  expect(parseCsvRows("a,b\nc,d\n")).toEqual([["a", "b"], ["c", "d"]]);
+});
+
+test("a parent created after its child is not a parent", () => {
+  /* Windows does not re-parent orphans and reissues a freed pid within seconds,
+     so ParentProcessId can name an unrelated live process. The tree walk that
+     terminates a host would otherwise reach it. */
+  const rows = new Map<number, WindowsProcessRow>([
+    [100, { pid: 100, rawPpid: 4, argv: [], created: BigInt(200), workingSetBytes: 0, cpuMs: null }],
+    [4, { pid: 4, rawPpid: null, argv: [], created: BigInt(500), workingSetBytes: 0, cpuMs: null }],
+    [200, { pid: 200, rawPpid: 4, argv: [], created: BigInt(900), workingSetBytes: 0, cpuMs: null }],
+  ]);
+  const links = windowsParentLinks(rows);
+  expect(links.get(100)).toBeUndefined();
+  expect(links.get(200)).toBe(4);
+});
+
+test("a link to a pid absent from the snapshot, and a self-link, are dropped", () => {
+  const rows = new Map<number, WindowsProcessRow>([
+    [10, { pid: 10, rawPpid: 999, argv: [], created: BigInt(1), workingSetBytes: 0, cpuMs: null }],
+    [11, { pid: 11, rawPpid: 11, argv: [], created: BigInt(1), workingSetBytes: 0, cpuMs: null }],
+  ]);
+  expect([...windowsParentLinks(rows).keys()]).toEqual([]);
+});
+
+test("the snapshot parse reads every column and survives an unusable row", () => {
+  const snapshot = parseWindowsProcessSnapshot(csv([
+    HEADER,
+    ["0", "0", "", "8192", "", "", ""],
+    ["not-a-pid", "4", "x", "1", "0", "0", "1"],
+    [
+      "1234",
+      "4",
+      'C:\\agents\\claude\\claude.exe --session-id abc',
+      "5242880",
+      "21200000",
+      "10000000",
+      "133700000000000000",
+    ],
+    ["4", "0", "", "40960", "", "", ""],
+  ]));
+
+  expect(snapshot.rows.get(1234)).toEqual({
+    pid: 1234,
+    rawPpid: 4,
+    argv: ["C:\\agents\\claude\\claude.exe", "--session-id", "abc"],
+    created: BigInt("133700000000000000"),
+    workingSetBytes: 5_242_880,
+    cpuMs: 3_120,
+  });
+  expect(snapshot.ppids.get(1234)).toBe(4);
+  /* System reports no creation time; it stays a usable row, and the ordering
+     rule simply has nothing to compare it against. pid 0 (Idle) is not a
+     process this backend can describe at all. */
+  expect(snapshot.rows.get(4)?.created).toBeNull();
+  /* Both CPU columns absent is "no reading", never zero: an evidence-based
+     liveness verdict must not read a missing column as an idle process. */
+  expect(snapshot.rows.get(4)?.cpuMs).toBeNull();
+  expect(snapshot.rows.has(0)).toBe(false);
+  expect(snapshot.rows.size).toBe(2);
+});
+
+test("a byte-order mark ahead of the header does not hide every column", () => {
+  const snapshot = parseWindowsProcessSnapshot("\ufeff" + csv([HEADER, ["7", "1", "x.exe", "1", "0", "0", "133700000000000000"]]));
+  expect(snapshot.rows.get(7)?.argv).toEqual(["x.exe"]);
+});
+
+test("a header without ProcessId yields an empty snapshot instead of nonsense rows", () => {
+  expect(parseWindowsProcessSnapshot(csv([["Name"], ["explorer"]])).rows.size).toBe(0);
+  expect(parseWindowsProcessSnapshot("").rows.size).toBe(0);
+});
+
+test("a DosPath loses its trailing separator, except at a drive root", () => {
+  expect(normalizeWindowsCwd("C:\\work\\proj\\")).toBe("C:\\work\\proj");
+  expect(normalizeWindowsCwd("c:\\work\\proj")).toBe("C:\\work\\proj");
+  /* `C:` alone is the current directory on C:, which is not `C:\`. */
+  expect(normalizeWindowsCwd("C:\\")).toBe("C:\\");
+  expect(normalizeWindowsCwd("")).toBeNull();
+  expect(normalizeWindowsCwd("C:\\work\\proj\\\0garbage")).toBe("C:\\work\\proj");
+});
+
+test("only rows that could be an agent pay for a working-directory read", () => {
+  /* Reading a cwd costs an OpenProcess plus three ReadProcessMemory calls.
+     Paying it for every process on the host is what this predicate prevents. */
+  const snapshot = parseWindowsProcessSnapshot(csv([
+    HEADER,
+    ["1", "0", "C:\\Windows\\explorer.exe", "1", "0", "0", "10"],
+    ["2", "1", '"C:\\Program Files\\claude\\claude.exe" -p hi', "1", "0", "0", "20"],
+    ["3", "1", "C:\\bun\\bun.exe C:\\tools\\codex.exe app-server", "1", "0", "0", "20"],
+  ]));
+  const asked: number[] = [];
+  const entries = snapshotEntries(snapshot, (pid) => {
+    asked.push(pid);
+    return "C:\\work";
+  }, 1);
+
+  expect(asked.sort()).toEqual([2, 3]);
+  expect(entries.find((entry) => entry.pid === 1)?.cwd).toBeNull();
+  expect(entries.find((entry) => entry.pid === 2)?.cwd).toBe("C:\\work");
+  expect(entries.every((entry) => entry.tty === 1)).toBe(true);
+});
+
+test("the agent predicate matches the scanner's basename rule on both separators", () => {
+  expect(looksLikeAgentArgv(["C:\\x\\claude.exe"])).toBe(true);
+  expect(looksLikeAgentArgv(["/usr/bin/codex"])).toBe(true);
+  expect(looksLikeAgentArgv(["C:\\bun.exe", "C:\\y\\codex.exe"])).toBe(true);
+  expect(looksLikeAgentArgv(["C:\\x\\codex-telegram-mcp.exe"])).toBe(false);
+  expect(looksLikeAgentArgv(["node", "server.js", "claude.exe"])).toBe(false);
+});

--- a/src/lib/proc/windowsSnapshot.ts
+++ b/src/lib/proc/windowsSnapshot.ts
@@ -1,0 +1,307 @@
+/**
+ * Pure parsers behind the Windows proc backend. Nothing here touches the
+ * filesystem, spawns a process or loads FFI, so every rule below is unit-
+ * testable on Linux and macOS as well — which matters because nobody working
+ * on this repository has a Windows machine and the only live exercise of the
+ * backend is the `windows-latest` leg of `platform-tests.yml`.
+ *
+ * The snapshot source is one Windows PowerShell call per TTL:
+ *
+ *   Get-CimInstance Win32_Process |
+ *     Select-Object ProcessId, ParentProcessId, CommandLine, WorkingSetSize,
+ *       @{n='Created';e={$_.CreationDate.ToFileTimeUtc()}} |
+ *     ConvertTo-Csv -NoTypeInformation
+ *
+ * CSV rather than JSON because Windows PowerShell 5.1 serialises a DateTime
+ * into JSON as `/Date(ms)/` and loses everything below the millisecond.
+ */
+
+import type { ProcSnapshotEntry } from "./types";
+
+/** One row of the Win32_Process projection above. */
+export interface WindowsProcessRow {
+  pid: number;
+  /** Parent pid as the snapshot reported it, before the stale-link filter. */
+  rawPpid: number | null;
+  argv: string[];
+  /**
+   * Process creation time as a FILETIME (100 ns ticks since 1601-01-01 UTC),
+   * or null when the column was empty — `Idle` and `System` report none.
+   *
+   * WMI's CreationDate is a CIM_DATETIME with *microsecond* resolution, so
+   * this value is the kernel's creation time truncated to whole microseconds.
+   * That is precise enough to order two processes, which is all this column is
+   * used for. It is deliberately NOT the identity token: see
+   * `windowsIdentity.ts`, which reads the untruncated value from the kernel.
+   */
+  created: bigint | null;
+  workingSetBytes: number;
+}
+
+export interface WindowsSnapshot {
+  rows: Map<number, WindowsProcessRow>;
+  /** pid → ppid with stale parent links already dropped. */
+  ppids: Map<number, number>;
+}
+
+/**
+ * Splits a Windows command line the way `CommandLineToArgvW` does, which is
+ * the only correct way to recover argv from `Win32_Process.CommandLine`:
+ * the command line is a single string and the program path routinely contains
+ * a space (`C:\Program Files\...`), so whitespace splitting — what the
+ * portable backend does to `ps` output — would break `argvEngine`'s
+ * basename match on argv[0].
+ *
+ * The rules, from the Windows documentation:
+ *  - argv[0] is special: backslashes are never escapes there, and the token
+ *    ends at the first whitespace, or at the closing quote when it opens with
+ *    one.
+ *  - Elsewhere, 2n backslashes before a quote produce n backslashes and the
+ *    quote toggles quoting; 2n+1 produce n backslashes and a literal quote.
+ *  - A quote inside a quoted block that is immediately followed by another
+ *    quote produces one literal quote and stays quoted.
+ */
+export function parseWindowsCommandLine(commandLine: string): string[] {
+  const argv: string[] = [];
+  const text = commandLine ?? "";
+  let index = 0;
+  const skipBlanks = (): void => {
+    while (index < text.length && (text[index] === " " || text[index] === "\t")) index += 1;
+  };
+
+  skipBlanks();
+  if (index >= text.length) return argv;
+
+  /* argv[0]: quotes group, backslashes are literal. */
+  let first = "";
+  if (text[index] === '"') {
+    index += 1;
+    while (index < text.length && text[index] !== '"') {
+      first += text[index];
+      index += 1;
+    }
+    if (index < text.length) index += 1;
+  } else {
+    while (index < text.length && text[index] !== " " && text[index] !== "\t") {
+      first += text[index];
+      index += 1;
+    }
+  }
+  argv.push(first);
+
+  for (;;) {
+    skipBlanks();
+    if (index >= text.length) break;
+    let arg = "";
+    let quoted = false;
+    while (index < text.length) {
+      const char = text[index]!;
+      if (char === "\\") {
+        let backslashes = 0;
+        while (index < text.length && text[index] === "\\") {
+          backslashes += 1;
+          index += 1;
+        }
+        if (text[index] === '"') {
+          arg += "\\".repeat(backslashes >> 1);
+          if (backslashes % 2 === 1) {
+            arg += '"';
+            index += 1;
+            continue;
+          }
+        } else {
+          arg += "\\".repeat(backslashes);
+          continue;
+        }
+      }
+      if (text[index] === '"') {
+        index += 1;
+        if (quoted && text[index] === '"') {
+          arg += '"';
+          index += 1;
+        } else {
+          quoted = !quoted;
+        }
+        continue;
+      }
+      if (!quoted && (text[index] === " " || text[index] === "\t")) break;
+      arg += text[index];
+      index += 1;
+    }
+    argv.push(arg);
+  }
+  return argv;
+}
+
+/**
+ * RFC 4180 rows out of `ConvertTo-Csv -NoTypeInformation` output. 5.1 quotes
+ * every field and doubles embedded quotes; the parser also accepts unquoted
+ * fields so a future PowerShell that quotes less does not silently return
+ * nothing. Line endings are CRLF from PowerShell and LF from the fixtures.
+ */
+export function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+  let started = false;
+  const endField = (): void => {
+    row.push(field);
+    field = "";
+    started = false;
+  };
+  const endRow = (): void => {
+    endField();
+    if (row.length > 1 || row[0] !== "") rows.push(row);
+    row = [];
+  };
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]!;
+    if (quoted) {
+      if (char === '"') {
+        if (text[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          quoted = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+    if (char === '"' && !started) {
+      quoted = true;
+      started = true;
+      continue;
+    }
+    if (char === ",") {
+      endField();
+      continue;
+    }
+    if (char === "\r") continue;
+    if (char === "\n") {
+      endRow();
+      continue;
+    }
+    field += char;
+    started = true;
+  }
+  if (field !== "" || row.length > 0) endRow();
+  return rows;
+}
+
+function toInteger(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function toFiletime(value: string | undefined): bigint | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  const parsed = BigInt(trimmed);
+  return parsed > BigInt(0) ? parsed : null;
+}
+
+/**
+ * Windows never re-parents an orphan, and it hands a freed pid back within
+ * seconds, so a row's ParentProcessId can name a live process that merely
+ * inherited the dead parent's number. A tree walk that trusted it would kill
+ * an unrelated process. Both creation times are already in the snapshot, so
+ * the false link is recognisable: a parent cannot have started after its own
+ * child. Links to a pid that is absent from the snapshot, and self-links, are
+ * dropped for the same reason.
+ */
+export function windowsParentLinks(rows: Map<number, WindowsProcessRow>): Map<number, number> {
+  const ppids = new Map<number, number>();
+  for (const [pid, row] of rows) {
+    const ppid = row.rawPpid;
+    if (ppid === null || ppid <= 0 || ppid === pid) continue;
+    const parent = rows.get(ppid);
+    if (!parent) continue;
+    if (parent.created !== null && row.created !== null && parent.created > row.created) continue;
+    ppids.set(pid, ppid);
+  }
+  return ppids;
+}
+
+const COLUMNS = ["ProcessId", "ParentProcessId", "CommandLine", "WorkingSetSize", "Created"] as const;
+
+/**
+ * Parses the CSV projection into rows plus the filtered parent links. A row
+ * whose ProcessId does not parse is skipped rather than throwing: the whole
+ * scan degrading to nothing because one system row was odd is worse than
+ * losing that row.
+ */
+export function parseWindowsProcessSnapshot(csv: string): WindowsSnapshot {
+  const rows = new Map<number, WindowsProcessRow>();
+  const parsed = parseCsvRows(csv);
+  const header = parsed[0];
+  if (!header) return { rows, ppids: new Map() };
+  const at = new Map(COLUMNS.map((name) => [name, header.indexOf(name)] as const));
+  const pidAt = at.get("ProcessId") ?? -1;
+  if (pidAt < 0) return { rows, ppids: new Map() };
+  const cell = (row: string[], name: (typeof COLUMNS)[number]): string | undefined => {
+    const column = at.get(name) ?? -1;
+    return column < 0 ? undefined : row[column];
+  };
+  for (const row of parsed.slice(1)) {
+    const pid = toInteger(row[pidAt]);
+    if (pid === null || pid <= 0) continue;
+    rows.set(pid, {
+      pid,
+      rawPpid: toInteger(cell(row, "ParentProcessId")),
+      argv: parseWindowsCommandLine(cell(row, "CommandLine") ?? ""),
+      created: toFiletime(cell(row, "Created")),
+      workingSetBytes: Math.max(0, toInteger(cell(row, "WorkingSetSize")) ?? 0),
+    });
+  }
+  return { rows, ppids: windowsParentLinks(rows) };
+}
+
+/**
+ * `RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath` always carries a
+ * trailing separator (`C:\work\proj\`); every caller compares it against a
+ * `path.join`ed value, which never does. A bare drive root keeps its
+ * separator, since `C:` alone means "the current directory on C:" to Windows
+ * and is not the same path as `C:\`.
+ */
+export function normalizeWindowsCwd(raw: string): string | null {
+  const trimmed = raw.replace(/\0.*$/s, "").trim();
+  if (!trimmed) return null;
+  if (/^[A-Za-z]:[\\/]$/.test(trimmed)) return trimmed[0]!.toUpperCase() + ":\\";
+  const stripped = trimmed.replace(/[\\/]+$/, "");
+  if (!stripped) return null;
+  return /^[a-z]:/.test(stripped) ? stripped[0]!.toUpperCase() + stripped.slice(1) : stripped;
+}
+
+/**
+ * `agentProcesses` drops every process whose cwd is null, so a backend that
+ * never resolved one would show zero agents. Resolving a cwd on Windows costs
+ * an OpenProcess plus three ReadProcessMemory calls, which is far too much to
+ * pay for every process on the host, so the backend pays it only for rows that
+ * could possibly be an agent. This predicate is deliberately looser than
+ * `argvEngine` — it does not know about helper arguments and matches the same
+ * first two tokens — so the backend never has to import the scanner.
+ */
+export function looksLikeAgentArgv(argv: string[]): boolean {
+  for (const token of argv.slice(0, 2)) {
+    const base = token.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+    if (base === "claude" || base === "claude.exe" || base === "codex" || base === "codex.exe") return true;
+  }
+  return false;
+}
+
+/** Snapshot rows as the backend's `listProcesses` contract wants them. */
+export function snapshotEntries(
+  snapshot: WindowsSnapshot,
+  cwdFor: (pid: number) => string | null,
+  tty: number,
+): ProcSnapshotEntry[] {
+  const list: ProcSnapshotEntry[] = [];
+  for (const [pid, row] of snapshot.rows) {
+    list.push({ pid, argv: row.argv, cwd: looksLikeAgentArgv(row.argv) ? cwdFor(pid) : null, tty });
+  }
+  return list;
+}

--- a/src/lib/proc/windowsSnapshot.ts
+++ b/src/lib/proc/windowsSnapshot.ts
@@ -9,6 +9,7 @@
  *
  *   Get-CimInstance Win32_Process |
  *     Select-Object ProcessId, ParentProcessId, CommandLine, WorkingSetSize,
+ *       UserModeTime, KernelModeTime,
  *       @{n='Created';e={$_.CreationDate.ToFileTimeUtc()}} |
  *     ConvertTo-Csv -NoTypeInformation
  *
@@ -36,6 +37,14 @@ export interface WindowsProcessRow {
    */
   created: bigint | null;
   workingSetBytes: number;
+  /**
+   * User + kernel CPU consumed since launch, in milliseconds, or null when the
+   * snapshot reported neither. `Win32_Process` counts both in 100 ns units, so
+   * unlike macOS — which has no cheap per-pid CPU read at all — Windows gets
+   * this for free out of the snapshot it already takes, and the liveness
+   * verdict that treats null as "no evidence" gets real evidence here.
+   */
+  cpuMs: number | null;
 }
 
 export interface WindowsSnapshot {
@@ -139,7 +148,11 @@ export function parseWindowsCommandLine(commandLine: string): string[] {
  * fields so a future PowerShell that quotes less does not silently return
  * nothing. Line endings are CRLF from PowerShell and LF from the fixtures.
  */
-export function parseCsvRows(text: string): string[][] {
+export function parseCsvRows(raw: string): string[][] {
+  /* A byte-order mark ahead of the header would attach itself to the first
+     column name and make every column lookup miss, which reads downstream as
+     "this machine has no processes". */
+  const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
   const rows: string[][] = [];
   let row: string[] = [];
   let field = "";
@@ -197,11 +210,14 @@ function toInteger(value: string | undefined): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
-function toFiletime(value: string | undefined): bigint | null {
+function toUnsigned(value: string | undefined): bigint | null {
   const trimmed = value?.trim();
-  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
-  const parsed = BigInt(trimmed);
-  return parsed > BigInt(0) ? parsed : null;
+  return trimmed && /^\d+$/.test(trimmed) ? BigInt(trimmed) : null;
+}
+
+function toFiletime(value: string | undefined): bigint | null {
+  const parsed = toUnsigned(value);
+  return parsed !== null && parsed > BigInt(0) ? parsed : null;
 }
 
 /**
@@ -226,7 +242,26 @@ export function windowsParentLinks(rows: Map<number, WindowsProcessRow>): Map<nu
   return ppids;
 }
 
-const COLUMNS = ["ProcessId", "ParentProcessId", "CommandLine", "WorkingSetSize", "Created"] as const;
+const COLUMNS = [
+  "ProcessId",
+  "ParentProcessId",
+  "CommandLine",
+  "WorkingSetSize",
+  "UserModeTime",
+  "KernelModeTime",
+  "Created",
+] as const;
+
+/** 100 ns ticks per millisecond, the unit both CPU columns are counted in. */
+const TICKS_PER_MILLISECOND = BigInt(10_000);
+
+function toCpuMs(user: string | undefined, kernel: string | undefined): number | null {
+  const userTicks = toUnsigned(user);
+  const kernelTicks = toUnsigned(kernel);
+  if (userTicks === null && kernelTicks === null) return null;
+  const total = ((userTicks ?? BigInt(0)) + (kernelTicks ?? BigInt(0))) / TICKS_PER_MILLISECOND;
+  return total > BigInt(Number.MAX_SAFE_INTEGER) ? null : Number(total);
+}
 
 /**
  * Parses the CSV projection into rows plus the filtered parent links. A row
@@ -255,6 +290,7 @@ export function parseWindowsProcessSnapshot(csv: string): WindowsSnapshot {
       argv: parseWindowsCommandLine(cell(row, "CommandLine") ?? ""),
       created: toFiletime(cell(row, "Created")),
       workingSetBytes: Math.max(0, toInteger(cell(row, "WorkingSetSize")) ?? 0),
+      cpuMs: toCpuMs(cell(row, "UserModeTime"), cell(row, "KernelModeTime")),
     });
   }
   return { rows, ppids: windowsParentLinks(rows) };
@@ -268,7 +304,7 @@ export function parseWindowsProcessSnapshot(csv: string): WindowsSnapshot {
  * and is not the same path as `C:\`.
  */
 export function normalizeWindowsCwd(raw: string): string | null {
-  const trimmed = raw.replace(/\0.*$/s, "").trim();
+  const trimmed = raw.replace(/\0[\s\S]*$/, "").trim();
   if (!trimmed) return null;
   if (/^[A-Za-z]:[\\/]$/.test(trimmed)) return trimmed[0]!.toUpperCase() + ":\\";
   const stripped = trimmed.replace(/[\\/]+$/, "");

--- a/src/lib/processGroup.test.ts
+++ b/src/lib/processGroup.test.ts
@@ -1,0 +1,201 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { procBackend } from "@/lib/proc";
+import { resetWindowsSnapshotForTests } from "@/lib/proc/windows";
+
+import {
+  processTreeTerminationOrder,
+  signalDetachedProcessGroup,
+  signalProcessGroup,
+  terminateProcessTree,
+  type ProcessTreeSource,
+} from "./processGroup";
+
+/*
+ * What replaces `kill(-pgid)` where there are no process groups.
+ *
+ * The rules below are pure or injected, so they hold on every platform; the
+ * `windows-latest` leg of `platform-tests.yml` runs the same file with the real
+ * `process.platform`, which is what proves `signalProcessGroup` actually takes
+ * the tree branch there instead of throwing on a negative pid.
+ */
+
+function source(ppids: Array<[number, number]>, identities: Record<number, string | null> = {}): ProcessTreeSource {
+  return {
+    ppidMap: () => new Map(ppids),
+    processIdentity: (pid) => (pid in identities ? identities[pid]! : `${pid}:start`),
+  };
+}
+
+test("a tree is signalled descendants first and the leader last", () => {
+  /* Order is the difference between killing a supervisor that immediately
+     respawns its child and killing the child first. */
+  const order = processTreeTerminationOrder(10, new Map([[11, 10], [12, 10], [13, 11]]));
+  expect(order[order.length - 1]).toBe(10);
+  expect(order.indexOf(13)).toBeLessThan(order.indexOf(11));
+  expect(order.slice().sort((a, b) => a - b)).toEqual([10, 11, 12, 13]);
+});
+
+test("a leader with no children is its own whole tree", () => {
+  expect(processTreeTerminationOrder(10, new Map())).toEqual([10]);
+});
+
+test("the walk reaches every descendant exactly once", () => {
+  const signalled: number[] = [];
+  const killed = terminateProcessTree(10, "SIGTERM", (pid) => signalled.push(pid), source([[11, 10], [12, 11]]));
+  expect(killed).toBe(true);
+  expect(signalled.sort((a, b) => a - b)).toEqual([10, 11, 12]);
+});
+
+test("a member whose identity changed under the walk is left alone", () => {
+  /* Windows reissues a freed pid within seconds. Between reading the parent map
+     and reaching a member, that member can have exited and its number can now
+     name something unrelated — an editor, another agent's host. Only the
+     kernel's creation-time token can tell, and it is re-read immediately before
+     the kill. */
+  let reads = 0;
+  const recycled: ProcessTreeSource = {
+    ppidMap: () => new Map([[11, 10], [12, 10]]),
+    processIdentity: (pid) => {
+      if (pid !== 11) return `${pid}:start`;
+      reads += 1;
+      return reads === 1 ? "11:start" : "11:someone-else";
+    },
+  };
+  const signalled: number[] = [];
+  terminateProcessTree(10, "SIGKILL", (pid) => signalled.push(pid), recycled);
+  expect(signalled).not.toContain(11);
+  expect(signalled.sort((a, b) => a - b)).toEqual([10, 12]);
+});
+
+test("a backend that cannot read identity still terminates the tree", () => {
+  /* Null for both reads is "unknown", not "changed": the walk degrades to the
+     unconditional kill `kill(-pgid)` already performs on Linux. */
+  const signalled: number[] = [];
+  terminateProcessTree(10, "SIGTERM", (pid) => signalled.push(pid), source([[11, 10]], { 10: null, 11: null }));
+  expect(signalled.sort((a, b) => a - b)).toEqual([10, 11]);
+});
+
+test("a member that refuses the signal does not abandon the rest of the tree", () => {
+  const signalled: number[] = [];
+  const killed = terminateProcessTree(10, "SIGTERM", (pid) => {
+    if (pid === 12) throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    signalled.push(pid);
+  }, source([[11, 10], [12, 10]]));
+  expect(killed).toBe(true);
+  expect(signalled.sort((a, b) => a - b)).toEqual([10, 11]);
+});
+
+test("a leader that was itself recycled is reported as not signalled", () => {
+  let reads = 0;
+  const recycled: ProcessTreeSource = {
+    ppidMap: () => new Map(),
+    processIdentity: () => {
+      reads += 1;
+      return reads === 1 ? "10:start" : "10:someone-else";
+    },
+  };
+  const signalled: number[] = [];
+  expect(terminateProcessTree(10, "SIGTERM", (pid) => signalled.push(pid), recycled)).toBe(false);
+  expect(signalled).toEqual([]);
+});
+
+test("a backend that throws while reading the tree still signals the leader", () => {
+  const exploding: ProcessTreeSource = {
+    ppidMap: () => {
+      throw new Error("snapshot unavailable");
+    },
+    processIdentity: () => null,
+  };
+  const signalled: number[] = [];
+  expect(terminateProcessTree(10, "SIGKILL", (pid) => signalled.push(pid), exploding)).toBe(true);
+  expect(signalled).toEqual([10]);
+});
+
+test("an unusable pid is never signalled on any platform", () => {
+  const signalled: number[] = [];
+  const record = (pid: number): void => {
+    signalled.push(pid);
+  };
+  expect(signalProcessGroup(0, "SIGTERM", record)).toBe(false);
+  expect(signalProcessGroup(undefined, "SIGTERM", record)).toBe(false);
+  expect(signalProcessGroup(-4, "SIGTERM", record)).toBe(false);
+  expect(signalled).toEqual([]);
+});
+
+test.if(process.platform !== "win32")("POSIX still signals the negative pid, once", () => {
+  const signalled: number[] = [];
+  expect(signalProcessGroup(4321, "SIGTERM", (pid) => signalled.push(pid))).toBe(true);
+  expect(signalled).toEqual([-4321]);
+});
+
+test.if(process.platform === "win32")("win32 signals real pids, never a negative one", () => {
+  /* `process.kill(-pid, …)` throws on Windows. Reaching that call at all would
+     mean a host is never terminated, only reported as un-terminatable. */
+  const signalled: number[] = [];
+  signalProcessGroup(process.pid, "SIGTERM", (pid) => {
+    signalled.push(pid);
+  });
+  expect(signalled).toContain(process.pid);
+  expect(signalled.every((pid) => pid > 0)).toBe(true);
+});
+
+test.if(process.platform === "win32")("a real child and its grandchild are both gone after one call", async () => {
+  /* The acceptance case: a structured host spawns an agent, the agent spawns
+     its own helper, and stopping the host must not leave the helper running.
+     On Linux one `kill(-pgid)` does that; here the walk has to find the
+     grandchild through the parent map and reach it first. */
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tree-kill-"));
+  const marker = path.join(sandbox, "grandchild.pid");
+  const script = [
+    "const grandchild = Bun.spawn([process.execPath, '-e', 'setInterval(() => {}, 1000)'],",
+    "  { stdout: 'ignore', stderr: 'ignore', stdin: 'ignore' });",
+    `Bun.write(${JSON.stringify(marker)}, String(grandchild.pid));`,
+    "setInterval(() => {}, 1000);",
+  ].join("\n");
+  const child = Bun.spawn([process.execPath, "-e", script], { stdout: "ignore", stderr: "ignore" });
+
+  try {
+    const deadline = Date.now() + 20_000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) await Bun.sleep(100);
+    const grandchild = Number(fs.readFileSync(marker, "utf8").trim());
+    expect(Number.isInteger(grandchild) && grandchild > 0).toBe(true);
+    resetWindowsSnapshotForTests();
+
+    expect(signalProcessGroup(child.pid, "SIGKILL")).toBe(true);
+
+    const gone = async (pid: number): Promise<boolean> => {
+      const until = Date.now() + 15_000;
+      while (Date.now() < until) {
+        if (!procBackend.pidAlive(pid)) return true;
+        await Bun.sleep(150);
+      }
+      return !procBackend.pidAlive(pid);
+    };
+    expect(await gone(grandchild)).toBe(true);
+    expect(await gone(child.pid)).toBe(true);
+  } finally {
+    try {
+      child.kill();
+    } catch {
+      /* already terminated by the walk under test */
+    }
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 60_000);
+
+test("a detached child falls back to its own handle when the group signal finds nothing", () => {
+  let killedDirectly = false;
+  const child = {
+    pid: undefined,
+    kill: () => {
+      killedDirectly = true;
+      return true;
+    },
+  };
+  expect(signalDetachedProcessGroup(child, "SIGTERM", () => undefined)).toBe(true);
+  expect(killedDirectly).toBe(true);
+});

--- a/src/lib/processGroup.ts
+++ b/src/lib/processGroup.ts
@@ -1,8 +1,86 @@
+import { procBackend } from "@/lib/proc";
+import { descendantPids } from "@/lib/proc/memory";
+
 export type ProcessSignal = (pid: number, signal: NodeJS.Signals) => void;
 
 export interface DetachedProcess {
   pid?: number;
   kill(signal?: NodeJS.Signals): boolean;
+}
+
+/** What the Windows tree walk needs from the process backend. */
+export interface ProcessTreeSource {
+  ppidMap(): Map<number, number>;
+  processIdentity(pid: number): string | null;
+}
+
+/**
+ * The order a process tree must be signalled in: every descendant before the
+ * process it descends from, leader last. `descendantPids` is a pre-order DFS,
+ * and reversing a pre-order puts each node after all of its descendants.
+ *
+ * Pure, so the ordering rule is asserted on every platform.
+ */
+export function processTreeTerminationOrder(leader: number, ppids: Map<number, number>): number[] {
+  return descendantPids(leader, ppids).reverse();
+}
+
+/**
+ * Windows replacement for `kill(-pgid)`.
+ *
+ * Windows has no process groups and no signals: `process.kill(pid, sig)` is
+ * `TerminateProcess`, `process.kill(-pid, …)` throws, and no handler runs in
+ * the child. What replaces "signal the group" is a walk of the parent map,
+ * descendants first. Three things change as a result, all of them named in the
+ * README's Windows section:
+ *
+ *  - The tree is the one the *snapshot* describes. A process that started
+ *    after the snapshot, or one that had already reparented away, is not in it.
+ *  - There is no atomicity. A group signal reaches every member at once; this
+ *    walk takes as long as it takes, and a child spawned mid-walk survives.
+ *  - Nothing is graceful. Both hosts already close the child's stdin before
+ *    their first signal, which is the one stop `claude -p` honours; after that
+ *    SIGTERM and SIGKILL are the same call.
+ *
+ * `taskkill /T /F` performs the same walk in one process, and is rejected for
+ * this seam because it neither orders the tree nor checks identity. Identity is
+ * the point: Windows hands a freed pid back within seconds, so a pid read out
+ * of the parent map may already name an unrelated process by the time the walk
+ * reaches it. Each member's kernel creation-time token is captured with the map
+ * and re-read immediately before the kill; a member whose token changed is
+ * skipped. (A backend that cannot read identity at all reports null for both,
+ * and the walk then kills unconditionally — the same exposure `kill(-pgid)`
+ * carries on Linux for a recycled leader.)
+ *
+ * Job Objects are the proper Windows primitive and are deferred: they need FFI
+ * on the spawn side and change how every child is created.
+ */
+export function terminateProcessTree(
+  leader: number,
+  signal: NodeJS.Signals,
+  signalProcess: ProcessSignal = process.kill,
+  source: ProcessTreeSource = procBackend,
+): boolean {
+  let order: number[];
+  let expected: Map<number, string | null>;
+  try {
+    order = processTreeTerminationOrder(leader, source.ppidMap());
+    expected = new Map(order.map((pid) => [pid, source.processIdentity(pid)]));
+  } catch {
+    order = [leader];
+    expected = new Map([[leader, null]]);
+  }
+  let leaderSignalled = false;
+  for (const pid of order) {
+    try {
+      if (source.processIdentity(pid) !== (expected.get(pid) ?? null)) continue;
+      signalProcess(pid, signal);
+      if (pid === leader) leaderSignalled = true;
+    } catch {
+      /* the member exited on its own, or is not ours to signal */
+    }
+  }
+  return leaderSignalled;
 }
 
 /** Signals an existing process group without falling through to a recycled leader pid. */
@@ -12,6 +90,7 @@ export function signalProcessGroup(
   signalProcess: ProcessSignal = process.kill,
 ): boolean {
   if (!pid || !Number.isInteger(pid) || pid <= 0) return false;
+  if (process.platform === "win32") return terminateProcessTree(pid, signal, signalProcess);
   try {
     signalProcess(-pid, signal);
     return true;

--- a/src/lib/projects/suggestionRoots.ts
+++ b/src/lib/projects/suggestionRoots.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 
+import { homeDirectory } from "@/lib/platformHome";
 import { projectCurationSnapshot } from "@/lib/projects/curation";
 import { normalizeSuggestionRoots } from "@/lib/projects/directorySuggestions";
 import { knownProjectRoots } from "@/lib/scanner/projectDirectories";
@@ -29,9 +30,10 @@ export function anchorForProjectRoot(root: string): string {
    demo/evidence runtimes (and this module's tests) repoint, and Bun's
    `os.homedir()` ignores the env override. Taking `os.homedir()` directly here
    would mean a viewer running under an isolated home still suggests — and
-   readdirs — the machine's real one. */
+   readdirs — the machine's real one. On Windows the override is `USERPROFILE`
+   instead; see `homeDirectory`. */
 function homeRoot(): string {
-  return path.resolve(process.env.HOME?.trim() || os.homedir());
+  return homeDirectory();
 }
 
 /**

--- a/src/lib/runtime/localEndpoint.test.ts
+++ b/src/lib/runtime/localEndpoint.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  defaultRuntimeHostEndpoint,
+  isNamedPipePath,
+  runtimeHostEndpoint,
+  runtimeHostFencePath,
+} from "./localEndpoint";
+
+const STATE_POSIX = "/home/user/.config/agent-log-viewer/state";
+const STATE_WIN = "C:\\profile\\.config\\agent-log-viewer\\state";
+const INSTALL = "0123456789abcdef";
+
+test("POSIX keeps today's socket and its adjacent fence, byte for byte", () => {
+  /* Windows support must move nothing on the platforms that already work: the
+     fence being a separate field is the only structural change, and on POSIX it
+     resolves to exactly the `${socketPath}.lock` the host has always used. */
+  expect(runtimeHostEndpoint(STATE_POSIX, INSTALL, "linux")).toEqual({
+    socketPath: `${STATE_POSIX}/runtime-host-${INSTALL}.sock`,
+    fencePath: `${STATE_POSIX}/runtime-host-${INSTALL}.sock.lock`,
+  });
+  expect(defaultRuntimeHostEndpoint(STATE_POSIX, "darwin")).toEqual({
+    socketPath: `${STATE_POSIX}/runtime-host.sock`,
+    fencePath: `${STATE_POSIX}/runtime-host.sock.lock`,
+  });
+});
+
+test("Windows listens on a named pipe and keeps its fence as a real file", () => {
+  /* A pipe name is not a path: it has no parent directory to create, no inode
+     to unlink, no mode to tighten, and nothing for a `.lock` sibling to sit
+     beside. The fence has to be a file, because the lock the kernel releases on
+     process death is a file-range lock. */
+  const endpoint = runtimeHostEndpoint(STATE_WIN, INSTALL, "win32");
+  expect(endpoint.socketPath).toBe(`\\\\.\\pipe\\agent-log-viewer-${INSTALL}`);
+  expect(endpoint.fencePath).toBe(path.win32.join(STATE_WIN, `runtime-host-${INSTALL}.lock`));
+  expect(isNamedPipePath(endpoint.socketPath)).toBe(true);
+  expect(isNamedPipePath(endpoint.fencePath)).toBe(false);
+});
+
+test("two installs never share an endpoint on either platform", () => {
+  const first = runtimeHostEndpoint(STATE_WIN, "aaaaaaaaaaaaaaaa", "win32");
+  const second = runtimeHostEndpoint(STATE_WIN, "bbbbbbbbbbbbbbbb", "win32");
+  expect(first.socketPath).not.toBe(second.socketPath);
+  expect(first.fencePath).not.toBe(second.fencePath);
+});
+
+test("a pipe name is recognised in every form the OS accepts, and a path is not", () => {
+  expect(isNamedPipePath("\\\\.\\pipe\\agent-log-viewer-x")).toBe(true);
+  expect(isNamedPipePath("\\\\?\\pipe\\agent-log-viewer-x")).toBe(true);
+  expect(isNamedPipePath("/home/user/runtime-host.sock")).toBe(false);
+  expect(isNamedPipePath("C:\\profile\\runtime-host.sock")).toBe(false);
+  expect(isNamedPipePath("\\\\server\\share\\runtime-host.sock")).toBe(false);
+});
+
+test("a host handed only a pipe name puts its fence in the state directory", () => {
+  expect(runtimeHostFencePath("/state/runtime-host.sock", "/state")).toBe("/state/runtime-host.sock.lock");
+  expect(runtimeHostFencePath("\\\\.\\pipe\\agent-log-viewer-abc", STATE_WIN))
+    .toBe(path.win32.join(STATE_WIN, "agent-log-viewer-abc.lock"));
+});

--- a/src/lib/runtime/localEndpoint.ts
+++ b/src/lib/runtime/localEndpoint.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+
+/**
+ * Where the runtime host listens, and where its singleton fence lives.
+ *
+ * On POSIX both are files in the state directory: a Unix socket and, beside it,
+ * `<socket>.lock`. Windows has no Unix sockets in the filesystem sense that
+ * `mkdir`/`unlink`/`chmod` assume, so the endpoint becomes a **named pipe** in
+ * the kernel's pipe namespace (`\\.\pipe\…`) — which `net.createServer().listen`
+ * and `net.createConnection` accept unchanged, so the Viewer's client, the
+ * CLI's readiness probe and the newline framing all stay as they are.
+ *
+ * A pipe name is not a path, so the fence cannot be derived from it by
+ * appending `.lock`: it gets its own name in the state directory. That split is
+ * the only reason `fencePath` exists as a separate value at all — on POSIX it
+ * is exactly today's `${socketPath}.lock` and nothing moves.
+ *
+ * Access control differs and the difference is documented, not papered over: a
+ * Unix socket inherits the state directory's `0700` and is `chmod 0600`, while
+ * a named pipe created through libuv carries the default DACL. Whether another
+ * local account can connect to it cannot be settled by a CI runner with one
+ * user, so the Viewer is documented as single-user on Windows.
+ */
+export interface RuntimeHostEndpoint {
+  socketPath: string;
+  fencePath: string;
+}
+
+const NAMED_PIPE_PREFIX = /^\\\\[.?]\\pipe\\/;
+
+/** True for a Windows named-pipe name rather than a filesystem path. Pure. */
+export function isNamedPipePath(pathname: string): boolean {
+  return NAMED_PIPE_PREFIX.test(pathname);
+}
+
+function endpoint(
+  stateDirectory: string,
+  fileStem: string,
+  pipeName: string,
+  platform: NodeJS.Platform,
+): RuntimeHostEndpoint {
+  /* The `platform` argument governs the separator too, so the Windows shape is
+     assertable from the Ubuntu leg and not only from the Windows one. */
+  if (platform === "win32") {
+    return {
+      socketPath: `\\\\.\\pipe\\${pipeName}`,
+      fencePath: path.win32.join(stateDirectory, `${fileStem}.lock`),
+    };
+  }
+  const socketPath = path.posix.join(stateDirectory, `${fileStem}.sock`);
+  return { socketPath, fencePath: `${socketPath}.lock` };
+}
+
+/**
+ * The endpoint for one install id — what the public CLI supervises. Pure, and
+ * deliberately duplicated (not imported) by `bin/server-runtime.mjs`, which
+ * cannot load TypeScript; `bin/server-runtime.test.ts` imports both and asserts
+ * they agree.
+ */
+export function runtimeHostEndpoint(
+  stateDirectory: string,
+  installId: string,
+  platform: NodeJS.Platform = process.platform,
+): RuntimeHostEndpoint {
+  return endpoint(stateDirectory, `runtime-host-${installId}`, `agent-log-viewer-${installId}`, platform);
+}
+
+/** The endpoint a host started with no `LLV_RUNTIME_HOST_SOCKET` binds. */
+export function defaultRuntimeHostEndpoint(
+  stateDirectory: string,
+  platform: NodeJS.Platform = process.platform,
+): RuntimeHostEndpoint {
+  return endpoint(stateDirectory, "runtime-host", "agent-log-viewer-runtime-host", platform);
+}
+
+/**
+ * The fence beside a socket the caller already has, for the hosts that are
+ * handed `LLV_RUNTIME_HOST_SOCKET` and no fence name. A pipe endpoint has no
+ * file to sit beside, so its fence goes to `fallbackDirectory`.
+ */
+export function runtimeHostFencePath(socketPath: string, fallbackDirectory: string): string {
+  if (!isNamedPipePath(socketPath)) return `${socketPath}.lock`;
+  const name = socketPath.slice(socketPath.lastIndexOf("\\") + 1);
+  return path.win32.join(fallbackDirectory, `${name || "runtime-host"}.lock`);
+}

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -19,6 +19,18 @@ import {
   searchTextForTranscript,
 } from "./describe";
 
+/* The recognisers are written over `path.sep`, so a hard-coded POSIX literal
+   here would assert nothing on the `windows-latest` leg of
+   `platform-tests.yml`. `abs` builds the same shape for the platform under
+   test; `POSIX_ONLY` marks the cases whose behaviour Windows deliberately does
+   not have, each of which has a Windows counterpart below stating what it
+   becomes instead. */
+const DRIVE = process.platform === "win32" ? "C:" : "";
+const abs = (...segments: string[]): string => DRIVE + path.sep + segments.join(path.sep);
+const POSIX_ONLY = process.platform !== "win32";
+const WINDOWS_ONLY = process.platform === "win32";
+const CLAUDE_TASK_CONTAINER = `claude-${process.getuid?.() ?? 1000}`;
+
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-describe-test-"));
 const REAL_STATE = process.env.LLV_STATE_DIR;
 const REAL_HOME = process.env.HOME;
@@ -54,26 +66,42 @@ afterAll(() => {
 });
 
 test("parseWorktreeGitdir resolves an absolute gitdir into repo + worktree name", () => {
+  /* Git for Windows writes the pointer with forward slashes and a drive letter
+     (`gitdir: C:/repo/.git/worktrees/<name>`); `path.resolve` normalises it
+     before the split, which is why the recogniser needs no Windows form. */
+  const pointer = WINDOWS_ONLY
+    ? "C:/home/user/.agents/tools/live-log-viewer-next/.git/worktrees/live-log-viewer-attention-queue"
+    : "/home/user/.agents/tools/live-log-viewer-next/.git/worktrees/live-log-viewer-attention-queue";
   const info = parseWorktreeGitdir(
-    "/home/user/.agents/tools/live-log-viewer-attention-queue",
-    "gitdir: /home/user/.agents/tools/live-log-viewer-next/.git/worktrees/live-log-viewer-attention-queue\n",
+    abs("home", "user", ".agents", "tools", "live-log-viewer-attention-queue"),
+    `gitdir: ${pointer}\n`,
   );
   expect(info).toEqual({
-    repo: "/home/user/.agents/tools/live-log-viewer-next",
+    repo: abs("home", "user", ".agents", "tools", "live-log-viewer-next"),
     worktree: "live-log-viewer-attention-queue",
   });
 });
 
 test("parseWorktreeGitdir resolves a relative gitdir against the checkout cwd", () => {
-  const info = parseWorktreeGitdir("/home/user/wt", "gitdir: ../main/.git/worktrees/wt");
-  expect(info).toEqual({ repo: "/home/user/main", worktree: "wt" });
+  const info = parseWorktreeGitdir(abs("home", "user", "wt"), "gitdir: ../main/.git/worktrees/wt");
+  expect(info).toEqual({ repo: abs("home", "user", "main"), worktree: "wt" });
 });
 
 test("parseWorktreeGitdir rejects gitdirs that are not linked worktrees", () => {
-  expect(parseWorktreeGitdir("/home/user/sub", "gitdir: /home/user/main/.git")).toBeNull();
-  expect(parseWorktreeGitdir("/home/user/sub", "not a git file")).toBeNull();
+  const sub = abs("home", "user", "sub");
+  expect(parseWorktreeGitdir(sub, `gitdir: ${abs("home", "user", "main", ".git")}`)).toBeNull();
+  expect(parseWorktreeGitdir(sub, "not a git file")).toBeNull();
   /* "worktrees" segment without a .git parent is another repo layout, not a linked checkout */
-  expect(parseWorktreeGitdir("/home/user/sub", "gitdir: /home/user/worktrees/x")).toBeNull();
+  expect(parseWorktreeGitdir(sub, `gitdir: ${abs("home", "user", "worktrees", "x")}`)).toBeNull();
+});
+
+test("a repository at the filesystem root keeps a usable root path", () => {
+  /* The recognisers rebuild the repo by rejoining a `path.sep` split. On POSIX
+     the empty prefix is the root; on Windows the same slice leaves a bare `C:`,
+     which means "the current directory on C:" and is not `C:\` — the repo would
+     then name a different, cwd-dependent place each time it was read. */
+  expect(parseWorktreeGitdir(abs("wt"), `gitdir: ${abs(".git", "worktrees", "wt")}`))
+    .toEqual({ repo: WINDOWS_ONLY ? "C:\\" : "/", worktree: "wt" });
 });
 
 test("an absent cwd cannot inherit the Viewer process project", () => {
@@ -206,38 +234,38 @@ test("a deleted nested checkout inside a Codex worktree groups under the main re
   expect(projectForCwd(dead)).toBe(identity.project);
 });
 
-test("a deleted worktree scratchpad cwd groups under the encoded parent repo", () => {
+test.if(POSIX_ONLY)("a deleted worktree scratchpad cwd groups under the encoded parent repo", () => {
   const repo = path.join(SANDBOX, "scratchpad-worktree-repository");
   createRepository(repo);
   const worktree = path.join(repo, ".worktrees", "runtime-host-spike");
   const slug = worktree.replace(/[^a-zA-Z0-9]/g, "-");
-  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad", "probes");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad", "probes");
   expect(fs.existsSync(dead)).toBe(false);
   expect(projectForCwd(dead)).toBe(projectForCwd(repo));
   expect(projectRootForCwd(dead)).toBe(repo);
 });
 
-test("a main-checkout scratchpad cwd groups under its encoded project", () => {
+test.if(POSIX_ONLY)("a main-checkout scratchpad cwd groups under its encoded project", () => {
   const repo = path.join(SANDBOX, "scratchpad-main-repository");
   createRepository(repo);
   const slug = repo.replace(/[^a-zA-Z0-9]/g, "-");
-  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad", "probes");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad", "probes");
   expect(fs.existsSync(dead)).toBe(false);
   expect(projectForCwd(dead)).toBe(projectForCwd(repo));
 });
 
-test("a deleted scratchpad encoded from an external repository keeps its canonical root", () => {
+test.if(POSIX_ONLY)("a deleted scratchpad encoded from an external repository keeps its canonical root", () => {
   const repo = path.join(SANDBOX, "external-root", "repo.with-hyphen");
   createRepository(repo);
   const slug = repo.replace(/[^a-zA-Z0-9]/g, "-");
-  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad", "probes");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad", "probes");
 
   expect(fs.existsSync(dead)).toBe(false);
   expect(projectForCwd(dead)).toBe(projectForCwd(repo));
   expect(projectRootForCwd(dead)).toBe(repo);
 
   const missingSlug = path.join(SANDBOX, "removed-external-repo").replace(/[^a-zA-Z0-9]/g, "-");
-  const missing = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, missingSlug, "deleted-session", "scratchpad");
+  const missing = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, missingSlug, "deleted-session", "scratchpad");
   expect(projectRootForCwd(missing)).toBeUndefined();
 });
 
@@ -249,12 +277,12 @@ test("the outer nested worktree wins over a later specialized container", () => 
   expect(projectForCwd(dead)).toBe(projectForCwd(repo));
 });
 
-test("a scratchpad encoded from nested worktrees keeps the outer project", () => {
+test.if(POSIX_ONLY)("a scratchpad encoded from nested worktrees keeps the outer project", () => {
   const repo = path.join(SANDBOX, "nested-scratchpad-repository");
   createRepository(repo);
   const nested = path.join(repo, ".worktrees", "outer", ".claude", "worktrees", "inner");
   const slug = nested.replace(/[^a-zA-Z0-9]/g, "-");
-  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad");
   expect(fs.existsSync(dead)).toBe(false);
   expect(projectForCwd(dead)).toBe(projectForCwd(repo));
   const root = path.join(SANDBOX, "nested-scratchpad-transcripts");
@@ -267,7 +295,7 @@ test("a scratchpad encoded from nested worktrees keeps the outer project", () =>
   });
 });
 
-test("a scratchpad encoded from a deleted Codex worktree keeps the repo project", () => {
+test.if(POSIX_ONLY)("a scratchpad encoded from a deleted Codex worktree keeps the repo project", () => {
   const state = useStateDirectory("deleted-codex-scratchpad-state");
   const identity = createRepository(path.join(SANDBOX, "deleted-codex-scratchpad-main"));
   expect(persistProjectAliases([
@@ -283,9 +311,59 @@ test("a scratchpad encoded from a deleted Codex worktree keeps the repo project"
     "inner",
   );
   const slug = codexWorktree.replace(/[^a-zA-Z0-9]/g, "-");
-  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad");
   expect(fs.existsSync(dead)).toBe(false);
   expect(projectForCwd(dead)).toBe(identity.project);
+});
+
+/* The Windows counterparts of the five scratchpad cases above. Recogniser #1
+   (`projectInfoFromClaudeTaskCwd`) and the slug walk it leans on
+   (`repoPathFromSlug`) are the two pieces of the grouping algorithm that
+   Windows does not get in phase 1, and AGENTS.md is explicit that a recogniser
+   must not be allowed to stop matching quietly. These say out loud what they
+   become: the container is still recognised and the key is still stable, but it
+   is the slug's key rather than the repository's, because the frontier walk
+   that recovers a repository path from a slug starts at the POSIX root and a
+   Windows slug starts at a drive letter. Nothing in the design claims to know
+   what Claude Code names that container on Windows — the layout has never been
+   observed — so the case that would settle it is listed as deferred, not
+   asserted here. */
+test.if(WINDOWS_ONLY)("a Windows scratchpad slug lands in Unresolved rather than under its repository", () => {
+  /* Measured on the Windows leg, and worse than "it groups by its slug": with
+     no repository path recovered there is no canonical project id either, and
+     `aliasedProjectInfo` answers Unresolved for a bare slug. Every scratchpad
+     session on Windows therefore pools together instead of grouping per
+     repository. That is the honest degrade until the slug walk learns drive
+     roots; the README says so. */
+  const repo = path.join(SANDBOX, "windows-scratchpad-repository");
+  createRepository(repo);
+  const slug = repo.replace(/[^a-zA-Z0-9]/g, "-");
+  // A Windows slug opens with a drive letter, and the slug walk starts at the
+  // POSIX root, which is precisely why it recovers nothing.
+  expect(slug.startsWith("-")).toBe(false);
+  expect(slug).toMatch(/^[A-Za-z]--/);
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad", "probes");
+
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectInfoFromCwd(dead)).toMatchObject({ unresolved: true });
+  expect(projectRootForCwd(dead)).toBeUndefined();
+  expect(projectForCwd(dead)).not.toBe(projectForCwd(repo));
+  // Still stable across reads, which is the part that must not regress.
+  expect(projectForCwd(dead)).toBe(projectForCwd(dead));
+});
+
+test.if(WINDOWS_ONLY)("a Windows worktree slug still names its worktree", () => {
+  /* `worktreeFromSlug` is pure string work over the encoded `--worktrees-`
+     marker, so it keeps working; only the repository-path recovery beneath it
+     goes away. */
+  const repo = path.join(SANDBOX, "windows-scratchpad-worktree-repo");
+  createRepository(repo);
+  const worktree = path.join(repo, ".worktrees", "runtime-host-spike");
+  const slug = worktree.replace(/[^a-zA-Z0-9]/g, "-");
+  const dead = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, slug, "deleted-session", "scratchpad", "probes");
+
+  expect(projectInfoFromCwd(dead)?.worktree).toBe("runtime-host-spike");
+  expect(projectRootForCwd(dead)).toBeUndefined();
 });
 
 test("a deleted nested worktree (repo/worktrees/<name>) still groups under its parent repo", () => {
@@ -294,9 +372,10 @@ test("a deleted nested worktree (repo/worktrees/<name>) still groups under its p
      path even after the checkout is deleted, no on-disk `.git` required. */
   const repo = path.join(SANDBOX, "deleted-nested-worktree-main");
   const identity = createRepository(repo);
-  const nested = `${repo}/worktrees/memory-ui-redesign`;
-  const nestedDotted = `${repo}/.worktrees/some-branch`;
-  const deepNested = `${repo}/worktrees/issue-1424/worktrees/pr-tools`; // worktree of a worktree
+  const nested = path.join(repo, "worktrees", "memory-ui-redesign");
+  const nestedDotted = path.join(repo, ".worktrees", "some-branch");
+  // worktree of a worktree
+  const deepNested = path.join(repo, "worktrees", "issue-1424", "worktrees", "pr-tools");
   expect(fs.existsSync(nested)).toBe(false);
   expect(projectForCwd(nested)).toBe(projectForCwd(repo));
   expect(projectForCwd(nestedDotted)).toBe(projectForCwd(repo));
@@ -321,7 +400,7 @@ test("conversation metadata carries the exact cwd and its canonical project root
 
 test("conversation metadata marks an unresolved deleted scratchpad root explicitly", () => {
   const missingSlug = path.join(SANDBOX, "removed-external-repo").replace(/[^a-zA-Z0-9]/g, "-");
-  const cwd = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, missingSlug, "deleted-session", "scratchpad");
+  const cwd = path.join(os.tmpdir(), CLAUDE_TASK_CONTAINER, missingSlug, "deleted-session", "scratchpad");
   const root = path.join(SANDBOX, "unresolved-scratchpad-transcripts");
   const transcript = path.join(root, "removed-external-repo", "session.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
@@ -416,7 +495,7 @@ test("a nested `worktrees` segment under .claude/.codex is left to its own recog
   expect(persistProjectAliases([
     { source: "shared-repository", target: identity.project, displayName: identity.displayName },
   ])).toBe(true);
-  const codex = `${state}/.codex/worktrees/2d25/shared-repository`;
+  const codex = path.join(state, ".codex", "worktrees", "2d25", "shared-repository");
   expect(projectForCwd(codex)).toBe(identity.project);
 });
 
@@ -669,7 +748,11 @@ test("the OpenClaw workspace keeps one project identity before and after deletio
   expect(withOpenclawStateDir(link, () => projectRootForCwd(workspace))).toBeUndefined();
 
   fs.rmSync(state, { recursive: true, force: true });
-  fs.rmSync(link, { force: true });
+  /* A directory symlink on Windows is removed with rmdir, not unlink; Bun's
+     `rm` answers EFAULT for one. The recogniser under test is platform-neutral,
+     so only its teardown forks. */
+  if (WINDOWS_ONLY) fs.rmdirSync(link);
+  else fs.rmSync(link, { force: true });
   expect(fs.existsSync(workspace)).toBe(false);
 
   const dead = withOpenclawStateDir(link, () => projectInfoFromCwd(workspace, "openclaw-dead"));

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -191,6 +191,20 @@ export function projectFromSlug(slug: string): string {
   return canonicalProject(slug);
 }
 
+/** Rejoins a `path.sep`-split absolute path into one.
+ *
+ * An empty prefix is the POSIX root. On Windows the same slice yields a bare
+ * drive letter, and `C:` there means "the current directory on drive C", a
+ * *relative* location that is not `C:\` — so it regains its separator. Without
+ * this, a repo checked out at a drive root would name a different project
+ * before and after its worktree was deleted, which is the one invariant the
+ * recognisers exist to hold (AGENTS.md). */
+function joinPathSegments(parts: string[]): string {
+  const joined = parts.join(path.sep);
+  if (!joined) return path.sep;
+  return /^[A-Za-z]:$/.test(joined) ? joined + path.sep : joined;
+}
+
 function worktreeFromPath(cwd: string): { repo: string; worktree: string } | null {
   const marker = path.sep + ".claude" + path.sep + "worktrees" + path.sep;
   const index = cwd.indexOf(marker);
@@ -216,7 +230,7 @@ function worktreeFromNested(cwd: string): { repo: string; worktree: string } | n
     if (parts[i - 1] === ".claude" || parts[i - 1] === ".codex") return null;
     const worktree = parts[i + 1];
     if (!worktree) return null;
-    return { repo: parts.slice(0, i).join(path.sep) || path.sep, worktree };
+    return { repo: joinPathSegments(parts.slice(0, i)), worktree };
   }
   return null;
 }
@@ -228,7 +242,14 @@ function repoPathFromSlug(slug: string): string | null {
   /* Slugs for repositories outside the two conventional roots are lossy:
      separators, dots, and spaces all become dashes. Walk only filesystem
      branches whose encoded prefix can still match, then accept a unique
-     existing directory (preferring a git root when ambiguity remains). */
+     existing directory (preferring a git root when ambiguity remains).
+
+     A slug always begins with the encoded separator of an absolute POSIX path.
+     A Windows cwd encodes its drive letter first (`C--Users-...`), so every
+     Windows slug is refused here and the deleted-cwd slug recovery is
+     unavailable there: such a session groups through its recorded cwd instead,
+     by the ordinary resolver. Seeding the frontier with each drive root is
+     phase 2; the degrade is stated in the README. */
   if (!slug.startsWith("-")) return null;
   const matches: string[] = [];
   let frontier: Array<{ pathname: string; encoded: string }> = [{ pathname: path.parse(path.resolve(path.sep)).root, encoded: "" }];
@@ -285,7 +306,12 @@ function worktreeFromCodexPath(cwd: string): { repo: string; worktree: string; p
 }
 
 /** Main-repo root + worktree name from a linked checkout's `.git` file
-    content (`gitdir: <main>/.git/worktrees/<name>`). Pure for testability. */
+    content (`gitdir: <main>/.git/worktrees/<name>`). Pure for testability.
+
+    Git for Windows writes that pointer with forward slashes and a drive letter
+    (`gitdir: C:/repo/.git/worktrees/<name>`); `path.resolve` normalises it to
+    backslashes before the split, so the recogniser needs no separate Windows
+    form. */
 export function parseWorktreeGitdir(cwd: string, gitFileText: string): { repo: string; worktree: string } | null {
   const target = /^gitdir:\s*(.+?)\s*$/m.exec(gitFileText)?.[1];
   if (!target) return null;
@@ -293,7 +319,7 @@ export function parseWorktreeGitdir(cwd: string, gitFileText: string): { repo: s
   const index = parts.lastIndexOf("worktrees");
   const worktree = index >= 0 ? parts[index + 1] : undefined;
   if (!worktree || parts[index - 1] !== ".git") return null;
-  return { repo: parts.slice(0, index - 1).join(path.sep) || path.sep, worktree };
+  return { repo: joinPathSegments(parts.slice(0, index - 1)), worktree };
 }
 
 /* A cwd's worktree resolution is one lstat + tiny read, but it runs on every

--- a/src/runtime-host/fenceLock.ts
+++ b/src/runtime-host/fenceLock.ts
@@ -1,0 +1,190 @@
+import { createRequire } from "node:module";
+
+/**
+ * The one property the runtime-host singleton fence needs from the OS: an
+ * exclusive, non-blocking lock that **the kernel releases when the holding
+ * process dies**. That is what makes a host killed with `SIGKILL` — or, on
+ * Windows, with `TerminateProcess`, which runs no exit handler at all — leave a
+ * fence its successor can take.
+ *
+ * POSIX gets it from `flock(LOCK_EX | LOCK_NB)` on the descriptor the fence
+ * already holds open. Windows has no `flock`; the equivalent is `LockFileEx` on
+ * a kernel handle, and the fence's descriptor cannot supply one: Bun's file
+ * descriptors on Windows are its own, not the C runtime's, so translating one
+ * with `_get_osfhandle` is asking the CRT about a number it never issued.
+ * Windows therefore opens the fence file a **second** time through
+ * `CreateFileW`, sharing freely so nothing else is disturbed, and locks a byte
+ * on that handle. The lock and the handle both die with the process, which is
+ * the property being bought.
+ *
+ * A failure to load is a hard error rather than a silent "unlocked": a fence
+ * that cannot lock is not a fence, and two runtime hosts on one endpoint is the
+ * outage this module exists to prevent.
+ */
+
+const LOCK_EX = 2;
+const LOCK_NB = 4;
+const LOCK_UN = 8;
+
+const LOCKFILE_FAIL_IMMEDIATELY = 0x00000001;
+const LOCKFILE_EXCLUSIVE_LOCK = 0x00000002;
+/**
+ * One byte, far past the owner record, and never the whole file.
+ *
+ * This is the difference that would otherwise have shipped as a Windows-only
+ * outage: `flock` is advisory, so a POSIX contender reads the owner JSON out of
+ * a fence another host holds. `LockFileEx` is **mandatory** — a locked range
+ * refuses every other handle's read as well — and the fence reads that JSON
+ * twice before it locks, while the CLI's readiness probe reads it on every
+ * poll. Locking a byte nobody reads keeps the mutual exclusion and leaves the
+ * record readable, the same reservation SQLite makes at this offset.
+ */
+const LOCK_OFFSET = 0x40000000;
+const LOCK_BYTES_LOW = 1;
+const LOCK_BYTES_HIGH = 0;
+/** sizeof(OVERLAPPED) on x64; LockFileEx requires a real, zeroed one. */
+const OVERLAPPED_BYTES = 32;
+/** OVERLAPPED.Offset / OffsetHigh on x64 (after two ULONG_PTR fields). */
+const OVERLAPPED_OFFSET_AT = 16;
+const OVERLAPPED_OFFSET_HIGH_AT = 20;
+
+/* GENERIC_READ | GENERIC_WRITE, written out: `|` in JavaScript is a signed
+   32-bit operator and would turn 0xC0000000 into a negative number. */
+const GENERIC_READ_WRITE = 0xc0000000;
+const FILE_SHARE_ALL = 0x00000001 | 0x00000002 | 0x00000004;
+const OPEN_EXISTING = 3;
+const FILE_ATTRIBUTE_NORMAL = 0x00000080;
+
+/** The fence file, named both ways because each platform locks a different one. */
+export interface FenceLockTarget {
+  fd: number;
+  filename: string;
+}
+
+/** A held lock. Releasing twice is harmless; the process dying releases it. */
+export interface HeldFenceLock {
+  release(): void;
+}
+
+interface BunFfiModule {
+  FFIType: { i32: number; u32: number; u64: number; ptr: number };
+  ptr(buffer: NodeJS.TypedArray): number | bigint;
+  dlopen(path: string, symbols: Record<string, unknown>): { symbols: Record<string, (...args: never[]) => unknown> };
+}
+
+type LockImplementation = (target: FenceLockTarget) => HeldFenceLock | null;
+
+let cached: LockImplementation | null = null;
+
+function loadFfi(): BunFfiModule {
+  const runtimeRequire = createRequire(import.meta.url);
+  return runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+}
+
+function posixLock(): LockImplementation {
+  const ffi = loadFfi();
+  const library = ffi.dlopen(
+    process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6",
+    { flock: { args: [ffi.FFIType.i32, ffi.FFIType.i32], returns: ffi.FFIType.i32 } },
+  );
+  const flock = (fd: number, operation: number): number =>
+    library.symbols.flock!(fd as never, operation as never) as number;
+  return (target) => {
+    if (flock(target.fd, LOCK_EX | LOCK_NB) !== 0) return null;
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        flock(target.fd, LOCK_UN);
+      },
+    };
+  };
+}
+
+/**
+ * A Windows HANDLE and a NULL argument are declared `u64`, not `ptr`.
+ * Pointer-typed arguments make Bun marshal the value as one of its own pointer
+ * objects, and handing that path a bare `0` crashes the process rather than
+ * passing NULL. `u64` is the same eight bytes in the same register with none of
+ * the marshalling — only the two real buffers below stay `ptr`.
+ */
+const NULL_ARGUMENT = BigInt(0);
+/** CreateFileW answers INVALID_HANDLE_VALUE, which reads as all-ones unsigned. */
+const INVALID_HANDLE = BigInt("0xffffffffffffffff");
+
+function windowsLock(): LockImplementation {
+  const ffi = loadFfi();
+  const { i32, u32, u64, ptr } = ffi.FFIType;
+  const kernel32 = ffi.dlopen("kernel32.dll", {
+    CreateFileW: { args: [ptr, u32, u32, u64, u32, u32, u64], returns: u64 },
+    CloseHandle: { args: [u64], returns: i32 },
+    LockFileEx: { args: [u64, u32, u32, u32, u32, ptr], returns: i32 },
+    UnlockFileEx: { args: [u64, u32, u32, u32, ptr], returns: i32 },
+  });
+
+  const lockRegion = (): Buffer => {
+    const overlapped = Buffer.alloc(OVERLAPPED_BYTES);
+    overlapped.writeUInt32LE(LOCK_OFFSET, OVERLAPPED_OFFSET_AT);
+    overlapped.writeUInt32LE(0, OVERLAPPED_OFFSET_HIGH_AT);
+    return overlapped;
+  };
+
+  return (target) => {
+    /* UTF-16LE and NUL-terminated, because this is the wide entry point and a
+       fence path can carry any character a Windows profile name can. */
+    const wide = Buffer.from(`${target.filename}\0`, "utf16le");
+    const handle = BigInt(kernel32.symbols.CreateFileW!(
+      ffi.ptr(wide) as never,
+      GENERIC_READ_WRITE as never,
+      FILE_SHARE_ALL as never,
+      NULL_ARGUMENT as never,
+      OPEN_EXISTING as never,
+      FILE_ATTRIBUTE_NORMAL as never,
+      NULL_ARGUMENT as never,
+    ) as bigint | number);
+    if (handle === NULL_ARGUMENT || handle === INVALID_HANDLE) {
+      throw new Error("runtime host fence file could not be opened for locking");
+    }
+    const close = (): void => {
+      kernel32.symbols.CloseHandle!(handle as never);
+    };
+    const locked = kernel32.symbols.LockFileEx!(
+      handle as never,
+      (LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY) as never,
+      0 as never,
+      LOCK_BYTES_LOW as never,
+      LOCK_BYTES_HIGH as never,
+      ffi.ptr(lockRegion()) as never,
+    ) as number;
+    if (locked === 0) {
+      close();
+      return null;
+    }
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        kernel32.symbols.UnlockFileEx!(
+          handle as never,
+          0 as never,
+          LOCK_BYTES_LOW as never,
+          LOCK_BYTES_HIGH as never,
+          ffi.ptr(lockRegion()) as never,
+        );
+        close();
+      },
+    };
+  };
+}
+
+function lockImplementation(): LockImplementation {
+  if (!cached) cached = process.platform === "win32" ? windowsLock() : posixLock();
+  return cached;
+}
+
+/** Takes the exclusive lock without waiting. Null means someone else holds it. */
+export function tryLockFenceExclusive(target: FenceLockTarget): HeldFenceLock | null {
+  return lockImplementation()(target);
+}

--- a/src/runtime-host/fixtures/runtimeHostFenceContender.ts
+++ b/src/runtime-host/fixtures/runtimeHostFenceContender.ts
@@ -3,6 +3,8 @@ import net from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { testEndpoint } from "./testEndpoint";
+
 const [moduleFilename, fenceFilename, barrierDir, contender] = process.argv.slice(2);
 if (!moduleFilename || !fenceFilename || !barrierDir || !contender) {
   throw new Error("runtime host fence contender arguments are required");
@@ -26,7 +28,7 @@ const waitForAsync = async (filename: string): Promise<void> => {
 
 const observedFilename = path.join(barrierDir, `observed-${contender}`);
 const outcomeFilename = path.join(barrierDir, `outcome-${contender}`);
-const listenerFilename = path.join(barrierDir, `listener-${contender}.sock`);
+const listenerFilename = testEndpoint(barrierDir, `listener-${contender}`);
 const releaseFilename = path.join(barrierDir, "release");
 const { RuntimeHostFence } = await import(pathToFileURL(moduleFilename).href);
 const fence = new RuntimeHostFence(fenceFilename, () => {

--- a/src/runtime-host/fixtures/runtimeHostFenceLegacyNullIdentity.ts
+++ b/src/runtime-host/fixtures/runtimeHostFenceLegacyNullIdentity.ts
@@ -3,6 +3,8 @@ import net from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { testEndpoint } from "./testEndpoint";
+
 const [role, hostModule, procModule, fenceFilename, sandbox] = process.argv.slice(2);
 if (!role || !hostModule || !procModule || !fenceFilename || !sandbox) {
   throw new Error("legacy runtime host fence fixture arguments are required");
@@ -22,7 +24,7 @@ if (role === "owner") {
     pid: process.pid,
     startIdentity: "legacy-owner-start",
   }), { mode: 0o600 });
-  const listenerFilename = path.join(sandbox, "listener-owner.sock");
+  const listenerFilename = testEndpoint(sandbox, "listener-owner");
   const server = net.createServer((socket) => socket.end("owner"));
   try {
     await new Promise<void>((resolve, reject) => {
@@ -42,7 +44,7 @@ if (role === "owner") {
   let server: net.Server | null = null;
   try {
     fence.acquire();
-    const listenerFilename = path.join(sandbox, "listener-contender.sock");
+    const listenerFilename = testEndpoint(sandbox, "listener-contender");
     server = net.createServer((socket) => socket.end("contender"));
     await new Promise<void>((resolve, reject) => {
       server!.once("error", reject);

--- a/src/runtime-host/fixtures/testEndpoint.ts
+++ b/src/runtime-host/fixtures/testEndpoint.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+/**
+ * A listening endpoint for a test, in the form the running platform can bind.
+ *
+ * POSIX gets a Unix socket inside the caller's sandbox directory. Windows has
+ * no such thing, so it gets a named pipe — which lives in a flat, machine-wide
+ * kernel namespace rather than under a directory, and therefore has to carry
+ * the sandbox's own unique name to stay unique. `mkdtemp` already made that
+ * name unique, so the basename is enough.
+ *
+ * This exists so the runtime-host socket and fence tests exercise the *real*
+ * endpoint on both legs of `platform-tests.yml` instead of being skipped on the
+ * one platform whose endpoint is different.
+ */
+export function testEndpoint(sandbox: string, name: string): string {
+  if (process.platform !== "win32") return path.join(sandbox, `${name}.sock`);
+  return `\\\\.\\pipe\\llv-test-${path.basename(sandbox)}-${name}`;
+}

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -2,7 +2,7 @@ import { discardWakatimeEnvironmentCredential } from "@/lib/wakatime/credential"
 
 discardWakatimeEnvironmentCredential();
 
-const { statePath } = await import("@/lib/configDir");
+const { stateDir, statePath } = await import("@/lib/configDir");
 const { procBackend } = await import("@/lib/proc");
 const { createServerRuntimeConsumers } = await import("@/lib/runtime/serverConsumers");
 const { requestPipelineTick } = await import("@/lib/pipelines/controllerSignal");
@@ -23,7 +23,13 @@ const { acquireRuntimeHostFence, runtimeHostFenceWaitPlan } = await import("./fe
 
 const { runtimeHostActivationRefusal } = await import("@/lib/runtime/flags");
 
-const socketPath = process.env.LLV_RUNTIME_HOST_SOCKET || statePath("runtime-host.sock");
+const { defaultRuntimeHostEndpoint, runtimeHostFencePath } = await import("@/lib/runtime/localEndpoint");
+/* One local endpoint: a Unix socket path on POSIX, a named pipe on Windows.
+   The fence is a real file on both, so on Windows it cannot be derived from the
+   endpoint by appending `.lock` — the CLI hands it over explicitly, and a host
+   started without one falls back to the state directory. */
+const defaultEndpoint = defaultRuntimeHostEndpoint(stateDir());
+const socketPath = process.env.LLV_RUNTIME_HOST_SOCKET || defaultEndpoint.socketPath;
 /* A started runtime-host is always an events host. The guard survives; it keys
    on the same reader the viewer uses, so a deployment that merely drops the
    variable no longer gets a viewer that believes events are live and a host
@@ -33,7 +39,9 @@ if (activationRefusal) throw new Error(activationRefusal);
 if (process.env.LLV_RUNTIME_LEGACY_SCHEDULER === "1" && process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
   throw new Error("runtime legacy scheduler requires LLV_ACCOUNT_CONTROLLER_DISABLED=1 to preserve single-writer reconciliation");
 }
-const fence = new RuntimeHostFence(`${socketPath}.lock`);
+const fence = new RuntimeHostFence(
+  process.env.LLV_RUNTIME_HOST_FENCE?.trim() || runtimeHostFencePath(socketPath, stateDir()),
+);
 /* #518: a staged successor generation boots while its predecessor still holds
    the singleton fence, and must wait for the predecessor's graceful exit
    instead of failing its container. Ordinary boots keep the immediate throw.

--- a/src/runtime-host/runtimeHostFence.test.ts
+++ b/src/runtime-host/runtimeHostFence.test.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
+import { testEndpoint } from "./fixtures/testEndpoint";
 import { RuntimeHostFence } from "./runtimeHostFence";
 
 const fixture = path.join(import.meta.dir, "fixtures", "runtimeHostFenceContender.ts");
@@ -30,6 +31,32 @@ async function readListener(socketPath: string): Promise<string> {
   });
 }
 
+/* "Exactly one host is serving" is asked by connecting, not by looking for a
+   file: a Windows endpoint is a named pipe, which has no directory entry to
+   stat. Connecting is the stronger question anyway — a leftover socket inode
+   that nothing listens on would pass an existence check.
+
+   A single refused connection does not settle it. A listener that has bound but
+   whose accept has not been scheduled yet refuses transiently, so each endpoint
+   is asked repeatedly for a short while; an endpoint nobody is serving refuses
+   every time and still answers nothing. */
+async function answeringListeners(endpoints: string[]): Promise<string[]> {
+  const answers: string[] = [];
+  for (const endpoint of endpoints) {
+    const deadline = Date.now() + 2_000;
+    for (;;) {
+      try {
+        answers.push(await readListener(endpoint));
+        break;
+      } catch {
+        if (Date.now() >= deadline) break;
+        await Bun.sleep(50);
+      }
+    }
+  }
+  return answers;
+}
+
 test("stale fence reclamation activates exactly one process after both observe the stale owner", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-race-"));
   const fenceFilename = path.join(sandbox, "runtime-host.lock");
@@ -45,7 +72,7 @@ test("stale fence reclamation activates exactly one process after both observe t
     const outcomes = outcomeFilenames.map((filename) => fs.readFileSync(filename, "utf8"));
     expect(outcomes.filter((outcome) => outcome === "active")).toHaveLength(1);
     const active = outcomes[0] === "active" ? "A" : "B";
-    expect(await readListener(path.join(sandbox, `listener-${active}.sock`))).toBe(active);
+    expect(await readListener(testEndpoint(sandbox, `listener-${active}`))).toBe(active);
   } finally {
     fs.writeFileSync(path.join(sandbox, "release"), "");
     await Promise.all(contenders.map((contender) => contender.exited));
@@ -106,11 +133,10 @@ test("a live legacy owner remains the only listener when its start identity is t
     await waitForFiles([outcomeFilename]);
 
     expect(fs.readFileSync(outcomeFilename, "utf8")).toStartWith("blocked:");
-    expect([
-      path.join(sandbox, "listener-owner.sock"),
-      path.join(sandbox, "listener-contender.sock"),
-    ].filter((filename) => fs.existsSync(filename))).toHaveLength(1);
-    expect(await readListener(path.join(sandbox, "listener-owner.sock"))).toBe("owner");
+    expect(await answeringListeners([
+      testEndpoint(sandbox, "listener-owner"),
+      testEndpoint(sandbox, "listener-contender"),
+    ])).toEqual(["owner"]);
     expect(fs.readFileSync(fenceFilename, "utf8")).toBe(ownerMetadata);
   } finally {
     fs.writeFileSync(releaseFilename, "");

--- a/src/runtime-host/runtimeHostFence.ts
+++ b/src/runtime-host/runtimeHostFence.ts
@@ -1,48 +1,49 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 
 import { procBackend } from "@/lib/proc";
+import { isNamedPipePath } from "@/lib/runtime/localEndpoint";
 
-const LOCK_EX = 2;
-const LOCK_NB = 4;
-const LOCK_UN = 8;
+import { tryLockFenceExclusive, type HeldFenceLock } from "./fenceLock";
+
 const MAX_OWNER_BYTES = 4_096;
-// Linux and Darwin expose O_CLOEXEC under different numeric values.
-const O_CLOEXEC = process.platform === "darwin" ? 0x01000000 : 0x00080000;
+
+/*
+ * How the fence file is opened, and why Windows asks by name.
+ *
+ * POSIX needs a numeric mask, because `O_CLOEXEC` — which keeps this descriptor
+ * out of every spawned child — and `O_NOFOLLOW` — which refuses a fence path
+ * that is a symlink — exist nowhere else. Windows has neither concern: a handle
+ * is not inheritable unless it is asked to be, and an ordinary open does not
+ * traverse a reparse point. `O_NOFOLLOW` is not even defined there, and one
+ * absent constant turns the whole `|` mask into `NaN`.
+ *
+ * Removing it is not enough, and this is the part worth writing down. The
+ * Windows runner reports the right numbers for the rest — `O_CREAT` 0x100,
+ * `O_EXCL` 0x400, the C runtime's own values, printed by
+ * `scripts/verify-platform-backend.ts` — and passing exactly those as a numeric
+ * mask still did not perform the open that was asked for: creating answered
+ * ENOENT for a directory that plainly exists, and opening an existing record
+ * left a descriptor that failed at its first truncate with EPERM. The named
+ * forms are translated by the runtime itself and do work. `wx+` is read-write,
+ * create, fail-if-exists, and does not truncate; `r+` is read-write on
+ * something that must already be there. Both were measured on the Windows leg,
+ * after a probe printed beside them had cleared `mkdirSync` of suspicion.
+ */
+const CREATE_EXCLUSIVE = process.platform === "win32"
+  ? "wx+"
+  : fs.constants.O_RDWR | fs.constants.O_CREAT | fs.constants.O_EXCL
+    | (process.platform === "darwin" ? 0x01000000 : 0x00080000) | fs.constants.O_NOFOLLOW;
+const OPEN_EXISTING = process.platform === "win32"
+  ? "r+"
+  : fs.constants.O_RDWR
+    | (process.platform === "darwin" ? 0x01000000 : 0x00080000) | fs.constants.O_NOFOLLOW;
 
 interface RuntimeHostFenceOwner {
   pid: number;
   startIdentity: string | null;
   acquisitionId?: string;
-}
-
-interface BunFfiModule {
-  FFIType: { i32: number };
-  dlopen(path: string, symbols: Record<string, unknown>): {
-    symbols: { flock: (fd: number, operation: number) => number };
-  };
-}
-
-let cachedFlock: ((fd: number, operation: number) => number) | null = null;
-
-function flock(fd: number, operation: number): number {
-  if (!cachedFlock) {
-    const runtimeRequire = createRequire(import.meta.url);
-    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
-    const library = ffi.dlopen(
-      process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6",
-      {
-        flock: {
-          args: [ffi.FFIType.i32, ffi.FFIType.i32],
-          returns: ffi.FFIType.i32,
-        },
-      },
-    );
-    cachedFlock = (lockedFd, lockedOperation) => library.symbols.flock(lockedFd, lockedOperation);
-  }
-  return cachedFlock(fd, operation);
 }
 
 function readOwner(fd: number): RuntimeHostFenceOwner | null {
@@ -81,6 +82,7 @@ export interface RuntimeHostSocketIdentity {
  */
 export class RuntimeHostFence {
   private fd: number | null = null;
+  private lock: HeldFenceLock | null = null;
   private acquisitionId: string | null = null;
 
   constructor(
@@ -102,24 +104,23 @@ export class RuntimeHostFence {
     fs.mkdirSync(path.dirname(this.filename), { recursive: true, mode: 0o700 });
     let created = false;
     let fd: number;
-    const openFlags = fs.constants.O_RDWR | O_CLOEXEC | fs.constants.O_NOFOLLOW;
     try {
-      fd = fs.openSync(this.filename, openFlags | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+      fd = fs.openSync(this.filename, CREATE_EXCLUSIVE, 0o600);
       created = true;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      fd = fs.openSync(this.filename, openFlags);
+      fd = fs.openSync(this.filename, OPEN_EXISTING);
     }
 
-    let locked = false;
+    let lock: HeldFenceLock | null = null;
     try {
       const observedOwner = readOwner(fd);
       if (!created && !observedOwner) throw new Error("runtime host singleton fence is held");
       if (observedOwner && !observedOwner.acquisitionId && this.ownerAlive(observedOwner)) {
         throw new Error("runtime host singleton fence is held");
       }
-      if (flock(fd, LOCK_EX | LOCK_NB) !== 0) throw new Error("runtime host singleton fence is held");
-      locked = true;
+      lock = tryLockFenceExclusive({ fd, filename: this.filename });
+      if (!lock) throw new Error("runtime host singleton fence is held");
 
       const lockedOwner = readOwner(fd);
       if (!created && !lockedOwner) throw new Error("runtime host singleton fence is held");
@@ -145,9 +146,10 @@ export class RuntimeHostFence {
         throw new Error("runtime host singleton fence changed during acquisition");
       }
       this.fd = fd;
+      this.lock = lock;
       this.acquisitionId = acquisitionId;
     } catch (error) {
-      if (locked) flock(fd, LOCK_UN);
+      lock?.release();
       fs.closeSync(fd);
       throw error;
     }
@@ -159,6 +161,10 @@ export class RuntimeHostFence {
    * captured by this acquisition is unlinked from the private retirement path.
    */
   removeOwnedSocket(socketPath: string, identity: RuntimeHostSocketIdentity): void {
+    /* A named pipe has no inode to retire: the kernel drops the name when the
+       last handle closes. Only the Docker deployment bootstrap calls this, and
+       that is Linux-only, but the endpoint kind is what decides, not the caller. */
+    if (isNamedPipePath(socketPath)) return;
     const fd = this.fd;
     const acquisitionId = this.acquisitionId;
     if (fd === null || !acquisitionId) throw new Error("runtime host singleton fence is not held");
@@ -201,11 +207,13 @@ export class RuntimeHostFence {
 
   release(): void {
     const fd = this.fd;
+    const lock = this.lock;
     this.fd = null;
+    this.lock = null;
     this.acquisitionId = null;
     if (fd === null) return;
     try {
-      flock(fd, LOCK_UN);
+      lock?.release();
     } finally {
       fs.closeSync(fd);
     }

--- a/src/runtime-host/socket.test.ts
+++ b/src/runtime-host/socket.test.ts
@@ -6,11 +6,22 @@ import path from "node:path";
 
 import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
+import { testEndpoint } from "./fixtures/testEndpoint";
 import type { RuntimeHost } from "./host";
 import { serveRuntimeHost } from "./socket";
 
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-socket-"));
 const servers: net.Server[] = [];
+
+/* The endpoint is a Unix socket path on POSIX and a named pipe on Windows; the
+   framing, timeouts, abort signal and connection caps asserted below are the
+   same code either way, and running this file on both legs of
+   `platform-tests.yml` is what says so. */
+let endpointCounter = 0;
+function nextEndpoint(): string {
+  endpointCounter += 1;
+  return testEndpoint(SANDBOX, `socket-${endpointCounter}`);
+}
 
 afterAll(async () => {
   await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
@@ -35,7 +46,7 @@ function stubHost(
 }
 
 function serve(host: RuntimeHost, socketErrors: Error[]): string {
-  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const socketPath = nextEndpoint();
   const server = serveRuntimeHost(socketPath, host);
   server.on("connection", (socket) => socket.on("error", (error) => socketErrors.push(error)));
   servers.push(server);
@@ -112,7 +123,7 @@ test("a timed-out socket destroyed by the server produces zero late writes", asy
   let releaseResponse = () => {};
   const gate = new Promise<void>((resolve) => { releaseResponse = () => resolve(); });
   const socketErrors: Error[] = [];
-  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const socketPath = nextEndpoint();
   const server = serveRuntimeHost(socketPath, stubHost(async (request) => {
     await gate;
     return { id: request.id, ok: true, result: {} };
@@ -133,7 +144,7 @@ test("a timed-out socket destroyed by the server produces zero late writes", asy
 });
 
 test("a write that fails after the peer vanished ends the connection, not the host", async () => {
-  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const socketPath = nextEndpoint();
   const server = serveRuntimeHost(socketPath, stubHost(async (request) => ({ id: request.id, ok: true, result: {} })));
   servers.push(server);
   await new Promise<void>((resolve) => server.once("listening", () => resolve()));

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -3,6 +3,7 @@ import net from "node:net";
 import path from "node:path";
 
 import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
+import { isNamedPipePath } from "@/lib/runtime/localEndpoint";
 
 import type { RuntimeHost } from "./host";
 import { PreserializedJson } from "./preserializedJson";
@@ -22,7 +23,16 @@ export interface RuntimeHostSocketOptions {
 
 export type RuntimeHostSocketHandler = Pick<RuntimeHost, "handle">;
 
-/** Newline-framed local protocol. It intentionally binds a Unix path only. */
+/**
+ * Newline-framed local protocol over one local endpoint: a Unix socket path on
+ * POSIX, a Windows named pipe (`\\.\pipe\…`) on win32. It never binds a TCP
+ * port. The filesystem preparation — creating the parent directory, unlinking a
+ * stale inode, tightening the mode once bound — belongs to the socket-path form
+ * only; a pipe name lives in the kernel's pipe namespace, has no parent
+ * directory and no mode, and its name disappears with the last handle. That
+ * difference in access control is documented rather than emulated: see
+ * `localEndpoint.ts`.
+ */
 export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHandler, options: RuntimeHostSocketOptions = {}): net.Server {
   const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT_MS;
   const deploymentTimeoutMs = options.deploymentTimeoutMs ?? DEPLOYMENT_SOCKET_TIMEOUT_MS;
@@ -34,8 +44,11 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHand
   if (!Number.isSafeInteger(maxWaitConnections) || maxWaitConnections < 1 || maxWaitConnections >= maxConnections) {
     throw new Error("runtime socket maxWaitConnections must reserve at least one command connection");
   }
-  fs.mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
-  try { fs.unlinkSync(socketPath); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  const namedPipe = isNamedPipePath(socketPath);
+  if (!namedPipe) {
+    fs.mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
+    try { fs.unlinkSync(socketPath); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  }
   let activeWaitConnections = 0;
   const server = net.createServer((socket) => {
     /* #1254: a peer that goes away mid-frame is a connection event, and the
@@ -106,7 +119,7 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHand
   // The remaining slots keep snapshot, control, and deployment traffic
   // admissible while total file descriptors and journal waiters stay bounded.
   server.maxConnections = maxConnections;
-  server.once("listening", () => fs.chmodSync(socketPath, 0o600));
+  if (!namedPipe) server.once("listening", () => fs.chmodSync(socketPath, 0o600));
   server.listen(socketPath);
   return server;
 }


### PR DESCRIPTION
Phase 1 of the merged `docs/design/windows-support.md`, for #1201. A user reported that the Viewer does not work on Windows: `package.json` declared `"os": ["linux", "darwin"]`, so the install failed with `EBADPLATFORM` before anything else could be tried, and there was no Windows process backend behind it.

## The binding constraint, and what answers it

Nobody working on this repository has a Windows machine, so nothing here is asserted — `.github/workflows/platform-tests.yml` runs it. Its Windows leg refuses a runner that is not Windows, fails when any kernel reader returns nothing, and only then runs the backend, the endpoint, the fence, the tree kill, the path handling and the launcher. This is the shape `macos-identity.yml` already uses for the Darwin readers, for the same reason: a job that fails when the behaviour does not hold.

Its Ubuntu leg runs the identical file list. That is what makes "Linux is unchanged" a witnessed claim: before this, no workflow in the repository ran the suite at all.

**The job earned its keep on its first four runs**, and every defect below was written blind and caught by CI rather than by reasoning:

| What the Windows leg refused | Why it was wrong |
|---|---|
| The singleton fence could not create its own file | A first boot on a fresh Windows machine could not make its own state file. `O_NOFOLLOW` does not exist there, and one absent constant turns the whole `|` mask into `NaN` — but removing it was not enough: the runner reports the *correct* numbers for the rest (`O_CREAT` 0x100, `O_EXCL` 0x400, printed by the verifier), and passing exactly those still answered ENOENT for a directory that plainly exists. The named forms (`wx+`, `r+`) are translated by the runtime and do work. Two wrong hypotheses were refuted along the way by probes the job prints, one of which cleared `mkdirSync`. |
| A process identity outlived the process it named | A Windows process object survives its process while any handle is open, and the spawning parent always holds one, so `GetProcessTimes` kept answering for the corpse. Identity now refuses a process whose exit code says it is gone. |
| The CLI could not find its own server from a checkout | `node_modules/.bin/next` is a `.cmd`/`.ps1`/`.exe` shim on Windows, never an extension-less file. It now falls back to Next's own JS entry point, which the Bun runtime was going to execute anyway. |
| Bun crashed passing a bare `0` to an FFI pointer argument | Handles and NULLs now cross as `u64` — the same eight bytes in the same register, with none of Bun's pointer marshalling. |

## What phase 1 contains

**A third process backend.** `portableBackend` is not slower on Windows, it is empty there — it shells out to `ps`, `lsof`, `vm_stat` and `sysctl`, and its identity token is Darwin-only, so a win32 scan returned nothing with nothing to say so. `src/lib/proc/windows.ts` takes one `Get-CimInstance Win32_Process` snapshot per five seconds for pids, lineage, command lines, working set and CPU, and reads two things from the kernel through `bun:ffi` that PowerShell cannot supply.

**The identity token, which is the part pid reuse makes load-bearing.** Windows hands a freed pid back within seconds, and every kill path plus the runtime-host fence re-reads a pid's identity before acting on it. The token is `${pid}:${creationFileTime}` from `GetProcessTimes` — the kernel's own creation time, the same quantity `/proc/<pid>/stat` field 22 and `proc_pidinfo` supply. Deliberately **not** the snapshot's `Win32_Process.CreationDate`, which is truncated to whole microseconds and is up to a TTL old, which is exactly the window a reused pid lives in; that column orders parents against children and does nothing else.

**Working directories.** `agentProcesses` drops any process whose cwd is unknown, so a backend that never resolved one would show zero agents. Windows has no `/proc/<pid>/cwd` and no `lsof -d cwd`: the cwd is read out of the target's own `RTL_USER_PROCESS_PARAMETERS` (`NtQueryInformationProcess` → `ReadProcessMemory`), for rows whose argv already looks like an agent, so the cost scales with the number of agents rather than with the process table. A 32-bit target is refused rather than read at x64 offsets, and every failure is `null` — the same "invisible" degrade macOS already has when `lsof` reports no cwd.

**Termination.** Windows has no process groups and no signals: `process.kill(pid, sig)` is `TerminateProcess`, `process.kill(-pid, …)` throws, and no handler runs in the child. `signalProcessGroup` gains a win32 arm that walks the parent map descendants-first and re-checks each member's identity immediately before killing it. A parent link whose parent started *after* its own child is dropped as the stale link it is — Windows never re-parents orphans, so a raw `ParentProcessId` can name an unrelated live process. `taskkill /T` would do the walk without either the ordering or the identity check.

**Paths.** The runtime host listens on a named pipe (`\\.\pipe\agent-log-viewer-<installId>`), which `net.createServer().listen` and `net.createConnection` take unchanged, so the newline framing, the Viewer's client and the CLI's readiness probe are untouched. The fence stays a real file and gets its kernel-released lock from `LockFileEx` on a handle it opens itself with `CreateFileW` — on a single reserved byte, not the whole file, because unlike `flock` that lock is *mandatory* and a whole-file lock would make the owner record unreadable to the fence's own pre-lock read and to every CLI readiness poll. `HOME` is ignored on win32, where it is not a Windows variable and the POSIX value Git Bash exports resolves to nothing.

**The CLI.** `rundll32.exe url.dll,FileProtocolHandler` opens the browser with no shell in the way, so the `&` between the viewer's query parameters is not a command separator. The `os` field admits `win32`.

## The worktree recognisers, said out loud

AGENTS.md is explicit that a recogniser must not be allowed to stop matching quietly, so each one's Windows behaviour is stated and tested rather than assumed:

| Recogniser | On Windows |
|---|---|
| `worktreeFromPath` (`.claude\worktrees\<name>`) | works; tested live and deleted |
| `worktreeFromNested` (`worktrees\<name>`) | works; tested, including a repository at a drive root, which previously rebuilt as a bare `C:` — a *relative* location, not `C:\` |
| `worktreeFromGitFile` | works; git for Windows writes `gitdir: C:/…` with forward slashes and `path.resolve` normalises it — tested in that form |
| `worktreeFromMemory` | works; the durable-map case runs on the Windows leg |
| `worktreeFromCodexPath` | untouched; Codex stays a WSL route |
| `projectInfoFromClaudeTaskCwd` + `repoPathFromSlug` | **stop resolving a repository, and the session lands in "Unresolved project".** A Windows slug starts with a drive letter and the frontier walk that recovers a repository path is rooted at the POSIX root, so nothing is found; without a repository there is no canonical project id either, and a bare slug is not one. Measured on the Windows leg, not predicted — the first draft of this PR claimed the gentler "groups by its own slug" and CI said otherwise. The scratchpad container is still recognised and a worktree name still survives; the project does not. |

## Separating what CI proves from what was reasoned about

**CI proves** (Windows leg): PowerShell is present and its CSV parses into a process table containing the runner's own process; the identity token is a real kernel FILETIME, stable across reads, different between two children, and **absent once a child exits**; `pidAlive` answers existence on Windows without terminating anything; the cwd read returns the runner's own working directory and a child's spawn directory; the parent map links a child to its parent; working set and CPU are readable; `LockFileEx` is exclusive, releasable, and leaves the owner record readable; the named pipe round-trips the runtime protocol with its framing, timeouts, abort signal and connection caps; exactly one of two contending hosts wins the fence; **a real child and its grandchild are both gone after one `signalProcessGroup`**; the launcher derives a pipe endpoint with a file fence; `package.json` admits win32.

**Reasoned about, not CI-settled**: whether Claude Code writes exactly the `projects/<slug>` directory `slugifyCwd` produces (needs an authenticated session); the Windows scratchpad and background-task layouts (never observed — hence the degrade above); whether another local account can connect to the named pipe (one runner user, so the Viewer is documented as single-user on Windows); whether a browser window actually appears from `rundll32` (headless runner — only that the spawn returns); behaviour under an elevated console; Codex's native Windows behaviour.

## Deliberately not in this PR

The structured hosts' `CHILD_ENV_ALLOWLIST` needs `SystemRoot` and friends before a Windows child can start, and the managed-account mode-bit predicates read POSIX bits — both live in files another live lane owns (`src/lib/runtime/` spawn path, `src/lib/accounts/**`), so they are named rather than touched. Also deferred, per the design: Job Objects, the drive-letter case normalisation, `repoPathFromSlug` drive roots, `RuntimeImageStore`, the resources rail, the reaper, the login supervisor, the MCP server, `--tailscale`, native Codex, and the `windows-latest` package-smoke job that would build and `npm install` the tarball.

## Gates

`bunx tsc --noEmit --incremental false` clean; the touched tests run by path under an isolated HOME/XDG_CONFIG_HOME/LLV_STATE_DIR/TMPDIR; `bun scripts/privacy-publication-gate.ts --base origin/main --check-commits` PASS. `eslint` cannot run in this checkout at all — `eslint-plugin-react` throws on ESLint 10 for every file, including files this branch does not touch.

Refs #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
