### PR TITLE
fix(migration): the viewer writes the Claude successor fork itself (#889)

### DIFF
--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -144,7 +144,9 @@ export function migrationSuccessorLaunchProfile(profile: LaunchProfile): LaunchP
 }
 
 export interface GenerationHostEvidence {
-  kind: "tmux" | "codex-app-server" | "claude-stream";
+  /** `claude-fork`: a successor transcript the viewer wrote itself (issue #889);
+      no process existed at creation, the broker host is published from it. */
+  kind: "tmux" | "codex-app-server" | "claude-stream" | "claude-fork";
   identity: string;
   epoch: number;
   verifiedAt: string;

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -111,7 +111,6 @@ test("Codex successor host publication is single-owner and cleanup releases that
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     publishCodexHost: async () => {
       publications += 1;
       await Promise.resolve();
@@ -157,7 +156,6 @@ test("Claude successor cleanup releases its published broker owner", async () =>
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     cancelClaude: async () => { legacyCancellations += 1; return true; },
     publishClaudeHost: async () => {
       publications += 1;
@@ -242,7 +240,6 @@ test("Claude publication waits for controller startup before replacing its verif
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     verifyClaudeHost: async () => tmuxLive,
     cancelClaude: async () => {
       if (!tmuxLive) return "absent";
@@ -331,7 +328,6 @@ test("a fenced Claude publication keeps receipt cleanup available", async () => 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     cancelClaude: async (host) => { cancelled.push(host.paneId); return true; },
     publishClaudeHost: async (input) => {
       if (input.ownsOperation && !await input.ownsOperation()) return async () => {};
@@ -371,134 +367,119 @@ test("a fenced Claude publication keeps receipt cleanup available", async () => 
   expect(cancelled).toEqual(["%46"]);
 });
 
-test("Claude successor provider uses registered homes and shared model normalization", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-"));
-  roots.push(base);
+const FORK_SOURCE_ID = "019f423a-d6e9-\x34903-b597-3e676b6ff3d4";
+const FORK_OPERATION_ID = "7d1c2b3a-4e5f-\x34a6b-8c7d-9e0f1a2b3c4d";
+
+function claudeForkFixture(base: string) {
   const source = accountRoot("claude", base, "source");
   const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "-repo", "019f423a-d6e9-\x37903-b597-3e676b6ff3d4.jsonl");
+  const sourcePath = path.join(source.transcriptRoot, "-repo", `${FORK_SOURCE_ID}.jsonl`);
   fs.mkdirSync(path.dirname(sourcePath), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  let command = "";
-  let launchTitle: string | null = null;
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const dependencies: ProviderDependencies = {
-    accounts: {
-      resolveSpawn: () => target,
-      resolveTranscriptOwner: () => source,
-    },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => {
-      command = spec.command;
-      launchTitle = spec.launchProfile?.title ?? null;
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%9", panePid: 99, host: claudeHost("%9", 99) };
-    },
-    verifyClaudeHost: async () => true,
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  };
-  const provider = new RegisteredSuccessorProvider(dependencies);
+  const quoted = `"sessionId":"${FORK_SOURCE_ID}"`;
+  fs.writeFileSync(sourcePath, [
+    JSON.stringify({ type: "user", sessionId: FORK_SOURCE_ID, cwd: "/repo", message: { role: "user", content: "Привіт, почнімо ✅" } }),
+    JSON.stringify({ type: "summary", leafUuid: "leaf", summary: "carries no session field" }),
+    JSON.stringify({ type: "assistant", sessionId: FORK_SOURCE_ID, message: { role: "assistant", content: [{ type: "text", text: `a quoted ${quoted} inside a value` }] } }),
+  ].join("\n") + "\n", { mode: 0o600 });
   const sourceGeneration: NativeGeneration = {
-    id: "019f423a-d6e9-\x37903-b597-3e676b6ff3d4",
+    id: FORK_SOURCE_ID,
     path: sourcePath,
     accountId: "source",
-    launchProfile: migrationSuccessorLaunchProfile(emptyLaunchProfile({
-      cwd: "/repo",
-      model: "claude-fable-20260701",
-      effort: "high",
-      title: "Claude session",
-      goal: { objective: "Migrate issue #913 identity", status: "active", tokensUsed: null, timeUsedSeconds: null },
-    })),
+    launchProfile: migrationSuccessorLaunchProfile(emptyLaunchProfile({ cwd: "/repo", model: "fable", title: "Claude session" })),
     historyHash: null,
     host: null,
     createdAt: "2026-07-10T11:00:00.000Z",
     archivedAt: null,
   };
-  const receipt = await provider.create({ engine: "claude", operationId: "019f423a-d6e9-\x34903-8597-3e676b6ff3d4", conversationId: "conversation_test", source: sourceGeneration, targetAccountId: "target", recordContinuityPath() {} });
-  expect(command).toContain("CLAUDE_CONFIG_DIR=");
-  expect(command).toContain("--model' 'fable'");
-  expect(command).not.toContain("claude-fable-");
-  expect(command).toContain("--effort' 'high'");
-  expect(launchTitle as string | null).toBe("migration successor · Migrate issue 913 identity");
-  expect(receipt.path.startsWith(target.transcriptRoot + path.sep)).toBeTrue();
-  expect(Object.values(registry.snapshot().receipts)).toContainEqual(expect.objectContaining({
-    launchProfile: expect.objectContaining({ title: "migration successor · Migrate issue 913 identity" }),
-  }));
-  await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: sourceGeneration.launchProfile })).resolves.toBeUndefined();
-});
-
-test("Claude successor verification rejects a missing durable transcript", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-missing-"));
-  roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const provider = new RegisteredSuccessorProvider({
+  const dependencies = {
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%11", panePid: 111, host: claudeHost("%11", 111) }),
     registry: new AgentRegistry(path.join(base, "provider-registry.json")),
     claudeJournalRoot: path.join(base, "claude-operations"),
     now: () => "2026-07-10T12:00:00.000Z",
-  });
-  const receipt = await provider.create({
-    engine: "claude",
-    operationId: "019f423a-d6e9-\x34903-8597-3e676b6ff3d4",
-    conversationId: "conversation_test",
+  } satisfies ProviderDependencies;
+  const input = {
+    engine: "claude" as const,
+    operationId: FORK_OPERATION_ID,
+    conversationId: "conversation_fork_test" as const,
     targetAccountId: "target",
-    source: { id: "source", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    source: sourceGeneration,
     recordContinuityPath() {},
-  });
+  };
+  const successorPath = path.join(target.transcriptRoot, "-repo", `${FORK_OPERATION_ID}.jsonl`);
+  return { source, target, sourcePath, sourceGeneration, dependencies, input, successorPath };
+}
 
-  await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }) }))
+test("Claude successor is a fork the viewer writes into the target root, with no launch", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-"));
+  roots.push(base);
+  const fixture = claudeForkFixture(base);
+  const recorded: string[] = [];
+  const provider = new RegisteredSuccessorProvider(fixture.dependencies);
+
+  const receipt = await provider.create({ ...fixture.input, recordContinuityPath(pathname) { recorded.push(pathname); } });
+
+  expect(receipt).toEqual({
+    operationId: FORK_OPERATION_ID,
+    nativeId: FORK_OPERATION_ID,
+    path: fixture.successorPath,
+    continuityPaths: [fixture.successorPath],
+    historyHash: expect.any(String),
+    host: { kind: "claude-fork", identity: FORK_OPERATION_ID, epoch: 1, verifiedAt: "2026-07-10T12:00:00.000Z" },
+  });
+  expect(recorded).toEqual([fixture.successorPath]);
+  const forked = fs.readFileSync(fixture.successorPath, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+  expect(forked.map((record) => record.sessionId)).toEqual([FORK_OPERATION_ID, undefined, FORK_OPERATION_ID]);
+  expect((forked[0]!.message as { content: string }).content).toBe("Привіт, почнімо ✅");
+  /* A mention inside a value is text, not identity: it stays as written. */
+  expect(JSON.stringify(forked[2])).toContain(FORK_SOURCE_ID);
+  expect(fs.statSync(fixture.successorPath).mode & 0o777).toBe(0o600);
+  expect(Object.values(fixture.dependencies.registry.snapshot().receipts)).toHaveLength(0);
+  await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: fixture.sourceGeneration.launchProfile }))
+    .resolves.toBeUndefined();
+});
+
+test("Claude successor verification rejects a fork that is no longer durable", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-missing-"));
+  roots.push(base);
+  const fixture = claudeForkFixture(base);
+  const provider = new RegisteredSuccessorProvider(fixture.dependencies);
+  const receipt = await provider.create(fixture.input);
+  fs.rmSync(receipt.path);
+
+  await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: fixture.sourceGeneration.launchProfile }))
     .rejects.toThrow("durable");
 });
 
-test("Claude agent exit fails full host verification and leaves the persisted receipt immutable", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-host-failure-"));
+test("a legacy tmux successor receipt still verifies pane liveness", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-legacy-pane-"));
   roots.push(base);
   const source = accountRoot("claude", base, "source");
   const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
   let verifiedHost: TmuxHostEvidence | null = null;
   const provider = new RegisteredSuccessorProvider({
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => {
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%12", panePid: 1212, host: claudeHost("%12", 1212) };
-    },
     verifyClaudeHost: async (host) => { verifiedHost = host; return false; },
     registry: new AgentRegistry(path.join(base, "provider-registry.json")),
-    claudeJournalRoot: path.join(base, "claude-operations"),
     now: () => "2026-07-10T12:00:00.000Z",
   });
-  const receipt = await provider.create({
-    engine: "claude",
-    operationId: "claude-host-failure",
-    conversationId: "conversation_claude_host_failure",
-    targetAccountId: "target",
-    source: { id: "source", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
-    recordContinuityPath() {},
-  });
-  const persisted = structuredClone(receipt);
+  const transcript = path.join(target.transcriptRoot, "legacy-pane.jsonl");
+  fs.writeFileSync(transcript, JSON.stringify({ sessionId: "legacy-pane" }) + "\n", { mode: 0o600 });
+  const receipt: ProviderReceipt = {
+    operationId: "legacy-pane",
+    nativeId: "legacy-pane",
+    path: transcript,
+    continuityPaths: [],
+    historyHash: "history",
+    host: { kind: "claude-stream", identity: "%12:1212", epoch: 1, verifiedAt: "2026-07-10T12:00:00.000Z", tmuxHost: claudeHost("%12", 1212) },
+  };
 
-  await expect(provider.verify(receipt, {
-    engine: "claude",
-    targetAccountId: "target",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }),
-  })).rejects.toThrow("host is not live");
-  expect(receipt).toEqual(persisted);
-  expect(verifiedHost).toMatchObject({ paneId: "%12", panePid: { pid: 1212 }, agent: { pid: 11212 } });
+  await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: emptyLaunchProfile({ cwd: "/repo" }) }))
+    .rejects.toThrow("host is not live");
+  expect(verifiedHost).toMatchObject({ paneId: "%12", panePid: { pid: 1212 } });
 });
 
 test("Claude cleanup cancels only the pane PID recorded by the losing receipt", async () => {
@@ -512,7 +493,6 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
     cancelClaude: async (host) => {
       if (observedPid !== host.panePid.pid) return false;
       cancelled.push([host.paneId, host.panePid.pid]);
@@ -554,7 +534,6 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
     now: () => "2026-07-10T12:00:00.000Z",
   });
   await expect(providerWithoutCleanup.cleanup(receipt)).rejects.toThrow("cleanup is still pending");
@@ -563,7 +542,6 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
     cancelClaude: async () => "absent",
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -573,297 +551,70 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
     cancelClaude: async () => "unverifiable",
     now: () => "2026-07-10T12:00:00.000Z",
   });
   await expect(unverifiableProvider.cleanup(receipt)).rejects.toThrow("cleanup is still pending");
 });
 
-test("concurrent Claude creates reuse one durable migration spawn receipt", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-concurrent-"));
+test("concurrent Claude creates publish one fork and return one receipt", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-concurrent-"));
   roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const conversation = registry.ensureConversation("claude", sourcePath, "source");
-  let spawns = 0;
-  const provider = new RegisteredSuccessorProvider({
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => {
-      spawns += 1;
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%21", panePid: 2121, host: claudeHost("%21", 2121) };
-    },
-    verifyClaudeHost: async () => true,
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  });
-  const input = {
-    engine: "claude" as const,
-    operationId: "claude-concurrent-operation",
-    conversationId: conversation.id,
-    targetAccountId: "target",
-    source: titledProviderSource(conversation.generations[0]!),
-    recordContinuityPath() {},
-  };
+  const fixture = claudeForkFixture(base);
+  const provider = new RegisteredSuccessorProvider(fixture.dependencies);
 
-  const receipts = await Promise.all([provider.create(input), provider.create(input)]);
+  const receipts = await Promise.all([provider.create(fixture.input), provider.create(fixture.input)]);
 
-  expect(spawns).toBe(1);
   expect(receipts[0]).toEqual(receipts[1]);
-  const launchReceipts = Object.values(registry.snapshot().receipts);
-  expect(launchReceipts).toHaveLength(1);
-  expect(launchReceipts[0]).toMatchObject({ conversationId: conversation.id, purpose: "migration-successor" });
+  expect(fs.readdirSync(path.dirname(fixture.successorPath)).sort()).toEqual([
+    `${FORK_OPERATION_ID}.jsonl`,
+    `${FORK_OPERATION_ID}.jsonl.llv-receipt.json`,
+  ]);
+  expect(Object.values(fixture.dependencies.registry.snapshot().receipts)).toHaveLength(0);
 });
 
-test("Claude create cancels the live host when continuity persistence fails", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-continuity-failure-"));
+test("Claude create writes no fork when continuity persistence fails", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-continuity-failure-"));
   roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const conversation = registry.ensureConversation("claude", sourcePath, "source");
-  const cancelled: string[] = [];
-  const provider = new RegisteredSuccessorProvider({
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => {
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%25", panePid: 2525, host: claudeHost("%25", 2525) };
-    },
-    cancelClaude: async (host) => { cancelled.push(host.paneId); return true; },
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  });
+  const fixture = claudeForkFixture(base);
 
-  await expect(provider.create({
-    engine: "claude",
-    operationId: "claude-continuity-failure",
-    conversationId: conversation.id,
-    targetAccountId: "target",
-    source: titledProviderSource(conversation.generations[0]!),
+  await expect(new RegisteredSuccessorProvider(fixture.dependencies).create({
+    ...fixture.input,
     recordContinuityPath() { throw new Error("registry unavailable"); },
   })).rejects.toThrow("registry unavailable");
 
-  expect(cancelled).toEqual(["%25"]);
-  const spawnReceipt = Object.values(registry.snapshot().receipts)[0]!;
-  expect(spawnReceipt).toMatchObject({ state: "path-pending", error: "migration continuity persistence failed" });
-  registry.reconcileConversations([{
-    engine: "claude",
-    path: spawnReceipt.artifactPath!,
-    accountId: "target",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }),
-    turn: { state: "idle", source: "empty", terminalAt: null },
-    observedAt: "2026-07-10T12:01:00.000Z",
-  }]);
-  expect(registry.conversationForPath(spawnReceipt.artifactPath!)?.id).toBe(conversation.id);
-  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
+  expect(fs.existsSync(path.dirname(fixture.successorPath))).toBeFalse();
 });
 
-test("Claude replay cancels its verified host when continuity persistence fails", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-replay-continuity-failure-"));
+test("Claude replay after a crash between the fork and its receipt reuses the fork", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-replay-"));
   roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const conversation = registry.ensureConversation("claude", sourcePath, "source");
-  const cancelled: string[] = [];
-  const dependencies = {
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%26", panePid: 2626, host: claudeHost("%26", 2626) }),
-    verifyClaudeHost: async () => true,
-    cancelClaude: async (host: TmuxHostEvidence) => { cancelled.push(host.paneId); return true; },
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  } satisfies ProviderDependencies;
-  const input = {
-    engine: "claude" as const,
-    operationId: "claude-replay-continuity-failure",
-    conversationId: conversation.id,
-    targetAccountId: "target",
-    source: titledProviderSource(conversation.generations[0]!),
-    recordContinuityPath() {},
-  };
-  await new RegisteredSuccessorProvider(dependencies).create(input);
-
-  await expect(new RegisteredSuccessorProvider(dependencies).create({
-    ...input,
-    recordContinuityPath() { throw new Error("registry unavailable on replay"); },
-  })).rejects.toThrow("registry unavailable on replay");
-
-  expect(cancelled).toEqual(["%26"]);
-  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "path-pending", error: "migration continuity persistence failed" });
-});
-
-test("Claude replay resumes a pane-free birth receipt and fences terminal spawn state", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-receipt-recovery-"));
-  roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const conversation = registry.ensureConversation("claude", sourcePath, "source");
-  let spawns = 0;
-  let forceTerminal = false;
-  const cancelled: string[] = [];
-  const dependencies = {
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec: ReturnType<typeof import("@/lib/agent/cli").claudeSuccessorSpecFor>, launch: import("@/lib/agent/registry").SpawnReceipt) => {
-      spawns += 1;
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      if (forceTerminal) registry.invalidateSpawnHost(launch.launchId, "forced terminal receipt");
-      return { paneId: "%23", panePid: 2323, host: claudeHost("%23", 2323) };
-    },
-    verifyClaudeHost: async () => true,
-    cancelClaude: async (host: TmuxHostEvidence) => { cancelled.push(host.paneId); return true; },
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  } satisfies ProviderDependencies;
-  const input = {
-    engine: "claude" as const,
-    operationId: "claude-pane-free-retry",
-    conversationId: conversation.id,
-    targetAccountId: "target",
-    source: titledProviderSource(conversation.generations[0]!),
-    recordContinuityPath() {},
-  };
+  const fixture = claudeForkFixture(base);
 
   await expect(new RegisteredSuccessorProvider({
-    ...dependencies,
-    afterClaudeReceiptCreated() { throw new Error("simulated crash after receipt birth"); },
-  }).create(input)).rejects.toThrow("simulated crash after receipt birth");
-  expect(spawns).toBe(0);
-  await expect(new RegisteredSuccessorProvider(dependencies).create(input)).resolves.toMatchObject({ host: { identity: "%23:2323" } });
-  expect(spawns).toBe(1);
+    ...fixture.dependencies,
+    afterClaudeForked() { throw new Error("simulated crash after fork"); },
+  }).create(fixture.input)).rejects.toThrow("simulated crash after fork");
+  const written = fs.statSync(fixture.successorPath);
 
-  forceTerminal = true;
-  const recorded: string[] = [];
-  await expect(new RegisteredSuccessorProvider(dependencies).create({
-    ...input,
-    operationId: "claude-terminal-fence",
-    recordContinuityPath(pathname) { recorded.push(pathname); },
-  })).rejects.toThrow("became terminal");
-  expect(recorded).toEqual([]);
-  expect(cancelled).toEqual(["%23"]);
+  const receipt = await new RegisteredSuccessorProvider(fixture.dependencies).create(fixture.input);
+
+  expect(receipt.path).toBe(fixture.successorPath);
+  const reused = fs.statSync(fixture.successorPath);
+  expect([reused.ino, reused.mtimeMs, reused.size]).toEqual([written.ino, written.mtimeMs, written.size]);
 });
 
-test("Claude crash recovery reuses the exact host and observer settlement keeps one owner", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-crash-recovery-"));
+test("Claude fork receipt cleanup owns no pane", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-fork-cleanup-"));
   roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
-  const conversation = registry.ensureConversation("claude", sourcePath, "source");
-  let spawns = 0;
-  const dependencies = {
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec: ReturnType<typeof import("@/lib/agent/cli").claudeSuccessorSpecFor>) => {
-      spawns += 1;
-      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%22", panePid: 2222, host: claudeHost("%22", 2222) };
-    },
-    verifyClaudeHost: async () => true,
-    registry,
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
-  } satisfies ProviderDependencies;
-  const input = {
-    engine: "claude" as const,
-    operationId: "claude-crash-operation",
-    conversationId: conversation.id,
-    targetAccountId: "target",
-    source: titledProviderSource(conversation.generations[0]!),
-    recordContinuityPath() {},
-  };
-
-  await expect(new RegisteredSuccessorProvider({
-    ...dependencies,
-    afterClaudeSpawned() { throw new Error("simulated crash after Claude spawn"); },
-  }).create(input)).rejects.toThrow("simulated crash after Claude spawn");
-  const launchBeforeRecovery = Object.values(registry.snapshot().receipts)[0]!;
-  registry.reconcileConversations([{
-    engine: "claude",
-    path: launchBeforeRecovery.artifactPath!,
-    accountId: "target",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
-    turn: { state: "idle", source: "empty", terminalAt: null },
-    observedAt: "2026-07-10T12:01:00.000Z",
-  }]);
-  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
-  expect(registry.conversationForPath(launchBeforeRecovery.artifactPath!)?.id).toBe(conversation.id);
-  const receipt = await new RegisteredSuccessorProvider(dependencies).create(input);
-  const launch = Object.values(registry.snapshot().receipts)[0]!;
-  const settled = registry.settleSpawn(launch.launchId, {
-    key: { engine: "claude", sessionId: receipt.nativeId },
-    artifactPath: receipt.path,
-    cwd: launch.cwd,
-    accountId: "target",
-    status: "live",
-    host: receipt.host.tmuxHost!,
-    claimEpoch: 0,
-    claimOwner: null,
-    pendingAction: null,
-  });
-
-  expect(spawns).toBe(1);
-  expect(settled).toMatchObject({ kind: "settled", conversation: { id: conversation.id } });
-  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
-  expect(registry.conversation(conversation.id)?.generations.map((generation) => generation.path)).toEqual([sourcePath]);
-});
-
-test("unknown Claude transcript model omits the successor override", async () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-unknown-"));
-  roots.push(base);
-  const source = accountRoot("claude", base, "source");
-  const target = accountRoot("claude", base, "target");
-  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
-  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
-  let command = "";
+  const fixture = claudeForkFixture(base);
   const provider = new RegisteredSuccessorProvider({
-    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
-    startCodex: async () => { throw new Error("unexpected Codex client"); },
-    claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => { command = spec.command; return { paneId: "%10", panePid: 110, host: claudeHost("%10", 110) }; },
-    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
-    claudeJournalRoot: path.join(base, "claude-operations"),
-    now: () => "2026-07-10T12:00:00.000Z",
+    ...fixture.dependencies,
+    cancelClaude: async () => { throw new Error("a fork has no pane to cancel"); },
   });
-  await provider.create({
-    engine: "claude",
-    operationId: "019f423a-d6e9-\x34903-8597-3e676b6ff3d4",
-    conversationId: "conversation_test",
-    targetAccountId: "target",
-    source: { id: "native", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo", model: "mythos-1", title: "Migrate unknown Claude model" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
-    recordContinuityPath() {},
-  });
-  expect(command).not.toContain("--model");
+  const receipt = await provider.create(fixture.input);
+
+  await expect(provider.cleanup(receipt)).resolves.toBeUndefined();
 });
 
 test("Codex cross-account successor stages the source rollout before resuming paginated history", async () => {
@@ -908,7 +659,6 @@ test("Codex cross-account successor stages the source rollout before resuming pa
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async (home) => client(home),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot: path.join(base, "migration-journal"),
     now: () => "2026-08-31T20:13:00.000Z",
   });
@@ -970,7 +720,6 @@ test("Codex successor provider accepts authenticated ChatGPT account responses a
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async (home) => client(home),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-10T12:00:00.000Z",
   });
   const profile = migrationSuccessorLaunchProfile(emptyLaunchProfile({ cwd: "/repo", model: "gpt-5.6-terra", effort: "high", fast: true, permissionMode: "never", readOnly: true, title: "Codex", goal: { objective: "Ship", status: "active", tokensUsed: null, timeUsedSeconds: null } }));
@@ -1035,7 +784,6 @@ test("a definite Codex fork rejection can retry the same operation", async () =>
   const provider = new RegisteredSuccessorProvider({
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(), claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-10T12:00:00.000Z", journalRoot: path.join(base, "journal"),
   });
   const input = { engine: "codex" as const, operationId: "definite-fork-retry", conversationId: "conversation_definite" as const, targetAccountId: "target", source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo", title: "Migrate provider fixture" }), historyHash: null, host: null, createdAt: "now", archivedAt: null }, recordContinuityPath() {} };
@@ -1074,7 +822,6 @@ test("concurrent Codex creates publish one successor for the same operation", as
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -1121,7 +868,6 @@ test("a fresh 51-conversation Codex drain skips recovery history scans", async (
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot: path.join(base, "provider-journal"),
     scanCodexForkArtifacts() { scanCalls += 1; return []; },
     now: () => "2026-07-10T12:00:00.000Z",
@@ -1170,7 +916,6 @@ test("first Codex operation fsyncs every newly created journal directory entry",
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -1230,7 +975,6 @@ test("Codex successor provider recovers a validated fork created before exact re
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-10T12:00:00.000Z",
     journalRoot,
     scanCodexForkArtifacts: () => [
@@ -1322,7 +1066,6 @@ test("Codex successor provider reuses one published copy after a crash", async (
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-10T12:00:00.000Z",
     journalRoot,
   } as ProviderDependencies & { journalRoot: string; afterCodexCopyPublished?: () => void };
@@ -1401,7 +1144,6 @@ test("Codex successor provider rejects an unregistered fork path before recordin
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client,
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-10T12:00:00.000Z",
   });
   const recorded: string[] = [];
@@ -1450,7 +1192,6 @@ test("a retry under a fresh operation identity recovers the fork the failed atte
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async (home) => client(home),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -1529,7 +1270,6 @@ test("orphan forks whose provenance died with their journals are re-forked once 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -1629,7 +1369,6 @@ test("orphan forks recorded by journals that predate conversation identity are s
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });
@@ -1696,7 +1435,6 @@ test("two forks inside one operation's own window resolve to the newest", async 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   } as ProviderDependencies & { journalRoot: string };
@@ -1752,7 +1490,6 @@ test("an explicit retry reauthorizes one fork after an unknown outcome produced 
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   } as ProviderDependencies & { journalRoot: string };
@@ -1820,7 +1557,6 @@ test("a late artifact from the first uncertain attempt is adopted after an opera
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => client(),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   } as ProviderDependencies & { journalRoot: string };
@@ -1923,7 +1659,6 @@ test("a retry re-forks when the source gained turns while the migration was park
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async (home) => client(home),
     claudeStatus: async () => ({ loggedIn: false }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     journalRoot,
     now: () => "2026-07-10T12:00:00.000Z",
   });

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -7,9 +7,11 @@ import type { AccountContext, AccountManager } from "@/lib/accounts/contracts";
 import { CodexAppServerClient, CodexAppServerError } from "@/lib/accounts/codexAppServer";
 import { sharedClaudeProjectsRoot } from "@/lib/accounts/claude";
 import { realClaudeLoginPorts } from "@/lib/accounts/claudeLogin";
-import { claudeSuccessorSpecFor } from "@/lib/agent/cli";
-import { agentRegistry, type AgentRegistry, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { resumeCwd } from "@/lib/agent/cli";
+import { normalizeClaudeLaunchModel } from "@/lib/agent/models";
+import { agentRegistry, type AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { sessionKey, sessionKeyId } from "@/lib/agent/sessionKey";
+import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { ClaudeStreamBrokerHost } from "@/lib/runtime/claudeStreamBrokerHost";
@@ -18,10 +20,10 @@ import { StructuredHostAdoptionCleanupError } from "@/lib/runtime/engineHost";
 import { hasStructuredDeliveryHost, publishStructuredDeliveryHost, releaseStructuredDeliveryHost, requireStructuredDeliveryControllerPublication } from "@/lib/runtime/structuredDeliveryController";
 import { bindClaudeHostPersistence, bindCodexHostPersistence, structuredHostsEnabled } from "@/lib/runtime/registry";
 import { materializeStructuredHostAccess, structuredHostAccessPolicy } from "@/lib/runtime/structuredSpawn";
-import { cleanupTmuxHostIfMatches, forgetResumePaneIfMatches, spawnAgentWithPrompt, verifyTmuxHostEvidence, type TmuxHostCleanupResult } from "@/lib/tmux";
+import { cleanupTmuxHostIfMatches, forgetResumePaneIfMatches, verifyTmuxHostEvidence, type TmuxHostCleanupResult } from "@/lib/tmux";
 
 import { launchProfileCodexSandbox, launchProfileEngineReadOnly, type LaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
-import { hashValidatedHistory, HistorySecurityError, MigrationTargetUnavailableError, safeCopyHistory, validateHistorySource } from "./safeHistoryCopy";
+import { forkClaudeHistory, hashValidatedHistory, HistorySecurityError, MigrationTargetUnavailableError, safeCopyHistory, validateHistorySource } from "./safeHistoryCopy";
 
 interface StructuredHostPublicationInput {
   receipt: ProviderReceipt;
@@ -35,13 +37,14 @@ export interface ProviderDependencies {
   accounts: Pick<AccountManager, "resolveSpawn" | "resolveTranscriptOwner">;
   startCodex(home: string): Promise<CodexAppServerClient>;
   claudeStatus(home: string): Promise<{ loggedIn: boolean }>;
-  spawnClaude(spec: ReturnType<typeof claudeSuccessorSpecFor>, receipt: SpawnReceipt): Promise<{ paneId: string; panePid?: number; host?: TmuxHostEvidence }>;
+  /** Liveness and cancellation of a legacy tmux-launched successor. A receipt
+      persisted before viewer-written forks still names such a pane. */
   verifyClaudeHost?(host: TmuxHostEvidence): Promise<boolean>;
   cancelClaude?(host: TmuxHostEvidence): Promise<boolean | TmuxHostCleanupResult>;
   registry?: AgentRegistry;
   claudeJournalRoot?: string;
-  afterClaudeSpawned?(): void;
-  afterClaudeReceiptCreated?(): void;
+  /** Test seam: runs after the fork is durable and before its receipt returns. */
+  afterClaudeForked?(): void;
   journalRoot?: string;
   afterCodexForkCreated?(): void;
   afterCodexForkReturned?(): void;
@@ -70,7 +73,6 @@ const defaultDependencies: ProviderDependencies = {
   accounts: accountManager,
   startCodex: (home) => CodexAppServerClient.start({ home }),
   claudeStatus: (home) => realClaudeLoginPorts.status(home),
-  spawnClaude: (spec, receipt) => spawnAgentWithPrompt(spec, "", receipt),
   verifyClaudeHost: (host) => verifyTmuxHostEvidence(host),
   cancelClaude: (host) => cleanupTmuxHostIfMatches(host),
   now: () => new Date().toISOString(),
@@ -393,10 +395,12 @@ async function publishClaudeSuccessorHost(
   let unregister = async () => {};
   let access: ReturnType<typeof materializeStructuredHostAccess> | null = null;
   try {
-    const tmuxHost = claudeTmuxHostFromReceipt(input.receipt);
-    const cancelled = await input.cancelClaude(tmuxHost);
-    if (!cleanupConfirmed(cancelled)) throw new Error("successor Claude host transition is still pending");
-    await forgetResumePaneIfMatches(input.receipt.path, tmuxHost);
+    if (input.receipt.host.kind !== "claude-fork") {
+      const tmuxHost = claudeTmuxHostFromReceipt(input.receipt);
+      const cancelled = await input.cancelClaude(tmuxHost);
+      if (!cleanupConfirmed(cancelled)) throw new Error("successor Claude host transition is still pending");
+      await forgetResumePaneIfMatches(input.receipt.path, tmuxHost);
+    }
     access = materializeStructuredHostAccess(
       structuredHostAccessPolicy(input.profile),
       input.target.env,
@@ -407,7 +411,10 @@ async function publishClaudeSuccessorHost(
       claudeConfigDir: input.target.kind === "managed" ? input.target.home : undefined,
       claudeProjectsDir: input.target.transcriptRoot,
       env: access.env,
-      model: input.profile.model ?? undefined,
+      /* Transcripts keep dated provider ids the CLI may refuse as a launch
+         argument; the launcher that used to project them is gone, so the
+         projection happens here. Unknown ids omit --model. */
+      model: normalizeClaudeLaunchModel(input.profile.model) ?? undefined,
       effort: input.profile.effort ?? undefined,
       readOnly: launchProfileEngineReadOnly(input.profile),
       restricted: input.profile.sandbox === "restricted",
@@ -1027,6 +1034,9 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       const status = await this.dependencies.claudeStatus(target.home);
       if (!status.loggedIn) throw new MigrationTargetUnavailableError("not-authenticated", "target Claude account is not authenticated");
       assertClaudeTranscript(receipt, target);
+      /* A viewer-written fork had no launch to outlive: the durable transcript
+         is its verification, and the broker host is published from it next. */
+      if (receipt.host.kind === "claude-fork") return;
       const host = claudeTmuxHostFromReceipt(receipt);
       const registry = this.dependencies.registry ?? agentRegistry();
       const tmuxLive = host.windowName === "claude-migration-successor"
@@ -1121,11 +1131,10 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     }
     const key = receipt.host.kind === "codex-app-server"
       ? sessionKey("codex", receipt.nativeId)
-      : receipt.host.kind === "claude-stream"
+      : receipt.host.kind === "claude-stream" || receipt.host.kind === "claude-fork"
         ? sessionKey("claude", receipt.nativeId)
         : null;
     if (key && await releaseStructuredDeliveryHost(key)) return;
-    if (receipt.host.kind === "codex-app-server") return;
     if (receipt.host.kind !== "claude-stream") return;
     const host = claudeTmuxHostFromReceipt(receipt);
     const cancelled = await this.dependencies.cancelClaude?.(host);
@@ -1143,9 +1152,9 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     recordContinuityPath: (pathname: string) => void,
   ): Promise<ProviderReceipt> {
     const journalRoot = this.dependencies.claudeJournalRoot ?? statePath("migration-provider-claude-operations");
+    void conversationId;
     return withCodexOperationLease(journalRoot, operationId, (assertLeaseOwned) => this.createClaudeLocked(
       operationId,
-      conversationId,
       sourcePath,
       profile,
       source,
@@ -1157,7 +1166,6 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
 
   private async createClaudeLocked(
     operationId: string,
-    conversationId: Parameters<SuccessorProviderPort["create"]>[0]["conversationId"],
     sourcePath: string,
     profile: LaunchProfile,
     source: AccountContext,
@@ -1169,98 +1177,34 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     if (!status.loggedIn) throw new MigrationTargetUnavailableError("not-authenticated", "target Claude account is not authenticated");
     const history = hashValidatedHistory(sourcePath, source.transcriptRoot);
     const nativeId = candidateUuid(operationId);
-    const spec = claudeSuccessorSpecFor({ sourcePath, candidateId: nativeId, targetHome: target.home, targetProjectsDir: target.transcriptRoot, profile });
-    const successorPath = spec.transcript ?? path.join(target.transcriptRoot, `${nativeId}.jsonl`);
-    const registry = this.dependencies.registry ?? agentRegistry();
-    const recordContinuityOrCancel = async (launchId: string, host: TmuxHostEvidence): Promise<void> => {
-      try {
-        recordContinuityPath(successorPath);
-      } catch (error) {
-        registry.preserveSpawnArtifactOwnership(launchId, "migration continuity persistence failed");
-        try {
-          const cleanup = await this.dependencies.cancelClaude?.(host);
-          if (cleanupConfirmed(cleanup)) await forgetResumePaneIfMatches(successorPath, host);
-        } catch { /* durable artifact ownership remains available to inventory recovery */ }
-        throw error;
-      }
-    };
-    const requestDigest = crypto.createHash("sha256").update(JSON.stringify({ operationId, conversationId, target: target.accountId, nativeId })).digest("hex");
-    const begun = registry.beginSpawnRequest({
-      engine: "claude",
-      cwd: profile.cwd,
-      launchProfile: profile,
-      clientAttemptId: `migration-successor:${operationId}`,
-      requestDigest,
-      accountId: target.accountId,
-      conversationId,
-      purpose: "migration-successor",
-      origin: { kind: "successor" },
-      expectedArtifactPath: successorPath,
-    });
-    if (begun.kind === "conflict") throw new Error("successor Claude operation receipt conflicts");
-    const spawnReceipt = begun.receipt;
-    if (begun.kind === "replay") {
-      if (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted") {
-        throw new Error("successor Claude operation receipt is terminal");
-      }
-      const host = spawnReceipt.verifiedHost;
-      if (host) {
-        if (!await this.dependencies.verifyClaudeHost?.(host)) {
-          throw new Error("successor Claude operation has no recoverable live host");
-        }
-        await recordContinuityOrCancel(spawnReceipt.launchId, host);
-        return {
-          operationId,
-          nativeId,
-          path: successorPath,
-          continuityPaths: [successorPath],
-          historyHash: history.hash,
-          host: { kind: "claude-stream", identity: `${host.paneId}:${host.panePid.pid}`, epoch: 1, verifiedAt: this.dependencies.now(), tmuxHost: host },
-        };
-      }
-      if (spawnReceipt.state !== "starting" || spawnReceipt.pane || fs.existsSync(successorPath)) throw new SuccessorPendingError();
-    } else {
-      this.dependencies.afterClaudeReceiptCreated?.();
-    }
+    const successorPath = claudeTranscriptPath(profile.cwd || resumeCwd(sourcePath), nativeId, target.transcriptRoot);
     assertLeaseOwned();
-    let pane: Awaited<ReturnType<ProviderDependencies["spawnClaude"]>>;
-    try {
-      pane = await this.dependencies.spawnClaude(spec, spawnReceipt);
-    } catch (error) {
-      registry.failSpawn(spawnReceipt.launchId, error instanceof Error ? error.message : String(error));
-      throw error;
-    }
-    if (!pane.host || pane.panePid === undefined || pane.host.paneId !== pane.paneId || pane.host.panePid.pid !== pane.panePid) {
-      registry.failSpawn(spawnReceipt.launchId, "successor Claude host evidence is unavailable");
-      throw new Error("successor Claude host evidence is unavailable");
-    }
-    const fenceReceipt = async (receipt: SpawnReceipt): Promise<void> => {
-      if (receipt.state !== "failed" && receipt.state !== "conflicted") return;
-      try { await this.dependencies.cancelClaude?.(pane.host!); } catch { /* terminal receipt fencing keeps cleanup best effort */ }
-      throw new Error("successor Claude operation receipt became terminal");
-    };
-    const bound = registry.bindSpawnPane(spawnReceipt.launchId, {
-      endpoint: pane.host.endpoint,
-      server: pane.host.server,
-      paneId: pane.host.paneId,
-      panePid: pane.host.panePid,
-      target: pane.host.paneId,
+    /* The continuity record precedes the file on purpose: from the moment the
+       fork exists the scanner must already know which conversation owns it, so
+       no tick can seat it as a lookalike of its own (issue #889). */
+    recordContinuityPath(successorPath);
+    /* The CLI's own `--fork-session` needs a prompt to write anything, and a
+       successor has no prompt to give — the operator's message is held for
+       after the commit. The viewer writes the fork itself and the broker host
+       resumes it under the target account (issue #889). */
+    forkClaudeHistory({
+      sourcePath,
+      sourceRoot: source.transcriptRoot,
+      targetRoot: target.transcriptRoot,
+      destination: successorPath,
+      sourceSessionId: path.basename(sourcePath, ".jsonl"),
+      sessionId: nativeId,
+      operationId,
     });
-    await fenceReceipt(bound);
-    const verified = registry.markSpawnHostVerified(spawnReceipt.launchId, pane.host);
-    await fenceReceipt(verified);
-    const delivered = registry.markSpawnPromptDelivered(spawnReceipt.launchId);
-    await fenceReceipt(delivered);
-    await recordContinuityOrCancel(spawnReceipt.launchId, pane.host);
     assertLeaseOwned();
-    this.dependencies.afterClaudeSpawned?.();
+    this.dependencies.afterClaudeForked?.();
     return {
       operationId,
       nativeId,
       path: successorPath,
       continuityPaths: [successorPath],
       historyHash: history.hash,
-      host: { kind: "claude-stream", identity: `${pane.paneId}:${pane.panePid}`, epoch: 1, verifiedAt: this.dependencies.now(), tmuxHost: pane.host },
+      host: { kind: "claude-fork", identity: nativeId, epoch: 1, verifiedAt: this.dependencies.now() },
     };
   }
 

--- a/src/lib/accounts/migration/safeHistoryCopy.test.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { CodexAppServerError } from "@/lib/accounts/codexAppServer";
 
-import { HistorySecurityError, safeCopyHistory, safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
+import { forkClaudeHistory, HistorySecurityError, safeCopyHistory, safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
 
 const roots: string[] = [];
 
@@ -216,5 +216,81 @@ describe("safe history copy", () => {
     fs.symlinkSync(outside, path.join(f.targetRoot, "linked"));
     expect(() => safeCopyHistory({ ...f, destinationRelative: "linked/rollout.jsonl", operationId: "target-link" }))
       .toThrow(HistorySecurityError);
+  });
+});
+
+describe("forkClaudeHistory", () => {
+  const sourceId = "019f423a-d6e9-\x34903-b597-3e676b6ff3d4";
+  const forkId = "7d1c2b3a-4e5f-\x34a6b-8c7d-9e0f1a2b3c4d";
+
+  function claudeFixture() {
+    const base = fixture();
+    const sourcePath = path.join(base.sourceRoot, "-repo", `${sourceId}.jsonl`);
+    fs.mkdirSync(path.dirname(sourcePath), { mode: 0o700 });
+    const lines = [
+      JSON.stringify({ type: "user", sessionId: sourceId, message: { role: "user", content: "Привіт ✅ — multi-byte text" } }),
+      JSON.stringify({ type: "summary", leafUuid: "leaf" }),
+      `{"type":"attachment", "sessionId": "${sourceId}", "spaced":true}`,
+      JSON.stringify({ type: "assistant", sessionId: sourceId, message: { content: [{ type: "text", text: `quoted "sessionId":"${sourceId}" in a value` }] } }),
+    ];
+    fs.writeFileSync(sourcePath, lines.join("\n") + "\n", { mode: 0o600 });
+    const destination = path.join(base.targetRoot, "-repo", `${forkId}.jsonl`);
+    const input = {
+      sourcePath,
+      sourceRoot: base.sourceRoot,
+      targetRoot: base.targetRoot,
+      destination,
+      sourceSessionId: sourceId,
+      sessionId: forkId,
+      operationId: "fork-operation",
+    };
+    return { ...base, sourcePath, destination, lines, input };
+  }
+
+  test("renames every top-level session id and keeps the other bytes, across chunk boundaries", () => {
+    const { destination, lines, input } = claudeFixture();
+
+    const result = forkClaudeHistory({ ...input, chunkBytes: 3 });
+
+    const forked = fs.readFileSync(destination, "utf8").split("\n");
+    expect(forked).toHaveLength(lines.length + 1);
+    expect(forked[0]).toBe(lines[0]!.replace(sourceId, forkId));
+    expect(forked[1]).toBe(lines[1]);
+    expect(forked[2]).toBe(`{"type":"attachment", "sessionId": "${forkId}", "spaced":true}`);
+    /* The escaped mention inside a string value is text, not identity. */
+    expect(forked[3]).toBe(lines[3]!.replace(`"sessionId":"${sourceId}",`, `"sessionId":"${forkId}",`));
+    expect(forked[3]).toContain(sourceId);
+    expect(result).toMatchObject({ path: destination, reused: false, rewritten: 3, size: Buffer.byteLength(forked.join("\n")) });
+    expect(fs.statSync(destination).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(fs.readFileSync(`${destination}.llv-receipt.json`, "utf8"))).toEqual({ operationId: "fork-operation", hash: result.hash, size: result.size });
+  });
+
+  test("adopts its own earlier fork, with or without its receipt, and refuses a foreign file", () => {
+    const { destination, input } = claudeFixture();
+    const first = forkClaudeHistory(input);
+
+    expect(forkClaudeHistory(input)).toMatchObject({ hash: first.hash, size: first.size, reused: true, rewritten: 0 });
+
+    /* A crash between the publish and the receipt leaves matching bytes behind. */
+    fs.rmSync(`${destination}.llv-receipt.json`);
+    expect(forkClaudeHistory(input)).toMatchObject({ hash: first.hash, reused: true });
+    expect(fs.existsSync(`${destination}.llv-receipt.json`)).toBeTrue();
+
+    expect(() => forkClaudeHistory({ ...input, operationId: "another-operation" })).toThrow(new HistorySecurityError("history-collision"));
+
+    fs.rmSync(`${destination}.llv-receipt.json`);
+    fs.appendFileSync(destination, JSON.stringify({ type: "user", sessionId: forkId, message: { content: "a turn the fork did not carry" } }) + "\n");
+    expect(() => forkClaudeHistory(input)).toThrow(new HistorySecurityError("history-collision"));
+  });
+
+  test("refuses a source that carries no session record and a destination outside the target root", () => {
+    const base = claudeFixture();
+    fs.writeFileSync(base.sourcePath, JSON.stringify({ type: "summary", leafUuid: "only" }) + "\n", { mode: 0o600 });
+    expect(() => forkClaudeHistory(base.input)).toThrow(new HistorySecurityError("history-integrity"));
+    expect(fs.existsSync(base.destination)).toBeFalse();
+
+    expect(() => forkClaudeHistory({ ...base.input, destination: path.join(base.root, `${forkId}.jsonl`) }))
+      .toThrow(new HistorySecurityError("unsafe-root"));
+    expect(() => forkClaudeHistory({ ...base.input, sessionId: sourceId })).toThrow(new HistorySecurityError("history-integrity"));
   });
 });

--- a/src/lib/accounts/migration/safeHistoryCopy.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { redactAppServerDetail } from "../codexAppServerProtocol";
 
@@ -369,6 +370,152 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
     return { path: destination, hash, size: total, reused: false };
   } finally {
     fs.closeSync(sourceFd);
+    if (targetFd !== null) fs.closeSync(targetFd);
+    fs.rmSync(temp, { force: true });
+  }
+}
+
+export interface ForkClaudeHistoryInput {
+  sourcePath: string;
+  sourceRoot: string;
+  targetRoot: string;
+  /** Absolute successor transcript path; must resolve under `targetRoot`. */
+  destination: string;
+  sourceSessionId: string;
+  sessionId: string;
+  operationId: string;
+  maxBytes?: number;
+  /** Read size per step. Tests shrink it to force a multi-byte character across a boundary. */
+  chunkBytes?: number;
+}
+
+export interface ForkClaudeHistoryResult {
+  path: string;
+  hash: string;
+  size: number;
+  reused: boolean;
+  /** Top-level `sessionId` fields renamed; zero on a reused fork. */
+  rewritten: number;
+}
+
+const CLAUDE_SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Writes a Claude session fork the way the CLI's `--fork-session` would have:
+ * the source transcript line for line, with every top-level `sessionId`
+ * renamed to the successor id. `claude --resume <successor>` under the target
+ * account then loads the whole conversation on its own — no launch, no prompt,
+ * no CLI turn (issue #889). Idempotent per operation: a fork this operation
+ * already published is adopted by its receipt, or by matching bytes when the
+ * crash landed between the publish and the receipt.
+ */
+export function forkClaudeHistory(input: ForkClaudeHistoryInput): ForkClaudeHistoryResult {
+  if (!CLAUDE_SESSION_ID.test(input.sourceSessionId) || !CLAUDE_SESSION_ID.test(input.sessionId)
+    || input.sourceSessionId === input.sessionId) {
+    throw new HistorySecurityError("history-integrity");
+  }
+  const maxBytes = input.maxBytes ?? DEFAULT_HISTORY_LIMIT;
+  const source = validateHistorySource(input.sourcePath, input.sourceRoot, maxBytes);
+  const relative = safeRelative(path.relative(path.resolve(input.targetRoot), path.resolve(input.destination)));
+  const parent = ensureDirectoryTree(input.targetRoot, path.dirname(relative));
+  const destination = path.join(parent, path.basename(relative));
+  const receiptPath = `${destination}.llv-receipt.json`;
+  const pattern = new RegExp(`"sessionId"(\\s*:\\s*)"${input.sourceSessionId}"`, "g");
+
+  /* One pass over the source: rewrites lines into `targetFd`, or only measures
+     what the rewrite would produce when `targetFd` is null. */
+  const rewrite = (targetFd: number | null): { hash: string; size: number; rewritten: number } => {
+    const sourceFd = fs.openSync(source.sourcePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    try {
+      const opened = fs.fstatSync(sourceFd);
+      if (opened.dev !== source.device || opened.ino !== source.inode || opened.size !== source.size) throw new HistorySecurityError("unsafe-source");
+      const digest = crypto.createHash("sha256");
+      const decoder = new StringDecoder("utf8");
+      const buffer = Buffer.allocUnsafe(Math.max(1, input.chunkBytes ?? 1024 * 1024));
+      let pending = "";
+      let read = 0;
+      let size = 0;
+      let rewritten = 0;
+      const emit = (text: string): void => {
+        if (!text) return;
+        const bytes = Buffer.from(text, "utf8");
+        digest.update(bytes);
+        size += bytes.length;
+        if (targetFd === null) return;
+        let offset = 0;
+        while (offset < bytes.length) offset += fs.writeSync(targetFd, bytes, offset, bytes.length - offset);
+      };
+      const rewriteLine = (line: string): string => {
+        if (!line.includes('"sessionId"')) return line;
+        return line.replace(pattern, (_match, separator: string) => {
+          rewritten += 1;
+          return `"sessionId"${separator}"${input.sessionId}"`;
+        });
+      };
+      for (;;) {
+        const count = fs.readSync(sourceFd, buffer, 0, buffer.length, null);
+        if (count === 0) break;
+        read += count;
+        if (read > maxBytes) throw new HistorySecurityError("history-too-large");
+        pending += decoder.write(buffer.subarray(0, count));
+        let start = 0;
+        let newline = pending.indexOf("\n");
+        let out = "";
+        while (newline !== -1) {
+          out += rewriteLine(pending.slice(start, newline)) + "\n";
+          start = newline + 1;
+          newline = pending.indexOf("\n", start);
+        }
+        pending = pending.slice(start);
+        emit(out);
+      }
+      pending += decoder.end();
+      emit(rewriteLine(pending));
+      if (read !== source.size) throw new HistorySecurityError("history-integrity");
+      if (rewritten === 0) throw new HistorySecurityError("history-integrity");
+      if (!sameIdentity(fs.fstatSync(sourceFd), source)) throw new HistorySecurityError("history-integrity");
+      return { hash: digest.digest("hex"), size, rewritten };
+    } finally {
+      fs.closeSync(sourceFd);
+    }
+  };
+
+  if (fs.existsSync(destination) || fs.existsSync(receiptPath)) {
+    const receipt = readReceipt(receiptPath);
+    const existing = hashFile(destination, maxBytes, undefined, true);
+    if (receipt) {
+      if (receipt.operationId !== input.operationId || receipt.hash !== existing.hash || receipt.size !== existing.size) {
+        throw new HistorySecurityError("history-collision");
+      }
+      return { path: destination, ...existing, reused: true, rewritten: 0 };
+    }
+    const expected = rewrite(null);
+    if (expected.hash !== existing.hash || expected.size !== existing.size) throw new HistorySecurityError("history-collision");
+    writeReceipt(receiptPath, { operationId: input.operationId, hash: existing.hash, size: existing.size });
+    return { path: destination, ...existing, reused: true, rewritten: 0 };
+  }
+
+  const temp = path.join(parent, `.${path.basename(destination)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  let targetFd: number | null = null;
+  try {
+    targetFd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW ?? 0), 0o600);
+    const written = rewrite(targetFd);
+    fs.fchmodSync(targetFd, 0o600);
+    fs.fsyncSync(targetFd);
+    fs.closeSync(targetFd);
+    targetFd = null;
+    if (!contained(fs.realpathSync(input.targetRoot), fs.realpathSync(parent))) throw new HistorySecurityError("unsafe-root");
+    try { fs.linkSync(temp, destination); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new HistorySecurityError("history-collision");
+      throw error;
+    }
+    fs.rmSync(temp, { force: true });
+    const published = fs.openSync(parent, "r");
+    try { fs.fsyncSync(published); } finally { fs.closeSync(published); }
+    writeReceipt(receiptPath, { operationId: input.operationId, hash: written.hash, size: written.size });
+    return { path: destination, hash: written.hash, size: written.size, reused: false, rewritten: written.rewritten };
+  } finally {
     if (targetFd !== null) fs.closeSync(targetFd);
     fs.rmSync(temp, { force: true });
   }

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -392,61 +392,6 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
   };
 }
 
-export function claudeSuccessorSpecFor(input: {
-  sourcePath: string;
-  candidateId: string;
-  targetHome: string;
-  targetProjectsDir: string;
-  profile: LaunchProfile;
-}): ResumeSpec {
-  if (!/^[0-9a-f-]{36}$/.test(input.candidateId)) throw new Error("candidate session id is invalid");
-  const args = [
-    resolveBinary("claude"),
-    "-p",
-    "--input-format", "stream-json",
-    "--output-format", "stream-json",
-    "--verbose",
-    "--replay-user-messages",
-    "--permission-prompt-tool", "stdio",
-  ];
-  const permissionMode = effectiveClaudePermissionMode(input.profile);
-  if (launchProfileEngineReadOnly(input.profile) || permissionMode === "plan") {
-    args.push("--permission-mode", "plan", "--disallowedTools", "Edit,Write,NotebookEdit");
-  } else if (permissionMode !== "bypassPermissions") {
-    if (permissionMode.length <= 64 && /^[a-zA-Z-]+$/.test(permissionMode)) {
-      args.push("--permission-mode", permissionMode);
-    }
-  } else {
-    args.push("--dangerously-skip-permissions");
-  }
-  if (explicitLaunchProfileSandbox(input.profile) === "restricted") args.push("--restricted");
-  const model = normalizeClaudeLaunchModel(input.profile.model);
-  if (model) args.push("--model", model);
-  if (input.profile.effort && /^[a-z]+$/.test(input.profile.effort)) args.push("--effort", input.profile.effort);
-  args.push("--resume", input.sourcePath, "--fork-session", "--session-id", input.candidateId);
-  const cwd = input.profile.cwd || resumeCwd(input.sourcePath);
-  const policy = applyClaudeSpawnPolicy(input.targetHome, {
-    allowSubagents: input.profile.allowSubagents,
-    baseSettingsPath: isManagedClaudeHome(input.targetHome) ? claudeSettingsPath() : null,
-    profileId: input.candidateId,
-    cwd,
-    mcpServers: input.profile.mcpServers,
-    mcpStatePath: isManagedClaudeHome(input.targetHome)
-      ? path.join(input.targetHome, ".claude.json")
-      : path.join(path.dirname(input.targetHome), ".claude.json"),
-  });
-  pushClaudePolicyArgs(args, policy);
-  return {
-    command: telegramScopedCommand(`${claudeEnvPrefix(input.targetHome, input.profile.mcpServers)} ${args.map(shellQuote).join(" ")}`, input.profile.mcpServers),
-    cwd,
-    windowName: "claude-migration-successor",
-    engine: "claude",
-    ["transcript"]: claudeTranscriptPath(input.profile.cwd || resumeCwd(input.sourcePath), input.candidateId, input.targetProjectsDir),
-    printMode: true,
-    launchProfile: { ...input.profile, model, permissionMode },
-  };
-}
-
 /** Whether a transcript can be reopened, and — when it cannot — which single
     condition refused it. A caller that only needs the command uses
     {@link resumeSpecFor}; a caller that has to tell the operator why nothing
@@ -594,6 +539,6 @@ function emptyLaunchProfileForResume(cwd: string, model: string | null, effort: 
 
 /** A resume window must land in a directory that still exists; the home
     directory is the safe fallback when the transcript's cwd is gone. */
-function resumeCwd(pathname: string): string {
+export function resumeCwd(pathname: string): string {
   return headCwd(pathname, { maxLines: 30, requireDir: true }) ?? os.homedir();
 }

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -168,7 +168,6 @@ function cleanupOnlyProvider(): RegisteredSuccessorProvider {
     },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => { throw new Error("unexpected Claude status"); },
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     now: () => "2026-07-13T12:01:00.000Z",
   });
 }
@@ -3440,7 +3439,6 @@ test("a published Claude successor preserves its migration-held reservation as c
     },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
     verifyClaudeHost: async () => true,
     publishClaudeHost: async () => {
       publications += 1;

--- a/src/lib/runtime/structuredHostAccess.test.ts
+++ b/src/lib/runtime/structuredHostAccess.test.ts
@@ -10,7 +10,6 @@ import {
   launchProfileEngineReadOnly,
 } from "@/lib/accounts/migration/contracts";
 import { reconcileMigrationInventory } from "@/lib/accounts/migration/coordinator";
-import { claudeSuccessorSpecFor } from "@/lib/agent/cli";
 import { AgentRegistry } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
@@ -160,36 +159,3 @@ test("inventory preserves both access axes from a pending structured launch rece
   }
 });
 
-test.each([
-  { readOnly: false, sandbox: "full", permissionMode: "bypassPermissions" },
-  { readOnly: false, sandbox: "restricted", permissionMode: "auto" },
-  { readOnly: true, sandbox: "full", permissionMode: "bypassPermissions" },
-  { readOnly: true, sandbox: "restricted", permissionMode: "auto" },
-] as const)(
-  "Claude successor keeps repository readOnly=$readOnly independent from sandbox=$sandbox",
-  ({ readOnly, sandbox, permissionMode }) => {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-stage-access-"));
-    try {
-      const targetHome = path.join(directory, "claude");
-      const targetProjectsDir = path.join(targetHome, "projects");
-      fs.mkdirSync(targetProjectsDir, { recursive: true, mode: 0o700 });
-      const spec = claudeSuccessorSpecFor({
-        sourcePath: path.join(directory, "source.jsonl"),
-        candidateId: crypto.randomUUID(),
-        targetHome,
-        targetProjectsDir,
-        profile: emptyLaunchProfile({ cwd: directory, readOnly, sandbox, permissionMode }),
-      });
-      if (sandbox === "restricted") {
-        expect(spec.command).toContain("'--permission-mode' 'auto'");
-        expect(spec.command).toContain("'--restricted'");
-      } else {
-        expect(spec.command).toContain("'--dangerously-skip-permissions'");
-        expect(spec.command).not.toContain("'--restricted'");
-      }
-      expect(spec.command).not.toContain("Edit,Write,NotebookEdit");
-    } finally {
-      fs.rmSync(directory, { recursive: true, force: true });
-    }
-  },
-);


### PR DESCRIPTION
## What breaks

Switching a Claude conversation to another account launches the successor in a tmux window as a promptless print-mode `--resume … --fork-session --session-id <new>` and waits for the CLI to write the fork. Claude Code only lets a promptless resume proceed when the session tail carries a deferred-tool marker; every other session exits with `No deferred tool marker found in the resumed session`, the coordinator files `provider-failed` ("successor provider failed a recoverable preflight"), and every Retry hits the same wall. Today that pinned a rate-limited orchestrator to its account (four failed attempts in a row, see #889).

Reproduced outside the viewer with the exact argv: under a pseudo-TTY the CLI exits 1 with the marker error in ~1 s; with piped or EOF stdin it exits 0 silently after the pipe closes. Neither writes the fork, so no launch mode without a prompt can produce a successor.

## What changes

- **The viewer writes the fork itself.** `forkClaudeHistory` copies the source transcript line for line with every top-level `sessionId` renamed to the successor id, under the target transcript root, with the same temp-file / hard-link / receipt discipline as the Codex copy. It is idempotent per operation: an earlier fork of the same operation is adopted by its receipt, or by matching bytes when a crash landed between the publish and the receipt. Escaped mentions of the id inside string values are left alone. Multi-byte text is decoded across chunk boundaries.
- **No launch in `create`.** The receipt carries a new host kind, `claude-fork`. `verify` takes the durable fork as its proof; `publishHost` adopts it through the stream broker exactly as before, minus the pane to cancel. Receipts persisted by the old launcher (`claude-stream` with a tmux host) still verify liveness and clean up their pane.
- **Continuity before the file.** The continuity record is written before the fork exists, so no scanner tick can seat the new transcript as a lookalike conversation. Without a spawn receipt there is no phantom launch card either.
- **Launcher retired.** `claudeSuccessorSpecFor` and its tests are gone. The model projection it performed (`normalizeClaudeLaunchModel`) moves to host publication, so dated provider ids still never reach `--model`.

## Verification

- `bun test` by path: `safeHistoryCopy.test.ts`, `provider.test.ts`, `structuredHostAccess.test.ts` (49 pass), `coordinator.test.ts`, `structuredAccountSwitch.test.ts`, `identityWaveMigration.test.ts`, `structuredDelivery.integration.test.ts`. `coordinator.test.ts` has 9 board-continuity failures that are identical at the merge base.
- `tsc --noEmit` clean; privacy gate PASS with `--check-commits`.
- End to end on a real 11 MB orchestrator transcript: `forkClaudeHistory` wrote the fork in 90 ms (2595 ids renamed), and `claude -p --resume <fork>` under an isolated home for the other account answered from the conversation's context.

Closes #889. A step toward #891: with the shared transcript store the fork is already a same-root copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
