### PR TITLE
fix(runtime): the pagination fallback reads persisted turns from the rollout on disk

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1630,13 +1630,24 @@ describe("CodexAppServerHost", () => {
 
   test("delivery confirmation survives a paginated thread that refuses hydration (#1332)", async () => {
     const threadId = "paginated-confirmation-thread";
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-paginated-confirm-"));
+    const rollout = path.join(directory, `${threadId}.jsonl`);
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: {
+        type: "item_completed",
+        turn_id: "persisted-turn",
+        item: { type: "UserMessage", id: "item-1", client_id: "operation-paginated-confirm", content: [{ type: "text", text: "hello" }] },
+      },
+    })}\n${JSON.stringify({
+      timestamp: "t2",
+      type: "event_msg",
+      payload: { type: "turn_completed", turn_id: "persisted-turn" },
+    })}\n`);
     const server = new FakeAppServer(threadId, threadId);
+    server.threadPath = rollout;
     server.hydratedReadError = "list_turns is not supported yet";
-    server.readTurns = [{
-      id: "persisted-turn",
-      status: "completed",
-      items: [{ type: "userMessage", clientId: "operation-paginated-confirm", content: [{ type: "text", text: "hello" }] }],
-    }];
     const host = await CodexAppServerHost.adopt(threadId, {
       cwd: "/repo",
       eventStore: new MemoryEventStore(),
@@ -1648,8 +1659,7 @@ describe("CodexAppServerHost", () => {
       turnId: "persisted-turn",
     });
     expect(server.requests.some((request) => request.method === "turn/start" || request.method === "turn/steer")).toBeFalse();
-    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
-    expect(turnsList?.params).toMatchObject({ sortDirection: "desc", itemsView: "full" });
+    expect(server.requests.some((request) => request.method === "thread/turns/list")).toBeFalse();
     expect((await host.health()).status).not.toBe("dead");
     await host.release();
   });
@@ -1966,8 +1976,11 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
-  test("a paginated thread that refuses hydration still proves materialization through turns/list (#1332)", async () => {
+  test("a paginated thread that refuses hydration still proves materialization from the rollout on disk (#1332)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-paginated-evidence-"));
+    const rollout = path.join(directory, "paginated-evidence-thread.jsonl");
     const server = new FakeAppServer("paginated-evidence-thread");
+    server.threadPath = rollout;
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       eventStore: new MemoryEventStore(),
@@ -1979,23 +1992,29 @@ describe("CodexAppServerHost", () => {
       turnId: "turn-1",
     });
     server.hydratedReadError = "list_turns is not supported yet";
-    server.readTurns = [{
-      id: "turn-1",
-      status: "inProgress",
-      items: [{ type: "userMessage", clientId: "operation-paginated", content: [{ type: "text", text: "hello" }] }],
-    }];
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: {
+        type: "item_completed",
+        turn_id: "turn-1",
+        item: { type: "UserMessage", id: "item-1", client_id: "operation-paginated", content: [{ type: "text", text: "hello" }] },
+      },
+    })}\n`);
     await expect(host.sessionMaterializationEvidence("operation-paginated")).resolves.toEqual({
       state: "materialized",
     });
-    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
-    expect(turnsList?.params).toMatchObject({ itemsView: "full", sortDirection: "asc" });
+    expect(server.requests.some((request) => request.method === "thread/turns/list")).toBeFalse();
     const fallbackRead = server.requests.findLast((request) => request.method === "thread/read");
     expect((fallbackRead?.params as { includeTurns?: boolean }).includeTurns).toBeUndefined();
     await host.release();
   });
 
-  test("the pagination fallback still reports an absent first message (#1332)", async () => {
+  test("the disk fallback still reports an absent first message (#1332)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-paginated-absent-"));
+    const rollout = path.join(directory, "paginated-absent-thread.jsonl");
     const server = new FakeAppServer("paginated-absent-thread");
+    server.threadPath = rollout;
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       eventStore: new MemoryEventStore(),
@@ -2007,7 +2026,11 @@ describe("CodexAppServerHost", () => {
       turnId: "turn-1",
     });
     server.hydratedReadError = "list_turns is not supported yet";
-    server.readTurns = [{ id: "turn-1", status: "inProgress", items: [] }];
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: { type: "item_completed", turn_id: "turn-1", item: { type: "AgentMessage", id: "item-2", text: "working" } },
+    })}\n`);
     await expect(host.sessionMaterializationEvidence("operation-paginated-absent")).resolves.toEqual({
       state: "absent",
       reason: "Codex app-server did not read back the confirmed first message",
@@ -2071,11 +2094,19 @@ describe("CodexAppServerHost", () => {
     const eventStore = new MemoryEventStore();
     eventStore.append("paginated-resume-thread", { kind: "turn-started", turnId: "crashed-turn", seq: 1 });
     const persistedItem = { type: "agentMessage", id: "response-item", text: "persisted response" };
-    const server = new FakeAppServer("paginated-resume-thread", "paginated-resume-thread", false, [{
-      id: "crashed-turn",
-      status: "completed",
-      items: [persistedItem],
-    }], { type: "idle" });
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-paginated-resume-"));
+    const rollout = path.join(directory, "paginated-resume-thread.jsonl");
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: { type: "item_completed", turn_id: "crashed-turn", item: persistedItem },
+    })}\n${JSON.stringify({
+      timestamp: "t2",
+      type: "event_msg",
+      payload: { type: "turn_completed", turn_id: "crashed-turn" },
+    })}\n`);
+    const server = new FakeAppServer("paginated-resume-thread", "paginated-resume-thread", false, [], { type: "idle" });
+    server.threadPath = rollout;
     server.paginatedResume = true;
     const host = await CodexAppServerHost.adopt("paginated-resume-thread", {
       cwd: "/repo",
@@ -2100,8 +2131,7 @@ describe("CodexAppServerHost", () => {
     const resumes = server.requests.filter((request) => request.method === "thread/resume");
     expect(resumes.length).toBe(2);
     expect((resumes[1]!.params as { excludeTurns?: boolean }).excludeTurns).toBeTrue();
-    const turnsList = server.requests.findLast((request) => request.method === "thread/turns/list");
-    expect(turnsList?.params).toMatchObject({ sortDirection: "desc", itemsView: "full" });
+    expect(server.requests.some((request) => request.method === "thread/turns/list")).toBeFalse();
     expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
     await host.release();
   });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 import { createHash, type Hash } from "node:crypto";
+import fs from "node:fs";
 
 import { isKnownEffortTier } from "@/lib/agent/efforts";
 import type { ProcessIdentity } from "@/lib/agent/registry";
@@ -467,9 +468,86 @@ function hydrationUnsupported(reason: string): boolean {
   return reason.startsWith("Codex app-server request failed:") && /not supported/i.test(reason);
 }
 
-function pagedTurns(value: unknown): JsonObject[] {
-  const outer = record(value);
-  return Array.isArray(outer?.data) ? outer.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
+/* The rollout is bounded before parsing so a very long thread cannot pull its
+   whole history into memory; the fallback consumers only need the window near
+   one end, and a partial leading line after the cut is skipped by JSON.parse. */
+const ROLLOUT_FALLBACK_READ_BYTES = 16 * 1024 * 1024;
+
+const ROLLOUT_TERMINAL_TURN_STATUS: Record<string, string> = {
+  turn_completed: "completed",
+  turn_complete: "completed",
+  turn_aborted: "interrupted",
+  turn_failed: "failed",
+};
+
+/** Turns reconstructed from the canonical rollout JSONL on disk. Codex 0.151
+    refuses full-history hydration on some threads and stubs the pagination
+    API it recommends instead ("list_turns is not supported yet"), so the
+    session store file is the one version-independent source of persisted
+    turns (#1332). Items are normalized to the wire shape the replay and
+    confirmation consumers expect (`clientId`, `userMessage`). */
+export function rolloutTurnsFromDisk(pathname: string | null | undefined): JsonObject[] {
+  if (!pathname) return [];
+  let raw: string;
+  try {
+    const stat = fs.statSync(pathname);
+    if (!stat.isFile()) return [];
+    if (stat.size > ROLLOUT_FALLBACK_READ_BYTES) {
+      const descriptor = fs.openSync(pathname, "r");
+      try {
+        const buffer = Buffer.alloc(ROLLOUT_FALLBACK_READ_BYTES);
+        const read = fs.readSync(descriptor, buffer, 0, buffer.length, stat.size - buffer.length);
+        raw = buffer.subarray(0, read).toString("utf8");
+      } finally {
+        fs.closeSync(descriptor);
+      }
+    } else {
+      raw = fs.readFileSync(pathname, "utf8");
+    }
+  } catch {
+    return [];
+  }
+  const order: string[] = [];
+  const turns = new Map<string, { id: string; status?: string; items: JsonObject[] }>();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const payload = record(record(parsed)?.payload);
+    if (!payload) continue;
+    const payloadType = stringField(payload, "type");
+    const turnId = stringField(payload, "turn_id") ?? stringField(payload, "turnId");
+    if (!payloadType || !turnId) continue;
+    let turn = turns.get(turnId);
+    if (!turn) {
+      turn = { id: turnId, items: [] };
+      turns.set(turnId, turn);
+      order.push(turnId);
+    }
+    const terminal = ROLLOUT_TERMINAL_TURN_STATUS[payloadType];
+    if (terminal) {
+      turn.status = terminal;
+      continue;
+    }
+    if (payloadType !== "item_completed") continue;
+    const item = record(payload.item);
+    if (!item) continue;
+    const itemType = stringField(item, "type");
+    const clientId = stringField(item, "client_id") ?? stringField(item, "clientId");
+    turn.items.push({
+      ...item,
+      ...(itemType ? { type: itemType === "UserMessage" ? "userMessage" : itemType } : {}),
+      ...(clientId ? { clientId } : {}),
+    });
+  }
+  return order.map((id) => {
+    const turn = turns.get(id)!;
+    return { id: turn.id, status: turn.status ?? "inProgress", items: turn.items } as JsonObject;
+  });
 }
 
 function resumedActiveTurnId(value: unknown): string | null {
@@ -1048,35 +1126,30 @@ export class CodexAppServerHost implements EngineHost {
       evidence through a metadata-only read plus one ascending full-items
       turns page (#1332). Every other error propagates unchanged so the
       caller's evidence classification stays intact. */
-  /** thread/resume with the #1332 pagination fallback: a paginated thread
-      refuses full-history resume, so retry with excludeTurns (metadata plus
-      live-resume state) and synthesize the latest turns page into the
-      hydrated response shape every replay consumer expects, oldest-first. */
+  /** thread/resume with the #1332 fallback: a paginated thread refuses
+      full-history resume, so retry with excludeTurns (metadata plus
+      live-resume state) and synthesize the persisted turns from the rollout
+      on disk — codex 0.151 stubs the pagination API its own deprecation
+      notice recommends, so the session store file is the only
+      version-independent source. */
   private async resumeThreadTolerantly(params: Record<string, unknown>): Promise<unknown> {
     try {
       return await this.rpc("thread/resume", params);
     } catch (error) {
       if (!hydrationUnsupported(safeError(error))) throw error;
       const resumed = await this.rpc("thread/resume", { ...params, excludeTurns: true });
-      const page = await this.rpc("thread/turns/list", {
-        threadId: params.threadId,
-        itemsView: "full",
-        sortDirection: "desc",
-        limit: 16,
-      });
-      const turns = pagedTurns(page);
-      turns.reverse();
       const outer = record(resumed) ?? {};
       const thread = record(outer.thread) ?? {};
+      const turns = rolloutTurnsFromDisk(stringField(thread, "path") ?? this.identity.path);
       return { ...outer, thread: { ...thread, turns } };
     }
   }
 
-  /** Hydrated thread read with the #1332 pagination fallback, returning the
-      hydrated response shape either way so every consumer of `thread.turns`
-      keeps working. `window` picks which end of a paginated thread the single
-      full-items page covers — "first" for materialization evidence, "latest"
-      for delivery confirmation; turns are always returned oldest-first. */
+  /** Hydrated thread read with the #1332 fallback, returning the hydrated
+      response shape either way so every consumer of `thread.turns` keeps
+      working. On refusal the persisted turns come from the rollout on disk;
+      `window` bounds which end survives — "first" for materialization
+      evidence, "latest" for delivery confirmation; always oldest-first. */
   private async readThreadWithTurns(window: "first" | "latest", timeoutMs?: number): Promise<unknown> {
     try {
       return await this.rpc("thread/read", {
@@ -1086,15 +1159,9 @@ export class CodexAppServerHost implements EngineHost {
     } catch (error) {
       if (!hydrationUnsupported(safeError(error))) throw error;
       const result = await this.rpc("thread/read", { threadId: this.identity.threadId }, timeoutMs);
-      const page = await this.rpc("thread/turns/list", {
-        threadId: this.identity.threadId,
-        itemsView: "full",
-        sortDirection: window === "first" ? "asc" : "desc",
-        limit: 16,
-      }, timeoutMs);
-      const turns = pagedTurns(page);
-      if (window === "latest") turns.reverse();
       const thread = record(record(result)?.thread) ?? {};
+      const persisted = rolloutTurnsFromDisk(stringField(thread, "path") ?? this.identity.path);
+      const turns = window === "first" ? persisted.slice(0, 64) : persisted.slice(-64);
       return { thread: { ...thread, turns } };
     }
   }


### PR DESCRIPTION
Round 4 of #1332 — root cause finally proven against the live app-server.

The empirical sequence (reproduced protocol-level on a fresh thread with production's exact initialize): `thread/start` OK → `turn/start` OK → **`thread/turns/list` answers `-32601 list_turns is not supported yet`**. Codex 0.151 stubs the very pagination API its own deprecation notice recommends, so rounds 1–3 replaced a broken call with another broken call, and every spawn kept parking as delivery-unverified.

The one version-independent source of persisted turns is the canonical rollout JSONL itself — the session store file. The fallback now takes a metadata-only `thread/read` (or an `excludeTurns` resume, which the schema does honour) for identity, path and live-resume state, and reconstructs turns from the rollout: `item_completed` records grouped by `turn_id`, items normalized to the wire shape (`client_id`→`clientId`, `UserMessage`→`userMessage`), terminal statuses from `turn_completed`/`turn_aborted`/`turn_failed`, bounded to the last 16 MiB of file. The replay, delivery-confirmation, and materialization-evidence consumers are unchanged. `rolloutTurnsFromDisk` was verified against a real production rollout (one turn, normalized `userMessage` item with its `clientId`, `interrupted` status from the abort record).

The four #1332 regression tests now run the fallback against real temp rollout files and assert `thread/turns/list` is never called. Host suite 123/123, spawn integration 82/82, tsc and privacy gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)