### PR TITLE
fix(deploy): clear completed runtime-host handoff intent

### DIFF
--- a/src/runtime-host/deployment.test.ts
+++ b/src/runtime-host/deployment.test.ts
@@ -532,7 +532,7 @@ test("issue 1268: the predecessor leaves success non-terminal until the staged r
   store.close();
 });
 
-test("issue 1268: terminal success requires runtime-host hand-off evidence even when generation tracking is unavailable", async () => {
+test("issue 1412: a failed runtime-host handoff settles terminal and clears deployment admission", async () => {
   const store = journal("host-successor-proof-required");
   const adapter = new FakeDeploymentAdapter();
   adapter.verifyHostFailure = new Error("runtime-host startup evidence is unavailable");
@@ -546,13 +546,20 @@ test("issue 1268: terminal success requires runtime-host hand-off evidence even 
   await coordinator.waitForDeployment(receipt.deploymentId);
 
   expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({
-    phase: "host-handoff",
-    terminal: false,
+    phase: "failed",
+    terminal: true,
     error: "runtime-host startup evidence is unavailable",
   });
+  expect(store.activeViewerDeployment()).toBeNull();
   expect(adapter.calls).toContain(
     `verify-host-successor:${store.viewerDeployment(receipt.deploymentId)?.candidate?.image}:${"b".repeat(40)}`,
   );
+  const next = await coordinator.requestViewerDeployment({
+    idempotencyKey: "deploy-after-host-successor-proof-failure",
+    revision: "c".repeat(40),
+  });
+  expect(next).toMatchObject({ state: "accepted", replayed: false, revision: "c".repeat(40) });
+  if (next.state === "accepted") await coordinator.waitForDeployment(next.deploymentId);
   store.close();
 });
 
@@ -620,10 +627,7 @@ test("issue 1216: the host-handoff step narrates the decision it made", async ()
   store.close();
 });
 
-/* A staging failure parks the deployment in a retryable `host-handoff` phase
-   and returns normally, so nothing printed it: the host stayed on the old
-   generation with no line in the log to say so. */
-test("issue 1216: a failed successor staging is printed, not only journalled", async () => {
+test("issue 1412: a promote whose successor staging fails is terminal and logged", async () => {
   const store = journal("host-handoff-failure-log");
   const adapter = new FakeDeploymentAdapter();
   adapter.stageHostFailure = new Error("runtime-host predecessor container is unavailable for successor staging");
@@ -637,9 +641,18 @@ test("issue 1216: a failed successor staging is printed, not only journalled", a
   if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
   await coordinator.waitForDeployment(receipt.deploymentId);
 
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({ phase: "host-handoff", terminal: false });
+  const status = store.viewerDeployment(receipt.deploymentId);
+  expect(status).toMatchObject({
+    phase: "failed",
+    terminal: true,
+    error: "runtime-host predecessor container is unavailable for successor staging",
+  });
+  if (!status?.candidate) throw new Error("published Viewer candidate is missing");
+  expect(adapter.current).toEqual(status.candidate);
+  expect(adapter.calls.findIndex((call) => call.startsWith("promote:")))
+    .toBeLessThan(adapter.calls.findIndex((call) => call.startsWith("stage-host-successor:")));
   expect(lines).toContain(
-    `[viewer deployment] ${receipt.deploymentId} host-handoff failed and stays retryable: runtime-host predecessor container is unavailable for successor staging`,
+    `[viewer deployment] ${receipt.deploymentId} host-handoff failed: runtime-host predecessor container is unavailable for successor staging`,
   );
   store.close();
 });
@@ -718,7 +731,7 @@ test("issue 521 review: consecutive same-revision deployments stage each distinc
   store.close();
 });
 
-test("issue 518: failed successor staging never hands the host back to the stale image", async () => {
+test("issue 1412: terminal successor staging failure cannot replay into hidden success", async () => {
   const store = journal("host-staging-failed");
   const adapter = new FakeDeploymentAdapter();
   adapter.stageHostFailure = new Error("docker tag failed");
@@ -732,36 +745,29 @@ test("issue 518: failed successor staging never hands the host back to the stale
   if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
   await coordinator.waitForDeployment(receipt.deploymentId);
 
-  /* The healthy Viewer remains promoted while the deployment stays in its
-     durable retry phase. A replay resumes successor staging from that phase
-     without rebuilding or promoting another candidate. */
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({
-    phase: "host-handoff",
-    terminal: false,
+  const failed = store.viewerDeployment(receipt.deploymentId);
+  expect(failed).toMatchObject({
+    phase: "failed",
+    terminal: true,
     error: "docker tag failed",
   });
+  if (!failed?.candidate) throw new Error("published Viewer candidate is missing");
+  expect(adapter.current).toEqual(failed.candidate);
   expect(handoffs).toEqual([]);
   const buildCalls = adapter.calls.filter((call) => call.startsWith("build:"));
+  const stageCalls = adapter.calls.filter((call) => call.startsWith("stage-host-successor:"));
   adapter.stageHostFailure = null;
   const replay = await coordinator.requestViewerDeployment({
     idempotencyKey: "deploy-host-staging-failed",
     revision: "b".repeat(40),
   });
   expect(replay).toMatchObject({ state: "accepted", replayed: true, deploymentId: receipt.deploymentId });
-  const handedOff = await coordinator.waitForDeployment(receipt.deploymentId);
-  if (!handedOff?.candidate) throw new Error("handoff candidate is missing");
-  await recoverHostHandoffAsSuccessor(
-    store,
-    adapter,
-    receipt.deploymentId,
-    handedOff.candidate,
-    { pid: 11, startIdentity: "11:recovery" },
-  );
+  await coordinator.waitForDeployment(receipt.deploymentId);
 
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({ phase: "succeeded", terminal: true, error: null });
+  expect(store.viewerDeployment(receipt.deploymentId)).toEqual(failed);
   expect(adapter.calls.filter((call) => call.startsWith("build:"))).toEqual(buildCalls);
-  expect(adapter.calls.filter((call) => call.startsWith("stage-host-successor:"))).toHaveLength(2);
-  expect(handoffs).toEqual([receipt.deploymentId]);
+  expect(adapter.calls.filter((call) => call.startsWith("stage-host-successor:"))).toEqual(stageCalls);
+  expect(handoffs).toEqual([]);
   store.close();
 });
 

--- a/src/runtime-host/deployment.ts
+++ b/src/runtime-host/deployment.ts
@@ -425,11 +425,14 @@ export class ViewerDeploymentCoordinator {
       const message = safeError(error);
       const latest = this.journal.viewerDeployment(status.deploymentId) ?? status;
       if (latest.phase === "host-handoff") {
-        this.log(`[viewer deployment] ${latest.deploymentId} host-handoff failed and stays retryable: ${message}`);
+        /* The Viewer has already published, so this failure records the split
+           loudly and releases deployment admission. Retaining an active row
+           here cannot repair the handoff and blocks every later deployment. */
+        this.log(`[viewer deployment] ${latest.deploymentId} host-handoff failed: ${message}`);
         this.journal.updateViewerDeployment(latest.deploymentId, {
           error: message,
-          phase: "host-handoff",
-          terminal: false,
+          phase: "failed",
+          terminal: true,
         });
         return;
       }

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -142,9 +142,10 @@ test("host adapter exposes fixed actions and carries structured release data", a
   await adapter.completeRuntimeHostHandoff({ image: candidate.image, revision: candidate.revision, container: "runtime-host-successor" });
 
   expect(calls.map((call) => call.action)).toEqual([
-    "resolve-revision", "build-candidate", "start-candidate", "verify-candidate", "current-mcp-runtime", "reconcile-mcp-runtime", "promote", "verify-promoted", "rollback", "stage-host-successor", "verify-host-successor", "complete-host-handoff",
+    "resolve-revision", "build-candidate", "start-candidate", "verify-candidate", "current-mcp-runtime", "reconcile-mcp-runtime", "promote", "verify-promoted", "rollback", "stage-host-successor", "verify-host-successor", "complete-host-handoff", "complete-host-handoff",
   ]);
   expect(calls[1]?.input).toEqual({ deploymentId: "deploy-1", revision: "a".repeat(40) });
+  expect(calls[11]?.input).toEqual({ generation: hostGeneration });
   expect(calls.at(-1)?.input).toEqual({ generation: { image: candidate.image, revision: candidate.revision, container: "runtime-host-successor" } });
   expect(calls.every((call) => !Object.hasOwn(call.input, "command") && !Object.hasOwn(call.input, "args"))).toBe(true);
 });

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -659,10 +659,16 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       revision: candidate.revision,
       container: runtimeHostSuccessorName(candidate.revision, candidate.image),
     };
-    return parseRuntimeHostHandoffEvidence(
+    const handoff = parseRuntimeHostHandoffEvidence(
       await this.run("verify-host-successor", { candidate }),
       expected,
     );
+    /* The successor also performs this cleanup during boot. Repeating the
+       idempotent action after its framed readiness proof closes the durable
+       contract: a handoff cannot settle successfully while its intent still
+       owns the next deployment. */
+    await this.completeRuntimeHostHandoff(expected);
+    return handoff;
   }
 
   async completeRuntimeHostHandoff(generation: { image: string; revision: string; container: string }): Promise<void> {

--- a/src/runtime-host/hostSuccessor.test.ts
+++ b/src/runtime-host/hostSuccessor.test.ts
@@ -154,6 +154,34 @@ const predecessorInspect = JSON.stringify([{
   },
 }]);
 
+function completedSuccessorInspection(
+  intent: RuntimeHostHandoffIntent,
+  healthStatus: "healthy" | "unhealthy" = "healthy",
+): string {
+  return JSON.stringify([{
+    Id: "completed-successor-id",
+    RestartCount: 0,
+    State: {
+      Status: "running",
+      Running: true,
+      Restarting: false,
+      Health: { Status: healthStatus },
+    },
+    Config: {
+      Image: intent.image,
+      Labels: {
+        [RUNTIME_HOST_SUCCESSOR_LABEL]: "1",
+        "dev.live-log-viewer.revision": intent.revision,
+      },
+      Env: [
+        `${RUNTIME_HOST_IMAGE_ENV}=${intent.image}`,
+        `${RUNTIME_HOST_REVISION_ENV}=${intent.revision}`,
+        `${RUNTIME_HOST_CONTAINER_ENV}=${intent.successorContainer}`,
+      ],
+    },
+  }]);
+}
+
 interface Harness {
   ports: RuntimeHostSuccessorPorts;
   calls: string[][];
@@ -167,6 +195,7 @@ interface Harness {
 function harness(overrides: {
   fenceOwnerPid?: number | null;
   handoffIntent?: RuntimeHostHandoffIntent;
+  completedHandoffIntentInspection?: string;
   runFailure?: Error;
   runConflict?: boolean;
   readIntentFailure?: Error;
@@ -224,6 +253,12 @@ function harness(overrides: {
       if (argv[0] === "container" && argv[1] === "ls") return "abc123\n";
       if (argv[0] === "container" && argv[1] === "inspect" && argv[2] === "abc123") {
         return overrides.predecessorInspect ?? predecessorInspect;
+      }
+      if (argv[0] === "container"
+        && argv[1] === "inspect"
+        && argv[2] === overrides.handoffIntent?.successorContainer
+        && overrides.completedHandoffIntentInspection) {
+        return overrides.completedHandoffIntentInspection;
       }
       if (argv[0] === "container" && argv[1] === "start" && overrides.startFailure) throw overrides.startFailure;
       if (argv[0] === "run") {
@@ -833,16 +868,68 @@ test("issue 521 review: a foreign durable intent blocks staging before Docker mu
     recordedAt: "2026-07-21T08:00:00.000Z",
   };
   const originalBytes = JSON.stringify(existingIntent);
-  const { ports, calls, events, records, intents, storedIntent } = harness({ handoffIntent: existingIntent });
+  const { ports, calls, events, records, intents, storedIntent } = harness({
+    handoffIntent: existingIntent,
+    completedHandoffIntentInspection: completedSuccessorInspection(existingIntent, "unhealthy"),
+  });
 
   await expect(stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports))
     .rejects.toThrow("runtime-host handoff intent is owned by another generation");
 
-  expect(calls).toEqual([]);
-  expect(events).toEqual([]);
+  expect(calls).toEqual([["container", "inspect", existingIntent.successorContainer]]);
+  expect(events).toEqual([`docker:container inspect ${existingIntent.successorContainer}`]);
   expect(records).toEqual([]);
   expect(intents).toEqual([]);
   expect(JSON.stringify(storedIntent())).toBe(originalBytes);
+});
+
+test("issue 1412: an intent left by a completed handoff does not block the next deployment", async () => {
+  const completedIntent: RuntimeHostHandoffIntent = {
+    revision: "a".repeat(40),
+    image: `agent-log-viewer:deploy-${"a".repeat(40)}-cafe`,
+    successorContainer: "llv-runtime-host-completed-successor",
+    predecessorId: "completed-predecessor",
+    recordedAt: "2026-09-01T08:00:00.000Z",
+  };
+  const { ports, calls, events, records, storedIntent } = harness({
+    handoffIntent: completedIntent,
+    completedHandoffIntentInspection: completedSuccessorInspection(completedIntent),
+  });
+
+  const staged = await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports);
+
+  expect(staged.successorContainer).toBe(runtimeHostSuccessorName(candidate.revision, candidate.image));
+  expect(calls[0]).toEqual(["container", "inspect", completedIntent.successorContainer]);
+  expect(events.indexOf("clear-handoff-intent")).toBeLessThan(events.indexOf("write-handoff-intent"));
+  expect(storedIntent()).toMatchObject({
+    revision: candidate.revision,
+    image: candidate.image,
+    successorContainer: staged.successorContainer,
+  });
+  expect(records).toHaveLength(1);
+});
+
+test("issue 1412: an exact-match intent still resumes without fence-owner predecessor discovery", async () => {
+  const successorContainer = runtimeHostSuccessorName(candidate.revision, candidate.image);
+  const exactIntent: RuntimeHostHandoffIntent = {
+    revision: candidate.revision,
+    image: candidate.image,
+    successorContainer,
+    predecessorId: "abc123",
+    recordedAt: "2026-09-01T08:00:00.000Z",
+  };
+  const originalBytes = JSON.stringify(exactIntent);
+  const { ports, calls, events, records, storedIntent } = harness({ handoffIntent: exactIntent });
+
+  const staged = await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports);
+
+  expect(staged).toEqual({ successorContainer });
+  expect(calls.some((argv) => argv[0] === "container" && argv[1] === "ls")).toBe(false);
+  expect(calls.some((argv) => argv[0] === "run")).toBe(false);
+  expect(calls).toContainEqual(["container", "start", successorContainer]);
+  expect(events).not.toContain("clear-handoff-intent");
+  expect(JSON.stringify(storedIntent())).toBe(originalBytes);
+  expect(records).toHaveLength(1);
 });
 
 test("issue 521 review: reboot recovery before durable intent retains the original predecessor", async () => {

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -74,6 +74,8 @@ export interface RuntimeHostGenerationIdentity {
   container: string;
 }
 
+type RuntimeHostSuccessorGeneration = Pick<ViewerReleaseIdentity, "image" | "revision">;
+
 /** How the staged successor waits for the singleton fence at boot (#1216).
     `handoff-budget` is the #518 deployment case: the predecessor has been
     asked to exit, so a bound on the wait is the detector for a hand-over that
@@ -292,7 +294,7 @@ function successorStartIdentity(raw: string): SuccessorStartIdentity {
 function successorMatchesGeneration(
   raw: string,
   name: string,
-  candidate: ViewerReleaseIdentity,
+  candidate: RuntimeHostSuccessorGeneration,
   options: RuntimeHostSuccessorOptions,
 ): boolean {
   const inspected = JSON.parse(raw) as Array<Record<string, unknown>>;
@@ -327,7 +329,7 @@ function encodedPredecessorId(raw: string, successorName: string): string | null
 function successorIsReady(
   raw: string,
   name: string,
-  candidate: ViewerReleaseIdentity,
+  candidate: RuntimeHostSuccessorGeneration,
   options: RuntimeHostSuccessorOptions,
 ): boolean {
   const inspected = JSON.parse(raw) as Array<Record<string, unknown>>;
@@ -336,6 +338,37 @@ function successorIsReady(
     && state.Status === "running"
     && state.Running === true
     && state.Restarting !== true;
+}
+
+/** A foreign intent can be retired only with generation-matched health proof
+    from its named successor. The container health check performs a framed
+    runtime-host probe for that generation, so `healthy` also proves the
+    successor acquired the singleton fence and is serving. */
+function successorCompletedHandoff(raw: string, intent: RuntimeHostHandoffIntent): boolean {
+  const inspected = JSON.parse(raw) as Array<Record<string, unknown>>;
+  const state = (inspected[0]?.State ?? {}) as Record<string, unknown>;
+  const health = (state.Health ?? {}) as Record<string, unknown>;
+  return successorIsReady(raw, intent.successorContainer, intent, {})
+    && health.Status === "healthy";
+}
+
+async function clearCompletedHandoffIntent(
+  intent: RuntimeHostHandoffIntent,
+  ports: RuntimeHostSuccessorPorts,
+): Promise<boolean> {
+  let inspection: string;
+  try {
+    inspection = await ports.docker(["container", "inspect", intent.successorContainer]);
+  } catch {
+    return false;
+  }
+  try {
+    if (!successorCompletedHandoff(inspection, intent)) return false;
+  } catch {
+    return false;
+  }
+  ports.clearHandoffIntent();
+  return true;
 }
 
 /** What the stability gate actually saw, appended to every gate failure so a
@@ -499,7 +532,11 @@ export async function stageRuntimeHostSuccessorContainer(
     && intent.image === candidate.image
     && intent.successorContainer === name;
   if (intent && !exactIntent) {
-    throw new Error("runtime-host handoff intent is owned by another generation");
+    phase("checking whether the recorded runtime-host handoff already completed");
+    if (!await clearCompletedHandoffIntent(intent, ports)) {
+      throw new Error("runtime-host handoff intent is owned by another generation");
+    }
+    phase("cleared the completed runtime-host handoff intent");
   }
   phase("tagging the runtime-host successor image");
   await ports.docker(["image", "inspect", candidate.image]);


### PR DESCRIPTION
## Summary

- Clear the durable handoff intent after verified successor startup.
- Recover a stale foreign intent when Docker health proves its recorded generation is serving.
- Preserve exact-match crash recovery without fence-owner predecessor discovery.
- Settle handoff failures terminal with their reason so later deployments can enter the lane.

## Recovery choice

The coordinator terminalizes a caught handoff failure immediately. The failed operation already supplies a bounded result and a durable reason. Keeping that deployment active blocks later deploys without advancing the handoff.

## Verification

- `bunx tsc --noEmit`
- `bun test src/runtime-host/hostSuccessor.test.ts src/runtime-host/deploymentAdapter.test.ts src/runtime-host/deployment.test.ts` (78 pass)
- `bun scripts/privacy-publication-gate.ts --base 4ec4e71b07a97003ca5ae300d27d15343723ecac`

Pushed SHA: `d658555bb747e58abd754ef4cb235e5923d24647`

Fixes #1412