### PR TITLE
fix(registry): complete SQLite mirror recovery

### DIFF
--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -3,7 +3,7 @@
 The registry supports four values for `LLV_AGENT_REGISTRY_SQLITE`:
 
 - `off` keeps `agent-registry.json` authoritative. This is the default.
-- `dual-write` reads JSON, writes JSON and SQLite under the existing JSON writer lock, and verifies parity after every mutation.
+- `dual-write` reads JSON, writes revision-stamped JSON and SQLite under the existing JSON writer lock, and verifies parity after every mutation.
 - `read` reads and transacts through `agent-registry.sqlite` in WAL mode, then refreshes `agent-registry.json` on a bounded five-second checkpoint cadence. Startup and release demotion write a revision-stamped checkpoint.
 - `sqlite` uses SQLite for reads and writes after the parity burn-in. It refreshes the JSON mirror at process start, repairs missing, malformed, stale, or torn mirror state from authoritative SQLite, and removes JSON serialization from registry operations. A mirror revision ahead of SQLite remains fenced because it can indicate durable-state rollback.
 

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -31,10 +31,10 @@ observed modes differ, so promotion cannot publish a split registry fleet.
 8. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
 9. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
 
-`/api/files` reports the backend mode, revision, transaction count, transaction p95,
-writer-wait p95, rollback-mirror checkpoint timestamp, and dirty-checkpoint state under
-`systemHealth.registry`. The cached response exposes the stable mirror checkpoint
-timestamp and omits time-decaying writer rate; rollout probes derive both values at
+`/api/files` reports the backend mode, authoritative and JSON-mirror revisions,
+transaction count, transaction p95, writer-wait p95, rollback-mirror checkpoint
+timestamp, and dirty-checkpoint state under `systemHealth.registry`. The cached
+response exposes the stable mirror checkpoint timestamp and omits time-decaying writer rate; rollout probes derive both values at
 observation time. `/api/runtime/deployments/capabilities/v1` reports
 `registryBackendMode` from the registry instance opened by that Viewer process.
 A rollout probe must

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -834,6 +834,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   const registryHealth = {
     backendMode: registryDiagnostics.backendMode,
     revision: registryDiagnostics.revision,
+    mirrorRevision: registryDiagnostics.mirrorRevision,
     transactionCount: registryDiagnostics.transactionCount,
     writerWaitP95Ms: registryDiagnostics.writerWaitP95Ms,
     transactionP95Ms: registryDiagnostics.transactionP95Ms,

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -441,6 +441,28 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
 });
 
+test("SQLite health exposes authoritative and mirror revisions without conditional-response churn", async () => {
+  scannedFiles = [];
+  const registry = new AgentRegistry(path.join(registryRoot, "sqlite-health.json"), undefined, undefined, {
+    sqliteMode: "sqlite",
+  });
+  setAgentRegistryForTests(registry);
+
+  const first = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await first.json() as {
+    systemHealth: { registry: { revision: number; mirrorRevision: number } };
+  };
+  const etag = first.headers.get("etag");
+  const second = await GET(new Request("http://127.0.0.1/api/files", {
+    headers: { "if-none-match": etag! },
+  }));
+
+  expect(body.systemHealth.registry.revision).toBe(registry.storageDiagnostics().revision!);
+  expect(body.systemHealth.registry.mirrorRevision).toBe(body.systemHealth.registry.revision);
+  expect(second.status).toBe(304);
+  expect(second.headers.get("x-llv-files-projection-cache")).toBe("hit");
+});
+
 test("a cross-process SQLite pipeline commit invalidates a warm files projection", async () => {
   scannedFiles = [];
   const real = realModules.get("@/lib/pipelines/store") as {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -462,6 +462,7 @@ test("authoritative SQLite startup stamps and repairs a legacy mirror", () => {
   const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
   const receipt = beginTestSpawn(registry, "/sqlite-legacy-mirror");
   registry.checkpointRollbackMirror();
+  const expected = registry.snapshot();
 
   const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & { _sqliteRevision?: number };
   delete mirror._sqliteRevision;
@@ -473,6 +474,8 @@ test("authoritative SQLite startup stamps and repairs a legacy mirror", () => {
   const revision = recovered.storageDiagnostics().revision;
   if (revision === null) throw new Error("expected an authoritative SQLite revision");
   expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+  expect(recovered.snapshot()).toEqual(expected);
+  expect(normalizeRegistry(repaired)).toEqual(expected);
   expect(repaired._sqliteRevision).toBe(revision);
 });
 
@@ -484,6 +487,7 @@ test.each(["malformed", "lower"] as const)(
     const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
     const receipt = beginTestSpawn(registry, `/sqlite-${scenario}-mirror`);
     registry.checkpointRollbackMirror();
+    const expected = registry.snapshot();
 
     const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & { _sqliteRevision: unknown };
     mirror._sqliteRevision = scenario === "malformed"
@@ -495,23 +499,40 @@ test.each(["malformed", "lower"] as const)(
     const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
     const revision = recovered.storageDiagnostics().revision;
     if (revision === null) throw new Error("expected an authoritative SQLite revision");
+    const repaired = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
     expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
-    expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number })._sqliteRevision)
-      .toBe(revision);
+    expect(recovered.snapshot()).toEqual(expected);
+    expect(normalizeRegistry(repaired)).toEqual(expected);
+    expect(repaired._sqliteRevision).toBe(revision);
   },
 );
 
-test("authoritative SQLite startup fences a mirror revision ahead of durable state", () => {
+test("authoritative SQLite startup fences an ahead mirror once and recovers on restart", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-ahead-"));
   const filename = path.join(directory, "agent-registry.json");
   const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const receipt = beginTestSpawn(registry, "/sqlite-ahead-mirror");
   registry.checkpointRollbackMirror();
-  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & {
+    _sqliteRevision: number;
+  };
   mirror._sqliteRevision += 1;
+  delete mirror.receipts[receipt.launchId];
+  const aheadRevision = mirror._sqliteRevision;
   fs.writeFileSync(filename, JSON.stringify(mirror));
 
   expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" }))
-    .toThrow("agent registry JSON mirror revision is ahead of SQLite");
+    .toThrow(/mirror revision \d+ is ahead of authoritative SQLite revision \d+.*next startup will rebuild/i);
+  const conflicts = fs.readdirSync(directory).filter((entry) => entry.includes(".sqlite-conflict-r"));
+  expect(conflicts).toHaveLength(1);
+  const conflict = JSON.parse(fs.readFileSync(path.join(directory, conflicts[0]!), "utf8")) as typeof mirror;
+  expect(conflict._sqliteRevision).toBe(aheadRevision);
+  expect(conflict.receipts[receipt.launchId]).toBeUndefined();
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const repaired = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+  expect(repaired._sqliteRevision).toBe(recovered.storageDiagnostics().revision!);
 });
 
 test("SQLite restart normalizes legacy held-delivery rows before parity", () => {
@@ -1080,6 +1101,42 @@ test("restart refreshes the JSON rollback mirror after a post-commit process exi
   expect(recovered.conversations.conversation_crash_mid_write).toBeDefined();
   expect(new AgentRegistry(filename).snapshot()).toEqual(recovered);
 });
+
+test.each(["before", "after"] as const)(
+  "authoritative SQLite restart recovers a mirror process exit %s atomic rename",
+  async (boundary) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-sqlite-${boundary}-rename-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const initialRevision = (JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number })._sqliteRevision;
+    const receipt = beginTestSpawn(registry, `/sqlite-mirror-${boundary}-rename`);
+    const expected = registry.snapshot();
+    const child = Bun.spawn([
+      process.execPath,
+      CHILD,
+      "sqlite-mirror-crash",
+      filename,
+      path.join(directory, "unused-ready"),
+      path.join(directory, "unused-release"),
+      boundary,
+    ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+
+    expect(await child.exited).toBe(boundary === "before" ? 75 : 76);
+    expect(await new Response(child.stderr).text()).toBe("");
+    const interrupted = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+    expect(interrupted._sqliteRevision).toBe(
+      boundary === "before" ? initialRevision : registry.storageDiagnostics().revision!,
+    );
+    if (boundary === "after") expect(normalizeRegistry(interrupted)).toEqual(expected);
+
+    const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const repaired = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+    expect(recovered.snapshot()).toEqual(expected);
+    expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+    expect(repaired._sqliteRevision).toBe(recovered.storageDiagnostics().revision!);
+    expect(fs.readdirSync(directory).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+  },
+);
 
 test("SQLite-only operations avoid JSON rewrites and the read mode prepares rollback", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-only-"));

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -324,6 +324,8 @@ for (const version of [1, 2]) {
 
     const first = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
     expect(first.snapshot().autoBalance.claude.restartedAt).toBe(first.snapshot().autoBalance.codex.restartedAt);
+    expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number })._sqliteRevision)
+      .toBe(first.storageDiagnostics().revision!);
 
     const ready = path.join(directory, "restart.ready");
     const release = path.join(directory, "restart.release");
@@ -342,6 +344,23 @@ for (const version of [1, 2]) {
     expect(await new Response(restarted.stderr).text()).toBe("");
   });
 }
+
+test("dual-write startup recreates a missing JSON mirror with the authoritative revision", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-dual-missing-mirror-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const first = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  const receipt = beginTestSpawn(first, "/dual-missing-mirror");
+  const expected = first.snapshot();
+  fs.renameSync(filename, `${filename}.legacy-missing`);
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number };
+
+  expect(recovered.snapshot()).toEqual(expected);
+  expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+  expect(mirror._sqliteRevision).toBe(recovered.storageDiagnostics().revision!);
+  expect(recovered.storageDiagnostics().mirrorRevision).toBe(mirror._sqliteRevision!);
+});
 
 test("supersedence edges round-trip JSON ↔ SQLite with parity intact", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-supersede-"));
@@ -421,6 +440,10 @@ test("dual-write keeps JSON authoritative and SQLite reads require parity", () =
   const sqliteFilename = path.join(directory, "agent-registry.sqlite");
   const dual = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
   const receipt = beginTestSpawn(dual, "/parity");
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number };
+
+  expect(mirror._sqliteRevision).toBe(dual.storageDiagnostics().revision!);
+  expect(dual.storageDiagnostics().mirrorRevision).toBe(mirror._sqliteRevision!);
 
   expect(new AgentRegistry(filename).snapshot().receipts[receipt.launchId]).toEqual(
     new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot().receipts[receipt.launchId],
@@ -775,6 +798,25 @@ test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   db.close();
 });
 
+test("dual-write rollback restores a stamped current mirror after a replacement failure", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-dual-rollback-stamp-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const dual = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "dual-write",
+    beforeDualWriteMutationReplace: () => { throw new Error("injected SQLite replacement failure"); },
+  });
+  const legacy = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number };
+  delete legacy._sqliteRevision;
+  fs.writeFileSync(filename, JSON.stringify(legacy));
+
+  expect(() => beginTestSpawn(dual, "/dual-rollback-stamp")).toThrow("injected SQLite replacement failure");
+
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number };
+  expect(mirror._sqliteRevision).toBe(dual.storageDiagnostics().revision!);
+  expect(dual.storageDiagnostics().mirrorRevision).toBe(mirror._sqliteRevision!);
+  expect(dual.snapshot().receipts).toEqual({});
+});
+
 for (const sqliteMode of ["read", "sqlite"] as const) {
   test(`${sqliteMode} mode leaves the durable revision unchanged after a missing claim release`, () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${sqliteMode}-noop-`));
@@ -848,6 +890,8 @@ test("dual-write startup serializes SQLite replacement with a concurrent writer"
   const dual = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
   expect(Object.values(dual.snapshot().conversations).some((conversation) =>
     conversation.generations.some((generation) => generation.path === "/sessions/concurrent-dual-writer.jsonl"))).toBeTrue();
+  expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number })._sqliteRevision)
+    .toBe(dual.storageDiagnostics().revision!);
 });
 
 for (const mode of ["read", "sqlite"] as const) {
@@ -930,6 +974,8 @@ test("dual-write mutation fails closed across a concurrent SQLite writer", async
   const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
   expect(recovered.conversationForPath("/sessions/sqlite.jsonl")).toBeDefined();
   expect(recovered.conversationForPath("/sessions/dual.jsonl")).toBeNull();
+  expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number })._sqliteRevision)
+    .toBe(recovered.storageDiagnostics().revision!);
   expect(new AgentRegistry(filename).snapshot()).toEqual(recovered.snapshot());
 });
 
@@ -1187,6 +1233,8 @@ test("dual-write release demotion leaves the authoritative JSON handoff untouche
   beginTestSpawn(successor, "/successor");
 
   expect(rollbackWrites).toBe(0);
+  expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number })._sqliteRevision)
+    .toBe(successor.storageDiagnostics().revision!);
   expect(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot())
     .toEqual(successor.snapshot());
 });

--- a/src/lib/agent/registry.sqliteChild.ts
+++ b/src/lib/agent/registry.sqliteChild.ts
@@ -11,6 +11,19 @@ function waitFor(pathname: string): void {
   while (!fs.existsSync(pathname)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
 }
 
+if (action === "sqlite-mirror-crash") {
+  new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "sqlite",
+    beforeMirrorRename: () => {
+      if (label === "before") process.exit(75);
+    },
+    afterMirrorRename: () => {
+      if (label === "after") process.exit(76);
+    },
+  });
+  process.exit(0);
+}
+
 if (action === "dual-startup") {
   new AgentRegistry(filename, undefined, undefined, {
     sqliteMode: "dual-write",

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2962,14 +2962,31 @@ export function normalizeRegistry(value: unknown, policy?: McpGrantPolicy): Regi
   }), policy);
 }
 
-function readFileWithPayload(filename: string, policy?: McpGrantPolicy): { file: RegistryFile; payload: string | null } {
+function sqliteRevisionFromParsed(value: unknown): number | null {
+  const revision = value && typeof value === "object"
+    ? (value as { _sqliteRevision?: unknown })._sqliteRevision
+    : undefined;
+  return Number.isSafeInteger(revision) && Number(revision) >= 0 ? Number(revision) : null;
+}
+
+function readFileWithPayload(
+  filename: string,
+  policy?: McpGrantPolicy,
+): { file: RegistryFile; payload: string | null; sqliteRevision: number | null } {
   try {
     const payload = fs.readFileSync(filename, "utf8");
+    const parsed = JSON.parse(payload);
     /* A whole file, so an entry no conversation owns is genuinely unowned and
        falls back to the baseline rather than keeping a claimed grant (#739). */
-    return { file: reboundAssembledMcpGrants(normalizeRegistry(JSON.parse(payload), policy), policy), payload };
+    return {
+      file: reboundAssembledMcpGrants(normalizeRegistry(parsed, policy), policy),
+      payload,
+      sqliteRevision: sqliteRevisionFromParsed(parsed),
+    };
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { file: clone(EMPTY), payload: null };
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { file: clone(EMPTY), payload: null, sqliteRevision: null };
+    }
     if (error instanceof RegistryReadError) throw error;
     throw new RegistryReadError(`agent registry cannot be read: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -3114,8 +3131,7 @@ export function sqliteModeFromEnvironment(): AgentRegistrySqliteMode {
 
 function sqliteMirrorRevision(filename: string): number | null {
   try {
-    const revision = (JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: unknown })._sqliteRevision;
-    return Number.isInteger(revision) && Number(revision) >= 0 ? Number(revision) : null;
+    return sqliteRevisionFromParsed(JSON.parse(fs.readFileSync(filename, "utf8")));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
@@ -3296,7 +3312,7 @@ export class AgentRegistry {
   }
 
   private currentMirrorRevision(): number | null {
-    if (this.sqliteMode !== "read" && this.sqliteMode !== "sqlite") return null;
+    if (this.sqliteMode === "off") return null;
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const before = registryFileSignature(this.filename);
       if (this.mirrorRevisionCache?.signature === before) return this.mirrorRevisionCache.revision;
@@ -3408,7 +3424,7 @@ export class AgentRegistry {
     }
   }
 
-  private compactAtStartupLocked(): void {
+  private compactAtStartupLocked(sqliteRevision?: number): void {
     let original: string;
     try {
       original = fs.readFileSync(this.filename, "utf8");
@@ -3427,7 +3443,7 @@ export class AgentRegistry {
       throw error;
     }
     compactDeliveryReservations(file, undefined, this.now());
-    if (serializeRegistry(file) !== original) writeAtomic(this.filename, file);
+    if (serializeRegistry(file, sqliteRevision) !== original) writeAtomic(this.filename, file, sqliteRevision);
   }
 
   private synchronizeDualWriteStartup(beforeReplace: (() => void) | undefined): void {
@@ -3435,7 +3451,7 @@ export class AgentRegistry {
     const claim = this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
     try {
       const sqlite = this.sqliteStore!.snapshot();
-      if (!fs.existsSync(this.filename)) writeAtomic(this.filename, sqlite.file);
+      if (!fs.existsSync(this.filename)) writeAtomic(this.filename, sqlite.file, sqlite.revision);
       const mirrorRevision = sqliteMirrorRevision(this.filename);
       if (mirrorRevision !== null && mirrorRevision !== sqlite.revision) {
         throw new RegistryParityError(
@@ -3443,7 +3459,7 @@ export class AgentRegistry {
         );
       }
       this.assertSqliteParity(sqlite);
-      this.compactAtStartupLocked();
+      this.compactAtStartupLocked(sqlite.revision);
       const file = readFile(this.filename, this.mcpGrantPolicy);
       beforeReplace?.();
       const replacement = this.sqliteStore!.replace(file, sqlite.revision);
@@ -3453,6 +3469,7 @@ export class AgentRegistry {
           `agent registry SQLite revision changed during dual-write startup: expected ${sqlite.revision}, current ${replacement.revision}`,
         );
       }
+      writeAtomic(this.filename, replacement.file, replacement.revision);
       this.assertSqliteParity();
     } finally {
       this.releaseLock(claim);
@@ -3827,11 +3844,17 @@ export class AgentRegistry {
         this.assertSqliteParity(sqlite);
       }
       const original = readFileWithPayload(this.filename, this.mcpGrantPolicy);
+      const rollbackFile = sqlite && original.sqliteRevision !== sqlite.revision
+        ? clone(original.file)
+        : null;
       const file = original.file;
       const result = mutator(file);
-      const payload = serializeRegistry(file);
-      const changed = original.payload !== payload;
-      if (changed) writeAtomicPayload(this.filename, payload);
+      const currentPayload = serializeRegistry(file, sqlite?.revision);
+      const changed = original.payload !== currentPayload;
+      if (changed) {
+        const payload = serializeRegistry(file, sqlite ? sqlite.revision + 1 : undefined);
+        writeAtomicPayload(this.filename, payload);
+      }
       if (sqlite && !changed) this.assertSqliteParity();
       if (sqlite && changed) {
         let replacement: SqliteRegistryReplacement;
@@ -3841,8 +3864,8 @@ export class AgentRegistry {
         } catch (error) {
           const durableSqlite = this.sqliteStore!.snapshot();
           if (durableSqlite.revision === sqlite.revision) {
-            if (original.payload === null) writeAtomic(this.filename, original.file, sqlite.revision);
-            else writeAtomicPayload(this.filename, original.payload);
+            if (rollbackFile) writeAtomic(this.filename, rollbackFile, sqlite.revision);
+            else writeAtomicPayload(this.filename, original.payload!);
           } else {
             this.mirrorSqliteSnapshot(durableSqlite);
           }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -3025,7 +3025,12 @@ function serializeRegistry(value: RegistryFile, sqliteRevision?: number): string
   return JSON.stringify(storage) + "\n";
 }
 
-function writeAtomicPayload(filename: string, payload: string): void {
+interface AtomicWriteHooks {
+  beforeRename?: () => void;
+  afterRename?: () => void;
+}
+
+function writeAtomicPayload(filename: string, payload: string, hooks?: AtomicWriteHooks): void {
   fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
   const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
   let fd: number | null = null;
@@ -3035,7 +3040,9 @@ function writeAtomicPayload(filename: string, payload: string): void {
     fs.fsyncSync(fd);
     fs.closeSync(fd);
     fd = null;
+    hooks?.beforeRename?.();
     fs.renameSync(temp, filename);
+    hooks?.afterRename?.();
     const dir = fs.openSync(path.dirname(filename), "r");
     try { fs.fsyncSync(dir); } finally { fs.closeSync(dir); }
   } finally {
@@ -3044,8 +3051,13 @@ function writeAtomicPayload(filename: string, payload: string): void {
   }
 }
 
-function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: number): void {
-  writeAtomicPayload(filename, serializeRegistry(value, sqliteRevision));
+function writeAtomic(
+  filename: string,
+  value: RegistryFile,
+  sqliteRevision?: number,
+  hooks?: AtomicWriteHooks,
+): void {
+  writeAtomicPayload(filename, serializeRegistry(value, sqliteRevision), hooks);
 }
 
 export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
@@ -3069,6 +3081,8 @@ export interface AgentRegistryStorageOptions {
   onSqliteRevisionQuery?: () => void;
   beforeDualWriteStartupReplace?: () => void;
   beforeDualWriteMutationReplace?: () => void;
+  beforeMirrorRename?: () => void;
+  afterMirrorRename?: () => void;
   mirrorCheckpointMs?: number;
   now?: () => number;
   scheduleMirrorCheckpoint?: (callback: () => void, delayMs: number) => { unref?(): unknown };
@@ -3078,6 +3092,7 @@ export interface AgentRegistryStorageOptions {
 export interface AgentRegistryStorageDiagnostics {
   backendMode: AgentRegistrySqliteMode;
   revision: number | null;
+  mirrorRevision: number | null;
   transactionCount: number;
   writerRatePerSecond: number;
   writerWaitP95Ms: number | null;
@@ -3127,6 +3142,8 @@ export class AgentRegistry {
   private readonly now: () => number;
   private readonly scheduleMirrorCheckpoint: (callback: () => void, delayMs: number) => { unref?(): unknown };
   private readonly afterMirrorWrite: (() => void) | undefined;
+  private readonly mirrorWriteHooks: AtomicWriteHooks;
+  private mirrorRevisionCache: { signature: string; revision: number | null } | null = null;
   private mirrorCheckpointPending = false;
   private mirrorCheckpointFailures = 0;
   private lastMirrorAt: number | null = null;
@@ -3171,6 +3188,10 @@ export class AgentRegistry {
     this.scheduleMirrorCheckpoint = storage.scheduleMirrorCheckpoint
       ?? ((callback, delayMs) => setTimeout(callback, delayMs));
     this.afterMirrorWrite = storage.afterMirrorWrite;
+    this.mirrorWriteHooks = {
+      beforeRename: storage.beforeMirrorRename,
+      afterRename: storage.afterMirrorRename,
+    };
     this.beforeDualWriteMutationReplace = storage.beforeDualWriteMutationReplace;
     this.sqliteStore = this.sqliteMode === "off"
       ? null
@@ -3196,6 +3217,7 @@ export class AgentRegistry {
       this.synchronizeDualWriteStartup(storage.beforeDualWriteStartupReplace);
     }
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
+      this.cleanupStaleTempFiles();
       const sqlite = this.sqliteStore!.snapshot();
       const mirrorRevision = sqliteMirrorRevision(this.filename);
       /* `read` is the parity burn-in, so a same-revision mismatch must stop
@@ -3206,7 +3228,10 @@ export class AgentRegistry {
         this.assertSqliteParity(sqlite);
       }
       if (mirrorRevision !== null && mirrorRevision > sqlite.revision) {
-        throw new RegistryParityError("agent registry JSON mirror revision is ahead of SQLite");
+        if (this.sqliteMode === "sqlite") this.fenceAheadMirror(mirrorRevision, sqlite.revision);
+        throw new RegistryParityError(
+          `agent registry JSON revision ${mirrorRevision} is ahead of SQLite revision ${sqlite.revision}`,
+        );
       }
       this.mirrorSqliteSnapshot(sqlite);
     }
@@ -3230,8 +3255,27 @@ export class AgentRegistry {
     }
   }
 
+  private fenceAheadMirror(mirrorRevision: number, sqliteRevision: number): void {
+    const conflictLabel = `sqlite-conflict-r${mirrorRevision}-over-r${sqliteRevision}`;
+    const conflict = `${this.filename}.${conflictLabel}`;
+    try {
+      fs.renameSync(this.filename, conflict);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    throw new RegistryParityError(
+      `agent registry JSON mirror revision ${mirrorRevision} is ahead of authoritative SQLite revision ${sqliteRevision}; `
+      + `conflicting mirror moved beside the registry as ${conflictLabel} and the next startup will rebuild from SQLite`,
+    );
+  }
+
   private mirrorSqliteSnapshot(initial: SqliteRegistrySnapshot): void {
-    writeAtomic(this.filename, initial.file, initial.revision);
+    writeAtomic(this.filename, initial.file, initial.revision, this.mirrorWriteHooks);
+    this.mirrorRevisionCache = {
+      signature: registryFileSignature(this.filename),
+      revision: initial.revision,
+    };
     this.afterMirrorWrite?.();
     const latestRevision = this.sqliteStore!.revision();
     this.lastMirrorAt = this.now();
@@ -3251,8 +3295,23 @@ export class AgentRegistry {
     return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
   }
 
+  private currentMirrorRevision(): number | null {
+    if (this.sqliteMode !== "read" && this.sqliteMode !== "sqlite") return null;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const before = registryFileSignature(this.filename);
+      if (this.mirrorRevisionCache?.signature === before) return this.mirrorRevisionCache.revision;
+      const revision = sqliteMirrorRevision(this.filename);
+      const after = registryFileSignature(this.filename);
+      if (before !== after) continue;
+      this.mirrorRevisionCache = { signature: after, revision };
+      return revision;
+    }
+    return sqliteMirrorRevision(this.filename);
+  }
+
   storageDiagnostics(): AgentRegistryStorageDiagnostics {
     const revision = this.sqliteStore?.revision() ?? null;
+    const mirrorRevision = this.currentMirrorRevision();
     if (revision !== null && this.lastMirroredRevision !== null && revision > this.lastMirroredRevision) {
       this.mirrorDirty = true;
     }
@@ -3265,6 +3324,7 @@ export class AgentRegistry {
     return {
       backendMode: this.sqliteMode,
       revision,
+      mirrorRevision,
       transactionCount: this.transactionCount,
       writerRatePerSecond: rollingTransactions / 60,
       writerWaitP95Ms: this.percentile(this.writerWaits),


### PR DESCRIPTION
## Impact

SQLite-backed registry mirrors now carry an attributable revision through dual-write startup, mutation, rollback, authoritative recovery, and demotion. Legacy missing, malformed, and lower stamps converge from readable SQLite, while an ahead conflict produces bounded evidence and one restart-safe recovery transition.

## Cause

Dual-write startup and mutation payloads serialized JSON without _sqliteRevision. A later authoritative SQLite boot could therefore receive an unstamped mirror. The ahead-revision fence also threw before creating a durable recovery transition, and health exposed only the authoritative revision.

## Fix

- stamp dual-write startup writes with the current SQLite revision and changed mutation payloads with the revision committed by their SQLite replacement
- restore a current stamped snapshot when replacement fails, while preserving no-op inode and revision behavior
- move an ahead mirror beside the registry as bounded conflict evidence, report both revisions, and let the next restart rebuild the live mirror from SQLite
- clean dead atomic-write temp files during read and SQLite startup
- expose mirrorRevision beside revision through stable health output
- cover exact legacy, malformed, lower, ahead, concurrent-writer, rollback, and process-exit behavior

## Verification

- Regression proof: the dual-write mutation test failed before the writer fix with an absent _sqliteRevision and passes after the change
- bunx tsc --noEmit --incremental false
- bun test src/lib/agent/registry.sqlite.test.ts under isolated state: 57 passed
- bun test src/app/api/files/route.test.ts under isolated state: 93 passed
- bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits

Closes #571