### PR TITLE
fix(feed): keep live-tail follow disarmed after upward intent (#1396)

### DIFF
--- a/src/components/LogFeed.suggestedReplies.dom.test.tsx
+++ b/src/components/LogFeed.suggestedReplies.dom.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { Window as HappyWindow } from "happy-dom";
+import type { ReactElement } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -144,6 +145,7 @@ afterEach(() => {
   for (const root of roots) flushSync(() => root.unmount());
   roots.clear();
   dom.document.body.replaceChildren();
+  tailState.lines = TRANSCRIPT;
 });
 afterAll(() => {
   globalThis.fetch = previousFetch;
@@ -173,6 +175,46 @@ const file = {
   conversationId: CONVERSATION_ID,
 } as FileEntry;
 
+function conversationFile(suffix: string): FileEntry {
+  return {
+    ...file,
+    path: `/fixtures/claude/projects/-repo/seat-${suffix}.jsonl`,
+    name: `seat-${suffix}.jsonl`,
+    conversationId: `conversation_seat_${suffix.replaceAll("-", "_")}`,
+  };
+}
+
+function feedElement(
+  follow: boolean,
+  setFollow: (value: boolean) => void,
+  feedFile: FileEntry,
+): ReactElement {
+  return (
+    <LogFeed
+      file={feedFile}
+      showSvc={false}
+      lineFilter=""
+      onStatus={() => undefined}
+      paused
+      follow={follow}
+      setFollow={setFollow}
+      compact
+    />
+  );
+}
+
+function transcriptWithUpdates(idPrefix: string, textPrefix: string, count: number): string[] {
+  return [
+    ...TRANSCRIPT,
+    ...Array.from({ length: count }, (_, index) => JSON.stringify({
+      type: "assistant",
+      uuid: `uuid-${idPrefix}-${index}`,
+      timestamp: AT(3 + index),
+      message: { role: "assistant", content: [{ type: "text", text: `${textPrefix} ${index + 1}.` }] },
+    })),
+  ];
+}
+
 function render(
   follow: boolean,
   setFollow: (value: boolean) => void = () => undefined,
@@ -183,18 +225,7 @@ function render(
   const root = createRoot(host as unknown as HTMLElement);
   roots.add(root);
   flushSync(() => {
-    root.render(
-      <LogFeed
-        file={feedFile}
-        showSvc={false}
-        lineFilter=""
-        onStatus={() => undefined}
-        paused
-        follow={follow}
-        setFollow={setFollow}
-        compact
-      />,
-    );
+    root.render(feedElement(follow, setFollow, feedFile));
   });
   return host as unknown as HTMLElement;
 }
@@ -217,6 +248,14 @@ function setScrollerGeometry(element: HTMLElement, height: number, viewport: num
     setHeight: (value: number) => { scrollHeight = value; },
     setTop: (value: number) => { element.scrollTop = value; },
   };
+}
+
+function touchEvent(type: "touchstart" | "touchmove" | "touchend", clientY?: number): Event {
+  const event = new dom.Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "touches", {
+    value: clientY === undefined ? [] : [{ clientX: 20, clientY }],
+  });
+  return event as unknown as Event;
 }
 
 async function settle(host: HTMLElement, selector: string, timeoutMs = 4_000): Promise<void> {
@@ -301,6 +340,148 @@ test("an upward wheel survives a concurrent glue and releases the scroll magnet 
   } finally {
     Date.now = originalNow;
   }
+});
+
+test("a burst of tail records cannot move the viewport down during an upward wheel gesture", () => {
+  const followChanges: boolean[] = [];
+  const feedFile = conversationFile("wheel-burst");
+  const host = render(true, (value) => followChanges.push(value), feedFile);
+  const root = [...roots].at(-1)!;
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_000, 200, 800);
+  const viewportPositions = [scroller.scrollTop];
+
+  try {
+    flushSync(() => {
+      scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -120 }) as unknown as Event);
+    });
+
+    for (let record = 1; record <= 3; record += 1) {
+      tailState.lines = transcriptWithUpdates("wheel-burst", "Burst update", record);
+      geometry.setHeight(1_000 + record * 100);
+      flushSync(() => {
+        root.render(feedElement(true, (value) => followChanges.push(value), feedFile));
+      });
+      viewportPositions.push(scroller.scrollTop);
+    }
+
+    expect(viewportPositions).toEqual([800, 800, 800, 800]);
+    expect(followChanges).toEqual([false]);
+  } finally {
+    tailState.lines = TRANSCRIPT;
+  }
+});
+
+test("a burst of tail records cannot move the viewport down during an upward touch gesture", () => {
+  const followChanges: boolean[] = [];
+  const feedFile = conversationFile("touch-burst");
+  const host = render(true, (value) => followChanges.push(value), feedFile);
+  const root = [...roots].at(-1)!;
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_000, 200, 800);
+  const viewportPositions = [scroller.scrollTop];
+
+  try {
+    flushSync(() => {
+      scroller.dispatchEvent(touchEvent("touchstart", 400));
+      scroller.dispatchEvent(touchEvent("touchmove", 460));
+    });
+
+    for (let record = 1; record <= 3; record += 1) {
+      tailState.lines = transcriptWithUpdates("touch-burst", "Touch burst update", record);
+      geometry.setHeight(1_000 + record * 100);
+      flushSync(() => {
+        root.render(feedElement(true, (value) => followChanges.push(value), feedFile));
+      });
+      viewportPositions.push(scroller.scrollTop);
+    }
+
+    expect(viewportPositions).toEqual([800, 800, 800, 800]);
+    expect(followChanges).toEqual([false]);
+  } finally {
+    tailState.lines = TRANSCRIPT;
+  }
+});
+
+test("follow stays disarmed across further arrivals and resizes until the operator reaches bottom", () => {
+  const followChanges: boolean[] = [];
+  const feedFile = conversationFile("durable-release");
+  const host = render(true, (value) => followChanges.push(value), feedFile);
+  const root = [...roots].at(-1)!;
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_000, 200, 800);
+
+  try {
+    flushSync(() => {
+      scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -200 }) as unknown as Event);
+      geometry.setTop(600);
+      scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    });
+
+    const releasedPositions: number[] = [];
+    for (let record = 1; record <= 3; record += 1) {
+      tailState.lines = transcriptWithUpdates("durable-release", "Durable update", record);
+      geometry.setHeight(1_000 + record * 100);
+      flushSync(() => {
+        root.render(feedElement(true, (value) => followChanges.push(value), feedFile));
+        for (const callback of resizeCallbacks) callback([], {} as ResizeObserver);
+      });
+      releasedPositions.push(scroller.scrollTop);
+    }
+
+    expect(releasedPositions).toEqual([600, 600, 600]);
+    expect(followChanges).toEqual([false]);
+
+    flushSync(() => {
+      scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 500 }) as unknown as Event);
+      geometry.setTop(1_100);
+      scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    });
+    expect(followChanges).toEqual([false, true]);
+
+    tailState.lines = [
+      ...tailState.lines,
+      JSON.stringify({
+        type: "assistant",
+        uuid: "uuid-after-bottom-return",
+        timestamp: AT(6),
+        message: { role: "assistant", content: [{ type: "text", text: "Following again." }] },
+      }),
+    ];
+    geometry.setHeight(1_400);
+    flushSync(() => {
+      root.render(feedElement(true, (value) => followChanges.push(value), feedFile));
+    });
+    expect(scroller.scrollTop).toBe(1_200);
+  } finally {
+    tailState.lines = TRANSCRIPT;
+  }
+});
+
+test("the jump-to-latest control clears the durable disarm and restores live-tail follow", async () => {
+  const followChanges: boolean[] = [];
+  const feedFile = conversationFile("jump-latest");
+  const host = render(true, (value) => followChanges.push(value), feedFile);
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_200, 200, 1_000);
+
+  flushSync(() => {
+    scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -200 }) as unknown as Event);
+    geometry.setTop(600);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  await settle(host, 'button[aria-label="Back to the live tail"]');
+
+  const jump = host.querySelector('button[aria-label="Back to the live tail"]') as HTMLButtonElement;
+  expect(jump).toBeTruthy();
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => { jump.click(); });
+
+  expect(scroller.scrollTop).toBe(1_000);
+  expect(followChanges).toEqual([false, true]);
+  expect(host.querySelector('button[aria-label="Back to the live tail"]')).toBeNull();
+  expect(host.querySelector("[data-live-tail-pill]")).toBeTruthy();
 });
 
 test("growth before an upward wheel survives resize glue and stays released through the next append", () => {

--- a/src/components/LogFeed.suggestedReplies.dom.test.tsx
+++ b/src/components/LogFeed.suggestedReplies.dom.test.tsx
@@ -52,6 +52,7 @@ Object.assign(globalThis, {
   Event: dom.Event,
   CustomEvent: dom.CustomEvent,
   MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
   KeyboardEvent: dom.KeyboardEvent,
   sessionStorage: dom.sessionStorage,
   localStorage: dom.localStorage,
@@ -258,6 +259,34 @@ function touchEvent(type: "touchstart" | "touchmove" | "touchend", clientY?: num
   return event as unknown as Event;
 }
 
+function pointerEvent(type: "pointerdown" | "pointerup", clientX: number): Event {
+  return new dom.PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX,
+    clientY: 100,
+    pointerType: "mouse",
+  }) as unknown as Event;
+}
+
+function setScrollerPointerGeometry(element: HTMLElement, contentWidth: number, totalWidth: number): void {
+  Object.defineProperties(element, {
+    clientLeft: { configurable: true, value: 0 },
+    clientWidth: { configurable: true, value: contentWidth },
+  });
+  element.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: totalWidth,
+    bottom: element.clientHeight,
+    width: totalWidth,
+    height: element.clientHeight,
+    toJSON: () => ({}),
+  });
+}
+
 async function settle(host: HTMLElement, selector: string, timeoutMs = 4_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline && !host.querySelector(selector)) {
@@ -456,6 +485,74 @@ test("follow stays disarmed across further arrivals and resizes until the operat
   } finally {
     tailState.lines = TRANSCRIPT;
   }
+});
+
+test("a pointer-driven scrollbar return to bottom re-arms follow without authorizing content clicks", () => {
+  const followChanges: boolean[] = [];
+  const host = render(true, (value) => followChanges.push(value), conversationFile("scrollbar-return"));
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_000, 200, 800);
+  setScrollerPointerGeometry(scroller, 300, 320);
+
+  flushSync(() => {
+    scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -200 }) as unknown as Event);
+    geometry.setTop(600);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => {
+    scroller.dispatchEvent(pointerEvent("pointerdown", 100));
+    geometry.setTop(800);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    scroller.dispatchEvent(pointerEvent("pointerup", 100));
+  });
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => {
+    geometry.setTop(600);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    scroller.dispatchEvent(pointerEvent("pointerdown", 310));
+    geometry.setTop(700);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => {
+    geometry.setTop(800);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    scroller.dispatchEvent(pointerEvent("pointerup", 310));
+  });
+  expect(followChanges).toEqual([false, true]);
+});
+
+test("an ended scrollbar gesture cannot authorize a later uncaused bottom-reaching scroll", () => {
+  const followChanges: boolean[] = [];
+  const host = render(true, (value) => followChanges.push(value), conversationFile("programmatic-bottom"));
+  const scroller = host.querySelector("[data-log-feed-scroller]") as HTMLElement;
+  const geometry = setScrollerGeometry(scroller, 1_000, 200, 800);
+  setScrollerPointerGeometry(scroller, 300, 320);
+
+  flushSync(() => {
+    scroller.dispatchEvent(new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: -200 }) as unknown as Event);
+    geometry.setTop(600);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => {
+    scroller.dispatchEvent(pointerEvent("pointerdown", 310));
+    geometry.setTop(700);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+    scroller.dispatchEvent(pointerEvent("pointerup", 310));
+  });
+  expect(followChanges).toEqual([false]);
+
+  flushSync(() => {
+    geometry.setTop(800);
+    scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event);
+  });
+  expect(followChanges).toEqual([false]);
 });
 
 test("the jump-to-latest control clears the durable disarm and restores live-tail follow", async () => {

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -123,6 +123,14 @@ function canScrollVertically(element: HTMLElement, deltaY: number): boolean {
   return false;
 }
 
+function pointerHitsVerticalScrollbar(element: HTMLElement, clientX: number): boolean {
+  if (element.scrollHeight <= element.clientHeight) return false;
+  const bounds = element.getBoundingClientRect();
+  const contentLeft = bounds.left + element.clientLeft;
+  const contentRight = contentLeft + element.clientWidth;
+  return clientX < contentLeft || clientX >= contentRight;
+}
+
 function distanceFromBottom(element: HTMLElement): number {
   return Math.max(0, element.scrollHeight - element.clientHeight - element.scrollTop);
 }
@@ -268,6 +276,9 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const pulseTimer = useRef<number | null>(null);
   const glueAtRef = useRef(0);
   const scrollCauseRef = useRef<ScrollCause | null>(null);
+  /* One scrollbar press can drive many scroll events. Its moving baseline
+     lives through the gesture; a stamped programmatic cause still wins. */
+  const scrollbarPointerRef = useRef<{ fromBottom: number } | null>(null);
   const feedTouchRef = useRef<{ x: number; y: number } | null>(null);
   const pillTouchRef = useRef<{ x: number; y: number } | null>(null);
   const restoreInitializedPathRef = useRef<string | null>(null);
@@ -377,6 +388,17 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     },
     [],
   );
+  useEffect(() => {
+    function releaseScrollbarPointer(): void { scrollbarPointerRef.current = null; }
+    window.addEventListener("pointerup", releaseScrollbarPointer, true);
+    window.addEventListener("pointercancel", releaseScrollbarPointer, true);
+    window.addEventListener("blur", releaseScrollbarPointer);
+    return () => {
+      window.removeEventListener("pointerup", releaseScrollbarPointer, true);
+      window.removeEventListener("pointercancel", releaseScrollbarPointer, true);
+      window.removeEventListener("blur", releaseScrollbarPointer);
+    };
+  }, []);
   useEffect(() => {
     hadQuestionRef.current = false;
     queueMicrotask(() => setEndedQuestion(null));
@@ -811,6 +833,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
         onWheelCapture={(event) => {
           if (event.deltaY) markUserScroll(event.deltaY);
         }}
+        onPointerDownCapture={(event) => {
+          if (event.button === 0 && pointerHitsVerticalScrollbar(event.currentTarget, event.clientX)) {
+            scrollbarPointerRef.current = { fromBottom: distanceFromBottom(event.currentTarget) };
+            scrollCauseRef.current = null;
+          }
+        }}
         onTouchStartCapture={(event) => {
           const touch = event.touches[0];
           feedTouchRef.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
@@ -836,7 +864,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
           const el = event.currentTarget;
           const fromBottom = distanceFromBottom(el);
           const atBottom = fromBottom <= 50;
-          const cause = scrollCauseRef.current;
+          const pendingCause = scrollCauseRef.current;
+          const scrollbarPointer = scrollbarPointerRef.current;
+          const cause: ScrollCause | null = scrollbarPointer && pendingCause?.kind !== "programmatic"
+            ? { kind: "user", fromBottom: scrollbarPointer.fromBottom, direction: null }
+            : pendingCause;
           const userDelta = cause?.kind === "user" ? fromBottom - cause.fromBottom : 0;
           const userInitiated = cause?.kind === "user"
             && userDelta !== 0
@@ -845,8 +877,10 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
           const userReturnedToBottom = atBottom && userInitiated && userDelta < 0;
           /* A concurrent glue can emit its own scroll at the bottom before the
              wheel's upward scroll. Keep a zero-movement user tag for that next
-             event; an opposite movement proves the tag did not cause it. */
-          if (cause?.kind !== "user" || userDelta !== 0) scrollCauseRef.current = null;
+             event; an opposite movement proves the tag did not cause it. A
+             scrollbar press keeps its separate moving baseline until release. */
+          if (scrollbarPointer) scrollbarPointer.fromBottom = fromBottom;
+          if (scrollbarPointer || cause?.kind !== "user" || userDelta !== 0) scrollCauseRef.current = null;
           const settling = nowMs() - glueAtRef.current < GLUE_SETTLE_MS;
           if (!settling || userInitiated) pendingRestoreRef.current = null;
           if (userReturnedToBottom && !magnetRef.current) setMagnet(true, true);

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -258,12 +258,17 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const [pulse, setPulse] = useState(false);
   const [endedQuestion, setEndedQuestion] = useState<string | null>(null);
   const hadQuestionRef = useRef(false);
+  /* Synchronous per-transcript follow authority: an upward input closes this
+     latch before a tail render can run with stale `magnet` state. While this
+     transcript stays selected, only an operator bottom return or an explicit
+     follow control writes it true again. */
   const magnetRef = useRef(magnet);
   const lastLenRef = useRef(0);
   const lastPrependRef = useRef(0);
   const pulseTimer = useRef<number | null>(null);
   const glueAtRef = useRef(0);
   const scrollCauseRef = useRef<ScrollCause | null>(null);
+  const feedTouchRef = useRef<{ x: number; y: number } | null>(null);
   const pillTouchRef = useRef<{ x: number; y: number } | null>(null);
   const restoreInitializedPathRef = useRef<string | null>(null);
   const pendingRestoreRef = useRef<PendingRestore | null>(null);
@@ -303,7 +308,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      treats near-in-time off-bottom positions as layout still settling. */
   const glue = () => {
     const el = scroller.current;
-    if (!el) return;
+    if (!el || !magnetRef.current) return;
     markProgrammaticScroll();
     el.scrollTop = el.scrollHeight;
     const pendingUser = scrollCauseRef.current;
@@ -527,8 +532,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
         : { icon: Sparkle, label: t("feed.working") };
 
   const jumpToTail = () => {
-    glue();
     setMagnet(true, true);
+    glue();
   };
 
   const transcriptGeneration = tailPath;
@@ -714,6 +719,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       fromBottom: distanceFromBottom(el),
       direction: direction === null || direction === 0 ? null : direction < 0 ? -1 : 1,
     };
+    if (direction !== null && direction < 0 && magnetRef.current) setMagnet(false);
   };
   const forwardPillVerticalDelta = (row: HTMLElement | null, deltaY: number): void => {
     const el = scroller.current;
@@ -805,7 +811,22 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
         onWheelCapture={(event) => {
           if (event.deltaY) markUserScroll(event.deltaY);
         }}
-        onTouchStartCapture={() => { markUserScroll(null); }}
+        onTouchStartCapture={(event) => {
+          const touch = event.touches[0];
+          feedTouchRef.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+          markUserScroll(null);
+        }}
+        onTouchMoveCapture={(event) => {
+          const touch = event.touches[0];
+          const previous = feedTouchRef.current;
+          if (!touch || !previous) return;
+          const deltaX = previous.x - touch.clientX;
+          const deltaY = previous.y - touch.clientY;
+          feedTouchRef.current = { x: touch.clientX, y: touch.clientY };
+          if (Math.abs(deltaY) > Math.abs(deltaX)) markUserScroll(deltaY);
+        }}
+        onTouchEndCapture={() => { feedTouchRef.current = null; }}
+        onTouchCancelCapture={() => { feedTouchRef.current = null; }}
         onKeyDownCapture={(event) => {
           if (["ArrowUp", "Home", "PageUp"].includes(event.key)) markUserScroll(-1);
           else if (["ArrowDown", "End", "PageDown"].includes(event.key)) markUserScroll(1);
@@ -821,13 +842,14 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
             && userDelta !== 0
             && (cause.direction === null || Math.sign(userDelta) === -cause.direction);
           const userReleasedMagnet = userInitiated && userDelta > 0;
+          const userReturnedToBottom = atBottom && userInitiated && userDelta < 0;
           /* A concurrent glue can emit its own scroll at the bottom before the
              wheel's upward scroll. Keep a zero-movement user tag for that next
              event; an opposite movement proves the tag did not cause it. */
           if (cause?.kind !== "user" || userDelta !== 0) scrollCauseRef.current = null;
           const settling = nowMs() - glueAtRef.current < GLUE_SETTLE_MS;
           if (!settling || userInitiated) pendingRestoreRef.current = null;
-          if (atBottom && !magnetRef.current && !userReleasedMagnet) setMagnet(true, true);
+          if (userReturnedToBottom && !magnetRef.current) setMagnet(true, true);
           else if ((userReleasedMagnet || !atBottom) && magnetRef.current) {
             /* Off-bottom right after a programmatic glue is layout settling
                (content-visibility estimates, pane resizes during a scheme


### PR DESCRIPTION
Closes #1396

## Impact

An upward wheel, touch drag, or scroll key now disarms live-tail follow before fresh records can move the viewport. Follow stays released through tail arrivals, content resizes, and programmatic glue until the operator reaches the bottom or activates the jump-to-latest control.

## Cause

The shipped gesture tag released the magnet on the resulting scroll event. A live tail render could arrive between the input event and that scroll event, observe stale magnet state, and glue the viewport to each new bottom.

## Fix

- Close the synchronous per-transcript follow latch as soon as upward intent is known.
- Make every glue consult that latch so stale content renders and resize callbacks cannot move the viewport.
- Re-arm from verified user movement back to the bottom or an explicit follow control.
- Track touch direction so upward touch intent receives the same early latch as wheel and keyboard input.
- Add wheel-burst, touch-burst, durable-arrival/bottom-return, and jump-control DOM regressions while retaining the shipped #1367 pill and resize-glue cases.

## Verification

- bunx tsc --noEmit
- bun test src/components/LogFeed.suggestedReplies.dom.test.tsx src/components/feed/SuggestedReplies.dom.test.tsx with isolated HOME, XDG_CONFIG_HOME, LLV_STATE_DIR, and TMPDIR: 19 passed, 54 assertions
- bun scripts/privacy-publication-gate.ts --base 3582778e4e068ce011802c1e6af9adc29a2d1b62
- git diff --check

The wheel-burst regression was red before the fix: the viewport advanced from 800 to 900, 1000, and 1100 across three records.