### PR TITLE
fix(board): dismiss finished branch cards without queueing shared-host kills (#574)

### DIFF
--- a/src/components/ProjectDashboard.selection.dom.test.tsx
+++ b/src/components/ProjectDashboard.selection.dom.test.tsx
@@ -339,6 +339,44 @@ test("closing a finished child card dismisses it without queueing a shared-host 
   expect(tmuxCalls).toEqual([]);
 });
 
+test("closing a live shared-host child preserves its root and sibling branches", async () => {
+  const parent = {
+    ...alphaOf(),
+    activity: "live" as const,
+    proc: "running" as const,
+    pid: 4101,
+  };
+  const child = {
+    ...file("/alpha-live-child", "Live child", Date.now() / 1000),
+    parent: "/alpha",
+    spawnOrigin: "viewer" as const,
+    activity: "live" as const,
+    proc: "running" as const,
+    pid: 4101,
+  };
+  const sibling = {
+    ...file("/alpha-live-sibling", "Sibling branch", Date.now() / 1000),
+    parent: "/alpha",
+    spawnOrigin: "viewer" as const,
+    activity: "recent" as const,
+  };
+  const host = mount([parent, child, sibling], [parent.path], [child.path, sibling.path]);
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${child.path}"]`) !== null)).toBe(true);
+
+  const close = Array.from(host.querySelectorAll(`[data-scheme-node="${child.path}"] button`)).find(
+    (button) => (button.getAttribute("aria-label") ?? "").startsWith("Remove column"),
+  ) as HTMLButtonElement | undefined;
+  expect(close).toBeTruthy();
+  flushSync(() => close!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never));
+
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${child.path}"]`) === null)).toBe(true);
+  await settle();
+  expect(host.querySelector(`[data-scheme-node="${parent.path}"]`)).not.toBeNull();
+  expect(host.querySelector(`[data-scheme-node="${sibling.path}"]`)).not.toBeNull();
+  expect(boards[PROJECT]!.prefs.hidden).toContain(child.path);
+  expect(tmuxCalls).toEqual([]);
+});
+
 test("the list publishes a multi-card selection in its own row order", async () => {
   const host = mount();
   expect(await waitFor(() => checkIn(host, "/beta") !== null)).toBe(true);

--- a/src/components/ProjectDashboard.selection.dom.test.tsx
+++ b/src/components/ProjectDashboard.selection.dom.test.tsx
@@ -60,6 +60,7 @@ const matchMediaFor = (query: string) => ({
 let projectCounter = 0;
 let PROJECT = "selection-contract-0";
 let boards: Record<string, BoardProjectStateV1> = {};
+let tmuxCalls: Array<Record<string, unknown>> = [];
 const emptyBoard = (): BoardProjectStateV1 => ({
   schemaVersion: 1,
   revision: 0,
@@ -101,6 +102,10 @@ const OVERRIDES: Record<string, unknown> = {
   fetch: (async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
     const method = (init?.method ?? "GET").toUpperCase();
+    if (url === "/api/tmux") {
+      tmuxCalls.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return { ok: true, status: 200, json: async () => ({ ok: true }), text: async () => "" };
+    }
     if (url.startsWith("/api/board")) {
       if (method === "GET") {
         const project = new URL(url, "http://x").searchParams.get("project")!;
@@ -150,6 +155,7 @@ beforeEach(() => {
   projectCounter += 1;
   PROJECT = `selection-contract-${projectCounter}`;
   boards = { [PROJECT]: seededBoard() };
+  tmuxCalls = [];
   resetSelectionSessionsForTest();
 });
 afterEach(() => {
@@ -183,8 +189,18 @@ const betaOf = () => file("/beta", "Beta", 1);
 const alpha = { path: "/alpha" };
 const beta = { path: "/beta" };
 
-function mount(files: FileEntry[] = [alphaOf(), betaOf()], manual?: string[]): HTMLElement {
-  if (manual) boards = { [PROJECT]: { ...seededBoard(), explicitManual: manual, prefs: { ...seededBoard().prefs, manual } } };
+function mount(files: FileEntry[] = [alphaOf(), betaOf()], manual?: string[], expanded: string[] = []): HTMLElement {
+  if (manual || expanded.length) {
+    const seed = seededBoard();
+    const nextManual = manual ?? seed.prefs.manual;
+    boards = {
+      [PROJECT]: {
+        ...seed,
+        explicitManual: nextManual,
+        prefs: { ...seed.prefs, manual: nextManual, expanded },
+      },
+    };
+  }
   const host = dom.document.createElement("div");
   dom.document.body.appendChild(host);
   const root = createRoot(host as unknown as Element);
@@ -281,6 +297,46 @@ test("a selected board card that the list has no row for is still published", as
   /* The leaf is in no list row, and is published anyway. */
   expect(slice().visiblePaths).not.toContain(leaf.path);
   expect(slice().selectedPaths).toEqual([leaf.path]);
+});
+
+test("closing a finished child card dismisses it without queueing a shared-host kill", async () => {
+  const parent = {
+    ...alphaOf(),
+    activity: "live" as const,
+    proc: "running" as const,
+    pid: 4101,
+  };
+  const child = {
+    ...file("/alpha-child", "Finished child", Date.now() / 1000),
+    parent: "/alpha",
+    spawnOrigin: "viewer" as const,
+    activity: "idle" as const,
+    proc: null,
+    pid: null,
+  };
+  const sibling = {
+    ...file("/alpha-sibling", "Sibling branch", Date.now() / 1000),
+    parent: "/alpha",
+    spawnOrigin: "viewer" as const,
+    activity: "recent" as const,
+  };
+  const host = mount([parent, child, sibling], [parent.path], [child.path, sibling.path]);
+  const childShown = await waitFor(() => host.querySelector(`[data-scheme-node="${child.path}"]`) !== null);
+  expect(childShown).toBe(true);
+  expect(host.querySelector(`[data-scheme-node="${sibling.path}"]`)).not.toBeNull();
+
+  const close = Array.from(host.querySelectorAll(`[data-scheme-node="${child.path}"] button`)).find(
+    (button) => (button.getAttribute("aria-label") ?? "").startsWith("Remove column"),
+  ) as HTMLButtonElement | undefined;
+  expect(close).toBeTruthy();
+  flushSync(() => close!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never));
+
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${child.path}"]`) === null)).toBe(true);
+  await settle();
+  expect(host.querySelector(`[data-scheme-node="${parent.path}"]`)).not.toBeNull();
+  expect(host.querySelector(`[data-scheme-node="${sibling.path}"]`)).not.toBeNull();
+  expect(boards[PROJECT]!.prefs.hidden).toContain(child.path);
+  expect(tmuxCalls).toEqual([]);
 });
 
 test("the list publishes a multi-card selection in its own row order", async () => {

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1280,16 +1280,10 @@ function ProjectDashboardView({
 
   /* The raw close, shared by an explicit user close and a history redo. */
   const applyClose = (path: string) => {
-    /* Closing a chat also puts out its host; fire-and-forget, since the node
-       disappears either way and a host that survived a failed request just
-       stays for the next close. Branch nodes are filtered server-side — they
-       share the root's host. */
-    void fetch("/api/tmux", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ action: "kill", path }),
-    }).catch(() => {});
-    /* One durable close, independent of the node's current render class: the
+    /* Card dismissal owns presentation only. Runtime termination stays on the
+       conversation's explicit process control: a child can share its root's
+       host, and a hidden root can still be running intentionally. One durable
+       close, independent of the node's current render class: the
        server reducer tombstones the path and strips manual/expanded membership,
        so a node closed while momentarily outside `autoPaths` no longer loses its
        tombstone and reappears (#60). The matching ephemeral jump target, if any,

--- a/src/components/scheme/BulkActionBar.tsx
+++ b/src/components/scheme/BulkActionBar.tsx
@@ -341,8 +341,8 @@ export const BulkActionBar = memo(function BulkActionBar({
               setConfirm("remove");
               return;
             }
-            /* Pure client removal (closeNode kills + hides); the emptied
-               selection prunes itself and the session ends with the cards. */
+            /* Presentation-only removal: each card is hidden durably while the
+               emptied selection prunes itself. Stop above owns host teardown. */
             for (const node of nodes) onRemove(node.file.path);
             setConfirm(null);
           }}

--- a/src/lib/conversation/actions.test.ts
+++ b/src/lib/conversation/actions.test.ts
@@ -2,13 +2,74 @@ import { expect, test } from "bun:test";
 
 import { applyConversationAction } from "./actions";
 
-function conversation(id: `conversation_${string}`, paths: string[]) {
+function conversation(
+  id: `conversation_${string}`,
+  paths: string[],
+  parentConversationId: `conversation_${string}` | null = null,
+) {
   return {
     id,
-    generations: paths.map((path, index) => ({ id: `session_${index}`, path })),
+    generations: paths.map((path, index) => ({
+      id: `session_${index}`,
+      path,
+      launchProfile: { parentConversationId },
+    })),
     continuityPaths: [] as string[],
   };
 }
+
+test("a finished child kill settles as a typed branch result without entering either executor", async () => {
+  const root = conversation("conversation_root", ["/sessions/root.jsonl"]);
+  const child = conversation("conversation_child", ["/sessions/child.jsonl"], root.id);
+  let structuredDispatches = 0;
+  let legacyKills = 0;
+
+  const result = await applyConversationAction({
+    operationId: "child-kill",
+    conversationId: child.id,
+    transcriptPath: "/sessions/child.jsonl",
+    action: "kill",
+  }, {
+    registry: () => ({
+      conversation: (id: string) => id === child.id ? child : root,
+      conversationForPath: (pathname: string) => pathname === "/sessions/child.jsonl" ? child : root,
+    } as never),
+    structuredEnabled: () => true,
+    dispatchStructuredControl: async () => {
+      structuredDispatches += 1;
+      return {
+        status: 202,
+        body: {
+          ok: true,
+          structured: true,
+          target: child.id,
+          operationId: "child-kill",
+          receipt: { operationId: "child-kill", status: "queued" },
+        },
+      };
+    },
+    interruptConversation: async () => ({ ok: true, target: "%1" }),
+    killConversation: async () => {
+      legacyKills += 1;
+      return { ok: true, target: "%1" };
+    },
+    resumeConversation: async () => ({ ok: true, target: "%1" }),
+    compactConversation: async () => ({ ok: true, target: "%1" }),
+    answerDialogKey: async () => ({ ok: true, target: "%1" }),
+  });
+
+  expect(result).toEqual({
+    status: 409,
+    body: {
+      ok: false,
+      outcome: "failed",
+      code: "branch-shares-root-host",
+      error: "branch conversations share their root runtime host; dismiss the branch card or terminate the root conversation explicitly",
+    },
+  });
+  expect(structuredDispatches).toBe(0);
+  expect(legacyKills).toBe(0);
+});
 
 test("conversation actions reject a transcript path owned by another durable conversation", async () => {
   const first = conversation("conversation_first", ["/sessions/first.jsonl"]);
@@ -175,7 +236,7 @@ test("current and continuity selectors remain valid in structured and legacy rou
   }
 });
 
-test("conversation actions carry the stable operation id through the structured ownership lane", async () => {
+test("an explicit root kill carries the stable operation id through the structured ownership lane", async () => {
   const owner = conversation("conversation_owner", ["/sessions/old.jsonl", "/sessions/current.jsonl"]);
   const controls: unknown[] = [];
   const result = await applyConversationAction({

--- a/src/lib/conversation/actions.test.ts
+++ b/src/lib/conversation/actions.test.ts
@@ -33,6 +33,12 @@ test("a finished child kill settles as a typed branch result without entering ei
     registry: () => ({
       conversation: (id: string) => id === child.id ? child : root,
       conversationForPath: (pathname: string) => pathname === "/sessions/child.jsonl" ? child : root,
+      canonicalConversationId: (id: string) => id,
+      readOnlySnapshot: () => ({
+        lineageEdges: {
+          [child.id]: { source: "engine-native", parentConversationId: root.id },
+        },
+      }),
     } as never),
     structuredEnabled: () => true,
     dispatchStructuredControl: async () => {
@@ -69,6 +75,65 @@ test("a finished child kill settles as a typed branch result without entering ei
   });
   expect(structuredDispatches).toBe(0);
   expect(legacyKills).toBe(0);
+});
+
+test("a viewer-spawned child with its own host remains explicitly terminable", async () => {
+  const root = conversation("conversation_root", ["/sessions/root.jsonl"]);
+  const child = conversation("conversation_child", ["/sessions/child.jsonl"], root.id);
+  const controls: unknown[] = [];
+
+  const result = await applyConversationAction({
+    operationId: "child-owned-kill",
+    conversationId: child.id,
+    transcriptPath: "/sessions/child.jsonl",
+    action: "kill",
+  }, {
+    registry: () => ({
+      conversation: (id: string) => id === child.id ? child : root,
+      conversationForPath: (pathname: string) => pathname === "/sessions/child.jsonl" ? child : root,
+      canonicalConversationId: (id: string) => id,
+      readOnlySnapshot: () => ({
+        lineageEdges: {
+          [child.id]: { source: "viewer-spawn", parentConversationId: root.id },
+        },
+      }),
+    } as never),
+    structuredEnabled: () => true,
+    dispatchStructuredControl: async (request) => {
+      controls.push(request);
+      return {
+        status: 202,
+        body: {
+          ok: true,
+          structured: true,
+          target: child.id,
+          operationId: "child-owned-kill",
+          receipt: { operationId: "child-owned-kill", status: "queued" },
+        },
+      };
+    },
+    interruptConversation: async () => ({ ok: true, target: "%1" }),
+    killConversation: async () => ({ ok: true, target: "%1" }),
+    resumeConversation: async () => ({ ok: true, target: "%1" }),
+    compactConversation: async () => ({ ok: true, target: "%1" }),
+    answerDialogKey: async () => ({ ok: true, target: "%1" }),
+  });
+
+  expect(result).toMatchObject({
+    status: 202,
+    body: {
+      ok: true,
+      target: child.id,
+      operationId: "child-owned-kill",
+      receipt: { status: "queued" },
+    },
+  });
+  expect(controls).toEqual([{
+    path: "/sessions/child.jsonl",
+    conversationId: child.id,
+    action: "kill",
+    operationId: "child-owned-kill",
+  }]);
 });
 
 test("conversation actions reject a transcript path owned by another durable conversation", async () => {

--- a/src/lib/conversation/actions.ts
+++ b/src/lib/conversation/actions.ts
@@ -1,4 +1,5 @@
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { BRANCH_SHARED_HOST_CODE, BRANCH_SHARED_HOST_ERROR, branchSharesRootHost } from "@/lib/conversation/branchControl";
 import {
   answerDialogKey,
   compactConversation,
@@ -28,6 +29,7 @@ type ConversationActionBody =
   | Omit<Extract<DeliveryOutcome, { ok: false }>, "status">
   | { ok: true; structured: true; target: string; outcome: "delivered" | "resumed"; spawned?: boolean }
   | { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } }
+  | { ok: false; outcome: "failed"; code: typeof BRANCH_SHARED_HOST_CODE; error: string }
   | { error: string };
 
 export type ConversationActionResult = { status: number; body: ConversationActionBody };
@@ -91,6 +93,18 @@ export async function applyConversationAction(
   }
   const conversation = byId ?? byPath;
   const transcriptPath = byId?.generations.at(-1)?.path ?? request.transcriptPath;
+
+  if (request.action === "kill" && branchSharesRootHost(conversation)) {
+    return {
+      status: 409,
+      body: {
+        ok: false,
+        outcome: "failed",
+        code: BRANCH_SHARED_HOST_CODE,
+        error: BRANCH_SHARED_HOST_ERROR,
+      },
+    };
+  }
 
   if (dependencies.structuredEnabled()) {
     const structured = await dependencies.dispatchStructuredControl({

--- a/src/lib/conversation/actions.ts
+++ b/src/lib/conversation/actions.ts
@@ -94,7 +94,7 @@ export async function applyConversationAction(
   const conversation = byId ?? byPath;
   const transcriptPath = byId?.generations.at(-1)?.path ?? request.transcriptPath;
 
-  if (request.action === "kill" && branchSharesRootHost(conversation)) {
+  if (request.action === "kill" && branchSharesRootHost(registry, conversation)) {
     return {
       status: 409,
       body: {

--- a/src/lib/conversation/branchControl.ts
+++ b/src/lib/conversation/branchControl.ts
@@ -1,10 +1,21 @@
-import type { RegistryConversation } from "@/lib/agent/registry";
+import type { AgentRegistry, RegistryConversation } from "@/lib/agent/registry";
 
 export const BRANCH_SHARED_HOST_CODE = "branch-shares-root-host" as const;
 export const BRANCH_SHARED_HOST_ERROR =
   "branch conversations share their root runtime host; dismiss the branch card or terminate the root conversation explicitly";
 
-export function branchSharesRootHost(conversation: RegistryConversation | null): boolean {
+type BranchLineageRegistry = Pick<AgentRegistry, "canonicalConversationId" | "readOnlySnapshot">;
+
+export function branchSharesRootHost(
+  registry: BranchLineageRegistry,
+  conversation: RegistryConversation | null,
+): boolean {
   const parentConversationId = conversation?.generations.at(-1)?.launchProfile.parentConversationId ?? null;
-  return Boolean(parentConversationId && parentConversationId !== conversation?.id);
+  if (!conversation || !parentConversationId || parentConversationId === conversation.id) return false;
+  const conversationId = registry.canonicalConversationId(conversation.id);
+  const lineage = registry.readOnlySnapshot().lineageEdges[conversationId];
+  /* Viewer-spawn lineage owns an independent host (pipeline stages included).
+     Engine-native lineage shares its root executor. Missing legacy provenance
+     stays protected because it cannot prove an independently owned host. */
+  return lineage?.source !== "viewer-spawn";
 }

--- a/src/lib/conversation/branchControl.ts
+++ b/src/lib/conversation/branchControl.ts
@@ -1,0 +1,10 @@
+import type { RegistryConversation } from "@/lib/agent/registry";
+
+export const BRANCH_SHARED_HOST_CODE = "branch-shares-root-host" as const;
+export const BRANCH_SHARED_HOST_ERROR =
+  "branch conversations share their root runtime host; dismiss the branch card or terminate the root conversation explicitly";
+
+export function branchSharesRootHost(conversation: RegistryConversation | null): boolean {
+  const parentConversationId = conversation?.generations.at(-1)?.launchProfile.parentConversationId ?? null;
+  return Boolean(parentConversationId && parentConversationId !== conversation?.id);
+}

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -488,7 +488,7 @@ export async function bindStructuredDeliveryQueue(
       return liveness?.state === "severed" ? liveness.reason : null;
     },
     (conversationId) => conversationId.startsWith("conversation_")
-      && branchSharesRootHost(registry.conversation(conversationId as `conversation_${string}`))
+      && branchSharesRootHost(registry, registry.conversation(conversationId as `conversation_${string}`))
       ? BRANCH_SHARED_HOST_ERROR
       : null,
   );

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type ProcessIdentity } from "@/lib/agent/registry";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
+import { BRANCH_SHARED_HOST_ERROR, branchSharesRootHost } from "@/lib/conversation/branchControl";
 
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import { runtimeSettingsCapability, type RuntimeEventInput, type RuntimeSession } from "./contracts";
@@ -486,6 +487,10 @@ export async function bindStructuredDeliveryQueue(
       const liveness = await conversationTurnLiveness(registry, conversationId, dependencies.liveness ?? {});
       return liveness?.state === "severed" ? liveness.reason : null;
     },
+    (conversationId) => conversationId.startsWith("conversation_")
+      && branchSharesRootHost(registry.conversation(conversationId as `conversation_${string}`))
+      ? BRANCH_SHARED_HOST_ERROR
+      : null,
   );
   let drainTimer: ReturnType<typeof setTimeout> | null = null;
   let drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "bun:test";
 
 import type { DeliveryReceipt, EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
-import { StructuredDeliveryQueue, type StructuredDeliveryQueuePort } from "./structuredDeliveryQueue";
+import {
+  CONTROL_SETTLEMENT_WINDOW_MS,
+  StructuredDeliveryQueue,
+  type StructuredDeliveryEffect,
+  type StructuredDeliveryQueuePort,
+} from "./structuredDeliveryQueue";
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContentDigest, type StructuredImageRef } from "./structuredContent";
 
 /**
@@ -1756,6 +1761,223 @@ test("an absent-host kill retries after terminal projection fails", async () => 
     ["kill-retry", "delivering", undefined],
     ["kill-retry", "delivered", undefined],
   ]);
+});
+
+test("a queued hostless kill past its settlement deadline terminalizes with retry guidance", async () => {
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let terminations = 0;
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "kill-deadline",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-deadline",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }],
+    status: async () => ({
+      status: "queued",
+      admittedAt: "2026-07-22T00:00:00.000Z",
+      at: "2026-07-22T00:00:00.000Z",
+    }),
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => null, async () => {
+    terminations += 1;
+    return false;
+  });
+
+  await queue.drain();
+
+  expect(terminations).toBe(0);
+  expect(transitions).toEqual([[
+    "kill-deadline",
+    "failed",
+    "kill control exceeded its 2-minute settlement deadline; retry from the current conversation state",
+  ]]);
+});
+
+test("every accepted runtime control shares the bounded terminal deadline", async () => {
+  const effects: StructuredDeliveryEffect[] = [
+    {
+      id: "answer-deadline",
+      kind: "runtime.answer",
+      eventSeq: 1,
+      payload: {
+        operationId: "answer-deadline",
+        conversationId: "conversation-answer",
+        attentionId: "attention-one",
+        resolution: { kind: "dismiss" },
+      },
+    },
+    {
+      id: "interrupt-deadline",
+      kind: "runtime.interrupt",
+      eventSeq: 2,
+      payload: { operationId: "interrupt-deadline", conversationId: "conversation-interrupt", turnId: "turn-one" },
+    },
+    {
+      id: "kill-deadline-all",
+      kind: "runtime.kill",
+      eventSeq: 3,
+      payload: {
+        operationId: "kill-deadline-all",
+        conversationId: "conversation-kill",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    },
+    {
+      id: "compact-deadline",
+      kind: "runtime.compact",
+      eventSeq: 4,
+      payload: {
+        operationId: "compact-deadline",
+        conversationId: "conversation-compact",
+        sessionKey: { engine: "claude", sessionId: "session-one" },
+      },
+    },
+    {
+      id: "reconfigure-deadline",
+      kind: "runtime.reconfigure",
+      eventSeq: 5,
+      payload: {
+        operationId: "reconfigure-deadline",
+        conversationId: "conversation-reconfigure",
+        sessionKey: { engine: "codex", sessionId: "thread-two" },
+        model: "gpt-5.6-sol",
+        effort: "high",
+        fast: false,
+      },
+    },
+  ];
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => effects,
+    status: async () => ({ status: "queued", admittedAt: "2026-07-22T00:00:00.000Z" }),
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => {
+    throw new Error("an expired control must settle before host resolution");
+  });
+
+  await queue.drain();
+
+  expect(transitions.sort(([left], [right]) => left.localeCompare(right))).toEqual([
+    ["answer-deadline", "failed", "answer control exceeded its 2-minute settlement deadline; retry from the current conversation state"],
+    ["compact-deadline", "failed", "compact control exceeded its 2-minute settlement deadline; retry from the current conversation state"],
+    ["interrupt-deadline", "failed", "interrupt control exceeded its 2-minute settlement deadline; retry from the current conversation state"],
+    ["kill-deadline-all", "failed", "kill control exceeded its 2-minute settlement deadline; retry from the current conversation state"],
+    ["reconfigure-deadline", "failed", "reconfigure control exceeded its 2-minute settlement deadline; retry from the current conversation state"],
+  ]);
+});
+
+test("restart recovery terminalizes a past-deadline issued kill without replaying it", async () => {
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let terminations = 0;
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "kill-issued-before-restart",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-issued-before-restart",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }],
+    status: async () => ({
+      status: "delivering",
+      admittedAt: "2026-07-22T00:00:00.000Z",
+    }),
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => host(async () => ({ outcome: "turn-started", turnId: "unexpected" })), async () => {
+    terminations += 1;
+    return true;
+  });
+
+  await queue.drain();
+
+  expect(terminations).toBe(0);
+  expect(transitions).toEqual([[
+    "kill-issued-before-restart",
+    "uncertain",
+    "kill control exceeded its 2-minute settlement deadline after actuation began; verify the conversation state before retrying",
+  ]]);
+});
+
+test("restart recovery rejects a queued branch kill before resolving or terminating its shared host", async () => {
+  const reason = "branch conversations share their root runtime host; dismiss the branch card or terminate the root conversation explicitly";
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let hostResolutions = 0;
+  let terminations = 0;
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "queued-branch-kill",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "queued-branch-kill",
+        conversationId: "conversation-child",
+        sessionKey: { engine: "codex", sessionId: "thread-child" },
+      },
+    }],
+    status: async () => ({ status: "queued", admittedAt: new Date().toISOString() }),
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => {
+    hostResolutions += 1;
+    return host(async () => ({ outcome: "turn-started", turnId: "unexpected" }));
+  }, async () => {
+    terminations += 1;
+    return true;
+  }, undefined, undefined, undefined, undefined, () => reason);
+
+  await queue.drain();
+
+  expect(hostResolutions).toBe(0);
+  expect(terminations).toBe(0);
+  expect(transitions).toEqual([["queued-branch-kill", "failed", reason]]);
+});
+
+test("a queued hostless kill schedules a drain that will cross its settlement deadline", async () => {
+  let retries = 0;
+  let terminations = 0;
+  const transitions: string[] = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "kill-awaiting-deadline",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-awaiting-deadline",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }],
+    status: async () => ({
+      status: "queued",
+      admittedAt: new Date(Date.now() - CONTROL_SETTLEMENT_WINDOW_MS + 30_000).toISOString(),
+    }),
+    transition: async (_operationId, status) => { transitions.push(status); },
+  }, () => null, async () => {
+    terminations += 1;
+    return false;
+  }, () => {
+    retries += 1;
+  });
+
+  await queue.drain();
+
+  expect(terminations).toBe(1);
+  expect(transitions).toEqual([]);
+  expect(retries).toBe(1);
 });
 
 test("an active-host kill retries after terminal projection fails", async () => {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -20,6 +20,14 @@ export interface StructuredDeliveryEffect {
 
 export type StructuredDeliveryTransition = "queued" | "delivering" | "applying" | "delivered" | "applied" | "answered" | "interrupted" | "failed" | "uncertain";
 
+interface StructuredOperationStatus {
+  status: string;
+  reason?: string | null;
+  /** Immutable admission time on current receipts; `at` supports older rows. */
+  admittedAt?: string;
+  at?: string;
+}
+
 export interface StructuredDeliveryQueuePort {
   effects(kinds?: readonly string[], afterEventSeq?: number): Promise<StructuredDeliveryEffect[]>;
   transition(
@@ -36,7 +44,7 @@ export interface StructuredDeliveryQueuePort {
       own state, read through the same type — and none of them may be converted
       into a definite answer when it fails. An unreadable fence is not an open
       one: it blocks this pass instead of authorising it (#1131). */
-  status?(operationId: string): Promise<{ status: string; reason?: string | null } | null>;
+  status?(operationId: string): Promise<StructuredOperationStatus | null>;
   /** Whether the durable DELIVERY RECORD has already ended this send (#1131).
       The journal cannot answer that during the outage in which it is written,
       which is exactly when it has to be honoured. */
@@ -53,9 +61,13 @@ export interface StructuredDeliveryQueuePort {
 
 export type StructuredHostResolver = (conversationId: string) => EngineHost | null;
 export type StructuredHostRecovery = (conversationId: string) => Promise<boolean>;
+export type StructuredKillRefusal = (conversationId: string) => string | null | Promise<string | null>;
 
 const STRUCTURED_DELIVERY_BATCH_SIZE = 100;
 const THREAD_READ_ATTEMPTS = 2;
+/** Controls carry no message reservation to settle them outside the journal,
+    so the queue itself gives every accepted control a terminal ceiling. */
+export const CONTROL_SETTLEMENT_WINDOW_MS = 2 * 60_000;
 const TERMINAL_DELIVERY_STATUSES = new Set([
   "turn-started",
   "steered",
@@ -164,6 +176,39 @@ function isCompactEffect(effect: DeliveryEffect): effect is CompactEffect {
 
 function isReconfigureEffect(effect: DeliveryEffect): effect is StructuredReconfigureEffect {
   return effect.kind === "reconfigure";
+}
+
+function isRuntimeControlEffect(
+  effect: DeliveryEffect,
+): effect is ControlEffect | CompactEffect | StructuredReconfigureEffect {
+  return isControlEffect(effect) || isReconfigureEffect(effect);
+}
+
+function controlSettlementDeadlineAt(receipt: StructuredOperationStatus | null): number | null {
+  if (!receipt) return null;
+  const admittedAt = Date.parse(receipt.admittedAt ?? receipt.at ?? "");
+  return Number.isFinite(admittedAt) ? admittedAt + CONTROL_SETTLEMENT_WINDOW_MS : null;
+}
+
+function expiredControlSettlement(
+  effect: ControlEffect | CompactEffect | StructuredReconfigureEffect,
+  receipt: StructuredOperationStatus | null,
+  now = Date.now(),
+): { status: "failed" | "uncertain"; reason: string } | null {
+  if (!receipt) return null;
+  const deadlineAt = controlSettlementDeadlineAt(receipt);
+  if (deadlineAt === null || now < deadlineAt) return null;
+  const action = effect.kind;
+  if (receipt.status === "delivering" || receipt.status === "applying") {
+    return {
+      status: "uncertain",
+      reason: `${action} control exceeded its 2-minute settlement deadline after actuation began; verify the conversation state before retrying`,
+    };
+  }
+  return {
+    status: "failed",
+    reason: `${action} control exceeded its 2-minute settlement deadline; retry from the current conversation state`,
+  };
 }
 
 function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
@@ -462,6 +507,8 @@ export class StructuredDeliveryQueue {
         could not be made at all, which {@link readSeveredHostReason} keeps
         separate rather than letting it out as a thrown drain pass (#1131). */
     private readonly severedHostReason: (conversationId: string) => Promise<string | null> = async () => null,
+    /** Refuses historical branch kills during recovery before host resolution. */
+    private readonly killRefusal: StructuredKillRefusal = () => null,
   ) {}
 
   drain(): Promise<void> {
@@ -614,11 +661,24 @@ export class StructuredDeliveryQueue {
 
   private async drainTarget(effects: DeliveryEffect[]): Promise<boolean> {
     const openEffects: DeliveryEffect[] = [];
-    const durableStatuses = new Map<string, { status: string; reason?: string | null } | null>();
+    const durableStatuses = new Map<string, StructuredOperationStatus | null>();
     for (const effect of effects) {
       const durable = await this.readStatus(effect.operationId);
       if (!durable.readable) return this.fenceUnavailable();
       if (durable.value && TERMINAL_DELIVERY_STATUSES.has(durable.value.status)) continue;
+      const expired = isRuntimeControlEffect(effect)
+        ? expiredControlSettlement(effect, durable.value)
+        : null;
+      if (expired) {
+        await this.transitionUnlessSettled(effect.operationId, expired.status, { reason: expired.reason });
+        continue;
+      }
+      /* A blocked hostless control may produce no journal or host event of its
+         own. Keep one bounded retry alive so a later pass observes the deadline
+         even when the rest of the runtime stays completely quiet. */
+      if (isRuntimeControlEffect(effect) && controlSettlementDeadlineAt(durable.value) !== null) {
+        this.retrySoon();
+      }
       durableStatuses.set(effect.operationId, durable.value);
       openEffects.push(effect);
     }
@@ -1029,7 +1089,7 @@ export class StructuredDeliveryQueue {
    * an attempted read that threw is unreadable, and the callers above never let
    * one of those authorise anything.
    */
-  private readStatus(operationId: string): Promise<Evidence<{ status: string; reason?: string | null } | null>> {
+  private readStatus(operationId: string): Promise<Evidence<StructuredOperationStatus | null>> {
     const read = this.port.status?.bind(this.port);
     return readOptionalEvidence(read && (() => read(operationId)), null, "delivery journal status is unavailable");
   }
@@ -1235,8 +1295,13 @@ export class StructuredDeliveryQueue {
   }
 
   private async drainControl(effect: ControlEffect): Promise<ControlDrainResult> {
-    const host = this.resolveHost(effect.conversationId);
     if (effect.kind === "kill") {
+      const refusal = await this.killRefusal(effect.conversationId);
+      if (refusal) {
+        await this.transitionUnlessSettled(effect.operationId, "failed", { reason: refusal });
+        return { blocked: false, terminated: false };
+      }
+      const host = this.resolveHost(effect.conversationId);
       if (!effect.sessionKey) {
         await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "structured host termination target is unavailable" });
         return { blocked: false, terminated: false };
@@ -1271,6 +1336,7 @@ export class StructuredDeliveryQueue {
         throw error;
       }
     }
+    const host = this.resolveHost(effect.conversationId);
     if (!host) {
       /* Holding the control was right while a host might still come back to
          answer it, and wrong once nothing can: the effect stays pending, the


### PR DESCRIPTION
## Impact

Closing a child card now hides it immediately while the root runtime and sibling branches keep running. Runtime termination remains available through the explicit conversation Stop control.

## Cause

ProjectDashboard.applyClose posted a kill for every card before writing the board tombstone. Structured routing admitted a child kill before the legacy shared-host guard could settle it, so a hostless child receipt could remain queued indefinitely.

## Fix

- Make board close a presentation-only mutation.
- Return a typed branch-shares-root-host result before either kill executor runs.
- Use durable lineage to protect engine-native shared-host branches while preserving independent viewer-spawn child teardown, including pipeline stages.
- Give answer, interrupt, kill, compact, and reconfigure controls a two-minute terminal deadline with retry or verification guidance.
- Refuse historical queued branch kills during restart recovery before host resolution.
- Keep the existing explicit root-kill path and terminal pipeline reaper.

## Verification

- Parent-revision red proof: board close emitted an action=kill request, and the direct child kill returned HTTP 202 with a queued receipt.
- bunx tsc --noEmit --incremental false: pass.
- Isolated focused tests: 92 passed, 315 assertions.
- Privacy publication gate with commit checks: pass.

Closes #574