### PR TITLE
fix(runtime): the rollout on disk outranks the engine's not-materialized answer

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1892,6 +1892,41 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("a rollout on disk outranks the engine's not-materialized answer (#1332)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-disk-outranks-"));
+    const rollout = path.join(directory, "disk-outranks-thread.jsonl");
+    const server = new FakeAppServer("disk-outranks-thread");
+    server.threadPath = rollout;
+    server.readError = "thread disk-outranks-thread is not materialized yet; includeTurns is unavailable before first user message";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-disk-outranks", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "turn-1",
+    });
+    await expect(host.sessionMaterializationEvidence("operation-disk-outranks")).resolves.toEqual({
+      state: "absent",
+      reason: "Codex app-server has not materialized the confirmed first message yet",
+    });
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: {
+        type: "item_completed",
+        turn_id: "turn-1",
+        item: { type: "UserMessage", id: "item-1", client_id: "operation-disk-outranks", content: [{ type: "text", text: "hello" }] },
+      },
+    })}\n`);
+    await expect(host.sessionMaterializationEvidence("operation-disk-outranks")).resolves.toEqual({
+      state: "materialized",
+    });
+    await host.release();
+  });
+
   test("fails materialization only after the confirmed first turn ends without a session", async () => {
     const server = new FakeAppServer("failed-materialization-thread");
     server.readError = "thread failed-materialization-thread is not materialized yet; includeTurns is unavailable before first user message";

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1173,6 +1173,13 @@ export class CodexAppServerHost implements EngineHost {
     } catch (error) {
       const reason = safeError(error);
       if (/not materialized yet/i.test(reason) && /before first user message/i.test(reason)) {
+        /* Codex 0.151 keeps giving this answer for threads whose rollout is
+           already on disk with the confirmed first message in it. The rollout
+           IS the session store, so it outranks the engine's claim (#1332). */
+        const persistedOnDisk = rolloutTurnsFromDisk(this.identity.path).some((turn) =>
+          Array.isArray(turn.items)
+          && turn.items.some((item) => stringField(item, "clientId") === clientMessageId));
+        if (persistedOnDisk) return { state: "materialized" };
         const confirmed = this.confirmedDeliveries.get(clientMessageId);
         const turnId = confirmed?.receipt.outcome !== "rejected"
           ? confirmed?.receipt.turnId ?? null


### PR DESCRIPTION
Round 5 of #1332, and the reason round 4 was still parking spawns: on codex 0.151, `thread/read {includeTurns:true}` keeps answering "not materialized yet; includeTurns is unavailable before first user message" for threads whose rollout is already on disk **with the confirmed first message persisted in it** — observed live with workers 1.8 MB into their rollouts while evidence stayed `absent`, until the five-minute durable-setup ceiling failed the spawn.

That error is classified before any fallback runs, so the disk reader from #1336 was never consulted. The not-materialized branch now checks the rollout first: if a persisted turn item carries the confirmed `clientMessageId`, evidence is `materialized` — the session store file outranks the engine's claim. When the rollout genuinely lacks the message, the branch behaves exactly as before, including the #1123 terminal-contradiction detection.

Regression test: with the engine pinned on the not-materialized answer, evidence reads `absent` while the rollout is empty and flips to `materialized` the moment the persisted first message appears on disk. Host suite 124/124, spawn integration 82/82, tsc and privacy gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)