### PR TITLE
fix(deps): override fast-uri to 3.1.7 to clear four high advisories blocking every PR

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,9 @@
   "patchedDependencies": {
     "next@16.3.2": "patches/next-16.3.2.patch",
   },
+  "overrides": {
+    "fast-uri": "^3.1.6",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -559,7 +562,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
   "license": "MIT",
   "patchedDependencies": {
     "next@16.3.2": "patches/next-16.3.2.patch"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.6"
   }
 }


### PR DESCRIPTION
## Why

Four `fast-uri` advisories published today turned the `audit` check red on **every** open PR, including the mobile v2 lane blocking a production deploy. They arrive transitively:

```
@modelcontextprotocol/sdk › ajv › fast-uri
eslint › ajv › fast-uri
```

`main` itself carries `fast-uri@3.1.4`, inside the affected range `>=3.1.3 <3.1.6`, so this is a repo-wide blocker rather than anything a branch introduced.

- GHSA-5jgf-p345-68v8 — host confusion via skipped IDN canonicalization
- GHSA-f65p-4m7j-42xc — SSRF via malformed IPv6 normalization
- GHSA-fph4-wmhf-6fwf — SSRF via repeated hostname percent-decoding
- GHSA-jqff-g426-hqxp — host confusion via percent-encoded scheme normalization

## What this does

Adds a single `overrides` entry pinning `fast-uri` to `^3.1.6`; the lockfile resolves to `3.1.7`. Verified locally: `bun install` clean, and `bun audit` no longer mentions `fast-uri` or any of the four advisory ids.

Chosen over extending `security/audit-allowlist.json` because these are four *high* SSRF/host-confusion issues and a patched version exists in-range — allowlisting would suppress the signal for a month to no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)