### PR TITLE
fix(mobile-v2): dictation keeps the composer controls reachable (#1483)

### DIFF
--- a/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
+++ b/src/components/mobile/MobileFocusView.keyboardInset.dom.test.tsx
@@ -202,7 +202,7 @@ test("integrated, portrait keyboard: long draft caps at 160px and the chrome fit
   expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(400);
 });
 
-test("integrated, rotated keyboard: the field yields below 160px so picker and send fit (#983 round 2)", async () => {
+test("integrated, a 280px visible viewport: the whole composer unit still fits it (#983 round 2, #1483)", async () => {
   dom.sessionStorage.setItem("llvDraft:/session", LONG_DRAFT);
   const vv = makeVisualViewport(280);
   (dom as unknown as Record<string, unknown>).visualViewport = vv;
@@ -214,9 +214,14 @@ test("integrated, rotated keyboard: the field yields below 160px so picker and s
   const textarea = composerTextarea();
   expect(textarea).not.toBeNull();
   expect(textarea.value).toBe(LONG_DRAFT);
-  expect(textarea.style.height).toBe("124px");
-  expect(124 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
-  /* Past the shrunken ceiling the field scrolls internally (issue #177 item 3
+  /* #983 reserved 156px of chrome here — a docked focus strip, a separate
+     conversation header and a 44px picker row under the input — and shrank the
+     field to 124px to pay for it. Mobile v2 renders none of the three, so the
+     reserve is the bar plus the composer box's own chrome (#1483) and the
+     shared 160px cap fits inside 280 again. */
+  expect(textarea.style.height).toBe("160px");
+  expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
+  /* Past the ceiling the field scrolls internally (issue #177 item 3
      preserved), never the window. */
   expect(textarea.className).toContain("overflow-y-auto");
 });

--- a/src/components/mobile/chatBudget.ts
+++ b/src/components/mobile/chatBudget.ts
@@ -31,7 +31,11 @@ export const BAR_PX = 52;
 /** The composer unit (§2 rule 8, §3.4): one box holding the field (32) and the
     tools row (44) — chip, attach, dictate, send slot — plus its padding and the
     14 px home inset. The inset lives INSIDE this number, which is why the
-    budget below subtracts no safe-area of its own. */
+    budget below subtracts no safe-area of its own. This is the unit at REST;
+    `MOBILE_COMPOSER_UNIT_CHROME_PX` in `lib/composerScroll` is the same box
+    counted from the other side — everything in these 109 px except the field —
+    and it is what the grow ceiling reserves so a dictated field never pushes
+    the tools row out of the box (#1483). */
 export const COMPOSER_PX = 109;
 /** The one banner slot under the bar (§2 rule 3): offline, degraded, or a
     decision that arrived elsewhere. It reserves its height in flow, so it is

--- a/src/hooks/useComposer.dictationInsert.dom.test.tsx
+++ b/src/hooks/useComposer.dictationInsert.dom.test.tsx
@@ -1,0 +1,187 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { useComposer, type UseComposerReturn } from "@/hooks/useComposer";
+import { COMPOSER_MAX_PX } from "@/lib/composerScroll";
+
+import { ComposerBar } from "@/components/ComposerBar";
+
+/*
+ * Issue #1483, cause 2 — a dictated chunk must never move the operator's
+ * viewport.
+ *
+ * `insertSpoken` runs on EVERY dictated segment: the realtime commits while
+ * the operator is still talking (`onLiveCommit`) and the transcript of a
+ * capped auto-stop (`onUnclaimedText`). It drops the caret at the end and
+ * scrolls the newest words into view, which is right. It did that after an
+ * unqualified `el.focus()`, and an unqualified focus lets the browser scroll
+ * the focused element into view — scrolling the composer's own scroll box, and
+ * on iOS the window with it. Dictating a long transcript, the operator scrolled
+ * down to reach Stop and the next chunk lifted the view straight back up.
+ *
+ * The newest words stay visible through the field's OWN `scrollTop`; nothing
+ * outside the textarea may move. The focus call is where that is decided, so
+ * this file asserts the call itself: `preventScroll` is the browser's one
+ * switch for "do not scroll anything to reach this element", and a focus call
+ * without it is a focus call that can scroll the page.
+ */
+
+const dom = new Window({ width: 390, height: 844 });
+/* rAF resolved by hand: `insertSpoken` defers its focus/caret/scroll work by a
+   frame, and a timer-driven frame would race the assertions. */
+let frames: (() => void)[] = [];
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  requestAnimationFrame: (cb: () => void) => frames.push(cb),
+  cancelAnimationFrame: () => {},
+});
+let mobile = true;
+(dom as unknown as { matchMedia(query: string): unknown }).matchMedia = (query: string) => ({
+  matches: mobile && query.includes("max-width"),
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+/* The field always overflows, so every insert lands past the grow ceiling and
+   has somewhere to scroll to. */
+const proto = dom.HTMLElement.prototype as unknown as Record<string, unknown>;
+Object.defineProperty(proto, "scrollHeight", { configurable: true, get: () => 2000 });
+
+function flushFrames(): void {
+  const queued = frames;
+  frames = [];
+  for (const cb of queued) cb();
+}
+
+let roots: Root[] = [];
+afterEach(() => {
+  for (const r of roots) flushSync(() => r.unmount());
+  roots = [];
+  frames = [];
+  mobile = true;
+  dom.document.body.replaceChildren();
+});
+afterAll(() => {
+  delete (proto as { scrollHeight?: unknown }).scrollHeight;
+});
+
+let composer: UseComposerReturn | null = null;
+function Harness() {
+  composer = useComposer({ initialText: () => "already typed", persistText: () => {}, submit: () => {} });
+  return (
+    <ComposerBar
+      composer={composer}
+      placeholder="Prompt"
+      textareaAriaLabel="Prompt"
+      imageAriaLabel="Add images"
+      leftSlot={<button type="button">model picker</button>}
+      sendLabelIdle="Send"
+      sendLabelRecording="Stop"
+      sendIdleClassName="bg-accent"
+    />
+  );
+}
+
+interface Spies {
+  field: HTMLTextAreaElement;
+  focusCalls: unknown[];
+  scrolledIntoView: number;
+  windowScrolls: number;
+}
+
+function mountComposer(): Spies {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  roots.push(root);
+  flushSync(() => root.render(<Harness />));
+  const field = host.querySelector("textarea") as unknown as HTMLTextAreaElement;
+  const spies: Spies = { field, focusCalls: [], scrolledIntoView: 0, windowScrolls: 0 };
+  /* Own properties shadow the prototype methods for this element only. */
+  field.focus = ((options?: unknown) => { spies.focusCalls.push(options); }) as HTMLTextAreaElement["focus"];
+  field.scrollIntoView = (() => { spies.scrolledIntoView += 1; }) as HTMLTextAreaElement["scrollIntoView"];
+  (dom as unknown as { scrollTo: () => void }).scrollTo = () => { spies.windowScrolls += 1; };
+  return spies;
+}
+
+test("a dictated chunk focuses the field without letting the browser scroll to it (#1483)", () => {
+  const spies = mountComposer();
+  flushSync(() => composer!.insertSpoken("the first dictated chunk"));
+  flushFrames();
+
+  /* One focus, and it carries the browser's "do not scroll to reach this"
+     switch. Without `preventScroll` the browser scrolls every ancestor — the
+     composer's own scroll box, then the window — to bring the field into view,
+     which is the jump the operator reported. */
+  expect(spies.focusCalls).toHaveLength(1);
+  expect(spies.focusCalls[0]).toBeDefined();
+  expect((spies.focusCalls[0] as { preventScroll?: boolean }).preventScroll).toBe(true);
+});
+
+test("every chunk of a long dictation keeps the same promise (#1483)", () => {
+  const spies = mountComposer();
+  for (const chunk of ["one", "two", "three", "four", "five"]) {
+    flushSync(() => composer!.insertSpoken(chunk));
+    flushFrames();
+  }
+  expect(spies.focusCalls).toHaveLength(5);
+  for (const options of spies.focusCalls) {
+    expect((options as { preventScroll?: boolean } | undefined)?.preventScroll).toBe(true);
+  }
+});
+
+test("the newest words stay visible inside the field, which scrolls internally (#1483)", () => {
+  const spies = mountComposer();
+  flushSync(() => composer!.insertSpoken("the newest words"));
+  /* Zeroed after the render's own autosize pass, so what the frame does next
+     is attributable to the insert alone. */
+  spies.field.scrollTop = 0;
+  flushFrames();
+
+  /* The field itself scrolls to its bottom — the one scroll this insert is
+     allowed to perform. */
+  expect(spies.field.scrollTop).toBe(spies.field.scrollHeight);
+  /* And the caret follows the text, so the operator keeps typing at the end. */
+  expect(spies.field.selectionStart).toBe(spies.field.value.length);
+  expect(spies.field.selectionEnd).toBe(spies.field.value.length);
+  /* Nothing outside the textarea moved: no element scrolled into view, no
+     window scroll. Both are the other roads to the same regression. */
+  expect(spies.scrolledIntoView).toBe(0);
+  expect(spies.windowScrolls).toBe(0);
+});
+
+test("desktop keeps its own ceiling and the same insert contract (#1483 changes nothing there)", () => {
+  mobile = false;
+  const spies = mountComposer();
+  /* The desktop ceiling is the fixed shared cap, untouched by the phone's
+     box budget: the overflowing field stops at COMPOSER_MAX_PX. */
+  expect(spies.field.style.height).toBe(`${COMPOSER_MAX_PX}px`);
+  flushSync(() => composer!.insertSpoken("spoken on a desktop"));
+  spies.field.scrollTop = 0;
+  flushFrames();
+  /* Focus, caret at the end and the field scrolled to the newest words — the
+     desktop's insert behaviour as it was. The one thing it now shares with the
+     phone is that reaching the field scrolls nothing around it. */
+  expect(spies.focusCalls).toHaveLength(1);
+  expect((spies.focusCalls[0] as { preventScroll?: boolean }).preventScroll).toBe(true);
+  expect(spies.field.scrollTop).toBe(spies.field.scrollHeight);
+  expect(spies.field.selectionStart).toBe(spies.field.value.length);
+  expect(spies.scrolledIntoView).toBe(0);
+  expect(spies.windowScrolls).toBe(0);
+});
+
+test("the insert appends to what is already typed and clears the last status (#1483 keeps today's contract)", () => {
+  const spies = mountComposer();
+  flushSync(() => composer!.setStatus({ kind: "err", text: "an earlier failure" }));
+  flushSync(() => composer!.insertSpoken("spoken words"));
+  flushFrames();
+  expect(spies.field.value).toBe("already typed spoken words");
+  expect(composer!.status).toBeNull();
+});

--- a/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
+++ b/src/hooks/useComposer.keyboardCeiling.dom.test.tsx
@@ -4,7 +4,7 @@ import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
 import { useComposer } from "@/hooks/useComposer";
-import { MOBILE_COMPOSER_CHROME_PX } from "@/lib/composerScroll";
+import { MOBILE_COMPOSER_CHROME_PX, MOBILE_COMPOSER_UNIT_CHROME_PX, mobileComposerUnitMax } from "@/lib/composerScroll";
 
 import { ComposerBar } from "@/components/ComposerBar";
 
@@ -15,6 +15,16 @@ import { ComposerBar } from "@/components/ComposerBar";
  * window.visualViewport reports the shrunken visible area. Sizing the field at
  * 40% of innerHeight then overflows the visible half-screen, pushing the model
  * picker and send/mic controls under the keyboard.
+ *
+ * Issue #1483 adds the second viewport the ceiling has to answer to. The
+ * composer is ONE box — field on top, tools row under it — inside a form whose
+ * own `max-h-[min(38dvh,20rem)]` scrolls what it cannot show, and `dvh` is the
+ * LAYOUT viewport, which the keyboard never shrinks. A field sized only against
+ * the visible area therefore still overflowed its own box while dictating with
+ * the keyboard down: the tools row holding Stop went below the box's bottom
+ * edge, reachable only by scrolling. So every height asserted here is checked
+ * against both bounds, and the #983 numbers that assumed the retired chrome are
+ * restated against the chrome the phone renders today.
  */
 
 /* A minimal visualViewport stand-in — happy-dom does not provide one. Resize
@@ -58,6 +68,12 @@ Object.defineProperty(proto, "scrollHeight", { configurable: true, get: () => 20
 
 const G = globalThis as { visualViewport?: unknown } & Record<string, unknown>;
 
+/** Put the layout viewport on a real phone frame before mounting: the box
+    budget is written in `dvh`, so the LAYOUT height is half the input. */
+function layoutViewport(width: number, height: number): void {
+  dom.happyDOM.setViewport({ width, height });
+}
+
 let roots: Root[] = [];
 afterEach(() => {
   for (const r of roots) flushSync(() => r.unmount());
@@ -65,6 +81,7 @@ afterEach(() => {
   dom.document.body.replaceChildren();
   delete (dom as unknown as Record<string, unknown>).visualViewport;
   delete G.visualViewport;
+  layoutViewport(390, 800);
 });
 afterAll(() => {
   delete (proto as { scrollHeight?: unknown }).scrollHeight;
@@ -102,71 +119,83 @@ function mountComposer(): HTMLTextAreaElement {
   return host.querySelector("textarea") as unknown as HTMLTextAreaElement;
 }
 
-test("keyboard open: the ceiling tracks the visual viewport, not the layout viewport (#983)", () => {
-  /* Layout viewport 800px, keyboard eating half: visible 400px. The field may
-     take 40% of what the user can SEE — max(160, 0.4·400) = 160px — never 40%
-     of the full screen (320px), which would not fit above the keyboard. */
-  const vv = makeVisualViewport(400);
+function openKeyboard(visible: number) {
+  const vv = makeVisualViewport(visible);
   (dom as unknown as Record<string, unknown>).visualViewport = vv;
   G.visualViewport = vv;
-  const textarea = mountComposer();
-  expect(dom.innerHeight).toBe(800);
-  expect(textarea.style.height).toBe("160px");
-});
+  return vv;
+}
 
-test("keyboard closes: a visualViewport resize re-opens the tall ceiling (#983)", () => {
-  const vv = makeVisualViewport(400);
-  (dom as unknown as Record<string, unknown>).visualViewport = vv;
-  G.visualViewport = vv;
-  const textarea = mountComposer();
-  expect(textarea.style.height).toBe("160px");
-  /* The keyboard folds away — only visualViewport says so on iOS. */
-  flushSync(() => vv.resizeTo(800));
-  expect(textarea.style.height).toBe("320px");
-});
-
-test("pinch zoom is not a keyboard: the scale factor cancels out of the budget (#983)", () => {
-  /* Zoomed 2×, no keyboard: the visual viewport halves in CSS px but the
-     layout budget is unchanged — the field keeps its full 40% ceiling. */
-  const vv = makeVisualViewport(400);
-  vv.scale = 2;
-  (dom as unknown as Record<string, unknown>).visualViewport = vv;
-  G.visualViewport = vv;
-  const textarea = mountComposer();
-  expect(textarea.style.height).toBe("320px");
-});
-
-test("rotated keyboard: the ceiling shrinks below 160px so the chrome fits the visible area (#983 round 2)", () => {
-  /* Landscape phone, keyboard up: 280px visible. The old 160px floor plus the
-     mandatory chrome (focus strip, conversation header, 44px picker row —
-     MOBILE_COMPOSER_CHROME_PX) needs ~316px, and the overflow-clipped shell
-     hides the overflow — the picker was unreachable. The ceiling must yield
-     the chrome's share first: 280 − 156 = 124px. */
-  const vv = makeVisualViewport(280);
-  (dom as unknown as Record<string, unknown>).visualViewport = vv;
-  G.visualViewport = vv;
-  const textarea = mountComposer();
-  expect(textarea.style.height).toBe("124px");
-  /* The arithmetic that decides visibility inside the clipped shell. */
-  expect(124 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
-  /* The tools row is present with its 44px row contract — the chip, the
-     picker and the send slot all still reachable — and the field scrolls
-     internally past the shrunken ceiling instead of pushing them out. */
+/** The two bounds a rendered field height has to clear at once (#1483): its
+    own box, and the visible area under the bar. */
+function expectToolsRowReachable(textarea: HTMLTextAreaElement, visible: number, layout: number): void {
+  const field = Number.parseInt(textarea.style.height, 10);
+  expect(field + MOBILE_COMPOSER_UNIT_CHROME_PX).toBeLessThanOrEqual(mobileComposerUnitMax(layout));
+  expect(field + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(visible);
+  /* The row itself is rendered, at its 44px contract, with the picker in it. */
   const row = dom.document.querySelector("[data-mobile2-tools]") as unknown as HTMLElement;
   expect(row).not.toBeNull();
   expect(row.className).toContain("min-h-11");
   expect(row.textContent).toContain("model picker");
+  /* Past the ceiling the field scrolls internally, never the page. */
   expect(textarea.className).toContain("overflow-y-auto");
+}
+
+test("keyboard open: the ceiling budgets against the visual viewport (#983)", () => {
+  /* Layout viewport 800px, keyboard eating half: visible 400px. The field may
+     take 40% of what the user can SEE — max(160, 0.4·400) = 160px — never 40%
+     of the full screen (320px), which would not fit above the keyboard. */
+  openKeyboard(400);
+  const textarea = mountComposer();
+  expect(dom.innerHeight).toBe(800);
+  expect(textarea.style.height).toBe("160px");
+  expectToolsRowReachable(textarea, 400, 800);
 });
 
-test("smaller rotated viewport: send stays visible because the field yields further (#983 round 2)", () => {
-  /* At 240px visible the budget after chrome is 84px — still above the 44px
-     one-row floor, so the field shrinks rather than pushing Send out. */
-  const vv = makeVisualViewport(240);
-  (dom as unknown as Record<string, unknown>).visualViewport = vv;
-  G.visualViewport = vv;
+test("keyboard closes: a visualViewport resize re-opens the tall ceiling (#983)", () => {
+  const vv = openKeyboard(400);
   const textarea = mountComposer();
-  expect(textarea.style.height).toBe("84px");
+  expect(textarea.style.height).toBe("160px");
+  /* The keyboard folds away — only visualViewport says so on iOS. */
+  flushSync(() => vv.resizeTo(800));
+  /* #983 re-opened this to a flat 320px, 40% of the 800px screen. The box the
+     field lives in tops out at min(38dvh, 20rem) = 304px here, and the tools
+     row needs 65 of those, so the field re-opens to 239 — still far past the
+     shared 160px cap, and now with Stop inside the box beside it. */
+  expect(textarea.style.height).toBe("239px");
+  expectToolsRowReachable(textarea, 800, 800);
+});
+
+test("pinch zoom is not a keyboard: the scale factor cancels out of the budget (#983)", () => {
+  /* Zoomed 2×, no keyboard: the visual viewport halves in CSS px but the
+     layout budget is unchanged — the field keeps its full ceiling. */
+  const vv = openKeyboard(400);
+  vv.scale = 2;
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("239px");
+  expectToolsRowReachable(textarea, 800, 800);
+});
+
+test("a keyboard-open viewport too short for the cap yields the chrome's share first (#983 round 2)", () => {
+  /* 280px visible on the 800px layout. #983 reserved 156px here — a docked
+     focus strip, a conversation header and a picker row under the input — and
+     shrank the field to 124px to pay for them. Mobile v2 renders none of the
+     three, so the honest reserve is 117 (the bar plus the box's own chrome)
+     and the 160px cap fits inside 280 again. */
+  openKeyboard(280);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("160px");
+  expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(280);
+  expectToolsRowReachable(textarea, 280, 800);
+});
+
+test("smaller visible viewport: send stays visible because the field yields further (#983 round 2)", () => {
+  /* At 240px visible the budget after chrome is 123px — still above the 44px
+     one-row floor, so the field shrinks rather than pushing Send out. */
+  openKeyboard(240);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("123px");
+  expectToolsRowReachable(textarea, 240, 800);
   const send = dom.document.querySelector('button[aria-label="Send"]') as unknown as HTMLElement;
   expect(send).not.toBeNull();
   /* The 44px tap-target contract. Mobile v2 makes the phone's slot a REAL
@@ -177,16 +206,53 @@ test("smaller rotated viewport: send stays visible because the field yields furt
 });
 
 test("an absurdly small visible viewport floors the field at one tap-target row (#983 round 2)", () => {
-  const vv = makeVisualViewport(150);
-  (dom as unknown as Record<string, unknown>).visualViewport = vv;
-  G.visualViewport = vv;
+  openKeyboard(150);
   const textarea = mountComposer();
   expect(textarea.style.height).toBe("44px");
 });
 
 test("without visualViewport the layout viewport still drives the ceiling (#177 item 3)", () => {
-  /* Older browsers / SSR hydration: no visualViewport at all. Today's
-     behaviour is preserved — 40% of window.innerHeight. */
+  /* Older browsers / SSR hydration: no visualViewport at all. The field still
+     opens into a tall multi-line input, bounded by its own box. */
   const textarea = mountComposer();
-  expect(textarea.style.height).toBe("320px");
+  expect(textarea.style.height).toBe("239px");
+  expectToolsRowReachable(textarea, 800, 800);
+});
+
+test("390×844 dictating with the keyboard down: Stop stays inside the box (#1483)", () => {
+  /* The operator's report. 40% of 844 is 338px, and 338 + the box's own 65px
+     of chrome is 403 — 83px past the form's 320px max-height, so the form
+     scrolled and the tools row sat below its bottom edge. The field takes 255
+     instead: 255 + 65 = 320 exactly, the whole unit visible with no scroll. */
+  layoutViewport(390, 844);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("255px");
+  expectToolsRowReachable(textarea, 844, 844);
+});
+
+test("430×932 dictating with the keyboard down: the taller phone gets the same promise (#1483)", () => {
+  layoutViewport(430, 932);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("255px");
+  expectToolsRowReachable(textarea, 932, 932);
+});
+
+test("390×844 with the keyboard up keeps its 40% share unchanged (#1483 costs the keyboard case nothing)", () => {
+  layoutViewport(390, 844);
+  openKeyboard(508);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("203px");
+  expectToolsRowReachable(textarea, 508, 844);
+});
+
+test("a rotated landscape phone: the box's own dvh cap is the tighter bound (#1483)", () => {
+  /* 844×390 rotated, keyboard up. The layout viewport is 390px tall, so the
+     box tops out at 38dvh = 148px and the field takes 83 of it. Budgeting the
+     box against the VISIBLE height would have under-read every keyboard-open
+     portrait frame, which is why the ceiling reads both viewports. */
+  layoutViewport(844, 390);
+  openKeyboard(280);
+  const textarea = mountComposer();
+  expect(textarea.style.height).toBe("83px");
+  expectToolsRowReachable(textarea, 280, 390);
 });

--- a/src/hooks/useComposer.ts
+++ b/src/hooks/useComposer.ts
@@ -30,6 +30,14 @@ function subscribeViewport(onChange: () => void) {
 function useViewportHeight(): number {
   return useSyncExternalStore(subscribeViewport, () => visibleViewportHeight(window.innerHeight, window.visualViewport), () => 800);
 }
+/* The LAYOUT viewport height, tracked beside the visible one. The composer
+   box's own maximum height is written in `dvh`, which the on-screen keyboard
+   does not shrink (#983), so the ceiling needs both numbers: the visible one
+   says what fits above the keyboard, this one says how tall the composer's own
+   scroll box is allowed to be (#1483). */
+function useLayoutViewportHeight(): number {
+  return useSyncExternalStore(subscribeViewport, () => window.innerHeight, () => 800);
+}
 
 /**
  * The on-screen keyboard's overlap with the layout viewport (#983): how much of
@@ -161,10 +169,16 @@ export function useComposer({ initialText, persistText, submit, disabled = false
      screen — budgeting against the full layout height there grew the field
      past what fits above the keyboard and pushed the picker/send controls out
      of view (#983); on a short rotated viewport even the 160px cap overflows,
-     so the ceiling yields the chrome's share first and shrinks below it. */
+     so the ceiling yields the chrome's share first and shrinks below it.
+     The LAYOUT height goes in beside it because the composer box's own cap is
+     written in `dvh`, which the keyboard leaves alone: with the keyboard DOWN
+     the visible viewport says the field has room it does not have, and the
+     field grew until the tools row holding Stop fell out of its own box
+     (#1483). */
   const isMobile = useIsMobile();
   const viewportH = useViewportHeight();
-  const maxPx = isMobile ? mobileComposerCeiling(viewportH) : COMPOSER_MAX_PX;
+  const layoutH = useLayoutViewportHeight();
+  const maxPx = isMobile ? mobileComposerCeiling(viewportH, layoutH) : COMPOSER_MAX_PX;
 
   const attachments = useImageAttachments({
     onError: (message) => setStatus({ kind: "err", text: message }),
@@ -178,11 +192,18 @@ export function useComposer({ initialText, persistText, submit, disabled = false
     setStatus(null);
     /* After the state-driven value updates, drop the caret at the end and
        scroll the newest words into view — an insert always follows the text,
-       so the batch/unclaimed transcript never lands off-screen. */
+       so the batch/unclaimed transcript never lands off-screen.
+
+       `preventScroll` is what keeps that promise to the field alone (#1483):
+       an unqualified focus() lets the browser scroll every ancestor to bring
+       the field into view, and dictation calls this on EVERY segment, so each
+       chunk yanked the operator's viewport back up — off the Stop control they
+       had just scrolled down to reach. The field's own scrollTop below shows
+       the newest words without moving anything outside the textarea. */
     requestAnimationFrame(() => {
       const el = inputRef.current;
       if (!el) return;
-      el.focus();
+      el.focus({ preventScroll: true });
       const end = el.value.length;
       el.setSelectionRange(end, end);
       el.scrollTop = el.scrollHeight;

--- a/src/lib/composerScroll.test.ts
+++ b/src/lib/composerScroll.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
-import { caretAtEnd, clampHeight, keyboardInset, MOBILE_COMPOSER_CHROME_PX, mobileComposerCeiling, shouldPin, visibleViewportHeight } from "./composerScroll";
+import {
+  caretAtEnd,
+  clampHeight,
+  keyboardInset,
+  MOBILE_COMPOSER_CHROME_PX,
+  MOBILE_COMPOSER_UNIT_CHROME_PX,
+  mobileComposerCeiling,
+  mobileComposerUnitMax,
+  shouldPin,
+  visibleViewportHeight,
+} from "./composerScroll";
 
 describe("clampHeight grows to fit then caps", () => {
   test("adds the 2px border allowance below the cap", () => {
@@ -67,24 +77,108 @@ describe("visibleViewportHeight — the keyboard-aware layout budget (#983)", ()
   });
 });
 
-describe("mobileComposerCeiling — the phone grow ceiling against the visible viewport (#983)", () => {
-  test("a full portrait viewport grows to 40%", () => {
-    expect(mobileComposerCeiling(800)).toBe(320);
+describe("mobileComposerCeiling — the phone grow ceiling against the visible viewport (#983, #1483)", () => {
+  test("a full portrait viewport grows to what the composer box can show", () => {
+    /* #983 read this as a flat 40% of the visible viewport (320px at 800).
+       That share ignored the box the field lives in: 320 + the unit's own
+       chrome overflows the composer's `max-h-[min(38dvh,20rem)]`, and the
+       overflow is the tools row. The field takes the box's budget instead. */
+    expect(mobileComposerCeiling(800, 800)).toBe(mobileComposerUnitMax(800) - MOBILE_COMPOSER_UNIT_CHROME_PX);
+    expect(mobileComposerCeiling(800, 800)).toBe(239);
   });
 
   test("a portrait keyboard-open viewport holds the 160px cap — the chrome still fits", () => {
-    expect(mobileComposerCeiling(400)).toBe(160);
+    expect(mobileComposerCeiling(400, 800)).toBe(160);
     expect(160 + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(400);
   });
 
+  test("the 40% grow rule still governs the range between the cap and the box budget", () => {
+    /* 390×844 and 430×932 with the keyboard up: 40% of what the operator can
+       see, unchanged by #1483 — the box has room for it. */
+    expect(mobileComposerCeiling(508, 844)).toBe(203);
+    expect(mobileComposerCeiling(596, 932)).toBe(238);
+  });
+
   test("a rotated keyboard-open viewport yields below 160px to keep the chrome visible (round 2)", () => {
-    expect(mobileComposerCeiling(280)).toBe(280 - MOBILE_COMPOSER_CHROME_PX);
-    expect(mobileComposerCeiling(240)).toBe(240 - MOBILE_COMPOSER_CHROME_PX);
+    /* Landscape: the layout viewport is 390px tall, so the composer box's own
+       38dvh cap is the tighter of the two bounds and the field yields to it. */
+    expect(mobileComposerCeiling(280, 390)).toBe(mobileComposerUnitMax(390) - MOBILE_COMPOSER_UNIT_CHROME_PX);
+    expect(mobileComposerCeiling(280, 390)).toBe(83);
+    expect(mobileComposerCeiling(240, 390)).toBe(83);
+  });
+
+  test("a visible viewport too short for the box budget yields to the keyboard instead", () => {
+    /* Below ~200px visible the bar plus the unit's chrome is what binds, and
+       the field gives up the difference. */
+    expect(mobileComposerCeiling(180, 390)).toBe(180 - MOBILE_COMPOSER_CHROME_PX);
   });
 
   test("never collapses below one 44px tap-target row", () => {
-    expect(mobileComposerCeiling(150)).toBe(44);
-    expect(mobileComposerCeiling(0)).toBe(44);
+    /* The one case that outranks the reachability arithmetic below: on a
+       viewport this small no field height keeps the tools row in view, and a
+       0px field would be worse than an overflowing one. */
+    expect(mobileComposerCeiling(150, 390)).toBe(44);
+    expect(mobileComposerCeiling(0, 0)).toBe(44);
+  });
+});
+
+/*
+ * Issue #1483 — dictation must never push Stop out of reach. The mobile v2
+ * composer is ONE box: the field on top and the tools row (chip · attach ·
+ * dictate · send slot) under it, inside the same border, inside a form whose
+ * own `max-h-[min(38dvh,20rem)]` scrolls what it cannot show. So the ceiling
+ * has two bounds to respect at once, and the operator loses Stop when either
+ * is broken: the field must fit its own box beside the tools row, AND the
+ * whole unit must fit the visible area under the bar.
+ */
+describe("mobileComposerCeiling — the grown field never pushes its own tools row out of reach (#1483)", () => {
+  const PHONES = [
+    { name: "390×844 portrait, keyboard closed (dictating)", visible: 844, layout: 844 },
+    { name: "390×844 portrait, keyboard open", visible: 508, layout: 844 },
+    { name: "430×932 portrait, keyboard closed (dictating)", visible: 932, layout: 932 },
+    { name: "430×932 portrait, keyboard open", visible: 596, layout: 932 },
+    { name: "375×667 portrait, keyboard closed", visible: 667, layout: 667 },
+    { name: "375×667 portrait, keyboard open", visible: 331, layout: 667 },
+    { name: "844×390 landscape, keyboard closed", visible: 390, layout: 390 },
+    { name: "844×390 landscape, keyboard open", visible: 280, layout: 390 },
+  ];
+
+  for (const phone of PHONES) {
+    test(`${phone.name}: the tools row stays inside the box and above the keyboard`, () => {
+      const field = mobileComposerCeiling(phone.visible, phone.layout);
+      /* Inside the composer's own scroll box: past this the FORM scrolls, and
+         reaching Stop costs a scroll that the next dictated chunk undoes. */
+      expect(field + MOBILE_COMPOSER_UNIT_CHROME_PX).toBeLessThanOrEqual(mobileComposerUnitMax(phone.layout));
+      /* Inside what the operator can see, under the one bar. */
+      expect(field + MOBILE_COMPOSER_CHROME_PX).toBeLessThanOrEqual(phone.visible);
+      /* Still a comfortable multi-line input: at 22px leading, four rows. */
+      expect(field).toBeGreaterThanOrEqual(83);
+    });
+  }
+
+  test("the reserve is the chrome the phone actually renders: the bar plus the unit's own", () => {
+    /* 52 (the one bar) + 65 (tools row 44, box padding and border 8, form
+       padding and top border 13). The #983 number reserved 156 for a docked
+       focus strip, a separate conversation header and a picker row under the
+       input, and mobile v2 renders none of those. */
+    expect(MOBILE_COMPOSER_UNIT_CHROME_PX).toBe(65);
+    expect(MOBILE_COMPOSER_CHROME_PX).toBe(52 + MOBILE_COMPOSER_UNIT_CHROME_PX);
+  });
+
+  test("the box budget follows the form's own max-height, in layout px", () => {
+    /* `min(38dvh, 20rem)`. `dvh` ignores the on-screen keyboard, so the budget
+       reads the LAYOUT viewport and an open keyboard never shrinks it. */
+    expect(mobileComposerUnitMax(844)).toBe(320);
+    expect(mobileComposerUnitMax(932)).toBe(320);
+    expect(mobileComposerUnitMax(667)).toBe(253);
+    expect(mobileComposerUnitMax(390)).toBe(148);
+  });
+
+  test("the field still grows past the desktop cap wherever the box has room", () => {
+    /* The point of the phone ceiling (#177 item 3) survives: a portrait phone
+       opens the field well past the shared 160px cap. */
+    expect(mobileComposerCeiling(844, 844)).toBeGreaterThan(160);
+    expect(mobileComposerCeiling(932, 932)).toBeGreaterThan(160);
   });
 });
 

--- a/src/lib/composerScroll.ts
+++ b/src/lib/composerScroll.ts
@@ -63,25 +63,62 @@ export const COMPOSER_MAX_PX = 160;
    (issue #177 item 3) — so a multi-line prompt is comfortable to read while
    typing, past which it scrolls internally. */
 const COMPOSER_MAX_VH = 0.4;
+/* The composer UNIT's own chrome, measured on the rendered phone box (#1483):
+   the tools row under the field (`data-mobile2-tools`, min-h-11 = 44px), the
+   box's own padding and border (pt-1 + pb-0.5 + two 1px edges = 8px), and the
+   bounded mobile composer form's padding and top border (py-1.5 + 1px = 13px).
+   Every pixel of it lives INSIDE the composer's own scroll box, so a field
+   taller than that box's budget minus this number pushes the tools row past
+   the box's bottom edge, where reaching Stop costs a scroll. */
+export const MOBILE_COMPOSER_UNIT_CHROME_PX = 65;
+/* Mobile v2's one bar above the conversation (§3.2) — the same 52px
+   `chatBudget.BAR_PX` publishes, kept here so this module stays free of any
+   component-layer import. */
+const MOBILE_BAR_PX = 52;
 /* The mobile chrome that must share the keyboard-open visible area with the
-   textarea (#983 round 2): the docked focus strip (~52px), the conversation
-   header (~52px), and the always-visible 44px runtime-picker row under the
-   input, with the row gaps and field border riding in the strips' slack. The
-   focus root clips its overflow, so whatever this chrome cannot fit is not
-   scrolled to — it is gone. */
-export const MOBILE_COMPOSER_CHROME_PX = 156;
+   textarea: the one bar above it and the composer unit's own chrome around it.
+   Re-derived for mobile v2 (#1483) — the #983 number reserved 156px for a
+   docked focus strip, a separate conversation header and an always-visible
+   44px runtime-picker row UNDER the input, and v2 renders none of the three:
+   the strip and the header folded into the bar, and the picker became a cell
+   of the tools row inside the box. The focus root clips its overflow, so
+   whatever this chrome cannot fit is not scrolled to — it is gone. */
+export const MOBILE_COMPOSER_CHROME_PX = MOBILE_BAR_PX + MOBILE_COMPOSER_UNIT_CHROME_PX;
+/* The bounded mobile composer form's own maximum height —
+   `max-h-[min(38dvh,20rem)]` — past which the FORM scrolls internally and the
+   tools row leaves its visible box while the viewport still has room. The cap
+   reads the LAYOUT viewport height because `dvh` ignores the on-screen
+   keyboard: the keyboard shrinks the visual viewport alone (#983). */
+const MOBILE_COMPOSER_UNIT_MAX_PX = 320; /* 20rem */
+const MOBILE_COMPOSER_UNIT_MAX_VH = 0.38;
+/** How tall the phone's composer box may render before it scrolls its own
+    content, for a given LAYOUT viewport height. */
+export function mobileComposerUnitMax(layoutHeight: number): number {
+  return Math.min(MOBILE_COMPOSER_UNIT_MAX_PX, Math.round(layoutHeight * MOBILE_COMPOSER_UNIT_MAX_VH));
+}
 /* One comfortable row at the 44px tap-target height: on a visible viewport too
    small for chrome plus field, the field stays usable rather than collapsing
    to zero. */
 const COMPOSER_CEILING_FLOOR_PX = 44;
 
-/** The phone grow ceiling for a given VISIBLE viewport height (#983): 40% of
-    what the user can see, floored at the shared cap while there is room — but
-    never more than what leaves the mandatory chrome visible. A short rotated
-    viewport with the keyboard open drops the budget below the 160px cap; the
-    field then scrolls internally sooner instead of pushing the picker and send
-    controls out of the clipped focus root. */
-export function mobileComposerCeiling(visibleHeight: number): number {
+/** The phone grow ceiling, from the VISIBLE viewport the operator can see
+    (#983) and the LAYOUT viewport the composer box's own `dvh` cap is written
+    against (#1483). The field grows to 40% of the visible area, floored at the
+    shared cap while there is room, and yields to whichever bound binds first:
+
+    - the composer box's own budget, so the tools row under the field — chip,
+      attach, dictate, the send slot that holds Stop — always fits inside the
+      box with it. Past it the box scrolls, and every dictated chunk undoes the
+      scroll that reached Stop, which is the trap #1483 reports;
+    - the visible area under the bar, so the whole unit clears the keyboard. A
+      short rotated viewport drops the budget below the 160px cap; the field
+      then scrolls internally sooner.
+
+    Below the one-row floor neither bound can be honored, and a usable field
+    outranks them: the ceiling stops there. */
+export function mobileComposerCeiling(visibleHeight: number, layoutHeight: number): number {
   const grown = Math.max(COMPOSER_MAX_PX, Math.round(visibleHeight * COMPOSER_MAX_VH));
-  return Math.max(COMPOSER_CEILING_FLOOR_PX, Math.min(grown, visibleHeight - MOBILE_COMPOSER_CHROME_PX));
+  const insideTheBox = mobileComposerUnitMax(layoutHeight) - MOBILE_COMPOSER_UNIT_CHROME_PX;
+  const aboveTheKeyboard = visibleHeight - MOBILE_COMPOSER_CHROME_PX;
+  return Math.max(COMPOSER_CEILING_FLOOR_PX, Math.min(grown, insideTheBox, aboveTheKeyboard));
 }


### PR DESCRIPTION
Closes #1483. Reported from the phone: once a lot of text had been dictated, the composer's tools row went out of reach, and every new dictated chunk lifted the view again, so Stop could not be pressed without scrolling twice over.

Two causes, both fixed:

**The grow ceiling reserved chrome that mobile v2 had retired.** `MOBILE_COMPOSER_CHROME_PX` still described the docked focus strip, the conversation header and a separate picker row. Re-derived from what the phone actually renders — the bar (52) plus the composer unit's own chrome (65, measured in the live DOM: 44 px tools row, box padding and borders, form padding) = 117.

**A second bound was the one that actually clipped the row.** The reserve only constrains the field against the *visible* viewport, which at 844 px is never the binding constraint. The composer form's own `max-h-[min(38dvh,20rem)]` is written in `dvh`, which the keyboard does not shrink — and dictation happens with the keyboard down. The ceiling now reads the layout viewport too and yields to whichever bound binds first.

**Every dictated insert re-focused and let the browser scroll.** `insertSpoken` now focuses with `{ preventScroll: true }`; the newest words still land in view through the field's own `scrollTop`.

Measured on the built page under headless Chromium, before → after at 390×844: the tools row sat at 873–917 in an 844 px viewport with the form scrolled; it now ends at 834 with `formScrolls=false` and `scrollY=0`. Same shape at 430×932. The yank reproduced directly: plain `focus()` moved the scroll box 0 → 191, `focus({preventScroll:true})` left it at 0.

Both guards verified RED before GREEN, and the reviewer independently re-ran each revert rather than trusting the report. Gates at `2e05b1eb`: tsc exit 0; fourteen test files by path green; capture harness 13 frames, 0 red; privacy gate PASS. Desktop provably unchanged — probed at 1440×900, nothing there relied on focus-scroll.

The tools row's layout is deliberately untouched; that is #1484 and waits on the operator's own decision.