### PR TITLE
feat(mobile-v2): lane 8 — attention badge, queue sheet and arrival banner (#1439)

### DIFF
--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, Crown, X } from "lucide-react";
+import { Crown, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import { formatConversationHash, isArchivedPredecessor, parseConversationHash, resolveConversationTarget, withoutArchivedPredecessors, type ConversationHash } from "@/lib/accounts/identity";
@@ -25,6 +25,8 @@ import { advanceAttentionCycle, attentionExpiries, attentionId, buildAttentionQu
 import { AttentionHost } from "./attention/AttentionHost";
 import { AttentionIsland, AttentionQueueRow } from "./attention/AttentionIsland";
 import { AttentionToast } from "./attention/AttentionToast";
+import { buildMobileAttentionQueue } from "./attention/attentionQueue";
+import { MobileAttentionSheet } from "./attention/MobileAttentionSheet";
 import { purgeLegacyOperatorCredential } from "./operatorCredential";
 import { ArtifactPreviewHost } from "./preview/ArtifactPreviewHost";
 import { VoiceBridgeRelayHost } from "./voice/VoiceBridgeRelayHost";
@@ -34,11 +36,9 @@ import { focusHandoffBus } from "./attention/focusHandoffBus";
 import { ConnectionPill } from "./ConnectionPill";
 import { resolveFavoriteRows, type FavoriteRow } from "./favorites/favoriteRows";
 import { KeepAwakeProvider } from "./KeepAwakeControl";
-import { MobilePipelineQueueRow } from "./mobile/MobileBoard";
 import { needsDecisionPipelineRows } from "./mobile/mobileBoardModel";
 import { getMobileNav } from "./mobile/mobileNav";
 import { MobileProjectSheet } from "./mobile/MobileProjectSheet";
-import { MobileSheet, MobileSheetRow, MobileSheetSection } from "./mobile/MobileSheet";
 import type { MobileShellHost } from "./mobile/MobileShell";
 import { OrchestratorDock, dockOpenFor, rememberDockOpen } from "./orchestrator/OrchestratorDock";
 import { OverviewBoard } from "./OverviewBoard";
@@ -773,7 +773,10 @@ export function Viewer() {
     () => (project === OVERVIEW || !isMobile ? [] : needsDecisionPipelineRows(pipelines, project, clock)),
     [pipelines, project, clock, isMobile],
   );
-  const shellQueueCount = shellQueue.length + shellPipelineRows.length;
+  /* Joined into the ONE list the badge counts, the sheet lists and its
+     «Next ›» walks (lane 8, `attentionQueue.ts`). */
+  const shellEntries = useMemo(() => buildMobileAttentionQueue(shellQueue, shellPipelineRows), [shellQueue, shellPipelineRows]);
+  const shellQueueCount = shellEntries.length;
 
   useEffect(() => {
     /* N and F are desktop keys (D4/D6): the phone layout renders without the
@@ -839,21 +842,6 @@ export function Viewer() {
     [queue, project, applyProject, requestFocus],
   );
 
-  /* The phone sheet's «Next ›» walks the list that sheet is showing — the
-     scoped one — so the count in its header, the rows under it and the button
-     that steps through them are one thing. The cycle pointer is the same one
-     the desktop's island and the N key move, so a phone and a desktop tab
-     never fight over where the operator is. */
-  const advanceShellAttention = useCallback(
-    (dir: 1 | -1) => {
-      const next = advanceAttentionCycle(cycleRef, shellQueue, dir);
-      if (!next) return;
-      if (next.project !== project) applyProject(next.project);
-      requestFocus(next.file.path);
-    },
-    [shellQueue, project, applyProject, requestFocus],
-  );
-
   /* A crowned row in the popover focuses its conversation, switching project
      first if the favorite lives elsewhere — same hand-off as an attention jump. */
   const openFavorite = useCallback(
@@ -895,7 +883,6 @@ export function Viewer() {
     <div ref={queueRef} className="pointer-events-auto relative">
       <AttentionIsland
         count={queue.length}
-        mobile={isMobile}
         queueOpen={queueOpen}
         filterActive={attentionFilter}
         onToggleQueue={() => setQueueOpen((value) => !value)}
@@ -998,63 +985,17 @@ export function Viewer() {
           );
         }
         if (name === "attention") {
-          const title = shellQueueCount ? `${t("mobile2.attention.title")} · ${shellQueueCount}` : t("mobile2.attention.title");
-          return (
-            <MobileSheet
-              name="attention"
-              title={title}
-              onClose={close}
-              extra={shellQueue.length > 1 ? (
-                <button
-                  type="button"
-                  data-attention-next
-                  className="inline-flex min-h-11 shrink-0 items-center gap-0.5 rounded-[8px] px-2 text-ui font-semibold text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-                  aria-label={t("attention.nextHint")}
-                  onClick={() => advanceShellAttention(1)}
-                >
-                  {t("mobile2.attention.next")}
-                  <ChevronRight className="h-4 w-4" aria-hidden />
-                </button>
-              ) : null}
-            >
-              {favoriteRows.length ? (
-                <>
-                  <MobileSheetSection>{t("favorites.sectionTitle")}</MobileSheetSection>
-                  {favoriteRows.map((row) => (
-                    <MobileSheetRow
-                      key={row.id}
-                      icon={<Crown className="h-[18px] w-[18px] fill-crown text-crown" aria-hidden />}
-                      label={cleanTitle(row.file.title, 90)}
-                      onSelect={() => openFavorite(row)}
-                    />
-                  ))}
-                </>
-              ) : null}
-              <MobileSheetSection count={shellQueueCount}>{t("attention.popoverTitle")}</MobileSheetSection>
-              {shellQueueCount ? (
-                <div className="flex flex-col gap-1.5 px-1.5">
-                  {shellQueue.map((item) => (
-                    <AttentionQueueRow key={item.id} item={item} onOpen={() => jumpToItem(item)} />
-                  ))}
-                  {/* The board's own row, so the two entries to one queue read
-                      the same words. It carries no destination until lane 7
-                      builds the pipeline screen — here as there. */}
-                  {shellPipelineRows.map((row) => (
-                    <MobilePipelineQueueRow key={row.id} row={row} />
-                  ))}
-                </div>
-              ) : (
-                <div className="px-4 py-4 text-center text-ui text-muted">{t("mobile2.attention.empty")}</div>
-              )}
-            </MobileSheet>
-          );
+          /* The Needs-you sheet (lane 8): the one list above, its rows opening
+             through the same hand-off a popover click performs (`jumpToItem`
+             moves the shared cycle pointer too, so «Next ›» here and N on a
+             desktop continue one sequence). Pipeline rows get their opener
+             from lane 7's pipeline screen. */
+          return <MobileAttentionSheet entries={shellEntries} now={clock} onOpenConversation={jumpToItem} onClose={close} />;
         }
         return null;
       },
     };
-    /* `t` is a fresh closure per render; `locale` is what changes its answers. */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMobile, shellQueue, shellQueueCount, shellPipelineRows, toastFile, openFile, files, projectCatalog, projectDisplayNames, pipelines, workflows, archivedProjects, crownedProjects, project, clock, loaded, catalogFailures, selectProject, createProject, favoriteRows, openFavorite, jumpToItem, advanceShellAttention, locale]);
+  }, [isMobile, shellEntries, toastFile, openFile, files, projectCatalog, projectDisplayNames, pipelines, workflows, archivedProjects, crownedProjects, project, clock, loaded, catalogFailures, selectProject, createProject, jumpToItem]);
 
   const shell = (
     <div className="flex h-full">

--- a/src/components/attention/AttentionIsland.dom.test.tsx
+++ b/src/components/attention/AttentionIsland.dom.test.tsx
@@ -45,7 +45,6 @@ function island(overrides: Partial<Parameters<typeof AttentionIsland>[0]> = {}) 
   return (
     <AttentionIsland
       count={3}
-      mobile={false}
       queueOpen={false}
       filterActive={false}
       onToggleQueue={() => {}}
@@ -112,18 +111,18 @@ test("the zero state is present, muted, inert and pulse-free", async () => {
   expect(zero.className).toContain("text-muted");
 });
 
-test("mobile keeps the compact count and a 44px Next, and hides the desktop-only filter", async () => {
-  const advances: Array<1 | -1> = [];
-  const host = await render(island({ mobile: true, count: 4, onNext: (dir) => advances.push(dir) }));
+/* The island is the DESKTOP corner since mobile v2 lane 8 (#1439). The phone's
+   badge is the shell's bar target — `⚠ n`, hidden at zero, 44 px, opening the
+   Needs-you sheet — and those assertions live with the shell
+   (MobileShell.dom.test.tsx) and the sheet (MobileAttentionSheet.dom.test.tsx).
+   What this component owes the phone is nothing: no compact face, no «⚠ 0». */
+test("the island has one face — the desktop's — and no phone variant to fall into", async () => {
+  const host = await render(island({ count: 4 }));
   const count = host.querySelector("[data-attention-count]")!;
-  const next = host.querySelector("[data-attention-next]")!;
-  expect(count.textContent).toContain("4");
-  expect(count.className).toContain("min-h-11");
-  expect(next.className).toContain("min-h-11");
-  expect(next.getAttribute("aria-label")).toContain("(N");
-  expect(host.querySelector("[data-attention-filter]")).toBeNull();
-  await click(next);
-  expect(advances).toEqual([1]);
+  expect(count.textContent).toContain("Needs you");
+  expect(count.className).not.toContain("min-h-11");
+  expect(host.querySelector("[data-attention-filter]")).not.toBeNull();
+  expect(host.querySelector("svg.lucide-triangle-alert")).toBeNull();
 });
 
 /* ------------------------------------------------------------------------- *
@@ -177,7 +176,6 @@ function Harness({ pointer, queue, projectQueue, onServe }: {
   return (
     <AttentionIsland
       count={queue.length}
-      mobile={false}
       queueOpen={false}
       filterActive={false}
       onToggleQueue={() => {}}

--- a/src/components/attention/AttentionIsland.tsx
+++ b/src/components/attention/AttentionIsland.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, Filter, TriangleAlert } from "lucide-react";
+import { ChevronRight, Filter } from "lucide-react";
 
 import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
@@ -12,7 +12,6 @@ import { decisionLine } from "./decision";
 interface Props {
   /** buildAttentionQueue's length, passed in so every surface shows one number. */
   count: number;
-  mobile: boolean;
   queueOpen: boolean;
   filterActive: boolean;
   onToggleQueue: () => void;
@@ -31,8 +30,15 @@ interface Props {
  * The zero state stays present and quiet: a muted, inert count with no pulse
  * and no controls, so the corner always answers "what needs me?". No element
  * here animates, so there is no motion to reduce.
+ *
+ * DESKTOP ONLY since mobile v2 lane 8 (#1439). The phone's badge is the
+ * shell's bar target (`MobileShell`): `⚠ n`, hidden at zero (README §4.6,
+ * Q3), opening the Needs-you sheet (`MobileAttentionSheet`) whose header
+ * carries «Next ›». The compact «⚠ 0» / count-and-chevron face this component
+ * used to render on the phone was the pill the audit's finding 8 named, and
+ * it is gone with the header row it lived in.
  */
-export function AttentionIsland({ count, mobile, queueOpen, filterActive, onToggleQueue, onNext, onToggleFilter }: Props) {
+export function AttentionIsland({ count, queueOpen, filterActive, onToggleQueue, onNext, onToggleFilter }: Props) {
   const { t } = useLocale();
 
   if (count === 0) {
@@ -44,15 +50,9 @@ export function AttentionIsland({ count, mobile, queueOpen, filterActive, onTogg
         aria-label={t("attention.badge", { count: 0 })}
         className="flex items-center rounded-full border border-border bg-card/95 px-3 py-1 text-[12px] font-bold text-muted shadow-1"
       >
-        {mobile ? (
-          <span className="inline-flex items-center gap-1">
-            <TriangleAlert className="h-3 w-3" aria-hidden /> 0
-          </span>
-        ) : (
-          <span>
-            <span className="uppercase tracking-[0.08em]">{t("attention.needsYou")}</span> 0
-          </span>
-        )}
+        <span>
+          <span className="uppercase tracking-[0.08em]">{t("attention.needsYou")}</span> 0
+        </span>
       </div>
     );
   }
@@ -62,61 +62,43 @@ export function AttentionIsland({ count, mobile, queueOpen, filterActive, onTogg
       <button
         type="button"
         data-attention-count
-        className={`text-[12px] font-bold text-warning hover:bg-warning/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 ${
-          mobile ? "inline-flex min-h-11 items-center px-3.5" : "px-3 py-1"
-        }`}
+        className="px-3 py-1 text-[12px] font-bold text-warning hover:bg-warning/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40"
         aria-expanded={queueOpen}
         aria-label={t("attention.badge", { count })}
         title={t("attention.openQueue")}
         onClick={onToggleQueue}
       >
-        {mobile ? (
-          <span className="inline-flex items-center gap-1">
-            <TriangleAlert className="h-3 w-3" aria-hidden /> {count}
-          </span>
-        ) : (
-          <span>
-            <span className="uppercase tracking-[0.08em]">{t("attention.needsYou")}</span> {count}
-          </span>
-        )}
+        <span>
+          <span className="uppercase tracking-[0.08em]">{t("attention.needsYou")}</span> {count}
+        </span>
       </button>
       <div className="h-4 w-px shrink-0 bg-warning/45" aria-hidden />
       <button
         type="button"
         data-attention-next
-        className={`text-[12px] font-bold text-warning hover:bg-warning/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 ${
-          mobile ? "inline-flex min-h-11 items-center px-2.5" : "inline-flex items-center gap-0.5 py-1 pl-2 pr-1.5"
-        }`}
+        className="inline-flex items-center gap-0.5 py-1 pl-2 pr-1.5 text-[12px] font-bold text-warning hover:bg-warning/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40"
         aria-label={t("attention.nextHint")}
         aria-keyshortcuts="n shift+n"
         title={t("attention.nextHint")}
         onClick={(event) => onNext(event.shiftKey ? -1 : 1)}
       >
-        {mobile ? <ChevronRight className="h-4 w-4" aria-hidden /> : (
-          <>
-            {t("attention.next")}
-            <ChevronRight className="h-3.5 w-3.5" aria-hidden />
-          </>
-        )}
+        {t("attention.next")}
+        <ChevronRight className="h-3.5 w-3.5" aria-hidden />
       </button>
-      {mobile ? null : (
-        <>
-          <div className="h-4 w-px shrink-0 bg-warning/45" aria-hidden />
-          <button
-            type="button"
-            data-attention-filter
-            className={`px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 ${
-              filterActive ? "bg-warning/30 text-warning" : "text-warning/70 hover:bg-warning/15 hover:text-warning"
-            }`}
-            aria-pressed={filterActive}
-            title={filterActive ? t("attention.filterOff") : t("attention.filterOn")}
-            aria-label={filterActive ? t("attention.filterOff") : t("attention.filterOn")}
-            onClick={onToggleFilter}
-          >
-            <Filter className="h-3.5 w-3.5" aria-hidden />
-          </button>
-        </>
-      )}
+      <div className="h-4 w-px shrink-0 bg-warning/45" aria-hidden />
+      <button
+        type="button"
+        data-attention-filter
+        className={`px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 ${
+          filterActive ? "bg-warning/30 text-warning" : "text-warning/70 hover:bg-warning/15 hover:text-warning"
+        }`}
+        aria-pressed={filterActive}
+        title={filterActive ? t("attention.filterOff") : t("attention.filterOn")}
+        aria-label={filterActive ? t("attention.filterOff") : t("attention.filterOn")}
+        onClick={onToggleFilter}
+      >
+        <Filter className="h-3.5 w-3.5" aria-hidden />
+      </button>
     </div>
   );
 }

--- a/src/components/attention/AttentionToast.arrival.dom.test.tsx
+++ b/src/components/attention/AttentionToast.arrival.dom.test.tsx
@@ -1,0 +1,186 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, jest, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+
+/*
+ * The arrival banner (mobile v2 lane 8, #1439; README §2 rule 3, §4.2
+ * `chat-arrival`, §4.6, §5 motion): a decision that arrives while the
+ * operator reads something else shows in the shell's banner slot and
+ * COLLAPSES into the bar's badge on its own after ~6 s. Under fake timers,
+ * because the clock is the subject: the collapse fires once, at 6 s, and
+ * neither a poll's re-render nor a fresh dismiss closure re-arms it.
+ *
+ * It also holds the one rule the shell cannot know: the conversation the
+ * banner announces is the one on screen, so the feed already shows the
+ * question and the banner says nothing.
+ */
+
+const dom = new Window({ url: "http://localhost/", width: 390, height: 844 });
+installActEnv();
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom, document: dom.document, navigator: dom.navigator, Node: dom.Node, HTMLElement: dom.HTMLElement,
+  Event: dom.Event, MouseEvent: dom.MouseEvent, sessionStorage: dom.sessionStorage, localStorage: dom.localStorage,
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+beforeAll(() => { for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; } });
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+});
+
+const { ARRIVAL_COLLAPSE_MS, AttentionToast } = await import("./AttentionToast");
+const { createMobileNav, MobileNavContext } = await import("@/components/mobile/mobileNav");
+type FileEntry = import("@/lib/types").FileEntry;
+type MobileNav = ReturnType<typeof createMobileNav>;
+
+/** A same-document history the nav store can push into. */
+function browserNav(): MobileNav {
+  const entries: { state: unknown; url: string }[] = [{ state: null, url: "http://localhost/#p=atlas" }];
+  let index = 0;
+  return createMobileNav({
+    history: {
+      get state() { return entries[index]!.state; },
+      pushState(state, _unused, url) { entries.splice(index + 1); entries.push({ state, url: url ?? entries[index]!.url }); index += 1; },
+      replaceState(state, _unused, url) { entries[index] = { state, url: url ?? entries[index]!.url }; },
+      back() { if (index > 0) index -= 1; },
+    },
+    href: () => entries[index]!.url,
+    onPopstate: () => () => {},
+  });
+}
+
+let root: Root | null = null;
+let nav: MobileNav;
+beforeEach(() => {
+  jest.useFakeTimers();
+  nav = browserNav();
+  dom.document.body.replaceChildren();
+});
+afterEach(async () => {
+  if (root) await act(async () => { root?.unmount(); });
+  root = null;
+  dom.document.body.replaceChildren();
+  /* happy-dom delivers hashchange on a window timer: drain anything pending
+     with nothing mounted before the real clock comes back. */
+  jest.advanceTimersByTime(50);
+  jest.useRealTimers();
+});
+
+const NOW = Math.floor(Date.now() / 1000);
+
+function file(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    root: "claude-projects", name: "worker.jsonl", path: "/transcripts/worker.jsonl", project: "alpha", title: "Migrate accounts to the new binding",
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: NOW - 30, size: 10, activity: "live", proc: "running", pid: 4242, model: "opus",
+    waitingInput: null,
+    pendingQuestion: {
+      kind: "plan", toolUseId: "tool-plan-1", transcriptPath: "/transcripts/worker.jsonl", pid: 4242, paneTarget: null, askedAt: new Date((NOW - 20) * 1000).toISOString(),
+      questions: [{ header: "", question: "Approve the plan", multiSelect: false, options: [] }], plan: "1. read 2. write",
+    },
+    ...overrides,
+  } as FileEntry;
+}
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host as unknown as Element);
+    root.render(<MobileNavContext.Provider value={nav}>{node}</MobileNavContext.Provider>);
+  });
+  return host as unknown as HTMLElement;
+}
+
+async function rerender(node: React.ReactNode): Promise<void> {
+  await act(async () => { root!.render(<MobileNavContext.Provider value={nav}>{node}</MobileNavContext.Provider>); });
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => { jest.advanceTimersByTime(ms); });
+}
+
+const banner = (host: HTMLElement) => host.querySelector("[data-mobile2-arrival]");
+
+test("the banner shows over a non-board screen and collapses into the badge on its own after ~6 s, exactly once", async () => {
+  nav.push({ kind: "chat", id: "/transcripts/other.jsonl" });
+  let dismissed = 0;
+  const host = await render(<AttentionToast file={file()} mobile onOpen={() => {}} onDismiss={() => { dismissed += 1; }} />);
+
+  expect(banner(host)).not.toBeNull();
+  expect(host.querySelector("[data-attention-toast-title]")!.textContent).toBe("Needs you · plan approval");
+  expect(ARRIVAL_COLLAPSE_MS).toBe(6_000);
+
+  await advance(ARRIVAL_COLLAPSE_MS - 1);
+  expect(dismissed).toBe(0);
+  await advance(1);
+  expect(dismissed).toBe(1);
+  /* Once: the host takes the arrival down on that call, and nothing here
+     rings a second time however long the clock runs. */
+  await advance(ARRIVAL_COLLAPSE_MS * 3);
+  expect(dismissed).toBe(1);
+});
+
+test("a poll's re-render with a fresh dismiss closure does not re-arm the collapse", async () => {
+  nav.push({ kind: "accounts" });
+  const calls: string[] = [];
+  const host = await render(<AttentionToast file={file()} mobile onOpen={() => {}} onDismiss={() => calls.push("first")} />);
+  await advance(4_000);
+  /* Two polls, two new closures, a title change on the same conversation. */
+  await rerender(<AttentionToast file={file({ title: "Migrate accounts to the new binding (v2)" })} mobile onOpen={() => {}} onDismiss={() => calls.push("second")} />);
+  await advance(1_000);
+  await rerender(<AttentionToast file={file()} mobile onOpen={() => {}} onDismiss={() => calls.push("third")} />);
+  expect(calls).toEqual([]);
+  /* 6 s after the ARRIVAL, not after the last render — and the latest closure
+     is the one that fires, so the host's current state is what gets updated. */
+  await advance(1_000);
+  expect(calls).toEqual(["third"]);
+  expect(banner(host)).not.toBeNull();
+});
+
+test("the × dismisses before the clock does, and the timer that follows has nothing left to do", async () => {
+  nav.push({ kind: "pipelines" });
+  const calls: string[] = [];
+  const host = await render(<AttentionToast file={file()} mobile onOpen={() => {}} onDismiss={() => calls.push("dismiss")} />);
+  await act(async () => {
+    host.querySelector("[data-attention-toast-dismiss]")!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never);
+  });
+  expect(calls).toEqual(["dismiss"]);
+  /* The host would unmount the banner on that call; this one stays mounted to
+     prove the clock still runs to its one collapse and no further. */
+  await advance(ARRIVAL_COLLAPSE_MS);
+  expect(calls).toEqual(["dismiss", "dismiss"]);
+});
+
+test("the conversation on screen is not announced to itself; leaving it brings the banner back until the clock collapses it", async () => {
+  nav.push({ kind: "chat", id: "/transcripts/worker.jsonl" });
+  let dismissed = 0;
+  const host = await render(<AttentionToast file={file()} mobile onOpen={() => {}} onDismiss={() => { dismissed += 1; }} />);
+  expect(banner(host)).toBeNull();
+
+  /* A sibling switch to another conversation: the decision is now elsewhere. */
+  await act(async () => { nav.replace({ kind: "chat", id: "/transcripts/other.jsonl" }); });
+  expect(banner(host)).not.toBeNull();
+
+  /* The clock ran the whole time; the badge takes over on schedule. */
+  await advance(ARRIVAL_COLLAPSE_MS);
+  expect(dismissed).toBe(1);
+});
+
+test("the body opens the conversation and the × is its own target, both 44 px", async () => {
+  nav.push({ kind: "chat", id: "/transcripts/other.jsonl" });
+  const events: string[] = [];
+  const host = await render(<AttentionToast file={file()} mobile onOpen={() => events.push("open")} onDismiss={() => events.push("dismiss")} />);
+  const open = host.querySelector("[data-attention-toast-open]")!;
+  const dismiss = host.querySelector("[data-attention-toast-dismiss]")!;
+  expect(open.getAttribute("aria-label")).toBe("Open Migrate accounts to the new binding");
+  expect(open.className).toContain("min-h-11");
+  expect(dismiss.className).toContain("h-11");
+  expect(dismiss.getAttribute("aria-label")).toBe("Dismiss");
+  await act(async () => { open.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never); });
+  expect(events).toEqual(["open"]);
+});

--- a/src/components/attention/AttentionToast.dom.test.tsx
+++ b/src/components/attention/AttentionToast.dom.test.tsx
@@ -200,7 +200,12 @@ test("an interrupted turn nobody is behind names no decision, on the toast or in
   }
 });
 
-test("open and dismiss stay separate targets, on the phone at full tap height", async () => {
+/* On the phone the toast is the ARRIVAL BANNER (mobile v2 lane 8, #1439): the
+   shell's one banner slot reads «Needs you · <decision>» over the title, the
+   body opens, × dismisses, both at 44 px. The collapse timer and the
+   own-conversation rule are in AttentionToast.arrival.dom.test.tsx, under fake
+   timers. */
+test("the phone banner names the decision under «Needs you», and open and dismiss stay separate 44 px targets", async () => {
   const events: string[] = [];
   const host = await render(
     <AttentionToast
@@ -211,10 +216,19 @@ test("open and dismiss stay separate targets, on the phone at full tap height", 
     />,
   );
 
+  expect(title(host)).toBe("Needs you · Rollout window");
+  expect(host.textContent).toContain("Ship the rollout");
+  /* The phone root is the arrival hook, never `data-attention-toast`: the
+     shell's banner slot is the one receipt the capture gate measures. */
+  expect(host.querySelector("[data-attention-toast]")).toBeNull();
+  const banner = host.querySelector("[data-mobile2-arrival]")!;
+  expect(banner.getAttribute("data-mobile2-arrival")).toBe("/transcripts/worker.jsonl");
+  expect(banner.className).toContain("min-h-11");
   const open = host.querySelector("[data-attention-toast-open]")!;
   const dismiss = host.querySelector("[data-attention-toast-dismiss]")!;
   expect(open.className).toContain("min-h-11");
   expect(dismiss.className).toContain("h-11");
+  expect(dismiss.className).toContain("w-11");
   await click(open);
   await click(dismiss);
   expect(events).toEqual(["open", "dismiss"]);

--- a/src/components/attention/AttentionToast.tsx
+++ b/src/components/attention/AttentionToast.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { X } from "lucide-react";
+import { useEffect, useRef } from "react";
 
+import { topScreen, useMobileNav } from "@/components/mobile/mobileNav";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -22,40 +24,34 @@ import { decisionLine } from "./decision";
  * that no longer carries one is worse than saying nothing specific.
  *
  * Desktop floats it under the attention island so a new toast visually docks
- * into the badge; the phone hands it the full width of an in-flow banner above
- * the board, where it reserves its own space instead of covering the toolbar.
- * Open and dismiss stay two separate targets in both.
+ * into the badge. The phone renders the ARRIVAL BANNER of mobile v2 instead
+ * (issue #1439, lane 8; README §2 rule 3, §4.2 `chat-arrival`, §4.6): the
+ * shell's one banner slot, directly under the bar, reads «Needs you · <the
+ * decision>» over the conversation's title, the body opens it, × dismisses,
+ * and it collapses into the bar's badge on its own after ~6 s
+ * (`ARRIVAL_COLLAPSE_MS`). The shell decides which screens get the slot (never
+ * the board: its queue is the first section); this component adds the one
+ * rule the shell cannot know — the conversation the banner announces is
+ * already on screen, so announcing it there would repeat the question card
+ * the feed is showing. Open and dismiss stay two separate targets in both.
  */
-export function AttentionToast({ file, mobile, onOpen, onDismiss }: {
+
+/** How long an arrival banner stays before it collapses into the badge. */
+export const ARRIVAL_COLLAPSE_MS = 6_000;
+
+export function AttentionToast({ file, mobile, onOpen, onDismiss, collapseMs = ARRIVAL_COLLAPSE_MS }: {
   file: FileEntry;
   mobile: boolean;
   onOpen: () => void;
   onDismiss: () => void;
+  /** Test seam for the phone's collapse; production uses the design's ~6 s. */
+  collapseMs?: number;
 }) {
   const { t, locale } = useLocale();
   const title = decisionLine(t, locale, file) ?? t("viewer.agentWaiting");
 
   if (mobile) {
-    return (
-      <div className="flex shrink-0 items-stretch gap-2 border-b border-warning/45 bg-warning-soft pl-3 pr-1.5 py-1.5" data-attention-toast>
-        <button
-          data-attention-toast-open
-          className="flex min-h-11 min-w-0 flex-1 flex-col justify-center text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-          onClick={onOpen}
-        >
-          <span data-attention-toast-title className="block text-[11px] font-bold text-warning">{title}</span>
-          <span className="truncate text-[13px] font-semibold text-primary">{file.title}</span>
-        </button>
-        <button
-          data-attention-toast-dismiss
-          className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-          aria-label={t("viewer.closeNotification")}
-          onClick={onDismiss}
-        >
-          <X className="h-5 w-5" aria-hidden />
-        </button>
-      </div>
-    );
+    return <ArrivalBanner file={file} decision={title} onOpen={onOpen} onDismiss={onDismiss} collapseMs={collapseMs} />;
   }
 
   return (
@@ -78,6 +74,68 @@ export function AttentionToast({ file, mobile, onOpen, onDismiss }: {
         onClick={onDismiss}
       >
         <X className="h-3.5 w-3.5" aria-hidden />
+      </button>
+    </div>
+  );
+}
+
+function ArrivalBanner({ file, decision, onOpen, onDismiss, collapseMs }: {
+  file: FileEntry;
+  decision: string;
+  onOpen: () => void;
+  onDismiss: () => void;
+  collapseMs: number;
+}) {
+  const { t } = useLocale();
+  const navState = useMobileNav();
+  const here = topScreen(navState);
+  /* The collapse is armed ONCE per announced conversation and runs on its own
+     clock: the host re-renders on every poll and hands down a fresh dismiss
+     closure each time, and re-arming on either would keep the banner up for as
+     long as anything on the page moved. The callback is read through a ref so
+     the timer fires whatever the host has for it by then. */
+  const dismissRef = useRef(onDismiss);
+  useEffect(() => { dismissRef.current = onDismiss; }, [onDismiss]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => dismissRef.current(), collapseMs);
+    return () => window.clearTimeout(timer);
+  }, [file.path, collapseMs]);
+
+  /* The conversation is what the operator is reading: its question card is in
+     the feed under this very bar, so the banner would only repeat it. The
+     timer above keeps running, so the badge still takes over on schedule. */
+  if (here.kind === "chat" && here.id === file.path) return null;
+
+  const title = file.title;
+  /* The root carries `data-mobile2-arrival` and NOT `data-attention-toast`:
+     the shell's slot (`[data-mobile2-banner]`) is the one banner surface the
+     capture's receipt gate measures, and a second receipt hook nested inside
+     it would read its own open target as a control it covers. */
+  return (
+    <div
+      data-mobile2-arrival={file.path}
+      className="flex min-h-11 shrink-0 items-stretch gap-1 border-b border-warning/45 bg-warning-soft pl-3 pr-0.5"
+    >
+      <button
+        type="button"
+        data-attention-toast-open
+        aria-label={t("mobile2.attention.open", { title })}
+        className="flex min-h-11 min-w-0 flex-1 flex-col justify-center py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40"
+        onClick={onOpen}
+      >
+        <span data-attention-toast-title className="block text-label font-bold leading-[1.2] text-warning">
+          {t("mobile2.attention.arrival", { decision })}
+        </span>
+        <span className="truncate text-body font-semibold leading-[1.25] text-primary">{title}</span>
+      </button>
+      <button
+        type="button"
+        data-attention-toast-dismiss
+        className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-[8px] text-warning active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        aria-label={t("mobile2.attention.dismiss")}
+        onClick={onDismiss}
+      >
+        <X className="h-5 w-5" aria-hidden />
       </button>
     </div>
   );

--- a/src/components/attention/MobileAttentionSheet.dom.test.tsx
+++ b/src/components/attention/MobileAttentionSheet.dom.test.tsx
@@ -1,0 +1,194 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { needsDecisionPipelineRows } from "@/components/mobile/mobileBoardModel";
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+import { buildAttentionQueue } from "../attention";
+import { buildMobileAttentionQueue } from "./attentionQueue";
+import { MobileAttentionSheet } from "./MobileAttentionSheet";
+
+/*
+ * The Needs-you sheet (mobile v2 lane 8, #1439; README §4.1, §4.6): one list
+ * of conversations and `needs_decision` pipelines, «Needs you · n» in the
+ * header, «Next ›» beside it when there is more than one item — skipping the
+ * item on screen and wrapping — rows that name the decision, and nothing at
+ * zero but the empty line.
+ */
+
+const dom = new Window({ url: "http://localhost/", width: 390, height: 844 });
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom, document: dom.document, navigator: dom.navigator, Node: dom.Node, HTMLElement: dom.HTMLElement,
+  Event: dom.Event, KeyboardEvent: dom.KeyboardEvent, MouseEvent: dom.MouseEvent, PointerEvent: dom.PointerEvent,
+  sessionStorage: dom.sessionStorage, localStorage: dom.localStorage,
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+beforeAll(() => { for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; } });
+afterAll(async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+});
+
+let roots: Root[] = [];
+beforeEach(() => { dom.document.body.replaceChildren(); dom.document.body.style.overflow = ""; roots = []; });
+afterEach(() => { for (const root of roots) flushSync(() => root.unmount()); roots = []; });
+
+function mount(node: React.ReactNode): HTMLElement {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  roots.push(root);
+  return host as unknown as HTMLElement;
+}
+
+const click = (el: Element | null) => {
+  if (!el) throw new Error("nothing to click");
+  el.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as never);
+};
+const q = (host: HTMLElement, selector: string) => host.querySelector(selector) as unknown as HTMLElement | null;
+const qa = (host: HTMLElement, selector: string) => Array.from(host.querySelectorAll(selector)) as unknown as HTMLElement[];
+
+const NOW = 1_800_000_000;
+const PROJECT = "atlas";
+
+function conversation(path: string, title: string, since: number, over: Partial<FileEntry> = {}): FileEntry {
+  return {
+    root: "claude-projects", name: path, path, project: PROJECT, title, engine: "codex", kind: "session", fmt: "codex",
+    parent: null, mtime: NOW - 60, size: 10, activity: "idle", proc: null, pid: null, model: "gpt-5.6", waitingInput: null,
+    pendingQuestion: {
+      kind: "question", toolUseId: `tool-${path}`, transcriptPath: path, pid: 4242, paneTarget: null, askedAt: new Date(since * 1000).toISOString(),
+      questions: [{ header: "", question: "Which endpoint first?", multiSelect: false, options: [] }],
+    },
+    ...over,
+  } as FileEntry;
+}
+
+function pipeline(id: string, task: string, state: Pipeline["state"], completedAt: number): Pipeline {
+  return {
+    id, task, taskIds: [], project: PROJECT, repoDir: "/repo", worktreeDir: "/repo-lane", branch: "lane/1", baseBranch: "main", baseRef: "main",
+    lastPassedCommit: "", stages: [{ id: "design", kind: "run" }, { id: "implement", kind: "run", role: { roleId: "builder" } }, { id: "review", kind: "review-loop" }, { id: "merge", kind: "run" }, { id: "deploy", kind: "run" }],
+    runs: [{ stageId: "review", attempts: [{ n: 2, state: "failed", verdict: { status: "fail", findings: ["remount drops the feed cache", "the switch is 640 ms"] }, completedAt: new Date(completedAt * 1000).toISOString() }] }],
+    cursor: { stageId: "review", state: "reviewing", input: null, activatedBy: null },
+    state, pausedState: null, stateDetail: null, srcPath: null, srcConversationId: null,
+    createdAt: new Date((NOW - 7_200) * 1000).toISOString(), closedAt: null,
+  } as unknown as Pipeline;
+}
+
+const FILES = [
+  conversation("/p/export.jsonl", "Implement the export endpoint", NOW - 540),
+  conversation("/p/migrate.jsonl", "Migrate accounts to the new binding", NOW - 120, {
+    engine: "claude", fmt: "claude", model: "opus",
+    pendingQuestion: { kind: "plan", toolUseId: "tool-plan", transcriptPath: "/p/migrate.jsonl", pid: 1, paneTarget: null, askedAt: new Date((NOW - 120) * 1000).toISOString(), questions: [], plan: "1. read" },
+  } as Partial<FileEntry>),
+];
+const PIPELINES = [pipeline("pipeline_atlas_p2", "Fast conversation switching", "needs_decision", NOW - 3_600), pipeline("pipeline_atlas_p1", "Board status projection", "running", NOW - 60)];
+const entries = () => buildMobileAttentionQueue(buildAttentionQueue(FILES, NOW, PROJECT), needsDecisionPipelineRows(PIPELINES, PROJECT, NOW));
+
+test("the sheet lists conversations and needs_decision pipelines as one list under «Needs you · n», rows naming the decision", () => {
+  const host = mount(<MobileAttentionSheet entries={entries()} now={NOW} onOpenConversation={() => {}} onClose={() => {}} screen={{ kind: "board" }} />);
+  const sheet = q(host, '[data-mobile2-sheet="attention"]')!;
+  expect(sheet).not.toBeNull();
+  expect(sheet.getAttribute("aria-label")).toBe("Needs you · 3");
+  expect(q(host, "h2")!.textContent).toBe("Needs you · 3");
+
+  const rows = qa(host, "[data-attention-row]");
+  expect(rows.map((row) => row.getAttribute("data-mobile2-go"))).toEqual(["chat", "chat", null]);
+  expect(rows[0]!.textContent).toContain("Implement the export endpoint");
+  expect(rows[0]!.querySelector("[data-attention-decision]")!.textContent).toBe("a question");
+  expect(rows[0]!.textContent).toContain("9m");
+  expect(rows[0]!.textContent).toContain("gpt-5.6");
+  expect(rows[0]!.querySelector('[data-mobile2-engine="codex"]')).not.toBeNull();
+  expect(rows[1]!.querySelector("[data-attention-decision]")!.textContent).toBe("plan approval");
+  /* The pipeline row: the board's words, prefixed with what it is. */
+  expect(rows[2]!.getAttribute("data-mobile2-pipeline-row")).toBe("pipeline_atlas_p2");
+  expect(rows[2]!.textContent).toContain("Fast conversation switching");
+  expect(rows[2]!.querySelector("[data-attention-decision]")!.textContent).toBe("pipeline · stage 3/5 · review loop failed · 2 findings");
+  expect(rows[2]!.textContent).toContain("1h");
+  /* Every row is a 44 px target. */
+  for (const row of rows) expect(row.className).toContain("min-h-11");
+});
+
+test("a conversation row opens through the host; a pipeline row is inert until the pipeline screen supplies an opener, then it is a door", () => {
+  const opened: string[] = [];
+  let host = mount(<MobileAttentionSheet entries={entries()} now={NOW} onOpenConversation={(item) => opened.push(item.file.path)} onClose={() => {}} screen={{ kind: "board" }} />);
+  click(q(host, '[data-mobile2-conversation="/p/migrate.jsonl"]'));
+  expect(opened).toEqual(["/p/migrate.jsonl"]);
+  const inert = q(host, '[data-mobile2-pipeline-row="pipeline_atlas_p2"]')!;
+  expect(inert.tagName).toBe("DIV");
+  expect(inert.getAttribute("data-mobile2-go")).toBeNull();
+  for (const root of roots) flushSync(() => root.unmount());
+  roots = [];
+
+  const pipelines: string[] = [];
+  host = mount(<MobileAttentionSheet entries={entries()} now={NOW} onOpenConversation={() => {}} onOpenPipeline={(row) => pipelines.push(row.id)} onClose={() => {}} screen={{ kind: "board" }} />);
+  const door = q(host, '[data-mobile2-pipeline-row="pipeline_atlas_p2"]')!;
+  expect(door.tagName).toBe("BUTTON");
+  expect(door.getAttribute("data-mobile2-go")).toBe("pipeline");
+  expect(door.getAttribute("aria-label")).toBe("Open the pipeline Fast conversation switching");
+  click(door);
+  expect(pipelines).toEqual(["pipeline_atlas_p2"]);
+});
+
+test("«Next ›» skips the item on screen and wraps, over both kinds once pipelines can be opened", () => {
+  const opened: string[] = [];
+  const props = { now: NOW, onOpenConversation: (item: { file: FileEntry }) => opened.push(item.file.path), onOpenPipeline: (row: { id: string }) => opened.push(row.id), onClose: () => {} };
+  /* From the board: the head. */
+  let host = mount(<MobileAttentionSheet entries={entries()} {...props} screen={{ kind: "board" }} />);
+  const next = q(host, "[data-attention-next]")!;
+  expect(next.className).toContain("min-h-11");
+  expect(next.getAttribute("aria-label")).toBe("Open the next one that needs you");
+  click(next);
+  for (const root of roots) flushSync(() => root.unmount());
+  roots = [];
+  /* From the first conversation: the second; from the second: the pipeline;
+     from the pipeline: wraps to the first. */
+  for (const screen of [{ kind: "chat" as const, id: "/p/export.jsonl" }, { kind: "chat" as const, id: "/p/migrate.jsonl" }, { kind: "pipeline" as const, id: "pipeline_atlas_p2" }]) {
+    host = mount(<MobileAttentionSheet entries={entries()} {...props} screen={screen} />);
+    click(q(host, "[data-attention-next]"));
+    for (const root of roots) flushSync(() => root.unmount());
+    roots = [];
+  }
+  expect(opened).toEqual(["/p/export.jsonl", "/p/migrate.jsonl", "pipeline_atlas_p2", "/p/export.jsonl"]);
+});
+
+test("without a pipeline opener «Next ›» walks the conversations only, and the row on screen is marked current", () => {
+  const opened: string[] = [];
+  const host = mount(<MobileAttentionSheet entries={entries()} now={NOW} onOpenConversation={(item) => opened.push(item.file.path)} onClose={() => {}} screen={{ kind: "chat", id: "/p/migrate.jsonl" }} />);
+  expect(q(host, '[data-mobile2-conversation="/p/migrate.jsonl"]')!.getAttribute("aria-current")).toBe("true");
+  expect(q(host, '[data-mobile2-conversation="/p/export.jsonl"]')!.getAttribute("aria-current")).toBeNull();
+  /* After the last conversation the pipeline has no door yet, so Next wraps
+     to the first conversation instead of stepping into nowhere. */
+  click(q(host, "[data-attention-next]"));
+  expect(opened).toEqual(["/p/export.jsonl"]);
+});
+
+test("one item shows no «Next ›», and zero items show the empty line under a bare «Needs you»", () => {
+  const one = buildMobileAttentionQueue(buildAttentionQueue([FILES[0]!], NOW, PROJECT), []);
+  let host = mount(<MobileAttentionSheet entries={one} now={NOW} onOpenConversation={() => {}} onClose={() => {}} screen={{ kind: "board" }} />);
+  expect(q(host, "[data-attention-next]")).toBeNull();
+  expect(q(host, "h2")!.textContent).toBe("Needs you · 1");
+  for (const root of roots) flushSync(() => root.unmount());
+  roots = [];
+
+  host = mount(<MobileAttentionSheet entries={[]} now={NOW} onOpenConversation={() => {}} onClose={() => {}} screen={{ kind: "board" }} />);
+  expect(q(host, "h2")!.textContent).toBe("Needs you");
+  expect(q(host, "[data-attention-next]")).toBeNull();
+  expect(q(host, "[data-mobile2-attention-empty]")!.textContent).toBe("Nothing needs you.");
+  expect(qa(host, "[data-attention-row]")).toHaveLength(0);
+});
+
+test("the × closes through the host", () => {
+  let closed = 0;
+  const host = mount(<MobileAttentionSheet entries={entries()} now={NOW} onOpenConversation={() => {}} onClose={() => { closed += 1; }} screen={{ kind: "board" }} />);
+  click(q(host, "[data-mobile2-close]"));
+  expect(closed).toBe(1);
+});

--- a/src/components/attention/MobileAttentionSheet.tsx
+++ b/src/components/attention/MobileAttentionSheet.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { ChevronRight } from "@/components/icons";
+import { ChatEngineMark } from "@/components/mobile/chatEngineMark";
+import type { MobileBoardPipelineRow } from "@/components/mobile/mobileBoardModel";
+import { topScreen, useMobileNav, type MobileScreen } from "@/components/mobile/mobileNav";
+import { MobileSheet } from "@/components/mobile/MobileSheet";
+import { useLocale } from "@/lib/i18n";
+
+import type { AttentionItem } from "../attention";
+import { stageChipLabel } from "../pipelines/pipelineModel";
+import { humanizeDuration } from "../turnDuration";
+import { cleanTitle } from "../utils";
+import { nextMobileAttention, type MobileAttentionEntry } from "./attentionQueue";
+import { decisionLine } from "./decision";
+
+/*
+ * The Needs-you sheet (issue #1439, lane 8; docs/design/mobile-v2/README.md
+ * §4.1, §4.6; the prototype's `attentionSheet`). The bar's `⚠ n` opens it
+ * over whatever screen is showing, and it lists the ONE phone queue
+ * (`attentionQueue.ts`): conversations waiting on a decision, stalled or at
+ * their account limit, and pipelines in `needs_decision`, in the board's
+ * Needs-you order. Its header says «Needs you · n» and, when there is more
+ * than one item, carries «Next ›», which skips the item the operator is
+ * looking at and wraps.
+ *
+ * Rows are the sheet-row anatomy (`.mrow`): a warning dot, the title, one meta
+ * line, a chevron. The meta line of a conversation is the DECISION — the one
+ * `decisionLine` the desktop's toast and popover row also read (#1167) — then
+ * how long it has waited, the engine glyph and the model; a pipeline's reads
+ * `pipeline · stage k/n · <stage> failed · n findings · age`, the same words
+ * the board's queue row uses (`MobilePipelineQueueRow`), so the two entries
+ * cannot describe one pipeline differently.
+ *
+ * A row is the phone's OPEN gesture (#1244): the conversation screen it pushes
+ * stamps the card seen. Pipelines have a destination once lane 7 lands the
+ * pipeline screen; until the host passes `onOpenPipeline`, a pipeline row is a
+ * statement rather than a control, and «Next ›» walks the conversations.
+ */
+
+export interface MobileAttentionSheetProps {
+  entries: readonly MobileAttentionEntry[];
+  /** Epoch seconds the ages are measured from. */
+  now: number;
+  onOpenConversation: (item: AttentionItem) => void;
+  /** The pipeline screen's opener (lane 7). Absent, pipeline rows are inert. */
+  onOpenPipeline?: (row: MobileBoardPipelineRow) => void;
+  onClose: () => void;
+  /** Test seam: the screen «Next ›» steps from. Production reads the nav store. */
+  screen?: MobileScreen;
+}
+
+const ROW = "flex min-h-11 w-full items-center gap-3 px-4 py-1.5 text-left active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40";
+const META = "flex items-center gap-[5px] overflow-hidden text-label font-medium tabular-nums text-muted";
+const SEP = <span aria-hidden className="shrink-0 opacity-60">·</span>;
+
+export function MobileAttentionSheet({ entries, now, onOpenConversation, onOpenPipeline, onClose, screen }: MobileAttentionSheetProps) {
+  const { t } = useLocale();
+  const navState = useMobileNav();
+  const here = screen ?? topScreen(navState);
+  /* «Next ›» walks what can be opened: every entry once the pipeline screen
+     has an opener, the conversations alone until then. */
+  const walkable = onOpenPipeline ? entries : entries.filter((entry) => entry.kind === "conversation");
+  const open = (entry: MobileAttentionEntry) => {
+    if (entry.kind === "conversation") onOpenConversation(entry.item);
+    else onOpenPipeline?.(entry.row);
+  };
+  const next = () => {
+    const target = nextMobileAttention(walkable, here, 1);
+    if (target) open(target);
+  };
+  const title = entries.length ? `${t("mobile2.attention.title")} · ${entries.length}` : t("mobile2.attention.title");
+  return (
+    <MobileSheet
+      name="attention"
+      title={title}
+      onClose={onClose}
+      extra={walkable.length > 1 ? (
+        <button
+          type="button"
+          data-attention-next
+          className="inline-flex min-h-11 shrink-0 items-center gap-0.5 rounded-[8px] px-2 text-ui font-semibold text-accent active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          aria-label={t("mobile2.attention.nextHint")}
+          onClick={next}
+        >
+          {t("mobile2.attention.next")}
+          <ChevronRight className="h-4 w-4" aria-hidden />
+        </button>
+      ) : null}
+    >
+      {entries.length ? (
+        <div className="flex flex-col" data-mobile2-attention-list>
+          {entries.map((entry) => entry.kind === "conversation" ? (
+            <ConversationRow key={entry.id} item={entry.item} now={now} current={here.kind === "chat" && here.id === entry.item.file.path} onOpen={() => open(entry)} />
+          ) : (
+            <PipelineRow key={entry.id} row={entry.row} current={here.kind === "pipeline" && here.id === entry.row.id} onOpen={onOpenPipeline ? () => open(entry) : undefined} />
+          ))}
+        </div>
+      ) : (
+        <div className="px-4 py-4 text-center text-ui text-muted" data-mobile2-attention-empty>{t("mobile2.attention.empty")}</div>
+      )}
+    </MobileSheet>
+  );
+}
+
+function ConversationRow({ item, now, current, onOpen }: { item: AttentionItem; now: number; current: boolean; onOpen: () => void }) {
+  const { t, locale } = useLocale();
+  const title = cleanTitle(item.file.title, 90);
+  const decision = decisionLine(t, locale, item.file, now) ?? t("status.stalled");
+  return (
+    <button
+      type="button"
+      data-attention-row={item.id}
+      data-mobile2-row="conversation"
+      data-mobile2-go="chat"
+      data-mobile2-conversation={item.file.path}
+      aria-current={current ? "true" : undefined}
+      aria-label={t("mobile2.attention.open", { title })}
+      className={ROW}
+      onClick={onOpen}
+    >
+      <span aria-hidden className={`h-2 w-2 shrink-0 rounded-full ${item.tier === "stalled" ? "bg-danger" : "bg-warning"}`} />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="min-w-0 truncate text-body font-semibold leading-[1.25] text-primary">{title}</span>
+        <span className={META}>
+          <span data-attention-decision className="shrink-0">{decision}</span>
+          {SEP}
+          <span className="shrink-0">{humanizeDuration(Math.max(0, now - item.since))}</span>
+          {item.file.model ? (
+            <>
+              {SEP}
+              <ChatEngineMark file={item.file} />
+              <span className="min-w-0 truncate">{item.file.model}</span>
+            </>
+          ) : null}
+        </span>
+      </span>
+      <ChevronRight className="h-[18px] w-[18px] shrink-0 text-muted" aria-hidden />
+    </button>
+  );
+}
+
+function PipelineRow({ row, current, onOpen }: { row: MobileBoardPipelineRow; current: boolean; onOpen?: () => void }) {
+  const { t } = useLocale();
+  const stageName = row.stageRef ? stageChipLabel(t, row.stageRef).toLocaleLowerCase() : "";
+  const meta = [
+    t("mobile2.attention.pipeline"),
+    t(row.stageFailed ? "mobile2.board.pipelineStageFailed" : "mobile2.board.pipelineStage", { stage: row.stage, total: row.total, name: stageName }),
+    row.findings ? t("mobile2.board.pipelineFindings", { count: row.findings }) : null,
+  ].filter(Boolean).join(" · ");
+  const Tag = onOpen ? "button" : "div";
+  return (
+    <Tag
+      {...(onOpen ? { type: "button" as const, onClick: onOpen, "aria-label": t("mobile2.board.openPipeline", { task: row.task }), "aria-current": current ? ("true" as const) : undefined } : {})}
+      data-attention-row={row.id}
+      data-mobile2-row="pipeline"
+      data-mobile2-go={onOpen ? "pipeline" : undefined}
+      data-mobile2-pipeline-row={row.id}
+      className={ROW}
+    >
+      <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-warning" />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="min-w-0 truncate text-body font-semibold leading-[1.25] text-primary">{row.task}</span>
+        <span className={META}>
+          <span data-attention-decision className="shrink-0">{meta}</span>
+          {row.seconds === null ? null : (
+            <>
+              {SEP}
+              <span className="shrink-0">{humanizeDuration(row.seconds)}</span>
+            </>
+          )}
+        </span>
+      </span>
+      {onOpen ? <ChevronRight className="h-[18px] w-[18px] shrink-0 text-muted" aria-hidden /> : null}
+    </Tag>
+  );
+}

--- a/src/components/attention/attentionQueue.test.ts
+++ b/src/components/attention/attentionQueue.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+
+import { needsDecisionPipelineRows } from "@/components/mobile/mobileBoardModel";
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+import { buildAttentionQueue } from "../attention";
+import { buildMobileAttentionQueue, isCurrentAttentionEntry, nextMobileAttention } from "./attentionQueue";
+
+/*
+ * One list for the phone (README §4.1, §4.6): conversations waiting on the
+ * operator and pipelines in `needs_decision`, joined in the board's order;
+ * «Next ›» skips the item on screen and wraps.
+ */
+
+const NOW = 1_800_000_000;
+const PROJECT = "atlas";
+
+function waiting(path: string, since: number): FileEntry {
+  return {
+    root: "claude-projects", name: path, path, project: PROJECT, title: path, engine: "claude", kind: "session", fmt: "claude",
+    parent: null, mtime: NOW - 60, size: 10, activity: "idle", proc: null, pid: null, model: "opus", pendingQuestion: null,
+    waitingInput: { since, screenTail: "❯ 1. Yes", target: "llv:0.0", menu: null },
+  } as FileEntry;
+}
+
+function pipeline(id: string, state: Pipeline["state"], completedAt: number): Pipeline {
+  return {
+    id, task: `Lane ${id}`, taskIds: [], project: PROJECT, repoDir: "/repo", worktreeDir: "/repo-lane", branch: "lane/1", baseBranch: "main", baseRef: "main",
+    lastPassedCommit: "", stages: [{ id: "implement", kind: "run" }, { id: "review", kind: "review-loop" }],
+    runs: [{ stageId: "review", attempts: [{ n: 1, state: "failed", verdict: { status: "fail", findings: ["one"] }, completedAt: new Date(completedAt * 1_000).toISOString() }] }],
+    cursor: { stageId: "review", state: "reviewing", input: null, activatedBy: null },
+    state, pausedState: null, stateDetail: null, srcPath: null, srcConversationId: null,
+    createdAt: new Date((NOW - 7_200) * 1_000).toISOString(), closedAt: null,
+  } as unknown as Pipeline;
+}
+
+const conversations = buildAttentionQueue([waiting("/p/new.jsonl", NOW - 100), waiting("/p/old.jsonl", NOW - 900)], NOW, PROJECT);
+const pipelines = needsDecisionPipelineRows([pipeline("p-decide", "needs_decision", NOW - 3_600), pipeline("p-run", "running", NOW - 60)], PROJECT, NOW);
+
+test("conversations and needs_decision pipelines are ONE list, conversations in queue order first, then the pipelines", () => {
+  const entries = buildMobileAttentionQueue(conversations, pipelines);
+  expect(entries.map((entry) => `${entry.kind}:${entry.kind === "conversation" ? entry.item.file.path : entry.row.id}`)).toEqual([
+    "conversation:/p/old.jsonl",
+    "conversation:/p/new.jsonl",
+    "pipeline:p-decide",
+  ]);
+  /* A running pipeline is not a decision, so it is not in the list — and the
+     badge that counts this list agrees with the board's Needs-you section. */
+  expect(entries).toHaveLength(3);
+  expect(entries.every((entry) => entry.id.length > 0)).toBe(true);
+});
+
+test("Next from the board (nothing on screen) opens the head; backward opens the tail", () => {
+  const entries = buildMobileAttentionQueue(conversations, pipelines);
+  expect(nextMobileAttention(entries, { kind: "board" })).toBe(entries[0]!);
+  expect(nextMobileAttention(entries, null)).toBe(entries[0]!);
+  expect(nextMobileAttention(entries, { kind: "board" }, -1)).toBe(entries[2]!);
+});
+
+test("Next skips the item the operator is looking at and wraps past the end, across both kinds", () => {
+  const entries = buildMobileAttentionQueue(conversations, pipelines);
+  /* From the first conversation: the second. */
+  expect(nextMobileAttention(entries, { kind: "chat", id: "/p/old.jsonl" })).toBe(entries[1]!);
+  /* From the last conversation: the pipeline. */
+  expect(nextMobileAttention(entries, { kind: "chat", id: "/p/new.jsonl" })).toBe(entries[2]!);
+  /* From the pipeline: wraps to the first conversation. */
+  expect(nextMobileAttention(entries, { kind: "pipeline", id: "p-decide" })).toBe(entries[0]!);
+  /* Backward wraps the other way. */
+  expect(nextMobileAttention(entries, { kind: "chat", id: "/p/old.jsonl" }, -1)).toBe(entries[2]!);
+  /* A screen showing something not in the list is the same as the board. */
+  expect(nextMobileAttention(entries, { kind: "chat", id: "/p/elsewhere.jsonl" })).toBe(entries[0]!);
+  expect(nextMobileAttention(entries, { kind: "accounts" })).toBe(entries[0]!);
+});
+
+test("the item on screen is never the answer: one entry, and that one open, has no Next", () => {
+  const only = buildMobileAttentionQueue(conversations.slice(0, 1), []);
+  expect(nextMobileAttention(only, { kind: "chat", id: conversations[0]!.file.path })).toBeNull();
+  expect(nextMobileAttention(only, { kind: "board" })).toBe(only[0]!);
+  expect(nextMobileAttention([], { kind: "board" })).toBeNull();
+});
+
+test("the current entry is keyed the way the screens are: the conversation by its path, the pipeline by its id", () => {
+  const entries = buildMobileAttentionQueue(conversations, pipelines);
+  expect(isCurrentAttentionEntry(entries[0]!, { kind: "chat", id: "/p/old.jsonl" })).toBe(true);
+  expect(isCurrentAttentionEntry(entries[0]!, { kind: "pipeline", id: "/p/old.jsonl" })).toBe(false);
+  expect(isCurrentAttentionEntry(entries[2]!, { kind: "pipeline", id: "p-decide" })).toBe(true);
+  expect(isCurrentAttentionEntry(entries[2]!, { kind: "chat", id: "p-decide" })).toBe(false);
+  expect(isCurrentAttentionEntry(entries[2]!, null)).toBe(false);
+});

--- a/src/components/attention/attentionQueue.ts
+++ b/src/components/attention/attentionQueue.ts
@@ -1,0 +1,63 @@
+import type { MobileBoardPipelineRow } from "@/components/mobile/mobileBoardModel";
+import type { MobileScreen } from "@/components/mobile/mobileNav";
+
+import type { AttentionItem } from "../attention";
+
+/*
+ * The phone's ONE attention list (issue #1439, lane 8; docs/design/mobile-v2/
+ * README.md §4.1, §4.6): conversations waiting on the operator and pipelines
+ * in `needs_decision`, as one ordered list. The bar's badge counts it, the
+ * Needs-you sheet lists it, the sheet's «Next ›» walks it — three entries to
+ * one queue, so none of them can promise an item another cannot reach.
+ *
+ * Pure on purpose. The conversation half is `buildAttentionQueue`'s answer,
+ * already scoped and ordered (blocked before stalled, oldest signal first);
+ * the pipeline half is `needsDecisionPipelineRows`, the same rows the board's
+ * Needs-you section renders. This module only joins them, in the order the
+ * board shows them, and answers "which one is next from here".
+ */
+
+export type MobileAttentionEntry =
+  | { kind: "conversation"; id: string; item: AttentionItem }
+  | { kind: "pipeline"; id: string; row: MobileBoardPipelineRow };
+
+/** Conversations first in queue order, then the pipelines — the board's
+    Needs-you order (`buildMobileBoard`), so the sheet and the section under
+    the bar list the same rows in the same sequence. */
+export function buildMobileAttentionQueue(
+  conversations: readonly AttentionItem[],
+  pipelines: readonly MobileBoardPipelineRow[],
+): MobileAttentionEntry[] {
+  return [
+    ...conversations.map((item): MobileAttentionEntry => ({ kind: "conversation", id: item.id, item })),
+    ...pipelines.map((row): MobileAttentionEntry => ({ kind: "pipeline", id: row.id, row })),
+  ];
+}
+
+/** Whether `entry` is what the screen on top of the stack shows: the
+    conversation screen is keyed by the transcript path, the pipeline screen
+    by the pipeline id. */
+export function isCurrentAttentionEntry(entry: MobileAttentionEntry, screen: MobileScreen | null): boolean {
+  if (!screen) return false;
+  if (entry.kind === "conversation") return screen.kind === "chat" && screen.id === entry.item.file.path;
+  return screen.kind === "pipeline" && screen.id === entry.row.id;
+}
+
+/**
+ * The entry «Next ›» goes to from `screen`: the one after the item the
+ * operator is looking at, wrapping past the end; the first (or, backward, the
+ * last) when the screen shows none of them. The item on screen is never the
+ * answer — with a single entry, and that entry open, there is nowhere to go
+ * and the sheet has no Next to offer.
+ */
+export function nextMobileAttention(
+  entries: readonly MobileAttentionEntry[],
+  screen: MobileScreen | null,
+  dir: 1 | -1 = 1,
+): MobileAttentionEntry | null {
+  if (!entries.length) return null;
+  const here = entries.findIndex((entry) => isCurrentAttentionEntry(entry, screen));
+  if (here === -1) return dir === 1 ? entries[0]! : entries[entries.length - 1]!;
+  const target = (here + dir + entries.length) % entries.length;
+  return target === here ? null : entries[target]!;
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2413,6 +2413,13 @@ export const en = {
   "mobile2.attention.title": "Needs you",
   "mobile2.attention.next": "Next",
   "mobile2.attention.empty": "Nothing needs you.",
+  /* mobile v2 lane 8 (#1439): the Needs-you sheet rows, the arrival banner.
+     Append-only, keys prefixed mobile2.attention.* */
+  "mobile2.attention.pipeline": "pipeline",
+  "mobile2.attention.nextHint": "Open the next one that needs you",
+  "mobile2.attention.arrival": "Needs you · {decision}",
+  "mobile2.attention.open": "Open {title}",
+  "mobile2.attention.dismiss": "Dismiss",
   "mobile2.accounts.title": "Accounts & limits",
   /* Mobile v2 feed (#1439, lane 4): the phone's message header, tool runs
      and question card. Append-only, keys prefixed mobile2.feed.* */

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -2342,6 +2342,13 @@ export const uk: Record<keyof typeof en, Message> = {
   "mobile2.attention.title": "Потребують вас",
   "mobile2.attention.next": "Далі",
   "mobile2.attention.empty": "Нічого не потребує вас.",
+  /* mobile v2 lane 8 (#1439): рядки аркуша «Потребують вас», банер надходження.
+     Лише дописування, ключі mobile2.attention.* */
+  "mobile2.attention.pipeline": "пайплайн",
+  "mobile2.attention.nextHint": "Відкрити наступне, що потребує вас",
+  "mobile2.attention.arrival": "Потребує вас · {decision}",
+  "mobile2.attention.open": "Відкрити {title}",
+  "mobile2.attention.dismiss": "Закрити",
   "mobile2.accounts.title": "Акаунти й ліміти",
   /* Стрічка mobile v2 (#1439, лінія 4): заголовок повідомлення на телефоні,
      серії інструментів і картка запитання. Лише дописування, ключі mobile2.feed.* */


### PR DESCRIPTION
## Summary

Mobile v2 lane 8 of `docs/design/mobile-v2/README.md` §8. Desktop untouched.

- One attention queue behind the badge, the sheet and Next: conversations **and** `needs_decision` pipelines in a single list, so the count and what you can reach through it agree.
- `Next ›` skips the current item and wraps.
- The arrival banner shows on every non-board screen and collapses after about six seconds; the board never shows arrivals — its badge carries them.
- Hidden entirely at zero on the phone.

Built and reviewed on Fable, both stages passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)