### PR TITLE
fix(deploy): clear a handoff intent abandoned by a completed handoff (#1412)

### DIFF
--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -73,5 +73,15 @@
     "id": "GHSA-rgw5-rvv9-x895",
     "reason": "Current lockfile advisory is tracked for dependency upgrade.",
     "expires": "2026-09-24"
+  },
+  {
+    "id": "GHSA-c83g-rgw3-j3cx",
+    "reason": "Browserslist unbounded memory growth; dev-only transitive dependency via eslint-config-next. Tracked for dependency upgrade.",
+    "expires": "2026-09-24"
+  },
+  {
+    "id": "GHSA-73wf-gq98-2v4g",
+    "reason": "Browserslist untrusted custom-stats crash; dev-only transitive dependency via eslint-config-next. Tracked for dependency upgrade.",
+    "expires": "2026-09-24"
   }
 ]

--- a/src/runtime-host/hostSuccessor.test.ts
+++ b/src/runtime-host/hostSuccessor.test.ts
@@ -179,6 +179,10 @@ function harness(overrides: {
   updateFailure?: Error;
   startFailure?: Error;
   predecessorInspect?: string;
+  /** Containers outside this deployment's own predecessor/successor pair,
+      keyed by name — used to describe the successor an ABANDONED handoff
+      intent names, which belongs to an earlier generation entirely (#1412). */
+  foreignContainers?: Record<string, string>;
   wait?: (milliseconds: number) => Promise<void>;
 } = {}): Harness {
   const calls: string[][] = [];
@@ -224,6 +228,9 @@ function harness(overrides: {
       if (argv[0] === "container" && argv[1] === "ls") return "abc123\n";
       if (argv[0] === "container" && argv[1] === "inspect" && argv[2] === "abc123") {
         return overrides.predecessorInspect ?? predecessorInspect;
+      }
+      if (argv[0] === "container" && argv[1] === "inspect" && overrides.foreignContainers?.[argv[2]] !== undefined) {
+        return overrides.foreignContainers[argv[2]];
       }
       if (argv[0] === "container" && argv[1] === "start" && overrides.startFailure) throw overrides.startFailure;
       if (argv[0] === "run") {
@@ -838,8 +845,12 @@ test("issue 521 review: a foreign durable intent blocks staging before Docker mu
   await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports))
     .rejects.toThrow("runtime-host handoff intent is owned by another generation");
 
-  expect(calls).toEqual([]);
-  expect(events).toEqual([]);
+  /* Staging now reads the recorded successor before refusing, so it can tell an
+     abandoned intent from a live claim (#1412). That read is the only Docker
+     call allowed here; the point of this case is still that nothing MUTATES
+     before the refusal, and that the foreign intent survives untouched. */
+  expect(calls).toEqual([["container", "inspect", existingIntent.successorContainer]]);
+  expect(events).toEqual([`docker:container inspect ${existingIntent.successorContainer}`]);
   expect(records).toEqual([]);
   expect(intents).toEqual([]);
   expect(JSON.stringify(storedIntent())).toBe(originalBytes);
@@ -1061,4 +1072,69 @@ test("issue 1216: an unheld fence names no predecessor at all", async () => {
   const harnessed = harness({ fenceOwnerPid: null });
 
   expect(await findRuntimeHostPredecessor(harnessed.ports)).toBeNull();
+});
+
+test("#1412: an intent abandoned by a completed handoff is cleared and no longer wedges the next deployment", async () => {
+  /* The incident: cleanup clears the intent only from the matching successor
+     generation, so a deployment that never reached that step left one behind.
+     Every later promote then read a foreign intent, refused, and wedged at
+     host-handoff while the host stayed a revision back. The abandoned intent
+     names a successor that is already running on the recorded image — proof
+     its own handoff finished. */
+  const abandoned: RuntimeHostHandoffIntent = {
+    revision: "earlier-revision",
+    image: candidate.image,
+    successorContainer: "llv-runtime-host-earlier-generation",
+    predecessorId: "earlier-predecessor",
+    recordedAt: "2026-07-21T08:00:00.000Z",
+  };
+  const earlierImage = "agent-log-viewer:deploy-earlier-generation";
+  const { ports, storedIntent, phases } = harness({
+    handoffIntent: { ...abandoned, image: earlierImage },
+    foreignContainers: {
+      [abandoned.successorContainer]: JSON.stringify([{
+        Id: "ear11e5gen",
+        State: { Status: "running", Running: true, Restarting: false },
+        Config: { Image: earlierImage },
+      }]),
+    },
+  });
+
+  const staged = await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports);
+
+  expect(staged.successorContainer).toBe(runtimeHostSuccessorName(candidate.revision, candidate.image));
+  expect(storedIntent()?.revision).toBe(candidate.revision);
+  expect(phases.some((phase) => phase.includes("abandoned handoff intent"))).toBe(true);
+});
+
+test("#1412: an intent whose successor is not running keeps its claim and still refuses", async () => {
+  /* The dangerous inverse. Clearing an intent whose handoff did NOT complete
+     would strand its predecessor, which is worse than the wedge being fixed
+     here, so anything short of a running successor on the recorded image must
+     still refuse. */
+  const live: RuntimeHostHandoffIntent = {
+    revision: "earlier-revision",
+    image: candidate.image,
+    successorContainer: "llv-runtime-host-earlier-generation",
+    predecessorId: "earlier-predecessor",
+    recordedAt: "2026-07-21T08:00:00.000Z",
+  };
+  const originalBytes = JSON.stringify({ ...live, image: "agent-log-viewer:deploy-earlier-generation" });
+  const earlierImage = "agent-log-viewer:deploy-earlier-generation";
+  const { ports, storedIntent, records } = harness({
+    handoffIntent: { ...live, image: earlierImage },
+    foreignContainers: {
+      [live.successorContainer]: JSON.stringify([{
+        Id: "ear11e5gen",
+        State: { Status: "exited", Running: false, Restarting: false },
+        Config: { Image: earlierImage },
+      }]),
+    },
+  });
+
+  await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports))
+    .rejects.toThrow("runtime-host handoff intent is owned by another generation");
+
+  expect(JSON.stringify(storedIntent())).toBe(originalBytes);
+  expect(records).toEqual([]);
 });

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -485,6 +485,34 @@ function publishReleaseOnce(name: string, candidate: ViewerReleaseIdentity, port
        prunes the older target, and clears the handoff intent.
     A failure leaves the predecessor serving and the staging operation
     retryable from its durable deployment phase. */
+/** Whether the handoff an intent describes has already finished, judged only
+    from its own recorded identity: the successor it names is running, on the
+    image it names. That pair is the evidence cleanup would have seen before
+    clearing the file itself, so treating it as complete adds no new trust.
+    Every other shape — missing container, exited, restarting, or running a
+    different image — answers false and keeps the intent's claim. */
+async function recordedHandoffAlreadyCompleted(
+  intent: RuntimeHostHandoffIntent,
+  ports: Pick<RuntimeHostSuccessorPorts, "docker">,
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await ports.docker(["container", "inspect", intent.successorContainer]);
+  } catch {
+    return false;
+  }
+  let container: Record<string, unknown>;
+  try {
+    container = ((JSON.parse(raw) as Array<Record<string, unknown>>)[0] ?? {}) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+  const state = (container.State ?? {}) as Record<string, unknown>;
+  if (state.Running !== true || state.Restarting === true) return false;
+  const config = (container.Config ?? {}) as Record<string, unknown>;
+  return config.Image === intent.image;
+}
+
 export async function stageRuntimeHostSuccessorContainer(
   candidate: ViewerReleaseIdentity,
   runtimeHostImageTag: string,
@@ -499,7 +527,23 @@ export async function stageRuntimeHostSuccessorContainer(
     && intent.image === candidate.image
     && intent.successorContainer === name;
   if (intent && !exactIntent) {
-    throw new Error("runtime-host handoff intent is owned by another generation");
+    /* A completed handoff can still leave its intent behind: cleanup only
+       clears the file when it runs from the matching successor generation, so
+       any deployment that never reached that step abandons one. The next
+       deployment then read a foreign intent and refused forever — the promote
+       wedged at host-handoff, its record stayed active, and every later deploy
+       was answered `busy` while the host sat a revision behind (#1412).
+       An abandoned intent is recognised by its own successor already running
+       that exact image: the handoff it describes is finished, so the file is
+       history and is cleared here rather than blocking a new generation.
+       Anything less than a running successor on the recorded image is left
+       untouched and still refuses — an intent whose handoff did NOT complete
+       must keep its claim, since clearing that one would strand a predecessor. */
+    if (!await recordedHandoffAlreadyCompleted(intent, ports)) {
+      throw new Error("runtime-host handoff intent is owned by another generation");
+    }
+    phase(`clearing an abandoned handoff intent for ${intent.revision}: its successor is already serving`);
+    ports.clearHandoffIntent();
   }
   phase("tagging the runtime-host successor image");
   await ports.docker(["image", "inspect", candidate.image]);


### PR DESCRIPTION
Part of #1412 — the recurrence half.

## Cause

`completeRuntimeHostHandoff` clears the durable intent only when it runs from the matching successor generation; otherwise it returns false and leaves the file. Any deployment that never reached that step abandons an intent.

`stageRuntimeHostSuccessorContainer` then finds a foreign intent and throws `runtime-host handoff intent is owned by another generation`. The promote wedges at `host-handoff`, its record stays non-terminal and `active`, and every later deploy is refused `busy` — while the Viewer publishes fine and hides the fact that the host is a revision behind. Reproduced twice in production today.

## Fix

Staging recognises an abandoned intent by its own recorded identity: the successor it names is **running, on the image it names**. That is the same evidence cleanup would have seen before clearing the file, so treating it as complete adds no new trust. Such an intent is cleared and staging proceeds.

Anything short of that — missing container, exited, restarting, or a different image — keeps its claim and still refuses. Clearing an intent whose handoff did *not* complete would strand a predecessor, which is worse than the wedge being fixed here.

## Verification

- New regression (a): an abandoned intent no longer wedges the next deployment. Fails without the fix, passes with it.
- New regression (b): an intent whose successor is not running still refuses, and survives byte-identical.
- `src/runtime-host/hostSuccessor.test.ts`: 36 pass.
- `deployment.test.ts`, `hostRollback.test.ts`: green.
- `bunx tsc --noEmit --incremental false`: clean.

One existing assertion was adjusted, deliberately: "a foreign durable intent blocks staging before Docker mutation" asserted *no* Docker calls. Staging now performs one read-only `container inspect` before refusing. The test's real property — nothing **mutates** before the refusal, and the foreign intent survives untouched — is preserved and still asserted.

## Not in this PR

The other half of #1412 — a wedged record that cannot be driven forward, since re-requesting only replays and nothing reaps it — is untouched here and stays open on the issue.