### PR TITLE
fix(composer): collapse failed-delivery receipts into one compact notice (#1362)

### DIFF
--- a/docs/design/delivery-state.md
+++ b/docs/design/delivery-state.md
@@ -53,3 +53,37 @@ quiet.
 
 Both locales (EN/UK), desktop and 390 px: identical anatomy; the failure row's
 action chips wrap under the message text at 390 px as before.
+
+## The failure notice (issue #1362)
+
+The problem class no longer renders one pill per attempt. While a settled
+message failure is showing, the disclosure's summary line **is** the notice:
+
+```
+▸ ⊘ not delivered — runtime host unavailable  ×3            ↻  ✕
+```
+
+- **Collapse.** Identical consecutive failures fold into one notice with an
+  attempt counter: the newest visible settled failure plus every consecutive
+  earlier one with the same cause (`deliveryNoticeRun`). Three retries of one
+  message are one notice, ×3. A textless message failure (no echo to group by)
+  joins the run and shares one history row per cause. An older failure with a
+  different cause waits in the history until the run in front of it is
+  dismissed, then surfaces as the next notice.
+- **At rest.** Status glyph + `not delivered — <terse cause>` on one
+  truncating line, the counter as plain muted text (never a badge). A known
+  reason code is its human sentence; a verbatim sentence takes its terse form
+  from `describeReceiptFailure` (`receipt.cause.*`), else its first clause. The
+  whole sentence rides on hover.
+- **Expand.** The full first sentence and the remediation after its semicolon
+  render once at the top of the history, then the per-message rows as before
+  (Retry / Edit & resend / Discard / Dismiss per row, ×N and superseded
+  history). The notice is the accordion's disclosure, not a copy of it.
+- **Subordinate but clearly an error.** A 2px danger edge, the glyph and the
+  status word carry the role (design §3.7: role in the edge, never a full
+  wash); fill and type are the composer's own sunken caption. Both themes read
+  through the same role tokens.
+- **Actions.** Quiet icon-buttons in the row: same-key Retry for a confirmed
+  failure of a message (never for a rejection or a discard), and Dismiss, which
+  clears the whole group — every settled attempt the counter counted.
+  44px hit areas on touch, inside the same 44px line.

--- a/src/components/TmuxComposer.deliveryNotice.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryNotice.dom.test.tsx
@@ -1,0 +1,377 @@
+/**
+ * Issue #1362 — failed deliveries under the composer are one compact notice.
+ *
+ * The operator photographed three identical full-width red pills, each
+ * carrying the whole error sentence with its tail clipped, one per retry. These
+ * tests pin the replacement: identical consecutive failures fold into ONE
+ * notice with an attempt counter, the at-rest form is a glyph plus a terse
+ * cause, the full sentence and its remediation live behind expand/hover, and
+ * dismissing the notice clears the group.
+ *
+ * Self-contained: the receipt stack is rendered directly, so nothing here mocks
+ * a module, touches the runtime bus, or reads any state directory.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import { setLocale, translate, type Locale } from "@/lib/i18n";
+
+import type { RuntimeReceipt } from "./runtime/runtimeModel";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+
+const { RuntimeComposerReceipts } = await import("@/components/TmuxComposer");
+
+const HOST_DOWN = "structured spawn runtime host is unavailable; start agent-log-viewer through its CLI and check the CLI log for the host startup failure";
+const HOST_DOWN_SENTENCE = "structured spawn runtime host is unavailable";
+const HOST_DOWN_REMEDIATION = "start agent-log-viewer through its CLI and check the CLI log for the host startup failure";
+const MESSAGE = "please rerun the failing suite and report";
+
+function receipt(overrides: Partial<RuntimeReceipt> & { operationId: string }): RuntimeReceipt {
+  return {
+    idempotencyKey: `key-${overrides.operationId}`,
+    conversationId: "conversation_1362",
+    kind: "send",
+    status: "failed",
+    reason: HOST_DOWN,
+    text: MESSAGE,
+    at: "2026-08-31T10:00:00.000Z",
+    revision: 1,
+    ...overrides,
+  };
+}
+
+/** Three failed retries of one message: same text, distinct attempts. */
+const threeRetries = (): RuntimeReceipt[] => [2, 1, 0].map((second) =>
+  receipt({ operationId: `op-retry-${second}`, at: `2026-08-31T10:00:0${second}.000Z` }));
+
+interface Mounted {
+  host: HTMLElement;
+  root: Root;
+  stack: () => HTMLDetailsElement;
+  summary: () => HTMLElement;
+  cleanup: () => void;
+}
+
+type Props = Partial<React.ComponentProps<typeof RuntimeComposerReceipts>> & { receipts: RuntimeReceipt[] };
+
+function view(props: Props): React.ReactElement {
+  const stamps = props.receipts.map((entry) => Date.parse(entry.at)).filter(Number.isFinite);
+  return (
+    <RuntimeComposerReceipts
+      onRetry={() => {}}
+      onEdit={() => {}}
+      nowMs={(stamps.length ? Math.max(...stamps) : 0) + 1_000}
+      session={{ host: "hosted", turn: "idle" }}
+      {...props}
+    />
+  );
+}
+
+function mount(props: Props, width = 1280): Mounted {
+  (dom as unknown as { innerWidth: number }).innerWidth = width;
+  const host = document.createElement("div");
+  host.style.width = `${width}px`;
+  document.body.append(host);
+  const root = createRoot(host);
+  act(() => { root.render(view(props)); });
+  return {
+    host,
+    root,
+    stack: () => host.querySelector("details[data-runtime-receipt-stack]") as HTMLDetailsElement,
+    summary: () => host.querySelector("details[data-runtime-receipt-stack] > summary") as HTMLElement,
+    cleanup: () => {
+      act(() => { root.unmount(); });
+      host.remove();
+    },
+  };
+}
+
+const rerender = (mounted: Mounted, props: Props) => act(() => { mounted.root.render(view(props)); });
+const click = (element: Element) => act(() => { (element as HTMLElement).click(); });
+/** Clicks one of the notice's own buttons and reports whether the handler
+    marked the click handled. In a browser the button's activation already
+    outranks the summary's, so the disclosure never toggles; the explicit
+    preventDefault is what a DOM that toggles on bubble (happy-dom) would need,
+    and it is the part the component controls. */
+const clickAction = (button: Element): boolean => {
+  const event = new dom.MouseEvent("click", { bubbles: true, cancelable: true });
+  act(() => { button.dispatchEvent(event as unknown as Event); });
+  return (event as unknown as Event).defaultPrevented;
+};
+const classes = (element: Element) => (element.getAttribute("class") ?? "").split(/\s+/);
+
+afterEach(() => {
+  setLocale("en");
+  (dom as unknown as { innerWidth: number }).innerWidth = 1280;
+});
+
+for (const locale of ["en", "uk"] as const satisfies readonly Locale[]) {
+  test(`#1362 three failed retries of one message collapse into one compact notice with ×3 (${locale})`, () => {
+    setLocale(locale);
+    const t = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate(locale, key, params);
+    const mounted = mount({ receipts: threeRetries(), onDismiss: () => {} });
+    const stack = mounted.stack();
+    const summary = mounted.summary();
+
+    /* One notice, collapsed, standing in for the accordion's summary line. */
+    expect(mounted.host.querySelectorAll("details[data-delivery-notice]")).toHaveLength(1);
+    expect(stack.hasAttribute("data-delivery-notice")).toBe(true);
+    expect(stack.open).toBe(false);
+
+    /* At rest: glyph + "not delivered — <terse cause>" + counter. */
+    const line = `${t("composer.receiptFailed")} — ${t("receipt.cause.hostUnavailable")}`;
+    const cause = summary.querySelector("[data-delivery-notice-cause]") as HTMLElement;
+    expect(cause.textContent).toBe(line);
+    expect(summary.querySelector("svg")).not.toBeNull();
+    const counter = summary.querySelector("[data-delivery-notice-count]") as HTMLElement;
+    expect(counter.textContent).toContain("×3");
+    expect(counter.textContent).toContain(t("runtime.receipt.attemptCount", { count: 3 }));
+    expect(summary.getAttribute("aria-label"))
+      .toBe(`${t("runtime.receipt.showDetails")}. ${line}. ${t("runtime.receipt.attemptCount", { count: 3 })}`);
+
+    /* Never the full sentence in the row, and never a pill per attempt. */
+    expect(summary.textContent).not.toContain(HOST_DOWN_SENTENCE);
+    expect(summary.textContent).not.toContain(HOST_DOWN_REMEDIATION);
+    expect(summary.querySelector("[data-receipt-preview]")).toBeNull();
+    expect(summary.querySelector("[data-receipt-problem-count]")).toBeNull();
+    expect(summary.querySelector("[data-receipt-status]")).toBeNull();
+    expect(summary.querySelector(".bg-danger-soft")).toBeNull();
+    /* Hover carries the whole sentence. */
+    expect(cause.getAttribute("title")).toBe(HOST_DOWN);
+
+    /* The detailed history keeps one row for the one message, counted. */
+    const details = stack.querySelector("[data-runtime-receipt-details]") as HTMLElement;
+    expect(details.querySelectorAll("[data-receipt-message]")).toHaveLength(1);
+    expect(details.querySelector("[data-receipt-attempt-count]")?.textContent).toContain("×3");
+    expect(details.querySelectorAll("[data-receipt-status]")).toHaveLength(1);
+
+    /* The live region still counts every failed attempt. */
+    const status = mounted.host.querySelector("[data-runtime-receipt-status]") as HTMLElement;
+    expect(status.textContent).toContain(t("runtime.receipt.statusProblems", { count: 3 }));
+    mounted.cleanup();
+  });
+}
+
+test("#1362 expanding the notice reveals the full cause and its remediation, once", () => {
+  const mounted = mount({ receipts: threeRetries(), onDismiss: () => {} });
+  const stack = mounted.stack();
+  const summary = mounted.summary();
+  const t = (key: Parameters<typeof translate>[1]) => translate("en", key);
+
+  click(summary);
+  expect(stack.open).toBe(true);
+  expect(summary.getAttribute("aria-label")).toContain(t("runtime.receipt.hideDetails"));
+
+  const details = stack.querySelector("[data-runtime-receipt-details]") as HTMLElement;
+  const detail = details.querySelector("[data-delivery-notice-detail]") as HTMLElement;
+  expect(detail).not.toBeNull();
+  expect(detail.querySelector("[data-delivery-notice-sentence]")?.textContent).toBe(HOST_DOWN_SENTENCE);
+  expect(detail.querySelector("[data-delivery-notice-remediation]")?.textContent).toBe(HOST_DOWN_REMEDIATION);
+  /* The sentence is explained once for the run, never once per attempt. */
+  expect(mounted.host.querySelectorAll("[data-delivery-notice-sentence]")).toHaveLength(1);
+  /* The history row's chip says the terse cause, never the whole sentence
+     again — that rides on its hover, and the detail block above already
+     showed it. */
+  const chip = details.querySelector('[data-receipt-status="failed"]') as HTMLElement;
+  expect(chip.textContent).toBe(translate("en", "receipt.human.verbatim", { reason: t("receipt.cause.hostUnavailable") }));
+  expect(chip.getAttribute("title")).toBe(translate("en", "receipt.human.verbatim", { reason: HOST_DOWN }));
+  expect(details.querySelector("[data-receipt-history]")?.textContent)
+    .toBe(`${translate("en", "receipt.human.verbatim", { reason: t("receipt.cause.hostUnavailable") })} ×2`);
+  /* The row's own action set is still there, behind the notice. */
+  const labels = [...details.querySelectorAll("button")].map((button) => button.textContent || button.getAttribute("aria-label"));
+  expect(labels).toContain(t("runtime.receipt.retry"));
+  expect(labels).toContain(t("runtime.receipt.edit"));
+  expect(labels).toContain(t("runtime.receipt.dismiss"));
+
+  click(summary);
+  expect(stack.open).toBe(false);
+  mounted.cleanup();
+});
+
+test("#1362 dismissing the collapsed notice clears the whole group and leaves a pending delivery alone", () => {
+  const batches: string[][] = [];
+  const pending = receipt({
+    operationId: "op-pending",
+    status: "queued",
+    reason: null,
+    text: "a different, still-moving ask",
+    at: "2026-08-31T10:00:05.000Z",
+  });
+  const mounted = mount({ receipts: [pending, ...threeRetries()], onDismiss: (ids) => batches.push(ids) });
+  const summary = mounted.summary();
+  expect(mounted.stack().hasAttribute("data-delivery-notice")).toBe(true);
+  expect(summary.querySelector("[data-receipt-pending-count]")).not.toBeNull();
+
+  const dismiss = summary.querySelector("[data-delivery-notice-dismiss]") as HTMLButtonElement;
+  expect(dismiss.getAttribute("aria-label")).toBe(translate("en", "runtime.receipt.dismiss"));
+  /* Dismissing is not expanding: the click is handled by the button alone. */
+  expect(clickAction(dismiss)).toBe(true);
+  expect(batches).toEqual([["op-retry-2", "op-retry-1", "op-retry-0"]]);
+
+  rerender(mounted, { receipts: [pending, ...threeRetries()], dismissed: new Set(batches.flat()), onDismiss: () => {} });
+  expect(mounted.host.querySelector("details[data-delivery-notice]")).toBeNull();
+  expect(mounted.summary().querySelector("[data-receipt-pending-count]")).not.toBeNull();
+  expect(mounted.summary().textContent).toContain(translate("en", "runtime.receipt.summary", { count: 1 }));
+
+  rerender(mounted, { receipts: threeRetries(), dismissed: new Set(batches.flat()), onDismiss: () => {} });
+  expect(mounted.host.textContent).toBe("");
+  mounted.cleanup();
+});
+
+test("#1362 the notice retries the newest failed attempt, and offers no retry for a rejection or a discard", () => {
+  const retries: string[] = [];
+  const mounted = mount({
+    receipts: threeRetries(),
+    onDismiss: () => {},
+    onRetry: (target, mode) => retries.push(`${target.operationId}:${mode ?? "same-key"}`),
+  });
+  const retry = mounted.summary().querySelector("[data-delivery-notice-retry]") as HTMLButtonElement;
+  expect(retry.getAttribute("aria-label")).toBe(translate("en", "runtime.receipt.retry"));
+  expect(clickAction(retry)).toBe(true);
+  expect(retries).toEqual(["op-retry-2:same-key"]);
+
+  rerender(mounted, {
+    receipts: [receipt({ operationId: "op-verify", resend: "verify-first", reason: "delivery outcome is unverified" })],
+    onDismiss: () => {},
+    onRetry: (target, mode) => retries.push(`${target.operationId}:${mode ?? "same-key"}`),
+  });
+  clickAction(mounted.summary().querySelector("[data-delivery-notice-retry]") as HTMLButtonElement);
+  expect(retries).toEqual(["op-retry-2:same-key", "op-verify:uncertain"]);
+
+  rerender(mounted, { receipts: [receipt({ operationId: "op-rejected", status: "rejected", reason: "stale-turn" })], onDismiss: () => {} });
+  expect(mounted.summary().querySelector("[data-delivery-notice-retry]")).toBeNull();
+  expect(mounted.summary().querySelector("[data-delivery-notice-dismiss]")).not.toBeNull();
+
+  rerender(mounted, { receipts: [receipt({ operationId: "op-discarded", reason: "delivery-discarded" })], onDismiss: () => {} });
+  expect(mounted.summary().querySelector("[data-delivery-notice-retry]")).toBeNull();
+  mounted.cleanup();
+});
+
+test("#1362 a known reason code reads as its human sentence with nothing further to reveal", () => {
+  const mounted = mount({ receipts: [receipt({ operationId: "op-dead", reason: "dead-host" })], onDismiss: () => {} });
+  const t = (key: Parameters<typeof translate>[1]) => translate("en", key);
+  const cause = mounted.summary().querySelector("[data-delivery-notice-cause]") as HTMLElement;
+  expect(cause.textContent).toBe(`${t("composer.receiptFailed")} — ${t("receipt.human.deadHost")}`);
+  expect(mounted.summary().querySelector("[data-delivery-notice-count]")).toBeNull();
+  click(mounted.summary());
+  expect(mounted.stack().open).toBe(true);
+  expect(mounted.host.querySelector("[data-delivery-notice-detail]")).toBeNull();
+  mounted.cleanup();
+});
+
+test("#1362 identical consecutive failures collapse; an older different cause stays in the history", () => {
+  const batches: string[][] = [];
+  const receipts = [
+    receipt({ operationId: "op-host-2", text: "second ask", at: "2026-08-31T10:00:02.000Z" }),
+    receipt({ operationId: "op-host-1", text: "first ask", at: "2026-08-31T10:00:01.000Z" }),
+    receipt({ operationId: "op-dead", text: "older ask", reason: "dead-host", at: "2026-08-31T10:00:00.000Z" }),
+  ];
+  const mounted = mount({ receipts, onDismiss: (ids) => batches.push(ids) });
+  const t = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
+  const summary = mounted.summary();
+  expect(summary.querySelector("[data-delivery-notice-cause]")?.textContent)
+    .toBe(`${t("composer.receiptFailed")} — ${t("receipt.cause.hostUnavailable")}`);
+  expect(summary.querySelector("[data-delivery-notice-count]")?.textContent).toContain("×2");
+  const details = mounted.stack().querySelector("[data-runtime-receipt-details]") as HTMLElement;
+  expect(details.querySelectorAll("[data-receipt-message]")).toHaveLength(3);
+  expect(mounted.host.querySelector("[data-runtime-receipt-status]")?.textContent)
+    .toContain(t("runtime.receipt.statusProblems", { count: 3 }));
+
+  clickAction(summary.querySelector("[data-delivery-notice-dismiss]") as HTMLButtonElement);
+  expect(batches).toEqual([["op-host-2", "op-host-1"]]);
+
+  /* With the run dismissed the older cause surfaces as the next notice. */
+  rerender(mounted, { receipts, dismissed: new Set(batches.flat()), onDismiss: () => {} });
+  expect(mounted.summary().querySelector("[data-delivery-notice-cause]")?.textContent)
+    .toBe(`${t("composer.receiptFailed")} — ${t("receipt.human.deadHost")}`);
+  expect(mounted.summary().querySelector("[data-delivery-notice-count]")).toBeNull();
+  mounted.cleanup();
+});
+
+test("#1362 textless failed sends collapse into the notice instead of stacking as standalone pills", () => {
+  const batches: string[][] = [];
+  const receipts = [2, 1, 0].map((second) =>
+    receipt({ operationId: `op-textless-${second}`, text: null, at: `2026-08-31T10:00:0${second}.000Z` }));
+  const mounted = mount({ receipts, onDismiss: (ids) => batches.push(ids) });
+  const stack = mounted.stack();
+  expect(stack.hasAttribute("data-delivery-notice")).toBe(true);
+  expect(mounted.summary().querySelector("[data-delivery-notice-count]")?.textContent).toContain("×3");
+  /* Every chip lives inside the accordion's history now; nothing stacks beside it. */
+  const chips = [...mounted.host.querySelectorAll("[data-receipt-status]")];
+  expect(chips).toHaveLength(1);
+  expect(chips.every((chip) => stack.contains(chip))).toBe(true);
+  const row = stack.querySelector("[data-receipt-standalone-row]") as HTMLElement;
+  expect(row.querySelector("[data-receipt-attempt-count]")?.textContent).toContain("×3");
+  expect(mounted.host.querySelectorAll("[data-receipt-message]")).toHaveLength(0);
+
+  clickAction(mounted.summary().querySelector("[data-delivery-notice-dismiss]") as HTMLButtonElement);
+  expect(batches).toEqual([["op-textless-2", "op-textless-1", "op-textless-0"]]);
+  rerender(mounted, { receipts, dismissed: new Set(batches.flat()), onDismiss: () => {} });
+  expect(mounted.host.textContent).toBe("");
+  mounted.cleanup();
+});
+
+test("#1362 the notice holds its anatomy at desktop and 390px in both locales", () => {
+  /* No pixel browser in CI — acceptance is structural: the classes that carry
+     the layout contract (one line, truncating cause, touch-sized actions, the
+     danger edge without a red wash) must be present at both widths. */
+  for (const width of [1280, 390] as const) {
+    for (const locale of ["en", "uk"] as const) {
+      setLocale(locale);
+      const mounted = mount({ receipts: threeRetries(), onDismiss: () => {} }, width);
+      const stack = mounted.stack();
+      const summary = mounted.summary();
+
+      const container = classes(stack);
+      expect(container).toContain("border-l-danger");
+      expect(container).not.toContain("bg-danger-soft");
+      expect(container).toContain("text-caption");
+
+      const row = classes(summary);
+      expect(row).toContain("min-h-11");
+      expect(row).toContain("max-h-11");
+      expect(row).toContain("overflow-hidden");
+      expect(row).not.toContain("py-1");
+
+      const cause = classes(summary.querySelector("[data-delivery-notice-cause]")!);
+      expect(cause).toContain("min-w-0");
+      expect(cause).toContain("flex-1");
+      expect(cause).toContain("truncate");
+      expect(classes(summary.querySelector("[data-delivery-notice-count]")!)).toContain("shrink-0");
+
+      /* 44px touch targets: a 44px-tall box whose hit area extends 6px past
+         each side of its 32px width (the composer's icon-button pattern), so
+         two of them leave the cause its width at 390px. */
+      for (const selector of ["[data-delivery-notice-retry]", "[data-delivery-notice-dismiss]"]) {
+        const button = classes(summary.querySelector(selector)!);
+        expect(button).toContain("h-11");
+        expect(button).toContain("w-8");
+        expect(button).toContain("before:-inset-x-1.5");
+        expect(button).not.toContain("rounded-full");
+      }
+
+      click(summary);
+      const sentence = classes(stack.querySelector("[data-delivery-notice-sentence]")!);
+      expect(sentence).toContain("break-words");
+      mounted.cleanup();
+    }
+  }
+});

--- a/src/components/TmuxComposer.deliveryState.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryState.dom.test.tsx
@@ -400,8 +400,9 @@ test("visual acceptance: the delivery surfaces hold at desktop and 390px in both
       const stack = host.querySelector("[data-runtime-receipt-stack]") as HTMLElement;
       const row = stack.querySelector("[data-receipt-message]")!.parentElement as HTMLElement;
       expect(row.className).toContain("flex-wrap");
-      const preview = stack.querySelector("[data-receipt-preview]") as HTMLElement;
-      expect(preview.className).toContain("truncate");
+      /* #1362: the collapsed face is the compact notice; its cause truncates. */
+      const cause = stack.querySelector("[data-delivery-notice-cause]") as HTMLElement;
+      expect(cause.className).toContain("truncate");
       const dismiss = stack.querySelector("[data-receipt-dismiss]") as HTMLElement;
       expect(dismiss.className).toContain("min-h-11");
       expect(dismiss.className).toContain("min-w-11");

--- a/src/components/TmuxComposer.dom.test.tsx
+++ b/src/components/TmuxComposer.dom.test.tsx
@@ -237,8 +237,11 @@ test("repeated identical attempts share one grouped row with counts and final st
   ));
 
   const summary = host.querySelector("summary")!;
-  expect(summary.textContent).toContain("Спроб доставки: 3");
-  expect(summary.textContent).toContain("проблем: 3");
+  /* #1362: settled failures read as one compact notice — status word, terse
+     cause, attempt counter — never as a count of pills. */
+  expect(summary.querySelector("[data-delivery-notice-cause]")?.textContent)
+    .toBe(`${translate("uk", "composer.receiptFailed")} — ${translate("uk", "receipt.human.deadHost")}`);
+  expect(summary.querySelector("[data-delivery-notice-count]")?.textContent).toContain("×3");
 
   // One logical send consumes one row: the text appears once with an attempt
   // count and the final state, never once per attempt.
@@ -671,7 +674,11 @@ test("expanded active attempts retain localized lifecycle status and aggregate c
 
     const summary = host.querySelector("summary")!;
     expect(summary.textContent).toContain(translate(locale, "runtime.receipt.pendingCount", { count: 4 }));
-    expect(summary.textContent).toContain(translate(locale, "runtime.receipt.problemCount", { count: 1 }));
+    /* #1362: the settled failure IS the notice beside the pending count — the
+       red issue badge no longer counts it a second time. */
+    expect(summary.querySelector("[data-delivery-notice-cause]")?.textContent)
+      .toBe(`${translate(locale, "composer.receiptFailed")} — ${translate(locale, "receipt.human.deadHost")}`);
+    expect(summary.querySelector("[data-receipt-problem-count]")).toBeNull();
     const details = host.querySelector("[data-runtime-receipt-details]")!;
     expect(details.querySelector('[data-receipt-status="pending"]')?.textContent)
       .toBe(translate(locale, "runtime.receipt.pending"));

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState, useSy
 import { createPortal } from "react-dom";
 
 import { ArrowRight, ArrowUpToLine, Check, ChevronRight, Loader2, Play, X } from "@/components/icons";
-import { RotateCcw } from "lucide-react";
+import { CircleAlert, RotateCcw } from "lucide-react";
 
 import type { TFunction } from "@/lib/i18n";
 
@@ -75,6 +75,7 @@ import {
   withDismissedReceipts,
   writeDismissedReceipts,
 } from "./runtime/deliveryState";
+import { deliveryNoticeRun, describeReceiptFailure, failureCauseKey } from "./runtime/deliveryNotice";
 import { mintIdempotencyKey, receiptIsAdmitted, receiptIsTerminal, type HostAxis, type TurnAxis } from "./runtime/runtimeModel";
 import { tmuxComposerRuntimeDependencies } from "./tmuxComposerRuntime";
 import { VoiceConversationButton } from "./VoiceConversation";
@@ -343,6 +344,42 @@ export function RuntimeComposerReceipts({
     return [...counts].map(([label, count]) => (count > 1 ? `${label} ×${count}` : label));
   };
   const standaloneReceipts = visibleStandaloneReceipts(receipts, dismissed);
+  /* #1362: a message receipt with no text echo used to render one standalone
+     pill per attempt — three retries, three full-width pills, each carrying
+     the whole sentence. Settled message failures belong to the notice and the
+     history under it now; only still-moving and non-message operations keep a
+     standalone chip. Textless failures with one cause share one history row. */
+  const textlessProblems = standaloneReceipts
+    .filter((receipt) => isMessage(receipt) && deliveryProblem(receipt.status))
+    .sort((left, right) => Date.parse(right.at) - Date.parse(left.at));
+  const standaloneChips = standaloneReceipts.filter((receipt) => !textlessProblems.includes(receipt));
+  const textlessRows = textlessProblems.reduce<RuntimeReceipt[][]>((rows, receipt) => {
+    const last = rows[rows.length - 1];
+    if (last && failureCauseKey(last[0]!.reason) === failureCauseKey(receipt.reason)) last.push(receipt);
+    else rows.push([receipt]);
+    return rows;
+  }, []);
+  /* The one compact notice (issue #1362) stands in for the summary line while
+     a settled failure is showing: identical consecutive failures fold into it
+     behind an attempt counter, the row names a terse cause, and the full
+     sentence with its remediation waits behind expand/hover. The per-message
+     history below keeps the detail — the notice is its disclosure, not a copy. */
+  const notice = deliveryNoticeRun(attemptGroups, textlessProblems);
+  const noticeFailure = notice ? describeReceiptFailure(t, notice.current.reason) : null;
+  const noticeLine = notice
+    ? noticeFailure?.cause
+      ? `${t("composer.receiptFailed")} — ${noticeFailure.cause}`
+      : t("composer.receiptFailed")
+    : null;
+  const noticeAttemptLabel = notice && notice.attempts.length > 1
+    ? t("runtime.receipt.attemptCount", { count: notice.attempts.length })
+    : null;
+  /* Same rule as the row: a same-key retry exists for a confirmed failure of a
+     message, never for a rejection (Edit mints the new key there) or a discard. */
+  const noticeRetryable = Boolean(notice
+    && notice.current.status === "failed"
+    && isMessage(notice.current)
+    && notice.current.reason !== "delivery-discarded");
   /* Collapsed is the default state, and it is what the operator photographed:
      a warning badge counting an attempt that was never coming. A row that went
      terminally uncertain counts as a PROBLEM here, so the summary reads
@@ -355,41 +392,87 @@ export function RuntimeComposerReceipts({
     !receiptIsTerminal(receipt.status) && !uncertainOperationIds.has(receipt.operationId));
   const problemReceipts = [
     ...visibleAttempts.filter((receipt) => deliveryProblem(receipt.status)),
+    ...textlessProblems,
     ...uncertainCurrent,
   ];
+  /* The notice already IS the settled-failure indicator, so beside it the red
+     count badge speaks only for deliveries that went terminally uncertain. */
+  const problemBadgeCount = notice ? uncertainCurrent.length : problemReceipts.length;
   const busyRetry = pendingReceipts.some((receipt) => typeof receipt.reason === "string" && RECOVERABLE_BUSY_RETRY_REASONS.has(receipt.reason));
   const receiptSummaryLabel = t("runtime.receipt.summary", { count: visibleAttempts.length });
   const disclosureLabel = t(detailsOpen ? "runtime.receipt.hideDetails" : "runtime.receipt.showDetails");
+  const summaryAriaLabel = noticeLine
+    ? `${disclosureLabel}. ${noticeLine}${noticeAttemptLabel ? `. ${noticeAttemptLabel}` : ""}`
+    : `${disclosureLabel}. ${receiptSummaryLabel}`;
+  /* On a phone the notice's actions keep the 44px hit area in a 32px box (the
+     composer's own icon-button pattern: the hit extends through `before:`),
+     so the terse cause keeps its width beside them at 390px. */
+  const noticeActionClass = "relative inline-flex h-11 w-8 shrink-0 items-center justify-center rounded-control text-muted before:absolute before:inset-y-0 before:-inset-x-1.5 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-50 sm:h-6 sm:w-6 sm:before:hidden";
 
   return (
     <>
-      {visibleAttempts.length ? (
+      {visibleAttempts.length || textlessRows.length ? (
         <>
           {/* `open` is controlled: the details element can unmount while all
               message receipts are resolved and remount for the next attempt,
               and the disclosure label must keep matching the real element. */}
           <details
-            className="group w-full min-w-0 rounded-control border border-border bg-sunken/55 text-caption text-secondary"
+            /* Failure reads through a 2px danger edge, the glyph and the label
+               only (design §3.7: role in the edge, never a full wash) — an
+               annotation under the composer, subordinate to it in both themes. */
+            className={`group w-full min-w-0 rounded-control border border-border ${
+              notice ? "border-l-2 border-l-danger " : ""
+            }bg-sunken/55 text-caption text-secondary`}
             data-runtime-receipt-stack
+            {...(notice ? { "data-delivery-notice": "" } : {})}
             open={detailsOpen}
             onToggle={(event) => setDetailsOpen(event.currentTarget.open)}
           >
             <summary
               aria-describedby={statusId}
-              aria-label={`${disclosureLabel}. ${receiptSummaryLabel}`}
-              className="flex min-h-11 max-h-11 cursor-pointer list-none items-center gap-1 overflow-hidden rounded-control px-1.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden"
+              aria-label={summaryAriaLabel}
+              /* The notice row drops the vertical padding so its 44px touch
+                 actions fit inside the same 44px line the summary always had. */
+              className={`flex min-h-11 max-h-11 cursor-pointer list-none items-center overflow-hidden rounded-control px-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden ${
+                notice ? "gap-1 sm:gap-1.5" : "gap-1 py-1"
+              }`}
             >
               <ChevronRight className="h-3 w-3 shrink-0 text-muted transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none" aria-hidden />
-              <span className="shrink-0 font-semibold text-primary">
-                {receiptSummaryLabel}
-              </span>
-              <span
-                className="min-w-[3rem] flex-1 truncate text-right text-muted"
-                data-receipt-preview
-                title={visibleAttempts[0]!.text ?? undefined}
-              >
-                {visibleAttempts[0]!.text}
-              </span>
+              {notice ? (
+                <>
+                  <CircleAlert className="h-3 w-3 shrink-0 text-danger" aria-hidden />
+                  {/* At rest: status word + terse cause on one truncating line;
+                      the whole sentence rides on hover. */}
+                  <span
+                    className="min-w-0 flex-1 truncate"
+                    data-delivery-notice-cause
+                    title={noticeFailure?.full ?? undefined}
+                  >
+                    <span className="font-semibold text-danger">{t("composer.receiptFailed")}</span>
+                    {noticeFailure?.cause ? <span className="text-secondary">{` — ${noticeFailure.cause}`}</span> : null}
+                  </span>
+                  {/* Counters are plain muted text, never badges (design rule 5). */}
+                  {noticeAttemptLabel ? (
+                    <span className="shrink-0 tabular-nums text-muted" data-delivery-notice-count title={noticeAttemptLabel}>
+                      <span aria-hidden>×{notice.attempts.length}</span>
+                      <span className="sr-only">{noticeAttemptLabel}</span>
+                    </span>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <span className="shrink-0 font-semibold text-primary">
+                    {receiptSummaryLabel}
+                  </span>
+                  <span
+                    className="min-w-[3rem] flex-1 truncate text-right text-muted"
+                    data-receipt-preview
+                    title={visibleAttempts[0]!.text ?? undefined}
+                  >
+                    {visibleAttempts[0]!.text}
+                  </span>
+                </>
+              )}
               <span className="flex shrink-0 items-center gap-1" data-receipt-counts>
                 {pendingReceipts.length ? (
                   <Badge
@@ -408,24 +491,84 @@ export function RuntimeComposerReceipts({
                     <span aria-hidden data-receipt-count-value>{pendingReceipts.length}</span>
                   </Badge>
                 ) : null}
-                {problemReceipts.length ? (
+                {problemBadgeCount ? (
                   <Badge
                     tone="danger"
                     data-receipt-problem-count
-                    aria-label={t("runtime.receipt.problemCount", { count: problemReceipts.length })}
-                    title={t("runtime.receipt.problemCount", { count: problemReceipts.length })}
+                    aria-label={t("runtime.receipt.problemCount", { count: problemBadgeCount })}
+                    title={t("runtime.receipt.problemCount", { count: problemBadgeCount })}
                   >
                     <span aria-hidden>!</span>
-                    <span className="sr-only">{t("runtime.receipt.problemCount", { count: problemReceipts.length })}</span>
-                    <span aria-hidden data-receipt-count-value>{problemReceipts.length}</span>
+                    <span className="sr-only">{t("runtime.receipt.problemCount", { count: problemBadgeCount })}</span>
+                    <span aria-hidden data-receipt-count-value>{problemBadgeCount}</span>
                   </Badge>
                 ) : null}
               </span>
+              {/* The notice's own actions, quiet icon-buttons (design §3.5:
+                  failed = danger + retry icon-button). A button carries its own
+                  activation, so a click here never toggles the disclosure; the
+                  explicit preventDefault says so in DOMs that toggle on bubble. */}
+              {notice && (noticeRetryable || onDismiss) ? (
+                <span className="-mr-1 flex shrink-0 items-center sm:mr-0" data-delivery-notice-actions>
+                  {noticeRetryable ? (
+                    <button
+                      type="button"
+                      data-delivery-notice-retry
+                      aria-label={t("runtime.receipt.retry")}
+                      title={t("runtime.receipt.retry")}
+                      disabled={actionsDisabled}
+                      className={`${noticeActionClass} hover:text-accent`}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        retryFailed(notice.current);
+                      }}
+                    >
+                      <RotateCcw className="h-3 w-3" aria-hidden />
+                    </button>
+                  ) : null}
+                  {/* Dismissing the notice clears its whole group: every settled
+                      attempt it counted (issue #264 rule 3 — a still-moving
+                      attempt is never hidden). */}
+                  {onDismiss ? (
+                    <button
+                      type="button"
+                      data-delivery-notice-dismiss
+                      aria-label={t("runtime.receipt.dismiss")}
+                      title={t("runtime.receipt.dismiss")}
+                      className={`${noticeActionClass} hover:text-danger`}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onDismiss(notice.dismissIds);
+                      }}
+                    >
+                      <X className="h-3 w-3" aria-hidden />
+                    </button>
+                  ) : null}
+                </span>
+              ) : null}
             </summary>
             <div
               className="max-h-36 space-y-1 overflow-y-auto border-t border-border/70 p-1.5"
               data-runtime-receipt-details
             >
+              {/* What expanding reveals (issue #1362): the full sentence and the
+                  remediation after it, once for the run — never once per
+                  attempt. Wraps rather than truncates: this is where the
+                  operator reads what to do. */}
+              {notice && noticeFailure?.detail ? (
+                <div className="rounded-control bg-card/70 px-2 py-1 text-secondary" data-delivery-notice-detail>
+                  <p className="whitespace-pre-wrap break-words" data-delivery-notice-sentence>
+                    {noticeFailure.detail.sentence}
+                  </p>
+                  {noticeFailure.detail.remediation ? (
+                    <p className="whitespace-pre-wrap break-words text-muted" data-delivery-notice-remediation>
+                      {noticeFailure.detail.remediation}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               {attemptGroups.map((group) => {
                 const receipt = group.current;
                 const history = supersededStatusLabels(group.attempts);
@@ -541,6 +684,48 @@ export function RuntimeComposerReceipts({
                   </div>
                 );
               })}
+              {/* Textless message failures (no echo to group by): one history
+                  row per consecutive cause, counted, with the same chip and
+                  dismissal the standalone pills used to carry. */}
+              {textlessRows.map((bucket) => {
+                const receipt = bucket[0]!;
+                return (
+                  <div
+                    key={receipt.operationId}
+                    className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 rounded-control bg-card/70 px-2 py-1"
+                    data-receipt-standalone-row
+                  >
+                    {bucket.length > 1 ? (
+                      <Badge
+                        tone="neutral"
+                        data-receipt-attempt-count
+                        aria-label={t("runtime.receipt.attemptCount", { count: bucket.length })}
+                        title={t("runtime.receipt.attemptCount", { count: bucket.length })}
+                      >
+                        <span aria-hidden>×{bucket.length}</span>
+                        <span className="sr-only">{t("runtime.receipt.attemptCount", { count: bucket.length })}</span>
+                      </Badge>
+                    ) : null}
+                    <ReceiptChip
+                      receipt={receipt}
+                      actionsDisabled={actionsDisabled}
+                      onRetry={receipt.status === "failed" ? () => retryFailed(receipt) : undefined}
+                    />
+                    {onDismiss ? (
+                      <button
+                        type="button"
+                        aria-label={t("runtime.receipt.dismiss")}
+                        title={t("runtime.receipt.dismiss")}
+                        data-receipt-dismiss
+                        className="inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:min-h-0 sm:min-w-0 sm:px-0.5"
+                        onClick={() => onDismiss(bucket.map((attempt) => attempt.operationId))}
+                      >
+                        <X className="h-3 w-3" aria-hidden />
+                      </button>
+                    ) : null}
+                  </div>
+                );
+              })}
             </div>
           </details>
           <span
@@ -554,19 +739,22 @@ export function RuntimeComposerReceipts({
               pending: t("runtime.receipt.statusPending", { count: pendingReceipts.length }),
               problems: t("runtime.receipt.statusProblems", { count: problemReceipts.length }),
             })}
-            {` ${attemptGroups
-              .map((group) => {
+            {` ${[
+              ...attemptGroups.map((group) => {
                 const wait = waitFor(group);
                 const current = (wait && deliveryWaitText(t, wait, group.current.queuePosition))
                   ?? runtimeReceiptStatusText(t, group.current);
                 return [current, ...supersededStatusLabels(group.attempts)].join(" · ");
-              })
-              .join(". ")}.`}
+              }),
+              ...textlessRows.map((bucket) => (bucket.length > 1
+                ? `${runtimeReceiptStatusText(t, bucket[0]!)} ×${bucket.length}`
+                : runtimeReceiptStatusText(t, bucket[0]!))),
+            ].join(". ")}.`}
             {busyRetry ? ` ${t("runtime.receipt.busyRetry")}` : null}
           </span>
         </>
       ) : null}
-      {standaloneReceipts.map((receipt) => {
+      {standaloneChips.map((receipt) => {
         const failed = receipt.status === "failed";
         return (
           <span key={receipt.operationId} className="inline-flex items-center gap-1">

--- a/src/components/runtime/ReceiptChip.tsx
+++ b/src/components/runtime/ReceiptChip.tsx
@@ -5,16 +5,28 @@ import { Clock3 } from "lucide-react";
 import { Badge, type BadgeTone } from "@/components/ui/Badge";
 import { useLocale, type TFunction } from "@/lib/i18n";
 
+import { describeReceiptFailure } from "./deliveryNotice";
 import { deliveryWaitText, type DeliveryWait } from "./deliveryWait";
 import { humanReceiptReasonKey, receiptIsTerminal, type ReceiptStatus, type RuntimeReceipt } from "./runtimeModel";
 
 /** Human sentence for a rejected/failed reason: a mapped sentence for a known
-    code, else the sanitized reason printed verbatim behind a "not delivered:"
-    prefix — never the raw `rejected: dead-host` stream (design §7). */
+    code, else the sanitized reason's terse cause behind a "not delivered:"
+    prefix — never the raw `rejected: dead-host` stream (design §7), and never
+    the whole sentence with its remediation in a chip (#1362): that lives in
+    the notice's expanded detail and on hover ({@link humanReasonFull}). */
 export function humanReason(t: TFunction, reason: string | null | undefined): string {
   const key = humanReceiptReasonKey(reason);
   if (key) return t(key);
-  return reason ? t("receipt.human.verbatim", { reason }) : t("composer.receiptFailed");
+  const { cause } = describeReceiptFailure(t, reason);
+  return cause ? t("receipt.human.verbatim", { reason: cause }) : t("composer.receiptFailed");
+}
+
+/** The whole sentence {@link humanReason} shortened, for hover — or null when
+    nothing was shortened. */
+export function humanReasonFull(t: TFunction, reason: string | null | undefined): string | null {
+  if (humanReceiptReasonKey(reason)) return null;
+  const { cause, full } = describeReceiptFailure(t, reason);
+  return full && full !== cause ? t("receipt.human.verbatim", { reason: full }) : null;
 }
 
 /** Badge tone per receipt status. Text carries the meaning; color reinforces. */
@@ -76,20 +88,28 @@ export function ReceiptChip({ receipt, wait = null, actionsDisabled = false, onR
     || wait?.phase === "awaiting-handover"
     || wait?.phase === "unconfirmed-admission";
   const waitText = wait ? deliveryWaitText(t, wait, receipt.queuePosition) : null;
+  const label = waitText ?? runtimeReceiptStatusText(t, receipt);
+  const fullLabel = failed ? humanReasonFull(t, receipt.reason) : null;
   return (
-    <span className="inline-flex flex-wrap items-center gap-1.5 text-[11px] font-semibold" data-operation={receipt.operationId}>
+    <span className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[11px] font-semibold" data-operation={receipt.operationId}>
+      {/* A failure chip says the terse cause (#1362) and can still run long
+          on a phone: it shrinks to its line and ends in an ellipsis instead of
+          clipping mid-word, and the whole sentence rides on hover. Moving
+          states keep their fixed chip. */}
       <Badge
         tone={uncertain || wait?.phase === "awaiting-host"
           ? "danger"
           : parked
             ? "warning"
             : tone(receipt.status)}
+        shrinkable={failed}
+        {...(failed ? { title: fullLabel ?? label } : {})}
         data-receipt-status={receipt.status}
         {...(wait ? { "data-receipt-wait": wait.phase } : {})}
         {...(failed || uncertain ? { role: "status", "aria-live": "polite" as const } : {})}
       >
         {parked ? <Clock3 className="mr-1 h-3 w-3" aria-hidden /> : null}
-        {waitText ?? runtimeReceiptStatusText(t, receipt)}
+        {failed ? <span className="min-w-0 truncate">{label}</span> : label}
       </Badge>
       {(failed || uncertain) && !discarded && onRetry ? (
         <button

--- a/src/components/runtime/deliveryNotice.test.ts
+++ b/src/components/runtime/deliveryNotice.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Issue #1362 — the composer's failed-delivery notice model.
+ *
+ * Pure: which settled failures fold into the one compact notice, what the
+ * notice says at rest, and what expanding it reveals.
+ */
+import { expect, test } from "bun:test";
+
+import { translate } from "@/lib/i18n";
+
+import { deliveryAttemptGroups } from "./deliveryState";
+import { deliveryNoticeRun, describeReceiptFailure, failureCauseKey } from "./deliveryNotice";
+import type { RuntimeReceipt } from "./runtimeModel";
+
+const t = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
+
+const HOST_DOWN = "structured spawn runtime host is unavailable; start agent-log-viewer through its CLI and check the CLI log for the host startup failure";
+
+function receipt(overrides: Partial<RuntimeReceipt> & { operationId: string }): RuntimeReceipt {
+  return {
+    idempotencyKey: `key-${overrides.operationId}`,
+    conversationId: "conversation_1362",
+    kind: "send",
+    status: "failed",
+    reason: HOST_DOWN,
+    text: "fix the failing test",
+    at: "2026-08-31T10:00:00.000Z",
+    revision: 1,
+    ...overrides,
+  };
+}
+
+test("#1362 a verbatim sentence splits into a terse cause and the remediation behind it", () => {
+  const described = describeReceiptFailure(t, HOST_DOWN);
+  expect(described.cause).toBe(t("receipt.cause.hostUnavailable"));
+  expect(described.full).toBe(HOST_DOWN);
+  expect(described.detail).toEqual({
+    sentence: "structured spawn runtime host is unavailable",
+    remediation: "start agent-log-viewer through its CLI and check the CLI log for the host startup failure",
+  });
+});
+
+test("#1362 a known reason code reads as its human sentence and has nothing further to reveal", () => {
+  const described = describeReceiptFailure(t, "dead-host");
+  expect(described.cause).toBe(t("receipt.human.deadHost"));
+  expect(described.full).toBe(t("receipt.human.deadHost"));
+  expect(described.detail).toBeNull();
+});
+
+test("#1362 an unknown short reason is the cause itself; an absent reason has no cause", () => {
+  expect(describeReceiptFailure(t, "quota-exceeded")).toEqual({ cause: "quota-exceeded", full: "quota-exceeded", detail: null });
+  expect(describeReceiptFailure(t, null)).toEqual({ cause: null, full: null, detail: null });
+  expect(describeReceiptFailure(t, "   ")).toEqual({ cause: null, full: null, detail: null });
+});
+
+test("#1362 the cause key ignores casing, spacing, and which alias named a known code", () => {
+  expect(failureCauseKey(HOST_DOWN)).toBe(failureCauseKey(`  Structured spawn RUNTIME host is unavailable;  ${"different remediation"}`));
+  expect(failureCauseKey("dead-host")).toBe(failureCauseKey("host-dead"));
+  expect(failureCauseKey("dead-host")).not.toBe(failureCauseKey(HOST_DOWN));
+});
+
+test("#1362 the run is the newest consecutive same-cause failures; older other causes stay behind it", () => {
+  const groups = deliveryAttemptGroups([
+    receipt({ operationId: "op-a2", text: "second ask", at: "2026-08-31T10:00:03.000Z" }),
+    receipt({ operationId: "op-a1", text: "first ask", at: "2026-08-31T10:00:02.000Z" }),
+    receipt({ operationId: "op-b", text: "older ask", reason: "dead-host", at: "2026-08-31T10:00:01.000Z" }),
+    receipt({ operationId: "op-a0", text: "oldest ask", at: "2026-08-31T10:00:00.000Z" }),
+  ]);
+  const run = deliveryNoticeRun(groups, []);
+  expect(run).not.toBeNull();
+  expect(run!.current.operationId).toBe("op-a2");
+  expect(run!.causeKey).toBe(failureCauseKey(HOST_DOWN));
+  expect(run!.attempts.map((attempt) => attempt.operationId)).toEqual(["op-a2", "op-a1"]);
+  expect(run!.dismissIds).toEqual(["op-a2", "op-a1"]);
+  expect(run!.groupCount).toBe(2);
+});
+
+test("#1362 three retries of one message count as three attempts of one group", () => {
+  const groups = deliveryAttemptGroups([2, 1, 0].map((second) =>
+    receipt({ operationId: `op-retry-${second}`, at: `2026-08-31T10:00:0${second}.000Z` })));
+  const run = deliveryNoticeRun(groups, [])!;
+  expect(run.groupCount).toBe(1);
+  expect(run.attempts).toHaveLength(3);
+  expect(run.dismissIds).toEqual(["op-retry-2", "op-retry-1", "op-retry-0"]);
+});
+
+test("#1362 a group still moving is not a failure, and no failures means no notice", () => {
+  const moving = deliveryAttemptGroups([
+    receipt({ operationId: "op-queued", status: "queued", reason: null, at: "2026-08-31T10:00:05.000Z" }),
+    receipt({ operationId: "op-stale", status: "rejected", reason: "stale-turn", at: "2026-08-31T10:00:04.000Z" }),
+  ]);
+  expect(deliveryNoticeRun(moving, [])).toBeNull();
+  expect(deliveryNoticeRun([], [])).toBeNull();
+});
+
+test("#1362 textless failed sends join the run by time and cause", () => {
+  const groups = deliveryAttemptGroups([
+    receipt({ operationId: "op-with-text", at: "2026-08-31T10:00:01.000Z" }),
+  ]);
+  const textless = [
+    receipt({ operationId: "op-textless-new", text: null, at: "2026-08-31T10:00:02.000Z" }),
+    receipt({ operationId: "op-textless-old", text: null, at: "2026-08-31T10:00:00.000Z" }),
+  ];
+  const run = deliveryNoticeRun(groups, textless)!;
+  expect(run.current.operationId).toBe("op-textless-new");
+  expect(run.attempts.map((attempt) => attempt.operationId)).toEqual(["op-textless-new", "op-with-text", "op-textless-old"]);
+  expect(run.groupCount).toBe(3);
+});

--- a/src/components/runtime/deliveryNotice.ts
+++ b/src/components/runtime/deliveryNotice.ts
@@ -1,0 +1,145 @@
+/**
+ * The composer's failed-delivery notice (issue #1362).
+ *
+ * The operator photographed three identical full-width red pills under the
+ * composer, one per retry, each carrying the whole error sentence with its
+ * tail clipped. This module is the pure half of the replacement: which settled
+ * failures fold into ONE compact notice, what that notice says at rest, and
+ * what expanding it reveals. The rendering lives in `RuntimeComposerReceipts`.
+ *
+ * No React, no I/O: the run and the wording are deterministic functions of
+ * the visible receipts, so the collapse rule can be pinned on its own.
+ */
+
+import type { MessageKey, TFunction } from "@/lib/i18n";
+
+import type { DeliveryAttemptGroup } from "./deliveryState";
+import { deliveryProblem } from "./deliveryState";
+import { humanReceiptReasonKey, receiptIsTerminal, type RuntimeReceipt } from "./runtimeModel";
+
+/**
+ * Terse causes for the verbatim sentence families the runtime produces. The
+ * sentence itself (and the remediation after its semicolon) stays reachable
+ * behind expand/hover; the row only ever shows the short form. Keyed on a
+ * pattern rather than an exact string because the subject varies ("structured
+ * spawn runtime host", "runtime host", "structured recovery runtime host").
+ */
+const CAUSE_PATTERNS: ReadonlyArray<readonly [RegExp, MessageKey]> = [
+  [/\bruntime host is unavailable\b/i, "receipt.cause.hostUnavailable"],
+  [/\btimed out\b/i, "receipt.cause.timedOut"],
+];
+
+function splitClauses(reason: string): { head: string; rest: string | null } {
+  const index = reason.indexOf(";");
+  if (index < 0) return { head: reason.trim(), rest: null };
+  const rest = reason.slice(index + 1).trim();
+  return { head: reason.slice(0, index).trim(), rest: rest || null };
+}
+
+function patternKey(head: string): MessageKey | null {
+  for (const [pattern, key] of CAUSE_PATTERNS) {
+    if (pattern.test(head)) return key;
+  }
+  return null;
+}
+
+/**
+ * Identity of a failure cause, so identical consecutive failures collapse
+ * regardless of casing, spacing, or which alias named a known reason code. A
+ * verbatim sentence is identified by its first clause; the remediation after
+ * the semicolon never splits a run.
+ */
+export function failureCauseKey(reason: string | null | undefined): string {
+  const trimmed = reason?.trim() ?? "";
+  if (!trimmed) return "";
+  const known = humanReceiptReasonKey(trimmed);
+  if (known) return `key:${known}`;
+  const { head } = splitClauses(trimmed);
+  return `verbatim:${patternKey(head) ?? head.replace(/\s+/g, " ").toLowerCase()}`;
+}
+
+export interface ReceiptFailureDescription {
+  /** The terse cause for the at-rest row, or null when the receipt has none. */
+  cause: string | null;
+  /** The whole reason, for hover. */
+  full: string | null;
+  /** What expanding reveals beyond the terse cause: the full first sentence
+      and the remediation after it. Null when the cause already says it all. */
+  detail: { sentence: string; remediation: string | null } | null;
+}
+
+/**
+ * The three forms one failure reason takes: a terse cause for the row, the
+ * whole sentence for hover, and the sentence plus remediation for expand. A
+ * known reason code is already a short human sentence and reveals nothing
+ * further; a verbatim sentence splits at its first semicolon into what
+ * happened and what to do about it.
+ */
+export function describeReceiptFailure(t: TFunction, reason: string | null | undefined): ReceiptFailureDescription {
+  const trimmed = reason?.trim() ?? "";
+  if (!trimmed) return { cause: null, full: null, detail: null };
+  const known = humanReceiptReasonKey(trimmed);
+  if (known) {
+    const sentence = t(known);
+    return { cause: sentence, full: sentence, detail: null };
+  }
+  const { head, rest } = splitClauses(trimmed);
+  const key = patternKey(head);
+  const cause = key ? t(key) : head;
+  const revealsMore = rest !== null || cause.toLowerCase() !== head.toLowerCase();
+  return {
+    cause,
+    full: trimmed,
+    detail: revealsMore ? { sentence: head, remediation: rest } : null,
+  };
+}
+
+export interface DeliveryNoticeRun {
+  /** Newest failed attempt of the run — owns the notice's cause and retry. */
+  current: RuntimeReceipt;
+  causeKey: string;
+  /** Every settled failed attempt the notice counts, newest first. */
+  attempts: RuntimeReceipt[];
+  /** Every settled attempt dismissing the notice hides (issue #264 rule 3). */
+  dismissIds: string[];
+  /** Logical messages behind the notice; one for a single message's retries. */
+  groupCount: number;
+}
+
+/**
+ * The failures the one notice stands for: the newest visible settled failure
+ * plus every consecutive earlier one with the same cause. Candidates are the
+ * message groups whose newest attempt is a settled problem, and the textless
+ * message receipts (no echo to group by) that failed — each counted as its own
+ * single-attempt group. A group still moving is not a failure, whatever its
+ * history says, and an older failure with a different cause waits its turn in
+ * the history until the run in front of it is dismissed.
+ */
+export function deliveryNoticeRun(
+  groups: readonly DeliveryAttemptGroup[],
+  textless: readonly RuntimeReceipt[],
+): DeliveryNoticeRun | null {
+  const candidates: DeliveryAttemptGroup[] = [
+    ...groups.filter((group) => deliveryProblem(group.current.status)),
+    ...textless
+      .filter((receipt) => deliveryProblem(receipt.status))
+      .map((receipt) => ({ current: receipt, attempts: [receipt] })),
+  ].sort((left, right) => Date.parse(right.current.at) - Date.parse(left.current.at));
+  const first = candidates[0];
+  if (!first) return null;
+  const causeKey = failureCauseKey(first.current.reason);
+  const run: DeliveryAttemptGroup[] = [];
+  for (const candidate of candidates) {
+    if (failureCauseKey(candidate.current.reason) !== causeKey) break;
+    run.push(candidate);
+  }
+  return {
+    current: first.current,
+    causeKey,
+    attempts: run.flatMap((group) => group.attempts.filter((attempt) => deliveryProblem(attempt.status))),
+    dismissIds: run.flatMap((group) => group.attempts
+      .filter((attempt) => receiptIsTerminal(attempt.status))
+      .map((attempt) => attempt.operationId)),
+    groupCount: run.length,
+  };
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -491,6 +491,8 @@ export const en = {
   "receipt.human.compactSentUnobserved": "sent — the Viewer couldn’t confirm the compaction finished",
   "receipt.human.compactDeclined": "sent — the agent finished /compact without compacting",
   "receipt.human.verbatim": "not delivered: {reason}",
+  "receipt.cause.hostUnavailable": "runtime host unavailable",
+  "receipt.cause.timedOut": "request timed out",
 
   // DraftAgentPane
   "spawnCard.starting": "Launch admitted. Starting the agent.",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -515,6 +515,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "receipt.human.compactSentUnobserved": "надіслано — Viewer не зміг підтвердити завершення стискання",
   "receipt.human.compactDeclined": "надіслано — агент завершив /compact, нічого не стиснувши",
   "receipt.human.verbatim": "не доставлено: {reason}",
+  "receipt.cause.hostUnavailable": "runtime host недоступний",
+  "receipt.cause.timedOut": "запит перевищив час очікування",
 
   "draft.readPrompt": "Прочитай розмову агента у файлі {src} і продовж роботу звідти: ",
   "draft.needDir": "вкажи робочу директорію",


### PR DESCRIPTION
## Summary

After a few delivery retries the composer stacked one full-width red pill per attempt, each carrying the whole error sentence with its tail clipped (#1362). This replaces that with one compact notice.

- **One notice, counted.** Identical consecutive settled failures fold into the receipt stack's summary line with an attempt counter: three failed retries of one message read `⊘ not delivered — runtime host unavailable ×3`. An older failure with a different cause waits in the history and surfaces as the next notice once the run in front of it is dismissed.
- **Terse at rest, full behind expand/hover.** The row shows a status glyph, the status word, and a terse cause (`receipt.cause.*` for known sentence families, the human sentence for known reason codes, else the sentence's first clause). Expanding reveals the full sentence and the remediation after its semicolon, once, at the top of the history; the whole sentence also rides on hover.
- **The accordion keeps the detailed history.** The per-message rows stay (Retry / Edit & resend / Discard / Dismiss, ×N, superseded history), with each chip reduced to the terse cause and the sentence on its hover. The notice is the accordion's disclosure rather than a copy of it.
- **Dismissal clears the group.** The notice's ✕ dismisses every settled attempt it counted; a still-moving attempt is never hidden. A same-key retry icon sits beside it for a confirmed failure of a message, never for a rejection or a discard.
- **Textless failures join in.** A message receipt with no text echo used to render as its own standalone pill per attempt; those now fold into the notice and share one history row per cause.

## Design

Fable direction, per the issue's goals: subordinate to the composer while clearly an error, in both themes.

- Role carried by a 2px danger edge, the glyph and the status word only (design system §3.7: role in the edge, never a full wash). Fill and type stay the receipt stack's sunken caption surface.
- The counter is plain muted tabular text, never a badge (rule 5). The red issue badge beside the notice counts only deliveries that went terminally uncertain.
- Actions are quiet icon-buttons (§3.5: failed = danger + retry icon-button). On phones they keep a 44px hit area in a 32px box through the composer's existing `before:` pattern, which is what leaves the cause its width at 390px. The summary stays the same 44px line it always was.
- No pill row, no full sentence per attempt: the history chip truncates with an ellipsis if it ever runs long.
- `docs/design/delivery-state.md` gains a section describing the anatomy and the collapse rule.

## Verification

- New tests, written first: `src/components/runtime/deliveryNotice.test.ts` (collapse rule, cause key, wording split) and `src/components/TmuxComposer.deliveryNotice.dom.test.tsx` (three retries → one notice ×3 in en and uk; expand → full cause and remediation once; dismiss → the whole group, pending delivery untouched; retry only for a confirmed failure; older cause stays in the history; textless failures collapse; desktop and 390px structural contract in both locales).
- Existing tests adapted to the new summary anatomy where they pinned the old one (mixed pending+failed summary, grouped attempts summary, visual acceptance preview → notice cause). Ran by path, all green:
  `TmuxComposer.dom.test.tsx`, `TmuxComposer.deliveryState.dom.test.tsx`, `TmuxComposer.reconciliation.dom.test.tsx`, `TmuxComposer.reconciliationExpiry.dom.test.tsx`, `runtime/deliveryWait.dom.test.tsx`, `runtime/runtimeComponents.render.test.tsx`, `runtime/deliveryState.test.ts`, `lib/i18n/i18n.test.ts`, plus the two new files (136 tests).
- `bunx tsc --noEmit` clean. `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` clean.
- Real-browser check (host Chrome over CDP against a throwaway scratch page on a dev server, not committed): at 1280px and 390px, light and dark, en and uk, the notice is one 44px line; at 390px the headline cause `не доставлено — runtime host недоступний ×3` fits unclipped beside 32×44 action boxes; expanded, the sentence and remediation wrap in a block above the history row whose chip reads `не доставлено: runtime host недоступний`. Evidence is the DOM assertions above; no rasters are committed (privacy gate).
- Note: `bunx eslint` crashes on every file in this checkout (eslint-plugin-react vs ESLint 10), on untouched files too; lint is not part of the gates.

Fixes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
