### PR TITLE
fix(runtime): an empty hydrated read defers to the rollout on disk

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1892,6 +1892,40 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("a successful hydrated read with no turns defers to the rollout on disk (#1332)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-empty-hydration-"));
+    const rollout = path.join(directory, "empty-hydration-thread.jsonl");
+    const server = new FakeAppServer("empty-hydration-thread");
+    server.threadPath = rollout;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(await host.send({ id: "operation-empty-hydration", text: "hello" })).toEqual({
+      outcome: "turn-started",
+      turnId: "turn-1",
+    });
+    await expect(host.sessionMaterializationEvidence("operation-empty-hydration")).resolves.toEqual({
+      state: "absent",
+      reason: "Codex app-server did not read back the confirmed first message",
+    });
+    fs.writeFileSync(rollout, `${JSON.stringify({
+      timestamp: "t1",
+      type: "event_msg",
+      payload: {
+        type: "item_completed",
+        turn_id: "turn-1",
+        item: { type: "UserMessage", id: "item-1", client_id: "operation-empty-hydration", content: [{ type: "text", text: "hello" }] },
+      },
+    })}\n`);
+    await expect(host.sessionMaterializationEvidence("operation-empty-hydration")).resolves.toEqual({
+      state: "materialized",
+    });
+    await host.release();
+  });
+
   test("a rollout on disk outranks the engine's not-materialized answer (#1332)", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-disk-outranks-"));
     const rollout = path.join(directory, "disk-outranks-thread.jsonl");

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1228,9 +1228,14 @@ export class CodexAppServerHost implements EngineHost {
     if (!persistedIdentity.path || persistedIdentity.path !== this.identity.path) {
       return { state: "failed", reason: "Codex app-server did not confirm the canonical transcript path" };
     }
-    const persistedFirstMessage = resumedTurns(result).some((turn) =>
+    /* Codex 0.151 can answer the hydrated read successfully while omitting
+       `thread.turns` entirely, so an empty reply is not absence evidence —
+       the rollout on disk decides before absent is ever reported (#1332). */
+    const turnHoldsFirstMessage = (turn: JsonObject): boolean =>
       Array.isArray(turn.items)
-      && turn.items.some((item) => stringField(item, "clientId") === clientMessageId));
+      && turn.items.some((item) => stringField(item, "clientId") === clientMessageId);
+    const persistedFirstMessage = resumedTurns(result).some(turnHoldsFirstMessage)
+      || rolloutTurnsFromDisk(this.identity.path).some(turnHoldsFirstMessage);
     return persistedFirstMessage
       ? { state: "materialized" }
       : { state: "absent", reason: "Codex app-server did not read back the confirmed first message" };


### PR DESCRIPTION
Round 6 of #1332 — the branch every previous round walked past.

Live disproof of round 5: a retried lane's spawn got its correct agentPath, its worker wrote 700 KB+ of rollout with the confirmed first message's `client_id` in it, no protocol error appeared anywhere — and the spawn still died at the five-minute ceiling with "session materialization was pending". So the hydrated read neither failed with the not-materialized answer (round 5's branch) nor with the not-supported answer (rounds 1–4): on codex 0.151 it can succeed while omitting `thread.turns` entirely. The evidence success path computed `persistedFirstMessage` off that empty array and answered `absent` forever.

An empty reply is not absence evidence. The success path now defers to the rollout on disk before ever reporting `absent`; a hydrated reply that does carry turns keeps deciding by itself first, and genuinely missing messages still report `absent` unchanged.

Regression test: a successful hydrated read with no turns reports `absent` while the rollout is empty and flips to `materialized` when the persisted first message lands on disk. Host suite 125/125, spawn integration 82/82, tsc and privacy gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)