### PR TITLE
perf(search): profile the global message search end to end and rank in memory on one match scan (#1429)

### DIFF
--- a/docs/performance/issue-1429-transcript-search.md
+++ b/docs/performance/issue-1429-transcript-search.md
@@ -1,0 +1,170 @@
+# Issue #1429 global message search profile
+
+Date: 2026-09-02
+Runtime: Bun 1.4.0, SQLite 3.53.2, 16-core Linux host
+Corpus: synthetic, `scripts/transcript-search-fixture.ts` (seed 1429): 6,729
+conversations / 250,000 indexed messages, 20% of rows replayed duplicates
+Production that day (read-only reference): 7,253 conversations / 249,812 messages
+
+The issue's first server-side measurement (30–160 ms) was taken on queries with
+a few hundred matches. Measured on words the operator actually types, the route
+itself was the cost: 0.5–4 s on the production instance for a word present in
+45% of the messages, and every one of those seconds stalled every other request
+the Viewer was serving.
+
+## Method
+
+`scripts/transcript-search-bench.ts` indexes the synthetic corpus into a scratch
+`LLV_STATE_DIR` and measures the same three queries on every surface:
+
+- **library** — `searchTranscripts` in-process (the SQLite work alone);
+- **route** — the exported route handler called in-process (plus title lookup
+  and JSON serialisation);
+- **http** — the same handler behind a loopback `Bun.serve`, fetched;
+- **mcp** — the packaged stdio server (`bin/mcp-server.mjs`, the release bundle
+  under Bun) pointed at that loopback Viewer, driven through the MCP SDK client
+  (receipts, control HTTP, redaction, result serialisation on top of http);
+- **ui** — the real palette (`GlobalSearch`) in happy-dom with `fetch` routed
+  to the loopback Viewer, from the last keystroke to the first rendered result
+  row, debounce included. *fast* types with 120 ms between keys so only the
+  final query is requested; *slow* leaves 300 ms after every key so each pause
+  fires its own request.
+
+Queries: `heliotrope` (rare, 3 hits), `harbor granite` (two common words, 18k
+matches), `ledger` (one very common word, 89k matches, 45% of the corpus).
+Medians of five runs. The production numbers below were taken read-only against
+the live index and the live route; no production content was copied anywhere.
+
+## Baseline: where the time went
+
+| surface | rare word | two common words | very common word |
+| --- | --- | --- | --- |
+| library, own messages | 13 ms | 125 ms | 446 ms |
+| library, all speakers | 12 ms | 277 ms | 1 369 ms |
+| http, own messages | 13 ms | 124 ms | 430 ms |
+| http, all speakers | 13 ms | 275 ms | 1 384 ms |
+| mcp (always all speakers) | 14 ms | 277 ms | 1 339 ms |
+| ui fast, own messages | 267 ms | 382 ms | 752 ms |
+| ui fast, all speakers | 267 ms | 531 ms | 1 630 ms |
+| ui slow, all speakers | 267 ms (10 req) | 544 ms (14 req) | 1 723 ms (6 req) |
+
+Reading down a column:
+
+- **The SQLite statements are the cost.** http ≈ route ≈ library on every
+  query; transport and serialisation add 0–15 ms.
+- **The MCP round trip adds ~1 ms** over http: the receipt claim and completion
+  (two `synchronous=FULL` transactions), `redactPayload` over the snippets and
+  the three JSON serialisations are invisible next to the query. Suspect 2 of
+  the issue is cleared.
+- **The palette adds the 250 ms debounce and a few ms of render.** ui-fast −
+  http − 250 is 4–15 ms on every row. Suspect 1's render cost is cleared; its
+  debounce is the whole answer for a rare word (267 ms, of which 13 ms is the
+  search).
+- **Every query paid a fixed ~12 ms** before doing anything: the corpus
+  statistics ran `COUNT(*)` over the 250k-row message table.
+
+The per-key pauses of *slow* typing fired 6–14 requests per run without
+changing the time to the final answer here, because a prefix of a word matches
+no token. What they did do is documented next.
+
+### Statement-level split on the production index (read-only)
+
+Very common word, all speakers, ~113k matched rows, one warm handle:
+
+| statement | ms |
+| --- | --- |
+| corpus stats (`COUNT(*)` over messages) | 12 |
+| `COUNT(*)` of the collapsed groups (join files, `GROUP BY speaker, body_hash`) | 358 |
+| page query (window functions over the join, second FTS scan for `snippet`, sort) | 1 311 |
+| — of which: FTS5 scan alone | 24 |
+| — of which: FTS5 scan with `bm25` | ~140 |
+| — of which: join to `transcript_files` by path, per matched row | ~5 µs × 113k ≈ 560 |
+| one `rowid = ? AND MATCH` seek (what per-row `snippet` lookups would cost) | 14 each |
+
+The `transcript_files` join by its text primary key, paid once in the count and
+once in the page query, was the largest single term. Bigger page caches and
+`mmap_size` changed nothing (±5%): the cost is CPU in joins and sorts, not I/O.
+Chunking the FTS scan by rowid ranges to yield between chunks costs 4× (every
+chunk re-seeks the doclists).
+
+### The stall nobody had measured
+
+`searchTranscripts` runs synchronously inside the route handler, on the
+Viewer's only thread. On the production instance, with a very-common-word
+search in progress:
+
+| request | alone | during the search |
+| --- | --- | --- |
+| rare-word search | 17 ms | 1 471 ms |
+| `/api/files?limit=1` | 130 ms | 1 532 ms |
+
+A request the palette aborted on the next keystroke was still computed in full
+there, and every later request queued behind it. This is what made the search
+feel slower than any single number above: the answer to the final query waited
+behind the abandoned ones, and the board's own polls waited with it.
+
+## After
+
+| surface | rare word | two common words | very common word |
+| --- | --- | --- | --- |
+| library, own messages | 2 ms | 64 ms | 176 ms |
+| library, all speakers | 2 ms | 98 ms | 346 ms |
+| http, own messages | 2 ms | 63 ms | 169 ms |
+| http, all speakers | 2 ms | 100 ms | 353 ms |
+| mcp (always all speakers) | 4 ms | 99 ms | 328 ms |
+| ui fast, own messages | 257 ms | 319 ms | 453 ms |
+| ui fast, all speakers | 256 ms | 358 ms | 632 ms |
+| ui slow, all speakers | 256 ms (10 req) | 377 ms (13 req) | 612 ms (6 req) |
+
+On the production index (read-only, same pages compared byte for byte with the
+previous SQL): `the`, all speakers, 1.5–2.1 s → 0.42–0.52 s; `the`, own
+messages, 0.6–2.8 s → 0.23–0.26 s; `the file`, own messages, 0.4–5 s →
+0.18–0.45 s; a 5k-match word 0.12–0.37 s → 0.05 s.
+
+## Mechanism
+
+1. **One match scan, ranking in memory** (`src/lib/search/transcriptSearch.ts`).
+   The scan reads six columns per matched row (id, bm25, speaker, body hash,
+   timestamp, transcript path) and never joins `transcript_files`; the files a
+   page can name are read once (keyed lookups up to 512 distinct transcripts,
+   one pass over the table beyond that). Duplicate collapsing, the total and the
+   page order are computed in memory in exactly the order the SQL used: bm25,
+   then newest transcript mtime, newest message timestamp, highest id. Snippets
+   are cut for the page's rows only, by one filtered match scan (`+rowid IN`)
+   rather than per-row seeks. The whole search runs inside one read transaction
+   so the passes share a snapshot while the indexer commits. A differential test
+   pins every row, order, snippet, duplicate count and total against the SQL it
+   replaced on a seeded corpus dense in ties and cross-file duplicates.
+2. **Corpus statistics from `transcript_files`.** `SUM(messages_count)` is
+   committed with each transcript's rows and equals the message count, without
+   the 250k-row walk.
+3. **One first-page request in flight, latest question wins**
+   (`src/components/search/useTranscriptSearch.ts`). The palette no longer
+   aborts the in-flight request on a refinement — the server would have
+   finished it anyway — and every refinement typed meanwhile collapses into the
+   one request that follows. The answer that arrives holds on screen as the
+   stale rows the design already shows. Pinned by request counts on gated
+   fetches, including the StrictMode rehearsal unmount.
+
+Result ordering and snippet shape are unchanged; the issue's suspect 3 (a
+query during a re-index) is unchanged too: WAL readers never wait on the
+writer, and the existing test for a search during a rebuild still holds.
+
+## Not fixed here
+
+The search still holds the Viewer's only thread for 170–350 ms on a
+very-common-word query, and every agent now runs several searches at the start
+of each task (#1428). Moving the search into a worker, and measuring an FTS5
+`optimize`/`merge` after complete index passes, is filed as #1438 with the
+numbers above.
+
+## Reproduce
+
+```
+bun scripts/transcript-search-fixture.ts /tmp/llv-search-corpus
+LLV_STATE_DIR=/tmp/llv-search-state bun scripts/transcript-search-bench.ts /tmp/llv-search-corpus --repeat 5
+```
+
+The first command writes ~410 MB of invented transcripts; the second indexes
+them (~25 s) and prints the table. `--skip-mcp` needs no bundle; the MCP
+surface needs `bun scripts/build-mcp.ts` first.

--- a/scripts/transcript-search-bench.ts
+++ b/scripts/transcript-search-bench.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end profile of the global message search (#1429) on the synthetic
+ * corpus `transcript-search-fixture.ts` writes: the same three queries on every
+ * surface the operator reaches it through.
+ *
+ *   LLV_STATE_DIR=<scratch> bun scripts/transcript-search-bench.ts <fixtureDir> [--repeat 5] [--json <file>] [--skip-mcp] [--skip-ui]
+ *
+ * Refuses to run without an explicit LLV_STATE_DIR so the index build can never
+ * touch the operator's live `transcript-search.sqlite`, and the MCP host it
+ * spawns keeps its receipts in that same scratch directory.
+ *
+ * Surfaces, from the inside out:
+ *   - library — `searchTranscripts` in this process: the SQLite work alone;
+ *   - route   — the exported route handler called in-process: library plus
+ *               title lookup and JSON serialisation;
+ *   - http    — the same handler served by a loopback Bun.serve and fetched:
+ *               what the browser and the MCP host actually wait for;
+ *   - mcp     — the packaged stdio server (`bin/mcp-server.mjs`, the release
+ *               bundle under Bun, as on the host) pointed at that loopback
+ *               Viewer, driven through the MCP SDK client: receipts, control
+ *               HTTP, redaction and result serialisation on top of http;
+ *   - ui      — the real palette (`GlobalSearch`) mounted in happy-dom with
+ *               `fetch` routed to the loopback Viewer: from the last keystroke
+ *               to the first rendered result row, debounce included. `fast`
+ *               types the query with 120 ms between keys so only the final
+ *               query is requested; `slow` leaves 300 ms after every key so
+ *               each pause fires its own request, which is what stacks queries
+ *               on the Viewer's event loop.
+ * Each cell is the median of `--repeat` runs. Numbers only; nothing from the
+ * corpus is printed.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { GET as searchRoute } from "@/app/api/search/transcripts/route";
+import { replaceConversationCatalog } from "@/lib/scanner/conversationCatalog";
+import { indexTranscriptSources, searchTranscripts, type TranscriptIndexSource, type TranscriptSpeaker } from "@/lib/search/transcriptSearch";
+import { TRANSCRIPT_SEARCH_DEBOUNCE_MS } from "@/components/search/useTranscriptSearch";
+
+import type { TranscriptFixtureManifest } from "./transcript-search-fixture";
+
+interface Cell {
+  surface: "library" | "route" | "http" | "mcp" | "ui-fast" | "ui-slow";
+  query: string;
+  speaker: string;
+  runs: number[];
+  median: number;
+  /** Requests the Viewer answered for the cell's runs (ui surfaces only). */
+  requests?: number;
+  total?: number;
+}
+
+function flag(args: string[], name: string): string | undefined {
+  const index = args.indexOf(`--${name}`);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle]! : (sorted[middle - 1]! + sorted[middle]!) / 2;
+}
+
+const args = process.argv.slice(2);
+const fixtureDir = args.find((arg) => !arg.startsWith("--") && !args.includes(`--${arg}`) && !/^\d+$/.test(arg) && !arg.endsWith(".json"));
+const stateDir = process.env.LLV_STATE_DIR;
+const defaultStateDir = path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"), "agent-log-viewer", "state");
+if (!fixtureDir || !stateDir || path.resolve(stateDir) === defaultStateDir) {
+  console.error("usage: LLV_STATE_DIR=<scratch> bun scripts/transcript-search-bench.ts <fixtureDir> [--repeat 5] [--json <file>] [--skip-mcp] [--skip-ui]");
+  process.exit(2);
+}
+const repeat = Math.max(1, Number(flag(args, "repeat") ?? 5) || 5);
+const jsonOut = flag(args, "json");
+const root = path.resolve(fixtureDir);
+const manifest = JSON.parse(fs.readFileSync(path.join(root, "manifest.json"), "utf8")) as TranscriptFixtureManifest;
+const sources: TranscriptIndexSource[] = manifest.files.map((file) => {
+  const absolute = path.join(root, file.path);
+  const stat = fs.statSync(absolute);
+  return { path: absolute, project: file.project, engine: file.engine, size: stat.size, mtimeMs: stat.mtimeMs };
+});
+
+const indexStartedAt = performance.now();
+const indexed = await indexTranscriptSources(sources, { complete: true });
+const indexMs = Math.round(performance.now() - indexStartedAt);
+if (indexed.failures.length) throw new Error(`${indexed.failures.length} fixture transcript(s) failed to index`);
+/* Titles come off the in-memory catalog in production; publish one of the
+   same size so the route's per-page title lookup is part of the measurement. */
+replaceConversationCatalog(manifest.files.map((file, index) => ({
+  path: path.join(root, file.path),
+  root: file.engine === "claude" ? "claude-projects" : "codex-sessions",
+  name: path.basename(file.path),
+  project: file.project,
+  title: `Fixture conversation ${index + 1}`,
+  firstPrompt: `Fixture conversation ${index + 1}`,
+  engine: file.engine,
+  kind: "session",
+  fmt: file.engine,
+  mtime: file.mtime,
+  size: 0,
+})));
+
+const queries = [manifest.probes.rare, manifest.probes.commonPair, manifest.probes.veryCommon];
+const speakers: Array<TranscriptSpeaker | undefined> = ["user", undefined];
+const cells: Cell[] = [];
+const stats = searchTranscripts({ query: manifest.probes.rare }).stats;
+console.log(`corpus: ${stats.conversationsIndexed} conversations / ${stats.messagesIndexed} messages; index build ${indexMs} ms (${indexed.filesRead} read, ${indexed.filesSkipped} unchanged)`);
+
+function url(origin: string, query: string, speaker: TranscriptSpeaker | undefined): string {
+  const params = new URLSearchParams({ q: query, limit: "20" });
+  if (speaker) params.set("speaker", speaker);
+  return `${origin}/api/search/transcripts?${params}`;
+}
+
+let served = 0;
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  fetch: (request) => {
+    served += 1;
+    return searchRoute(request);
+  },
+});
+const origin = server.url.origin;
+
+for (const query of queries) {
+  for (const speaker of speakers) {
+    const label = speaker ?? "all";
+    const library: number[] = [];
+    let total = 0;
+    for (let run = 0; run < repeat; run += 1) {
+      const startedAt = performance.now();
+      total = searchTranscripts({ query, speaker, limit: 20 }).total;
+      library.push(performance.now() - startedAt);
+    }
+    cells.push({ surface: "library", query, speaker: label, runs: library, median: median(library), total });
+    const route: number[] = [];
+    for (let run = 0; run < repeat; run += 1) {
+      const startedAt = performance.now();
+      await (await searchRoute(new Request(url("http://127.0.0.1", query, speaker)))).json();
+      route.push(performance.now() - startedAt);
+    }
+    cells.push({ surface: "route", query, speaker: label, runs: route, median: median(route), total });
+    const http: number[] = [];
+    for (let run = 0; run < repeat; run += 1) {
+      const startedAt = performance.now();
+      await (await fetch(url(origin, query, speaker))).json();
+      http.push(performance.now() - startedAt);
+    }
+    cells.push({ surface: "http", query, speaker: label, runs: http, median: median(http), total });
+  }
+}
+
+if (!args.includes("--skip-mcp")) {
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  environment.LLV_STATE_DIR = stateDir;
+  environment.LLV_VIEWER_CONTROL_URL = origin;
+  delete environment.LLV_VIEWER_DEPLOY_TARGET;
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+    cwd: process.cwd(),
+    env: environment,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "transcript-search-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    /* The tool has no speaker argument: it always searches both sides. */
+    for (const query of queries) {
+      const runs: number[] = [];
+      let total = 0;
+      for (let run = 0; run < repeat; run += 1) {
+        const startedAt = performance.now();
+        const result = await client.callTool({
+          name: "search_transcripts",
+          arguments: { clientRequestId: `bench-${Date.now()}-${run}-${Math.random().toString(36).slice(2)}`, query, limit: 20 },
+        });
+        runs.push(performance.now() - startedAt);
+        const structured = result.structuredContent as { ok?: boolean; total?: number; error?: string } | undefined;
+        if (!structured?.ok) throw new Error(`search_transcripts failed: ${structured?.error ?? "no structured content"}`);
+        total = structured.total ?? 0;
+      }
+      cells.push({ surface: "mcp", query, speaker: "all", runs, median: median(runs), total });
+    }
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+if (!args.includes("--skip-ui")) {
+  const { Window } = await import("happy-dom");
+  const dom = new Window({ url: "http://localhost/" });
+  Object.assign(globalThis, {
+    window: dom,
+    document: dom.document,
+    navigator: dom.navigator,
+    location: dom.location,
+    history: dom.history,
+    localStorage: dom.localStorage,
+    Node: dom.Node,
+    HTMLElement: dom.HTMLElement,
+    HTMLInputElement: dom.HTMLInputElement,
+    Element: dom.Element,
+    Event: dom.Event,
+    KeyboardEvent: dom.KeyboardEvent,
+    MouseEvent: dom.MouseEvent,
+  });
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+    realFetch(new URL(String(input), origin), init)) as typeof fetch;
+  const { createElement } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { GlobalSearch } = await import("@/components/search/GlobalSearch");
+  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const valueSetter = Object.getOwnPropertyDescriptor(dom.HTMLInputElement.prototype, "value")!.set!;
+  for (const query of queries) {
+    for (const speaker of speakers) {
+      for (const typing of ["fast", "slow"] as const) {
+        const gap = typing === "fast" ? 120 : 300;
+        const runs: number[] = [];
+        let requests = 0;
+        for (let run = 0; run < repeat; run += 1) {
+          const mountNode = dom.document.createElement("div");
+          dom.document.body.append(mountNode);
+          const host = mountNode as unknown as HTMLElement;
+          const mounted = createRoot(host);
+          mounted.render(createElement(GlobalSearch, { mobile: false, onClose: () => {}, onOpen: () => {} }));
+          await sleep(20);
+          if (!speaker) {
+            host.querySelector<HTMLElement>('[data-search-scope="everything"]')!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as unknown as Event);
+            await sleep(20);
+          }
+          const input = host.querySelector<HTMLInputElement>("[data-search-input]")!;
+          input.focus();
+          const servedBefore = served;
+          let lastKeyAt = 0;
+          for (let length = 1; length <= query.length; length += 1) {
+            valueSetter.call(input, query.slice(0, length));
+            lastKeyAt = performance.now();
+            input.dispatchEvent(new dom.Event("input", { bubbles: true }) as unknown as Event);
+            input.dispatchEvent(new dom.KeyboardEvent("keydown", { key: query[length - 1]!, bubbles: true }) as unknown as Event);
+            if (length < query.length) await sleep(gap);
+          }
+          const deadline = lastKeyAt + 60_000;
+          let resultAt: number | null = null;
+          while (performance.now() < deadline) {
+            /* The first row that answers the FINAL query: a held (stale) list
+               from an earlier pause does not count. */
+            const list = host.querySelector("[data-search-stale]");
+            if (!list && host.querySelector("[data-search-result]") && !host.querySelector("[data-search-updating]")) { resultAt = performance.now(); break; }
+            await sleep(2);
+          }
+          if (resultAt === null) throw new Error(`palette showed no result for ${query} (${speaker ?? "all"}, ${typing}) within 60 s`);
+          runs.push(resultAt - lastKeyAt);
+          /* Let every request the pauses fired settle before the next run. */
+          await sleep(TRANSCRIPT_SEARCH_DEBOUNCE_MS + 50);
+          requests += served - servedBefore;
+          mounted.unmount();
+          host.remove();
+        }
+        cells.push({ surface: typing === "fast" ? "ui-fast" : "ui-slow", query, speaker: speaker ?? "all", runs, median: median(runs), requests: Math.round(requests / repeat) });
+      }
+    }
+  }
+}
+
+server.stop(true);
+
+const label = (query: string) => query === manifest.probes.rare ? "rare word" : query === manifest.probes.commonPair ? "two common words" : "one very common word";
+console.log("\n| surface | query | speaker | matches | median ms | runs (ms) |");
+console.log("| --- | --- | --- | --- | --- | --- |");
+for (const cell of cells) {
+  const extra = cell.requests !== undefined ? ` (${cell.requests} req/run)` : "";
+  console.log(`| ${cell.surface} | ${label(cell.query)} | ${cell.speaker} | ${cell.total ?? ""} | ${Math.round(cell.median)}${extra} | ${cell.runs.map((run) => Math.round(run)).join(" / ")} |`);
+}
+if (jsonOut) {
+  fs.writeFileSync(jsonOut, JSON.stringify({
+    corpus: { conversations: stats.conversationsIndexed, messages: stats.messagesIndexed, indexMs, seed: manifest.seed },
+    debounceMs: TRANSCRIPT_SEARCH_DEBOUNCE_MS,
+    cells: cells.map((cell) => ({ ...cell, query: label(cell.query), runs: cell.runs.map((run) => Math.round(run * 10) / 10), median: Math.round(cell.median * 10) / 10 })),
+  }, null, 2) + "\n");
+  console.log(`\nwrote ${jsonOut}`);
+}
+process.exit(0);

--- a/scripts/transcript-search-fixture.test.ts
+++ b/scripts/transcript-search-fixture.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { TRANSCRIPT_FIXTURE_PROBES, writeTranscriptFixture, type TranscriptFixtureManifest } from "./transcript-search-fixture";
+
+function digest(root: string, manifest: TranscriptFixtureManifest): string {
+  const hash = crypto.createHash("sha256");
+  for (const file of manifest.files) hash.update(fs.readFileSync(path.join(root, file.path)));
+  return hash.digest("hex");
+}
+
+/** Every message the index would hold: Claude records, and Codex response
+    items (the event twin of each fresh Codex turn is what the reader collapses). */
+function indexedMessages(root: string, manifest: TranscriptFixtureManifest): Array<{ speaker: string; body: string }> {
+  const messages: Array<{ speaker: string; body: string }> = [];
+  for (const file of manifest.files) {
+    for (const line of fs.readFileSync(path.join(root, file.path), "utf8").split("\n")) {
+      if (!line) continue;
+      const parsed = JSON.parse(line) as { type: string; message?: { content: unknown }; payload?: { type?: string; role?: string; content?: Array<{ text?: string }> } };
+      if (file.engine === "claude" && (parsed.type === "user" || parsed.type === "assistant")) {
+        const content = parsed.message?.content;
+        messages.push({
+          speaker: parsed.type,
+          body: typeof content === "string" ? content : (content as Array<{ text?: string }>).map((part) => part.text ?? "").join("\n"),
+        });
+      } else if (parsed.type === "response_item" && parsed.payload?.type === "message") {
+        messages.push({ speaker: parsed.payload.role!, body: parsed.payload.content!.map((part) => part.text ?? "").join("\n") });
+      }
+    }
+  }
+  return messages;
+}
+
+test("the corpus is deterministic under a seed and keeps the probe frequencies it promises", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-search-fixture-"));
+  try {
+    const options = { conversations: 80, messages: 3_000, seed: 7 };
+    const first = writeTranscriptFixture(path.join(sandbox, "first"), options);
+    const second = writeTranscriptFixture(path.join(sandbox, "second"), options);
+
+    expect(first.files.map((file) => file.path)).toEqual(second.files.map((file) => file.path));
+    expect(digest(path.join(sandbox, "first"), first)).toBe(digest(path.join(sandbox, "second"), second));
+
+    const messages = indexedMessages(path.join(sandbox, "first"), first);
+    const count = (predicate: (body: string) => boolean) => messages.filter((message) => predicate(message.body)).length;
+    const word = (value: string) => new RegExp(`\\b${value}\\b`);
+    const [harbor, granite] = TRANSCRIPT_FIXTURE_PROBES.commonPair.split(" ");
+
+    expect(messages).toHaveLength(first.messages);
+    /* Three placed hits; a resumed rollout may replay one of them. */
+    expect(count((body) => word(TRANSCRIPT_FIXTURE_PROBES.rare).test(body))).toBeGreaterThanOrEqual(3);
+    expect(count((body) => word(TRANSCRIPT_FIXTURE_PROBES.rare).test(body))).toBeLessThanOrEqual(5);
+    const veryCommon = count((body) => word(TRANSCRIPT_FIXTURE_PROBES.veryCommon).test(body)) / messages.length;
+    expect(veryCommon).toBeGreaterThan(0.38);
+    expect(veryCommon).toBeLessThan(0.52);
+    const pair = count((body) => word(harbor!).test(body) && word(granite!).test(body)) / messages.length;
+    expect(pair).toBeGreaterThan(0.05);
+    expect(pair).toBeLessThan(0.13);
+    const operator = messages.filter((message) => message.speaker === "user").length / messages.length;
+    expect(operator).toBeGreaterThan(0.2);
+    expect(operator).toBeLessThan(0.33);
+    /* Replays make the duplicate groups the search collapses. */
+    const distinct = new Set(messages.map((message) => `${message.speaker}\0${message.body.trim().replace(/\s+/gu, " ")}`)).size;
+    expect(distinct).toBeLessThan(messages.length * 0.95);
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/scripts/transcript-search-fixture.ts
+++ b/scripts/transcript-search-fixture.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+/**
+ * Synthetic transcript corpus for profiling the global message search (#1429).
+ *
+ * Writes Claude and Codex transcripts whose shape follows the production index
+ * this search runs over (7.2k conversations, 250k indexed messages, ~780-byte
+ * mean body with a long tail, one operator message per four agent messages,
+ * resumed Codex rollouts replaying their whole history) without carrying a
+ * byte of real content: every body is built from an invented vocabulary.
+ * Deterministic under `--seed`, so two runs profile the same corpus.
+ *
+ *   bun scripts/transcript-search-fixture.ts <outDir> [--conversations 7200] [--messages 250000] [--seed 1429]
+ *
+ * Three probe words have a pinned frequency so the three issue-#1429 queries
+ * are reproducible on any size:
+ *   - `heliotrope` — rare: exactly three messages in the corpus;
+ *   - `harbor granite` — two common words: ~20% and ~13% of messages, ~9% both;
+ *   - `ledger` — one very common word: ~45% of messages.
+ * `manifest.json` in <outDir> lists every file with its project and engine.
+ * Only ever point it at a scratch directory.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+export interface TranscriptFixtureFile {
+  /** Relative to the fixture root. */
+  path: string;
+  project: string;
+  engine: "claude" | "codex";
+  /** Seconds; resumed rollouts are newer than the rollout they replay. */
+  mtime: number;
+}
+
+export interface TranscriptFixtureManifest {
+  seed: number;
+  conversations: number;
+  /** Indexable messages the generator wrote, replays included. */
+  messages: number;
+  probes: { rare: string; commonPair: string; veryCommon: string };
+  files: TranscriptFixtureFile[];
+}
+
+export const TRANSCRIPT_FIXTURE_PROBES = {
+  rare: "heliotrope",
+  commonPair: "harbor granite",
+  veryCommon: "ledger",
+} as const;
+
+const VOCABULARY = (
+  "cadence meadow signal orbit lantern quorum ripple saffron timber velvet willow zenith anchor basalt copper "
+  + "drift ember fathom glacier hollow ingot juniper kestrel lumen marble nectar oriole pebble quartz reed summit "
+  + "tundra umber vapor wander yarrow beacon cinder delta fjord gable heron isle keel loom mesa nimbus onyx "
+  + "prism ridge sable talon vale wren aspen bramble cobalt dune estuary flint grove harrow inlet jetty knoll "
+  + "larch moss nook orchard pine quay rill shale thicket upland verge wharf yew ashlar bower crag dell "
+  + "eddy fen gorge heath islet karst lea moor ness oxbow pool rune spur tarn undertow vane weir"
+).split(" ");
+const CODE_WORDS = "return const await async export import function while break continue yield throw catch".split(" ");
+const PROJECTS = Array.from({ length: 40 }, (_value, index) => `fixture-project-${String(index + 1).padStart(2, "0")}`);
+
+function flag(args: string[], name: string, fallback: number): number {
+  const index = args.indexOf(`--${name}`);
+  const value = index >= 0 ? Number(args[index + 1]) : Number.NaN;
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+class Random {
+  private state: number;
+  constructor(seed: number) { this.state = seed >>> 0; }
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0;
+    let t = this.state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+  int(min: number, max: number): number { return min + Math.floor(this.next() * (max - min + 1)); }
+  pick<T>(items: readonly T[]): T { return items[Math.floor(this.next() * items.length)]!; }
+  chance(probability: number): boolean { return this.next() < probability; }
+  hex(length: number): string { let out = ""; while (out.length < length) out += Math.floor(this.next() * 16).toString(16); return out; }
+}
+
+/** Body lengths follow the production tail: most bodies are a sentence or
+    two, a few percent are tool-output sized, a handful are enormous. */
+function bodyWordCount(random: Random): number {
+  const roll = random.next();
+  if (roll < 0.65) return random.int(4, 30);
+  if (roll < 0.92) return random.int(30, 220);
+  if (roll < 0.985) return random.int(220, 900);
+  return random.int(900, 9_000);
+}
+
+function sentence(random: Random, words: string[], count: number): string {
+  const out: string[] = [];
+  for (let i = 0; i < count; i += 1) out.push(random.chance(0.08) ? random.pick(CODE_WORDS) : random.pick(words));
+  out[0] = out[0]![0]!.toUpperCase() + out[0]!.slice(1);
+  return `${out.join(" ")}.`;
+}
+
+interface Planned { rare: boolean; harbor: boolean; granite: boolean; ledger: boolean }
+
+function body(random: Random, planned: Planned): string {
+  const total = bodyWordCount(random);
+  const chunks: string[] = [];
+  let remaining = total;
+  while (remaining > 0) {
+    const count = Math.min(remaining, random.int(4, 18));
+    chunks.push(sentence(random, VOCABULARY, count));
+    remaining -= count;
+    if (random.chance(0.15)) chunks.push("\n");
+  }
+  const text = chunks.join(" ").replace(/ \n /g, "\n");
+  const inserts: string[] = [];
+  if (planned.ledger) inserts.push(TRANSCRIPT_FIXTURE_PROBES.veryCommon);
+  if (planned.harbor) inserts.push("harbor");
+  if (planned.granite) inserts.push("granite");
+  if (planned.rare) inserts.push(TRANSCRIPT_FIXTURE_PROBES.rare);
+  if (!inserts.length) return text;
+  const words = text.split(" ");
+  for (const word of inserts) words.splice(random.int(0, words.length), 0, word);
+  return words.join(" ");
+}
+
+interface Message { speaker: "user" | "assistant"; body: string; at: number }
+
+function isoAt(seconds: number, millis = 0): string {
+  return new Date(seconds * 1_000 + millis).toISOString();
+}
+
+function claudeLines(messages: Message[]): string[] {
+  const lines: string[] = [];
+  for (const message of messages) {
+    lines.push(JSON.stringify(message.speaker === "user"
+      ? { type: "user", timestamp: isoAt(message.at), message: { role: "user", content: message.body } }
+      : { type: "assistant", timestamp: isoAt(message.at), message: { role: "assistant", content: [{ type: "text", text: message.body }] } }));
+  }
+  return lines;
+}
+
+/** Codex writes each turn twice (event and response item, milliseconds apart)
+    and the index reader collapses that pair, so the fixture writes both. */
+function codexLines(messages: Message[], replayed: Message[]): string[] {
+  const lines: string[] = [JSON.stringify({ type: "session_meta", payload: { cwd: "/workspace/fixture" } })];
+  for (const message of replayed) {
+    lines.push(JSON.stringify({
+      type: "response_item",
+      timestamp: isoAt(message.at),
+      payload: message.speaker === "user"
+        ? { type: "message", role: "user", content: [{ type: "input_text", text: message.body }] }
+        : { type: "message", role: "assistant", content: [{ type: "output_text", text: message.body }] },
+    }));
+  }
+  for (const message of messages) {
+    lines.push(JSON.stringify({
+      type: "event_msg",
+      timestamp: isoAt(message.at),
+      payload: message.speaker === "user" ? { type: "user_message", message: message.body } : { type: "agent_message", message: message.body },
+    }));
+    lines.push(JSON.stringify({
+      type: "response_item",
+      timestamp: isoAt(message.at, 1),
+      payload: message.speaker === "user"
+        ? { type: "message", role: "user", content: [{ type: "input_text", text: message.body }] }
+        : { type: "message", role: "assistant", content: [{ type: "output_text", text: message.body }] },
+    }));
+    if (message.speaker === "assistant") {
+      lines.push(JSON.stringify({ type: "event_msg", timestamp: isoAt(message.at, 2), payload: { type: "token_count", info: { total_token_usage: { input_tokens: message.body.length } } } }));
+    }
+  }
+  return lines;
+}
+
+export function writeTranscriptFixture(outDir: string, options: { conversations: number; messages: number; seed: number }): TranscriptFixtureManifest {
+  const random = new Random(options.seed);
+  const files: TranscriptFixtureFile[] = [];
+  fs.mkdirSync(outDir, { recursive: true });
+  const baseAt = Date.UTC(2026, 0, 1) / 1_000;
+  /* Slots are counted over freshly produced messages, which replays never
+     touch, so the last one lands before the budget fills with replayed rows. */
+  const rareSlots = new Set([
+    Math.floor(options.messages * 0.004),
+    Math.floor(options.messages * 0.4),
+    Math.floor(options.messages * 0.72),
+  ]);
+  let written = 0;
+  let produced = 0;
+  let conversation = 0;
+  const perConversation = Math.max(1, Math.round(options.messages / options.conversations));
+  while (written < options.messages && conversation < options.conversations) {
+    const engine: "claude" | "codex" = random.chance(0.5) ? "claude" : "codex";
+    const project = random.pick(PROJECTS);
+    const count = Math.max(1, Math.round(perConversation * (0.4 + random.next() * 1.2)));
+    const startAt = baseAt + Math.floor(random.next() * 240 * 86_400);
+    const messages: Message[] = [];
+    for (let index = 0; index < count && written < options.messages; index += 1) {
+      const harbor = random.chance(0.2);
+      const planned: Planned = {
+        rare: rareSlots.has(produced),
+        harbor,
+        granite: harbor ? random.chance(0.45) : random.chance(0.05),
+        ledger: random.chance(0.45),
+      };
+      const speaker: Message["speaker"] = index % 4 === 0 ? "user" : "assistant";
+      messages.push({ speaker, body: body(random, planned), at: startAt + index * random.int(5, 240) });
+      produced += 1;
+      written += 1;
+    }
+    conversation += 1;
+    const fileIndex = files.length;
+    if (engine === "claude") {
+      const relative = path.join("claude", "projects", `-workspace-${project}`, `${random.hex(8)}-${random.hex(4)}-4${random.hex(3)}-a${random.hex(3)}-${random.hex(12)}.jsonl`);
+      writeLines(outDir, relative, claudeLines(messages));
+      files.push({ path: relative, project, engine, mtime: baseAt + fileIndex * 60 });
+      continue;
+    }
+    const day = new Date(startAt * 1_000);
+    const stamp = `${day.getUTCFullYear()}-${String(day.getUTCMonth() + 1).padStart(2, "0")}-${String(day.getUTCDate()).padStart(2, "0")}T00-00-00`;
+    const threadId = `${random.hex(8)}-${random.hex(4)}-4${random.hex(3)}-a${random.hex(3)}-${random.hex(12)}`;
+    const relative = path.join("codex", "sessions", String(day.getUTCFullYear()), String(day.getUTCMonth() + 1).padStart(2, "0"), `rollout-${stamp}-${threadId}.jsonl`);
+    writeLines(outDir, relative, codexLines(messages, []));
+    files.push({ path: relative, project, engine, mtime: baseAt + fileIndex * 60 });
+    /* A resumed rollout replays the whole prior history as response items and
+       then continues; a third of Codex conversations resume once or twice. */
+    let history = messages;
+    let resumes = random.chance(0.34) ? random.int(1, 2) : 0;
+    let generation = 1;
+    while (resumes > 0 && written < options.messages) {
+      resumes -= 1;
+      const fresh: Message[] = [];
+      const freshCount = Math.max(1, Math.round(perConversation * 0.5 * random.next()));
+      const lastAt = history.at(-1)!.at;
+      for (let index = 0; index < freshCount && written < options.messages; index += 1) {
+        const harbor = random.chance(0.2);
+        fresh.push({
+          speaker: index % 4 === 0 ? "user" : "assistant",
+          body: body(random, { rare: rareSlots.has(produced), harbor, granite: harbor ? random.chance(0.45) : random.chance(0.05), ledger: random.chance(0.45) }),
+          at: lastAt + 3_600 + index * random.int(5, 240),
+        });
+        produced += 1;
+        written += 1;
+      }
+      const resumedRelative = path.join("codex", "sessions", String(day.getUTCFullYear()), String(day.getUTCMonth() + 1).padStart(2, "0"), `rollout-${stamp}-${threadId}-resume-${generation}.jsonl`);
+      writeLines(outDir, resumedRelative, codexLines(fresh, history));
+      files.push({ path: resumedRelative, project, engine, mtime: baseAt + files.length * 60 + generation });
+      history = [...history, ...fresh];
+      generation += 1;
+      /* Replayed history counts as indexed messages, as it does in production. */
+      written += history.length - fresh.length;
+    }
+  }
+  for (const file of files) fs.utimesSync(path.join(outDir, file.path), file.mtime, file.mtime);
+  const manifest: TranscriptFixtureManifest = {
+    seed: options.seed,
+    conversations: files.length,
+    messages: written,
+    probes: { ...TRANSCRIPT_FIXTURE_PROBES },
+    files,
+  };
+  fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest));
+  return manifest;
+}
+
+function writeLines(outDir: string, relative: string, lines: string[]): void {
+  const target = path.join(outDir, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, lines.join("\n") + "\n");
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const outDir = args.find((arg) => !arg.startsWith("--") && !/^\d+$/.test(arg));
+  if (!outDir) {
+    console.error("usage: bun scripts/transcript-search-fixture.ts <outDir> [--conversations N] [--messages N] [--seed N]");
+    process.exit(2);
+  }
+  const startedAt = performance.now();
+  const manifest = writeTranscriptFixture(path.resolve(outDir), {
+    conversations: flag(args, "conversations", 7_200),
+    messages: flag(args, "messages", 250_000),
+    seed: flag(args, "seed", 1_429),
+  });
+  console.log(`wrote ${manifest.conversations} transcripts / ${manifest.messages} indexable messages in ${((performance.now() - startedAt) / 1_000).toFixed(1)} s`);
+}

--- a/src/components/search/useTranscriptSearch.dom.test.tsx
+++ b/src/components/search/useTranscriptSearch.dom.test.tsx
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+
+import type { TranscriptSearchRow } from "@/app/api/search/transcripts/route";
+
+/*
+ * Issue #1429 — what the palette's hook asks the server, and when.
+ *
+ * The server answers a first page synchronously on the Viewer's only thread,
+ * so a request the browser abandons is still paid for there. These tests pin
+ * the request discipline that keeps that cost bounded: one first page in
+ * flight, refinements typed meanwhile never abort it and never fan out, and
+ * only the newest question follows once it answers. Counts and URLs only —
+ * nothing here asserts a duration.
+ */
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const dom = new Window({ url: "http://localhost/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  location: dom.location,
+  history: dom.history,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Element: dom.Element,
+  Event: dom.Event,
+});
+
+const { createRoot } = await import("react-dom/client");
+const { TRANSCRIPT_SEARCH_DEBOUNCE_MS, useTranscriptSearch } = await import("./useTranscriptSearch");
+type Search = ReturnType<typeof useTranscriptSearch>;
+
+interface Page {
+  items: TranscriptSearchRow[];
+  nextCursor: string | null;
+  total: number;
+  stats: { conversationsIndexed: number; messagesIndexed: number; fieldsSearched: string[]; tokenizer: string };
+}
+
+function row(over: Partial<TranscriptSearchRow> = {}): TranscriptSearchRow {
+  return {
+    snippet: "heliotrope totals",
+    speaker: "user",
+    timestamp: 1_700_000_000,
+    transcriptPath: "/sessions/alpha.jsonl",
+    byteOffset: 0,
+    lineNumber: 1,
+    project: "reports",
+    engine: "claude",
+    title: "Weekly totals",
+    ...over,
+  };
+}
+
+function page(over: Partial<Page> = {}): Page {
+  return {
+    items: [],
+    nextCursor: null,
+    total: 0,
+    stats: { conversationsIndexed: 12, messagesIndexed: 4_310, fieldsSearched: ["message.body"], tokenizer: "t" },
+    ...over,
+  };
+}
+
+/** One request the hook has issued and the test has not yet answered. */
+interface Pending {
+  url: string;
+  signal: AbortSignal;
+  answer: (page: Page) => void;
+}
+
+let pending: Pending[] = [];
+let latest: Search | null = null;
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function Harness({ query, speaker }: { query: string; speaker?: "user" }) {
+  latest = useTranscriptSearch({ query, speaker });
+  return null;
+}
+
+beforeEach(() => {
+  pending = [];
+  latest = null;
+  Object.assign(globalThis, {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (!url.startsWith("/api/search/transcripts")) return Promise.resolve(Response.json({}));
+      return new Promise<Response>((resolve, reject) => {
+        /* A real fetch rejects when its signal aborts; the stub must too, or
+           an aborted request would hang forever instead of settling. */
+        const signal = init!.signal!;
+        const abort = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+        if (signal.aborted) {
+          abort();
+          return;
+        }
+        signal.addEventListener("abort", abort, { once: true });
+        pending.push({ url, signal, answer: (answered) => resolve(Response.json(answered)) });
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  if (!root) return;
+  const mounted = root;
+  root = null;
+  await act(async () => mounted.unmount());
+  host?.remove();
+  host = null;
+});
+
+async function render(props: { query: string; speaker?: "user" }) {
+  if (!root) {
+    host = document.createElement("div");
+    document.body.append(host);
+    root = createRoot(host);
+  }
+  const mounted = root;
+  await act(async () => {
+    mounted.render(<Harness {...props} />);
+  });
+}
+
+async function settle(ms: number) {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+}
+
+async function answer(request: Pending, answered: Page) {
+  await act(async () => {
+    request.answer(answered);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+}
+
+test("a refinement waits for the answer in flight instead of aborting it, and only the newest question follows", async () => {
+  await render({ query: "heliotrope", speaker: "user" });
+  await settle(10);
+  expect(pending).toHaveLength(1);
+  const first = pending[0]!;
+
+  /* Two refinements, each past its own debounce, while the first request is
+     still unanswered. */
+  await render({ query: "heliotropes", speaker: "user" });
+  await settle(TRANSCRIPT_SEARCH_DEBOUNCE_MS + 50);
+  await render({ query: "heliotropes again", speaker: "user" });
+  await settle(TRANSCRIPT_SEARCH_DEBOUNCE_MS + 50);
+
+  expect(pending).toHaveLength(1);
+  expect(first.signal.aborted).toBe(false);
+  expect(latest!.loading).toBe(true);
+
+  await answer(first, page({ items: [row()], total: 1 }));
+
+  /* Exactly one more request, for the question the operator ended on; the
+     intermediate one was never asked. */
+  expect(pending).toHaveLength(2);
+  expect(pending[1]!.url).toContain("q=heliotropes+again");
+  /* Meanwhile the first answer holds on screen as rows that must not be
+     activated. */
+  expect(latest!.items).toHaveLength(1);
+  expect(latest!.stale).toBe(true);
+  expect(latest!.loading).toBe(true);
+
+  await answer(pending[1]!, page({ items: [row({ title: "Final" })], total: 1 }));
+
+  expect(pending).toHaveLength(2);
+  expect(latest!.stale).toBe(false);
+  expect(latest!.loading).toBe(false);
+  expect(latest!.items.map((item) => item.title)).toEqual(["Final"]);
+});
+
+test("unmounting is the one thing that aborts a search in flight", async () => {
+  await render({ query: "heliotrope", speaker: "user" });
+  await settle(10);
+  const first = pending[0]!;
+  expect(first.signal.aborted).toBe(false);
+
+  const mounted = root!;
+  root = null;
+  await act(async () => mounted.unmount());
+
+  expect(first.signal.aborted).toBe(true);
+});
+
+test("retry asks the same question again, and a speaker flip asks it at once", async () => {
+  await render({ query: "heliotrope", speaker: "user" });
+  await settle(10);
+  await answer(pending[0]!, page({ items: [row()], total: 1 }));
+  expect(pending).toHaveLength(1);
+
+  await act(async () => { latest!.retry(); });
+  await settle(10);
+  expect(pending).toHaveLength(2);
+  expect(pending[1]!.url).toBe(pending[0]!.url);
+  await answer(pending[1]!, page({ items: [row()], total: 1 }));
+
+  await render({ query: "heliotrope" });
+  await settle(10);
+  expect(pending).toHaveLength(3);
+  expect(pending[2]!.url).not.toContain("speaker=");
+});
+
+test("StrictMode's rehearsal unmount does not strand the first search", async () => {
+  /* Development mounts every effect twice: the cleanup aborts the request the
+     first pass started, and the second pass must ask again rather than sit
+     behind a controller that will never answer. */
+  const { StrictMode } = await import("react");
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  const mounted = root;
+  await act(async () => {
+    mounted.render(<StrictMode><Harness query="heliotrope" speaker="user" /></StrictMode>);
+  });
+  await settle(10);
+
+  const live = pending.filter((request) => !request.signal.aborted);
+  expect(live).toHaveLength(1);
+  expect(latest!.loading).toBe(true);
+
+  await answer(live[0]!, page({ items: [row()], total: 1 }));
+
+  expect(latest!.loading).toBe(false);
+  expect(latest!.items).toHaveLength(1);
+  expect(pending.filter((request) => !request.signal.aborted)).toHaveLength(1);
+});

--- a/src/components/search/useTranscriptSearch.ts
+++ b/src/components/search/useTranscriptSearch.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { TranscriptSearchRow } from "@/app/api/search/transcripts/route";
 import type { TranscriptCorpusStats, TranscriptSpeaker } from "@/lib/search/transcriptSearch";
@@ -170,18 +170,51 @@ export function useTranscriptSearch({
   const [moreRequest, setMoreRequest] = useState<MoreRequest | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
 
+  /* First pages go out one at a time, and the newest question takes the next
+     turn. Aborting the fetch on every refinement looked responsive but changed
+     nothing where the time is spent: `searchTranscripts` is synchronous on the
+     Viewer's only thread, so an abandoned request still ran to completion
+     there and every later one queued behind it (#1429) — a common word typed
+     in two pauses stacked its two queries in front of the answer the operator
+     was waiting for, and stalled the board's own polls with them. Waiting for
+     the in-flight answer costs nothing (it was going to be computed anyway),
+     every intermediate question is dropped for free, and the answer that does
+     arrive holds on screen as the stale rows the design already shows. */
+  const inFlight = useRef<AbortController | null>(null);
+  const asked = useRef<{ key: string; nonce: number } | null>(null);
+  const [turn, setTurn] = useState(0);
   useEffect(() => {
-    if (!active) return;
+    if (!active) {
+      asked.current = null;
+      return;
+    }
+    if (inFlight.current) return;
+    if (asked.current?.key === requestKey && asked.current.nonce === retryNonce) return;
     const controller = new AbortController();
-    void fetchTranscriptSearchPage(request.query, request.speaker, null, controller.signal)
-      .then((page) => setSettled({ key: requestKey, speaker: request.speaker, page, error: false }))
+    const key = requestKey;
+    const speaker = request.speaker;
+    inFlight.current = controller;
+    asked.current = { key, nonce: retryNonce };
+    void fetchTranscriptSearchPage(request.query, speaker, null, controller.signal)
+      .then((page) => setSettled({ key, speaker, page, error: false }))
       .catch((cause: unknown) => {
         if ((cause as { name?: string }).name !== "AbortError") {
-          setSettled({ key: requestKey, speaker: request.speaker, page: EMPTY_PAGE, error: true });
+          setSettled({ key, speaker, page: EMPTY_PAGE, error: true });
         }
+      })
+      .finally(() => {
+        if (inFlight.current !== controller) return;
+        inFlight.current = null;
+        /* An aborted answer is no answer: forget the question was asked, so a
+           hook that is still mounted (StrictMode's rehearsal unmount) asks it
+           again. Then re-run with whatever the debounce settled on meanwhile:
+           the latest question, or nothing new. */
+        if (controller.signal.aborted) asked.current = null;
+        setTurn((value) => value + 1);
       });
-    return () => controller.abort();
-  }, [active, request.query, request.speaker, requestKey, retryNonce]);
+  }, [active, request.query, request.speaker, requestKey, retryNonce, turn]);
+  /* The one abort left: the palette closing mid-answer. */
+  useEffect(() => () => inFlight.current?.abort(), []);
 
   useEffect(() => {
     if (!moreRequest || moreRequest.key !== requestKey) return;

--- a/src/lib/search/transcriptSearch.test.ts
+++ b/src/lib/search/transcriptSearch.test.ts
@@ -5,12 +5,13 @@ import os from "node:os";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
-import { snippetSegments } from "./snippet";
+import { SNIPPET_MATCH_CLOSE, SNIPPET_MATCH_OPEN, snippetSegments } from "./snippet";
 import {
   indexTranscriptSources,
   InvalidTranscriptSearchCursorError,
   searchTranscripts,
   type TranscriptIndexSource,
+  type TranscriptSearchItem,
 } from "./transcriptSearch";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-transcript-search-"));
@@ -533,4 +534,198 @@ test("snippets mark matched terms with sentinels a message body cannot contain",
   expect(snippet).toContain("rows[0]");
   expect(snippetSegments(snippet).filter((segment) => segment.match))
     .toEqual([{ text: "cobalt", match: true }]);
+});
+
+/* The SQL `searchTranscripts` ran before #1429 — two queries over the joined
+   match set, window functions for the duplicate collapse — kept here verbatim
+   as the oracle for the in-memory ranking that replaced it: same rows, same
+   order, same snippets, same duplicate counts, same totals. */
+function legacySearch(
+  db: Database,
+  rawQuery: string,
+  speaker?: "user" | "assistant",
+  project?: string,
+): { total: number; items: Omit<TranscriptSearchItem, never>[] } {
+  const query = rawQuery.trim().split(/\s+/).filter(Boolean)
+    .map((term) => `"${term.replaceAll('"', '""')}"`).join(" AND ");
+  const filters: Array<{ clause: string; binding: string }> = [];
+  if (project) filters.push({ clause: " AND f.project = ?", binding: project });
+  if (speaker) filters.push({ clause: " AND m.speaker = ?", binding: speaker });
+  const where = filters.map((filter) => filter.clause).join("");
+  const bindings = [query, ...filters.map((filter) => filter.binding)];
+  const total = (db.query(`
+    SELECT COUNT(*) AS count
+    FROM (
+      SELECT m.speaker, m.body_hash
+      FROM transcript_messages_fts
+      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+      JOIN transcript_files AS f ON f.path = m.transcript_path
+      WHERE transcript_messages_fts MATCH ?${where}
+      GROUP BY m.speaker, m.body_hash
+    ) AS collapsed
+  `).get(...bindings) as { count: number }).count;
+  const rows = db.query(`
+    WITH ranked AS (
+      SELECT
+        m.id, m.speaker, m.timestamp, m.transcript_path, m.byte_offset, m.line_number, f.project, f.engine, f.mtime_ms,
+        COUNT(*) OVER (PARTITION BY m.speaker, m.body_hash) AS duplicate_count,
+        ROW_NUMBER() OVER (
+          PARTITION BY m.speaker, m.body_hash
+          ORDER BY f.mtime_ms DESC, COALESCE(m.timestamp, 0) DESC, m.id DESC
+        ) AS duplicate_rank
+      FROM transcript_messages_fts
+      JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
+      JOIN transcript_files AS f ON f.path = m.transcript_path
+      WHERE transcript_messages_fts MATCH ?${where}
+    )
+    SELECT
+      snippet(transcript_messages_fts, 0, '${SNIPPET_MATCH_OPEN}', '${SNIPPET_MATCH_CLOSE}', '…', 24) AS snippet,
+      ranked.speaker, ranked.duplicate_count, ranked.timestamp, ranked.transcript_path,
+      ranked.byte_offset, ranked.line_number, ranked.project, ranked.engine
+    FROM ranked
+    JOIN transcript_messages_fts ON transcript_messages_fts.rowid = ranked.id
+    WHERE ranked.duplicate_rank = 1 AND transcript_messages_fts MATCH ?
+    ORDER BY bm25(transcript_messages_fts), ranked.mtime_ms DESC,
+      COALESCE(ranked.timestamp, 0) DESC, ranked.id DESC
+    LIMIT ? OFFSET ?
+  `).all(...bindings, query, 10_000, 0) as Array<{
+    snippet: string;
+    speaker: "user" | "assistant";
+    duplicate_count: number;
+    timestamp: number | null;
+    transcript_path: string;
+    byte_offset: number;
+    line_number: number;
+    project: string;
+    engine: "claude" | "codex";
+  }>;
+  return {
+    total,
+    items: rows.map((row) => ({
+      snippet: row.snippet,
+      speaker: row.speaker,
+      duplicateCount: row.duplicate_count,
+      timestamp: row.timestamp,
+      transcriptPath: row.transcript_path,
+      byteOffset: row.byte_offset,
+      lineNumber: row.line_number,
+      project: row.project,
+      engine: row.engine,
+    })),
+  };
+}
+
+function everyPage(query: string, speaker: "user" | "assistant" | undefined, project: string | undefined, limit: number) {
+  const items: TranscriptSearchItem[] = [];
+  let cursor: string | null = null;
+  let total = 0;
+  let pages = 0;
+  do {
+    const page = searchTranscripts({ query, speaker, project, limit, cursor });
+    items.push(...page.items);
+    total = page.total;
+    cursor = page.nextCursor;
+    pages += 1;
+    if (pages > 500) throw new Error("pagination did not terminate");
+  } while (cursor);
+  return { items, total };
+}
+
+test("ranks, collapses and pages exactly as the SQL it replaced", async () => {
+  /* A seeded corpus dense in the ways that exercise every tie-break: an
+     eight-word vocabulary so scores collide, bodies repeated across files with
+     whitespace variants so groups span transcripts, five distinct mtimes
+     shared by many files, some records without timestamps. */
+  let seed = 1_429;
+  const random = () => {
+    seed = (seed + 0x6d2b79f5) >>> 0;
+    let t = seed;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const words = ["cobalt", "marigold", "saffron", "report", "ledger", "totals", "weekly", "draft"];
+  const pool: string[] = [];
+  const sources: TranscriptIndexSource[] = [];
+  for (let file = 0; file < 24; file += 1) {
+    const engine = file % 2 ? "codex" : "claude";
+    const lines: string[] = [];
+    for (let index = 0; index < 4 + (file % 9); index += 1) {
+      let body: string;
+      if (pool.length && random() < 0.35) {
+        body = pool[Math.floor(random() * pool.length)]!.replace(" ", random() < 0.5 ? "  " : "\n");
+      } else {
+        body = Array.from({ length: 1 + Math.floor(random() * 6) }, () => words[Math.floor(random() * words.length)]!).join(" ");
+        pool.push(body);
+      }
+      const speaker = index % 3 === 0 ? "user" : "assistant";
+      const timestamp = random() < 0.15
+        ? undefined
+        : new Date(Date.UTC(2026, 7, 20, 0, 0, Math.floor(random() * 3_600))).toISOString();
+      lines.push(JSON.stringify(engine === "claude"
+        ? { type: speaker, ...(timestamp ? { timestamp } : {}), message: { content: body } }
+        : {
+          type: "event_msg",
+          ...(timestamp ? { timestamp } : {}),
+          payload: { type: speaker === "user" ? "user_message" : "agent_message", message: body },
+        }));
+    }
+    const pathname = path.join(sandbox, `differential-${file}.jsonl`);
+    fs.writeFileSync(pathname, lines.join("\n") + "\n");
+    sources.push({ ...source(pathname, engine, `project-${file % 3}`), mtimeMs: 1_000 + (file % 5) * 1_000 });
+  }
+  await indexTranscriptSources(sources, { complete: true });
+
+  const db = new Database(statePath("transcript-search.sqlite"), { readonly: true, strict: true });
+  try {
+    let compared = 0;
+    let collapsed = 0;
+    for (const query of ["cobalt", "cobalt report", "ledger", "weekly totals draft"]) {
+      for (const speaker of [undefined, "user", "assistant"] as const) {
+        for (const project of [undefined, "project-1"]) {
+          const expected = legacySearch(db, query, speaker, project);
+          const actual = everyPage(query, speaker, project, 3);
+          expect(actual.total).toBe(expected.total);
+          expect(actual.items).toEqual(expected.items);
+          compared += expected.items.length;
+          collapsed += expected.items.filter((item) => item.duplicateCount > 1).length;
+        }
+      }
+    }
+    /* The pin only means something if the corpus produced the cases. */
+    expect(compared).toBeGreaterThan(100);
+    expect(collapsed).toBeGreaterThan(10);
+  } finally {
+    db.close();
+  }
+});
+
+test("equal scores order by newest transcript, then newest message, then highest id", async () => {
+  /* Two-token bodies with one hit each score identically under bm25, so only
+     the tie-break decides the order. */
+  const older = path.join(sandbox, "tie-older.jsonl");
+  const newer = path.join(sandbox, "tie-newer.jsonl");
+  fs.writeFileSync(older, JSON.stringify({
+    type: "user",
+    timestamp: "2026-08-20T10:00:00.000Z",
+    message: { content: "cobalt gamma" },
+  }) + "\n");
+  fs.writeFileSync(newer, [
+    JSON.stringify({ type: "user", timestamp: "2026-08-20T08:00:00.000Z", message: { content: "cobalt alpha" } }),
+    JSON.stringify({ type: "user", timestamp: "2026-08-20T09:00:00.000Z", message: { content: "cobalt beta" } }),
+    JSON.stringify({ type: "user", timestamp: "2026-08-20T09:00:00.000Z", message: { content: "cobalt delta" } }),
+  ].join("\n") + "\n");
+  await indexTranscriptSources([
+    { ...source(older, "claude", "ties"), mtimeMs: 1_000 },
+    { ...source(newer, "claude", "ties"), mtimeMs: 3_000 },
+  ], { complete: true });
+
+  const items = searchTranscripts({ query: "cobalt" }).items;
+
+  expect(items.map((item) => [path.basename(item.transcriptPath), item.lineNumber])).toEqual([
+    ["tie-newer.jsonl", 3],
+    ["tie-newer.jsonl", 2],
+    ["tie-newer.jsonl", 1],
+    ["tie-older.jsonl", 1],
+  ]);
 });

--- a/src/lib/search/transcriptSearch.ts
+++ b/src/lib/search/transcriptSearch.ts
@@ -89,17 +89,39 @@ type FileIdentityRow = {
   engine: string;
 };
 
-type SearchRow = {
-  snippet: string;
-  speaker: TranscriptSpeaker;
-  duplicate_count: number;
-  timestamp: number | null;
-  transcript_path: string;
-  byte_offset: number;
-  line_number: number;
+/** One matched message as the ranking pass reads it: `values()` tuples,
+    because a common word matches a third of the corpus and the objects would
+    cost more than the query. */
+type HitRow = [
+  id: number,
+  score: number,
+  speaker: TranscriptSpeaker,
+  bodyHash: string,
+  timestamp: number | null,
+  transcriptPath: string,
+];
+
+type TranscriptFileRow = {
   project: string;
   engine: "claude" | "codex";
+  mtime_ms: number;
 };
+
+interface RankedHit {
+  id: number;
+  score: number;
+  speaker: TranscriptSpeaker;
+  timestamp: number | null;
+  transcriptPath: string;
+  mtimeMs: number;
+}
+
+/** One result row: the newest occurrence of a body, and how many the index
+    holds for that speaker. */
+interface CollapsedHit {
+  newest: RankedHit;
+  duplicateCount: number;
+}
 
 function sqliteDatabase(): typeof import("bun:sqlite").Database {
   const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
@@ -517,16 +539,123 @@ function decodeCursor(value: string | null | undefined, scope: string): number {
 }
 
 function corpusStats(db: Database): TranscriptCorpusStats {
-  const conversations = db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM transcript_files").get()?.count ?? 0;
-  const messages = db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM transcript_messages").get()?.count ?? 0;
+  /* Every transcript's `messages_count` is committed with its rows, so one
+     pass over the files table answers exactly what `COUNT(*)` over the message
+     table did — minus the ~12 ms that walk cost every search, one-hit searches
+     included. */
+  const row = db.query<{ conversations: number; messages: number | null }, []>(
+    "SELECT COUNT(*) AS conversations, SUM(messages_count) AS messages FROM transcript_files",
+  ).get();
   return {
-    conversationsIndexed: conversations,
-    messagesIndexed: messages,
+    conversationsIndexed: row?.conversations ?? 0,
+    messagesIndexed: row?.messages ?? 0,
     fieldsSearched: TRANSCRIPT_SEARCH_FIELDS,
     tokenizer: TRANSCRIPT_SEARCH_TOKENIZER,
   };
 }
 
+/* Past this many distinct transcripts, reading the whole files table once
+   (thousands of short rows) is cheaper than one keyed lookup per path. */
+const TRANSCRIPT_FILE_LOOKUP_CAP = 512;
+
+function transcriptFiles(db: Database, paths: ReadonlySet<string>): Map<string, TranscriptFileRow> {
+  const files = new Map<string, TranscriptFileRow>();
+  if (!paths.size) return files;
+  if (paths.size <= TRANSCRIPT_FILE_LOOKUP_CAP) {
+    const lookup = db.query<TranscriptFileRow, [string]>(
+      "SELECT project, engine, mtime_ms FROM transcript_files WHERE path = ?",
+    );
+    for (const pathname of paths) {
+      const file = lookup.get(pathname);
+      if (file) files.set(pathname, file);
+    }
+    return files;
+  }
+  const rows = db.query("SELECT path, project, engine, mtime_ms FROM transcript_files").values() as Array<
+    [string, string, "claude" | "codex", number]
+  >;
+  for (const [pathname, project, engine, mtime_ms] of rows) {
+    if (paths.has(pathname)) files.set(pathname, { project, engine, mtime_ms });
+  }
+  return files;
+}
+
+/* Newest transcript generation first, then newest message, then highest id.
+   This order picks which occurrence represents a replayed body (a resumed
+   rollout retains the original message timestamp, so the transcript mtime is
+   what identifies the newest generation) and breaks ties between equal bm25
+   scores. */
+function newerFirst(a: RankedHit, b: RankedHit): number {
+  return b.mtimeMs - a.mtimeMs
+    || (b.timestamp ?? 0) - (a.timestamp ?? 0)
+    || b.id - a.id;
+}
+
+/* bm25 is negative and lower is better, so ascending score is best first. */
+function bestFirst(a: CollapsedHit, b: CollapsedHit): number {
+  return a.newest.score - b.newest.score || newerFirst(a.newest, b.newest);
+}
+
+function pageItems(
+  db: Database,
+  query: string,
+  page: readonly CollapsedHit[],
+  files: ReadonlyMap<string, TranscriptFileRow>,
+): TranscriptSearchItem[] {
+  if (!page.length) return [];
+  const ids = page.map((group) => group.newest.id);
+  /* `+rowid` keeps FTS5 from turning the id list into one doclist seek per row,
+     which on a common term costs ~14 ms EACH; an ordinary match scan filtered
+     in place is a fraction of that, and `snippet` runs only for the rows that
+     pass the filter. */
+  const snippets = new Map<number, string>();
+  const snippetRows = db.query(`
+    SELECT rowid, snippet(transcript_messages_fts, 0, '${SNIPPET_MATCH_OPEN}', '${SNIPPET_MATCH_CLOSE}', '…', 24)
+    FROM transcript_messages_fts
+    WHERE transcript_messages_fts MATCH ? AND +rowid IN (${ids.map(() => "?").join(", ")})
+  `).values(query, ...ids) as Array<[number, string]>;
+  for (const [id, snippet] of snippetRows) snippets.set(id, snippet);
+  const location = db.query<{ byte_offset: number; line_number: number }, [number]>(
+    "SELECT byte_offset, line_number FROM transcript_messages WHERE id = ?",
+  );
+  return page.map(({ newest, duplicateCount }) => {
+    const where = location.get(newest.id);
+    const file = files.get(newest.transcriptPath);
+    if (!where || !file) throw new Error("transcript search page row vanished within its read snapshot");
+    return {
+      snippet: snippets.get(newest.id) ?? "",
+      speaker: newest.speaker,
+      duplicateCount,
+      timestamp: newest.timestamp,
+      transcriptPath: newest.transcriptPath,
+      byteOffset: where.byte_offset,
+      lineNumber: where.line_number,
+      project: file.project,
+      engine: file.engine,
+    };
+  });
+}
+
+/**
+ * Ranking happens here rather than in SQL, and on purpose (#1429).
+ *
+ * The previous shape — a window function over the joined match set to collapse
+ * duplicates, a second `COUNT(*)` over the same join for the total, and a
+ * re-scan of the match set to attach snippets — cost, on a 250k-message index,
+ * 1.5 s for a word in a third of the messages and 0.4 s for the operator's own
+ * messages alone, most of it in one place: the join to `transcript_files` by
+ * path, ~5 µs for every one of a hundred thousand matched rows, paid twice.
+ *
+ * Now one match scan reads the six columns ranking needs; the files a page can
+ * name are read once; duplicate collapsing, the total and the page order are
+ * computed in memory in exactly the order the SQL used (bm25, then newest
+ * transcript, newest message, highest id); and snippets are cut for the page's
+ * rows only. Same rows, same order, same snippets, same totals — pinned by the
+ * differential test against the old SQL — at roughly a third of the time.
+ *
+ * All of it runs inside one read transaction, so the passes see one snapshot
+ * even while the background indexer commits between them.
+ */
 export function searchTranscripts(options: {
   query: string;
   project?: string;
@@ -537,88 +666,52 @@ export function searchTranscripts(options: {
 }): TranscriptSearchResult {
   const db = openQueryDatabase();
   try {
-    const query = ftsQuery(options.query);
-    const stats = corpusStats(db);
-    if (!query) return { items: [], nextCursor: null, total: 0, stats };
-    const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 20)));
-    const scope = cursorScope(query, options.project, options.speaker);
-    const offset = decodeCursor(options.cursor, scope);
-    /* Filter clause and bindings are built from one list so the two queries
-       below can never disagree about parameter order. */
-    const filters: Array<{ clause: string; binding: string }> = [];
-    if (options.project) filters.push({ clause: " AND f.project = ?", binding: options.project });
-    if (options.speaker) filters.push({ clause: " AND m.speaker = ?", binding: options.speaker });
-    const where = filters.map((filter) => filter.clause).join("");
-    const bindings = [query, ...filters.map((filter) => filter.binding)];
-    const total = (db.query(`
-      SELECT COUNT(*) AS count
-      FROM (
-        SELECT m.speaker, m.body_hash
+    db.exec("BEGIN");
+    try {
+      const query = ftsQuery(options.query);
+      const stats = corpusStats(db);
+      if (!query) return { items: [], nextCursor: null, total: 0, stats };
+      const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 20)));
+      const scope = cursorScope(query, options.project, options.speaker);
+      const offset = decodeCursor(options.cursor, scope);
+      const hits = db.query(`
+        SELECT transcript_messages_fts.rowid, bm25(transcript_messages_fts), m.speaker, m.body_hash, m.timestamp, m.transcript_path
         FROM transcript_messages_fts
         JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
-        JOIN transcript_files AS f ON f.path = m.transcript_path
-        WHERE transcript_messages_fts MATCH ?${where}
-        GROUP BY m.speaker, m.body_hash
-      ) AS collapsed
-    `).get(...bindings) as { count: number } | null)?.count ?? 0;
-    const rows = db.query(`
-      WITH ranked AS (
-        SELECT
-          m.id,
-          m.speaker,
-          m.timestamp,
-          m.transcript_path,
-          m.byte_offset,
-          m.line_number,
-          f.project,
-          f.engine,
-          f.mtime_ms,
-          COUNT(*) OVER (PARTITION BY m.speaker, m.body_hash) AS duplicate_count,
-          ROW_NUMBER() OVER (
-            PARTITION BY m.speaker, m.body_hash
-            /* Replayed records retain their original message timestamp. The
-               transcript mtime identifies the newest rollout generation. */
-            ORDER BY f.mtime_ms DESC, COALESCE(m.timestamp, 0) DESC, m.id DESC
-          ) AS duplicate_rank
-        FROM transcript_messages_fts
-        JOIN transcript_messages AS m ON m.id = transcript_messages_fts.rowid
-        JOIN transcript_files AS f ON f.path = m.transcript_path
-        WHERE transcript_messages_fts MATCH ?${where}
-      )
-      SELECT
-        snippet(transcript_messages_fts, 0, '${SNIPPET_MATCH_OPEN}', '${SNIPPET_MATCH_CLOSE}', '…', 24) AS snippet,
-        ranked.speaker,
-        ranked.duplicate_count,
-        ranked.timestamp,
-        ranked.transcript_path,
-        ranked.byte_offset,
-        ranked.line_number,
-        ranked.project,
-        ranked.engine
-      FROM ranked
-      JOIN transcript_messages_fts ON transcript_messages_fts.rowid = ranked.id
-      WHERE ranked.duplicate_rank = 1 AND transcript_messages_fts MATCH ?
-      ORDER BY bm25(transcript_messages_fts), ranked.mtime_ms DESC,
-        COALESCE(ranked.timestamp, 0) DESC, ranked.id DESC
-      LIMIT ? OFFSET ?
-    `).all(...bindings, query, limit, offset) as SearchRow[];
-    const nextOffset = offset + rows.length;
-    return {
-      items: rows.map((row) => ({
-        snippet: row.snippet,
-        speaker: row.speaker,
-        duplicateCount: row.duplicate_count,
-        timestamp: row.timestamp,
-        transcriptPath: row.transcript_path,
-        byteOffset: row.byte_offset,
-        lineNumber: row.line_number,
-        project: row.project,
-        engine: row.engine,
-      })),
-      nextCursor: nextOffset < total ? encodeCursor(nextOffset, scope) : null,
-      total,
-      stats,
-    };
+        WHERE transcript_messages_fts MATCH ?${options.speaker ? " AND m.speaker = ?" : ""}
+      `).values(...(options.speaker ? [query, options.speaker] : [query])) as HitRow[];
+      const paths = new Set<string>();
+      for (const hit of hits) paths.add(hit[5]);
+      const files = transcriptFiles(db, paths);
+      const groups = new Map<string, CollapsedHit>();
+      for (const [id, score, speaker, bodyHash, timestamp, transcriptPath] of hits) {
+        const file = files.get(transcriptPath);
+        /* A message whose transcript row is gone, or outside the requested
+           project, is not a result — the inner join used to drop it. */
+        if (!file || (options.project && file.project !== options.project)) continue;
+        const hit: RankedHit = { id, score, speaker, timestamp, transcriptPath, mtimeMs: file.mtime_ms };
+        const key = `${speaker}\0${bodyHash}`;
+        const group = groups.get(key);
+        if (!group) {
+          groups.set(key, { newest: hit, duplicateCount: 1 });
+          continue;
+        }
+        group.duplicateCount += 1;
+        if (newerFirst(hit, group.newest) < 0) group.newest = hit;
+      }
+      const ranked = [...groups.values()].sort(bestFirst);
+      const total = ranked.length;
+      const items = pageItems(db, query, ranked.slice(offset, offset + limit), files);
+      const nextOffset = offset + items.length;
+      return {
+        items,
+        nextCursor: nextOffset < total ? encodeCursor(nextOffset, scope) : null,
+        total,
+        stats,
+      };
+    } finally {
+      db.exec("COMMIT");
+    }
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary

Profiles the global message search ("find my messages" in the board, `search_transcripts` over MCP) end to end on a synthetic corpus of the production shape, and fixes what the profile showed was local: the SQL shape (a per-row join to the files table paid twice, a second FTS scan for snippets, a fixed 12 ms `COUNT(*)` on every query) and the palette's cancel-and-refetch per keystroke, which cost the server nothing less. Result ordering, snippet shape, duplicate counts and totals are unchanged and pinned by a differential test against the replaced SQL; the same comparison held byte for byte on the production index (read-only).

Fixes #1429. What is larger than this lane — the search still runs on the Viewer's only thread — is filed with numbers as #1438.

## Profile

Corpus: `scripts/transcript-search-fixture.ts` (seed 1429), 6,729 conversations / 250,000 indexed messages, 20% replayed duplicates, invented text only; production that day had 7,253 / 249,812. Queries: a rare word (3 hits), two common words (18k matches), one very common word (89k matches, 45% of the corpus). Medians of five runs of `scripts/transcript-search-bench.ts`; full method in `docs/performance/issue-1429-transcript-search.md`.

Before → after:

| surface | rare word | two common words | very common word |
| --- | --- | --- | --- |
| library (`searchTranscripts`), own messages | 13 → 2 ms | 125 → 64 ms | 446 → 176 ms |
| library, all speakers | 12 → 2 ms | 277 → 98 ms | 1 369 → 346 ms |
| HTTP route (loopback), own messages | 13 → 2 ms | 124 → 63 ms | 430 → 169 ms |
| HTTP route, all speakers | 13 → 2 ms | 275 → 100 ms | 1 384 → 353 ms |
| MCP tool round trip (packaged stdio server, always all speakers) | 14 → 4 ms | 277 → 99 ms | 1 339 → 328 ms |
| UI, last keystroke to first result row, own messages | 267 → 257 ms | 382 → 319 ms | 752 → 453 ms |
| UI, all speakers | 267 → 256 ms | 531 → 358 ms | 1 630 → 632 ms |

Where the time goes:

- **The SQLite statements are the cost on every surface.** HTTP ≈ route ≈ library; transport and JSON add 0–15 ms. The MCP round trip adds ~1 ms over HTTP (receipt claim and completion, redaction, serialisation are invisible next to the query): suspect 2 cleared. The palette adds its 250 ms debounce plus 4–15 ms of render: suspect 1's render cost cleared; for a rare word the debounce is 95% of the wait.
- **Inside the statements** (production index, read-only, very common word, ~113k matched rows): FTS5 scan 24 ms, with `bm25` ~140 ms; the join to `transcript_files` by its text primary key ~5 µs per matched row ≈ 560 ms, paid once in the `COUNT(*)` query and again in the page query; window functions and a second FTS scan to attach snippets on top. A per-row `rowid = ? AND MATCH` seek costs 14 ms on a common term, so snippets cannot be looked up one by one either. Bigger page caches and `mmap` changed nothing: CPU, not I/O. Suspect 4 confirmed, suspect 3 (a query during a re-index) not implicated: WAL readers never wait on the writer.
- **The stall nobody had measured.** `searchTranscripts` is synchronous on the Viewer's only thread. On production, during one very-common-word search, a rare-word search took 1 471 ms instead of 17 ms and `/api/files?limit=1` took 1 532 ms instead of 130 ms. A request the palette aborted on the next keystroke was still computed in full there, and every later request queued behind it. That is why it felt slower than any single number: the final answer waited behind the abandoned ones, and the board's polls waited with it.

## Mechanism

- `src/lib/search/transcriptSearch.ts`: one match scan reads six columns per matched row and never joins the files table; the files a page can name are read once (keyed lookups up to 512 distinct transcripts, one pass beyond); duplicate collapsing, total and page order are computed in memory in exactly the SQL's order (bm25, newest transcript mtime, newest message timestamp, highest id); snippets are cut for the page's rows by one filtered scan (`+rowid IN`, which keeps FTS5 off per-row seeks); everything inside one read transaction so the passes share a snapshot while the indexer commits. Corpus statistics sum `messages_count` from `transcript_files` instead of walking 250k message rows.
- `src/components/search/useTranscriptSearch.ts`: one first-page request in flight, the newest question takes the next turn. A refinement no longer aborts the in-flight request (the server finished it anyway) and intermediate questions are never asked; the answer that arrives holds on screen as the stale rows the design already shows. Unmount is the one abort left, and an aborted request is re-askable so StrictMode's rehearsal unmount cannot strand the first search.
- `scripts/transcript-search-fixture.ts` / `scripts/transcript-search-bench.ts`: the reproducible corpus and the five-surface profile; `docs/performance/issue-1429-transcript-search.md`: the write-up.

## Verification

- `bunx tsc --noEmit --incremental false`: clean.
- Tests by path, 69 pass: `src/lib/search/transcriptSearch.test.ts` (existing 13 plus the differential pin against the replaced SQL and an explicit tie-order pin), `transcriptFeed.test.ts`, `snippet.test.ts`, `src/app/api/search/transcripts/route.test.ts`, `src/components/search/useTranscriptSearch.test.ts`, `useTranscriptSearch.dom.test.tsx` (new: request counts on gated fetches, unmount abort, retry and speaker flip, StrictMode rehearsal), `GlobalSearch.dom.test.tsx`, `src/lib/mcp/searchTranscripts.test.ts`, `src/components/Viewer.deepLink.dom.test.tsx`, `scripts/transcript-search-fixture.test.ts`. The coalescing test fails on the previous hook (request count), so it is a live pin.
- Production equivalence (read-only): the shipped `searchTranscripts` and the previous SQL returned identical pages, totals and snippets for six queries at offsets 0, 40 and 100 on the live index; `SUM(messages_count)` equalled `COUNT(*)`.
- `bun scripts/privacy-publication-gate.ts --require-known-values --check-commits --base <merge-base>`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
