### PR TITLE
fix(starting): retire image-only launch bubbles on adoption

### DIFF
--- a/src/components/LogFeed.spawnPathFlip.dom.test.tsx
+++ b/src/components/LogFeed.spawnPathFlip.dom.test.tsx
@@ -163,11 +163,13 @@ mock.module("@/hooks/useToolActivityCues", () => ({
 const { LogFeed } = await import("./LogFeed");
 const { resetLogTailCacheForTests } = await import("@/hooks/useLogTail");
 const { resetCanonicalAssistantClaimsForTests } = await import("./conversation/liveTurnHandoff");
+const { readOutbox, resetOutboxForTests } = await import("./conversation/outbox");
 
 const roots = new Set<Root>();
 beforeEach(() => {
   setLocale("en");
   dom.sessionStorage.clear();
+  resetOutboxForTests();
   resetCanonicalAssistantClaimsForTests();
   resetLogTailCacheForTests();
   bus.events = [];
@@ -295,4 +297,68 @@ test("a placeholder whose host has not named an artifact yet reads nothing and s
     `subscribe:${ARTIFACT_PATH}`,
   ]);
   oneRendering(host);
+});
+
+test.each([
+  ["roleless", ""],
+  ["role", "You are a Builder in plain mode."],
+])("an image-only %s launch retires its launch-owned delivering bubble when the live transcript is adopted", async (kind, promptEcho) => {
+  session = { ...sessionBase, artifactPath: null, liveTurn: null, activeTurnId: null };
+  const launchId = `launch-image-only-${kind}`;
+  const spawn = {
+    launchId,
+    clientAttemptId: null,
+    accountId: null,
+    conversationId: CONVERSATION_ID,
+    generation: 1,
+    state: "queued" as const,
+    initialMessage: "queued" as const,
+    retrySafe: false,
+    error: null,
+    ["prompt"]: "",
+    promptImages: 1,
+    promptAt: Date.parse(AT(0)),
+    promptEcho,
+  };
+  const owner = { conversationId: CONVERSATION_ID, generation: 1 };
+  const preAdoption = { ...launchCard, generation: 1, spawn } as FileEntry;
+  const adopted = {
+    ...transcriptCard,
+    generation: 1,
+    launch: {
+      launchId,
+      clientAttemptId: null,
+      accountId: null,
+      conversationId: CONVERSATION_ID,
+      generation: 1,
+      state: "queued",
+      initialMessage: "queued",
+      retrySafe: false,
+      error: null,
+    },
+  } as FileEntry;
+
+  const { host, paint } = mount();
+  paint(preAdoption);
+  await settle();
+  expect(host.querySelector<HTMLElement>(`[data-outbox-entry="${launchId}"]`)?.dataset.outboxState)
+    .toBe("delivering");
+  expect(readOutbox(CONVERSATION_ID).find((entry) => entry.id === launchId)).toMatchObject({
+    text: "",
+    images: 1,
+    state: "delivering",
+    launchOwned: true,
+    owner,
+    ...(promptEcho ? { echoText: promptEcho } : {}),
+  });
+
+  paint(adopted);
+  await settle();
+  expect(Boolean(host.querySelector(`[data-outbox-entry="${launchId}"]`))).toBeFalse();
+  expect(readOutbox(CONVERSATION_ID).find((entry) => entry.id === launchId)).toMatchObject({
+    state: "delivering",
+    launchOwned: true,
+    adoptedAt: expect.any(Number),
+    owner,
+  });
 });

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -27,6 +27,7 @@ import {
 import { orderedConversationTail } from "./conversation/tailOrder";
 import {
   publishTranscriptEchoes,
+  retireLaunchOutboxOnAdoption,
   seedLaunchOutbox,
   settleLaunchOutboxDelivered,
   settleLaunchOutboxFailed,
@@ -174,6 +175,17 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       && paneLaunchOwner.conversationId === launchOwner.conversationId
       && paneLaunchOwner.generation === launchOwner.generation,
   );
+  /* A materialized `file.launch` is the server's live-adoption signal. Retire
+     the starting-window bubble at that hand-off even when an image-only launch
+     has no text echo and its delivery receipt still reads queued/delivering. */
+  useEffect(() => {
+    if (!memoryKey || !file?.launch || !launchOwnsThisPane || !launchOwner) return;
+    retireLaunchOutboxOnAdoption(memoryKey, {
+      id: file.launch.launchId,
+      adoptedAt: nowMs(),
+      owner: launchOwner,
+    });
+  }, [memoryKey, file?.launch?.launchId, launchOwner, launchOwnsThisPane]);
   /* Live streaming text: `delta` events from the structured host render the
      in-flight assistant reply immediately, ahead of the transcript flush. The
      host is resolved by conversation identity FIRST (round-1 P1#3): during
@@ -552,7 +564,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      a fresh refresh) seeds the same launch-owned bubble the composer path seeds.
      Keyed by the launch id under the stable conversation identity, so it is
      idempotent with the composer's own seed (no duplicate), survives a refresh,
-     folds through transcript adoption, and retires on its transcript echo. */
+     and retires on its transcript echo or the live transcript's adoption. */
   useEffect(() => {
     if (!memoryKey || !launch?.launchId || !launchOwnsThisPane) return;
     const promptText = launch.prompt ?? "";

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -15,6 +15,7 @@ import {
   publishTranscriptEchoes,
   readOutbox,
   resetOutboxForTests,
+  retireLaunchOutboxOnAdoption,
   seedLaunchOutbox,
   settleLaunchOutboxDelivered,
   settleLaunchOutboxFailed,
@@ -1653,6 +1654,45 @@ describe("seedLaunchOutbox (P1#2)", () => {
     /* Transcript adoption: the flushed transcript echoes the prompt exactly once,
        which retires the launch-owned bubble — one window, zero duplicate. */
     expect(visibleOutbox(refreshed, echoes(identical), 5_000)).toEqual([]);
+  });
+
+  test("issue 617: live adoption hides a role launch while preserving its delayed scaffold echo for occurrence ordering", () => {
+    const scaffold = "You are a Builder in plain mode.";
+    const owner = { conversationId: "conversation_617", generation: 1 };
+    seedLaunchOutbox("conversation_617", {
+      id: "launch_617",
+      text: "",
+      images: 1,
+      at: 1_000,
+      echoText: scaffold,
+      owner,
+    });
+    retireLaunchOutboxOnAdoption("conversation_617", {
+      id: "launch_617",
+      adoptedAt: 2_000,
+      owner,
+    });
+    enqueueOutbox("conversation_617", {
+      id: "younger-identical",
+      text: scaffold,
+      images: 0,
+      at: 3_000,
+    });
+
+    publishTranscriptEchoes("conversation_617", [{
+      generation: "generation-live",
+      id: "launch-scaffold-row",
+      text: scaffold,
+    }]);
+
+    const queue = readOutbox("conversation_617");
+    expect(queue.find((entry) => entry.id === "launch_617")).toMatchObject({
+      state: "delivering",
+      adoptedAt: 2_000,
+      retiredEchoId: expect.any(String),
+    });
+    expect(visibleOutbox(queue, echoes(scaffold), 2_001, owner).map((entry) => entry.id))
+      .toEqual(["younger-identical"]);
   });
 });
 

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -51,6 +51,11 @@ export interface OutboxEntry {
   /** Assistant output began for the turn created by this submission. This is
       causal delivery proof and permanently retires the optimistic bubble. */
   responseStartedAt?: number;
+  /** The server attached this launch to its materialized live transcript. That
+      conversation replaces the optimistic launch bubble even when an image-only
+      prompt has no text echo to match. The entry stays in recent history so a
+      later text echo can still consume its exact occurrence. */
+  adoptedAt?: number;
   error?: string;
   /** The attachment bytes of this submission did not survive a page refresh
       (previews are memory-only). The entry is held back rather than delivered
@@ -59,8 +64,9 @@ export interface OutboxEntry {
   /** The initial launch prompt (issue #561/#569): the SPAWN delivers it, not the
       composer. It renders as the conversation's first optimistic user bubble but
       is never dispatched by the composer's queue and never blocks the serial
-      drain of the operator's follow-up messages. It retires on its transcript
-      echo like any other bubble. */
+      drain of the operator's follow-up messages. Live transcript adoption
+      retires it; an earlier transcript echo retires it through the ordinary
+      occurrence path. */
   launchOwned?: true;
   /** The canonical text this bubble's transcript echo will carry (issue #615),
       when it differs from the displayed {@link text}. A role launch DISPLAYS the
@@ -266,7 +272,7 @@ const OCCURRENCE_COMPLETED_LIMIT = ECHO_LEDGER_LIMIT;
 const occurrenceTombstones = new Map<string, readonly PersistedOccurrenceTombstone[]>();
 const EMPTY_OCCURRENCE_TOMBSTONES: readonly PersistedOccurrenceTombstone[] = [];
 
-type CurrentLaunchTerminalReason = "response-started" | "delivered-ttl";
+type CurrentLaunchTerminalReason = "live-adopted" | "response-started" | "delivered-ttl";
 
 interface PersistedCurrentLaunch {
   id: string;
@@ -339,7 +345,7 @@ function persistedQueue(cardId: string): readonly OutboxEntry[] {
       else delete counted.files;
       /* The initial launch prompt is owned by the spawn, not the composer: it
          survives a refresh exactly as it was (never re-dispatched, never
-         re-queued) and retires on its transcript echo. */
+         re-queued) until its transcript echo or live adoption retires it. */
       if (entry.launchOwned) return counted;
       const unsettled = entry.state === "delivering" || entry.state === "queued";
       /* A `delivering` entry recorded before a refresh has no owner in this
@@ -382,6 +388,7 @@ function isPersistedCurrentLaunch(value: unknown): value is PersistedCurrentLaun
     && (raw.retiredEchoId === undefined || typeof raw.retiredEchoId === "string")
     && (raw.retiredAt === undefined || typeof raw.retiredAt === "number")
     && (raw.terminalReason === undefined
+      || raw.terminalReason === "live-adopted"
       || raw.terminalReason === "response-started"
       || raw.terminalReason === "delivered-ttl");
 }
@@ -469,9 +476,16 @@ function terminalReasonForLaunch(
 function recordCurrentLaunchEntry(cardId: string, entry: OutboxEntry, nowMs = Date.now()): void {
   if (!entry.launchOwned) return;
   const settledAt = entry.settledAt ?? (entry.state === "delivered" ? entry.at : undefined);
-  const terminalReason = entry.responseStartedAt !== undefined
-    ? "response-started"
-    : terminalReasonForLaunch({ settledAt }, nowMs);
+  let terminalReason = terminalReasonForLaunch({ settledAt }, nowMs);
+  let retiredAt = terminalReason ? (settledAt ?? entry.at) + OUTBOX_DELIVERED_TTL_MS : undefined;
+  if (entry.responseStartedAt !== undefined) {
+    terminalReason = "response-started";
+    retiredAt = entry.responseStartedAt;
+  }
+  if (entry.adoptedAt !== undefined) {
+    terminalReason = "live-adopted";
+    retiredAt = entry.adoptedAt;
+  }
   const candidate = {
     id: entry.id,
     at: entry.at,
@@ -481,9 +495,7 @@ function recordCurrentLaunchEntry(cardId: string, entry: OutboxEntry, nowMs = Da
     recordCurrentLaunchRetirement(cardId, {
       ...candidate,
       terminalReason,
-      retiredAt: terminalReason === "response-started"
-        ? entry.responseStartedAt
-        : (settledAt ?? entry.at) + OUTBOX_DELIVERED_TTL_MS,
+      ...(retiredAt !== undefined ? { retiredAt } : {}),
     });
     return;
   }
@@ -589,7 +601,12 @@ function mergeOccurrenceTombstones(
 }
 
 function occurrenceTombstone(entry: OutboxEntry): PersistedOccurrenceTombstone | null {
-  if (entry.state !== "delivered" && entry.responseStartedAt === undefined && !entry.retiredEchoId) return null;
+  if (
+    entry.state !== "delivered"
+    && entry.responseStartedAt === undefined
+    && entry.adoptedAt === undefined
+    && !entry.retiredEchoId
+  ) return null;
   const key = echoKey(entry.echoText ?? entry.text);
   if (!key) return null;
   return {
@@ -879,6 +896,37 @@ export function settleLaunchOutboxFailed(
   };
   recordCurrentLaunchEntry(cardId, updated);
   write(cardId, queue.map((item) => (item.id === launch.id ? updated : item)));
+}
+
+/** Retire the optimistic launch bubble when its live transcript is adopted.
+    Adoption is the causal hand-off from the starting window to the materialized
+    conversation, including image-only launches whose transcript has no text
+    echo. The terminal row stays in recent history to reserve any later matching
+    scaffold echo ahead of younger identical submissions. */
+export function retireLaunchOutboxOnAdoption(
+  cardId: string,
+  launch: { id: string; adoptedAt: number; owner: OutboxOwner },
+): void {
+  const current = readCurrentLaunch(cardId);
+  if (current && current.id !== launch.id) return;
+  const queue = readOutbox(cardId);
+  const existing = queue.find((item) => item.id === launch.id);
+  const at = current?.at ?? existing?.at ?? launch.adoptedAt;
+  if (!current?.retiredEchoId && !current?.terminalReason) {
+    recordCurrentLaunchRetirement(cardId, {
+      id: launch.id,
+      at,
+      terminalReason: "live-adopted",
+      retiredAt: launch.adoptedAt,
+    });
+  }
+  if (!existing || !existing.launchOwned) return;
+  const adopted: OutboxEntry = {
+    ...existing,
+    owner: launch.owner,
+    adoptedAt: existing.adoptedAt ?? launch.adoptedAt,
+  };
+  write(cardId, queue.map((item) => (item.id === launch.id ? adopted : item)));
 }
 
 /**
@@ -1310,6 +1358,7 @@ export function visibleOutbox(
       consumed.set(key, floor + 1);
       continue;
     }
+    if (entry.adoptedAt !== undefined) continue;
     if (entry.responseStartedAt !== undefined) continue;
     if (entry.state === "delivered") {
       const settledAt = entry.settledAt ?? entry.at;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,23 +65,21 @@ export interface StructuredSpawnCardState {
   initialMessage: "pending" | "queued" | "delivered" | "failed";
   retrySafe: boolean;
   error: string | null;
-  /** The initial launch prompt (issue #614), sourced from the queued initial
-      delivery so ANY surface — not only the browser that ran the composer —
-      renders it as the conversation's first user bubble while the transcript is
-      still absent. Present only while the delivery still carries its text (it is
-      cleared once delivered, by which point the transcript echoes it); the seed
-      it produces is keyed by {@link launchId}, so it survives a refresh and
-      transcript adoption and never duplicates the composer's own seed. */
+  /** The durable initial-launch display text (issue #614), projected so every
+      surface renders the first user bubble while the transcript is absent. The
+      seed is keyed by {@link launchId}, survives refresh, and retires when the
+      materialized live transcript is adopted. */
   prompt?: string;
   /** How many images rode with the launch prompt, for the bubble's count chip. */
   promptImages?: number;
   /** Submission moment (ms) of the launch prompt — the receipt's creation time —
       so the seeded bubble orders ahead of any follow-up the operator queues. */
   promptAt?: number;
-  /** The canonical text the transcript will echo for this launch (issue #615) —
-      the delivered message, which for a role launch is the scaffold PLUS the raw
-      draft. The optimistic bubble displays `prompt` (the raw draft) but retires on
-      THIS text, so a scaffolded role launch never lingers and never duplicates. */
+  /** The canonical text the transcript can echo before adoption (issue #615) —
+      the delivered message, which for a role launch is the scaffold plus the raw
+      draft. The optimistic bubble displays `prompt` while this text owns its echo
+      occurrence; live adoption also retires image-only launches with an empty
+      echo. */
   promptEcho?: string;
   /** When the launch's initial message actually reached the agent (ms, issue
       #648). A structured / MCP spawn journals its first user record with SDK /


### PR DESCRIPTION
## What changed

- Retire the launch-owned starting bubble when the server attaches the launch to its materialized live transcript.
- Preserve the receipt state and delayed scaffold occurrence ownership after that hand-off.
- Cover roleless and role image-only launches through the real spawn-to-live card flip.

## Cause

Image-only launches can have no text echo. The launch-owned bubble therefore stayed in its delivering presentation after the live transcript had already been adopted.

## Verification

- bun test src/components/LogFeed.spawnPathFlip.dom.test.tsx src/components/conversation/outbox.test.ts: 62 passed
- bunx tsc --noEmit --incremental false: passed
- privacy publication gate with commit inspection: passed
- full-diff self-review: no findings

Fixes #617