### PR TITLE
fix(spawn): drop unset fields when replaying the Viewer MCP entry (#1410)

### DIFF
--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -117,3 +117,46 @@ test("a Codex thread approves Viewer and retains optional server approval policy
     },
   });
 });
+
+test("a replayed Viewer entry drops the unset fields config/read reports as null (#1410)", () => {
+  /* Codex answers config/read with every optional field present, using null
+     for the ones nobody configured. Replaying those nulls back made Codex
+     refuse the launch outright ("invalid type: string ``, expected f64"), so
+     no session could start. */
+  const thread = headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {
+        viewer: {
+          command: "bun",
+          args: ["/opt/viewer/bin/mcp-server.mjs"],
+          environment_id: "local",
+          enabled: true,
+          tool_timeout_sec: null,
+          startup_timeout_sec: null,
+        },
+      },
+    },
+  }) as { mcp_servers: Record<string, Record<string, unknown>> };
+
+  expect(thread.mcp_servers.viewer).toEqual({
+    command: "bun",
+    args: ["/opt/viewer/bin/mcp-server.mjs"],
+    environment_id: "local",
+    enabled: true,
+    default_tools_approval_mode: "approve",
+  });
+  expect("tool_timeout_sec" in thread.mcp_servers.viewer).toBe(false);
+  expect("startup_timeout_sec" in thread.mcp_servers.viewer).toBe(false);
+});
+
+test("a replayed Viewer entry keeps a timeout the operator actually set (#1410)", () => {
+  const thread = headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {
+        viewer: { command: "bun", args: ["/opt/viewer/bin/mcp-server.mjs"], tool_timeout_sec: 120 },
+      },
+    },
+  }) as { mcp_servers: Record<string, Record<string, unknown>> };
+
+  expect(thread.mcp_servers.viewer.tool_timeout_sec).toBe(120);
+});

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -9,6 +9,17 @@ function record(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
 }
 
+/** `config/read` reports every optional field of a server, using null for the
+    ones nobody set — `tool_timeout_sec: null` for a server that never declared
+    one. Codex will not accept those nulls back as input: replaying the entry
+    verbatim makes it reject the whole launch with "invalid type: string ``,
+    expected f64" and no session starts at all (#1410). Only fields carrying a
+    real value are replayed; an absent field stays absent, which is what the
+    operator's configuration said in the first place. */
+function withoutUnsetFields(server: JsonObject): JsonObject {
+  return Object.fromEntries(Object.entries(server).filter(([, value]) => value !== null && value !== undefined));
+}
+
 /** Per-plugin thread table for a granted session: every plugin Codex knows
  *  about, with only the granted names enabled. Codex 0.145 accepts this table
  *  on `thread/start` but resolves plugins from the global config instead, so it
@@ -58,7 +69,7 @@ export function headlessCodexThreadConfig(
         /* A replacement app-server must receive the launch definition again.
            Its predecessor owned the stdio child, so an enable flag alone
            leaves a resumed thread with no connector process to call (#1346). */
-        ...(name === "viewer" ? server as JsonObject : {}),
+        ...(name === "viewer" ? withoutUnsetFields(server as JsonObject) : {}),
         enabled: enabled.has(name),
         ...(approval ? { default_tools_approval_mode: approval } : {}),
       }];


### PR DESCRIPTION
Fixes #1410 — no Codex session could start after the promote.

## Cause

`config/read` answers with every optional field of an MCP server present, using `null` for the ones nobody configured:

```
{ command: "bun", args: [...], environment_id: "local", enabled: true, tool_timeout_sec: null }
```

The re-host work replays the Viewer entry onto each new thread so a replacement app-server gets its launch definition back. It spread that entry verbatim, so those nulls went back to Codex as input. Codex types `tool_timeout_sec` as a float and rejects null, failing the entire launch with `invalid type: string ``, expected f64` — every lane spawn died instantly.

Confirmed against the live app-server: `config/read` returns `tool_timeout_sec: null` for a Viewer entry whose config.toml declares only `command` and `args`.

## Fix

Replay only fields carrying a real value. An unset field stays unset, which is what the configuration said. A timeout the operator did set still survives.

## Verification

- Both new regressions fail on the parent commit and pass here.
- `src/lib/codexHeadlessConfig.test.ts`: 12 pass.
- `src/lib/agent/spawnPolicy.test.ts`: green.
- `bunx tsc --noEmit --incremental false`: clean.