### PR TITLE
fix(mobile-v2): the desktop scheme's subagent badges no longer float over the phone feed (#1439)

### DIFF
--- a/src/components/mobile/MobileConversationMenu.tsx
+++ b/src/components/mobile/MobileConversationMenu.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { ArrowRightLeft, Bot, Boxes, ChevronRight, CornerDownRight, Crown, FoldVertical, Info, ListTree, PencilLine, RotateCw, Search, Square, SquareTerminal, X } from "lucide-react";
+import { ArrowRightLeft, Bot, Boxes, ChevronRight, CornerDownRight, Crown, FoldVertical, GitFork, Info, ListTree, PencilLine, RotateCw, Search, Square, SquareTerminal, X } from "lucide-react";
 
 import { useLocale } from "@/lib/i18n";
 import { cleanTitle } from "@/lib/title";
 import type { FileEntry } from "@/lib/types";
+
+import type { SubagentBadge } from "../scheme/subagentBadgeModel";
 
 import { AttachTerminalDialog } from "../AttachTerminalDialog";
 import { canHandoff } from "../HandoffHandle";
@@ -12,7 +14,7 @@ import { useAgentControlActions } from "../AgentControlStrip";
 import { useProcessKill } from "../TaskHeader";
 import { effortTitle, engineBadge } from "../utils";
 import { MobileMeter } from "./MobileMeter";
-import { MobileSheet, MobileSheetDivider, MobileSheetRow } from "./MobileSheet";
+import { MobileSheet, MobileSheetDivider, MobileSheetRow, MobileSheetSection } from "./MobileSheet";
 import { showReceipt } from "./MobileReceipt";
 import { chatStateBits, type StagePosition } from "./mobileChatState";
 
@@ -51,6 +53,8 @@ export function MobileConversationMenu({
   onToggleCrown,
   onHandoff,
   onOpenHost,
+  subagents = [],
+  onOpenSubagent,
   onOpenSearch,
   onOpenProjectMenu,
   projectName,
@@ -79,6 +83,11 @@ export function MobileConversationMenu({
       board owns the draft, so the row only asks for it. */
   onHandoff?: () => void;
   onOpenHost: () => void;
+  /** This conversation's spawned children, as in-flow rows (README §6: the
+      phone has no badge rail over the feed — #1439). Each row opens the
+      child's CURRENT generation, the path the model already resolved. */
+  subagents?: readonly SubagentBadge[];
+  onOpenSubagent?: (path: string) => void;
   /** The search palette (#1054): a bar target on the board, a row here (§3.1). */
   onOpenSearch?: () => void;
   /** Swaps this sheet for the project's own menu. Every screen's `⋯` opens the
@@ -128,6 +137,7 @@ export function MobileConversationMenu({
     });
   };
   const showPipelineRow = Boolean(onOpenPipeline) && (stage !== null || pipelineCount > 0);
+  const showSubagents = subagents.length > 0 && onOpenSubagent !== undefined;
   return (
     <>
       <MobileSheet name="menu" title={title} onClose={onClose}>
@@ -182,7 +192,25 @@ export function MobileConversationMenu({
               attrs={{ "data-mobile2-menu-row": "pipeline" }}
             />
           ) : null}
-          {onOpenSeat || showPipelineRow ? <MobileSheetDivider /> : null}
+          {showSubagents ? (
+            <>
+              <MobileSheetSection count={subagents.length}>{t("mobile2.chat.menuSubagents")}</MobileSheetSection>
+              {subagents.map((child) => (
+                <MobileSheetRow
+                  key={child.id}
+                  icon={<GitFork className="h-[18px] w-[18px]" aria-hidden />}
+                  label={cleanTitle(child.title, 60)}
+                  trailing={t(`subagentTray.state.${child.state}`)}
+                  /* Unavailable is not a destination — the same reading the
+                     desktop badge gives a dead child. */
+                  disabled={child.state === "dead"}
+                  onSelect={act(() => onOpenSubagent?.(child.path))}
+                  attrs={{ "data-mobile2-menu-row": "subagent", "data-mobile2-subagent": child.id, "data-mobile2-subagent-state": child.state }}
+                />
+              ))}
+            </>
+          ) : null}
+          {onOpenSeat || showPipelineRow || showSubagents ? <MobileSheetDivider /> : null}
           <MobileSheetRow
             icon={<PencilLine className="h-[18px] w-[18px]" aria-hidden />}
             label={t("mobile2.chat.menuRename")}

--- a/src/components/mobile/MobileFocusView.badges.dom.test.tsx
+++ b/src/components/mobile/MobileFocusView.badges.dom.test.tsx
@@ -7,11 +7,16 @@ import type { FileEntry } from "@/lib/types";
 import { emptyStore } from "@/components/runtime/runtimeModel";
 
 /*
- * 390px acceptance for PR #441: the REAL phone wrapper (`MobileFocusView`)
- * mounts the subagent badge/anchor interaction on the focused conversation —
- * the two-tap title-then-navigation the desktop board already carries — and
- * navigates to the CURRENT non-archived generation rather than the stale
- * file-order entry.
+ * 390 × 844 acceptance for #1439's phone conversation screen and its subagents.
+ *
+ * The desktop scheme's `SubagentBadges` positions every badge absolutely from
+ * `layoutBadges(children, cardRect)`; the phone has no scheme canvas and no card
+ * rect, so mounted there the badges landed down the feed's left edge, over the
+ * prose (the prod defect the operator reported on commit 6b59d462). The phone
+ * gives the feed its full width (lane 4) and reaches a child through the
+ * conversation's own `⋯` menu: an in-flow row per child, which navigates to the
+ * CURRENT non-archived generation rather than the stale file-order entry — the
+ * same guarantee the badge used to carry (PR #441).
  */
 
 const dom = new HappyWindow({ innerWidth: 390, innerHeight: 844 });
@@ -112,24 +117,40 @@ const childCurrent = conversation({
   parent: "/parent.jsonl", conversationId: "conv_child", generation: 2, mtime: 6,
 });
 
-test("the focused conversation mounts its subagent badge at 390px", async () => {
+async function openMenu(): Promise<void> {
+  const more = dom.document.querySelector('[data-mobile2-open="menu"]') as unknown as HTMLButtonElement | null;
+  expect(more).not.toBeNull();
+  flushSync(() => more!.click());
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("the phone conversation screen mounts no absolutely-positioned desktop badges over the feed at 390 × 844", async () => {
   const host = await renderFocus([parent, childStale, childCurrent], "/parent.jsonl", () => undefined);
-  const badge = host.querySelector('[data-subagent-badge="conv_child"]') as HTMLButtonElement | null;
-  expect(badge).not.toBeNull();
-  expect(badge!.hasAttribute("data-scheme-ui")).toBe(true);
-  expect(badge!.className).toContain("pointer-events-auto");
+  const pane = host.querySelector('[data-testid="mobile-focused-pane"]');
+  expect(pane).not.toBeNull();
+  /* No desktop badge, no overflow chip, no rail to hold them. */
+  expect(host.querySelector("[data-subagent-badge], [data-subagent-overflow]")).toBeNull();
+  expect(host.querySelector('[data-testid="mobile-subagent-rail"]')).toBeNull();
+  /* Nothing that names a subagent is taken out of the flow inside the pane:
+     an absolutely-positioned marker there is exactly what floated over the
+     prose, wherever its coordinates come from. */
+  const floating = [...pane!.querySelectorAll("[data-subagent-badge], [data-subagent-overflow], [data-subagent-fold]")]
+    .filter((node) => (node as HTMLElement).className.split(/\s+/).includes("absolute"));
+  expect(floating).toEqual([]);
 });
 
-test("two taps navigate to the current non-archived generation, not the stale file-order entry", async () => {
+test("the ⋯ menu lists the child as an in-flow row that opens the current non-archived generation", async () => {
   const selected: string[] = [];
-  const host = await renderFocus([childStale, childCurrent, parent], "/parent.jsonl", (file) => selected.push(file.path));
-  const badge = host.querySelector('[data-subagent-badge="conv_child"]') as HTMLButtonElement;
-  const tap = () => badge.dispatchEvent(new dom.PointerEvent("pointerup", { bubbles: true, pointerType: "touch" }) as unknown as Event);
+  await renderFocus([childStale, childCurrent, parent], "/parent.jsonl", (file) => selected.push(file.path));
+  await openMenu();
+  const rows = [...dom.document.querySelectorAll('[data-mobile2-menu-row="subagent"]')] as unknown as HTMLButtonElement[];
+  expect(rows.map((row) => row.getAttribute("data-mobile2-subagent"))).toEqual(["conv_child"]);
+  const row = rows[0]!;
+  expect(row.textContent).toContain("Spawned worker");
+  /* A sheet row, in the flow of the sheet: never the scheme's floating chip. */
+  expect(row.className.split(/\s+/)).not.toContain("absolute");
+  expect(row.hasAttribute("data-scheme-ui")).toBe(false);
 
-  flushSync(() => tap());
-  expect(badge.getAttribute("aria-expanded")).toBe("true");
-  expect(selected).toEqual([]);
-
-  flushSync(() => tap());
+  flushSync(() => row.click());
   expect(selected).toEqual(["/child-gen2.jsonl"]);
 });

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -7,6 +7,7 @@ import { TaskSheet, type TaskSheetView } from "@/components/tasks/TaskSheet";
 import { taskRelationsByPath } from "@/components/tasks/taskRelations";
 import { useBoardState } from "@/hooks/useBoardState";
 import { useKeyboardInset } from "@/hooks/useComposer";
+import { useNowSeconds } from "@/hooks/useNowSeconds";
 import { useRuntimeBusState } from "@/hooks/useRuntime";
 import { selectionInOrder, viewBus } from "@/hooks/viewPresenceBus";
 import { projectDisplayName } from "@/lib/displayNames";
@@ -40,7 +41,7 @@ import { focusHandoffBus } from "@/components/attention/focusHandoffBus";
 import { deckKey } from "@/components/scheme/agentLinks";
 import { buildFocusFrameIndex, stageAnchorAliases } from "@/components/scheme/focusFrames";
 import { buildSchemeLayout } from "@/components/scheme/layout";
-import { SubagentBadges } from "@/components/scheme/SubagentBadges";
+import { subagentsOf } from "@/components/scheme/subagentBadgeModel";
 import type { SubagentTrayApi } from "@/components/scheme/SubagentTrayView";
 import type { WorkerStack } from "@/components/scheme/workerCollapse";
 
@@ -81,12 +82,6 @@ export const SWIPE_ZONE = "[data-mobile2-bar], [data-mobile2-dock]";
 /** How long the title cell's end-of-list bump runs (§5). */
 export const BUMP_MS = 200;
 const EMPTY_PATHS: ReadonlySet<string> = new Set();
-
-/* Height of the phone's bottom-up subagent badge rail — the 12-badge hard cap
-   at 30 px + 6 px gaps. It anchors to the focused pane's left edge and lifts
-   clear of the composer; expansion grows rightward inside the 390 px viewport,
-   so it never adds horizontal overflow. */
-const SUBAGENT_RAIL_H = 12 * 36;
 
 /** True when a touch that landed on `target` belongs to the swipe zone. */
 export function inSwipeZone(target: EventTarget | null): boolean {
@@ -338,6 +333,15 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
   const activeDeck = useMemo(() => layout.decks.find((deck) => deck.key === resolvedKey) ?? null, [layout, resolvedKey]);
   const activeDraft = useMemo(() => layout.drafts.find((draft) => draft.key === resolvedKey) ?? null, [layout, resolvedKey]);
   const activeFile = activeNode?.file ?? null;
+  /* The focused conversation's spawned children, for the `⋯` menu's rows. The
+     desktop reads the same model for its badges; the state a row shows moves
+     with this clock, so a child that goes quiet leaves «working» without a
+     rescan (issue #669). */
+  const nowSeconds = useNowSeconds();
+  const subagents = useMemo(
+    () => (activeFile ? subagentsOf(conversationIdentity(activeFile), files, undefined, nowSeconds) : []),
+    [activeFile, files, nowSeconds],
+  );
   /* Report the focused conversation up so the project shell can dock its
      handoff control in the host sheet (issue #177 item 5). */
   useEffect(() => {
@@ -604,6 +608,11 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
           onToggleCrown={favoritesApi ? () => favoritesApi.toggle(conversationIdentity(activeFile)) : undefined}
           onHandoff={onHandoff ? () => onHandoff(activeFile) : undefined}
           onOpenHost={() => nav.openSheet("host")}
+          subagents={subagents}
+          onOpenSubagent={(path) => {
+            const target = files.find((item) => item.path === path);
+            if (target) onSelect(target);
+          }}
           onOpenSearch={onOpenSearch}
           onOpenProjectMenu={boardSheet ? () => setMenuFace("board") : undefined}
           projectName={displayName}
@@ -629,28 +638,11 @@ export function MobileFocusView({ project, projectName, groups, manual, files, f
         relatedTasks={relatedTasksByPath.get(activeNode.file.path)}
         onOpenTask={openPipelineTask}
       />
-      {/* The folded children (PR #441): the same 30 px bottom-up circles the
-          desktop board carries, anchored to the pane's left edge and lifted
-          above the composer. The overlay is pointer-events-none and reserves no
-          height, so it costs the transcript nothing — but it is the phone's ONE
-          route to a folded child, so it stays until the feed opens members
-          itself (§3.4). The docked subagent TRAY, which did spend 44 px, is
-          gone with the rest of this screen's chrome. */}
-      <div
-        data-testid="mobile-subagent-rail"
-        className="pointer-events-none absolute bottom-20 left-2 z-[20]"
-        style={{ width: 0, height: SUBAGENT_RAIL_H }}
-      >
-        <SubagentBadges
-          conversationId={conversationIdentity(activeNode.file)}
-          entries={files}
-          cardRect={{ x: 0, y: 0, w: 0, h: SUBAGENT_RAIL_H }}
-          onNavigate={(path) => {
-            const target = files.find((item) => item.path === path);
-            if (target) onSelect(target);
-          }}
-        />
-      </div>
+      {/* No badge rail and no docked tray over the feed (README §3.4, §6):
+          the desktop scheme's badges are laid out from a card rect the phone
+          does not have, so mounted here they floated down the feed's left edge
+          over the prose (#1439). The children are rows in the `⋯` menu instead
+          — `subagents`, below — so the transcript keeps its full width. */}
     </div>
   ) : activeDeck ? (
     <div key={activeDeck.key} className="relative min-h-0 flex-1">

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2521,6 +2521,7 @@ export const en = {
   "mobile2.chat.menuCompact": "Compact context",
   "mobile2.chat.menuDetails": "Details & host",
   "mobile2.chat.menuTerminal": "Open in terminal",
+  "mobile2.chat.menuSubagents": "Subagents",
   "mobile2.chat.menuClose": "Close card",
   "mobile2.chat.menuCloseHint": "stays in the catalog",
   "mobile2.chat.menuKill": "Kill agent",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -2444,6 +2444,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "mobile2.chat.menuCompact": "Стиснути контекст",
   "mobile2.chat.menuDetails": "Деталі й хост",
   "mobile2.chat.menuTerminal": "Відкрити в терміналі",
+  "mobile2.chat.menuSubagents": "Підагенти",
   "mobile2.chat.menuClose": "Закрити картку",
   "mobile2.chat.menuCloseHint": "лишиться в каталозі",
   "mobile2.chat.menuKill": "Вбити агента",


### PR DESCRIPTION
## Why

Reported by the operator against the deployed build (`6b59d462`): on the phone, small circular badges carrying short lineage ids floated down the left edge of the conversation and overlapped the message prose.

Cause: `MobileFocusView` rendered `SubagentBadges` from the desktop scheme canvas. That component positions each badge absolutely from a `cardRect` (`left: position.x - cardRect.x`). There is no scheme canvas on the phone, so the badges were laid out against coordinates that correspond to nothing on screen and landed on top of the feed.

The mobile v2 design has no badge column on the conversation screen — lane 4's shipped rule is that message content gets the full width.

## What changed

The phone stops rendering the desktop overlay and reaches subagents through the conversation menu instead, which is where §4.2 puts that kind of affordance. The shared read model (`subagentBadgeModel`) is reused rather than forked, so the desktop scheme keeps its badges unchanged — `src/components/scheme/**` is untouched.

The existing badge dom test is re-expressed against the new contract: mounting the phone conversation screen with subagent entries must produce no absolutely-positioned badges over the feed.

Verified by the orchestrator at this head: `MobileFocusView.badges.dom.test.tsx` and `MobileConversationMenu.answers.dom.test.tsx` — 6 pass / 0 fail / 38 expects — and `bunx tsc --noEmit` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)