### PR TITLE
fix(runtime): thread adoption survives codex paginated threads refusing full-history resume

### DIFF
--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -329,7 +329,7 @@ export class CodexAppServerClient {
       ...headlessCodexThreadConfig(effectiveConfig),
       ...(options.effort ? { model_reasoning_effort: options.effort } : {}),
     };
-    const response = await this.request("thread/resume", {
+    const resumeParams = {
       threadId,
       ...(options.path ? { path: options.path } : {}),
       ...(options.cwd ? { cwd: options.cwd } : {}),
@@ -338,7 +338,16 @@ export class CodexAppServerClient {
       ...(options.approvalPolicy ? { approvalPolicy: options.approvalPolicy } : {}),
       ...(options.sandbox ? { sandbox: options.sandbox } : {}),
       config,
-    });
+    };
+    let response: unknown;
+    try {
+      response = await this.request("thread/resume", resumeParams);
+    } catch (error) {
+      /* Paginated threads refuse full-history resume (#1332); this consumer
+         only reads id and path, so metadata plus live state is enough. */
+      if (!(error instanceof Error && /not supported/i.test(error.message))) throw error;
+      response = await this.request("thread/resume", { ...resumeParams, excludeTurns: true });
+    }
     const thread = isRecord(response) && isRecord(response.thread) ? response.thread : response;
     if (!isRecord(thread)) throw protocolError("thread/resume response is malformed");
     return { id: requiredString(thread, "id", "thread/resume"), path: typeof thread.path === "string" ? thread.path : null };

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -122,6 +122,9 @@ class FakeAppServer extends EventEmitter {
   /* Rejects only hydrated reads (includeTurns), the way codex 0.151+ paginated
      threads do; metadata-only reads and thread/turns/list keep answering. */
   hydratedReadError: string | null = null;
+  /* Rejects full-history thread/resume the way paginated threads do; a resume
+     with excludeTurns succeeds and omits thread.turns. */
+  paginatedResume = false;
   mcpServers: Record<string, unknown> = {
     playwright: { command: "npx", enabled: true },
     "telegram-readonly": { command: "uv", enabled: true },
@@ -214,6 +217,10 @@ class FakeAppServer extends EventEmitter {
     });
     if (method === "thread/start" || method === "thread/resume") {
       const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
+      const excludeTurns = Boolean((message.params as { excludeTurns?: boolean } | undefined)?.excludeTurns);
+      if (method === "thread/resume" && this.paginatedResume && !excludeTurns) {
+        return this.respondError(message.id, "list_turns is not supported yet");
+      }
       if (method === "thread/resume" && this.resumeRequest) {
         for (const request of Array.isArray(this.resumeRequest) ? this.resumeRequest : [this.resumeRequest]) {
           if (request.id) this.request(request.id, request.method, request.params);
@@ -224,7 +231,7 @@ class FakeAppServer extends EventEmitter {
         thread: {
           id,
           ...(!this.omitThreadPath ? { path: this.threadPath ?? `/sessions/${id}.jsonl` } : {}),
-          turns: this.turns,
+          ...(excludeTurns ? {} : { turns: this.turns }),
           ...(this.resumeStatus ? { status: this.resumeStatus } : {}),
         },
       });
@@ -2056,6 +2063,45 @@ describe("CodexAppServerHost", () => {
       seq: 3,
     });
     expect((await replay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: 4 });
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    await host.release();
+  });
+
+  test("adopts a paginated thread that refuses full-history resume (#1332)", async () => {
+    const eventStore = new MemoryEventStore();
+    eventStore.append("paginated-resume-thread", { kind: "turn-started", turnId: "crashed-turn", seq: 1 });
+    const persistedItem = { type: "agentMessage", id: "response-item", text: "persisted response" };
+    const server = new FakeAppServer("paginated-resume-thread", "paginated-resume-thread", false, [{
+      id: "crashed-turn",
+      status: "completed",
+      items: [persistedItem],
+    }], { type: "idle" });
+    server.paginatedResume = true;
+    const host = await CodexAppServerHost.adopt("paginated-resume-thread", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 1,
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(1)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({
+      kind: "item",
+      turnId: "crashed-turn",
+      item: persistedItem,
+      phase: "completed",
+      seq: 2,
+    });
+    expect((await replay.next()).value).toEqual({
+      kind: "turn-ended",
+      turnId: "crashed-turn",
+      status: "completed",
+      seq: 3,
+    });
+    const resumes = server.requests.filter((request) => request.method === "thread/resume");
+    expect(resumes.length).toBe(2);
+    expect((resumes[1]!.params as { excludeTurns?: boolean }).excludeTurns).toBeTrue();
+    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
+    expect(turnsList?.params).toMatchObject({ sortDirection: "desc", itemsView: "full" });
     expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
     await host.release();
   });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -837,7 +837,7 @@ export class CodexAppServerHost implements EngineHost {
         granted,
       );
       const result = threadId
-        ? await provisional.rpc("thread/resume", {
+        ? await provisional.resumeThreadTolerantly({
           threadId,
           ...(options.permissionProfile ? { permissions: options.permissionProfile } : {}),
           config,
@@ -1048,6 +1048,30 @@ export class CodexAppServerHost implements EngineHost {
       evidence through a metadata-only read plus one ascending full-items
       turns page (#1332). Every other error propagates unchanged so the
       caller's evidence classification stays intact. */
+  /** thread/resume with the #1332 pagination fallback: a paginated thread
+      refuses full-history resume, so retry with excludeTurns (metadata plus
+      live-resume state) and synthesize the latest turns page into the
+      hydrated response shape every replay consumer expects, oldest-first. */
+  private async resumeThreadTolerantly(params: Record<string, unknown>): Promise<unknown> {
+    try {
+      return await this.rpc("thread/resume", params);
+    } catch (error) {
+      if (!hydrationUnsupported(safeError(error))) throw error;
+      const resumed = await this.rpc("thread/resume", { ...params, excludeTurns: true });
+      const page = await this.rpc("thread/turns/list", {
+        threadId: params.threadId,
+        itemsView: "full",
+        sortDirection: "desc",
+        limit: 16,
+      });
+      const turns = pagedTurns(page);
+      turns.reverse();
+      const outer = record(resumed) ?? {};
+      const thread = record(outer.thread) ?? {};
+      return { ...outer, thread: { ...thread, turns } };
+    }
+  }
+
   /** Hydrated thread read with the #1332 pagination fallback, returning the
       hydrated response shape either way so every consumer of `thread.turns`
       keeps working. `window` picks which end of a paginated thread the single


### PR DESCRIPTION
Round 3 of #1332 (after #1333 covered the evidence read and #1334 the confirmation read).

Production evidence after deploying #1334: spawns still parked with the same not-supported answer. The remaining site is thread ADOPTION: a spawn creates its thread through the accounts client, and the delivery host then adopts it with `thread/resume` — a full-history replay, which a paginated thread refuses. That refusal precedes both fixed reads, so first-message delivery kept settling unverified.

`resumeThreadTolerantly`: on the refusal, resume again with `excludeTurns: true` (metadata + live-resume state, per the 0.151 schema) and synthesize the latest full-items `thread/turns/list` page (descending fetch, returned oldest-first) into the hydrated response shape, so `threadFromResult`, `threadStatus`, `resumedActiveTurnId` and the history replay all keep working unchanged. The accounts-side `resumeThread` applies the same retry — it consumes only `id`/`path`. Hydration-capable app-servers keep byte-identical behaviour.

Regression test: adoption of a paginated thread replays persisted history from the synthesized page (asserting the second resume carries `excludeTurns` and the page was fetched `desc`/`full`), ending idle with no duplicate turn. Host suite 123/123; spawn integration green; tsc and privacy gate pass.

Note: `src/lib/accounts/codexAppServer.test.ts` keeps its one pre-existing environment-dependent red ("successor thread methods…" expects a fixed `mcp_servers` set, and this machine's codex config injects the viewer MCP server) — red at `origin/main` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)