### PR TITLE
fix(deploy): settle runtime-host handoff failures (#1412)

### DIFF
--- a/src/runtime-host/deployment.test.ts
+++ b/src/runtime-host/deployment.test.ts
@@ -532,7 +532,7 @@ test("issue 1268: the predecessor leaves success non-terminal until the staged r
   store.close();
 });
 
-test("issue 1268: terminal success requires runtime-host hand-off evidence even when generation tracking is unavailable", async () => {
+test("issue 1412: a failed runtime-host handoff settles terminal and clears deployment admission", async () => {
   const store = journal("host-successor-proof-required");
   const adapter = new FakeDeploymentAdapter();
   adapter.verifyHostFailure = new Error("runtime-host startup evidence is unavailable");
@@ -546,13 +546,20 @@ test("issue 1268: terminal success requires runtime-host hand-off evidence even 
   await coordinator.waitForDeployment(receipt.deploymentId);
 
   expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({
-    phase: "host-handoff",
-    terminal: false,
+    phase: "failed",
+    terminal: true,
     error: "runtime-host startup evidence is unavailable",
   });
+  expect(store.activeViewerDeployment()).toBeNull();
   expect(adapter.calls).toContain(
     `verify-host-successor:${store.viewerDeployment(receipt.deploymentId)?.candidate?.image}:${"b".repeat(40)}`,
   );
+  const next = await coordinator.requestViewerDeployment({
+    idempotencyKey: "deploy-after-host-successor-proof-failure",
+    revision: "c".repeat(40),
+  });
+  expect(next).toMatchObject({ state: "accepted", replayed: false, revision: "c".repeat(40) });
+  if (next.state === "accepted") await coordinator.waitForDeployment(next.deploymentId);
   store.close();
 });
 
@@ -620,10 +627,7 @@ test("issue 1216: the host-handoff step narrates the decision it made", async ()
   store.close();
 });
 
-/* A staging failure parks the deployment in a retryable `host-handoff` phase
-   and returns normally, so nothing printed it: the host stayed on the old
-   generation with no line in the log to say so. */
-test("issue 1216: a failed successor staging is printed, not only journalled", async () => {
+test("issue 1412: a promote whose successor staging fails is terminal and logged", async () => {
   const store = journal("host-handoff-failure-log");
   const adapter = new FakeDeploymentAdapter();
   adapter.stageHostFailure = new Error("runtime-host predecessor container is unavailable for successor staging");
@@ -637,9 +641,18 @@ test("issue 1216: a failed successor staging is printed, not only journalled", a
   if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
   await coordinator.waitForDeployment(receipt.deploymentId);
 
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({ phase: "host-handoff", terminal: false });
+  const status = store.viewerDeployment(receipt.deploymentId);
+  expect(status).toMatchObject({
+    phase: "failed",
+    terminal: true,
+    error: "runtime-host predecessor container is unavailable for successor staging",
+  });
+  if (!status?.candidate) throw new Error("published Viewer candidate is missing");
+  expect(adapter.current).toEqual(status.candidate);
+  expect(adapter.calls.findIndex((call) => call.startsWith("promote:")))
+    .toBeLessThan(adapter.calls.findIndex((call) => call.startsWith("stage-host-successor:")));
   expect(lines).toContain(
-    `[viewer deployment] ${receipt.deploymentId} host-handoff failed and stays retryable: runtime-host predecessor container is unavailable for successor staging`,
+    `[viewer deployment] ${receipt.deploymentId} host-handoff failed: runtime-host predecessor container is unavailable for successor staging`,
   );
   store.close();
 });
@@ -718,7 +731,7 @@ test("issue 521 review: consecutive same-revision deployments stage each distinc
   store.close();
 });
 
-test("issue 518: failed successor staging never hands the host back to the stale image", async () => {
+test("issue 1412: terminal successor staging failure cannot replay into hidden success", async () => {
   const store = journal("host-staging-failed");
   const adapter = new FakeDeploymentAdapter();
   adapter.stageHostFailure = new Error("docker tag failed");
@@ -732,36 +745,29 @@ test("issue 518: failed successor staging never hands the host back to the stale
   if (receipt.state !== "accepted") throw new Error("deployment was not accepted");
   await coordinator.waitForDeployment(receipt.deploymentId);
 
-  /* The healthy Viewer remains promoted while the deployment stays in its
-     durable retry phase. A replay resumes successor staging from that phase
-     without rebuilding or promoting another candidate. */
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({
-    phase: "host-handoff",
-    terminal: false,
+  const failed = store.viewerDeployment(receipt.deploymentId);
+  expect(failed).toMatchObject({
+    phase: "failed",
+    terminal: true,
     error: "docker tag failed",
   });
+  if (!failed?.candidate) throw new Error("published Viewer candidate is missing");
+  expect(adapter.current).toEqual(failed.candidate);
   expect(handoffs).toEqual([]);
   const buildCalls = adapter.calls.filter((call) => call.startsWith("build:"));
+  const stageCalls = adapter.calls.filter((call) => call.startsWith("stage-host-successor:"));
   adapter.stageHostFailure = null;
   const replay = await coordinator.requestViewerDeployment({
     idempotencyKey: "deploy-host-staging-failed",
     revision: "b".repeat(40),
   });
   expect(replay).toMatchObject({ state: "accepted", replayed: true, deploymentId: receipt.deploymentId });
-  const handedOff = await coordinator.waitForDeployment(receipt.deploymentId);
-  if (!handedOff?.candidate) throw new Error("handoff candidate is missing");
-  await recoverHostHandoffAsSuccessor(
-    store,
-    adapter,
-    receipt.deploymentId,
-    handedOff.candidate,
-    { pid: 11, startIdentity: "11:recovery" },
-  );
+  await coordinator.waitForDeployment(receipt.deploymentId);
 
-  expect(store.viewerDeployment(receipt.deploymentId)).toMatchObject({ phase: "succeeded", terminal: true, error: null });
+  expect(store.viewerDeployment(receipt.deploymentId)).toEqual(failed);
   expect(adapter.calls.filter((call) => call.startsWith("build:"))).toEqual(buildCalls);
-  expect(adapter.calls.filter((call) => call.startsWith("stage-host-successor:"))).toHaveLength(2);
-  expect(handoffs).toEqual([receipt.deploymentId]);
+  expect(adapter.calls.filter((call) => call.startsWith("stage-host-successor:"))).toEqual(stageCalls);
+  expect(handoffs).toEqual([]);
   store.close();
 });
 

--- a/src/runtime-host/deployment.ts
+++ b/src/runtime-host/deployment.ts
@@ -425,11 +425,14 @@ export class ViewerDeploymentCoordinator {
       const message = safeError(error);
       const latest = this.journal.viewerDeployment(status.deploymentId) ?? status;
       if (latest.phase === "host-handoff") {
-        this.log(`[viewer deployment] ${latest.deploymentId} host-handoff failed and stays retryable: ${message}`);
+        /* The Viewer has already published, so this failure records the split
+           loudly and releases deployment admission. Retaining an active row
+           here cannot repair the handoff and blocks every later deployment. */
+        this.log(`[viewer deployment] ${latest.deploymentId} host-handoff failed: ${message}`);
         this.journal.updateViewerDeployment(latest.deploymentId, {
           error: message,
-          phase: "host-handoff",
-          terminal: false,
+          phase: "failed",
+          terminal: true,
         });
         return;
       }

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -142,9 +142,10 @@ test("host adapter exposes fixed actions and carries structured release data", a
   await adapter.completeRuntimeHostHandoff({ image: candidate.image, revision: candidate.revision, container: "runtime-host-successor" });
 
   expect(calls.map((call) => call.action)).toEqual([
-    "resolve-revision", "build-candidate", "start-candidate", "verify-candidate", "current-mcp-runtime", "reconcile-mcp-runtime", "promote", "verify-promoted", "rollback", "stage-host-successor", "verify-host-successor", "complete-host-handoff",
+    "resolve-revision", "build-candidate", "start-candidate", "verify-candidate", "current-mcp-runtime", "reconcile-mcp-runtime", "promote", "verify-promoted", "rollback", "stage-host-successor", "verify-host-successor", "complete-host-handoff", "complete-host-handoff",
   ]);
   expect(calls[1]?.input).toEqual({ deploymentId: "deploy-1", revision: "a".repeat(40) });
+  expect(calls[11]?.input).toEqual({ generation: hostGeneration });
   expect(calls.at(-1)?.input).toEqual({ generation: { image: candidate.image, revision: candidate.revision, container: "runtime-host-successor" } });
   expect(calls.every((call) => !Object.hasOwn(call.input, "command") && !Object.hasOwn(call.input, "args"))).toBe(true);
 });

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -13,7 +13,8 @@ import type {
 import { HostCommandViewerDeploymentAdapter } from "./deploymentAdapter";
 import { promotedViewerReadinessPhase } from "./deploymentHealth";
 import { PROMOTE_ACTION_TIMEOUT_MS } from "./deploymentHotState";
-import { runtimeHostSuccessorName } from "./hostSuccessor";
+import type { RuntimeHostHandoffIntent } from "./hostRelease";
+import { completeRuntimeHostHandoff, runtimeHostSuccessorName } from "./hostSuccessor";
 
 const sandboxes: string[] = [];
 afterEach(() => {
@@ -148,6 +149,45 @@ test("host adapter exposes fixed actions and carries structured release data", a
   expect(calls[11]?.input).toEqual({ generation: hostGeneration });
   expect(calls.at(-1)?.input).toEqual({ generation: { image: candidate.image, revision: candidate.revision, container: "runtime-host-successor" } });
   expect(calls.every((call) => !Object.hasOwn(call.input, "command") && !Object.hasOwn(call.input, "args"))).toBe(true);
+});
+
+/* #1412: the adapter repeats `complete-host-handoff` after the successor's
+   framed readiness proof, and the successor already ran the same cleanup at
+   boot. That repeat is only safe while the second run for one generation is
+   inert — it must clear nothing twice and reach Docker no second time. */
+test("issue 1412: a second completion of one handoff generation touches nothing", async () => {
+  const revision = "a".repeat(40);
+  const image = `agent-log-viewer:deploy-${revision}-cafe`;
+  const generation = { image, revision, container: runtimeHostSuccessorName(revision, image) };
+  let intent: RuntimeHostHandoffIntent | null = {
+    revision,
+    image,
+    successorContainer: generation.container,
+    predecessorId: "predecessor-of-the-completed-handoff",
+    recordedAt: "2026-09-01T08:00:00.000Z",
+  };
+  const clears: number[] = [];
+  const calls: string[][] = [];
+  const ports = {
+    docker: async (argv: string[]) => {
+      calls.push(argv);
+      return argv[1] === "inspect" ? JSON.stringify([{ Id: "successor-id" }]) : "";
+    },
+    readHandoffIntent: () => intent,
+    clearHandoffIntent: () => { clears.push(calls.length); intent = null; },
+  };
+
+  /* The successor's own boot-time cleanup. */
+  expect(await completeRuntimeHostHandoff(generation, ports)).toBe(true);
+  expect(intent).toBeNull();
+  const bootCalls = [...calls];
+  expect(bootCalls).toContainEqual(["container", "rm", "-f", "predecessor-of-the-completed-handoff"]);
+
+  /* The repeat the adapter issues once `verify-host-successor` has proved the
+     successor's readiness. */
+  expect(await completeRuntimeHostHandoff(generation, ports)).toBe(false);
+  expect(calls).toEqual(bootCalls);
+  expect(clears).toHaveLength(1);
 });
 
 /* A diagnosis the gate collected is worth nothing if it stops at this boundary

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -659,10 +659,16 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       revision: candidate.revision,
       container: runtimeHostSuccessorName(candidate.revision, candidate.image),
     };
-    return parseRuntimeHostHandoffEvidence(
+    const handoff = parseRuntimeHostHandoffEvidence(
       await this.run("verify-host-successor", { candidate }),
       expected,
     );
+    /* The successor also performs this cleanup during boot. Repeating the
+       idempotent action after its framed readiness proof closes the durable
+       contract: a handoff cannot settle successfully while its intent still
+       owns the next deployment. */
+    await this.completeRuntimeHostHandoff(expected);
+    return handoff;
   }
 
   async completeRuntimeHostHandoff(generation: { image: string; revision: string; container: string }): Promise<void> {


### PR DESCRIPTION
## Summary

The remaining half of #1412, rebased onto current main. Two deployment-side behaviours:

- **A caught host-handoff failure settles terminal.** `ViewerDeploymentCoordinator` used to park a failure caught in the `host-handoff` phase as `phase: "host-handoff", terminal: false`. The row stayed active, so every later deployment was answered `busy`, while nothing in that record could advance the handoff. It now settles `phase: "failed", terminal: true` with the reason, releasing deployment admission (issue asks 3 and 4).
- **A verified handoff clears its own intent.** After `verify-host-successor` returns the successor's framed readiness proof, the adapter repeats the idempotent `completeRuntimeHostHandoff(expected)` for that exact generation, so a handoff cannot settle successfully while its intent still owns the next deployment (issue ask 1).

Supersedes PR #1414 for this remaining half: that branch conflicts with main because it also carries the stale-intent recovery, which main already has as a3560453 (PR #1413). The first commit here is PR #1414's own commit, cherry-picked with its author and `Co-Authored-By` trailer preserved; the conflicting `hostSuccessor.ts` / `hostSuccessor.test.ts` hunks were dropped in favour of main's. PR #1414 can be closed once this merges.

## Mechanism

The Viewer is already promoted and healthy by the time the coordinator reaches `host-handoff`. A failure there is a published-Viewer / stale-host split, which is a fact to record rather than a state to retry from: the durable phase carried no way to re-execute (a same-key request replays, a different revision is refused `busy`, and the record's owner is the live host so no reaper claims it). Terminalising with the reason is what makes the split visible and lets the next promote enter the lane.

`verifyRuntimeHostSuccessor` is only reached by a generation that did not have to stage a successor — the successor itself, once it has resumed the durable record — which is the generation `completeRuntimeHostHandoff` is contracted to accept. It returns early when the intent it reads does not match the generation it was given, so calling it again after the successor's own boot-time cleanup is a no-op: no Docker call, no second clear. Running it from the verification path means the clear happens on the same evidence that settles the deployment `succeeded`, instead of depending on the successor having reached its boot cleanup.

## What was deliberately not ported

PR #1414's `hostSuccessor` half duplicates main's #1413 fix with a stricter probe (it additionally requires Docker `Health.Status === "healthy"`); main's version judges an abandoned intent from a running successor on the recorded image. Both satisfy issue ask 2, so main's stands unchanged and `hostSuccessor.test.ts` is untouched. PR #1414's extra assertion that an exact-match intent resumes without fence-owner discovery is coverage of pre-existing #521 behaviour that neither the issue nor this change alters, so it is not carried over either.

## Verification

Run at `52236f5f0d6d3e98c9ee250b363c69c6ef5468ec`, on top of main tip `ec8d1883`:

- `bunx tsc --noEmit` — clean.
- `bun test src/runtime-host/deployment.test.ts src/runtime-host/deploymentAdapter.test.ts src/runtime-host/hostSuccessor.test.ts` — 79 pass, 0 fail. `hostSuccessor.test.ts` is unchanged on this branch, so main's #1413 behaviour is covered as-is.
- `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main)` — PASS, including with `LLV_PRIVACY_KNOWN_VALUE_FINGERPRINTS_FILE=scripts/privacy-known-value-fingerprints.json`.
- Red before green: with only `deployment.ts` and `deploymentAdapter.ts` reverted to main's versions and the tests in place, four cases fail — `issue 1412: a failed runtime-host handoff settles terminal and clears deployment admission`, `issue 1412: a promote whose successor staging fails is terminal and logged`, `issue 1412: terminal successor staging failure cannot replay into hidden success`, and `host adapter exposes fixed actions and carries structured release data` (75 pass, 4 fail).

The first of those proves both halves of the admission fix in one case: the wedged record reads `phase: "failed", terminal: true` with its reason, `activeViewerDeployment()` is null, and a following request for a different revision is accepted rather than refused `busy`. The adapter case pins the doubled `complete-host-handoff` action with the successor's own generation as its input.

`issue 1412: a second completion of one handoff generation touches nothing` (second commit) supplies the other half of that pin, which #1414 never covered: it drives the real `completeRuntimeHostHandoff` twice over one intent — the successor's boot cleanup, then the adapter's repeat — and requires the second run to return `false`, reach Docker no second time and clear nothing again. It lives beside the adapter test because the repeat is what needs the guarantee, which keeps `hostSuccessor.test.ts` untouched. Mutation-checked: making the early return touch Docker before returning fails it.

Fixes #1412
