### PR TITLE
feat(mobile): orchestrator controls reachable from a phone, and a legible rename editor (#1347, #1348)

### DIFF
--- a/evidence/issue-1347-1348/geometry.json
+++ b/evidence/issue-1347-1348/geometry.json
@@ -1,0 +1,376 @@
+{
+  "viewport": {
+    "width": 390,
+    "height": 844
+  },
+  "rename-editor": [
+    {
+      "scheme": "light",
+      "viewportWidth": 390,
+      "scrollWidth": 390,
+      "paneHeaderScrollWidth": 376,
+      "paneHeaderClientWidth": 376,
+      "editor": {
+        "label": "",
+        "left": 7,
+        "right": 383,
+        "top": 58,
+        "bottom": 110,
+        "width": 376,
+        "height": 52
+      },
+      "input": {
+        "label": "Session title",
+        "left": 15,
+        "right": 279,
+        "top": 62,
+        "bottom": 106,
+        "width": 264,
+        "height": 44
+      },
+      "inputValueLength": 115,
+      "inputScrollWidth": 852,
+      "inputClientWidth": 262,
+      "fontSizePx": 16,
+      "color": "rgb(28, 28, 34)",
+      "background": "rgb(243, 243, 246)",
+      "caretColor": "rgb(90, 81, 224)",
+      "controls": [
+        {
+          "label": "Save name",
+          "left": 283,
+          "right": 327,
+          "top": 62,
+          "bottom": 106,
+          "width": 44,
+          "height": 44
+        },
+        {
+          "label": "Cancel",
+          "left": 331,
+          "right": 375,
+          "top": 62,
+          "bottom": 106,
+          "width": 44,
+          "height": 44
+        }
+      ],
+      "contrast": 15.309473498862143
+    },
+    {
+      "scheme": "dark",
+      "viewportWidth": 390,
+      "scrollWidth": 390,
+      "paneHeaderScrollWidth": 376,
+      "paneHeaderClientWidth": 376,
+      "editor": {
+        "label": "",
+        "left": 7,
+        "right": 383,
+        "top": 58,
+        "bottom": 110,
+        "width": 376,
+        "height": 52
+      },
+      "input": {
+        "label": "Session title",
+        "left": 15,
+        "right": 279,
+        "top": 62,
+        "bottom": 106,
+        "width": 264,
+        "height": 44
+      },
+      "inputValueLength": 115,
+      "inputScrollWidth": 852,
+      "inputClientWidth": 262,
+      "fontSizePx": 16,
+      "color": "rgb(232, 232, 236)",
+      "background": "rgb(16, 16, 20)",
+      "caretColor": "rgb(143, 136, 255)",
+      "controls": [
+        {
+          "label": "Save name",
+          "left": 283,
+          "right": 327,
+          "top": 62,
+          "bottom": 106,
+          "width": 44,
+          "height": 44
+        },
+        {
+          "label": "Cancel",
+          "left": 331,
+          "right": 375,
+          "top": 62,
+          "bottom": 106,
+          "width": 44,
+          "height": 44
+        }
+      ],
+      "contrast": 15.534497752306052
+    }
+  ],
+  "orchestrator-controls": {
+    "row": [
+      {
+        "scheme": "light",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": null,
+        "rotateDraft": null
+      },
+      {
+        "scheme": "dark",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": null,
+        "rotateDraft": null
+      }
+    ],
+    "sheet": [
+      {
+        "scheme": "light",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": {
+          "rotate": {
+            "label": "Rotate",
+            "left": 12,
+            "right": 378,
+            "top": 229.5,
+            "bottom": 273.5,
+            "width": 366,
+            "height": 44
+          },
+          "identityText": "Claudeopus · highspare24%Replaced an earlier orchestrator",
+          "contextPercent": "24",
+          "predecessor": true,
+          "mandateView": true
+        },
+        "rotateDraft": null
+      },
+      {
+        "scheme": "dark",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": {
+          "rotate": {
+            "label": "Rotate",
+            "left": 12,
+            "right": 378,
+            "top": 229.5,
+            "bottom": 273.5,
+            "width": 366,
+            "height": 44
+          },
+          "identityText": "Claudeopus · highspare24%Replaced an earlier orchestrator",
+          "contextPercent": "24",
+          "predecessor": true,
+          "mandateView": true
+        },
+        "rotateDraft": null
+      }
+    ],
+    "rotate": [
+      {
+        "scheme": "light",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": {
+          "rotate": null,
+          "identityText": "",
+          "contextPercent": null,
+          "predecessor": false,
+          "mandateView": false
+        },
+        "rotateDraft": {
+          "confirm": {
+            "label": "Rotate orchestrator",
+            "left": 119.953125,
+            "right": 378,
+            "top": 790,
+            "bottom": 834,
+            "width": 258.046875,
+            "height": 44
+          },
+          "cancel": {
+            "label": "Keep this one",
+            "left": 12,
+            "right": 111.953125,
+            "top": 790,
+            "bottom": 834,
+            "width": 99.953125,
+            "height": 44
+          },
+          "mandate": {
+            "label": "You run the Atlas board. Talk to me here",
+            "left": 12,
+            "right": 378,
+            "top": 505,
+            "bottom": 748,
+            "width": 366,
+            "height": 243
+          },
+          "scrollerBottom": 779
+        }
+      },
+      {
+        "scheme": "dark",
+        "scrollWidth": 390,
+        "stripHeight": 53,
+        "rowOpen": {
+          "label": "Orchestrator opus — live. Opens its conversation.",
+          "left": 6,
+          "right": 86.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 80.359375,
+          "height": 44
+        },
+        "rowControls": {
+          "label": "Orchestrator controls: rotate, model, account and mandate",
+          "left": 90.359375,
+          "right": 134.359375,
+          "top": 4,
+          "bottom": 48,
+          "width": 44,
+          "height": 44
+        },
+        "firstChipLeft": 149.359375,
+        "sheet": {
+          "rotate": null,
+          "identityText": "",
+          "contextPercent": null,
+          "predecessor": false,
+          "mandateView": false
+        },
+        "rotateDraft": {
+          "confirm": {
+            "label": "Rotate orchestrator",
+            "left": 119.953125,
+            "right": 378,
+            "top": 790,
+            "bottom": 834,
+            "width": 258.046875,
+            "height": 44
+          },
+          "cancel": {
+            "label": "Keep this one",
+            "left": 12,
+            "right": 111.953125,
+            "top": 790,
+            "bottom": 834,
+            "width": 99.953125,
+            "height": 44
+          },
+          "mandate": {
+            "label": "You run the Atlas board. Talk to me here",
+            "left": 12,
+            "right": 378,
+            "top": 505,
+            "bottom": 748,
+            "width": 366,
+            "height": 243
+          },
+          "scrollerBottom": 779
+        }
+      }
+    ]
+  }
+}

--- a/scripts/capture-issue-979-mobile-orchestrator.ts
+++ b/scripts/capture-issue-979-mobile-orchestrator.ts
@@ -20,6 +20,12 @@
  * Every shot also CHECKS what it is showing: the row keeps its 44px target and
  * sits left of the first conversation chip, the phone never grows a horizontal
  * scrollbar (#353), and the sheet's confirm control stays inside the viewport.
+ *
+ * Issue #1347 adds the seat's CONTROLS to the same run: a live row's second
+ * target (the controls entry point, measured like the row's own), the sheet it
+ * opens with Rotate inside the viewport, and the rotate draft — which carries
+ * the mandate textarea, so it is measured with the keyboard open exactly as
+ * the create draft is.
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
@@ -165,9 +171,11 @@ async function checkPhoneGeometry(page: Page, state: string): Promise<{ row: num
   const geometry = await page.evaluate(() => {
     const row = document.querySelector("[data-orchestrator-row]");
     const button = document.querySelector("[data-orchestrator-row-open]");
+    const controls = document.querySelector("[data-orchestrator-row-controls]");
     const chip = document.querySelector(".overflow-x-auto button");
     const rowRect = row?.getBoundingClientRect();
     const chipRect = chip?.getBoundingClientRect();
+    const controlsRect = controls?.getBoundingClientRect();
     const stripRect = row?.parentElement?.getBoundingClientRect();
     return {
       row: rowRect ? Math.round(rowRect.height) : 0,
@@ -176,11 +184,22 @@ async function checkPhoneGeometry(page: Page, state: string): Promise<{ row: num
       chipLeft: chipRect ? Math.round(chipRect.left) : Number.POSITIVE_INFINITY,
       strip: stripRect ? Math.round(stripRect.height) : 0,
       button: button ? Math.round(button.getBoundingClientRect().height) : 0,
+      controls: controlsRect ? { height: Math.round(controlsRect.height), width: Math.round(controlsRect.width), left: Math.round(controlsRect.left), right: Math.round(controlsRect.right) } : null,
       scrollWidth: document.documentElement.scrollWidth,
       innerWidth: window.innerWidth,
     };
   });
   if (geometry.button < 44) throw new Error(`${state}: the row's tap target is ${geometry.button}px, under the 44px floor`);
+  /* The seat's controls (#1347): a live row's second target is held to the
+     same bar as its first — a phone target, inside the viewport, in the pinned
+     slot ahead of the scrolling chips. */
+  if (geometry.controls) {
+    if (geometry.controls.height < 44 || geometry.controls.width < 44) {
+      throw new Error(`${state}: the controls entry point is ${geometry.controls.width}×${geometry.controls.height}px, under the 44px floor`);
+    }
+    if (geometry.controls.right > geometry.innerWidth) throw new Error(`${state}: the controls entry point ends at ${geometry.controls.right}px, past the ${geometry.innerWidth}px viewport`);
+    if (geometry.controls.left >= geometry.chipLeft) throw new Error(`${state}: the controls entry point starts at ${geometry.controls.left}px, not before the first chip at ${geometry.chipLeft}px`);
+  }
   /* «Before the first chip» means nothing without a chip to be before: a strip
      that rendered none would otherwise pass this check by default. */
   if (geometry.chips === 0) throw new Error(`${state}: the strip drew no conversation chips, so the pin's position proves nothing`);
@@ -195,6 +214,29 @@ async function checkPhoneGeometry(page: Page, state: string): Promise<{ row: num
      sideways — only the chip strip inside it does. */
   if (geometry.scrollWidth > geometry.innerWidth) throw new Error(`${state}: the document scrolls to ${geometry.scrollWidth}px at ${geometry.innerWidth}px`);
   return { row: geometry.row, strip: geometry.strip, button: geometry.button };
+}
+
+/** Rotate on the live sheet (#1347): a phone target, inside the viewport. */
+async function checkRotateReach(page: Page, state: string): Promise<void> {
+  const reach = await page.evaluate(() => {
+    const rotate = document.querySelector("[data-orchestrator-rotate]");
+    const rect = rotate?.getBoundingClientRect();
+    return {
+      present: Boolean(rotate),
+      height: rect ? Math.round(rect.height) : 0,
+      right: rect ? Math.round(rect.right) : 0,
+      bottom: rect ? Math.round(rect.bottom) : 0,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      identity: Boolean(document.querySelector("[data-orchestrator-incumbent]")),
+    };
+  });
+  if (!reach.present) throw new Error(`${state}: the live sheet offers no Rotate control`);
+  if (!reach.identity) throw new Error(`${state}: the live sheet does not name the incumbent`);
+  if (reach.height < 44) throw new Error(`${state}: Rotate is ${reach.height}px tall`);
+  if (reach.right > reach.viewportWidth || reach.bottom > reach.viewportHeight) {
+    throw new Error(`${state}: Rotate ends at ${reach.right}×${reach.bottom}px, outside the ${reach.viewportWidth}×${reach.viewportHeight}px viewport`);
+  }
 }
 
 async function checkSheetReach(page: Page, state: string): Promise<void> {
@@ -319,7 +361,17 @@ async function main(): Promise<void> {
     const hosted = { proc: "running", pid: 4_979 };
     const overLimit = { ctx: { usedTokens: 142_000, windowTokens: 200_000, pct: 71, source: "transcript", confidence: "reported", observedAt: "2100-01-02T11:59:00.000Z" } };
     const failedIntent = { clientRequestId: "seatreq-000003", mode: "spawn", launchId: null, error: "orchestrator cwd could not be resolved — pass cwd explicitly or set LLV_ORCHESTRATOR_CWD" };
-    const states: { id: string; answer: SeatAnswer; patch?: Record<string, unknown>; open?: "row" | "marker"; edit?: boolean }[] = [
+    /* `GET /api/orchestrator/seat/status` for the live states: the incumbent
+       the sheet names and the rotate draft prefills from (#1347). */
+    const incumbent = {
+      project: "atlas", designated: true, conversationId: "conversation_atlas_orchestrator", predecessorConversationId: "conversation_atlas_predecessor",
+      engine: "claude", model: "opus", effort: "high", accountId: null, cwd: REPO_DIR, transcriptPath,
+      liveness: { lifecycle: "running", hostState: "alive", silentForMs: 0 },
+      context: { tokens: 24_000, limit: 100_000, percent: 24, estimated: false, basis: "provider-reported usage" },
+      transcriptFacts: { bytes: 4_096, messageCount: 12, toolCount: 3, compactionCount: 0 },
+      rotation: { recommended: false, level: "none", reasons: [], thresholdUnknown: false },
+    };
+    const states: { id: string; answer: SeatAnswer; patch?: Record<string, unknown>; open?: "row" | "marker" | "controls"; edit?: boolean; rotate?: boolean }[] = [
       { id: "row-draft", answer: { seat: null, pending: null, exists: true } },
       { id: "sheet-draft", answer: { seat: null, pending: null, exists: true }, open: "row" },
       { id: "sheet-draft-edited", answer: { seat: null, pending: null, exists: true }, open: "row", edit: true },
@@ -335,6 +387,9 @@ async function main(): Promise<void> {
       { id: "row-intent-error", answer: { seat: null, pending: seat(transcriptPath, { conversationId: null, state: "pending", activatedAt: null, intent: failedIntent }), exists: true } },
       { id: "sheet-intent-error", answer: { seat: null, pending: seat(transcriptPath, { conversationId: null, state: "pending", activatedAt: null, intent: failedIntent }), exists: true }, open: "row" },
       { id: "row-live", answer: { seat: seat(transcriptPath), pending: null, exists: true }, patch: hosted },
+      /* #1347: the seat's controls, from the row's second target. */
+      { id: "sheet-live-controls", answer: { seat: seat(transcriptPath), pending: null, exists: true }, patch: hosted, open: "controls" },
+      { id: "sheet-rotate", answer: { seat: seat(transcriptPath), pending: null, exists: true }, patch: hosted, open: "controls", rotate: true },
       { id: "row-live-resumable", answer: { seat: seat(transcriptPath), pending: null, exists: true } },
       { id: "row-live-rotation", answer: { seat: seat(transcriptPath), pending: null, exists: true }, patch: { ...hosted, ...overLimit } },
       {
@@ -364,6 +419,8 @@ async function main(): Promise<void> {
         const page: Page = await context.newPage();
         await page.route("**/api/orchestrator/seat*", (route) =>
           route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(state.answer) }));
+        await page.route("**/api/orchestrator/seat/status*", (route) =>
+          route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(incumbent) }));
         if (state.patch) {
           const patch = state.patch;
           await page.route("**/api/files*", async (route) => {
@@ -380,8 +437,22 @@ async function main(): Promise<void> {
         const rowState = await page.getAttribute("[data-orchestrator-row]", "data-orchestrator-row-state");
         const geometry = await checkPhoneGeometry(page, `${state.id}/${scheme}`);
         if (state.open) {
-          await page.click(state.open === "marker" ? "[data-orchestrator-row-transition-open]" : "[data-orchestrator-row-open]");
+          await page.click(
+            state.open === "marker"
+              ? "[data-orchestrator-row-transition-open]"
+              : state.open === "controls"
+                ? "[data-orchestrator-row-controls]"
+                : "[data-orchestrator-row-open]",
+          );
           await page.waitForSelector('[data-testid="mobile-orchestrator-sheet"]', { timeout: 10_000 });
+          if (state.open === "controls") {
+            await page.waitForSelector("[data-orchestrator-rotate]", { timeout: 10_000 });
+            await checkRotateReach(page, `${state.id}/${scheme}`);
+          }
+          if (state.rotate) {
+            await page.click("[data-orchestrator-rotate]");
+            await page.waitForSelector('[data-orchestrator-draft="rotate"]', { timeout: 10_000 });
+          }
           if (state.edit) {
             await page.fill("[data-orchestrator-mandate]", "You are the Atlas orchestrator.\n\nYou own this board and you talk to me here, directly, whenever you have something worth saying.\n\n## What you do\n- one lane per issue, one owner per file\n- a fresh reviewer every round\n- merge only on APPROVE with green gates\n- never deploy red");
           }

--- a/src/components/mobile/MobileOrchestratorRow.tsx
+++ b/src/components/mobile/MobileOrchestratorRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bot, LoaderCircle, RotateCw, TriangleAlert } from "lucide-react";
+import { Bot, LoaderCircle, RotateCw, SlidersHorizontal, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { applySpawnedConversationSnapshot } from "@/hooks/useFiles";
@@ -25,11 +25,29 @@ import {
   seatRequestSettled,
   type SeatSubmitFailure,
 } from "../orchestrator/seatState";
+import { useOrchestratorIncumbent } from "../orchestrator/useOrchestratorIncumbent";
 import { useOrchestratorSeat } from "../orchestrator/useOrchestratorSeat";
+import { useSeatConfirm } from "../orchestrator/useSeatConfirm";
 import { useSeatSurface } from "../orchestrator/useSeatSurface";
-import { MobileOrchestratorSheet, type SeatConfirmPayload } from "./MobileOrchestratorSheet";
-import { readSeatDraftField, writeSeatDraftField } from "./orchestratorDraftStorage";
+import { MobileOrchestratorSheet, type SeatConfirmPayload, type SeatRotateFlow } from "./MobileOrchestratorSheet";
+import { readSeatDraftField, seatFlowStorage, writeSeatDraftField } from "./orchestratorDraftStorage";
 import { ROW_STATE_LABEL, ROW_TONE, orchestratorRowView } from "./orchestratorRowState";
+
+/**
+ * Why the sheet is open. `handoff` arms the landing: the sheet was opened to
+ * CHANGE which conversation holds the seat — the create flow, or a rotation —
+ * so when a seat other than `from` goes live the phone lands IN that
+ * conversation instead of leaving the operator on a sheet about it. A sheet
+ * opened deliberately on a live seat to read it, or to reach its controls, is
+ * not armed.
+ */
+interface SheetOpening {
+  handoff: boolean;
+  /** The conversation the armed handoff is replacing: null for a create (any
+      live seat lands), the incumbent's id for a rotation (only the successor
+      lands — the incumbent stays live for the whole draft). */
+  from: string | null;
+}
 
 /**
  * The phone's pinned orchestrator row (PRD #976 slice C, issue #979).
@@ -54,12 +72,22 @@ import { ROW_STATE_LABEL, ROW_TONE, orchestratorRowView } from "./orchestratorRo
  *    that can act on it: create, resume a stuck designation, read a terminal
  *    error, re-read an unavailable seat.
  *
- * Confirm goes to `POST /api/orchestrator/seat`, never to raw `/api/spawn`,
- * and carries ONE `clientRequestId` per submission — minted on the first
- * confirm, persisted under the same key the desktop dock uses, replayed by a
- * retry, and released only once the seat read says where it landed. A phone
- * drops its connection mid-POST far more often than a desktop does, so this is
- * the path that decides whether a lost reply costs a second orchestrator.
+ * A live seat gets a SECOND target beside the chip (issue #1347): its controls.
+ * The desktop dock carries them in the incumbent header — who holds the seat,
+ * Rotate, and the draft that adjusts the seat's settings — and the phone had
+ * none of it: the row's tap opened the chat and nothing else, so an operator
+ * on a phone could not find where rotation lived. The controls open the same
+ * sheet on its live view; nothing there is a long-press, a menu, or an overflow
+ * that touch never reveals.
+ *
+ * Confirm goes to `POST /api/orchestrator/seat`, rotation to `POST
+ * /api/orchestrator/rotate` (`../orchestrator/useSeatConfirm`, the dock's own
+ * discipline), never to raw `/api/spawn` — and each carries ONE
+ * `clientRequestId` per submission: minted on the first confirm, persisted
+ * under the same keys the desktop dock uses, replayed by a retry, and released
+ * only once the seat read says where it landed. A phone drops its connection
+ * mid-POST far more often than a desktop does, so this is the path that decides
+ * whether a lost reply costs a second orchestrator.
  */
 export function MobileOrchestratorRow({
   project,
@@ -85,24 +113,73 @@ export function MobileOrchestratorRow({
      perfectly good create. */
   const inFlight = useRef(false);
   const [submitFailure, setSubmitFailure] = useState<SeatSubmitFailure | null>(null);
-  /* `handoff` marks a sheet opened on a state that has no conversation yet: it
-     is the create flow, so when the seat goes live the phone lands IN the
-     conversation instead of leaving the operator on a sheet about it. A sheet
-     opened deliberately on a live seat (the transition marker) is not armed. */
-  const [sheet, setSheet] = useState<{ handoff: boolean } | null>(null);
+  const [sheet, setSheet] = useState<SheetOpening | null>(null);
+  /* The conversation the open rotate draft is replacing. Non-null IS the rotate
+     mode, and matching it against the current seat is what closes the draft the
+     moment the successor lands — no completion callback, no stale flag. */
+  const [rotateFrom, setRotateFrom] = useState<string | null>(null);
+  /* Opening the rotate draft is a read first: see `openRotate`. */
+  const [rotateOpening, setRotateOpening] = useState(false);
 
   const seatConversationId = status?.seat?.conversationId ?? null;
+  const seated = Boolean(seatConversationId && status?.exists);
+  /* The incumbent's wear and parameters are a question only while the sheet
+     is showing them or a rotate draft is about to prefill from them: the row
+     itself carries the board's own reading, so a phone that never opens the
+     sheet never pays for the slower status poll. */
+  const { incumbent: read, refresh: refreshIncumbent } = useOrchestratorIncumbent(project, seated && sheet !== null);
+  /* A reading is only about the conversation it names: right after a rotation
+     the seat has already advanced to the successor while this slower poll still
+     describes the predecessor. */
+  const incumbent = read && read.conversationId === seatConversationId ? read : null;
+  const currentPath = incumbent?.transcriptPath ?? null;
+  const seatPath = status?.seat?.path ?? null;
   const file = useMemo(
     () => (seatConversationId
       ? files.find((entry) => entry.conversationId === seatConversationId)
-        ?? files.find((entry) => entry.path === status?.seat?.path)
+        /* The registry's current generation for the id (#1182), then the path
+           the seat recorded at activation, as hints of decreasing freshness. */
+        ?? files.find((entry) => currentPath !== null && entry.path === currentPath)
+        ?? files.find((entry) => entry.path === seatPath)
         ?? null
       : null),
-    [files, seatConversationId, status?.seat?.path],
+    [files, seatConversationId, currentPath, seatPath],
   );
   const surface = useSeatSurface(file);
-  const state = deriveOrchestratorPanelState({ status, statusFailed: failed, submitting, submitFailure, file, surface });
+
+  /* The rotate flow, on the dock's own Rotate keys: a rotation half-written on
+     one surface continues — and replays the same durable intent — on the other. */
+  const rotateStorage = useMemo(() => seatFlowStorage("Rotate", project), [project]);
+  const rotate = useSeatConfirm({ url: "/api/orchestrator/rotate", project, storage: rotateStorage, field: "requestId", status, refresh });
+
+  const state = deriveOrchestratorPanelState({
+    status,
+    statusFailed: failed,
+    /* Only one of the two flows can be in play — the create draft exists only
+       without a seat, the rotate draft only with one — so their outcomes fold
+       into the one derivation without ever masking each other. */
+    submitting: submitting || rotate.submitting,
+    submitFailure: submitFailure ?? rotate.failure,
+    file,
+    surface,
+    incumbent,
+  });
   const view = orchestratorRowView(state, { conversationReady: Boolean(file) });
+
+  /* A rotation whose outcome is not yet settled KEEPS the draft, even after the
+     incumbent's card is closed underneath it — its retained key is reachable
+     only from this flow. Settled, the draft gives way: to the successor's live
+     view, or to the create draft over a real vacancy. */
+  const rotateUnsettled = rotate.submitting
+    || (rotate.failure !== null && !seatRequestSettled(status, rotate.failure.clientRequestId));
+  const rotatingLive = state.kind === "live" && rotateFrom !== null && rotateFrom === state.conversationId;
+  const rotatingVacant = state.kind !== "live" && rotateFrom !== null && rotateUnsettled && status?.seat != null;
+  const rotating = rotatingLive || rotatingVacant;
+  useEffect(() => {
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- the draft closes itself when the seat it was replacing is no longer the seat */
+    if (rotateFrom !== null && !rotating) setRotateFrom(null);
+  }, [rotateFrom, rotating]);
+
   /* A key kept through an unknown outcome is released the moment the seat read
      says where it landed. Held any longer it becomes a trap: the seat command
      answers a replay of a COMPLETED intent with the old seat, so the next
@@ -215,32 +292,76 @@ export function MobileOrchestratorRow({
     if (file) onOpenConversation(file);
   }, [file, onOpenConversation]);
 
-  /* The create flow's landing: the seat this sheet was opened to create now has
-     a conversation, so the phone goes there. */
+  /**
+   * Open the rotate draft — on the incumbent's OWN parameters.
+   *
+   * «The same draft, prefilled» is true only if those parameters are in hand
+   * when the form MOUNTS: the shared launch module reads its defaults once, in
+   * its initializers, so a draft opened before the status read answered would
+   * prefill the generic orchestrator defaults and never correct itself. So the
+   * read comes first and the button says it is working.
+   */
+  const openRotate = useCallback(async () => {
+    const from = status?.seat?.conversationId ?? null;
+    if (!from) return;
+    setRotateOpening(true);
+    try {
+      await refreshIncumbent();
+    } finally {
+      setRotateOpening(false);
+      setRotateFrom(from);
+    }
+  }, [status?.seat?.conversationId, refreshIncumbent]);
+
+  const rotateFlow: SeatRotateFlow = {
+    open: rotating,
+    seat: rotatingLive && state.kind === "live" ? state.seat : rotatingVacant ? status?.seat ?? null : null,
+    vacated: rotatingVacant,
+    opening: rotateOpening,
+    submitting: rotate.submitting,
+    failure: rotate.failure,
+    onOpen: () => void openRotate(),
+    onCancel: () => {
+      setRotateFrom(null);
+      setSheet({ handoff: false, from: null });
+    },
+    onConfirm: (input) => {
+      /* Arm the landing on the SUCCESSOR: the incumbent stays live under the
+         draft for as long as the rotation takes, and must not be what lands. */
+      setSheet({ handoff: true, from: rotateFrom });
+      void rotate.submit(input);
+    },
+  };
+
+  /* The landing: the seat this sheet was opened to change now holds a
+     conversation other than the one it was replacing, so the phone goes there. */
+  const liveConversationId = state.kind === "live" ? state.conversationId : null;
   useEffect(() => {
-    if (!sheet?.handoff || state.kind !== "live" || !file) return;
-    /* eslint-disable-next-line react-hooks/set-state-in-effect -- the handoff out of the create sheet, once per created seat */
+    if (!sheet?.handoff || liveConversationId === null || !file) return;
+    if (sheet.from !== null && sheet.from === liveConversationId) return;
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- the handoff out of the sheet, once per created or rotated seat */
     setSheet(null);
+    setRotateFrom(null);
     onOpenConversation(file);
-  }, [sheet, state.kind, file, onOpenConversation]);
+  }, [sheet, liveConversationId, file, onOpenConversation]);
 
   const tone = ROW_TONE[view.state];
   const stateWord = t(ROW_STATE_LABEL[view.state]);
-  const incumbent = file?.model?.trim() || (file ? engineBadge(file).label : "");
+  const incumbentLabel = file?.model?.trim() || (file ? engineBadge(file).label : "");
   /* A healthy seat says who it is and lets the dot carry «fine»; anything else
      spells the state out in words beside it — colour is never the only carrier. */
   const label = view.state === "draft"
     ? t("orchMobile.create")
-    : !incumbent
+    : !incumbentLabel
       ? stateWord
       : view.state === "live"
-        ? incumbent
-        : `${incumbent} · ${stateWord}`;
+        ? incumbentLabel
+        : `${incumbentLabel} · ${stateWord}`;
   const rowAria = [
     view.state === "draft"
       ? t("orchMobile.rowCreateAria")
       : view.tap === "conversation"
-        ? t("orchMobile.rowLiveAria", { model: incumbent || t("orchPanel.title"), state: stateWord })
+        ? t("orchMobile.rowLiveAria", { model: incumbentLabel || t("orchPanel.title"), state: stateWord })
         : t("orchMobile.rowStatusAria", { state: stateWord }),
     view.rotation ? t(view.rotation === "strongly_recommend" ? "orchPanel.rotationStrong" : "orchPanel.rotation") : "",
   ].filter(Boolean).join(" · ");
@@ -262,7 +383,7 @@ export function MobileOrchestratorRow({
             openConversation();
             return;
           }
-          setSheet({ handoff: state.kind !== "live" });
+          setSheet({ handoff: state.kind !== "live", from: null });
         }}
         aria-label={rowAria}
         title={rowAria}
@@ -276,6 +397,22 @@ export function MobileOrchestratorRow({
         )}
         {view.rotation ? <RotateCw className="h-3.5 w-3.5 shrink-0 text-warning" aria-hidden /> : null}
       </button>
+      {/* The seat's controls (issue #1347): visible beside the chip whenever the
+          chip's own tap is the conversation, so the one row that opens the
+          chat also shows where rotation and the seat's settings live. */}
+      {view.tap === "conversation" ? (
+        <button
+          type="button"
+          data-orchestrator-row-controls
+          onClick={() => setSheet({ handoff: false, from: null })}
+          aria-haspopup="dialog"
+          aria-label={t("orchMobile.controlsAria")}
+          title={t("orchMobile.controlsAria")}
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-control border border-border bg-canvas text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <SlidersHorizontal className="h-4 w-4" aria-hidden />
+        </button>
+      ) : null}
       {/* A designation riding ALONGSIDE the incumbent gets its own control: the
           row's tap still opens the chat, because a failed rotation must never be
           the thing that takes the conversation away. */}
@@ -283,7 +420,7 @@ export function MobileOrchestratorRow({
         <button
           type="button"
           data-orchestrator-row-transition-open
-          onClick={() => setSheet({ handoff: false })}
+          onClick={() => setSheet({ handoff: false, from: null })}
           aria-haspopup="dialog"
           aria-label={t(view.transition === "error" ? "orchMobile.transitionAria" : "orchMobile.pendingAria")}
           title={t(view.transition === "error" ? "orchMobile.transitionAria" : "orchMobile.pendingAria")}
@@ -301,10 +438,13 @@ export function MobileOrchestratorRow({
           projectName={projectName}
           projectCwd={projectCwd || undefined}
           state={state}
+          status={status}
           file={file}
+          incumbent={incumbent}
           pendingMandate={status?.pending?.mandate ?? ""}
           viewerMcpRegistered={status?.viewerMcpRegistered === true}
           submitting={submitting}
+          rotate={rotateFlow}
           onConfirm={(payload) => void confirm(payload)}
           onRecheck={() => void refresh()}
           onOpenConversation={() => {

--- a/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
@@ -72,10 +72,13 @@ function quietBannerCount(file: FileEntry): number {
       project="atlas"
       projectName="Atlas"
       state={state}
+      status={{ seat, pending: null, exists: true, viewerMcpRegistered: false }}
       file={file}
+      incumbent={null}
       pendingMandate=""
       viewerMcpRegistered={false}
       submitting={false}
+      rotate={{ open: false, seat: null, vacated: false, opening: false, submitting: false, failure: null, onOpen: () => undefined, onCancel: () => undefined, onConfirm: () => undefined }}
       onConfirm={() => undefined}
       onRecheck={() => undefined}
       onOpenConversation={() => undefined}

--- a/src/components/mobile/MobileOrchestratorSheet.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.tsx
@@ -1,19 +1,38 @@
 "use client";
 
-import { Bot, LoaderCircle, RotateCcw, TriangleAlert } from "lucide-react";
+import { Bot, CornerDownRight, LoaderCircle, RefreshCw, RotateCcw, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { X } from "@/components/icons";
-import { AgentLaunchControls, useAgentLaunchDraft, type LaunchEngine, type SpeedChoice } from "@/components/draft/AgentLaunchControls";
+import {
+  AgentLaunchControls,
+  useAgentLaunchDraft,
+  type LaunchAccountCatalog,
+  type LaunchEngine,
+  type SpeedChoice,
+} from "@/components/draft/AgentLaunchControls";
 import { useModalLayer } from "@/components/modalLayer";
+import { Badge } from "@/components/ui/Badge";
 import { useKeyboardInset } from "@/hooks/useComposer";
-import { engineBadge } from "@/components/utils";
+import { engineBadgeFor } from "@/components/utils";
 import { useLocale, type MessageKey } from "@/lib/i18n";
 import { ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
+import type { OrchestratorSeat } from "@/lib/orchestrator/seats";
 import type { FileEntry } from "@/lib/types";
 
-import { orchestratorQuietBannerEligible, type OrchestratorPanelState, type RotationHint, type SeatTransition } from "../orchestrator/seatState";
-import { readSeatDraftField, writeSeatDraftField } from "./orchestratorDraftStorage";
+import { boardContext, ContextMeter } from "../orchestrator/IncumbentHeader";
+import type { OrchestratorIncumbent } from "../orchestrator/incumbent";
+import {
+  deriveRotateDraftState,
+  orchestratorQuietBannerEligible,
+  type OrchestratorPanelState,
+  type OrchestratorSeatStatus,
+  type RotationHint,
+  type SeatSubmitFailure,
+  type SeatTransition,
+} from "../orchestrator/seatState";
+import type { SeatConfirmLaunch } from "../orchestrator/useSeatConfirm";
+import { readSeatDraftField, readSeatFlowField, writeSeatDraftField, writeSeatFlowField } from "./orchestratorDraftStorage";
 import { ROW_STATE_LABEL, ROW_TONE, orchestratorRowView } from "./orchestratorRowState";
 
 /** Everything one confirm carries. The row owns the POST — and with it the one
@@ -33,8 +52,34 @@ export interface SeatConfirmPayload {
 }
 
 /**
- * The phone's orchestrator sheet (PRD #976 slice C): the create draft, and
- * every seat state that is not «a conversation you can open».
+ * The rotate flow as the sheet sees it (issue #1347). The row owns the state —
+ * the durable confirm on `POST /api/orchestrator/rotate`, the incumbent read
+ * the draft prefills from, and which conversation the open draft is replacing
+ * — and the sheet renders it, exactly as the dock's panel does for the desktop.
+ */
+export interface SeatRotateFlow {
+  /** The rotate draft is showing, over the live view. */
+  open: boolean;
+  /** The seat the draft replaces: the live one, or — after its conversation was
+      closed while the rotation was still in the air — the vacated record the
+      rotation is still settling against. Null when nothing is being rotated. */
+  seat: OrchestratorSeat | null;
+  /** The seat's conversation was closed while this rotation is in flight. */
+  vacated: boolean;
+  /** The press landed and the incumbent's own parameters are being re-read, so
+      the draft opens PREFILLED rather than on the generic defaults. */
+  opening: boolean;
+  submitting: boolean;
+  failure: SeatSubmitFailure | null;
+  onOpen: () => void;
+  onCancel: () => void;
+  onConfirm: (input: { body: Record<string, unknown>; launch: SeatConfirmLaunch }) => void;
+}
+
+/**
+ * The phone's orchestrator sheet (PRD #976 slice C): the create draft, every
+ * seat state that is not «a conversation you can open» — and, since #1347, the
+ * seat's CONTROLS for the state that is.
  *
  * It is the same draft as the desktop dock — the shared launch module
  * (`useAgentLaunchDraft` + `AgentLaunchControls`), the same default mandate in
@@ -42,6 +87,15 @@ export interface SeatConfirmPayload {
  * rendered as a fullscreen sheet in the pattern this codebase already uses for
  * one (`TaskSheet`, the focus view's map): `fixed inset-0`, its own header row,
  * one scrolling body, one primary action parked at the thumb.
+ *
+ * On a live seat it is what the dock's incumbent header is on the desktop: who
+ * holds the seat (engine, model at tier, account, context fullness), the
+ * lineage it replaced, the mandate it runs under, and the one control that
+ * acts on it — Rotate, which opens the SAME draft prefilled from the incumbent
+ * (engine, model, reasoning, account, mandate) over the seat it would replace,
+ * with its own two-way footer: keep this one, or rotate. The operator asked for
+ * these from a phone and could not find them (#1347): the row's tap opened the
+ * conversation and nothing else. Nothing here rotates on its own.
  *
  * It never mounts a conversation. A seat that goes live while this is open
  * hands off to `MobileFocusView` (the row closes the sheet and pins the pane),
@@ -52,17 +106,21 @@ export interface SeatConfirmPayload {
  * on-screen keyboard is exactly the case #983 repaired for the focus root — so
  * the sheet budgets against the SAME `useKeyboardInset` signal rather than
  * measuring the viewport a second way. The footer action stays above the
- * keyboard, and the body scrolls under it.
+ * keyboard, and the body scrolls under it. Both safe-area insets are padded:
+ * the header's controls clear the notch, the footer clears the home indicator.
  */
 export function MobileOrchestratorSheet({
   project,
   projectName,
   projectCwd,
   state,
+  status,
   file,
+  incumbent,
   pendingMandate,
   viewerMcpRegistered,
   submitting,
+  rotate,
   onConfirm,
   onRecheck,
   onOpenConversation,
@@ -72,13 +130,19 @@ export function MobileOrchestratorSheet({
   projectName: string;
   projectCwd?: string;
   state: OrchestratorPanelState;
+  /** The seat read itself, for the rotate draft's own error state. */
+  status: OrchestratorSeatStatus | null;
   /** The seat conversation as the files feed knows it, when it does. */
   file: FileEntry | null;
+  /** The status read for the CURRENT seat, once it has answered; null keeps
+      the identity on what the board itself knows about the conversation. */
+  incumbent: OrchestratorIncumbent | null;
   /** The pending intent's own mandate, replayed verbatim when a stuck
       designation is resumed. */
   pendingMandate: string;
   viewerMcpRegistered: boolean;
   submitting: boolean;
+  rotate: SeatRotateFlow;
   onConfirm: (payload: SeatConfirmPayload) => void;
   onRecheck: () => void;
   onOpenConversation: () => void;
@@ -87,9 +151,6 @@ export function MobileOrchestratorSheet({
   const { t } = useLocale();
   const kbInset = useKeyboardInset();
   const sheetRef = useRef<HTMLFormElement>(null);
-  const mandateBlockRef = useRef<HTMLDivElement>(null);
-  const revealedRef = useRef(false);
-  const [mandateFocused, setMandateFocused] = useState(false);
   const [mandate, setMandateState] = useState(() => readSeatDraftField(project, "mandate") || ORCHESTRATOR_SYSTEM_PROMPT);
   const [formError, setFormError] = useState<string | null>(null);
   const launch = useAgentLaunchDraft({
@@ -106,27 +167,6 @@ export function MobileOrchestratorSheet({
      trapped, Escape closes, body scroll locked, focus back to the row. */
   useModalLayer({ containerRef: sheetRef, onClose });
 
-  /* The keyboard costs the body scroller most of its height, and everything
-     above the mandate — an intent error's card, then engine/account/reasoning —
-     can fill what is left, leaving the operator typing into a field below the
-     scroller's own fold (#1004). So the field is brought to the top of the
-     scroller once the keyboard is actually up: the block, not the textarea, so
-     its label comes along.
-     Both orders arrive here — focus first and the keyboard after (a tap), or
-     the keyboard already up (focus moving in from another field) — because the
-     condition is the state, not either event. It fires ONCE per typing session:
-     after that the scroller is the operator's, and a keyboard that resizes
-     under them never yanks it back. */
-  useEffect(() => {
-    if (!mandateFocused || kbInset <= 0) {
-      revealedRef.current = false;
-      return;
-    }
-    if (revealedRef.current) return;
-    revealedRef.current = true;
-    mandateBlockRef.current?.scrollIntoView({ block: "start" });
-  }, [mandateFocused, kbInset]);
-
   const setMandate = (value: string) => {
     setMandateState(value);
     /* Stored only while it differs from the default, so an untouched draft
@@ -136,6 +176,8 @@ export function MobileOrchestratorSheet({
 
   const view = orchestratorRowView(state, { conversationReady: Boolean(file) });
   const drafting = state.kind === "draft" || state.kind === "intent-error";
+  const rotating = rotate.open && rotate.seat !== null;
+  const mode = rotating ? "rotate" : state.kind === "live" ? "live" : "create";
   const params = {
     engine: launch.engine,
     model: launch.model,
@@ -156,26 +198,30 @@ export function MobileOrchestratorSheet({
 
   /* ONE primary action, parked at the thumb, whatever the state is. A sheet
      that can be opened on six different states and offers a way forward on
-     only one of them is the dead end the panel's own design refuses. */
-  const primary: { key: MessageKey; run: () => void; busy: boolean } | null = drafting
-    ? { key: state.kind === "intent-error" ? "orchPanel.confirmRetry" : "orchPanel.confirm", run: submitDraft, busy: submitting }
-    : state.kind === "creating"
-      ? (!submitting && state.clientRequestId
-        ? {
-            key: "orchPanel.creatingResume",
-            run: () => onConfirm({ ...params, mandate: pendingMandate || ORCHESTRATOR_SYSTEM_PROMPT, replayRequestId: state.clientRequestId }),
-            busy: false,
-          }
-        : null)
-      : state.kind === "unavailable"
-        ? { key: "orchPanel.recheck", run: onRecheck, busy: false }
-        : state.kind === "live" && file
-          ? { key: "orchMobile.open", run: onOpenConversation, busy: false }
-          : null;
+     only one of them is the dead end the panel's own design refuses. The rotate
+     draft brings its own footer — two ways out, keep or rotate — so it takes
+     the slot over. */
+  const primary: { key: MessageKey; run: () => void; busy: boolean } | null = rotating
+    ? null
+    : drafting
+      ? { key: state.kind === "intent-error" ? "orchPanel.confirmRetry" : "orchPanel.confirm", run: submitDraft, busy: submitting }
+      : state.kind === "creating"
+        ? (!submitting && state.clientRequestId
+          ? {
+              key: "orchPanel.creatingResume",
+              run: () => onConfirm({ ...params, mandate: pendingMandate || ORCHESTRATOR_SYSTEM_PROMPT, replayRequestId: state.clientRequestId }),
+              busy: false,
+            }
+          : null)
+        : state.kind === "unavailable"
+          ? { key: "orchPanel.recheck", run: onRecheck, busy: false }
+          : state.kind === "live" && file
+            ? { key: "orchMobile.open", run: onOpenConversation, busy: false }
+            : null;
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex flex-col bg-canvas pb-[env(safe-area-inset-bottom)]"
+      className="fixed inset-0 z-[60] flex flex-col bg-canvas pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
       /* The keyboard's overlap with this full-height surface (#983). Inline so
          it wins over the safe-area padding above: with the keyboard up, the
          home indicator is behind it and the only inset that matters is this. */
@@ -190,6 +236,7 @@ export function MobileOrchestratorSheet({
         tabIndex={-1}
         data-testid="mobile-orchestrator-sheet"
         data-orchestrator-sheet-state={view.state}
+        data-orchestrator-sheet-mode={mode}
         className="flex min-h-0 flex-1 flex-col focus-visible:outline-none"
         onSubmit={(event) => {
           event.preventDefault();
@@ -217,169 +264,434 @@ export function MobileOrchestratorSheet({
           </button>
         </header>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 py-3">
-          {state.kind === "loading" ? (
-            <Centered>
-              <LoaderCircle className="h-5 w-5 animate-spin text-muted" aria-hidden />
-              <p className="text-ui text-muted" role="status">{t("orchPanel.loading")}</p>
-            </Centered>
-          ) : state.kind === "unavailable" ? (
-            <Centered>
-              <TriangleAlert className="h-6 w-6 text-warning" aria-hidden />
-              <p className="text-body font-semibold text-primary" role="alert">{t("orchPanel.unavailable")}</p>
-              <p className="text-ui leading-4 text-muted">{t("orchPanel.unavailableHint")}</p>
-            </Centered>
-          ) : state.kind === "creating" ? (
-            <Centered>
-              <LoaderCircle className="h-5 w-5 animate-spin text-accent" aria-hidden />
-              <p className="text-body font-semibold text-primary" role="status">{t("orchPanel.creating")}</p>
-              <p className="text-ui leading-4 text-muted">{t("orchPanel.creatingHint")}</p>
-              {state.launchId ? (
-                <p className="max-w-full truncate font-mono text-caption text-muted" title={state.launchId}>
-                  {t("orchPanel.receipt", { launchId: state.launchId })}
-                </p>
-              ) : null}
-              {/* Durably pending with nothing of ours on the wire: the request
-                  that accepted it died, and only a re-post of its OWN key
-                  converges it — the phone's most likely failure by far. */}
-              {!submitting && state.clientRequestId ? (
-                <p className="text-ui leading-4 text-muted">{t("orchPanel.creatingStuck")}</p>
-              ) : null}
-            </Centered>
-          ) : state.kind === "live" ? (
-            <LiveView state={state} file={file} />
-          ) : (
-            <>
-              {state.kind === "intent-error" ? (
-                <div className="shrink-0 rounded-surface border border-danger/40 bg-danger-soft px-3 py-2.5" role="alert" data-orchestrator-intent-error>
-                  <p className="flex items-center gap-1.5 text-ui font-semibold text-danger">
-                    <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
-                    {t(state.retry === "same" ? "orchPanel.errorUnknownTitle" : "orchPanel.errorTitle")}
-                  </p>
-                  <pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-words font-sans text-ui leading-4 text-secondary">
-                    {state.error}
-                  </pre>
-                  <p className="mt-1 text-caption text-muted">
-                    {t(state.retry === "same" ? "orchPanel.errorUnknownHint" : "orchPanel.errorHint")}
-                  </p>
-                </div>
-              ) : (
-                <div className="shrink-0">
-                  <h2 className="text-title font-semibold text-primary">{t("orchPanel.draftTitle")}</h2>
-                  {state.vacated ? (
-                    <p className="mt-1 text-ui leading-4 text-muted">
-                      {t("orchPanel.draftHintVacated", { project: projectName })}
+        {rotating && rotate.seat ? (
+          <RotateDraft
+            project={project}
+            seat={rotate.seat}
+            vacated={rotate.vacated}
+            incumbent={incumbent}
+            file={file}
+            projectCwd={projectCwd}
+            catalog={launch.catalog}
+            status={status}
+            viewerMcpRegistered={viewerMcpRegistered}
+            submitting={rotate.submitting}
+            failure={rotate.failure}
+            onConfirm={rotate.onConfirm}
+            onCancel={rotate.onCancel}
+          />
+        ) : (
+          <>
+            <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 py-3">
+              {state.kind === "loading" ? (
+                <Centered>
+                  <LoaderCircle className="h-5 w-5 animate-spin text-muted" aria-hidden />
+                  <p className="text-ui text-muted" role="status">{t("orchPanel.loading")}</p>
+                </Centered>
+              ) : state.kind === "unavailable" ? (
+                <Centered>
+                  <TriangleAlert className="h-6 w-6 text-warning" aria-hidden />
+                  <p className="text-body font-semibold text-primary" role="alert">{t("orchPanel.unavailable")}</p>
+                  <p className="text-ui leading-4 text-muted">{t("orchPanel.unavailableHint")}</p>
+                </Centered>
+              ) : state.kind === "creating" ? (
+                <Centered>
+                  <LoaderCircle className="h-5 w-5 animate-spin text-accent" aria-hidden />
+                  <p className="text-body font-semibold text-primary" role="status">{t("orchPanel.creating")}</p>
+                  <p className="text-ui leading-4 text-muted">{t("orchPanel.creatingHint")}</p>
+                  {state.launchId ? (
+                    <p className="max-w-full truncate font-mono text-caption text-muted" title={state.launchId}>
+                      {t("orchPanel.receipt", { launchId: state.launchId })}
                     </p>
                   ) : null}
-                </div>
-              )}
-
-              {/* The dock's own intro, word for word (#1163): the phone meets
-                  this draft in the same three sentences, so what an orchestrator
-                  is never depends on which surface you created it from. */}
-              <p className="shrink-0 text-ui leading-5 text-secondary" data-orchestrator-intro>
-                {t("orchPanel.introTalk")}{" "}
-                {t("orchPanel.introRuns")}{" "}
-                {t("orchPanel.introReports")}
-              </p>
-
-              <p
-                className="shrink-0 rounded-control border border-border bg-card px-3 py-2 font-mono text-caption text-secondary"
-                data-viewer-mcp-status={viewerMcpRegistered ? "registered" : "missing"}
-                role="status"
-              >
-                {t(viewerMcpRegistered ? "orchPanel.viewerMcpRegistered" : "orchPanel.viewerMcpMissing")}
-              </p>
-
-              {/* The shared launch module, in the phone's own layout: the same
-                  fields and the same invariants the dock has, lifted to 44px
-                  touch targets from OUTSIDE the module — its own recipe
-                  documents that the surrounding row owns the hit area. */}
-              <div className="shrink-0 [&_button]:min-h-11 [&_select]:min-h-11">
-                <AgentLaunchControls draft={launch} disabled={submitting} stacked />
-              </div>
-
-              <div ref={mandateBlockRef} className="flex min-h-[180px] flex-1 flex-col gap-1">
-                <div className="flex min-h-11 items-center gap-2">
-                  <label className="text-label font-semibold text-muted" htmlFor="mobile-orchestrator-mandate">
-                    {t("orchPanel.mandate")}
-                  </label>
-                  {mandate !== ORCHESTRATOR_SYSTEM_PROMPT ? (
-                    <button
-                      type="button"
-                      onClick={() => setMandate(ORCHESTRATOR_SYSTEM_PROMPT)}
-                      disabled={submitting}
-                      className="inline-flex min-h-11 items-center gap-1 rounded-control border border-border bg-card px-3 text-caption font-semibold text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
-                    >
-                      <RotateCcw className="h-3.5 w-3.5" aria-hidden /> {t("orchPanel.restoreDefault")}
-                    </button>
+                  {/* Durably pending with nothing of ours on the wire: the request
+                      that accepted it died, and only a re-post of its OWN key
+                      converges it — the phone's most likely failure by far. */}
+                  {!submitting && state.clientRequestId ? (
+                    <p className="text-ui leading-4 text-muted">{t("orchPanel.creatingStuck")}</p>
                   ) : null}
-                  <span className="ml-auto shrink-0 text-caption text-muted">{t("orchPanel.mandateSent")}</span>
-                </div>
-                <textarea
-                  id="mobile-orchestrator-mandate"
-                  data-orchestrator-mandate
-                  value={mandate}
-                  disabled={submitting}
-                  onChange={(event) => setMandate(event.target.value)}
-                  onFocus={() => setMandateFocused(true)}
-                  onBlur={() => setMandateFocused(false)}
-                  spellCheck={false}
-                  /* Prose the agent reads, so sans (design system §1.1); the
-                     only mono here is the cwd caption, which is a path. */
-                  className="min-h-[160px] w-full flex-1 resize-none rounded-surface border border-border bg-sunken px-3 py-2.5 text-ui leading-[1.45] text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
-                />
-                {projectCwd ? (
-                  <p className="truncate font-mono text-caption text-muted" title={projectCwd}>
-                    {t("orchPanel.cwd", { cwd: projectCwd })}
-                  </p>
-                ) : null}
-              </div>
-            </>
-          )}
-        </div>
+                </Centered>
+              ) : state.kind === "live" ? (
+                <LiveView state={state} file={file} incumbent={incumbent} catalog={launch.catalog} rotate={rotate} />
+              ) : (
+                <>
+                  {state.kind === "intent-error" ? (
+                    <IntentError error={state.error} retry={state.retry} rotate={false} />
+                  ) : (
+                    <div className="shrink-0">
+                      <h2 className="text-title font-semibold text-primary">{t("orchPanel.draftTitle")}</h2>
+                      {state.vacated ? (
+                        <p className="mt-1 text-ui leading-4 text-muted">
+                          {t("orchPanel.draftHintVacated", { project: projectName })}
+                        </p>
+                      ) : null}
+                    </div>
+                  )}
 
-        {primary ? (
-          <div className="flex shrink-0 flex-col gap-2 border-t border-border bg-sunken px-3 py-2.5">
-            {formError ? <p className="text-ui font-semibold text-danger" role="alert">{formError}</p> : null}
-            <button
-              type="submit"
-              data-orchestrator-confirm
-              disabled={primary.busy}
-              className="inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-control border border-accent bg-accent px-3 text-body font-semibold text-white shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
-            >
-              {primary.busy ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden /> : <Bot className="h-4 w-4" aria-hidden />}
-              {t(primary.key)}
-            </button>
-          </div>
-        ) : null}
+                  {/* The dock's own intro, word for word (#1163): the phone meets
+                      this draft in the same three sentences, so what an orchestrator
+                      is never depends on which surface you created it from. */}
+                  <p className="shrink-0 text-ui leading-5 text-secondary" data-orchestrator-intro>
+                    {t("orchPanel.introTalk")}{" "}
+                    {t("orchPanel.introRuns")}{" "}
+                    {t("orchPanel.introReports")}
+                  </p>
+
+                  <ViewerMcpStatus registered={viewerMcpRegistered} />
+
+                  {/* The shared launch module, in the phone's own layout: the same
+                      fields and the same invariants the dock has, lifted to 44px
+                      touch targets from OUTSIDE the module — its own recipe
+                      documents that the surrounding row owns the hit area. */}
+                  <div className="shrink-0 [&_button]:min-h-11 [&_select]:min-h-11">
+                    <AgentLaunchControls draft={launch} disabled={submitting} stacked />
+                  </div>
+
+                  <MandateField
+                    id="mobile-orchestrator-mandate"
+                    value={mandate}
+                    disabled={submitting}
+                    edited={mandate !== ORCHESTRATOR_SYSTEM_PROMPT}
+                    restoreKey="orchPanel.restoreDefault"
+                    onChange={setMandate}
+                    onRestore={() => setMandate(ORCHESTRATOR_SYSTEM_PROMPT)}
+                    cwdLine={projectCwd ? t("orchPanel.cwd", { cwd: projectCwd }) : null}
+                  />
+                </>
+              )}
+            </div>
+
+            {primary ? (
+              <div className="flex shrink-0 flex-col gap-2 border-t border-border bg-sunken px-3 py-2.5">
+                {formError ? <p className="text-ui font-semibold text-danger" role="alert">{formError}</p> : null}
+                <button
+                  type="submit"
+                  data-orchestrator-confirm
+                  disabled={primary.busy}
+                  className="inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-control border border-accent bg-accent px-3 text-body font-semibold text-white shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+                >
+                  {primary.busy ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden /> : <Bot className="h-4 w-4" aria-hidden />}
+                  {t(primary.key)}
+                </button>
+              </div>
+            ) : null}
+          </>
+        )}
       </form>
     </div>
   );
 }
 
-/** A seated orchestrator, read from the sheet rather than from its own chat:
-    who it is, what is riding alongside it, and the one control that takes the
-    operator into the conversation. */
-function LiveView({ state, file }: { state: Extract<OrchestratorPanelState, { kind: "live" }>; file: FileEntry | null }) {
+/**
+ * The rotate draft on the phone (issue #1347): the SAME form the dock opens,
+ * prefilled with the incumbent's own parameters, over the seat it would replace.
+ *
+ * Mounted only while it is open, which is what makes «prefilled» true: the
+ * launch draft reads its initial engine/model/effort/account through the
+ * injected storage, so the incumbent's values are the defaults and the
+ * operator's edits are what persist over them — under the dock's own Rotate
+ * keys, so a rotation half-written on one surface continues on the other.
+ *
+ * The handoff is NOT composed here. `POST /api/orchestrator/rotate` hands the
+ * successor its predecessor's transcript path and the project's open tasks; the
+ * text in this textarea is the MANDATE, and duplicating the handoff into it
+ * would deliver the same instructions twice in two wordings.
+ */
+function RotateDraft({
+  project,
+  seat,
+  vacated,
+  incumbent,
+  file,
+  projectCwd,
+  catalog,
+  status,
+  viewerMcpRegistered,
+  submitting,
+  failure,
+  onConfirm,
+  onCancel,
+}: {
+  project: string;
+  seat: OrchestratorSeat;
+  vacated: boolean;
+  incumbent: OrchestratorIncumbent | null;
+  file: FileEntry | null;
+  projectCwd?: string;
+  catalog: LaunchAccountCatalog | null;
+  status: OrchestratorSeatStatus | null;
+  viewerMcpRegistered: boolean;
+  submitting: boolean;
+  failure: SeatSubmitFailure | null;
+  onConfirm: SeatRotateFlow["onConfirm"];
+  onCancel: () => void;
+}) {
   const { t } = useLocale();
-  const badge = file ? engineBadge(file) : null;
+  const [formError, setFormError] = useState<string | null>(null);
+  const [mandate, setMandateState] = useState(() => readSeatFlowField("Rotate", project, "mandate") || seat.mandate);
+  /* «Prefilled» in the operator's words: what the incumbent is ACTUALLY running
+     on, read through the launch module's own storage seam rather than by forking
+     it. Only the initializers call `read`, so switching engine here is never
+     re-defaulted back to the predecessor's account or model. */
+  const inherited: Record<string, string> = {
+    engine: incumbent?.engine ?? (file?.engine === "codex" ? "codex" : file?.engine === "claude" ? "claude" : ""),
+    model: incumbent?.model ?? file?.model ?? "",
+    effort: incumbent?.effort ?? "",
+    accountId: incumbent?.accountId ?? "",
+  };
+  const launch = useAgentLaunchDraft({
+    storage: {
+      read: (name) => readSeatFlowField("Rotate", project, name) || (inherited[name] ?? ""),
+      write: (name, value) => writeSeatFlowField("Rotate", project, name, value),
+    },
+    catalog,
+    initialEngine: ORCHESTRATOR_SPAWN_CONFIG.engine,
+    initialModel: ORCHESTRATOR_SPAWN_CONFIG.model,
+    initialEffort: ORCHESTRATOR_SPAWN_CONFIG.effort,
+  });
+  const state = deriveRotateDraftState({ status, submitFailure: failure });
+  const errored = state.kind === "intent-error";
+  /* The successor inherits the predecessor's checkout unless the operator says
+     otherwise — so the rotate body carries no cwd at all, and the row below
+     states which directory that is (issue #903). */
+  const cwd = (incumbent?.cwd ?? null) ?? projectCwd;
+
+  const confirm = () => {
+    /* Emptiness is the only question trim answers here — the successor's
+       mandate is posted exactly as it was typed. */
+    if (!mandate.trim()) {
+      setFormError(t("orchPanel.mandateRequired"));
+      return;
+    }
+    setFormError(null);
+    onConfirm({
+      body: {
+        project,
+        mandate,
+        engine: launch.engine,
+        ...(launch.model ? { model: launch.model } : {}),
+        ...(launch.effort ? { effort: launch.effort } : {}),
+        ...(launch.engine === "codex" && launch.speed ? { fast: launch.speed === "fast" } : {}),
+        ...(launch.launchAccountId ? { accountId: launch.launchAccountId } : {}),
+      },
+      launch: { draft: launch, cwd: cwd ?? "", firstMessage: mandate },
+    });
+  };
+
+  return (
+    <>
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 py-3" data-orchestrator-draft="rotate">
+        {/* The seat's card was closed while this rotation was still in the air.
+            The rotation is the live question, so it keeps the surface — with
+            the vacancy stated above it — until it says where it landed. */}
+        {vacated ? <Note tone="quiet">{t("orchPanel.rotateVacated")}</Note> : null}
+        {errored ? (
+          <IntentError error={state.error} retry={state.retry} rotate />
+        ) : (
+          <div className="shrink-0">
+            <h2 className="text-title font-semibold text-primary">{t("orchPanel.rotateHeading")}</h2>
+            <p className="mt-1 text-ui leading-4 text-muted">{t("orchPanel.rotateHint")}</p>
+          </div>
+        )}
+
+        <ViewerMcpStatus registered={viewerMcpRegistered} />
+
+        {/* The seat's settings — engine, account, model and reasoning — as the
+            same shared module the create draft mounts, at the phone's 44px
+            targets. What the operator adjusts here is what the successor runs
+            on. */}
+        <div className="shrink-0 [&_button]:min-h-11 [&_select]:min-h-11">
+          <AgentLaunchControls draft={launch} disabled={submitting} stacked />
+        </div>
+
+        <MandateField
+          id="mobile-orchestrator-rotate-mandate"
+          value={mandate}
+          disabled={submitting}
+          edited={mandate !== seat.mandate}
+          restoreKey="orchPanel.restoreIncumbent"
+          onChange={(value) => {
+            setMandateState(value);
+            writeSeatFlowField("Rotate", project, "mandate", value === seat.mandate ? "" : value);
+          }}
+          onRestore={() => {
+            setMandateState(seat.mandate);
+            writeSeatFlowField("Rotate", project, "mandate", "");
+          }}
+          cwdLine={cwd ? t("orchPanel.cwdInherited", { cwd }) : null}
+        />
+      </div>
+
+      <div className="flex shrink-0 flex-col gap-2 border-t border-border bg-sunken px-3 py-2.5">
+        {formError ? <p className="text-ui font-semibold text-danger" role="alert">{formError}</p> : null}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            data-orchestrator-rotate-cancel
+            onClick={onCancel}
+            disabled={submitting}
+            className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-control border border-border bg-card px-3 text-ui font-semibold text-secondary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+          >
+            {t("orchPanel.rotateCancel")}
+          </button>
+          {/* Its own button, not the form's submit: the sheet's submit is the
+              live view's «open the conversation», and a rotation must never be
+              what an Enter in some other field triggers. */}
+          <button
+            type="button"
+            data-orchestrator-confirm
+            onClick={confirm}
+            disabled={submitting}
+            className="inline-flex min-h-11 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-control border border-accent bg-accent px-3 text-body font-semibold text-white shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+          >
+            {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden /> : <RefreshCw className="h-4 w-4" aria-hidden />}
+            <span className="truncate">{t(errored ? "orchPanel.confirmRetry" : "orchPanel.rotateConfirm")}</span>
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/**
+ * The mandate textarea, with the one behaviour the phone needs from it: the
+ * keyboard costs the body scroller most of its height, and everything above the
+ * mandate — an intent error's card, then engine/account/reasoning — can fill
+ * what is left, leaving the operator typing into a field below the scroller's
+ * own fold (#1004). So the field is brought to the top of the scroller once the
+ * keyboard is actually up: the block, not the textarea, so its label comes
+ * along.
+ *
+ * Both orders arrive here — focus first and the keyboard after (a tap), or the
+ * keyboard already up (focus moving in from another field) — because the
+ * condition is the state, not either event. It fires ONCE per typing session:
+ * after that the scroller is the operator's, and a keyboard that resizes under
+ * them never yanks it back. Shared by the create and the rotate drafts, so both
+ * are typed into the same way.
+ */
+function MandateField({
+  id,
+  value,
+  disabled,
+  edited,
+  restoreKey,
+  onChange,
+  onRestore,
+  cwdLine,
+}: {
+  id: string;
+  value: string;
+  disabled: boolean;
+  edited: boolean;
+  restoreKey: MessageKey;
+  onChange: (value: string) => void;
+  onRestore: () => void;
+  cwdLine: string | null;
+}) {
+  const { t } = useLocale();
+  const kbInset = useKeyboardInset();
+  const blockRef = useRef<HTMLDivElement>(null);
+  const revealedRef = useRef(false);
+  const [focused, setFocused] = useState(false);
+  useEffect(() => {
+    if (!focused || kbInset <= 0) {
+      revealedRef.current = false;
+      return;
+    }
+    if (revealedRef.current) return;
+    revealedRef.current = true;
+    blockRef.current?.scrollIntoView({ block: "start" });
+  }, [focused, kbInset]);
+
+  return (
+    <div ref={blockRef} className="flex min-h-[180px] flex-1 flex-col gap-1">
+      <div className="flex min-h-11 items-center gap-2">
+        <label className="text-label font-semibold text-muted" htmlFor={id}>
+          {t("orchPanel.mandate")}
+        </label>
+        {edited ? (
+          <button
+            type="button"
+            onClick={onRestore}
+            disabled={disabled}
+            className="inline-flex min-h-11 items-center gap-1 rounded-control border border-border bg-card px-3 text-caption font-semibold text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden /> {t(restoreKey)}
+          </button>
+        ) : null}
+        <span className="ml-auto shrink-0 text-caption text-muted">{t("orchPanel.mandateSent")}</span>
+      </div>
+      <textarea
+        id={id}
+        data-orchestrator-mandate
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        spellCheck={false}
+        /* Prose the agent reads, so sans (design system §1.1); the only mono
+           here is the cwd caption, which is a path. */
+        className="min-h-[160px] w-full flex-1 resize-none rounded-surface border border-border bg-sunken px-3 py-2.5 text-ui leading-[1.45] text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+      />
+      {cwdLine ? (
+        <p className="truncate font-mono text-caption text-muted" title={cwdLine}>
+          {cwdLine}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** A seated orchestrator, read from the sheet rather than from its own chat:
+    who it is, what is riding alongside it, the rules it runs under, and the
+    controls the desktop header carries — Rotate first among them. The one
+    control that takes the operator INTO the conversation stays the footer's. */
+function LiveView({
+  state,
+  file,
+  incumbent,
+  catalog,
+  rotate,
+}: {
+  state: Extract<OrchestratorPanelState, { kind: "live" }>;
+  file: FileEntry | null;
+  incumbent: OrchestratorIncumbent | null;
+  catalog: LaunchAccountCatalog | null;
+  rotate: SeatRotateFlow;
+}) {
+  const { t } = useLocale();
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
       <div className="shrink-0">
         <h2 className="text-title font-semibold text-primary">{t("orchMobile.liveTitle")}</h2>
-        <p className="mt-1 flex flex-wrap items-center gap-1.5 text-ui text-muted">
-          {badge ? (
-            <span className="rounded-full px-2 py-0.5 text-caption font-semibold" style={badge.style}>{badge.label}</span>
-          ) : null}
-          {file?.model ? <span className="text-ui font-semibold text-secondary">{file.model}</span> : null}
-          <span>{t(ROW_STATE_LABEL[state.liveness])}</span>
-        </p>
+        <p className="mt-1 text-ui text-muted">{t(ROW_STATE_LABEL[state.liveness])}</p>
+      </div>
+      <SeatIdentity incumbent={incumbent} file={file} catalog={catalog} predecessorConversationId={state.seat.predecessorConversationId} />
+      {/* Rotate: a control, and only a control. The advisory below states the
+          recommendation; this performs it, and ONLY when pressed and then
+          confirmed in the draft it opens. */}
+      <div className="flex shrink-0 flex-col gap-1">
+        <button
+          type="button"
+          data-orchestrator-rotate
+          onClick={rotate.onOpen}
+          disabled={rotate.opening || rotate.submitting}
+          title={t("orchPanel.rotateTitle")}
+          className="inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-control border border-border bg-card px-3 text-body font-semibold text-primary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+        >
+          {rotate.opening
+            ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden />
+            : <RefreshCw className="h-4 w-4" aria-hidden />}
+          {t(rotate.opening ? "orchMobile.rotateOpening" : "orchPanel.rotate")}
+        </button>
+        <p className="text-caption leading-4 text-muted">{t("orchPanel.rotateTitle")}</p>
       </div>
       {state.transition ? <TransitionCard transition={state.transition} /> : null}
       {state.rotation ? <RotationCard rotation={state.rotation} /> : null}
       {orchestratorQuietBannerEligible(state, file) ? <Note tone="warning">{t("orchPanel.stalled")}</Note> : null}
       {state.liveness === "resumable" ? <Note tone="quiet">{t("orchPanel.resumable")}</Note> : null}
+      <MandateView seat={state.seat} />
       {file ? (
         <p className="text-ui leading-4 text-muted">{t("orchMobile.liveHint")}</p>
       ) : (
@@ -398,6 +710,129 @@ function LiveView({ state, file }: { state: Extract<OrchestratorPanelState, { ki
         </Centered>
       )}
     </div>
+  );
+}
+
+/**
+ * WHO is holding the seat — the desktop's incumbent header (`IncumbentHeader`),
+ * in the sheet's own layout: engine, model at tier, account and context
+ * fullness on one wrapping row, the lineage link under it. The status read
+ * answers first; until it has, the board's own card fills the row, so the
+ * identity is populated on the first paint instead of waiting out the poll.
+ */
+function SeatIdentity({
+  incumbent,
+  file,
+  catalog,
+  predecessorConversationId,
+}: {
+  incumbent: OrchestratorIncumbent | null;
+  file: FileEntry | null;
+  catalog: LaunchAccountCatalog | null;
+  predecessorConversationId: string | null;
+}) {
+  const { t } = useLocale();
+  const designated = incumbent?.designated ? incumbent : null;
+  const engine = designated?.engine ?? (file?.engine === "claude" || file?.engine === "codex" ? file.engine : null);
+  const model = designated?.model ?? file?.model ?? null;
+  const effort = designated?.effort ?? null;
+  const accountId = designated?.accountId ?? null;
+  const account = accountId
+    ? catalog?.[engine ?? "claude"]?.accounts.find((candidate) => candidate.id === accountId)?.label ?? accountId
+    : null;
+  const badge = engine ? engineBadgeFor(engine) : null;
+  const context = designated?.context ?? boardContext(file);
+
+  return (
+    <div
+      data-orchestrator-incumbent
+      className="flex shrink-0 flex-col gap-1.5 rounded-surface border border-border bg-sunken px-3 py-2.5"
+      aria-label={t("orchPanel.incumbentAria")}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        {badge ? <Badge style={badge.style}>{badge.label}</Badge> : null}
+        {model ? (
+          <span className="min-w-0 shrink truncate text-ui font-semibold text-primary" title={effort ? `${model} · ${effort}` : model}>
+            {model}
+            {effort ? <span className="font-normal text-muted"> · {effort}</span> : null}
+          </span>
+        ) : (
+          <span className="text-ui text-muted">{t("orchPanel.incumbentUnknown")}</span>
+        )}
+        {account ? (
+          <Badge tone="neutral" shrinkable title={t("orchPanel.accountTitle", { account })}>
+            <span className="min-w-0 truncate">{account}</span>
+          </Badge>
+        ) : null}
+        <ContextMeter context={context} />
+      </div>
+      {predecessorConversationId ? (
+        <a
+          href={"#c=" + encodeURIComponent(predecessorConversationId)}
+          data-orchestrator-predecessor={predecessorConversationId}
+          title={t("orchPanel.predecessorTitle")}
+          className="inline-flex min-h-11 min-w-0 items-center gap-1 self-start text-ui text-muted hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <CornerDownRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span className="truncate">{t("orchPanel.predecessor")}</span>
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+/** The mandate the seat is running under, readable in place: the rules the
+    dock folds behind a disclosure in its drafts, here folded the same way. It
+    is the text the rotate draft opens prefilled with. */
+function MandateView({ seat }: { seat: OrchestratorSeat }) {
+  const { t } = useLocale();
+  return (
+    <details data-orchestrator-mandate-view className="shrink-0 rounded-control border border-border bg-card/60">
+      <summary className="min-h-11 cursor-pointer select-none list-item px-3 py-2.5 text-label font-semibold text-secondary marker:text-muted hover:text-primary">
+        {seat.promptVersion === null ? t("orchMobile.mandateViewCustom") : t("orchMobile.mandateView", { version: seat.promptVersion })}
+      </summary>
+      <pre className="max-h-56 overflow-y-auto whitespace-pre-wrap break-words border-t border-border px-3 py-2 font-sans text-ui leading-5 text-secondary">
+        {seat.mandate}
+      </pre>
+    </details>
+  );
+}
+
+/** A failed designation — or a failed ROTATION, which says something different:
+    the incumbent is still running, and «nothing is running» would be a lie
+    exactly when the operator is deciding whether to try again. */
+function IntentError({ error, retry, rotate }: { error: string; retry: "fresh" | "same"; rotate: boolean }) {
+  const { t } = useLocale();
+  return (
+    <div className="shrink-0 rounded-surface border border-danger/40 bg-danger-soft px-3 py-2.5" role="alert" data-orchestrator-intent-error>
+      <p className="flex items-center gap-1.5 text-ui font-semibold text-danger">
+        <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
+        {t(retry === "same"
+          ? rotate ? "orchPanel.rotateErrorUnknownTitle" : "orchPanel.errorUnknownTitle"
+          : rotate ? "orchPanel.rotateErrorTitle" : "orchPanel.errorTitle")}
+      </p>
+      <pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-words font-sans text-ui leading-4 text-secondary">
+        {error}
+      </pre>
+      <p className="mt-1 text-caption text-muted">
+        {t(retry === "same"
+          ? rotate ? "orchPanel.rotateErrorUnknownHint" : "orchPanel.errorUnknownHint"
+          : rotate ? "orchPanel.rotateErrorHint" : "orchPanel.errorHint")}
+      </p>
+    </div>
+  );
+}
+
+function ViewerMcpStatus({ registered }: { registered: boolean }) {
+  const { t } = useLocale();
+  return (
+    <p
+      className="shrink-0 rounded-control border border-border bg-card px-3 py-2 font-mono text-caption text-secondary"
+      data-viewer-mcp-status={registered ? "registered" : "missing"}
+      role="status"
+    >
+      {t(registered ? "orchPanel.viewerMcpRegistered" : "orchPanel.viewerMcpMissing")}
+    </p>
   );
 }
 
@@ -423,21 +858,27 @@ function TransitionCard({ transition }: { transition: SeatTransition }) {
 }
 
 /** The advisory and nothing more — rotation happens only when the operator asks
-    for it, and the ask is slice B's (#978) own control on the desktop panel. */
+    for it, through the Rotate control above, and confirms the draft it opens. */
 function RotationCard({ rotation }: { rotation: RotationHint }) {
   const { t } = useLocale();
+  const summary = rotation.reasons.map((reason) => (
+    reason === "context"
+      ? t("orchPanel.rotationContext", { percent: String(rotation.contextPercent ?? 0) })
+      : t("orchPanel.rotationDead")
+  )).join(" · ");
   return (
     <div className="shrink-0 rounded-surface border border-warning/45 bg-warning-soft px-3 py-2" role="status" data-orchestrator-rotation={rotation.level}>
       <p className="text-ui font-semibold text-warning">
         {t(rotation.level === "strongly_recommend" ? "orchPanel.rotationStrong" : "orchPanel.rotation")}
       </p>
-      <p className="mt-0.5 text-caption leading-4 text-secondary">
-        {rotation.reasons.map((reason) => (
-          reason === "context"
-            ? t("orchPanel.rotationContext", { percent: String(rotation.contextPercent ?? 0) })
-            : t("orchPanel.rotationDead")
-        )).join(" · ")}
-      </p>
+      {summary ? <p className="mt-0.5 text-caption leading-4 text-secondary">{summary}</p> : null}
+      {/* The server's own reasons, verbatim: each names the threshold it crossed
+          and whether the number behind it is an estimate. */}
+      {rotation.notes?.length ? (
+        <ul className="mt-0.5 list-disc pl-3.5 text-caption leading-4 text-muted marker:text-muted/60">
+          {rotation.notes.map((note) => <li key={note}>{note}</li>)}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/src/components/mobile/issue1347Evidence.browser.test.tsx
+++ b/src/components/mobile/issue1347Evidence.browser.test.tsx
@@ -1,0 +1,461 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { act } from "react";
+import { installActEnv } from "@/test-helpers/actEnv";
+import fs from "node:fs";
+import path from "node:path";
+import { Window } from "happy-dom";
+import { createRoot } from "react-dom/client";
+import { chromium, type Browser } from "playwright-core";
+
+import { PERSISTENT_CHROME } from "@/components/mobile/chatBudget";
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import { setLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+/**
+ * Browser-rendered evidence for issues #1347 and #1348, at a 390×844 phone
+ * viewport, in BOTH colour schemes, against the production CSS:
+ *
+ *   bun run build && bun test src/components/mobile/issue1347Evidence.browser.test.tsx
+ *
+ * #1348 — the rename editor. The operator tapped the pencil and got a field
+ * with no visible text. Happy-dom does no layout, so the claim that the field
+ * now has real width, real ink and a real caret is settled here: the REAL
+ * `MobileFocusView` is rendered into the phone's header, the editor is opened,
+ * and Chromium measures the input's box, its computed colour against its
+ * surface, its caret colour and its font size — and that a long title scrolls
+ * INSIDE the field rather than pushing the row wide.
+ *
+ * #1347 — the orchestrator controls. The pinned row's new entry point and the
+ * sheet's Rotate control are measured as 44px targets inside the viewport, the
+ * rotate draft's two footer actions likewise, and the strip row keeps the height
+ * the chat-first budget reserves for it. The keyboard-open case is a live
+ * measurement and lives in `scripts/capture-issue-979-mobile-orchestrator.ts`.
+ *
+ * Every measurement is written to `evidence/issue-1347-1348/geometry.json`;
+ * the frames and HTML beside it are regenerated on demand and not committed.
+ */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualLogTail = await import("@/hooks/useLogTail");
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ enabled: false, connection: "live", resyncedAt: null, lastEventAt: null, store: emptyStore() }),
+  useRuntime: () => ({ enabled: false, connection: "live", resyncedAt: null, store: emptyStore() }),
+  useRuntimeEnabled: () => false,
+  useRuntimeSession: () => null,
+  useRuntimeSessionByArtifact: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+  refreshRuntime: () => Promise.resolve(false),
+}));
+mock.module("@/hooks/useLogTail", () => ({
+  useLogTail: () => ({
+    lines: [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null,
+    paused: false, setPaused: () => undefined, clear: () => undefined,
+    hasMore: false, loadingOlder: false, loadOlder: async () => 0, prependGen: 0,
+  }),
+}));
+
+const EVIDENCE_DIR = path.join(process.cwd(), "evidence", "issue-1347-1348");
+const CSS_DIR = path.join(process.cwd(), ".next", "static", "css");
+
+function productionCss(): string {
+  const files = fs.existsSync(CSS_DIR) ? fs.readdirSync(CSS_DIR).filter((name) => name.endsWith(".css")) : [];
+  return files.map((name) => fs.readFileSync(path.join(CSS_DIR, name), "utf8")).join("\n");
+}
+
+const dom = new Window({ url: "http://localhost/", innerWidth: 390, innerHeight: 844 });
+installActEnv();
+(dom as unknown as { matchMedia(q: string): unknown }).matchMedia = (q: string) => ({
+  matches: /max-width|pointer: coarse/.test(String(q)),
+  media: String(q),
+  onchange: null,
+  addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; },
+});
+class TestResizeObserver { observe() {} unobserve() {} disconnect() {} }
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLInputElement: dom.HTMLInputElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  PointerEvent: dom.MouseEvent,
+  ResizeObserver: TestResizeObserver,
+  IntersectionObserver: undefined,
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+});
+(dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const seat = {
+  project: "atlas", seatEpoch: 4, conversationId: "conversation_orchestrator", path: "/repo/atlas/orchestrator.jsonl",
+  mandate: "You run the Atlas board. Talk to me here, directly, whenever you have something worth saying.",
+  promptVersion: 3, predecessorConversationId: "conversation_predecessor", state: "active",
+  intent: { clientRequestId: "seatreq-0001", mode: "spawn", launchId: "launch-0001", error: null },
+  designatedAt: "2100-01-02T11:00:00.000Z", activatedAt: "2100-01-02T11:00:02.000Z",
+};
+const incumbent = {
+  project: "atlas", designated: true, conversationId: "conversation_orchestrator", predecessorConversationId: "conversation_predecessor",
+  engine: "claude", model: "opus", effort: "high", accountId: "spare", cwd: "/repo/atlas/worktrees/board",
+  transcriptPath: "/repo/atlas/orchestrator.jsonl",
+  liveness: { lifecycle: "running", hostState: "alive", silentForMs: 0 },
+  context: { tokens: 24_000, limit: 100_000, percent: 24, estimated: false, basis: "provider-reported usage" },
+  transcriptFacts: { bytes: 4_096, messageCount: 12, toolCount: 3, compactionCount: 0 },
+  rotation: { recommended: false, level: "none", reasons: [], thresholdUnknown: false },
+};
+const accounts = {
+  claude: { active: "primary", accounts: [{ id: "primary", label: "primary", authPresent: true }, { id: "spare", label: "spare", authPresent: true }] },
+  codex: { active: "", accounts: [] },
+};
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  const url = String(input);
+  if (url.startsWith("/api/orchestrator/seat/status")) return json(incumbent);
+  if (url.startsWith("/api/orchestrator/seat")) return json({ seat, pending: null, exists: true });
+  if (url.startsWith("/api/accounts")) return json(accounts);
+  return json({});
+}) as typeof fetch;
+
+const { MobileFocusView } = await import("./MobileFocusView");
+const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
+const { resetOrchestratorIncumbentCacheForTests } = await import("../orchestrator/useOrchestratorIncumbent");
+
+let browser: Browser;
+
+/* Synthetic, no operator content: a long conversation title — the string that
+   has to scroll inside the editor — and the seat conversation. */
+const LONG_TITLE = "Builder · keep every orchestrator control reachable from a 390px phone viewport, and make the rename editor legible";
+
+function conversation(over: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/repo/atlas/other.jsonl", root: "claude-projects", name: "other.jsonl", project: "atlas", title: "Some other work",
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 100, size: 1, activity: "live",
+    proc: "running", pid: 3, conversationId: "conversation_other", model: "sonnet", cwd: "/repo/atlas", projectRoot: "/repo/atlas",
+    renamable: true, effort: "high",
+    pendingQuestion: null, waitingInput: null,
+    ...over,
+  } as unknown as FileEntry;
+}
+const focused = conversation({ path: "/repo/atlas/focused.jsonl", name: "focused.jsonl", conversationId: "conversation_focused", title: LONG_TITLE, mtime: 200 });
+const orchestrator = conversation({ path: "/repo/atlas/orchestrator.jsonl", name: "orchestrator.jsonl", conversationId: "conversation_orchestrator", title: "Run the Atlas board", model: "opus", mtime: 10 });
+
+const view = (files: FileEntry[], focus: string) => (
+  <MobileFocusView
+    project="atlas"
+    projectName="atlas"
+    groups={[]}
+    manual={files}
+    files={files}
+    flows={[]}
+    pipelines={[]}
+    tasks={[]}
+    drafts={[]}
+    loaded
+    focus={focus}
+    onSelect={() => undefined}
+    onClose={() => undefined}
+    onDraftClose={() => undefined}
+    onDraftSpawned={() => undefined}
+  />
+);
+
+beforeEach(() => {
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+  resetOrchestratorSeatCacheForTests();
+  resetOrchestratorIncumbentCacheForTests();
+  setLocale("en");
+});
+afterEach(() => {
+  document.body.replaceChildren();
+});
+afterAll(async () => {
+  await browser?.close();
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+});
+
+const settle = async (rounds = 3) => {
+  for (let round = 0; round < rounds; round += 1) {
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 30)); });
+  }
+};
+
+const CSS = productionCss();
+const VIEWPORT = { width: 390, height: 844 };
+
+function pageHtml(inner: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><style>${CSS}
+    html,body{margin:0;padding:0;background:var(--color-canvas,#fff);}
+    #evidence-host{display:flex;flex-direction:column;width:${VIEWPORT.width}px;height:100vh;}
+    </style></head><body><div id="evidence-host">${inner}</div></body></html>`;
+}
+
+interface Box { label: string; left: number; right: number; top: number; bottom: number; width: number; height: number }
+interface EditorGeometry {
+  scheme: "light" | "dark";
+  viewportWidth: number;
+  scrollWidth: number;
+  paneHeaderScrollWidth: number;
+  paneHeaderClientWidth: number;
+  editor: Box | null;
+  input: Box | null;
+  inputValueLength: number;
+  inputScrollWidth: number;
+  inputClientWidth: number;
+  fontSizePx: number;
+  color: string;
+  background: string;
+  caretColor: string;
+  contrast: number;
+  controls: Box[];
+}
+interface ControlsGeometry {
+  scheme: "light" | "dark";
+  scrollWidth: number;
+  stripHeight: number;
+  rowOpen: Box | null;
+  rowControls: Box | null;
+  firstChipLeft: number;
+  sheet: { rotate: Box | null; identityText: string; contextPercent: string | null; predecessor: boolean; mandateView: boolean } | null;
+  rotateDraft: { confirm: Box | null; cancel: Box | null; mandate: Box | null; scrollerBottom: number } | null;
+}
+
+async function withPage<T>(inner: string, key: string, scheme: "light" | "dark", measure: (page: import("playwright-core").Page) => Promise<T>): Promise<T> {
+  const page = await browser.newPage({ viewport: VIEWPORT, deviceScaleFactor: 1, colorScheme: scheme });
+  await page.setContent(pageHtml(inner), { waitUntil: "load" });
+  fs.writeFileSync(path.join(EVIDENCE_DIR, `${key}-${scheme}.html`), pageHtml(inner));
+  const result = await measure(page);
+  await page.screenshot({ path: path.join(EVIDENCE_DIR, `${key}-${scheme}.png`) });
+  await page.close();
+  return result;
+}
+
+/* WCAG relative luminance from a CSS `rgb(a)` string, for the ink-on-surface
+   contrast the operator's «no visible text» complaint is ultimately about. */
+function luminance(css: string): number {
+  const parts = css.match(/[\d.]+/g)?.slice(0, 3).map(Number) ?? [0, 0, 0];
+  const [r, g, b] = parts.map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  }) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x) as [number, number];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const BOX = `(el) => { const r = el.getBoundingClientRect(); return { label: el.getAttribute("aria-label") ?? el.textContent?.trim().slice(0, 40) ?? "", left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height }; }`;
+
+async function measureEditor(page: import("playwright-core").Page, scheme: "light" | "dark", title: string): Promise<EditorGeometry> {
+  const raw = await page.evaluate(({ boxSource, value }) => {
+    const box = new Function("return " + boxSource)() as (el: Element) => Box;
+    const header = document.querySelector("[data-testid='mobile-focused-pane'] header") as HTMLElement | null;
+    const editor = document.querySelector("[data-session-title-editor]") as HTMLElement | null;
+    const input = document.querySelector("input[aria-label='Session title']") as HTMLInputElement | null;
+    /* React writes the value as a property, which the static markup does not
+       carry: put the title back so the field measures what the phone shows. */
+    if (input) input.value = value;
+    const style = input ? getComputedStyle(input) : null;
+    const controls: Box[] = [];
+    for (const node of Array.from(editor?.querySelectorAll("button") ?? [])) controls.push(box(node));
+    return {
+      viewportWidth: window.innerWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      paneHeaderScrollWidth: header?.scrollWidth ?? -1,
+      paneHeaderClientWidth: header?.clientWidth ?? -1,
+      editor: editor ? box(editor) : null,
+      input: input ? box(input) : null,
+      inputValueLength: input?.value.length ?? 0,
+      inputScrollWidth: input?.scrollWidth ?? -1,
+      inputClientWidth: input?.clientWidth ?? -1,
+      fontSizePx: style ? parseFloat(style.fontSize) : -1,
+      color: style?.color ?? "",
+      background: style?.backgroundColor ?? "",
+      caretColor: style?.caretColor ?? "",
+      controls,
+    };
+  }, { boxSource: BOX, value: title });
+  return { scheme, ...raw, contrast: contrast(raw.color, raw.background) };
+}
+
+async function measureControls(page: import("playwright-core").Page, scheme: "light" | "dark"): Promise<ControlsGeometry> {
+  const raw = await page.evaluate(({ boxSource }) => {
+    const box = new Function("return " + boxSource)() as (el: Element) => Box;
+    const row = document.querySelector("[data-orchestrator-row]");
+    const open = document.querySelector("[data-orchestrator-row-open]");
+    const controls = document.querySelector("[data-orchestrator-row-controls]");
+    const chip = document.querySelector(".overflow-x-auto button");
+    const sheet = document.querySelector("[data-testid='mobile-orchestrator-sheet']");
+    const rotate = sheet?.querySelector("[data-orchestrator-rotate]") ?? null;
+    const draft = sheet?.querySelector("[data-orchestrator-draft='rotate']") ?? null;
+    return {
+      scrollWidth: document.documentElement.scrollWidth,
+      stripHeight: row?.parentElement ? Math.round(row.parentElement.getBoundingClientRect().height) : -1,
+      rowOpen: open ? box(open) : null,
+      rowControls: controls ? box(controls) : null,
+      firstChipLeft: chip ? chip.getBoundingClientRect().left : Number.POSITIVE_INFINITY,
+      sheet: sheet ? {
+        rotate: rotate ? box(rotate) : null,
+        identityText: sheet.querySelector("[data-orchestrator-incumbent]")?.textContent ?? "",
+        contextPercent: sheet.querySelector("[data-orchestrator-context]")?.getAttribute("data-orchestrator-context") ?? null,
+        predecessor: Boolean(sheet.querySelector("[data-orchestrator-predecessor]")),
+        mandateView: Boolean(sheet.querySelector("[data-orchestrator-mandate-view]")),
+      } : null,
+      rotateDraft: draft ? {
+        confirm: sheet?.querySelector("[data-orchestrator-confirm]") ? box(sheet!.querySelector("[data-orchestrator-confirm]")!) : null,
+        cancel: sheet?.querySelector("[data-orchestrator-rotate-cancel]") ? box(sheet!.querySelector("[data-orchestrator-rotate-cancel]")!) : null,
+        mandate: sheet?.querySelector("[data-orchestrator-mandate]") ? box(sheet!.querySelector("[data-orchestrator-mandate]")!) : null,
+        scrollerBottom: draft.getBoundingClientRect().bottom,
+      } : null,
+    };
+  }, { boxSource: BOX });
+  return { scheme, ...raw };
+}
+
+async function renderFocusView(files: FileEntry[], focus: string, drive: (host: HTMLElement) => Promise<void>): Promise<string> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => { root.render(view(files, focus)); });
+  await settle();
+  await drive(host as unknown as HTMLElement);
+  await settle();
+  const html = host.innerHTML;
+  await act(async () => root.unmount());
+  host.remove();
+  return html;
+}
+
+const click = async (host: HTMLElement, selector: string) => {
+  const target = host.querySelector(selector) as HTMLButtonElement | null;
+  expect(target, selector).not.toBeNull();
+  await act(async () => { target!.click(); });
+  await settle();
+};
+
+test("issues 1347 + 1348: the phone's rename editor and orchestrator controls measure as usable at 390px in both themes", async () => {
+  expect(CSS.length).toBeGreaterThan(10_000);
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  browser = await chromium.launch({ executablePath: chromium.executablePath() });
+
+  /* ---- #1348: the rename editor over the focused pane's header ---------- */
+  const editorHtml = await renderFocusView([conversation({}), focused, orchestrator], focused.path, async (host) => {
+    await click(host, "[data-testid='mobile-focused-pane'] header button[aria-label^='Rename']");
+    expect(host.querySelector("input[aria-label='Session title']")).not.toBeNull();
+  });
+  const editors: EditorGeometry[] = [];
+  for (const scheme of ["light", "dark"] as const) {
+    const geometry = await withPage(editorHtml, "rename-editor", scheme, (page) => measureEditor(page, scheme, LONG_TITLE));
+    editors.push(geometry);
+    /* The page never scrolls sideways, and the header row is not clipped. */
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(390);
+    expect(geometry.paneHeaderScrollWidth).toBeLessThanOrEqual(geometry.paneHeaderClientWidth);
+    /* The field has REAL width — the whole complaint — inside the viewport,
+       and a long title scrolls within it instead of widening the row. */
+    expect(geometry.input).not.toBeNull();
+    expect(geometry.input!.width).toBeGreaterThanOrEqual(160);
+    expect(geometry.input!.left).toBeGreaterThanOrEqual(0);
+    expect(geometry.input!.right).toBeLessThanOrEqual(390);
+    expect(geometry.input!.height).toBeGreaterThanOrEqual(44);
+    expect(geometry.inputValueLength).toBe(LONG_TITLE.length);
+    expect(geometry.inputScrollWidth).toBeGreaterThan(geometry.inputClientWidth);
+    /* Legible in this theme: ink against surface at the AA text floor, a caret
+       that is not transparent, and type the phone will not zoom. */
+    expect(geometry.contrast).toBeGreaterThanOrEqual(4.5);
+    expect(geometry.caretColor).not.toMatch(/rgba\(\s*0,\s*0,\s*0,\s*0\)|transparent/);
+    expect(geometry.caretColor).not.toBe(geometry.background);
+    expect(geometry.fontSizePx).toBeGreaterThanOrEqual(16);
+    /* Save and Cancel stay inside the same row at phone targets. */
+    expect(geometry.controls.length).toBeGreaterThanOrEqual(2);
+    for (const control of geometry.controls) {
+      expect(control.left).toBeGreaterThanOrEqual(0);
+      expect(control.right).toBeLessThanOrEqual(390);
+      expect(control.height).toBeGreaterThanOrEqual(44);
+      expect(control.width).toBeGreaterThanOrEqual(44);
+    }
+  }
+
+  /* ---- #1347: the pinned row's entry point, the sheet, the rotate draft --- */
+  const files = [conversation({}), orchestrator];
+  const rowHtml = await renderFocusView(files, "/repo/atlas/other.jsonl", async (host) => {
+    expect(host.querySelector("[data-orchestrator-row]")?.getAttribute("data-orchestrator-row-state")).toBe("live");
+  });
+  const sheetHtml = await renderFocusView(files, "/repo/atlas/other.jsonl", async (host) => {
+    await click(host, "[data-orchestrator-row-controls]");
+    expect(host.querySelector("[data-orchestrator-rotate]")).not.toBeNull();
+  });
+  const rotateHtml = await renderFocusView(files, "/repo/atlas/other.jsonl", async (host) => {
+    await click(host, "[data-orchestrator-row-controls]");
+    await click(host, "[data-orchestrator-rotate]");
+    await settle(4);
+    expect(host.querySelector("[data-orchestrator-draft='rotate']")).not.toBeNull();
+  });
+
+  const controls: Record<string, ControlsGeometry[]> = { row: [], sheet: [], rotate: [] };
+  for (const scheme of ["light", "dark"] as const) {
+    const row = await withPage(rowHtml, "orchestrator-row", scheme, (page) => measureControls(page, scheme));
+    controls.row!.push(row);
+    expect(row.scrollWidth).toBeLessThanOrEqual(390);
+    /* The entry point: a 44px target on the row, inside the viewport, ahead
+       of the first conversation chip — in the pinned slot, not the scroller. */
+    expect(row.rowControls).not.toBeNull();
+    expect(row.rowControls!.width).toBeGreaterThanOrEqual(44);
+    expect(row.rowControls!.height).toBeGreaterThanOrEqual(44);
+    expect(row.rowControls!.left).toBeGreaterThanOrEqual(0);
+    expect(row.rowControls!.right).toBeLessThanOrEqual(390);
+    expect(row.rowControls!.left).toBeLessThan(row.firstChipLeft);
+    expect(row.rowOpen!.right).toBeLessThanOrEqual(row.rowControls!.left + 1);
+    /* The chat-first budget (#419): the pin still rides the strip row within
+       the height the transcript's share is computed against. */
+    expect(row.stripHeight).toBeLessThanOrEqual(PERSISTENT_CHROME.focusStrip);
+
+    const sheet = await withPage(sheetHtml, "orchestrator-sheet-live", scheme, (page) => measureControls(page, scheme));
+    controls.sheet!.push(sheet);
+    expect(sheet.sheet).not.toBeNull();
+    expect(sheet.sheet!.rotate).not.toBeNull();
+    expect(sheet.sheet!.rotate!.height).toBeGreaterThanOrEqual(44);
+    expect(sheet.sheet!.rotate!.left).toBeGreaterThanOrEqual(0);
+    expect(sheet.sheet!.rotate!.right).toBeLessThanOrEqual(390);
+    expect(sheet.sheet!.rotate!.bottom).toBeLessThanOrEqual(844);
+    expect(sheet.sheet!.identityText).toContain("opus");
+    expect(sheet.sheet!.identityText).toContain("spare");
+    expect(sheet.sheet!.contextPercent).toBe("24");
+    expect(sheet.sheet!.predecessor).toBe(true);
+    expect(sheet.sheet!.mandateView).toBe(true);
+
+    const rotate = await withPage(rotateHtml, "orchestrator-sheet-rotate", scheme, (page) => measureControls(page, scheme));
+    controls.rotate!.push(rotate);
+    expect(rotate.rotateDraft).not.toBeNull();
+    for (const control of [rotate.rotateDraft!.confirm, rotate.rotateDraft!.cancel]) {
+      expect(control).not.toBeNull();
+      expect(control!.height).toBeGreaterThanOrEqual(44);
+      expect(control!.left).toBeGreaterThanOrEqual(0);
+      expect(control!.right).toBeLessThanOrEqual(390);
+      expect(control!.bottom).toBeLessThanOrEqual(844);
+    }
+    /* The mandate is on screen in the draft's own scroller. (What it and the
+       pickers are PREFILLED with is a property React writes, which static
+       markup does not carry — the DOM suite pins the prefill.) */
+    expect(rotate.rotateDraft!.mandate).not.toBeNull();
+    expect(rotate.rotateDraft!.mandate!.top).toBeLessThan(rotate.rotateDraft!.scrollerBottom);
+  }
+
+  fs.writeFileSync(
+    path.join(EVIDENCE_DIR, "geometry.json"),
+    JSON.stringify({ viewport: VIEWPORT, "rename-editor": editors, "orchestrator-controls": controls }, null, 2),
+  );
+});

--- a/src/components/mobile/mobileOrchestratorControls.dom.test.tsx
+++ b/src/components/mobile/mobileOrchestratorControls.dom.test.tsx
@@ -1,0 +1,528 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * The phone's orchestrator CONTROLS (issue #1347), against the REAL
+ * `MobileFocusView` at 390×844.
+ *
+ * The desktop dock's incumbent header carries the seat's identity and the one
+ * control that acts on it — Rotate, which opens the seat's own configuration
+ * (engine, model, reasoning, account, mandate) prefilled from the incumbent.
+ * The phone had none of it: a live seat's pinned row opened the conversation
+ * and nothing else, so an operator on a phone could not find where rotation
+ * lived. Every claim here is about the phone's surface: the entry point is
+ * VISIBLE on the row (not a hidden overflow), the sheet names the incumbent,
+ * Rotate opens the same prefilled draft, confirm goes to the ROTATE route
+ * exactly once per submission, and a landed rotation lands the phone in the
+ * successor's conversation.
+ */
+
+const dom = new HappyWindow({ innerWidth: 390, innerHeight: 844 });
+class TestResizeObserver { observe() {} unobserve() {} disconnect() {} }
+Object.assign(globalThis, {
+  window: dom, document: dom.document, navigator: dom.navigator,
+  Node: dom.Node, HTMLElement: dom.HTMLElement, HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLSelectElement: dom.HTMLSelectElement, HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event, CustomEvent: dom.CustomEvent, MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent ?? dom.MouseEvent,
+  sessionStorage: dom.sessionStorage, localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver, IntersectionObserver: undefined,
+});
+(dom as unknown as { matchMedia: (q: string) => unknown }).matchMedia = (query: string) => ({
+  matches: true, media: query, addEventListener() {}, removeEventListener() {},
+});
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualLogTail = await import("@/hooks/useLogTail");
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ enabled: false, connection: "live", resyncedAt: null, lastEventAt: null, store: emptyStore() }),
+  useRuntime: () => ({ enabled: false, connection: "live", resyncedAt: null, store: emptyStore() }),
+  useRuntimeEnabled: () => false,
+  useRuntimeSession: () => null,
+  useRuntimeSessionByArtifact: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+  refreshRuntime: () => Promise.resolve(false),
+}));
+mock.module("@/hooks/useLogTail", () => ({
+  useLogTail: () => ({
+    lines: [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null,
+    paused: false, setPaused: () => undefined, clear: () => undefined,
+    hasMore: false, loadingOlder: false, loadOlder: async () => 0, prependGen: 0,
+  }),
+}));
+
+const { MobileFocusView } = await import("./MobileFocusView");
+const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
+const { resetOrchestratorIncumbentCacheForTests } = await import("../orchestrator/useOrchestratorIncumbent");
+
+interface SeatAnswer { seat: unknown; pending: unknown; exists: boolean }
+interface Recorded { url: string; method: string; body: Record<string, unknown> }
+
+let seatAnswer: SeatAnswer;
+let incumbentAnswer: Record<string, unknown>;
+let postRotate: (body: Record<string, unknown>) => Promise<Response>;
+const requests: Recorded[] = [];
+const realFetch = globalThis.fetch;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const accounts = {
+  claude: { active: "primary", accounts: [{ id: "primary", label: "primary", authPresent: true }, { id: "spare", label: "spare", authPresent: true }] },
+  codex: { active: "codex-primary", accounts: [{ id: "codex-primary", label: "codex-primary", authPresent: true }] },
+};
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input);
+  const method = init?.method ?? "GET";
+  const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+  requests.push({ url, method, body });
+  if (url.startsWith("/api/orchestrator/rotate") && method === "POST") return postRotate(body);
+  if (url.startsWith("/api/orchestrator/seat/status")) return json(incumbentAnswer);
+  if (url.startsWith("/api/orchestrator/seat")) return json(seatAnswer);
+  if (url.startsWith("/api/accounts")) return json(accounts);
+  return json({});
+}) as typeof fetch;
+
+const roots = new Set<Root>();
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+  globalThis.fetch = realFetch;
+});
+beforeEach(() => {
+  resetOrchestratorSeatCacheForTests();
+  resetOrchestratorIncumbentCacheForTests();
+  requests.length = 0;
+  seatAnswer = { seat: seat(), pending: null, exists: true };
+  incumbentAnswer = incumbent();
+  postRotate = async () => json({
+    ok: true, accepted: true, state: "accepted", conversationId: "conv_successor", launchId: "launch-b",
+    transport: "structured", initialMessage: "pending", seat: seat({ conversationId: "conv_successor", path: "/successor.jsonl", predecessorConversationId: "conv_orchestrator" }),
+  }, 202);
+});
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+function conversation(over: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/other.jsonl", root: "claude-projects", name: "other.jsonl", project: "atlas", title: "Some other work",
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 100, size: 1, activity: "live",
+    proc: "running", pid: 3, conversationId: "conv_other", model: "sonnet", cwd: "/repo/atlas", projectRoot: "/repo/atlas",
+    pendingQuestion: null, waitingInput: null,
+    ...over,
+  } as FileEntry;
+}
+
+const orchestrator = conversation({
+  path: "/orchestrator.jsonl", name: "orchestrator.jsonl", title: "Run the Atlas board",
+  conversationId: "conv_orchestrator", model: "opus", mtime: 10,
+});
+const successor = conversation({
+  path: "/successor.jsonl", name: "successor.jsonl", title: "Run the Atlas board (successor)",
+  conversationId: "conv_successor", model: "opus", mtime: 200, pid: 9,
+});
+
+function seat(over: Record<string, unknown> = {}) {
+  return {
+    project: "atlas", seatEpoch: 4, conversationId: "conv_orchestrator", path: "/orchestrator.jsonl",
+    mandate: "You run the Atlas board.", promptVersion: 3, predecessorConversationId: "conv_predecessor", state: "active",
+    intent: { clientRequestId: "seatreq-0001", mode: "spawn", launchId: "launch-0001", error: null },
+    designatedAt: "2100-01-02T11:00:00.000Z", activatedAt: "2100-01-02T11:00:02.000Z",
+    ...over,
+  };
+}
+
+/** `GET /api/orchestrator/seat/status`: the incumbent as the server reads it. */
+function incumbent(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    project: "atlas", designated: true, conversationId: "conv_orchestrator", predecessorConversationId: "conv_predecessor",
+    engine: "claude", model: "opus", effort: "high", accountId: "spare", cwd: "/repo/atlas/worktrees/board",
+    transcriptPath: "/orchestrator.jsonl",
+    liveness: { lifecycle: "running", hostState: "alive", silentForMs: 0 },
+    context: { tokens: 24_000, limit: 100_000, percent: 24, estimated: false, basis: "provider-reported usage" },
+    transcriptFacts: { bytes: 4_096, messageCount: 12, toolCount: 3, compactionCount: 0 },
+    rotation: { recommended: false, level: "none", reasons: [], thresholdUnknown: false },
+    ...over,
+  };
+}
+
+const view = (files: FileEntry[]) => (
+  <MobileFocusView
+    project="atlas"
+    projectName="atlas"
+    groups={[]}
+    manual={files}
+    files={files}
+    flows={[]}
+    pipelines={[]}
+    tasks={[]}
+    drafts={[]}
+    loaded
+    focus={null}
+    onSelect={() => undefined}
+    onClose={() => undefined}
+    onDraftClose={() => undefined}
+    onDraftSpawned={() => undefined}
+  />
+);
+
+async function settle(root: Root, element: React.ReactElement, rounds = 4): Promise<void> {
+  for (let round = 0; round < rounds; round += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushSync(() => root.render(element));
+  }
+}
+
+async function mount(files: FileEntry[]): Promise<{ host: HTMLElement; root: Root; rerender: (next: FileEntry[]) => Promise<void> }> {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  flushSync(() => root.render(view(files)));
+  await settle(root, view(files));
+  return {
+    host: host as unknown as HTMLElement,
+    root,
+    rerender: async (next: FileEntry[]) => {
+      flushSync(() => root.render(view(next)));
+      await settle(root, view(next), 2);
+    },
+  };
+}
+
+/* A controlled field, typed through its own React props — see the #979 suite. */
+function type(field: HTMLTextAreaElement, value: string): void {
+  const key = Object.keys(field).find((name) => name.startsWith("__reactProps$"))!;
+  const props = (field as unknown as Record<string, { onChange(event: unknown): void }>)[key]!;
+  field.value = value;
+  flushSync(() => props.onChange({ target: field }));
+}
+
+const row = (host: HTMLElement) => host.querySelector("[data-orchestrator-row]") as HTMLElement;
+const openButton = (host: HTMLElement) => host.querySelector("[data-orchestrator-row-open]") as HTMLButtonElement;
+const controlsButton = (host: HTMLElement) => host.querySelector("[data-orchestrator-row-controls]") as HTMLButtonElement | null;
+const sheet = (host: HTMLElement) => host.querySelector('[data-testid="mobile-orchestrator-sheet"]') as HTMLElement | null;
+const rotateButton = (host: HTMLElement) => sheet(host)?.querySelector("[data-orchestrator-rotate]") as HTMLButtonElement | null;
+const confirmButton = (host: HTMLElement) => sheet(host)!.querySelector("[data-orchestrator-confirm]") as HTMLButtonElement;
+const rotatePosts = () => requests.filter((request) => request.method === "POST" && request.url.startsWith("/api/orchestrator/rotate"));
+const seatPosts = () => requests.filter((request) => request.method === "POST" && request.url === "/api/orchestrator/seat");
+const focusedPath = (host: HTMLElement) =>
+  host.querySelector('[data-testid="mobile-focused-pane"] [data-link-path]')?.getAttribute("data-link-path") ?? null;
+
+/** Open the sheet from the row's controls entry point, and wait for the
+    incumbent read the sheet asks for. */
+async function openControls(host: HTMLElement, root: Root, files: FileEntry[]): Promise<HTMLElement> {
+  const entry = controlsButton(host);
+  expect(entry).not.toBeNull();
+  flushSync(() => entry!.click());
+  await settle(root, view(files), 4);
+  const panel = sheet(host);
+  expect(panel).not.toBeNull();
+  return panel!;
+}
+
+/** Press Rotate and wait out the incumbent re-read the press starts. */
+async function openRotate(host: HTMLElement, root: Root, files: FileEntry[]): Promise<void> {
+  const rotate = rotateButton(host);
+  expect(rotate).not.toBeNull();
+  flushSync(() => rotate!.click());
+  await settle(root, view(files), 5);
+}
+
+test("a live seat's pinned row carries a VISIBLE controls entry point beside the chip, at a phone tap target", async () => {
+  const files = [conversation({}), orchestrator];
+  const { host } = await mount(files);
+  expect(row(host).getAttribute("data-orchestrator-row-state")).toBe("live");
+  /* The row's own tap still opens the conversation (#979's decision)… */
+  expect(row(host).getAttribute("data-orchestrator-row-tap")).toBe("conversation");
+
+  /* …and the controls are a SECOND, always-rendered target right beside it —
+     not a long-press, not a menu, not an overflow that touch never reveals. */
+  const entry = controlsButton(host);
+  expect(entry).not.toBeNull();
+  expect(entry!.className).toContain("h-11");
+  expect(entry!.className).toContain("w-11");
+  expect(entry!.getAttribute("aria-haspopup")).toBe("dialog");
+  const aria = entry!.getAttribute("aria-label") ?? "";
+  expect(aria.toLowerCase()).toContain("rotate");
+  /* Inside the pinned slot, so it can never scroll away with the chip strip. */
+  expect(entry!.closest("[data-orchestrator-row]")).toBe(row(host));
+  expect(entry!.closest(".overflow-x-auto")).toBeNull();
+});
+
+test("the controls sheet names the incumbent the way the desktop header does, shows its mandate, and offers Rotate", async () => {
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  const panel = await openControls(host, root, files);
+
+  /* Opened deliberately on a live seat: it stays, it does not hand off. */
+  expect(sheet(host)).not.toBeNull();
+  expect(panel.getAttribute("data-orchestrator-sheet-state")).toBe("live");
+
+  /* WHO holds the seat: engine, model at tier, account and context fullness —
+     the same reading the desktop's incumbent header renders. */
+  const identity = panel.querySelector("[data-orchestrator-incumbent]") as HTMLElement | null;
+  expect(identity).not.toBeNull();
+  expect(identity!.textContent).toContain("Claude");
+  expect(identity!.textContent).toContain("opus");
+  expect(identity!.textContent).toContain("high");
+  expect(identity!.textContent).toContain("spare");
+  expect(identity!.querySelector("[data-orchestrator-context]")?.getAttribute("data-orchestrator-context")).toBe("24");
+  expect(identity!.textContent).toContain("24%");
+  /* The handoff lineage the desktop header links to. */
+  expect(panel.querySelector('[data-orchestrator-predecessor="conv_predecessor"]')).not.toBeNull();
+
+  /* The mandate the seat is running under is readable here, not only from a
+     rotate draft that edits it. */
+  const mandateView = panel.querySelector("[data-orchestrator-mandate-view]") as HTMLElement | null;
+  expect(mandateView).not.toBeNull();
+  expect(mandateView!.textContent).toContain("You run the Atlas board.");
+  expect(mandateView!.textContent).toContain("v3");
+
+  /* Rotate: a labelled 44px control, and only a control — nothing rotates
+     until the draft it opens is confirmed. */
+  const rotate = rotateButton(host);
+  expect(rotate).not.toBeNull();
+  expect(rotate!.className).toContain("min-h-11");
+  expect(rotate!.textContent).toContain("Rotate");
+  expect(rotatePosts()).toHaveLength(0);
+  /* The conversation stays one tap away as the footer's primary action. */
+  expect(confirmButton(host).textContent).toContain("Open the conversation");
+});
+
+test("Rotate opens the seat's configuration prefilled from the incumbent, and the draft is the SAME shape the desktop has", async () => {
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  await openControls(host, root, files);
+  await openRotate(host, root, files);
+
+  const panel = sheet(host)!;
+  expect(panel.getAttribute("data-orchestrator-sheet-mode")).toBe("rotate");
+  const draft = panel.querySelector('[data-orchestrator-draft="rotate"]');
+  expect(draft).not.toBeNull();
+  /* The incumbent's own mandate, editable; the server composes the handoff. */
+  const mandate = panel.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement;
+  expect(mandate.value).toBe("You run the Atlas board.");
+  expect(panel.textContent).toContain("Replace this project's orchestrator");
+  /* The shared launch module: engine radios, the account the incumbent runs
+     under, and the 44px floor applied from outside it. */
+  const engines = [...panel.querySelectorAll('[role="radio"]')].map((node) => node.textContent);
+  expect(engines).toEqual(["Claude", "Codex"]);
+  const account = panel.querySelector('select[aria-label*="Claude"]') as HTMLSelectElement;
+  expect(account).not.toBeNull();
+  expect(account.value).toBe("spare");
+  const model = panel.querySelector('select[aria-label="Agent model"]') as HTMLSelectElement;
+  expect(model.value).toBe("opus");
+  expect(panel.querySelector('[role="radiogroup"]')!.closest("[class*='min-h-11']")).not.toBeNull();
+  /* The successor continues in the predecessor's checkout, and says so. */
+  expect(panel.textContent).toContain("/repo/atlas/worktrees/board");
+  /* Two ways out, both at the thumb: keep the incumbent, or rotate. */
+  expect(confirmButton(host).textContent).toContain("Rotate orchestrator");
+  expect(confirmButton(host).className).toContain("min-h-11");
+  const cancel = panel.querySelector("[data-orchestrator-rotate-cancel]") as HTMLButtonElement;
+  expect(cancel).not.toBeNull();
+  expect(cancel.className).toContain("min-h-11");
+
+  /* Keep this one: back to the live view, nothing posted. */
+  flushSync(() => cancel.click());
+  await settle(root, view(files), 2);
+  expect(sheet(host)!.getAttribute("data-orchestrator-sheet-mode")).toBe("live");
+  expect(rotatePosts()).toHaveLength(0);
+});
+
+test("confirming a rotation posts to the ROTATE route once — never the seat route, never raw spawn — with the adjusted seat settings", async () => {
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  await openControls(host, root, files);
+  await openRotate(host, root, files);
+
+  type(sheet(host)!.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement, "You run Atlas now. Talk to me here.");
+  /* Adjust a seat setting end to end: the account this seat will run under.
+     A native `change` on the select reaches React's own change plugin (a
+     happy-dom select is a Proxy, so its React props are not enumerable). */
+  const account = sheet(host)!.querySelector('select[aria-label*="Claude"]') as HTMLSelectElement;
+  account.value = "primary";
+  flushSync(() => account.dispatchEvent(new dom.Event("change", { bubbles: true }) as unknown as Event));
+
+  flushSync(() => confirmButton(host).click());
+  await settle(root, view(files), 3);
+
+  const posts = rotatePosts();
+  expect(posts).toHaveLength(1);
+  expect(seatPosts()).toHaveLength(0);
+  expect(requests.some((request) => request.url.includes("/api/spawn"))).toBe(false);
+  expect(posts[0]!.body).toMatchObject({ project: "atlas", mandate: "You run Atlas now. Talk to me here.", engine: "claude", model: "opus", effort: "high", accountId: "primary" });
+  expect(String(posts[0]!.body.clientRequestId)).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+  /* No cwd: the server continues the successor in the predecessor's checkout. */
+  expect(posts[0]!.body.cwd).toBeUndefined();
+});
+
+test("a double tap rotates ONCE, and a retry after a lost reply replays the SAME key instead of rotating twice", async () => {
+  postRotate = async () => {
+    throw new Error("network down");
+  };
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  await openControls(host, root, files);
+  await openRotate(host, root, files);
+
+  flushSync(() => {
+    confirmButton(host).click();
+    confirmButton(host).click();
+  });
+  await settle(root, view(files), 3);
+  expect(rotatePosts()).toHaveLength(1);
+  /* The reply was lost, so a successor may already exist: the draft says so
+     and stays open over the incumbent, which is still on the seat. */
+  expect(sheet(host)!.getAttribute("data-orchestrator-sheet-mode")).toBe("rotate");
+  expect(sheet(host)!.querySelector("[data-orchestrator-intent-error]")!.textContent).toContain("replays the same request");
+  expect(row(host).getAttribute("data-orchestrator-row-state")).toBe("live");
+
+  postRotate = async () => json({ ok: true, replayed: true, conversationId: "conv_successor", seat: seat({ conversationId: "conv_successor", path: "/successor.jsonl" }) });
+  flushSync(() => confirmButton(host).click());
+  await settle(root, view(files), 3);
+  const posts = rotatePosts();
+  expect(posts).toHaveLength(2);
+  expect(posts[1]!.body.clientRequestId).toBe(posts[0]!.body.clientRequestId);
+});
+
+test("a rotation the server refused surfaces in the draft with retry, and the retry carries a FRESH key", async () => {
+  postRotate = async () => json({ error: "no orchestrator is designated for this project", code: "no_incumbent" }, 409);
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  await openControls(host, root, files);
+  await openRotate(host, root, files);
+
+  flushSync(() => confirmButton(host).click());
+  await settle(root, view(files), 3);
+  expect(sheet(host)!.querySelector("[data-orchestrator-intent-error]")!.textContent).toContain("no orchestrator is designated");
+  /* The incumbent's conversation was never taken away by the failure. */
+  expect(row(host).getAttribute("data-orchestrator-row-state")).toBe("live");
+  expect(row(host).getAttribute("data-orchestrator-row-tap")).toBe("conversation");
+
+  postRotate = async () => json({ ok: true, conversationId: "conv_successor", launchId: "launch-b", seat: seat({ conversationId: "conv_successor", path: "/successor.jsonl" }) }, 202);
+  flushSync(() => confirmButton(host).click());
+  await settle(root, view(files), 3);
+  const posts = rotatePosts();
+  expect(posts).toHaveLength(2);
+  expect(posts[1]!.body.clientRequestId).not.toBe(posts[0]!.body.clientRequestId);
+});
+
+test("a landed rotation hands the phone off into the SUCCESSOR's conversation, with the composer", async () => {
+  const files = [conversation({}), orchestrator, successor];
+  const { host, root } = await mount(files);
+  /* Default focus is the newest conversation; the incumbent is the seat. */
+  expect(row(host).getAttribute("data-orchestrator-row-state")).toBe("live");
+  await openControls(host, root, files);
+  await openRotate(host, root, files);
+
+  postRotate = async () => {
+    /* The rotation landed: the next seat read reports the successor. */
+    seatAnswer = { seat: seat({ conversationId: "conv_successor", path: "/successor.jsonl", predecessorConversationId: "conv_orchestrator", seatEpoch: 5 }), pending: null, exists: true };
+    incumbentAnswer = incumbent({ conversationId: "conv_successor", transcriptPath: "/successor.jsonl", predecessorConversationId: "conv_orchestrator" });
+    return json({ ok: true, accepted: true, state: "accepted", conversationId: "conv_successor", launchId: "launch-b", transport: "structured", initialMessage: "pending" }, 202);
+  };
+  flushSync(() => confirmButton(host).click());
+  await settle(root, view(files), 6);
+
+  /* The draft is gone with the incumbent it was replacing, and the phone is IN
+     the successor's conversation — the standard focus view, composer included. */
+  expect(sheet(host)).toBeNull();
+  expect(focusedPath(host)).toBe("/successor.jsonl");
+  expect(host.querySelector('[data-testid="bounded-mobile-composer"]')).not.toBeNull();
+  expect(row(host).getAttribute("data-orchestrator-row-state")).toBe("live");
+  expect(rotatePosts()).toHaveLength(1);
+});
+
+test("a seat whose transcript is not in view still reaches Rotate from the sheet — rotation is the way forward for a gone host", async () => {
+  /* No file answers for the seat: the row's tap opens the sheet itself. */
+  seatAnswer = { seat: seat({ conversationId: "conv_missing", path: "/missing.jsonl" }), pending: null, exists: true };
+  incumbentAnswer = incumbent({ conversationId: "conv_missing", transcriptPath: "/missing.jsonl" });
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  expect(row(host).getAttribute("data-orchestrator-row-tap")).toBe("sheet");
+  flushSync(() => openButton(host).click());
+  await settle(root, view(files), 4);
+  expect(sheet(host)).not.toBeNull();
+  expect(rotateButton(host)).not.toBeNull();
+  await openRotate(host, root, files);
+  expect(sheet(host)!.querySelector('[data-orchestrator-draft="rotate"]')).not.toBeNull();
+  expect((sheet(host)!.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement).value).toBe("You run the Atlas board.");
+});
+
+/* A minimal visualViewport stand-in — happy-dom has none, and the keyboard is
+   the only thing that shrinks it (#983's signal, `useKeyboardInset`). */
+function makeVisualViewport(height: number) {
+  const listeners = new Set<() => void>();
+  return {
+    height, scale: 1, offsetTop: 0,
+    addEventListener(type: string, cb: () => void) { if (type === "resize") listeners.add(cb); },
+    removeEventListener(type: string, cb: () => void) { if (type === "resize") listeners.delete(cb); },
+    resizeTo(next: number) {
+      this.height = next;
+      for (const cb of [...listeners]) cb();
+    },
+  };
+}
+
+test("the rotate draft stays operable with the keyboard open: the sheet pads the inset, the mandate is revealed once, the confirm survives", async () => {
+  const vv = makeVisualViewport(844);
+  (dom as unknown as Record<string, unknown>).visualViewport = vv;
+  (globalThis as Record<string, unknown>).visualViewport = vv;
+  try {
+    const files = [conversation({}), orchestrator];
+    const { host, root } = await mount(files);
+    await openControls(host, root, files);
+    await openRotate(host, root, files);
+
+    const field = sheet(host)!.querySelector("[data-orchestrator-mandate]") as HTMLTextAreaElement;
+    const block = field.parentElement as HTMLElement & { scrollIntoView: (options?: unknown) => void };
+    const reveals: unknown[] = [];
+    block.scrollIntoView = (options?: unknown) => { reveals.push(options); };
+
+    flushSync(() => field.focus());
+    await settle(root, view(files), 2);
+    expect(reveals).toHaveLength(0);
+
+    /* The keyboard opens under the focused field (#983's signal). */
+    flushSync(() => vv.resizeTo(508));
+    await settle(root, view(files), 2);
+    expect(reveals).toEqual([{ block: "start" }]);
+    /* The full-height surface yields the keyboard's share, so the confirm at
+       the thumb is above it rather than behind it. */
+    const surface = sheet(host)!.parentElement as HTMLElement;
+    expect(surface.style.paddingBottom).toBe("336px");
+    expect(confirmButton(host)).not.toBeNull();
+    expect(confirmButton(host).textContent).toContain("Rotate orchestrator");
+
+    flushSync(() => vv.resizeTo(468));
+    await settle(root, view(files), 2);
+    expect(reveals).toHaveLength(1);
+  } finally {
+    delete (dom as unknown as Record<string, unknown>).visualViewport;
+    delete (globalThis as Record<string, unknown>).visualViewport;
+  }
+});
+
+test("the sheet respects the phone's safe-area insets at both ends", async () => {
+  const files = [conversation({}), orchestrator];
+  const { host, root } = await mount(files);
+  await openControls(host, root, files);
+  const surface = sheet(host)!.parentElement as HTMLElement;
+  expect(surface.className).toContain("fixed inset-0");
+  expect(surface.className).toContain("pb-[env(safe-area-inset-bottom)]");
+  expect(surface.className).toContain("pt-[env(safe-area-inset-top)]");
+});

--- a/src/components/mobile/orchestratorDraftStorage.ts
+++ b/src/components/mobile/orchestratorDraftStorage.ts
@@ -1,3 +1,5 @@
+import type { LaunchDraftStorage } from "@/components/draft/AgentLaunchControls";
+
 /*
  * Where a phone keeps an orchestrator draft between mounts.
  *
@@ -8,25 +10,47 @@
  * started in the dock and continued on the phone (or in a tab that was resized
  * across the mobile breakpoint mid-submit) must replay the same durable intent
  * rather than mint a second designation.
+ *
+ * Create and rotate keep SEPARATE drafts (issue #1347), exactly as the dock
+ * does: they are different decisions about different orchestrators, and a
+ * half-written rotation must never overwrite the create draft the operator
+ * would need if the seat were vacated.
  */
 
-const storageKey = (project: string, name: string) => `llvOrchestratorDraft:${project}:${name}`;
+/** The two designation flows a project can hold a draft for. */
+export type SeatDraftFlow = "Draft" | "Rotate";
 
-export function readSeatDraftField(project: string, name: string): string {
+const storageKey = (flow: SeatDraftFlow, project: string, name: string) => `llvOrchestrator${flow}:${project}:${name}`;
+
+export function readSeatFlowField(flow: SeatDraftFlow, project: string, name: string): string {
   if (typeof window === "undefined") return "";
   try {
-    return window.sessionStorage.getItem(storageKey(project, name)) ?? "";
+    return window.sessionStorage.getItem(storageKey(flow, project, name)) ?? "";
   } catch {
     return "";
   }
 }
 
-export function writeSeatDraftField(project: string, name: string, value: string): void {
+export function writeSeatFlowField(flow: SeatDraftFlow, project: string, name: string, value: string): void {
   if (typeof window === "undefined") return;
   try {
-    if (value) window.sessionStorage.setItem(storageKey(project, name), value);
-    else window.sessionStorage.removeItem(storageKey(project, name));
+    if (value) window.sessionStorage.setItem(storageKey(flow, project, name), value);
+    else window.sessionStorage.removeItem(storageKey(flow, project, name));
   } catch {
     /* private mode */
   }
+}
+
+/** The create draft's own fields — the pre-#1347 API, unchanged. */
+export const readSeatDraftField = (project: string, name: string): string => readSeatFlowField("Draft", project, name);
+export const writeSeatDraftField = (project: string, name: string, value: string): void => writeSeatFlowField("Draft", project, name, value);
+
+/** One flow's persistence, as the shared launch module's own storage seam. A
+    caller that hands this to `useSeatConfirm` keeps ONE instance per mount
+    (`useMemo`): the flow's submit callback depends on it. */
+export function seatFlowStorage(flow: SeatDraftFlow, project: string): LaunchDraftStorage {
+  return {
+    read: (name) => readSeatFlowField(flow, project, name),
+    write: (name, value) => writeSeatFlowField(flow, project, name, value),
+  };
 }

--- a/src/components/orchestrator/IncumbentHeader.tsx
+++ b/src/components/orchestrator/IncumbentHeader.tsx
@@ -115,8 +115,10 @@ export function IncumbentHeader({
 }
 
 /** The board's own context read, in the status route's shape — what the header
-    shows until the slower status poll answers with the server's reading. */
-function boardContext(file: FileEntry | null): IncumbentContext | null {
+    shows until the slower status poll answers with the server's reading.
+    Exported for the phone's seat identity (issue #1347), which reads the same
+    fallback so both surfaces show one number for one seat. */
+export function boardContext(file: FileEntry | null): IncumbentContext | null {
   const ctx = file?.ctx;
   if (!ctx) return null;
   return {
@@ -135,8 +137,11 @@ function boardContext(file: FileEntry | null): IncumbentContext | null {
  *
  * An inferred number is marked «~» and says why in its own tooltip — a guess
  * must never be readable as a provider-reported count.
+ *
+ * Exported for the phone's orchestrator sheet (issue #1347): the meter is the
+ * same reading on both surfaces, so it is the same component.
  */
-function ContextMeter({ context }: { context: IncumbentContext | null }) {
+export function ContextMeter({ context }: { context: IncumbentContext | null }) {
   const { t } = useLocale();
   if (!context || context.tokens === null) return null;
   const { percent, estimated } = context;

--- a/src/components/session/SessionTitle.mobile.dom.test.tsx
+++ b/src/components/session/SessionTitle.mobile.dom.test.tsx
@@ -1,0 +1,258 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * Renaming a focused conversation on a phone (issue #1348), against the REAL
+ * `MobileFocusView` → `BranchPane` → `SessionTitle` at 390×844.
+ *
+ * The operator tapped the pencil and got a field with no visible text. The
+ * pane header at that width is a single flex row already carrying the status
+ * dot, the status word, the kill control, the details toggle, the favourite
+ * crown, delete and close — every one a fixed 44px target — and the inline
+ * editor then joined that row with THREE more 44px targets of its own, so the
+ * `min-w-0 flex-1` input was the only thing left to give and gave everything:
+ * zero width, text and caret included. On top of that the input was set in
+ * 12px type, which iOS Safari answers by zooming the page on focus, panning the
+ * caret out of view. This file pins the phone's rename render path: the editor
+ * takes the header row over instead of sharing it, the field is set in a size
+ * the phone will not zoom, its face is spelled out for both themes, and a drag
+ * inside it moves the text rather than the conversation.
+ */
+
+const dom = new HappyWindow({ innerWidth: 390, innerHeight: 844 });
+class TestResizeObserver { observe() {} unobserve() {} disconnect() {} }
+Object.assign(globalThis, {
+  window: dom, document: dom.document, navigator: dom.navigator,
+  Node: dom.Node, HTMLElement: dom.HTMLElement, HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLInputElement: dom.HTMLInputElement,
+  Event: dom.Event, CustomEvent: dom.CustomEvent, MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent, FocusEvent: dom.FocusEvent,
+  PointerEvent: dom.PointerEvent ?? dom.MouseEvent,
+  sessionStorage: dom.sessionStorage, localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver, IntersectionObserver: undefined,
+});
+(dom as unknown as { matchMedia: (q: string) => unknown }).matchMedia = (query: string) => ({
+  matches: true, media: query, addEventListener() {}, removeEventListener() {},
+});
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualLogTail = await import("@/hooks/useLogTail");
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ enabled: false, connection: "live", resyncedAt: null, lastEventAt: null, store: emptyStore() }),
+  useRuntime: () => ({ enabled: false, connection: "live", resyncedAt: null, store: emptyStore() }),
+  useRuntimeEnabled: () => false,
+  useRuntimeSession: () => null,
+  useRuntimeSessionByArtifact: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useLogTail", () => ({
+  useLogTail: () => ({
+    lines: [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null,
+    paused: false, setPaused: () => undefined, clear: () => undefined,
+    hasMore: false, loadingOlder: false, loadOlder: async () => 0, prependGen: 0,
+  }),
+}));
+
+const { MobileFocusView } = await import("../mobile/MobileFocusView");
+const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
+
+interface Recorded { url: string; method: string; body: Record<string, unknown> }
+const requests: Recorded[] = [];
+const realFetch = globalThis.fetch;
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input);
+  const method = init?.method ?? "GET";
+  const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+  requests.push({ url, method, body });
+  if (url.startsWith("/api/session/title")) {
+    return json({ ok: true, override: { key: "uuid:claude:renamed", title: body.title, revision: 1, updatedAt: "t" }, revision: 1 });
+  }
+  if (url.startsWith("/api/orchestrator/seat")) return json({ seat: null, pending: null, exists: true });
+  if (url.startsWith("/api/accounts")) return json({ claude: { active: "", accounts: [] }, codex: { active: "", accounts: [] } });
+  return json({});
+}) as typeof fetch;
+
+const roots = new Set<Root>();
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+  globalThis.fetch = realFetch;
+});
+beforeEach(() => {
+  resetOrchestratorSeatCacheForTests();
+  requests.length = 0;
+});
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+const LONG_TITLE = "Builder · keep every orchestrator control reachable from a 390px phone viewport, and make the rename editor legible";
+
+function conversation(over: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/other.jsonl", root: "claude-projects", name: "other.jsonl", project: "atlas", title: "Some other work",
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 100, size: 1, activity: "live",
+    proc: "running", pid: 3, conversationId: "conv_other", model: "sonnet", cwd: "/repo/atlas", projectRoot: "/repo/atlas",
+    renamable: true, pendingQuestion: null, waitingInput: null,
+    ...over,
+  } as FileEntry;
+}
+
+const focused = conversation({ path: "/focused.jsonl", name: "focused.jsonl", conversationId: "conv_focused", title: LONG_TITLE, mtime: 200 });
+const neighbour = conversation({});
+
+const view = (files: FileEntry[]) => (
+  <MobileFocusView
+    project="atlas"
+    projectName="atlas"
+    groups={[]}
+    manual={files}
+    files={files}
+    flows={[]}
+    pipelines={[]}
+    tasks={[]}
+    drafts={[]}
+    loaded
+    focus="/focused.jsonl"
+    onSelect={() => undefined}
+    onClose={() => undefined}
+    onDraftClose={() => undefined}
+    onDraftSpawned={() => undefined}
+  />
+);
+
+async function settle(root: Root, element: React.ReactElement, rounds = 3): Promise<void> {
+  for (let round = 0; round < rounds; round += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushSync(() => root.render(element));
+  }
+}
+
+async function mount(files: FileEntry[]): Promise<{ host: HTMLElement; root: Root }> {
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  roots.add(root);
+  flushSync(() => root.render(view(files)));
+  await settle(root, view(files));
+  return { host: host as unknown as HTMLElement, root };
+}
+
+const paneHeader = (host: HTMLElement) => host.querySelector('[data-testid="mobile-focused-pane"] header') as HTMLElement;
+const pencil = (host: HTMLElement) => paneHeader(host).querySelector('button[aria-label^="Rename"]') as HTMLButtonElement;
+const editor = (host: HTMLElement) => paneHeader(host).querySelector("[data-session-title-editor]") as HTMLElement | null;
+const input = (host: HTMLElement) => paneHeader(host).querySelector('input[aria-label="Session title"]') as HTMLInputElement | null;
+const focusedPath = (host: HTMLElement) =>
+  host.querySelector('[data-testid="mobile-focused-pane"] [data-link-path]')?.getAttribute("data-link-path") ?? null;
+
+function typeInto(field: HTMLInputElement, value: string): void {
+  Object.getOwnPropertyDescriptor(dom.HTMLInputElement.prototype, "value")!.set!.call(field, value);
+  field.dispatchEvent(new dom.Event("input", { bubbles: true }) as unknown as Event);
+}
+
+/** A finger moving across `target`: touchstart at `from`, touchend at `to`. */
+function drag(target: Element, from: number, to: number): void {
+  const start = new dom.Event("touchstart", { bubbles: true, cancelable: true }) as unknown as Event;
+  Object.assign(start, { touches: [{ clientX: from, clientY: 20 }], changedTouches: [{ clientX: from, clientY: 20 }] });
+  const end = new dom.Event("touchend", { bubbles: true, cancelable: true }) as unknown as Event;
+  Object.assign(end, { touches: [], changedTouches: [{ clientX: to, clientY: 22 }] });
+  flushSync(() => {
+    target.dispatchEvent(start);
+    target.dispatchEvent(end);
+  });
+}
+
+test("the phone's rename editor shows the current title in a field that takes the header row over, set in a size the phone will not zoom", async () => {
+  const files = [neighbour, focused];
+  const { host, root } = await mount(files);
+  expect(focusedPath(host)).toBe("/focused.jsonl");
+  /* The phone's always-visible launcher (#33 mobile variant). */
+  expect(pencil(host).className).toContain("h-11");
+
+  flushSync(() => pencil(host).click());
+  await settle(root, view(files), 1);
+
+  /* The current title is IN the field, whole, and preselected. */
+  const field = input(host);
+  expect(field).not.toBeNull();
+  expect(field!.value).toBe(LONG_TITLE);
+  expect(field!.getAttribute("type")).toBe("text");
+  expect(dom.document.activeElement).toBe(field as unknown as typeof dom.document.activeElement);
+
+  /* The editor is not one more cell in the crowded identity row: it lays over
+     that row edge to edge, so the seven fixed 44px controls beside the title
+     cannot squeeze the field to nothing. */
+  const box = editor(host);
+  expect(box).not.toBeNull();
+  expect(box!.getAttribute("data-session-title-editor")).toBe("mobile");
+  expect(box!.className).toContain("absolute");
+  expect(box!.className).toContain("inset-x-0");
+  expect(box!.className).toContain("top-0");
+  expect(box!.className).not.toContain("flex-1");
+
+  /* The field itself: a 44px row, 16px type (iOS zooms anything smaller on
+     focus, which pans the caret off screen), and a face spelled out for both
+     themes — surface, ink and caret all from the role tokens. */
+  const cls = field!.className;
+  expect(cls).toContain("h-11");
+  expect(cls).toContain("text-[16px]");
+  expect(cls).toContain("bg-canvas");
+  expect(cls).toContain("text-primary");
+  expect(cls).toContain("caret-accent");
+  expect(cls).toContain("flex-1");
+  expect(cls).toContain("min-w-0");
+
+  /* Save and Cancel keep their phone targets inside the same row. */
+  const save = box!.querySelector('button[aria-label="Save name"]') as HTMLButtonElement;
+  const cancel = box!.querySelector('button[aria-label="Cancel"]') as HTMLButtonElement;
+  expect(save.className).toContain("h-11");
+  expect(cancel.className).toContain("h-11");
+});
+
+test("a drag inside the rename field scrolls the title, never the conversation under it", async () => {
+  const files = [neighbour, focused];
+  const { host, root } = await mount(files);
+  flushSync(() => pencil(host).click());
+  await settle(root, view(files), 1);
+  const field = input(host)!;
+
+  /* The pane header is the phone's swipe handle: a leftward drag on it steps to
+     the next conversation. The same drag inside the editor is the operator
+     moving through a long title, so it must stay in the field. */
+  drag(field, 300, 100);
+  await settle(root, view(files), 1);
+  expect(focusedPath(host)).toBe("/focused.jsonl");
+  expect(input(host)).not.toBeNull();
+  expect(input(host)!.value).toBe(LONG_TITLE);
+});
+
+test("Enter saves what was typed and the phone header shows the new name", async () => {
+  const files = [neighbour, focused];
+  const { host, root } = await mount(files);
+  flushSync(() => pencil(host).click());
+  await settle(root, view(files), 1);
+  const field = input(host)!;
+  flushSync(() => typeInto(field, "Phone rename"));
+  flushSync(() => field.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }) as unknown as Event));
+  await settle(root, view(files), 3);
+
+  const saves = requests.filter((request) => request.url === "/api/session/title");
+  expect(saves).toHaveLength(1);
+  expect(saves[0]!.body).toMatchObject({ path: "/focused.jsonl", title: "Phone rename" });
+  expect(input(host)).toBeNull();
+  expect(paneHeader(host).textContent).toContain("Phone rename");
+});

--- a/src/components/session/SessionTitle.tsx
+++ b/src/components/session/SessionTitle.tsx
@@ -269,13 +269,33 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
   };
 
   const stop = (event: React.PointerEvent) => event.stopPropagation();
+  /* The phone's pane header is also its swipe handle (`MobileFocusView` steps
+     to the next conversation on a horizontal drag across it). A drag INSIDE
+     the editor is the operator moving through a long title, so it stays here
+     — the same isolation the metadata row gives its own horizontal scroll. */
+  const stopTouch = (event: React.TouchEvent) => event.stopPropagation();
 
   if (editing) {
     return (
       <span
         ref={editorRef}
-        className={`inline-flex min-w-0 flex-1 items-center gap-1 ${className}`}
+        data-session-title-editor={isMobile ? "mobile" : "inline"}
+        className={
+          isMobile
+            /* Issue #1348: on the phone the editor TAKES THE HEADER ROW OVER
+               instead of joining it. That row is a single non-wrapping flex line
+               already holding seven fixed 44px controls (status, kill, details,
+               favourite, delete, close, and this pencil), and an inline editor
+               added three more; at 390px the `min-w-0 flex-1` input was the only
+               shrinkable cell and shrank to nothing — an edit field with no
+               visible text, caret included. Laid over the row, edge to edge,
+               the field owns the width and the controls come back on close. */
+            ? `absolute inset-x-0 top-0 z-20 flex items-center gap-1 bg-card px-2 py-1 ${className}`
+            : `inline-flex min-w-0 flex-1 items-center gap-1 ${className}`
+        }
         onPointerDown={stop}
+        onTouchStart={stopTouch}
+        onTouchEnd={stopTouch}
         onBlur={onEditorBlur}
       >
         <input
@@ -283,8 +303,21 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
           type="text"
           value={value}
           maxLength={120}
-          className="min-w-0 flex-1 rounded-[6px] border border-accent/50 bg-canvas px-1.5 py-0.5 text-[12px] font-semibold text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          className={
+            isMobile
+              /* 16px, not 12px: iOS Safari zooms the page on focusing any smaller
+                 field, which pans the caret out of the visible viewport. The
+                 face is spelled out from the role tokens — surface, ink AND
+                 caret — so it reads the same in the light and dark themes. */
+              ? "h-11 min-w-0 flex-1 rounded-control border border-accent/50 bg-canvas px-3 text-[16px] font-medium text-primary caret-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              : "min-w-0 flex-1 rounded-[6px] border border-accent/50 bg-canvas px-1.5 py-0.5 text-[12px] font-semibold text-primary caret-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          }
           aria-label={t("rename.inputAria")}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          enterKeyHint="done"
           onChange={(event) => setValue(event.target.value)}
           onKeyDown={onKeyDown}
         />

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1993,6 +1993,10 @@ export const en = {
   "orchMobile.liveTitle": "This project's orchestrator",
   "orchMobile.liveHint": "It answers in its own conversation. Opening it lands there, with the composer.",
   "orchMobile.open": "Open the conversation",
+  "orchMobile.controlsAria": "Orchestrator controls: rotate, model, account and mandate",
+  "orchMobile.rotateOpening": "Reading the current seat settings…",
+  "orchMobile.mandateView": "Mandate v{version} — the rules it runs under",
+  "orchMobile.mandateViewCustom": "Mandate — the custom rules it runs under",
 
   // BranchPane
   "branch.live": "working",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1937,6 +1937,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "orchMobile.liveTitle": "Оркестратор цього проєкту",
   "orchMobile.liveHint": "Він відповідає у власній розмові. Відкрийте її — і ви в ній, разом із полем вводу.",
   "orchMobile.open": "Відкрити розмову",
+  "orchMobile.controlsAria": "Керування оркестратором: заміна, модель, акаунт і мандат",
+  "orchMobile.rotateOpening": "Читаю поточні налаштування місця…",
+  "orchMobile.mandateView": "Мандат v{version} — правила, за якими він працює",
+  "orchMobile.mandateViewCustom": "Мандат — власні правила, за якими він працює",
 
   "branch.live": "працює",
   "branch.waiting": "закінчив хід — чекає відповіді",


### PR DESCRIPTION
## Summary

Two operator-reported phone defects on a ~390px viewport.

**#1347 — orchestrator controls unreachable from a phone.** A live seat's pinned row opened the conversation and nothing else, and the sheet's live view had no control on it. The desktop dock carries the seat's controls in its incumbent header (who holds the seat, Rotate, and the draft that adjusts the seat's settings); the phone had none of them. Now:

- The pinned row carries a second, always-rendered 44px target beside the chip on a live seat (`data-orchestrator-row-controls`), labelled "Orchestrator controls: rotate, model, account and mandate". It is in the pinned slot, ahead of the scrolling chips, never behind an overflow.
- The sheet's live view renders what the desktop header renders: engine badge, model at tier, account, the context meter (the dock's own component, exported rather than copied), the predecessor link, plus a full-width **Rotate** control and the mandate the seat runs under in a disclosure. "Open the conversation" stays the footer's primary action.
- Rotate re-reads the incumbent, then opens the rotate draft in the sheet: the shared launch module (engine, account, model, reasoning) prefilled from the incumbent, the incumbent's own mandate in the keyboard-aware mandate field the create draft already had, the inherited working directory, and a two-way footer (Keep this one / Rotate orchestrator). A rotation that fails stays in the draft with the error and a retry; the incumbent stays live under it.
- A landed rotation lands the phone in the successor's conversation, the way a created seat does.

**#1348 — rename editor with no visible text.** The pane header at 390px is one non-wrapping flex row already holding seven fixed 44px controls; the inline editor joined it with three more, and its `min-w-0 flex-1` input was the only shrinkable cell, so it shrank to zero width, caret included. The input was also set in 12px type, which iOS Safari answers by zooming the page on focus and panning the caret out of view. Now, on the phone, the editor lays over the header row edge to edge; the input is 44px tall, 16px, with surface, ink and caret spelled out from the role tokens (both themes); a drag inside the field stays in the field instead of triggering the header's conversation swipe; Save and Cancel keep their 44px targets in the same row. Desktop rename is unchanged.

Scope note: the rotation authority is untouched (that is #1402); the rotate route and `operatorAuthority.ts` are not in this diff. There is no seat-tick settings surface on the desktop panel (the seat tick is configured through the MCP tool only), so the seat settings reachable here are the ones the desktop exposes through the rotate draft: the successor's engine, model, reasoning, account and mandate.

## Mechanism

- `MobileOrchestratorRow`: owns the rotate flow through the dock's own `useSeatConfirm` on `POST /api/orchestrator/rotate`, under the dock's `llvOrchestratorRotate:<project>:*` keys, so one idempotency key per submission is minted, persisted, replayed on a lost reply and released on a terminal refusal; never the seat route, never raw spawn, no `cwd` (the server continues the successor in the predecessor's checkout). The incumbent read (`useOrchestratorIncumbent`) is enabled only while the sheet is open on a seated project, so a phone that never opens the sheet never pays for the status poll. `openRotate` awaits a fresh incumbent read before mounting the draft so the launch module's initializers see the incumbent's parameters. The handoff is keyed on the conversation the draft was replacing, so the incumbent, which stays live under the draft, is never what lands.
- `MobileOrchestratorSheet`: `SeatIdentity` (the phone's incumbent header), `LiveView` with Rotate and `MandateView`, `RotateDraft` with its own footer (its confirm is `type="button"`, so a rotation is never what an Enter elsewhere in the form triggers), and a shared `MandateField` carrying the #1004 reveal-on-keyboard behaviour for both drafts. Root pads `env(safe-area-inset-top)` and `env(safe-area-inset-bottom)` and keeps budgeting the keyboard through `useKeyboardInset`.
- `orchestratorDraftStorage`: create and rotate keep separate drafts (`seatFlowStorage("Draft" | "Rotate", project)`), byte-identical to the desktop's keys; the pre-existing create API is unchanged.
- `SessionTitle`: on `useIsMobile()` the editor renders `absolute inset-x-0 top-0 z-20` over the header row (the pane section is the positioned ancestor), the input gets `h-11 text-[16px] bg-canvas text-primary caret-accent`, and the editor stops touch propagation so the header's swipe handle never fires from inside it.
- `IncumbentHeader`: `ContextMeter` and `boardContext` are exported; no behaviour change.
- i18n: four new `orchMobile.*` keys in both locales.

## Verification

DOM tests (bun, happy-dom, real `MobileFocusView` at 390×844), run by path:

- `src/components/mobile/mobileOrchestratorControls.dom.test.tsx` (new, 10 tests): visible controls entry point at 44px inside the pinned slot; sheet names the incumbent (engine, model, tier, account, 24% context) and shows the predecessor link and mandate view; Rotate opens the prefilled draft (mandate, account `spare`, model `opus`, inherited cwd, Keep/Rotate footer at 44px); confirm posts to the rotate route once with the adjusted account, no seat-route or spawn call, no cwd; double tap posts once and a lost reply's retry replays the same key; a refused rotation surfaces with retry under a fresh key; a landed rotation hands off into the successor's conversation with the composer; a seat with no transcript in view still reaches Rotate; keyboard open pads the sheet by the inset and reveals the mandate once with the confirm still present; both safe-area classes. Written RED first (10/10 failed on the missing entry point and Rotate), GREEN after.
- `src/components/session/SessionTitle.mobile.dom.test.tsx` (new, 3 tests): the title is in the field and focused, the editor takes the row over, face classes present, Save/Cancel at 44px; a drag inside the field keeps the focused conversation (RED before: it switched to the neighbour); Enter saves. 2/3 RED before, GREEN after.
- Existing suites green by path: `mobileOrchestratorRow.dom.test.tsx` (13), `SessionTitle.dom.test.tsx` (20), `MobileOrchestratorSheet.render.test.tsx` (4), `OrchestratorPanel.dom.test.tsx` (46), `OrchestratorDock.dom.test.tsx` (12), `MobileFocusView.{strip,badges,seen,superseded}.dom.test.tsx`, `mobileHeaderFit.dom.test.tsx`, `BranchPane.stageTitle.render.test.tsx`, `i18n.test.ts`.

Browser-rendered geometry (`src/components/mobile/issue1347Evidence.browser.test.tsx`, Chromium via playwright-core against the production CSS, 390×844, light and dark), recorded in `evidence/issue-1347-1348/geometry.json` (frames are not committed; the privacy gate rejects rasters):

| measurement | light | dark |
| --- | --- | --- |
| rename input box | 264×44 at x 15..279 | 264×44 at x 15..279 |
| rename input font / ink:surface contrast | 16px / 15.3:1 | 16px / 15.5:1 |
| caret colour | rgb(90, 81, 224) | rgb(143, 136, 255) |
| long title scrolls inside the field | scrollWidth 852 > clientWidth 262 | same |
| pane header / document scroll width | 376/376, 390 | 376/376, 390 |
| row controls target | 44×44 at x 90..134, first chip at 149 | same |
| strip row height vs chat budget | 53px | 53px |
| sheet Rotate | 366×44, bottom 274 | same |
| rotate draft Keep / Rotate | 100×44 / 258×44, bottom 834 | same |

Gates: `bunx tsc --noEmit` clean (exit 0 read from its log); `bun run build` passes; `bun scripts/privacy-publication-gate.ts --base $(git merge-base HEAD origin/main)` PASS (also with `--check-commits` and the fingerprint catalog); eslint clean on the touched component files (running eslint directly on files under `scripts/` crashes in `react/display-name` on main too, unrelated).

Live keyboard-open measurement: `scripts/capture-issue-979-mobile-orchestrator.ts` gains the controls sheet and the rotate draft, and measures the draft with the keyboard open (visualViewport shrunk by 336px: confirm above the keyboard, focused mandate line above the fold, no window scroll). Run locally against this branch's production build under the pinned Bun 1.4.0 (the machine's own Bun 1.3.3 cannot serve this build's compiled middleware at all, a pre-existing runtime mismatch unrelated to this branch): exit 0, 36 frames across 15 states in both colour schemes; the new `sheet-live-controls` and `sheet-rotate` states passed in both schemes, and `sheet-rotate-keyboard` passed the keyboard-open checks (confirm above a 336px keyboard, focused mandate line above the fold, no window scroll, sheet body the only scroller). Frames stay under the temp root; no raster is committed.

Fixes #1347
Fixes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
