### PR TITLE
feat(models): register Claude Fable 5.1 and point the launch alias at it

### DIFF
--- a/src/lib/scanner/modelRegistry.test.ts
+++ b/src/lib/scanner/modelRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { MODEL_REGISTRY_VERSION, normalizeModelKey, registryWindow } from "./modelRegistry";
+import { MODEL_REGISTRY_VERSION, normalizeModelKey, registryWindow, resolveRegistryKey } from "./modelRegistry";
 
 describe("normalizeModelKey", () => {
   test("normalizes exact API, Bedrock, Vertex, dated, and 1M aliases", () => {
@@ -19,11 +19,23 @@ describe("normalizeModelKey", () => {
 
 describe("registryWindow", () => {
   test("contains the frozen documented registry seed", () => {
-    expect(MODEL_REGISTRY_VERSION).toBe("2026-07-10");
+    expect(MODEL_REGISTRY_VERSION).toBe("2026-09-01");
     expect(registryWindow("fable-5", "standard")).toBe(1_000_000);
     expect(registryWindow("opus-4-8", "standard")).toBe(1_000_000);
     expect(registryWindow("sonnet-4-5", "standard")).toBe(200_000);
     expect(registryWindow("sonnet-4-5", "1m")).toBe(1_000_000);
     expect(registryWindow("haiku-4-5", "standard")).toBe(200_000);
+  });
+
+  test("Fable 5.1 is known, and the launch alias resolves to it", () => {
+    /* Claude Code resolves the `fable` launch alias to claude-fable-5-1, so a
+       session reports that exact id. Without its own entry the window would
+       read as unknown, and the alias would keep pointing at the superseded
+       Fable 5 entry. Fable 5 stays registered — it is still selectable and
+       still what the gateway provider resolves `fable` to. */
+    expect(registryWindow("fable-5-1", "standard")).toBe(1_000_000);
+    expect(normalizeModelKey("claude-fable-5-1")).toEqual({ key: "fable-5-1", mode: "standard" });
+    expect(resolveRegistryKey("fable")).toBe("fable-5-1");
+    expect(registryWindow("fable-5", "standard")).toBe(1_000_000);
   });
 });

--- a/src/lib/scanner/modelRegistry.ts
+++ b/src/lib/scanner/modelRegistry.ts
@@ -1,4 +1,4 @@
-export const MODEL_REGISTRY_VERSION = "2026-07-10";
+export const MODEL_REGISTRY_VERSION = "2026-09-01";
 
 interface RegistryEntry {
   standard: number;
@@ -11,6 +11,7 @@ const TWO_HUNDRED_THOUSAND = 200_000;
 /** Official-doc snapshot. Exact keys keep future model revisions unknown until
     the registry is deliberately updated and its version is bumped. */
 const MODEL_REGISTRY: Readonly<Record<string, RegistryEntry>> = {
+  "fable-5-1": { standard: ONE_MILLION },
   "fable-5": { standard: ONE_MILLION },
   "mythos-5": { standard: ONE_MILLION },
   "mythos-preview": { standard: ONE_MILLION },
@@ -27,7 +28,7 @@ const MODEL_REGISTRY: Readonly<Record<string, RegistryEntry>> = {
 };
 
 const MODEL_REGISTRY_ALIASES: Readonly<Record<string, string>> = {
-  fable: "fable-5",
+  fable: "fable-5-1",
   opus: "opus-4-8",
   sonnet: "sonnet-5",
   haiku: "haiku-4-5",


### PR DESCRIPTION
Claude Fable 5.1 shipped; Fable 5 is now listed as legacy.

## What actually changes

Lanes and flows in this repo launch with the short alias `fable`, never a pinned id. **Claude Code 2.1.257 resolves that alias to `claude-fable-5-1`** — verified in the shipped client catalog:

```
fable: { default: "claude-fable-5-1", per_provider: { gateway: "claude-fable-5" } }
latest_per_family: { fable: "claude-fable-5-1", ... }
```

So no launch profile, flow, workflow, or label needs editing, and no version string belongs in the UI. Claude Code 2.1.251 and earlier do **not** know `claude-fable-5-1` at all, so the client must be on 2.1.257+ for any of this to take effect.

What does need a change is the scanner registry. It keys context windows on exact model ids by design — "Exact keys keep future model revisions unknown until the registry is deliberately updated and its version is bumped." This is that deliberate update:

- add `fable-5-1` at a 1M context window (per the published model overview);
- repoint the `fable` alias from `fable-5` to `fable-5-1`;
- bump `MODEL_REGISTRY_VERSION`, which the suite pins as a drift tripwire.

`fable-5` stays registered — it is still selectable, and still what the gateway provider resolves the alias to.

## Deliberately not included

**Mythos 5.1.** The client catalog lists `claude-mythos-5-1` alongside Fable 5.1, and the registry already tracks `mythos-5`. But no context window is published for it, and guessing one is precisely what the exact-key rule exists to prevent. Left unknown on purpose rather than filled in by analogy.

## Verification

- `src/lib/scanner/modelRegistry.test.ts`: 4 pass, including a new case asserting the alias resolves to `fable-5-1` and that Fable 5 still resolves.
- `src/lib/agent/models.test.ts`: green.
- `bunx tsc --noEmit --incremental false`: clean.