### PR TITLE
fix(header): collapse the top-bar account chips into one compact switcher (#1331)

### DIFF
--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -4,14 +4,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { ClaudeLoginView, EngineAccountsState } from "@/hooks/useEngineAccounts";
 import { translate } from "@/lib/i18n";
 
-import { AccountsPanel } from "./AccountsPanel";
+import { AccountsPanel, type ProjectAccountContext } from "./AccountsPanel";
 
 const base = (over: Partial<EngineAccountsState> = {}): EngineAccountsState => ({
   engine: "codex",
   accounts: [
     // Each capacity chip is reconciled from the account's own windows, so the
     // fixture carries the windows the chip percentages come from.
-    { id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+    { id: "main", label: "Main", kind: "legacy", authPresent: true, plan: "Team", loginPending: false, loginState: "authenticated", deviceAuth: null,
       limits: { freshness: "fresh", session: { usedPercent: 88, resetsAt: null, windowMinutes: 300 }, weekly: null } },
     { id: "work", label: "Work", kind: "managed", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
       limits: { freshness: "stale", session: null, weekly: { usedPercent: 36, resetsAt: null, windowMinutes: 10_080 } } },
@@ -37,8 +37,8 @@ const base = (over: Partial<EngineAccountsState> = {}): EngineAccountsState => (
   ...over,
 });
 
-const render = (state: EngineAccountsState, placement?: "footer" | "header") =>
-  renderToStaticMarkup(<AccountsPanel state={state} onClose={() => {}} placement={placement} />);
+const render = (state: EngineAccountsState, placement?: "footer" | "header", projectContext?: ProjectAccountContext) =>
+  renderToStaticMarkup(<AccountsPanel state={state} onClose={() => {}} placement={placement} projectContext={projectContext} />);
 
 test("titles the panel per engine and keeps the mobile-only backdrop before the dialog", () => {
   expect(render(base())).toContain("Codex accounts");
@@ -72,7 +72,29 @@ test("renders a capacity chip per account and dims the stale one", () => {
   const html = render(base());
   expect(html).toContain("12%");
   expect(html).toContain("64%");
+  expect(html).toContain("Team");
   expect(html).toContain("opacity-55"); // the stale Work chip
+});
+
+test("the expanded toolbar panel retains project pool, carrier, and outside-pool detail", () => {
+  const projectContext: ProjectAccountContext = {
+    project: "project-atlas",
+    restricted: true,
+    allowed: [
+      { accountId: "account-north", label: "North star" },
+      { accountId: "account-harbor", label: "Harbor light" },
+    ],
+    carrying: [{ accountId: "account-harbor", label: "Harbor light" }],
+    outsidePool: [{ accountId: "account-south", label: "South ridge", at: "2026-08-30T09:00:00.000Z", actor: "operator" }],
+  };
+  const html = render(base(), "header", projectContext);
+  expect(html).toContain('data-project-account-detail="project-atlas"');
+  expect(html).toContain("North star");
+  expect(html).toContain('data-project-account-carrying="account-harbor"');
+  expect(html).toContain("Harbor light · carrying");
+  expect(html).toContain('data-project-account-outside-pool="account-south"');
+  expect(html).toContain("South ridge · outside the pool");
+  expect(html).not.toContain("truncate rounded-full");
 });
 
 test("shows account ids and auth health when labels collide", () => {

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -171,7 +171,8 @@ function AuthIdentity({ account }: { account: AccountOption }) {
   const tone = health === "authenticated" ? "success" : health === "signed_out" || health === "error" ? "danger" : "neutral";
   return (
     <span className="flex min-w-0 items-center gap-1 text-[9.5px] font-medium text-muted">
-      <code className="truncate font-mono">{account.id}</code>
+      <code className="truncate font-mono" title={account.id}>{account.id}</code>
+      {account.plan ? <Badge tone="neutral" className="px-1.5 py-0 text-[9px]">{account.plan}</Badge> : null}
       <Badge tone={tone} className="px-1.5 py-0 text-[9px]">{t(AUTH_HEALTH_KEY[health])}</Badge>
     </span>
   );
@@ -216,7 +217,7 @@ function AccountRow({ account, engine, quota, activeId, onSelect, onRemove, onCo
           style={{ backgroundColor: isActive ? tint.color : "transparent", boxShadow: isActive ? "none" : "inset 0 0 0 1.5px var(--color-border)" }}
         />
         <span className="min-w-0 flex-1">
-          <span className={`block truncate text-[13px] leading-tight ${isActive ? "font-bold text-primary" : "font-semibold"}`}>{account.label}</span>
+          <span className={`block break-words text-[13px] leading-tight ${isActive ? "font-bold text-primary" : "font-semibold"}`}>{account.label}</span>
           <AuthIdentity account={account} />
         </span>
         <CapacityChip quota={quota} engine={engine} />
@@ -283,6 +284,74 @@ function AccountRow({ account, engine, quota, activeId, onSelect, onRemove, onCo
         ) : null}
       </div>
     </div>
+  );
+}
+
+export type ProjectAccountContext = {
+  project: string;
+  restricted: boolean;
+  allowed: { accountId: string; label: string }[];
+  carrying: { accountId: string; label: string }[];
+  outsidePool: { accountId: string; label: string; at: string; actor: "operator" | "agent" }[];
+};
+
+/** Project pool detail formerly painted as one chip per account in the primary
+    toolbar. It now lives inside the engine panel, where full labels and the
+    reason each account is present remain available without consuming the row. */
+function ProjectAccountDetail({ context }: { context: ProjectAccountContext }) {
+  const { t } = useLocale();
+  const carrying = new Set(context.carrying.map((account) => account.accountId));
+  const chosen = new Map(context.outsidePool.map((account) => [account.accountId, account] as const));
+  const extra = [...context.carrying, ...context.outsidePool]
+    .filter((account, index, list) => list.findIndex((item) => item.accountId === account.accountId) === index);
+  const rows = context.restricted
+    ? [...context.allowed, ...extra.filter((account) => !context.allowed.some((item) => item.accountId === account.accountId))]
+    : extra;
+
+  return (
+    <section data-project-account-detail={context.project} className="border-b border-border bg-canvas/55 px-3.5 py-2.5">
+      <div className="mb-1.5 flex items-center gap-2 text-[10px] font-semibold text-muted">
+        <span>{t("projectAccounts.label")}</span>
+        {!context.restricted ? (
+          <span className="rounded-full border border-border bg-card px-1.5 py-0.5 text-secondary">
+            {t("projectAccounts.any")}
+          </span>
+        ) : null}
+      </div>
+      {rows.length ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {rows.map((account) => {
+            const choice = chosen.get(account.accountId);
+            return (
+              <span
+                key={account.accountId}
+                title={choice
+                  ? t(choice.actor === "agent" ? "projectAccounts.chosenByAgent" : "projectAccounts.chosenByOperator", {
+                      label: account.label,
+                      at: choice.at,
+                    })
+                  : carrying.has(account.accountId)
+                    ? t("projectAccounts.carryingAria", { label: account.label })
+                    : account.accountId}
+                {...(carrying.has(account.accountId) ? { "data-project-account-carrying": account.accountId } : {})}
+                {...(choice ? { "data-project-account-outside-pool": account.accountId } : {})}
+                className={`max-w-full break-words rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
+                  choice
+                    ? "border-warning/45 bg-warning-soft text-warning"
+                    : carrying.has(account.accountId)
+                      ? "border-accent/45 bg-accent/10 text-primary"
+                      : "border-border bg-card text-secondary"
+                }`}
+              >
+                {account.label}
+                {carrying.has(account.accountId) ? ` · ${t("projectAccounts.carrying")}` : ""}
+                {choice ? ` · ${t("projectAccounts.outsidePool")}` : ""}
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
@@ -528,6 +597,7 @@ export function AccountsPanel({
   placement = "footer",
   focusAccountId = null,
   quotaOverride,
+  projectContext,
 }: {
   state: EngineAccountsState;
   onClose: () => void;
@@ -536,6 +606,7 @@ export function AccountsPanel({
       (issue #229 — a header account badge steers here). */
   focusAccountId?: string | null;
   quotaOverride?: { accountId: string; quota: ReconciledQuota; now: number };
+  projectContext?: ProjectAccountContext;
 }) {
   const { t } = useLocale();
   const { accounts, active, status, notice, mutation, engine } = state;
@@ -618,6 +689,8 @@ export function AccountsPanel({
         </header>
 
         <p className="sr-only" role="status" aria-live="polite">{announcement}</p>
+
+        {projectContext ? <ProjectAccountDetail context={projectContext} /> : null}
 
         {mutation ? (
           <div role="status" aria-live="polite" className="flex items-center gap-2 border-b border-border bg-accent/5 px-3 py-2 text-[11px] font-semibold text-primary">

--- a/src/components/EngineAccountSwitch.dom.test.tsx
+++ b/src/components/EngineAccountSwitch.dom.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { EngineAccountsState } from "@/hooks/useEngineAccounts";
+
+import { EngineAccountSwitchControl } from "./EngineAccountSwitch";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+});
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; host: HTMLDivElement }> = [];
+afterEach(async () => {
+  await Promise.all(mounted.splice(0).map(async ({ root, host }) => {
+    await act(async () => root.unmount());
+    host.remove();
+  }));
+  document.body.replaceChildren();
+});
+
+function accountState(select: EngineAccountsState["select"]): EngineAccountsState {
+  return {
+    engine: "codex",
+    accounts: [
+      {
+        id: "account-north",
+        label: "North star",
+        kind: "legacy",
+        authPresent: true,
+        authHealth: "authenticated",
+        plan: "Team",
+        loginPending: false,
+        loginState: "authenticated",
+        deviceAuth: null,
+        limits: { freshness: "fresh", session: { usedPercent: 28, resetsAt: null, windowMinutes: 300 }, weekly: null },
+      },
+      {
+        id: "account-harbor",
+        label: "Harbor light",
+        kind: "managed",
+        authPresent: true,
+        authHealth: "authenticated",
+        plan: "Pro",
+        loginPending: false,
+        loginState: "authenticated",
+        deviceAuth: null,
+        limits: { freshness: "fresh", session: { usedPercent: 9, resetsAt: null, windowMinutes: 300 }, weekly: null },
+      },
+    ],
+    active: "account-north",
+    identityVersion: 0,
+    status: "ready",
+    notice: null,
+    challenge: null,
+    mutation: null,
+    migration: null,
+    autoBalance: null,
+    refresh: async () => true,
+    add: async () => true,
+    retryNotice: async () => true,
+    select,
+    submitLoginCode: async () => true,
+    cancelLogin: async () => true,
+    retryLogin: async () => true,
+    remove: async () => true,
+    cleanupOrphans: async () => true,
+    copyTerminalCommand: async () => true,
+  };
+}
+
+test("the active account is collapsed at rest and the full switch flow opens on demand", async () => {
+  let selected: string | null = null;
+  const state = accountState(async (id) => { selected = id; return true; });
+  const projectContext = {
+    project: "project-atlas",
+    restricted: true,
+    allowed: [{ accountId: "account-north", label: "North star" }],
+    carrying: [{ accountId: "account-harbor", label: "Harbor light" }],
+    outsidePool: [],
+  };
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted.push({ root, host });
+
+  await act(async () => root.render(<EngineAccountSwitchControl state={state} projectContext={projectContext} />));
+
+  const trigger = host.querySelector('button[aria-haspopup="dialog"]') as HTMLButtonElement;
+  expect(trigger).toBeTruthy();
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(trigger.textContent).toContain("North star");
+  expect(host.textContent).not.toContain("Harbor light");
+  expect(host.querySelector('[role="dialog"]')).toBeNull();
+
+  await act(async () => trigger.click());
+
+  expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  expect(host.querySelector('[role="dialog"]')).toBeTruthy();
+  expect(host.textContent).toContain("North star");
+  expect(host.textContent).toContain("Harbor light");
+  expect(host.textContent).toContain("Team");
+  expect(host.textContent).toContain("Pro");
+  expect(host.textContent).toContain("72%");
+  expect(host.textContent).toContain("91%");
+  expect(host.querySelector('[data-project-account-detail="project-atlas"]')).toBeTruthy();
+  expect(host.querySelector('[data-project-account-carrying="account-harbor"]')).toBeTruthy();
+
+  const harbor = [...host.querySelectorAll("button")].find((button) => button.textContent?.includes("Harbor light"));
+  expect(harbor).toBeTruthy();
+  await act(async () => harbor!.click());
+  expect(selected).toBe("account-harbor");
+});

--- a/src/components/EngineAccountSwitch.dom.test.tsx
+++ b/src/components/EngineAccountSwitch.dom.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
 import type { EngineAccountsState } from "@/hooks/useEngineAccounts";
+import { installActEnv } from "@/test-helpers/actEnv";
 
 import { EngineAccountSwitchControl } from "./EngineAccountSwitch";
 
@@ -19,7 +20,7 @@ Object.assign(globalThis, {
   PointerEvent: dom.PointerEvent,
   KeyboardEvent: dom.KeyboardEvent,
 });
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+installActEnv();
 
 const mounted: Array<{ root: Root; host: HTMLDivElement }> = [];
 afterEach(async () => {
@@ -120,5 +121,5 @@ test("the active account is collapsed at rest and the full switch flow opens on 
   const harbor = [...host.querySelectorAll("button")].find((button) => button.textContent?.includes("Harbor light"));
   expect(harbor).toBeTruthy();
   await act(async () => harbor!.click());
-  expect(selected).toBe("account-harbor");
+  expect(selected as unknown as string).toBe("account-harbor");
 });

--- a/src/components/EngineAccountSwitch.tsx
+++ b/src/components/EngineAccountSwitch.tsx
@@ -2,17 +2,17 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { useEngineAccounts } from "@/hooks/useEngineAccounts";
+import { type EngineAccountsState, useEngineAccounts } from "@/hooks/useEngineAccounts";
 import { useLocale } from "@/lib/i18n";
 
-import { AccountsPanel } from "./AccountsPanel";
+import { AccountsPanel, type ProjectAccountContext } from "./AccountsPanel";
 import { ChevronDown, Loader2 } from "./icons";
 import { engineTintOf } from "./utils";
 
 const ENGINE_LABEL: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
 
 /**
- * Compact per-engine account trigger in the Switchboard header (issue #40).
+ * Compact per-engine account trigger in account-bearing headers (#40, #1331).
  * One button per engine opens the canonical {@link AccountsPanel}, sharing the
  * limits footer's direct account selection, add-account form, and sign-in
  * controls. The trigger stays mounted while account data loads or recovers, so
@@ -21,8 +21,13 @@ const ENGINE_LABEL: Record<"claude" | "codex", string> = { claude: "Claude", cod
  * side; the active account label joins it from `sm:` up, and always lives in
  * the accessible name.
  */
-export function EngineAccountSwitch({ engine }: { engine: "claude" | "codex" }) {
-  const state = useEngineAccounts(engine);
+export function EngineAccountSwitch({ engine, projectContext }: { engine: "claude" | "codex"; projectContext?: ProjectAccountContext }) {
+  return <EngineAccountSwitchControl state={useEngineAccounts(engine)} projectContext={projectContext} />;
+}
+
+/** Interactive rendering half, separated so collapsed and expanded behavior
+    can be exercised with a deterministic account state. */
+export function EngineAccountSwitchControl({ state, projectContext }: { state: EngineAccountsState; projectContext?: ProjectAccountContext }) {
   const { t } = useLocale();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -45,14 +50,14 @@ export function EngineAccountSwitch({ engine }: { engine: "claude" | "codex" }) 
     return () => window.removeEventListener("pointerdown", onDown);
   }, [open]);
 
-  const engineName = ENGINE_LABEL[engine];
-  const tint = engineTintOf(engine);
+  const engineName = ENGINE_LABEL[state.engine];
+  const tint = engineTintOf(state.engine);
   const activeAccount = state.accounts.find((account) => account.id === state.active);
   const label = activeAccount?.label ?? t("accounts.trigger");
   const draining = state.migration?.state === "draining";
 
   return (
-    <div ref={containerRef} className="relative">
+    <div ref={containerRef} data-account-switch-engine={state.engine} className="relative shrink-0">
       <button
         ref={triggerRef}
         type="button"
@@ -71,7 +76,7 @@ export function EngineAccountSwitch({ engine }: { engine: "claude" | "codex" }) 
           <ChevronDown className="h-3 w-3 shrink-0 text-muted" aria-hidden />
         )}
       </button>
-      {open ? <AccountsPanel state={state} onClose={close} placement="header" /> : null}
+      {open ? <AccountsPanel state={state} onClose={close} placement="header" projectContext={projectContext} /> : null}
     </div>
   );
 }

--- a/src/components/ProjectAccounts.render.test.tsx
+++ b/src/components/ProjectAccounts.render.test.tsx
@@ -21,16 +21,26 @@ function view(over: Partial<ProjectAccountsView["engines"][number]> = {}): Proje
 
 const render = (value: ProjectAccountsView | null) => renderToStaticMarkup(<ProjectAccountsStrip view={value} />);
 
-test("a fenced project names the accounts it may use", () => {
+test("a fenced project collapses its account row into one engine switch", () => {
   const html = render(view());
-  expect(html).toContain("Reserved");
   expect(html).toContain(`data-project-accounts="${ATLAS}"`);
+  expect(html.match(/aria-haspopup="dialog"/g)?.length).toBe(1);
+  expect(html).toContain("Claude");
+  expect(html).not.toContain("Reserved");
 });
 
-test("the account carrying the project's work is marked as carrying", () => {
-  const html = render(view({ carrying: [{ accountId: "acct-reserved", label: "Reserved" }] }));
-  expect(html).toContain('data-project-account-carrying="acct-reserved"');
-  expect(html).toContain("carrying");
+test("many project accounts still paint one collapsed control for their engine", () => {
+  const html = render(view({
+    allowed: [
+      { accountId: "account-north", label: "North star" },
+      { accountId: "account-harbor", label: "Harbor light" },
+    ],
+    carrying: [{ accountId: "account-harbor", label: "Harbor light" }],
+  }));
+  expect(html.match(/aria-haspopup="dialog"/g)?.length).toBe(1);
+  expect(html).not.toContain("North star");
+  expect(html).not.toContain("Harbor light");
+  expect(html).not.toContain("truncate rounded-full");
 });
 
 test("a project that is neither fenced nor busy renders nothing", () => {
@@ -38,16 +48,24 @@ test("a project that is neither fenced nor busy renders nothing", () => {
   expect(render(null)).toBe("");
 });
 
-test("an unfenced project that IS busy shows who is carrying it, and says any account may", () => {
+test("an unfenced busy project still gets one on-demand engine control", () => {
   const html = render(view({ restricted: false, allowed: [], carrying: [{ accountId: "acct-spare", label: "Spare" }] }));
-  expect(html).toContain("any account");
-  expect(html).toContain('data-project-account-carrying="acct-spare"');
+  expect(html.match(/aria-haspopup="dialog"/g)?.length).toBe(1);
+  expect(html).not.toContain("any account");
+  expect(html).not.toContain("Spare");
 });
 
-test("a carrier outside the allowed set is still shown, and still marked", () => {
-  const html = render(view({ carrying: [{ accountId: "acct-legacy", label: "Legacy" }] }));
-  expect(html).toContain("Reserved");
-  expect(html).toContain('data-project-account-carrying="acct-legacy"');
+test("two relevant engines render at most one control each", () => {
+  const html = render({
+    project: ATLAS,
+    engines: [
+      view().engines[0],
+      { engine: "codex", restricted: false, allowed: [], carrying: [{ accountId: "account-south", label: "South ridge" }], outsidePool: [] },
+    ],
+  });
+  expect(html.match(/aria-haspopup="dialog"/g)?.length).toBe(2);
+  expect(html.match(/data-account-switch-engine="claude"/g)?.length).toBe(1);
+  expect(html.match(/data-account-switch-engine="codex"/g)?.length).toBe(1);
 });
 
 test("a malformed payload parses to nothing rather than throwing", () => {
@@ -59,35 +77,11 @@ test("a malformed payload parses to nothing rather than throwing", () => {
   });
 });
 
-test("an account chosen from outside the pool is shown, dated and attributed", () => {
+test("an account chosen outside the pool stays collapsed at rest", () => {
   const html = render(view({
     outsidePool: [{ accountId: "acct-outside", label: "Outside", at: "2026-08-30T09:00:00.000Z", actor: "operator" }],
   }));
-  /* The pool still reads as the pool, and the deliberate choice reads as a
-     choice: shown beside it, marked, and naming who made it. */
-  expect(html).toContain("Reserved");
-  expect(html).toContain('data-project-account-outside-pool="acct-outside"');
-  expect(html).toContain("outside the pool");
-  expect(html).toContain("by you");
-  expect(html).toContain("2026-08-30T09:00:00.000Z");
-});
-
-test("an agent's choice is attributed to the agent", () => {
-  const html = render(view({
-    outsidePool: [{ accountId: "acct-outside", label: "Outside", at: "2026-08-30T09:00:00.000Z", actor: "agent" }],
-  }));
-  expect(html).toContain('data-project-account-outside-pool="acct-outside"');
-  expect(html).toContain("by an agent");
-});
-
-test("a choice of an account that is also carrying reads as both, on one chip", () => {
-  const html = render(view({
-    carrying: [{ accountId: "acct-outside", label: "Outside" }],
-    outsidePool: [{ accountId: "acct-outside", label: "Outside", at: "2026-08-30T09:00:00.000Z", actor: "operator" }],
-  }));
-  expect(html.match(/acct-outside/g)?.length).toBeGreaterThan(0);
-  expect(html).toContain('data-project-account-carrying="acct-outside"');
-  expect(html).toContain('data-project-account-outside-pool="acct-outside"');
-  expect(html).toContain("carrying");
-  expect(html).toContain("outside the pool");
+  expect(html.match(/aria-haspopup="dialog"/g)?.length).toBe(1);
+  expect(html).not.toContain("Outside");
+  expect(html).not.toContain("2026-08-30T09:00:00.000Z");
 });

--- a/src/components/ProjectAccounts.tsx
+++ b/src/components/ProjectAccounts.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { useLocale } from "@/lib/i18n";
+import { EngineAccountSwitch } from "./EngineAccountSwitch";
 
 /** One engine's block of the project view served by /api/account-project-bindings. */
 export interface ProjectAccountsEngineView {
@@ -68,13 +68,9 @@ export function parseProjectAccountsView(body: unknown): ProjectAccountsView | n
  * which of them are carrying its work right now, and which were deliberately
  * chosen from outside that set.
  *
- * It stays silent for a project that is neither fenced nor busy — the common
- * case, and one where a permanent "any account" chip in the header would be
- * noise. A restricted project always renders, because there the pool is exactly
- * what a reader needs in order to understand a parked stage; and an out-of-pool
- * choice renders beside it, named and dated, because the pool binds what the
- * Viewer selects on its own and a person reaching past it is a fact about the
- * project rather than a fault.
+ * It stays silent for a project that is neither fenced nor busy. Relevant
+ * engines each get one compact active-account switch; project pool, carrier,
+ * and out-of-pool detail moves into that switch's panel (#1331).
  */
 export function ProjectAccounts({ project }: { project: string }) {
   const [view, setView] = useState<ProjectAccountsView | null>(null);
@@ -100,66 +96,24 @@ export function ProjectAccounts({ project }: { project: string }) {
 
 /** The rendering half, separated so it can be exercised without a fetch. */
 export function ProjectAccountsStrip({ view }: { view: ProjectAccountsView | null }) {
-  const { t } = useLocale();
   const shown = (view?.engines ?? []).filter((engine) =>
     engine.restricted || engine.carrying.length > 0 || engine.outsidePool.length > 0);
   if (!view || !shown.length) return null;
-  const project = view.project;
   return (
-    <div data-project-accounts={project} className="flex min-w-0 flex-wrap items-center gap-1 text-[10px]">
-      <span className="font-semibold text-muted">{t("projectAccounts.label")}</span>
-      {shown.map((engine) => {
-        const carrying = new Set(engine.carrying.map((account) => account.accountId));
-        /* An account outside the allowed set is still shown — carrying, chosen,
-           or both: a session may predate the binding, and a switch onto it may
-           be a decision somebody made. Hiding either would make the pool look
-           like something it is not. */
-        const chosen = new Map(engine.outsidePool.map((account) => [account.accountId, account] as const));
-        const extra = [...engine.carrying, ...engine.outsidePool]
-          .filter((account, index, list) => list.findIndex((item) => item.accountId === account.accountId) === index);
-        const rows = engine.restricted
-          ? [...engine.allowed, ...extra.filter((account) => !engine.allowed.some((item) => item.accountId === account.accountId))]
-          : extra;
-        return (
-          <span key={engine.engine} className="flex min-w-0 items-center gap-1">
-            <span className="font-semibold text-muted">{engine.engine}</span>
-            {engine.restricted ? null : (
-              <span className="rounded-full border border-border bg-canvas px-1.5 py-0.5 font-semibold text-secondary">
-                {t("projectAccounts.any")}
-              </span>
-            )}
-            {rows.map((account) => {
-              const choice = chosen.get(account.accountId);
-              return (
-                <span
-                  key={`${engine.engine}:${account.accountId}`}
-                  title={choice
-                    ? t(choice.actor === "agent" ? "projectAccounts.chosenByAgent" : "projectAccounts.chosenByOperator", {
-                        label: account.label,
-                        at: choice.at,
-                      })
-                    : carrying.has(account.accountId)
-                      ? t("projectAccounts.carryingAria", { label: account.label })
-                      : account.accountId}
-                  {...(carrying.has(account.accountId) ? { "data-project-account-carrying": account.accountId } : {})}
-                  {...(choice ? { "data-project-account-outside-pool": account.accountId } : {})}
-                  className={`max-w-[160px] truncate rounded-full border px-1.5 py-0.5 font-semibold ${
-                    choice
-                      ? "border-warning/45 bg-warning-soft text-warning"
-                      : carrying.has(account.accountId)
-                        ? "border-accent/45 bg-accent/10 text-primary"
-                        : "border-border bg-canvas text-secondary"
-                  }`}
-                >
-                  {account.label}
-                  {carrying.has(account.accountId) ? ` · ${t("projectAccounts.carrying")}` : ""}
-                  {choice ? ` · ${t("projectAccounts.outsidePool")}` : ""}
-                </span>
-              );
-            })}
-          </span>
-        );
-      })}
+    <div data-project-accounts={view.project} className="flex min-w-0 shrink-0 items-center gap-1">
+      {shown.map((engine) => (
+        <EngineAccountSwitch
+          key={engine.engine}
+          engine={engine.engine}
+          projectContext={{
+            project: view.project,
+            restricted: engine.restricted,
+            allowed: engine.allowed,
+            carrying: engine.carrying,
+            outsidePool: engine.outsidePool,
+          }}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1745,9 +1745,9 @@ function ProjectDashboardView({
             held its 45vw and pushed «More actions» off a 390px screen instead).
             Desktop keeps its natural width. */}
         <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 max-w-[45vw]" : ""}`} title={projectName}>{projectName}</h1>
-        {/* #1279's project side: which accounts this project may use and which
-            are carrying its work. Desktop only, and silent unless the project
-            is fenced or busy, so it costs the phone header no slot at all. */}
+        {/* The project account surface is one compact switch per relevant engine
+            (#1331). Pool/carrier detail opens on demand; the phone remains
+            unchanged, and quiet projects still spend no header slot. */}
         {!isMobile ? <ProjectAccounts project={project} /> : null}
         {/* Desktop only. On the phone the whole history island — undo and redo
             together — rides the «⋯» menu, which is how search bought its 44px

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -26,7 +26,7 @@ const claudePayload = (over: Record<string, unknown> = {}) => ({
   claude: {
     active: "main",
     accounts: [
-      { id: "main", label: "Main", authPresent: true, auth: { state: "authenticated" }, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 12, window: "session", freshness: "fresh" } },
+      { id: "main", label: "Main", authPresent: true, auth: { state: "authenticated", plan: "Team" }, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 12, window: "session", freshness: "fresh" } },
       { id: "work", label: "Work", authPresent: true, auth: { state: "unknown" }, loginPending: false, loginState: "authenticated", deviceAuth: null },
     ],
     ...over,
@@ -49,6 +49,7 @@ test("a claude store reads body.claude, its engine endpoints, and parses migrati
   expect(calls[0].url).toBe("/api/accounts");
   expect(store.active).toBe("main");
   expect(store.accounts.map((account) => account.authHealth)).toEqual(["authenticated", "unknown"]);
+  expect(store.accounts.map((account) => account.plan)).toEqual(["Team", null]);
   expect(store.migration).toMatchObject({ intentId: "i1", origin: "auto", state: "draining", counts: { done: 1, total: 3 } });
   expect(store.autoBalance).toMatchObject({ enabled: true, state: "draining" });
   unsub();

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -121,6 +121,8 @@ export type AccountOption = {
   kind?: "legacy" | "managed";
   authPresent: boolean;
   authHealth?: AccountAuthHealth;
+  /** Public subscription tier reported by the account read. */
+  plan?: string | null;
   loginPending: boolean;
   loginState: ManagedAttemptState | "idle" | "authenticated";
   attemptState?: ManagedAttemptState | null;
@@ -317,13 +319,15 @@ function accountResponse(body: unknown, engine: Engine): EngineResponse {
     // The phase is authoritative for pending state (C3): a nonterminal login
     // keeps the row pending even when the server's raw `loginPending` lags.
     const loginPending = login ? NONTERMINAL_CLAUDE_LOGIN_PHASES.has(login.phase) : account.loginPending === true;
-    const authState = typeof account.auth === "object" && account.auth !== null
-      ? (account.auth as { state?: unknown }).state
+    const auth = typeof account.auth === "object" && account.auth !== null
+      ? account.auth as { state?: unknown; plan?: unknown }
       : null;
+    const authState = auth?.state;
     const authHealth: AccountAuthHealth = authState === "authenticated" || authState === "signed_out" || authState === "unknown" || authState === "error"
       ? authState
       : account.authPresent ? "unknown" : "signed_out";
-    return { ...account, authHealth, login, loginPending, limits: parseAccountLimits(account.limits), projects: parseBoundProjects((raw as { projects?: unknown }).projects) };
+    const plan = typeof auth?.plan === "string" && auth.plan.trim() ? auth.plan : null;
+    return { ...account, authHealth, plan, login, loginPending, limits: parseAccountLimits(account.limits), projects: parseBoundProjects((raw as { projects?: unknown }).projects) };
   });
   return {
     active: section.active,


### PR DESCRIPTION
## Impact

The project toolbar now shows one compact active-account switch per relevant engine. Full account and project-pool detail opens from that control, leaving navigation, search, task, and pipeline actions room in the primary row.

## Cause

The project account-pool projection rendered every allowed, carrying, and outside-pool account as a truncated toolbar chip. Each additional account consumed horizontal space while the switch action and quota detail lived on another surface.

## Fix

- Reuse the canonical engine account switch in the project toolbar.
- Move project pool, carrier, and outside-pool context into the opened accounts panel.
- Surface plan tier with the existing remaining-limit and active-account detail.
- Preserve the singleton account-selection flow used for future launches.
- Keep the mobile toolbar and conversation-card account badge behavior unchanged.

## Verification

- `bunx tsc --noEmit --incremental false`
- Isolated touched tests: 94 passed, 331 assertions
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits`

Closes #1331