### PR TITLE
fix(orchestrator): one rotation authority contract for the MCP tool and the route (#1402)

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -149,7 +149,9 @@ reaches one reaches the other. What replaces a prohibition is a name. Every
 rotation records who triggered it — operator or agent, the triggering
 conversation, and the seat epoch it held — on the successor's designation and
 on the predecessor's revocation, so the lineage `get_orchestrator` reports
-carries both which seat replaced which and on whose word.
+carries both which seat replaced which and on whose word. Retrying the same
+idempotency key replays that record verbatim, so the name it answers with is
+always the one the rotation was recorded under, whoever sends the retry.
 
 The mandate itself lands in the feed as a single folded **Mandate** card with
 the delivery's line count, and a rotation handoff as its second section — so an

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -141,6 +141,16 @@ moves. Both cards stay linked, and the successor's header links back.
 Nothing rotates by itself. Crossing the threshold changes what the dock says
 and nothing else.
 
+The dock button is one way in; `rotate_orchestrator` is another. It performs
+the same rotation from any session — including the seat rotating itself, when
+you say so from a phone and the dock is out of reach — because the tool and
+`POST /api/orchestrator/rotate` share one authority contract: whatever actor
+reaches one reaches the other. What replaces a prohibition is a name. Every
+rotation records who triggered it — operator or agent, the triggering
+conversation, and the seat epoch it held — on the successor's designation and
+on the predecessor's revocation, so the lineage `get_orchestrator` reports
+carries both which seat replaced which and on whose word.
+
 The mandate itself lands in the feed as a single folded **Mandate** card with
 the delivery's line count, and a rotation handoff as its second section — so an
 8 KB first message stays one row you can open when you want it.

--- a/src/app/api/orchestrator/rotate/route.ts
+++ b/src/app/api/orchestrator/rotate/route.ts
@@ -1,30 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireOperatorAuthority } from "@/lib/agent/operatorAuthority";
-import { executeOrchestratorRotation } from "@/lib/orchestrator/seatCommand";
+import { handleOrchestratorRotationRequest } from "@/lib/orchestrator/seatCommand";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
 /* Explicit orchestrator rotation (two-axis contract). Behavior lives in
    `@/lib/orchestrator/seatCommand`; a route module may export only the
    documented route fields. Rotation is NEVER automatic — this route runs only
-   when explicitly called, and context pressure elsewhere only recommends. */
+   when explicitly called, and context pressure elsewhere only recommends.
+
+   Authority lives there too, in ONE contract this route and the
+   `rotate_orchestrator` MCP tool share (#1402): the tool posts here, so
+   whatever actor reaches this route rotates, whichever surface it came from.
+   The contract bans nobody and names everybody — cross-origin is still refused
+   below, because that is the perimeter and not an actor rule. */
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: NextRequest): Promise<NextResponse<Record<string, unknown> | ApiError>> {
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
-  const operator = requireOperatorAuthority(req);
-  if (!operator.ok) {
-    return NextResponse.json({ error: operator.error }, { status: operator.status });
-  }
   let body: Record<string, unknown>;
   try {
     body = (await req.json()) as Record<string, unknown>;
   } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
-  const result = await executeOrchestratorRotation(body);
+  const result = await handleOrchestratorRotationRequest(req, body);
   return NextResponse.json(result.body, { status: result.status });
 }

--- a/src/app/api/orchestrator/seat/route.test.ts
+++ b/src/app/api/orchestrator/seat/route.test.ts
@@ -15,11 +15,18 @@ import { POST as rotatePost } from "../rotate/route";
 import { GET as seatGet, POST as seatPost } from "./route";
 
 /*
- * BLOCKING 1 (#758 review), the route half: the designation surface refuses a
+ * BLOCKING 1 (#758 review), the route half: the DESIGNATION surface refuses a
  * caller that names itself as an agent conversation via the forwarded launch
  * capability, before the body is read and before anything durable changes.
  * The binding half — that the MCP tools actually forward that capability — is
  * proven in `src/lib/mcp/orchestratorTools.test.ts`.
+ *
+ * ROTATION is the deliberate exception (#1402), and it is asserted here at the
+ * route rather than assumed: the identical request that the seat route refuses
+ * as an agent reaches the rotation command, which answers on its own terms.
+ * The accepted end-to-end rotation, with the caller attributed, lives in
+ * `src/lib/orchestrator/rotationAuthority.test.ts` — this file must not run a
+ * real spawn.
  */
 
 let sandbox = "";
@@ -60,19 +67,30 @@ function agentRequest(pathname: string, body: unknown): NextRequest {
   });
 }
 
-test("a capability-presenting agent is refused designation at both routes, and no seat state changes", async () => {
+test("a capability-presenting agent is refused DESIGNATION at the seat route, and no seat state changes", async () => {
   const seat = await seatPost(agentRequest("/api/orchestrator/seat", {
     project: "proj-a",
     mandate: "mine now",
     clientRequestId: "req_00000001",
   }));
   expect(seat.status).toBe(403);
+  expect(await seat.json()).toMatchObject({ error: expect.stringContaining("an agent may not perform it") });
 
+  const { active, pending } = orchestratorSeatFor("proj-a");
+  expect(active).toBeNull();
+  expect(pending).toBeNull();
+});
+
+test("REGRESSION (#1402): the same agent request is ADMITTED by the rotation route, which answers about the seat and not about the caller", async () => {
   const rotate = await rotatePost(agentRequest("/api/orchestrator/rotate", {
     project: "proj-a",
     clientRequestId: "req_00000002",
   }));
-  expect(rotate.status).toBe(403);
+
+  /* Not 403 and not the operator-only sentence: nothing is designated for this
+     project, so the rotation command's own refusal is what comes back. */
+  expect(rotate.status).toBe(409);
+  expect(await rotate.json()).toMatchObject({ code: "no_incumbent" });
 
   const { active, pending } = orchestratorSeatFor("proj-a");
   expect(active).toBeNull();

--- a/src/app/api/orchestrator/seat/route.test.ts
+++ b/src/app/api/orchestrator/seat/route.test.ts
@@ -21,9 +21,9 @@ import { GET as seatGet, POST as seatPost } from "./route";
  * The binding half — that the MCP tools actually forward that capability — is
  * proven in `src/lib/mcp/orchestratorTools.test.ts`.
  *
- * ROTATION is the deliberate exception (#1402), and it is asserted here at the
- * route rather than assumed: the identical request that the seat route refuses
- * as an agent reaches the rotation command, which answers on its own terms.
+ * ROTATION is the deliberate exception (#1402), and the route itself is what
+ * proves it here: the identical request that the seat route refuses as an agent
+ * reaches the rotation command, which answers on its own terms.
  * The accepted end-to-end rotation, with the caller attributed, lives in
  * `src/lib/orchestrator/rotationAuthority.test.ts` — this file must not run a
  * real spawn.
@@ -81,7 +81,7 @@ test("a capability-presenting agent is refused DESIGNATION at the seat route, an
   expect(pending).toBeNull();
 });
 
-test("REGRESSION (#1402): the same agent request is ADMITTED by the rotation route, which answers about the seat and not about the caller", async () => {
+test("REGRESSION (#1402): the same agent request is ADMITTED by the rotation route, which answers about the seat whoever asked", async () => {
   const rotate = await rotatePost(agentRequest("/api/orchestrator/rotate", {
     project: "proj-a",
     clientRequestId: "req_00000002",

--- a/src/lib/agent/operatorAuthority.test.ts
+++ b/src/lib/agent/operatorAuthority.test.ts
@@ -149,14 +149,14 @@ test("REGRESSION (#1402): rotation NAMES every caller and refuses none — the a
   const workerCapability = crypto.randomBytes(32).toString("base64url");
   setCallerConversationResolverForTests(() => "conversation_worker");
 
-  /* The self-named agent: refused every operator-only action, and named — not
-     refused — for rotation. There is no other answer this function can give. */
+  /* The self-named agent: refused for every operator-only action, and named
+     for rotation. There is no other answer this function can give. */
   const agent = request({ ...BROWSER, [VIEWER_SPAWN_CAPABILITY_HEADER]: workerCapability });
   expect(requireOperatorAuthority(agent).ok).toBe(false);
   expect(rotationActor(agent)).toEqual({ kind: "agent", conversationId: "conversation_worker" });
 
-  /* The operator's own tab names no conversation, and is labelled as itself
-     rather than left anonymous. */
+  /* The operator's own tab names no conversation, and carries the `operator`
+     label to say so. */
   setCallerConversationResolverForTests(() => null);
   expect(rotationActor(request(BROWSER))).toEqual({ kind: "operator", conversationId: null });
   /* A background lane's marker classifies activity and has never been an actor

--- a/src/lib/agent/operatorAuthority.test.ts
+++ b/src/lib/agent/operatorAuthority.test.ts
@@ -11,6 +11,7 @@ import {
   directOperatorActivityAuthority,
   internalServiceHeaders,
   requireOperatorAuthority,
+  rotationActor,
   setCallerConversationResolverForTests,
   voiceTransportOperator,
 } from "./operatorAuthority";
@@ -138,6 +139,30 @@ test("direct activity accepts a browser and rejects server-authenticated backgro
        the product's existing operator-authority contract. */
     expect(requireOperatorAuthority(serviceRequest).ok).toBe(true);
   }
+});
+
+/* --------------------------------------------------------------------------- *
+ * Rotation asks the same question and answers it with a NAME (#1402).
+ * --------------------------------------------------------------------------- */
+
+test("REGRESSION (#1402): rotation NAMES every caller and refuses none — the agent it used to reject included", () => {
+  const workerCapability = crypto.randomBytes(32).toString("base64url");
+  setCallerConversationResolverForTests(() => "conversation_worker");
+
+  /* The self-named agent: refused every operator-only action, and named — not
+     refused — for rotation. There is no other answer this function can give. */
+  const agent = request({ ...BROWSER, [VIEWER_SPAWN_CAPABILITY_HEADER]: workerCapability });
+  expect(requireOperatorAuthority(agent).ok).toBe(false);
+  expect(rotationActor(agent)).toEqual({ kind: "agent", conversationId: "conversation_worker" });
+
+  /* The operator's own tab names no conversation, and is labelled as itself
+     rather than left anonymous. */
+  setCallerConversationResolverForTests(() => null);
+  expect(rotationActor(request(BROWSER))).toEqual({ kind: "operator", conversationId: null });
+  /* A background lane's marker classifies activity and has never been an actor
+     rule; rotation reads the same thing here as it does without it. */
+  expect(rotationActor(request({ ...BROWSER, ...internalServiceHeaders("mcp") })))
+    .toEqual({ kind: "operator", conversationId: null });
 });
 
 test("an invalid internal-service claim cannot impersonate authenticated background provenance", () => {

--- a/src/lib/agent/operatorAuthority.ts
+++ b/src/lib/agent/operatorAuthority.ts
@@ -163,13 +163,13 @@ export interface ViewerActor {
  * holds". So the surface agents are told to prefer was the one surface that could
  * not do it, and the shell fallback was the only working path.
  *
- * Nobody ever configured that ban, and the operator's rule is that controls are
- * CAPABILITY, not prohibition: their word is the trigger, and whoever acts on it
- * must be able to execute through the first-class tool. So rotation asks who the
- * caller is and never whether they may — this function BANS NOBODY and cannot
- * refuse. Its answer is attribution: the rotation record carries the actor kind and
- * the triggering conversation, so a rotation nobody can be stopped from performing
- * is still a rotation everybody can see the author of.
+ * Nobody ever configured that ban. The operator's rule is that a control is a
+ * CAPABILITY: their word is the trigger, and whoever acts on it must be able to
+ * execute through the first-class tool. So rotation asks only who the caller is —
+ * this function BANS NOBODY and cannot refuse. Its answer is attribution: the
+ * rotation record carries the actor kind and the triggering conversation, so a
+ * rotation nobody can be stopped from performing is still a rotation everybody can
+ * see the author of.
  *
  * The perimeter is unchanged and is not this function's job: `rejectCrossOrigin`
  * runs first in the route, exactly as it does for every other authority decision

--- a/src/lib/agent/operatorAuthority.ts
+++ b/src/lib/agent/operatorAuthority.ts
@@ -82,6 +82,8 @@ export function callerConversationId(request: Pick<NextRequest, "headers">): str
  *   act and does not follow transport rules.
  * - AGENTS. A caller presenting a conversation capability is refused every
  *   operator-only action, including designation, whatever role it holds.
+ *   ROTATION IS NOT ONE OF THEM (#1402): see `rotationActor` below, which asks
+ *   the same question and answers it with a NAME. It has no refusal to give.
  *
  * Residual, stated plainly rather than papered over: a local process running as
  * the operator's uid can send the same same-origin-shaped request the browser
@@ -137,6 +139,46 @@ function internalServiceClaim(request: Pick<NextRequest, "headers">): "absent" |
 export function directOperatorActivityAuthority(request: Pick<NextRequest, "headers">): OperatorAuthority {
   if (internalServiceClaim(request) === "valid") return SERVICE_REFUSED;
   return requireOperatorAuthority(request);
+}
+
+/** Who a request says it is. `operator` is the local browser — anything that
+    named no conversation; `agent` is a caller that named itself with the
+    conversation capability the registry issued it. */
+export type ViewerActorKind = "operator" | "agent";
+
+export interface ViewerActor {
+  kind: ViewerActorKind;
+  /** The conversation the caller named itself with; null for the operator. */
+  conversationId: string | null;
+}
+
+/**
+ * ROTATION AUTHORITY — the one contract, shared by both rotation surfaces (#1402).
+ *
+ * `POST /api/orchestrator/rotate` and the `rotate_orchestrator` MCP tool used to
+ * disagree about the same actor: the route accepted the local caller and performed
+ * the rotation, while the tool — which reaches the rotation only through that
+ * route, forwarding the calling session's own conversation capability — was refused
+ * by `requireOperatorAuthority` as "an agent may not perform it, whatever role it
+ * holds". So the surface agents are told to prefer was the one surface that could
+ * not do it, and the shell fallback was the only working path.
+ *
+ * Nobody ever configured that ban, and the operator's rule is that controls are
+ * CAPABILITY, not prohibition: their word is the trigger, and whoever acts on it
+ * must be able to execute through the first-class tool. So rotation asks who the
+ * caller is and never whether they may — this function BANS NOBODY and cannot
+ * refuse. Its answer is attribution: the rotation record carries the actor kind and
+ * the triggering conversation, so a rotation nobody can be stopped from performing
+ * is still a rotation everybody can see the author of.
+ *
+ * The perimeter is unchanged and is not this function's job: `rejectCrossOrigin`
+ * runs first in the route, exactly as it does for every other authority decision
+ * here. Because the tool holds no second copy of the rule — it posts to the route
+ * and inherits whatever the route decides — the two surfaces cannot drift again.
+ */
+export function rotationActor(request: Pick<NextRequest, "headers">): ViewerActor {
+  const conversationId = callerConversationId(request);
+  return conversationId ? { kind: "agent", conversationId } : { kind: "operator", conversationId: null };
 }
 
 /**

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1936,9 +1936,8 @@ function derivedRequestId(base: string, suffix: string): string {
  * lane (no capability in the environment) forwards nothing and passes.
  *
  * ROTATION is the exception, and the same header is what makes it work (#1402):
- * the rotation route reads this name to ATTRIBUTE the rotation rather than to
- * refuse it, so the seat the operator told to rotate can do it here instead of
- * falling back to a shell.
+ * the rotation route reads this name to ATTRIBUTE the rotation, so the seat the
+ * operator told to rotate performs it here and the shell fallback is gone.
  */
 function callerCapabilityHeaders(): Record<string, string> {
   const capability = process.env[VIEWER_SPAWN_CAPABILITY_ENV]?.trim() ?? "";
@@ -2340,9 +2339,8 @@ async function sendMessageToOrchestrator(
 
     Authority is the ROUTE's (#1402), and there is no copy of it here: this posts
     the calling session's own capability like every other control call, and the
-    rotation route names the caller instead of refusing it. What comes back
-    includes that name, so the caller reads the attribution its rotation was
-    recorded under. */
+    rotation route admits that caller and names it. What comes back includes that
+    name, so the caller reads the attribution its rotation was recorded under. */
 async function rotateOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
   const project = canonicalOrchestratorProject(required(args, "project"));
   const result = await control.post("/api/orchestrator/rotate", {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1934,6 +1934,11 @@ function derivedRequestId(base: string, suffix: string): string {
  * the launch environment; presenting it is how an agent names itself, and the
  * routes' `requireOperatorAuthority` refuses a self-named caller. An operator
  * lane (no capability in the environment) forwards nothing and passes.
+ *
+ * ROTATION is the exception, and the same header is what makes it work (#1402):
+ * the rotation route reads this name to ATTRIBUTE the rotation rather than to
+ * refuse it, so the seat the operator told to rotate can do it here instead of
+ * falling back to a shell.
  */
 function callerCapabilityHeaders(): Record<string, string> {
   const capability = process.env[VIEWER_SPAWN_CAPABILITY_ENV]?.trim() ?? "";
@@ -1973,6 +1978,9 @@ async function getOrchestrator(args: McpToolArgs, dependencies: ViewerMcpDomainD
       conversationId: revocation.conversationId,
       seatEpoch: revocation.seatEpoch,
       revokedAt: revocation.revokedAt,
+      /* Who ordered the rotation that ended this seat, when the record carries
+         it; null on designations made before rotation was attributed (#1402). */
+      triggeredBy: revocation.triggeredBy ?? null,
       successorConversationId: revocation.successorConversationId ?? null,
     })),
   };
@@ -2328,7 +2336,13 @@ async function sendMessageToOrchestrator(
 }
 
 /** rotate_orchestrator: explicit handoff to a successor. Never called by any
-    heuristic — see the rotation command's contract. */
+    heuristic — see the rotation command's contract.
+
+    Authority is the ROUTE's (#1402), and there is no copy of it here: this posts
+    the calling session's own capability like every other control call, and the
+    rotation route names the caller instead of refusing it. What comes back
+    includes that name, so the caller reads the attribution its rotation was
+    recorded under. */
 async function rotateOrchestrator(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
   const project = canonicalOrchestratorProject(required(args, "project"));
   const result = await control.post("/api/orchestrator/rotate", {
@@ -2342,6 +2356,9 @@ async function rotateOrchestrator(args: McpToolArgs, control: ViewerControlDepen
     transcriptPath: result.path ?? null,
     seat: result.seat ?? null,
     rotatedFrom: result.rotatedFrom ?? null,
+    /* Actor kind, triggering conversation and its seat epoch: who this rotation
+       is recorded against. */
+    triggeredBy: result.triggeredBy ?? null,
     /* Whether the prior handoffs were summarized or kept verbatim, and why. */
     handoff: result.handoff ?? null,
     replayed: result.replayed === true,

--- a/src/lib/mcp/orchestratorTools.test.ts
+++ b/src/lib/mcp/orchestratorTools.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { agentRegistry } from "@/lib/agent/registry";
-import { requireOperatorAuthority, setCallerConversationResolverForTests } from "@/lib/agent/operatorAuthority";
+import { requireOperatorAuthority, rotationActor, setCallerConversationResolverForTests } from "@/lib/agent/operatorAuthority";
 import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
 import { beginOrchestratorSeatIntent, completeOrchestratorSeatIntent, orchestratorSeatFor } from "@/lib/orchestrator/seats";
 import { persistProjectAliases } from "@/lib/projects/aliases";
@@ -53,15 +53,31 @@ function controlStub(responses: Record<string, Record<string, unknown>> = {}) {
   return { posts, control };
 }
 
-/** A control plane whose DESIGNATION endpoints run the REAL operator gate
+/** A control plane whose DESIGNATION endpoint runs the REAL operator gate
     against exactly the headers the binding forwarded — the same check the seat
-    and rotation routes make first, without reaching a real spawn. */
+    route makes first, without reaching a real spawn.
+
+    The rotation route is deliberately NOT on that gate (#1402): it runs the
+    rotation authority contract, which names the caller instead of refusing it,
+    and the rotations it admits are recorded with that name. */
 function gatedControlStub() {
   const designations: string[] = [];
+  const rotations: (string | null)[] = [];
   const control: ViewerControlDependencies = {
     post: async (pathname, _body, headers) => {
-      if (pathname === "/api/orchestrator/seat" || pathname === "/api/orchestrator/rotate") {
-        const operator = requireOperatorAuthority({ headers: new Headers(headers ?? {}) });
+      const request = { headers: new Headers(headers ?? {}) };
+      if (pathname === "/api/orchestrator/rotate") {
+        const actor = rotationActor(request);
+        rotations.push(actor.conversationId);
+        return {
+          ok: true,
+          conversationId: SEATED_ID,
+          seat: { conversationId: SEATED_ID },
+          triggeredBy: { kind: actor.kind, conversationId: actor.conversationId, seatEpoch: null },
+        };
+      }
+      if (pathname === "/api/orchestrator/seat") {
+        const operator = requireOperatorAuthority(request);
         if (!operator.ok) throw new Error(operator.error);
         designations.push(pathname);
         return { ok: true, conversationId: SEATED_ID, seat: { conversationId: SEATED_ID } };
@@ -69,7 +85,7 @@ function gatedControlStub() {
       return { ok: true, outcome: "delivered" };
     },
   };
-  return { designations, control };
+  return { designations, rotations, control };
 }
 
 function bindingsWith(control: ViewerControlDependencies) {
@@ -157,6 +173,9 @@ test("get_orchestrator surfaces bidirectional predecessor lineage after a replac
     seatEpoch: 1,
     revokedAt: AT,
     successorConversationId: SEATED_ID,
+    /* This replacement was seeded directly on the store, so it carries no
+       actor; a rotation through either surface names one (#1402). */
+    triggeredBy: null,
   }]);
 });
 
@@ -314,27 +333,46 @@ function restoreCapabilityCaller(): void {
   setCallerConversationResolverForTests(null);
 }
 
-test("a NON-OPERATOR caller cannot designate itself or anyone: create, rotate and send's create branch are refused by the real operator gate, writing nothing — while the tools stay callable", async () => {
+test("a NON-OPERATOR caller cannot DESIGNATE itself or anyone: create and send's create branch are refused by the real operator gate, writing nothing", async () => {
   asCapabilityCaller();
   try {
     const { designations, control } = gatedControlStub();
     const tools = bindingsWith(control);
 
-    /* All three designation paths run — the tools are ON the surface for this
-       session (axis 1) — and every one is refused by the gate that reads the
+    /* Both designation paths run — the tools are ON the surface for this
+       session (axis 1) — and both are refused by the gate that reads the
        forwarded conversation capability, before anything durable changes. */
     await expect(tools.create_orchestrator({
       clientRequestId: "create-x",
       project: "proj-a",
       conversationId: "conversation_worker",
     })).rejects.toThrow();
-    await expect(tools.rotate_orchestrator({ clientRequestId: "rotate-x", project: "proj-a" })).rejects.toThrow();
     await expect(tools.send_message_to_orchestrator({ clientRequestId: "send-x", project: "proj-a", text: "hi" })).rejects.toThrow();
 
     expect(designations).toEqual([]);
     const { active, pending } = orchestratorSeatFor("proj-a");
     expect(active).toBeNull();
     expect(pending).toBeNull();
+  } finally {
+    restoreCapabilityCaller();
+  }
+});
+
+test("REGRESSION (#1402): the same non-operator caller ROTATES, and the rotation is attributed to it", async () => {
+  asCapabilityCaller();
+  try {
+    const { rotations, control } = gatedControlStub();
+    const result = await bindingsWith(control).rotate_orchestrator({
+      clientRequestId: "rotate-x",
+      project: "proj-a",
+    }) as Record<string, unknown>;
+
+    /* The tool forwarded the caller's own capability, exactly as it does for
+       create — and rotation reads that name to attribute rather than to
+       refuse. See src/lib/orchestrator/rotationAuthority.test.ts for the same
+       call carried end to end into the durable seat record. */
+    expect(rotations).toEqual(["conversation_worker"]);
+    expect(result.triggeredBy).toMatchObject({ kind: "agent", conversationId: "conversation_worker" });
   } finally {
     restoreCapabilityCaller();
   }

--- a/src/lib/mcp/orchestratorTools.test.ts
+++ b/src/lib/mcp/orchestratorTools.test.ts
@@ -58,8 +58,8 @@ function controlStub(responses: Record<string, Record<string, unknown>> = {}) {
     route makes first, without reaching a real spawn.
 
     The rotation route is deliberately NOT on that gate (#1402): it runs the
-    rotation authority contract, which names the caller instead of refusing it,
-    and the rotations it admits are recorded with that name. */
+    rotation authority contract, which admits the caller and names it, and the
+    rotations it admits are recorded under that name. */
 function gatedControlStub() {
   const designations: string[] = [];
   const rotations: (string | null)[] = [];
@@ -368,9 +368,9 @@ test("REGRESSION (#1402): the same non-operator caller ROTATES, and the rotation
     }) as Record<string, unknown>;
 
     /* The tool forwarded the caller's own capability, exactly as it does for
-       create — and rotation reads that name to attribute rather than to
-       refuse. See src/lib/orchestrator/rotationAuthority.test.ts for the same
-       call carried end to end into the durable seat record. */
+       create — and rotation reads that name to attribute the rotation. See
+       src/lib/orchestrator/rotationAuthority.test.ts for the same call carried
+       end to end into the durable seat record. */
     expect(rotations).toEqual(["conversation_worker"]);
     expect(result.triggeredBy).toMatchObject({ kind: "agent", conversationId: "conversation_worker" });
   } finally {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1734,7 +1734,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
     "A project with no binding for an engine allows every account of that engine, which is exactly the behaviour it has always had; `restricted: false` on an engine's block says so. Binding a project to a subset fences every selection for its work, including the automatic switch under rate-limit pressure: when every allowed account is out of capacity that is reported and the work parks, and an account outside the set is never chosen.",
     "`project` defaults to your own on a list, and is required to add or remove.",
   ].join(" "),
-  rotate_orchestrator: "Explicitly hand a project's orchestrator seat to a fresh successor: bounded handoff (predecessor transcript reference, open tasks, optional notes), atomic designation switch, manager-authority-only revocation of the predecessor, bidirectional lineage. Never triggered automatically.",
+  rotate_orchestrator: "Explicitly hand a project's orchestrator seat to a fresh successor: bounded handoff (predecessor transcript reference, open tasks, optional notes), atomic designation switch, manager-authority-only revocation of the predecessor, bidirectional lineage. Callable from any session, including the seat rotating itself; the answer and the durable record both name who triggered it. Never triggered automatically.",
 };
 
 const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key for this logical call.");

--- a/src/lib/orchestrator/rotationAuthority.test.ts
+++ b/src/lib/orchestrator/rotationAuthority.test.ts
@@ -184,8 +184,8 @@ test("REGRESSION (#1402): the designated seat rotates ITSELF through rotate_orch
   expect(spawns).toHaveLength(1);
   expect(result.conversationId).toBe(SUCCESSOR_ID);
   expect(result.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
-  /* Attribution, on the answer: the caller reads back who it was recorded as
-     rather than trusting that anything was recorded. */
+  /* Attribution, on the answer: the caller reads back the name its rotation was
+     recorded under, so it never has to trust that one was written. */
   expect(result.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
 
   /* ...and on the durable record, both halves of the lineage. */
@@ -220,6 +220,53 @@ test("REGRESSION (#1402): a conversation holding no seat rotates too — no role
     conversationId: BYSTANDER_ID,
     seatEpoch: null,
   });
+});
+
+test("REGRESSION (#1402): an idempotent replay by a DIFFERENT actor answers with the actor that ORDERED the rotation", async () => {
+  seatSeeded();
+  callerIs(SEAT_ID);
+  const { deps, spawns } = dependencies();
+  const ordered: OrchestratorSeatTrigger = { kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 };
+  const key = "rotate-replay-1";
+
+  const first = await tools(routeBackedControl(deps).control).rotate_orchestrator({
+    clientRequestId: key,
+    project: "proj-a",
+  }) as Record<string, unknown>;
+  expect(first.triggeredBy).toEqual(ordered);
+  expect(spawns).toHaveLength(1);
+
+  /* A different conversation now retries the SAME idempotency key — a lost
+     response replayed by whoever was handed the key. The rotation is finished
+     and durable; this request performs nothing. */
+  callerIs(BYSTANDER_ID);
+
+  const routeReplay = await routeAnswer(headersFor("seat"), { clientRequestId: key, project: "proj-a" }, deps);
+  expect(routeReplay.status).toBe(200);
+  expect(routeReplay.body.replayed).toBe(true);
+  /* The answer reports what the record holds: the seat that ordered it. The
+     replaying caller's own identity describes the retry and is never written
+     over the attribution. */
+  expect(routeReplay.body.triggeredBy).toEqual(ordered);
+
+  const toolReplay = await tools(routeBackedControl(deps).control).rotate_orchestrator({
+    clientRequestId: key,
+    project: "proj-a",
+  }) as Record<string, unknown>;
+  expect(toolReplay.replayed).toBe(true);
+  expect(toolReplay.triggeredBy).toEqual(ordered);
+
+  /* One rotation happened, and the durable record still names its author on
+     both halves of the lineage. */
+  expect(spawns).toHaveLength(1);
+  const active = orchestratorSeatFor("proj-a").active;
+  expect(active?.conversationId).toBe(SUCCESSOR_ID);
+  expect(active?.triggeredBy).toEqual(ordered);
+  expect(orchestratorRevocations()).toEqual([expect.objectContaining({
+    conversationId: SEAT_ID,
+    successorConversationId: SUCCESSOR_ID,
+    triggeredBy: ordered,
+  })]);
 });
 
 test("REGRESSION (#1402): the operator-only rule still refuses this exact request — and rotation no longer asks it", async () => {
@@ -271,7 +318,7 @@ test("the route and the MCP tool answer the same for the same actor: ACCEPTED, w
       expect(answer.triggeredBy).toEqual(expected);
       expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual(expected);
       if (surface === "tool") {
-        /* The tool reached the route rather than deciding anything itself. */
+        /* The tool decided nothing itself; it reached the route. */
         expect(posted.map((call) => call.pathname)).toEqual(["/api/orchestrator/rotate"]);
       }
     }

--- a/src/lib/orchestrator/rotationAuthority.test.ts
+++ b/src/lib/orchestrator/rotationAuthority.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { requireOperatorAuthority, setCallerConversationResolverForTests } from "@/lib/agent/operatorAuthority";
+import { VIEWER_SPAWN_CAPABILITY_ENV, VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
+import { viewerMcpBindings, type ViewerControlDependencies } from "@/lib/mcp/bindings";
+
+import {
+  handleOrchestratorRotationRequest,
+  type SeatCommandDependencies,
+  type SeatCommandResult,
+} from "./seatCommand";
+import {
+  beginOrchestratorSeatIntent,
+  completeOrchestratorSeatIntent,
+  orchestratorRevocations,
+  orchestratorSeatFor,
+  type OrchestratorSeatTrigger,
+} from "./seats";
+
+/**
+ * ONE ROTATION CONTRACT, TWO SURFACES (#1402).
+ *
+ * The incident: the operator, on a phone where the dock's Rotate control is out
+ * of reach, told the seat to rotate itself. `rotate_orchestrator` answered "this
+ * is an operator-only action; an agent may not perform it, whatever role it
+ * holds" — and the seat then performed the identical rotation through
+ * `POST /api/orchestrator/rotate`, same actor, same machine, same body, because
+ * the route's gate accepted the local caller. The surface agents are told to
+ * prefer was the only one that refused, and the shell was the only way through.
+ *
+ * Two things are asserted here, and they are the whole fix:
+ *
+ * 1. Rotation BANS NOBODY. A designated seat rotates itself through the tool,
+ *    end to end, and so does a conversation that holds no seat at all. What
+ *    replaced the ban is ATTRIBUTION: the answer and the durable record both
+ *    name the actor kind, the triggering conversation, and the seat epoch it
+ *    held.
+ * 2. The two surfaces cannot disagree, because the tool posts to the route and
+ *    holds no copy of the rule. Both are driven here through
+ *    `handleOrchestratorRotationRequest` — the function the route runs — with
+ *    the same actor, and compared in the accept case AND in a refusal.
+ *
+ * Nothing here spawns a process or touches the operator's live registry: the
+ * seat command's spawn/deliver/summarize seams are injected, and every read and
+ * write lands in a private state directory.
+ */
+
+const AT = "2026-07-29T00:00:00.000Z";
+const SEAT_ID = "conversation_11111111-1111-4111-8111-111111111111";
+const BYSTANDER_ID = "conversation_22222222-2222-4222-8222-222222222222";
+const SUCCESSOR_ID = "conversation_33333333-3333-4333-8333-333333333333";
+const CAPABILITY = crypto.randomBytes(32).toString("base64url");
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+let previousCapability: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  previousCapability = process.env[VIEWER_SPAWN_CAPABILITY_ENV];
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-rotation-authority-"));
+  process.env.LLV_STATE_DIR = sandbox;
+});
+
+afterEach(() => {
+  setCallerConversationResolverForTests(null);
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousCapability === undefined) delete process.env[VIEWER_SPAWN_CAPABILITY_ENV];
+  else process.env[VIEWER_SPAWN_CAPABILITY_ENV] = previousCapability;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+/** The calling session names itself exactly as a launched agent does: its
+    capability in the environment, which the registry maps to `conversationId`. */
+function callerIs(conversationId: string): void {
+  process.env[VIEWER_SPAWN_CAPABILITY_ENV] = CAPABILITY;
+  const digest = crypto.createHash("sha256").update(CAPABILITY).digest("hex");
+  setCallerConversationResolverForTests((presented) => (presented === digest ? conversationId : null));
+}
+
+/** An operator lane: nothing in the environment to forward, so the request
+    names no conversation. */
+function callerIsOperator(): void {
+  delete process.env[VIEWER_SPAWN_CAPABILITY_ENV];
+  setCallerConversationResolverForTests(() => null);
+}
+
+function seatSeeded(project = "proj-a", conversationId = SEAT_ID): void {
+  beginOrchestratorSeatIntent({ project, mandate: "own the board", clientRequestId: "seed_0000001", mode: "spawn", now: AT });
+  completeOrchestratorSeatIntent({ project, clientRequestId: "seed_0000001", conversationId, path: "/tmp/seat.jsonl", now: AT });
+}
+
+function dependencies(): { deps: SeatCommandDependencies; spawns: Record<string, unknown>[] } {
+  const spawns: Record<string, unknown>[] = [];
+  const deps: SeatCommandDependencies = {
+    spawn: async (body) => {
+      spawns.push(body);
+      return { status: 200, body: { ok: true, conversationId: SUCCESSOR_ID, path: "/tmp/successor.jsonl" } };
+    },
+    deliver: async () => ({ ok: true, outcome: "delivered" }),
+    conversationTarget: (conversationId) => ({
+      kind: "eligible",
+      conversationId,
+      path: "/tmp/seat.jsonl",
+      cwd: "/workspace",
+      project: "proj-a",
+      engine: "claude",
+    }),
+    projectTasks: () => [],
+    summarizeHandoffs: async () => ({ kind: "fallback", reason: "unavailable" }),
+    launchSettlement: () => ({ kind: "unknown" }),
+    stampRegistryIdentity: () => {},
+    runtimeIdentity: () => ({ engine: null, model: null }),
+    now: () => AT,
+  };
+  return { deps, spawns };
+}
+
+interface PostedCall {
+  pathname: string;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+}
+
+/**
+ * The MCP tool's real control plane, with only the transport replaced: a post to
+ * the rotation route runs the ROUTE's own handler over the headers the binding
+ * forwarded, and a refusal is turned into a thrown error by the same rule
+ * `postViewerControl` applies in production (`result.error` or a non-ok status
+ * becomes the tool's exception). Nothing about authority is re-decided here.
+ */
+function routeBackedControl(deps: SeatCommandDependencies): {
+  control: ViewerControlDependencies;
+  posted: PostedCall[];
+} {
+  const posted: PostedCall[] = [];
+  const control: ViewerControlDependencies = {
+    post: async (pathname, body, headers) => {
+      posted.push({ pathname, body, headers: headers ?? {} });
+      if (pathname !== "/api/orchestrator/rotate") return { ok: true, outcome: "delivered" };
+      const answer = await routeAnswer(headers ?? {}, body, deps);
+      const failed = typeof answer.body.error === "string" || answer.status >= 400;
+      if (failed) throw new Error(String(answer.body.error ?? `Viewer control request failed with status ${answer.status}`));
+      return answer.body;
+    },
+  };
+  return { control, posted };
+}
+
+/** What `POST /api/orchestrator/rotate` answers, driven through the same
+    function the route module calls after its cross-origin check. */
+function routeAnswer(
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+  deps: SeatCommandDependencies,
+): Promise<SeatCommandResult> {
+  return handleOrchestratorRotationRequest({ headers: new Headers(headers) }, body, deps);
+}
+
+function tools(control: ViewerControlDependencies) {
+  return viewerMcpBindings(undefined, control, {} as never);
+}
+
+test("REGRESSION (#1402): the designated seat rotates ITSELF through rotate_orchestrator, and the record names it", async () => {
+  seatSeeded();
+  callerIs(SEAT_ID);
+  const { deps, spawns } = dependencies();
+  const { control, posted } = routeBackedControl(deps);
+
+  const result = await tools(control).rotate_orchestrator({
+    clientRequestId: "rotate-self-1",
+    project: "proj-a",
+    handoffNotes: "the operator asked for this from a phone",
+  }) as Record<string, unknown>;
+
+  /* The tool forwarded the seat's own capability — the very thing that used to
+     make the route refuse it — and the rotation happened anyway. */
+  expect(posted[0]!.headers[VIEWER_SPAWN_CAPABILITY_HEADER]).toBe(CAPABILITY);
+  expect(spawns).toHaveLength(1);
+  expect(result.conversationId).toBe(SUCCESSOR_ID);
+  expect(result.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
+  /* Attribution, on the answer: the caller reads back who it was recorded as
+     rather than trusting that anything was recorded. */
+  expect(result.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
+
+  /* ...and on the durable record, both halves of the lineage. */
+  const active = orchestratorSeatFor("proj-a").active;
+  expect(active?.conversationId).toBe(SUCCESSOR_ID);
+  expect(active?.predecessorConversationId).toBe(SEAT_ID);
+  expect(active?.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
+  expect(orchestratorRevocations()).toEqual([expect.objectContaining({
+    conversationId: SEAT_ID,
+    successorConversationId: SUCCESSOR_ID,
+    triggeredBy: { kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 },
+  })]);
+});
+
+test("REGRESSION (#1402): a conversation holding no seat rotates too — no role gate survives on this path", async () => {
+  seatSeeded();
+  callerIs(BYSTANDER_ID);
+  const { deps, spawns } = dependencies();
+  const { control } = routeBackedControl(deps);
+
+  const result = await tools(control).rotate_orchestrator({
+    clientRequestId: "rotate-bystander-1",
+    project: "proj-a",
+  }) as Record<string, unknown>;
+
+  expect(spawns).toHaveLength(1);
+  expect(result.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
+  /* Not a seat, so no epoch of its own — named all the same. */
+  expect(result.triggeredBy).toEqual({ kind: "agent", conversationId: BYSTANDER_ID, seatEpoch: null });
+  expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual({
+    kind: "agent",
+    conversationId: BYSTANDER_ID,
+    seatEpoch: null,
+  });
+});
+
+test("REGRESSION (#1402): the operator-only rule still refuses this exact request — and rotation no longer asks it", async () => {
+  seatSeeded();
+  callerIs(SEAT_ID);
+  const { deps } = dependencies();
+  const request = { headers: new Headers({ [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY }) };
+
+  /* The old gate is intact for the actions it still governs — designation among
+     them — and it is exactly what returned 403 to the seat that night. */
+  const operatorOnly = requireOperatorAuthority(request);
+  expect(operatorOnly.ok).toBe(false);
+  if (!operatorOnly.ok) {
+    expect(operatorOnly.error).toContain("an agent may not perform it, whatever role it holds");
+  }
+
+  /* The same request, on the rotation path, rotates. */
+  const answer = await routeAnswer({ [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY }, {
+    project: "proj-a",
+    clientRequestId: "rotate-gate-1",
+  }, deps);
+  expect(answer.status).toBe(200);
+  expect(answer.body.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
+});
+
+test("the route and the MCP tool answer the same for the same actor: ACCEPTED, with identical attribution", async () => {
+  for (const actor of ["seat", "operator"] as const) {
+    for (const surface of ["tool", "route"] as const) {
+      /* One fresh store per run, seeded identically, so any difference between
+         the two answers is a difference between the SURFACES. */
+      fs.rmSync(sandbox, { recursive: true, force: true });
+      fs.mkdirSync(sandbox, { recursive: true });
+      seatSeeded();
+      if (actor === "seat") callerIs(SEAT_ID);
+      else callerIsOperator();
+
+      const { deps } = dependencies();
+      const { control, posted } = routeBackedControl(deps);
+      const request = { clientRequestId: "rotate-parity-1", project: "proj-a" };
+      const answer = surface === "tool"
+        ? await tools(control).rotate_orchestrator(request) as Record<string, unknown>
+        : (await routeAnswer(headersFor(actor), request, deps)).body;
+
+      const expected: OrchestratorSeatTrigger = actor === "seat"
+        ? { kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 }
+        : { kind: "operator", conversationId: null, seatEpoch: null };
+      expect(answer.conversationId).toBe(SUCCESSOR_ID);
+      expect(answer.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
+      expect(answer.triggeredBy).toEqual(expected);
+      expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual(expected);
+      if (surface === "tool") {
+        /* The tool reached the route rather than deciding anything itself. */
+        expect(posted.map((call) => call.pathname)).toEqual(["/api/orchestrator/rotate"]);
+      }
+    }
+  }
+});
+
+test("the route and the MCP tool answer the same for the same actor: REFUSED, and the refusal is not about the actor", async () => {
+  /* Nothing designated, so there is no incumbent to rotate. This is the rotation
+     command's OWN refusal — the only kind left on this path — and it must reach
+     both surfaces identically for the same actor that the accept case above
+     rotates with. */
+  callerIs(SEAT_ID);
+  const { deps, spawns } = dependencies();
+  const { control } = routeBackedControl(deps);
+  const request = { clientRequestId: "rotate-parity-2", project: "proj-a" };
+
+  const refusal = await routeAnswer(headersFor("seat"), request, deps);
+  expect(refusal.status).toBe(409);
+  expect(refusal.body.code).toBe("no_incumbent");
+
+  await expect(tools(control).rotate_orchestrator(request)).rejects.toThrow(String(refusal.body.error));
+  expect(spawns).toEqual([]);
+
+  /* The same actor, one designation later, rotates — so the refusal above was
+     about the seat's absence and never about who was asking. */
+  seatSeeded();
+  const accepted = await routeAnswer(headersFor("seat"), { ...request, clientRequestId: "rotate-parity-3" }, deps);
+  expect(accepted.status).toBe(200);
+  expect(accepted.body.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
+});
+
+/** Exactly what the MCP binding forwards for each actor, so the route is driven
+    with the same evidence the tool sends. */
+function headersFor(actor: "seat" | "operator"): Record<string, string> {
+  return actor === "seat" ? { [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY } : {};
+}

--- a/src/lib/orchestrator/rotationAuthority.test.ts
+++ b/src/lib/orchestrator/rotationAuthority.test.ts
@@ -1,17 +1,27 @@
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { NextRequest } from "next/server";
+
+import { POST as rotateRoute } from "@/app/api/orchestrator/rotate/route";
 import { requireOperatorAuthority, setCallerConversationResolverForTests } from "@/lib/agent/operatorAuthority";
 import { VIEWER_SPAWN_CAPABILITY_ENV, VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
-import { viewerMcpBindings, type ViewerControlDependencies } from "@/lib/mcp/bindings";
+import {
+  productionViewerControlDependencies,
+  viewerMcpBindings,
+  viewerMcpToolPolicy,
+  type ViewerMcpDomainDependencies,
+} from "@/lib/mcp/bindings";
+import { MemoryMcpReceiptStore, createMcpToolService, createViewerMcpServer } from "@/lib/mcp/server";
 
 import {
-  handleOrchestratorRotationRequest,
+  setSeatCommandDependenciesForTests,
   type SeatCommandDependencies,
-  type SeatCommandResult,
 } from "./seatCommand";
 import {
   beginOrchestratorSeatIntent,
@@ -40,12 +50,21 @@ import {
  *    name the actor kind, the triggering conversation, and the seat epoch it
  *    held.
  * 2. The two surfaces cannot disagree, because the tool posts to the route and
- *    holds no copy of the rule. Both are driven here through
- *    `handleOrchestratorRotationRequest` — the function the route runs — with
- *    the same actor, and compared in the accept case AND in a refusal.
+ *    holds no copy of the rule.
  *
- * Nothing here spawns a process or touches the operator's live registry: the
- * seat command's spawn/deliver/summarize seams are injected, and every read and
+ * BOTH SURFACES ARE DRIVEN AT THEIR PUBLIC BOUNDARY, because the claim is about
+ * those boundaries and nothing smaller:
+ *
+ *   - the tool: an in-memory MCP client speaking the protocol to the real
+ *     `createViewerMcpServer` registration, through the real tool service (its
+ *     per-call policy and its receipts) and the real bindings, which reach the
+ *     Viewer over the production control transport — a genuine HTTP request;
+ *   - the route: `POST /api/orchestrator/rotate`, the exported route module
+ *     itself, served on a loopback listener that both surfaces address.
+ *
+ * The seam that keeps this off the operator's machine is the seat command's
+ * spawn/deliver/summarize dependencies, injected for the duration of a test:
+ * nothing here starts a process or delivers to a live host, and every read and
  * write lands in a private state directory.
  */
 
@@ -55,25 +74,94 @@ const BYSTANDER_ID = "conversation_22222222-2222-4222-8222-222222222222";
 const SUCCESSOR_ID = "conversation_33333333-3333-4333-8333-333333333333";
 const CAPABILITY = crypto.randomBytes(32).toString("base64url");
 
+type Actor = "seat" | "operator";
+
+interface RotationAnswer {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+interface RouteRequestRecord {
+  pathname: string;
+  capability: string | null;
+}
+
 let sandbox = "";
 let previousStateDir: string | undefined;
 let previousCapability: string | undefined;
+let previousControlUrl: string | undefined;
+let previousDeployTarget: string | undefined;
+let previousViewerPort: string | undefined;
+let listener: ReturnType<typeof Bun.serve> | null = null;
+let controlOrigin = "";
+let routeRequests: RouteRequestRecord[] = [];
+
+/** The Viewer, as far as any caller is concerned: one loopback listener that
+    serves the exported rotation route module. */
+beforeAll(() => {
+  listener = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname !== "/api/orchestrator/rotate" || request.method !== "POST") {
+        return Response.json({ error: `no route for ${request.method} ${url.pathname}` }, { status: 404 });
+      }
+      routeRequests.push({
+        pathname: url.pathname,
+        capability: request.headers.get(VIEWER_SPAWN_CAPABILITY_HEADER),
+      });
+      const answer = await rotateRoute(new NextRequest(url, {
+        method: "POST",
+        headers: request.headers,
+        body: await request.text(),
+      }));
+      return new Response(await answer.text(), {
+        status: answer.status,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  controlOrigin = `http://127.0.0.1:${listener.port}`;
+});
+
+afterAll(() => {
+  listener?.stop(true);
+  listener = null;
+});
 
 beforeEach(() => {
   previousStateDir = process.env.LLV_STATE_DIR;
   previousCapability = process.env[VIEWER_SPAWN_CAPABILITY_ENV];
+  previousControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+  previousDeployTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
+  previousViewerPort = process.env.LLV_VIEWER_PORT;
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-rotation-authority-"));
   process.env.LLV_STATE_DIR = sandbox;
+  /* Where the MCP bindings' production control transport sends its request.
+     The release-redirect contract needs the deploy target AND the port, so an
+     environment carrying neither stays pinned to this endpoint. */
+  process.env.LLV_VIEWER_CONTROL_URL = controlOrigin;
+  delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  delete process.env.LLV_VIEWER_PORT;
+  routeRequests = [];
 });
 
 afterEach(() => {
   setCallerConversationResolverForTests(null);
-  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
-  else process.env.LLV_STATE_DIR = previousStateDir;
-  if (previousCapability === undefined) delete process.env[VIEWER_SPAWN_CAPABILITY_ENV];
-  else process.env[VIEWER_SPAWN_CAPABILITY_ENV] = previousCapability;
+  setSeatCommandDependenciesForTests(null);
+  restore("LLV_STATE_DIR", previousStateDir);
+  restore(VIEWER_SPAWN_CAPABILITY_ENV, previousCapability);
+  restore("LLV_VIEWER_CONTROL_URL", previousControlUrl);
+  restore("LLV_VIEWER_DEPLOY_TARGET", previousDeployTarget);
+  restore("LLV_VIEWER_PORT", previousViewerPort);
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
+
+function restore(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 /** The calling session names itself exactly as a launched agent does: its
     capability in the environment, which the registry maps to `conversationId`. */
@@ -95,6 +183,9 @@ function seatSeeded(project = "proj-a", conversationId = SEAT_ID): void {
   completeOrchestratorSeatIntent({ project, clientRequestId: "seed_0000001", conversationId, path: "/tmp/seat.jsonl", now: AT });
 }
 
+/** The seat command's outward seams, installed for the exported route to use:
+    a rotation completes without a process being started or a host being
+    written to. */
 function dependencies(): { deps: SeatCommandDependencies; spawns: Record<string, unknown>[] } {
   const spawns: Record<string, unknown>[] = [];
   const deps: SeatCommandDependencies = {
@@ -118,75 +209,107 @@ function dependencies(): { deps: SeatCommandDependencies; spawns: Record<string,
     runtimeIdentity: () => ({ engine: null, model: null }),
     now: () => AT,
   };
+  setSeatCommandDependenciesForTests(deps);
   return { deps, spawns };
 }
 
-interface PostedCall {
-  pathname: string;
-  body: Record<string, unknown>;
-  headers: Record<string, string>;
+/** Exactly what the MCP binding forwards for each actor, so a direct route call
+    carries the same evidence the tool sends. */
+function capabilityHeaders(actor: Actor): Record<string, string> {
+  return actor === "seat" ? { [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY } : {};
 }
 
-/**
- * The MCP tool's real control plane, with only the transport replaced: a post to
- * the rotation route runs the ROUTE's own handler over the headers the binding
- * forwarded, and a refusal is turned into a thrown error by the same rule
- * `postViewerControl` applies in production (`result.error` or a non-ok status
- * becomes the tool's exception). Nothing about authority is re-decided here.
- */
-function routeBackedControl(deps: SeatCommandDependencies): {
-  control: ViewerControlDependencies;
-  posted: PostedCall[];
-} {
-  const posted: PostedCall[] = [];
-  const control: ViewerControlDependencies = {
-    post: async (pathname, body, headers) => {
-      posted.push({ pathname, body, headers: headers ?? {} });
-      if (pathname !== "/api/orchestrator/rotate") return { ok: true, outcome: "delivered" };
-      const answer = await routeAnswer(headers ?? {}, body, deps);
-      const failed = typeof answer.body.error === "string" || answer.status >= 400;
-      if (failed) throw new Error(String(answer.body.error ?? `Viewer control request failed with status ${answer.status}`));
-      return answer.body;
+/** `POST /api/orchestrator/rotate`: the exported route module over HTTP, same
+    listener the MCP tool reaches. */
+async function routeRotation(actor: Actor, body: Record<string, unknown>): Promise<RotationAnswer> {
+  const response = await fetch(new URL("/api/orchestrator/rotate", controlOrigin), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: controlOrigin,
+      ...capabilityHeaders(actor),
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() as Record<string, unknown> };
+}
+
+/* The tool surface, with nothing about it simulated: the caller identity the
+   policy classifies is the session's own, and the bindings hold the production
+   control transport, so `rotate_orchestrator` makes a real request to the
+   listener above. */
+const domainDependencies = {
+  attentionAuthority: () => ({ kind: "worker" as const, conversationId: SEAT_ID, role: "orchestrator" }),
+} as unknown as ViewerMcpDomainDependencies;
+
+interface McpSession {
+  client: Client;
+  close(): Promise<void>;
+}
+
+/** A fresh MCP process, as far as anything durable can tell: its own receipt
+    store, its own protocol connection to a freshly registered tool surface. */
+async function mcpSession(): Promise<McpSession> {
+  const service = createMcpToolService(
+    viewerMcpBindings(undefined, productionViewerControlDependencies(), domainDependencies),
+    new MemoryMcpReceiptStore(),
+    viewerMcpToolPolicy(domainDependencies),
+  );
+  const server = createViewerMcpServer(service);
+  const client = new Client({ name: "rotation-authority-regression", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
     },
   };
-  return { control, posted };
 }
 
-/** What `POST /api/orchestrator/rotate` answers, driven through the same
-    function the route module calls after its cross-origin check. */
-function routeAnswer(
-  headers: Record<string, string>,
-  body: Record<string, unknown>,
-  deps: SeatCommandDependencies,
-): Promise<SeatCommandResult> {
-  return handleOrchestratorRotationRequest({ headers: new Headers(headers) }, body, deps);
+interface ToolAnswer {
+  failed: boolean;
+  payload: Record<string, unknown>;
 }
 
-function tools(control: ViewerControlDependencies) {
-  return viewerMcpBindings(undefined, control, {} as never);
+/** One `rotate_orchestrator` call over the MCP protocol, from a session that
+    has never called anything before. */
+async function toolRotation(args: Record<string, unknown>): Promise<ToolAnswer> {
+  const session = await mcpSession();
+  try {
+    const result = await session.client.callTool({ name: "rotate_orchestrator", arguments: args });
+    return {
+      failed: result.isError === true,
+      payload: (result.structuredContent ?? {}) as Record<string, unknown>,
+    };
+  } finally {
+    await session.close();
+  }
 }
 
-test("REGRESSION (#1402): the designated seat rotates ITSELF through rotate_orchestrator, and the record names it", async () => {
+test("REGRESSION (#1402): the designated seat rotates ITSELF through rotate_orchestrator, end to end, and the record names it", async () => {
   seatSeeded();
   callerIs(SEAT_ID);
-  const { deps, spawns } = dependencies();
-  const { control, posted } = routeBackedControl(deps);
+  const { spawns } = dependencies();
 
-  const result = await tools(control).rotate_orchestrator({
+  const { failed, payload } = await toolRotation({
     clientRequestId: "rotate-self-1",
     project: "proj-a",
     handoffNotes: "the operator asked for this from a phone",
-  }) as Record<string, unknown>;
+  });
 
-  /* The tool forwarded the seat's own capability — the very thing that used to
-     make the route refuse it — and the rotation happened anyway. */
-  expect(posted[0]!.headers[VIEWER_SPAWN_CAPABILITY_HEADER]).toBe(CAPABILITY);
+  expect(failed).toBe(false);
+  /* The tool reached the Viewer over HTTP and forwarded the seat's own
+     capability — the very thing that used to make the route refuse it — and the
+     rotation happened anyway. */
+  expect(routeRequests).toEqual([{ pathname: "/api/orchestrator/rotate", capability: CAPABILITY }]);
   expect(spawns).toHaveLength(1);
-  expect(result.conversationId).toBe(SUCCESSOR_ID);
-  expect(result.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
+  expect(payload.conversationId).toBe(SUCCESSOR_ID);
+  expect(payload.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
   /* Attribution, on the answer: the caller reads back the name its rotation was
      recorded under, so it never has to trust that one was written. */
-  expect(result.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
+  expect(payload.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
 
   /* ...and on the durable record, both halves of the lineage. */
   const active = orchestratorSeatFor("proj-a").active;
@@ -203,18 +326,18 @@ test("REGRESSION (#1402): the designated seat rotates ITSELF through rotate_orch
 test("REGRESSION (#1402): a conversation holding no seat rotates too — no role gate survives on this path", async () => {
   seatSeeded();
   callerIs(BYSTANDER_ID);
-  const { deps, spawns } = dependencies();
-  const { control } = routeBackedControl(deps);
+  const { spawns } = dependencies();
 
-  const result = await tools(control).rotate_orchestrator({
+  const { failed, payload } = await toolRotation({
     clientRequestId: "rotate-bystander-1",
     project: "proj-a",
-  }) as Record<string, unknown>;
+  });
 
+  expect(failed).toBe(false);
   expect(spawns).toHaveLength(1);
-  expect(result.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
+  expect(payload.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
   /* Not a seat, so no epoch of its own — named all the same. */
-  expect(result.triggeredBy).toEqual({ kind: "agent", conversationId: BYSTANDER_ID, seatEpoch: null });
+  expect(payload.triggeredBy).toEqual({ kind: "agent", conversationId: BYSTANDER_ID, seatEpoch: null });
   expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual({
     kind: "agent",
     conversationId: BYSTANDER_ID,
@@ -225,23 +348,21 @@ test("REGRESSION (#1402): a conversation holding no seat rotates too — no role
 test("REGRESSION (#1402): an idempotent replay by a DIFFERENT actor answers with the actor that ORDERED the rotation", async () => {
   seatSeeded();
   callerIs(SEAT_ID);
-  const { deps, spawns } = dependencies();
+  const { spawns } = dependencies();
   const ordered: OrchestratorSeatTrigger = { kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 };
   const key = "rotate-replay-1";
 
-  const first = await tools(routeBackedControl(deps).control).rotate_orchestrator({
-    clientRequestId: key,
-    project: "proj-a",
-  }) as Record<string, unknown>;
-  expect(first.triggeredBy).toEqual(ordered);
+  const first = await toolRotation({ clientRequestId: key, project: "proj-a" });
+  expect(first.payload.triggeredBy).toEqual(ordered);
   expect(spawns).toHaveLength(1);
 
   /* A different conversation now retries the SAME idempotency key — a lost
-     response replayed by whoever was handed the key. The rotation is finished
-     and durable; this request performs nothing. */
+     response replayed by whoever was handed the key, from a session whose
+     receipts know nothing about the first call. The rotation is finished and
+     durable; this request performs nothing. */
   callerIs(BYSTANDER_ID);
 
-  const routeReplay = await routeAnswer(headersFor("seat"), { clientRequestId: key, project: "proj-a" }, deps);
+  const routeReplay = await routeRotation("seat", { clientRequestId: key, project: "proj-a" });
   expect(routeReplay.status).toBe(200);
   expect(routeReplay.body.replayed).toBe(true);
   /* The answer reports what the record holds: the seat that ordered it. The
@@ -249,12 +370,17 @@ test("REGRESSION (#1402): an idempotent replay by a DIFFERENT actor answers with
      over the attribution. */
   expect(routeReplay.body.triggeredBy).toEqual(ordered);
 
-  const toolReplay = await tools(routeBackedControl(deps).control).rotate_orchestrator({
-    clientRequestId: key,
-    project: "proj-a",
-  }) as Record<string, unknown>;
-  expect(toolReplay.replayed).toBe(true);
-  expect(toolReplay.triggeredBy).toEqual(ordered);
+  const toolReplay = await toolRotation({ clientRequestId: key, project: "proj-a" });
+  expect(toolReplay.failed).toBe(false);
+  expect(toolReplay.payload.conversationId).toBe(SUCCESSOR_ID);
+  expect(toolReplay.payload.triggeredBy).toEqual(ordered);
+  /* `replayed` on an MCP answer is the SERVICE's flag — whether this tool
+     receipt was already settled — and this replaying session has no receipt for
+     the key, so it reads false while the rotation underneath it was replayed.
+     That envelope predates this work and is the same for every tool; what the
+     rotation replayed is proven by the route's own flag above, by the single
+     spawn below, and by the successor the answer names. */
+  expect(toolReplay.payload.replayed).toBe(false);
 
   /* One rotation happened, and the durable record still names its author on
      both halves of the lineage. */
@@ -272,22 +398,20 @@ test("REGRESSION (#1402): an idempotent replay by a DIFFERENT actor answers with
 test("REGRESSION (#1402): the operator-only rule still refuses this exact request — and rotation no longer asks it", async () => {
   seatSeeded();
   callerIs(SEAT_ID);
-  const { deps } = dependencies();
-  const request = { headers: new Headers({ [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY }) };
+  dependencies();
 
   /* The old gate is intact for the actions it still governs — designation among
      them — and it is exactly what returned 403 to the seat that night. */
-  const operatorOnly = requireOperatorAuthority(request);
+  const operatorOnly = requireOperatorAuthority({
+    headers: new Headers({ [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY }),
+  });
   expect(operatorOnly.ok).toBe(false);
   if (!operatorOnly.ok) {
     expect(operatorOnly.error).toContain("an agent may not perform it, whatever role it holds");
   }
 
-  /* The same request, on the rotation path, rotates. */
-  const answer = await routeAnswer({ [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY }, {
-    project: "proj-a",
-    clientRequestId: "rotate-gate-1",
-  }, deps);
+  /* The same request, on the rotation route, rotates. */
+  const answer = await routeRotation("seat", { project: "proj-a", clientRequestId: "rotate-gate-1" });
   expect(answer.status).toBe(200);
   expect(answer.body.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
 });
@@ -299,28 +423,31 @@ test("the route and the MCP tool answer the same for the same actor: ACCEPTED, w
          the two answers is a difference between the SURFACES. */
       fs.rmSync(sandbox, { recursive: true, force: true });
       fs.mkdirSync(sandbox, { recursive: true });
+      routeRequests = [];
       seatSeeded();
       if (actor === "seat") callerIs(SEAT_ID);
       else callerIsOperator();
 
-      const { deps } = dependencies();
-      const { control, posted } = routeBackedControl(deps);
+      const { spawns } = dependencies();
       const request = { clientRequestId: "rotate-parity-1", project: "proj-a" };
       const answer = surface === "tool"
-        ? await tools(control).rotate_orchestrator(request) as Record<string, unknown>
-        : (await routeAnswer(headersFor(actor), request, deps)).body;
+        ? (await toolRotation(request)).payload
+        : (await routeRotation(actor, request)).body;
 
       const expected: OrchestratorSeatTrigger = actor === "seat"
         ? { kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 }
         : { kind: "operator", conversationId: null, seatEpoch: null };
+      expect(spawns).toHaveLength(1);
       expect(answer.conversationId).toBe(SUCCESSOR_ID);
       expect(answer.rotatedFrom).toMatchObject({ conversationId: SEAT_ID });
       expect(answer.triggeredBy).toEqual(expected);
       expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual(expected);
-      if (surface === "tool") {
-        /* The tool decided nothing itself; it reached the route. */
-        expect(posted.map((call) => call.pathname)).toEqual(["/api/orchestrator/rotate"]);
-      }
+      /* Whichever surface was asked, one rotation route request carried the
+         actor's own evidence: the tool decided nothing itself. */
+      expect(routeRequests).toEqual([{
+        pathname: "/api/orchestrator/rotate",
+        capability: actor === "seat" ? CAPABILITY : null,
+      }]);
     }
   }
 });
@@ -331,27 +458,23 @@ test("the route and the MCP tool answer the same for the same actor: REFUSED, an
      both surfaces identically for the same actor that the accept case above
      rotates with. */
   callerIs(SEAT_ID);
-  const { deps, spawns } = dependencies();
-  const { control } = routeBackedControl(deps);
+  const { spawns } = dependencies();
   const request = { clientRequestId: "rotate-parity-2", project: "proj-a" };
 
-  const refusal = await routeAnswer(headersFor("seat"), request, deps);
+  const refusal = await routeRotation("seat", request);
   expect(refusal.status).toBe(409);
   expect(refusal.body.code).toBe("no_incumbent");
 
-  await expect(tools(control).rotate_orchestrator(request)).rejects.toThrow(String(refusal.body.error));
+  const toolRefusal = await toolRotation(request);
+  expect(toolRefusal.failed).toBe(true);
+  expect(toolRefusal.payload.ok).toBe(false);
+  expect(toolRefusal.payload.error).toBe(refusal.body.error);
   expect(spawns).toEqual([]);
 
   /* The same actor, one designation later, rotates — so the refusal above was
      about the seat's absence and never about who was asking. */
   seatSeeded();
-  const accepted = await routeAnswer(headersFor("seat"), { ...request, clientRequestId: "rotate-parity-3" }, deps);
+  const accepted = await routeRotation("seat", { ...request, clientRequestId: "rotate-parity-3" });
   expect(accepted.status).toBe(200);
   expect(accepted.body.triggeredBy).toEqual({ kind: "agent", conversationId: SEAT_ID, seatEpoch: 1 });
 });
-
-/** Exactly what the MCP binding forwards for each actor, so the route is driven
-    with the same evidence the tool sends. */
-function headersFor(actor: "seat" | "operator"): Record<string, string> {
-  return actor === "seat" ? { [VIEWER_SPAWN_CAPABILITY_HEADER]: CAPABILITY } : {};
-}

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -6,7 +6,7 @@ import { validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, identityMaterializationFence } from "@/lib/agent/registry";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { defaultModelFor } from "@/lib/agent/models";
-import { internalServiceHeaders } from "@/lib/agent/operatorAuthority";
+import { internalServiceHeaders, rotationActor, type ViewerActor } from "@/lib/agent/operatorAuthority";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { deliverConversationMessage } from "@/lib/delivery";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
@@ -31,6 +31,7 @@ import {
 } from "./handoffDigest";
 import { orchestratorMandateForDelivery } from "./prompt";
 import {
+  activeOrchestratorSeats,
   beginOrchestratorSeatIntent,
   completeOrchestratorSeatIntent,
   failOrchestratorSeatIntent,
@@ -38,6 +39,7 @@ import {
   orchestratorSeatFor,
   repairOrchestratorSeatRuntimeIdentity,
   type OrchestratorSeat,
+  type OrchestratorSeatTrigger,
 } from "./seats";
 
 /* The one confirm behind the board draft's Orchestrator role: DESIGNATE this
@@ -159,10 +161,13 @@ function resolveOrchestratorCwd(project: string, requested: unknown): string | n
 
 async function postSpawnInProcess(body: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }> {
   const { executeSpawnRequest } = await import("@/lib/agent/spawnCommand");
-  /* An in-process call on the operator's behalf: the seat route has already
-     verified same-origin operator authority, so this presents the operator
-     spawn capability — the same lane the MCP server's spawn_agent uses. Only
-     `headers` and `json` are read by the spawn command. */
+  /* An in-process call the VIEWER makes, on its own authority: the designation
+     surfaces have already made their authority decision — the seat route by
+     refusing an agent, the rotation route by naming one (#1402) — so this
+     presents the operator spawn capability either way, the same lane the MCP
+     server's spawn_agent uses. Who triggered the designation travels on the
+     seat record, not on this spawn. Only `headers` and `json` are read by the
+     spawn command. */
   const request = {
     headers: new Headers({
       host: "127.0.0.1",
@@ -450,6 +455,10 @@ function reconcilePendingSeatIntent(project: string, dependencies: SeatCommandDe
 export async function executeOrchestratorSeatRequest(
   rawBody: Record<string, unknown>,
   dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
+  /* Who triggered this designation, resolved from the REQUEST by the caller.
+     Deliberately not a `rawBody` field: the body is caller-supplied JSON, and
+     attribution that a caller can write is not attribution. */
+  triggeredBy: OrchestratorSeatTrigger | null = null,
 ): Promise<SeatCommandResult> {
   const namedProject = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
   if (!namedProject) return { status: 400, body: { error: "project must be a valid project key" } };
@@ -523,6 +532,7 @@ export async function executeOrchestratorSeatRequest(
       engine: target.engine ?? null,
       model: target.model ?? null,
       promptVersion,
+      triggeredBy,
       now: dependencies.now(),
     });
     if (begun.kind === "completed") {
@@ -623,6 +633,7 @@ export async function executeOrchestratorSeatRequest(
     engine: resolvedRuntime.value.config.engine,
     model: resolvedRuntime.value.config.model,
     promptVersion,
+    triggeredBy,
     now: dependencies.now(),
   });
   if (begun.kind === "completed") {
@@ -725,6 +736,36 @@ const HANDOFF_TASK_TEXT_CAP = 140;
 const HANDOFF_NOTES_CAP = 2_000;
 
 /**
+ * THE shared entry point for `POST /api/orchestrator/rotate` (#1402).
+ *
+ * The route is a Next module and may export only route fields, so the two steps
+ * that decide a rotation live here instead: resolve WHO is asking with the one
+ * rotation authority contract, and rotate. The `rotate_orchestrator` MCP tool
+ * posts to that route and holds no copy of either step, so the tool's answer is
+ * the route's answer by construction — for the actor it accepts and for every
+ * refusal the rotation itself makes.
+ *
+ * Cross-origin rejection stays in the route, ahead of this: it is the perimeter,
+ * and it is the only thing here that turns a caller away.
+ */
+export function handleOrchestratorRotationRequest(
+  request: Pick<NextRequest, "headers">,
+  rawBody: Record<string, unknown>,
+  dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
+): Promise<SeatCommandResult> {
+  return executeOrchestratorRotation(rawBody, dependencies, rotationActor(request));
+}
+
+/** The caller's own seat epoch, when the caller IS a designated seat — which is
+    what tells a self-rotation apart from a rotation ordered from elsewhere. */
+function rotationTrigger(actor: ViewerActor): OrchestratorSeatTrigger {
+  const seat = actor.conversationId
+    ? activeOrchestratorSeats().find((candidate) => candidate.conversationId === actor.conversationId)
+    : undefined;
+  return { kind: actor.kind, conversationId: actor.conversationId, seatEpoch: seat?.seatEpoch ?? null };
+}
+
+/**
  * Rotation (two-axis contract): hand the seat to a fresh successor.
  *
  * The handoff is BOUNDED and durable-state-based: the successor's launch
@@ -748,7 +789,13 @@ const HANDOFF_NOTES_CAP = 2_000;
 export async function executeOrchestratorRotation(
   rawBody: Record<string, unknown>,
   dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
+  /* WHO ordered this rotation. Never a refusal — rotation bans nobody — and
+     never read off `rawBody`, so nothing a caller writes can claim to be
+     someone else. Null is an in-process caller that named nobody, and records
+     unknown provenance rather than crediting the operator with it. */
+  actor: ViewerActor | null = null,
 ): Promise<SeatCommandResult> {
+  const triggeredBy = actor ? rotationTrigger(actor) : null;
   const namedProject = typeof rawBody.project === "string" ? validExplicitProject(rawBody.project) : null;
   if (!namedProject) return { status: 400, body: { error: "project must be a valid project key" } };
   const project = canonicalOrchestratorProject(namedProject);
@@ -812,9 +859,9 @@ export async function executeOrchestratorRotation(
   const current = orchestratorSeatFor(project).active;
   if (!current || current.conversationId !== incumbent.conversationId || current.seatEpoch !== incumbent.seatEpoch) {
     const conflict = incumbentChangedResult(project, incumbent.seatEpoch, current);
-    return { status: conflict.status, body: { ...conflict.body, rotatedFrom } };
+    return { status: conflict.status, body: { ...conflict.body, rotatedFrom, triggeredBy } };
   }
-  if (composed.kind === "too_large") return { status: 413, body: { ...composed.body, rotatedFrom } };
+  if (composed.kind === "too_large") return { status: 413, body: { ...composed.body, rotatedFrom, triggeredBy } };
 
   const outcome = await executeOrchestratorSeatRequest({
     project,
@@ -842,12 +889,16 @@ export async function executeOrchestratorRotation(
         ? { cwd: predecessor.cwd }
         : {}),
     ...(rawBody.accountId !== undefined ? { accountId: rawBody.accountId } : {}),
-  }, dependencies);
+  }, dependencies, triggeredBy);
   return {
     status: outcome.status,
     body: {
       ...outcome.body,
       rotatedFrom,
+      /* Who ordered it, on the answer as well as on the durable record: the
+         caller that just rotated a seat reads back the attribution it was
+         recorded under rather than having to trust that one was written. */
+      triggeredBy,
       ...(composed.handoff ? { handoff: composed.handoff } : {}),
     },
   };

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -751,9 +751,28 @@ const HANDOFF_NOTES_CAP = 2_000;
 export function handleOrchestratorRotationRequest(
   request: Pick<NextRequest, "headers">,
   rawBody: Record<string, unknown>,
-  dependencies: SeatCommandDependencies = productionSeatCommandDependencies,
+  dependencies: SeatCommandDependencies = activeSeatCommandDependencies(),
 ): Promise<SeatCommandResult> {
   return executeOrchestratorRotation(rawBody, dependencies, rotationActor(request));
+}
+
+let seatCommandDependenciesForTests: SeatCommandDependencies | null = null;
+
+/**
+ * Tests only; `null` restores the production seams. Seamed here rather than in
+ * the route, because a route module may export only route fields.
+ *
+ * `POST /api/orchestrator/rotate` is the surface the rotation contract is about
+ * (#1402), so the regression drives the exported route itself over loopback —
+ * and a route takes no dependency argument. This is how that run reaches a
+ * rotation without spawning a process or delivering to a live host.
+ */
+export function setSeatCommandDependenciesForTests(dependencies: SeatCommandDependencies | null): void {
+  seatCommandDependenciesForTests = dependencies;
+}
+
+function activeSeatCommandDependencies(): SeatCommandDependencies {
+  return seatCommandDependenciesForTests ?? productionSeatCommandDependencies;
 }
 
 /** The caller's own seat epoch, when the caller IS a designated seat — which is

--- a/src/lib/orchestrator/seatCommand.ts
+++ b/src/lib/orchestrator/seatCommand.ts
@@ -166,8 +166,8 @@ async function postSpawnInProcess(body: Record<string, unknown>): Promise<{ stat
      refusing an agent, the rotation route by naming one (#1402) — so this
      presents the operator spawn capability either way, the same lane the MCP
      server's spawn_agent uses. Who triggered the designation travels on the
-     seat record, not on this spawn. Only `headers` and `json` are read by the
-     spawn command. */
+     seat record; this spawn carries none of it. Only `headers` and `json` are
+     read by the spawn command. */
   const request = {
     headers: new Headers({
       host: "127.0.0.1",
@@ -792,7 +792,7 @@ export async function executeOrchestratorRotation(
   /* WHO ordered this rotation. Never a refusal — rotation bans nobody — and
      never read off `rawBody`, so nothing a caller writes can claim to be
      someone else. Null is an in-process caller that named nobody, and records
-     unknown provenance rather than crediting the operator with it. */
+     unknown provenance; the operator is never credited by default. */
   actor: ViewerActor | null = null,
 ): Promise<SeatCommandResult> {
   const triggeredBy = actor ? rotationTrigger(actor) : null;
@@ -895,13 +895,35 @@ export async function executeOrchestratorRotation(
     body: {
       ...outcome.body,
       rotatedFrom,
-      /* Who ordered it, on the answer as well as on the durable record: the
-         caller that just rotated a seat reads back the attribution it was
-         recorded under rather than having to trust that one was written. */
-      triggeredBy,
+      /* Who ordered it, on the answer as well as on the durable record, so the
+         caller reads back the attribution its rotation was recorded under. */
+      triggeredBy: attributedTrigger(outcome.body, triggeredBy),
       ...(composed.handoff ? { handoff: composed.handoff } : {}),
     },
   };
+}
+
+/**
+ * THE ANSWER REPORTS WHAT THE RECORD HOLDS (#1402).
+ *
+ * Every outcome that reached a seat carries that seat, and the seat's own
+ * `triggeredBy` was written by the request that created the intent. So an
+ * idempotent replay — a lost response retried, whichever actor holds the key —
+ * answers with the actor that ORDERED the rotation. The replaying caller's own
+ * identity is a fact about the retry, and writing it over the attribution would
+ * make the answer contradict the durable record it is reporting.
+ *
+ * When no seat was reached, the request was refused before anything was
+ * recorded; there the answer names the actor that asked, and there is no record
+ * for it to disagree with.
+ */
+function attributedTrigger(
+  body: Record<string, unknown>,
+  requested: OrchestratorSeatTrigger | null,
+): OrchestratorSeatTrigger | null {
+  const seat = body.seat;
+  if (!seat || typeof seat !== "object" || Array.isArray(seat)) return requested;
+  return (seat as OrchestratorSeat).triggeredBy ?? null;
 }
 
 type RotationMandate =

--- a/src/lib/orchestrator/seats.test.ts
+++ b/src/lib/orchestrator/seats.test.ts
@@ -82,12 +82,48 @@ test("replacement revokes the predecessor in the same write and bumps the epoch"
       revokedAt: AT,
       /* Bidirectional lineage: the revocation names its successor… */
       successorConversationId: "conversation_b",
+      /* Nothing named an actor for this designation, so provenance is unknown
+         rather than assumed to be the operator (#1402). */
+      triggeredBy: null,
     });
     expect(swapped.seat.seatEpoch).toBe(2);
     /* …and the successor seat names its predecessor. */
     expect(swapped.seat.predecessorConversationId).toBe("conversation_a");
   }
   expect(orchestratorSeatFor("proj-a").active?.conversationId).toBe("conversation_b");
+});
+
+test("#1402: a designation's trigger survives the file — on the seat it created and on the seat it ended", () => {
+  const trigger = { kind: "agent" as const, conversationId: "conversation_a", seatEpoch: 1 };
+  beginOrchestratorSeatIntent({ project: "proj-a", mandate: "first", clientRequestId: "req_0000001", mode: "spawn", now: AT });
+  completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000001", conversationId: "conversation_a", path: null, now: AT });
+
+  /* The seat rotating ITSELF: the actor is written on the intent, before the
+     successor exists, and read back off disk by every later reader. */
+  beginOrchestratorSeatIntent({
+    project: "proj-a",
+    mandate: "second",
+    clientRequestId: "req_0000002",
+    mode: "spawn",
+    triggeredBy: trigger,
+    now: AT,
+  });
+  expect(orchestratorSeatFor("proj-a").pending?.triggeredBy).toEqual(trigger);
+
+  completeOrchestratorSeatIntent({ project: "proj-a", clientRequestId: "req_0000002", conversationId: "conversation_b", path: null, now: AT });
+  expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toEqual(trigger);
+  expect(orchestratorRevocations()).toEqual([expect.objectContaining({
+    conversationId: "conversation_a",
+    successorConversationId: "conversation_b",
+    triggeredBy: trigger,
+  })]);
+
+  /* Provenance is unknown or it is absent — never half-written. */
+  const raw = JSON.parse(fs.readFileSync(path.join(sandbox, "orchestrator-seats.json"), "utf8")) as Record<string, unknown>;
+  const seats = raw.seats as Record<string, Record<string, unknown>>;
+  seats["proj-a"]!.triggeredBy = { kind: "impostor", conversationId: "conversation_z" };
+  fs.writeFileSync(path.join(sandbox, "orchestrator-seats.json"), JSON.stringify(raw), "utf8");
+  expect(orchestratorSeatFor("proj-a").active?.triggeredBy).toBeNull();
 });
 
 test("editing the mandate for the SAME conversation revokes nothing", () => {

--- a/src/lib/orchestrator/seats.test.ts
+++ b/src/lib/orchestrator/seats.test.ts
@@ -82,8 +82,8 @@ test("replacement revokes the predecessor in the same write and bumps the epoch"
       revokedAt: AT,
       /* Bidirectional lineage: the revocation names its successor… */
       successorConversationId: "conversation_b",
-      /* Nothing named an actor for this designation, so provenance is unknown
-         rather than assumed to be the operator (#1402). */
+      /* Nothing named an actor for this designation, so provenance stays
+         unknown; the operator is never assumed (#1402). */
       triggeredBy: null,
     });
     expect(swapped.seat.seatEpoch).toBe(2);

--- a/src/lib/orchestrator/seats.ts
+++ b/src/lib/orchestrator/seats.ts
@@ -49,6 +49,26 @@ export interface OrchestratorSeatIntent {
   error: string | null;
 }
 
+/**
+ * WHO triggered the designation this seat came from (#1402).
+ *
+ * Rotation refuses nobody, so this is what answers for it: the record names the
+ * actor kind the request presented, the conversation that named itself (null for
+ * the operator's own browser, which names none), and the seat epoch that caller
+ * held at the time when it was itself a designated seat — which is how a seat
+ * that rotated ITSELF is legible as exactly that, rather than as an anonymous
+ * successor appearing beside a revoked predecessor.
+ *
+ * Absent on every designation made before this existed, and on paths that never
+ * carry an actor; a reader must treat it as unknown provenance, never as "the
+ * operator did it".
+ */
+export interface OrchestratorSeatTrigger {
+  kind: "operator" | "agent";
+  conversationId: string | null;
+  seatEpoch: number | null;
+}
+
 export interface OrchestratorSeat {
   project: string;
   /** Monotonic designation epoch; strictly increases across the whole file. */
@@ -71,6 +91,8 @@ export interface OrchestratorSeat {
       matching revocation carries `successorConversationId`, so the link is
       bidirectional and both cards stay navigable. */
   predecessorConversationId: string | null;
+  /** Who triggered this designation, when the request named an actor. */
+  triggeredBy?: OrchestratorSeatTrigger | null;
   state: "pending" | "active";
   intent: OrchestratorSeatIntent;
   designatedAt: string;
@@ -101,6 +123,9 @@ export interface OrchestratorRevocation {
   revokedAt: string;
   /** The seat that replaced it — the other half of the rotation lineage. */
   successorConversationId?: string | null;
+  /** Who triggered the rotation that ended this seat (#1402), copied from the
+      successor's intent so the lineage entry answers "who did this" on its own. */
+  triggeredBy?: OrchestratorSeatTrigger | null;
 }
 
 interface OrchestratorSeatFile {
@@ -134,6 +159,19 @@ function atomicWriteJson(filePath: string, value: unknown): void {
   fs.renameSync(temp, filePath);
 }
 
+/** A trigger survives the round trip only when it is fully formed; a half-written
+    one is dropped rather than reported as partial provenance. */
+function normalizeSeatTrigger(value: unknown): OrchestratorSeatTrigger | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const trigger = value as Partial<OrchestratorSeatTrigger>;
+  if (trigger.kind !== "operator" && trigger.kind !== "agent") return null;
+  const conversationId = typeof trigger.conversationId === "string" && trigger.conversationId ? trigger.conversationId : null;
+  const seatEpoch = typeof trigger.seatEpoch === "number" && Number.isInteger(trigger.seatEpoch) && trigger.seatEpoch >= 1
+    ? trigger.seatEpoch
+    : null;
+  return { kind: trigger.kind, conversationId, seatEpoch };
+}
+
 function normalizeSeat(value: unknown): OrchestratorSeat | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const seat = value as Partial<OrchestratorSeat>;
@@ -164,6 +202,7 @@ function normalizeSeat(value: unknown): OrchestratorSeat | null {
     mandate: seat.mandate,
     promptVersion: typeof seat.promptVersion === "number" && Number.isInteger(seat.promptVersion) ? seat.promptVersion : null,
     predecessorConversationId: typeof seat.predecessorConversationId === "string" ? seat.predecessorConversationId : null,
+    triggeredBy: normalizeSeatTrigger(seat.triggeredBy),
     state: seat.state,
     intent: {
       clientRequestId: intent.clientRequestId,
@@ -229,6 +268,7 @@ function readOrchestratorSeatFileOrNull(): OrchestratorSeatFile | null {
           seatEpoch: revocation.seatEpoch,
           revokedAt: revocation.revokedAt,
           successorConversationId: typeof revocation.successorConversationId === "string" ? revocation.successorConversationId : null,
+          triggeredBy: normalizeSeatTrigger(revocation.triggeredBy),
         });
       }
     }
@@ -354,6 +394,9 @@ function readOrchestratorSeatMigrationEvidence(): OrchestratorSeatMigrationEvide
       seatEpoch: revocation.seatEpoch,
       revokedAt: revocation.revokedAt,
       successorConversationId: revocation.successorConversationId ?? null,
+      /* Carried, not dropped: this reader's whole point is that a rewrite
+         publishes nothing less than it read. */
+      triggeredBy: normalizeSeatTrigger(revocation.triggeredBy),
     });
   }
   for (const candidate of arrayEvidence(raw.history, "history")) {
@@ -426,6 +469,9 @@ export function beginOrchestratorSeatIntent(input: {
   engine?: string | null;
   model?: string | null;
   promptVersion?: number | null;
+  /** Who triggered this designation, resolved from the request by the caller —
+      never read off a caller-supplied body, so attribution cannot be dictated. */
+  triggeredBy?: OrchestratorSeatTrigger | null;
   now?: string;
 }): BeginSeatIntentResult {
   return withAccountMutationLock(() => {
@@ -475,6 +521,7 @@ export function beginOrchestratorSeatIntent(input: {
       mandate: input.mandate,
       promptVersion: input.promptVersion ?? null,
       predecessorConversationId: null,
+      triggeredBy: input.triggeredBy ?? null,
       state: "pending",
       intent: { clientRequestId: input.clientRequestId, mode: input.mode, launchId: null, error: null },
       designatedAt: input.now ?? new Date().toISOString(),
@@ -529,6 +576,12 @@ export function completeOrchestratorSeatIntent(input: {
         /* Bidirectional lineage: the revocation names its successor, the
            successor seat names its predecessor, and both cards stay navigable. */
         successorConversationId: input.conversationId,
+        /* ...and WHO ended this seat (#1402), carried from the pending intent
+           that the triggering request wrote it on. Reading it off the intent is
+           what keeps the answer truthful for a rotation that settles long after
+           its request returned — an accepted spawn activates from the
+           reconciler, which has no request to ask. */
+        triggeredBy: pending.triggeredBy ?? null,
       };
       file.revocations.push(revoked);
     }

--- a/src/lib/orchestrator/seats.ts
+++ b/src/lib/orchestrator/seats.ts
@@ -56,12 +56,12 @@ export interface OrchestratorSeatIntent {
  * actor kind the request presented, the conversation that named itself (null for
  * the operator's own browser, which names none), and the seat epoch that caller
  * held at the time when it was itself a designated seat — which is how a seat
- * that rotated ITSELF is legible as exactly that, rather than as an anonymous
- * successor appearing beside a revoked predecessor.
+ * that rotated ITSELF is legible as exactly that. The bare lineage shows only an
+ * anonymous successor standing beside a revoked predecessor.
  *
  * Absent on every designation made before this existed, and on paths that never
- * carry an actor; a reader must treat it as unknown provenance, never as "the
- * operator did it".
+ * carry an actor. A reader must treat that absence as unknown provenance; "the
+ * operator did it" is never a safe reading of it.
  */
 export interface OrchestratorSeatTrigger {
   kind: "operator" | "agent";
@@ -160,7 +160,7 @@ function atomicWriteJson(filePath: string, value: unknown): void {
 }
 
 /** A trigger survives the round trip only when it is fully formed; a half-written
-    one is dropped rather than reported as partial provenance. */
+    one is dropped, so partial provenance is never reported. */
 function normalizeSeatTrigger(value: unknown): OrchestratorSeatTrigger | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const trigger = value as Partial<OrchestratorSeatTrigger>;
@@ -394,8 +394,8 @@ function readOrchestratorSeatMigrationEvidence(): OrchestratorSeatMigrationEvide
       seatEpoch: revocation.seatEpoch,
       revokedAt: revocation.revokedAt,
       successorConversationId: revocation.successorConversationId ?? null,
-      /* Carried, not dropped: this reader's whole point is that a rewrite
-         publishes nothing less than it read. */
+      /* Carried through the migration: this reader's whole point is that a
+         rewrite publishes everything it read. */
       triggeredBy: normalizeSeatTrigger(revocation.triggeredBy),
     });
   }


### PR DESCRIPTION
## Summary

`rotate_orchestrator` refused the designated seat with "this is an operator-only action; an agent may not perform it, whatever role it holds", while `POST /api/orchestrator/rotate` performed the identical rotation for the same actor, same machine, same body. The tool reaches the rotation only through that route and forwards the calling session's own conversation capability; the route's operator gate read that name as a disqualifier. The surface agents are told to prefer was the one surface that could not rotate, and a shell call was the only way through — which is exactly the shape the tooling audit counts as a bypass.

Rotation now carries no actor ban at all. Both surfaces share one contract, `rotationActor`, which resolves who is calling and has no refusal to give. Attribution stands in for prohibition: every rotation records the actor kind, the triggering conversation and the seat epoch that caller held.

Designation is unchanged. `create_orchestrator` and `POST /api/orchestrator/seat` still refuse a self-named caller; only rotation and its authority seam moved.

## Mechanism

- `src/lib/agent/operatorAuthority.ts` — `rotationActor(request)` returns `{ kind: "operator" | "agent", conversationId }`. It bans nobody and cannot refuse; the cross-origin perimeter is untouched and still runs first in the route.
- `src/lib/orchestrator/seatCommand.ts` — `handleOrchestratorRotationRequest(request, body, deps)` is the one entry point the route calls: resolve the actor, then rotate. A route module may export only route fields, so the shared step lives here where both the route and the tests can reach it. `executeOrchestratorRotation` takes the actor as an argument and never off `rawBody`, so nothing a caller writes can claim to be someone else.
- `src/app/api/orchestrator/rotate/route.ts` — cross-origin check, parse, hand to that seam. The MCP binding keeps posting to this route and holds no copy of the rule, so the two surfaces cannot answer differently for one actor.
- `src/lib/orchestrator/seats.ts` — `OrchestratorSeatTrigger` (`kind`, `conversationId`, `seatEpoch`) rides the pending intent, lands on the activated seat, and is copied onto the predecessor's revocation in the same atomic write. It is read off the intent, so a rotation whose spawn settles from the reconciler long after its request returned is still attributed. A malformed trigger normalizes to `null`, which reads as unknown provenance; "the operator did it" is never a safe reading of it.
- `src/lib/orchestrator/seatCommand.ts` — the rotation answer's `triggeredBy` is read off the seat the outcome carries, so an idempotent replay reports the actor that ORDERED the rotation. `executeOrchestratorSeatRequest` short-circuits a completed or still-pending intent and hands back the persisted seat; composing the answer from the request in front of it made the answer contradict the record. A refusal that recorded nothing still names the actor that asked, and there is no record for it to disagree with.
- `src/lib/orchestrator/seatCommand.ts` — `setSeatCommandDependenciesForTests` substitutes the seat command's spawn/deliver/summarize seams at the module. A Next route module takes no dependency argument, so this is how the regression drives the exported rotation route for real without starting a process or delivering to a live host.
- Read surfaces: the rotation answer and the `rotate_orchestrator` payload carry `triggeredBy`, and `get_orchestrator`'s lineage entries carry it per revocation. Records written before this exist read as `null`.
- The successor spawn still runs on the Viewer's own capability, as it always did; who triggered the designation travels on the seat record.

## Verification

Head `546a9637`, rebased onto `origin/main` (`f462d032`). Every gate below was run at that commit.

`bunx tsc --noEmit --incremental false` — clean.

`bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main)` — PASS, with and without the fingerprint catalog.

Test files run by path (never a directory sweep):

| File | Result |
| --- | --- |
| `src/lib/orchestrator/rotationAuthority.test.ts` (new) | 6 pass |
| `src/lib/orchestrator/seatCommand.test.ts` | 59 pass |
| `src/lib/orchestrator/seats.test.ts` | 26 pass |
| `src/lib/orchestrator/authority.test.ts` | 8 pass |
| `src/lib/mcp/orchestratorTools.test.ts` | 17 pass |
| `src/lib/mcp/bindings.test.ts` | 51 pass |
| `src/lib/mcp/server.test.ts` | 33 pass |
| `src/lib/mcp/toolAllowlist.test.ts` | 17 pass |
| `src/lib/mcp/managerAuthority.test.ts` | 6 pass |
| `src/app/api/orchestrator/seat/route.test.ts` | 3 pass |
| `src/app/api/orchestrator/seat/status/incumbent.test.ts` | 9 pass |
| `src/lib/agent/operatorAuthority.test.ts` | 10 pass |

### Both surfaces are driven at their public boundary

The regression addresses each surface where a caller actually meets it, so nothing about the claim rests on an internal function:

- **The tool** — an in-memory MCP client speaks the protocol to the real `createViewerMcpServer` registration, through the real tool service (its per-call policy and its receipt store) and the real bindings, which reach the Viewer over the production control transport. That is a genuine HTTP request.
- **The route** — a loopback listener serves the exported `POST /api/orchestrator/rotate` module, and both callers address it. The listener records what it received, so the seat's capability is asserted on the wire.
- **Isolation** — the seat command's spawn/deliver/summarize seams are substituted for the duration of a test, and every read and write lands in a private state directory. No process is started, no live host is written to, and the operator's registry is never touched.

What the cases assert:

- **The seat rotates itself through the tool, end to end.** One HTTP request reaches the rotation route carrying the seat's own capability — the thing that used to make the route refuse it — and the rotation completes: successor seated, predecessor revoked, both halves of the lineage carrying `{ kind: "agent", conversationId: <seat>, seatEpoch: 1 }`, on the answer and in the durable store.
- **A conversation holding no seat rotates too**, attributed with a null epoch: no role gate survives on this path.
- **Route and tool agree for the same actor.** The accept case runs the identical request through both surfaces, for a seat actor and an operator actor, against freshly seeded stores, and compares the answer, the recorded attribution, and the one route request each surface produced. The refuse case uses the rotation's own refusal (nothing designated → 409 `no_incumbent`): the tool's failure envelope carries the route's error verbatim, for the same actor the accept case rotates with.
- **A replay never rewrites the attribution.** One rotation by the seat, then the same idempotency key retried from a different conversation — through the route, and through a fresh MCP session whose receipts know nothing of the first call. One spawn, and the ordering seat named on both answers, on the successor's designation and on the predecessor's revocation.
- **The old ban is proven gone.** One case shows `requireOperatorAuthority` still refusing the exact request that the rotation route accepts, and the seat-route regression drives the real route modules: the request that the seat route answers 403 gets 409 `no_incumbent` from the rotation route with no seat state changed.

Mutation-checked twice at this head:

- reinstating the operator gate on the rotation seam turns **all six** cases red;
- refusing `rotate_orchestrator` in the MCP tool policy turns the **five tool-driven** cases red and leaves the pure route case green — which is how the protocol and policy layers are shown to be carrying the call.

One assertion changed meaning when the test moved to the real boundary: `replayed` on an MCP answer is the tool service's flag, whether that `clientRequestId` was already settled, and it shadows the binding's field for every tool exactly as it did before this branch. A replaying session holds no receipt, so it reads `false` while the rotation underneath it was replayed. The rotation's own replay flag is asserted on the route answer, and the single spawn plus the named successor carry the rest.

Note: `bunx eslint` cannot run in this checkout (`eslint-plugin-react` fails to load under ESLint 10 with `contextOrFilename.getFilename is not a function`). It fails identically on files this branch does not touch, which makes it a pre-existing environment issue; issue #1259 tracks it.

Fixes #1402
