### PR TITLE
ci(privacy): time out and retry the media tools install (#1456)

### DIFF
--- a/.github/workflows/privacy-publication.yml
+++ b/.github/workflows/privacy-publication.yml
@@ -51,10 +51,20 @@ jobs:
         working-directory: trusted
         run: bun install --frozen-lockfile
 
+      # A stalled apt mirror hung this step for 20+ minutes three times on
+      # 2026-09-02 (#1456): fail fast with a hard timeout and one retry.
       - name: Install media inspection tools
+        timeout-minutes: 4
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes ffmpeg tesseract-ocr tesseract-ocr-eng tesseract-ocr-ukr
+          APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
+          for attempt in 1 2; do
+            if sudo apt-get $APT_OPTS update \
+              && sudo apt-get $APT_OPTS install --yes ffmpeg tesseract-ocr tesseract-ocr-eng tesseract-ocr-ukr; then
+              exit 0
+            fi
+            echo "apt install attempt $attempt failed"
+          done
+          exit 1
 
       - name: Verify privacy gate behavior
         working-directory: trusted

--- a/.github/workflows/privacy-tracker-audit.yml
+++ b/.github/workflows/privacy-tracker-audit.yml
@@ -41,10 +41,20 @@ jobs:
       - name: Install trusted dependencies
         run: bun install --frozen-lockfile
 
+      # A stalled apt mirror hung this step for 20+ minutes three times on
+      # 2026-09-02 (#1456): fail fast with a hard timeout and one retry.
       - name: Install media inspection tools
+        timeout-minutes: 4
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes ffmpeg tesseract-ocr tesseract-ocr-eng tesseract-ocr-ukr
+          APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
+          for attempt in 1 2; do
+            if sudo apt-get $APT_OPTS update \
+              && sudo apt-get $APT_OPTS install --yes ffmpeg tesseract-ocr tesseract-ocr-eng tesseract-ocr-ukr; then
+              exit 0
+            fi
+            echo "apt install attempt $attempt failed"
+          done
+          exit 1
 
       - name: Audit public tracker surfaces
         env:


### PR DESCRIPTION
## Summary

Closes #1456.

The "Install media inspection tools" step in the two privacy workflows hung three times today for 20–30 minutes on a stalled package mirror, blocking every PR merge. The step now carries a hard `timeout-minutes`, apt fetch timeouts with retries, and a second attempt, so a stalled mirror fails fast and visibly instead of holding the run for the job's six-hour limit. Nothing else in the workflows changes.

Reviewed by a fresh Fable reviewer (APPROVE) on the lane branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)