### PR TITLE
fix(spawn): materialization evidence hunts the wire id, not the held delivery's client id

### DIFF
--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -916,7 +916,7 @@ class RoundTripHost implements SpawnedStructuredHost {
     this.materializationFailure = options.materializationFailure ?? null;
   }
 
-  async sessionMaterializationEvidence(): Promise<
+  async sessionMaterializationEvidence(_clientMessageId: string): Promise<
     | { state: "materialized" }
     | { state: "absent"; reason: string }
     | { state: "unavailable"; reason: string }

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -1516,8 +1516,10 @@ test("a live Codex host whose transcript materializes after the former 30-second
   const host = new RoundTripHost("codex", artifactPath, id, { materializeTranscript: false });
   let now = 0;
   let evidenceChecks = 0;
-  host.sessionMaterializationEvidence = async () => {
+  const evidenceIds: string[] = [];
+  host.sessionMaterializationEvidence = async (clientMessageId: string) => {
     evidenceChecks += 1;
+    evidenceIds.push(clientMessageId);
     return evidenceChecks === 1
       ? { state: "absent", reason: "Codex app-server has not materialized the confirmed first message yet" }
       : { state: "materialized" };
@@ -1564,6 +1566,10 @@ test("a live Codex host whose transcript materializes after the former 30-second
 
     expect(now).toBeGreaterThan(INITIAL_MESSAGE_TIMEOUT_MS);
     expect(evidenceChecks).toBe(2);
+    /* Evidence hunts the id the engine wire carries — the operation id the
+       drain stamps on the spawn first message — never the held delivery's
+       clientMessageId (#1332). */
+    expect(evidenceIds[0]).toBe(`spawn_message_${begun.receipt.launchId}`);
     expect(response).toMatchObject({ state: "settled", path: artifactPath, initialMessage: "delivered" });
     expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "completed" });
     expect(host.releaseCount).toBe(0);

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -1741,10 +1741,15 @@ export async function spawnStructuredConversation(
         ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
       materializationPending = true;
       try {
+        /* The id the engine wire actually carries: the drain stamps the spawn
+           first message with the OPERATION id (`spawn_message_<launchId>`),
+           not the held delivery's `spawn_<launchId>` clientMessageId, and the
+           persisted rollout item echoes the wire id. Hunting the wrong id
+           left materialization pending forever (#1332). */
         await withinDurableSetup(waitForStructuredSessionMaterialization(
           host,
           identity.path,
-          `spawn_${input.receipt.launchId}`,
+          `spawn_message_${input.receipt.launchId}`,
           {
             now,
             sleep,


### PR DESCRIPTION
Round 7 of #1332 — and the mismatch that made rounds 1–6 look unfixable.

Definitive live evidence: a lane attempt with `launchId 632226ca-…` persisted its first message in the rollout as `client_id: spawn_message_632226ca-…`, while the materialization wait asked the host about `spawn_632226ca-…` — the held delivery's `clientMessageId`, an id that never reaches the engine wire. Evidence could not observe the message on ANY codex version; the 0.151 protocol refusals fixed in rounds 1–6 only hid this by failing earlier. With them fixed, spawns died at the five-minute ceiling with healthy workers megabytes into their rollouts.

One-line fix at the only evidence callsite: hunt `spawn_message_${launchId}` — the operation id the drain stamps on the wire (the same id `registry` and `structuredDeliveryController` already treat as the spawn operation id). This also aligns the `confirmedDeliveries` lookup inside the terminal-contradiction detection, which is keyed by the wire id from `item/completed` notifications.

The slow-transcript integration test now records the id evidence is queried with and pins the wire form. Spawn integration 82/82, host suite 125/125, tsc and privacy gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)