### PR TITLE
fix(runtime): startup retries only for hosts a live incumbent process still holds (#1364)

### DIFF
--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -2205,6 +2205,75 @@ test.each(["codex", "claude"] as const)(
   },
 );
 
+test.each(["codex", "claude"] as const)(
+  "an eligible %s row with pending work and no live engine process completes the pass for on-demand hosting (#1364)",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-abandoned-row-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    const client = runtimeJournalClient(journal);
+    const sessionId = engine === "codex"
+      ? "25300000-0000-0000-0000-000000000044"
+      : "25300000-0000-0000-0000-000000000045";
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "dead",
+      turn: "terminal",
+    });
+    const stored = registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+    /* The production shape this guards: a session long dead, its endpoint
+       released, a held delivery keeping it adoption-eligible forever, and a
+       writer claim adoption cannot take. The claim owner here is this test
+       process, so the real adopter's claim is refused without launching
+       anything — the row ends the pass unresolved with no process to wait
+       for. Before the fix this failed the pass and startup replayed it every
+       minute without end. */
+    registry.upsert({
+      key: stored.key,
+      artifactPath: stored.artifactPath,
+      cwd: stored.cwd,
+      accountId: stored.accountId,
+      launchProfile: stored.launchProfile,
+      status: "dead",
+      host: stored.host,
+      structuredHost: {
+        ...stored.structuredHost!,
+        endpoint: "stdio:released",
+        process: null,
+      },
+      claimEpoch: stored.claimEpoch,
+      claimOwner: `structured-host:${JSON.stringify({
+        pid: process.pid,
+        startIdentity: procBackend.processIdentity(process.pid),
+      })}`,
+      pendingAction: stored.pendingAction,
+    });
+    const delivery = registry.holdDelivery(conversation.id, "deliver once something can host this again", "abandoned-row-pending");
+    const dependencies: StructuredStartupDependencies = {
+      registry,
+      client,
+      orchestratorSeats: () => [],
+      refreshTranscriptState: async () => {},
+      resolveCodexOwner: () => null,
+      resolveClaudeOwner: () => null,
+      ...(engine === "codex" ? { adoptClaude: async () => [] } : { adopt: async () => [] }),
+    };
+
+    try {
+      await adoptStructuredHostsAtStartup(dependencies);
+      expect(registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]).toMatchObject({
+        structuredHost: { endpoint: "stdio:released", process: null },
+      });
+      expect(registry.pendingDeliveries(conversation.id).map((item) => item.id)).toContain(delivery.id);
+    } finally {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
 test("a seat whose row reads busy is owed no nudge when its transcript cannot be read", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-orchestrator-unreadable-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -5,10 +5,11 @@ import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
-import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type ProcessIdentity, type RegistryFile } from "@/lib/agent/registry";
 import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import { activeOrchestratorSeats, type OrchestratorSeat } from "@/lib/orchestrator/seats";
+import { procBackend } from "@/lib/proc";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { readStableTailRecords } from "@/lib/scanner/activity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -345,17 +346,30 @@ function assertAdoptedHostsAreClaimed(
   );
 }
 
+function structuredHostProcessAlive(identity: ProcessIdentity): boolean {
+  return procBackend.pidAlive(identity.pid)
+    && (identity.startIdentity === null || procBackend.processIdentity(identity.pid) === identity.startIdentity);
+}
+
 /** Every row selected before adoption must end the pass with a host published
     by this Viewer or cease to be eligible. The durable target appoints the
     candidate before the incumbent's demotion poll releases its engines. A
     candidate that reaches adoption in that window sees the old live process
-    and must retry until demotion records and completes the handoff (#1296). */
+    and must retry until demotion records and completes the handoff (#1296).
+
+    Only a live recorded engine process argues that window is open. A row whose
+    process is gone or already released has nothing left to hand over — its
+    adoption attempt ran this pass and produced nothing, and rows with
+    permanently pending work (a held delivery for a dead session) stay in that
+    shape forever. Failing the pass for them replays full startup every minute
+    without end (#1364); their work waits for on-demand hosting instead. */
 function assertEligibleHostsResolved(
   registry: AgentRegistry,
   shouldAdopt: StructuredHostAdoptionFilter,
   adopted: readonly AdoptedStructuredHost[],
   productionAdopter: (key: SessionKey) => boolean,
   claimed: (key: SessionKey) => boolean = hasStructuredDeliveryHost,
+  processAlive: (identity: ProcessIdentity) => boolean = structuredHostProcessAlive,
 ): void {
   const adoptedKeys = new Set(adopted.map((item) => sessionKeyId(item.key)));
   const unresolved = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
@@ -365,7 +379,18 @@ function assertEligibleHostsResolved(
       && !adoptedKeys.has(sessionKeyId(entry.key))
       && !claimed(entry.key));
   if (unresolved.length === 0) return;
-  const keys = unresolved.map((entry) => sessionKeyId(entry.key));
+  const contested = unresolved.filter((entry) => {
+    const process = entry.structuredHost?.process;
+    return Boolean(process && processAlive(process));
+  });
+  const abandoned = unresolved.filter((entry) => !contested.includes(entry));
+  if (abandoned.length > 0) {
+    console.error("[structured hosts] eligible hosts have no live engine process to hand over; leaving them to on-demand hosting", {
+      keys: abandoned.map((entry) => sessionKeyId(entry.key)),
+    });
+  }
+  if (contested.length === 0) return;
+  const keys = contested.map((entry) => sessionKeyId(entry.key));
   console.error("[structured hosts] eligible hosts remain owned by the incumbent Viewer; retrying startup", { keys });
   throw new RuntimeHostUnavailableError(
     `structured startup left ${keys.length} eligible host(s) owned by the incumbent Viewer: ${keys.join(", ")}`,


### PR DESCRIPTION
## What breaks

Since #1302 (the #1296 assert), any adoption-eligible registry row that ends the startup pass unresolved fails the entire pass. Rows that are `dead` with `endpoint: stdio:released`, `process: null` and a held delivery are eligible forever (the pending work keeps `shouldAdopt` true) and can never resolve — there is no process to hand over and adoption produces nothing for them. Production ended up with 33 such rows, so structured startup replayed the full pass — transcript refresh included — every ~55 seconds without end. That loop pinned the viewer at 200%+ CPU, pushed `/` past a 30s timeout and `/api/files` to 20s+, and survived a full machine reboot because the shape lives in the registry, in no process.

## The fix

`assertEligibleHostsResolved` now scopes the retry to rows whose recorded engine process is alive — which is the exact window #1296 describes: a candidate that reaches adoption while the incumbent's demotion poll has yet to release its engines. Rows with no live engine process are logged once and left to on-demand hosting, their pre-#1302 path. Both existing hand-over regression tests keep a live fixture engine and still assert the throw.

## Tests

- New `test.each(codex|claude)`: an eligible dead row with a held delivery, a released endpoint and no process completes the pass and keeps its delivery pending. RED on the previous assert (both engines fail with the retry throw), GREEN with the fix.
- `bun test src/lib/runtime/startup.test.ts`: 82 pass, 0 fail.
- `bunx tsc --noEmit`: clean.

Refs #1364, #1296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2CE43BWhmGKXovHVppLyL