### PR TITLE
fix(seat): survive Viewer restarts with MCP re-hosting (#1346 #1354)

### DIFF
--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -13,7 +13,7 @@ test("headless Codex threads allow only the registered Viewer MCP server", () =>
     },
   })).toEqual({
     mcp_servers: {
-      viewer: { enabled: true, default_tools_approval_mode: "approve" },
+      viewer: { command: "agent-log-viewer-mcp", enabled: true, default_tools_approval_mode: "approve" },
       docs: { enabled: false },
     },
     features: { plugins: false, apps: false, multi_agent: false, realtime_conversation: true },

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -55,7 +55,10 @@ export function headlessCodexThreadConfig(
           ? configuredApproval
           : null;
       return [name, {
-        ...(name === "viewer" && viewerMissing ? server as JsonObject : {}),
+        /* A replacement app-server must receive the launch definition again.
+           Its predecessor owned the stdio child, so an enable flag alone
+           leaves a resumed thread with no connector process to call (#1346). */
+        ...(name === "viewer" ? server as JsonObject : {}),
         enabled: enabled.has(name),
         ...(approval ? { default_tools_approval_mode: approval } : {}),
       }];

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -205,8 +205,9 @@ async function requestViewerControl(
   pathname: string,
   init: RequestInit,
   context: McpToolCallContext = {},
+  pinConfiguredEndpoint = false,
 ): Promise<{ response: Response; parsed: unknown; unreadable: boolean }> {
-  const baseUrl = viewerControlOrigin();
+  const baseUrl = viewerControlOrigin(process.env, pinConfiguredEndpoint);
   const now = Date.now();
   const deadlineAt = context.deadlineAt;
   const retryable = deadlineAt !== undefined;
@@ -275,12 +276,13 @@ async function requestViewerControl(
 async function getViewerControl(
   pathname: string,
   context: McpToolCallContext = {},
+  pinConfiguredEndpoint = false,
 ): Promise<Record<string, unknown>> {
   const { response, parsed: controlPayload, unreadable } = await requestViewerControl(pathname, {
     headers: {
       accept: "application/json",
     },
-  }, context);
+  }, context, pinConfiguredEndpoint);
   /* A body of literal `null` is valid JSON, so `.catch` never fires and every
      later `result.x` throws a TypeError before the status can be classified —
      which is how a 405 from a revision that does not serve the route arrived as
@@ -320,6 +322,7 @@ async function postViewerControl(
   body: Record<string, unknown>,
   headers: Record<string, string> = {},
   context: McpToolCallContext = {},
+  pinConfiguredEndpoint = false,
 ): Promise<Record<string, unknown>> {
   /* Every control mutation carries its endpoint's idempotency identity
      (clientAttemptId, clientMessageId or clientRequestId). Repeating the same
@@ -331,7 +334,7 @@ async function postViewerControl(
       ...headers,
     },
     body: JSON.stringify(body),
-  }, context);
+  }, context, pinConfiguredEndpoint);
   /* A body of literal `null` is valid JSON, so `.catch` never fires and every
      later `result.x` throws a TypeError before the status can be classified —
      which is how a 405 from a revision that does not serve the route arrived as
@@ -365,10 +368,20 @@ async function postViewerControl(
   return result;
 }
 
-const productionViewerControlDependencies: ViewerControlDependencies = {
-  get: getViewerControl,
-  post: postViewerControl,
-};
+export function productionViewerControlDependencies(
+  pinConfiguredEndpoint = false,
+): ViewerControlDependencies {
+  return {
+    get: (pathname, context) => getViewerControl(pathname, context, pinConfiguredEndpoint),
+    post: (pathname, body, headers, context) => postViewerControl(
+      pathname,
+      body,
+      headers,
+      context,
+      pinConfiguredEndpoint,
+    ),
+  };
+}
 
 function readViewerControl(
   control: ViewerControlDependencies,
@@ -3556,7 +3569,7 @@ export function viewerMcpToolPolicy(
 
 export function viewerMcpBindings(
   linkTaskDependencies: LinkTaskToPipelineDependencies = productionLinkTaskDependencies,
-  controlDependencies: ViewerControlDependencies = productionViewerControlDependencies,
+  controlDependencies: ViewerControlDependencies = productionViewerControlDependencies(),
   domainDependencies: ViewerMcpDomainDependencies = productionDomainDependencies,
 ): McpToolBindings {
   return {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -132,6 +132,7 @@ import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
 import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolCallContext, type McpToolPayload } from "./server";
+import { viewerControlOrigin } from "./controlEndpoint";
 import {
   productionSelectedContextDependencies,
   resolveSelectedContext,
@@ -166,7 +167,6 @@ export interface ViewerControlDependencies {
   ): Promise<Record<string, unknown>>;
 }
 
-const VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
 const CONTROL_ATTEMPT_TIMEOUT_MS = 5_000;
 const CONTROL_RECOVERY_BUDGET_MS = 8_000;
 const CONTROL_UNSCOPED_RECOVERY_BUDGET_MS = 5_000;
@@ -206,7 +206,7 @@ async function requestViewerControl(
   init: RequestInit,
   context: McpToolCallContext = {},
 ): Promise<{ response: Response; parsed: unknown; unreadable: boolean }> {
-  const baseUrl = process.env.LLV_VIEWER_CONTROL_URL?.trim() || VIEWER_CONTROL_URL;
+  const baseUrl = viewerControlOrigin();
   const now = Date.now();
   const deadlineAt = context.deadlineAt;
   const retryable = deadlineAt !== undefined;
@@ -225,7 +225,12 @@ async function requestViewerControl(
       reason: "Viewer control reconnect attempt timed out",
     });
     try {
-      const response = await fetch(new URL(pathname, baseUrl), { ...init, signal: attempt.signal });
+      const headers = new Headers(init.headers);
+      if (init.method === "POST") {
+        headers.set("origin", baseUrl);
+        headers.set("sec-fetch-site", "same-origin");
+      }
+      const response = await fetch(new URL(pathname, baseUrl), { ...init, headers, signal: attempt.signal });
       if (TRANSIENT_CONTROL_STATUSES.has(response.status)) {
         lastFailure = `status ${response.status}`;
         await response.body?.cancel().catch(() => {});
@@ -316,7 +321,6 @@ async function postViewerControl(
   headers: Record<string, string> = {},
   context: McpToolCallContext = {},
 ): Promise<Record<string, unknown>> {
-  const baseUrl = process.env.LLV_VIEWER_CONTROL_URL?.trim() || VIEWER_CONTROL_URL;
   /* Every control mutation carries its endpoint's idempotency identity
      (clientAttemptId, clientMessageId or clientRequestId). Repeating the same
      request after a lost transport answer therefore asks for its receipt. */
@@ -324,8 +328,6 @@ async function postViewerControl(
     method: "POST",
     headers: {
       "content-type": "application/json",
-      origin: baseUrl,
-      "sec-fetch-site": "same-origin",
       ...headers,
     },
     body: JSON.stringify(body),

--- a/src/lib/mcp/controlEndpoint.test.ts
+++ b/src/lib/mcp/controlEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -52,6 +52,38 @@ test("an explicit development endpoint stays authoritative without a release tar
   })).toBe("http://127.0.0.1:19003");
 });
 
+test("an explicit endpoint with no release environment never reads ambient release state", () => {
+  const endpoint = "http://127.0.0.1:19004";
+  const readFile = spyOn(fs, "readFileSync").mockImplementation(() => {
+    throw new Error("ambient release state was read");
+  });
+  try {
+    expect(viewerControlOrigin({ LLV_VIEWER_CONTROL_URL: endpoint })).toBe(endpoint);
+    expect(readFile).not.toHaveBeenCalled();
+  } finally {
+    readFile.mockRestore();
+  }
+});
+
+test("every partial release environment stays pinned to its explicit endpoint", () => {
+  const endpoint = "http://127.0.0.1:19005";
+  const readFile = spyOn(fs, "readFileSync").mockImplementation(() => {
+    throw new Error("partial release state was read");
+  });
+  try {
+    for (const partial of [
+      { LLV_VIEWER_DEPLOY_TARGET: "fixture-target.json" },
+      { LLV_VIEWER_PORT: "19006" },
+      { LLV_STATE_DIR: "fixture-state", LLV_VIEWER_PORT: "19006" },
+    ]) {
+      expect(viewerControlOrigin({ LLV_VIEWER_CONTROL_URL: endpoint, ...partial })).toBe(endpoint);
+    }
+    expect(readFile).not.toHaveBeenCalled();
+  } finally {
+    readFile.mockRestore();
+  }
+});
+
 test("a malformed release target fails loudly instead of preserving a stale launch URL", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-invalid-target-"));
   try {
@@ -60,6 +92,7 @@ test("a malformed release target fails loudly instead of preserving a stale laun
     expect(() => viewerControlOrigin({
       LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:18004",
       LLV_VIEWER_DEPLOY_TARGET: target,
+      LLV_VIEWER_PORT: "8898",
     })).toThrow("Viewer release target is invalid");
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });

--- a/src/lib/mcp/controlEndpoint.test.ts
+++ b/src/lib/mcp/controlEndpoint.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { viewerControlOrigin } from "./controlEndpoint";
+
+function releaseTarget(directory: string, endpoint: string): string {
+  const filename = path.join(directory, "viewer-release.json");
+  fs.writeFileSync(filename, JSON.stringify({
+    revision: "a".repeat(40),
+    image: "viewer:fixture",
+    container: "viewer-fixture",
+    endpoint,
+  }));
+  return filename;
+}
+
+test("a durable client carrying a retired launch URL resolves the stable Viewer listener", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-endpoint-"));
+  try {
+    const target = releaseTarget(directory, "http://127.0.0.1:19001");
+    expect(viewerControlOrigin({
+      LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:18001",
+      LLV_VIEWER_DEPLOY_TARGET: target,
+      LLV_VIEWER_PORT: "8898",
+    })).toBe("http://127.0.0.1:8898");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a candidate health probe keeps the exact endpoint named by the active release", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-candidate-"));
+  try {
+    const endpoint = "http://127.0.0.1:19002";
+    const target = releaseTarget(directory, endpoint);
+    expect(viewerControlOrigin({
+      LLV_VIEWER_CONTROL_URL: endpoint,
+      LLV_VIEWER_DEPLOY_TARGET: target,
+      LLV_VIEWER_PORT: "8898",
+    })).toBe(endpoint);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("an explicit development endpoint stays authoritative without a release target", () => {
+  expect(viewerControlOrigin({
+    LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:19003",
+    LLV_VIEWER_DEPLOY_TARGET: "missing-fixture-target.json",
+  })).toBe("http://127.0.0.1:19003");
+});
+
+test("a malformed release target fails loudly instead of preserving a stale launch URL", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-invalid-target-"));
+  try {
+    const target = path.join(directory, "viewer-release.json");
+    fs.writeFileSync(target, "{}");
+    expect(() => viewerControlOrigin({
+      LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:18004",
+      LLV_VIEWER_DEPLOY_TARGET: target,
+    })).toThrow("Viewer release target is invalid");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/mcp/controlEndpoint.test.ts
+++ b/src/lib/mcp/controlEndpoint.test.ts
@@ -30,16 +30,16 @@ test("a durable client carrying a retired launch URL resolves the stable Viewer 
   }
 });
 
-test("a candidate health probe keeps the exact endpoint named by the active release", () => {
+test("an admitted candidate health probe keeps its exact endpoint before promotion", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-candidate-"));
   try {
     const endpoint = "http://127.0.0.1:19002";
-    const target = releaseTarget(directory, endpoint);
+    const target = releaseTarget(directory, "http://127.0.0.1:18002");
     expect(viewerControlOrigin({
       LLV_VIEWER_CONTROL_URL: endpoint,
       LLV_VIEWER_DEPLOY_TARGET: target,
       LLV_VIEWER_PORT: "8898",
-    })).toBe(endpoint);
+    }, true)).toBe(endpoint);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/mcp/controlEndpoint.ts
+++ b/src/lib/mcp/controlEndpoint.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
+
+type ControlEnvironment = Readonly<Record<string, string | undefined>>;
+
+function releaseTargetPath(env: ControlEnvironment): string {
+  const configured = env.LLV_VIEWER_DEPLOY_TARGET?.trim();
+  if (configured) return configured;
+  const stateDirectory = env.LLV_STATE_DIR?.trim();
+  if (stateDirectory) return path.join(stateDirectory, "viewer-release.json");
+  const configRoot = env.XDG_CONFIG_HOME?.trim() || path.join(os.homedir(), ".config");
+  return path.join(configRoot, "agent-log-viewer", "state", "viewer-release.json");
+}
+
+function loopbackOrigin(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const endpoint = new URL(value);
+    if (endpoint.protocol !== "http:") return null;
+    if (!["127.0.0.1", "localhost", "[::1]", "::1"].includes(endpoint.hostname)) return null;
+    if (!endpoint.port) return null;
+    return endpoint.origin;
+  } catch {
+    return null;
+  }
+}
+
+function currentReleaseOrigin(env: ControlEnvironment): string | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(releaseTargetPath(env), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error("Viewer release target could not be read", { cause: error });
+  }
+  let target: Record<string, unknown>;
+  try {
+    target = JSON.parse(raw) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error("Viewer release target is invalid", { cause: error });
+  }
+  const endpoint = loopbackOrigin(target.endpoint);
+  if (typeof target.image !== "string"
+    || typeof target.container !== "string"
+    || typeof target.revision !== "string"
+    || !/^[0-9a-f]{40}$/.test(target.revision)
+    || !endpoint) throw new Error("Viewer release target is invalid");
+  return endpoint;
+}
+
+function stableControlOrigin(env: ControlEnvironment): string {
+  const configuredPort = env.LLV_VIEWER_PORT?.trim();
+  if (!configuredPort) return DEFAULT_VIEWER_CONTROL_URL;
+  if (!/^\d+$/.test(configuredPort)) throw new Error("LLV_VIEWER_PORT must be a valid TCP port");
+  const port = Number(configuredPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("LLV_VIEWER_PORT must be a valid TCP port");
+  }
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Resolve the control origin for each tool call. Deployment health probes keep
+ * their exact active-release endpoint. A durable client carrying any older
+ * launch URL resolves through the runtime host's stable listener (#1354).
+ */
+export function viewerControlOrigin(env: ControlEnvironment = process.env): string {
+  const configured = env.LLV_VIEWER_CONTROL_URL?.trim();
+  if (!configured) return stableControlOrigin(env);
+  const currentRelease = currentReleaseOrigin(env);
+  if (!currentRelease) return configured;
+  if (loopbackOrigin(configured) === currentRelease) return currentRelease;
+  return stableControlOrigin(env);
+}

--- a/src/lib/mcp/controlEndpoint.ts
+++ b/src/lib/mcp/controlEndpoint.ts
@@ -67,9 +67,17 @@ function stableControlOrigin(env: ControlEnvironment): string {
  * their exact active-release endpoint. A durable client carrying any older
  * launch URL resolves through the runtime host's stable listener (#1354).
  */
-export function viewerControlOrigin(env: ControlEnvironment = process.env): string {
+export function viewerControlOrigin(
+  env: ControlEnvironment = process.env,
+  pinConfiguredEndpoint = false,
+): string {
   const configured = env.LLV_VIEWER_CONTROL_URL?.trim();
   if (!configured) return stableControlOrigin(env);
+  /* Candidate health runs before promotion, while the durable release target
+     still names the incumbent. Its runtime-host-admitted caller must exercise
+     the explicit candidate endpoint instead of being redirected to the stable
+     listener and grading the incumbent on the candidate's behalf. */
+  if (pinConfiguredEndpoint) return configured;
   const currentRelease = currentReleaseOrigin(env);
   if (!currentRelease) return configured;
   if (loopbackOrigin(configured) === currentRelease) return currentRelease;

--- a/src/lib/mcp/controlEndpoint.ts
+++ b/src/lib/mcp/controlEndpoint.ts
@@ -1,19 +1,8 @@
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 
 const DEFAULT_VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
 
 type ControlEnvironment = Readonly<Record<string, string | undefined>>;
-
-function releaseTargetPath(env: ControlEnvironment): string {
-  const configured = env.LLV_VIEWER_DEPLOY_TARGET?.trim();
-  if (configured) return configured;
-  const stateDirectory = env.LLV_STATE_DIR?.trim();
-  if (stateDirectory) return path.join(stateDirectory, "viewer-release.json");
-  const configRoot = env.XDG_CONFIG_HOME?.trim() || path.join(os.homedir(), ".config");
-  return path.join(configRoot, "agent-log-viewer", "state", "viewer-release.json");
-}
 
 function loopbackOrigin(value: unknown): string | null {
   if (typeof value !== "string" || !value.trim()) return null;
@@ -29,9 +18,11 @@ function loopbackOrigin(value: unknown): string | null {
 }
 
 function currentReleaseOrigin(env: ControlEnvironment): string | null {
+  const targetPath = env.LLV_VIEWER_DEPLOY_TARGET?.trim();
+  if (!targetPath) return null;
   let raw: string;
   try {
-    raw = fs.readFileSync(releaseTargetPath(env), "utf8");
+    raw = fs.readFileSync(targetPath, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw new Error("Viewer release target could not be read", { cause: error });
@@ -64,8 +55,9 @@ function stableControlOrigin(env: ControlEnvironment): string {
 
 /**
  * Resolve the control origin for each tool call. Deployment health probes keep
- * their exact active-release endpoint. A durable client carrying any older
- * launch URL resolves through the runtime host's stable listener (#1354).
+ * their exact active-release endpoint. A durable client carrying an explicit
+ * release target and stable port resolves an older launch URL through the
+ * runtime host's stable listener (#1354).
  */
 export function viewerControlOrigin(
   env: ControlEnvironment = process.env,
@@ -78,6 +70,10 @@ export function viewerControlOrigin(
      the explicit candidate endpoint instead of being redirected to the stable
      listener and grading the incumbent on the candidate's behalf. */
   if (pinConfiguredEndpoint) return configured;
+  /* Redirecting a retired launch URL requires the complete release contract.
+     A partial environment stays pinned to its explicit endpoint and
+     cannot consult the operator's implicit state path or default port. */
+  if (!env.LLV_VIEWER_DEPLOY_TARGET?.trim() || !env.LLV_VIEWER_PORT?.trim()) return configured;
   const currentRelease = currentReleaseOrigin(env);
   if (!currentRelease) return configured;
   if (loopbackOrigin(configured) === currentRelease) return currentRelease;

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import net from "node:net";
@@ -14,6 +14,11 @@ const originalRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
 const originalRuntimeSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
 const originalRuntimeJournal = process.env.LLV_RUNTIME_JOURNAL;
 const originalViewerControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+const originalViewerDeployTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
+const originalViewerPort = process.env.LLV_VIEWER_PORT;
+const originalStateDirectory = process.env.LLV_STATE_DIR;
+const originalConfigHome = process.env.XDG_CONFIG_HOME;
+const originalHome = process.env.HOME;
 const sandboxes: string[] = [];
 const netServers: net.Server[] = [];
 const netSockets = new Set<net.Socket>();
@@ -34,7 +39,41 @@ afterEach(async () => {
   else process.env.LLV_RUNTIME_JOURNAL = originalRuntimeJournal;
   if (originalViewerControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
   else process.env.LLV_VIEWER_CONTROL_URL = originalViewerControlUrl;
+  if (originalViewerDeployTarget === undefined) delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  else process.env.LLV_VIEWER_DEPLOY_TARGET = originalViewerDeployTarget;
+  if (originalViewerPort === undefined) delete process.env.LLV_VIEWER_PORT;
+  else process.env.LLV_VIEWER_PORT = originalViewerPort;
+  if (originalStateDirectory === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDirectory;
+  if (originalConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalConfigHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
 });
+
+function installViewerControlFixture(origin: string): void {
+  const endpoint = new URL(origin);
+  if (endpoint.port === "8898") throw new Error("a Viewer control fixture cannot use the production port");
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-viewer-control-fixture-"));
+  const stateDirectory = path.join(sandbox, "state");
+  const configHome = path.join(sandbox, "config");
+  const target = path.join(stateDirectory, "viewer-release.json");
+  fs.mkdirSync(stateDirectory, { recursive: true });
+  fs.mkdirSync(configHome, { recursive: true });
+  fs.writeFileSync(target, JSON.stringify({
+    revision: "f".repeat(40),
+    image: "viewer:fixture",
+    container: "viewer-fixture",
+    endpoint: origin,
+  }));
+  sandboxes.push(sandbox);
+  process.env.HOME = sandbox;
+  process.env.XDG_CONFIG_HOME = configHome;
+  process.env.LLV_STATE_DIR = stateDirectory;
+  process.env.LLV_VIEWER_DEPLOY_TARGET = target;
+  process.env.LLV_VIEWER_CONTROL_URL = origin;
+  process.env.LLV_VIEWER_PORT = endpoint.port;
+}
 
 function deployment(deploymentId: string, revision = "a".repeat(40)) {
   return {
@@ -183,7 +222,7 @@ test("the production Viewer control adapter reads a live plane with no runtime v
       return Response.json({ count: 1, deployments: [deployment] });
     },
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
 
   try {
     expect(await viewerMcpBindings().deployment_status({
@@ -193,6 +232,60 @@ test("the production Viewer control adapter reads a live plane with no runtime v
       deployments: [deployment],
     });
   } finally {
+    server.stop(true);
+  }
+});
+
+test("a control-URL-only fixture can send only to itself and never to the production port", async () => {
+  delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  delete process.env.LLV_VIEWER_PORT;
+  delete process.env.LLV_STATE_DIR;
+  delete process.env.XDG_CONFIG_HOME;
+  const deployment = {
+    deploymentId: "deployment_control_url_only",
+    phase: "succeeded",
+    revision: "b".repeat(40),
+  };
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({ count: 1, deployments: [deployment] }),
+  });
+  if (server.port === 8898) {
+    server.stop(true);
+    throw new Error("the control-URL-only fixture selected the production port");
+  }
+  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  const ambientRelease = JSON.stringify({
+    revision: "c".repeat(40),
+    image: "viewer:ambient-fixture",
+    container: "viewer-ambient-fixture",
+    endpoint: "http://127.0.0.1:19007",
+  });
+  const readFile = spyOn(fs, "readFileSync").mockImplementation(
+    (() => ambientRelease) as unknown as typeof fs.readFileSync,
+  );
+  const requests: string[] = [];
+  const fetchRequest = globalThis.fetch.bind(globalThis);
+  const guardedFetch = async (input: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.port === "8898") throw new Error("a fixture request attempted to reach the production port");
+    requests.push(url.href);
+    return fetchRequest(input, init);
+  };
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(guardedFetch as typeof fetch);
+
+  try {
+    expect(await viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-control-url-only",
+    })).toEqual({ count: 1, deployments: [deployment] });
+    expect(readFile).not.toHaveBeenCalled();
+    expect(requests).toEqual([
+      `${server.url.origin}/api/runtime/deployments?limit=25`,
+    ]);
+  } finally {
+    fetchSpy.mockRestore();
+    readFile.mockRestore();
     server.stop(true);
   }
 });
@@ -215,7 +308,7 @@ test("the production Viewer control adapter returns a failed deployment domain o
         : Response.json(deployment);
     },
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
   const bindings = viewerMcpBindings();
 
   try {
@@ -261,7 +354,7 @@ test("deployment_status exposes the absent-plane code and keeps an unreachable p
       );
     },
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
   const absentService = createMcpToolService(viewerMcpBindings(), new MemoryMcpReceiptStore());
 
   const absent = await absentService.callTool("deployment_status", {
@@ -459,7 +552,7 @@ test("a control surface that does not serve the route yet falls back instead of 
       return new Response("Method Not Allowed", { status: 405 });
     },
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
 
   try {
     expect(await viewerMcpBindings().deployment_status({
@@ -481,7 +574,7 @@ test("a 404 keeps its domain meaning and is never mistaken for an unserved route
     port: 0,
     fetch: () => Response.json({ error: "viewer deployment was not found" }, { status: 404 }),
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
 
   try {
     await expect(viewerMcpBindings().deployment_status({
@@ -510,7 +603,7 @@ test("a null response body is classified by status instead of crashing the read"
     port: 0,
     fetch: () => new Response("null", { status: 405, headers: { "content-type": "application/json" } }),
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
 
   try {
     expect(await viewerMcpBindings().deployment_status({
@@ -606,7 +699,7 @@ test("malformed successful control bodies never become successful undefined depl
         : Response.json({});
     },
   });
-  process.env.LLV_VIEWER_CONTROL_URL = server.url.origin;
+  installViewerControlFixture(server.url.origin);
 
   try {
     await expect(viewerMcpBindings().deployment_status({
@@ -634,7 +727,7 @@ test("a timed-out 2xx body is surfaced instead of becoming an empty success", as
       ].join("\r\n"));
     });
   });
-  process.env.LLV_VIEWER_CONTROL_URL = origin;
+  installViewerControlFixture(origin);
 
   await expect(viewerMcpBindings().deployment_status({
     clientRequestId: "deployment-timed-out-success-body",
@@ -656,7 +749,7 @@ test("a control surface that never answers falls back instead of hanging the pro
   const { origin } = await listenTcp(() => {
     /* Keep the accepted connection open without sending headers. */
   });
-  process.env.LLV_VIEWER_CONTROL_URL = origin;
+  installViewerControlFixture(origin);
 
   const started = Date.now();
   expect(await viewerMcpBindings().deployment_status({

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2272,12 +2272,16 @@ export function createViewerMcpServer(service: McpToolService): McpServer {
 
 export async function startViewerMcpServer(): Promise<void> {
   const { admittedMcpHealthProbe, MCP_HEALTH_PROBE_CAPABILITY_ENV } = await import("./healthProbeAdmission");
-  const { viewerMcpBindings, viewerMcpToolPolicy } = await import("./bindings");
+  const {
+    productionViewerControlDependencies,
+    viewerMcpBindings,
+    viewerMcpToolPolicy,
+  } = await import("./bindings");
   const healthProbeCapability = process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
   delete process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
   const hostHealthProbe = await admittedMcpHealthProbe(healthProbeCapability);
   const service = createMcpToolService(
-    viewerMcpBindings(),
+    viewerMcpBindings(undefined, productionViewerControlDependencies(hostHealthProbe)),
     new SqliteMcpReceiptStore(statePath("mcp-receipts.sqlite"), {
       legacyFilePath: statePath("mcp-receipts.json"),
     }),

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -177,3 +177,54 @@ test("an already-running packaged MCP channel retries through a same-port Viewer
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 }, 20_000);
+
+test("a packaged MCP tool falls back from a retired launch port to the stable Viewer resolver", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-dead-launch-port-"));
+  const retiredViewer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => spawnResult("retired"),
+  });
+  const retiredOrigin = retiredViewer.url.origin;
+  await retiredViewer.stop(true);
+  let stableRequests = 0;
+  const stableViewer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => {
+      stableRequests += 1;
+      return spawnResult("stable_resolver");
+    },
+  });
+  const targetFile = path.join(sandbox, "viewer-release.json");
+  fs.writeFileSync(targetFile, JSON.stringify({
+    revision: "a".repeat(40),
+    image: "viewer:fixture",
+    container: "viewer-fixture",
+    endpoint: stableViewer.url.origin,
+  }));
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  environment.LLV_STATE_DIR = sandbox;
+  environment.LLV_VIEWER_DEPLOY_TARGET = targetFile;
+  environment.LLV_VIEWER_CONTROL_URL = retiredOrigin;
+  environment.LLV_VIEWER_PORT = String(stableViewer.port);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+    cwd: process.cwd(),
+    env: environment,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "viewer-dead-launch-port", version: "1.0.0" });
+  try {
+    await client.connect(transport);
+    expect((await callSpawn(client, "dead-launch-port-fallback")).structuredContent)
+      .toMatchObject({ ok: true, conversationId: "conversation_stable_resolver" });
+    expect(stableRequests).toBe(1);
+  } finally {
+    await client.close().catch(() => {});
+    await stableViewer.stop(true);
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 12_000);

--- a/src/lib/roles/defaults.ts
+++ b/src/lib/roles/defaults.ts
@@ -12,8 +12,6 @@ const REVIEW_FENCES = [
 const REVIEW_FRAME_RULES =
   "Two standing rules. (1) Anchor the frame: when the assignment carries the requester's originating requirement, validate the work against that verbatim requirement, never against the artifact's previous revision — WRONG-PREMISE (\"this does not serve the original requirement\") is an expected verdict and outranks any finding about internal rigour. (2) Over-engineering pass: on every review, flag machinery heavier than the problem it solves (a library plus wrapper where a native primitive does), name the simpler mechanism, and report what to cut — OVER-BUILT is a first-class verdict, and a round that only removes scope is a successful round.";
 
-const VIEWER_BASE_URL = `http://127.0.0.1:${process.env.PORT?.trim() || "8898"}`;
-
 export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
   {
     id: "orchestrator",
@@ -29,9 +27,9 @@ export const ROLE_DEFAULTS: readonly RoleDefinition[] = [
       { key: "mergePolicy", label: "Merge policy", description: "Delivery policy for backlog-campaign mode.", kind: "select", options: ["pr", "merge"] },
       { key: "completionPolicy", label: "Completion policy", description: "Terminal policy for backlog-campaign mode.", kind: "select", options: ["pr-opened", "merged", "released"] },
     ],
-    promptScaffold: `You are the Orchestrator. Drive work through the production Viewer API at ${VIEWER_BASE_URL}. Use fresh empty sessions with src lineage; forks are disabled. Keep every worker visible and controllable in the Viewer.\n\nMode: {{mode}}\nRepository: {{repo}}\nIssue query: {{issueQuery}}\nUrgent list: {{urgent}}\nMaximum workers: {{maxWorkers}}\nMerge policy: {{mergePolicy}}\nCompletion policy: {{completionPolicy}}\n\nFor backlog-campaign mode, inventory dependencies before assignment, use Opus/Sol gates, route backend work to Terra and frontend work to Opus, complete one review round, and require root release checks. Before a Viewer replacement, preserve the external-worker deployment barrier.`,
+    promptScaffold: "You are the Orchestrator. Drive work through the production Viewer MCP tools. Use fresh empty sessions with src lineage; forks are disabled. Keep every worker visible and controllable in the Viewer.\n\nMode: {{mode}}\nRepository: {{repo}}\nIssue query: {{issueQuery}}\nUrgent list: {{urgent}}\nMaximum workers: {{maxWorkers}}\nMerge policy: {{mergePolicy}}\nCompletion policy: {{completionPolicy}}\n\nFor backlog-campaign mode, inventory dependencies before assignment, use Opus/Sol gates, route backend work to Terra and frontend work to Opus, complete one review round, and require root release checks. Before a Viewer replacement, preserve the external-worker deployment barrier.",
     safetyFences: [
-      `Viewer control uses ${VIEWER_BASE_URL} with src lineage.`,
+      "Viewer control uses the Viewer MCP tools with src lineage.",
       "Fresh empty sessions only; forks are disabled.",
       "One owner holds a file at a time across active worktrees.",
     ],

--- a/src/lib/roles/registry.test.ts
+++ b/src/lib/roles/registry.test.ts
@@ -36,7 +36,8 @@ test("role registry exposes the frozen eight role ids and campaign-ready orchest
     completionPolicy: "released",
   });
   expect(orchestrator.ok && orchestrator.value.config).toEqual({ engine: "claude", model: "opus", effort: "high" });
-  expect(orchestrator.ok && orchestrator.value.prompt).toContain(`http://127.0.0.1:${process.env.PORT?.trim() || "8898"}`);
+  expect(orchestrator.ok && orchestrator.value.prompt).toContain("Viewer MCP tools");
+  expect(orchestrator.ok && orchestrator.value.prompt).not.toMatch(/(?:https?:\/\/)?(?:127\.0\.0\.1|localhost|\[::1\]):\d+/);
   expect(orchestrator.ok && orchestrator.value.prompt).toContain("Repository: Latand/live-log-viewer-next");
   expect(orchestrator.ok && orchestrator.value.prompt).toContain("Issue query: is:open");
   expect(orchestrator.ok && orchestrator.value.prompt).toContain("Urgent list: #35");

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 import { procBackend } from "@/lib/proc";
+import { systemBootEpoch } from "@/lib/processIdentity";
 import { STRUCTURED_HOST_STAMP_ENV, structuredHostStamp } from "@/lib/scanner/process";
 import { saveTelegramSession, TELEGRAM_CONNECTOR_TOKEN_ENV } from "@/lib/telegram/sessionStore";
 
@@ -221,11 +222,17 @@ describe("ClaudeStreamBrokerHost", () => {
       },
     }));
     const child = new FakeClaude(new RecordingDeliveryLedger());
-    const captured: { args?: string[] } = {};
+    const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const host = await ClaudeStreamBrokerHost.start({
       cwd: "/repo",
       claudeConfigDir: home,
       mcpServers: ["viewer", "agent-browser"],
+      env: {
+        NODE_ENV: "test",
+        LLV_STATE_DIR: "fixture-state",
+        LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+        LLV_VIEWER_PORT: "8898",
+      },
       eventStore: new MemoryEventStore(),
       readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
       readTranscript: () => [],
@@ -233,6 +240,11 @@ describe("ClaudeStreamBrokerHost", () => {
     });
 
     expect(captured.args).toContain("--strict-mcp-config");
+    expect(captured.options?.env).toMatchObject({
+      LLV_STATE_DIR: "fixture-state",
+      LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+      LLV_VIEWER_PORT: "8898",
+    });
     expect(captured.args).not.toContain("--safe-mode");
     const mcpConfigPath = captured.args![captured.args!.indexOf("--mcp-config") + 1]!;
     const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, "utf8")) as { mcpServers: Record<string, unknown> };
@@ -1703,7 +1715,7 @@ describe("ClaudeStreamBrokerHost", () => {
       structuredHost: {
         kind: "claude-broker",
         endpoint: `stdio:${orphan.pid}`,
-        process: { pid: orphan.pid, startIdentity },
+        process: { pid: orphan.pid, startIdentity, bootEpoch: systemBootEpoch() },
         eventCursor: 2,
         protocolVersion: "2.1.197",
         writerClaimEpoch: 1,
@@ -1777,7 +1789,7 @@ describe("ClaudeStreamBrokerHost", () => {
       structuredHost: {
         kind: "claude-broker",
         endpoint: `stdio:${orphan.pid}`,
-        process: { pid: orphan.pid, startIdentity },
+        process: { pid: orphan.pid, startIdentity, bootEpoch: systemBootEpoch() },
         eventCursor: 2,
         protocolVersion: "2.1.197",
         writerClaimEpoch: 1,

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1531,8 +1531,15 @@ describe("ClaudeStreamBrokerHost", () => {
     }
   });
 
-  test("boot adoption resumes claimed Claude rows and persists broker columns", async () => {
+  test("boot re-host resumes Claude with a relaunched Viewer MCP connector (#1346)", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-adoption-"));
+    const accountHome = path.join(directory, "claude-home");
+    fs.mkdirSync(accountHome, { recursive: true });
+    fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
+      mcpServers: {
+        viewer: { type: "stdio", command: "bun", args: ["bin/mcp-server.mjs"] },
+      },
+    }));
     const registryPath = path.join(directory, "agent-registry.json");
     const registry = new AgentRegistry(registryPath);
     const sessionId = "adopted-claude-session";
@@ -1560,11 +1567,20 @@ describe("ClaudeStreamBrokerHost", () => {
     });
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);
-    const captured: { args?: string[] } = {};
+    const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const adopted = await adoptClaudeRegistryHosts(
       registry,
       () => ({
         cwd: "/repo",
+        claudeConfigDir: accountHome,
+        mcpStatePath: path.join(accountHome, ".claude.json"),
+        mcpServers: ["viewer"],
+        env: {
+          NODE_ENV: "test",
+          LLV_STATE_DIR: "fixture-state",
+          LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+          LLV_VIEWER_PORT: "8898",
+        },
         deliveryLedger: ledger,
         eventStore: new MemoryEventStore(),
         readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }),
@@ -1575,6 +1591,17 @@ describe("ClaudeStreamBrokerHost", () => {
     );
     expect(adopted).toHaveLength(1);
     expect(captured.args).toContain("--resume");
+    const mcpConfigPath = captured.args![captured.args!.indexOf("--mcp-config") + 1]!;
+    expect(JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"))).toEqual({
+      mcpServers: {
+        viewer: { type: "stdio", command: "bun", args: ["bin/mcp-server.mjs"] },
+      },
+    });
+    expect(captured.options?.env).toMatchObject({
+      LLV_STATE_DIR: "fixture-state",
+      LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+      LLV_VIEWER_PORT: "8898",
+    });
     expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
       status: "idle",
       claimEpoch: 3,
@@ -1595,11 +1622,20 @@ describe("ClaudeStreamBrokerHost", () => {
 
     const restartedRegistry = new AgentRegistry(registryPath);
     const replacement = new FakeClaude(ledger);
-    const restartCaptured: { args?: string[] } = {};
+    const restartCaptured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const restarted = await adoptClaudeRegistryHosts(
       restartedRegistry,
       () => ({
         cwd: "/repo",
+        claudeConfigDir: accountHome,
+        mcpStatePath: path.join(accountHome, ".claude.json"),
+        mcpServers: ["viewer"],
+        env: {
+          NODE_ENV: "test",
+          LLV_STATE_DIR: "fixture-state",
+          LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+          LLV_VIEWER_PORT: "8898",
+        },
         deliveryLedger: ledger,
         eventStore: new MemoryEventStore(),
         readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }),
@@ -1610,6 +1646,12 @@ describe("ClaudeStreamBrokerHost", () => {
     );
     expect(restarted).toHaveLength(1);
     expect(restartCaptured.args).toContain("--resume");
+    const restartMcpConfigPath = restartCaptured.args![restartCaptured.args!.indexOf("--mcp-config") + 1]!;
+    expect(JSON.parse(fs.readFileSync(restartMcpConfigPath, "utf8"))).toEqual({
+      mcpServers: {
+        viewer: { type: "stdio", command: "bun", args: ["bin/mcp-server.mjs"] },
+      },
+    });
     expect(restartedRegistry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
       status: "idle",
       host: null,

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -247,6 +247,9 @@ const CHILD_ENV_ALLOWLIST = [
   "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_RUNTIME_DIR",
   "DBUS_SESSION_BUS_ADDRESS", "SSL_CERT_FILE", "SSL_CERT_DIR",
   "LLV_SPAWN_CAPABILITY",
+  /* The re-hosted Viewer MCP launcher resolves the current release and the
+     runtime host's stable listener from these non-secret inputs. */
+  "LLV_STATE_DIR", "LLV_VIEWER_DEPLOY_TARGET", "LLV_VIEWER_PORT",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1762,6 +1762,54 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("a Codex re-host reconstructs the full Viewer stdio MCP connector", async () => {
+    const server = new FakeAppServer("viewer-rehost-thread");
+    const captured: { options?: SpawnOptionsWithoutStdio } = {};
+    server.mcpServers = {
+      viewer: {
+        command: "bun",
+        args: ["bin/mcp-server.mjs"],
+        env: { LLV_STATE_DIR: "fixture-state" },
+        enabled: true,
+        default_tools_approval_mode: "prompt",
+      },
+      unrelated: { command: "unrelated-mcp", enabled: true },
+    };
+    const host = await CodexAppServerHost.adopt("viewer-rehost-thread", {
+      cwd: "/repo",
+      mcpServers: ["viewer"],
+      env: {
+        NODE_ENV: "test",
+        LLV_STATE_DIR: "fixture-state",
+        LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+        LLV_VIEWER_PORT: "8898",
+      },
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server, captured),
+    });
+
+    expect(captured.options?.env).toMatchObject({
+      LLV_STATE_DIR: "fixture-state",
+      LLV_VIEWER_DEPLOY_TARGET: "fixture-target",
+      LLV_VIEWER_PORT: "8898",
+    });
+    expect(server.requests.find((request) => request.method === "thread/resume")?.params).toMatchObject({
+      config: {
+        mcp_servers: {
+          viewer: {
+            command: "bun",
+            args: ["bin/mcp-server.mjs"],
+            env: { LLV_STATE_DIR: "fixture-state" },
+            enabled: true,
+            default_tools_approval_mode: "approve",
+          },
+          unrelated: { enabled: false },
+        },
+      },
+    });
+    await host.release();
+  });
+
   test("rejects a resume response for a different durable thread", async () => {
     const server = new FakeAppServer("server-default", "different-thread");
     const eventStore = new MemoryEventStore();
@@ -3799,7 +3847,7 @@ describe("CodexAppServerHost", () => {
     )).rejects.toThrow("structured hosts are disabled");
   });
 
-  test("boot adoption resumes every flagged Codex registry row", async () => {
+  test("boot re-host resumes Codex and reconstructs its Viewer MCP connector (#1346)", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-adoption-"));
     const registryPath = path.join(directory, "agent-registry.json");
     const registry = new AgentRegistry(registryPath);
@@ -3841,7 +3889,17 @@ describe("CodexAppServerHost", () => {
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );
     expect(adopted).toHaveLength(1);
-    expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    expect(server.requests.find((request) => request.method === "thread/resume")?.params).toMatchObject({
+      config: {
+        mcp_servers: {
+          viewer: {
+            command: "bun",
+            args: [expect.stringContaining("bin/mcp-server.mjs")],
+            enabled: true,
+          },
+        },
+      },
+    });
     expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost).toMatchObject({
       eventCursor: 13,
       writerClaimEpoch: 4,

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -3,11 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "node:child_process";
 import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { procBackend } from "@/lib/proc";
 import { STRUCTURED_HOST_STAMP_ENV, structuredHostStamp } from "@/lib/scanner/process";
 import { saveTelegramSession, TELEGRAM_CONNECTOR_TOKEN_ENV } from "@/lib/telegram/sessionStore";
 
@@ -388,6 +389,14 @@ function fakeSpawn(server: FakeAppServer, captured?: { args?: string[]; options?
     }
     return server as unknown as ChildProcessWithoutNullStreams;
   };
+}
+
+async function waitForCondition(predicate: () => boolean | Promise<boolean>, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (await predicate()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(message);
 }
 
 const ownedFakeProcess = {
@@ -3946,6 +3955,226 @@ describe("CodexAppServerHost", () => {
     });
     await releasedRows[0]!.host.release();
   });
+
+  test("a severed seat re-hosts in a distinct process with a discoverable working Viewer MCP", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-seat-successor-process-"));
+    const home = path.join(directory, "home");
+    const configHome = path.join(directory, "config");
+    const stateDirectory = path.join(directory, "state");
+    const tempDirectory = path.join(directory, "tmp");
+    const targetPath = path.join(stateDirectory, "viewer-release.json");
+    const transcriptPath = path.join(directory, "seat-successor.jsonl");
+    const registryPath = path.join(directory, "agent-registry.json");
+    const eventsPath = path.join(directory, "events");
+    const mcpProofPath = path.join(directory, "viewer-mcp-proof.json");
+    const incumbentReadyPath = path.join(directory, "incumbent-ready.json");
+    const successorReadyPath = path.join(directory, "successor-ready.json");
+    for (const pathname of [home, configHome, stateDirectory, tempDirectory]) {
+      fs.mkdirSync(pathname, { recursive: true, mode: 0o700 });
+    }
+    fs.writeFileSync(transcriptPath, "");
+    const deployment = {
+      deploymentId: "deployment_seat_successor",
+      phase: "succeeded",
+      revision: "e".repeat(40),
+    };
+    let controlRequests = 0;
+    const control = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        controlRequests += 1;
+        const url = new URL(request.url);
+        expect(url.pathname).toBe("/api/runtime/deployments");
+        expect(url.searchParams.get("limit")).toBe("25");
+        return Response.json({ count: 1, deployments: [deployment] });
+      },
+    });
+    if (control.port === 8898) {
+      control.stop(true);
+      throw new Error("the seat-successor fixture selected the production port");
+    }
+    fs.writeFileSync(targetPath, JSON.stringify({
+      revision: "e".repeat(40),
+      image: "viewer:fixture",
+      container: "viewer-fixture",
+      endpoint: control.url.origin,
+    }));
+    const environment: NodeJS.ProcessEnv = {
+      NODE_ENV: "test",
+      PATH: process.env.PATH,
+      HOME: home,
+      XDG_CONFIG_HOME: configHome,
+      XDG_CACHE_HOME: path.join(directory, "cache"),
+      XDG_DATA_HOME: path.join(directory, "data"),
+      XDG_STATE_HOME: path.join(directory, "xdg-state"),
+      TMPDIR: tempDirectory,
+      LLV_STATE_DIR: stateDirectory,
+      LLV_VIEWER_DEPLOY_TARGET: targetPath,
+      LLV_VIEWER_PORT: String(control.port),
+    };
+    const hostFixture = path.join(import.meta.dir, "fixtures", "seatSuccessorHost.ts");
+    type FixtureIdentity = { pid: number; startIdentity: string };
+    type FixtureReady = {
+      mode: "incumbent" | "successor";
+      sessionId: string;
+      viewer: FixtureIdentity;
+      engine: FixtureIdentity;
+      eventCursor: number;
+      activeTurnRef: string | null;
+      proof?: {
+        enginePid: number;
+        toolNames?: string[];
+        structuredContent?: unknown;
+        error?: string;
+      };
+    };
+    type FixtureFailure = { mode?: "incumbent" | "successor"; error: string };
+    type FixtureHostProcess = ChildProcessWithoutNullStreams & { pid: number };
+    const launchHost = (mode: "incumbent" | "successor", readyPath: string): FixtureHostProcess => {
+      const child = spawn(process.execPath,
+        [hostFixture, mode, registryPath, eventsPath, transcriptPath, mcpProofPath, readyPath], {
+          cwd: process.cwd(),
+          env: environment,
+          detached: true,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      if (!child.pid) {
+        child.kill("SIGKILL");
+        throw new Error("fixture host process has no pid");
+      }
+      return child as FixtureHostProcess;
+    };
+    const diagnostics = new Map<number, string>();
+    const observeDiagnostics = (child: FixtureHostProcess) => {
+      diagnostics.set(child.pid, "");
+      child.stdout.resume();
+      child.stderr.on("data", (chunk) => {
+        diagnostics.set(child.pid, `${diagnostics.get(child.pid) ?? ""}${String(chunk)}`.slice(-4_000));
+      });
+    };
+    const readReady = async (filename: string, child: FixtureHostProcess): Promise<FixtureReady> => {
+      await waitForCondition(
+        () => fs.existsSync(filename) || child.exitCode !== null || child.signalCode !== null,
+        `fixture host ${child.pid} produced no ready evidence: ${diagnostics.get(child.pid) ?? ""}`,
+      );
+      if (!fs.existsSync(filename)) {
+        throw new Error(`fixture host ${child.pid} exited before readiness: ${diagnostics.get(child.pid) ?? ""}`);
+      }
+      const result = JSON.parse(fs.readFileSync(filename, "utf8")) as FixtureReady | FixtureFailure;
+      if ("error" in result) throw new Error(`fixture host ${child.pid} failed: ${result.error}`);
+      return result;
+    };
+    const waitForChildExit = async (child: FixtureHostProcess, timeoutMs: number): Promise<boolean> => {
+      if (child.exitCode !== null || child.signalCode !== null) return true;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          new Promise<true>((resolve) => child.once("exit", () => resolve(true))),
+          new Promise<false>((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+    const killExactEngine = async (identity: FixtureIdentity): Promise<void> => {
+      if (procBackend.processIdentity(identity.pid) === identity.startIdentity) {
+        try { process.kill(identity.pid, "SIGKILL"); } catch { /* fixture engine already exited */ }
+      }
+      await waitForCondition(
+        () => procBackend.processIdentity(identity.pid) !== identity.startIdentity,
+        `fixture engine ${identity.pid} survived termination`,
+      );
+    };
+    const stopHost = async (
+      child: FixtureHostProcess | null,
+      engine: FixtureIdentity | null,
+    ): Promise<void> => {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+        if (!await waitForChildExit(child, 1_000)) {
+          child.kill("SIGKILL");
+          await waitForChildExit(child, 1_000);
+        }
+      }
+      if (engine) await killExactEngine(engine);
+    };
+    let incumbent: FixtureHostProcess | null = null;
+    let successor: FixtureHostProcess | null = null;
+    let incumbentEngine: FixtureIdentity | null = null;
+    let successorEngine: FixtureIdentity | null = null;
+    try {
+      incumbent = launchHost("incumbent", incumbentReadyPath);
+      observeDiagnostics(incumbent);
+      const incumbentReady = await readReady(incumbentReadyPath, incumbent);
+      incumbentEngine = incumbentReady.engine;
+      expect(incumbentReady.mode).toBe("incumbent");
+      expect(incumbentReady.viewer.pid).toBe(incumbent.pid);
+      expect(incumbentReady.viewer.pid).not.toBe(process.pid);
+      expect(incumbentReady.engine.pid).not.toBe(incumbentReady.viewer.pid);
+      expect(incumbentReady.activeTurnRef).toBe("turn-1");
+
+      incumbent.kill("SIGKILL");
+      await waitForChildExit(incumbent, 1_000);
+      await killExactEngine(incumbentReady.engine);
+      const strandedRegistry = new AgentRegistry(registryPath).snapshot();
+      expect(strandedRegistry.entries[`codex:${incumbentReady.sessionId}`]).toMatchObject({
+        status: "live",
+        claimOwner: expect.any(String),
+        structuredHost: {
+          process: { pid: incumbentReady.engine.pid },
+          activeTurnRef: "turn-1",
+        },
+      });
+
+      successor = launchHost("successor", successorReadyPath);
+      observeDiagnostics(successor);
+      const successorReady = await readReady(successorReadyPath, successor);
+      successorEngine = successorReady.engine;
+      expect(successorReady.mode).toBe("successor");
+      expect(successorReady.sessionId).toBe(incumbentReady.sessionId);
+      expect(successorReady.viewer.pid).toBe(successor.pid);
+      expect(successorReady.viewer.pid).not.toBe(incumbentReady.viewer.pid);
+      expect(successorReady.engine.pid).not.toBe(incumbentReady.engine.pid);
+      expect(successorReady.engine.pid).not.toBe(successorReady.viewer.pid);
+      expect(successorReady.proof).not.toHaveProperty("error");
+      expect(successorReady.proof?.enginePid).toBe(successorReady.engine.pid);
+      expect(successorReady.proof?.toolNames).toContain("deployment_status");
+      expect(successorReady.proof?.structuredContent).toMatchObject({
+        ok: true,
+        toolName: "deployment_status",
+        count: 1,
+        deployments: [deployment],
+      });
+      expect(controlRequests).toBe(1);
+      const events = new FileRuntimeEventStore(eventsPath).load(successorReady.sessionId);
+      expect(events).toContainEqual(expect.objectContaining({
+        kind: "item",
+        phase: "completed",
+        item: expect.objectContaining({
+          type: "mcpToolCall",
+          server: "viewer",
+          tool: "deployment_status",
+          status: "completed",
+        }),
+      }));
+      expect(events).toContainEqual(expect.objectContaining({ kind: "turn-ended", status: "completed" }));
+      expect(new AgentRegistry(registryPath).snapshot().entries[`codex:${successorReady.sessionId}`])
+        .toMatchObject({
+          status: "idle",
+          claimOwner: expect.any(String),
+          structuredHost: {
+            process: { pid: successorReady.engine.pid },
+            activeTurnRef: null,
+          },
+        });
+    } finally {
+      await stopHost(successor, successorEngine);
+      await stopHost(incumbent, incumbentEngine);
+      control.stop(true);
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  }, 30_000);
 
   test("boot adoption starts only Codex rows admitted by its candidate filter", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-filtered-structured-adoption-"));

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -250,6 +250,11 @@ const CHILD_ENV_ALLOWLIST = [
   "SSL_CERT_FILE",
   "SSL_CERT_DIR",
   "LLV_SPAWN_CAPABILITY",
+  /* The re-hosted Viewer MCP launcher resolves the current release and the
+     runtime host's stable listener from these non-secret inputs. */
+  "LLV_STATE_DIR",
+  "LLV_VIEWER_DEPLOY_TARGET",
+  "LLV_VIEWER_PORT",
 ] as const;
 /**
  * Desktop-session variables forwarded ONLY to a host that holds a plugin grant

--- a/src/lib/runtime/fixtures/codexSeatSuccessor.ts
+++ b/src/lib/runtime/fixtures/codexSeatSuccessor.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+type JsonObject = Record<string, unknown>;
+
+const [mode, markerPath, transcriptPath] = process.argv.slice(2);
+if ((mode !== "hold" && mode !== "probe") || !markerPath || !transcriptPath) {
+  throw new Error("seat-successor fixture arguments are invalid");
+}
+
+const threadId = "seat-successor-thread";
+let viewerServer: { command: string; args: string[] } | null = null;
+let turn = 0;
+
+function record(value: unknown): JsonObject | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
+}
+
+function send(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function respond(id: number, result: unknown): void {
+  send({ jsonrpc: "2.0", id, result });
+}
+
+function notify(method: string, params: JsonObject): void {
+  send({ jsonrpc: "2.0", method, params });
+}
+
+function writeMarker(value: unknown): void {
+  const temporary = `${markerPath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value));
+  fs.renameSync(temporary, markerPath);
+}
+
+function captureViewerServer(params: JsonObject | null): void {
+  const config = record(params?.config);
+  const servers = record(config?.mcp_servers);
+  const viewer = record(servers?.viewer);
+  if (!viewer || viewer.enabled !== true || typeof viewer.command !== "string"
+    || !Array.isArray(viewer.args) || !viewer.args.every((argument) => typeof argument === "string")) {
+    viewerServer = null;
+    return;
+  }
+  viewerServer = { command: viewer.command, args: viewer.args as string[] };
+}
+
+async function exerciseViewerMcp(turnId: string): Promise<void> {
+  let client: Client | null = null;
+  try {
+    if (!viewerServer) throw new Error("the resumed thread has no launchable Viewer MCP definition");
+    const environment = Object.fromEntries(Object.entries(process.env)
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+    const transport = new StdioClientTransport({
+      command: viewerServer.command,
+      args: viewerServer.args,
+      cwd: process.cwd(),
+      env: environment,
+      stderr: "pipe",
+    });
+    client = new Client({ name: "seat-successor-fixture", version: "1.0.0" });
+    await client.connect(transport);
+    const tools = await client.listTools();
+    const toolNames = tools.tools.map((tool) => tool.name);
+    if (!toolNames.includes("deployment_status")) {
+      throw new Error("deployment_status is absent from the Viewer MCP tool list");
+    }
+    const result = await client.callTool({
+      name: "deployment_status",
+      arguments: { clientRequestId: "seat-successor-deployment-status" },
+    });
+    if (result.isError) throw new Error("Viewer MCP deployment_status returned an error");
+    writeMarker({
+      enginePid: process.pid,
+      toolNames,
+      structuredContent: result.structuredContent,
+    });
+    notify("item/completed", {
+      threadId,
+      turnId,
+      item: {
+        id: "viewer-deployment-status",
+        type: "mcpToolCall",
+        server: "viewer",
+        tool: "deployment_status",
+        status: "completed",
+        result: result.structuredContent,
+      },
+    });
+    notify("turn/completed", { threadId, turn: { id: turnId, status: "completed" } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeMarker({ enginePid: process.pid, error: message });
+    notify("item/completed", {
+      threadId,
+      turnId,
+      item: {
+        id: "viewer-deployment-status",
+        type: "mcpToolCall",
+        server: "viewer",
+        tool: "deployment_status",
+        status: "failed",
+        error: message,
+      },
+    });
+    notify("turn/completed", { threadId, turn: { id: turnId, status: "failed" } });
+  } finally {
+    await client?.close().catch(() => {});
+  }
+}
+
+async function accept(message: JsonObject): Promise<void> {
+  if (typeof message.id !== "number") return;
+  const params = record(message.params);
+  if (message.method === "initialize") {
+    respond(message.id, { userAgent: "codex_seat_successor_fixture/1.0.0" });
+    return;
+  }
+  if (message.method === "account/read") {
+    respond(message.id, { account: { type: "chatgpt", planType: "fixture" }, requiresOpenaiAuth: false });
+    return;
+  }
+  if (message.method === "model/list") {
+    respond(message.id, { data: [{ id: "fixture-model", isDefault: true, inputModalities: ["text"] }] });
+    return;
+  }
+  if (message.method === "config/read") {
+    respond(message.id, { config: { mcp_servers: {} } });
+    return;
+  }
+  if (message.method === "thread/start" || message.method === "thread/resume") {
+    captureViewerServer(params);
+    respond(message.id, {
+      thread: {
+        id: threadId,
+        path: transcriptPath,
+        turns: [],
+        status: { type: "idle", activeFlags: [] },
+      },
+    });
+    return;
+  }
+  if (message.method === "thread/read") {
+    respond(message.id, { thread: { id: threadId, path: transcriptPath, turns: [] } });
+    return;
+  }
+  if (message.method === "thread/turns/list") {
+    respond(message.id, { data: [], nextCursor: null, backwardsCursor: null });
+    return;
+  }
+  if (message.method === "turn/start") {
+    const turnId = `turn-${++turn}`;
+    respond(message.id, { turn: { id: turnId } });
+    notify("turn/started", { threadId, turn: { id: turnId } });
+    if (typeof params?.clientUserMessageId === "string") {
+      notify("item/completed", {
+        threadId,
+        turnId,
+        item: {
+          type: "userMessage",
+          clientId: params.clientUserMessageId,
+          content: params.input,
+        },
+      });
+    }
+    if (mode === "probe") await exerciseViewerMcp(turnId);
+    return;
+  }
+  if (message.method === "turn/interrupt") {
+    respond(message.id, {});
+    return;
+  }
+  respond(message.id, {});
+}
+
+let buffer = "";
+process.stdin.setEncoding("utf8");
+for await (const chunk of process.stdin) {
+  buffer += chunk;
+  let newline = buffer.indexOf("\n");
+  while (newline >= 0) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (line) await accept(JSON.parse(line) as JsonObject);
+    newline = buffer.indexOf("\n");
+  }
+}

--- a/src/lib/runtime/fixtures/seatSuccessorHost.ts
+++ b/src/lib/runtime/fixtures/seatSuccessorHost.ts
@@ -1,0 +1,170 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+import { captureProcessIdentity } from "@/lib/processIdentity";
+
+import { CodexAppServerHost } from "../codexAppServerHost";
+import { FileRuntimeEventStore } from "../eventStore";
+import { adoptCodexRegistryHosts, bindCodexHostPersistence } from "../registry";
+
+const [mode, registryPath, eventsPath, transcriptPath, mcpProofPath, readyPath] = process.argv.slice(2);
+if ((mode !== "incumbent" && mode !== "successor")
+  || !registryPath || !eventsPath || !transcriptPath || !mcpProofPath || !readyPath) {
+  throw new Error("seat-successor host fixture arguments are invalid");
+}
+
+const engineFixture = path.join(import.meta.dir, "codexSeatSuccessor.ts");
+const eventStore = new FileRuntimeEventStore(eventsPath);
+const registry = new AgentRegistry(registryPath);
+let host: CodexAppServerHost | null = null;
+let stopping = false;
+
+function spawnEngine(engineMode: "hold" | "probe") {
+  return (_command: string, _args: string[], options: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams => spawn(
+    process.execPath,
+    [engineFixture, engineMode, mcpProofPath, transcriptPath],
+    { ...options, stdio: ["pipe", "pipe", "pipe"] },
+  );
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (await predicate()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(message);
+}
+
+function writeReady(value: unknown): void {
+  const temporary = `${readyPath}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value));
+  fs.renameSync(temporary, readyPath);
+}
+
+function hostIdentity(current: CodexAppServerHost) {
+  return current.health().then((health) => {
+    if (!health.pid || !health.processStartIdentity) throw new Error("fixture engine process identity is unavailable");
+    const viewer = captureProcessIdentity(process.pid);
+    if (!viewer.startIdentity) throw new Error("fixture Viewer process identity is unavailable");
+    return {
+      viewer: { pid: viewer.pid, startIdentity: viewer.startIdentity },
+      engine: { pid: health.pid, startIdentity: health.processStartIdentity },
+      eventCursor: health.eventCursor,
+      activeTurnRef: health.activeTurnRef,
+    };
+  });
+}
+
+async function startIncumbent(): Promise<void> {
+  host = await CodexAppServerHost.start({
+    cwd: process.cwd(),
+    env: process.env,
+    mcpServers: ["viewer"],
+    eventStore,
+    requestTimeoutMs: 5_000,
+    shutdownGraceMs: 250,
+    spawnProcess: spawnEngine("hold"),
+  });
+  const key = { engine: "codex" as const, sessionId: host.identity.threadId };
+  registry.upsert({
+    key,
+    artifactPath: transcriptPath,
+    cwd: process.cwd(),
+    accountId: null,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:pending",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: null,
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const claimed = registry.claimStructuredHost(key, captureProcessIdentity(process.pid), { allowUnhosted: true });
+  if (!claimed?.claimOwner) throw new Error("the incumbent fixture host claim was unavailable");
+  await bindCodexHostPersistence(
+    registry,
+    key,
+    host,
+    claimed.claimOwner,
+    claimed.claimEpoch,
+    "dead",
+    { cursorDebounceMs: 0 },
+  );
+  const receipt = await host.send({ id: "seat-successor-held-turn", text: "hold this turn" });
+  if (receipt.outcome !== "turn-started") throw new Error("the incumbent fixture turn did not start");
+  await waitFor(async () => (await host!.health()).status === "active", "the incumbent fixture turn stayed idle");
+  writeReady({
+    mode,
+    sessionId: key.sessionId,
+    ...(await hostIdentity(host)),
+  });
+}
+
+async function startSuccessor(): Promise<void> {
+  const adopted = await adoptCodexRegistryHosts(
+    registry,
+    () => ({
+      cwd: process.cwd(),
+      env: process.env,
+      mcpServers: ["viewer"],
+      eventStore,
+      requestTimeoutMs: 5_000,
+      shutdownGraceMs: 250,
+      spawnProcess: spawnEngine("probe"),
+    }),
+    { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+  );
+  if (adopted.length !== 1) throw new Error(`expected one adopted seat, received ${adopted.length}`);
+  host = adopted[0]!.host;
+  const receipt = await host.send({ id: "seat-successor-mcp-turn", text: "call Viewer MCP" });
+  if (receipt.outcome !== "turn-started") throw new Error("the successor fixture turn did not start");
+  await waitFor(() => fs.existsSync(mcpProofPath), "the successor fixture produced no Viewer MCP proof");
+  const proof = JSON.parse(fs.readFileSync(mcpProofPath, "utf8")) as { error?: string };
+  if (proof.error) throw new Error(proof.error);
+  await waitFor(async () => (await host!.health()).status === "idle", "the successor fixture turn did not complete");
+  writeReady({
+    mode,
+    sessionId: adopted[0]!.key.sessionId,
+    ...(await hostIdentity(host)),
+    proof,
+  });
+}
+
+async function stop(): Promise<void> {
+  if (stopping) return;
+  stopping = true;
+  await releaseHost();
+  process.exit(0);
+}
+
+async function releaseHost(): Promise<void> {
+  const current: CodexAppServerHost | null = host;
+  if (current) await current.release().catch(() => {});
+}
+
+process.on("SIGTERM", () => { void stop(); });
+process.on("SIGINT", () => { void stop(); });
+
+try {
+  if (mode === "incumbent") await startIncumbent();
+  else await startSuccessor();
+  await new Promise<void>(() => {});
+} catch (error) {
+  writeReady({
+    mode,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  await releaseHost();
+  process.exitCode = 1;
+}

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -520,6 +520,8 @@ export async function adoptCodexRegistryHosts(
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
           };
+          /* The production static method calls `this.open`; keep its class
+             receiver instead of extracting it into an unbound function. */
           const host = dependencies.adoptHost
             ? await dependencies.adoptHost(entry.key.sessionId, options)
             : await CodexAppServerHost.adopt(entry.key.sessionId, options);
@@ -609,6 +611,7 @@ export async function adoptClaudeRegistryHosts(
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
           };
+          /* Claude adoption has the same receiver-bound static open seam. */
           const host = dependencies.adoptHost
             ? await dependencies.adoptHost(entry.key.sessionId, options)
             : await ClaudeStreamBrokerHost.adopt(entry.key.sessionId, options);

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -516,10 +516,13 @@ export async function adoptCodexRegistryHosts(
           return;
         }
         try {
-          const host = await (dependencies.adoptHost ?? CodexAppServerHost.adopt)(entry.key.sessionId, {
+          const options = {
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
-          });
+          };
+          const host = dependencies.adoptHost
+            ? await dependencies.adoptHost(entry.key.sessionId, options)
+            : await CodexAppServerHost.adopt(entry.key.sessionId, options);
           await bindCodexHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
         } catch (error) {
@@ -602,10 +605,13 @@ export async function adoptClaudeRegistryHosts(
           return;
         }
         try {
-          const host = await (dependencies.adoptHost ?? ClaudeStreamBrokerHost.adopt)(entry.key.sessionId, {
+          const options = {
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
-          });
+          };
+          const host = dependencies.adoptHost
+            ? await dependencies.adoptHost(entry.key.sessionId, options)
+            : await ClaudeStreamBrokerHost.adopt(entry.key.sessionId, options);
           await bindClaudeHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
         } catch (error) {


### PR DESCRIPTION
## Summary

- preserve the engine class receiver during startup adoption so Codex and Claude re-hosts complete
- replay the full Viewer stdio MCP definition and stable resolver environment into replacement harnesses
- render the orchestrator scaffold around Viewer MCP tools with no host-port literal
- route retired launch URLs through the stable runtime-host listener while candidate probes stay pinned to their exact endpoint

## Verification

Pinned head: `99edaca2fa8615a26f6191deb9f6bdfdc1c492bc`  
Pinned merge base: `d4ee411937a986d32800e53b1101a9efca5168c3`

- `bunx tsc --noEmit`: pass
- six touched test files in one explicit by-path invocation: 202 pass, 0 fail
- mutation check: the connector-definition, retired-port, and URL-free scaffold regressions each went red under the pre-fix behavior
- `bun scripts/privacy-publication-gate.ts --base d4ee411937a986d32800e53b1101a9efca5168c3`: pass
- focused self-review across correctness, test sensitivity, silent failures, types, comments, and simplification: no findings

Fixes https://github.com/Latand/live-log-viewer-next/issues/1346
Fixes https://github.com/Latand/live-log-viewer-next/issues/1354