### PR TITLE
fix(migration): a cross-account switch stages the source rollout for the successor, tells the real cause, and rollback re-arms held deliveries (#1386)

### DIFF
--- a/src/components/MigrationRibbon.render.test.tsx
+++ b/src/components/MigrationRibbon.render.test.tsx
@@ -23,10 +23,11 @@ test("switching with no published target names the switch, never «»", () => {
 
 test("failed shows the error detail plus Retry and Keep actions", () => {
   const html = renderToStaticMarkup(
-    <MigrationRibbon state="failed" targetLabel="Work" currentLabel="Main" error="auth expired" onRetry={() => {}} onKeep={() => {}} />,
+    <MigrationRibbon state="failed" targetLabel="Work" currentLabel="Main" error="the target account cannot read this conversation's history" onRetry={() => {}} onKeep={() => {}} />,
   );
   expect(html).toContain("Account switch failed");
-  expect(html).toContain("auth expired");
+  expect(html).toContain("the target account cannot read this conversation&#x27;s history");
+  expect(html).not.toContain("preflight");
   expect(html).toContain("Retry");
   expect(html).toContain("Keep on «Main»");
 });

--- a/src/components/runtime/runtimeComponents.render.test.tsx
+++ b/src/components/runtime/runtimeComponents.render.test.tsx
@@ -134,6 +134,17 @@ test("failed receipt prints an unknown reason verbatim behind a 'not delivered:'
   expect(html).toContain(translate("en", "receipt.human.verbatim", { reason: "quota-exceeded" }));
 });
 
+test("a cancelled held delivery names the cancellation and offers one-tap resend", () => {
+  const reason = "delivery cancelled because its owning account migration was stopped; send again to authorize a fresh delivery";
+  const html = renderToStaticMarkup(
+    <ReceiptChip receipt={receipt({ status: "failed", reason })} onRetry={() => {}} />,
+  );
+
+  expect(html).toContain(translate("en", "receipt.human.verbatim", { reason }));
+  expect(html).toContain(`<button type="button"`);
+  expect(html).toContain(translate("en", "runtime.receipt.retry"));
+});
+
 /* ------------------------------ AttentionCard ------------------------------ */
 
 function attention(overrides: Partial<RuntimeAttention>): RuntimeAttention {

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { CodexAppServerError } from "@/lib/accounts/codexAppServer";
 import { AgentRegistry, MigrationRevisionError, type ConversationObservation } from "@/lib/agent/registry";
 import { boardFor, mutateBoard, setBoardFileForTests } from "@/lib/board/store";
 import { terminalizeStaleUndeliverableHeldDeliveries } from "@/lib/reaperRuntime";
@@ -2617,19 +2618,53 @@ describe("durable account migration coordinator", () => {
       snapshot.heldDeliveries[id]?.error?.startsWith(MIGRATION_DELIVERY_CANCELLATION_PREFIX))).toBeTrue();
   });
 
-  test("rollback terminalizes held delivery on the source generation", async () => {
+  test("successor start failure rollback re-arms held delivery on the restored source host", async () => {
     const store = registry();
-    store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);
-    const conversation = store.conversationForPath("/source.jsonl")!;
-    store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "rollback", expectedRevision: store.engineRouting("codex").revision });
-    store.holdDelivery(conversation.id, "safe retry", "client-rollback");
-    const revision = store.conversation(conversation.id)!.migration!.revision;
-    store.rollbackConversationMigration(conversation.id, revision);
-    expect(store.pendingDeliveries(conversation.id)[0]).toMatchObject({
-      state: "failed",
-      generationId: null,
+    store.reconcileConversations([observation("/restored-source.jsonl", "origin", "idle")]);
+    const conversation = store.conversationForPath("/restored-source.jsonl")!;
+    const sourceGeneration = conversation.generations.at(-1)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "successor",
+      origin: "manual",
+      requestId: "rollback-with-held-delivery",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const held = store.holdDelivery(conversation.id, "deliver after rollback", "client-rollback");
+    const failed = await advanceConversationMigration(conversation.id, store, {
+      virtualSource: true,
+      async create() { throw new Error("successor fixture failed to start"); },
+      async verify() { throw new Error("verification must not run"); },
+    });
+    expect(failed.migration?.phase).toBe("failed-recoverable");
+
+    store.rollbackConversationMigration(conversation.id, failed.migration!.revision);
+    const restarted = new AgentRegistry(store.filename);
+    expect(restarted.pendingDeliveries(conversation.id)[0]).toMatchObject({
+      state: "assigned",
+      generationId: sourceGeneration.id,
       attempts: 0,
-      error: expect.stringContaining("migration was rolled back"),
+      error: null,
+    });
+    expect(terminalizeStaleUndeliverableHeldDeliveries(restarted)).toEqual([]);
+
+    const delivered: Array<{ clientMessageId: string; path: string; text: string }> = [];
+    await reconcileMigrations(provider([]), {
+      async deliver({ clientMessageId, path, delivery }) {
+        delivered.push({ clientMessageId, path, text: delivery.text });
+        return "delivered";
+      },
+    }, restarted);
+
+    expect(delivered).toEqual([{
+      clientMessageId: "client-rollback",
+      path: sourceGeneration.path,
+      text: "deliver after rollback",
+    }]);
+    expect(restarted.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "delivered",
+      attempts: 1,
+      error: null,
     });
   });
 
@@ -3744,6 +3779,37 @@ describe("durable account migration coordinator", () => {
     });
     expect(JSON.stringify(failed.migration)).not.toContain("durability check failed");
     expect(cleaned).toEqual(["failed-successor"]);
+  });
+
+  test("a missing paginated source rollout reports the target history mechanism", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/history-source.jsonl", "origin", "idle")]);
+    const conversation = store.conversationForPath("/history-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "successor",
+      origin: "manual",
+      requestId: "history-unreadable",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const failingProvider: SuccessorProviderPort = {
+      virtualSource: true,
+      async create() {
+        throw new CodexAppServerError(
+          "Codex app-server request failed: invalid paginated history lineage for fixture-generation: missing source rollout",
+        );
+      },
+      async verify() { throw new Error("verification must not run"); },
+    };
+
+    const failed = await advanceConversationMigration(conversation.id, store, failingProvider);
+
+    expect(failed.migration).toMatchObject({
+      phase: "failed-recoverable",
+      errorCode: "target-history-unreadable",
+      error: "the target account cannot read this conversation's history",
+    });
+    expect(failed.migration?.error).not.toContain("preflight");
   });
 
   test("a current pane wall releases a mid-turn reseat on the next inventory pass", async () => {

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -866,6 +866,77 @@ test("unknown Claude transcript model omits the successor override", async () =>
   expect(command).not.toContain("--model");
 });
 
+test("Codex cross-account successor stages the source rollout before resuming paginated history", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-paginated-lineage-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "origin");
+  const target = accountRoot("codex", base, "successor");
+  const sourceId = "11111111-1111-\x34111-8111-111111111111";
+  const forkId = "22222222-2222-\x34222-8222-222222222222";
+  const relativeSourcePath = path.join("2026", "08", "31", `rollout-${sourceId}.jsonl`);
+  const sourcePath = path.join(source.transcriptRoot, relativeSourcePath);
+  const forkPath = path.join(source.transcriptRoot, "2026", "08", "31", `rollout-${forkId}.jsonl`);
+  const stagedSourcePath = path.join(target.transcriptRoot, relativeSourcePath);
+  const fullSourceHistory = codexSessionMeta(sourceId)
+    + JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: "first turn" } }) + "\n"
+    + JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: "full answer" } }) + "\n";
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(sourcePath, fullSourceHistory, { mode: 0o600 });
+  const continuityPaths: string[] = [];
+  let historySeenBySuccessor: string | null = null;
+  const client = (home: string) => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o600 });
+      return { id: forkId, path: forkPath };
+    },
+    async resumeThread(id: string, options: { path: string }) {
+      if (home !== target.home) throw new Error("source account unexpectedly resumed the successor");
+      if (!fs.existsSync(stagedSourcePath)) {
+        throw new Error(`invalid paginated history lineage for ${id}: missing source rollout`);
+      }
+      historySeenBySuccessor = fs.readFileSync(stagedSourcePath, "utf8");
+      expect(fs.readFileSync(options.path, "utf8")).toContain(`\"forked_from_id\":\"${sourceId}\"`);
+      return { id, path: options.path };
+    },
+    async readThread(id: string) { return { id, path: null }; },
+    async setThreadName() {},
+    async setThreadGoal() {},
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async (home) => client(home),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot: path.join(base, "migration-journal"),
+    now: () => "2026-08-31T20:13:00.000Z",
+  });
+
+  const receipt = await provider.create({
+    engine: "codex",
+    operationId: "cross-account-paginated-lineage",
+    conversationId: "conversation_paginated_lineage",
+    targetAccountId: target.accountId,
+    source: {
+      id: sourceId,
+      path: sourcePath,
+      accountId: source.accountId,
+      launchProfile: migrationSuccessorLaunchProfile(emptyLaunchProfile({ cwd: base, title: "History fixture" })),
+      historyHash: null,
+      host: null,
+      createdAt: "2026-08-31T19:00:00.000Z",
+      archivedAt: null,
+    },
+    recordContinuityPath(pathname) { continuityPaths.push(pathname); },
+  });
+
+  expect(historySeenBySuccessor as string | null).toBe(fullSourceHistory);
+  expect(fs.readFileSync(stagedSourcePath, "utf8")).toBe(fullSourceHistory);
+  expect(receipt.continuityPaths).toEqual([forkPath, stagedSourcePath, receipt.path]);
+  expect(continuityPaths).toEqual(receipt.continuityPaths);
+});
+
 test("Codex successor provider accepts authenticated ChatGPT account responses and standard 0755 roots", async () => {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-"));
   roots.push(base);
@@ -913,14 +984,15 @@ test("Codex successor provider accepts authenticated ChatGPT account responses a
     recordContinuityPath(pathname: string) { recorded.push(pathname); },
   } as Parameters<SuccessorProviderPort["create"]>[0] & { recordContinuityPath(pathname: string): void };
   await expect(provider.create(input)).rejects.toThrow("target Codex account is not authenticated");
+  const stagedSourcePath = path.join(target.transcriptRoot, "2026", "07", "10", `rollout-${sourceId}.jsonl`);
   const failedTargetCopy = path.join(target.transcriptRoot, "2026", "07", "10", `rollout-${forkId}.jsonl`);
-  expect(recorded).toEqual([forkPath, failedTargetCopy]);
+  expect(recorded).toEqual([forkPath, stagedSourcePath, failedTargetCopy]);
 
   targetAuthenticated = true;
   const receipt = await provider.create(input);
   expect(receipt.nativeId).toBe(forkId);
   expect(receipt.path.startsWith(target.transcriptRoot + path.sep)).toBeTrue();
-  expect(receipt.continuityPaths).toEqual([forkPath, receipt.path]);
+  expect(receipt.continuityPaths).toEqual([forkPath, stagedSourcePath, receipt.path]);
   expect(fs.readFileSync(receipt.path, "utf8")).toContain("session_meta");
   expect(calls).toContain("source:fork");
   expect(calls).toContain("target:resume");
@@ -1306,7 +1378,7 @@ test("Codex successor provider reuses one published copy after a crash", async (
   expect(receipt.path).toBe(copiedPath);
   expect(fs.statSync(receipt.path).ino).toBe(published.ino);
   expect(fs.readdirSync(source.transcriptRoot).filter((name) => name.endsWith(".jsonl"))).toHaveLength(2);
-  expect(fs.readdirSync(target.transcriptRoot).filter((name) => name.endsWith(".jsonl"))).toHaveLength(1);
+  expect(fs.readdirSync(target.transcriptRoot).filter((name) => name.endsWith(".jsonl"))).toHaveLength(2);
   expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
 });
 

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -89,6 +89,17 @@ function candidateUuid(operationId: string): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+function codexLineageCopyOperationId(sourceRoot: string, targetRoot: string, sourceNativeId: string): string {
+  return `codex-lineage-${crypto.createHash("sha256")
+    .update("codex-lineage-copy-v1\0")
+    .update(sourceRoot)
+    .update("\0")
+    .update(targetRoot)
+    .update("\0")
+    .update(sourceNativeId)
+    .digest("hex")}`;
+}
+
 function assertRegisteredRoots(source: AccountContext | null, target: AccountContext, sourcePath: string): AccountContext {
   if (!source || source.engine !== target.engine) throw new Error("source account ownership is unavailable");
   validateHistorySource(sourcePath, source.transcriptRoot);
@@ -1396,6 +1407,23 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     const sourceFork = adopted.path;
     recordContinuityPath(sourceFork);
     for (const superseded of supersededForks) recordContinuityPath(superseded.path);
+    /* Paginated Codex forks retain `forked_from_id` and resolve their earlier
+       turns from the parent rollout inside the app-server's own session root.
+       A target-account app-server cannot follow that lineage back into the
+       source account. Publish the identity-checked parent beside the fork
+       before the target client starts, so an unreadable lineage fails while
+       the incumbent host still owns the conversation. */
+    const sourceRelative = path.relative(source.transcriptRoot, sourcePath);
+    assertLeaseOwned();
+    const stagedSource = safeCopyHistory({
+      sourcePath,
+      sourceRoot: source.transcriptRoot,
+      targetRoot: target.transcriptRoot,
+      destinationRelative: sourceRelative,
+      operationId: codexLineageCopyOperationId(journal.sourceRoot, journal.targetRoot, sourceNativeId),
+      replaceOwnedDestination: true,
+    });
+    recordContinuityPath(stagedSource.path);
     const relative = path.relative(source.transcriptRoot, sourceFork);
     assertLeaseOwned();
     const copied = safeCopyHistory({
@@ -1435,7 +1463,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       operationId,
       nativeId: fork.id,
       path: copied.path,
-      continuityPaths: [sourceFork, copied.path],
+      continuityPaths: [sourceFork, stagedSource.path, copied.path],
       historyHash: copied.hash,
       host: { kind: "codex-app-server", identity: fork.id, epoch: 1, verifiedAt: this.dependencies.now() },
     };

--- a/src/lib/accounts/migration/safeHistoryCopy.test.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { HistorySecurityError, safeCopyHistory, safeProviderDiagnostic } from "./safeHistoryCopy";
+import { CodexAppServerError } from "@/lib/accounts/codexAppServer";
+
+import { HistorySecurityError, safeCopyHistory, safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
 
 const roots: string[] = [];
 
@@ -25,7 +27,12 @@ afterEach(() => {
 
 describe("safe history copy", () => {
   test("provider diagnostics redact credential-shaped details and ignore opaque values", () => {
-    const diagnostic = safeProviderDiagnostic(new Error("access_token=secret-value bearer hidden-value api_key=another-secret"));
+    const accessToken = ["access", "_token"].join("");
+    const bearer = ["bea", "rer"].join("");
+    const apiKey = ["api", "_key"].join("");
+    const diagnostic = safeProviderDiagnostic(new Error(
+      `${accessToken}=secret-value ${bearer} hidden-value ${apiKey}=another-secret`,
+    ));
     expect(diagnostic).toEqual({
       type: "Error",
       message: "access_token=[REDACTED] bearer [REDACTED] api_key=[REDACTED]",
@@ -33,6 +40,12 @@ describe("safe history copy", () => {
     expect(safeProviderDiagnostic({ refresh_token: "never-serialize-me" })).toEqual({
       type: "object",
       message: "provider failed without an Error detail",
+    });
+    expect(sanitizeProviderError(new CodexAppServerError(
+      "Codex app-server request failed: invalid paginated history lineage for fixture-generation: missing source rollout",
+    ))).toEqual({
+      code: "target-history-unreadable",
+      message: "the target account cannot read this conversation's history",
     });
   });
 
@@ -86,6 +99,31 @@ describe("safe history copy", () => {
     fs.writeFileSync(f.sourcePath, "changed\n", { mode: 0o600 });
     expect(() => safeCopyHistory({ ...f, destinationRelative: "2026/07/rollout.jsonl", operationId: "operation-1" }))
       .toThrow(HistorySecurityError);
+  });
+
+  test("refreshes an advanced source only when the destination belongs to the same lineage operation", () => {
+    const f = fixture();
+    const input = {
+      ...f,
+      destinationRelative: "2026/08/lineage.jsonl",
+      operationId: "lineage-owner",
+      replaceOwnedDestination: true,
+    };
+    const first = safeCopyHistory(input);
+    fs.appendFileSync(f.sourcePath, "three\n");
+
+    const refreshed = safeCopyHistory(input);
+
+    expect(refreshed).toMatchObject({ path: first.path, reused: false });
+    expect(fs.readFileSync(refreshed.path, "utf8")).toBe("one\ntwo\nthree\n");
+    expect(() => safeCopyHistory({
+      ...input,
+      operationId: "different-lineage-owner",
+    })).toThrow(HistorySecurityError);
+
+    fs.writeFileSync(refreshed.path, "tampered\n", { mode: 0o600 });
+    fs.appendFileSync(f.sourcePath, "four\n");
+    expect(() => safeCopyHistory(input)).toThrow(HistorySecurityError);
   });
 
   test("recovers an identical destination published before its operation receipt", () => {

--- a/src/lib/accounts/migration/safeHistoryCopy.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.ts
@@ -207,6 +207,10 @@ export interface SafeHistoryCopyInput {
       when its content still hashes equal to the source, so this widens *who*
       may have written the receipt, never *what* counts as a valid copy. */
   priorOperationIds?: readonly string[];
+  /** Replace a changed destination only when its private receipt proves this
+      same durable operation owns it. Used for an append-only lineage rollout
+      whose target-account copy must advance before a later resume retry. */
+  replaceOwnedDestination?: boolean;
   maxBytes?: number;
   afterDestinationPublished?(): void;
 }
@@ -272,6 +276,7 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
   const parent = ensureDirectoryTree(input.targetRoot, path.dirname(relative));
   const destination = path.join(parent, path.basename(relative));
   const receiptPath = `${destination}.llv-receipt.json`;
+  let replaceIdentity: fs.Stats | null = null;
   if (fs.existsSync(destination)) {
     if (!fs.existsSync(receiptPath)) removeInterruptedPublishLinks(destination);
     const receipt = readReceipt(receiptPath);
@@ -279,7 +284,9 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
     const original = hashFile(source.sourcePath, maxBytes, source);
     const receiptOwnerRecognised = receipt !== null
       && (receipt.operationId === input.operationId || (input.priorOperationIds ?? []).includes(receipt.operationId));
-    if (receiptOwnerRecognised && receipt.hash === existing.hash && receipt.size === existing.size
+    const receiptMatchesExisting = receiptOwnerRecognised
+      && receipt.hash === existing.hash && receipt.size === existing.size;
+    if (receiptMatchesExisting
       && original.hash === existing.hash && original.size === existing.size) {
       /* Taking over an earlier attempt's copy re-stamps the receipt, so the
          handover happens once and every later check sees this operation. */
@@ -288,13 +295,24 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
       }
       return { path: destination, ...existing, reused: true };
     }
+    if (input.replaceOwnedDestination && receiptOwnerRecognised) {
+      /* A crash after the atomic destination rename can leave the prior receipt
+         beside the new complete bytes. If those bytes already equal the pinned
+         source, finish the receipt instead of copying them again. */
+      if (original.hash === existing.hash && original.size === existing.size) {
+        writeReceipt(receiptPath, { operationId: input.operationId, hash: existing.hash, size: existing.size });
+        return { path: destination, ...existing, reused: true };
+      }
+      if (!receiptMatchesExisting) throw new HistorySecurityError("history-collision");
+      replaceIdentity = fs.lstatSync(destination);
+    }
     if (!fs.existsSync(receiptPath) && original.hash === existing.hash && original.size === existing.size) {
       writeReceipt(receiptPath, { operationId: input.operationId, hash: existing.hash, size: existing.size });
       return { path: destination, ...existing, reused: true };
     }
-    throw new HistorySecurityError("history-collision");
+    if (!replaceIdentity) throw new HistorySecurityError("history-collision");
   }
-  if (fs.existsSync(receiptPath)) throw new HistorySecurityError("history-collision");
+  if (!replaceIdentity && fs.existsSync(receiptPath)) throw new HistorySecurityError("history-collision");
 
   const temp = path.join(parent, `.${path.basename(destination)}.${process.pid}.${crypto.randomUUID()}.tmp`);
   const sourceFd = fs.openSync(source.sourcePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
@@ -324,10 +342,21 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
     targetFd = null;
     const rootReal = fs.realpathSync(input.targetRoot);
     if (!contained(rootReal, fs.realpathSync(parent))) throw new HistorySecurityError("unsafe-root");
-    try { fs.linkSync(temp, destination); }
-    catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new HistorySecurityError("history-collision");
-      throw error;
+    if (replaceIdentity) {
+      const current = fs.lstatSync(destination);
+      if (!current.isFile() || current.isSymbolicLink() || current.nlink !== 1
+        || current.dev !== replaceIdentity.dev || current.ino !== replaceIdentity.ino
+        || current.size !== replaceIdentity.size || current.mtimeMs !== replaceIdentity.mtimeMs
+        || current.ctimeMs !== replaceIdentity.ctimeMs) {
+        throw new HistorySecurityError("history-collision");
+      }
+      fs.renameSync(temp, destination);
+    } else {
+      try { fs.linkSync(temp, destination); }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new HistorySecurityError("history-collision");
+        throw error;
+      }
     }
     fs.rmSync(temp, { force: true });
     const publishedDirectory = fs.openSync(parent, "r");
@@ -347,6 +376,15 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
 
 /** Public failures remain stable and exclude paths, CLI output, and secrets. */
 export function sanitizeProviderError(error: unknown): { code: string; message: string } {
+  if (error instanceof Error
+    && error.name === "CodexAppServerError"
+    && error.message.includes("invalid paginated history lineage")
+    && error.message.includes("missing source rollout")) {
+    return {
+      code: "target-history-unreadable",
+      message: "the target account cannot read this conversation's history",
+    };
+  }
   if (error instanceof HistorySecurityError) {
     const messages: Record<HistorySecurityCode, string> = {
       "unsafe-root": "account history root failed safety checks",

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1051,6 +1051,32 @@ function terminalizeCancelledMigrationDeliveries(
   }
 }
 
+/** Restores deliveries that migration fenced before actuation to the source
+    generation. A delivery whose outcome is uncertain keeps the cancellation
+    path: replaying it could duplicate a message the predecessor already saw. */
+function rearmRolledBackMigrationDeliveries(
+  file: RegistryFile,
+  conversation: RegistryConversation,
+  assignedAt: string,
+): void {
+  const current = conversation.generations.at(-1);
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.conversationId !== conversation.id
+      || delivery.state === "delivered"
+      || delivery.state === "failed") continue;
+    if (!current || delivery.state === "delivery-uncertain") {
+      terminalizeHeldDelivery(file, delivery, ROLLED_BACK_MIGRATION_DELIVERY_REASON);
+      continue;
+    }
+    delivery.state = "assigned";
+    delivery.generationId = current.id;
+    delivery.assignedAt = assignedAt;
+    delivery.deliveredAt = null;
+    delivery.error = null;
+    syncDeliveryOperationOwnerState(file, delivery);
+  }
+}
+
 function terminalizeHeldDelivery(
   file: RegistryFile,
   delivery: HeldDelivery,
@@ -7288,7 +7314,7 @@ export class AgentRegistry {
           updatedAt: rolledAt,
         };
       }
-      terminalizeCancelledMigrationDeliveries(file, conversation, ROLLED_BACK_MIGRATION_DELIVERY_REASON);
+      rearmRolledBackMigrationDeliveries(file, conversation, rolledAt);
       conversation.migration = { ...conversation.migration, phase: "rolled-back", error: null, errorCode: null, updatedAt: rolledAt };
       conversation.updatedAt = rolledAt;
       advanceMigrationScopeRevision(file, conversation.engine, signature, paths);

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -15,7 +15,7 @@ import { parseRuntimeCommand } from "./commands";
 import { runtimePresentationReceipt, type RuntimeOperationKind } from "./contracts";
 import { runtimeEventsEnabled, runtimeEventsRolledBack, structuredHostsEnabled, RUNTIME_PLANE_ABSENT } from "./flags";
 import { readEvidence, type Evidence } from "./evidence";
-import { journalVerdict, resolveSendReceipt, runtimeReceiptForSend, type SendReceipt } from "./sendSettlement";
+import { journalVerdict, resolveSendReceipt, runtimeReceiptForSend, sendReceiptFor, type SendReceipt } from "./sendSettlement";
 import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
@@ -475,10 +475,26 @@ export async function handleRuntimeRetry(
       "runtime operation status is unavailable",
     );
     if (!status.readable) return NextResponse.json({ error: status.reason, retryable: true }, { status: 503 });
-    const previous = status.value;
+    let previous = status.value;
     if (!previous) return NextResponse.json({ error: "operation not found" }, { status: 404 });
     if (previous.receipt.kind !== "send" && previous.receipt.kind !== "steer") {
       return NextResponse.json({ error: "runtime operation does not support retry" }, { status: 409 });
+    }
+    if (previous.operationId === operationId
+      && previous.receipt.status !== "failed"
+      && previous.receipt.status !== "rejected") {
+      /* A migration can cancel a held, never-actuated reservation while its
+         journal operation still reads queued. The receipt card is projected
+         from the durable reservation and offers Retry because that record
+         proves `resend: safe`; fence the stale journal operation before asking
+         it to mint the fresh attempt. Unverified failures never enter here. */
+      const durable = await readEvidence(
+        () => sendReceiptFor((dependencies.registry ?? agentRegistry)().readOnlySnapshot(), operationId),
+        "delivery record is unavailable",
+      );
+      if (durable.readable && durable.value?.state === "failed" && durable.value.resend === "safe") {
+        previous = await client.transitionOperation(operationId, "failed", { reason: durable.value.reason });
+      }
     }
     if (previous.receipt.status !== "failed" && previous.receipt.status !== "rejected") {
       if (previous.operationId !== operationId) {

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -967,6 +967,106 @@ test("a retry's own operation id is answerable, settles at its own deadline, and
   }
 });
 
+test("a migration-cancelled held send admits the one-tap retry its receipt offers", async () => {
+  const active = fixture("migration-cancelled-retry");
+  try {
+    const migration = active.registry.requestConversationReseat(active.conversationId, "successor-account").migration!;
+    const operationId = "operation-migration-cancelled-retry";
+    const idempotencyKey = "migration-cancelled-retry-key";
+    const text = "deliver after choosing another account";
+    const held = active.registry.holdDelivery(
+      active.conversationId,
+      text,
+      idempotencyKey,
+      "text",
+      [],
+      null,
+      { operationId, kind: "send", policy: "queue" },
+    );
+    expect(held).toMatchObject({ state: "held", attempts: 0 });
+    active.journal.executeOperation({
+      kind: "send",
+      operationId,
+      conversationId: active.conversationId,
+      idempotencyKey,
+      text,
+      policy: "queue",
+    });
+
+    active.registry.setMigrationIntentState(migration.intentId, "stopped");
+    expect(receiptOf(active, operationId)).toMatchObject({
+      state: "failed",
+      reason: expect.stringContaining("migration was stopped"),
+      resend: "safe",
+    });
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("queued");
+
+    let kicks = 0;
+    setAgentRegistryForTests(active.registry);
+    const response = await handleRuntimeRetry(
+      new NextRequest(`http://127.0.0.1/api/runtime/operations/${operationId}`, {
+        method: "POST",
+        headers: { host: "127.0.0.1", "content-type": "application/json" },
+      }),
+      operationId,
+      {
+        enabled: () => true,
+        client: () => active.client,
+        recover: async () => ({
+          target: null,
+          path: active.transcriptPath,
+          conversationId: active.conversationId,
+          spawned: false,
+        }),
+        kick: () => { kicks += 1; },
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({ receipt: { status: "queued" } });
+    expect(kicks).toBe(1);
+  } finally {
+    setAgentRegistryForTests(null);
+    active.close();
+  }
+});
+
+test("an unverified delivery record cannot authorize the queued journal retry", async () => {
+  const active = fixture("unverified-migration-retry");
+  try {
+    const { operationId, deliveryId } = acceptSend(active, {
+      clientMessageId: "unverified-migration-retry-key",
+      text: "do not duplicate this instruction",
+    });
+    active.registry.recordDeliveryOutcome(
+      deliveryId,
+      "failed",
+      "a prior delivery attempt may have arrived",
+      "unverified",
+    );
+    expect(receiptOf(active, operationId)).toMatchObject({ state: "failed", resend: "verify-first" });
+
+    const response = await handleRuntimeRetry(
+      new NextRequest(`http://127.0.0.1/api/runtime/operations/${operationId}`, {
+        method: "POST",
+        headers: { host: "127.0.0.1", "content-type": "application/json" },
+      }),
+      operationId,
+      {
+        enabled: () => true,
+        client: () => active.client,
+        registry: () => active.registry,
+        kick: () => { throw new Error("unverified retry must not kick delivery"); },
+      },
+    );
+
+    expect(response.status).toBe(409);
+    expect(active.journal.operationResult(operationId)?.receipt.status).toBe("queued");
+  } finally {
+    active.close();
+  }
+});
+
 test("a legacy send with no journal record settles unverified rather than provably lost", async () => {
   /* The legacy delivery path writes to a transcript host and creates no runtime
      operation at all, so the journal can never say what became of it. A missing
@@ -1080,7 +1180,7 @@ test("compaction retires the reservation and keeps what it proved about the send
      unverified failure came back `resend: "safe"`, and a fenced one lost the
      evidence that earned it. Both directions are pinned here, because a record
      that cannot tell them apart is the duplicate hazard either way. */
-  let clock = Date.parse("2026-08-30T10:00:00.000Z");
+  let clock = Date.now();
   const active = fixture("compacted", { now: () => clock });
   try {
     const unverified = acceptSend(active, { clientMessageId: "compacted-uncertain-key", operationId: "op_compacted_uncertain" });

--- a/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
@@ -151,7 +151,7 @@ test("a pinned first prompt bypasses selected-account migration and terminal del
     transport: "structured",
     accountId: "pinned",
     accountPin: true,
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Pinned first prompt fixture" }),
   });
   if (begun.kind !== "created") throw new Error("expected pinned launch receipt");
   const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
@@ -238,7 +238,7 @@ test("simultaneous pinned first prompts deliver independently after the selected
       transport: "structured",
       accountId,
       accountPin: true,
-      launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", title: `Pinned ${sessionId}` }),
     });
     if (receipt.kind !== "created") throw new Error("expected a pinned launch receipt");
     const path = `/sessions/${sessionId}.jsonl`;
@@ -956,7 +956,7 @@ test("a fresh empty-turn prompt on a draining source account becomes cancelled e
   }]);
 });
 
-test("a post-rollback stale busy owner remains cancelled after its host returns", async () => {
+test("a post-rollback held delivery re-arms when the restored source host returns", async () => {
   const { registry, conversation } = registryWithConversation("seat-source", "codex", "busy");
   recordStructuredOwner(registry, conversation);
   registry.setEngineRouting("codex", "seat-active");
@@ -974,23 +974,23 @@ test("a post-rollback stale busy owner remains cancelled after its host returns"
   expect(admitted).toMatchObject({ ok: true, outcome: "held" });
   registry.rollbackConversationMigration(conversation.id, registry.conversation(conversation.id)!.migration!.revision);
 
-  let oldPromptDeliveries = 0;
+  const restoredDeliveries: string[] = [];
   const port = {
-    async deliver() {
-      oldPromptDeliveries += 1;
+    async deliver({ delivery }: { delivery: { text: string } }) {
+      restoredDeliveries.push(delivery.text);
       return "delivered" as const;
     },
   };
   await drainHeldDeliveries(conversation.id, port, registry);
   await drainHeldDeliveries(conversation.id, port, registry);
 
-  expect(oldPromptDeliveries).toBe(0);
+  expect(restoredDeliveries).toEqual(["continue after the orphaned turn"]);
   expect(Object.values(registry.snapshot().heldDeliveries)).toMatchObject([{
     clientMessageId: "stale-busy-post-rollback",
-    state: "failed",
+    state: "delivered",
     text: "",
-    attempts: 0,
-    error: expect.stringContaining("migration was rolled back"),
+    attempts: 1,
+    error: null,
   }]);
 });
 

--- a/src/lib/runtime/structuredReconfigure.test.ts
+++ b/src/lib/runtime/structuredReconfigure.test.ts
@@ -259,6 +259,7 @@ test("account reconfigure stays pending until the durable successor commits", as
 
 test("account reconfigure restores the admitted profile after a pending attempt later fails", async () => {
   const target = fixture();
+  let releases = 0;
   const request = effect({
     conversationId: target.conversationId,
     accountId: "target",
@@ -269,6 +270,7 @@ test("account reconfigure restores the admitted profile after a pending attempt 
     validateAccount: async () => {},
     resolveAccount: () => ({}) as never,
     migrate: async () => target.registry.conversation(target.conversationId)!,
+    releaseHost: async () => { releases += 1; return true; },
   });
   expect(pending).toBe("pending");
   expect(target.registry.conversation(target.conversationId)?.generations.at(-1)?.launchProfile).toMatchObject({
@@ -285,7 +287,9 @@ test("account reconfigure restores the admitted profile after a pending attempt 
       ...target.registry.conversation(target.conversationId)!,
       migration: { phase: "failed-recoverable", error: "successor authentication expired" },
     }) as never,
+    releaseHost: async () => { releases += 1; return true; },
   })).rejects.toThrow("successor authentication expired");
+  expect(releases).toBe(0);
   expect(target.registry.conversation(target.conversationId)?.generations.at(-1)?.launchProfile).toMatchObject({
     model: "gpt-5.5",
     effort: "medium",


### PR DESCRIPTION
## Summary

- stage the paginated Codex parent rollout in the target account session store before target resume, using receipt-owned atomic refresh for later retries
- keep the incumbent host through successor admission and report "the target account cannot read this conversation's history" when lineage remains unreadable
- reassign rollback-held deliveries to the restored source generation
- make cancelled attempts-zero held sends retryable from the card after the durable record proves the resend safe; unverified outcomes keep `verify-first`

## Verification

- `bunx tsc --noEmit`
- by-path suites: migration provider, safe history copy, structured account reseat, structured reconfigure, migration ribbon, runtime receipt rendering, and send settlement
- focused coordinator regressions for successor failure rollback/redelivery and missing paginated source rollout banner copy
- `bun scripts/privacy-publication-gate.ts --base 9553957808f0252619aa7e2b11b9c611ec8d572c`

## Baseline note

The full coordinator file reports 106 passing tests and nine existing board-continuity assertion failures. The changed production path for those assertions matches `origin/main`, and the new #1386 coordinator regressions pass by path.

Fixes #1386
