### PR TITLE
fix(privacy): the commit check reads the commits the branch adds, names every commit it flags, and exempts the forge's own committer (#1315)

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -2832,6 +2832,24 @@ describe("commitMessageFindings", () => {
     return result.stdout.toString();
   }
 
+  /* A commit whose message git records EXACTLY as given. `git commit -m` cleans
+     the message up and ends it with a newline; `commit-tree` writes what it is
+     handed, which is how a message with no terminal newline reaches a branch. */
+  function rawCommit(repo: string, message: string): string {
+    const tree = git(repo, "rev-parse", "HEAD^{tree}").trim();
+    const parent = git(repo, "rev-parse", "HEAD").trim();
+    const result = Bun.spawnSync({
+      cmd: ["git", "-C", repo, "commit-tree", tree, "-p", parent],
+      stderr: "pipe",
+      stdin: new TextEncoder().encode(message),
+      stdout: "pipe",
+    });
+    expect(result.exitCode).toBe(0);
+    const commit = result.stdout.toString().trim();
+    runGit(repo, ["update-ref", "refs/heads/feature", commit]);
+    return commit;
+  }
+
   /* The footer `git cherry-pick -x` appends, spelled out where a test needs the
      shape without performing the pick. */
   const cherryPickLine = `(cherry picked from commit ${"0123456789abcdef".repeat(2) + "01234567"})`;
@@ -3209,6 +3227,33 @@ describe("commitMessageFindings", () => {
 
     expect(commitMessageFindings(repo, "no-such-base", notices).get("inspection_error")).toBe(1);
     expect(notices).toEqual(["commit_message: range unreadable"]);
+  });
+
+  test("reads a message that is nothing but a hash-shaped value", () => {
+    /* #1315, second round. The hashes and the messages arrived in one stream
+       that carries no lengths, so the reader decided where a message ended by
+       SHAPE: forty lowercase hex characters were the next commit's hash. A raw
+       commit whose whole message is such a value — and git records one with no
+       terminal newline when it is handed one — was read as a hash and never
+       scanned, so a value the gate knows passed the check. */
+    const repo = gitRepo();
+    const value = `${"fedcba9876543210".repeat(2)}89abcdef`;
+    const flagged = rawCommit(repo, value);
+    /* No terminal newline: the message is the last thing in the object. */
+    expect(git(repo, "cat-file", "commit", flagged).endsWith(value)).toBe(true);
+
+    const result = runGateArguments(
+      ["--base", "main", "--check-commits"],
+      { LLV_PRIVACY_KNOWN_VALUES: value },
+      repo,
+    );
+    const output = result.stdout.toString();
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toBe(
+      `PRIVACY GATE: FAIL\nknown_value: 1\ncommit_message: ${flagged.slice(0, 12)} message known_value\n`,
+    );
+    expect(output).not.toContain(value);
   });
 });
 

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -3153,6 +3153,63 @@ describe("commitMessageFindings", () => {
     const findings = commitMessageFindings(repo, "main");
     expect(findings.has("resource_identifier")).toBe(false);
   });
+
+  test("a message already on the protected base is not this branch's surface", () => {
+    /* #1315. The range was `base...HEAD`, and to `git log` three dots are the
+       SYMMETRIC difference — not the ancestry cut they are to `git diff` — so
+       a branch that was merely BEHIND the base inherited every message the
+       base had gained since the fork. The finding named a commit this branch
+       did not write and cannot change, and no push it could make would clear
+       it. */
+    const repo = gitRepo();
+    const person = ["someone", "personal.dev"].join("@");
+    runGit(repo, ["commit", "--allow-empty", "--quiet", "-m", "feat: the branch's own work"]);
+    runGit(repo, ["checkout", "--quiet", "main"]);
+    runGit(repo, ["commit", "--allow-empty", "--quiet", "-m", `fix: write to ${person} about it`]);
+    runGit(repo, ["checkout", "--quiet", "feature"]);
+
+    expect(commitMessageFindings(repo, "main").size).toBe(0);
+  });
+
+  test("the same message on the branch's own commit is still flagged", () => {
+    /* The other half of the range: narrowing it must not stop reading what the
+       branch does publish. */
+    const repo = gitRepo();
+    const person = ["someone", "personal.dev"].join("@");
+    runGit(repo, ["commit", "--allow-empty", "--quiet", "-m", `fix: write to ${person} about it`]);
+
+    expect(commitMessageFindings(repo, "main").get("email_address")).toBe(1);
+  });
+
+  test("names the commit and the field for every message it flags", () => {
+    const repo = gitRepo();
+    const person = ["someone", "personal.dev"].join("@");
+    const segment = ["home", "fixture-person"].join("/");
+    runGit(repo, ["commit", "--allow-empty", "--quiet", "-m", `fix: write to ${person} about it`]);
+    const first = git(repo, "rev-parse", "HEAD").trim();
+    runGit(repo, ["commit", "--allow-empty", "--quiet", "-m", `fix: read /${segment}/notes.txt`]);
+    const second = git(repo, "rev-parse", "HEAD").trim();
+
+    const notices: string[] = [];
+    commitMessageFindings(repo, "main", notices);
+
+    expect(notices).toEqual([
+      `commit_message: ${second.slice(0, 12)} message home_path`,
+      `commit_message: ${first.slice(0, 12)} message email_address`,
+    ]);
+    /* The notice locates the finding; the report is itself published, so it
+       never quotes what it found. */
+    expect(notices.join("\n")).not.toContain(person);
+    expect(notices.join("\n")).not.toContain(segment);
+  });
+
+  test("names an unreadable range rather than reporting it silently", () => {
+    const repo = gitRepo();
+    const notices: string[] = [];
+
+    expect(commitMessageFindings(repo, "no-such-base", notices).get("inspection_error")).toBe(1);
+    expect(notices).toEqual(["commit_message: range unreadable"]);
+  });
 });
 
 describe("mergeBoundaryReview", () => {
@@ -3188,6 +3245,42 @@ describe("mergeBoundaryReview", () => {
   function head(repo: string): string {
     const result = Bun.spawnSync({ cmd: ["git", "-C", repo, "rev-parse", "HEAD"], stderr: "pipe", stdout: "pipe" });
     return result.stdout.toString().trim();
+  }
+
+  function identityField(repo: string, format: string): string {
+    const result = Bun.spawnSync({
+      cmd: ["git", "-C", repo, "log", "-1", `--format=${format}`, "HEAD"],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    return result.stdout.toString().trim();
+  }
+
+  /* What the forge records as COMMITTER on a commit it composes itself: its
+     own web-flow mailbox, whose local part is exactly `noreply`. It names the
+     forge and identifies nobody, which is why the machine-attribution rule
+     already reads it as a tool. */
+  const forgeWebFlowIdentity = { email: ["noreply", "github.com"].join("@"), name: "GitHub" };
+
+  /* The commit the "Update branch" button composes: the base merged into the
+     branch, authored by the account that pressed it and committed by the
+     forge. */
+  function mergeAsForge(repo: string, base: string, branch: string): void {
+    const result = Bun.spawnSync({
+      cmd: ["git", "merge", "--quiet", "--no-ff", "-m", `Merge branch '${base}' into ${branch}`, base],
+      cwd: repo,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_EMAIL: canonicalIdentity.email,
+        GIT_AUTHOR_NAME: canonicalIdentity.name,
+        GIT_COMMITTER_EMAIL: forgeWebFlowIdentity.email,
+        GIT_COMMITTER_NAME: forgeWebFlowIdentity.name,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
   }
 
   test("a non-canonical author becomes an attributable trailer at the merge boundary", () => {
@@ -3337,6 +3430,59 @@ describe("mergeBoundaryReview", () => {
     const output = result.stdout.toString();
 
     expect(result.exitCode).toBe(1);
-    expect(output).toBe("PRIVACY GATE: FAIL\nemail_address: 1\n");
+    expect(output).toBe(
+      `PRIVACY GATE: FAIL\nemail_address: 1\ncommit_message: ${head(repo).slice(0, 12)} message email_address\n`,
+    );
+    expect(output).not.toContain(personal);
+  });
+
+  test("a forge-composed 'Update branch' merge commit passes every field the gate reads", () => {
+    /* #1315 read this commit as the one that failed. It is clean on all three
+       surfaces, and this pins that: the AUTHOR is an account on the forge's
+       no-reply host, the COMMITTER is the forge's own web-flow identity, and
+       the MESSAGE the forge writes carries no address at all. The finding on
+       that pull request came from a commit already on the base, which the
+       range above no longer reads. */
+    const repo = gitRepo();
+    commit(repo, "feat: the branch's own work", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "main"]);
+    commit(repo, "chore: the base moves on", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "feature"]);
+    mergeAsForge(repo, "main", "feature");
+
+    expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
+    expect(identityField(repo, "%ae")).toBe(canonicalIdentity.email);
+
+    const review = mergeBoundaryReview(repo, "main");
+    expect(review.findings.size).toBe(0);
+    expect(review.notices).toEqual([]);
+    expect(commitMessageFindings(repo, "main").size).toBe(0);
+
+    const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
+    expect(result.stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("a message with a real-looking address still fails behind a forge merge, and is named", () => {
+    /* The narrowed range and the forge exemptions must not carry a person
+       across with them: this commit is the branch's own, and the merge that
+       follows it publishes it either way. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, `feat: write to ${personal} about it`, canonicalIdentity);
+    const flagged = head(repo);
+    runGit(repo, ["checkout", "--quiet", "main"]);
+    commit(repo, "chore: the base moves on", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "feature"]);
+    mergeAsForge(repo, "main", "feature");
+
+    const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
+    const output = result.stdout.toString();
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toBe(
+      `PRIVACY GATE: FAIL\nemail_address: 1\ncommit_message: ${flagged.slice(0, 12)} message email_address\n`,
+    );
+    expect(output).not.toContain(personal);
   });
 });

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -3571,4 +3571,29 @@ describe("mergeBoundaryReview", () => {
     expect(review.notices[0]).not.toContain("committer");
     expect(review.notices[0]).not.toContain(personal);
   });
+
+  test("the exemption names the forge's address, and reads the name beside it", () => {
+    /* An identity is a name as well as a mailbox, and the mailbox is the only
+       part of it the forge decides. A commit committed under the forge's
+       address carries whatever name it was committed with — so the exemption
+       drops that one address out of what the composed trailer publishes, and
+       everything else on the trailer is read as it always was. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: something", canonicalIdentity);
+    runGit(repo, [
+      "-c", `user.name=${personal}`,
+      "-c", `user.email=${forgeWebFlowIdentity.email}`,
+      "commit", "--quiet", "--amend", "--no-edit",
+    ]);
+
+    expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
+    expect(identityField(repo, "%cn")).toBe(personal);
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+    expect(review.notices).toHaveLength(1);
+    expect(review.notices[0]).toContain("committer");
+    expect(review.notices[0]).not.toContain(personal);
+  });
 });

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -3310,14 +3310,14 @@ describe("mergeBoundaryReview", () => {
   /* The commit the "Update branch" button composes: the base merged into the
      branch, authored by the account that pressed it and committed by the
      forge. */
-  function mergeAsForge(repo: string, base: string, branch: string): void {
+  function mergeAsForge(repo: string, base: string, branch: string, author = canonicalIdentity): void {
     const result = Bun.spawnSync({
       cmd: ["git", "merge", "--quiet", "--no-ff", "-m", `Merge branch '${base}' into ${branch}`, base],
       cwd: repo,
       env: {
         ...process.env,
-        GIT_AUTHOR_EMAIL: canonicalIdentity.email,
-        GIT_AUTHOR_NAME: canonicalIdentity.name,
+        GIT_AUTHOR_EMAIL: author.email,
+        GIT_AUTHOR_NAME: author.name,
         GIT_COMMITTER_EMAIL: forgeWebFlowIdentity.email,
         GIT_COMMITTER_NAME: forgeWebFlowIdentity.name,
       },
@@ -3444,11 +3444,26 @@ describe("mergeBoundaryReview", () => {
     expect(review.findings.get("email_address")).toBe(1);
   });
 
-  test("reports an unreadable range rather than passing it", () => {
+  test("reports an unreadable range rather than passing it, and names which read failed", () => {
     const repo = gitRepo();
     const review = mergeBoundaryReview(repo, "no-such-base");
 
     expect(review.findings.get("inspection_error")).toBe(1);
+    expect(review.notices).toEqual(["merge_boundary: range unreadable"]);
+  });
+
+  test("both commit reads name themselves when the base cannot be resolved", () => {
+    /* One flag runs two reads over the commits. `inspection_error: 2` with no
+       notice under it says only that something the gate could not read exists
+       somewhere. */
+    const repo = gitRepo();
+    commit(repo, "feat: something", canonicalIdentity);
+
+    const result = runGateArguments(["--base", "no-such-base", "--check-commits"], {}, repo);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.toString()).toContain("commit_message: range unreadable");
+    expect(result.stdout.toString()).toContain("merge_boundary: range unreadable");
   });
 
   test("the gate reads the merge boundary under --check-commits and withholds the address", () => {
@@ -3484,10 +3499,11 @@ describe("mergeBoundaryReview", () => {
   test("a forge-composed 'Update branch' merge commit passes every field the gate reads", () => {
     /* #1315 read this commit as the one that failed. It is clean on all three
        surfaces, and this pins that: the AUTHOR is an account on the forge's
-       no-reply host, the COMMITTER is the forge's own web-flow identity, and
-       the MESSAGE the forge writes carries no address at all. The finding on
-       that pull request came from a commit already on the base, which the
-       range above no longer reads. */
+       no-reply host, the COMMITTER is the forge's own web-flow identity — now
+       exempt as an identity of the forge's, where before it passed only as
+       some vendor's no-reply mailbox — and the MESSAGE the forge writes
+       carries no address at all. The finding on that pull request came from a
+       commit already on the base, which the range above no longer reads. */
     const repo = gitRepo();
     commit(repo, "feat: the branch's own work", canonicalIdentity);
     runGit(repo, ["checkout", "--quiet", "main"]);
@@ -3529,5 +3545,30 @@ describe("mergeBoundaryReview", () => {
       `PRIVACY GATE: FAIL\nemail_address: 1\ncommit_message: ${flagged.slice(0, 12)} message email_address\n`,
     );
     expect(output).not.toContain(personal);
+  });
+
+  test("the forge's own committer is exempt while the author of the same commit is still read", () => {
+    /* The exemption is the committer field of a commit the forge composed, and
+       it covers that field only. The account that pressed the button is the
+       author, and a merge whose author is a person publishes that person the
+       moment the branch is squashed — so the finding survives the exemption
+       and names which of the two fields it came from. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, "feat: the branch's own work", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "main"]);
+    commit(repo, "chore: the base moves on", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "feature"]);
+    mergeAsForge(repo, "main", "feature", { email: personal, name: "Someone" });
+
+    expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
+    const review = mergeBoundaryReview(repo, "main");
+
+    expect(review.findings.get("email_address")).toBe(1);
+    expect(review.notices).toHaveLength(1);
+    expect(review.notices[0]).toContain(head(repo).slice(0, 12));
+    expect(review.notices[0]).toContain("author");
+    expect(review.notices[0]).not.toContain("committer");
+    expect(review.notices[0]).not.toContain(personal);
   });
 });

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -3310,7 +3310,13 @@ describe("mergeBoundaryReview", () => {
   /* The commit the "Update branch" button composes: the base merged into the
      branch, authored by the account that pressed it and committed by the
      forge. */
-  function mergeAsForge(repo: string, base: string, branch: string, author = canonicalIdentity): void {
+  function mergeAsForge(
+    repo: string,
+    base: string,
+    branch: string,
+    author = canonicalIdentity,
+    committer = forgeWebFlowIdentity,
+  ): void {
     const result = Bun.spawnSync({
       cmd: ["git", "merge", "--quiet", "--no-ff", "-m", `Merge branch '${base}' into ${branch}`, base],
       cwd: repo,
@@ -3318,8 +3324,8 @@ describe("mergeBoundaryReview", () => {
         ...process.env,
         GIT_AUTHOR_EMAIL: author.email,
         GIT_AUTHOR_NAME: author.name,
-        GIT_COMMITTER_EMAIL: forgeWebFlowIdentity.email,
-        GIT_COMMITTER_NAME: forgeWebFlowIdentity.name,
+        GIT_COMMITTER_EMAIL: committer.email,
+        GIT_COMMITTER_NAME: committer.name,
       },
       stderr: "pipe",
       stdout: "pipe",
@@ -3511,6 +3517,7 @@ describe("mergeBoundaryReview", () => {
     runGit(repo, ["checkout", "--quiet", "feature"]);
     mergeAsForge(repo, "main", "feature");
 
+    expect(identityField(repo, "%P").split(" ")).toHaveLength(2);
     expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
     expect(identityField(repo, "%ae")).toBe(canonicalIdentity.email);
 
@@ -3522,6 +3529,32 @@ describe("mergeBoundaryReview", () => {
     const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
     expect(result.stdout.toString()).toBe("PRIVACY GATE: PASS\n");
     expect(result.exitCode).toBe(0);
+  });
+
+  test("a single-parent commit with the forge's web-flow committer is attributable and named", () => {
+    /* The forge mailbox identifies a merge only when the commit graph agrees.
+       A normal commit can carry the same committer identity, and that field
+       remains part of what a squash merge composes into its message even when
+       its author happens to carry the identical identity. */
+    const repo = gitRepo();
+    const personal = ["someone", "personal.dev"].join("@");
+    commit(repo, `feat: write to ${personal} about it`, forgeWebFlowIdentity);
+    const flagged = head(repo);
+
+    expect(identityField(repo, "%P").split(" ")).toHaveLength(1);
+    expect(identityField(repo, "%ae")).toBe(forgeWebFlowIdentity.email);
+    expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
+
+    const result = runGateArguments(["--base", "main", "--check-commits"], {}, repo);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.toString()).toBe(
+      `PRIVACY GATE: FAIL\nemail_address: 2\n`
+      + `commit_message: ${flagged.slice(0, 12)} message email_address\n`
+      + `merge_boundary: ${flagged.slice(0, 12)} committer identity composes an attributable `
+      + "Co-authored-by trailer (address withheld)\n",
+    );
+    expect(result.stdout.toString()).not.toContain(personal);
+    expect(result.stdout.toString()).not.toContain(forgeWebFlowIdentity.email);
   });
 
   test("a message with a real-looking address still fails behind a forge merge, and is named", () => {
@@ -3580,13 +3613,16 @@ describe("mergeBoundaryReview", () => {
        everything else on the trailer is read as it always was. */
     const repo = gitRepo();
     const personal = ["someone", "personal.dev"].join("@");
-    commit(repo, "feat: something", canonicalIdentity);
-    runGit(repo, [
-      "-c", `user.name=${personal}`,
-      "-c", `user.email=${forgeWebFlowIdentity.email}`,
-      "commit", "--quiet", "--amend", "--no-edit",
-    ]);
+    commit(repo, "feat: the branch's own work", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "main"]);
+    commit(repo, "chore: the base moves on", canonicalIdentity);
+    runGit(repo, ["checkout", "--quiet", "feature"]);
+    mergeAsForge(repo, "main", "feature", canonicalIdentity, {
+      email: forgeWebFlowIdentity.email,
+      name: personal,
+    });
 
+    expect(identityField(repo, "%P").split(" ")).toHaveLength(2);
     expect(identityField(repo, "%ce")).toBe(forgeWebFlowIdentity.email);
     expect(identityField(repo, "%cn")).toBe(personal);
     const review = mergeBoundaryReview(repo, "main");

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1495,7 +1495,13 @@ export function commitMessageFindings(
 
 export type MergeBoundaryReview = { findings: Map<FindingClass, number>; notices: string[] };
 
-type CommitIdentity = { address: string; commit: string; field: "author" | "committer"; name: string };
+type CommitIdentity = {
+  address: string;
+  commit: string;
+  field: "author" | "committer";
+  name: string;
+  parentCount: number;
+};
 
 /* The forge's account namespace, `<id>+<handle>` or `<handle>` at the no-reply
    host of its own domain. The forge issues that address for one purpose: so a
@@ -1514,12 +1520,11 @@ function isForgeAccountAddress(address: string): boolean {
   return address.slice(separator + 1).toLowerCase() === FORGE_ACCOUNT_DOMAIN;
 }
 
-/* The mailbox the forge writes as COMMITTER on a commit it composes itself —
-   the "Update branch" button, a merge run from the pull request page, an edit
-   made in the web editor. It is the forge's own web-flow identity: it names
-   the forge, it is the same address on every repository, and it identifies
-   nobody. The account that pressed the button is the AUTHOR, and the rule
-   above already reads that field.
+/* The mailbox the forge writes as COMMITTER on a merge commit it composes —
+   the "Update branch" button or a merge run from the pull request page. It is
+   the forge's own web-flow identity: it names the forge, it is the same address
+   on every repository, and it identifies nobody. The account that pressed the
+   button is the AUTHOR, and the rule above already reads that field.
    Stated here rather than left to the message rules: the merge boundary is the
    identity path, and an identity question is answered by identity rules. The
    machine-attribution mailbox rule reaches the same verdict on this address
@@ -1533,16 +1538,24 @@ function isForgeAccountAddress(address: string): boolean {
    beside it. That name is scanned, and a person in it is reported. */
 const FORGE_COMPOSER_ADDRESS = ["noreply", FORGE_DOMAIN].join("@");
 
-function isForgeComposerAddress(address: string, identity: CommitIdentity): boolean {
-  return identity.field === "committer"
-    && identity.address.toLowerCase() === FORGE_COMPOSER_ADDRESS
-    && address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
+function isForgeComposerMailbox(address: string): boolean {
+  return address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
 }
 
-/** Every identity git recorded on the commits the merge will squash. */
+function isForgeComposerIdentityAddress(address: string, identity: CommitIdentity): boolean {
+  return identity.field === "committer"
+    && isForgeComposerMailbox(identity.address)
+    && isForgeComposerMailbox(address);
+}
+
+function isForgeComposerAddress(address: string, identity: CommitIdentity): boolean {
+  return identity.parentCount > 1 && isForgeComposerIdentityAddress(address, identity);
+}
+
+/** Each distinct identity git recorded on the commits the merge will squash. */
 function branchIdentities(repository: string, base: string): CommitIdentity[] | undefined {
   const result = Bun.spawnSync({
-    cmd: ["git", "-C", repository, "log", "--format=%H%x00%an%x00%ae%x00%cn%x00%ce", `${base}..HEAD`],
+    cmd: ["git", "-C", repository, "log", "--format=%H%x00%P%x00%an%x00%ae%x00%cn%x00%ce", `${base}..HEAD`],
     env: withoutWakatimeCredential(process.env),
     stderr: "pipe",
     stdout: "pipe",
@@ -1550,14 +1563,22 @@ function branchIdentities(repository: string, base: string): CommitIdentity[] | 
   if (result.exitCode !== 0) return undefined;
   const identities: CommitIdentity[] = [];
   /* An identity carries no newline — git refuses to record one — so a commit
-     is a line and its five fields are NUL-separated within it. */
+     is a line and its six fields are NUL-separated within it. */
   for (const line of result.stdout.toString().split("\n")) {
     if (line === "") continue;
-    const [commit, authorName, authorAddress, committerName, committerAddress] = line.split("\0");
+    const [commit, parents, authorName, authorAddress, committerName, committerAddress] = line.split("\0");
     if (committerAddress === undefined) return undefined;
-    identities.push({ address: authorAddress, commit, field: "author", name: authorName });
-    if (committerName === authorName && committerAddress === authorAddress) continue;
-    identities.push({ address: committerAddress, commit, field: "committer", name: committerName });
+    const parentCount = parents === "" ? 0 : parents.split(" ").length;
+    const sameIdentity = committerName === authorName && committerAddress === authorAddress;
+    /* Equal identities compose one finding. The forge mailbox is
+       field-sensitive, so represent that pair as its committer record. */
+    if (sameIdentity && isForgeComposerMailbox(committerAddress)) {
+      identities.push({ address: committerAddress, commit, field: "committer", name: committerName, parentCount });
+      continue;
+    }
+    identities.push({ address: authorAddress, commit, field: "author", name: authorName, parentCount });
+    if (sameIdentity) continue;
+    identities.push({ address: committerAddress, commit, field: "committer", name: committerName, parentCount });
   }
   return identities;
 }
@@ -1582,8 +1603,8 @@ function composedAttributionMessage(identity: CommitIdentity): string {
  * made without them, so the question is never whether an identity publishes but
  * whose. Three answers publish nobody: an account on the forge's no-reply host,
  * which the forge issues so that the account's own address is not what its
- * commits carry; the forge's own web-flow mailbox where the forge committed a
- * commit it composed; and the machine-attribution mailboxes the trailer rule
+ * commits carry; the forge's own web-flow mailbox on a real merge commit the
+ * forge composed; and the machine-attribution mailboxes the trailer rule
  * already names. Every other identity is a person, and is reported exactly as
  * an address in a file is.
  *
@@ -1606,7 +1627,13 @@ export function mergeBoundaryReview(repository: string, base: string): MergeBoun
   }
   for (const identity of identities) {
     const { attributable } = commitMessageAddressReview(composedAttributionMessage(identity));
-    const publishes = attributable.some((address) => {
+    /* The composed trailer rules classify any exact `noreply` local part as
+       machine attribution. For the forge's web-flow mailbox, the commit graph
+       is the additional proof: a zero- or one-parent commit did not come from
+       the forge's merge composer and remains attributable. */
+    const unverifiedForgeComposer = isForgeComposerIdentityAddress(identity.address, identity)
+      && !isForgeComposerAddress(identity.address, identity);
+    const publishes = unverifiedForgeComposer || attributable.some((address) => {
       return !isForgeAccountAddress(address) && !isForgeComposerAddress(address, identity);
     });
     if (!publishes) continue;

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1526,11 +1526,17 @@ function isForgeAccountAddress(address: string): boolean {
    through the trailer the review composes below, so the gate's verdict on a
    forge-composed merge is what it was — but it was reached by a rule about
    MESSAGES, and narrowing that rule would have silently taken the forge's own
-   merges with it. */
+   merges with it.
+   Like every exemption here, this one names an ADDRESS the scan already found
+   and never skips a read: an identity is a name as well as a mailbox, and a
+   commit can be committed under this mailbox with anything at all in the name
+   beside it. That name is scanned, and a person in it is reported. */
 const FORGE_COMPOSER_ADDRESS = ["noreply", FORGE_DOMAIN].join("@");
 
-function isForgeComposerIdentity(identity: CommitIdentity): boolean {
-  return identity.field === "committer" && identity.address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
+function isForgeComposerAddress(address: string, identity: CommitIdentity): boolean {
+  return identity.field === "committer"
+    && identity.address.toLowerCase() === FORGE_COMPOSER_ADDRESS
+    && address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
 }
 
 /** Every identity git recorded on the commits the merge will squash. */
@@ -1599,9 +1605,10 @@ export function mergeBoundaryReview(repository: string, base: string): MergeBoun
     return { findings, notices };
   }
   for (const identity of identities) {
-    if (isForgeComposerIdentity(identity)) continue;
     const { attributable } = commitMessageAddressReview(composedAttributionMessage(identity));
-    const publishes = attributable.some((address) => !isForgeAccountAddress(address));
+    const publishes = attributable.some((address) => {
+      return !isForgeAccountAddress(address) && !isForgeComposerAddress(address, identity);
+    });
     if (!publishes) continue;
     addFinding(findings, "email_address");
     /* The notice names the commit, the field and the trailer, and never the

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1233,6 +1233,8 @@ export function formatPrivacyReport(findings: Map<FindingClass, number>, notices
   return `${lines.join("\n")}\n`;
 }
 
+const COMMIT_HASH = /^[0-9a-f]{40}$/;
+
 const commitMessageFindingClasses = new Set<FindingClass>([
   "credential",
   "email_address",
@@ -1389,27 +1391,76 @@ export function commitMessageAddressReview(message: string): CommitAddressReview
   return { attributable: [...attributable], exempt: [...exempt] };
 }
 
-export function commitMessageFindings(repository: string, base: string): Map<FindingClass, number> {
+/**
+ * The messages this branch publishes when it is pushed.
+ *
+ * The range is `base..HEAD` — the commits the branch ADDS. It read
+ * `base...HEAD` until #1315, and to `git log` the three-dot form is the
+ * SYMMETRIC difference — not the ancestry cut the identical spelling means to
+ * the `git diff` in `changedPaths`, which is how it got here. So every commit
+ * already on the protected base but not on the branch was scanned too, and a
+ * finding on one of them is reported against this pull request. Those messages
+ * were published when they landed; this branch neither wrote them nor can
+ * change them, and a branch that is merely BEHIND the base inherited every one
+ * of them.
+ *
+ * That is what made the forge's "Update branch" button useless against such a
+ * finding: the button merges the base tip, another merge lands on the base
+ * seconds later, the gate resolves its base to the newer tip, and the branch
+ * is behind again with the same finding nobody on it can fix.
+ *
+ * The identity half below has always read `base..HEAD`; the two halves of
+ * `--check-commits` now read the same commits.
+ */
+export function commitMessageFindings(
+  repository: string,
+  base: string,
+  notices?: string[],
+): Map<FindingClass, number> {
   const findings = new Map<FindingClass, number>();
   const result = Bun.spawnSync({
-    cmd: ["git", "-C", repository, "log", "--format=%B%x00", `${base}...HEAD`],
+    cmd: ["git", "-C", repository, "log", "--format=%H%x00%B%x00", `${base}..HEAD`],
     env: withoutWakatimeCredential(process.env),
     stderr: "pipe",
     stdout: "pipe",
   });
   if (result.exitCode !== 0) {
     addFinding(findings, "inspection_error");
+    notices?.push("commit_message: range unreadable");
     return findings;
   }
-  const messages = result.stdout.toString().split("\0").filter(Boolean);
-  for (const message of messages) {
+  let commit = "";
+  /* Two NUL-separated fields per commit, hash then message. The walk names a
+     chunk by its SHAPE rather than by its position, so a message that somehow
+     carried a NUL splits into two chunks that are both still scanned instead
+     of shifting the pairing and turning half the messages into hashes nobody
+     reads. A message that is nothing but a full hash is read as one and not
+     scanned; it holds no address, path or credential either way. */
+  for (const chunk of result.stdout.toString().split("\0")) {
+    const message = chunk.startsWith("\n") ? chunk.slice(1) : chunk;
+    if (message === "") continue;
+    if (COMMIT_HASH.test(message)) {
+      commit = message;
+      continue;
+    }
     const messageFindings = sensitiveClasses(message);
     if (messageFindings.has("email_address")) {
       const { attributable, exempt } = commitMessageAddressReview(message);
       if (exempt.length > 0 && attributable.length === 0) messageFindings.delete("email_address");
     }
+    const reported: FindingClass[] = [];
     for (const finding of messageFindings) {
-      if (commitMessageFindingClasses.has(finding)) addFinding(findings, finding);
+      if (!commitMessageFindingClasses.has(finding)) continue;
+      addFinding(findings, finding);
+      reported.push(finding);
+    }
+    /* The notice names WHERE the finding is and never WHAT it is: this report
+       is published as a check run's log on a public repository, and a report
+       that quoted the address or the path to prove it leaked, leaks it.
+       `git show -s <commit>` names it to whoever is fixing it. */
+    if (reported.length > 0) {
+      const classes = reported.sort((left, right) => left.localeCompare(right)).join(", ");
+      notices?.push(`commit_message: ${commit.slice(0, 12)} message ${classes}`);
     }
   }
   return findings;
@@ -1542,7 +1593,7 @@ if (import.meta.main) {
   );
   const notices: string[] = [];
   if (arguments_.includes("--check-commits")) {
-    for (const [finding, count] of commitMessageFindings(inspectionRoot, trustedBase)) {
+    for (const [finding, count] of commitMessageFindings(inspectionRoot, trustedBase, notices)) {
       pathFindings.set(finding, (pathFindings.get(finding) ?? 0) + count);
     }
     /* The branch commits publish their messages when they are pushed; the merge

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1391,6 +1391,37 @@ export function commitMessageAddressReview(message: string): CommitAddressReview
   return { attributable: [...attributable], exempt: [...exempt] };
 }
 
+/* The commits the branch adds, newest first, one full hash per line. A hash
+   holds no newline, so this read has no boundary to guess at — which is why
+   the messages are fetched one at a time below rather than packed into this
+   same stream. `--no-abbrev-commit` neutralises a checkout that configured
+   `log.abbrevCommit`, and the shape check is what makes each hash safe to
+   hand back to git as an argument. */
+function branchCommitHashes(repository: string, base: string): string[] | undefined {
+  const result = Bun.spawnSync({
+    cmd: ["git", "-C", repository, "log", "--no-abbrev-commit", "--format=%H", `${base}..HEAD`],
+    env: withoutWakatimeCredential(process.env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (result.exitCode !== 0) return undefined;
+  const hashes = result.stdout.toString().split("\n").filter((line) => line !== "");
+  return hashes.every((hash) => COMMIT_HASH.test(hash)) ? hashes : undefined;
+}
+
+/* One commit's message, the whole of stdout. Asking for exactly one commit is
+   what removes the ambiguity: no delimiter has to survive the message, so no
+   message can be read as anything but a message. */
+function commitMessage(repository: string, commit: string): string | undefined {
+  const result = Bun.spawnSync({
+    cmd: ["git", "-C", repository, "log", "-1", "--format=%B", commit, "--"],
+    env: withoutWakatimeCredential(process.env),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return result.exitCode === 0 ? result.stdout.toString() : undefined;
+}
+
 /**
  * The messages this branch publishes when it is pushed.
  *
@@ -1418,29 +1449,25 @@ export function commitMessageFindings(
   notices?: string[],
 ): Map<FindingClass, number> {
   const findings = new Map<FindingClass, number>();
-  const result = Bun.spawnSync({
-    cmd: ["git", "-C", repository, "log", "--format=%H%x00%B%x00", `${base}..HEAD`],
-    env: withoutWakatimeCredential(process.env),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  if (result.exitCode !== 0) {
+  const commits = branchCommitHashes(repository, base);
+  if (commits === undefined) {
     addFinding(findings, "inspection_error");
     notices?.push("commit_message: range unreadable");
     return findings;
   }
-  let commit = "";
-  /* Two NUL-separated fields per commit, hash then message. The walk names a
-     chunk by its SHAPE rather than by its position, so a message that somehow
-     carried a NUL splits into two chunks that are both still scanned instead
-     of shifting the pairing and turning half the messages into hashes nobody
-     reads. A message that is nothing but a full hash is read as one and not
-     scanned; it holds no address, path or credential either way. */
-  for (const chunk of result.stdout.toString().split("\0")) {
-    const message = chunk.startsWith("\n") ? chunk.slice(1) : chunk;
-    if (message === "") continue;
-    if (COMMIT_HASH.test(message)) {
-      commit = message;
+  /* The hashes and the messages are read separately on purpose. One stream of
+     `%H%x00%B%x00` carries no length, so the reader has to decide where each
+     message ends, and until this round it decided by SHAPE: a chunk of forty
+     lowercase hex characters was the next hash. A raw commit whose entire
+     message is such a value — git writes one without a terminal newline when
+     it is handed one — was therefore read as a hash and never scanned, and a
+     value the gate knows passed the check. Nothing is inferred now: git is
+     asked for the hashes, and then for each message by its hash. */
+  for (const commit of commits) {
+    const message = commitMessage(repository, commit);
+    if (message === undefined) {
+      addFinding(findings, "inspection_error");
+      notices?.push(`commit_message: ${commit.slice(0, 12)} message unreadable`);
       continue;
     }
     const messageFindings = sensitiveClasses(message);

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -1514,6 +1514,25 @@ function isForgeAccountAddress(address: string): boolean {
   return address.slice(separator + 1).toLowerCase() === FORGE_ACCOUNT_DOMAIN;
 }
 
+/* The mailbox the forge writes as COMMITTER on a commit it composes itself —
+   the "Update branch" button, a merge run from the pull request page, an edit
+   made in the web editor. It is the forge's own web-flow identity: it names
+   the forge, it is the same address on every repository, and it identifies
+   nobody. The account that pressed the button is the AUTHOR, and the rule
+   above already reads that field.
+   Stated here rather than left to the message rules: the merge boundary is the
+   identity path, and an identity question is answered by identity rules. The
+   machine-attribution mailbox rule reaches the same verdict on this address
+   through the trailer the review composes below, so the gate's verdict on a
+   forge-composed merge is what it was — but it was reached by a rule about
+   MESSAGES, and narrowing that rule would have silently taken the forge's own
+   merges with it. */
+const FORGE_COMPOSER_ADDRESS = ["noreply", FORGE_DOMAIN].join("@");
+
+function isForgeComposerIdentity(identity: CommitIdentity): boolean {
+  return identity.field === "committer" && identity.address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
+}
+
 /** Every identity git recorded on the commits the merge will squash. */
 function branchIdentities(repository: string, base: string): CommitIdentity[] | undefined {
   const result = Bun.spawnSync({
@@ -1555,11 +1574,12 @@ function composedAttributionMessage(identity: CommitIdentity): string {
  *
  * Git records an author and a committer on every commit and a commit cannot be
  * made without them, so the question is never whether an identity publishes but
- * whose. Two answers publish nobody: an account on the forge's no-reply host,
+ * whose. Three answers publish nobody: an account on the forge's no-reply host,
  * which the forge issues so that the account's own address is not what its
- * commits carry, and the machine-attribution mailboxes the trailer rule already
- * names. Every other identity is a person, and is reported exactly as an
- * address in a file is.
+ * commits carry; the forge's own web-flow mailbox where the forge committed a
+ * commit it composed; and the machine-attribution mailboxes the trailer rule
+ * already names. Every other identity is a person, and is reported exactly as
+ * an address in a file is.
  *
  * The no-reply host is read only here, on the identities the merge composes.
  * A commit message that writes such an address into a trailer by hand, or into
@@ -1572,9 +1592,14 @@ export function mergeBoundaryReview(repository: string, base: string): MergeBoun
   const identities = branchIdentities(repository, base);
   if (identities === undefined) {
     addFinding(findings, "inspection_error");
+    /* A failure of this check names itself too. It is one of two reads behind
+       one flag, and a bare `inspection_error: 1` said which of them failed only
+       to whoever went and read the source. */
+    notices.push("merge_boundary: range unreadable");
     return { findings, notices };
   }
   for (const identity of identities) {
+    if (isForgeComposerIdentity(identity)) continue;
     const { attributable } = commitMessageAddressReview(composedAttributionMessage(identity));
     const publishes = attributable.some((address) => !isForgeAccountAddress(address));
     if (!publishes) continue;


### PR DESCRIPTION
Closes #1315.

## What actually tripped the gate

The issue's mechanism was a suspicion, so this branch tested it before changing
anything. A fixture repository was built with exactly the shape the issue
describes — a `Merge branch 'main' into <branch>` commit whose author is an
account on the forge's no-reply host and whose committer is the forge's own
web-flow identity — and the gate was run on it. Its own output:

```
$ bun scripts/privacy-publication-gate.ts --repository <fixture> --check-commits --base main
PRIVACY GATE: PASS
```

It passes, and it passed before this branch as well. That commit is clean on
every field the gate reads:

| field | what the forge records | how the gate reads it |
| --- | --- | --- |
| author | an account on the forge's no-reply host | exempt at the merge boundary since #1251 |
| committer | the forge's web-flow mailbox, local part exactly `noreply` | exempt as machine attribution |
| message | `Merge branch 'main' into <branch>` | carries no address at all |

**So the answer is none of the three: the field that failed was none of the
forge merge commit's own.** A test pins that, so the next reader does not have
to re-derive it. The committer's exemption was real but indirect — it held
because the address is *some vendor's* no-reply mailbox, a rule about messages.
The third round below states it at the merge boundary as a rule about the
forge's identity, where the question belongs.

The real failure was then reproduced from the failing run itself. The check run
resolved its base to `b1951075` (main's tip at that moment) and the head it
scanned was `5497e72f`, the forge's `Merge branch 'main' into …` commit.
Running the gate against that head reproduces CI byte for byte:

```
$ bun scripts/privacy-publication-gate.ts --repository <checkout of 5497e72f> --check-commits --base b1951075
PRIVACY GATE: FAIL
email_address: 1
```

There is no `merge_boundary:` line in that output, which already rules the
identity path out — `mergeBoundaryReview` never reports without one. Walking
the scanned range commit by commit puts the finding in one place:

```
b1951075b9f3 BASE-SIDE   classes=["email_address"]  attributable=[one bot account handle]
5497e72f77e6 branch-side classes=[]                 <- the forge merge commit
26fb9c61e687 branch-side classes=["email_address"]  attributable=[]
d8b27ea46833 branch-side classes=["email_address"]  attributable=[]
f747e9a4dac1 branch-side classes=["email_address"]  attributable=[]
e02e826c0eb4 branch-side classes=["email_address"]  attributable=[]
20328de2abd5 branch-side classes=["email_address"]  attributable=[]
mergeBoundaryReview findings: []   notices: []
```

The single finding is on `b1951075` — **main's own tip, a commit the pull
request does not contain.** `commitMessageFindings` read `base...HEAD`, and to
`git log` three dots are the *symmetric difference*, not the ancestry cut the
identical spelling means to the `git diff` in `changedPaths` a few hundred lines
above it. A branch that is merely *behind* the base therefore inherited every
message the base had gained since the fork.

`b1951075` is a squash-merge commit the forge composed, and the
`Co-authored-by:` trailer it wrote there names a bot account on the forge's own
no-reply host. The message rule reads that as attributable on purpose — #1251
made the no-reply-host reading the merge boundary only, and AGENTS.md says so
explicitly. That rule is unchanged here.

And this is why the **Update branch** button could not clear it. The button
merged main at `1ead1073`; `b1951075` landed on main seconds later; the gate
resolved its base to the newer tip, and the branch was behind again with the
same finding. Exactly one commit separates the two, and that one commit was the
whole failure. No push the branch could make would fix a message it did not
write.

## The fix

`commitMessageFindings` now reads `base..HEAD` — the commits the branch adds.
The identity half of the same flag (`branchIdentities`) has always read
`base..HEAD`, so the two halves of `--check-commits` disagreed about which
commits belong to the branch; they now read the same range. Nothing the branch
publishes stops being read: a message the branch does carry is still flagged,
and a test covers that half too.

Every message finding now names its commit and the field:

```
PRIVACY GATE: FAIL
email_address: 1
commit_message: 862773996577 message email_address
```

Like the merge-boundary notice, it names *where* the finding is and never
*what* it is — this report is a check run's log on a public repository, and a
report that quoted the address to prove it leaked would leak it. An unreadable
range now says `commit_message: range unreadable` instead of reporting a bare
`inspection_error`.

Path findings are deliberately left alone: they still report as a class count.
Naming the file would have rewritten 73 exact-output assertions in this file's
suite, which is a change worth making on its own terms rather than inside this
one.

## Verification

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test scripts/privacy-publication-gate.test.ts` — 154 pass, 0 fail.
- The same suite run against the **pre-fix** gate: 5 fail — the three new
  message/notice tests, the updated body-address test, and the new
  behind-a-forge-merge test. The other two added tests are green on both sides
  by design: they pin behaviour that was already correct and must stay so (the
  forge merge passing, and a branch-side address still failing).
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main) --check-commits` on this branch — `PRIVACY GATE: PASS`.
- `scripts/bun-spawn-credential-isolation.test.ts` fails identically at the
  merge base and on this branch (pre-existing, byte-identical diff).

Lint is not a gate here (#1259).


---

## Second round — a message could still be read as a hash

Review of `b1aa82ba` found a second way the message read could miss a message,
independent of the range. It reproduces:

```
$ git commit-tree <tree> -p <parent> < a message that is 40 lowercase hex characters, no terminal newline
$ bun scripts/privacy-publication-gate.ts --repository <fixture> --base main --check-commits
PRIVACY GATE: PASS                       # the message is a configured known value
```

The identical message with a trailing newline failed, as it always had:

```
PRIVACY GATE: FAIL
known_value: 1
commit_message: 6b93f0d63d29 message known_value
```

The two reads came out of one `%H%x00%B%x00` stream, which carries no lengths,
so the reader had to decide where each message ended — and it decided by
**shape**: forty lowercase hex characters were the next commit's hash. Git
records a message exactly as it is handed one, so a raw commit written without
a terminal newline put such a value in the message position, and it was
consumed as a hash nobody scans.

Nothing is inferred now. The hashes are read on their own — a hash holds no
newline, so that stream has no boundary to guess at — and each message is then
fetched by its hash, one commit at a time, where no delimiter has to survive
the message. A read that fails between the two names the commit it could not
read instead of counting it clean: `commit_message: <commit> message
unreadable`. `--no-abbrev-commit` keeps `%H` full under a checkout that
configured `log.abbrevCommit`, and the shape check on each hash is what makes
it safe to hand back to git as an argument.

Cost of the per-commit read, measured on this checkout: about 6 ms per commit
(20 commits in 164 ms, 209 in 1.3 s). The check run's range is a pull request's
own commits, so it is tens of milliseconds there.

### Verification of this round

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test scripts/privacy-publication-gate.test.ts` — 155 pass, 0 fail, under
  an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`.
- The new test against the **pre-fix** gate (restored with `git show`, no
  stash): fails on `exit 1` — it got `0`, the PASS above.
- `bun scripts/privacy-publication-gate.ts --check-commits --require-known-values`
  on this branch — `PRIVACY GATE: PASS` both with `--base $(git merge-base HEAD
  origin/main)` and with `--base $(git rev-parse origin/main)`, which is how the
  check run resolves it.

### The check run reproduced #1315 on this pull request

While this round was in flight `main` advanced by one commit, and the check run
on head `7575ea22` failed:

```
PRIVACY_BASE_SHA: e2d7c4135d7d8ec1415f859a1f54f2474fd96f3e
PRIVACY GATE: FAIL
email_address: 1
```

That job runs the **trusted** gate — the copy on the default branch, still the
pre-fix `base...HEAD` reader — against the candidate head. This branch was one
commit behind, so the symmetric difference handed that gate main's own tip,
whose forge-composed `Co-authored-by:` trailer names a bot account on the
forge's no-reply host. No push the branch could make would clear it; rebasing
onto the tip did, and every check is green on `f5eda6c8`. So the failure #1315
reports was reproduced on this pull request, by the gate this pull request
fixes, and it stops reproducing once this is the trusted gate.

Run under the same conditions, main's gate against this head before and after
the rebase, the prediction and the check run agree:

```
$ bun <main's gate> --repository <this branch, behind> --base <main tip> --check-commits
PRIVACY GATE: FAIL / email_address: 1
$ bun <main's gate> --repository <this branch, rebased> --base <main tip> --check-commits
PRIVACY GATE: PASS
```



---

## Third round — the committer exemption stated where the question is asked

The directive for this round was to establish the failing field from a fixture
commit, then exempt the forge's own committer at the merge boundary the way
#1251 exempted forge no-reply authors, and to make every commit-check failure
name the commit and the field.

### The fixture, and the gate's own output

The fixture is a branch with one clean commit of its own, a base that moves on,
and a merge composed the way the "Update branch" button composes it — author
`Fixture Maintainer <4242+…@users.noreply.github.com>`, committer
`GitHub <noreply@github.com>`, message `Merge branch 'main' into feature`.
Every address in it is invented. Each row below is one run of the gate; "gate
as on main" is the copy at `e2d7c413`, the trusted one the check run uses,
extracted with `git show`:

| fixture | gate as on main (`e2d7c413`) | this branch |
| --- | --- | --- |
| forge merge, nothing else non-canonical | `PASS` | `PASS` |
| the same, plus an address on the **base's** tip | `FAIL` `email_address: 1` | `PASS` |
| the same, plus an address in a **branch** commit's message | `FAIL` `email_address: 1` | `FAIL` + `commit_message: 0182c94878a4 message email_address` |
| the merge's **committer** replaced by a person | `FAIL` + `merge_boundary: 75d163d6743d committer identity …` | same |
| the merge's **author** replaced by a person | `FAIL` + `merge_boundary: 9a1f62125498 author identity …` | same |

The verbatim runs of the two rows that matter most:

```
$ bun scripts/privacy-publication-gate.ts --repository <forge-merge fixture> --base main --check-commits
PRIVACY GATE: PASS
exit=0

$ bun <gate as on main> --repository <same fixture, base gained one commit with an address> --base main --check-commits
PRIVACY GATE: FAIL
email_address: 1
```

The forge's merge commit trips nothing, on either gate. The `email_address: 1`
the issue reports is the second row — a commit on the base, named by nothing,
fixable by nobody on the branch — which is what the first round removed.

### The exemption

The merge boundary reviews an identity by composing a `Co-authored-by:` trailer
from it and running the message rules over that. The forge's web-flow committer
survived that review as a machine-attribution mailbox: its local part is
exactly `noreply`, so it read as *a vendor's* no-reply address, the same way a
model's sign-off does. True today, and reached by a rule about messages —
narrow that rule and the forge's own merges go with it, silently.

`mergeBoundaryReview` now states the exemption itself, beside the forge-account
rule #1251 added:

```ts
const FORGE_COMPOSER_ADDRESS = ["noreply", FORGE_DOMAIN].join("@");

function isForgeComposerAddress(address: string, identity: CommitIdentity): boolean {
  return identity.field === "committer"
    && identity.address.toLowerCase() === FORGE_COMPOSER_ADDRESS
    && address.toLowerCase() === FORGE_COMPOSER_ADDRESS;
}
```

It is the **committer field only**, because that is the field the forge writes
on a commit it composed. The account that pressed the button is the author, and
that field is still read: a forge merge authored by a person reports
`merge_boundary: <commit> author identity …` and says `author`, not
`committer`. The verdict on a forge-composed merge is what it was — the fixture
passed before this round too, and the table above is the evidence — so this
changes no result; it moves an identity decision out of the message rules.

It names an **address**, not an identity to skip, which is the doctrine the
rest of this file already states: the exemption drops one address out of what
the composed trailer publishes and reads everything else on that trailer. An
identity is a name as well as a mailbox, and only the mailbox is the forge's —
a commit committed under that address carries whatever name it was committed
with. The first form of this skipped the whole identity, so a person's address
in the committer NAME went unread; a test now holds that shut, and it fails
against that form:

```
$ bun test scripts/privacy-publication-gate.test.ts -t "reads the name beside it"   # against the skipping form
expect(received).toBe(expected)   Expected: 1   Received: undefined
(fail) mergeBoundaryReview > the exemption names the forge's address, and reads the name beside it
```

### Naming every commit-check failure

`--check-commits` runs two reads over the commits, and until now only one of
them named an unreadable range. Both do:

```
PRIVACY GATE: FAIL
inspection_error: 2
commit_message: range unreadable
merge_boundary: range unreadable
```

With that, every failure the commit check can report names the commit and the
field: `commit_message: <commit> message <classes>`, `commit_message: <commit>
message unreadable`, `merge_boundary: <commit> author|committer identity …`,
and the two range notices. Path findings still report as a class count only:
the issue lists author, committer and message, a file finding's location is
already in the diff, and the path the gate inspects is absolute — printing it
into a check run's log on a public repository is the home-path class this gate
exists to refuse.

### Verification of this round

- `bunx tsc --noEmit --incremental false` — clean.
- `bun test scripts/privacy-publication-gate.test.ts` — 158 pass, 0 fail, under
  an isolated `HOME`/`XDG_CONFIG_HOME`/`LLV_STATE_DIR`/`TMPDIR`, with every
  fixture repository under that `TMPDIR`.
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main) --check-commits`
  on this branch — `PRIVACY GATE: PASS`.
- Tests added: the forge's committer exempt while the author of the same commit
  is still read and named; a person's address in the committer NAME still read
  beside the exempt mailbox; the merge boundary naming an unreadable range;
  both reads naming themselves through the CLI. The two tests the specification
  lists — a forge-composed `Merge branch 'main' into …` passing, and a message
  with a real-looking address failing and being named — landed in the first
  round and are unchanged.

Lint is not a gate here (#1259). Nothing was deployed, promoted or restarted.

