### PR TITLE
fix(resume): settle legacy host readiness before returning

### DIFF
--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -303,6 +303,7 @@ interface FakeHostState {
   deliverError: unknown | null;
   spawnCalls: number;
   failSpawn: boolean;
+  spawnError: unknown | null;
   panePidOverride: number | null;
   serverPid: number | null;
   paneObservation: "available" | "no-server" | "failure";
@@ -337,6 +338,7 @@ function fakeHost(
     deliverError: null,
     spawnCalls: 0,
     failSpawn: false,
+    spawnError: null,
     panePidOverride: null,
     serverPid: 900,
     paneObservation: "available",
@@ -395,6 +397,7 @@ function fakeHost(
     spawn: async (resumeSpec: ResumeSpec, payload: string): Promise<SpawnedPane> => {
       state.spawnCalls += 1;
       state.spawnSpecs.push({ spec: resumeSpec, payload });
+      if (state.spawnError) throw state.spawnError;
       if (state.failSpawn) throw new Error("tmux resume failed");
       await Promise.resolve();
       const panePid = 300;
@@ -804,6 +807,22 @@ describe("transcript host resolver", () => {
       target: "agents:5.0",
     });
     expect(state.spawnCalls).toBe(2);
+  });
+
+  test("sanitizes a legacy resume pane-buffer failure before it reaches the caller", async () => {
+    const { resolver, state } = fakeHost(false);
+    const raw = "no buffer viewer-1788299999999-481516";
+    state.spawnError = new Error(raw);
+
+    const outcome = await resolver.deliverToTranscriptHost({ entry: state.entry, spec, payload: "" });
+
+    expect(outcome).toEqual({
+      ok: false,
+      outcome: "failed",
+      error: "Pane buffer unreadable — message was not sent.",
+      status: 500,
+    });
+    expect(JSON.stringify(outcome)).not.toContain(raw);
   });
 
   test("reports post-paste delivery ambiguity without retyping the payload", async () => {

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -14,6 +14,7 @@ import {
   panePidOf,
   paneInfo,
   paneLaunchId,
+  operatorSafeTmuxDeliveryError,
   rememberResumePane,
   resumePaneRecords,
   sendText,
@@ -346,7 +347,13 @@ function isDescendantOf(pid: number, ancestor: number, parentPid: (pid: number) 
 
 function failure(error: unknown, status = 500, actuation?: "started"): HostDeliveryOutcome {
   const resolvedStatus = error instanceof TranscriptHostConflictError ? 409 : status;
-  return { ok: false, outcome: "failed", error: error instanceof Error ? error.message : String(error), status: resolvedStatus, ...(actuation ? { actuation } : {}) };
+  return {
+    ok: false,
+    outcome: "failed",
+    error: operatorSafeTmuxDeliveryError(error, actuation === "started"),
+    status: resolvedStatus,
+    ...(actuation ? { actuation } : {}),
+  };
 }
 
 export function createTranscriptHostObserver(dependencies: TranscriptHostObservationDependencies) {
@@ -481,14 +488,27 @@ export function createTranscriptHostResolver(
 
     const prepared = dependencies.beginResume?.(input.entry, input.spec) ?? null;
     const resumeSpec = prepared?.spec ?? input.spec;
-    const spawned = await dependencies.spawn(resumeSpec, "", prepared?.receipt);
-    await dependencies.remember(input.entry.path, resumeSpec, spawned);
+    let spawnFailure: unknown = null;
+    try {
+      const spawned = await dependencies.spawn(resumeSpec, "", prepared?.receipt);
+      await dependencies.remember(input.entry.path, resumeSpec, spawned);
+    } catch (error) {
+      /* Read the host once more before answering a launch error. A CLI can
+         reach its live composer while a presentation-sensitive detector times
+         out; observation both identifies that pane and settles its durable
+         receipt. The record then decides the resume and every immediate send. */
+      spawnFailure = error;
+    }
     snapshot = await observe(true);
-    if (snapshot.observation === "failure") throw new Error(`tmux pane observation failed: ${snapshot.observationError}`);
+    if (snapshot.observation === "failure") {
+      if (spawnFailure) throw spawnFailure;
+      throw new Error(`tmux pane observation failed: ${snapshot.observationError}`);
+    }
     const resumedConflict = conflictForPath(snapshot, input.entry.path, conversationIdForPath);
     if (resumedConflict) throw new TranscriptHostConflictError(resumedConflict);
     host = snapshot.canonicalFor(input.entry.path);
     if (!host || !(await revalidate(host, input.entry))) {
+      if (spawnFailure) throw spawnFailure;
       throw new Error("resumed agent host could not be identified safely");
     }
     return { host, resumed: true };

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -550,7 +550,12 @@ export function createTranscriptHostResolver(
           }
         }
         try {
-          await dependencies.deliver(decision.host.paneId, input.payload);
+          /* Resume-only calls carry no message. Once observation has reconciled
+             the host, an empty tmux paste can add only a transport failure (and
+             was the source of the raw `no buffer` response over a live host). */
+          if (input.payload !== "") {
+            await dependencies.deliver(decision.host.paneId, input.payload);
+          }
           try {
             await dependencies.confirmAlive?.(decision.host);
           } catch (error) {

--- a/src/lib/conversation/resumeLiveness.test.ts
+++ b/src/lib/conversation/resumeLiveness.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, expect, test } from "bun:test";
 
+import { listCodexAccounts } from "@/lib/accounts/codex";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import {
   AgentRegistry,
@@ -18,6 +19,7 @@ import {
   type TranscriptHost,
 } from "@/lib/agent/transcriptHost";
 import type { ResumeSpec } from "@/lib/agent/cli";
+import { statePath } from "@/lib/configDir";
 import { conversationDeliverabilityFromRecord } from "./deliverability";
 import { deliverConversationMessage, resumeConversation } from "@/lib/delivery";
 import type { AgentProcess } from "@/lib/scanner/process";
@@ -28,9 +30,17 @@ const SESSION_ID = "00000000-0000-0000-0000-000000000000";
 const TRANSCRIPT_PATH = `/fixtures/codex/rollout-2026-09-01T10-00-00-${SESSION_ID}.jsonl`;
 
 const sandboxes: string[] = [];
+const previousAccountEnvironment = {
+  stateDir: process.env.LLV_STATE_DIR,
+  codexHome: process.env.LLV_CODEX_HOME,
+};
 
 afterEach(() => {
   setAgentRegistryForTests(null);
+  if (previousAccountEnvironment.stateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousAccountEnvironment.stateDir;
+  if (previousAccountEnvironment.codexHome === undefined) delete process.env.LLV_CODEX_HOME;
+  else process.env.LLV_CODEX_HOME = previousAccountEnvironment.codexHome;
   for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
@@ -83,6 +93,26 @@ function evidence(host: TranscriptHost): TmuxHostEvidence {
 test("a detector timeout after starting a legacy host settles resume, immediate send, and deliverability from one live record", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-resume-liveness-"));
   sandboxes.push(sandbox);
+  const accountStateDir = path.join(sandbox, "account-state");
+  const codexHome = path.join(sandbox, "codex-home");
+  process.env.LLV_STATE_DIR = accountStateDir;
+  process.env.LLV_CODEX_HOME = codexHome;
+
+  const accountReadPaths = [
+    statePath("codex-accounts.json"),
+    statePath("account-project-bindings.json"),
+    ...listCodexAccounts().map((account) => path.join(account.home, "auth.json")),
+  ];
+  expect(accountReadPaths).toEqual([
+    path.join(accountStateDir, "codex-accounts.json"),
+    path.join(accountStateDir, "account-project-bindings.json"),
+    path.join(codexHome, "auth.json"),
+  ]);
+  expect(accountReadPaths.every((pathname) => {
+    const relative = path.relative(sandbox, pathname);
+    return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  })).toBe(true);
+
   const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
   setAgentRegistryForTests(registry);
   registry.reconcileConversations([{

--- a/src/lib/conversation/resumeLiveness.test.ts
+++ b/src/lib/conversation/resumeLiveness.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test } from "bun:test";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import {
+  AgentRegistry,
+  setAgentRegistryForTests,
+  type SpawnReceipt,
+  type TmuxHostEvidence,
+} from "@/lib/agent/registry";
+import {
+  beginRegistryResume,
+  createTranscriptHostResolver,
+  reconcileObservedTranscriptHosts,
+  type TranscriptHost,
+} from "@/lib/agent/transcriptHost";
+import type { ResumeSpec } from "@/lib/agent/cli";
+import { conversationDeliverabilityFromRecord } from "./deliverability";
+import { deliverConversationMessage, resumeConversation } from "@/lib/delivery";
+import type { AgentProcess } from "@/lib/scanner/process";
+import type { PaneRef } from "@/lib/tmux";
+import type { FileEntry } from "@/lib/types";
+
+const SESSION_ID = "00000000-0000-0000-0000-000000000000";
+const TRANSCRIPT_PATH = `/fixtures/codex/rollout-2026-09-01T10-00-00-${SESSION_ID}.jsonl`;
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  setAgentRegistryForTests(null);
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function fixtureEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: TRANSCRIPT_PATH,
+    root: "codex-sessions",
+    name: path.basename(TRANSCRIPT_PATH),
+    project: "fixture-project",
+    cwd: "/fixtures/project",
+    title: "Resume liveness fixture",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: "done",
+    pid: null,
+    model: "fixture-model",
+    effort: "high",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+const resumeSpec: ResumeSpec = {
+  command: `codex resume ${SESSION_ID}`,
+  cwd: "/fixtures/project",
+  windowName: "codex-resume-fixture",
+  engine: "codex",
+  launchProfile: emptyLaunchProfile({ cwd: "/fixtures/project" }),
+};
+
+function evidence(host: TranscriptHost): TmuxHostEvidence {
+  return {
+    kind: "tmux",
+    endpoint: "/fixtures/tmux",
+    server: { pid: host.tmuxServerPid, startIdentity: "server:900" },
+    paneId: host.paneId,
+    panePid: { pid: host.panePid, startIdentity: "pane:300" },
+    windowName: host.windowName ?? "",
+    agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
+    argv: host.agentArgv,
+  };
+}
+
+test("a detector timeout after starting a legacy host settles resume, immediate send, and deliverability from one live record", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-resume-liveness-"));
+  sandboxes.push(sandbox);
+  const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  setAgentRegistryForTests(registry);
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: TRANSCRIPT_PATH,
+    accountId: "fixture-account",
+    launchProfile: emptyLaunchProfile({ cwd: "/fixtures/project", project: "fixture-project" }),
+    turn: { state: "terminal", source: "assistant", terminalAt: "2026-09-01T09:59:00.000Z" },
+    observedAt: "2026-09-01T10:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(TRANSCRIPT_PATH)!;
+  let currentEntry = fixtureEntry();
+  let panes = new Map<number, PaneRef>();
+  let agents: AgentProcess[] = [];
+  let ppids = new Map<number, number>();
+  let launchId: string | null = null;
+  let remembered = 0;
+  const delivered: string[] = [];
+
+  const resolver = createTranscriptHostResolver({
+    listFiles: async () => [currentEntry],
+    panes: async () => ({ kind: "available" as const, panes }),
+    ppidMap: () => ppids,
+    agents: () => agents,
+    serverPid: async () => 900,
+    resumeRecords: async () => ({ serverPid: 900, records: new Map() }),
+    panePid: async (paneId) => [...panes.entries()].find(([, pane]) => pane.paneId === paneId)?.[0] ?? null,
+    paneWindowName: async () => resumeSpec.windowName,
+    alive: (pid) => agents.some((agent) => agent.pid === pid),
+    argv: (pid) => agents.find((agent) => agent.pid === pid)?.argv ?? [],
+    parentPid: (pid) => ppids.get(pid) ?? null,
+    identity: (pid) => pid === 400 ? "agent:400" : null,
+    launchId: async () => launchId,
+    conversationIdForPath: (pathname) => pathname === TRANSCRIPT_PATH ? conversation.id : null,
+    beginResume: (entry, spec) => beginRegistryResume(entry, spec, registry),
+    spawn: async (_spec, _text, receipt?: SpawnReceipt) => {
+      if (!receipt) throw new Error("resume receipt is required");
+      launchId = receipt.launchId;
+      registry.bindSpawnPane(receipt.launchId, {
+        endpoint: "/fixtures/tmux",
+        server: { pid: 900, startIdentity: "server:900" },
+        paneId: "%9",
+        panePid: { pid: 300, startIdentity: "pane:300" },
+        target: "fixture:9.0",
+      });
+      panes = new Map([[300, { paneId: "%9", target: "fixture:9.0", windowName: resumeSpec.windowName }]]);
+      agents = [{
+        pid: 400,
+        engine: "codex",
+        argv: ["codex", "resume", SESSION_ID],
+        cwd: "/fixtures/project",
+        tty: 1,
+      }];
+      ppids = new Map([[400, 300]]);
+      currentEntry = fixtureEntry({ pid: 400, proc: "running", activity: "live" });
+      registry.failSpawn(receipt.launchId, "agent never reached a launch-ready prompt");
+      throw new Error("agent never reached a launch-ready prompt");
+    },
+    remember: async () => { remembered += 1; },
+    deliver: async (paneId, text) => {
+      if (text) delivered.push(`${paneId}:${text}`);
+    },
+    reconcile: (hosts) => reconcileObservedTranscriptHosts(hosts, { registry, evidenceForHost: evidence }),
+  });
+  const sharedOverrides = {
+    pathAllowed: () => true,
+    listFiles: async () => [currentEntry],
+    recover: async () => null,
+    resumeSpecFor: () => resumeSpec,
+    deliver: resolver.deliverToTranscriptHost,
+  };
+
+  const resumed = await resumeConversation(TRANSCRIPT_PATH, {
+    ...sharedOverrides,
+    registry,
+  });
+
+  expect(resumed).toMatchObject({ ok: true, outcome: "resumed", spawned: true });
+  expect(remembered).toBe(0);
+  expect(conversationDeliverabilityFromRecord(registry.readOnlySnapshot(), {
+    conversationId: conversation.id,
+  })).toMatchObject({
+    deliverable: true,
+    condition: "deliverable",
+    transport: "legacy",
+    hostStatus: "live",
+  });
+
+  const sent = await deliverConversationMessage({
+    pid: null,
+    path: TRANSCRIPT_PATH,
+    conversationId: conversation.id,
+    clientMessageId: "send-after-resume",
+    text: "deliver immediately",
+    images: [],
+  }, sharedOverrides);
+
+  expect(sent).toMatchObject({ ok: true, outcome: "delivered-to-live" });
+  expect(delivered).toEqual(["%9:deliver immediately"]);
+});

--- a/src/lib/conversation/resumeLiveness.test.ts
+++ b/src/lib/conversation/resumeLiveness.test.ts
@@ -143,7 +143,8 @@ test("a detector timeout after starting a legacy host settles resume, immediate 
     },
     remember: async () => { remembered += 1; },
     deliver: async (paneId, text) => {
-      if (text) delivered.push(`${paneId}:${text}`);
+      if (!text) throw new Error("no buffer viewer-1788299999999-481516");
+      delivered.push(`${paneId}:${text}`);
     },
     reconcile: (hosts) => reconcileObservedTranscriptHosts(hosts, { registry, evidenceForHost: evidence }),
   });
@@ -162,7 +163,9 @@ test("a detector timeout after starting a legacy host settles resume, immediate 
 
   expect(resumed).toMatchObject({ ok: true, outcome: "resumed", spawned: true });
   expect(remembered).toBe(0);
-  expect(conversationDeliverabilityFromRecord(registry.readOnlySnapshot(), {
+  const settled = registry.readOnlySnapshot();
+  expect(settled.receipts[launchId!]).toMatchObject({ state: "completed", error: null });
+  expect(conversationDeliverabilityFromRecord(settled, {
     conversationId: conversation.id,
   })).toMatchObject({
     deliverable: true,

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -7,6 +7,7 @@ import { afterAll, expect, test } from "bun:test";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { reconcileMigrations } from "@/lib/accounts/migration/coordinator";
 import { emptyLaunchProfile, type HeldDelivery } from "@/lib/accounts/migration/contracts";
+import { conversationDeliverabilityFromRecord } from "@/lib/conversation/deliverability";
 import type { RuntimeHostClient } from "./client";
 import type { RuntimeSnapshot } from "./contracts";
 import { MAX_STRUCTURED_IMAGE_ENCODED_BYTES, RuntimeImageStore, runtimeImageCapability } from "./runtimeImageStore";
@@ -1138,7 +1139,7 @@ test("legacy synchronization rejects structured command semantics before fallbac
   expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
 });
 
-test("conflicting persisted ownership stays fenced during runtime client absence", async () => {
+test("a durable legacy host wins over retained structured adapter metadata during runtime client absence", async () => {
   const { registry, conversation } = registryWithConversation();
   recordLegacyOwner(registry, conversation);
   const generation = conversation.generations.at(-1)!;
@@ -1166,7 +1167,57 @@ test("conflicting persisted ownership stays fenced during runtime client absence
     registry: () => registry,
   });
 
-  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
+  expect(result).toBeNull();
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("a live legacy record outranks a stale structured projection for the send immediately after resume", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const generation = conversation.generations.at(-1)!;
+  registry.setStructuredHost({ engine: conversation.engine, sessionId: generation.id }, {
+    kind: "codex-app-server",
+    endpoint: "stdio:stale-after-resume",
+    process: null,
+    eventCursor: 9,
+    protocolVersion: "v2",
+    writerClaimEpoch: 2,
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+  });
+  const staleRuntime = snapshot(conversation.id);
+  staleRuntime.sessions[0] = { ...staleRuntime.sessions[0]!, host: "unhosted" };
+  let recoveryCalls = 0;
+
+  expect(conversationDeliverabilityFromRecord(registry.readOnlySnapshot(), {
+    conversationId: conversation.id,
+  })).toMatchObject({
+    deliverable: true,
+    condition: "deliverable",
+    transport: "legacy",
+    hostStatus: "idle",
+  });
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "send-immediately-after-legacy-resume",
+    text: "deliver through the host the resume just settled",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => ({ snapshot: async () => staleRuntime }) as unknown as RuntimeHostClient,
+    registry: () => registry,
+    republish: async () => false,
+    recover: async () => {
+      recoveryCalls += 1;
+      return null;
+    },
+  });
+
+  expect(result).toBeNull();
+  expect(recoveryCalls).toBe(0);
   expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
 });
 

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -224,12 +224,23 @@ function persistedCurrentOwner(
     : registry.conversationForPath(request.path);
   const generation = conversation?.generations.at(-1);
   if (!conversation || !generation) return null;
-  const entry = registry.readOnlySnapshot().entries[`${conversation.engine}:${generation.id}`];
+  const snapshot = registry.readOnlySnapshot();
+  const entry = snapshot.entries[`${conversation.engine}:${generation.id}`];
   if (!entry || entry.artifactPath !== generation.path) return null;
-  const structured = entry.structuredHost !== null && entry.structuredHost !== undefined;
-  const legacy = entry.host !== null;
-  if (structured === legacy) return null;
-  return { kind: structured ? "structured" : "legacy", conversation };
+  const deliverability = conversationDeliverabilityFromRecord(snapshot, {
+    conversationId: conversation.id,
+    transcriptPath: generation.path,
+  });
+  /* A current legacy host wins over retained structured adapter metadata, the
+     same verdict conversation_deliverability exposes. This keeps a stale
+     runtime projection from recovering over the pane resume just settled. */
+  if (deliverability.deliverable && deliverability.transport === "legacy") {
+    return { kind: "legacy", conversation };
+  }
+  if (entry.host === null && entry.structuredHost !== null && entry.structuredHost !== undefined) {
+    return { kind: "structured", conversation };
+  }
+  return null;
 }
 
 function heldOutcomeDuringRuntimeSynchronization(
@@ -665,6 +676,10 @@ export async function enqueueStructuredMessage(
   }
   const rawImages = imageAdmission.images;
   const registry = (dependencies.registry ?? agentRegistry)();
+  const durableOwner = persistedCurrentOwner(request, registry);
+  if (durableOwner?.kind === "legacy") {
+    return requiresStructuredCommand(request) ? legacyCommandUnavailable() : null;
+  }
   const client = (dependencies.client ?? runtimeHostClient)();
   if (!client) {
     return holdDuringRuntimeSynchronization(

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -36,6 +36,32 @@ test("informational lines above a ready composer do not hide late launch readine
   expect(screenAtIdleComposer(claude)).toBe(true);
 });
 
+test("the Codex composer stays launch-ready beneath usage and unrecognized bullet notices", () => {
+  for (const notice of [
+    "• You have 1 usage limit reset available. Run /usage to use one.",
+    "• A future Codex informational notice the Viewer does not recognize",
+    "You've hit your usage limit. Try again at 7:55 PM.",
+  ]) {
+    expect(screenAtIdleComposer([
+      notice,
+      "",
+      "› Ask Codex to do anything",
+      "  …",
+    ].join("\n"))).toBe(true);
+  }
+});
+
+test("an interaction below the composer still vetoes launch readiness", () => {
+  expect(screenAtIdleComposer([
+    "› Ask Codex to do anything",
+    "",
+    "Do you want to proceed?",
+    "  1. Yes",
+    "  2. No",
+    "  Enter to select",
+  ].join("\n"))).toBe(false);
+});
+
 test("quiet streamed output without a composer never reads as at-composer", () => {
   expect(screenAtIdleComposer(QUIET_OUTPUT)).toBe(false);
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -289,13 +289,13 @@ export function launchPromptLanded(engine: "claude" | "codex", screen: string, p
 }
 
 /**
- * Positive idle-composer detection: the composer prompt is drawn, the ready
- * hints are on the status bar, and no busy/interrupt hint remains. A quiet
- * screen that merely lacks a menu (a long-running command, streamed output)
- * matches none of this and must never read as "parked at the prompt".
+ * Positive idle-composer detection: the bottom-most composer prompt is drawn
+ * and no busy/interrupt hint remains below it. Footer hints carry presentation
+ * only; Codex may replace them with informational notices.
+ * A quiet screen that merely lacks a menu (a long-running command, streamed
+ * output) still has no prompt and must never read as "parked at the prompt".
  */
 export function screenAtIdleComposer(screen: string): boolean {
-  if (screenWaitsForInput(screen)) return false;
   const lines = screen.split("\n");
   let composerIdx = -1;
   for (let index = lines.length - 1; index >= 0; index -= 1) {
@@ -305,8 +305,10 @@ export function screenAtIdleComposer(screen: string): boolean {
     }
   }
   if (composerIdx === -1) return false;
+  const interactionRegion = lines.slice(composerIdx).join("\n");
+  if (screenWaitsForInput(interactionRegion)) return false;
   const statusRegion = lines.slice(composerIdx + 1).join("\n");
-  return READY_MARKERS.test(statusRegion) && !BUSY_MARKERS.test(statusRegion);
+  return !BUSY_MARKERS.test(statusRegion);
 }
 
 /** Short readable tail of a captured screen, for error messages and logs. */


### PR DESCRIPTION
Closes #1387

## Summary

- treat the active composer line as launch readiness while preserving busy and interaction gates beneath it
- reconcile a host that became live during a detector timeout and settle its durable receipt before returning success
- route immediate sends from the durable deliverability record so a stale structured projection cannot contradict a live legacy host
- reuse the shipped pane-buffer sanitizer for legacy resume failures

## Regression coverage

- usage-reset and unrecognized bullet notices above the Codex composer
- live host settlement after a launch detector timeout
- immediate send after resume through the same durable legacy record
- stale structured projection losing to current legacy deliverability
- raw pane-buffer identifiers removed from resume errors

## Verification

- `bunx tsc --noEmit`
- `bun test src/lib/status.test.ts src/lib/agent/transcriptHost.test.ts src/lib/conversation/resumeLiveness.test.ts src/lib/runtime/structuredMessageDelivery.test.ts src/lib/deliveryPaneBufferError.test.ts src/lib/runtime/structuredDeliveryLegacyVerdict.integration.test.ts` (103 passed)
- `bun scripts/privacy-publication-gate.ts --base 9553957808f0252619aa7e2b11b9c611ec8d572c`
- `git diff --check`