### PR TITLE
fix(starting): reconcile role echo on direct live adoption

### DIFF
--- a/src/components/LogFeed.outboxTailOrder.dom.test.tsx
+++ b/src/components/LogFeed.outboxTailOrder.dom.test.tsx
@@ -61,6 +61,7 @@ const fixtureLines = fs
   )
   .split("\n")
   .filter(Boolean);
+let tailLines = fixtureLines;
 
 const actualRuntimeHooks = await import("@/hooks/useRuntime");
 const actualLogTail = await import("@/hooks/useLogTail");
@@ -78,7 +79,7 @@ mock.module("@/hooks/useRuntime", () => ({
 mock.module("@/hooks/useLogTail", () => ({
   ...actualLogTail,
   useLogTail: () => ({
-    lines: fixtureLines,
+    lines: tailLines,
     linesStart: 0,
     size: 1,
     loading: false,
@@ -99,7 +100,7 @@ mock.module("@/hooks/useToolActivityCues", () => ({
 }));
 
 const { LogFeed } = await import("./LogFeed");
-const { enqueueOutbox, resetOutboxForTests, updateOutbox } = await import("./conversation/outbox");
+const { enqueueOutbox, readOutbox, resetOutboxForTests, seedLaunchOutbox, updateOutbox } = await import("./conversation/outbox");
 
 /* The newest fixture record: the agent's reply after the tool call. */
 const NEWEST_RECORD_AT = Date.parse("2026-08-06T13:44:33.481Z");
@@ -110,6 +111,7 @@ const roots = new Set<Root>();
 beforeEach(() => {
   Date.now = () => NOW;
   setLocale("en");
+  tailLines = fixtureLines;
   dom.sessionStorage.clear();
   resetOutboxForTests();
 });
@@ -146,7 +148,7 @@ const file: FileEntry = {
   conversationId: "conversation-tail-order",
 } as FileEntry;
 
-function render(): HTMLElement {
+function render(renderedFile: FileEntry = file): HTMLElement {
   const host = dom.document.createElement("div");
   dom.document.body.append(host);
   const root = createRoot(host as unknown as HTMLElement);
@@ -154,7 +156,7 @@ function render(): HTMLElement {
   flushSync(() => {
     root.render(
       <LogFeed
-        file={file}
+        file={renderedFile}
         showSvc={false}
         lineFilter=""
         onStatus={() => undefined}
@@ -208,4 +210,59 @@ test("a delivery newer than the whole transcript still renders its bubble at the
      position IS its chronological position. */
   const rows = [...host.querySelectorAll("[data-feed-kind], [data-outbox-entry]")];
   expect(rows.at(-1)?.getAttribute("data-outbox-entry")).toBe("delivered-after-reply");
+});
+
+test.each([
+  ["builder", "Ship the focused repair.", "You are a Builder in plain mode.\n\nShip the focused repair."],
+  ["reviewer", "Review the focused repair.", "You are a Reviewer.\nSafety fences:\n- stay in scope\n\nReview the focused repair."],
+])("issue 616: direct 202-to-live %s adoption renders only the scaffolded transcript echo", (_role, raw, scaffolded) => {
+  const conversationId = "conversation_direct_adoption";
+  const launchId = "launch_direct_adoption";
+  const transcriptAt = NEWEST_RECORD_AT;
+  tailLines = [JSON.stringify({
+    timestamp: new Date(transcriptAt).toISOString(),
+    type: "response_item",
+    payload: {
+      type: "message",
+      id: "message_direct_adoption",
+      role: "user",
+      content: [{ type: "input_text", text: scaffolded }],
+    },
+  })];
+
+  /* The accepted 202 seeded the raw operator draft and the provisional window
+     already attached its exact owner. The first files response is live, so no
+     intermediate placeholder poll supplied the role scaffold's echo identity. */
+  seedLaunchOutbox(conversationId, {
+    id: launchId,
+    text: raw,
+    images: 0,
+    at: transcriptAt - 1_000,
+    owner: { conversationId, generation: 1 },
+  });
+  const adoptedFile: FileEntry = {
+    ...file,
+    path: "/fixtures/direct-adoption.jsonl",
+    name: "direct-adoption.jsonl",
+    conversationId,
+    generation: 1,
+    launch: {
+      launchId,
+      clientAttemptId: null,
+      accountId: null,
+      conversationId,
+      generation: 1,
+      state: "recovered",
+      initialMessage: "delivered",
+      retrySafe: false,
+      error: null,
+      deliveredAt: transcriptAt - 500,
+      promptEcho: scaffolded,
+    },
+  };
+
+  const host = render(adoptedFile);
+  expect(host.querySelectorAll('[data-feed-kind="user"]')).toHaveLength(1);
+  expect(host.querySelector("[data-outbox-entry]") === null).toBe(true);
+  expect(readOutbox(conversationId)[0]).toMatchObject({ text: raw, echoText: scaffolded });
 });

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -553,19 +553,20 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      Keyed by the launch id under the stable conversation identity, so it is
      idempotent with the composer's own seed (no duplicate), survives a refresh,
      folds through transcript adoption, and retires on its transcript echo. */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!memoryKey || !launch?.launchId || !launchOwnsThisPane) return;
     const promptText = launch.prompt ?? "";
     const promptImages = launch.promptImages ?? 0;
-    if (!promptText.trim() && !promptImages) return;
+    if (!promptText.trim() && !promptImages && !launch.promptEcho) return;
     seedLaunchOutbox(memoryKey, {
       id: launch.launchId,
       text: promptText,
       images: promptImages,
       at: launch.promptAt ?? Date.now(),
-      /* The canonical echo identity (issue #615): the bubble displays the raw
-         draft but retires on the delivered (possibly scaffolded) transcript
-         echo. Reconciled onto a composer-seeded bubble under the same id. */
+      /* The canonical echo identity (issue #615/#616): the bubble displays the
+         raw draft and retires on the delivered scaffolded transcript echo. An
+         adopted live fact can carry this identity after its display fields have
+         retired, reconciling the 202 seed before the browser paints. */
       ...(launch.promptEcho ? { echoText: launch.promptEcho } : {}),
       owner: launchOwner!,
       state: launchOutboxState(launch.initialMessage),

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -670,7 +670,6 @@ export function seedLaunchOutbox(
     error?: string;
   },
 ): void {
-  if (!entry.text.trim() && !entry.images) return;
   const currentLaunch = readCurrentLaunch(cardId);
   if (currentLaunch?.id === entry.id) {
     const terminalReason = terminalReasonForLaunch(currentLaunch, Date.now());
@@ -722,6 +721,10 @@ export function seedLaunchOutbox(
     }
     return;
   }
+  /* An adopted live fact can carry only `echoText`: its display fields have
+     already retired because the transcript owns the visible row. Such a fact
+     may reconcile an existing raw 202 seed and must never create an empty row. */
+  if (!entry.text.trim() && !entry.images) return;
   /* Recurring LogFeed projections can outlive the recent queue entry. Durable
      retirement under this submission id keeps the compacted launch terminal
      across refresh and identity adoption. */

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -717,7 +717,7 @@ test("issue 615 HIGH1: the launch prompt projects from the durable display paylo
     const scanLagFacts = scanLag.facts.get(artifactPath)!;
     expect(scanLagFacts).toMatchObject({ state: "recovered" });
     expect(scanLagFacts.prompt).toBeUndefined();
-    expect(scanLagFacts.promptEcho).toBeUndefined();
+    expect(scanLagFacts.promptEcho).toBe("scaffold\n\nLLV615_RAW_PROMPT");
     expect(scanLagFacts.promptImages).toBeUndefined();
     /* The delivered receipt time remains available after the readable transcript
        path takes over the window (issue #648). */
@@ -725,14 +725,14 @@ test("issue 615 HIGH1: the launch prompt projects from the durable display paylo
     expect(typeof deliveredAt).toBe("number");
     expect(Number.isFinite(deliveredAt)).toBe(true);
 
-    /* The response that ADOPTS the live transcript stops projecting the prompt —
-       the transcript now renders the message, so the facts carry no bubble. */
+    /* The response that ADOPTS the live transcript stops projecting fields that
+       can draw a prompt bubble. Its echo identity remains for reconciliation. */
     const adopted = projectLaunchConversations([scannedFile(artifactPath)], snapshot, createdMs + 21_000);
     expect(adopted.cards).toEqual([]);
     const facts = adopted.facts.get(artifactPath)!;
     expect(facts).toMatchObject({ state: "recovered" });
     expect(facts.prompt).toBeUndefined();
-    expect(facts.promptEcho).toBeUndefined();
+    expect(facts.promptEcho).toBe("scaffold\n\nLLV615_RAW_PROMPT");
     expect(facts.promptImages).toBeUndefined();
     /* The delivered receipt time survives prompt scrubbing: a materialized window
        whose echo never matches can still settle the launch bubble (issue #648). */
@@ -766,6 +766,56 @@ test("issue 615 HIGH1: the durable display payload survives restart and never le
     });
     if (other.kind !== "created") throw new Error("expected structured launch creation");
     expect(restarted.snapshot().receipts[other.receipt.launchId]?.launchDisplay).toBeNull();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  ["builder", "Ship the focused repair.", "You are a Builder in plain mode.\n\nShip the focused repair."],
+  ["reviewer", "Review the focused repair.", "You are a Reviewer.\nSafety fences:\n- stay in scope\n\nReview the focused repair."],
+])("issue 616: a zero-intermediate-poll %s launch carries its canonical echo into direct live adoption", (_role, raw, scaffolded) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-616-direct-adoption-"));
+  const artifactPath = path.join(directory, `${SETTLED_SESSION_ID}.jsonl`);
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: scaffolded })}\n`);
+    const registry = legacyRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      launchDisplay: { prompt: raw, images: 0, echo: scaffolded },
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: SETTLED_SESSION_ID },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "idle",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    observeArtifact(registry, artifactPath, directory);
+
+    /* The accepted 202 is followed by a first files response that already
+       carries the live transcript. No placeholder projection gets an earlier
+       chance to attach the scaffolded echo identity to the raw browser seed. */
+    const adopted = projectLaunchConversations(
+      [scannedFile(artifactPath)],
+      registry.snapshot(),
+      Date.parse(begun.receipt.createdAt) + 1_000,
+    );
+    const facts = adopted.facts.get(artifactPath)!;
+    expect(adopted.cards).toEqual([]);
+    expect(facts.prompt).toBeUndefined();
+    expect(facts.promptImages).toBeUndefined();
+    expect(facts.promptEcho).toBe(scaffolded);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
@@ -1225,7 +1275,7 @@ test("a rejected launch projects a terminal failed card with zero conversation a
 test("a pipeline stage placeholder carries durable spawn lineage without an operator handoff flag", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-lineage-projection-"));
   try {
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const registry = legacyRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
     const parentPath = path.join(directory, "parent.jsonl");
     const parent = registry.ensureConversation("codex", parentPath, "work");
     const begun = registry.beginSpawnRequest({
@@ -1266,7 +1316,7 @@ test("a pipeline stage placeholder carries durable spawn lineage without an oper
 test("an agent-authenticated child with launch display stays caller-owned", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-caller-owned-display-projection-"));
   try {
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const registry = legacyRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
     const parentPath = path.join(directory, "parent.jsonl");
     const parent = registry.ensureConversation("codex", parentPath, "work");
     const begun = registry.beginSpawnRequest({
@@ -1299,7 +1349,7 @@ test("an agent-authenticated child with launch display stays caller-owned", () =
 test("an operator handoff placeholder keeps its provenance after later flow enrollment", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-enrolled-handoff-placeholder-"));
   try {
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const registry = legacyRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
     const parentPath = path.join(directory, "parent.jsonl");
     const parent = registry.ensureConversation("codex", parentPath, "work");
     const begun = registry.beginSpawnRequest({
@@ -1343,7 +1393,7 @@ test("materialized handoffs and historical stages stay input-immutable", () => {
   const pipelineSessionId = "historical-pipeline-stage";
   const pipelineArtifactPath = path.join(directory, `${pipelineSessionId}.jsonl`);
   try {
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const registry = legacyRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
     const parentPath = path.join(directory, "parent.jsonl");
     const parent = registry.ensureConversation("codex", parentPath, "work");
     const begun = registry.beginSpawnRequest({

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -164,19 +164,20 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
   };
 }
 
-/** The launch facts INSIDE an adopted live conversation window (issue #615): the
-    transcript now renders the operator's message itself, so the launch stops
-    contributing a prompt bubble in the same response — only its transient status
-    chips remain. Strips every prompt-display field from the state. */
+/** The launch facts INSIDE an adopted live conversation window (issue #615/#616):
+    the transcript now renders the operator's message itself, so the launch stops
+    contributing a prompt bubble in the same response. The canonical echo identity
+    remains long enough for a browser-seeded raw role prompt to reconcile with that
+    transcript row on a direct 202-to-live adoption. */
 function launchFactsWithoutPrompt(spawn: StructuredSpawnCardState): StructuredSpawnCardState {
-  if (spawn.prompt === undefined && spawn.promptEcho === undefined && spawn.promptImages === undefined && spawn.promptAt === undefined) {
+  if (spawn.prompt === undefined && spawn.promptImages === undefined && spawn.promptAt === undefined) {
     return spawn;
   }
   const facts = { ...spawn };
+  if (facts.promptEcho === facts.prompt) delete facts.promptEcho;
   delete facts.prompt;
   delete facts.promptImages;
   delete facts.promptAt;
-  delete facts.promptEcho;
   return facts;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,7 +81,10 @@ export interface StructuredSpawnCardState {
   /** The canonical text the transcript will echo for this launch (issue #615) —
       the delivered message, which for a role launch is the scaffold PLUS the raw
       draft. The optimistic bubble displays `prompt` (the raw draft) but retires on
-      THIS text, so a scaffolded role launch never lingers and never duplicates. */
+      THIS text, so a scaffolded role launch never lingers and never duplicates.
+      When it differs from `prompt`, it remains on adopted live facts after the
+      display fields retire, allowing a direct 202-to-live path to reconcile the
+      browser's raw seed (issue #616). */
   promptEcho?: string;
   /** When the launch's initial message actually reached the agent (ms, issue
       #648). A structured / MCP spawn journals its first user record with SDK /


### PR DESCRIPTION
## Summary

- carry a scaffold-different launch echo identity into adopted live facts
- reconcile the raw 202 seed before the live transcript frame is painted
- cover zero-intermediate-poll builder and reviewer adoption paths

Closes #616

## Verification

- bun test src/lib/agent/spawnProjection.test.ts src/components/LogFeed.outboxTailOrder.dom.test.tsx: 41 pass
- bunx tsc --noEmit --incremental false: pass
- privacy publication gate with commit checks: pass
- focused self-review: no findings