### PR TITLE
feat(switching): cached feed on switch, no board remount, in-app conversation links, measured (#1432)

### DIFF
--- a/scripts/profile-switching.ts
+++ b/scripts/profile-switching.ts
@@ -1,0 +1,670 @@
+/**
+ * Real-browser switching profile for issue #1432.
+ *
+ *   bun scripts/profile-switching.ts [--port 3121] [--cdp-port 9333] [--out file.md] [--keep]
+ *
+ * Seeds a throwaway home with the same invented corpus the DOM profile uses
+ * (`src/test-helpers/switchingFixtures.ts`: short, long and tool-heavy
+ * conversations in two projects), boots the repository's own Next.js dev
+ * server under that home, and drives a headless Chrome over raw CDP through
+ * the switching scenarios on a desktop viewport and a 390px phone viewport.
+ * Every step reports real milliseconds and animation frames from the gesture
+ * to the milestone, measured inside the page with `performance.now()` and
+ * `requestAnimationFrame`.
+ *
+ * Nothing here names a person, an account or a machine: the home, the
+ * projects and every transcript are invented, and the run deletes its home.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { en } from "@/lib/i18n/en";
+import { appendedLine, switchingCorpus, transcriptText, type SwitchingConversation } from "@/test-helpers/switchingFixtures";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const args = new Map<string, string>();
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index]!;
+  if (!arg.startsWith("--")) continue;
+  const next = process.argv[index + 1];
+  if (next && !next.startsWith("--")) {
+    args.set(arg.slice(2), next);
+    index += 1;
+  } else {
+    args.set(arg.slice(2), "1");
+  }
+}
+const PORT = Number(args.get("port") ?? 3121);
+const CDP_PORT = Number(args.get("cdp-port") ?? 9333);
+const KEEP = args.has("keep");
+const OUT = args.get("out");
+/** `--dump`: print what the scanner made of the seeded home, then stop. */
+const DUMP = args.has("dump");
+/** `--server-log <file>`: keep the dev server's own output for the run. */
+const SERVER_LOG = args.get("server-log");
+const CHROME = process.env.LLV_PROFILE_CHROME ?? "/usr/bin/google-chrome-stable";
+
+/* ── throwaway home ─────────────────────────────────────────────────────── */
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-1432-profile-"));
+const home = path.join(root, "home");
+const slug = (value: string) => value.replace(/[^A-Za-z0-9]/g, "-");
+const cwdFor = (project: string) => path.join(home, "Projects", project);
+const corpus = switchingCorpus(cwdFor);
+
+/** Session ids in the transcript's own shape, assembled from the corpus index. */
+function sessionIdFor(index: number): string {
+  const tail = (index + 1).toString(16).padStart(12, "0");
+  return [`c${index}`.padEnd(8, "0"), "0000", "4000", "8000", tail].join("-");
+}
+
+interface Seeded extends SwitchingConversation {
+  /** Absolute transcript path as the scanner will report it. */
+  diskPath: string;
+}
+
+function seedHome(): Seeded[] {
+  const seeded: Seeded[] = [];
+  corpus.forEach((entry, index) => {
+    const cwd = cwdFor(entry.project);
+    fs.mkdirSync(cwd, { recursive: true });
+    const dir = path.join(home, ".claude", "projects", slug(cwd));
+    fs.mkdirSync(dir, { recursive: true });
+    const diskPath = path.join(dir, `${sessionIdFor(index)}.jsonl`);
+    fs.writeFileSync(diskPath, transcriptText(entry.lines));
+    seeded.push({ ...entry, diskPath });
+  });
+  /* No account is seeded: the switching paths under measurement never touch
+     one, and a fake sign-in only makes the account controller spend the run
+     talking to a provider that will refuse it. */
+  /* Older mtimes for the older shapes so the board orders them the same way
+     the DOM profile's fixtures do. */
+  const base = Date.now();
+  for (const entry of seeded) {
+    const age = entry.shape === "short" ? 0 : entry.shape === "long" ? 60_000 : 120_000;
+    fs.utimesSync(entry.diskPath, new Date(base - age), new Date(base - age));
+  }
+  return seeded;
+}
+
+function buildEnvironment(): NodeJS.ProcessEnv {
+  const uid = process.getuid?.() ?? 1000;
+  const tmp = path.join(root, "tmp");
+  const config = path.join(home, ".config");
+  for (const dir of [home, tmp, path.join(tmp, `claude-${uid}`), path.join(root, "tmux"), path.join(root, "cache"), path.join(root, "runtime"), config, path.join(config, "agent-log-viewer", "state")]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.chmodSync(path.join(root, "runtime"), 0o700);
+  return {
+    NODE_ENV: "development",
+    PATH: process.env.PATH,
+    HOME: home,
+    TMPDIR: tmp,
+    TMP: tmp,
+    TEMP: tmp,
+    TMUX_TMPDIR: path.join(root, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(root, "cache"),
+    XDG_RUNTIME_DIR: path.join(root, "runtime"),
+    LLV_STATE_DIR: path.join(config, "agent-log-viewer", "state"),
+    LLV_CLAUDE_HOME: path.join(home, ".claude"),
+    LLV_CODEX_HOME: path.join(home, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    TZ: "UTC",
+    LANG: "C.UTF-8",
+    LC_ALL: "C.UTF-8",
+    LOGNAME: "profile", USER: "profile",
+    SHELL: "/bin/sh",
+  };
+}
+
+/* ── processes ──────────────────────────────────────────────────────────── */
+
+function outputLines(child: ChildProcess): () => string {
+  const lines: string[] = [];
+  const push = (chunk: Buffer) => {
+    for (const line of chunk.toString().split("\n")) if (line.trim()) lines.push(line);
+    if (lines.length > 400) lines.splice(0, lines.length - 400);
+  };
+  child.stdout?.on("data", push);
+  child.stderr?.on("data", push);
+  return () => lines.join("\n");
+}
+
+async function stop(child: ChildProcess | null): Promise<void> {
+  if (!child || child.exitCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGTERM");
+  await Promise.race([exited, Bun.sleep(5_000)]);
+  if (child.exitCode === null) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+async function waitForServer(url: string, child: ChildProcess, logs: () => string, timeoutMs = 240_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`dev server exited early\n${logs()}`);
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+      if (response.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(`dev server did not answer within ${timeoutMs} ms\n${logs()}`);
+}
+
+/* ── raw CDP ────────────────────────────────────────────────────────────── */
+
+class Cdp {
+  private seq = 0;
+  private readonly pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>();
+  private readonly waiters = new Map<string, Array<(params: unknown) => void>>();
+  private constructor(private readonly ws: WebSocket) {
+    ws.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data)) as { id?: number; method?: string; params?: unknown; error?: { message?: string; code?: number }; result?: unknown };
+      if (message.id === undefined) {
+        if (message.method) {
+          const list = this.waiters.get(message.method);
+          if (list?.length) {
+            this.waiters.delete(message.method);
+            for (const resolve of list) resolve(message.params);
+          }
+        }
+        return;
+      }
+      const entry = this.pending.get(message.id);
+      if (!entry) return;
+      this.pending.delete(message.id);
+      if (message.error) entry.reject(new Error(`CDP ${JSON.stringify(message.error)}`));
+      else entry.resolve(message.result);
+    });
+  }
+  /** Resolve on the next occurrence of a CDP event, or null after `timeoutMs`. */
+  waitFor(method: string, timeoutMs: number): Promise<unknown | null> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        const list = this.waiters.get(method) ?? [];
+        this.waiters.set(method, list.filter((entry) => entry !== settle));
+        resolve(null);
+      }, timeoutMs);
+      const settle = (params: unknown) => {
+        clearTimeout(timer);
+        resolve(params);
+      };
+      this.waiters.set(method, [...(this.waiters.get(method) ?? []), settle]);
+    });
+  }
+  static async connect(url: string): Promise<Cdp> {
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", () => reject(new Error("CDP websocket failed to open")), { once: true });
+    });
+    return new Cdp(ws);
+  }
+  send<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    const id = ++this.seq;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  /** Evaluate an expression (may be a promise) and return its JSON value. */
+  async evaluate<T>(expression: string): Promise<T> {
+    const result = await this.send<{ result: { value?: T }; exceptionDetails?: { text: string; exception?: { description?: string } } }>("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (result.exceptionDetails) {
+      const details = result.exceptionDetails as { text: string; exception?: { description?: string; value?: unknown } };
+      throw new Error(`${details.exception?.description ?? details.text}\n${JSON.stringify(details).slice(0, 1200)}\nexpression: ${expression.slice(0, 400)}`);
+    }
+    return result.result.value as T;
+  }
+  close(): void {
+    this.ws.close();
+  }
+}
+
+async function pageWebSocketUrl(): Promise<string> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const targets = (await (await fetch(`http://127.0.0.1:${CDP_PORT}/json/list`)).json()) as Array<{ type: string; webSocketDebuggerUrl: string }>;
+      const page = targets.find((target) => target.type === "page");
+      if (page) return page.webSocketDebuggerUrl;
+    } catch {
+      /* chrome still starting */
+    }
+    await Bun.sleep(250);
+  }
+  throw new Error("headless chrome exposed no page target");
+}
+
+/* ── in-page measurement ────────────────────────────────────────────────── */
+
+/** Installed once per document: milestone polling per animation frame. */
+const PROBE = String.raw`
+(() => {
+  if (window.__profile) return;
+  const pane = (path) => document.querySelector('[data-link-path="' + path + '"]');
+  const probe = {
+    rows: (path) => { const el = pane(path); return el ? el.querySelectorAll('[data-feed-kind]').length : 0; },
+    ringed: (path) => { const node = document.querySelector('[data-scheme-node="' + path + '"]'); return !!(node && node.querySelector(':scope > .ring-2')); },
+    rail: () => { const el = document.querySelector('button[aria-current="page"]'); return el ? el.textContent.trim() : ""; },
+    skeleton: () => !!document.querySelector('[role="status"][aria-busy="true"][aria-live="polite"]'),
+    focusedPane: () => document.querySelector('[data-testid="mobile-focused-pane"] [data-link-path]'),
+    focusedPath: () => { const el = probe.focusedPane(); return el ? el.getAttribute('data-link-path') : null; },
+    focusedRows: () => { const el = probe.focusedPane(); return el ? el.querySelectorAll('[data-feed-kind]').length : 0; },
+    chip: (path, title) => Array.from(document.querySelectorAll('button[title]')).find((b) => b.title === title) || null,
+    chipActive: (title) => { const b = probe.chip(null, title); return !!(b && b.className.includes('border-accent/60')); },
+    firstRow: (path) => { const el = pane(path); return el ? el.querySelector('[data-feed-key]') : null; },
+    /* Poll until every named check holds; report when EACH one first held. */
+    untilEach: (checks, timeoutMs) => new Promise((resolve, reject) => {
+      const start = performance.now();
+      const at = {};
+      const tick = () => {
+        for (const [key, fn] of Object.entries(checks)) {
+          if (at[key] !== undefined) continue;
+          let ok = false;
+          try { ok = fn(); } catch (error) { reject(error); return; }
+          if (ok) at[key] = Math.round((performance.now() - start) * 10) / 10;
+        }
+        if (Object.keys(checks).every((key) => at[key] !== undefined)) { resolve(at); return; }
+        if (performance.now() - start > timeoutMs) { reject(new Error('milestones not reached: ' + JSON.stringify(at) + ' :: ' + document.body.innerText.slice(0, 200))); return; }
+        setTimeout(tick, 2);
+      };
+      tick();
+    }),
+    /* Network requests that started after sinceMs (a performance.now() stamp): when, how long, what. */
+    requestsSince: (sinceMs) => performance.getEntriesByType('resource')
+      .filter((entry) => entry.startTime >= sinceMs && entry.name.includes('/api/'))
+      .map((entry) => { const u = new URL(entry.name); return { at: Math.round(entry.startTime - sinceMs), ms: Math.round(entry.duration), name: (u.pathname + u.search).slice(0, 90) }; }),
+    /* Poll on a short timer until check() holds; resolve with real ms since the
+       call and the animation frames that elapsed meanwhile. Headless Chrome
+       throttles requestAnimationFrame for an unfocused page, so the frame
+       counter is an observer, never the clock the poll rides on. */
+    until: (check, timeoutMs, watch) => new Promise((resolve, reject) => {
+      const start = performance.now();
+      let frames = 0;
+      let counting = true;
+      const seen = {};
+      const frame = () => { if (!counting) return; frames += 1; requestAnimationFrame(frame); };
+      requestAnimationFrame(frame);
+      const tick = () => {
+        if (watch) for (const [key, fn] of Object.entries(watch)) if (fn()) seen[key] = true;
+        let ok = false;
+        try { ok = check(); } catch (error) { counting = false; reject(error); return; }
+        if (ok) { counting = false; resolve({ ms: Math.round((performance.now() - start) * 10) / 10, frames, seen }); return; }
+        if (performance.now() - start > timeoutMs) {
+          counting = false;
+          const nodes = Array.from(document.querySelectorAll('[data-scheme-node]')).map((node) => [String(node.getAttribute('data-scheme-node')).split('/').pop(), !!node.querySelector(':scope > .ring-2'), node.querySelectorAll('[data-feed-kind]').length]);
+          reject(new Error('milestone not reached: ' + check.toString().slice(0, 160) + ' :: hash=' + location.hash.slice(0, 80) + ' rail=' + probe.rail() + ' skeleton=' + probe.skeleton() + ' nodes=' + JSON.stringify(nodes) + ' focused=' + probe.focusedPath() + ' :: ' + document.body.innerText.slice(0, 160).replace(/\n/g, ' ')));
+          return;
+        }
+        setTimeout(tick, 2);
+      };
+      tick();
+    }),
+  };
+  window.__profile = probe;
+})();
+`;
+
+interface Milestone {
+  ms: number;
+  frames: number;
+  seen: Record<string, boolean>;
+  /** API requests the page issued between the gesture and the milestone. */
+  requests?: Array<{ at: number; ms: number; name: string }>;
+  /** False when the milestone never showed within its budget: the row says
+      so and the run goes on, so one missing ring cannot blank a whole table. */
+  reached?: false;
+}
+
+interface Row {
+  surface: string;
+  step: string;
+  ms: number | string;
+  frames: number | string;
+  notes: string;
+}
+const rows: Row[] = [];
+const describeRequests = (requests: Array<{ at: number; ms: number; name: string }>) =>
+  requests.slice(0, 12).map((entry) => `+${entry.at}ms ${entry.name} (${entry.ms}ms)`).join("; ");
+const record = (surface: string, step: string, milestone: Milestone, notes = ""): void => {
+  const requestNotes = milestone.requests?.length ? `requests ${describeRequests(milestone.requests)}` : "";
+  const missed = milestone.reached === false ? "NOT REACHED within the budget" : "";
+  const allNotes = [missed, notes, requestNotes].filter(Boolean).join("; ");
+  const ms = milestone.reached === false ? `>${milestone.ms}` : milestone.ms;
+  rows.push({ surface, step, ms, frames: milestone.frames, notes: allNotes });
+  console.log(`  ${surface} | ${step} | ${ms} ms | ${milestone.frames} frames${allNotes ? " | " + allNotes : ""}`);
+};
+
+const js = JSON.stringify;
+
+/** Run `gesture`, then wait for every named check; returns when each first held plus the API requests the step issued. */
+async function measureEach(cdp: Cdp, gesture: string, checks: Record<string, string>, timeoutMs = 30_000): Promise<{ at: Record<string, number>; requests: Array<{ at: number; ms: number; name: string }> }> {
+  const source = `{${Object.entries(checks).map(([key, expression]) => `${js(key)}: () => (${expression})`).join(",")}}`;
+  return cdp.evaluate(`(async () => {
+    const p = window.__profile;
+    const since = performance.now();
+    ${gesture};
+    const at = await p.untilEach(${source}, ${timeoutMs});
+    return { at, requests: p.requestsSince(since) };
+  })()`);
+}
+
+/** Run `gesture` (a JS statement) and wait for `check` (a JS expression) on the
+    same frame clock; the API requests issued meanwhile ride along, so a slow
+    step can be attributed to the server or to the client. */
+async function measure(cdp: Cdp, gesture: string, check: string, timeoutMs = 20_000, watch: Record<string, string> = {}): Promise<Milestone> {
+  const watchSource = `{${Object.entries(watch).map(([key, expression]) => `${js(key)}: () => (${expression})`).join(",")}}`;
+  try {
+    return await cdp.evaluate<Milestone>(`(async () => {
+      const p = window.__profile;
+      const since = performance.now();
+      ${gesture};
+      const milestone = await p.until(() => (${check}), ${timeoutMs}, ${watchSource});
+      return { ...milestone, requests: p.requestsSince(since) };
+    })()`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("milestone not reached")) throw error;
+    console.log(`  ! not reached within ${timeoutMs} ms: ${message.split("\n")[0]?.slice(0, 400)}`);
+    return { ms: timeoutMs, frames: "" as unknown as number, seen: {}, reached: false };
+  }
+}
+
+async function navigate(cdp: Cdp, url: string): Promise<void> {
+  /* The load event of the NEW document, armed before the navigation is
+     issued: polling readyState right after Page.navigate reads the old
+     document, and a probe installed there dies with its context. */
+  const loaded = cdp.waitFor("Page.loadEventFired", 120_000);
+  await cdp.send("Page.navigate", { url });
+  await loaded;
+  await cdp.evaluate(PROBE);
+}
+
+/* ── scenarios ──────────────────────────────────────────────────────────── */
+
+interface Scanned {
+  path: string;
+  conversationId?: string;
+  title: string;
+}
+
+interface Catalog {
+  files: Scanned[];
+  /** Scanner project key per display name (a non-git directory keys as a hash). */
+  keys: Record<string, string>;
+}
+
+async function scannedFiles(origin: string): Promise<Catalog> {
+  const body = (await (await fetch(`${origin}/api/files`)).json()) as { files: Scanned[]; projectCatalog?: Array<{ project: string; displayName?: string }> };
+  const keys: Record<string, string> = {};
+  for (const entry of body.projectCatalog ?? []) keys[entry.displayName ?? entry.project] = entry.project;
+  return { files: body.files, keys };
+}
+
+function findSeeded(seeded: Seeded[], project: string, shape: string): Seeded {
+  const entry = seeded.find((candidate) => candidate.project === project && candidate.shape === shape);
+  if (!entry) throw new Error(`corpus has no ${project}/${shape}`);
+  return entry;
+}
+
+async function runDesktop(cdp: Cdp, origin: string, seeded: Seeded[], catalog: Catalog): Promise<void> {
+  const short = findSeeded(seeded, "alpha", "short");
+  const long = findSeeded(seeded, "alpha", "long");
+  const tools = findSeeded(seeded, "alpha", "toolheavy");
+  const betaA = findSeeded(seeded, "beta", "short");
+  const betaB = findSeeded(seeded, "beta", "long");
+  const projectUrl = (name: string) => `${origin}/#p=${encodeURIComponent(catalog.keys[name] ?? name)}`;
+  /* Every «Open conversation» button is a conversation-hash anchor; the
+     transcript-path form resolves through the same in-app route as `#c=`. */
+  const hashOf = (entry: Seeded) => `#f=${encodeURIComponent(entry.diskPath)}`;
+  const alphaPaths = [short.diskPath, long.diskPath, tools.diskPath];
+  const betaPaths = [betaA.diskPath, betaB.diskPath];
+  const painted = (paths: string[]) => paths.map((p) => `p.rows(${js(p)}) > 0`).join(" && ");
+
+  await cdp.send("Emulation.clearDeviceMetricsOverride");
+  await cdp.send("Emulation.setEmulatedMedia", { features: [] });
+  await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: false });
+
+  /* Warm the dev server's compile once, then measure a cold mount. */
+  await navigate(cdp, projectUrl("alpha"));
+  await measure(cdp, "", painted(alphaPaths), 120_000);
+  await navigate(cdp, "about:blank");
+  await navigate(cdp, projectUrl("alpha"));
+  const mount = await cdp.evaluate<{ at: Record<string, number>; requests: Array<{ at: number; ms: number; name: string }> }>(`(async () => {
+    const p = window.__profile;
+    const at = await p.untilEach({
+      nodes: () => document.querySelectorAll('[data-scheme-node]').length >= ${alphaPaths.length},
+      ${alphaPaths.map((path, index) => `rows${index}: () => p.rows(${js(path)}) > 0`).join(",\n      ")}
+    }, 60000);
+    const base = performance.now() - Math.max(...Object.values(at));
+    return { at: Object.fromEntries(Object.entries(at).map(([key, value]) => [key, Math.round(value + base)])), requests: p.requestsSince(0) };
+  })()`);
+  record("desktop", "navigate → three cards painted (cold, since navigation start)", { ms: Math.max(...alphaPaths.map((_, index) => mount.at[`rows${index}`]!)), frames: "", seen: {} } as unknown as Milestone,
+    `nodes at ${mount.at.nodes}ms; rows per pane ${alphaPaths.map((_, index) => mount.at[`rows${index}`]).join("/")}ms; requests ${describeRequests(mount.requests)}`);
+
+  /* An in-app «Open conversation» link: every such button is a #c= anchor. */
+  /* The click is dispatched the way a pointer does it — cancelable — and the
+     browser's default (the hash navigation) is applied only when the app did
+     not claim it, so the row can say which route the link took. */
+  const link = (hash: string) => `const a = document.createElement("a"); a.href = ${js(hash)}; a.textContent = "open"; document.body.append(a); window.__linkInApp = !a.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })); a.remove(); if (!window.__linkInApp) location.hash = ${js(hash)}`;
+  const inApp = () => cdp.evaluate<boolean>("window.__linkInApp === true").then((value) => (value ? "in-app yes" : "in-app no (hash navigation)"));
+  const open = await measure(cdp, link(hashOf(short)), `p.ringed(${js(short.diskPath)})`, 20_000, { skeleton: "p.skeleton()" });
+  record("desktop", "«Open conversation» link → target ringed", open, `${await inApp()}; skeleton ${open.seen.skeleton ? "shown" : "never"}; hash ${(await cdp.evaluate<string>("location.hash")).slice(0, 12)}…`);
+
+  /* Project switch through the rail: first visit (cold board) and revisit. */
+  const railClick = (label: string) => `Array.from(document.querySelectorAll("button")).find((b) => (b.textContent || "").trim().startsWith(${js(label)})).click()`;
+  const betaVisit = await measureEach(cdp, railClick("beta"), {
+    rail: `p.rail().startsWith("beta")`,
+    skeleton: `p.skeleton()`,
+    nodes: `document.querySelectorAll('[data-scheme-node]').length >= ${betaPaths.length}`,
+    ...Object.fromEntries(betaPaths.map((path, index) => [`rows${index}`, `p.rows(${js(path)}) > 0`])),
+  });
+  record("desktop", "project switch (first visit) → rail highlight", { ms: betaVisit.at.rail!, frames: "", seen: {} } as unknown as Milestone);
+  record("desktop", "project switch (first visit) → cards painted (cold)", { ms: Math.max(...betaPaths.map((_, index) => betaVisit.at[`rows${index}`]!)), frames: "", seen: {} } as unknown as Milestone,
+    `skeleton at ${betaVisit.at.skeleton}ms; nodes at ${betaVisit.at.nodes}ms; rows per pane ${betaPaths.map((_, index) => betaVisit.at[`rows${index}`]).join("/")}ms; requests ${describeRequests(betaVisit.requests)}`);
+  const alphaRail = await measure(cdp, railClick("alpha"), `p.rail().startsWith("alpha")`);
+  record("desktop", "project switch (revisit) → rail highlight", alphaRail);
+  const alphaPaint = await measure(cdp, "", painted(alphaPaths), 30_000, { skeleton: "p.skeleton()" });
+  record("desktop", "project switch (revisit) → cards painted from cache", alphaPaint, `skeleton ${alphaPaint.seen.skeleton ? "shown" : "never"}`);
+
+  /* A cross-project link from alpha to beta's long conversation. */
+  const cross = await measure(cdp, link(hashOf(betaB)), `p.rail().startsWith("beta")`, 20_000, { skeleton: "p.skeleton()" });
+  record("desktop", "cross-project link → rail switched", cross, await inApp());
+  const crossPaint = await measure(cdp, "", painted(betaPaths), 30_000, { skeleton: "p.skeleton()" });
+  record("desktop", "cross-project link → beta cards painted from cache", crossPaint, `skeleton ${cross.seen.skeleton || crossPaint.seen.skeleton ? "shown" : "never"}`);
+  const crossRing = await measure(cdp, "", `p.ringed(${js(betaB.diskPath)})`);
+  record("desktop", "cross-project link → target ringed", crossRing);
+  await measure(cdp, railClick("alpha"), painted(alphaPaths), 30_000);
+
+  /* Keyboard: select a card, then ArrowRight to a neighbour. */
+  const selectCard = (p: string) => `{ const n = document.querySelector('[data-scheme-node=${js(p)}]'); n.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 })); n.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })); }`;
+  await measure(cdp, selectCard(short.diskPath), `p.ringed(${js(short.diskPath)})`);
+  const arrow = await measure(cdp, `window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }))`, `!p.ringed(${js(short.diskPath)}) && (p.ringed(${js(long.diskPath)}) || p.ringed(${js(tools.diskPath)}))`);
+  record("desktop", "ArrowRight → ring moves to the neighbour card", arrow);
+  const clickFocus = await measure(cdp, selectCard(tools.diskPath), `p.ringed(${js(tools.diskPath)})`);
+  record("desktop", "click on a card → ring moves", clickFocus);
+
+  /* The tail moves on disk: scanner watch → stream → parse → paint. */
+  const rowsBefore = await cdp.evaluate<number>(`window.__profile.rows(${js(short.diskPath)})`);
+  /* Stashed on the page, never returned: CDP cannot serialise a DOM node. */
+  await cdp.evaluate(`(window.__profileFirstRow = window.__profile.firstRow(${js(short.diskPath)})) !== undefined`);
+  const appendedAt = Date.now();
+  fs.appendFileSync(short.diskPath, appendedLine("alpha", 9_001, "desktop", cwdFor) + "\n");
+  const fresh = await measure(cdp, "", `p.rows(${js(short.diskPath)}) > ${rowsBefore}`, 30_000);
+  const preserved = await cdp.evaluate<boolean>(`window.__profile.firstRow(${js(short.diskPath)}) === window.__profileFirstRow`);
+  record("desktop", "fresh tail record on disk → appended to the short card", { ...fresh, ms: Date.now() - appendedAt }, `first row node preserved ${preserved ? "yes" : "no"}`);
+
+  /* A cold deep link from the URL. */
+  await navigate(cdp, "about:blank");
+  await navigate(cdp, `${origin}/${hashOf(betaA)}`);
+  const cold = await cdp.evaluate<Milestone>(`(async () => { const p = window.__profile; const m = await p.until(() => p.rail().startsWith("beta") && p.rows(${js(betaA.diskPath)}) > 0, 60000); return { ms: Math.round(performance.now()), frames: m.frames, seen: {} }; })()`);
+  record("desktop", "cold URL deep link → target project and card painted (since navigation start)", cold);
+}
+
+async function runPhone(cdp: Cdp, origin: string, seeded: Seeded[], catalog: Catalog): Promise<void> {
+  const short = findSeeded(seeded, "alpha", "short");
+  const long = findSeeded(seeded, "alpha", "long");
+  const projectUrl = (name: string) => `${origin}/#p=${encodeURIComponent(catalog.keys[name] ?? name)}`;
+  const titleOf = (entry: Seeded) => {
+    const row = catalog.files.find((file) => file.path === entry.diskPath);
+    if (!row) throw new Error(`scanner reported no row for ${entry.shape}`);
+    return row.title;
+  };
+  /* The strip chip's title attribute is the cleaned title, capped at 60. */
+  const chipTitle = (entry: Seeded) => `Array.from(document.querySelectorAll('button[title]')).find((b) => b.title.startsWith(${js(titleOf(entry).slice(0, 40))}))`;
+
+  await cdp.send("Emulation.setDeviceMetricsOverride", { width: 390, height: 844, deviceScaleFactor: 2, mobile: true });
+  await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 });
+  await cdp.send("Emulation.setEmulatedMedia", { features: [{ name: "pointer", value: "coarse" }, { name: "hover", value: "none" }] });
+
+  await navigate(cdp, "about:blank");
+  await navigate(cdp, projectUrl("alpha"));
+  const mount = await cdp.evaluate<Milestone>(`(async () => { const p = window.__profile; const m = await p.until(() => p.focusedRows() > 0, 60000); return { ms: Math.round(performance.now()), frames: m.frames, seen: {} }; })()`);
+  record("phone", "navigate → focused pane painted (cold, since navigation start)", mount, `focused ${await cdp.evaluate<string>("window.__profile.focusedPath()") === short.diskPath ? "short" : "other"}`);
+
+  const tapChip = (entry: Seeded) => `${chipTitle(entry)}.click()`;
+  const chipA = await measure(cdp, tapChip(short), `p.chipActive(${chipTitle(short)}.title) && p.focusedPath() === ${js(short.diskPath)}`);
+  record("phone", "tap chip A (short) → chip highlighted and pane focused", chipA);
+  const rowsA = await measure(cdp, "", `p.focusedPath() === ${js(short.diskPath)} && p.focusedRows() >= ${short.lines.length}`);
+  record("phone", "tap chip A → A rows painted", rowsA);
+
+  const chipB = await measure(cdp, tapChip(long), `p.focusedPath() === ${js(long.diskPath)}`);
+  record("phone", "tap chip B (long, cold) → pane focused", chipB);
+  const rowsB = await measure(cdp, "", `p.focusedPath() === ${js(long.diskPath)} && p.focusedRows() > 0`, 30_000);
+  record("phone", "tap chip B (long, cold) → B rows painted", rowsB, `rows on screen ${await cdp.evaluate<number>("window.__profile.focusedRows()")}`);
+
+  const back = await measure(cdp, tapChip(short), `p.focusedPath() === ${js(short.diskPath)} && p.focusedRows() > 0`);
+  record("phone", "tap chip A again (cached) → A's previous rows on screen", back);
+
+  await cdp.evaluate(`(window.__profileFirstRow = window.__profile.firstRow(${js(short.diskPath)})) !== undefined`);
+  const rowsBefore = await cdp.evaluate<number>(`window.__profile.rows(${js(short.diskPath)})`);
+  const appendedAt = Date.now();
+  fs.appendFileSync(short.diskPath, appendedLine("alpha", 9_002, "phone", cwdFor) + "\n");
+  const fresh = await measure(cdp, "", `p.rows(${js(short.diskPath)}) > ${rowsBefore}`, 30_000);
+  const preserved = await cdp.evaluate<boolean>(`window.__profile.firstRow(${js(short.diskPath)}) === window.__profileFirstRow`);
+  record("phone", "fresh tail record on disk → appended to A", { ...fresh, ms: Date.now() - appendedAt }, `first row node preserved ${preserved ? "yes" : "no"}`);
+
+  /* Header swipe to the neighbour pane (synthetic touch sequence on the pane header). */
+  const swipe = `{
+    const header = document.querySelector('[data-testid="mobile-focused-pane"] header');
+    const r = header.getBoundingClientRect();
+    const touch = (x) => new Touch({ identifier: 1, target: header, clientX: x, clientY: r.top + r.height / 2 });
+    header.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, touches: [touch(r.left + 200)], changedTouches: [touch(r.left + 200)] }));
+    header.dispatchEvent(new TouchEvent("touchend", { bubbles: true, cancelable: true, touches: [], changedTouches: [touch(r.left + 60)] }));
+  }`;
+  const before = await cdp.evaluate<string>("window.__profile.focusedPath()");
+  const hop = await measure(cdp, swipe, `p.focusedPath() !== ${js(before)} && p.focusedRows() > 0`);
+  record("phone", "header swipe → neighbour pane focused with cached rows", hop);
+
+  /* Project switch through the drawer: first visit, then revisit. */
+  const drawer = `document.querySelector('button[aria-label=${js(en["dash.openProjects"])}]').click()`;
+  const railClick = (label: string) => `Array.from(document.querySelectorAll("button")).find((b) => (b.textContent || "").trim().startsWith(${js(label)})).click()`;
+  await cdp.evaluate(drawer);
+  const toBeta = await measure(cdp, railClick("beta"), `${betaFocusedCheck(seeded)} && p.focusedRows() > 0`, 30_000, { skeleton: "p.skeleton()" });
+  record("phone", "drawer project switch (first visit) → focused pane painted (cold)", toBeta, `skeleton ${toBeta.seen.skeleton ? "shown" : "never"}`);
+  await cdp.evaluate(drawer);
+  const backAlpha = await measure(cdp, railClick("alpha"), `${alphaFocusedCheck(seeded)} && p.focusedRows() > 0`, 30_000, { skeleton: "p.skeleton()" });
+  record("phone", "drawer project switch (revisit) → focused pane painted from cache", backAlpha, `skeleton ${backAlpha.seen.skeleton ? "shown" : "never"}`);
+}
+
+function betaFocusedCheck(seeded: Seeded[]): string {
+  const paths = seeded.filter((entry) => entry.project === "beta").map((entry) => entry.diskPath);
+  return `[${paths.map((candidate) => js(candidate)).join(",")}].includes(p.focusedPath())`;
+}
+function alphaFocusedCheck(seeded: Seeded[]): string {
+  const paths = seeded.filter((entry) => entry.project === "alpha").map((entry) => entry.diskPath);
+  return `[${paths.map((candidate) => js(candidate)).join(",")}].includes(p.focusedPath())`;
+}
+
+/* ── main ───────────────────────────────────────────────────────────────── */
+
+async function main(): Promise<void> {
+  const seeded = seedHome();
+  const env = buildEnvironment();
+  const origin = `http://127.0.0.1:${PORT}`;
+  const server = spawn(
+    process.execPath,
+    ["--bun", path.join(repoRoot, "node_modules/.bin/next"), "dev", "--webpack", "--hostname", "127.0.0.1", "--port", String(PORT)],
+    { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const serverLogs = outputLines(server);
+  let chrome: ChildProcess | null = null;
+  let cdp: Cdp | null = null;
+  try {
+    console.log(`dev server starting on ${origin} under ${root}`);
+    await waitForServer(`${origin}/api/files`, server, serverLogs);
+    /* The scanner needs a moment to attribute the seeded transcripts. */
+    let catalog: Catalog = { files: [], keys: {} };
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      catalog = await scannedFiles(origin);
+      if (seeded.every((entry) => catalog.files.some((file) => file.path === entry.diskPath)) && catalog.keys.alpha && catalog.keys.beta) break;
+      await Bun.sleep(1_000);
+    }
+    const missing = seeded.filter((entry) => !catalog.files.some((file) => file.path === entry.diskPath));
+    if (missing.length) throw new Error(`scanner never listed ${missing.map((entry) => entry.shape).join(", ")}\n${serverLogs()}`);
+    console.log(`scanner lists ${catalog.files.length} transcripts`);
+    if (DUMP) {
+      const body = (await (await fetch(`${origin}/api/files`)).json()) as { files: Array<Record<string, unknown>>; projectCatalog: unknown; projectCwds: unknown };
+      const redact = (value: unknown) => JSON.stringify(value).replaceAll(root, "<root>");
+      for (const file of body.files) {
+        console.log(redact(Object.fromEntries(["path", "project", "cwd", "projectRoot", "activity", "kind", "root", "title", "conversationId"].map((key) => [key, file[key]]))));
+      }
+      console.log("catalog", redact(body.projectCatalog));
+      console.log("cwds", redact(body.projectCwds));
+      return;
+    }
+
+    chrome = spawn(CHROME, [
+      "--headless=new",
+      `--remote-debugging-port=${CDP_PORT}`,
+      `--user-data-dir=${path.join(root, "chrome")}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--disable-gpu",
+      "--hide-scrollbars",
+      "--window-size=1280,800",
+      "about:blank",
+    ], { env: { ...process.env, HOME: root }, stdio: "ignore" });
+    cdp = await Cdp.connect(await pageWebSocketUrl());
+    await cdp.send("Page.enable");
+    await cdp.send("Runtime.enable");
+
+    console.log("desktop 1280×800");
+    await runDesktop(cdp, origin, seeded, catalog);
+    console.log("phone 390×844");
+    await runPhone(cdp, origin, seeded, catalog);
+
+    const header = "| surface | step | real ms since gesture | frames | notes |\n|---|---|---:|---:|---|";
+    const body = rows.map((row) => `| ${row.surface} | ${row.step} | ${row.ms} | ${row.frames} | ${row.notes} |`).join("\n");
+    const table = `#1432 switching profile (real browser: headless Chrome, Next.js dev server, throwaway home)\n${header}\n${body}\n`;
+    console.log(`\n${table}`);
+    if (OUT) fs.writeFileSync(OUT, table);
+  } finally {
+    cdp?.close();
+    await stop(chrome);
+    await stop(server);
+    if (SERVER_LOG) fs.writeFileSync(SERVER_LOG, serverLogs().replaceAll(root, "<root>"));
+    if (KEEP) console.log(`kept ${root}`);
+    else fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error));
+  process.exit(1);
+});

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -35,6 +35,7 @@ import {
   type OutboxOwner,
 } from "./conversation/outbox";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
+import { claimFeedSession, releaseFeedSession, takeFeedSession } from "./feed/sessionPool";
 import { FeedItem } from "./feed/FeedItem";
 import { MessageProvenanceProvider, useDeliveredMessageProvenance } from "./feed/messageProvenance";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
@@ -55,6 +56,13 @@ const RENDER_STEP = 1500;
     the full history in steps. */
 const COMPACT_INITIAL = 300;
 const COMPACT_STEP = 500;
+/** The first commit of a transcript paints only its last rows (#1432): a
+    project switch mounts several panes at once and a phone switch remounts
+    one, and mounting the whole initial window in that commit is what stood
+    between the gesture and the first frame. The window grows to its initial
+    count right after that frame; the magnet keeps the tail in view and a
+    released reader keeps its anchor, so nothing the operator sees moves. */
+const FIRST_PAINT_ROWS = 60;
 /** Live-tail window while the magnet holds the bottom. Touch devices run on
     a far smaller tab memory budget (iOS kills the renderer past it), so the
     window shrinks there; «show earlier» still walks the full history. */
@@ -261,7 +269,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const anchorRef = useRef<{ top: number; height: number } | null>(null);
   const initialCount = compact ? COMPACT_INITIAL : RENDER_STEP;
   const revealStep = compact ? COMPACT_STEP : RENDER_STEP;
-  const [visibleCount, setVisibleCount] = useState(initialCount);
+  const firstPaintCount = Math.min(FIRST_PAINT_ROWS, initialCount);
+  const [visibleCount, setVisibleCount] = useState(firstPaintCount);
   const [newCount, setNewCount] = useState(0);
   const [pulse, setPulse] = useState(false);
   const [endedQuestion, setEndedQuestion] = useState<string | null>(null);
@@ -357,8 +366,27 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     return true;
   };
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => setVisibleCount(initialCount), [tailPath, initialCount]);
+  /* First frame: the last FIRST_PAINT_ROWS. Next frame: the full initial
+     window, with the scroll anchored exactly as a «show earlier» reveal is. */
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVisibleCount(firstPaintCount);
+    if (firstPaintCount >= initialCount) return;
+    /* Two frames: the first commit paints, the second grows the window. A
+       host without animation frames (a bare test document) grows on a
+       macrotask instead. */
+    const raf = typeof requestAnimationFrame === "function";
+    const schedule = (fn: () => void) => (raf ? requestAnimationFrame(fn) : (setTimeout(fn, 0) as unknown as number));
+    const cancel = (handle: number) => (raf ? cancelAnimationFrame(handle) : clearTimeout(handle));
+    let handle = schedule(() => {
+      handle = schedule(() => {
+        const el = scroller.current;
+        if (el) anchorRef.current = { top: el.scrollTop, height: el.scrollHeight };
+        setVisibleCount((count) => Math.max(count, initialCount));
+      });
+    });
+    return () => cancel(handle);
+  }, [tailPath, initialCount, firstPaintCount]);
   /* Same instance, new transcript: pick up that transcript's remembered state. */
   useEffect(() => {
     if (!memoryKey) return;
@@ -424,11 +452,24 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      which changes every /api/files poll); anything else reuses it. Feeding
      inside the memo is safe: feed() is idempotent for an unchanged window. */
   const lf = lineFilter.toLowerCase();
+  /* The session outlives this mount (#1432): a conversation that was on screen
+     earlier comes back with its parse intact — taken from the pool here, given
+     back when the key changes or the feed unmounts — so a switch paints the
+     previous rows without re-parsing the retained window. The key is exactly
+     the parse configuration above; a session is owned by one mount at a time. */
+  const sessionKey = file && tailPath ? [tailPath, file.engine, file.fmt, showSvc ? "1" : "0", lf, locale].join("\u0000") : null;
   const session: FeedSession | null = useMemo(
-    () => (file ? createFeedSession({ engine: file.engine, fmt: file.fmt, showSvc, lineFilter: lf }) : null),
+    () => (file && sessionKey
+      ? takeFeedSession(sessionKey) ?? createFeedSession({ engine: file.engine, fmt: file.fmt, showSvc, lineFilter: lf })
+      : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tailPath, file?.engine, file?.fmt, showSvc, lf, locale],
+    [sessionKey],
   );
+  useEffect(() => {
+    if (!sessionKey || !session) return;
+    claimFeedSession(sessionKey, session);
+    return () => releaseFeedSession(sessionKey, session);
+  }, [sessionKey, session]);
   const feed = useMemo(
     () => (file && session ? session.feed(tail.lines, tail.linesStart, file.activity === "live") : EMPTY_FEED),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -35,7 +35,7 @@ import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow, res
 import { compactPipelineArtifactPaths, compactPipelineLayoutFlows, createDraftPipeline, excludeCompactPipelineArtifacts, patchPipeline, pipelineFullPanePaths, pipelinesForProject, replaceCompactPipelineEphemeral, resolvePipelineMemberPaths, type PipelineTemplate } from "./pipelines/pipelineModel";
 import { PipelineTemplatePicker } from "./pipelines/PipelineTemplatePicker";
 import { buildSchemeLayout } from "./scheme/layout";
-import { buildSubagentTrays } from "./scheme/subagentTray";
+import { buildSubagentTrays, subagentTraySignature } from "./scheme/subagentTray";
 import type { SubagentTrayApi } from "./scheme/SubagentTrayView";
 import { conversationIdentity, formatConversationHash } from "@/lib/accounts/identity";
 import { recordFocusNavigation } from "@/lib/navigation/focusHistory";
@@ -86,6 +86,11 @@ const HIGHLIGHT_MS = 1800;
     minutes wide, so both the millisecond and the seconds clock tick here. */
 const BOARD_CLOCK_MS = 30_000;
 const ACTIVE_DELIVERY_RECEIPTS = new Set(["pending", "delivering", "applying", "queued", "uncertain"]);
+/* Stable empties for the layout inputs: a fresh `[]` per render re-lays-out
+   the board (#1432). */
+const EMPTY_MANUAL: FileEntry[] = [];
+const EMPTY_DRAFTS: string[] = [];
+const EMPTY_TASKS: BoardTask[] = [];
 
 interface Props {
   files: FileEntry[];
@@ -623,9 +628,15 @@ function ProjectDashboardView({
         else setDraftCwd(id, initialDraftCwd);
       }
     }
+    /* Identity-preserving (#1432): this effect re-runs on every same-project
+       open (`openNonce`), and a fresh array or set for unchanged content
+       re-laid-out the whole board through the drafts input. */
     /* eslint-disable-next-line react-hooks/set-state-in-effect */
-    setDrafts(restored);
-    setPendingRestoredHandoffs(new Set(unresolved.map(({ id }) => id)));
+    setDrafts((prev) => (prev.length === restored.length && prev.every((id, index) => id === restored[index]) ? prev : restored));
+    setPendingRestoredHandoffs((prev) => {
+      const next = new Set(unresolved.map(({ id }) => id));
+      return prev.size === next.size && [...next].every((id) => prev.has(id)) ? prev : next;
+    });
     const resolveSourceCwd = (id: string, sourcePath: string, attempt = 0) => {
       void fetch("/api/spawn?project=" + encodeURIComponent(project) + "&src=" + encodeURIComponent(sourcePath))
         .then(async (response) => {
@@ -867,6 +878,7 @@ function ProjectDashboardView({
     () => buildBranchGroups(sceneFiles, project, { expandedConversationPaths: expandedConversations, keepExpandedPaths, now: nowSeconds }),
     [sceneFiles, project, expandedConversations, keepExpandedPaths, nowSeconds],
   );
+  const engineProjectionRef = useRef<{ signature: string; projection: ReturnType<typeof buildSubagentTrays> } | null>(null);
   const engineProjection = useMemo(() => {
     const hiddenPaths = new Set(prefs.hidden);
     const placedPaths = new Set<string>(prefs.manual);
@@ -884,7 +896,7 @@ function ProjectDashboardView({
     /* Existing surfaces keep authority: a claimed pipeline artifact, a folded
        worker, or launch history is never re-owned by the tray projection. */
     const claimedPaths = new Set<string>([...compactPipelinePaths, ...collapsedPaths, ...launchHistoryPaths]);
-    return buildSubagentTrays({
+    const next = buildSubagentTrays({
       entries: files,
       foldedEngineChildIds: new Set(board.prefs.foldedEngineChildIds ?? []),
       expandedTrayParentIds: new Set(board.prefs.expandedEngineTrayParentIds ?? []),
@@ -894,6 +906,13 @@ function ProjectDashboardView({
       hostEligibleParentIds,
       now: nowSeconds,
     });
+    /* Value-stable (#1432): the projection reaches every card through the
+       tray API, so an equal projection keeps its earlier identity. */
+    const signature = subagentTraySignature(next);
+    const previous = engineProjectionRef.current;
+    if (previous && previous.signature === signature) return previous.projection;
+    engineProjectionRef.current = { signature, projection: next };
+    return next;
   }, [baseGroups, prefs.hidden, prefs.manual, board.prefs.foldedEngineChildIds, board.prefs.expandedEngineTrayParentIds, filesByPath, project, files, compactPipelinePaths, collapsedPaths, launchHistoryPaths, pinnedPaths, nowSeconds]);
   const groups = useMemo(
     () => (engineProjection.promotedPaths.size || engineProjection.foldedPaths.size
@@ -1454,15 +1473,21 @@ function ProjectDashboardView({
     pendingFocusRef.current = path;
     setEphemeral((prev) => (prev.includes(path) ? prev : [...prev, path]));
   };
+  /* The tray API reaches every card through NodesLayer's props, so its
+     identity must move only when the PROJECTION moves (#1432). `board` is
+     rebuilt on every render (its setters delegate to the shared store) and
+     `openTrayMember` closes over the latest files, so both are read through a
+     ref the handlers dereference at call time. */
+  const trayHandlersRef = useRef({ board, openTrayMember });
+  trayHandlersRef.current = { board, openTrayMember };
   const trayApi = useMemo<SubagentTrayApi>(() => ({
     trays: engineProjection.traysByParent,
     foldedChildPaths: engineProjection.foldedPaths,
-    onToggleExpanded: (parentId, expanded) => board.setEngineTrayExpanded(parentId, expanded),
-    onOpenMember: openTrayMember,
-    onUnfold: (id, path) => board.setEngineChildFold(id, path, false),
-    onFoldChild: (id, path) => board.setEngineChildFold(id, path, true),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [engineProjection, board]);
+    onToggleExpanded: (parentId, expanded) => trayHandlersRef.current.board.setEngineTrayExpanded(parentId, expanded),
+    onOpenMember: (path) => trayHandlersRef.current.openTrayMember(path),
+    onUnfold: (id, path) => trayHandlersRef.current.board.setEngineChildFold(id, path, false),
+    onFoldChild: (id, path) => trayHandlersRef.current.board.setEngineChildFold(id, path, true),
+  }), [engineProjection]);
   const openFullCatalogFile = onOpenCatalogFile ?? openSwitchboardFile;
 
   /* Expand a terminal direct review group back onto the board (#289 + #325):
@@ -1528,17 +1553,21 @@ function ProjectDashboardView({
     statusBits.push(t("dash.quietTrees", { count: cards.length }));
   }
 
-  const visibleGroups = groups
+  /* Memoised (#1432): these arrays are SchemeBoard's layout inputs. Rebuilt
+     inline they took a fresh identity on every dashboard render — a highlight,
+     a clock tick — and every one of those re-laid-out the whole board and
+     re-rendered every card. */
+  const visibleGroups = useMemo(() => groups
     .map((group) => ({ ...group, columns: group.columns.filter((column) => !hiddenSet.has(column.file.path)) }))
-    .filter((group) => group.columns.length);
+    .filter((group) => group.columns.length), [groups, hiddenSet]);
   /* Parentless background processes dock as colored strips at the top of the
      canvas instead of hanging as lone stub nodes in the middle of it. */
-  const dockedTasks = visibleGroups.filter((group) => group.orphanTask).map((group) => group.columns[0]!.file);
-  const schemeGroups = visibleGroups.filter((group) => !group.orphanTask);
+  const dockedTasks = useMemo(() => visibleGroups.filter((group) => group.orphanTask).map((group) => group.columns[0]!.file), [visibleGroups]);
+  const schemeGroups = useMemo(() => visibleGroups.filter((group) => !group.orphanTask), [visibleGroups]);
   /* Active pipelines keep the scheme available before the first transcript;
      SchemeBoard anchors their world-space PipelineGroups beside linked tasks. */
   const activePipelines = useMemo(() => pipelinesForProject(pipelines, project, files), [pipelines, project, files]);
-  const visibleDrafts = drafts.filter((id) => !pendingRestoredHandoffs.has(id));
+  const visibleDrafts = useMemo(() => drafts.filter((id) => !pendingRestoredHandoffs.has(id)), [drafts, pendingRestoredHandoffs]);
   const hasNodes =
     schemeGroups.length > 0 || schemeManual.length > 0 || visibleDrafts.length > 0 || projectTasks.length > 0 || activePipelines.length > 0;
   /* Scheme-visible project files, freshest first. They gate live activity for
@@ -1577,15 +1606,22 @@ function ProjectDashboardView({
      exists only for an implementer placed as a board node — the same layout the
      scheme draws. Derive availability from that layout's nodes, so a scanned but
      unplaced (hidden/tombstoned) implementer disables the action (#93 finding). */
-  const pipelineLayout = buildSchemeLayout(hasNodes ? schemeGroups : archiveGroups, hasNodes ? schemeManual : [], files, compactLayoutFlows, hasNodes ? visibleDrafts : [], pipelines, [], new Set(), isolatedCompactHistoryPaths, [], new Set(), { now: nowSeconds });
+  const layoutGroups = hasNodes ? schemeGroups : archiveGroups;
+  const layoutManual = hasNodes ? schemeManual : EMPTY_MANUAL;
+  const layoutDrafts = hasNodes ? visibleDrafts : EMPTY_DRAFTS;
+  const pipelineLayout = useMemo(
+    () => buildSchemeLayout(layoutGroups, layoutManual, files, compactLayoutFlows, layoutDrafts, pipelines, [], new Set(), isolatedCompactHistoryPaths, [], new Set(), { now: nowSeconds }),
+    [layoutGroups, layoutManual, files, compactLayoutFlows, layoutDrafts, pipelines, isolatedCompactHistoryPaths, nowSeconds],
+  );
   /* Worker rows the scheme still draws in a retained form — an active flow's
      reviewer round deck keeps its finished rounds as deck tabs. Those are
      re-admitted here so a folded reviewer is never listed twice (its deck AND a
-     worker stack). Derived inline (like pipelineLayout above) so the React
-     Compiler owns the caching — a manual useMemo over the non-memoized
-     pipelineLayout can't be preserved. */
-  const deckReviewerPaths = new Set<string>();
-  for (const deck of pipelineLayout.decks) for (const round of deck.rounds) if (round.file) deckReviewerPaths.add(round.file.path);
+     worker stack). */
+  const deckReviewerPaths = useMemo(() => {
+    const paths = new Set<string>();
+    for (const deck of pipelineLayout.decks) for (const round of deck.rounds) if (round.file) paths.add(round.file.path);
+    return paths;
+  }, [pipelineLayout]);
   /* The board's placed conversation windows, in layout order — the fallback the
      non-scheme publisher below reports as visible when the history list has no
      rows of its own (#771 requirement a). Carried as a newline-joined signature
@@ -1598,10 +1634,10 @@ function ProjectDashboardView({
      exclude set: a closed worker is a tombstone — it must not resurface as a
      stack member (its manual/expanded pin was dropped on close, so it would
      otherwise re-qualify as a plain collapse candidate). */
-  const workerStacks = groupWorkerStacks(collapsibleWorkers, deckFlows, new Set([...deckReviewerPaths, ...hiddenSet, ...launchHistoryPaths, ...compactPipelinePaths]), {
+  const workerStacks = useMemo(() => groupWorkerStacks(collapsibleWorkers, deckFlows, new Set([...deckReviewerPaths, ...hiddenSet, ...launchHistoryPaths, ...compactPipelinePaths]), {
     pipelineIdOf,
     originOf: spawnerRootOf,
-  });
+  }), [collapsibleWorkers, deckFlows, deckReviewerPaths, hiddenSet, launchHistoryPaths, compactPipelinePaths, pipelineIdOf, spawnerRootOf]);
   const listAvailable = catalogKnown || historyRows.length > 0;
   /* A landing from the resolver outranks the saved preference for as long as it
      stands (see `openedConversation`). It cannot conjure a surface that has
@@ -2006,17 +2042,17 @@ function ProjectDashboardView({
             <MobileFocusView
               project={project}
               projectName={projectName}
-              groups={hasNodes ? schemeGroups : archiveGroups}
-              manual={hasNodes ? schemeManual : []}
+              groups={layoutGroups}
+              manual={layoutManual}
               files={files}
               flows={flows}
               reviewGroups={directReviewGroups}
               pipelines={pipelines}
               surfacePipelines={activePipelines}
               workerStacks={workerStacks}
-              tasks={hasNodes ? boardTasks : []}
+              tasks={hasNodes ? boardTasks : EMPTY_TASKS}
               sheetTasks={projectTasks}
-              drafts={hasNodes ? visibleDrafts : []}
+              drafts={layoutDrafts}
               favorites={favoriteIdSet}
               isolatedManualPaths={isolatedCompactHistoryPaths}
               loaded={loaded}
@@ -2070,18 +2106,18 @@ function ProjectDashboardView({
             ) : projectView === "scheme" && schemeAvailable ? (
               <SchemeBoard
                 project={project}
-                groups={hasNodes ? schemeGroups : archiveGroups}
-                manual={hasNodes ? schemeManual : []}
+                groups={layoutGroups}
+                manual={layoutManual}
                 files={files}
                 flows={flows}
                 reviewGroups={directReviewGroups}
                 pipelines={pipelines}
                 surfacePipelines={activePipelines}
                 now={nowSeconds}
-                tasks={hasNodes ? boardTasks : []}
+                tasks={hasNodes ? boardTasks : EMPTY_TASKS}
                 allTasks={projectTasks}
                 workerStacks={workerStacks}
-                drafts={hasNodes ? visibleDrafts : []}
+                drafts={layoutDrafts}
                 favorites={favoriteIdSet}
                 isolatedManualPaths={isolatedCompactHistoryPaths}
                 focus={highlight}

--- a/src/components/Viewer.deepLink.dom.test.tsx
+++ b/src/components/Viewer.deepLink.dom.test.tsx
@@ -206,12 +206,15 @@ afterEach(() => {
 /** `/api/files` serves `filesByPin` keyed by the request's `path` param
     (`""` = the unpinned global scope); `/api/board` is a real in-memory board
     so the focus request can actually place its card. Everything else 404s. */
-function stubFetch(filesByPin: (pin: string) => FileEntry[]) {
+function stubFetch(filesByPin: (pin: string) => FileEntry[], delayByPin?: (pin: string) => number) {
   globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
     requestLog.push(url);
     if (url.startsWith("/api/files")) {
       const pin = new URL(url, "http://localhost").searchParams.get("path") ?? "";
+      /* A per-scope delay models a pinned fetch slower than the global one. */
+      const delay = delayByPin?.(pin) ?? 0;
+      if (delay > 0) await Bun.sleep(delay);
       return new Response(
         JSON.stringify({ files: filesByPin(pin), projectCatalog }),
         { headers: { "content-type": "application/json" } },
@@ -466,6 +469,41 @@ test("#c= whose row arrives only via the pinned fetch keeps its pin after resolv
   expect(host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`)).not.toBeNull();
   await expectNavigationQuiescence();
 });
+
+/** Mirrors `STALE_FOCUS_REPLAY_MS` in Viewer.tsx. */
+const STALE_DEADLINE_MS = 8_000;
+
+test("the not-found deadline waits for the pinned scope's own payload; a stand-in from another scope does not start it", async () => {
+  /* A warm tab: the global scope has already answered when the hash changes
+     (a pasted link, the palette, Back/Forward), so the pinned scope is served
+     by the last-known stand-in at once (#1432). The pinned fetch, the only one
+     that can carry the target, outlasts the deadline. The stand-in carries
+     `loaded` and says nothing about the target, so it must not start the
+     clock: with the clock started on it, a slow pinned fetch was reported
+     stale before it could answer, and the row it finally carried was dropped. */
+  stubFetch(
+    (pin) => (pin === CONVERSATION_ID || pin === TARGET_PATH ? [otherRow, targetRow] : [otherRow]),
+    (pin) => (pin === CONVERSATION_ID ? STALE_DEADLINE_MS + 600 : 0),
+  );
+  const filesRequests = () => requestLog.filter((url) => url.startsWith("/api/files"));
+
+  const host = await mountViewer();
+  expect(filesRequests().some((url) => !url.includes("path="))).toBe(true);
+
+  await act(async () => { dom.location.hash = `#c=${encodeURIComponent(CONVERSATION_ID)}`; });
+  expect(await waitFor(() => filesRequests().some((url) => url.includes("path=")))).toBe(true);
+
+  /* Past the deadline as measured from the stand-in: no notice, still pending. */
+  await act(async () => { await Bun.sleep(STALE_DEADLINE_MS + 300); });
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+  expect(host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`)).toBeNull();
+
+  /* The pinned payload lands and the link resolves. */
+  expect(await waitFor(() => host.querySelector(`[data-scheme-node="${TARGET_PATH}"]`) !== null, 3_000)).toBe(true);
+  expect(dom.localStorage.getItem("llvProject")).toBe(TARGET_PROJECT);
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+  await expectNavigationQuiescence();
+}, 20_000);
 
 test("legacy #f= to an archived predecessor transcript opens it the same way", async () => {
   dom.location.hash = `#f=${encodeURIComponent(TARGET_PATH)}`;

--- a/src/components/Viewer.switching.dom.test.tsx
+++ b/src/components/Viewer.switching.dom.test.tsx
@@ -1,0 +1,783 @@
+/**
+ * Switching profile and regression pins for issue #1432: switching between
+ * conversations and between projects must be smooth and fast, measured.
+ *
+ * The real Viewer mounts here under fake timers over an invented corpus of
+ * three conversation shapes (short, long, tool-heavy) in two projects (see
+ * `switchingFixtures`). Every step records three things:
+ *
+ *   - virtual ms: how much fake time had to pass before the milestone showed
+ *     (0 = it was on screen in the same synchronous flush as the gesture);
+ *   - real ms: wall time since the gesture, read from the OS clock through a
+ *     subprocess (every in-process clock is fake here) — nothing sleeps for
+ *     real, so this is the work React, the parser and the layout did;
+ *   - render counts: mounts and re-renders per component from the DevTools
+ *     commit hook, so a switch that rebuilds the dashboard or re-renders every
+ *     card is caught even when it is fast on this machine.
+ *
+ * The table is printed at the end so the same file produces the before and
+ * after rows of the PR profile.
+ */
+import { afterAll, afterEach, beforeEach, expect, jest, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import { installRenderProbe } from "@/test-helpers/renderProbe";
+import { appendedLine, fileEntryFor, switchingCorpus, transcriptText } from "@/test-helpers/switchingFixtures";
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
+import { en } from "@/lib/i18n/en";
+import type { FileEntry, LogChunk } from "@/lib/types";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+installActEnv();
+/* Before react-dom loads: the renderer reads the DevTools hook once. */
+const probe = installRenderProbe();
+
+const dom = new Window({ url: "http://localhost/" });
+let mobile = false;
+const matchMedia = (query: string) => ({
+  matches: mobile && (String(query).includes("max-width: 767px") || String(query).includes("pointer: coarse")),
+  media: String(query),
+  onchange: null,
+  addListener() {},
+  removeListener() {},
+  addEventListener() {},
+  removeEventListener() {},
+  dispatchEvent() { return false; },
+});
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  location: dom.location,
+  history: dom.history,
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Element: dom.Element,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+  TouchEvent: dom.TouchEvent,
+  MutationObserver: dom.MutationObserver,
+  /* The board camera reads its viewport size from the first ResizeObserver
+     callback; without one it fits the world into a 0×0 box, zooms out to the
+     floor and puts every pane to sleep (dormant), so no feed ever subscribes. */
+  ResizeObserver: class {
+    constructor(private readonly callback: (entries: Array<{ target: Element; contentRect: DOMRect }>) => void) {}
+    observe(target: Element) { this.callback([{ target, contentRect: target.getBoundingClientRect() }]); }
+    unobserve() {}
+    disconnect() {}
+  },
+  /* Every pane is on screen: BranchPane pauses the feed of a pane its observer
+     has not reported visible, so the double answers "intersecting" at once. */
+  IntersectionObserver: class {
+    constructor(private readonly callback: (entries: Array<{ isIntersecting: boolean }>) => void) {}
+    observe() { this.callback([{ isIntersecting: true }]); }
+    unobserve() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  },
+  requestAnimationFrame: (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  matchMedia,
+});
+Object.assign(dom, { matchMedia });
+(dom.HTMLElement.prototype as unknown as { animate: () => unknown }).animate = () => ({ cancel() {}, addEventListener() {} });
+(dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+/* happy-dom lays nothing out: every rect is 0×0. The board viewport is the one
+   element whose size decides behaviour (the camera's fit and the dormant
+   threshold), so it alone reports a desktop-sized box. */
+const BOARD_RECT = { x: 0, y: 0, left: 0, top: 0, right: 1200, bottom: 800, width: 1200, height: 800, toJSON() {} };
+const elementPrototype = dom.HTMLElement.prototype as unknown as { getBoundingClientRect(this: HTMLElement): unknown };
+const realRect = elementPrototype.getBoundingClientRect;
+elementPrototype.getBoundingClientRect = function (this: HTMLElement) {
+  if ((this.getAttribute("aria-label") ?? "").startsWith("Agent board")) return BOARD_RECT;
+  return realRect.call(this);
+};
+
+mock.module("@/hooks/runtimeBus", () => ({
+  SNAPSHOT_URL: "/api/runtime/snapshot",
+  STREAM_URL: "/api/runtime/stream",
+  STREAM_RECONNECTED_EVENT: "llv:stream-reconnected",
+  isRuntimeUiEnabled: () => false,
+  getRuntimeBus: () => ({
+    getState: () => ({ connection: "offline" }),
+    subscribe: () => () => {},
+    subscribeFilesRevision: () => () => {},
+  }),
+}));
+
+const { act } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { Viewer } = await import("./Viewer");
+const { resetFilesClientCacheForTests } = await import("@/hooks/useFiles");
+const { resetLogTailCacheForTests } = await import("@/hooks/useLogTail");
+const { resetFeedSessionPoolForTests } = await import("./feed/sessionPool");
+const { resetPendingOpensForTest, resetSelectionSessionsForTest } = await import("@/hooks/useBoardState");
+const { OPEN_KEY } = await import("./orchestrator/OrchestratorDock");
+
+/* ── corpus ─────────────────────────────────────────────────────────────── */
+
+const corpus = switchingCorpus();
+const byShape = (project: string, shape: string) => corpus.find((entry) => entry.project === project && entry.shape === shape)!;
+const SHORT = byShape("alpha", "short");
+const LONG = byShape("alpha", "long");
+const TOOLS = byShape("alpha", "toolheavy");
+const BETA_A = byShape("beta", "short");
+const BETA_B = byShape("beta", "long");
+/* Beyond the capped feed: served only to a pinned request, the way a deep link
+   to an old conversation reaches the client. */
+const GAMMA = { ...byShape("alpha", "short"), conversationId: "conv-alpha-gamma", path: "/sessions/alpha/gamma.jsonl", title: "Gamma archive" };
+
+/** Live transcript bytes per path; a pushed tail record appends here. */
+let transcripts = new Map<string, string>();
+const bytes = (text: string) => new TextEncoder().encode(text).length;
+
+function seedTranscripts(): void {
+  transcripts = new Map([...corpus, GAMMA].map((entry) => [entry.path, transcriptText(entry.lines)]));
+}
+
+function tailChunk(path: string, offset: number): LogChunk | null {
+  const text = transcripts.get(path) ?? "";
+  const size = bytes(text);
+  if (offset >= size) return null;
+  return { data: text.slice(offset), offset: size, size, start: offset };
+}
+
+let appended = 0;
+function appendRecord(path: string, project: string): void {
+  appended += 1;
+  transcripts.set(path, (transcripts.get(path) ?? "") + appendedLine(project, 5_000 + appended, String(appended)) + "\n");
+}
+
+function allFiles(): FileEntry[] {
+  return [
+    fileEntryFor(SHORT),
+    /* The long conversation continues the short one: its card carries the
+       lineage chip, which is one of the `#c=` deep links the addendum names. */
+    fileEntryFor(LONG, { continues: { conversationId: SHORT.conversationId, path: SHORT.path, round: 1 } }),
+    fileEntryFor(TOOLS),
+    fileEntryFor(BETA_A),
+    /* A cross-project link: a beta card that continues the alpha tool run. */
+    fileEntryFor(BETA_B, { continues: { conversationId: TOOLS.conversationId, path: TOOLS.path, round: 2 } }),
+  ];
+}
+
+const projectCatalog = [
+  { project: "alpha", smt: 4_102_488_000, conversations: 4 },
+  { project: "beta", smt: 4_102_487_000, conversations: 2 },
+];
+
+/* ── transport doubles ──────────────────────────────────────────────────── */
+
+/** Server-side latency the fake transport charges every response. */
+const RTT_MS = 20;
+/** The log bus reconnects its stream on a short window for a subscriber that
+    arrives on a settled stream (a switch), the long one for churn. */
+const PROMPT_RECONNECT_MS = 40;
+
+let boards: Record<string, BoardProjectStateV1> = {};
+const emptyBoard = (): BoardProjectStateV1 => ({
+  schemaVersion: 1,
+  revision: 0,
+  updatedAt: new Date(0).toISOString(),
+  pathAliases: {},
+  prefs: { manual: [], hidden: [], expanded: [], favorites: [], foldedEngineChildIds: [], expandedEngineTrayParentIds: [], viewMode: null, taskPanelOpen: false },
+});
+function seededBoard(manual: string[]): BoardProjectStateV1 {
+  return { ...emptyBoard(), revision: 1, explicitManual: manual, prefs: { ...emptyBoard().prefs, manual } };
+}
+
+const requests: string[] = [];
+const delayed = <T,>(value: T): Promise<T> => new Promise((resolve) => setTimeout(() => resolve(value), RTT_MS));
+
+globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+  const url = String(input);
+  requests.push(url);
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (url.startsWith("/api/files")) {
+    const pin = new URL(url, "http://localhost").searchParams.get("path") ?? "";
+    const files = pin === GAMMA.conversationId || pin === GAMMA.path ? [...allFiles(), fileEntryFor(GAMMA)] : allFiles();
+    return delayed(Response.json({ files, projectCatalog, flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: { tmux: { status: "healthy" } } }));
+  }
+  if (url.startsWith("/api/board")) {
+    if (method === "GET") {
+      const project = new URL(url, "http://localhost").searchParams.get("project") ?? "";
+      return delayed(Response.json({ ok: true, board: boards[project] ?? emptyBoard() }));
+    }
+    const body = JSON.parse(String(init?.body)) as { project: string; mutations?: BoardMutationV1[] };
+    const current = boards[body.project] ?? emptyBoard();
+    const reduced = applyBoardMutations(current, body.mutations ?? []);
+    const next = { ...reduced, schemaVersion: 1 as const, revision: current.revision + 1, updatedAt: new Date(0).toISOString(), pathAliases: reduced.pathAliases ?? {} };
+    boards[body.project] = next;
+    return delayed(Response.json({ ok: true, applied: true, board: next }));
+  }
+  if (url === "/api/logs" && method === "POST") {
+    const { reqs } = JSON.parse(String(init?.body)) as { reqs: Array<{ id: string; path: string; offset: number }> };
+    const chunks: Record<string, LogChunk> = {};
+    for (const req of reqs) {
+      const size = bytes(transcripts.get(req.path) ?? "");
+      chunks[req.id] = tailChunk(req.path, req.offset) ?? { data: "", offset: size, size, start: req.offset };
+    }
+    return delayed(Response.json({ chunks }));
+  }
+  if (url.startsWith("/api/log?")) return delayed(Response.json({ data: "", offset: 0, start: 0, size: 0 }));
+  return delayed(new Response("not found", { status: 404 }));
+}) as unknown as typeof fetch;
+
+/**
+ * The tail stream as the browser sees it: one EventSource per subscription
+ * set, answering each subscription from its offset after RTT_MS, and pushing
+ * whatever `appendRecord` added when the test says the tail moved.
+ */
+class FakeEventSource {
+  static open: FakeEventSource[] = [];
+  static connects = 0;
+  private listeners = new Map<string, Set<(event: { data: string }) => void>>();
+  private closed = false;
+  readonly subs: Array<{ id: string; path: string; offset: number }>;
+  onerror: (() => void) | null = null;
+  constructor(url: string) {
+    FakeEventSource.connects += 1;
+    this.subs = JSON.parse(new URL(url, "http://localhost").searchParams.get("subs") ?? "[]") as FakeEventSource["subs"];
+    FakeEventSource.open.push(this);
+    setTimeout(() => {
+      if (this.closed) return;
+      for (const sub of this.subs) this.deliver(sub);
+    }, RTT_MS);
+  }
+  addEventListener(type: string, listener: (event: { data: string }) => void): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+  removeEventListener(type: string, listener: (event: { data: string }) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+  close(): void {
+    this.closed = true;
+    FakeEventSource.open = FakeEventSource.open.filter((source) => source !== this);
+  }
+  private deliver(sub: { id: string; path: string; offset: number }): void {
+    const chunk = tailChunk(sub.path, sub.offset);
+    if (!chunk) return;
+    sub.offset = chunk.offset;
+    for (const listener of this.listeners.get("chunk") ?? []) listener({ data: JSON.stringify({ id: sub.id, chunk }) });
+  }
+  /** The tail of `path` grew: every open subscription for it gets the delta after RTT_MS. */
+  static push(path: string): void {
+    for (const source of [...FakeEventSource.open]) {
+      for (const sub of source.subs) {
+        if (sub.path !== path) continue;
+        setTimeout(() => { if (!source.closed) source.deliver(sub); }, RTT_MS);
+      }
+    }
+  }
+}
+(globalThis as { EventSource?: unknown }).EventSource = FakeEventSource;
+
+/* ── clock, settling, measurement ───────────────────────────────────────── */
+
+/* Under bun's fake timers EVERY in-process clock — Date, performance,
+   process.hrtime, Bun.nanoseconds — advances only with the fake time, so real
+   CPU cost is unmeasurable from JS. A subprocess reads the OS clock (~1 ms per
+   read); it is read once at the start of a step and once at each milestone,
+   never inside the settle loop. Nothing here sleeps for real, so the elapsed
+   real time of a step is the work React, the parser and the layout did. */
+function realNowMs(): number {
+  return Number(Buffer.from(Bun.spawnSync(["date", "+%s%N"]).stdout).toString().trim()) / 1e6;
+}
+let stepStartedAt = realNowMs();
+/** Start a measured step: render counts and the real clock both restart. */
+function beginStep(): void {
+  probe.reset();
+  stepStartedAt = realNowMs();
+}
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let round = 0; round < 12; round += 1) await Promise.resolve();
+  });
+}
+/** Let `ms` of fake time pass, then settle. */
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+    for (let round = 0; round < 12; round += 1) await Promise.resolve();
+  });
+  await flush();
+}
+
+interface Milestone {
+  virtualMs: number;
+  /** Real milliseconds since `beginStep`, cumulative within the step. */
+  workMs: number;
+}
+let currentHost: HTMLElement | null = null;
+/** What the harness can see when a milestone never arrives. */
+function describeHost(): string {
+  const host = currentHost;
+  if (!host) return "no host";
+  const nodes = Array.from(host.querySelectorAll("[data-scheme-node]")).map((element) => element.getAttribute("data-scheme-node"));
+  const tails = Array.from(host.querySelectorAll("[data-tail-line-count]")).map((element) => element.getAttribute("data-tail-line-count"));
+  return [
+    `nodes=${JSON.stringify(nodes)}`,
+    `skeleton=${host.querySelector('[role="status"][aria-busy="true"]') !== null}`,
+    `feedRows=${host.querySelectorAll("[data-feed-kind]").length}`,
+    `tailLineCounts=${JSON.stringify(tails)}`,
+    `streams=${FakeEventSource.connects} open=${FakeEventSource.open.length}`,
+    `requests=${JSON.stringify(requests.slice(-8))}`,
+    `text=${(host.textContent ?? "").slice(0, 300)}`,
+  ].join("\n");
+}
+
+/** Fake ms (in 5 ms steps) until `check` holds; throws after `maxMs`. */
+async function until(check: () => boolean, maxMs = 5_000): Promise<Milestone> {
+  await flush();
+  let virtualMs = 0;
+  while (!check()) {
+    if (virtualMs >= maxMs) throw new Error(`milestone not reached within ${maxMs} virtual ms\n${describeHost()}`);
+    await advance(5);
+    virtualMs += 5;
+  }
+  return { virtualMs, workMs: realNowMs() - stepStartedAt };
+}
+
+interface Row {
+  surface: string;
+  step: string;
+  virtualMs: number | string;
+  workMs: number | string;
+  renders: string;
+}
+const rows: Row[] = [];
+const record = (surface: string, step: string, milestone: Milestone, renders = ""): void => {
+  rows.push({ surface, step, virtualMs: milestone.virtualMs, workMs: Math.round(milestone.workMs), renders });
+};
+
+afterAll(() => {
+  const header = "| surface | step | fake ms until on screen | real ms since gesture | renders / mounts |\n|---|---|---:|---:|---|";
+  const body = rows.map((row) => `| ${row.surface} | ${row.step} | ${row.virtualMs} | ${row.workMs} | ${row.renders} |`).join("\n");
+  console.log(`\n#1432 switching profile (bun DOM, fake timers)\n${header}\n${body}\n`);
+  probe.uninstall();
+});
+
+/* ── harness ────────────────────────────────────────────────────────────── */
+
+let mounted: { unmount: () => void } | null = null;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mobile = false;
+  seedTranscripts();
+  appended = 0;
+  requests.length = 0;
+  FakeEventSource.open = [];
+  FakeEventSource.connects = 0;
+  boards = {
+    alpha: seededBoard([SHORT.path, LONG.path, TOOLS.path]),
+    beta: seededBoard([BETA_A.path, BETA_B.path]),
+  };
+  dom.localStorage.clear();
+  dom.sessionStorage.clear();
+  dom.location.hash = "";
+  document.body.replaceChildren();
+  resetFilesClientCacheForTests();
+  resetLogTailCacheForTests();
+  resetFeedSessionPoolForTests();
+  resetPendingOpensForTest();
+  resetSelectionSessionsForTest();
+  beginStep();
+});
+
+afterEach(() => {
+  if (mounted) {
+    const root = mounted;
+    mounted = null;
+    act(() => { root.unmount(); });
+  }
+  document.body.replaceChildren();
+  dom.location.hash = "";
+  /* happy-dom delivers hashchange on a window timer. Under fake timers that
+     timer only fires when advanced; leaving it pending across useRealTimers
+     wedges every later hashchange in this process, so drain it now with no
+     listeners left. */
+  jest.advanceTimersByTime(50);
+  jest.useRealTimers();
+});
+
+async function mountViewer(project: string): Promise<HTMLElement> {
+  dom.localStorage.setItem("llvProject", project);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted = root;
+  await act(async () => { root.render(<Viewer />); });
+  await flush();
+  currentHost = host as unknown as HTMLElement;
+  return currentHost;
+}
+
+const node = (host: HTMLElement, path: string) => host.querySelector(`[data-scheme-node="${path}"]`);
+const ringed = (host: HTMLElement, path: string) => (node(host, path)?.querySelector(":scope > .ring-2") ?? null) !== null;
+/* A conversation pane on either surface: the board card's section and the
+   phone's focused pane both carry the transcript path as their link target. */
+const pane = (host: HTMLElement, path: string) => host.querySelector(`[data-link-path="${path}"]`);
+const feedRows = (host: HTMLElement, path: string) => pane(host, path)?.querySelectorAll("[data-feed-kind]").length ?? 0;
+const tailLines = (scope: Element | null) => Number(scope?.querySelector("[data-tail-line-count]")?.getAttribute("data-tail-line-count") ?? "0");
+const skeleton = (host: HTMLElement) => host.querySelector('[role="status"][aria-busy="true"]') !== null;
+const railButton = (host: HTMLElement, label: string) =>
+  Array.from(host.querySelectorAll("button")).find((button) => (button.textContent ?? "").trim().startsWith(label)) as HTMLButtonElement | undefined;
+const currentRail = (host: HTMLElement) => (host.querySelector('button[aria-current="page"]')?.textContent ?? "").trim();
+
+function dispatch(target: EventTarget, event: unknown): boolean {
+  return target.dispatchEvent(event as Event);
+}
+async function click(element: Element): Promise<void> {
+  await act(async () => {
+    dispatch(element, new dom.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+async function keydown(key: string): Promise<void> {
+  await act(async () => {
+    dispatch(window, new dom.KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+}
+/** A browser's default action on an in-document `#…` link: change the hash,
+    unless the click was handled in-app. */
+async function clickAnchor(anchor: HTMLAnchorElement): Promise<{ handledInApp: boolean }> {
+  let handledInApp = false;
+  await act(async () => {
+    const event = new dom.MouseEvent("click", { bubbles: true, cancelable: true });
+    const notPrevented = dispatch(anchor, event);
+    handledInApp = !notPrevented;
+    const href = anchor.getAttribute("href") ?? "";
+    if (notPrevented && href.startsWith("#") && dom.location.hash !== href) dom.location.hash = href;
+  });
+  return { handledInApp };
+}
+
+/** Whether the cold feeds of every path have painted: rows in each card. */
+const painted = (host: HTMLElement, paths: string[]) => paths.every((path) => feedRows(host, path) > 0);
+
+async function mountAlphaDesktop(): Promise<{ host: HTMLElement; paint: Milestone }> {
+  const host = await mountViewer("alpha");
+  const paint = await until(() => painted(host, [SHORT.path, LONG.path, TOOLS.path]));
+  return { host, paint };
+}
+
+/* ── desktop ────────────────────────────────────────────────────────────── */
+
+test("desktop: an in-app «Open conversation» link focuses the card without rebuilding the board", async () => {
+  dom.localStorage.setItem(`${OPEN_KEY}:alpha`, "1");
+  const { host, paint } = await mountAlphaDesktop();
+  const boot = probe.snapshot();
+  expect(boot.mounts.ProjectDashboardView ?? 0).toBe(1);
+  expect(boot.mounts.OrchestratorDock ?? 0).toBe(1);
+  expect(boot.mounts.OrchestratorPanel ?? 0).toBe(1);
+  record("desktop", "mount → three cards painted (cold)", paint, `NodeShell mounts ${boot.mounts.NodeShell ?? 0}, LogFeed renders ${boot.renders.LogFeed ?? 0}`);
+
+  /* The lineage chip on the long card deep-links the short one. */
+  const chip = node(host, LONG.path)?.querySelector("a[data-continues-chip]") as HTMLAnchorElement | null;
+  expect(chip).not.toBeNull();
+  beginStep();
+  let sawSkeleton = false;
+  const { handledInApp } = await clickAnchor(chip!);
+  sawSkeleton ||= skeleton(host);
+  const highlight = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return ringed(host, SHORT.path);
+  });
+  const after = probe.snapshot();
+  const otherFeedRenders = [LONG.path, TOOLS.path].reduce((sum, path) => sum + probe.rendersFor("LogFeed", path), 0);
+  record("desktop", "«Open conversation» link → target ringed", highlight,
+    `in-app ${handledInApp ? "yes" : "no (hash navigation)"}; skeleton ${sawSkeleton ? "shown" : "never"}; dashboard mounts +${after.mounts.ProjectDashboardView ?? 0}; dock mounts +${after.mounts.OrchestratorDock ?? 0}; orchestrator panel mounts +${after.mounts.OrchestratorPanel ?? 0}; NodeShell mounts +${after.mounts.NodeShell ?? 0}; other cards' LogFeed renders ${otherFeedRenders}; /api/files requests ${requests.filter((url) => url.startsWith("/api/files")).length}`);
+
+  /* Issue #1432 acceptance: no dashboard remount, no orchestrator panel
+     reload, no card rebuild, and the highlight lands in the same flush. */
+  expect(handledInApp).toBe(true);
+  expect(sawSkeleton).toBe(false);
+  expect(after.mounts.ProjectDashboardView ?? 0).toBe(0);
+  expect(after.mounts.OrchestratorDock ?? 0).toBe(0);
+  expect(after.mounts.OrchestratorPanel ?? 0).toBe(0);
+  expect(after.mounts.NodeShell ?? 0).toBe(0);
+  expect(highlight.virtualMs).toBe(0);
+  /* The URL still carries the deep link, so reload and share keep working. */
+  expect(dom.location.hash).toBe(`#c=${encodeURIComponent(SHORT.conversationId)}`);
+  /* Focusing one card must not re-render the feeds of the others. */
+  expect(otherFeedRenders).toBe(0);
+});
+
+test("desktop: a cross-project link switches the project, then focuses — from the last known catalog", async () => {
+  const { host } = await mountAlphaDesktop();
+  /* A focus has already happened in this session: the lineage chip on the
+     long card ringed the short one. The cross-project open below must still
+     move, which it did not while the request nonce restarted after the
+     project switch cleared the request (the real-browser profile's sequence). */
+  await clickAnchor(node(host, LONG.path)?.querySelector("a[data-continues-chip]") as HTMLAnchorElement);
+  await until(() => ringed(host, SHORT.path));
+  /* Visit beta once so its board is known, then come back. */
+  await click(railButton(host, "beta")!);
+  await until(() => painted(host, [BETA_A.path, BETA_B.path]));
+  beginStep();
+  const filesBefore = requests.filter((url) => url.startsWith("/api/files")).length;
+
+  const chip = node(host, BETA_B.path)?.querySelector("a[data-continues-chip]") as HTMLAnchorElement | null;
+  expect(chip).not.toBeNull();
+  let sawSkeleton = false;
+  const { handledInApp } = await clickAnchor(chip!);
+  const switched = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return currentRail(host).startsWith("alpha");
+  });
+  const boardPaint = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return painted(host, [SHORT.path, LONG.path, TOOLS.path]);
+  });
+  const highlight = await until(() => ringed(host, TOOLS.path));
+  const after = probe.snapshot();
+  record("desktop", "cross-project link → rail switched", switched, `in-app ${handledInApp ? "yes" : "no"}`);
+  record("desktop", "cross-project link → alpha cards painted from cache", { virtualMs: switched.virtualMs + boardPaint.virtualMs, workMs: boardPaint.workMs }, `skeleton ${sawSkeleton ? "shown" : "never"}; dashboard mounts +${after.mounts.ProjectDashboardView ?? 0}; LogFeed renders ${after.renders.LogFeed ?? 0}; /api/files requests +${requests.filter((url) => url.startsWith("/api/files")).length - filesBefore}`);
+  record("desktop", "cross-project link → target ringed", { virtualMs: switched.virtualMs + boardPaint.virtualMs + highlight.virtualMs, workMs: highlight.workMs });
+
+  expect(handledInApp).toBe(true);
+  expect(sawSkeleton).toBe(false);
+  expect(after.mounts.ProjectDashboardView ?? 0).toBe(0);
+  expect(switched.virtualMs).toBe(0);
+  expect(boardPaint.virtualMs).toBe(0);
+  expect(dom.location.hash).toBe(`#c=${encodeURIComponent(TOOLS.conversationId)}`);
+});
+
+test("desktop: a project switch paints the revisited board synchronously and never remounts the dashboard", async () => {
+  const { host } = await mountAlphaDesktop();
+  beginStep();
+
+  /* First visit: the board GET is the only thing that can gate the paint. */
+  let sawSkeleton = false;
+  await click(railButton(host, "beta")!);
+  const railFirst = await until(() => currentRail(host).startsWith("beta"));
+  const firstPaint = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return painted(host, [BETA_A.path, BETA_B.path]);
+  });
+  const firstVisit = probe.snapshot();
+  record("desktop", "project switch (first visit) → rail highlight", railFirst);
+  record("desktop", "project switch (first visit) → cards painted (cold)", firstPaint, `skeleton ${sawSkeleton ? "shown while /api/board loads" : "never"}; dashboard mounts +${firstVisit.mounts.ProjectDashboardView ?? 0}; NodeShell mounts ${firstVisit.mounts.NodeShell ?? 0}`);
+
+  /* Revisit: everything is known — the board, the tails, the parsed feeds. */
+  beginStep();
+  sawSkeleton = false;
+  await click(railButton(host, "alpha")!);
+  const railBack = await until(() => currentRail(host).startsWith("alpha"));
+  const revisitPaint = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return painted(host, [SHORT.path, LONG.path, TOOLS.path]);
+  });
+  const revisit = probe.snapshot();
+  record("desktop", "project switch (revisit) → rail highlight", railBack);
+  record("desktop", "project switch (revisit) → cards painted from cache", revisitPaint, `skeleton ${sawSkeleton ? "shown" : "never"}; dashboard mounts +${revisit.mounts.ProjectDashboardView ?? 0}; NodeShell mounts ${revisit.mounts.NodeShell ?? 0}; LogFeed renders ${revisit.renders.LogFeed ?? 0}`);
+  /* A fresh catalog does not gate any of this: the files feed is global. */
+  const catalogRequests = requests.filter((url) => url.startsWith("/api/files")).length;
+
+  expect(railFirst.virtualMs).toBe(0);
+  expect(railBack.virtualMs).toBe(0);
+  expect(firstVisit.mounts.ProjectDashboardView ?? 0).toBe(0);
+  expect(revisit.mounts.ProjectDashboardView ?? 0).toBe(0);
+  expect(sawSkeleton).toBe(false);
+  expect(revisitPaint.virtualMs).toBe(0);
+  expect(catalogRequests).toBe(1);
+});
+
+test("desktop: moving the focus between cards re-renders only the cards whose ring changed", async () => {
+  const { host } = await mountAlphaDesktop();
+  /* First move through the in-app link channel (the long card's chip focuses
+     the short one), second move by clicking another card on the board. Both
+     are gestures the board answers without a network round trip. */
+  const chip = node(host, LONG.path)?.querySelector("a[data-continues-chip]") as HTMLAnchorElement;
+  await clickAnchor(chip);
+  await until(() => ringed(host, SHORT.path));
+  beginStep();
+  /* Second move: the switchboard-style select of another card on the board. */
+  const toolsCard = node(host, TOOLS.path)!;
+  await act(async () => {
+    dispatch(toolsCard, new dom.MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    dispatch(toolsCard, new dom.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+  const after = probe.snapshot();
+  record("desktop", "focus moves short → tool-heavy (click on card)", { virtualMs: 0, workMs: realNowMs() - stepStartedAt },
+    `NodeShell renders ${after.renders.NodeShell ?? 0} (${Object.entries(after.byPath).filter(([key]) => key.startsWith("NodeShell:")).length} cards); LogFeed renders ${after.renders.LogFeed ?? 0}; BranchPane renders ${after.renders.BranchPane ?? 0}; dashboard renders ${after.renders.ProjectDashboardView ?? 0}`);
+  /* The long card is neither the previous nor the new focus: nothing about it
+     changed on screen, so it must not have rendered. */
+  expect(probe.rendersFor("NodeShell", LONG.path)).toBe(0);
+  expect(probe.rendersFor("LogFeed", LONG.path)).toBe(0);
+});
+
+test("desktop: a fresh tail record on one card leaves the other cards' panes untouched", async () => {
+  const { host } = await mountAlphaDesktop();
+  const rowsBefore = feedRows(host, SHORT.path);
+  const firstRow = pane(host, SHORT.path)!.querySelector("[data-feed-key]");
+  beginStep();
+  appendRecord(SHORT.path, "alpha");
+  FakeEventSource.push(SHORT.path);
+  const fresh = await until(() => feedRows(host, SHORT.path) > rowsBefore);
+  const after = probe.snapshot();
+  const otherFeedRenders = [LONG.path, TOOLS.path].reduce((sum, path) => sum + probe.rendersFor("LogFeed", path), 0);
+  record("desktop", "fresh tail record → appended to the short card", fresh,
+    `LogFeed renders ${after.renders.LogFeed ?? 0}; other cards' LogFeed renders ${otherFeedRenders}; NodeShell renders ${after.renders.NodeShell ?? 0}; first row node preserved ${pane(host, SHORT.path)!.querySelector("[data-feed-key]") === firstRow ? "yes" : "no"}`);
+  expect(fresh.virtualMs).toBeLessThanOrEqual(PROMPT_RECONNECT_MS + RTT_MS + 5);
+  expect(pane(host, SHORT.path)!.querySelector("[data-feed-key]")).toBe(firstRow);
+  expect(otherFeedRenders).toBe(0);
+});
+
+test("desktop: an Arrow key moves the ring to the neighbour card and re-renders nothing else", async () => {
+  const { host } = await mountAlphaDesktop();
+  const shortCard = node(host, SHORT.path)!;
+  await act(async () => {
+    dispatch(shortCard, new dom.MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    dispatch(shortCard, new dom.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await until(() => ringed(host, SHORT.path));
+  beginStep();
+  await keydown("ArrowRight");
+  const moved = await until(() => !ringed(host, SHORT.path) && [LONG.path, TOOLS.path].some((path) => ringed(host, path)));
+  const after = probe.snapshot();
+  const target = [LONG.path, TOOLS.path].find((path) => ringed(host, path))!;
+  const untouched = [LONG.path, TOOLS.path].find((path) => path !== target)!;
+  record("desktop", "ArrowRight → ring moves to the neighbour card", moved,
+    `NodeShell renders ${after.renders.NodeShell ?? 0}; LogFeed renders ${after.renders.LogFeed ?? 0}; untouched card NodeShell renders ${probe.rendersFor("NodeShell", untouched)}; dashboard renders ${after.renders.ProjectDashboardView ?? 0}`);
+  expect(moved.virtualMs).toBe(0);
+  expect(probe.rendersFor("NodeShell", untouched)).toBe(0);
+  expect(probe.rendersFor("LogFeed", untouched)).toBe(0);
+});
+
+test("desktop: a cold deep link from the URL still resolves a beyond-cap conversation", async () => {
+  dom.location.hash = `#c=${encodeURIComponent(GAMMA.conversationId)}`;
+  const host = await mountViewer("beta");
+  const resolved = await until(() => node(host, GAMMA.path) !== null);
+  record("desktop", "cold URL deep link (beyond cap) → card on board", resolved, `/api/files requests ${requests.filter((url) => url.startsWith("/api/files")).length}`);
+  expect(currentRail(host).startsWith("alpha")).toBe(true);
+  expect(dom.location.hash).toBe(`#c=${encodeURIComponent(GAMMA.conversationId)}`);
+  expect(host.querySelector("[data-stale-focus-notice]")).toBeNull();
+});
+
+/* ── phone (390px) ──────────────────────────────────────────────────────── */
+
+const focusedPane = (host: HTMLElement) => host.querySelector('[data-testid="mobile-focused-pane"]');
+const focusedTitle = (host: HTMLElement) => focusedPane(host)?.querySelector("header")?.textContent ?? "";
+const chipFor = (host: HTMLElement, title: string) => host.querySelector(`button[title="${title}"]`) as HTMLButtonElement | null;
+const chipActive = (host: HTMLElement, title: string) => chipFor(host, title)?.className.includes("border-accent/60") ?? false;
+
+function swipe(header: HTMLElement, dx: number): void {
+  const start = { clientX: 200, clientY: 40 };
+  const end = { clientX: 200 + dx, clientY: 40 };
+  dispatch(header, new dom.TouchEvent("touchstart", { bubbles: true, touches: [start] } as never));
+  dispatch(header, new dom.TouchEvent("touchend", { bubbles: true, changedTouches: [end] } as never));
+}
+
+test("phone: A → B → A shows A's previous rows synchronously, then the fresh tail lands without a flash", async () => {
+  mobile = true;
+  const host = await mountViewer("alpha");
+  const firstPane = await until(() => focusedPane(host) !== null && tailLines(focusedPane(host)) > 0);
+  const firstTitle = focusedTitle(host);
+  record("phone", `mount → focused pane (${firstTitle.includes("Tool") ? "tool-heavy" : firstTitle.includes("Long") ? "long" : "short"}) painted (cold)`, firstPane);
+
+  /* A: the short conversation. Cold unless the first pane already was it. */
+  beginStep();
+  await click(chipFor(host, SHORT.title)!);
+  const aChip = await until(() => chipActive(host, SHORT.title));
+  const aRows = await until(() => focusedTitle(host).includes(SHORT.title) && tailLines(focusedPane(host)) === SHORT.lines.length);
+  record("phone", "tap chip A (cold) → chip highlighted", aChip);
+  record("phone", "tap chip A (cold) → A rows painted", { virtualMs: aChip.virtualMs + aRows.virtualMs, workMs: aRows.workMs }, `LogFeed renders ${probe.renders("LogFeed")}`);
+
+  /* B: the long conversation, cold. */
+  beginStep();
+  await click(chipFor(host, LONG.title)!);
+  const bChip = await until(() => chipActive(host, LONG.title));
+  const bRows = await until(() => focusedTitle(host).includes(LONG.title) && tailLines(focusedPane(host)) === LONG.lines.length);
+  record("phone", "tap chip B (cold, long) → chip highlighted", bChip);
+  record("phone", "tap chip B (cold, long) → B rows painted", { virtualMs: bChip.virtualMs + bRows.virtualMs, workMs: bRows.workMs }, `LogFeed renders ${probe.renders("LogFeed")}`);
+
+  /* Back to A: cached. The rows must be there in the same flush as the tap. */
+  beginStep();
+  await click(chipFor(host, SHORT.title)!);
+  const backChip = await until(() => chipActive(host, SHORT.title));
+  const cachedRows = await until(() => focusedTitle(host).includes(SHORT.title) && feedRows(host, SHORT.path) > 0);
+  const cached = probe.snapshot();
+  record("phone", "tap chip A again (cached) → chip highlighted", backChip);
+  record("phone", "tap chip A again (cached) → A's previous rows on screen", { virtualMs: backChip.virtualMs + cachedRows.virtualMs, workMs: cachedRows.workMs }, `LogFeed renders ${cached.renders.LogFeed ?? 0}; MobileFocusView mounts +${cached.mounts.MobileFocusView ?? 0}; dashboard mounts +${cached.mounts.ProjectDashboardView ?? 0}`);
+  expect(backChip.virtualMs).toBe(0);
+  expect(cachedRows.virtualMs).toBe(0);
+  expect(cached.mounts.ProjectDashboardView ?? 0).toBe(0);
+  expect(cached.mounts.MobileFocusView ?? 0).toBe(0);
+  expect(feedRows(host, SHORT.path)).toBeGreaterThan(0);
+
+  /* The tail moves: the new record appends; the rows already on screen keep
+     their DOM nodes (no flash, no remount). */
+  const firstRow = focusedPane(host)!.querySelector("[data-feed-key]");
+  const rowsBefore = feedRows(host, SHORT.path);
+  beginStep();
+  appendRecord(SHORT.path, "alpha");
+  FakeEventSource.push(SHORT.path);
+  const fresh = await until(() => feedRows(host, SHORT.path) > rowsBefore);
+  record("phone", "fresh tail record → appended to A", fresh, `first row node preserved ${focusedPane(host)!.querySelector("[data-feed-key]") === firstRow ? "yes" : "no"}`);
+  expect(focusedPane(host)!.querySelector("[data-feed-key]")).toBe(firstRow);
+  expect(fresh.virtualMs).toBeLessThanOrEqual(PROMPT_RECONNECT_MS + RTT_MS + 5);
+});
+
+test("phone: the header swipe hops panes with the same cached paint", async () => {
+  mobile = true;
+  const host = await mountViewer("alpha");
+  await until(() => focusedPane(host) !== null && tailLines(focusedPane(host)) > 0);
+  /* Visit both neighbours once so their feeds are cached. */
+  await click(chipFor(host, SHORT.title)!);
+  await until(() => focusedTitle(host).includes(SHORT.title) && tailLines(focusedPane(host)) > 0);
+  await click(chipFor(host, LONG.title)!);
+  await until(() => focusedTitle(host).includes(LONG.title) && tailLines(focusedPane(host)) > 0);
+  await click(chipFor(host, TOOLS.title)!);
+  await until(() => focusedTitle(host).includes(TOOLS.title) && tailLines(focusedPane(host)) > 0);
+  /* Strip order is layout order; a swipe hops to the neighbour. */
+  const chips = Array.from(host.querySelectorAll('button[title]')).map((button) => button.getAttribute("title") ?? "").filter((title) => [SHORT.title, LONG.title, TOOLS.title].includes(title));
+  const index = chips.indexOf(TOOLS.title);
+  const target = index > 0 ? chips[index - 1]! : chips[index + 1]!;
+  const dx = index > 0 ? 120 : -120;
+
+  beginStep();
+  await act(async () => { swipe(focusedPane(host)!.querySelector("header") as HTMLElement, dx); });
+  const hop = await until(() => focusedTitle(host).includes(target) && chipActive(host, target));
+  const rowsOnScreen = await until(() => feedRows(host, byShape("alpha", target === SHORT.title ? "short" : target === LONG.title ? "long" : "toolheavy").path) > 0);
+  record("phone", "header swipe → neighbour pane highlighted", hop);
+  record("phone", "header swipe → neighbour rows (cached) on screen", { virtualMs: hop.virtualMs + rowsOnScreen.virtualMs, workMs: rowsOnScreen.workMs }, `LogFeed renders ${probe.renders("LogFeed")}`);
+  expect(hop.virtualMs).toBe(0);
+  expect(rowsOnScreen.virtualMs).toBe(0);
+});
+
+test("phone: switching project through the drawer paints the revisited board from cache", async () => {
+  mobile = true;
+  const host = await mountViewer("alpha");
+  await until(() => focusedPane(host) !== null && tailLines(focusedPane(host)) > 0);
+  const openDrawer = () => host.querySelector(`button[aria-label="${en["dash.openProjects"]}"]`) as HTMLButtonElement;
+
+  await click(openDrawer());
+  await click(railButton(host, "beta")!);
+  await until(() => focusedPane(host) !== null && focusedTitle(host).includes("Beta") && tailLines(focusedPane(host)) > 0);
+
+  beginStep();
+  let sawSkeleton = false;
+  await click(openDrawer());
+  await click(railButton(host, "alpha")!);
+  const paint = await until(() => {
+    sawSkeleton ||= skeleton(host);
+    return focusedPane(host) !== null && !focusedTitle(host).includes("Beta") && feedRows(host, SHORT.path) + feedRows(host, LONG.path) + feedRows(host, TOOLS.path) > 0;
+  });
+  const after = probe.snapshot();
+  record("phone", "drawer project switch (revisit) → focused pane painted from cache", paint, `skeleton ${sawSkeleton ? "shown" : "never"}; dashboard mounts +${after.mounts.ProjectDashboardView ?? 0}; MobileFocusView mounts +${after.mounts.MobileFocusView ?? 0}; BranchPane mounts ${after.mounts.BranchPane ?? 0}`);
+  expect(sawSkeleton).toBe(false);
+  expect(paint.virtualMs).toBe(0);
+  expect(after.mounts.ProjectDashboardView ?? 0).toBe(0);
+  /* Exactly one pane mounts: the remembered focus, not a wrong first guess
+     that is torn down a frame later. */
+  expect(after.mounts.BranchPane ?? 0).toBe(1);
+});

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -507,18 +507,22 @@ export function Viewer() {
      and from its own pinned request) must FAIL VISIBLY: sitting silently on the
      default view read as "the page just reloads and nothing opens". Same
      bounded deadline the Back/Forward replay uses; the countdown starts only
-     once a certified payload exists, and a resolution clearing `pendingHash`
-     cancels it. The popstate path arms its own identity-checked timer — for a
-     replayed entry both reach the same notice. */
+     once a payload certified for the pinned request scope exists, and a
+     resolution clearing `pendingHash` cancels it. The last-known stand-in
+     another scope lends while the pinned fetch is in flight (#1432) carries
+     `loaded` and says nothing about the target, so it must not start the
+     clock: a pinned fetch slower than the deadline would otherwise be reported
+     stale before it could answer. The popstate path arms its own
+     identity-checked timer — for a replayed entry both reach the same notice. */
   useEffect(() => {
-    if (!pendingHash || !loaded) return;
+    if (!pendingHash || !loaded || !scopeCertified) return;
     const timer = window.setTimeout(() => {
       setPendingHash(null);
       dispatchCatalogPin({ kind: "release" });
       setStaleFocusNotice(true);
     }, STALE_FOCUS_REPLAY_MS);
     return () => window.clearTimeout(timer);
-  }, [pendingHash, loaded]);
+  }, [pendingHash, loaded, scopeCertified]);
 
   const releaseCatalogFile = useCallback((path: string) => {
     dispatchCatalogPin({ kind: "release", path });

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -125,7 +125,7 @@ export function Viewer() {
   const [project, setProject] = useState<string>(OVERVIEW);
   const [pendingHash, setPendingHash] = useState<ConversationHash | null>(null);
   const [catalogPin, dispatchCatalogPin] = useReducer(reduceCatalogPin, null);
-  const { files: allFiles, requestScope, projectCatalog: polledProjectCatalog, projectAliases, projectDisplayNames: polledProjectDisplayNames, crownedProjects: serverCrownedProjects, projectCwds, flows: polledFlows, pipelines, pipelinesError, workflows, tasks, conversationAliases, launchRoutes, loaded, catalogFailures } = useFiles(null, filesRequestPin(pendingHash, catalogPin?.path ?? null));
+  const { files: allFiles, requestScope, projectCatalog: polledProjectCatalog, projectAliases, projectDisplayNames: polledProjectDisplayNames, crownedProjects: serverCrownedProjects, projectCwds, flows: polledFlows, pipelines, pipelinesError, workflows, tasks, conversationAliases, launchRoutes, loaded, scopeCertified, catalogFailures } = useFiles(null, filesRequestPin(pendingHash, catalogPin?.path ?? null));
   /* Crown/create curation (server-durable): the optimistic client seam plus
      the overlay entries for projects created before the next catalog poll. */
   const { crownedProjects, toggleCrown, createProject, createdCatalog } = useProjectCuration(serverCrownedProjects, polledProjectCatalog);
@@ -222,6 +222,12 @@ export function Viewer() {
   /* The jump channel into the board: nonce so repeated jumps to the same node
      re-flash (D9); consumed by ProjectDashboard's pendingFocusRef path. */
   const [focusRequest, setFocusRequest] = useState<{ path: string; nonce: number; catalog: boolean } | null>(null);
+  /* Monotonic across the whole session, never derived from the previous
+     request: a project switch clears the request to null, and a nonce read
+     back from `null` restarted at 1 — the value the board's edge gate had
+     already consumed for the last focus in the previous project — so the
+     first cross-project open after any focus moved nothing (#1432). */
+  const focusNonceRef = useRef(0);
   /* Placement without navigation — see `placePath` below. Its own state and its
      own nonce, so a place and a focus can never consume each other's edge. */
   const [placeRequest, setPlaceRequest] = useState<{ path: string; nonce: number } | null>(null);
@@ -440,7 +446,8 @@ export function Viewer() {
     localStorage.setItem(PROJECT_KEY, key);
     setDrawerOpen(false);
     setOpenNonce((value) => value + 1);
-    setFocusRequest((previous) => ({ path: file.path, nonce: (previous?.nonce ?? 0) + 1, catalog: true }));
+    focusNonceRef.current += 1;
+    setFocusRequest({ path: file.path, nonce: focusNonceRef.current, catalog: true });
     /* A hydrated open is the RESOLVER arriving (deep link, hashchange,
        popstate replay): it re-types the entry the tab is standing on and never
        pushes, so initial restoration adds no duplicate and a replay cannot
@@ -521,12 +528,13 @@ export function Viewer() {
 
   useEffect(() => {
     if (!catalogPin?.hydrated || pendingHash) return;
-    /* A scope transition (the pin just moved to a new request URL) serves the
-       EMPTY placeholder until its own fetch lands. That placeholder is not
-       evidence the transcript disappeared — releasing the hydrated pin on it
-       dropped every freshly resolved beyond-cap deep link right after it
-       opened. Only a certified payload may retire the pin. */
-    if (!loaded) return;
+    /* A scope transition (the pin just moved to a new request URL) is served
+       by the previous scope's rows until its own fetch lands (#1432). That
+       stand-in is not evidence the transcript disappeared — releasing the
+       hydrated pin on it dropped every freshly resolved beyond-cap deep link
+       right after it opened. Only a payload certified for THIS scope may
+       retire the pin. */
+    if (!loaded || !scopeCertified) return;
     const currentPath = catalogPin.conversationId
       ? files.find((file) => file.conversationId === catalogPin.conversationId)?.path
       : undefined;
@@ -536,7 +544,7 @@ export function Viewer() {
       pending: false,
       currentPath,
     });
-  }, [catalogPin, pendingHash, allFiles, files, loaded]);
+  }, [catalogPin, pendingHash, allFiles, files, loaded, scopeCertified]);
 
   /* The one queue every counter shows: badge, popover and the tab title all
      read the same list, stalled tail included (D10). The clock advances at the
@@ -616,8 +624,54 @@ export function Viewer() {
        with no scanned entry still navigates, it just leaves no history. */
     const file = filesRef.current.find((entry) => entry.path === path);
     if (file) recordFocusNavigation(file, projectKey(file));
-    setFocusRequest((prev) => ({ path, nonce: (prev?.nonce ?? 0) + 1, catalog: false }));
+    focusNonceRef.current += 1;
+    setFocusRequest({ path, nonce: focusNonceRef.current, catalog: false });
   }, []);
+
+  /* In-app conversation links (#1432 addendum): «Open conversation» chips on
+     MCP call cards, «Open it on the board» in the orchestrator panel, the
+     lineage chip on a card, a report row — every one is an `#c=` / `#f=`
+     anchor. Left to the browser, the click became a hash navigation and the
+     resolver's pinned round trip, which blanked and rebuilt the board. A
+     target the tab already knows is opened here instead, in the same tick as
+     the click, through the SAME hand-off an accepted `request_attention`
+     handoff and an attention jump use: switch the project only when the
+     target lives elsewhere, then `requestFocus` — the card materializes on
+     the board it is already showing, the camera glides, the ring lands, and
+     the typed history entry is PUSHED (the URL still carries the link for
+     reload and share). No hash navigation, no pinned refetch, no remount of
+     the dashboard or the orchestrator panel. A target the current payload
+     cannot name — beyond the capped feed, or not scanned yet — falls through
+     to the browser, and the cold resolver path handles it exactly as before. */
+  const openLinkedFile = useCallback((file: FileEntry) => {
+    const key = projectKey(file);
+    if (key !== project) applyProject(key);
+    requestFocus(file.path);
+  }, [project, applyProject, requestFocus]);
+  const linkResolveRef = useRef({ allFiles, conversationAliases, launchRoutes });
+  useEffect(() => {
+    linkResolveRef.current = { allFiles, conversationAliases, launchRoutes };
+  }, [allFiles, conversationAliases, launchRoutes]);
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      const target = event.target as Element | null;
+      const anchor = target && typeof target.closest === "function" ? target.closest("a[href]") : null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href") ?? "";
+      if (!/^#(?:c|f)=./.test(href)) return;
+      const windowTarget = anchor.getAttribute("target");
+      if (windowTarget && windowTarget !== "_self") return;
+      const intent = parseConversationHash(href);
+      const known = linkResolveRef.current;
+      const hit = resolveConversationTarget(known.allFiles, intent, known.conversationAliases, known.launchRoutes);
+      if (!hit) return;
+      event.preventDefault();
+      openLinkedFile(hit);
+    };
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, [openLinkedFile]);
 
   /* Reveal a card without going to it. `requestFocus` above both materializes
      the node and arms the board's glide; a focus handoff wants only the first,

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -183,7 +183,10 @@ export function Viewer() {
   /* This tab's optimistic flow closes apply before anything renders: the X
      on a flow strip clears the reviewer side of the scheme instantly. */
   const flows = useEffectiveFlows(polledFlows);
-  useAgentChimes(files, requestScope);
+  /* A stand-in served for a scope still loading (#1432) is not scanned for
+     chimes: it is the last certified payload under a new label, and scanning
+     it would let the pinned answer's hydrated rows ring instead of seeding. */
+  useAgentChimes(files, requestScope, scopeCertified);
   const { archivedProjects, archiveProject, unarchiveProject } = useArchivedProjects(files, projectAliases);
   const catalogProjects = useMemo(() => new Set(projectCatalog.map((entry) => entry.project)), [projectCatalog]);
   const catalogConversationCounts = useMemo(

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -102,6 +102,33 @@ function itemsOfKind(feed: ReturnType<typeof buildFeed>, kind: Item["kind"]) {
   return feed.items.filter((item) => item.kind === kind);
 }
 
+describe("feed session reuse across panes (#1432)", () => {
+  const record = (text: string, index: number) =>
+    JSON.stringify({ type: "assistant", uuid: `row-${index}`, timestamp: "2026-08-31T10:00:00.000Z", message: { role: "assistant", content: [{ type: "text", text }] } });
+
+  test("a window of the same length with different bytes is re-parsed, never served from the stale snapshot", () => {
+    /* A pooled session outlives its pane and can meet the same path rewritten
+       in place — the same line count, other content. Same start, same end. */
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const first = session.feed([record("First mandate accepted.", 1)], 0, false);
+    expect(first.items.map((entry) => (entry.item as { text?: string }).text)).toEqual(["First mandate accepted."]);
+
+    const rewritten = session.feed([record("Second mandate accepted.", 2)], 0, false);
+    expect(rewritten.items.map((entry) => (entry.item as { text?: string }).text)).toEqual(["Second mandate accepted."]);
+  });
+
+  test("an unchanged window keeps its snapshot identity and appended lines parse incrementally", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const lines = [record("one", 1), record("two", 2)];
+    const first = session.feed(lines, 0, false);
+    expect(session.feed(lines, 0, false)).toBe(first);
+    const grown = session.feed([...lines, record("three", 3)], 0, false);
+    expect(grown.items.map((entry) => (entry.item as { text?: string }).text)).toEqual(["one", "two", "three"]);
+    /* Rows already parsed keep their identity: the memoised feed items skip. */
+    expect(grown.items[0]!.item).toBe(first.items[0]!.item);
+  });
+});
+
 describe("feed session parity with one-shot parse", () => {
   test("a completed response keeps its receipt-to-completion total after the next turn starts", () => {
     const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -1220,6 +1220,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   /** Window start of the previous feed — a start that moved backwards means
       prepended history, which a sequential parser cannot resume across. */
   let lastStart = -Infinity;
+  /** The last line consumed, so a rewritten window of equal length is caught. */
+  let lastConsumedLine: string | undefined;
   /* Dedup/marker state remembers the source line it came from: when that line
      slides out of the window the state clears, matching what a re-parse of
      the shortened window would know. */
@@ -2894,6 +2896,14 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       reset();
       consumedEnd = start;
     }
+    /* Same window, different bytes: a session that outlives its pane (#1432,
+       `feed/sessionPool`) can meet a transcript rewritten in place at the same
+       line count. The last consumed line is the cheapest witness; when it no
+       longer matches, nothing consumed can be trusted. */
+    if (consumedEnd > start && lines[consumedEnd - start - 1] !== lastConsumedLine) {
+      reset();
+      consumedEnd = start;
+    }
     lastStart = start;
     if (dropBefore(start)) {
       reset();
@@ -2903,6 +2913,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       curSrc = start + i;
       consume(lines[i]);
     }
+    if (lines.length) lastConsumedLine = lines[lines.length - 1]!;
     consumedEnd = end;
     if (!snapshot || snapshotLive !== isLive) {
       snapshot = buildSnapshot(isLive);

--- a/src/components/feed/sessionPool.ts
+++ b/src/components/feed/sessionPool.ts
@@ -1,0 +1,55 @@
+/**
+ * Parsed feed sessions of conversations that are not on screen (#1432).
+ *
+ * A `FeedSession` is an incremental parser over one transcript window: it
+ * keeps every item it has produced and parses only lines it has not seen. Its
+ * owner used to be one `LogFeed` mount, so every switch that unmounted a pane
+ * (the phone's focus view, a project switch on the desktop board) threw the
+ * parse away and redid it — the whole retained window — the moment the same
+ * conversation came back, even though `useLogTail` had kept the raw lines.
+ *
+ * This pool keeps a session across those unmounts. A mounting feed TAKES the
+ * session for its key, so at most one live feed owns a session at a time: two
+ * panes reading the same transcript with different windows would otherwise
+ * drive one parser back and forth and re-parse on every render. A feed that
+ * unmounts (or changes key) RELEASES its session back here. Bounded and
+ * least-recently-released, like the tail cache it mirrors.
+ */
+import type { FeedSession } from "./parse";
+
+const POOL_CAP = 16;
+const pool = new Map<string, FeedSession>();
+
+/** Take a pooled session for `key`; it leaves the pool until released. */
+export function takeFeedSession(key: string): FeedSession | null {
+  const session = pool.get(key);
+  if (!session) return null;
+  pool.delete(key);
+  return session;
+}
+
+/** Re-assert ownership of a session a mount already holds. StrictMode runs an
+    effect's cleanup and re-runs it on mount; the cleanup released the session
+    while the feed still uses it, so the re-run takes it back out of the pool. */
+export function claimFeedSession(key: string, session: FeedSession): void {
+  if (pool.get(key) === session) pool.delete(key);
+}
+
+/** Return a session for later reuse under `key`. */
+export function releaseFeedSession(key: string, session: FeedSession): void {
+  pool.delete(key);
+  pool.set(key, session);
+  while (pool.size > POOL_CAP) {
+    const oldest = pool.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    pool.delete(oldest);
+  }
+}
+
+export function pooledFeedSessionCountForTests(): number {
+  return pool.size;
+}
+
+export function resetFeedSessionPoolForTests(): void {
+  pool.clear();
+}

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -51,6 +51,15 @@ import { MobileMapLite } from "./MobileMapLite";
 export { MobilePipelineDock } from "./MobilePipelineDock";
 
 const focusKey = (project: string) => "llvFocus:" + project;
+/** The pane this tab last pinned in `project`, or null (also on the server). */
+function rememberedFocus(project: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return sessionStorage.getItem(focusKey(project));
+  } catch {
+    return null;
+  }
+}
 
 /* Attention-first default: the conversation whose move it is beats a running
    one, freshness breaks ties inside a class. */
@@ -157,7 +166,15 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
      browser has no reason to touch the window scroll at all. Zero whenever
      the layout viewport already matches the visible one. */
   const kbInset = useKeyboardInset();
-  const [focusPath, setFocusPath] = useState<string | null>(null);
+  /* The pinned pane, tagged with the project it belongs to. A project switch
+     re-reads that project's remembered focus DURING the render that changes
+     `project` (#1432): the old effect-based reset painted the previous
+     project's pin (or the attention fallback) for one frame, mounted that
+     pane's feed, then tore it down for the remembered one. */
+  const [focusState, setFocusState] = useState<{ project: string; key: string | null }>(() => ({ project, key: rememberedFocus(project) }));
+  if (focusState.project !== project) setFocusState({ project, key: rememberedFocus(project) });
+  const focusPath = focusState.key;
+  const setFocusPath = useCallback((key: string | null) => setFocusState((prev) => (prev.key === key ? prev : { project: prev.project, key })), []);
   const [mapOpen, setMapOpen] = useState(false);
   const [pipelineSheetOpen, setPipelineSheetOpen] = useState(false);
   const [mapFrame, setMapFrame] = useState<"all" | "current">("all");
@@ -250,7 +267,6 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    setFocusPath(sessionStorage.getItem(focusKey(project)));
     setMapOpen(false);
   }, [project]);
 

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -36,6 +36,8 @@ import { resolveExpandedNode } from "./expandedNode";
 import { autoEditTokenFor, clearStaleRename, requestRename, titleUnderRename, type RenameRequest } from "./renameRequest";
 import { currentWorkRect, currentWorkRects, rectUnion } from "./currentWork";
 import { buildSchemeLayout } from "./layout";
+import type { SchemeLayout } from "./layout";
+import { reconcileLayoutNodes } from "./layoutIdentity";
 import { Minimap, stackDotsFor, type StackDot } from "./Minimap";
 import { boardClusters, chipObstacleRects, screenKeepoutObstacles } from "./offscreenClusters";
 import type { WorkerStack } from "./workerCollapse";
@@ -311,10 +313,17 @@ export function SchemeBoard({
      encloses them plus the planned-stage placeholders — and the pipeline's linked
      task cards (#531), so the pipeline reads as a single region — never a
      detached control card with a duplicate stage graph. */
-  const layout = useMemo(
-    () => buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, { now }),
-    [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, now],
-  );
+  /* Node identities carry over from the previous layout wherever the node
+     is unchanged (#1432), so a relayout that moved nothing re-renders no card. */
+  const previousLayoutRef = useRef<SchemeLayout | null>(null);
+  const layout = useMemo(() => {
+    const built = reconcileLayoutNodes(
+      previousLayoutRef.current,
+      buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, { now }),
+    );
+    previousLayoutRef.current = built;
+    return built;
+  }, [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds, now]);
 
   /* NO PRUNING HERE (#771). The selection outlives this view, so dropping a path
      because THIS layout does not place it would delete the operator's selection

--- a/src/components/scheme/layoutIdentity.ts
+++ b/src/components/scheme/layoutIdentity.ts
@@ -1,0 +1,55 @@
+/**
+ * Identity reconciliation for the board layout (#1432).
+ *
+ * `buildSchemeLayout` is pure: every call returns fresh node objects even when
+ * nothing moved. Cards are memoised on their node, so a relayout that changed
+ * nothing about a card — a poll that touched another row, a board-prefs write,
+ * the 30 s clock — still re-rendered every pane on the board through the fresh
+ * identities alone. Reusing the previous layout's node object wherever the
+ * node is equal field for field keeps those cards' props identical, and the
+ * memo does the rest.
+ */
+import type { SchemeLayout, SchemeNode } from "./layout";
+
+function sameEntries<T>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((item, index) => item === b[index]);
+}
+
+function sameAncestry(a: SchemeNode["ancestry"], b: SchemeNode["ancestry"]): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.hostPath === b.hostPath
+    && a.unresolvedParentId === b.unresolvedParentId
+    && a.depth === b.depth
+    && sameEntries(a.elided, b.elided);
+}
+
+/** Two nodes that would render identically: same scanned entry (by identity,
+    which the files feed already keeps stable for unchanged rows), same
+    geometry, same docked tasks and history, same lineage standing. */
+export function sameSchemeNode(a: SchemeNode, b: SchemeNode): boolean {
+  return a.file === b.file
+    && a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h
+    && a.isRoot === b.isRoot
+    && a.lineageOrderKey === b.lineageOrderKey
+    && sameEntries(a.tasks, b.tasks)
+    && sameEntries(a.under, b.under)
+    && sameAncestry(a.ancestry, b.ancestry);
+}
+
+/** The next layout with every unchanged node carried over from `previous` by
+    identity; the node array itself is carried over too when nothing changed. */
+export function reconcileLayoutNodes(previous: SchemeLayout | null, next: SchemeLayout): SchemeLayout {
+  if (!previous) return next;
+  const before = new Map(previous.nodes.map((node) => [node.file.path, node] as const));
+  let reused = 0;
+  const nodes = next.nodes.map((node) => {
+    const prior = before.get(node.file.path);
+    if (!prior || !sameSchemeNode(prior, node)) return node;
+    reused += 1;
+    return prior;
+  });
+  if (reused === 0) return next;
+  const unchanged = reused === next.nodes.length && sameEntries(previous.nodes, nodes);
+  return { ...next, nodes: unchanged ? previous.nodes : nodes };
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Layers } from "lucide-react";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import { ChevronRight } from "@/components/icons";
 import { conversationIdentity } from "@/lib/accounts/identity";
@@ -71,6 +71,7 @@ import {
 } from "./layout";
 
 const EMPTY_RELATIONS: readonly TaskRelation[] = [];
+const EMPTY_TASKS: BoardTask[] = [];
 const EMPTY_RUNTIME_ACTIVITY_BY_PATH = new Map<string, Activity>();
 
 function sameRuntimeActivityByPath(left: Map<string, Activity>, right: Map<string, Activity>): boolean {
@@ -933,7 +934,12 @@ function SelectionCheck({
   );
 }
 
-function NodeShell({
+/* Memoised (#1432): a focus move, a lasso toggle or a poll re-renders
+   NodesLayer, and this shell must re-render only when something about ITS
+   card changed — ring, dim, node geometry, flow/pipeline attachment. Every
+   callback and collection it receives is identity-stable across a NodesLayer
+   render for that to hold (see the useCallback/EMPTY_* constants there). */
+const NodeShell = memo(function NodeShell({
   node,
   ringed,
   marked,
@@ -1206,7 +1212,7 @@ function NodeShell({
       ) : null}
     </div>
   );
-}
+});
 
 /** A conversation draft as a scheme citizen: positioned like a fresh root node. */
 function DraftShell({
@@ -1576,10 +1582,10 @@ export const NodesLayer = memo(function NodesLayer({
 
   /* Board pipeline strip actions: a run stage chip / verdict opens the stage's
      own node by path; a review-loop chip routes through openPipelineFlow. */
-  const openPipelinePath = (path: string) => {
+  const openPipelinePath = useCallback((path: string) => {
     const file = files.find((entry) => entry.path === path);
     if (file) onSelect(file);
-  };
+  }, [files, onSelect]);
   /* Paths still in the scan; a run stage action is disabled once its transcript
      leaves the file set (AC4). */
   const renderablePaths = useMemo(() => new Set(files.map((entry) => entry.path)), [files]);
@@ -1600,14 +1606,20 @@ export const NodesLayer = memo(function NodesLayer({
   /* Flow ids with a rendered deck: a deck exists only for a placed implementer
      node, so derive from the layout's nodes to disable review actions whose
      implementer is unplaced. */
-  const renderableFlows = useMemo(() => renderableFlowIds(flows, new Set(layout.nodes.map((node) => node.file.path))), [flows, layout]);
+  /* Keyed on the placed PATHS, not the layout object: a relayout that placed
+     the same nodes must hand every card the same set (#1432). */
+  const placedPathKey = useMemo(() => layout.nodes.map((node) => node.file.path).join("\n"), [layout.nodes]);
+  const renderableFlows = useMemo(
+    () => renderableFlowIds(flows, new Set(placedPathKey ? placedPathKey.split("\n") : [])),
+    [flows, placedPathKey],
+  );
   /* A review-loop stage's reviewer transcript is folded into the flow's round
      deck, so focus the deck's latest round to reveal that reviewer; the node is
      removed. This is the same round-focus channel FlowStrip drives (#93 §2.2). */
-  const openPipelineFlow = (flowId: string) => {
+  const openPipelineFlow = useCallback((flowId: string) => {
     const flow = flows.find((candidate) => candidate.id === flowId);
     if (flow) onFocusRound(flow.id, flow.rounds.at(-1)?.n ?? 1);
-  };
+  }, [flows, onFocusRound]);
 
   /* A stack or deck stays lit when any conversation inside it is in the
      queue — a stalled branch may live in a mini stack, and a blocked
@@ -1687,7 +1699,7 @@ export const NodesLayer = memo(function NodesLayer({
             flow={flowsByImpl.get(node.file.path) ?? null}
             pipeline={pipeline}
             pipelineStage={pipelineStageByPath.get(node.file.path) ?? null}
-            linkedTasks={pipeline ? linkedTasksByPipeline.get(pipeline.id) ?? [] : []}
+            linkedTasks={pipeline ? linkedTasksByPipeline.get(pipeline.id) ?? EMPTY_TASKS : EMPTY_TASKS}
             relatedTasks={relatedTasksByPath?.get(node.file.path) ?? EMPTY_RELATIONS}
             flows={flows}
             files={files}

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -400,6 +400,23 @@ function memberOrder(left: TrayMember, right: TrayMember, timeById: ReadonlyMap<
   );
 }
 
+/** A value signature of a projection: two projections with the same signature
+    fold and promote the same paths and draw the same trays, so a consumer may
+    keep the earlier object and every card memoised on it stays put (#1432). */
+export function subagentTraySignature(projection: SubagentTrayProjection): string {
+  const sorted = (values: Iterable<string>) => [...values].sort();
+  const trays = [...projection.traysByParent.values()]
+    .map((tray) => [
+      tray.parentConversationId,
+      tray.count,
+      tray.hottest,
+      tray.expanded,
+      tray.members.map((member) => [member.id, member.path, member.title, member.engine, member.model, member.state, member.avatarSeed]),
+    ])
+    .sort((left, right) => String(left[0]).localeCompare(String(right[0])));
+  return JSON.stringify([sorted(projection.promotedPaths), sorted(projection.foldedPaths), sorted(projection.foldedIds), trays]);
+}
+
 /**
  * The presence projection: partition every current-generation engine-native
  * child into promoted nodes and folded tray rows, grouped by durable parent id.

--- a/src/hooks/logBus.test.ts
+++ b/src/hooks/logBus.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Stream reconnect pacing on the shared log bus (#1432): a subscriber that
+ * arrives on a settled stream — the operator switching conversations — must
+ * not wait the churn-coalescing window before its pane goes live.
+ */
+import { afterEach, beforeEach, expect, jest, test } from "bun:test";
+
+class FakeEventSource {
+  static connects: Array<{ at: number; subs: Array<{ path: string; offset: number }> }> = [];
+  private closed = false;
+  constructor(url: string) {
+    const subs = JSON.parse(new URL(url, "http://localhost").searchParams.get("subs") ?? "[]") as Array<{ path: string; offset: number }>;
+    FakeEventSource.connects.push({ at: Date.now(), subs });
+  }
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  close(): void { this.closed = true; }
+  onerror: (() => void) | null = null;
+}
+(globalThis as { EventSource?: unknown }).EventSource = FakeEventSource;
+
+const { subscribeLog } = await import("./logBus");
+
+const subscriber = (path: string, offset = 0) => ({ path, getOffset: () => offset, onChunk: () => {} });
+let unsubscribes: Array<() => void> = [];
+const subscribe = (path: string, offset = 0) => {
+  const off = subscribeLog(subscriber(path, offset));
+  unsubscribes.push(off);
+  return off;
+};
+const connectsAtOrBefore = (ms: number) => FakeEventSource.connects.filter((entry) => entry.at <= ms).length;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(0);
+  FakeEventSource.connects = [];
+});
+
+afterEach(() => {
+  /* Dropping the last subscriber stops every transport, so the module's
+     state is idle for the next test. */
+  for (const off of unsubscribes.splice(0)) off();
+  jest.useRealTimers();
+});
+
+test("the first subscriber on a settled stream connects on the short window", () => {
+  subscribe("/sessions/a.jsonl");
+  jest.advanceTimersByTime(39);
+  expect(FakeEventSource.connects.length).toBe(0);
+  jest.advanceTimersByTime(1);
+  expect(FakeEventSource.connects.length).toBe(1);
+  expect(FakeEventSource.connects[0]!.subs.map((sub) => sub.path)).toEqual(["/sessions/a.jsonl"]);
+});
+
+test("a burst of subscribers in one tick shares one prompt connection", () => {
+  subscribe("/sessions/a.jsonl");
+  subscribe("/sessions/b.jsonl", 128);
+  subscribe("/sessions/c.jsonl");
+  jest.advanceTimersByTime(40);
+  expect(FakeEventSource.connects.length).toBe(1);
+  expect(FakeEventSource.connects[0]!.subs.length).toBe(3);
+});
+
+test("a subscriber arriving while the stream is fresh waits the long window; one arriving after it is prompt again", () => {
+  subscribe("/sessions/a.jsonl");
+  jest.advanceTimersByTime(40);
+  expect(FakeEventSource.connects.length).toBe(1);
+  /* 100 ms after the connect: churn territory — coalesce on the long window. */
+  jest.advanceTimersByTime(100);
+  subscribe("/sessions/b.jsonl");
+  jest.advanceTimersByTime(200);
+  expect(connectsAtOrBefore(340)).toBe(1);
+  jest.advanceTimersByTime(100);
+  expect(FakeEventSource.connects.length).toBe(2);
+  expect(FakeEventSource.connects[1]!.at).toBe(440);
+  /* Well after that reconnect: a switch, served promptly. */
+  jest.advanceTimersByTime(1000);
+  subscribe("/sessions/c.jsonl", 512);
+  jest.advanceTimersByTime(40);
+  expect(FakeEventSource.connects.length).toBe(3);
+  expect(FakeEventSource.connects[2]!.at).toBe(1480);
+});
+
+test("an unsubscribe alone never triggers a prompt reconnect", () => {
+  subscribe("/sessions/a.jsonl");
+  const offB = subscribe("/sessions/b.jsonl");
+  jest.advanceTimersByTime(40);
+  expect(FakeEventSource.connects.length).toBe(1);
+  jest.advanceTimersByTime(1000);
+  offB();
+  unsubscribes = unsubscribes.filter((off) => off !== offB);
+  jest.advanceTimersByTime(299);
+  expect(FakeEventSource.connects.length).toBe(1);
+  jest.advanceTimersByTime(1);
+  expect(FakeEventSource.connects.length).toBe(2);
+});

--- a/src/hooks/logBus.ts
+++ b/src/hooks/logBus.ts
@@ -5,7 +5,17 @@ import type { LogChunk } from "@/lib/types";
 
 const POLL_MS = 1200;
 const MAX_REQS = 64;
+/* Subscription churn (panes scrolling in and out of view, a board relayout)
+   coalesces into one stream reconnect on the long window. A subscriber
+   arriving on a SETTLED stream — nothing reconnected for a full window — is
+   the operator switching conversations (#1432): its pane is on screen now,
+   blank or showing cached rows, and every millisecond before the stream
+   carries it is a pane that is not live. That first arrival reconnects on
+   the short window; anything arriving while a reconnect is still fresh
+   coalesces on the long one, so churn can never exceed one prompt reconnect
+   per long window. */
 const RECONNECT_DEBOUNCE_MS = 300;
+const PROMPT_RECONNECT_DEBOUNCE_MS = 40;
 const SSE_RETRY_MS = 60_000;
 
 export type LogBusResult = LogChunk | { error: string } | { transportError: true };
@@ -22,6 +32,10 @@ const subs = new Set<LogSubscriber>();
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let sseRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+/** When the pending reconnect fires; a shorter request moves it earlier. */
+let reconnectDueAt = Number.POSITIVE_INFINITY;
+/** When the stream last (re)connected — what "settled" is measured from. */
+let streamStartedAt = Number.NEGATIVE_INFINITY;
 let source: EventSource | null = null;
 let inFlight = false;
 let kickPending = false;
@@ -51,6 +65,8 @@ function stopAllTransports(): void {
   stopPolling();
   sseRetryTimer = clearTimer(sseRetryTimer, clearTimeout);
   reconnectTimer = clearTimer(reconnectTimer, clearTimeout);
+  reconnectDueAt = Number.POSITIVE_INFINITY;
+  streamStartedAt = Number.NEGATIVE_INFINITY;
   usingFallback = false;
   inFlight = false;
   kickPending = false;
@@ -147,8 +163,10 @@ function startSse(): void {
   usingFallback = false;
   stopPolling();
   sseRetryTimer = clearTimer(sseRetryTimer, clearTimeout);
+  reconnectDueAt = Number.POSITIVE_INFINITY;
   closeSource();
 
+  streamStartedAt = Date.now();
   const generation = sseGeneration;
   const active = [...subs];
   const reqs = active.map((sub, i) => ({ id: String(i), path: sub.path, offset: sub.getOffset() }));
@@ -181,8 +199,16 @@ function scheduleSseReconnect(delay = RECONNECT_DEBOUNCE_MS): void {
     kickPoll();
     return;
   }
+  const dueAt = Date.now() + delay;
+  /* A pending reconnect that already fires no later than this request keeps
+     its slot: a burst of subscribers still produces exactly one connection. */
+  if (reconnectTimer !== null && reconnectDueAt <= dueAt) return;
   reconnectTimer = clearTimer(reconnectTimer, clearTimeout);
-  reconnectTimer = setTimeout(startSse, delay);
+  reconnectDueAt = dueAt;
+  reconnectTimer = setTimeout(() => {
+    reconnectDueAt = Number.POSITIVE_INFINITY;
+    startSse();
+  }, delay);
 }
 
 export function subscribeLog(sub: LogSubscriber): () => void {
@@ -191,7 +217,8 @@ export function subscribeLog(sub: LogSubscriber): () => void {
     if (pollTimer === null) pollTimer = setInterval(() => void pollTick(), POLL_MS);
     kickPoll();
   } else {
-    scheduleSseReconnect();
+    const settled = Date.now() - streamStartedAt >= RECONNECT_DEBOUNCE_MS;
+    scheduleSseReconnect(settled ? PROMPT_RECONNECT_DEBOUNCE_MS : RECONNECT_DEBOUNCE_MS);
   }
   return () => {
     subs.delete(sub);

--- a/src/hooks/useAgentChimes.test.ts
+++ b/src/hooks/useAgentChimes.test.ts
@@ -178,3 +178,32 @@ test("full-cap tail churn: a recently seen identity survives eviction and stays 
   );
   expect(p4.chimes).toEqual([]);
 });
+
+/* #1432: a request scope with no representation yet (a `#c=` pin this tab has
+   never fetched) is answered by the last certified representation re-labelled
+   for that scope and marked uncertified. That stand-in carries nothing the tab
+   has not already scanned, so it must not be scanned under the pending scope:
+   doing so made the pinned scope the baseline, and the pinned answer's
+   hydrated rows then rang as transitions instead of seeding silently. */
+test("a stand-in for a scope still loading is not scanned, so the pinned answer still seeds silently", () => {
+  const global = "/api/files";
+  const pinned = "/api/files?pin=%2Fdeep";
+  const feed = [live("/a"), waiting("/b")];
+  const seed = planScopedAgentChimes(feed, null, global);
+  const standIn = planScopedAgentChimes(feed, seed, pinned, false);
+  expect(standIn).toBe(seed);
+  /* The pinned answer hydrates a conversation that finished long ago. */
+  const answered = planScopedAgentChimes([...feed, waiting("/deep")], standIn, pinned);
+  expect(answered.chimes).toEqual([]);
+  /* A real transition landing in that same answer is still audible. */
+  const transition = planScopedAgentChimes([waiting("/a"), waiting("/b"), waiting("/deep")], standIn, pinned);
+  expect(transition.chimes).toEqual([{ kind: "question", id: "/a" }]);
+});
+
+test("a stand-in before any certified scan leaves the baseline unseeded", () => {
+  const pinned = "/api/files?pin=%2Fb";
+  const none = planScopedAgentChimes([waiting("/b")], null, pinned, false);
+  expect(none).toBeNull();
+  const first = planScopedAgentChimes([waiting("/b")], none, pinned);
+  expect(first.chimes).toEqual([]);
+});

--- a/src/hooks/useAgentChimes.ts
+++ b/src/hooks/useAgentChimes.ts
@@ -135,12 +135,33 @@ export function planAgentChimes(
  * deep-link request can hydrate an entry this tab has never observed; that
  * entry seeds the retained history silently. Previously tracked conversations
  * still announce a real lifecycle transition during the same request.
+ *
+ * `certified` is the payload's own claim to `scope`. A scope still loading is
+ * answered by the last certified representation re-labelled for it (#1432);
+ * that stand-in holds nothing this tab has not already scanned, and scanning
+ * it under the pending scope would make that scope the baseline, so the
+ * pinned answer's hydrated rows would ring as transitions. An uncertified
+ * payload is therefore a no-op: the baseline stays with the scope that
+ * actually produced it, `null` when nothing certified has been scanned yet.
  */
 export function planScopedAgentChimes(
   files: readonly FileEntry[],
   previous: ScopedChimePlan | null,
   scope: string,
-): ScopedChimePlan {
+): ScopedChimePlan;
+export function planScopedAgentChimes(
+  files: readonly FileEntry[],
+  previous: ScopedChimePlan | null,
+  scope: string,
+  certified: boolean,
+): ScopedChimePlan | null;
+export function planScopedAgentChimes(
+  files: readonly FileEntry[],
+  previous: ScopedChimePlan | null,
+  scope: string,
+  certified = true,
+): ScopedChimePlan | null {
+  if (!certified) return previous;
   const plan = planAgentChimes(
     files,
     previous?.tracked ?? null,
@@ -165,17 +186,21 @@ export function planScopedAgentChimes(
  * happened BECAUSE the transcript changed, so its mtime names that transition
  * and stays the same value across every refetch and re-render that observes it —
  * where a call-time timestamp would make each observation look like a new event.
+ *
+ * `certified` says whether `files` is the answer of a request for `scope` or a
+ * stand-in served while that request is still loading (#1432); a stand-in is
+ * not scanned, see {@link planScopedAgentChimes}.
  */
-export function useAgentChimes(files: FileEntry[], scope: string | null) {
+export function useAgentChimes(files: FileEntry[], scope: string | null, certified = true) {
   const historyRef = useRef<ScopedChimePlan | null>(null);
 
   useEffect(() => unlockAudioOnGesture(), []);
 
   useEffect(() => {
     if (!files.length || !scope) return;
-    const plan = planScopedAgentChimes(files, historyRef.current, scope);
+    const plan = planScopedAgentChimes(files, historyRef.current, scope, certified);
     historyRef.current = plan;
-    if (!plan.chimes.length) return;
+    if (!plan?.chimes.length) return;
     const changedAt = new Map(files.map((file) => [conversationIdentity(file), file.mtime]));
     plan.chimes.forEach((planned, voice) => {
       const cue = CUE_OF_LIFECYCLE[planned.kind];
@@ -186,5 +211,5 @@ export function useAgentChimes(files: FileEntry[], scope: string | null) {
         delayMs: voice * STAGGER_MS,
       });
     });
-  }, [files, scope]);
+  }, [files, scope, certified]);
 }

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -1065,6 +1065,17 @@ export function useBoardState(project: string | null): BoardState {
   const [bound, setBound] = useState<{ project: string | null; snapshot: BoardSnapshot }>(
     () => ({ project, snapshot: initialBoardSnapshot(project) }),
   );
+  /* A project switch re-tags DURING the render that changes `project` (#1432):
+     the session cache already holds the settled arrangement of every project
+     this tab visited, so a revisit paints its board in the same frame as the
+     rail click — no skeleton, no unmount of every card, no re-parse of every
+     feed. A project this tab has not loaded yet still starts unavailable and
+     holds the skeleton until its first GET lands, exactly as before; the
+     effect below then binds the store and replaces this first snapshot with
+     the live one. React allows this set-state-in-render for the component's
+     own state, and it costs one synchronous re-render before any child sees
+     the stale tag. */
+  if (bound.project !== project) setBound({ project, snapshot: initialBoardSnapshot(project) });
 
   useEffect(() => {
     if (typeof window === "undefined" || project === null) {

--- a/src/hooks/useFiles.dom.test.tsx
+++ b/src/hooks/useFiles.dom.test.tsx
@@ -58,6 +58,7 @@ function ScopedProbe({ pinnedPath }: { pinnedPath?: string }) {
     files: data.files.map((entry) => entry.path),
     pins: data.pinOverlayPaths,
     scope: data.requestScope,
+    certified: data.scopeCertified,
     task: data.pipelines[0]?.task ?? "",
   })}</div>;
 }
@@ -98,12 +99,14 @@ test("concurrent pinned and global hooks keep their scopes through local pipelin
     files: ["/global", pinnedPath],
     pins: [pinnedPath],
     scope: `/api/files?path=${encodeURIComponent(pinnedPath)}`,
+    certified: true,
     task: "patched",
   }));
   expect(host.children[1]?.textContent).toBe(JSON.stringify({
     files: ["/global"],
     pins: [],
     scope: "/api/files",
+    certified: true,
     task: "patched",
   }));
 
@@ -116,6 +119,7 @@ test("concurrent pinned and global hooks keep their scopes through local pipelin
     files: ["/global"],
     pins: [],
     scope: "/api/files",
+    certified: true,
     task: "server",
   }));
 
@@ -123,7 +127,10 @@ test("concurrent pinned and global hooks keep their scopes through local pipelin
   host.remove();
 });
 
-test("hook initialization paints only an exact request-scope cache snapshot", async () => {
+/* #1432: a scope with no representation yet paints the last known GLOBAL rows,
+   marked uncertified, instead of an empty placeholder — and never the rows only
+   another pin admitted. */
+test("hook initialization paints the last known global rows for an unfetched scope, never another pin's rows", async () => {
   const pinA = "/archive/pin-a.jsonl";
   const pinB = "/archive/pin-b.jsonl";
   let calls = 0;
@@ -160,9 +167,12 @@ test("hook initialization paints only an exact request-scope cache snapshot", as
     </>);
   });
 
-  expect(host.children[0]?.textContent).toContain('"files":[]');
-  expect(host.children[1]?.textContent).toContain('"files":[]');
+  expect(host.children[0]?.textContent).toContain('"files":["/global"]');
+  expect(host.children[0]?.textContent).toContain('"certified":false');
+  expect(host.children[1]?.textContent).toContain('"files":["/global"]');
+  expect(host.children[1]?.textContent).toContain('"certified":false');
   expect(host.children[2]?.textContent).toContain(pinA);
+  expect(host.children[2]?.textContent).toContain('"certified":true');
   expect(host.children[0]?.textContent).not.toContain(pinA);
   expect(host.children[1]?.textContent).not.toContain(pinA);
 
@@ -197,11 +207,13 @@ test("an already-mounted hook drops pin-only rows in the render that changes sco
   expect(host.textContent).toContain(pinA);
 
   flushSync(() => { root.render(<ScopedProbe pinnedPath={pinB} />); });
-  expect(host.textContent).toContain('"files":[]');
+  expect(host.textContent).toContain('"files":["/global"]');
+  expect(host.textContent).toContain('"certified":false');
   expect(host.textContent).not.toContain(pinA);
 
   flushSync(() => { root.render(<ScopedProbe />); });
-  expect(host.textContent).toContain('"files":[]');
+  expect(host.textContent).toContain('"files":["/global"]');
+  expect(host.textContent).toContain('"certified":false');
   expect(host.textContent).not.toContain(pinA);
 
   release();

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -48,6 +48,37 @@ test("global client cache serves stale rows while revalidation patches changed f
   expect(second.tasks).toBe(first.tasks);
 });
 
+test("an unfetched scope is answered by the global rows, uncertified and identity-stable, until its own fetch lands (#1432)", async () => {
+  const pin = "/archive/beyond-cap.jsonl";
+  const cache = createFilesClientCache(async (input) => {
+    const pinnedPath = new URL(String(input), "http://localhost").searchParams.get("path");
+    return new Response(JSON.stringify({
+      files: pinnedPath ? [file("/a", "A"), file(pinnedPath, "Pinned")] : [file("/a", "A")],
+      pinOverlayPaths: pinnedPath ? [pinnedPath] : [],
+    }), { status: 200 });
+  });
+  await cache.revalidate();
+
+  const standIn = cache.readScope(pin);
+  expect(standIn.requestScope).toBe(filesApiUrl(undefined, pin));
+  expect(standIn.loaded).toBe(true);
+  expect(standIn.scopeCertified).toBe(false);
+  expect(standIn.files.map((entry) => entry.path)).toEqual(["/a"]);
+  /* The same stand-in object comes back while nothing changed: a consumer
+     rendering it repeatedly must not see a fresh identity each time. */
+  expect(cache.readScope(pin)).toBe(standIn);
+
+  await cache.revalidate(pin);
+  const certified = cache.readScope(pin);
+  expect(certified.scopeCertified).toBe(true);
+  expect(certified.files.map((entry) => entry.path)).toEqual(["/a", pin]);
+  /* Another scope asked while the pinned one is the freshest: the pin-only
+     row stays with the request that admitted it. */
+  const other = cache.readScope("/archive/other.jsonl");
+  expect(other.scopeCertified).toBe(false);
+  expect(other.files.map((entry) => entry.path)).toEqual(["/a"]);
+});
+
 test("an ordinary hydration waits for an in-flight forced revision refresh", async () => {
   let calls = 0;
   let forcedResolved = false;

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -52,6 +52,13 @@ export interface FilesData {
   /** `spawn:<launchId>` → canonical conversation id (issue #569). */
   launchRoutes: Record<string, string>;
   loaded: boolean;
+  /** The rows above were fetched for exactly `requestScope`. False while a
+      newly requested scope — a deep-link pin — is still loading and the
+      freshest certified representation of another scope stands in for it
+      (#1432): the board keeps painting what it has instead of a placeholder,
+      and only a certified payload may make scope-specific claims such as
+      "the pinned transcript is not in the feed". */
+  scopeCertified: boolean;
   /** Consecutive `/api/files` failures since the last success (issue #696).
       Non-zero means everything above is unconfirmed: an empty catalog is a
       failed fetch, and the UI must say so instead of presenting the affirmative
@@ -60,7 +67,7 @@ export interface FilesData {
 }
 
 const HEALTHY_SYSTEM = { tmux: { status: "healthy" as const } };
-const EMPTY: FilesData = { files: [], pinOverlayPaths: [], requestScope: null, projectCatalog: [], projectAliases: {}, projectDisplayNames: {}, crownedProjects: [], projectCwds: {}, flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, launchRoutes: {}, loaded: false, catalogFailures: 0 };
+const EMPTY: FilesData = { files: [], pinOverlayPaths: [], requestScope: null, projectCatalog: [], projectAliases: {}, projectDisplayNames: {}, crownedProjects: [], projectCwds: {}, flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, launchRoutes: {}, loaded: false, scopeCertified: false, catalogFailures: 0 };
 
 export function filesApiUrl(_project?: string | null, pinnedPath?: string | null): string {
   const params: string[] = [];
@@ -133,7 +140,7 @@ function patchRows<T>(previous: readonly T[], incoming: readonly T[], keyOf: (va
 
 function parsedFilesData(parsed: FilesResponse | FileEntry[], requestScope: string): FilesData {
   if (Array.isArray(parsed)) {
-    return { files: parsed, pinOverlayPaths: [], requestScope, projectCatalog: [], projectAliases: {}, projectDisplayNames: {}, crownedProjects: [], projectCwds: {}, flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, launchRoutes: {}, loaded: true, catalogFailures: 0 };
+    return { files: parsed, pinOverlayPaths: [], requestScope, projectCatalog: [], projectAliases: {}, projectDisplayNames: {}, crownedProjects: [], projectCwds: {}, flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, launchRoutes: {}, loaded: true, scopeCertified: true, catalogFailures: 0 };
   }
   return {
     files: parsed.files ?? [],
@@ -153,6 +160,7 @@ function parsedFilesData(parsed: FilesResponse | FileEntry[], requestScope: stri
     conversationAliases: parsed.conversationAliases ?? {},
     launchRoutes: parsed.launchRoutes ?? {},
     loaded: true,
+    scopeCertified: true,
     catalogFailures: 0,
   };
 }
@@ -244,10 +252,11 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     return composed;
   };
 
-  const withPipelineOverlays = (data: FilesData): FilesData => ({
-    ...data,
-    pipelines: pipelinesWithOverlays(data.pipelines),
-  });
+  const withPipelineOverlays = (data: FilesData): FilesData => (pipelineOverlays.size
+    ? { ...data, pipelines: pipelinesWithOverlays(data.pipelines) }
+    /* No overlay: the representation itself is the answer, identity intact,
+       so a consumer reading an unchanged scope sees an unchanged object. */
+    : data);
 
   const withSpawnedOverlays = (data: FilesData): FilesData => {
     if (!spawnedOverlays.size) return data;
@@ -269,9 +278,32 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     }
   };
 
+  /* A scope with no representation yet — a deep-link pin that was just
+     requested — is answered with the freshest certified snapshot of ANY scope,
+     re-labelled for the requested URL and marked uncertified (#1432). Before
+     this the answer was the empty placeholder: every `#c=` open blanked the
+     files feed, dropped the board to its skeleton and rebuilt every card, twice
+     (once for the id pin, once for the path pin), before the pinned fetch even
+     landed. Memoised on the snapshot so an unchanged stand-in keeps its
+     identity across renders. */
+  let standIn: { source: FilesData; requestScope: string; data: FilesData } | null = null;
+  const standInFor = (requestScope: string): FilesData => {
+    if (standIn && standIn.source === snapshot && standIn.requestScope === requestScope) return standIn.data;
+    /* The global representation is the natural stand-in. Failing that, the
+       snapshot minus the rows only ITS pin admitted: a pin-only row belongs to
+       the request that asked for it and must never leak into another scope. */
+    const base = representations.get(filesApiUrl())?.data ?? snapshot;
+    const pinOnly = new Set(base.pinOverlayPaths);
+    const files = pinOnly.size ? base.files.filter((file) => !pinOnly.has(file.path)) : base.files;
+    standIn = { source: snapshot, requestScope, data: { ...base, files, pinOverlayPaths: [], requestScope, scopeCertified: false } };
+    return standIn.data;
+  };
+
   const exactScopeRepresentation = (requestScope: string): FilesData => {
     const representation = representations.get(requestScope)?.data
-      ?? (snapshot.requestScope === requestScope ? snapshot : { ...EMPTY, requestScope });
+      ?? (snapshot.requestScope === requestScope
+        ? snapshot
+        : snapshot.loaded ? standInFor(requestScope) : { ...EMPTY, requestScope });
     return withCatalogFailures(withPipelineOverlays(withSpawnedOverlays(representation)));
   };
 

--- a/src/hooks/useLogTail.ts
+++ b/src/hooks/useLogTail.ts
@@ -94,6 +94,32 @@ export interface LogTailState {
   prependGen: number;
 }
 
+/** What the hook renders for one transcript, tagged with that transcript's
+    path so a switch can never show one conversation's lines under another's
+    title (#1432). */
+interface TailView {
+  path: string | null;
+  win: { lines: string[]; start: number };
+  size: number;
+  loading: boolean;
+  error: string | null;
+  tickTime: Date | null;
+  hasMore: boolean;
+}
+
+function viewFor(file: FileEntry | null, cap: number): TailView {
+  const cached = file ? readTailCache(file.path, cap) : null;
+  return {
+    path: file?.path ?? null,
+    win: cached?.win ?? { lines: [], start: 0 },
+    size: cached?.size ?? file?.size ?? 0,
+    loading: Boolean(file && !cached),
+    error: null,
+    tickTime: cached?.tickTime ?? null,
+    hasMore: cached?.hasMore ?? false,
+  };
+}
+
 /**
  * Forward tail polling plus on-demand backward history: `lines` always hold a
  * contiguous window ending at the live tail; `loadOlder` extends the window
@@ -103,28 +129,29 @@ export interface LogTailState {
  * trimming never shifts what is being read.
  */
 export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 2500): LogTailState {
-  const [initialSnapshot] = useState(() => file ? readTailCache(file.path, cap) : null);
-  const initialWin = initialSnapshot?.win ?? { lines: [], start: 0 };
+  const path = file?.path ?? null;
   const capRef = useRef(cap);
-  /* One atomic window state: the lines plus the absolute index of lines[0],
-     updated together so a trim and its start shift can never tear. */
-  const [win, setWin] = useState<{ lines: string[]; start: number }>(initialWin);
-  const [size, setSize] = useState(initialSnapshot?.size ?? 0);
-  const [loading, setLoading] = useState(Boolean(file && !initialSnapshot));
-  const [error, setError] = useState<string | null>(null);
-  const [tickTime, setTickTime] = useState<Date | null>(initialSnapshot?.tickTime ?? null);
+  const [view, setView] = useState<TailView>(() => viewFor(file, cap));
+  /* The window follows the path IN THE SAME RENDER (#1432). Re-seating it from
+     an effect painted the previous conversation's lines under the new file for
+     a frame — and parsed them for nothing — before the cached window (or the
+     empty loading state) replaced them. Set-state-in-render on the hook's own
+     state is React's sanctioned form of this: the render restarts at once with
+     the switched window and nothing below ever sees the mismatch. */
+  if (view.path !== path) setView(viewFor(file, capRef.current));
   const [paused, setPaused] = useState(false);
-  const [hasMore, setHasMore] = useState(initialSnapshot?.hasMore ?? false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [prependGen, setPrependGen] = useState(0);
-  const winRef = useRef(initialWin);
-  const sizeRef = useRef(initialSnapshot?.size ?? 0);
-  const tickTimeRef = useRef<Date | null>(initialSnapshot?.tickTime ?? null);
-  const hasMoreRef = useRef(initialSnapshot?.hasMore ?? false);
-  const offsetRef = useRef(initialSnapshot?.offset ?? 0);
-  const startRef = useRef(initialSnapshot?.historyStart ?? 0);
-  const tailRef = useRef(initialSnapshot?.partial ?? "");
-  const firstRef = useRef(initialSnapshot?.first ?? true);
+  /* Transport state lives in refs, re-seated by the path effect below from
+     the same cached snapshot the render switched to. */
+  const winRef = useRef(view.win);
+  const sizeRef = useRef(view.size);
+  const tickTimeRef = useRef<Date | null>(view.tickTime);
+  const hasMoreRef = useRef(view.hasMore);
+  const offsetRef = useRef(0);
+  const startRef = useRef(0);
+  const tailRef = useRef("");
+  const firstRef = useRef(true);
   const genRef = useRef(0);
   const olderBusyRef = useRef(false);
 
@@ -132,18 +159,25 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
     capRef.current = cap;
   }, [cap]);
 
-  const updateWin = (next: { lines: string[]; start: number }) => {
+  /* Every state write names the transcript it is for: a chunk or a history
+     page that lands after the pane switched away is dropped, never merged
+     into the newer conversation's window. */
+  const patch = (target: string | null, next: Partial<Omit<TailView, "path">>) => {
+    setView((prev) => (prev.path === target ? { ...prev, ...next } : prev));
+  };
+
+  const updateWin = (target: string | null, next: { lines: string[]; start: number }) => {
     winRef.current = next;
-    setWin(next);
+    patch(target, { win: next });
   };
 
-  const updateHasMore = (next: boolean) => {
+  const updateHasMore = (target: string | null, next: boolean) => {
     hasMoreRef.current = next;
-    setHasMore(next);
+    patch(target, { hasMore: next });
   };
 
-  const saveSnapshot = (path: string) => {
-    writeTailCache(path, {
+  const saveSnapshot = (target: string) => {
+    writeTailCache(target, {
       win: winRef.current,
       size: sizeRef.current,
       offset: offsetRef.current,
@@ -155,25 +189,28 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
     });
   };
 
-  const resetWindow = () => {
+  const resetWindow = (target: string | null) => {
     offsetRef.current = 0;
     startRef.current = 0;
     tailRef.current = "";
     firstRef.current = true;
-    updateHasMore(false);
+    updateHasMore(target, false);
   };
 
   const clear = useCallback(() => {
-    if (file) tailCache.delete(file.path);
-    updateWin({ lines: [], start: 0 });
-    resetWindow();
-  }, [file?.path]);
+    if (path) tailCache.delete(path);
+    updateWin(path, { lines: [], start: 0 });
+    resetWindow(path);
+  }, [path]);
 
   useEffect(() => {
     genRef.current += 1;
-    const cached = file ? readTailCache(file.path, capRef.current) : null;
-    const nextWin = cached?.win ?? { lines: [], start: 0 };
-    winRef.current = nextWin;
+    /* The rendered window already switched (see the render above); the
+       transport state — offset, history start, decoder partial — is re-seated
+       here from the same snapshot, so the live subscription continues forward
+       from where the cached window ends instead of re-reading it. */
+    const cached = path ? readTailCache(path, capRef.current) : null;
+    winRef.current = cached?.win ?? { lines: [], start: 0 };
     offsetRef.current = cached?.offset ?? 0;
     startRef.current = cached?.historyStart ?? 0;
     tailRef.current = cached?.partial ?? "";
@@ -181,41 +218,34 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
     hasMoreRef.current = cached?.hasMore ?? false;
     sizeRef.current = cached?.size ?? file?.size ?? 0;
     tickTimeRef.current = cached?.tickTime ?? null;
-    setWin(nextWin);
-    setHasMore(hasMoreRef.current);
-    setSize(sizeRef.current);
-    setTickTime(tickTimeRef.current);
-    setError(null);
-    setLoading(Boolean(file && !cached));
-  }, [file?.path]);
+  }, [path]);
 
   /* Forward polling rides the shared log bus: one batched request per tick
      for every mounted pane. A paused pane unsubscribes entirely — the server
      must not keep re-reading bytes nobody consumes — and resuming triggers
      the bus's immediate tick, so catch-up beats the old fixed interval. */
   useEffect(() => {
-    if (!file || paused || pausedInput) return;
+    if (!path || paused || pausedInput) return;
+    const target = path;
     let alive = true;
     const gen = genRef.current;
     const unsubscribe = subscribeLog({
-      path: file.path,
+      path: target,
       getOffset: () => offsetRef.current,
       onChunk: (result) => {
         if (!alive || gen !== genRef.current) return;
         if ("transportError" in result) {
-          setError(translate(getLocale(), "common.serverUnavailable"));
-          setLoading(false);
+          patch(target, { error: translate(getLocale(), "common.serverUnavailable"), loading: false });
           return;
         }
         if ("error" in result && result.error) {
-          setError(result.error);
-          setLoading(false);
+          patch(target, { error: result.error, loading: false });
           return;
         }
         const chunk = result as LogChunk;
         if (offsetRef.current > chunk.size) {
-          resetWindow();
-          updateWin({ lines: [], start: 0 });
+          resetWindow(target);
+          updateWin(target, { lines: [], start: 0 });
         }
         if (chunk.data) {
           let data = tailRef.current + chunk.data;
@@ -227,17 +257,17 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
               startRef.current = chunk.start + (nl >= 0 ? utf8len(data.slice(0, nl + 1)) : utf8len(data));
               data = nl >= 0 ? data.slice(nl + 1) : "";
             }
-            updateHasMore(startRef.current > 0);
+            updateHasMore(target, startRef.current > 0);
           }
           const parts = data.split("\n");
           tailRef.current = parts.pop() ?? "";
           const complete = parts.map((line) => line.trim()).filter(Boolean);
-          if (offsetRef.current === 0) updateWin({ lines: complete, start: 0 });
+          if (offsetRef.current === 0) updateWin(target, { lines: complete, start: 0 });
           else if (complete.length) {
             const prev = winRef.current;
             const merged = prev.lines.concat(complete);
             const capNow = capRef.current;
-            updateWin(capNow > 0 && merged.length > capNow
+            updateWin(target, capNow > 0 && merged.length > capNow
               ? { lines: merged.slice(-capNow), start: prev.start + (merged.length - capNow) }
               : { lines: merged, start: prev.start });
           }
@@ -245,26 +275,26 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
         }
         offsetRef.current = chunk.offset;
         sizeRef.current = chunk.size;
-        setSize(chunk.size);
-        setError(null);
+        const next: Partial<Omit<TailView, "path">> = { size: chunk.size, error: null, loading: false };
         /* Idle polls must not re-render every pane every 1.2s: the tick time
            moves only when bytes actually arrived (status reads "last data"). */
         if (chunk.data) {
           tickTimeRef.current = new Date();
-          setTickTime(tickTimeRef.current);
+          next.tickTime = tickTimeRef.current;
         }
-        saveSnapshot(file.path);
-        setLoading(false);
+        patch(target, next);
+        saveSnapshot(target);
       },
     });
     return () => {
       alive = false;
       unsubscribe();
     };
-  }, [file?.path, paused, pausedInput]);
+  }, [path, paused, pausedInput]);
 
   const loadOlder = useCallback(async (): Promise<number> => {
-    if (!file || olderBusyRef.current || startRef.current <= 0) return 0;
+    if (!path || olderBusyRef.current || startRef.current <= 0) return 0;
+    const target = path;
     olderBusyRef.current = true;
     setLoadingOlder(true);
     const gen = genRef.current;
@@ -273,7 +303,7 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
       let start = startRef.current;
       // A chunk may end mid-line; hop further back until the first newline shows up.
       for (let hop = 0; hop < OLDER_CHUNK_HOPS; hop += 1) {
-        const res = await fetch(`/api/log?path=${encodeURIComponent(file.path)}&before=${start}`);
+        const res = await fetch(`/api/log?path=${encodeURIComponent(target)}&before=${start}`);
         const json = (await res.json()) as LogChunk | { error?: string };
         if (gen !== genRef.current) return 0;
         if ("error" in json && json.error) return 0;
@@ -295,13 +325,13 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
       if (parts.at(-1) === "") parts.pop();
       const complete = parts.map((line) => line.trim()).filter(Boolean);
       startRef.current = newStart;
-      updateHasMore(newStart > 0);
+      updateHasMore(target, newStart > 0);
       if (complete.length) {
         const prev = winRef.current;
-        updateWin({ lines: complete.concat(prev.lines), start: prev.start - complete.length });
+        updateWin(target, { lines: complete.concat(prev.lines), start: prev.start - complete.length });
         setPrependGen((value) => value + 1);
       }
-      saveSnapshot(file.path);
+      saveSnapshot(target);
       return complete.length;
     } catch {
       return 0;
@@ -309,7 +339,21 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
       olderBusyRef.current = false;
       setLoadingOlder(false);
     }
-  }, [file?.path]);
+  }, [path]);
 
-  return { lines: win.lines, linesStart: win.start, size, loading, error, tickTime, paused, setPaused, clear, hasMore, loadingOlder, loadOlder, prependGen };
+  return {
+    lines: view.win.lines,
+    linesStart: view.win.start,
+    size: view.size,
+    loading: view.loading,
+    error: view.error,
+    tickTime: view.tickTime,
+    paused,
+    setPaused,
+    clear,
+    hasMore: view.hasMore,
+    loadingOlder,
+    loadOlder,
+    prependGen,
+  };
 }

--- a/src/test-helpers/renderProbe.ts
+++ b/src/test-helpers/renderProbe.ts
@@ -1,0 +1,142 @@
+/**
+ * Render and mount counter for DOM tests (issue #1432: "measure render counts,
+ * not only timings").
+ *
+ * It rides the React DevTools commit hook, which the development build of
+ * react-dom calls after every commit with the finished root. Walking the
+ * committed fiber tree the way the DevTools profiler does — descend only into
+ * subtrees whose child pointer moved, count a function fiber as rendered when
+ * it carries the PerformedWork flag, as mounted when it has no alternate —
+ * gives per-component render and mount counts without touching product code.
+ *
+ * Install BEFORE react-dom is imported: the renderer reads the hook once, at
+ * module evaluation. Test files therefore import react-dom dynamically after
+ * calling {@link installRenderProbe}.
+ */
+
+interface FiberLike {
+  tag: number;
+  type: unknown;
+  flags: number;
+  alternate: FiberLike | null;
+  child: FiberLike | null;
+  sibling: FiberLike | null;
+  memoizedProps: Record<string, unknown> | null;
+}
+
+const PERFORMED_WORK = 0b1;
+/* FunctionComponent, ForwardRef, SimpleMemoComponent. MemoComponent (14) wraps
+   a FunctionComponent fiber of the same name, so it is skipped to avoid double
+   counting. */
+const COUNTED_TAGS = new Set([0, 11, 15]);
+
+export interface RenderCounts {
+  renders: Record<string, number>;
+  mounts: Record<string, number>;
+  /** `Component:path` for components whose props name a transcript. */
+  byPath: Record<string, number>;
+  commits: number;
+}
+
+export interface RenderProbe {
+  /** Counts since the last reset. */
+  snapshot(): RenderCounts;
+  reset(): void;
+  /** Convenience: renders of one component since the last reset. */
+  renders(name: string): number;
+  mounts(name: string): number;
+  /** Renders of a path-bearing component (NodeShell, BranchPane, LogFeed) for one path. */
+  rendersFor(name: string, path: string): number;
+  uninstall(): void;
+}
+
+function componentName(fiber: FiberLike): string | null {
+  let type = fiber.type as { displayName?: string; name?: string; render?: unknown } | null;
+  if (fiber.tag === 11 && type && typeof type === "object") type = (type as { render?: unknown }).render as typeof type;
+  if (typeof type !== "function") return null;
+  const fn = type as unknown as { displayName?: string; name?: string };
+  return fn.displayName || fn.name || null;
+}
+
+function pathOf(fiber: FiberLike): string | null {
+  const props = fiber.memoizedProps;
+  if (!props) return null;
+  const node = props.node as { file?: { path?: string } } | undefined;
+  if (node?.file?.path) return node.file.path;
+  const file = props.file as { path?: string } | undefined;
+  return file?.path ?? null;
+}
+
+export function installRenderProbe(): RenderProbe {
+  let renders = new Map<string, number>();
+  let mounts = new Map<string, number>();
+  let byPath = new Map<string, number>();
+  let commits = 0;
+  const bump = (map: Map<string, number>, key: string) => map.set(key, (map.get(key) ?? 0) + 1);
+
+  const visit = (fiber: FiberLike, freshSubtree: boolean): void => {
+    const mounted = freshSubtree || fiber.alternate === null;
+    if (COUNTED_TAGS.has(fiber.tag)) {
+      const name = componentName(fiber);
+      if (name) {
+        if (mounted) bump(mounts, name);
+        if (mounted || (fiber.flags & PERFORMED_WORK) !== 0) {
+          bump(renders, name);
+          const path = pathOf(fiber);
+          if (path) bump(byPath, `${name}:${path}`);
+        }
+      }
+    }
+    if (mounted) {
+      for (let child = fiber.child; child; child = child.sibling) visit(child, true);
+      return;
+    }
+    /* A bailed-out subtree keeps the previous tree's child pointer: nothing
+       below it did work, so there is nothing to count. */
+    if (fiber.alternate && fiber.alternate.child === fiber.child) return;
+    for (let child = fiber.child; child; child = child.sibling) visit(child, false);
+  };
+
+  let rendererId = 0;
+  const hook = {
+    supportsFiber: true,
+    isDisabled: false,
+    renderers: new Map<number, unknown>(),
+    inject(renderer: unknown): number {
+      rendererId += 1;
+      hook.renderers.set(rendererId, renderer);
+      return rendererId;
+    },
+    onCommitFiberRoot(_id: number, root: { current: FiberLike }): void {
+      commits += 1;
+      const current = root.current;
+      visit(current, current.alternate === null);
+    },
+    onCommitFiberUnmount(): void {},
+    onPostCommitFiberRoot(): void {},
+    onScheduleFiberRoot(): void {},
+    setStrictMode(): void {},
+    checkDCE(): void {},
+  };
+  const globals = globalThis as { __REACT_DEVTOOLS_GLOBAL_HOOK__?: unknown };
+  const previous = globals.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  globals.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+
+  const toRecord = (map: Map<string, number>) => Object.fromEntries([...map.entries()].sort(([a], [b]) => a.localeCompare(b)));
+  return {
+    snapshot: () => ({ renders: toRecord(renders), mounts: toRecord(mounts), byPath: toRecord(byPath), commits }),
+    reset() {
+      renders = new Map();
+      mounts = new Map();
+      byPath = new Map();
+      commits = 0;
+    },
+    renders: (name) => renders.get(name) ?? 0,
+    mounts: (name) => mounts.get(name) ?? 0,
+    rendersFor: (name, path) => byPath.get(`${name}:${path}`) ?? 0,
+    uninstall() {
+      if (previous === undefined) delete globals.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      else globals.__REACT_DEVTOOLS_GLOBAL_HOOK__ = previous;
+    },
+  };
+}

--- a/src/test-helpers/switchingFixtures.ts
+++ b/src/test-helpers/switchingFixtures.ts
@@ -1,0 +1,190 @@
+/**
+ * Invented conversations for the switching profile (issue #1432): three
+ * transcripts of distinct shapes — short, long, tool-heavy — across two
+ * projects, as Claude-format JSONL the real feed parser consumes. Shared by the
+ * DOM timing test and the real-browser profile script so both measure the
+ * same corpus. Nothing here names a person, an account, or a machine.
+ */
+import type { FileEntry } from "@/lib/types";
+
+export const SWITCHING_PROJECTS = ["alpha", "beta"] as const;
+export type SwitchingProject = (typeof SWITCHING_PROJECTS)[number];
+
+export type SwitchingShape = "short" | "long" | "toolheavy";
+
+export interface SwitchingConversation {
+  project: SwitchingProject;
+  shape: SwitchingShape;
+  /** Stable id, so `#c=` links and history entries resolve it. */
+  conversationId: string;
+  /** Transcript path the scanner would report. Invented, absolute-looking. */
+  path: string;
+  title: string;
+  lines: string[];
+}
+
+const STAMP = "2100-01-02T10:00:00.000Z";
+
+function stamp(index: number): string {
+  const base = Date.parse(STAMP);
+  return new Date(base + index * 7_000).toISOString();
+}
+
+/** Record ids in the transcript's own shape, assembled from parts at runtime. */
+function uuid(seed: string, index: number): string {
+  const tail = (index + 1).toString(16).padStart(12, "0");
+  return [`${seed}000000`.slice(0, 8), "0000", "4000", "8000", tail].join("-");
+}
+
+/** Where a corpus project's transcripts say they ran. The DOM test never
+    reads it; the real-browser profile seeds a throwaway home and points it at
+    that home's own project directories so the scanner groups them. */
+export type CwdFor = (project: string) => string;
+const defaultCwd: CwdFor = (project) => `/repos/${project}`;
+
+function userLine(project: string, index: number, text: string, cwd: CwdFor = defaultCwd): string {
+  return JSON.stringify({
+    type: "user",
+    uuid: uuid("a1", index),
+    timestamp: stamp(index),
+    cwd: cwd(project),
+    message: { role: "user", content: text },
+  });
+}
+
+function assistantText(project: string, index: number, text: string, cwd: CwdFor = defaultCwd): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid: uuid("b2", index),
+    timestamp: stamp(index),
+    cwd: cwd(project),
+    message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text }] },
+  });
+}
+
+function toolUse(project: string, index: number, id: string, command: string, cwd: CwdFor = defaultCwd): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid: uuid("c3", index),
+    timestamp: stamp(index),
+    cwd: cwd(project),
+    message: {
+      role: "assistant",
+      model: "claude-sonnet-4-5",
+      content: [{ type: "tool_use", id, name: "Bash", input: { command, description: "Run a repository check" } }],
+    },
+  });
+}
+
+function toolResult(project: string, index: number, id: string, output: string, cwd: CwdFor = defaultCwd): string {
+  return JSON.stringify({
+    type: "user",
+    uuid: uuid("d4", index),
+    timestamp: stamp(index),
+    cwd: cwd(project),
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: output }] },
+  });
+}
+
+const PROSE = [
+  "The build finished and every focused test stayed green.",
+  "I re-read the scanner contract before touching the cache, so the offsets stay contiguous.",
+  "A switch must paint from what the tab already holds and refine when the fresh tail lands.",
+  "Board membership converges through the shared store; nothing here writes prefs directly.",
+];
+
+/** ~12 records: a short exchange. */
+export function shortLines(project: string, cwd: CwdFor = defaultCwd): string[] {
+  const lines: string[] = [];
+  for (let turn = 0; turn < 6; turn += 1) {
+    lines.push(userLine(project, turn * 2, `Please check item ${turn + 1} of the release list.`, cwd));
+    lines.push(assistantText(project, turn * 2 + 1, PROSE[turn % PROSE.length]!, cwd));
+  }
+  return lines;
+}
+
+/** ~1500 records of prose turns: the long conversation. */
+export function longLines(project: string, records = 1500, cwd: CwdFor = defaultCwd): string[] {
+  const lines: string[] = [];
+  for (let index = 0; index < records; index += 1) {
+    lines.push(index % 2 === 0
+      ? userLine(project, index, `Continue with step ${index / 2 + 1}; keep the summary short.`, cwd)
+      : assistantText(project, index, `${PROSE[index % PROSE.length]} (step ${(index - 1) / 2 + 1})`, cwd));
+  }
+  return lines;
+}
+
+/** ~900 records dominated by tool calls with multi-line outputs. */
+export function toolHeavyLines(project: string, calls = 300, cwd: CwdFor = defaultCwd): string[] {
+  const lines: string[] = [];
+  let index = 0;
+  lines.push(userLine(project, index++, "Audit every module and report what fails.", cwd));
+  for (let call = 0; call < calls; call += 1) {
+    const id = `tool-${call.toString(36).padStart(4, "0")}`;
+    lines.push(toolUse(project, index++, id, `bun test src/module-${call}.test.ts`, cwd));
+    const output = Array.from({ length: 6 }, (_, row) => `module-${call} case ${row}: ok (${(row * 3 + call) % 97} ms)`).join("\n");
+    lines.push(toolResult(project, index++, id, `${output}\n6 pass\n0 fail`, cwd));
+    if (call % 25 === 24) lines.push(assistantText(project, index++, `Batch ${(call + 1) / 25} of ${calls / 25} audited; no failures so far.`, cwd));
+  }
+  lines.push(assistantText(project, index++, "Every module passed. Nothing to fix.", cwd));
+  return lines;
+}
+
+function conversation(project: SwitchingProject, shape: SwitchingShape, title: string, lines: string[]): SwitchingConversation {
+  return {
+    project,
+    shape,
+    conversationId: `conv-${project}-${shape}`,
+    path: `/sessions/${project}/${shape}.jsonl`,
+    title,
+    lines,
+  };
+}
+
+/** The whole corpus: three shapes in `alpha`, two short ones in `beta`. */
+export function switchingCorpus(cwd: CwdFor = defaultCwd): SwitchingConversation[] {
+  return [
+    conversation("alpha", "short", "Short session", shortLines("alpha", cwd)),
+    conversation("alpha", "long", "Long session", longLines("alpha", 1500, cwd)),
+    conversation("alpha", "toolheavy", "Tool-heavy session", toolHeavyLines("alpha", 300, cwd)),
+    conversation("beta", "short", "Beta first session", shortLines("beta", cwd)),
+    conversation("beta", "long", "Beta second session", longLines("beta", 400, cwd)),
+  ];
+}
+
+export function transcriptText(lines: readonly string[]): string {
+  return lines.length ? lines.join("\n") + "\n" : "";
+}
+
+/** One more assistant record, appended to simulate the live tail moving. */
+export function appendedLine(project: string, index: number, marker: string, cwd: CwdFor = defaultCwd): string {
+  return assistantText(project, index, `Fresh tail record ${marker}.`, cwd);
+}
+
+/** The scanner-shaped entry for a corpus conversation. */
+export function fileEntryFor(entry: SwitchingConversation, overrides: Partial<FileEntry> = {}): FileEntry {
+  const text = transcriptText(entry.lines);
+  return {
+    path: entry.path,
+    root: "claude-projects",
+    name: `${entry.shape}.jsonl`,
+    project: entry.project,
+    cwd: `/repos/${entry.project}`,
+    title: entry.title,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 4_102_488_000 - (entry.shape === "short" ? 0 : entry.shape === "long" ? 60 : 120),
+    size: new TextEncoder().encode(text).length,
+    activity: "recent",
+    proc: null,
+    pid: null,
+    model: "sonnet",
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: entry.conversationId,
+    generation: 1,
+    ...overrides,
+  } as FileEntry;
+}


### PR DESCRIPTION
## Summary

Switching between conversations and between projects now paints from what the tab already holds, and the "Open conversation" / "Open it on the board" links move the operator inside the running app.

- **Conversation switch:** the tail window follows the selected transcript in the same render (no frame of the previous conversation's lines under the new title), parsed feed sessions survive a pane unmount through a small pool, the first commit of a pane paints its last 60 rows and grows on the next frame, and the shared log stream reconnects on a 40 ms window for a subscriber arriving on a settled stream.
- **Project switch:** the board store and the phone's focus view re-tag themselves during the render that changes the project, so a revisit paints the settled arrangement in the same frame as the rail click. No dashboard remount, no client-side transcript re-parse. A project this tab has never loaded still holds the skeleton until its board GET lands (#172).
- **Nothing re-renders that did not change on screen:** layout inputs memoised, tray projection and tray API identity-stable, unchanged layout nodes carry their identity across relayouts, node shell memoised. A focus move re-renders the one or two cards whose ring changed.
- **In-app links (operator addendum):** every conversation-hash anchor the tab can resolve opens through the same hand-off an accepted `request_attention` uses: project switch only when the target lives elsewhere, then `requestFocus`. No hash navigation, no pinned refetch, no remount of the dashboard or the orchestrator panel; the typed history entry is pushed so the URL still carries the link. Cold deep links from a URL keep resolving through the existing path.
- **A pre-existing bug this exposed:** the focus-request nonce restarted after a project switch cleared the request, so the first cross-project open after any focus moved nothing (attention popover, favorites, Next included). The nonce is now monotonic; the DOM test and the browser "before" table both show the lost ring.
- **Last-known catalog first:** a request scope without a representation yet is answered by the freshest certified representation of another scope, marked uncertified, instead of the empty placeholder that blanked the board on every deep-link pin.
- **The stand-in stays silent (review round 3):** the chime scan ignores an uncertified stand-in payload, so a warm-tab deep link to a conversation waiting on a question seeds the chime baseline silently as it did before, where the stand-in had let the pinned answer ring.

Refs #1432. The issue's cold target ("well under half a second cold on the production corpus") is verified on the client side only: the browser cold rows below are bounded by the dev server, so the issue stays open on that one point. Refs #1444 (follow-up with the numbers to date: the same run against a production build and the production corpus).

## Profile

Same three fixtures (short ≈12 records, long 1 500 records, tool-heavy ≈900 records) in project alpha, two conversations in beta; all invented. Before = origin/main with the same test and script dropped in; after = this branch.

### DOM test, fake timers (`bun test src/components/Viewer.switching.dom.test.tsx`)

"fake ms" is how much fake time had to pass before the milestone was on screen (0 = same synchronous flush as the gesture); "work ms" is real CPU time since the gesture read from the OS clock. Render and mount counts come from the DevTools commit hook.

| surface | step | before fake / work ms | after fake / work ms | before renders / mounts | after renders / mounts |
|---|---|---:|---:|---|---|
| desktop | mount → three cards painted (cold) | 340 / 436 | 80 / 421 | | |
| desktop | «Open conversation» link → target ringed | 45 / 480 | **0 / 29** | hash navigation; skeleton shown; NodeShell mounts +6; other cards' LogFeed renders 10; /api/files requests 3 | in-app; skeleton never; dashboard +0, dock +0, orchestrator panel +0, NodeShell +0; other LogFeed renders 0; /api/files requests 1 |
| desktop | cross-project link → rail switched | 45 / 369 | **0 / 89** | hash navigation | in-app |
| desktop | cross-project link → cards painted from cache | 45 / 385 | **0 / 91** | skeleton shown; LogFeed renders 14; /api/files +2 | skeleton never; dashboard +0; LogFeed renders 6; /api/files +0 |
| desktop | cross-project link → target ringed | 45 / 389 | **0 / 93** | | |
| desktop | project switch (first visit) → rail highlight | 0 / 19 | 0 / 20 | | |
| desktop | project switch (first visit) → cards painted (cold) | 340 / 172 | **80 / 158** | skeleton while /api/board loads; dashboard +0 | same |
| desktop | project switch (revisit) → rail highlight | 0 / 166 | 0 / 89 | | |
| desktop | project switch (revisit) → cards painted from cache | 0 / 173 | 0 / 92 | skeleton never; dashboard +0; LogFeed renders 6 | same |
| desktop | focus moves short → tool-heavy (click on card) | 0 / 21 | 0 / 9 | NodeShell renders 3 (3 cards); LogFeed 3; BranchPane 3 | **NodeShell 1 (1 card); LogFeed 1; BranchPane 1** |
| desktop | fresh tail record → appended | 20 / 9 | 20 / 7 | first row node preserved | same |
| desktop | ArrowRight → ring moves to neighbour | 0 / 17 | 0 / 16 | NodeShell renders 3; untouched card 1 | **NodeShell 2; untouched card 0** |
| desktop | cold URL deep link (beyond cap) → card on board | 40 / 85 | 40 / 72 | | |
| phone 390px | mount → focused pane painted (cold) | 340 / 41 | **80 / 31** | | |
| phone | tap chip A (cold) → highlighted / rows | 0 / 6, 0 / 7 | 0 / 6, 0 / 7 | | |
| phone | tap chip B (cold, long) → rows painted | 320 / 107 | **60 / 97** | LogFeed renders 6 | LogFeed renders 7 |
| phone | tap chip A again (cached) → previous rows on screen | 0 / 17 | 0 / 16 | MobileFocusView +0; dashboard +0 | same |
| phone | fresh tail record → appended | 320 / 3 | **60 / 3** | first row node preserved | same |
| phone | header swipe → neighbour highlighted / cached rows | 0 / 104, 0 / 107 | **0 / 28, 0 / 30** | | |
| phone | drawer project switch (revisit) → pane painted from cache | 0 / 22 | 0 / 34 | MobileFocusView mounts **+1**; BranchPane mounts 1 | MobileFocusView mounts **+0**; BranchPane mounts 1 |

The 340 → 80 and 320 → 60 rows are the stream reconnect window (300 ms coalescing → 40 ms prompt) plus a 20 ms fake round trip. The before table was produced by the test as it stood before the orchestrator-panel column and the prior-focus step were added to it; the after table is the committed test.

### Real browser (`bun scripts/profile-switching.ts`: headless Chrome, `next dev --webpack`, throwaway home, desktop 1280×800 and phone 390×844)

Milliseconds are `performance.now()` from the gesture; frames are `requestAnimationFrame` ticks meanwhile. Steps that involve a server round trip are bounded by the dev server here: the server log shows 400–1 600 ms of Next.js dev overhead per request with application code in single digits, which is why #1444 asks for the same run against a production build.

| surface | step | before ms (frames) | after ms (frames) | notes |
|---|---|---:|---:|---|
| desktop | «Open conversation» link → target ringed | 5 163 (287) | **77 (1)** | before: hash navigation, skeleton shown, pinned /api/files 1.9 s; after: in-app, skeleton never |
| desktop | project switch (first visit) → rail highlight | 33 | 55 | |
| desktop | project switch (first visit) → cards painted (cold) | 9 533 | 5 655 | dev server: /api/board 2.0 s → 3.5 s, bindings 2.5 s → 2.7 s; skeleton until the board GET lands |
| desktop | project switch (revisit) → rail highlight | 253 (2) | 158 (1) | |
| desktop | project switch (revisit) → cards painted from cache | 1.0 (0) | 0.6 (0) | skeleton never |
| desktop | cross-project link → rail switched | 6 024 (350) | **302 (1)** | before: hash navigation, pinned /api/files 5.3 s; after: in-app |
| desktop | cross-project link → cards painted from cache | 1.4 (0) | 0.8 (0) | before: skeleton shown; after: never |
| desktop | cross-project link → target ringed | **not reached in 20 s** | **0 (0)** | the nonce bug above |
| desktop | ArrowRight → ring moves to neighbour | 27 (1) | 30 (1) | |
| desktop | click on a card → ring moves | 30 (1) | 21 (1) | |
| desktop | fresh tail record on disk → appended | 14 557 | 11 399 | dev server (presence request 10–13 s in the same window); first row node preserved |
| desktop | cold URL deep link (from navigation start) | 27 452 | 20 971 | dev compile |
| phone | tap chip A → highlighted / rows | 0.1 / 0 (0) | 0.1 / 0.1 (0) | |
| phone | tap chip B (long, cold) → pane focused / rows | 47 (1) / 4 331 | 47 (1) / 4 225 | rows: dev server (tmux targets 4 s, presence 1.8 s beside the stream) |
| phone | tap chip A again (cached) → previous rows | 35 (1) | 68 (1) | |
| phone | header swipe → neighbour with cached rows | 327 (1) | **130 (1)** | |
| phone | drawer project switch (first visit) → pane painted | 7 222 | 7 276 | dev server: /api/board 3.4–3.7 s; skeleton shown |
| phone | drawer project switch (revisit) → pane from cache | 56 (1) | 155 (1) | skeleton never |

Single samples on a busy machine; the frame count is the reliable unit for the client steps.

## Mechanism

- `src/hooks/useLogTail.ts`: the rendered window is state tagged with its path and re-seated during render when the path changes; transport state (offset, history start, decoder partial) is re-seated in the path effect from the same cached snapshot; every write names its target path.
- `src/components/feed/sessionPool.ts` + `LogFeed.tsx`: a mounting feed takes the pooled session for its parse configuration and releases it on unmount or key change (one owner at a time). `feed/parse.ts` resets when the last consumed line no longer matches the window, so a rewritten transcript of equal length is never served from a stale snapshot.
- `LogFeed.tsx`: `visibleCount` starts at 60 and grows to the initial window on the second animation frame with the scroll anchored like a "show earlier" reveal.
- `src/hooks/logBus.ts`: a subscriber arriving ≥300 ms after the last (re)connect reconnects in 40 ms; arrivals inside that window keep the 300 ms coalescing.
- `src/hooks/useBoardState.ts` and `mobile/MobileFocusView.tsx`: set-state-in-render on the component's own state when `project` changes, reading the session cache / `sessionStorage`.
- `ProjectDashboard.tsx`, `scheme/layoutIdentity.ts`, `scheme/nodes.tsx`, `scheme/subagentTray.ts`, `scheme/SchemeBoard.tsx`: memoised layout inputs, value-stable tray projection (signature), ref-backed tray handlers, node identity reconciliation across layouts, memoised `NodeShell`.
- `src/hooks/useFiles.ts`: `scopeCertified` on `FilesData`; an unfetched scope reads the freshest certified representation minus pin-only rows; `Viewer.tsx` retires a hydrated pin only on a certified payload.
- `src/hooks/useAgentChimes.ts`: `planScopedAgentChimes` takes the payload's certification and is a no-op for an uncertified stand-in, so the baseline keeps the scope that actually produced it; `useAgentChimes` passes the flag through and `Viewer.tsx` hands it `scopeCertified` (review round 3).
- `src/components/Viewer.tsx`: a capture-phase click listener resolves `#c=` / `#f=` anchors against the current payload and opens them through `applyProject` + `requestFocus`; unresolvable targets fall through to the browser. `focusNonceRef` makes the request nonce monotonic. The not-found deadline for a deep link (8 s) now waits for a payload certified for the pinned request scope, as the retire-pin effect already did: the last-known stand-in carries `loaded` and says nothing about the target, so on a warm tab it no longer starts the clock before the pinned fetch can answer (review round 2).

Out of scope, left as hash navigation (in-document, resolver path, no blank board any more): the superseded-conversation banner (`SupersededBanner.tsx`) and the switchboard's cross-project open in `ProjectDashboard.tsx`; both are recorded in #1444, as is the render-phase pool take in `LogFeed.tsx` (a discarded concurrent render loses the pooled session and the next mount re-parses once; perf only). The starting-window reconciliation in `LogFeed` and `workingSince.ts`, the search overlay, and the orchestrator prompt scaffolds are untouched.

## Verification

- `bunx tsc --noEmit --incremental false`: clean.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits`: PASS.
- New pins: `Viewer.switching.dom.test.tsx` (10 tests: cached feed on switch A→B→A, no dashboard / orchestrator panel remount on link and project switch, untouched cards not re-rendered on click and ArrowRight, in-app link with the URL still carrying the deep link, cross-project link after a prior focus, cold beyond-cap deep link, phone chip / swipe / drawer parity), `hooks/logBus.test.ts` (4), `feed/parse.test.ts` (+2: rewritten window, incremental identity), `hooks/useFiles.test.ts` (+1) and `useFiles.dom.test.tsx` (stand-in scope).
- RED check: with the nonce derived from the previous request, the cross-project DOM test fails ("milestone not reached"); with the monotonic nonce it passes.
- RED check (round 2): `Viewer.deepLink.dom.test.tsx` gained a pin where the global scope answers at once and the pinned fetch outlasts the deadline; with the countdown gated on `loaded` alone the stale notice appears at 8 s and the row is dropped, with the `scopeCertified` gate the link resolves when the pinned payload lands (11 tests green).
- RED check (round 3): `useAgentChimes.test.ts` gained the global scan → stand-in under the pinned scope → pinned answer sequence with an attention-state pin-only row. Without the certification gate the stand-in step records the pinned scope and the answer plans a question chime; with it, zero chimes, and a real live → waiting transition in the same answer still rings (15 tests green).
- Touched files green by path on the rebased tree: `Viewer.switching`, `useAgentChimes` (15), `OrchestratorPanel.dom` (46), `feed/parse` (119), `useLogTail.dom`, `useFiles` ×3, `logBus`, `useBoardState`, `LogFeed.*` ×5, `ProjectDashboard.selection` / `.searchLanding`, `MobileFocusView.strip` / `.viewport`, `SchemeBoard.selection`, `nodes.dom`, `subagentTray`, `Viewer.deepLink` / `.orchestratorDock`, `OrchestratorDock.dom`.
- Red at the merge base too, unchanged by this branch: `ProjectDashboard.launchClaim.dom.test.tsx` (1), `SchemeBoard.lineage.dom.test.tsx` (2), `layout.lineage.test.ts` (1).
- Real-browser run: `bun scripts/profile-switching.ts --out <file>` (needs Chrome at `/usr/bin/google-chrome-stable` or `LLV_PROFILE_CHROME`); both tables above are from that script, the before one with the script dropped into a checkout of origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


