### PR TITLE
fix(mcp): scope Viewer deployment tool to Viewer project

### DIFF
--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -365,6 +365,7 @@ test("runtime-bound MCP tools use the live Viewer control surface", async () => 
   const designatedSeat = {
     callerAttribution: () => ({ kind: "manager" as const, conversationId: "conversation_seat", role: null }),
     callerProject: () => "proj-a",
+    viewerProject: () => "proj-a",
     authorizedSeats: () => [{ conversationId: "conversation_seat", path: null, project: "proj-a" }],
     /* #845: the send resolves the conversation it names from ONE injected registry
        projection rather than reaching for the registry itself. */

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -74,6 +74,7 @@ import { PIPELINE_LIST_DEFAULT_LIMIT, projectPipelineListRows } from "@/lib/pipe
 import { findPipelineRecord, loadPipelinesForList } from "@/lib/pipelines/store";
 import type { CreatePipelineRequest, PatchPipelineRequest, Pipeline, PipelineAction } from "@/lib/pipelines/types";
 import type { PauseResumeActor } from "@/lib/pauseResumeActor";
+import { isRepositoryProjectId, projectIdentityFromRemote } from "@/lib/projects/identity";
 import { listFiles } from "@/lib/scanner";
 import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
 import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
@@ -444,6 +445,10 @@ export interface ViewerMcpDomainDependencies {
       Null means the invariant "a registered session has a canonical project"
       is violated, and unscoped directive routing fails closed diagnostically. */
   callerProject?(): string | null;
+  /** The canonical project of the repository that owns this Viewer. The MCP
+      launcher sets its cwd to the selected Viewer package root, and this
+      resolver returns the repository key used by seats and conversations. */
+  viewerProject(): string | null;
 }
 
 /**
@@ -461,6 +466,29 @@ function productionCallerProject(): string | null {
   if (conversation.projectOwnership?.project) return conversation.projectOwnership.project;
   const cwd = conversation.generations.at(-1)?.launchProfile?.cwd?.trim();
   return cwd ? projectForCwd(cwd) : null;
+}
+
+function viewerRepositoryRemote(repoDir: string): string | null {
+  const manifest = JSON.parse(fs.readFileSync(path.join(repoDir, "package.json"), "utf8")) as unknown;
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return null;
+  const repository = (manifest as { repository?: unknown }).repository;
+  if (typeof repository === "string") return repository.trim() || null;
+  if (!repository || typeof repository !== "object" || Array.isArray(repository)) return null;
+  const url = (repository as { url?: unknown }).url;
+  return typeof url === "string" ? url.trim() || null : null;
+}
+
+/** The launcher runs from the selected Viewer package root. Source checkouts
+    carry `.git`; managed release packages carry the same repository identity in
+    package metadata. Both paths feed the shared project-key derivation. */
+function productionViewerProject(): string | null {
+  const repoDir = process.cwd();
+  const configuredRemote = process.env.LLV_VIEWER_CANONICAL_REMOTE?.trim();
+  if (configuredRemote) return projectIdentityFromRemote(configuredRemote, repoDir)?.project ?? null;
+  const project = projectForCwd(repoDir);
+  if (project && isRepositoryProjectId(project)) return project;
+  const remote = viewerRepositoryRemote(repoDir);
+  return remote ? projectIdentityFromRemote(remote, repoDir)?.project ?? null : null;
 }
 
 /** Server-derived origin of the current caller. Shared by the attention record
@@ -647,6 +675,7 @@ export const productionDomainDependencies: ViewerMcpDomainDependencies = {
     (conversationId) => authorizedManagerSeats(productionManagerAuthoritySources())
       .some((seat) => seat.conversationId === conversationId),
   ),
+  viewerProject: productionViewerProject,
 };
 
 function text(value: unknown): string {
@@ -1489,6 +1518,12 @@ async function deployExactSha(
     throw new McpToolRefusal(
       "a designated orchestrator deploys only as its own project's seat; this session's seat belongs to another project",
       { code: "deploy_cross_project", revision },
+    );
+  }
+  if (seat.project !== dependencies.viewerProject()) {
+    throw new McpToolRefusal(
+      "this tool deploys the Agent Log Viewer application that serves this MCP; it cannot deploy the caller's project, and no Viewer surface deploys other projects",
+      { code: "deploy_foreign_project", revision },
     );
   }
 

--- a/src/lib/mcp/deployAuthority.test.ts
+++ b/src/lib/mcp/deployAuthority.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
+import { McpToolRefusal } from "./server";
 
 /**
  * The deploy executor's authority (#795, superseding contract).
@@ -11,7 +12,8 @@ import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
  * authorization row, and never anything parsed out of prose. What this file
  * proves: a non-designated caller never reaches the endpoint, a designated
  * seat acting from another project's context never reaches it, and the
- * designated seat's own call forwards exactly the revision and idempotency key.
+ * designated seat of another project cannot deploy the Viewer, and the Viewer's
+ * designated seat forwards exactly the revision and idempotency key.
  */
 
 const SHA = "4f3c1b9a8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a";
@@ -22,6 +24,7 @@ function bindings(options: {
   kind: "manager" | "agent" | "gateway" | "unidentified";
   conversationId?: string | null;
   callerProject?: string | null;
+  viewerProject?: string | null;
   seats?: { conversationId: string; path: string | null; project: string }[];
 }) {
   posted = [];
@@ -39,13 +42,24 @@ function bindings(options: {
       role: options.kind === "agent" ? "builder" : null,
     }),
     callerProject: () => options.callerProject ?? null,
+    viewerProject: () => options.viewerProject === undefined ? "proj-a" : options.viewerProject,
     authorizedSeats: () => options.seats ?? [
       { conversationId: "conversation_seat", path: null, project: "proj-a" },
     ],
   } as never);
 }
 
-test("the designated seat deploys directly: revision and idempotency key, nothing else", async () => {
+async function refusal(run: Promise<unknown>): Promise<McpToolRefusal> {
+  try {
+    await run;
+    throw new Error("expected deploy refusal");
+  } catch (error) {
+    expect(error).toBeInstanceOf(McpToolRefusal);
+    return error as McpToolRefusal;
+  }
+}
+
+test("the Viewer project's designated seat reaches the deployments POST", async () => {
   const tools = bindings({ kind: "manager", callerProject: "proj-a" });
   const receipt = await tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA });
   expect(receipt).toMatchObject({ revision: SHA, state: "accepted" });
@@ -58,29 +72,48 @@ test("the designated seat deploys directly: revision and idempotency key, nothin
 test("a session attributed as an agent, the gateway, or nobody may not execute a deploy", async () => {
   for (const kind of ["agent", "gateway", "unidentified"] as const) {
     const tools = bindings({ kind, callerProject: "proj-a" });
-    await expect(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }))
-      .rejects.toThrow(/designated orchestrator/i);
+    const error = await refusal(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }));
+    expect(error.message).toMatch(/designated orchestrator/i);
+    expect(error.details).toMatchObject({ code: "deploy_caller_not_designated" });
     expect(posted).toEqual([]);
   }
 });
 
 test("a manager-attributed caller with no validated seat is refused", async () => {
   const tools = bindings({ kind: "manager", conversationId: "conversation_impostor", callerProject: "proj-a" });
-  await expect(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }))
-    .rejects.toThrow(/no validated seat/i);
+  const error = await refusal(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }));
+  expect(error.message).toMatch(/no validated seat/i);
+  expect(error.details).toMatchObject({ code: "deploy_caller_not_designated" });
   expect(posted).toEqual([]);
 });
 
 test("a designated seat acting from another project's context is refused cross-project", async () => {
   const tools = bindings({ kind: "manager", callerProject: "proj-b" });
-  await expect(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }))
-    .rejects.toThrow(/own project/i);
+  const error = await refusal(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }));
+  expect(error.message).toMatch(/own project/i);
+  expect(error.details).toMatchObject({ code: "deploy_cross_project" });
   expect(posted).toEqual([]);
 
   /* The same seat in its own project context deploys. */
   const own = bindings({ kind: "manager", callerProject: "proj-a" });
   await own.deploy_exact_sha({ clientRequestId: "d2", revision: SHA });
   expect(posted).toHaveLength(1);
+});
+
+test("a designated seat of another project is refused before the deployments POST", async () => {
+  const tools = bindings({
+    kind: "manager",
+    callerProject: "another-project",
+    viewerProject: "viewer-project",
+    seats: [{ conversationId: "conversation_seat", path: null, project: "another-project" }],
+  });
+
+  const error = await refusal(tools.deploy_exact_sha({ clientRequestId: "d1", revision: SHA }));
+  expect(error.details).toMatchObject({ code: "deploy_foreign_project", revision: SHA });
+  expect(error.message).toContain("deploys the Agent Log Viewer application that serves this MCP");
+  expect(error.message).toContain("cannot deploy the caller's project");
+  expect(error.message).toContain("no Viewer surface deploys other projects");
+  expect(posted).toEqual([]);
 });
 
 test("an abbreviated SHA is refused before the endpoint is called at all", async () => {

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -293,6 +293,19 @@ test("get_conversation listTools publishes every bounded tail target", async () 
   });
 });
 
+test("deploy_exact_sha publishes the Viewer-only deployment target", async () => {
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    const description = listed.tools.find((candidate) => candidate.name === "deploy_exact_sha")?.description;
+
+    expect(description).toContain("Agent Log Viewer application that serves this MCP");
+    expect(description).toContain("never deploys the calling project's code");
+    expect(description).toContain("designated orchestrator decides when to deploy");
+    expect(description).toContain("nobody asks the operator for a confirmation");
+    expect(description).toContain("Idempotent by clientRequestId");
+  });
+});
+
 test("conversation_action publishes full-generation archive outcomes and the 100-target bound", async () => {
   let calls = 0;
   await withProtocolClient(inertBindings({

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1670,7 +1670,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   list_conversations: "List scanned Viewer conversations with durable ids and transcript paths.",
   search_transcripts: "Search indexed user and assistant message bodies across every scanned transcript store. Returns match snippets with speaker, timestamp, transcript path and byte offset; project is optional, and empty pages include corpus statistics. Queries never read transcript files.",
   get_conversation: "Read a conversation summary and its recent messages and tools. With tailLines, conversationId or selectedContext uses the bounded identity path, while transcriptPath uses the validated pinned reader; both return a bounded raw tail without a corpus scan.",
-  deploy_exact_sha: "Deploy one full commit SHA. The designated orchestrator decides when to deploy and calls this directly; authority is the server-attributed designated seat, and nobody asks the operator for a confirmation, a phrase, or a SHA. Idempotent by clientRequestId; deployments serialize at the runtime host.",
+  deploy_exact_sha: "Deploy one full commit SHA of the Agent Log Viewer application that serves this MCP; this tool never deploys the calling project's code. The designated orchestrator decides when to deploy and calls this directly; authority is the server-attributed designated seat, and nobody asks the operator for a confirmation, a phrase, or a SHA. Idempotent by clientRequestId; deployments serialize at the runtime host.",
   get_pipeline: "Read one pipeline by durable id.",
   board_snapshot: "Read a bounded, redacted snapshot of the Viewer board, durable placement, and the selected project's hidden conversation count.",
   list_flows: "List durable implement-review flows.",

--- a/src/lib/projects/identity.test.ts
+++ b/src/lib/projects/identity.test.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 
 import { afterAll, expect, test } from "bun:test";
 
-import { isCanonicalProjectId, projectIdentityFromDirectory, projectIdentityFromRepositoryRoot, repositoryRootForPath } from "./identity";
+import {
+  isCanonicalProjectId,
+  projectIdentityFromDirectory,
+  projectIdentityFromRemote,
+  projectIdentityFromRepositoryRoot,
+  repositoryRootForPath,
+} from "./identity";
 
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-identity-"));
 
@@ -45,6 +51,16 @@ test("scp, ssh, and https clones of one remote resolve to one identity", () => {
   expect(new Set(identities.map((identity) => identity.canonicalRemote)))
     .toEqual(new Set(["example.invalid/team/shared-repository"]));
   expect(identities[0]!.displayName).toBe("shared-repository");
+});
+
+test("packaged repository metadata resolves to the checkout's project identity", () => {
+  const checkout = createRepository("packaged-checkout", "git@example.invalid:team/shared-repository.git");
+  const packaged = projectIdentityFromRemote(
+    "git+https://example.invalid/team/shared-repository.git",
+    SANDBOX,
+  );
+
+  expect(packaged).toEqual(projectIdentityFromRepositoryRoot(checkout));
 });
 
 test("an https remote never parses as an scp host", () => {

--- a/src/lib/projects/identity.test.ts
+++ b/src/lib/projects/identity.test.ts
@@ -54,7 +54,7 @@ test("scp, ssh, and https clones of one remote resolve to one identity", () => {
 });
 
 test("packaged repository metadata resolves to the checkout's project identity", () => {
-  const checkout = createRepository("packaged-checkout", "git@example.invalid:team/shared-repository.git");
+  const checkout = createRepository("packaged-checkout", "https://example.invalid/team/shared-repository.git");
   const packaged = projectIdentityFromRemote(
     "git+https://example.invalid/team/shared-repository.git",
     SANDBOX,

--- a/src/lib/projects/identity.ts
+++ b/src/lib/projects/identity.ts
@@ -160,6 +160,26 @@ function remoteDisplayName(remote: string): string | null {
   return name || null;
 }
 
+function repositoryProjectIdentity(canonical: string): RepositoryProjectIdentity | null {
+  const displayName = remoteDisplayName(canonical);
+  if (!displayName) return null;
+  const digest = crypto.createHash("sha256").update(canonical).digest("hex").slice(0, 32);
+  return {
+    project: `repo-${digest}`,
+    displayName,
+    canonicalRemote: canonical,
+  };
+}
+
+/** Derive the same canonical repository project identity from repository
+    metadata when a packaged release has no `.git` directory of its own. */
+export function projectIdentityFromRemote(remote: string, root: string): RepositoryProjectIdentity | null {
+  const value = remote.trim();
+  if (!value) return null;
+  const canonical = canonicalRemote(value, root);
+  return canonical ? repositoryProjectIdentity(canonical) : null;
+}
+
 export function projectIdentityFromRepositoryRoot(root: string): RepositoryProjectIdentity | null {
   const directory = gitDirectory(root);
   if (!directory) return null;
@@ -178,12 +198,5 @@ export function projectIdentityFromRepositoryRoot(root: string): RepositoryProje
     }
   })();
   const canonical = remote ? canonicalRemote(remote, root) : `local:${localRoot}`;
-  const displayName = canonical ? remoteDisplayName(canonical) : null;
-  if (!canonical || !displayName) return null;
-  const digest = crypto.createHash("sha256").update(canonical).digest("hex").slice(0, 32);
-  return {
-    project: `repo-${digest}`,
-    displayName,
-    canonicalRemote: canonical,
-  };
+  return canonical ? repositoryProjectIdentity(canonical) : null;
 }


### PR DESCRIPTION
Closes #1321

## Impact
A designated orchestrator for another project could select the Viewer deployment tool and reach the production deployment endpoint.

## Cause
The authority checks bound the seat to the caller project without binding it to the repository deployed by the Viewer. The published tool description also omitted the deployment target.

## Fix
- derive the Viewer project from the shared canonical repository identity
- refuse every foreign-project seat with deploy_foreign_project before the deployments POST
- identify the Agent Log Viewer as the sole deployment target in the tool schema
- preserve the earlier designated-caller and cross-project refusals

## Scope
The deployments route and runtime host are unchanged. No deployment, restart, promotion, or rollback was performed.

## Verification
- 80 focused tests across the four touched test files
- TypeScript no-emit check
- MCP bundle build
- privacy publication gate with commit inspection