### PR TITLE
fix(runtime): delivery confirmation and thread reads survive codex paginated threads

### DIFF
--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -345,7 +345,9 @@ export class CodexAppServerClient {
   }
 
   async readThread(threadId: string): Promise<AppServerThreadRef> {
-    const response = await this.request("thread/read", { threadId, includeTurns: true });
+    /* Metadata-only on purpose: this reader consumes id and path, and turns
+       hydration is refused on codex 0.151+ paginated threads (#1332). */
+    const response = await this.request("thread/read", { threadId });
     const thread = isRecord(response) && isRecord(response.thread) ? response.thread : response;
     if (!isRecord(thread)) throw protocolError("thread/read response is malformed");
     return { id: requiredString(thread, "id", "thread/read"), path: typeof thread.path === "string" ? thread.path : null };

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -243,8 +243,10 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "thread/turns/list") {
       if (this.readError) return this.respondError(message.id, this.readError);
+      const turns = [...(this.readTurns ?? this.turns)];
+      if ((message.params as { sortDirection?: string } | undefined)?.sortDirection === "desc") turns.reverse();
       return this.respond(message.id, {
-        data: this.readTurns ?? this.turns,
+        data: turns,
         nextCursor: null,
         backwardsCursor: null,
       });
@@ -1615,6 +1617,32 @@ describe("CodexAppServerHost", () => {
       turnId: "persisted-turn",
     });
     expect(server.requests.some((request) => request.method === "turn/start" || request.method === "turn/steer")).toBeFalse();
+    expect((await host.health()).status).not.toBe("dead");
+    await host.release();
+  });
+
+  test("delivery confirmation survives a paginated thread that refuses hydration (#1332)", async () => {
+    const threadId = "paginated-confirmation-thread";
+    const server = new FakeAppServer(threadId, threadId);
+    server.hydratedReadError = "list_turns is not supported yet";
+    server.readTurns = [{
+      id: "persisted-turn",
+      status: "completed",
+      items: [{ type: "userMessage", clientId: "operation-paginated-confirm", content: [{ type: "text", text: "hello" }] }],
+    }];
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-paginated-confirm", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "persisted-turn",
+    });
+    expect(server.requests.some((request) => request.method === "turn/start" || request.method === "turn/steer")).toBeFalse();
+    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
+    expect(turnsList?.params).toMatchObject({ sortDirection: "desc", itemsView: "full" });
     expect((await host.health()).status).not.toBe("dead");
     await host.release();
   });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1048,31 +1048,37 @@ export class CodexAppServerHost implements EngineHost {
       evidence through a metadata-only read plus one ascending full-items
       turns page (#1332). Every other error propagates unchanged so the
       caller's evidence classification stays intact. */
-  private async readPersistedThreadSnapshot(): Promise<{ result: unknown; turns: JsonObject[] }> {
+  /** Hydrated thread read with the #1332 pagination fallback, returning the
+      hydrated response shape either way so every consumer of `thread.turns`
+      keeps working. `window` picks which end of a paginated thread the single
+      full-items page covers — "first" for materialization evidence, "latest"
+      for delivery confirmation; turns are always returned oldest-first. */
+  private async readThreadWithTurns(window: "first" | "latest", timeoutMs?: number): Promise<unknown> {
     try {
-      const result = await this.rpc("thread/read", {
+      return await this.rpc("thread/read", {
         threadId: this.identity.threadId,
         includeTurns: true,
-      });
-      return { result, turns: resumedTurns(result) };
+      }, timeoutMs);
     } catch (error) {
       if (!hydrationUnsupported(safeError(error))) throw error;
-      const result = await this.rpc("thread/read", { threadId: this.identity.threadId });
+      const result = await this.rpc("thread/read", { threadId: this.identity.threadId }, timeoutMs);
       const page = await this.rpc("thread/turns/list", {
         threadId: this.identity.threadId,
         itemsView: "full",
-        sortDirection: "asc",
+        sortDirection: window === "first" ? "asc" : "desc",
         limit: 16,
-      });
-      return { result, turns: pagedTurns(page) };
+      }, timeoutMs);
+      const turns = pagedTurns(page);
+      if (window === "latest") turns.reverse();
+      const thread = record(record(result)?.thread) ?? {};
+      return { thread: { ...thread, turns } };
     }
   }
 
   async sessionMaterializationEvidence(clientMessageId: string): Promise<SessionMaterializationEvidence> {
     let result: unknown;
-    let persistedTurns: JsonObject[];
     try {
-      ({ result, turns: persistedTurns } = await this.readPersistedThreadSnapshot());
+      result = await this.readThreadWithTurns("first");
     } catch (error) {
       const reason = safeError(error);
       if (/not materialized yet/i.test(reason) && /before first user message/i.test(reason)) {
@@ -1124,7 +1130,7 @@ export class CodexAppServerHost implements EngineHost {
     if (!persistedIdentity.path || persistedIdentity.path !== this.identity.path) {
       return { state: "failed", reason: "Codex app-server did not confirm the canonical transcript path" };
     }
-    const persistedFirstMessage = persistedTurns.some((turn) =>
+    const persistedFirstMessage = resumedTurns(result).some((turn) =>
       Array.isArray(turn.items)
       && turn.items.some((item) => stringField(item, "clientId") === clientMessageId));
     return persistedFirstMessage
@@ -2250,7 +2256,7 @@ export class CodexAppServerHost implements EngineHost {
       const timeoutMs = this.activeTurnId
         ? this.requestTimeoutMs * ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER
         : this.requestTimeoutMs;
-      thread = await this.rpc("thread/read", { threadId: this.identity.threadId, includeTurns: true }, timeoutMs);
+      thread = await this.readThreadWithTurns("latest", timeoutMs);
     } catch (error) {
       const message = safeError(error);
       if (/not materialized yet/i.test(message) && /before first user message/i.test(message)) return null;


### PR DESCRIPTION
Round 2 of #1332 (follow-up to #1333, which covered only the materialization-evidence read).

Production evidence after deploying #1333: lanes still parked with "delivery … unverified: Codex app-server request failed: list_turns is not supported yet". The throwing site is the delivery-confirmation replay — `confirmedDelivery` hydrates `thread/read {includeTurns:true}` before materialization evidence is ever consulted — plus the accounts-side `readThread`, which requested hydration while consuming only `id`/`path`.

One shared host helper (`readThreadWithTurns`) now serves both windows: the ascending first full-items `thread/turns/list` page for materialization evidence, the latest page (descending fetch, returned oldest-first) for delivery confirmation — synthesized into the hydrated response shape, so every existing `thread.turns` consumer (`resumedTurns`, `threadFromResult`, `rememberConfirmedDeliveries`) works unchanged. Hydration-capable app-servers keep byte-identical behaviour. The accounts `readThread` goes metadata-only.

Regression test: a queued send on a paginated thread that refuses hydration settles through `thread/turns/list` (asserting `sortDirection: desc`, `itemsView: full`) without starting a duplicate turn; the fake app-server now honours `sortDirection`. Host suite 122/122; spawn integration 82/82; tsc and privacy gate pass.

Note: `src/lib/accounts/codexAppServer.test.ts` has one pre-existing red at the merge base ("successor thread methods use the structured fork…", a `thread/resume` params expectation) — verified red at `origin/main` in a detached worktree; untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)