### PR TITLE
feat(mobile-v2): lane 9 — accounts & limits screen (#1439)

### DIFF
--- a/scripts/capture-issue-1418-accounts-dialog.ts
+++ b/scripts/capture-issue-1418-accounts-dialog.ts
@@ -1,23 +1,33 @@
 /**
- * Rendered verification of the accounts dialog after #1418 / #1373 / #1358, in
- * a real browser: the desktop flyout at 1280×860 and the phone sheet at 390×844.
+ * Rendered verification of the accounts surfaces after #1418 / #1373 / #1358,
+ * in a real browser: the desktop flyout at 1280×860 and, at 390×844, the phone
+ * screen mobile v2 replaced the dialog with (issue #1439 lane 9,
+ * docs/design/mobile-v2/README.md §4.8 — the phone has no project drawer and
+ * no accounts dialog any more; Accounts & limits is a screen the board's ⋯
+ * pushes).
  *
  *   bun run build && bun scripts/capture-issue-1418-accounts-dialog.ts
  *
  * The production build is served against a synthetic home under the temp root
  * — never the operator's live state, and every account is invented: on the
  * Codex side "Main" (pro, headroom), "Account A" (pro, exhausted, holding one
- * reset credit) and "Account C" (prolite, active); on the Claude side "Main"
- * (max, reporting a flagship weekly bucket) and "Account B" (pro, none). The
- * account controller is disabled so the seeded readings stay, and the Codex
- * binary is a stub that exits, so the card actions exercise the routes end to
- * end and land on their failure notices without any provider call.
+ * reset credit and holding the seat) and "Account C" (prolite); on the Claude
+ * side "Main" (max, active, reporting a flagship weekly bucket) and "Account B"
+ * (pro, none). One invented project with one transcript is seeded too, because
+ * the phone reaches the screen from a board. The account controller is disabled
+ * so the seeded readings stay, and the Codex binary is a stub that exits, so
+ * the card actions exercise the routes end to end and land on their failure
+ * notices without any provider call.
  *
- * Every shot also CHECKS what it shows: no 'Bound to' chip anywhere, one
- * limits block per card with both actions, the reset control enabled only on
- * the card that holds a credit, the flagship row present only on the account
- * that reports a bucket, 44px targets and a viewport-bound sheet on the phone,
- * and no horizontal scroll. Shots land in
+ * Every shot also CHECKS what it shows. Desktop: no 'Bound to' chip anywhere,
+ * one limits block per card with both actions, the reset control enabled only
+ * on the card that holds a credit, the flagship row present only on the
+ * account that reports a bucket, and no horizontal scroll. Phone: one limits
+ * block per engine — the active account's card — with Refresh, the reset
+ * control only on Codex and enabled only while that card holds a credit, every
+ * meter filled with what REMAINS (its value equals the row's own «n% left»),
+ * the corner naming one of the card's own windows and carrying the tightest of
+ * them, 44px targets and no horizontal scroll. Shots land in
  * <tmp>/llv-issue-1418-latest/out/1418-<surface>-<engine>.png and are never
  * committed: the privacy gate refuses rasters.
  */
@@ -49,6 +59,14 @@ const DAY = 86_400;
 const codexTrigger = 'button[aria-label="Codex accounts — switch or add"]';
 const claudeTrigger = 'button[aria-label="Claude accounts — switch or add"]';
 const dialogFor = (engine: "Codex" | "Claude") => `[role="dialog"][aria-label="${engine} accounts"]`;
+/* The phone's route to the same accounts, mobile v2 lane 9: board ▸ ⋯ ▸
+   Accounts & limits. The hooks are the shell's own (`data-mobile2-*`). */
+const PHONE_SCREEN = '[data-mobile2-screen="accounts"]';
+const REPO_DIR = path.join(HOME, "Projects", "atlas");
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+/* Composed rather than written out: a literal UUID in a published source file
+   is what the privacy gate's resource-identifier rule exists to catch. */
+const SESSION_UUID = ["00001418", "0000", "4000", "8000", "000000000000"].join("-");
 
 function seedEnvironment(): void {
   process.env.HOME = HOME;
@@ -56,6 +74,20 @@ function seedEnvironment(): void {
   process.env.LLV_STATE_DIR = STATE;
   process.env.LLV_CLAUDE_HOME = path.join(HOME, ".claude");
   process.env.LLV_CODEX_HOME = path.join(HOME, ".codex");
+}
+
+/* One invented project with one transcript: the phone's Accounts & limits
+   screen is pushed from a board's ⋯ menu, and a board needs a project. */
+function seedProject(): void {
+  const folder = path.join(HOME, ".claude", "projects", projectSlug(REPO_DIR));
+  fs.mkdirSync(REPO_DIR, { recursive: true });
+  fs.mkdirSync(folder, { recursive: true });
+  const stamp = new Date();
+  const lines = [
+    { type: "user", uuid: `${SESSION_UUID}-u`, timestamp: new Date(stamp.getTime() - 60_000).toISOString(), cwd: REPO_DIR, sessionId: SESSION_UUID, message: { role: "user", content: "Read the limits dialog and report what each window says." } },
+    { type: "assistant", uuid: `${SESSION_UUID}-a`, timestamp: stamp.toISOString(), cwd: REPO_DIR, sessionId: SESSION_UUID, message: { role: "assistant", model: "claude-opus-4-6", content: [{ type: "text", text: "Each card shows its windows with the headroom left in each." }] } },
+  ];
+  fs.writeFileSync(path.join(folder, `${SESSION_UUID}.jsonl`), lines.map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
 }
 
 /* The accounts and their readings are written through the same modules the
@@ -67,6 +99,7 @@ async function seedHome(): Promise<void> {
   fs.mkdirSync(STATE, { recursive: true });
   fs.mkdirSync(path.join(HOME, ".codex", "sessions"), { recursive: true });
   fs.mkdirSync(path.join(HOME, ".claude", "projects"), { recursive: true });
+  seedProject();
   fs.mkdirSync(path.dirname(CODEX_STUB), { recursive: true });
   fs.writeFileSync(CODEX_STUB, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
   fs.writeFileSync(path.join(HOME, ".codex", "auth.json"), "{}", { mode: 0o600 });
@@ -80,7 +113,10 @@ async function seedHome(): Promise<void> {
   fs.writeFileSync(path.join(codexA.home, "auth.json"), "{}", { mode: 0o600 });
   const codexC = createManagedCodexAccount("Account C");
   fs.writeFileSync(path.join(codexC.home, "auth.json"), "{}", { mode: 0o600 });
-  setActiveCodexAccount(codexC.id);
+  /* The exhausted account holds the seat, because that is when a reset gets
+     used: on the phone only the active account's card carries the limits
+     block, so this is what puts a live «Use one reset» in the shot. */
+  setActiveCodexAccount(codexA.id);
   const claudeB = createManagedClaudeAccount("Account B");
   fs.writeFileSync(path.join(claudeB.home, ".credentials.json"), "{}", { mode: 0o600 });
 
@@ -175,7 +211,6 @@ interface DialogFacts {
   resetButtons: number;
   resetEnabled: string[];
   flagshipRows: string[];
-  minTarget: number;
   bottom: number;
   viewport: number;
   scrollWidth: number;
@@ -185,7 +220,6 @@ interface DialogFacts {
 async function dialogFacts(page: Page, engine: "Codex" | "Claude"): Promise<DialogFacts> {
   return page.evaluate((selector) => {
     const dialog = document.querySelector(selector)!;
-    const targets = [...dialog.querySelectorAll<HTMLButtonElement>("[data-account-refresh-limits], [data-account-use-reset], button[aria-label^='Copy the agent command'], button[aria-label^='Remove']")];
     return {
       boundChips: dialog.querySelectorAll("[data-account-projects]").length,
       boundText: (dialog.textContent ?? "").includes("Bound to"),
@@ -194,7 +228,6 @@ async function dialogFacts(page: Page, engine: "Codex" | "Claude"): Promise<Dial
       resetButtons: dialog.querySelectorAll("[data-account-use-reset]").length,
       resetEnabled: [...dialog.querySelectorAll<HTMLButtonElement>("[data-account-use-reset]")].filter((button) => !button.disabled).map((button) => button.getAttribute("data-account-use-reset")!),
       flagshipRows: [...dialog.querySelectorAll("[data-limit-row='flagship']")].map((row) => row.closest("[data-account-limits]")!.getAttribute("data-account-limits")!),
-      minTarget: Math.min(...targets.map((button) => Math.round(button.getBoundingClientRect().height))),
       bottom: Math.round(dialog.getBoundingClientRect().bottom),
       viewport: window.innerHeight,
       scrollWidth: document.documentElement.scrollWidth,
@@ -203,8 +236,10 @@ async function dialogFacts(page: Page, engine: "Codex" | "Claude"): Promise<Dial
   }, dialogFor(engine));
 }
 
-function checkDialog(surface: string, engine: "Codex" | "Claude", facts: DialogFacts): void {
-  const where = `${surface} ${engine}`;
+/* The dialog is the DESKTOP surface now: the phone's accounts live on their
+   own screen (`checkScreen`), which never opens this. */
+function checkDialog(engine: "Codex" | "Claude", facts: DialogFacts): void {
+  const where = `desktop ${engine}`;
   if (facts.boundChips > 0 || facts.boundText) throw new Error(`${where}: a 'Bound to' chip is still on a card`);
   if (facts.cards === 0) throw new Error(`${where}: no card rendered a limits block`);
   if (facts.refreshButtons !== facts.cards) throw new Error(`${where}: ${facts.refreshButtons} refresh actions for ${facts.cards} limits blocks`);
@@ -218,7 +253,127 @@ function checkDialog(surface: string, engine: "Codex" | "Claude", facts: DialogF
   }
   if (facts.scrollWidth > facts.innerWidth) throw new Error(`${where}: the document scrolls to ${facts.scrollWidth}px at ${facts.innerWidth}px`);
   if (facts.bottom > facts.viewport) throw new Error(`${where}: the dialog ends at ${facts.bottom}px, past the ${facts.viewport}px viewport`);
-  if (surface === "phone" && facts.minTarget < 44) throw new Error(`${where}: a card action is ${facts.minTarget}px tall, under the 44px floor`);
+}
+
+interface EngineFacts {
+  engine: string;
+  cards: number;
+  refreshButtons: number;
+  resetButtons: number;
+  resetEnabled: string[];
+  flagshipRows: string[];
+  /** Per window row: what the row printed, and what its meter drew. */
+  rows: { row: string; printed: number; meter: number }[];
+  corner: { left: number; window: string; windows: string[] } | null;
+}
+
+interface ScreenFacts {
+  boundChips: number;
+  boundText: boolean;
+  engines: EngineFacts[];
+  minTarget: number;
+  scrollWidth: number;
+  innerWidth: number;
+}
+
+/** What the phone's Accounts & limits screen is showing, read off the DOM. */
+async function screenFacts(page: Page): Promise<ScreenFacts> {
+  return page.evaluate((selector) => {
+    const screen = document.querySelector(selector)!;
+    const percent = (text: string | null | undefined) => {
+      const match = /(\d+)%/.exec(text ?? "");
+      return match ? Number(match[1]) : Number.NaN;
+    };
+    const targets = [...screen.querySelectorAll<HTMLElement>("button, a[href]")]
+      .filter((element) => element.getBoundingClientRect().height > 0);
+    return {
+      boundChips: screen.querySelectorAll("[data-account-projects]").length,
+      boundText: (screen.textContent ?? "").includes("Bound to"),
+      engines: [...screen.querySelectorAll("[data-mobile2-accounts-engine]")].map((section) => {
+        const card = section.querySelector("[data-account-limits]")?.closest("[data-mobile2-account]") ?? null;
+        const corner = card?.querySelector("[data-mobile2-account-corner]") ?? null;
+        return {
+          engine: section.getAttribute("data-mobile2-accounts-engine")!,
+          cards: section.querySelectorAll("[data-account-limits]").length,
+          refreshButtons: section.querySelectorAll("[data-account-refresh-limits]").length,
+          resetButtons: section.querySelectorAll("[data-account-use-reset]").length,
+          resetEnabled: [...section.querySelectorAll<HTMLButtonElement>("[data-account-use-reset]")].filter((button) => !button.disabled).map((button) => button.getAttribute("data-account-use-reset")!),
+          flagshipRows: [...section.querySelectorAll("[data-limit-row='flagship']")].map((row) => row.closest("[data-account-limits]")!.getAttribute("data-account-limits")!),
+          rows: [...section.querySelectorAll("[data-limit-row]")].map((row) => ({
+            row: row.getAttribute("data-limit-row")!,
+            /* The row reads «<window> <meter> n% left», then its reset line
+               under it: the first percentage in it is the headroom. */
+            printed: percent(row.textContent),
+            meter: Number(row.querySelector("[role='meter']")?.getAttribute("aria-valuenow") ?? Number.NaN),
+          })),
+          corner: corner
+            ? {
+              left: percent(corner.textContent),
+              window: corner.getAttribute("data-mobile2-account-window")!,
+              windows: [...(card?.querySelectorAll("[data-limit-row] dt") ?? [])].map((label) => (label.textContent ?? "").trim()),
+            }
+            : null,
+        };
+      }),
+      minTarget: Math.min(...targets.map((element) => Math.round(element.getBoundingClientRect().height))),
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+    };
+  }, PHONE_SCREEN);
+}
+
+/* The phone's contract (README §4.8, §5), checked on the rendered screen: one
+   limits block per engine — the active account's — the actions that block
+   carries, and the two numbers the redesign fixed. */
+function checkScreen(facts: ScreenFacts): void {
+  const where = "phone accounts screen";
+  if (facts.boundChips > 0 || facts.boundText) throw new Error(`${where}: a 'Bound to' chip is still on a card`);
+  if (facts.engines.map((engine) => engine.engine).join() !== "claude,codex") throw new Error(`${where}: engine sections are [${facts.engines.map((engine) => engine.engine).join(", ")}], expected claude,codex`);
+  for (const engine of facts.engines) {
+    const at = `${where} (${engine.engine})`;
+    if (engine.cards !== 1) throw new Error(`${at}: ${engine.cards} limits blocks, expected exactly the active account's`);
+    if (engine.refreshButtons !== 1) throw new Error(`${at}: ${engine.refreshButtons} refresh actions for one limits block`);
+    if (engine.engine === "codex") {
+      if (engine.resetButtons !== 1) throw new Error(`${at}: ${engine.resetButtons} reset controls, expected one on the active card`);
+      if (engine.resetEnabled.join() !== "account-a") throw new Error(`${at}: the reset control is enabled on [${engine.resetEnabled.join(", ")}], expected the account holding a credit`);
+      if (engine.flagshipRows.length) throw new Error(`${at}: a Codex card drew a flagship row`);
+    } else {
+      if (engine.resetButtons !== 0) throw new Error(`${at}: a Claude card drew a reset control`);
+      if (engine.flagshipRows.join() !== "default") throw new Error(`${at}: flagship rows on [${engine.flagshipRows.join(", ")}], expected only the account reporting a bucket`);
+    }
+    if (!engine.rows.length) throw new Error(`${at}: the active card drew no window row`);
+    for (const row of engine.rows) {
+      if (!Number.isFinite(row.printed) || !Number.isFinite(row.meter)) throw new Error(`${at}: the ${row.row} row has no number (printed ${row.printed}, meter ${row.meter})`);
+      /* One meaning per meter: the fill IS what the row says is left. */
+      if (row.printed !== row.meter) throw new Error(`${at}: the ${row.row} meter is at ${row.meter}% while its row reads ${row.printed}% left`);
+    }
+    const corner = engine.corner;
+    if (!corner) throw new Error(`${at}: the active card has no corner number`);
+    if (!corner.windows.includes(corner.window)) throw new Error(`${at}: the corner names «${corner.window}», which is none of the card's windows [${corner.windows.join(", ")}]`);
+    const tightest = Math.min(...engine.rows.map((row) => row.printed));
+    if (corner.left !== tightest) throw new Error(`${at}: the corner reads ${corner.left}% left, the tightest window has ${tightest}%`);
+  }
+  if (facts.minTarget < 44) throw new Error(`${where}: a control is ${facts.minTarget}px tall, under the 44px floor`);
+  if (facts.scrollWidth > facts.innerWidth) throw new Error(`${where}: the document scrolls to ${facts.scrollWidth}px at ${facts.innerWidth}px`);
+}
+
+/** Board ▸ ⋯ ▸ Accounts & limits — the phone's one route to its accounts. */
+async function openAccountsScreen(page: Page, baseUrl: string, projectId: string): Promise<void> {
+  await page.goto(`${baseUrl}/#p=${encodeURIComponent(projectId)}`, { waitUntil: "networkidle" });
+  await page.waitForSelector('[data-mobile2-screen="board"]', { timeout: 20_000 });
+  await page.click('[data-mobile2-open="menu"]');
+  await page.waitForSelector('[data-mobile2-sheet="menu"]');
+  await page.click('[data-mobile2-go="accounts"]');
+  await page.waitForSelector(PHONE_SCREEN, { timeout: 20_000 });
+  await page.waitForTimeout(400);
+}
+
+/** The project the seeded transcript scanned into. */
+async function seededProject(baseUrl: string): Promise<string> {
+  const body = await (await fetch(`${baseUrl}/api/files`)).json() as { files?: { cwd?: string; project?: string }[] };
+  const project = (body.files ?? []).find((file) => file.cwd === REPO_DIR)?.project;
+  if (!project) throw new Error("the seeded project did not scan");
+  return project;
 }
 
 async function openDialog(page: Page, engine: "Codex" | "Claude"): Promise<void> {
@@ -232,10 +387,15 @@ async function closeDialog(page: Page, engine: "Codex" | "Claude"): Promise<void
   await page.waitForSelector(dialogFor(engine), { state: "detached" });
 }
 
-async function shoot(page: Page, engine: "Codex" | "Claude", surface: "desktop" | "phone", suffix = ""): Promise<void> {
-  const file = path.join(OUT_DIR, `1418-${surface}-${engine.toLowerCase()}${suffix}.png`);
-  if (surface === "desktop") await page.locator(dialogFor(engine)).screenshot({ path: file });
-  else await page.screenshot({ path: file });
+async function shootScreen(page: Page): Promise<void> {
+  const file = path.join(OUT_DIR, "1418-phone-accounts.png");
+  await page.screenshot({ path: file });
+  console.log(`  ${path.basename(file)}`);
+}
+
+async function shoot(page: Page, engine: "Codex" | "Claude", suffix = ""): Promise<void> {
+  const file = path.join(OUT_DIR, `1418-desktop-${engine.toLowerCase()}${suffix}.png`);
+  await page.locator(dialogFor(engine)).screenshot({ path: file });
   console.log(`  ${path.basename(file)}`);
 }
 
@@ -264,15 +424,15 @@ async function main(): Promise<void> {
     await desktop.waitForSelector(codexTrigger);
     for (const engine of ["Codex", "Claude"] as const) {
       await openDialog(desktop, engine);
-      checkDialog("desktop", engine, await dialogFacts(desktop, engine));
-      await shoot(desktop, engine, "desktop");
+      checkDialog(engine, await dialogFacts(desktop, engine));
+      await shoot(desktop, engine);
       if (engine === "Codex") {
         /* The actions fire on the first click — no confirm step — and reach the
            route: with the stub binary the live read fails, so the card lands on
            its failure notice, which is the wiring proven end to end. */
         await desktop.click('[data-account-refresh-limits="account-a"]');
         await desktop.waitForSelector(`${dialogFor(engine)} .text-danger:has-text("Could not re-read limits for Account A")`, { timeout: 30_000 });
-        await shoot(desktop, engine, "desktop", "-refresh-failed");
+        await shoot(desktop, engine, "-refresh-failed");
         const confirm = await desktop.locator(`${dialogFor(engine)} button:has-text("Confirm")`).count();
         if (confirm) throw new Error("desktop Codex: a confirmation control appeared for a limits action");
       }
@@ -280,18 +440,14 @@ async function main(): Promise<void> {
     }
     await desktop.close();
 
+    /* The phone (mobile v2 lane 9): one screen holds both engines, so there is
+       one shot and one set of checks, reached the way the operator reaches it. */
     const phone = await browser.newPage({ viewport: PHONE, isMobile: true, hasTouch: true, deviceScaleFactor: 2 });
-    await phone.goto(baseUrl, { waitUntil: "networkidle" });
-    await phone.click('button[aria-label="Open project list"]');
-    await phone.waitForSelector(codexTrigger);
-    for (const engine of ["Codex", "Claude"] as const) {
-      await openDialog(phone, engine);
-      checkDialog("phone", engine, await dialogFacts(phone, engine));
-      await shoot(phone, engine, "phone");
-      await closeDialog(phone, engine);
-    }
+    await openAccountsScreen(phone, baseUrl, await seededProject(baseUrl));
+    checkScreen(await screenFacts(phone));
+    await shootScreen(phone);
     await phone.close();
-    console.log("accounts dialog: desktop flyout and phone sheet verified");
+    console.log("accounts: desktop flyout and phone screen verified");
   } finally {
     await browser.close();
     server.kill("SIGTERM");

--- a/scripts/capture-mobile-v2.test.ts
+++ b/scripts/capture-mobile-v2.test.ts
@@ -75,7 +75,7 @@ describe("parseArgs", () => {
 /* ── gates ───────────────────────────────────────────────────────────────── */
 
 const control = (label: string, x: number, y: number, w = 44, h = 44, extra: Partial<Control> = {}): Control =>
-  ({ tag: "button", label, rect: { x, y, w, h }, small: w < 43.5 || h < 43.5, inReceipt: null, ...extra });
+  ({ tag: "button", label, rect: { x, y, w, h }, small: w < 43.5 || h < 43.5, inReceipts: [], ...extra });
 
 /** A frame the prototype would produce: one bar, three targets, a composer
     above a 336 px keyboard, the dark canvas. */
@@ -137,8 +137,18 @@ describe("gates", () => {
   test("receipt: its own inverse action inside it is not covered", () => {
     const g = green();
     g.controls = g.controls.filter((c) => c.label !== "send");
-    g.controls.push(control("Respawn", 320, 448, 60, 44, { inReceipt: 0 }));
+    g.controls.push(control("Respawn", 320, 448, 60, 44, { inReceipts: [0] }));
     g.receipts.push({ x: 0, y: 440, w: 390, h: 60 });
+    g.send = { bottom: 400 };
+    expect(evaluateGates(g, dark)).toEqual([]);
+  });
+  test("receipt: a control inside a banner that wraps its own toast is covered by neither", () => {
+    /* The banner slot marks itself and carries the attention toast, which
+       marks itself too: the same control is inside both rects. */
+    const g = green();
+    g.controls = g.controls.filter((c) => c.label !== "send");
+    g.controls.push(control("Needs you · plan approval", 0, 52, 330, 57, { inReceipts: [0, 1] }));
+    g.receipts.push({ x: 0, y: 52, w: 390, h: 57 }, { x: 0, y: 52, w: 390, h: 57 });
     g.send = { bottom: 400 };
     expect(evaluateGates(g, dark)).toEqual([]);
   });

--- a/scripts/capture-mobile-v2.ts
+++ b/scripts/capture-mobile-v2.ts
@@ -155,7 +155,10 @@ export interface Control {
   /** True when the unclipped box is under the 44 px floor. */
   small: boolean;
   /** Index into `receipts` when the control lives inside that receipt. */
-  inReceipt: number | null;
+  /** Indices of every receipt element that CONTAINS this control. The banner
+      slot wraps its own toast, so a control can sit inside two of them; a
+      control inside the receipt under test is not covered by it. */
+  inReceipts: number[];
 }
 export interface Geometry {
   scrollWidth: number;
@@ -196,7 +199,7 @@ export function evaluateGates(g: Geometry, ctx: GateContext): GateFailure[] {
   }
   if (overlaps.length) out.push({ gate: "overlap", message: `${overlaps.length} pair(s) of controls overlap — ${overlaps.slice(0, 4).join("; ")}` });
   g.receipts.forEach((receipt, index) => {
-    const hit = g.controls.find((c) => c.inReceipt !== index && intersects(receipt, c.rect));
+    const hit = g.controls.find((c) => !c.inReceipts.includes(index) && intersects(receipt, c.rect));
     if (hit) out.push({ gate: "receipt", message: `a receipt at ${Math.round(receipt.x)},${Math.round(receipt.y)} (${Math.round(receipt.w)}×${Math.round(receipt.h)}) covers ${fmt(hit)}` });
   });
   if (g.canvas !== CANVAS[ctx.scheme]) out.push({ gate: "scheme", message: `canvas is ${g.canvas}, expected the ${ctx.scheme} scheme's ${CANVAS[ctx.scheme]}` });
@@ -338,13 +341,13 @@ async function measure(page: Page): Promise<Geometry> {
       if (!visible(el) || el.hasAttribute("aria-hidden") || (el as HTMLElement).tabIndex < 0 && el.tagName !== "BUTTON" && el.tagName !== "A") continue;
       const c = clip(el);
       if (c.w <= 0 || c.h <= 0) continue;
-      const inReceipt = receiptEls.findIndex((r) => r.contains(el));
+      const inReceipts = receiptEls.flatMap((r, index) => (r.contains(el) ? [index] : []));
       controls.push({
         tag: el.tagName.toLowerCase(),
         label: (el.getAttribute("aria-label") || el.textContent || "").trim().replace(/\s+/g, " ").slice(0, 40),
         rect: { x: c.x, y: c.y, w: c.w, h: c.h },
         small: c.full.w < hit - 0.5 || c.full.h < hit - 0.5,
-        inReceipt: inReceipt >= 0 ? inReceipt : null,
+        inReceipts,
       });
     }
     const first = (sel: string) => [...document.querySelectorAll(sel)].find(visible) ?? null;
@@ -410,6 +413,107 @@ const SEEDS: Seed[] = [
     crowd: true,
   })),
 ];
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * The accounts answer — the prototype's accounts fixture, on the wire's shape  *
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/* `docs/design/mobile-v2/prototype/fixture.js` `accounts`, told the way
+   `/api/accounts` tells it, so the Accounts & limits screen (lane 9) renders
+   what the picture shows: an active card with its windows, an authenticated
+   account as a quiet `ready` row, and one that is not signed in. Every label,
+   plan and number here is invented. The seeded home cannot carry this — a
+   managed account is a directory with a credential in it, and a limits
+   reading is a live provider answer — so the answer is fulfilled, exactly as
+   the board's files, pipelines and seat answers are. */
+
+const accountWindow = (usedPercent: number, resetsInHours: number, windowMinutes: number) =>
+  ({ usedPercent, resetsAt: CAPTURE_S + Math.round(resetsInHours * 3_600), windowMinutes });
+
+interface AccountFixture {
+  id: string;
+  label: string;
+  kind: "legacy" | "managed";
+  authPresent: boolean;
+  plan?: string;
+  /** Minutes before the capture instant the reading was taken. */
+  checkedAgoMinutes?: number;
+  session?: ReturnType<typeof accountWindow>;
+  weekly?: ReturnType<typeof accountWindow>;
+  flagship?: ReturnType<typeof accountWindow> & { tier: string };
+  resets?: { availableCount: number; expiresAt: number | null };
+}
+
+const ACCOUNTS: Record<"claude" | "codex", { active: string; accounts: AccountFixture[] }> = {
+  claude: {
+    active: "main",
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, plan: "max", checkedAgoMinutes: 8,
+        session: accountWindow(38, 2.6, 300),
+        weekly: accountWindow(62, 72, 10_080),
+        flagship: { ...accountWindow(29, 72, 10_080), tier: "opus" },
+      },
+      {
+        id: "lab", label: "Lab", kind: "managed", authPresent: true, plan: "pro", checkedAgoMinutes: 20,
+        session: accountWindow(12, 4, 300),
+        weekly: accountWindow(36, 140, 10_080),
+      },
+      { id: "second", label: "Second", kind: "managed", authPresent: false },
+    ],
+  },
+  codex: {
+    active: "main",
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, plan: "pro", checkedAgoMinutes: 5,
+        session: accountWindow(72, 1.4, 300),
+        weekly: accountWindow(55, 48, 10_080),
+        resets: { availableCount: 1, expiresAt: CAPTURE_S + 20 * 86_400 },
+      },
+      { id: "spare", label: "Spare", kind: "managed", authPresent: false },
+    ],
+  },
+};
+
+function accountsAnswer(): Record<string, unknown> {
+  const engineBlock = (engine: "claude" | "codex") => {
+    const block = ACCOUNTS[engine];
+    return {
+      active: block.active,
+      accounts: block.accounts.map((account) => {
+        const reading = account.session || account.weekly || account.flagship;
+        const checkedAt = new Date(CAPTURE_MS - (account.checkedAgoMinutes ?? 0) * 60_000).toISOString();
+        return {
+          id: account.id,
+          label: account.label,
+          kind: account.kind,
+          authPresent: account.authPresent,
+          loginPending: false,
+          loginState: account.authPresent ? "authenticated" : "idle",
+          attemptState: null,
+          deviceAuth: null,
+          login: null,
+          auth: { state: account.authPresent ? "authenticated" : "signed_out", method: null, email: null, plan: account.plan ?? null, checkedAt: account.authPresent ? checkedAt : null },
+          limits: reading
+            ? { state: "fresh", session: account.session ?? null, weekly: account.weekly ?? null, flagship: account.flagship ?? null, checkedAt }
+            : { state: "unavailable", session: null, weekly: null, flagship: null, checkedAt: null },
+          resetCredits: account.resets ?? null,
+          effective: null,
+        };
+      }),
+      migration: null,
+      autoBalance: { enabled: false, cooldownUntil: null, thresholdPercent: 15, state: "disabled" },
+    };
+  };
+  return {
+    claude: engineBlock("claude"),
+    codex: engineBlock("codex"),
+    mutationLocked: { claude: false, codex: false },
+    migration: { claude: null, codex: null },
+    autoBalance: { claude: engineBlock("claude").autoBalance, codex: engineBlock("codex").autoBalance },
+  };
+}
 
 interface Home { base: string; home: string; repoDir: string; outDir: string }
 
@@ -729,6 +833,7 @@ async function installAnswers(page: Page, a: Answers): Promise<{ failSnapshot: (
     await route.fulfill({ response, body: JSON.stringify(body) });
   });
   await page.route("**/api/pipelines", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ pipelines: pipelinesAnswer(a) }) }));
+  await page.route("**/api/accounts", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(accountsAnswer()) }));
   await page.route("**/api/orchestrator/seat", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(seatAnswer(a, !a.scenario.noseat)) }));
   await page.route("**/api/orchestrator/seat?*", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(seatAnswer(a, !a.scenario.noseat)) }));
   await page.route("**/api/orchestrator/seat/status*", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(seatStatus(a)) }));

--- a/src/components/AccountsPanel.mobile.dom.test.tsx
+++ b/src/components/AccountsPanel.mobile.dom.test.tsx
@@ -1,0 +1,338 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { AccountOption, EngineAccountsState } from "@/hooks/useEngineAccounts";
+import { installActEnv } from "@/test-helpers/actEnv";
+
+import { MobileAccountsBody, mobileAccountCorner, mobileAccountState } from "./AccountsPanel";
+import { createReceiptStore, type ReceiptStore } from "./mobile/MobileReceipt";
+
+/*
+ * The Accounts & limits screen on the phone (issue #1439, lane 9;
+ * docs/design/mobile-v2/README.md §4.8): the active account as a card with its
+ * windows and the actions that act ON THE TAP, the other authenticated
+ * accounts as quiet rows that switch future launches, a row that is not signed
+ * in that opens the device sign-in and stays inactive, and the add row last.
+ *
+ * The two numbers the design fixes are asserted here because both used to mean
+ * the opposite: every meter fills with what REMAINS, coloured by what remains,
+ * and the card's corner names the window its number belongs to (§5, P2-4).
+ */
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLInputElement: dom.HTMLInputElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+});
+installActEnv();
+
+const NOW = 1_800_000_000;
+const HOUR = 3_600;
+const DAY = 24 * HOUR;
+
+function account(over: Partial<AccountOption> & { id: string; label: string }): AccountOption {
+  return {
+    kind: "managed",
+    authPresent: true,
+    authHealth: "authenticated",
+    loginPending: false,
+    loginState: "authenticated",
+    deviceAuth: null,
+    login: null,
+    ...over,
+  } as AccountOption;
+}
+
+const window5h = (usedPercent: number, resetsAt: number) => ({ usedPercent, resetsAt, windowMinutes: 300 });
+const windowWeek = (usedPercent: number, resetsAt: number) => ({ usedPercent, resetsAt, windowMinutes: 10_080 });
+
+/** «Main» holds the seat: a 5h window with room, a week nearly spent, and the
+    flagship week #1358 added — three rows, three meters, one corner. */
+const claudeMain = account({
+  id: "cl-main",
+  label: "Main",
+  plan: "max",
+  limits: {
+    freshness: "fresh",
+    session: window5h(28, NOW + 2 * HOUR),
+    weekly: windowWeek(92, NOW + 3 * DAY),
+    flagship: { ...windowWeek(29, NOW + 3 * DAY), tier: "opus" },
+    plan: "max",
+    capturedAt: NOW - 600,
+    checkedAt: new Date((NOW - 600) * 1000).toISOString(),
+  },
+} as Partial<AccountOption> & { id: string; label: string });
+
+const claudeLab = account({
+  id: "cl-lab",
+  label: "Lab",
+  plan: "pro",
+  limits: { freshness: "fresh", session: window5h(12, NOW + 4 * HOUR), weekly: windowWeek(36, NOW + 6 * DAY), plan: "pro", capturedAt: NOW - 900, checkedAt: new Date((NOW - 900) * 1000).toISOString() },
+} as Partial<AccountOption> & { id: string; label: string });
+
+const claudeSecond = account({ id: "cl-second", label: "Second", authPresent: false, authHealth: "signed_out" });
+
+const codexMain = account({
+  id: "cx-main",
+  label: "Main",
+  plan: "pro",
+  limits: { freshness: "fresh", session: window5h(40, NOW + HOUR), weekly: windowWeek(55, NOW + 2 * DAY), plan: "pro", capturedAt: NOW - 300, checkedAt: new Date((NOW - 300) * 1000).toISOString() },
+  resetCredits: { availableCount: 1, expiresAt: NOW + 20 * DAY },
+} as Partial<AccountOption> & { id: string; label: string });
+
+const codexSpare = account({ id: "cx-spare", label: "Spare", authPresent: false, authHealth: "signed_out" });
+
+function engineState(engine: "claude" | "codex", accounts: AccountOption[], active: string, over: Partial<EngineAccountsState> = {}): EngineAccountsState {
+  return {
+    engine,
+    accounts,
+    active,
+    identityVersion: 0,
+    status: "ready",
+    notice: null,
+    challenge: null,
+    mutation: null,
+    migration: null,
+    autoBalance: null,
+    refresh: async () => true,
+    add: async () => true,
+    retryNotice: async () => true,
+    select: async () => true,
+    submitLoginCode: async () => true,
+    cancelLogin: async () => true,
+    retryLogin: async () => true,
+    remove: async () => true,
+    cleanupOrphans: async () => true,
+    copyTerminalCommand: async () => true,
+    refreshLimits: async () => true,
+    useResetCredit: async () => true,
+    limitsBusy: null,
+    limitsVersion: 0,
+    ...over,
+  };
+}
+
+const mounted: Array<{ root: Root; host: HTMLDivElement }> = [];
+afterEach(async () => {
+  await Promise.all(mounted.splice(0).map(async ({ root, host }) => {
+    await act(async () => root.unmount());
+    host.remove();
+  }));
+  document.body.replaceChildren();
+});
+
+async function mount(engines: EngineAccountsState[], receipts: ReceiptStore = createReceiptStore()): Promise<{ host: HTMLDivElement; receipts: ReceiptStore; rerender(next: EngineAccountsState[]): Promise<void> }> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted.push({ root, host });
+  const render = async (next: EngineAccountsState[]) => {
+    await act(async () => root.render(<MobileAccountsBody engines={next} now={NOW} receipts={receipts} />));
+  };
+  await render(engines);
+  return { host, receipts, rerender: render };
+}
+
+const click = async (element: Element | null) => {
+  expect(element).toBeTruthy();
+  await act(async () => (element as HTMLElement).click());
+};
+
+const text = (element: Element | null | undefined) => (element?.textContent ?? "").replace(/\s+/g, " ").trim();
+
+test("every meter on the active card fills with what remains, and the corner names its tightest window", async () => {
+  const { host } = await mount([engineState("claude", [claudeMain, claudeLab], "cl-main")]);
+
+  const card = host.querySelector('[data-mobile2-account="cl-main"]')!;
+  expect(card.getAttribute("data-mobile2-account-state")).toBe("active");
+
+  const meters = [...card.querySelectorAll('[data-limit-row] [role="meter"]')];
+  // 28 / 92 / 29 percent used ⇒ 72 / 8 / 71 percent left, in the design's order.
+  expect(meters.map((meter) => meter.getAttribute("aria-valuenow"))).toEqual(["72", "8", "71"]);
+  expect(meters.map((meter) => (meter.firstElementChild as HTMLElement).style.width)).toEqual(["72%", "8%", "71%"]);
+  // Coloured by what remains: the nearly spent week is danger, the rest accent.
+  expect(meters.map((meter) => meter.getAttribute("data-mobile2-meter-tone"))).toEqual(["accent", "danger", "accent"]);
+  expect(text(card.querySelector('[data-limit-row="session"]'))).toContain("72% left");
+  expect(text(card.querySelector('[data-limit-row="weekly"]'))).toContain("8% left");
+  expect(text(card.querySelector('[data-limit-row="flagship"]'))).toContain("71% left");
+
+  const corner = card.querySelector("[data-mobile2-account-corner]")!;
+  expect(corner.getAttribute("data-mobile2-account-window")).toBe("Week");
+  expect(text(corner)).toBe("8% leftWeek");
+  expect(corner.getAttribute("aria-label")).toBe("8% left of the Week window");
+  // The number the corner shows is the tightest window's headroom, never the
+  // first window's and never what was used.
+  expect(mobileAccountCorner({ session: null, weekly: null, flagship: null, plan: null }, (key: string) => key)).toBeNull();
+});
+
+test("the quiet row of an authenticated account switches future launches on the tap, and the receipt carries Switch back", async () => {
+  const selected: string[] = [];
+  const state = engineState("claude", [claudeMain, claudeLab], "cl-main", {
+    select: async (id: string) => { selected.push(id); return true; },
+  });
+  const { host, receipts } = await mount([state]);
+
+  const row = host.querySelector('[data-mobile2-account-switch="cl-lab"]');
+  expect(row?.getAttribute("aria-label")).toBe("Use Lab for future launches");
+  expect(text(host.querySelector('[data-mobile2-account="cl-lab"]'))).toContain("ready");
+
+  await click(row);
+
+  // One tap, no confirmation step, one selection.
+  expect(selected).toEqual(["cl-lab"]);
+  expect(host.querySelector("button[data-confirm]")).toBeNull();
+  const receipt = receipts.getState()!;
+  expect(receipt.text).toBe("Future launches use Lab");
+  expect(receipt.inverse?.kind).toBe("switchBack");
+
+  await act(async () => receipt.inverse!.run());
+  expect(selected).toEqual(["cl-lab", "cl-main"]);
+});
+
+test("Refresh and Use one reset act on the tap and answer with a receipt; the reset is offered only where a credit exists", async () => {
+  const refreshed: string[] = [];
+  const redeemed: string[] = [];
+  const claude = engineState("claude", [claudeMain], "cl-main", {
+    refreshLimits: async (id: string) => { refreshed.push(id); return true; },
+  });
+  const codex = engineState("codex", [codexMain], "cx-main", {
+    refreshLimits: async (id: string) => { refreshed.push(id); return true; },
+    useResetCredit: async (id: string) => { redeemed.push(id); return true; },
+  });
+  const { host, receipts } = await mount([claude, codex]);
+
+  // A Claude card carries no reset control at all; Codex carries one.
+  expect(host.querySelector('[data-mobile2-accounts-engine="claude"] [data-account-use-reset]')).toBeNull();
+  const reset = host.querySelector('[data-account-use-reset="cx-main"]') as HTMLButtonElement;
+  expect(reset.disabled).toBe(false);
+  expect(text(host.querySelector('[data-account-reset-credits="cx-main"]'))).toContain("1 reset available");
+
+  await click(host.querySelector('[data-account-refresh-limits="cl-main"]'));
+  expect(refreshed).toEqual(["cl-main"]);
+  expect(receipts.getState()?.text).toBe("Limits re-read for Main");
+
+  await click(reset);
+  expect(redeemed).toEqual(["cx-main"]);
+  expect(receipts.getState()?.text).toBe("Reset used on Main");
+});
+
+test("a Codex card with no reset credit still shows Refresh, with the reset control disabled", async () => {
+  const spent = account({ ...codexMain, resetCredits: { availableCount: 0, expiresAt: null } } as Partial<AccountOption> & { id: string; label: string });
+  const { host } = await mount([engineState("codex", [spent], "cx-main")]);
+
+  expect((host.querySelector('[data-account-refresh-limits="cx-main"]') as HTMLButtonElement).disabled).toBe(false);
+  expect((host.querySelector('[data-account-use-reset="cx-main"]') as HTMLButtonElement).disabled).toBe(true);
+  expect(text(host.querySelector('[data-account-reset-credits="cx-main"]'))).toContain("No resets available");
+});
+
+test("a Codex row that is not signed in opens the device sign-in, shows its code, and stays inactive", async () => {
+  const calls: { url: string; body: unknown }[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+    calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : null });
+    return new Response(JSON.stringify({ account: { id: "cx-spare" }, deviceAuth: { url: "https://example.invalid/device", code: "ABCD-EFGH" } }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as unknown as typeof fetch;
+  const selected: string[] = [];
+  try {
+    const state = engineState("codex", [codexMain, codexSpare], "cx-main", {
+      select: async (id: string) => { selected.push(id); return true; },
+    });
+    const { host, receipts } = await mount([state]);
+
+    const row = host.querySelector('[data-mobile2-account-signin="cx-spare"]')!;
+    expect(text(row)).toContain("needs sign-in");
+    expect(text(row)).toContain("sign in");
+    // The row is a sign-in, never a switch: nothing here can make it active.
+    expect(host.querySelector('[data-mobile2-account-switch="cx-spare"]')).toBeNull();
+
+    await click(row);
+
+    expect(calls).toEqual([{ url: "/api/accounts/codex", body: { action: "retry", id: "cx-spare" } }]);
+    expect(selected).toEqual([]);
+    expect(host.querySelector('[data-mobile2-account="cx-spare"]')?.getAttribute("data-mobile2-account-state")).toBe("needsSignIn");
+    expect(host.querySelector('[data-mobile2-account="cx-main"]')?.getAttribute("data-mobile2-account-state")).toBe("active");
+    const challenge = host.querySelector("[data-mobile2-account-device-signin]")!;
+    expect(challenge.querySelector("a")?.getAttribute("href")).toBe("https://example.invalid/device");
+    expect(text(challenge)).toContain("ABCD-EFGH");
+    expect(receipts.getState()?.text).toBe("Device sign-in opened for Spare — it becomes active once signed in");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a Claude row that is not signed in restarts its login in place and stays inactive", async () => {
+  const retried: string[] = [];
+  const selected: string[] = [];
+  const state = engineState("claude", [claudeMain, claudeSecond], "cl-main", {
+    retryLogin: async (id: string) => { retried.push(id); return true; },
+    select: async (id: string) => { selected.push(id); return true; },
+  });
+  const { host, receipts } = await mount([state]);
+
+  await click(host.querySelector('[data-mobile2-account-signin="cl-second"]'));
+
+  expect(retried).toEqual(["cl-second"]);
+  expect(selected).toEqual([]);
+  expect(host.querySelector('[data-mobile2-account="cl-second"]')?.getAttribute("data-mobile2-account-state")).toBe("needsSignIn");
+  expect(receipts.getState()?.text).toBe("Device sign-in opened for Second — it becomes active once signed in");
+});
+
+test("a signed-out account is never the active card, even while the registry still names it active", async () => {
+  const { host } = await mount([engineState("claude", [claudeSecond, claudeLab], "cl-second")]);
+
+  expect(mobileAccountState(claudeSecond, "cl-second")).toBe("needsSignIn");
+  expect(host.querySelector('[data-mobile2-account="cl-second"]')?.getAttribute("data-mobile2-account-state")).toBe("needsSignIn");
+  expect(host.querySelector("[data-account-limits]")).toBeNull();
+  expect(host.querySelector('[data-mobile2-account-signin="cl-second"]')).toBeTruthy();
+});
+
+test("the screen is one section per engine — the active card first, the add row last", async () => {
+  const { host } = await mount([
+    engineState("claude", [claudeLab, claudeMain, claudeSecond], "cl-main"),
+    engineState("codex", [codexMain], "cx-main"),
+  ]);
+
+  const sections = [...host.querySelectorAll("[data-mobile2-accounts-engine]")];
+  expect(sections.map((section) => section.getAttribute("data-mobile2-accounts-engine"))).toEqual(["claude", "codex"]);
+
+  const claude = sections[0];
+  expect([...claude.querySelectorAll("[data-mobile2-account]")].map((card) => card.getAttribute("data-mobile2-account"))).toEqual(["cl-main", "cl-lab", "cl-second"]);
+  const last = claude.lastElementChild!;
+  expect(last.querySelector('[data-mobile2-account-add="claude"]')).toBeTruthy();
+  expect(text(last)).toContain("Add a Claude account");
+  expect(text(claude.querySelector('[data-mobile2-account="cl-main"]'))).toContain("Max plan");
+  // A quiet row keeps its own reading line: plan and when it was last checked.
+  expect(text(claude.querySelector('[data-mobile2-account="cl-lab"]'))).toContain("checked");
+});
+
+test("an account with no reading says so instead of drawing an empty meter", async () => {
+  const bare = account({ id: "cl-bare", label: "Bare" });
+  const { host } = await mount([engineState("claude", [bare], "cl-bare")]);
+
+  expect(host.querySelector('[data-mobile2-account="cl-bare"] [role="meter"]')).toBeNull();
+  expect(host.querySelector("[data-mobile2-account-corner]")).toBeNull();
+  expect(text(host.querySelector("[data-account-limits]"))).toContain("no reading yet");
+});
+
+test("the account a badge steered here (#229) is ringed on the screen it lands on", async () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted.push({ root, host });
+  await act(async () => root.render(
+    <MobileAccountsBody engines={[engineState("claude", [claudeMain, claudeLab], "cl-main")]} now={NOW} focusAccountId="cl-lab" receipts={createReceiptStore()} />,
+  ));
+
+  expect(host.querySelector('[data-mobile2-account="cl-lab"]')?.className).toContain("ring-accent/50");
+  expect(host.querySelector('[data-mobile2-account="cl-main"]')?.className).not.toContain("ring-accent/50");
+});

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -11,6 +11,7 @@ import {
   type AccountOperation,
   type AccountAuthHealth,
   type AccountOption,
+  type DeviceAuth,
   type EngineAccountsState,
   type LimitsAction,
 } from "@/hooks/useEngineAccounts";
@@ -899,14 +900,19 @@ export function AccountsPanel({
 
 export type MobileAccountState = "active" | "ready" | "needsSignIn" | "pending";
 
-/** One state per row: a live sign-in outranks everything (the row shows the
-    device sign-in), then a missing or signed-out credential (the row stays
-    inactive even when the registry still names it active), then active. */
+const MOBILE_STATE_OF: Record<RowState, MobileAccountState> = {
+  pending: "pending",
+  needsLogin: "needsSignIn",
+  active: "active",
+  idle: "ready",
+};
+
+/** One state per row, in the phone's words. The precedence is the dialog's own
+    `rowState` — a live sign-in outranks everything, then a missing or
+    signed-out credential (the row stays inactive even when the registry still
+    names it active), then active — so the two surfaces cannot drift apart. */
 export function mobileAccountState(account: AccountOption, activeId: string): MobileAccountState {
-  if (account.loginPending) return "pending";
-  if (!account.authPresent || authHealth(account) === "signed_out") return "needsSignIn";
-  if (account.id === activeId) return "active";
-  return "ready";
+  return MOBILE_STATE_OF[rowState(account, activeId)];
 }
 
 /** The corner number: the tightest window, named. `null` without a reading. */
@@ -929,20 +935,27 @@ function mobileSignInAvailable(engine: "claude" | "codex", account: AccountOptio
 
 /** Codex keeps its device-login contract on the accounts route (`action:
     "retry"`); the store has no verb for it, so the screen asks the route and
-    re-reads the list, which then carries the pending login and its code. */
-async function startCodexDeviceSignIn(state: EngineAccountsState, accountId: string): Promise<boolean> {
+    re-reads the list, which then carries the pending login. The verification
+    link and its code come back in THAT answer and nowhere else, so the caller
+    keeps what it was handed and the row shows it. */
+async function startCodexDeviceSignIn(state: EngineAccountsState, accountId: string): Promise<{ ok: boolean; deviceAuth: DeviceAuth | null }> {
+  let deviceAuth: DeviceAuth | null = null;
   try {
     const response = await fetch("/api/accounts/codex", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action: "retry", id: accountId }),
     });
-    if (!response.ok) return false;
+    if (!response.ok) return { ok: false, deviceAuth: null };
+    const body = await response.json().catch(() => null) as { deviceAuth?: { url?: unknown; code?: unknown } } | null;
+    const url = body?.deviceAuth?.url;
+    const code = body?.deviceAuth?.code;
+    if (typeof url === "string" && typeof code === "string") deviceAuth = { url, code };
   } catch {
-    return false;
+    return { ok: false, deviceAuth: null };
   }
   await state.refresh();
-  return true;
+  return { ok: true, deviceAuth };
 }
 
 function planLabel(plan: string | null | undefined, t: TFunction): string | null {
@@ -998,7 +1011,7 @@ function MobileAccountHead({ account, engine, state, quota, t }: { account: Acco
   const corner = state === "pending" ? null : mobileAccountCorner(quota, t);
   const plan = planLabel(account.plan ?? quota.plan, t);
   const observed = limitRows(quota, t).map((row) => row.window.observedAt).filter((value): value is number => value !== null);
-  const checked = state === "active" && observed.length ? formatCheckedClock(new Date(Math.min(...observed) * 1000).toISOString()) : null;
+  const checked = observed.length ? formatCheckedClock(new Date(Math.min(...observed) * 1000).toISOString()) : null;
   return (
     <>
       <MobileEngineFill engine={engine} />
@@ -1028,23 +1041,25 @@ function MobileAccountHead({ account, engine, state, quota, t }: { account: Acco
 }
 
 /** The device sign-in a pending row shows under itself: Codex hands over the
-    verification link and its code; Claude's login row carries its own link,
-    code entry and Cancel. Both are 44 px targets. */
-function MobilePendingSignIn({ account, engine, state, loginBusy }: { account: AccountOption; engine: "claude" | "codex"; state: EngineAccountsState; loginBusy: boolean }) {
+    verification link and its code — from the list when it carries one, else
+    from the answer this screen's own tap was handed; Claude's login row
+    carries its own link, code entry and Cancel. Both are 44 px targets. */
+function MobilePendingSignIn({ account, engine, state, loginBusy, deviceAuth }: { account: AccountOption; engine: "claude" | "codex"; state: EngineAccountsState; loginBusy: boolean; deviceAuth: DeviceAuth | null }) {
   const { t } = useLocale();
   if (engine === "claude") return account.login ? <ClaudeLoginRow key={account.login.operationId} account={account} state={state} loginBusy={loginBusy} /> : null;
-  if (!account.deviceAuth) return null;
+  const challenge = account.deviceAuth ?? deviceAuth;
+  if (!challenge) return null;
   return (
     <div data-mobile2-account-device-signin className="flex items-center gap-2 px-3 text-label text-muted">
-      <a href={account.deviceAuth.url} target="_blank" rel="noreferrer noopener" className="inline-flex min-h-11 items-center font-semibold text-accent underline">
+      <a href={challenge.url} target="_blank" rel="noreferrer noopener" className="inline-flex min-h-11 items-center font-semibold text-accent underline">
         {t("mobile2.accounts.openSignIn")}
       </a>
-      <code className="select-all font-mono text-ui font-semibold text-primary">{account.deviceAuth.code}</code>
+      <code className="select-all font-mono text-ui font-semibold text-primary">{challenge.code}</code>
     </div>
   );
 }
 
-function MobileAccountCard({ account, engine, state, quota, now, engineState, receipts, focused, loginBusy, onSwitch, onSignIn }: {
+function MobileAccountCard({ account, engine, state, quota, now, engineState, receipts, focused, loginBusy, deviceAuth, onSwitch, onSignIn }: {
   account: AccountOption;
   engine: "claude" | "codex";
   state: MobileAccountState;
@@ -1054,6 +1069,9 @@ function MobileAccountCard({ account, engine, state, quota, now, engineState, re
   receipts: ReceiptStore;
   focused: boolean;
   loginBusy: boolean;
+  /** The device sign-in this screen's own tap opened for this account, when
+      the account list does not carry the challenge itself. */
+  deviceAuth: DeviceAuth | null;
   onSwitch: () => void;
   onSignIn: () => void;
 }) {
@@ -1088,7 +1106,7 @@ function MobileAccountCard({ account, engine, state, quota, now, engineState, re
         ) : (
           <div className={rowClass}>{head}</div>
         )}
-        {state === "pending" ? <MobilePendingSignIn account={account} engine={engine} state={engineState} loginBusy={loginBusy} /> : null}
+        {state === "pending" || deviceAuth ? <MobilePendingSignIn account={account} engine={engine} state={engineState} loginBusy={loginBusy} deviceAuth={deviceAuth} /> : null}
         {engine === "claude" && state === "needsSignIn" && account.login?.result?.status === "failure"
           ? <ClaudeLoginRow key={account.login.operationId} account={account} state={engineState} loginBusy={loginBusy} />
           : null}
@@ -1234,6 +1252,7 @@ function MobileEngineSection({ state, now, focusAccountId, receipts }: { state: 
   const { engine, accounts, active, notice, status } = state;
   const engineName = engineDisplay(engine);
   const loginBusy = engine === "claude" && accounts.some((account) => account.login != null && NONTERMINAL_CLAUDE_LOGIN_PHASES.has(account.login.phase));
+  const [challenge, setChallenge] = useState<{ accountId: string; deviceAuth: DeviceAuth } | null>(null);
   /* The active card leads; the rest keep the registry's order. */
   const ordered = [...accounts].sort((a, b) => Number(mobileAccountState(b, active) === "active") - Number(mobileAccountState(a, active) === "active"));
 
@@ -1244,9 +1263,15 @@ function MobileEngineSection({ state, now, focusAccountId, receipts }: { state: 
       receipts.show(t("mobile2.accounts.switched", { label: account.label }), { kind: "switchBack", run: () => void state.select(before) });
     });
   };
+  /* A sign-in tap opens the device sign-in and nothing else: the account it
+     names never becomes the active one here (P2-8, README §4.8). It returns
+     that way — by signing in — and the next list read is what says so. */
   const signIn = (account: AccountOption) => {
-    const started = engine === "claude" ? state.retryLogin(account.id) : startCodexDeviceSignIn(state, account.id);
-    void started.then((ok) => {
+    const started = engine === "claude"
+      ? state.retryLogin(account.id).then((ok) => ({ ok, deviceAuth: null as DeviceAuth | null }))
+      : startCodexDeviceSignIn(state, account.id);
+    void started.then(({ ok, deviceAuth }) => {
+      setChallenge(ok && deviceAuth ? { accountId: account.id, deviceAuth } : null);
       receipts.show(t(ok ? "mobile2.accounts.signInStarted" : "mobile2.accounts.signInFailed", { label: account.label }));
     });
   };
@@ -1271,6 +1296,7 @@ function MobileEngineSection({ state, now, focusAccountId, receipts }: { state: 
           receipts={receipts}
           focused={account.id === focusAccountId}
           loginBusy={loginBusy}
+          deviceAuth={challenge?.accountId === account.id ? challenge.deviceAuth : null}
           onSwitch={() => switchTo(account)}
           onSignIn={() => signIn(account)}
         />

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -1,23 +1,28 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import { Fragment, useEffect, useRef, useState } from "react";
 
 import {
   accountNoticeText,
   claudeLoginErrKey,
   NONTERMINAL_CLAUDE_LOGIN_PHASES,
+  useEngineAccounts,
   type AccountOperation,
   type AccountAuthHealth,
   type AccountOption,
   type EngineAccountsState,
   type LimitsAction,
 } from "@/hooks/useEngineAccounts";
+import { consumePendingAccountPanel, onAccountPanelRequest } from "@/lib/accounts/openPanel";
 import { claudeTierDisplayName } from "@/lib/agent/models";
 import { type TFunction, useLocale } from "@/lib/i18n";
 import { handleOverlayEscape } from "@/lib/overlay";
-import { effectiveQuota, quotaReadingFromAccountLimits, reconcileQuotaReadings, type ReconciledQuota } from "@/lib/rateLimit";
+import { effectiveQuota, quotaReadingFromAccountLimits, reconcileQuotaReadings, type ReconciledQuota, type ReconciledQuotaWindow } from "@/lib/rateLimit";
 
-import { Loader2, RotateCw, SquareTerminal, Trash2, X, Zap } from "./icons";
+import { ArrowRight, ChevronRight, Command, Loader2, RotateCw, Sparkle, SquareTerminal, Trash2, X, Zap } from "./icons";
+import { MobileMeter, meterTone, type MeterTone } from "./mobile/MobileMeter";
+import { receipts as tabReceipts, type ReceiptStore } from "./mobile/MobileReceipt";
 import { Badge } from "./ui/Badge";
 import { formatCheckedClock, formatQuotaAsOf, formatResetClock, formatResetEta, windowLabel } from "./rateLimit";
 import { engineTintOf } from "./utils";
@@ -46,6 +51,22 @@ function capacityColor(percent: number, engineColor: string): string {
 
 function accountQuota(account: AccountOption, now: number) {
   return reconcileQuotaReadings(null, quotaReadingFromAccountLimits(account.limits), now);
+}
+
+type LimitRowKey = "session" | "weekly" | "flagship";
+
+/** The windows an account reports, in the order every surface lists them:
+    session, week, then the flagship tier's own week (#1358) when the account
+    reports a distinct bucket. Each row carries the label its horizon earns. */
+type LimitRow = { key: LimitRowKey; label: string; window: ReconciledQuotaWindow };
+
+function limitRows(quota: ReconciledQuota, t: TFunction): LimitRow[] {
+  const candidates: { key: LimitRowKey; label: string; window: ReconciledQuotaWindow | null }[] = [
+    { key: "session", label: windowLabel(t, "session", quota.session?.value.windowMinutes), window: quota.session },
+    { key: "weekly", label: windowLabel(t, "weekly", quota.weekly?.value.windowMinutes), window: quota.weekly },
+    { key: "flagship", label: quota.flagship ? t("limits.tierWeek", { tier: claudeTierDisplayName(quota.flagship.value.tier) }) : "", window: quota.flagship },
+  ];
+  return candidates.filter((row): row is LimitRow => row.window != null);
 }
 
 function CapacityChip({ quota, engine }: { quota: ReconciledQuota; engine: "claude" | "codex" }) {
@@ -106,13 +127,7 @@ function AccountLimitsBlock({ account, engine, quota, now, busy, disabled, wideL
   onUseReset: () => void;
 }) {
   const { t } = useLocale();
-  const rows = [
-    { key: "session", label: windowLabel(t, "session", quota.session?.value.windowMinutes), window: quota.session },
-    { key: "weekly", label: windowLabel(t, "weekly", quota.weekly?.value.windowMinutes), window: quota.weekly },
-    // The flagship tier's own week (#1358), named by the provider's tier; the
-    // row exists only when the account reports a distinct bucket.
-    { key: "flagship", label: quota.flagship ? t("limits.tierWeek", { tier: claudeTierDisplayName(quota.flagship.value.tier) }) : "", window: quota.flagship },
-  ].filter((row): row is { key: string; label: string; window: NonNullable<typeof row.window> } => row.window != null);
+  const rows = limitRows(quota, t);
   const stale = rows.some((row) => row.window.stale);
   const observed = rows.map((row) => row.window.observedAt).filter((value): value is number => value !== null);
   const observedAt = observed.length ? Math.min(...observed) : null;
@@ -859,4 +874,453 @@ export function AccountsPanel({
       </div>
     </>
   );
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *
+ * Mobile v2 — the Accounts & limits screen (#1439, lane 9)                    *
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/*
+ * docs/design/mobile-v2/README.md §4.8: a screen from `⋯`, per engine. The
+ * active account is a card — filled engine mark, label, `active`, plan,
+ * "checked 14:32", the lowest window in the corner as `38% left / Week`,
+ * coloured by what remains — with its windows as `label · meter · % left` and
+ * the reset line under each, the resets line, and Refresh / Use one reset as
+ * 44 px text buttons. Other authenticated accounts are quiet rows (`ready`)
+ * that switch future launches on the tap, with Switch back in the receipt.
+ * Accounts that are not signed in are quiet rows with a trailing `sign in →`
+ * that opens the device sign-in; they become active only after it returns.
+ * "Add a … account" is last.
+ *
+ * Every meter fills with what REMAINS (§5); the corner names its window; no
+ * action asks for confirmation (§2 rule 9). The desktop dialog above is
+ * untouched: this is the phone's layout over the same account store.
+ */
+
+export type MobileAccountState = "active" | "ready" | "needsSignIn" | "pending";
+
+/** One state per row: a live sign-in outranks everything (the row shows the
+    device sign-in), then a missing or signed-out credential (the row stays
+    inactive even when the registry still names it active), then active. */
+export function mobileAccountState(account: AccountOption, activeId: string): MobileAccountState {
+  if (account.loginPending) return "pending";
+  if (!account.authPresent || authHealth(account) === "signed_out") return "needsSignIn";
+  if (account.id === activeId) return "active";
+  return "ready";
+}
+
+/** The corner number: the tightest window, named. `null` without a reading. */
+export function mobileAccountCorner(quota: ReconciledQuota, t: TFunction): { left: number; window: string; tone: MeterTone } | null {
+  const effective = effectiveQuota(quota);
+  if (!effective) return null;
+  const window = effective.window === "flagship"
+    ? t("limits.tierWeek", { tier: claudeTierDisplayName(quota.flagship?.value.tier ?? "") })
+    : windowLabel(t, effective.window === "weekly" ? "weekly" : "session", effective.value.windowMinutes);
+  const left = Math.round(effective.percent);
+  return { left, window, tone: meterTone(left) };
+}
+
+/** The sign-in a row can start: Claude restarts its login in place for any
+    account; Codex re-runs the device login for a managed account. A legacy
+    Codex home signs in from the terminal, so its row carries no action. */
+function mobileSignInAvailable(engine: "claude" | "codex", account: AccountOption): boolean {
+  return engine === "claude" || account.kind === "managed";
+}
+
+/** Codex keeps its device-login contract on the accounts route (`action:
+    "retry"`); the store has no verb for it, so the screen asks the route and
+    re-reads the list, which then carries the pending login and its code. */
+async function startCodexDeviceSignIn(state: EngineAccountsState, accountId: string): Promise<boolean> {
+  try {
+    const response = await fetch("/api/accounts/codex", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "retry", id: accountId }),
+    });
+    if (!response.ok) return false;
+  } catch {
+    return false;
+  }
+  await state.refresh();
+  return true;
+}
+
+function planLabel(plan: string | null | undefined, t: TFunction): string | null {
+  const trimmed = plan?.trim();
+  if (!trimmed) return null;
+  return t("mobile2.accounts.plan", { plan: trimmed.charAt(0).toUpperCase() + trimmed.slice(1) });
+}
+
+const MOBILE_BADGE: Record<"success" | "neutral" | "warning", string> = {
+  success: "bg-success-soft text-success",
+  neutral: "bg-sunken text-muted",
+  warning: "bg-warning-soft text-warning",
+};
+
+function MobileBadge({ tone, children }: { tone: keyof typeof MOBILE_BADGE; children: React.ReactNode }) {
+  return (
+    <span className={`inline-flex h-5 shrink-0 items-center gap-1 rounded-full px-[7px] text-caption font-semibold leading-none ${MOBILE_BADGE[tone]}`}>
+      {children}
+    </span>
+  );
+}
+
+/** The filled 36 px engine circle: the account card is one of the two places
+    the filled mark survives (README §5). */
+function MobileEngineFill({ engine }: { engine: "claude" | "codex" }) {
+  const Glyph = engine === "codex" ? Command : Sparkle;
+  return (
+    <span aria-hidden data-mobile2-engine={engine} className={`inline-grid h-9 w-9 shrink-0 place-items-center rounded-full text-white ${engine === "codex" ? "bg-codex" : "bg-claude"}`}>
+      <Glyph className="h-[18px] w-[18px]" strokeWidth={2.5} />
+    </span>
+  );
+}
+
+const CORNER_TONE: Record<MeterTone, string> = { accent: "text-primary", warning: "text-warning", danger: "text-danger" };
+
+function MobileCorner({ corner, t }: { corner: NonNullable<ReturnType<typeof mobileAccountCorner>>; t: TFunction }) {
+  return (
+    <span
+      data-mobile2-account-corner
+      data-mobile2-account-window={corner.window}
+      aria-label={t("mobile2.accounts.cornerAria", { left: corner.left, window: corner.window })}
+      className={`ml-auto shrink-0 pr-1.5 text-right text-ui font-bold leading-[1.2] tabular-nums ${CORNER_TONE[corner.tone]}`}
+    >
+      {t("mobile2.meter.left", { left: corner.left })}
+      <small className="block text-caption font-semibold text-muted">{corner.window}</small>
+    </span>
+  );
+}
+
+const MOBILE_ACTION = "inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-[8px] px-2 text-ui font-semibold text-accent active:bg-sunken disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40";
+
+function MobileAccountHead({ account, engine, state, quota, t }: { account: AccountOption; engine: "claude" | "codex"; state: MobileAccountState; quota: ReconciledQuota; t: TFunction }) {
+  const corner = state === "pending" ? null : mobileAccountCorner(quota, t);
+  const plan = planLabel(account.plan ?? quota.plan, t);
+  const observed = limitRows(quota, t).map((row) => row.window.observedAt).filter((value): value is number => value !== null);
+  const checked = state === "active" && observed.length ? formatCheckedClock(new Date(Math.min(...observed) * 1000).toISOString()) : null;
+  return (
+    <>
+      <MobileEngineFill engine={engine} />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className={`flex items-center gap-1.5 text-body font-semibold leading-[1.25] ${state === "active" ? "text-primary" : "text-secondary"}`}>
+          <span className="min-w-0 truncate">{account.label}</span>
+          {state === "active" ? <MobileBadge tone="success">{t("accounts.active")}</MobileBadge> : null}
+          {state === "ready" ? <MobileBadge tone="neutral">{t("mobile2.accounts.ready")}</MobileBadge> : null}
+          {state === "needsSignIn" ? <MobileBadge tone="warning">{t("accounts.needsLogin")}</MobileBadge> : null}
+          {state === "pending" ? (
+            <MobileBadge tone="neutral">
+              <Loader2 className="h-[11px] w-[11px] animate-spin motion-reduce:animate-none" aria-hidden />
+              {t("mobile2.accounts.pending")}
+            </MobileBadge>
+          ) : null}
+        </span>
+        <span className="flex items-center gap-[5px] overflow-hidden text-label tabular-nums text-muted">
+          {plan ? <span className="min-w-0 truncate">{plan}</span> : null}
+          {plan && checked ? <span aria-hidden className="shrink-0 opacity-60">·</span> : null}
+          {checked ? <span className="min-w-0 truncate">{t("mobile2.accounts.checked", { time: checked })}</span> : null}
+          {!plan && !checked ? <span className="min-w-0 truncate">{t(AUTH_HEALTH_KEY[authHealth(account)])}</span> : null}
+        </span>
+      </span>
+      {corner ? <MobileCorner corner={corner} t={t} /> : null}
+    </>
+  );
+}
+
+/** The device sign-in a pending row shows under itself: Codex hands over the
+    verification link and its code; Claude's login row carries its own link,
+    code entry and Cancel. Both are 44 px targets. */
+function MobilePendingSignIn({ account, engine, state, loginBusy }: { account: AccountOption; engine: "claude" | "codex"; state: EngineAccountsState; loginBusy: boolean }) {
+  const { t } = useLocale();
+  if (engine === "claude") return account.login ? <ClaudeLoginRow key={account.login.operationId} account={account} state={state} loginBusy={loginBusy} /> : null;
+  if (!account.deviceAuth) return null;
+  return (
+    <div data-mobile2-account-device-signin className="flex items-center gap-2 px-3 text-label text-muted">
+      <a href={account.deviceAuth.url} target="_blank" rel="noreferrer noopener" className="inline-flex min-h-11 items-center font-semibold text-accent underline">
+        {t("mobile2.accounts.openSignIn")}
+      </a>
+      <code className="select-all font-mono text-ui font-semibold text-primary">{account.deviceAuth.code}</code>
+    </div>
+  );
+}
+
+function MobileAccountCard({ account, engine, state, quota, now, engineState, receipts, focused, loginBusy, onSwitch, onSignIn }: {
+  account: AccountOption;
+  engine: "claude" | "codex";
+  state: MobileAccountState;
+  quota: ReconciledQuota;
+  now: number;
+  engineState: EngineAccountsState;
+  receipts: ReceiptStore;
+  focused: boolean;
+  loginBusy: boolean;
+  onSwitch: () => void;
+  onSignIn: () => void;
+}) {
+  const { t } = useLocale();
+  const busy = engineState.mutation !== null;
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (focused) ref.current?.scrollIntoView({ block: "nearest" });
+  }, [focused]);
+  const ring = focused ? "ring-2 ring-inset ring-accent/50" : "";
+  const rowClass = "flex min-h-11 w-full items-center gap-2.5 text-left";
+
+  if (state !== "active") {
+    const quiet = `mx-3 mb-1.5 rounded-[12px] bg-quiet pl-3 pr-1 ring-1 ring-inset ring-border ${ring}`;
+    const signIn = state === "needsSignIn" && mobileSignInAvailable(engine, account);
+    const head = <MobileAccountHead account={account} engine={engine} state={state} quota={quota} t={t} />;
+    return (
+      <div ref={ref} data-mobile2-account={account.id} data-mobile2-account-state={state} className={quiet}>
+        {state === "ready" ? (
+          <button type="button" data-mobile2-account-switch={account.id} aria-label={t("mobile2.accounts.switchAria", { label: account.label })} disabled={busy} className={`${rowClass} active:bg-sunken disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40`} onClick={onSwitch}>
+            {head}
+            <ChevronRight className="h-[18px] w-[18px] shrink-0 text-muted" aria-hidden />
+          </button>
+        ) : signIn ? (
+          <button type="button" data-mobile2-account-signin={account.id} aria-label={t("mobile2.accounts.signInAria", { label: account.label })} disabled={busy || loginBusy} className={`${rowClass} active:bg-sunken disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40`} onClick={onSignIn}>
+            {head}
+            <span className="inline-flex shrink-0 items-center gap-[3px] pr-1.5 text-label font-semibold text-accent">
+              {t("mobile2.accounts.signIn")}
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+            </span>
+          </button>
+        ) : (
+          <div className={rowClass}>{head}</div>
+        )}
+        {state === "pending" ? <MobilePendingSignIn account={account} engine={engine} state={engineState} loginBusy={loginBusy} /> : null}
+        {engine === "claude" && state === "needsSignIn" && account.login?.result?.status === "failure"
+          ? <ClaudeLoginRow key={account.login.operationId} account={account} state={engineState} loginBusy={loginBusy} />
+          : null}
+      </div>
+    );
+  }
+
+  const rows = limitRows(quota, t);
+  const resets = engine === "codex" ? account.resetCredits ?? null : null;
+  const canRedeem = resets !== null && resets.availableCount > 0;
+  const limitsBusy = engineState.limitsBusy?.accountId === account.id ? engineState.limitsBusy.operation : null;
+  const refreshing = limitsBusy === "refreshLimits";
+  const redeeming = limitsBusy === "resetCredit";
+  const actionsDisabled = busy || limitsBusy !== null || !account.authPresent;
+  return (
+    <div ref={ref} data-mobile2-account={account.id} data-mobile2-account-state="active" className={`mx-3 mb-1.5 rounded-[12px] bg-card pb-1.5 pl-3 pr-1 pt-0.5 shadow-1 ${ring}`}>
+      <div className={rowClass}>
+        <MobileAccountHead account={account} engine={engine} state={state} quota={quota} t={t} />
+      </div>
+      <dl data-account-limits={account.id} aria-label={t("accounts.limitsAria", { label: account.label })} className="flex flex-col gap-[5px] pr-2 pt-0.5">
+        {rows.length === 0 ? <div className="text-label text-muted">{t("mobile2.accounts.noReading")}</div> : null}
+        {rows.map(({ key, label, window }) => {
+          const w = window.value;
+          const left = Math.max(0, Math.min(100, Math.round(100 - w.usedPercent)));
+          const stale = window.stale ? formatQuotaAsOf(window.observedAt) ?? t("accounts.limitsStale") : null;
+          return (
+            <div key={key} data-limit-row={key} className={`grid grid-cols-[80px_1fr_auto] items-center gap-x-2 gap-y-1 text-label text-muted ${window.stale ? "opacity-70" : ""}`}>
+              <dt className="truncate font-semibold text-secondary">{label}</dt>
+              <dd className="min-w-0"><MobileMeter left={left} label={t("mobile2.accounts.windowAria", { window: label, label: account.label })} /></dd>
+              <dd className="font-semibold tabular-nums text-primary">{t("mobile2.meter.left", { left })}</dd>
+              <dd className="col-start-2 col-end-4 -mt-1 truncate text-caption">
+                {w.resetsAt ? t("limits.reset", { eta: formatResetEta(w.resetsAt, now), at: formatResetClock(w.resetsAt, now) }) : null}
+                {w.resetsAt && stale ? " · " : null}
+                {stale}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+      {engine === "codex" ? (
+        <div data-account-reset-credits={account.id} className={`pr-2 pt-1 text-label ${canRedeem ? "font-semibold text-primary" : "text-muted"}`}>
+          {resets === null
+            ? t("accounts.resetsUnknown")
+            : resets.availableCount === 0
+              ? t("accounts.resetsNone")
+              : t("accounts.resetsAvailable", { count: resets.availableCount })}
+          {resets !== null && resets.availableCount > 0 && resets.expiresAt !== null ? ` · ${t("accounts.resetsExpire", { at: formatResetClock(resets.expiresAt, now) })}` : null}
+        </div>
+      ) : null}
+      <div className="mt-0.5 flex items-center gap-1">
+        <button
+          type="button"
+          data-account-refresh-limits={account.id}
+          aria-label={t("accounts.refreshLimitsAria", { label: account.label })}
+          aria-busy={refreshing || undefined}
+          disabled={actionsDisabled}
+          className={MOBILE_ACTION}
+          onClick={() => void engineState.refreshLimits(account.id).then((ok) => { if (ok) receipts.show(t("mobile2.accounts.refreshed", { label: account.label })); })}
+        >
+          {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" aria-hidden /> : <RotateCw className="h-3.5 w-3.5" aria-hidden />}
+          {t("accounts.refreshLimits")}
+        </button>
+        {engine === "codex" ? (
+          <button
+            type="button"
+            data-account-use-reset={account.id}
+            aria-label={t("accounts.useResetAria", { label: account.label })}
+            aria-busy={redeeming || undefined}
+            disabled={actionsDisabled || !canRedeem}
+            className={MOBILE_ACTION}
+            onClick={() => void engineState.useResetCredit(account.id).then((ok) => { if (ok) receipts.show(t("mobile2.accounts.resetUsed", { label: account.label })); })}
+          >
+            {redeeming ? <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" aria-hidden /> : <Zap className="h-3.5 w-3.5" aria-hidden />}
+            {t("accounts.useReset")}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** "Add a … account", last in the section: a quiet row that turns into the
+    label field and its Add on the tap (an account needs a name before the
+    device sign-in can start). The field is 16 px so iOS never zooms. */
+function MobileAddAccountRow({ state, engineName, loginBusy }: { state: EngineAccountsState; engineName: string; loginBusy: boolean }) {
+  const { t } = useLocale();
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState("");
+  const busy = state.mutation !== null;
+  if (!open) {
+    return (
+      <div className="mx-3 mb-1.5 rounded-[12px] bg-quiet pl-3 pr-1 ring-1 ring-inset ring-border">
+        <button type="button" data-mobile2-account-add={state.engine} disabled={busy || loginBusy} className="flex min-h-14 w-full items-center gap-2.5 text-left active:bg-sunken disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40" onClick={() => setOpen(true)}>
+          <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-strong" />
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="truncate text-body font-semibold leading-[1.25] text-secondary">{t("mobile2.accounts.add", { engine: engineName })}</span>
+            <span className="truncate text-label text-muted">{t("mobile2.accounts.addHint")}</span>
+          </span>
+          <Plus className="h-[18px] w-[18px] shrink-0 text-muted" aria-hidden />
+        </button>
+      </div>
+    );
+  }
+  return (
+    <form
+      data-mobile2-account-add-form={state.engine}
+      className="mx-3 mb-1.5 flex items-center gap-2 rounded-[12px] bg-quiet p-2 ring-1 ring-inset ring-border"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const trimmed = label.trim();
+        if (!trimmed || busy) return;
+        void state.add(trimmed).then((created) => {
+          if (created) {
+            setLabel("");
+            setOpen(false);
+          }
+        });
+      }}
+    >
+      <input
+        value={label}
+        onChange={(event) => setLabel(event.target.value)}
+        aria-label={t("mobile2.accounts.addLabel")}
+        placeholder={t("accounts.labelPlaceholder")}
+        autoComplete="off"
+        autoCapitalize="words"
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- the row the operator just tapped became this field
+        autoFocus
+        className="h-11 min-w-0 flex-1 rounded-[8px] border border-border bg-canvas px-2.5 text-[16px] outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      />
+      <button type="button" className="inline-flex h-11 min-w-11 items-center justify-center rounded-[8px] px-2 text-ui font-semibold text-secondary active:bg-sunken" onClick={() => { setOpen(false); setLabel(""); }}>
+        {t("mobile2.accounts.addCancel")}
+      </button>
+      <button type="submit" disabled={busy || loginBusy || label.trim() === ""} className="inline-flex h-11 min-w-11 items-center justify-center rounded-[8px] px-3 text-ui font-bold text-accent active:bg-sunken disabled:opacity-40">
+        {t("accounts.confirmAdd")}
+      </button>
+    </form>
+  );
+}
+
+function MobileEngineSection({ state, now, focusAccountId, receipts }: { state: EngineAccountsState; now: number; focusAccountId: string | null; receipts: ReceiptStore }) {
+  const { t } = useLocale();
+  const { engine, accounts, active, notice, status } = state;
+  const engineName = engineDisplay(engine);
+  const loginBusy = engine === "claude" && accounts.some((account) => account.login != null && NONTERMINAL_CLAUDE_LOGIN_PHASES.has(account.login.phase));
+  /* The active card leads; the rest keep the registry's order. */
+  const ordered = [...accounts].sort((a, b) => Number(mobileAccountState(b, active) === "active") - Number(mobileAccountState(a, active) === "active"));
+
+  const switchTo = (account: AccountOption) => {
+    const before = active;
+    void state.select(account.id).then((ok) => {
+      if (!ok) return;
+      receipts.show(t("mobile2.accounts.switched", { label: account.label }), { kind: "switchBack", run: () => void state.select(before) });
+    });
+  };
+  const signIn = (account: AccountOption) => {
+    const started = engine === "claude" ? state.retryLogin(account.id) : startCodexDeviceSignIn(state, account.id);
+    void started.then((ok) => {
+      receipts.show(t(ok ? "mobile2.accounts.signInStarted" : "mobile2.accounts.signInFailed", { label: account.label }));
+    });
+  };
+
+  return (
+    <section data-mobile2-accounts-engine={engine} aria-label={t("accounts.titleFor", { engine: engineName })}>
+      <div className="flex min-h-[34px] items-center gap-1.5 px-3 pt-1.5 text-label font-semibold text-secondary">
+        {engineName}
+        <span className="text-caption font-semibold tabular-nums text-muted">{accounts.length}</span>
+      </div>
+      {status === "loading" && accounts.length === 0 ? <div className="px-3 pb-2 text-label text-muted">{t("accounts.loading")}</div> : null}
+      {status !== "loading" && accounts.length === 0 ? <div className="px-3 pb-2 text-label text-muted">{t("mobile2.accounts.noAccounts", { engine: engineName })}</div> : null}
+      {ordered.map((account) => (
+        <MobileAccountCard
+          key={account.id}
+          account={account}
+          engine={engine}
+          state={mobileAccountState(account, active)}
+          quota={accountQuota(account, now)}
+          now={now}
+          engineState={state}
+          receipts={receipts}
+          focused={account.id === focusAccountId}
+          loginBusy={loginBusy}
+          onSwitch={() => switchTo(account)}
+          onSignIn={() => signIn(account)}
+        />
+      ))}
+      {notice?.kind === "error" ? (
+        <div role="alert" data-mobile2-accounts-notice className="mx-3 mb-1.5 flex items-center gap-2 pl-3 text-label text-danger">
+          <span className="min-w-0 flex-1 leading-snug">{accountNoticeText(t, notice)}</span>
+          {notice.action ? (
+            <button type="button" disabled={state.mutation !== null} className={`${MOBILE_ACTION} shrink-0`} onClick={() => void state.retryNotice()}>
+              {notice.action.kind === "forceRemove" ? t("accounts.forceRemove") : notice.action.kind === "cleanupOrphans" ? t("accounts.cleanupOrphans") : t("accounts.retry")}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      <MobileAddAccountRow state={state} engineName={engineName} loginBusy={loginBusy} />
+    </section>
+  );
+}
+
+/** The screen's body over given engine states — the shape the tests drive. */
+export function MobileAccountsBody({ engines, now, focusAccountId = null, receipts = tabReceipts }: {
+  engines: EngineAccountsState[];
+  /** Unix seconds the reset ETAs and staleness are read against. */
+  now: number;
+  /** The account a badge tap steered here (issue #229): scrolled to and ringed. */
+  focusAccountId?: string | null;
+  receipts?: ReceiptStore;
+}) {
+  return (
+    <div data-mobile2-accounts-body className="flex flex-col pb-5 pt-1">
+      {engines.map((state) => <MobileEngineSection key={state.engine} state={state} now={now} focusAccountId={focusAccountId} receipts={receipts} />)}
+    </div>
+  );
+}
+
+/** The screen the shell mounts under its bar: both engines' stores, the
+    presentation clock, and the focus a badge asked for. */
+export function MobileAccountsPanel({ receipts }: { receipts?: ReceiptStore }) {
+  const claude = useEngineAccounts("claude");
+  const codex = useEngineAccounts("codex");
+  const [focus, setFocus] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  useEffect(() => {
+    const id = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  useEffect(() => {
+    const pending = consumePendingAccountPanel("claude") ?? consumePendingAccountPanel("codex");
+    if (pending) setFocus(pending.accountId);
+    return onAccountPanelRequest((request) => setFocus(request.accountId));
+  }, []);
+  return <MobileAccountsBody engines={[claude, codex]} now={now} focusAccountId={focus} receipts={receipts} />;
 }

--- a/src/components/EngineAccountSwitch.dom.test.tsx
+++ b/src/components/EngineAccountSwitch.dom.test.tsx
@@ -6,7 +6,8 @@ import { createRoot, type Root } from "react-dom/client";
 import type { EngineAccountsState } from "@/hooks/useEngineAccounts";
 import { installActEnv } from "@/test-helpers/actEnv";
 
-import { EngineAccountSwitchControl } from "./EngineAccountSwitch";
+import { getMobileNav, topScreen } from "./mobile/mobileNav";
+import { EngineAccountSwitch, EngineAccountSwitchControl } from "./EngineAccountSwitch";
 
 const dom = new Window();
 Object.assign(globalThis, {
@@ -19,6 +20,14 @@ Object.assign(globalThis, {
   MouseEvent: dom.MouseEvent,
   PointerEvent: dom.PointerEvent,
   KeyboardEvent: dom.KeyboardEvent,
+});
+/** Phone or desktop, per test: `useIsMobile` reads this and nothing else. */
+let phone = false;
+(dom as unknown as { matchMedia(query: string): unknown }).matchMedia = (query: string) => ({
+  matches: phone,
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
 });
 installActEnv();
 
@@ -126,4 +135,62 @@ test("the active account is collapsed at rest and the full switch flow opens on 
   expect(harbor).toBeTruthy();
   await act(async () => harbor!.click());
   expect(selected as unknown as string).toBe("account-harbor");
+});
+
+/*
+ * The phone has ONE accounts surface (mobile v2 lane 9, README §3.1 and §4.8):
+ * the Accounts & limits screen the board menu pushes. A trigger on a
+ * phone-sized viewport goes there instead of floating the desktop dialog over
+ * whatever the operator is looking at — the dialog is a 95vw flyout with its
+ * own scroller, which is exactly the surface this redesign replaces.
+ */
+
+test("with an accounts screen to open, the trigger pushes it and never opens the dialog", async () => {
+  let opened = 0;
+  const state = accountState(async () => true);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted.push({ root, host });
+
+  await act(async () => root.render(<EngineAccountSwitchControl state={state} onOpenScreen={() => { opened += 1; }} />));
+
+  const trigger = host.querySelector('button[aria-haspopup="dialog"]') as HTMLButtonElement;
+  // Nothing expands here: the control hands over to a screen.
+  expect(trigger.getAttribute("aria-expanded")).toBeNull();
+
+  await act(async () => trigger.click());
+
+  expect(opened).toBe(1);
+  expect(host.querySelector('[role="dialog"]')).toBeNull();
+  expect(host.textContent).not.toContain("Harbor light");
+});
+
+test("on a phone the mounted switch lands the shell on the accounts screen", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    claude: { active: "cl-main", accounts: [{ id: "cl-main", label: "Main", kind: "managed", authPresent: true, loginPending: false }] },
+    codex: { active: "cx-main", accounts: [{ id: "cx-main", label: "Main", kind: "managed", authPresent: true, loginPending: false }] },
+  }), { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+  phone = true;
+  try {
+    const nav = getMobileNav();
+    nav.home();
+    expect(topScreen(nav.getState()).kind).toBe("board");
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    mounted.push({ root, host });
+    await act(async () => root.render(<EngineAccountSwitch engine="codex" />));
+
+    await act(async () => (host.querySelector('button[aria-haspopup="dialog"]') as HTMLButtonElement).click());
+
+    expect(topScreen(nav.getState()).kind).toBe("accounts");
+    expect(host.querySelector('[role="dialog"]')).toBeNull();
+    nav.home();
+  } finally {
+    phone = false;
+    globalThis.fetch = realFetch;
+  }
 });

--- a/src/components/EngineAccountSwitch.tsx
+++ b/src/components/EngineAccountSwitch.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useRef, useState } from "react";
 
 import { type EngineAccountsState, useEngineAccounts } from "@/hooks/useEngineAccounts";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useLocale } from "@/lib/i18n";
 
 import { AccountsPanel, type ProjectAccountContext } from "./AccountsPanel";
 import { ChevronDown, Loader2 } from "./icons";
+import { getMobileNav } from "./mobile/mobileNav";
 import { engineTintOf } from "./utils";
 
 const ENGINE_LABEL: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
@@ -22,12 +24,18 @@ const ENGINE_LABEL: Record<"claude" | "codex", string> = { claude: "Claude", cod
  * the accessible name.
  */
 export function EngineAccountSwitch({ engine, projectContext }: { engine: "claude" | "codex"; projectContext?: ProjectAccountContext }) {
-  return <EngineAccountSwitchControl state={useEngineAccounts(engine)} projectContext={projectContext} />;
+  const isMobile = useIsMobile();
+  /* The phone has one accounts surface (mobile v2 lane 9, README §4.8): the
+     Accounts & limits screen. The trigger pushes it instead of floating the
+     desktop dialog over whatever the operator is looking at. */
+  const openScreen = isMobile ? () => getMobileNav().push({ kind: "accounts" }) : undefined;
+  return <EngineAccountSwitchControl state={useEngineAccounts(engine)} projectContext={projectContext} onOpenScreen={openScreen} />;
 }
 
 /** Interactive rendering half, separated so collapsed and expanded behavior
-    can be exercised with a deterministic account state. */
-export function EngineAccountSwitchControl({ state, projectContext }: { state: EngineAccountsState; projectContext?: ProjectAccountContext }) {
+    can be exercised with a deterministic account state. With `onOpenScreen`
+    the trigger hands over to that screen and never opens the dialog. */
+export function EngineAccountSwitchControl({ state, projectContext, onOpenScreen }: { state: EngineAccountsState; projectContext?: ProjectAccountContext; onOpenScreen?: () => void }) {
   const { t } = useLocale();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,11 +69,11 @@ export function EngineAccountSwitchControl({ state, projectContext }: { state: E
       <button
         ref={triggerRef}
         type="button"
-        aria-expanded={open}
+        aria-expanded={onOpenScreen ? undefined : open}
         aria-haspopup="dialog"
         aria-label={`${t("accounts.triggerAria", { engine: engineName })} — ${label}`}
         title={`${engineName} · ${label}`}
-        onClick={() => setOpen((value) => !value)}
+        onClick={() => (onOpenScreen ? onOpenScreen() : setOpen((value) => !value))}
         className="flex h-8 items-center gap-1 rounded-[7px] border border-border bg-canvas px-2 text-[11px] font-semibold hover:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
       >
         <span className="shrink-0 font-bold" style={{ color: tint.color }}>{engineName}</span>
@@ -76,7 +84,7 @@ export function EngineAccountSwitchControl({ state, projectContext }: { state: E
           <ChevronDown className="h-3 w-3 shrink-0 text-muted" aria-hidden />
         )}
       </button>
-      {open ? <AccountsPanel state={state} onClose={close} placement="header" projectContext={projectContext} /> : null}
+      {open && !onOpenScreen ? <AccountsPanel state={state} onClose={close} placement="header" projectContext={projectContext} /> : null}
     </div>
   );
 }

--- a/src/components/mobile/MobileShell.board.dom.test.tsx
+++ b/src/components/mobile/MobileShell.board.dom.test.tsx
@@ -355,6 +355,12 @@ test("Accounts & limits pushes the shell's accounts screen; ‹ returns to the b
   expect(q(root, '[data-mobile2-screen="board"]')).toBeNull();
   expect(q(root, "[data-mobile2-sheet]")).toBeNull();
   expect(q(root, "[data-mobile2-accounts]")).not.toBeNull();
+  /* Lane 9: what the screen holds is the phone's own accounts layout — one
+     section per engine over the same account store — never the desktop limits
+     footer it inherited from the project drawer. */
+  expect(q(root, "[data-mobile2-accounts-body]")).not.toBeNull();
+  expect([...root.querySelectorAll("[data-mobile2-accounts-engine]")].map((section) => section.getAttribute("data-mobile2-accounts-engine")))
+    .toEqual(["claude", "codex"]);
   const bar = q(root, "[data-mobile2-bar]")!;
   expect(q(bar, "[data-mobile2-back]")).not.toBeNull();
   expect(q(bar, '[data-mobile2-open="menu"]')).not.toBeNull();

--- a/src/components/mobile/MobileShell.tsx
+++ b/src/components/mobile/MobileShell.tsx
@@ -7,7 +7,7 @@ import type { ConnectionState } from "@/components/runtime/runtimeModel";
 import { useRuntimeBusState } from "@/hooks/useRuntime";
 import { useLocale } from "@/lib/i18n";
 
-import { LimitsFooter } from "../LimitsFooter";
+import { MobileAccountsPanel } from "../AccountsPanel";
 import { MobileReceipt } from "./MobileReceipt";
 import { screenKey, topScreen, useMobileNav, useMobileNavStore, type MobileScreenKind, type MobileSheetName } from "./mobileNav";
 
@@ -332,15 +332,14 @@ export function MobileBarTitle({ children }: { children: ReactNode }) {
 }
 
 /** The accounts screen the board menu pushes (README §3.1, §4.8): the shell's
-    bar with ‹ and the accounts surface the project drawer used to carry. Lane 9
-    lays the accounts out for the phone; the screen and its route are the
-    shell's. */
+    bar with ‹ over the phone's accounts layout (lane 9, `AccountsPanel.tsx`);
+    the screen and its route are the shell's. */
 export function MobileAccountsScreen({ host, renderSheet }: { host?: MobileShellHost | null; renderSheet?: SheetRenderer }) {
   const { t } = useLocale();
   return (
     <MobileShell screen="accounts" back title={<MobileBarTitle>{t("mobile2.accounts.title")}</MobileBarTitle>} host={host} renderSheet={renderSheet}>
-      <div className="min-h-0 flex-1 overflow-y-auto" data-mobile2-accounts>
-        <LimitsFooter />
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain" data-mobile2-accounts>
+        <MobileAccountsPanel />
       </div>
     </MobileShell>
   );

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2540,4 +2540,29 @@ export const en = {
   "mobile2.chat.draftMeta": "draft · not sent yet",
   "mobile2.chat.menuPredecessor": "Predecessor · round {round}",
   "mobile2.chat.menuSeat": "Orchestrator seat",
+  /* Mobile v2 accounts & limits screen (#1439, lane 9): per engine, the
+     active account as a card with its windows and actions, the other accounts
+     as quiet rows, sign-in rows, and the add row. Append-only, keys prefixed
+     mobile2.accounts.* */
+  "mobile2.accounts.ready": "ready",
+  "mobile2.accounts.pending": "signing in",
+  "mobile2.accounts.plan": "{plan} plan",
+  "mobile2.accounts.checked": "checked {time}",
+  "mobile2.accounts.noReading": "no reading yet",
+  "mobile2.accounts.noAccounts": "No {engine} accounts yet",
+  "mobile2.accounts.cornerAria": "{left}% left of the {window} window",
+  "mobile2.accounts.windowAria": "{window} window for {label}",
+  "mobile2.accounts.signIn": "sign in",
+  "mobile2.accounts.signInAria": "Sign in to {label}",
+  "mobile2.accounts.signInStarted": "Device sign-in opened for {label} — it becomes active once signed in",
+  "mobile2.accounts.signInFailed": "Could not open the device sign-in for {label}",
+  "mobile2.accounts.openSignIn": "Open the device sign-in",
+  "mobile2.accounts.switchAria": "Use {label} for future launches",
+  "mobile2.accounts.switched": "Future launches use {label}",
+  "mobile2.accounts.refreshed": "Limits re-read for {label}",
+  "mobile2.accounts.resetUsed": "Reset used on {label}",
+  "mobile2.accounts.add": "Add a {engine} account",
+  "mobile2.accounts.addHint": "opens the device sign-in",
+  "mobile2.accounts.addLabel": "Label for the new account",
+  "mobile2.accounts.addCancel": "Cancel",
 } satisfies Dictionary;

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -2463,4 +2463,28 @@ export const uk: Record<keyof typeof en, Message> = {
   "mobile2.chat.draftMeta": "чернетка · ще не надіслано",
   "mobile2.chat.menuPredecessor": "Попередник · раунд {round}",
   "mobile2.chat.menuSeat": "Місце оркестратора",
+  /* Екран акаунтів і лімітів mobile v2 (#1439, лінія 9): для кожного рушія
+     активний акаунт як картка з вікнами й діями, решта — тихі рядки, рядки
+     входу та рядок додавання. Лише дописування, ключі mobile2.accounts.* */
+  "mobile2.accounts.ready": "готовий",
+  "mobile2.accounts.pending": "вхід триває",
+  "mobile2.accounts.plan": "план {plan}",
+  "mobile2.accounts.checked": "перевірено {time}",
+  "mobile2.accounts.noReading": "ще без показників",
+  "mobile2.accounts.noAccounts": "Акаунтів {engine} ще немає",
+  "mobile2.accounts.cornerAria": "{left}% лишилося у вікні {window}",
+  "mobile2.accounts.windowAria": "Вікно {window} для {label}",
+  "mobile2.accounts.signIn": "увійти",
+  "mobile2.accounts.signInAria": "Увійти в {label}",
+  "mobile2.accounts.signInStarted": "Відкрито вхід через пристрій для {label} — стане активним після входу",
+  "mobile2.accounts.signInFailed": "Не вдалося відкрити вхід через пристрій для {label}",
+  "mobile2.accounts.openSignIn": "Відкрити вхід через пристрій",
+  "mobile2.accounts.switchAria": "Використовувати {label} для наступних запусків",
+  "mobile2.accounts.switched": "Наступні запуски використовують {label}",
+  "mobile2.accounts.refreshed": "Ліміти перечитано для {label}",
+  "mobile2.accounts.resetUsed": "Скидання використано на {label}",
+  "mobile2.accounts.add": "Додати акаунт {engine}",
+  "mobile2.accounts.addHint": "відкриває вхід через пристрій",
+  "mobile2.accounts.addLabel": "Назва нового акаунта",
+  "mobile2.accounts.addCancel": "Скасувати",
 };


### PR DESCRIPTION
Mobile v2 slice 9 from `docs/design/mobile-v2/README.md` §8 row 9: the phone's Accounts & limits screen, mounted into the shipped `MobileShell`.

- switch / refresh / use-reset act on a single tap, with receipts
- a row that is not signed in opens the device sign-in and stays inactive (Claude and Codex paths)
- the corner number names its window; meters fill with what REMAINS
- `capture-issue-1418` still green, its phone half re-pointed at the mobile v2 screen

Desktop behaviour unchanged — the desktop half of `AccountsPanel` is a pure extraction of `limitRows`. i18n is append-only under `mobile2.accounts.*`.

Gates at `78d06659`: `bunx tsc --noEmit --incremental false` exit 0; tests by path green (accounts 10/20/35, switch 3+3, shell 9+10, harness 33, i18n 20); `capture-mobile-v2 --only=accounts --strict` green at both sizes and schemes; privacy gate PASS.

Reviewed fresh-context on Opus: NO FINDINGS — APPROVE.