### PR TITLE
fix(runtime): isolate structured delivery failures per conversation

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3318,7 +3318,7 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
   const reviewRepo = path.join(process.env.LLV_STATE_DIR!, "retry-review-repo");
   fs.mkdirSync(reviewRepo, { recursive: true });
   expect(spawnSync("git", ["init", "-b", "main"], { cwd: reviewRepo }).status).toBe(0);
-  expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd: reviewRepo }).status).toBe(0);
+  expect(spawnSync("git", ["config", "user.email", "noreply"], { cwd: reviewRepo }).status).toBe(0);
   expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd: reviewRepo }).status).toBe(0);
   fs.writeFileSync(path.join(reviewRepo, "repair.txt"), "repair\n");
   expect(spawnSync("git", ["add", "repair.txt"], { cwd: reviewRepo }).status).toBe(0);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2021,6 +2021,40 @@ test("durable conversation identity never adopts a competing cwd session", async
   expect(loadPipelines()[0]!.cursor?.stageId).toBe("plan");
 });
 
+test("a stage with no transcript parks on its first-message drain failure", async () => {
+  const h = harness();
+  await create(h.ports);
+  await tickPipelines([], h.ports);
+  h.ports.spawnAgent = async (_input, onReserved) => {
+    onReserved({ launchId: "launch-drain-timeout", conversationId: "conversation_drain_timeout" });
+    return {
+      launchId: "launch-drain-timeout",
+      conversationId: "conversation_drain_timeout",
+      sessionId: "session-drain-timeout",
+      "transcript": null,
+      paneId: null,
+    };
+  };
+  await tickPipelines([], h.ports);
+  h.setConversationActive(false);
+  const reason = "first message never drained: runtime host request timed out";
+  h.ports.spawnReceipt = () => ({
+    state: "failed",
+    launchId: "launch-drain-timeout",
+    conversationId: "conversation_drain_timeout",
+    sessionId: "session-drain-timeout",
+    "transcript": null,
+    paneId: null,
+    error: reason,
+  });
+
+  await tickPipelines([], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked).toMatchObject({ state: "needs_decision", stateDetail: reason });
+  expect(parked.runs[0]!.attempts[0]!.error).toBe(reason);
+});
+
 test("a worker that dies after transcript discovery enters bounded verdict recovery", async () => {
   const h = harness();
   await create(h.ports);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2021,7 +2021,7 @@ test("durable conversation identity never adopts a competing cwd session", async
   expect(loadPipelines()[0]!.cursor?.stageId).toBe("plan");
 });
 
-test("a stage with no transcript parks on its first-message drain failure", async () => {
+test("a stage with an unwritten transcript parks on its first-message drain failure", async () => {
   const h = harness();
   await create(h.ports);
   await tickPipelines([], h.ports);
@@ -2031,7 +2031,7 @@ test("a stage with no transcript parks on its first-message drain failure", asyn
       launchId: "launch-drain-timeout",
       conversationId: "conversation_drain_timeout",
       sessionId: "session-drain-timeout",
-      "transcript": null,
+      "transcript": "/codex/unwritten-stage.jsonl",
       paneId: null,
     };
   };
@@ -2043,7 +2043,7 @@ test("a stage with no transcript parks on its first-message drain failure", asyn
     launchId: "launch-drain-timeout",
     conversationId: "conversation_drain_timeout",
     sessionId: "session-drain-timeout",
-    "transcript": null,
+    "transcript": "/codex/unwritten-stage.jsonl",
     paneId: null,
     error: reason,
   });

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2055,6 +2055,41 @@ test("a stage with an unwritten transcript parks on its first-message drain fail
   expect(parked.runs[0]!.attempts[0]!.error).toBe(reason);
 });
 
+test("a runtime-host outage does not hide a terminal spawn receipt's drain cause (#1314)", async () => {
+  const h = harness();
+  await create(h.ports);
+  await tickPipelines([], h.ports);
+  h.ports.spawnAgent = async (_input, onReserved) => {
+    onReserved({ launchId: "launch-drain-outage", conversationId: "conversation_drain_outage" });
+    return {
+      launchId: "launch-drain-outage",
+      conversationId: "conversation_drain_outage",
+      sessionId: "session-drain-outage",
+      "transcript": "/codex/unwritten-outage-stage.jsonl",
+      paneId: null,
+    };
+  };
+  await tickPipelines([], h.ports);
+  /* The runtime host is unreachable: liveness answers null, not false. */
+  h.setConversationActive(null);
+  const reason = "first message never drained: runtime host request timed out";
+  h.ports.spawnReceipt = () => ({
+    state: "failed",
+    launchId: "launch-drain-outage",
+    conversationId: "conversation_drain_outage",
+    sessionId: "session-drain-outage",
+    "transcript": "/codex/unwritten-outage-stage.jsonl",
+    paneId: null,
+    error: reason,
+  });
+
+  await tickPipelines([], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked).toMatchObject({ state: "needs_decision", stateDetail: reason });
+  expect(parked.runs[0]!.attempts[0]!.error).toBe(reason);
+});
+
 test("a worker that dies after transcript discovery enters bounded verdict recovery", async () => {
   const h = harness();
   await create(h.ports);

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1790,7 +1790,11 @@ async function tickRunStage(
     && (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted")
     ? spawnReceipt.error ?? `stage spawn cannot recover from receipt state ${spawnReceipt.state}`
     : null;
-  if (structuredActive === false && terminalSpawnFailure) {
+  /* A terminal spawn receipt is durable evidence; only an affirmatively
+     active agent outranks it. A runtime-host outage answers null, and that
+     unknown must not hide the real drain cause behind a later
+     transcript-unreadable park (#1314). */
+  if (!attempt.paneId && attempt.conversationId && structuredActive !== true && terminalSpawnFailure) {
     park(pipeline, terminalSpawnFailure, attempt);
     return;
   }

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -127,6 +127,7 @@ export type PipelineCloseReport = {
 export type PipelineStageLaunchReservation = Pick<PipelineStageSpawn, "launchId" | "conversationId">;
 export type PipelineSpawnReceipt = PipelineStageSpawn & {
   state: "starting" | "pane-bound" | "host-verified" | "prompt-delivered" | "path-pending" | "completed" | "failed" | "conflicted";
+  error?: string | null;
 };
 
 export interface PipelinePorts {
@@ -618,6 +619,7 @@ export function defaultPipelinePorts(): PipelinePorts {
         sessionId: receipt.key?.sessionId ?? null,
         "transcript": receipt.artifactPath,
         paneId: receipt.verifiedHost?.paneId ?? receipt.pane?.paneId ?? null,
+        error: receipt.error,
       };
     },
     claimSpawnRetry: (launchId, claimId) => {
@@ -1772,7 +1774,7 @@ async function tickRunStage(
       attempt.agentPath = receipt.transcript;
       attempt.paneId = receipt.paneId;
       if (receipt.state === "failed" || receipt.state === "conflicted" || (receipt.state === "starting" && !receipt.paneId && !receipt.transcript)) {
-        park(pipeline, `stage spawn cannot recover from receipt state ${receipt.state}`, attempt);
+        park(pipeline, receipt.error ?? `stage spawn cannot recover from receipt state ${receipt.state}`, attempt);
         return;
       }
     }
@@ -1784,7 +1786,14 @@ async function tickRunStage(
     ? await ports.conversationAgentActive(attempt.conversationId)
     : null;
   if (!attempt.agentPath) {
-    if (structuredActive === false) park(pipeline, "structured stage ended before its session was discovered", attempt);
+    const spawnReceipt = attempt.launchId ? ports.spawnReceipt(attempt.launchId) : null;
+    const spawnError = spawnReceipt
+      && (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted")
+      ? spawnReceipt.error
+      : null;
+    if (structuredActive === false) {
+      park(pipeline, spawnError ?? "structured stage ended before its session was discovered", attempt);
+    }
     else if (attempt.paneId && !(await ports.paneAgentAlive(attempt.paneId))) park(pipeline, "stage agent exited before its session was discovered", attempt);
     return;
   }

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1785,14 +1785,18 @@ async function tickRunStage(
   const structuredActive = !attempt.paneId && attempt.conversationId
     ? await ports.conversationAgentActive(attempt.conversationId)
     : null;
+  const spawnReceipt = attempt.launchId ? ports.spawnReceipt(attempt.launchId) : null;
+  const terminalSpawnFailure = spawnReceipt
+    && (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted")
+    ? spawnReceipt.error ?? `stage spawn cannot recover from receipt state ${spawnReceipt.state}`
+    : null;
+  if (structuredActive === false && terminalSpawnFailure) {
+    park(pipeline, terminalSpawnFailure, attempt);
+    return;
+  }
   if (!attempt.agentPath) {
-    const spawnReceipt = attempt.launchId ? ports.spawnReceipt(attempt.launchId) : null;
-    const spawnError = spawnReceipt
-      && (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted")
-      ? spawnReceipt.error
-      : null;
     if (structuredActive === false) {
-      park(pipeline, spawnError ?? "structured stage ended before its session was discovered", attempt);
+      park(pipeline, "structured stage ended before its session was discovered", attempt);
     }
     else if (attempt.paneId && !(await ports.paneAgentAlive(attempt.paneId))) park(pipeline, "stage agent exited before its session was discovered", attempt);
     return;

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -71,6 +71,7 @@ interface ControllerState {
   terminateActiveHost: ((key: SessionKey, expected?: Readonly<ProcessIdentity>) => Promise<boolean>) | null;
   completeActive: ((adopted: readonly StructuredDeliveryHost[]) => Promise<void>) | null;
   stopActive: () => void;
+  lastDrainError?: string | null;
   /* Distinguishes "this process hosts the controller and is between
      publications" from "this process never hosted one at all" (#1191). */
   everPublished?: boolean;
@@ -87,6 +88,7 @@ const state: ControllerState = controllerStore.__llvStructuredDeliveryController
   terminateActiveHost: null,
   completeActive: null,
   stopActive: () => {},
+  lastDrainError: null,
   everPublished: false,
 };
 
@@ -505,6 +507,10 @@ export async function bindStructuredDeliveryQueue(
       drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;
     } catch (error) {
       if (stopped) return;
+      if (state.activeQueue === queue) {
+        const message = error instanceof Error ? error.message : String(error);
+        state.lastDrainError = (message.trim() || "structured delivery drain failed").slice(0, 240);
+      }
       const retryMs = drainBackoffMs;
       const retryScheduled = scheduleDrain(retryMs);
       if (retryScheduled) {
@@ -1048,6 +1054,10 @@ export function hasStructuredDeliveryHost(key: SessionKey): boolean {
 export function structuredDeliveryHostForConversation(conversationId: string): EngineHost | null {
   if (!conversationId.startsWith("conversation_") || !state.activeRegistry || !state.activeHosts) return null;
   return hostResolver(state.activeRegistry, state.activeHosts)(conversationId);
+}
+
+export function structuredDeliveryLastError(conversationId: string): string | null {
+  return state.activeQueue?.lastTargetError(conversationId) ?? state.lastDrainError ?? null;
 }
 
 export async function publishStructuredDeliveryHost(

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -79,6 +79,138 @@ test("structured delivery preserves queue order within one conversation", async 
   ]);
 });
 
+test("one conversation transition failure does not stop another conversation in the same pass", async () => {
+  const sent: string[] = [];
+  const port: StructuredDeliveryQueuePort = {
+    effects: async () => [
+      {
+        id: "effect:op-failing",
+        kind: "runtime.send",
+        eventSeq: 1,
+        payload: { operationId: "op-failing", conversationId: "conversation-failing", text: "first", policy: "queue" },
+      },
+      {
+        id: "effect:op-delivered",
+        kind: "runtime.send",
+        eventSeq: 2,
+        payload: { operationId: "op-delivered", conversationId: "conversation-delivered", text: "second", policy: "queue" },
+      },
+    ],
+    transition: async (operationId, status) => {
+      if (operationId === "op-failing" && status === "delivering") {
+        throw new Error("transition unavailable");
+      }
+    },
+  };
+  const queue = new StructuredDeliveryQueue(port, () => host(async (entry) => {
+    sent.push(entry.id);
+    return { outcome: "turn-started", turnId: `turn-${entry.id}` };
+  }));
+
+  await queue.drain();
+
+  expect(sent).toEqual(["op-delivered"]);
+  expect(queue.lastTargetError("conversation-failing")).toBe("transition unavailable");
+});
+
+test("one malformed effect transition failure does not stop another conversation", async () => {
+  const sent: string[] = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [
+      {
+        id: "effect:op-malformed",
+        kind: "runtime.send",
+        eventSeq: 1,
+        payload: {
+          operationId: "op-malformed",
+          conversationId: "conversation-malformed",
+          text: "malformed",
+          contentDigest: "invalid",
+        },
+      },
+      {
+        id: "effect:op-ready",
+        kind: "runtime.send",
+        eventSeq: 2,
+        payload: { operationId: "op-ready", conversationId: "conversation-ready", text: "ready", policy: "queue" },
+      },
+    ],
+    transition: async (operationId, status) => {
+      if (operationId === "op-malformed" && status === "failed") throw new Error("transition unavailable");
+    },
+  }, () => host(async (entry) => {
+    sent.push(entry.id);
+    return { outcome: "turn-started", turnId: "turn-ready" };
+  }));
+
+  await queue.drain();
+
+  expect(sent).toEqual(["op-ready"]);
+});
+
+test("an effect-page failure remains available to a queued conversation deadline", async () => {
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => { throw new Error("runtime host request timed out"); },
+    transition: async () => {},
+  }, () => null);
+
+  await expect(queue.drain()).rejects.toThrow("runtime host request timed out");
+
+  expect(queue.lastTargetError("conversation-pending")).toBe("runtime host request timed out");
+});
+
+test("an uncertain operation already held by a pass is skipped", async () => {
+  const transitions: string[] = [];
+  const sent: string[] = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-uncertain",
+      kind: "runtime.send",
+      eventSeq: 1,
+      payload: { operationId: "op-uncertain", conversationId: "conversation-one", text: "settled", policy: "queue" },
+    }],
+    status: async () => ({ status: "uncertain", reason: "delivery outcome is unverified" }),
+    transition: async (operationId) => {
+      transitions.push(operationId);
+      throw new Error("runtime operation transition is invalid");
+    },
+  }, () => host(async (entry) => {
+    sent.push(entry.id);
+    return { outcome: "turn-started", turnId: "turn-unexpected" };
+  }));
+
+  await queue.drain();
+
+  expect(transitions).toEqual([]);
+  expect(sent).toEqual([]);
+});
+
+test("a dead-host requeue refused after terminal settlement does not fail the pass", async () => {
+  let status = "queued";
+  let recoveries = 0;
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-settled-during-pass",
+      kind: "runtime.send",
+      eventSeq: 1,
+      payload: { operationId: "op-settled-during-pass", conversationId: "conversation-one", text: "settled", policy: "queue" },
+    }],
+    status: async () => ({ status, reason: status === "uncertain" ? "delivery outcome is unverified" : null }),
+    transition: async (_operationId, next) => {
+      if (next !== "queued") return;
+      status = "uncertain";
+      throw new Error("runtime operation transition is invalid");
+    },
+  }, () => null, undefined, undefined, async () => {
+    recoveries += 1;
+    return false;
+  });
+
+  await queue.drain();
+
+  expect(recoveries).toBe(0);
+});
+
 test("a busy structured turn keeps reconfigure queued and applies it before later messages", async () => {
   const actions: string[] = [];
   const terminal = new Set<string>();

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -81,6 +81,7 @@ test("structured delivery preserves queue order within one conversation", async 
 
 test("one conversation transition failure does not stop another conversation in the same pass", async () => {
   const sent: string[] = [];
+  let targetRetryRequests = 0;
   const port: StructuredDeliveryQueuePort = {
     effects: async () => [
       {
@@ -105,12 +106,34 @@ test("one conversation transition failure does not stop another conversation in 
   const queue = new StructuredDeliveryQueue(port, () => host(async (entry) => {
     sent.push(entry.id);
     return { outcome: "turn-started", turnId: `turn-${entry.id}` };
-  }));
+  }), undefined, () => {
+    targetRetryRequests += 1;
+  });
 
   await queue.drain();
 
   expect(sent).toEqual(["op-delivered"]);
   expect(queue.lastTargetError("conversation-failing")).toBe("transition unavailable");
+  expect(targetRetryRequests).toBe(1);
+});
+
+test("an all-target failure is left to the pass-level retry path", async () => {
+  let targetRetryRequests = 0;
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-failing",
+      kind: "runtime.send",
+      eventSeq: 1,
+      payload: { operationId: "op-failing", conversationId: "conversation-failing", text: "first", policy: "queue" },
+    }],
+    transition: async () => { throw new Error("transition unavailable"); },
+  }, () => host(async () => ({ outcome: "turn-started", turnId: "turn-unexpected" })), undefined, () => {
+    targetRetryRequests += 1;
+  });
+
+  await expect(queue.drain()).rejects.toThrow("structured delivery failed for every target: transition unavailable");
+
+  expect(targetRetryRequests).toBe(0);
 });
 
 test("one malformed effect transition failure does not stop another conversation", async () => {
@@ -132,6 +155,47 @@ test("one malformed effect transition failure does not stop another conversation
         id: "effect:op-ready",
         kind: "runtime.send",
         eventSeq: 2,
+        payload: { operationId: "op-ready", conversationId: "conversation-ready", text: "ready", policy: "queue" },
+      },
+    ],
+    transition: async (operationId, status) => {
+      if (operationId === "op-malformed" && status === "failed") throw new Error("transition unavailable");
+    },
+  }, () => host(async (entry) => {
+    sent.push(entry.id);
+    return { outcome: "turn-started", turnId: "turn-ready" };
+  }));
+
+  await queue.drain();
+
+  expect(sent).toEqual(["op-ready"]);
+});
+
+test("a malformed effect blocks later delivery only within its conversation", async () => {
+  const sent: string[] = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [
+      {
+        id: "effect:op-malformed",
+        kind: "runtime.send",
+        eventSeq: 1,
+        payload: {
+          operationId: "op-malformed",
+          conversationId: "conversation-blocked",
+          text: "malformed",
+          contentDigest: "invalid",
+        },
+      },
+      {
+        id: "effect:op-blocked",
+        kind: "runtime.send",
+        eventSeq: 2,
+        payload: { operationId: "op-blocked", conversationId: "conversation-blocked", text: "blocked", policy: "queue" },
+      },
+      {
+        id: "effect:op-ready",
+        kind: "runtime.send",
+        eventSeq: 3,
         payload: { operationId: "op-ready", conversationId: "conversation-ready", text: "ready", policy: "queue" },
       },
     ],

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -56,6 +56,17 @@ export type StructuredHostRecovery = (conversationId: string) => Promise<boolean
 
 const STRUCTURED_DELIVERY_BATCH_SIZE = 100;
 const THREAD_READ_ATTEMPTS = 2;
+const TERMINAL_DELIVERY_STATUSES = new Set([
+  "turn-started",
+  "steered",
+  "delivered",
+  "applied",
+  "interrupted",
+  "answered",
+  "rejected",
+  "failed",
+  "uncertain",
+]);
 
 interface SendEffect {
   operationId: string;
@@ -415,6 +426,8 @@ async function sendWithReadRetry(host: EngineHost, entry: QueueEntry): Promise<D
 export class StructuredDeliveryQueue {
   private activeDrain: Promise<void> | null = null;
   private rerun = false;
+  private readonly targetErrors = new Map<string, string>();
+  private lastPassError: string | null = null;
   /** This executor's identity, minted per instance and never persisted beyond
       the `delivering` rows it writes. A successor instance — in this process or
       in the one that replaced it — is a different executor by construction,
@@ -462,6 +475,10 @@ export class StructuredDeliveryQueue {
     return this.activeDrain;
   }
 
+  lastTargetError(conversationId: string): string | null {
+    return this.targetErrors.get(conversationId) ?? this.lastPassError;
+  }
+
   /** Guarantees a drain pass whose journal read starts after this request. */
   async drainAfterAdmission(): Promise<void> {
     const precedingDrain = this.activeDrain;
@@ -474,7 +491,12 @@ export class StructuredDeliveryQueue {
   private async drainUntilSettled(): Promise<void> {
     do {
       this.rerun = false;
-      await this.drainPass();
+      try {
+        await this.drainPass();
+      } catch (error) {
+        this.lastPassError = failureReason(error);
+        throw error;
+      }
     } while (this.rerun);
   }
 
@@ -497,11 +519,20 @@ export class StructuredDeliveryQueue {
     }
     if (rawEffects.length === 0) return;
     const grouped = new Map<string, DeliveryEffect[]>();
+    const isolatedTargets: Array<[string, () => Promise<boolean>]> = [];
     const effects: DeliveryEffect[] = [];
     for (const rawEffect of rawEffects) {
       if (rawEffect.kind === "runtime.kill-boundary") {
         const boundary = successfulKillBoundary(rawEffect);
-        if (!boundary) throw new Error(`structured kill boundary ${rawEffect.eventSeq} is invalid`);
+        if (!boundary) {
+          const conversationId = typeof rawEffect.payload.conversationId === "string"
+            ? rawEffect.payload.conversationId
+            : `effect-${rawEffect.eventSeq}`;
+          isolatedTargets.push([conversationId, async () => {
+            throw new Error(`structured kill boundary ${rawEffect.eventSeq} is invalid`);
+          }]);
+          continue;
+        }
         const current = this.successfulKillBoundaries.get(boundary.conversationId);
         if (!current || boundary.eventSeq > current.eventSeq) {
           this.successfulKillBoundaries.set(boundary.conversationId, boundary);
@@ -514,8 +545,14 @@ export class StructuredDeliveryQueue {
         continue;
       }
       const operationId = typeof rawEffect.payload.operationId === "string" ? rawEffect.payload.operationId : "";
-      if (!operationId) throw new Error(`structured delivery effect ${rawEffect.eventSeq} is invalid`);
-      await this.port.transition(operationId, "failed", { reason: "structured delivery effect is invalid" });
+      const conversationId = typeof rawEffect.payload.conversationId === "string"
+        ? rawEffect.payload.conversationId
+        : `effect-${rawEffect.eventSeq}`;
+      isolatedTargets.push([conversationId, async () => {
+        if (!operationId) throw new Error(`structured delivery effect ${rawEffect.eventSeq} is invalid`);
+        await this.transitionUnlessSettled(operationId, "failed", { reason: "structured delivery effect is invalid" });
+        return false;
+      }]);
     }
     effects.sort((left, right) => {
       const leftControl = isControlEffect(left);
@@ -533,10 +570,54 @@ export class StructuredDeliveryQueue {
       target.push(effect);
       grouped.set(effect.conversationId, target);
     }
-    await Promise.all([...grouped.values()].map((target) => this.drainTarget(target)));
+    const targets: Array<[string, () => Promise<boolean>]> = [
+      ...[...grouped.entries()].map(([conversationId, target]) => [
+        conversationId,
+        () => this.drainTarget(target),
+      ] as [string, () => Promise<boolean>]),
+      ...isolatedTargets,
+    ];
+    const outcomes = await Promise.allSettled(
+      targets.map(async ([conversationId, drain]) => {
+        try {
+          return await drain();
+        } catch (error) {
+          this.targetErrors.set(conversationId, failureReason(error));
+          this.retrySoon();
+          console.error("[structured delivery] conversation drain failed", {
+            conversationId,
+            error: failureReason(error),
+          });
+          throw error;
+        }
+      }),
+    );
+    outcomes.forEach((outcome, index) => {
+      if (outcome.status === "fulfilled" && outcome.value === false) {
+        this.targetErrors.delete(targets[index]![0]);
+      }
+    });
+    const failures = outcomes.filter((outcome): outcome is PromiseRejectedResult => outcome.status === "rejected");
+    if (failures.length === outcomes.length && failures.length > 0) {
+      const reason = failures.at(-1)!.reason;
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `structured delivery failed for every target: ${failureReason(reason)}`,
+      );
+    }
   }
 
   private async drainTarget(effects: DeliveryEffect[]): Promise<boolean> {
+    const openEffects: DeliveryEffect[] = [];
+    const durableStatuses = new Map<string, { status: string; reason?: string | null } | null>();
+    for (const effect of effects) {
+      const durable = await this.readStatus(effect.operationId);
+      if (!durable.readable) return this.fenceUnavailable();
+      if (durable.value && TERMINAL_DELIVERY_STATUSES.has(durable.value.status)) continue;
+      durableStatuses.set(effect.operationId, durable.value);
+      openEffects.push(effect);
+    }
+    effects = openEffects;
     const killedGenerations = new Set<string>();
     const reconfigures = effects.filter(isReconfigureEffect);
     const currentReconfigure = reconfigures.reduce<StructuredReconfigureEffect | null>(
@@ -545,7 +626,7 @@ export class StructuredDeliveryQueue {
     );
     for (const effect of reconfigures) {
       if (effect !== currentReconfigure) {
-        await this.port.transition(effect.operationId, "failed", { reason: "superseded" });
+        await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "superseded" });
       }
     }
     for (const effect of effects) {
@@ -561,7 +642,7 @@ export class StructuredDeliveryQueue {
         if (effect.sessionKey
           ? killedGenerations.has(`${effect.sessionKey.engine}:${effect.sessionKey.sessionId}`)
           : killedGenerations.size > 0) {
-          await this.port.transition(effect.operationId, "failed", { reason: "conversation-killed" });
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "conversation-killed" });
           continue;
         }
         const blocked = await this.drainReconfigure(effect);
@@ -590,7 +671,7 @@ export class StructuredDeliveryQueue {
       }
       const killBoundary = this.successfulKillBoundaries.get(effect.conversationId);
       if (killBoundary && effect.eventSeq <= killBoundary.eventSeq) {
-        await this.port.transition(effect.operationId, "failed", {
+        await this.transitionUnlessSettled(effect.operationId, "failed", {
           reason: "structured host was intentionally terminated; retry the operation",
         });
         continue;
@@ -614,10 +695,9 @@ export class StructuredDeliveryQueue {
          through to the engine call, so a send an executor was already
          delivering could be delivered a SECOND time by whichever pass caught
          the journal at a bad moment. */
-      const durable = await this.readStatus(effect.operationId);
-      if (!durable.readable) return this.fenceUnavailable();
-      if (durable.value?.status === "delivering") {
-        if (await this.deliveringOwnerDisposition(effect.conversationId, durable.value.reason) !== "abandoned") continue;
+      const durable = durableStatuses.get(effect.operationId) ?? null;
+      if (durable?.status === "delivering") {
+        if (await this.deliveringOwnerDisposition(effect.conversationId, durable.reason) !== "abandoned") continue;
         await this.terminalizeUnverified(effect.operationId, DELIVERY_UNVERIFIED_BY_EARLIER_EXECUTOR);
         continue;
       }
@@ -637,7 +717,7 @@ export class StructuredDeliveryQueue {
       }
       const host = this.resolveHost(effect.conversationId);
       if (!host) {
-        await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+        if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) continue;
         await this.recoverUnavailableHost(effect);
         return true;
       }
@@ -649,7 +729,7 @@ export class StructuredDeliveryQueue {
       if (!state.readable) return this.fenceUnavailable();
       const health = state.value;
       if (health.status === "dead" || health.status === "unhosted") {
-        await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+        if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) continue;
         await this.recoverUnavailableHost(effect);
         return true;
       }
@@ -688,11 +768,11 @@ export class StructuredDeliveryQueue {
          claim is recorded as unknown instead, which proves nothing to anybody
          and is exactly what it should prove. */
       const claim = await this.readHostClaim(effect.conversationId);
-      await this.port.transition(
+      if (!await this.transitionUnlessSettled(
         effect.operationId,
         "delivering",
         { turnId: deliveryFence, reason: deliveringOwnershipReason(this.executorId, claim) },
-      );
+      )) continue;
       if (shouldInterrupt) {
         try {
           await host.interrupt(health.activeTurnRef!);
@@ -709,10 +789,10 @@ export class StructuredDeliveryQueue {
           if (!afterFailure.readable
             || afterFailure.value.status === "dead"
             || afterFailure.value.status === "unhosted") {
-            await this.port.transition(effect.operationId, "queued", { reason });
+            await this.transitionUnlessSettled(effect.operationId, "queued", { reason });
             return true;
           }
-          await this.port.transition(effect.operationId, "queued", { reason: "interrupt-auto-retry" });
+          await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "interrupt-auto-retry" });
           this.retrySoon();
           return true;
         }
@@ -726,11 +806,11 @@ export class StructuredDeliveryQueue {
         const afterInterrupt = afterInterruptState.value;
         if (afterInterrupt.status === "dead" || afterInterrupt.status === "unhosted") {
           this.interruptAcknowledged.delete(effect.operationId);
-          await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+          if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) continue;
           return true;
         }
         if (afterInterrupt.status !== "idle") {
-          await this.port.transition(effect.operationId, "queued", { reason: "interrupt-requested" });
+          await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "interrupt-requested" });
           return true;
         }
         this.interruptAcknowledged.delete(effect.operationId);
@@ -755,7 +835,7 @@ export class StructuredDeliveryQueue {
              receipt rather than writing a second message. Its own operation is
              retried, so this is the one failure after actuation that may go
              back to `queued`. */
-          await this.port.transition(effect.operationId, "queued", { reason: "delivery-auto-retry" });
+          await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "delivery-auto-retry" });
           this.retrySoon();
           return true;
         }
@@ -785,16 +865,16 @@ export class StructuredDeliveryQueue {
       if (receipt.outcome === "rejected") {
         if (receipt.reason === "stale-turn") {
           if (effect.kind === "send" && effect.policy !== "steer-if-active") {
-            await this.port.transition(effect.operationId, "queued", { reason: receipt.reason });
+            await this.transitionUnlessSettled(effect.operationId, "queued", { reason: receipt.reason });
             return true;
           }
-          await this.port.transition(effect.operationId, "failed", { reason: receipt.reason });
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: receipt.reason });
           continue;
         }
-        await this.port.transition(effect.operationId, "queued", { reason: receipt.reason });
+        await this.transitionUnlessSettled(effect.operationId, "queued", { reason: receipt.reason });
         return true;
       }
-      await this.port.transition(effect.operationId, "delivered", { turnId: receipt.turnId });
+      await this.transitionUnlessSettled(effect.operationId, "delivered", { turnId: receipt.turnId });
     }
     return false;
   }
@@ -851,7 +931,7 @@ export class StructuredDeliveryQueue {
        host purely to run this control. Sends are fenced the same way. */
     const killBoundary = this.successfulKillBoundaries.get(effect.conversationId);
     if (killBoundary && effect.eventSeq <= killBoundary.eventSeq) {
-      await this.port.transition(effect.operationId, "failed", {
+      await this.transitionUnlessSettled(effect.operationId, "failed", {
         reason: "structured host was intentionally terminated; retry the operation",
       });
       return { blocked: false, terminated: false };
@@ -864,12 +944,14 @@ export class StructuredDeliveryQueue {
        asynchronous, and a kill behind this effect must not wait a whole pass
        for it. */
     if (!host) {
-      await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) {
+        return { blocked: false, terminated: false };
+      }
       await this.recoverUnavailableHost(effect);
       return { blocked: false, terminated: false };
     }
     if (!hostSupportsCompact(host)) {
-      await this.port.transition(effect.operationId, "failed", { reason: "unsupported-capability" });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "unsupported-capability" });
       return { blocked: false, terminated: false };
     }
     /* Same fence as the message path, and the same answer to an unreadable
@@ -882,20 +964,24 @@ export class StructuredDeliveryQueue {
     }
     const health = state.value;
     if (health.status === "dead" || health.status === "unhosted") {
-      await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) {
+        return { blocked: false, terminated: false };
+      }
       await this.recoverUnavailableHost(effect);
       return { blocked: false, terminated: false };
     }
     /* Admission fenced the durable turn axis; this re-reads the live host, so a
        turn that started in between fails the control instead of racing it. */
     if (health.status !== "idle" || health.activeTurnRef) {
-      await this.port.transition(effect.operationId, "failed", { reason: "busy-turn" });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "busy-turn" });
       return { blocked: false, terminated: false };
     }
     /* Durable marker first: a restart that finds the receipt in `delivering`
        knows the control may already have reached the engine and terminalizes it
        as unverified instead of compacting the thread a second time. */
-    await this.port.transition(effect.operationId, "delivering");
+    if (!await this.transitionUnlessSettled(effect.operationId, "delivering")) {
+      return { blocked: false, terminated: false };
+    }
     /* Marked before the run exists: a compaction that settles immediately would
        otherwise clear the barrier before it was ever raised. */
     this.compactingConversations.add(effect.conversationId);
@@ -917,7 +1003,7 @@ export class StructuredDeliveryQueue {
       });
       /* The receipt records which compaction closed it: the only durable place
          the lifecycle evidence survives alongside the operation. */
-      await this.port.transition(effect.operationId, "delivered", {
+      await this.transitionUnlessSettled(effect.operationId, "delivered", {
         reason: outcome.compactionId ? `compaction:${outcome.compactionId}` : null,
       });
     } catch (error) {
@@ -925,7 +1011,7 @@ export class StructuredDeliveryQueue {
         await this.terminalizeUnverified(effect.operationId, failureReason(error));
         return;
       }
-      await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason: failureReason(error) });
     }
   }
 
@@ -946,6 +1032,23 @@ export class StructuredDeliveryQueue {
   private readSettled(operationId: string): Promise<Evidence<boolean>> {
     const read = this.port.settled?.bind(this.port);
     return readOptionalEvidence(read && (() => read(operationId)), false, "durable delivery record is unavailable");
+  }
+
+  private async transitionUnlessSettled(
+    operationId: string,
+    status: StructuredDeliveryTransition,
+    details?: { turnId?: string | null; reason?: string | null },
+  ): Promise<boolean> {
+    try {
+      await this.port.transition(operationId, status, details);
+      return true;
+    } catch (error) {
+      const durable = await this.readStatus(operationId);
+      if (durable.readable && durable.value && TERMINAL_DELIVERY_STATUSES.has(durable.value.status)) {
+        return false;
+      }
+      throw error;
+    }
   }
 
   private readHostClaim(conversationId: string): Promise<Evidence<string | null>> {
@@ -1055,9 +1158,9 @@ export class StructuredDeliveryQueue {
    */
   private async terminalizeUnverified(operationId: string, reason: string): Promise<void> {
     try {
-      await this.port.transition(operationId, "uncertain", { reason });
+      await this.transitionUnlessSettled(operationId, "uncertain", { reason });
     } catch {
-      await this.port.transition(operationId, "failed", { reason });
+      await this.transitionUnlessSettled(operationId, "failed", { reason });
     }
   }
 
@@ -1072,19 +1175,19 @@ export class StructuredDeliveryQueue {
       const health = state.value;
       if (health.status === "active" || health.status === "attention" || health.activeTurnRef) return true;
     }
-    await this.port.transition(effect.operationId, "applying");
+    if (!await this.transitionUnlessSettled(effect.operationId, "applying")) return false;
     try {
       const outcome = await this.reconfigure(effect, {
         isCurrent: () => this.isCurrentReconfigure(effect),
       });
       if (outcome === "pending") {
-        await this.port.transition(effect.operationId, "queued", { reason: "turn-boundary" });
+        await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "turn-boundary" });
         this.retrySoon();
         return true;
       }
-      await this.port.transition(effect.operationId, "applied");
+      await this.transitionUnlessSettled(effect.operationId, "applied");
     } catch (error) {
-      await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason: failureReason(error) });
     }
     return false;
   }
@@ -1117,12 +1220,12 @@ export class StructuredDeliveryQueue {
         this.rerun = true;
         return;
       }
-      await this.port.transition(effect.operationId, "failed", {
+      await this.transitionUnlessSettled(effect.operationId, "failed", {
         reason: "structured host recovery did not start; retry the operation",
       });
     } catch (error) {
       const reason = `structured host recovery failed: ${failureReason(error)}`.slice(0, 240);
-      await this.port.transition(effect.operationId, "failed", { reason });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason });
     }
   }
 
@@ -1130,7 +1233,7 @@ export class StructuredDeliveryQueue {
     const host = this.resolveHost(effect.conversationId);
     if (effect.kind === "kill") {
       if (!effect.sessionKey) {
-        await this.port.transition(effect.operationId, "failed", { reason: "structured host termination target is unavailable" });
+        await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "structured host termination target is unavailable" });
         return { blocked: false, terminated: false };
       }
       if (!host) {
@@ -1138,24 +1241,28 @@ export class StructuredDeliveryQueue {
           if (!await this.terminateHost(effect.conversationId, effect.sessionKey)) {
             return { blocked: true, terminated: false };
           }
-          await this.port.transition(effect.operationId, "delivering");
-          await this.port.transition(effect.operationId, "delivered");
+          if (!await this.transitionUnlessSettled(effect.operationId, "delivering")) {
+            return { blocked: false, terminated: true };
+          }
+          await this.transitionUnlessSettled(effect.operationId, "delivered");
           return { blocked: false, terminated: true };
         } catch (error) {
-          await this.port.transition(effect.operationId, "queued", { reason: failureReason(error) });
+          await this.transitionUnlessSettled(effect.operationId, "queued", { reason: failureReason(error) });
           throw error;
         }
       }
-      await this.port.transition(effect.operationId, "delivering");
+      if (!await this.transitionUnlessSettled(effect.operationId, "delivering")) {
+        return { blocked: false, terminated: false };
+      }
       try {
         if (!await this.terminateHost(effect.conversationId, effect.sessionKey)) {
-          await this.port.transition(effect.operationId, "failed", { reason: "structured host termination is unavailable" });
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "structured host termination is unavailable" });
           return { blocked: false, terminated: false };
         }
-        await this.port.transition(effect.operationId, "delivered");
+        await this.transitionUnlessSettled(effect.operationId, "delivered");
         return { blocked: false, terminated: true };
       } catch (error) {
-        await this.port.transition(effect.operationId, "queued", { reason: failureReason(error) });
+        await this.transitionUnlessSettled(effect.operationId, "queued", { reason: failureReason(error) });
         throw error;
       }
     }
@@ -1174,7 +1281,7 @@ export class StructuredDeliveryQueue {
         return { blocked: true, terminated: false };
       }
       if (!severed.value) return { blocked: true, terminated: false };
-      await this.port.transition(
+      await this.transitionUnlessSettled(
         effect.operationId,
         effect.kind === "interrupt" ? "interrupted" : "failed",
         { reason: `structured host is severed: ${severed.value}`.slice(0, 240) },
@@ -1191,24 +1298,24 @@ export class StructuredDeliveryQueue {
     }
     const health = state.value;
     if (health.status === "dead" || health.status === "unhosted") {
-      await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+      await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" });
       return { blocked: true, terminated: false };
     }
-    await this.port.transition(effect.operationId, "delivering", {
+    if (!await this.transitionUnlessSettled(effect.operationId, "delivering", {
       ...(effect.kind === "interrupt" ? { turnId: effect.turnId ?? health.activeTurnRef } : {}),
-    });
+    })) return { blocked: false, terminated: false };
     try {
       if (effect.kind === "answer") {
         await host.answer(effect.attentionId!, effect.resolution);
-        await this.port.transition(effect.operationId, "answered");
+        await this.transitionUnlessSettled(effect.operationId, "answered");
       } else {
         const turnId = effect.turnId ?? health.activeTurnRef;
         if (!turnId || (health.activeTurnRef && health.activeTurnRef !== turnId)) {
-          await this.port.transition(effect.operationId, "failed", { reason: "stale-turn" });
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "stale-turn" });
           return { blocked: false, terminated: false };
         }
         await host.interrupt(turnId);
-        await this.port.transition(effect.operationId, "interrupted", { turnId });
+        await this.transitionUnlessSettled(effect.operationId, "interrupted", { turnId });
       }
       return { blocked: false, terminated: false };
     } catch (error) {
@@ -1223,10 +1330,10 @@ export class StructuredDeliveryQueue {
       const afterFailure = await this.readHealth(host);
       if (afterFailure.readable
         && (afterFailure.value.status === "dead" || afterFailure.value.status === "unhosted")) {
-        await this.port.transition(effect.operationId, "queued", { reason });
+        await this.transitionUnlessSettled(effect.operationId, "queued", { reason });
         return { blocked: true, terminated: false };
       }
-      await this.port.transition(effect.operationId, "failed", { reason });
+      await this.transitionUnlessSettled(effect.operationId, "failed", { reason });
       return { blocked: false, terminated: false };
     }
   }

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -519,7 +519,12 @@ export class StructuredDeliveryQueue {
     }
     if (rawEffects.length === 0) return;
     const grouped = new Map<string, DeliveryEffect[]>();
-    const isolatedTargets: Array<[string, () => Promise<boolean>]> = [];
+    const targetPreparations = new Map<string, Array<() => Promise<void>>>();
+    const prepareTarget = (conversationId: string, prepare: () => Promise<void>) => {
+      const preparations = targetPreparations.get(conversationId) ?? [];
+      preparations.push(prepare);
+      targetPreparations.set(conversationId, preparations);
+    };
     const effects: DeliveryEffect[] = [];
     for (const rawEffect of rawEffects) {
       if (rawEffect.kind === "runtime.kill-boundary") {
@@ -528,9 +533,9 @@ export class StructuredDeliveryQueue {
           const conversationId = typeof rawEffect.payload.conversationId === "string"
             ? rawEffect.payload.conversationId
             : `effect-${rawEffect.eventSeq}`;
-          isolatedTargets.push([conversationId, async () => {
+          prepareTarget(conversationId, async () => {
             throw new Error(`structured kill boundary ${rawEffect.eventSeq} is invalid`);
-          }]);
+          });
           continue;
         }
         const current = this.successfulKillBoundaries.get(boundary.conversationId);
@@ -548,11 +553,10 @@ export class StructuredDeliveryQueue {
       const conversationId = typeof rawEffect.payload.conversationId === "string"
         ? rawEffect.payload.conversationId
         : `effect-${rawEffect.eventSeq}`;
-      isolatedTargets.push([conversationId, async () => {
+      prepareTarget(conversationId, async () => {
         if (!operationId) throw new Error(`structured delivery effect ${rawEffect.eventSeq} is invalid`);
         await this.transitionUnlessSettled(operationId, "failed", { reason: "structured delivery effect is invalid" });
-        return false;
-      }]);
+      });
     }
     effects.sort((left, right) => {
       const leftControl = isControlEffect(left);
@@ -570,20 +574,20 @@ export class StructuredDeliveryQueue {
       target.push(effect);
       grouped.set(effect.conversationId, target);
     }
-    const targets: Array<[string, () => Promise<boolean>]> = [
-      ...[...grouped.entries()].map(([conversationId, target]) => [
-        conversationId,
-        () => this.drainTarget(target),
-      ] as [string, () => Promise<boolean>]),
-      ...isolatedTargets,
-    ];
+    const conversationIds = new Set([...grouped.keys(), ...targetPreparations.keys()]);
+    const targets: Array<[string, () => Promise<boolean>]> = [...conversationIds].map((conversationId) => [
+      conversationId,
+      async () => {
+        for (const prepare of targetPreparations.get(conversationId) ?? []) await prepare();
+        return this.drainTarget(grouped.get(conversationId) ?? []);
+      },
+    ]);
     const outcomes = await Promise.allSettled(
       targets.map(async ([conversationId, drain]) => {
         try {
           return await drain();
         } catch (error) {
           this.targetErrors.set(conversationId, failureReason(error));
-          this.retrySoon();
           console.error("[structured delivery] conversation drain failed", {
             conversationId,
             error: failureReason(error),
@@ -605,6 +609,7 @@ export class StructuredDeliveryQueue {
         `structured delivery failed for every target: ${failureReason(reason)}`,
       );
     }
+    if (failures.length > 0) this.retrySoon();
   }
 
   private async drainTarget(effects: DeliveryEffect[]): Promise<boolean> {

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -688,12 +688,13 @@ test.each(["hosted", "recovering"] as const)("a matching %s session fails its qu
   const reconciled = await reconcileStructuredSpawnReplay(begun.receipt.launchId, registry, client, {
     now: () => admittedAt + STRUCTURED_SPAWN_DURABLE_SETUP_TIMEOUT_MS,
     releaseHost: async () => { released += 1; return true; },
+    drainError: () => "runtime host request timed out",
   });
 
   expect(reconciled).toMatchObject({
     state: "failed",
     initialMessage: "failed",
-    error: `structured spawn durable setup remained incomplete for ${STRUCTURED_SPAWN_DURABLE_SETUP_TIMEOUT_MS}ms`,
+    error: "first message never drained: runtime host request timed out",
   });
   expect(released).toBe(1);
 });

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -33,7 +33,7 @@ import { StructuredHostAdoptionCleanupError, type EngineHost, type HostState } f
 import { messageOriginRole, type MessageOrigin } from "./messageOrigin";
 import { runtimeSettingsCapability, type RuntimeOperationResult, type RuntimeSession } from "./contracts";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
-import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "./structuredDeliveryController";
+import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost, structuredDeliveryLastError } from "./structuredDeliveryController";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { runtimeImageCapability, runtimeImageStore } from "./runtimeImageStore";
 import { publishFilesRevision } from "./filesRevision";
@@ -324,6 +324,7 @@ export async function reconcileStructuredSpawnReplay(
     timeoutMs?: number;
     releaseHost?: (key: SessionKey) => Promise<boolean>;
     terminateHostProcess?: (expected: ProcessIdentity) => Promise<boolean>;
+    drainError?: (conversationId: string) => string | null;
   } = {},
 ): Promise<SpawnReceipt & { initialMessage: "pending" | "queued" | "delivered" | "failed" }> {
   const current = registry.readOnlySnapshot().receipts[launchId];
@@ -449,7 +450,12 @@ export async function reconcileStructuredSpawnReplay(
   let terminalReason = failedOperationReason(operation, "structured initial message")
     ?? failedOperationReason(spawnOperation, "structured spawn");
   if (!terminalReason && ageMs >= timeoutMs) {
-    if (liveRuntimeSession) {
+    if (liveRuntimeSession && messageStatus === "queued") {
+      const drainError = (options.drainError ?? structuredDeliveryLastError)(current.conversationId)
+        ?? operation?.receipt.reason
+        ?? `no delivery drain error was recorded before the ${timeoutMs}ms deadline`;
+      terminalReason = `first message never drained: ${drainError}`;
+    } else if (liveRuntimeSession) {
       terminalReason = `structured spawn durable setup remained incomplete for ${timeoutMs}ms`;
     } else if (effectHistoryUnavailable) {
       terminalReason = `structured spawn runtime effect history remained unavailable for ${timeoutMs}ms`;

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1100,6 +1100,44 @@ test("structured send receipts advance through the durable delivery lifecycle", 
   journal.close();
 });
 
+test("effectBatch omits an uncertain operation even when its outbox row remains pending", () => {
+  const dir = sandbox("terminal-effect-filter");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { structuredHosts: true });
+  journal.append({
+    scope: runtimeScope("session", "conv-terminal"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conv-terminal",
+      sessionKey: { engine: "codex", sessionId: "thread-terminal" },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+    },
+  });
+  journal.executeOperation({
+    kind: "send",
+    operationId: "op-terminal",
+    idempotencyKey: "key-terminal",
+    conversationId: "conv-terminal",
+    text: "settle once",
+    policy: "queue",
+  });
+  const payload = journal.effectBatch()[0]!.payload;
+  journal.transitionOperation("op-terminal", "uncertain", { reason: "delivery outcome is unverified" });
+  journal.close();
+
+  const database = new Database(filename);
+  database.query("UPDATE outbox SET state = 'pending', payload_json = ? WHERE id = ?")
+    .run(JSON.stringify(payload), "effect:op-terminal");
+  database.close();
+
+  const reopened = new RuntimeJournal(filename, { structuredHosts: true });
+  expect(reopened.effectBatch()).toEqual([]);
+  reopened.close();
+});
+
 test("a terminal structured send retries from its full journaled request", () => {
   const dir = sandbox("structured-delivery-retry");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { structuredHosts: true });

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1114,7 +1114,21 @@ export class RuntimeJournal {
       : "state = 'pending'";
     const kindFilter = kinds ? ` AND kind IN (${kinds.map(() => "?").join(", ")})` : "";
     const rows = this.db.query<{ id: string; kind: string; payload_json: string; event_seq: number }, Array<string | number>>(
-      `SELECT id, kind, payload_json, event_seq FROM outbox WHERE ${stateFilter}${kindFilter} AND event_seq > ? ORDER BY event_seq LIMIT ?`,
+      `SELECT id, kind, payload_json, event_seq
+       FROM outbox
+       WHERE ${stateFilter}${kindFilter}
+         AND event_seq > ?
+         AND (
+           id NOT LIKE 'effect:%'
+           OR NOT EXISTS (
+             SELECT 1
+             FROM operations
+             WHERE operations.operation_id = substr(outbox.id, 8)
+               AND json_extract(operations.receipt_json, '$.status') NOT IN ('pending', 'queued', 'delivering', 'applying')
+           )
+         )
+       ORDER BY event_seq
+       LIMIT ?`,
     ).all(...(kinds ?? []), afterEventSeq, limit);
     return rows.map((row) => {
       const payload = JSON.parse(row.payload_json) as Record<string, unknown>;


### PR DESCRIPTION
Closes #1314.

## Impact

A failed transition or timed-out host request for one conversation now leaves other structured hosts free to receive their queued messages. Spawn failures name the drain error that held the first message, and pipeline parking preserves that reason.

## Cause

`drainPass` awaited every conversation through one rejecting aggregate. One target failure ended the pass. A terminal receipt could also race a pass that already held its effect and reject the pass's next transition.

## Fix

- Drain conversations independently, log each failed target with its conversation and error, and request another target pass after partial failure. When every target fails, the controller retains its exponential retry path.
- Keep malformed work serialized with later effects from the same conversation, preserving control and message ordering.
- Filter terminal operation receipts from the runtime journal effect batch, including `uncertain`, and tolerate a concurrently terminal receipt after a fresh status read.
- Retain the latest target or pass drain error. A queued first message that reaches the existing 300-second durable-setup deadline fails as `first message never drained: <error>`.
- Carry the durable spawn failure into the pipeline park reason even when the artifact path is known and the transcript was never written.

The 300-second deadline and its admission-based measurement are unchanged.

## Verification

The new acceptance tests failed against current `origin/main` before the source changes.

- `bun test src/lib/runtime/structuredDeliveryQueue.test.ts src/runtime-host/journal.test.ts src/lib/pipelines/engine.test.ts`: 344 passed.
- Focused queued-first-message deadline tests in `src/lib/runtime/structuredSpawn.integration.test.ts`: 2 passed.
- Full touched-path run: 419 passed. Three older structured-spawn tests failed with the same assertions on `origin/main`: two stale-live writer-epoch cases and one post-kill admission-error case.
- `bunx tsc --noEmit --incremental false`: passed.
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main) --check-commits`: passed.

Repo-wide lint remains excluded under #1259.

## Release requirement

`src/runtime-host/` changed. Rebuild the runtime-host image during release before promotion.
