### PR TITLE
fix(runtime): spawn verification survives codex paginated threads

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -119,6 +119,9 @@ class FakeAppServer extends EventEmitter {
   autoCompleteUserMessage = true;
   readTurns: unknown[] | null = null;
   readError: string | null = null;
+  /* Rejects only hydrated reads (includeTurns), the way codex 0.151+ paginated
+     threads do; metadata-only reads and thread/turns/list keep answering. */
+  hydratedReadError: string | null = null;
   mcpServers: Record<string, unknown> = {
     playwright: { command: "npx", enabled: true },
     "telegram-readonly": { command: "uv", enabled: true },
@@ -228,12 +231,22 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "thread/read") {
       if (this.readError) return this.respondError(message.id, this.readError);
+      const hydrated = Boolean((message.params as { includeTurns?: boolean } | undefined)?.includeTurns);
+      if (hydrated && this.hydratedReadError) return this.respondError(message.id, this.hydratedReadError);
       return this.respond(message.id, {
         thread: {
           id: this.threadId,
           ...(!this.omitThreadReadPath ? { path: this.threadPath ?? `/sessions/${this.threadId}.jsonl` } : {}),
-          turns: this.readTurns ?? this.turns,
+          ...(hydrated ? { turns: this.readTurns ?? this.turns } : {}),
         },
+      });
+    }
+    if (method === "thread/turns/list") {
+      if (this.readError) return this.respondError(message.id, this.readError);
+      return this.respond(message.id, {
+        data: this.readTurns ?? this.turns,
+        nextCursor: null,
+        backwardsCursor: null,
       });
     }
     if (method === "turn/start") {
@@ -1914,6 +1927,55 @@ describe("CodexAppServerHost", () => {
     }];
     await expect(host.sessionMaterializationEvidence("operation-materialized")).resolves.toEqual({
       state: "materialized",
+    });
+    await host.release();
+  });
+
+  test("a paginated thread that refuses hydration still proves materialization through turns/list (#1332)", async () => {
+    const server = new FakeAppServer("paginated-evidence-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-paginated", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "turn-1",
+    });
+    server.hydratedReadError = "list_turns is not supported yet";
+    server.readTurns = [{
+      id: "turn-1",
+      status: "inProgress",
+      items: [{ type: "userMessage", clientId: "operation-paginated", content: [{ type: "text", text: "hello" }] }],
+    }];
+    await expect(host.sessionMaterializationEvidence("operation-paginated")).resolves.toEqual({
+      state: "materialized",
+    });
+    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
+    expect(turnsList?.params).toMatchObject({ itemsView: "full", sortDirection: "asc" });
+    const fallbackRead = server.requests.findLast((request) => request.method === "thread/read");
+    expect((fallbackRead?.params as { includeTurns?: boolean }).includeTurns).toBeUndefined();
+    await host.release();
+  });
+
+  test("the pagination fallback still reports an absent first message (#1332)", async () => {
+    const server = new FakeAppServer("paginated-absent-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-paginated-absent", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "turn-1",
+    });
+    server.hydratedReadError = "list_turns is not supported yet";
+    server.readTurns = [{ id: "turn-1", status: "inProgress", items: [] }];
+    await expect(host.sessionMaterializationEvidence("operation-paginated-absent")).resolves.toEqual({
+      state: "absent",
+      reason: "Codex app-server did not read back the confirmed first message",
     });
     await host.release();
   });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -460,6 +460,18 @@ function resumedTurns(value: unknown): JsonObject[] {
   return Array.isArray(page?.data) ? page.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
 }
 
+/** Codex 0.151+ deprecates `ThreadReadParams.includeTurns`: a paginated thread
+    refuses full-history hydration with "list_turns is not supported yet" and
+    expects `thread/turns/list` paging instead (#1332). */
+function hydrationUnsupported(reason: string): boolean {
+  return reason.startsWith("Codex app-server request failed:") && /not supported/i.test(reason);
+}
+
+function pagedTurns(value: unknown): JsonObject[] {
+  const outer = record(value);
+  return Array.isArray(outer?.data) ? outer.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
+}
+
 function resumedActiveTurnId(value: unknown): string | null {
   const activeTurn = resumedTurns(value).findLast((turn) => stringField(turn, "status") === "inProgress");
   return activeTurn ? stringField(activeTurn, "id") : null;
@@ -1031,13 +1043,36 @@ export class CodexAppServerHost implements EngineHost {
     return this.awaitDeliveryConfirmation(entry, { outcome: "turn-started", turnId });
   }
 
-  async sessionMaterializationEvidence(clientMessageId: string): Promise<SessionMaterializationEvidence> {
-    let result: unknown;
+  /** Persisted-thread snapshot for materialization evidence: full-history
+      hydration first; a paginated thread that refuses it yields the same
+      evidence through a metadata-only read plus one ascending full-items
+      turns page (#1332). Every other error propagates unchanged so the
+      caller's evidence classification stays intact. */
+  private async readPersistedThreadSnapshot(): Promise<{ result: unknown; turns: JsonObject[] }> {
     try {
-      result = await this.rpc("thread/read", {
+      const result = await this.rpc("thread/read", {
         threadId: this.identity.threadId,
         includeTurns: true,
       });
+      return { result, turns: resumedTurns(result) };
+    } catch (error) {
+      if (!hydrationUnsupported(safeError(error))) throw error;
+      const result = await this.rpc("thread/read", { threadId: this.identity.threadId });
+      const page = await this.rpc("thread/turns/list", {
+        threadId: this.identity.threadId,
+        itemsView: "full",
+        sortDirection: "asc",
+        limit: 16,
+      });
+      return { result, turns: pagedTurns(page) };
+    }
+  }
+
+  async sessionMaterializationEvidence(clientMessageId: string): Promise<SessionMaterializationEvidence> {
+    let result: unknown;
+    let persistedTurns: JsonObject[];
+    try {
+      ({ result, turns: persistedTurns } = await this.readPersistedThreadSnapshot());
     } catch (error) {
       const reason = safeError(error);
       if (/not materialized yet/i.test(reason) && /before first user message/i.test(reason)) {
@@ -1089,7 +1124,7 @@ export class CodexAppServerHost implements EngineHost {
     if (!persistedIdentity.path || persistedIdentity.path !== this.identity.path) {
       return { state: "failed", reason: "Codex app-server did not confirm the canonical transcript path" };
     }
-    const persistedFirstMessage = resumedTurns(result).some((turn) =>
+    const persistedFirstMessage = persistedTurns.some((turn) =>
       Array.isArray(turn.items)
       && turn.items.some((item) => stringField(item, "clientId") === clientMessageId));
     return persistedFirstMessage
@@ -1422,9 +1457,10 @@ export class CodexAppServerHost implements EngineHost {
 
   private async ensureCanonicalTranscriptPath(): Promise<void> {
     if (this.identity.path) return;
+    /* Metadata-only on purpose: this reader consumes nothing but the thread
+       identity and path, and hydration is refused on paginated threads (#1332). */
     const result = await this.rpc("thread/read", {
       threadId: this.identity.threadId,
-      includeTurns: true,
     });
     const recovered = threadFromResult(result, "thread/read");
     if (recovered.threadId !== this.identity.threadId) {


### PR DESCRIPTION
Closes #1332.

Codex 0.151+ deprecates `ThreadReadParams.includeTurns` (its schema: full-history hydration is deprecated for paginated threads; page with `thread/turns/list` / `thread/items/list`). A paginated thread answers the hydration request with "list_turns is not supported yet"; `sessionMaterializationEvidence` treated that as a throw, so first-message delivery settled as unverified and every new structured codex spawn on an affected account parked while its worker kept running.

One fallback seam in the app-server host: on the refusal, a metadata-only `thread/read` supplies identity and canonical path, and one ascending full-items `thread/turns/list` page supplies the persisted first-message evidence — the same turn/items shape the hydrated path consumed, so the matching logic is shared. `ensureCanonicalTranscriptPath` drops hydration outright (it never consumed turns). Behaviour on hydration-capable app-servers stays byte-identical; absent/failed/timeout classifications are unchanged, including the #1123 terminal-contradiction detection.

Regression tests: the injected refusal resolves `materialized` through the pagination API (asserting `itemsView: full`, ascending order, and a metadata-only fallback read) and still reports `absent` when the page lacks the confirmed `clientId`; the pre-existing hydration-path tests stay green (121/121 host, 82/82 spawn integration; tsc and the privacy gate pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)