### PR TITLE
fix: the Viewer decides who may reach it from the connection, not from a header (#1496, #1495)

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -78,6 +78,7 @@ jobs:
           src/runtime-host/socket.test.ts
           src/runtime-host/runtimeHostFence.test.ts
           bin/server-runtime.test.ts
+          bin/bind-guard.test.ts
 
   windows-platform:
     name: Windows (native)
@@ -146,3 +147,4 @@ jobs:
           src/runtime-host/socket.test.ts
           src/runtime-host/runtimeHostFence.test.ts
           bin/server-runtime.test.ts
+          bin/bind-guard.test.ts

--- a/bin/bind-guard.test.ts
+++ b/bin/bind-guard.test.ts
@@ -1,0 +1,262 @@
+import net from "node:net";
+import { expect, test } from "bun:test";
+
+import {
+  classifyBindProbeFailure,
+  linkLocalScopeZone,
+  newlyBoundNonLoopbackAddress,
+  nonLoopbackProbeAddresses,
+  readNonLoopbackBindState,
+} from "./server-runtime.mjs";
+
+/**
+ * The loopback bind guard asks one question per non-loopback address: is it
+ * bound after the Viewer launched, with nothing in the reading taken before the
+ * launch to excuse that? Everything here drives that question through its two
+ * platform-dependent halves — how an address is named, and what a failed listen
+ * means — because the runner that broke it (Windows) cannot be run from this
+ * checkout.
+ *
+ * Addresses below are invented. `fe80::1` and `fe80::2` are link-local by
+ * construction and belong to no machine.
+ */
+
+function interfaceEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    address: "fe80::1",
+    family: "IPv6",
+    internal: false,
+    scopeid: 12,
+    ...overrides,
+  };
+}
+
+async function availablePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("could not reserve a TCP port");
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+test("a Windows link-local address is scoped by interface index, never by adapter name", () => {
+  const addresses = nonLoopbackProbeAddresses({
+    platform: "win32",
+    interfaces: { "Ethernet 3": [interfaceEntry()] },
+  });
+
+  expect(addresses).toEqual(["fe80::1%12"]);
+});
+
+test("a POSIX link-local address keeps the interface name as its zone", () => {
+  const addresses = nonLoopbackProbeAddresses({
+    platform: "linux",
+    interfaces: { eth0: [interfaceEntry()] },
+  });
+
+  expect(addresses).toEqual(["fe80::1%eth0"]);
+});
+
+test("a link-local address whose scope cannot be expressed is skipped, not probed unscoped", () => {
+  const addresses = nonLoopbackProbeAddresses({
+    platform: "win32",
+    interfaces: {
+      "Ethernet 3": [interfaceEntry({ scopeid: 0 })],
+      "Ethernet 4": [interfaceEntry({ address: "192.0.2.10", family: "IPv4", scopeid: 0 })],
+    },
+  });
+
+  expect(addresses).toEqual(["192.0.2.10"]);
+});
+
+test("internal addresses never enter the probe set", () => {
+  const addresses = nonLoopbackProbeAddresses({
+    platform: "linux",
+    interfaces: {
+      lo: [interfaceEntry({ address: "127.0.0.1", family: "IPv4", internal: true, scopeid: 0 })],
+      eth0: [interfaceEntry({ address: "192.0.2.10", family: "IPv4", scopeid: 0 })],
+    },
+  });
+
+  expect(addresses).toEqual(["192.0.2.10"]);
+});
+
+test("Windows answers an exclusive-use conflict with EACCES, which is occupancy", () => {
+  expect(classifyBindProbeFailure({ code: "EADDRINUSE" }, "linux")).toBe("occupied");
+  expect(classifyBindProbeFailure({ code: "EADDRINUSE" }, "win32")).toBe("occupied");
+  expect(classifyBindProbeFailure({ code: "EACCES" }, "win32")).toBe("occupied");
+  expect(classifyBindProbeFailure({ code: "EACCES" }, "linux")).toBe("unevaluated");
+  expect(classifyBindProbeFailure({ code: "EINVAL" }, "win32")).toBe("unevaluated");
+  expect(classifyBindProbeFailure({ code: "ENOTFOUND" }, "win32")).toBe("unevaluated");
+  expect(classifyBindProbeFailure(new Error("Failed to listen at fe80::1%Ethernet 3"), "win32")).toBe("unevaluated");
+});
+
+test("linkLocalScopeZone refuses a zone it cannot express rather than inventing one", () => {
+  expect(linkLocalScopeZone({ scopeid: 12 }, "Ethernet 3", "win32")).toBe("12");
+  expect(linkLocalScopeZone({ scopeid: 0 }, "Ethernet 3", "win32")).toBeNull();
+  expect(linkLocalScopeZone({ scopeid: 1.5 }, "Ethernet 3", "win32")).toBeNull();
+  expect(linkLocalScopeZone({ scopeid: 12 }, "eth0", "linux")).toBe("eth0");
+  expect(linkLocalScopeZone({ scopeid: 12 }, "", "linux")).toBeNull();
+});
+
+test("a probe that cannot answer for one address neither aborts the reading nor counts as exposure", async () => {
+  const port = await availablePort();
+  const unevaluable = "fe80::1%12";
+  const state = await readNonLoopbackBindState(port, {
+    platform: "win32",
+    addresses: [unevaluable, "192.0.2.10"],
+    listen: async (address: string) => {
+      if (address === unevaluable) throw Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    },
+  });
+
+  expect([...state.unevaluated.keys()]).toEqual([unevaluable]);
+  expect([...state.free]).toEqual(["192.0.2.10"]);
+  expect([...state.occupied]).toEqual([]);
+
+  // Startup proceeds: the reading resolved, and the address nobody could
+  // evaluate is not evidence that the Viewer widened its bind.
+  const before = await readNonLoopbackBindState(port, {
+    platform: "win32",
+    addresses: [unevaluable],
+    listen: async () => {
+      throw Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    },
+  });
+  expect(newlyBoundNonLoopbackAddress(before, state)).toBeNull();
+});
+
+test("every address failing the probe is still not an aborted reading", async () => {
+  const port = await availablePort();
+  const state = await readNonLoopbackBindState(port, {
+    platform: "win32",
+    addresses: ["fe80::1%12", "fe80::2%13"],
+    listen: async () => {
+      throw Object.assign(new Error("Failed to listen"), { code: "EINVAL" });
+    },
+  });
+
+  expect(state.unevaluated.size).toBe(2);
+  expect(state.free.size).toBe(0);
+  expect(state.occupied.size).toBe(0);
+});
+
+test("an address that was free before launch and is bound after it still stops startup", async () => {
+  const port = await availablePort();
+  const address = "192.0.2.10";
+  const before = await readNonLoopbackBindState(port, {
+    platform: "linux",
+    addresses: [address],
+    listen: async () => {},
+  });
+  const after = await readNonLoopbackBindState(port, {
+    platform: "linux",
+    addresses: [address],
+    listen: async () => {
+      throw Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+    },
+  });
+
+  expect([...before.free]).toEqual([address]);
+  expect([...after.occupied]).toEqual([address]);
+  expect(newlyBoundNonLoopbackAddress(before, after)).toBe(address);
+});
+
+test("an address occupied before launch is never attributed to the Viewer", async () => {
+  const port = await availablePort();
+  const address = "192.0.2.10";
+  const occupied = async () => {
+    throw Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+  };
+  const before = await readNonLoopbackBindState(port, { platform: "linux", addresses: [address], listen: occupied });
+  const after = await readNonLoopbackBindState(port, { platform: "linux", addresses: [address], listen: occupied });
+
+  expect(newlyBoundNonLoopbackAddress(before, after)).toBeNull();
+});
+
+test("an address nobody could evaluate before launch is not evidence when it is occupied after", async () => {
+  const port = await availablePort();
+  const address = "fe80::1%12";
+  const before = await readNonLoopbackBindState(port, {
+    platform: "win32",
+    addresses: [address],
+    listen: async () => {
+      throw Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    },
+  });
+  const after = await readNonLoopbackBindState(port, {
+    platform: "win32",
+    addresses: [address],
+    listen: async () => {
+      throw Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+    },
+  });
+
+  expect([...after.occupied]).toEqual([address]);
+  expect(newlyBoundNonLoopbackAddress(before, after)).toBeNull();
+});
+
+test("an enumeration that cannot list any interface stays fatal", async () => {
+  const port = await availablePort();
+  const unreadable = new Proxy({}, {
+    ownKeys() {
+      throw new Error("network interfaces unavailable");
+    },
+  });
+
+  expect(() => nonLoopbackProbeAddresses({ platform: "linux", interfaces: unreadable }))
+    .toThrow("network interfaces unavailable");
+  await expect(readNonLoopbackBindState(port, { platform: "linux", interfaces: unreadable }))
+    .rejects.toThrow("network interfaces unavailable");
+});
+
+test("the live probe answers for every enumerated address without aborting", async () => {
+  const port = await availablePort();
+  const addresses = nonLoopbackProbeAddresses();
+  const state = await readNonLoopbackBindState(port);
+
+  // Whatever this machine's interfaces look like — including a Windows adapter
+  // whose name can never be an IPv6 zone — the reading completes and every
+  // address lands in exactly one bucket.
+  expect(state.occupied.size + state.free.size + state.unevaluated.size).toBe(addresses.length);
+  for (const address of addresses) {
+    const buckets = [state.occupied.has(address), state.free.has(address), state.unevaluated.has(address)];
+    expect(buckets.filter(Boolean).length).toBe(1);
+  }
+  // A port reserved and released moments ago is held by nobody, so nothing the
+  // live probe sees is a widened bind.
+  expect(newlyBoundNonLoopbackAddress(state, state)).toBeNull();
+});
+
+test("the live enumeration never carries a zone this platform cannot use", () => {
+  for (const address of nonLoopbackProbeAddresses()) {
+    const zone = address.includes("%") ? address.slice(address.indexOf("%") + 1) : null;
+    if (zone === null) continue;
+    expect(zone).not.toBe("");
+    if (process.platform === "win32") expect(zone).toMatch(/^\d+$/);
+  }
+});
+
+test("an address that appeared only after launch is still evidence, not an excuse", async () => {
+  const port = await availablePort();
+  const before = await readNonLoopbackBindState(port, {
+    platform: "linux",
+    addresses: [],
+    listen: async () => {},
+  });
+  const after = await readNonLoopbackBindState(port, {
+    platform: "linux",
+    addresses: ["192.0.2.10"],
+    listen: async () => {
+      throw Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+    },
+  });
+
+  // An interface that came up mid-launch was never observed free, but a
+  // wildcard bind serves it too, and nothing excuses it. The guard fails closed.
+  expect(newlyBoundNonLoopbackAddress(before, after)).toBe("192.0.2.10");
+});

--- a/bin/cli.exposure.integration.test.ts
+++ b/bin/cli.exposure.integration.test.ts
@@ -122,21 +122,21 @@ function captureOutput(child: ReturnType<typeof spawn>) {
 
 /**
  * A `bin/server-runtime.mjs` that behaves exactly like the real one except that
- * one address cannot be evaluated — the shape a Windows runner produces for a
- * link-local zone its resolver rejects. Every other address, and the CLI under
- * test, goes through the real module.
+ * the bind probe fails for one address the way a Windows resolver fails for a
+ * link-local zone it will not accept. The failure is delivered through the real
+ * per-address seam, so the reading, its classification and the CLI's handling
+ * of the result are all the shipped code.
  */
 function unevaluableProbeModule(address: string): string {
   const real = JSON.stringify(pathToFileURL(path.resolve("bin/server-runtime.mjs")).href);
   return [
     `export * from ${real};`,
-    `import { nonLoopbackProbeAddresses, readNonLoopbackBindState as read } from ${real};`,
+    `import { attemptAddressBind, readNonLoopbackBindState as read } from ${real};`,
     `const UNEVALUABLE = ${JSON.stringify(address)};`,
-    "export async function readNonLoopbackBindState(port, options = {}) {",
-    "  const addresses = nonLoopbackProbeAddresses().filter((candidate) => candidate !== UNEVALUABLE);",
-    "  const state = await read(port, { ...options, addresses });",
-    '  state.unevaluated.set(UNEVALUABLE, "getaddrinfo ENOTFOUND " + UNEVALUABLE);',
-    "  return state;",
+    "export function readNonLoopbackBindState(port, options = {}) {",
+    "  return read(port, { ...options, listen: (address, addressPort) => address === UNEVALUABLE",
+    '    ? Promise.reject(Object.assign(new Error("getaddrinfo ENOTFOUND " + address), { code: "ENOTFOUND" }))',
+    "    : attemptAddressBind(address, addressPort) });",
     "}",
   ].join("\n");
 }
@@ -284,14 +284,23 @@ test("an address the platform will not evaluate neither stops startup nor claims
   const port = await availablePort();
   const child = spawn(process.execPath, ["--bun", fixture.cli, "--no-open", "--port", String(port)], {
     cwd: path.dirname(path.dirname(fixture.cli)),
-    env: fixture.env,
+    // LLV_LANG pins the message table the assertion below reads, so the
+    // operator's own locale cannot decide whether this test passes.
+    env: { ...fixture.env, LLV_LANG: "en" },
     stdio: ["ignore", "pipe", "pipe"],
   });
   children.add(child);
   const output = captureOutput(child);
 
-  await waitForStatus("127.0.0.1", port, 200);
+  // The banner comes first: it is the assertion that names the CLI's own stderr
+  // when a probe the guard could not answer killed startup instead.
   await output.waitFor("Agent Log Viewer", 10_000);
+  // What the guard could not cover is said out loud rather than only recorded.
+  await output.waitFor(
+    `the exposure check skipped addresses this machine would not answer for: ${nonLoopbackAddress}`,
+    10_000,
+  );
+  await waitForStatus("127.0.0.1", port, 200);
   expect(child.exitCode).toBeNull();
   expect(child.signalCode).toBeNull();
   // The probe could not answer for that address and the guard read nothing into

--- a/bin/cli.exposure.integration.test.ts
+++ b/bin/cli.exposure.integration.test.ts
@@ -1,0 +1,191 @@
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import { networkInterfaces, tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "bun:test";
+
+const fixtures = new Set<string>();
+const children = new Set<ReturnType<typeof spawn>>();
+
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  }
+  await Promise.all([...children].map(async (child) => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await Promise.race([
+      new Promise<void>((resolve) => child.once("exit", () => resolve())),
+      Bun.sleep(3_000),
+    ]);
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }));
+  children.clear();
+  await Promise.all([...fixtures].map((fixture) => rm(fixture, { recursive: true, force: true })));
+  fixtures.clear();
+});
+
+async function availablePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("could not reserve a TCP port");
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+function nonLoopbackIpv4Address(): string {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === "IPv4" && !address.internal) return address.address;
+    }
+  }
+  throw new Error("the CLI exposure regression needs a non-loopback IPv4 interface");
+}
+
+async function probe(hostname: string, port: number): Promise<number> {
+  return new Promise((resolve) => {
+    const request = http.get({ hostname, port, path: "/api/files", timeout: 1_000 }, (response) => {
+      response.resume();
+      response.once("end", () => resolve(response.statusCode ?? 0));
+    });
+    request.once("timeout", () => {
+      request.destroy();
+      resolve(0);
+    });
+    request.once("error", () => resolve(0));
+  });
+}
+
+async function waitForStatus(hostname: string, port: number, expected: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await probe(hostname, port) === expected) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`listener at ${hostname}:${port} did not reach status ${expected}`);
+}
+
+async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number | null> {
+  if (child.exitCode !== null) return child.exitCode;
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      child.off("exit", onExit);
+      resolve(null);
+    }, timeoutMs);
+    const onExit = (code: number | null) => {
+      clearTimeout(timeout);
+      resolve(code);
+    };
+    child.once("exit", onExit);
+    if (child.exitCode !== null) {
+      child.off("exit", onExit);
+      clearTimeout(timeout);
+      resolve(child.exitCode);
+    }
+  });
+}
+
+async function checkoutFixture(options: { ignoreHostname?: boolean } = {}): Promise<{ cli: string; env: NodeJS.ProcessEnv }> {
+  const fixture = await mkdtemp(path.join(tmpdir(), "llv-cli-exposure-"));
+  fixtures.add(fixture);
+  const bin = path.join(fixture, "bin");
+  const nextBin = path.join(fixture, "node_modules", ".bin");
+  const runtimeHost = path.join(fixture, "dist", "runtime-host.mjs");
+  const home = path.join(fixture, "home");
+  const state = path.join(fixture, "state");
+  await Promise.all([
+    mkdir(bin, { recursive: true }),
+    mkdir(nextBin, { recursive: true }),
+    mkdir(path.dirname(runtimeHost), { recursive: true }),
+    mkdir(home, { recursive: true }),
+    mkdir(state, { recursive: true }),
+  ]);
+  await Promise.all([
+    copyFile(path.resolve("bin/cli.mjs"), path.join(bin, "cli.mjs")),
+    copyFile(path.resolve("bin/server-runtime.mjs"), path.join(bin, "server-runtime.mjs")),
+    copyFile(path.resolve("bin/tailscale.mjs"), path.join(bin, "tailscale.mjs")),
+    writeFile(path.join(fixture, "package.json"), JSON.stringify({ type: "module", version: "0.0.0" })),
+    writeFile(path.join(nextBin, "next"), `
+const hostnameIndex = process.argv.indexOf("--hostname");
+const hostname = ${options.ignoreHostname ? JSON.stringify("0.0.0.0") : "hostnameIndex === -1 ? \"0.0.0.0\" : process.argv[hostnameIndex + 1]"};
+const server = Bun.serve({
+  hostname,
+  port: Number(process.env.PORT),
+  fetch() { return new Response("ok"); },
+});
+const stop = () => { server.stop(true); process.exit(0); };
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);
+`),
+    writeFile(runtimeHost, `
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+const socketPath = process.env.LLV_RUNTIME_HOST_SOCKET;
+const fencePath = process.env.LLV_RUNTIME_HOST_FENCE;
+mkdirSync(path.dirname(socketPath), { recursive: true });
+rmSync(socketPath, { force: true });
+const server = net.createServer((socket) => socket.end());
+server.listen(socketPath, () => writeFileSync(fencePath, JSON.stringify({
+  pid: process.pid,
+  startIdentity: process.pid + ":fixture",
+  acquisitionId: "fixture-acquisition-id",
+})));
+const stop = () => server.close(() => {
+  rmSync(socketPath, { force: true });
+  rmSync(fencePath, { force: true });
+  process.exit(0);
+});
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);
+`),
+  ]);
+  return {
+    cli: path.join(bin, "cli.mjs"),
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: path.join(home, ".config"),
+      LLV_STATE_DIR: state,
+      TMPDIR: path.join(fixture, "tmp"),
+      LLV_BUN_EXECUTABLE: process.execPath,
+    },
+  };
+}
+
+test("the checkout next start path keeps the default listener on loopback", async () => {
+  const fixture = await checkoutFixture();
+  await mkdir(fixture.env.TMPDIR!, { recursive: true });
+  const port = await availablePort();
+  const child = spawn(process.execPath, ["--bun", fixture.cli, "--no-open", "--port", String(port)], {
+    cwd: path.dirname(path.dirname(fixture.cli)),
+    env: fixture.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+
+  await waitForStatus("127.0.0.1", port, 200);
+  expect(await probe(nonLoopbackIpv4Address(), port)).toBe(0);
+});
+
+test("the CLI rejects a checkout server that binds beyond the requested loopback address", async () => {
+  const fixture = await checkoutFixture({ ignoreHostname: true });
+  await mkdir(fixture.env.TMPDIR!, { recursive: true });
+  const port = await availablePort();
+  const child = spawn(process.execPath, ["--bun", fixture.cli, "--no-open", "--port", String(port)], {
+    cwd: path.dirname(path.dirname(fixture.cli)),
+    env: fixture.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+
+  await waitForStatus("127.0.0.1", port, 200);
+  const exitCode = await waitForExit(child, 2_000);
+  expect(exitCode).toBe(1);
+  expect(await probe(nonLoopbackIpv4Address(), port)).toBe(0);
+});

--- a/bin/cli.exposure.integration.test.ts
+++ b/bin/cli.exposure.integration.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import net from "node:net";
 import { networkInterfaces, tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, expect, test } from "bun:test";
 
 const fixtures = new Set<string>();
@@ -119,7 +120,28 @@ function captureOutput(child: ReturnType<typeof spawn>) {
   };
 }
 
-async function checkoutFixture(options: { ignoreHostname?: boolean } = {}): Promise<{ cli: string; env: NodeJS.ProcessEnv }> {
+/**
+ * A `bin/server-runtime.mjs` that behaves exactly like the real one except that
+ * one address cannot be evaluated — the shape a Windows runner produces for a
+ * link-local zone its resolver rejects. Every other address, and the CLI under
+ * test, goes through the real module.
+ */
+function unevaluableProbeModule(address: string): string {
+  const real = JSON.stringify(pathToFileURL(path.resolve("bin/server-runtime.mjs")).href);
+  return [
+    `export * from ${real};`,
+    `import { nonLoopbackProbeAddresses, readNonLoopbackBindState as read } from ${real};`,
+    `const UNEVALUABLE = ${JSON.stringify(address)};`,
+    "export async function readNonLoopbackBindState(port, options = {}) {",
+    "  const addresses = nonLoopbackProbeAddresses().filter((candidate) => candidate !== UNEVALUABLE);",
+    "  const state = await read(port, { ...options, addresses });",
+    '  state.unevaluated.set(UNEVALUABLE, "getaddrinfo ENOTFOUND " + UNEVALUABLE);',
+    "  return state;",
+    "}",
+  ].join("\n");
+}
+
+async function checkoutFixture(options: { ignoreHostname?: boolean; unevaluableAddress?: string } = {}): Promise<{ cli: string; env: NodeJS.ProcessEnv }> {
   const fixture = await mkdtemp(path.join(tmpdir(), "llv-cli-exposure-"));
   fixtures.add(fixture);
   const bin = path.join(fixture, "bin");
@@ -136,7 +158,9 @@ async function checkoutFixture(options: { ignoreHostname?: boolean } = {}): Prom
   ]);
   await Promise.all([
     copyFile(path.resolve("bin/cli.mjs"), path.join(bin, "cli.mjs")),
-    copyFile(path.resolve("bin/server-runtime.mjs"), path.join(bin, "server-runtime.mjs")),
+    options.unevaluableAddress === undefined
+      ? copyFile(path.resolve("bin/server-runtime.mjs"), path.join(bin, "server-runtime.mjs"))
+      : writeFile(path.join(bin, "server-runtime.mjs"), unevaluableProbeModule(options.unevaluableAddress)),
     copyFile(path.resolve("bin/tailscale.mjs"), path.join(bin, "tailscale.mjs")),
     writeFile(path.join(fixture, "package.json"), JSON.stringify({ type: "module", version: "0.0.0" })),
     writeFile(path.join(nextBin, "next"), `
@@ -251,4 +275,26 @@ test("the CLI rejects a checkout server that binds beyond the requested loopback
   const exitCode = await waitForExit(child, 2_000);
   expect(exitCode).toBe(1);
   expect(await probe(nonLoopbackIpv4Address(), port)).toBe(0);
+});
+
+test("an address the platform will not evaluate neither stops startup nor claims exposure", async () => {
+  const nonLoopbackAddress = nonLoopbackIpv4Address();
+  const fixture = await checkoutFixture({ unevaluableAddress: nonLoopbackAddress });
+  await mkdir(fixture.env.TMPDIR!, { recursive: true });
+  const port = await availablePort();
+  const child = spawn(process.execPath, ["--bun", fixture.cli, "--no-open", "--port", String(port)], {
+    cwd: path.dirname(path.dirname(fixture.cli)),
+    env: fixture.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+  const output = captureOutput(child);
+
+  await waitForStatus("127.0.0.1", port, 200);
+  await output.waitFor("Agent Log Viewer", 10_000);
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBeNull();
+  // The probe could not answer for that address and the guard read nothing into
+  // the silence: startup survived, and the listener is still loopback-only.
+  expect(await probe(nonLoopbackAddress, port)).toBe(0);
 });

--- a/bin/cli.exposure.integration.test.ts
+++ b/bin/cli.exposure.integration.test.ts
@@ -90,6 +90,30 @@ async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): 
   });
 }
 
+function captureOutput(child: ReturnType<typeof spawn>) {
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += String(chunk);
+  });
+
+  return {
+    async waitFor(text: string, timeoutMs: number): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (output.includes(text)) return;
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(`CLI exited before ${JSON.stringify(text)} appeared:\n${output}`);
+        }
+        await Bun.sleep(25);
+      }
+      throw new Error(`CLI output did not include ${JSON.stringify(text)}:\n${output}`);
+    },
+  };
+}
+
 async function checkoutFixture(options: { ignoreHostname?: boolean } = {}): Promise<{ cli: string; env: NodeJS.ProcessEnv }> {
   const fixture = await mkdtemp(path.join(tmpdir(), "llv-cli-exposure-"));
   fixtures.add(fixture);
@@ -168,8 +192,12 @@ test("the checkout next start path keeps the default listener on loopback", asyn
     stdio: ["ignore", "pipe", "pipe"],
   });
   children.add(child);
+  const output = captureOutput(child);
 
   await waitForStatus("127.0.0.1", port, 200);
+  await output.waitFor("Agent Log Viewer", 10_000);
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBeNull();
   expect(await probe(nonLoopbackIpv4Address(), port)).toBe(0);
 });
 

--- a/bin/cli.exposure.integration.test.ts
+++ b/bin/cli.exposure.integration.test.ts
@@ -8,6 +8,7 @@ import { afterEach, expect, test } from "bun:test";
 
 const fixtures = new Set<string>();
 const children = new Set<ReturnType<typeof spawn>>();
+const listeners = new Set<net.Server>();
 
 afterEach(async () => {
   for (const child of children) {
@@ -22,6 +23,10 @@ afterEach(async () => {
     if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
   }));
   children.clear();
+  await Promise.all([...listeners].map((listener) => new Promise<void>((resolve, reject) => {
+    listener.close((error) => error ? reject(error) : resolve());
+  })));
+  listeners.clear();
   await Promise.all([...fixtures].map((fixture) => rm(fixture, { recursive: true, force: true })));
   fixtures.clear();
 });
@@ -199,6 +204,36 @@ test("the checkout next start path keeps the default listener on loopback", asyn
   expect(child.exitCode).toBeNull();
   expect(child.signalCode).toBeNull();
   expect(await probe(nonLoopbackIpv4Address(), port)).toBe(0);
+});
+
+test("a pre-existing non-loopback listener does not impersonate a widened Viewer bind", async () => {
+  const fixture = await checkoutFixture();
+  await mkdir(fixture.env.TMPDIR!, { recursive: true });
+  const port = await availablePort();
+  const nonLoopbackAddress = nonLoopbackIpv4Address();
+  const unrelated = http.createServer((_request, response) => {
+    response.writeHead(204);
+    response.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    unrelated.once("error", reject);
+    unrelated.listen({ host: nonLoopbackAddress, port, exclusive: true }, resolve);
+  });
+  listeners.add(unrelated);
+
+  const child = spawn(process.execPath, ["--bun", fixture.cli, "--no-open", "--port", String(port)], {
+    cwd: path.dirname(path.dirname(fixture.cli)),
+    env: fixture.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+  const output = captureOutput(child);
+
+  await waitForStatus("127.0.0.1", port, 200);
+  await output.waitFor("Agent Log Viewer", 10_000);
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBeNull();
+  expect(await probe(nonLoopbackAddress, port)).toBe(204);
 });
 
 test("the CLI rejects a checkout server that binds beyond the requested loopback address", async () => {

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync } from "node:fs";
 import http from "node:http";
 import net from "node:net";
-import { homedir, networkInterfaces } from "node:os";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +14,8 @@ import {
   cliRuntimeHostConfig,
   cliRuntimeHostEnvironment,
   discardWakatimeEnvironmentCredential,
+  newlyBoundNonLoopbackAddress,
+  readNonLoopbackBindState,
   viewerChildProcessOptions,
   viewerServerBunRuntime,
 } from "./server-runtime.mjs";
@@ -597,41 +599,6 @@ async function waitForReadiness(port) {
   throw new Error(m.serverTimeout(READINESS_TIMEOUT_MS / 1000));
 }
 
-function addressIsBound(hostname, port) {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", (error) => {
-      if (error?.code === "EADDRINUSE") {
-        resolve(true);
-        return;
-      }
-      reject(error);
-    });
-    server.listen({ host: hostname, port, exclusive: true }, () => {
-      server.close((error) => error ? reject(error) : resolve(false));
-    });
-  });
-}
-
-async function boundNonLoopbackAddresses(port) {
-  const addresses = new Set();
-  for (const [interfaceName, entries] of Object.entries(networkInterfaces())) {
-    for (const entry of entries ?? []) {
-      if (entry.internal) continue;
-      const address = entry.family === "IPv6" && entry.scopeid > 0
-        ? `${entry.address}%${interfaceName}`
-        : entry.address;
-      addresses.add(address);
-    }
-  }
-
-  const occupied = new Set();
-  for (const address of addresses) {
-    if (await addressIsBound(address, port)) occupied.add(address);
-  }
-  return occupied;
-}
-
 function localUrl(options) {
   const host = options.hostname === "::1" ? "[::1]" : options.hostname;
   return `http://${host}:${options.port}/`;
@@ -853,10 +820,15 @@ async function main() {
     process.exit(1);
   }
 
-  let occupiedNonLoopbackAddresses = new Set();
+  // Snapshot who holds each non-loopback address before the Viewer exists, so
+  // the post-readiness guard can only attribute a NEWLY bound one to it. An
+  // address this machine will not answer for is recorded as unevaluated and
+  // carried; only an unreadable interface list leaves the guard blind enough
+  // to stop here.
+  let bindStateBeforeLaunch = { occupied: new Set(), free: new Set(), unevaluated: new Map() };
   if (isLoopbackHostname(options.hostname)) {
     try {
-      occupiedNonLoopbackAddresses = await boundNonLoopbackAddresses(options.port);
+      bindStateBeforeLaunch = await readNonLoopbackBindState(options.port);
     } catch (error) {
       fail(m.bindCheckFail(error instanceof Error ? error.message : String(error)));
     }
@@ -905,11 +877,10 @@ async function main() {
   // framework silently widening a requested loopback bind before the listener
   // can remain exposed.
   if (isLoopbackHostname(options.hostname)) {
-    let exposedAddress;
+    let exposedAddress = null;
     try {
-      const boundAddresses = await boundNonLoopbackAddresses(options.port);
-      exposedAddress = [...boundAddresses]
-        .find((address) => !occupiedNonLoopbackAddresses.has(address)) ?? null;
+      const bindStateAfterLaunch = await readNonLoopbackBindState(options.port);
+      exposedAddress = newlyBoundNonLoopbackAddress(bindStateBeforeLaunch, bindStateAfterLaunch);
     } catch (error) {
       await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);
       fail(m.bindCheckFail(error instanceof Error ? error.message : String(error)));

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -4,7 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync } from "node:fs";
 import http from "node:http";
 import net from "node:net";
-import { homedir } from "node:os";
+import { homedir, networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -80,6 +80,8 @@ Options:
     tsLinkWarn: () => "  The link contains an access key — don't forward it to others.",
     tsCookie: () => "  After the first open the key is stored in a cookie for 30 days.",
     nonLocalWarn: () => "Warning: a non-local address exposes the viewer to the network, so access-key mode is forced on.",
+    unexpectedNonLocalBind: (address) => `The server bound ${address} even though loopback was requested. Startup was stopped before the viewer could remain exposed.`,
+    bindCheckFail: (detail) => `Couldn't verify the server bind: ${detail}. Startup was stopped.`,
     serverNotReady: () => "Server not ready.",
     runtimeHostEntryMissing: () => "The runtime host is missing from this install. Reinstall agent-log-viewer and try again.",
     runtimeHostStartFail: (detail) => `Couldn't start the structured runtime host: ${detail}`,
@@ -118,6 +120,8 @@ Options:
     tsLinkWarn: () => "  Посилання містить ключ доступу — не пересилайте його стороннім.",
     tsCookie: () => "  Після першого відкриття ключ зберігається у cookie на 30 днів.",
     nonLocalWarn: () => "Увага: нелокальна адреса відкриває viewer для мережі, тому режим ключа доступу увімкнено примусово.",
+    unexpectedNonLocalBind: (address) => `Сервер прив'язався до ${address}, хоча було запитано локальну адресу. Запуск зупинено, щоб viewer не залишився відкритим у мережу.`,
+    bindCheckFail: (detail) => `Не вдалося перевірити адресу сервера: ${detail}. Запуск зупинено.`,
     serverNotReady: () => "Сервер не готовий.",
     runtimeHostEntryMissing: () => "У цьому пакеті немає runtime host. Перевстановіть agent-log-viewer і повторіть спробу.",
     runtimeHostStartFail: (detail) => `Не вдалося запустити structured runtime host: ${detail}`,
@@ -240,7 +244,7 @@ function readPackageJson(packageRoot) {
   }
 }
 
-function resolveServer(packageRoot) {
+function resolveServer(packageRoot, hostname) {
   const bunRuntime = viewerServerBunRuntime();
   const commandFor = (command, args, bunEntry = command, bunArgs = args) => bunRuntime
     ? { command: bunRuntime, args: ["--bun", bunEntry, ...bunArgs] }
@@ -279,7 +283,7 @@ function resolveServer(packageRoot) {
   }
 
   return {
-    ...commandFor(nextBin, ["start"]),
+    ...commandFor(nextBin, ["start", "--hostname", hostname]),
     cwd: packageRoot,
     label: "next start",
   };
@@ -593,6 +597,36 @@ async function waitForReadiness(port) {
   throw new Error(m.serverTimeout(READINESS_TIMEOUT_MS / 1000));
 }
 
+function addressIsBound(hostname, port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", (error) => {
+      if (error?.code === "EADDRINUSE") {
+        resolve(true);
+        return;
+      }
+      reject(error);
+    });
+    server.listen({ host: hostname, port, exclusive: true }, () => {
+      server.close((error) => error ? reject(error) : resolve(false));
+    });
+  });
+}
+
+async function boundNonLoopbackAddress(port) {
+  const addresses = new Set();
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (!entry.internal) addresses.add(entry.address);
+    }
+  }
+
+  for (const address of addresses) {
+    if (await addressIsBound(address, port)) return address;
+  }
+  return null;
+}
+
 function localUrl(options) {
   const host = options.hostname === "::1" ? "[::1]" : options.hostname;
   return `http://${host}:${options.port}/`;
@@ -814,7 +848,7 @@ async function main() {
     process.exit(1);
   }
 
-  const server = resolveServer(packageRoot);
+  const server = resolveServer(packageRoot, options.hostname);
   const runtimeHostConfig = cliRuntimeHostConfig(packageRoot);
   const runtimeHostEnvironment = cliRuntimeHostEnvironment(process.env, runtimeHostConfig);
   const runtimeHostSupervisor = createRuntimeHostSupervisor(
@@ -851,6 +885,23 @@ async function main() {
   } catch (error) {
     await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);
     fail(error instanceof Error ? error.message : m.serverNotReady());
+  }
+
+  // Verify the kernel-visible bind after readiness. This catches a launcher or
+  // framework silently widening a requested loopback bind before the listener
+  // can remain exposed.
+  if (isLoopbackHostname(options.hostname)) {
+    let exposedAddress;
+    try {
+      exposedAddress = await boundNonLoopbackAddress(options.port);
+    } catch (error) {
+      await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);
+      fail(m.bindCheckFail(error instanceof Error ? error.message : String(error)));
+    }
+    if (exposedAddress !== null) {
+      await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);
+      fail(m.unexpectedNonLocalBind(exposedAddress));
+    }
   }
 
   if (

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -615,9 +615,13 @@ function addressIsBound(hostname, port) {
 
 async function boundNonLoopbackAddress(port) {
   const addresses = new Set();
-  for (const entries of Object.values(networkInterfaces())) {
+  for (const [interfaceName, entries] of Object.entries(networkInterfaces())) {
     for (const entry of entries ?? []) {
-      if (!entry.internal) addresses.add(entry.address);
+      if (entry.internal) continue;
+      const address = entry.family === "IPv6" && entry.scopeid > 0
+        ? `${entry.address}%${interfaceName}`
+        : entry.address;
+      addresses.add(address);
     }
   }
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -84,6 +84,7 @@ Options:
     nonLocalWarn: () => "Warning: a non-local address exposes the viewer to the network, so access-key mode is forced on.",
     unexpectedNonLocalBind: (address) => `The server bound ${address} even though loopback was requested. Startup was stopped before the viewer could remain exposed.`,
     bindCheckFail: (detail) => `Couldn't verify the server bind: ${detail}. Startup was stopped.`,
+    bindCheckSkipped: (addresses) => `Warning: the exposure check skipped addresses this machine would not answer for: ${addresses}.`,
     serverNotReady: () => "Server not ready.",
     runtimeHostEntryMissing: () => "The runtime host is missing from this install. Reinstall agent-log-viewer and try again.",
     runtimeHostStartFail: (detail) => `Couldn't start the structured runtime host: ${detail}`,
@@ -124,6 +125,7 @@ Options:
     nonLocalWarn: () => "Увага: нелокальна адреса відкриває viewer для мережі, тому режим ключа доступу увімкнено примусово.",
     unexpectedNonLocalBind: (address) => `Сервер прив'язався до ${address}, хоча було запитано локальну адресу. Запуск зупинено, щоб viewer не залишився відкритим у мережу.`,
     bindCheckFail: (detail) => `Не вдалося перевірити адресу сервера: ${detail}. Запуск зупинено.`,
+    bindCheckSkipped: (addresses) => `Увага: перевірка на відкритість пропустила адреси, на які ця машина не відповідає: ${addresses}.`,
     serverNotReady: () => "Сервер не готовий.",
     runtimeHostEntryMissing: () => "У цьому пакеті немає runtime host. Перевстановіть agent-log-viewer і повторіть спробу.",
     runtimeHostStartFail: (detail) => `Не вдалося запустити structured runtime host: ${detail}`,
@@ -880,6 +882,12 @@ async function main() {
     let exposedAddress = null;
     try {
       const bindStateAfterLaunch = await readNonLoopbackBindState(options.port);
+      // An address the guard could not evaluate narrows what it covered, so say
+      // which. Recording it where nobody reads it would make a security check
+      // degrade in silence.
+      if (bindStateAfterLaunch.unevaluated.size > 0) {
+        console.error(m.bindCheckSkipped([...bindStateAfterLaunch.unevaluated.keys()].join(", ")));
+      }
       exposedAddress = newlyBoundNonLoopbackAddress(bindStateBeforeLaunch, bindStateAfterLaunch);
     } catch (error) {
       await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -613,7 +613,7 @@ function addressIsBound(hostname, port) {
   });
 }
 
-async function boundNonLoopbackAddress(port) {
+async function boundNonLoopbackAddresses(port) {
   const addresses = new Set();
   for (const [interfaceName, entries] of Object.entries(networkInterfaces())) {
     for (const entry of entries ?? []) {
@@ -625,10 +625,11 @@ async function boundNonLoopbackAddress(port) {
     }
   }
 
+  const occupied = new Set();
   for (const address of addresses) {
-    if (await addressIsBound(address, port)) return address;
+    if (await addressIsBound(address, port)) occupied.add(address);
   }
-  return null;
+  return occupied;
 }
 
 function localUrl(options) {
@@ -852,6 +853,15 @@ async function main() {
     process.exit(1);
   }
 
+  let occupiedNonLoopbackAddresses = new Set();
+  if (isLoopbackHostname(options.hostname)) {
+    try {
+      occupiedNonLoopbackAddresses = await boundNonLoopbackAddresses(options.port);
+    } catch (error) {
+      fail(m.bindCheckFail(error instanceof Error ? error.message : String(error)));
+    }
+  }
+
   const server = resolveServer(packageRoot, options.hostname);
   const runtimeHostConfig = cliRuntimeHostConfig(packageRoot);
   const runtimeHostEnvironment = cliRuntimeHostEnvironment(process.env, runtimeHostConfig);
@@ -897,7 +907,9 @@ async function main() {
   if (isLoopbackHostname(options.hostname)) {
     let exposedAddress;
     try {
-      exposedAddress = await boundNonLoopbackAddress(options.port);
+      const boundAddresses = await boundNonLoopbackAddresses(options.port);
+      exposedAddress = [...boundAddresses]
+        .find((address) => !occupiedNonLoopbackAddresses.has(address)) ?? null;
     } catch (error) {
       await stopAll(serverProcess, tailscaleProcessRef.current, runtimeHostSupervisor);
       fail(m.bindCheckFail(error instanceof Error ? error.message : String(error)));

--- a/bin/server-runtime.mjs
+++ b/bin/server-runtime.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import net from "node:net";
+import { homedir, networkInterfaces } from "node:os";
 import { join, posix, resolve, win32 } from "node:path";
 
 export const WAKATIME_CREDENTIAL_ENV = "WAKATIME_API_KEY";
@@ -153,4 +154,193 @@ export function cliRuntimeHostEnvironment(base, config) {
     LLV_SPAWN_TRANSPORT: "structured",
     NEXT_PUBLIC_RUNTIME_UI: "1",
   };
+}
+
+/**
+ * The loopback bind guard.
+ *
+ * `bin/cli.mjs` reads every non-loopback address twice — once before the Viewer
+ * launches, once after it answers — and stops startup when an address that was
+ * free before is bound after. Both halves of that reading are
+ * platform-dependent, so both are exported and driven directly by
+ * `bin/bind-guard.test.ts`: the Windows runner this guard first broke on cannot
+ * be run from a Linux checkout.
+ *
+ * The rule the guard follows is that only a *change* between the two readings
+ * is evidence. An address the probe cannot evaluate is recorded and carried,
+ * never read as exposure and never fatal — a question the kernel refuses to
+ * answer is not an answer.
+ */
+
+/** Addresses in fe80::/10 are link-local and unbindable without a zone. */
+const LINK_LOCAL_IPV6 = /^fe[89ab][0-9a-f]:/i;
+
+/**
+ * The zone that names a link-local address's interface to this platform's
+ * resolver.
+ *
+ * A zone is written `<address>%<zone>`, and the two families of operating
+ * system disagree on what a zone is. POSIX resolvers take the interface name
+ * (`fe80::1%eth0`). Windows takes the numeric interface index and nothing else
+ * (`fe80::1%12`); an adapter name such as `Ethernet 3` is rejected there, which
+ * is how this guard came to abort every Windows startup. Node reports that
+ * index as `scopeid` on both.
+ *
+ * Returns null when this platform's zone cannot be expressed for the entry. The
+ * caller then drops the address rather than probing an unscoped link-local one,
+ * which no resolver can bind either.
+ *
+ * @param {{ scopeid?: number }} entry
+ * @param {string} interfaceName
+ * @param {NodeJS.Platform} [platform]
+ * @returns {string | null}
+ */
+export function linkLocalScopeZone(entry, interfaceName, platform = process.platform) {
+  if (platform === "win32") {
+    return Number.isInteger(entry.scopeid) && entry.scopeid > 0 ? String(entry.scopeid) : null;
+  }
+  return interfaceName || null;
+}
+
+/**
+ * Every non-loopback address the guard will ask about, named the way this
+ * platform's resolver accepts. Throws only when the interface list itself
+ * cannot be read, which leaves the guard blind rather than uncertain about one
+ * address.
+ *
+ * @param {{ interfaces?: Record<string, unknown[] | undefined>, platform?: NodeJS.Platform }} [options]
+ * @returns {string[]}
+ */
+export function nonLoopbackProbeAddresses(options = {}) {
+  const platform = options.platform ?? process.platform;
+  const interfaces = options.interfaces ?? networkInterfaces();
+  const addresses = new Set();
+  for (const [interfaceName, entries] of Object.entries(interfaces)) {
+    for (const entry of entries ?? []) {
+      if (entry.internal) continue;
+      const scoped = entry.family === "IPv6"
+        && (entry.scopeid > 0 || LINK_LOCAL_IPV6.test(entry.address));
+      if (!scoped) {
+        addresses.add(entry.address);
+        continue;
+      }
+      const zone = linkLocalScopeZone(entry, interfaceName, platform);
+      if (zone === null) continue;
+      addresses.add(`${entry.address}%${zone}`);
+    }
+  }
+  return [...addresses];
+}
+
+/**
+ * What a failed bind says about the address it failed on.
+ *
+ * A rejection can be any value, so the code is read defensively rather than
+ * assumed to be a Node system error.
+ *
+ * @param {unknown} error
+ * @param {NodeJS.Platform} [platform]
+ * @returns {"occupied" | "unevaluated"}
+ */
+export function classifyBindProbeFailure(error, platform = process.platform) {
+  const code = /** @type {{ code?: string } | null | undefined} */ (error)?.code;
+  if (code === "EADDRINUSE") return "occupied";
+  // Windows answers a bind against an address:port another process already
+  // holds under SO_EXCLUSIVEADDRUSE with EACCES rather than EADDRINUSE, so
+  // reading it as occupancy is what keeps the guard's evidence intact there. A
+  // permission-denied EACCES that has nothing to do with occupancy is stable
+  // across both readings, cancels out, and so can never manufacture a widened
+  // bind on its own.
+  if (code === "EACCES" && platform === "win32") return "occupied";
+  return "unevaluated";
+}
+
+/**
+ * Bind an address once and release it. Resolves when the address was free,
+ * rejects with the operating system's error otherwise.
+ *
+ * @param {string} address
+ * @param {number} port
+ * @returns {Promise<void>}
+ */
+function listenProbe(address, port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      // A connection landing inside the probe's window must not reach the
+      // process as an unhandled `error`. The probe answers about an address; it
+      // never serves anything.
+      socket.on("error", () => {});
+      socket.destroy();
+    });
+    server.once("error", reject);
+    server.listen({ host: address, port, exclusive: true }, () => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  });
+}
+
+/**
+ * One reading of every non-loopback address, sorted into what the guard knows:
+ * `occupied` and `free` are answers, `unevaluated` maps an address to why the
+ * platform would not answer for it.
+ *
+ * A per-address failure never rejects. Only an unreadable interface list does.
+ *
+ * @param {number} port
+ * @param {{
+ *   addresses?: string[],
+ *   interfaces?: Record<string, unknown[] | undefined>,
+ *   listen?: (address: string, port: number) => Promise<void>,
+ *   platform?: NodeJS.Platform,
+ * }} [options]
+ * @returns {Promise<{ occupied: Set<string>, free: Set<string>, unevaluated: Map<string, string> }>}
+ */
+export async function readNonLoopbackBindState(port, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const addresses = options.addresses
+    ?? nonLoopbackProbeAddresses({ platform, interfaces: options.interfaces });
+  const listen = options.listen ?? listenProbe;
+  const occupied = new Set();
+  const free = new Set();
+  const unevaluated = new Map();
+  for (const address of addresses) {
+    try {
+      await listen(address, port);
+      free.add(address);
+    } catch (error) {
+      if (classifyBindProbeFailure(error, platform) === "occupied") {
+        occupied.add(address);
+        continue;
+      }
+      unevaluated.set(address, error instanceof Error ? error.message : String(error));
+    }
+  }
+  return { occupied, free, unevaluated };
+}
+
+/**
+ * The guard's verdict: the first address bound after launch that the reading
+ * taken before launch gives no reason to excuse, or null when nothing changed.
+ *
+ * There are exactly two excuses. Somebody already held the address before the
+ * Viewer existed, so its occupancy is not the Viewer's. Or nobody could
+ * evaluate the address before the Viewer existed, so there is no before-state
+ * to compare against and silence is not evidence — which is what makes an
+ * unanswerable probe safe to carry.
+ *
+ * Everything else stays evidence, including an address that only appeared
+ * between the two readings: a guard for a listener that must not be reachable
+ * fails closed when it cannot excuse what it sees.
+ *
+ * @param {{ occupied: Set<string>, unevaluated: Map<string, string> }} before
+ * @param {{ occupied: Set<string> }} after
+ * @returns {string | null}
+ */
+export function newlyBoundNonLoopbackAddress(before, after) {
+  for (const address of after.occupied) {
+    if (before.occupied.has(address)) continue;
+    if (before.unevaluated.has(address)) continue;
+    return address;
+  }
+  return null;
 }

--- a/bin/server-runtime.mjs
+++ b/bin/server-runtime.mjs
@@ -257,13 +257,15 @@ export function classifyBindProbeFailure(error, platform = process.platform) {
 
 /**
  * Bind an address once and release it. Resolves when the address was free,
- * rejects with the operating system's error otherwise.
+ * rejects with the operating system's error otherwise. This is the per-address
+ * half of the probe, and the half whose failures differ by platform, so it is
+ * exported for a caller that needs to substitute it.
  *
  * @param {string} address
  * @param {number} port
  * @returns {Promise<void>}
  */
-function listenProbe(address, port) {
+export function attemptAddressBind(address, port) {
   return new Promise((resolve, reject) => {
     const server = net.createServer((socket) => {
       // A connection landing inside the probe's window must not reach the
@@ -299,7 +301,7 @@ export async function readNonLoopbackBindState(port, options = {}) {
   const platform = options.platform ?? process.platform;
   const addresses = options.addresses
     ?? nonLoopbackProbeAddresses({ platform, interfaces: options.interfaces });
-  const listen = options.listen ?? listenProbe;
+  const listen = options.listen ?? attemptAddressBind;
   const occupied = new Set();
   const free = new Set();
   const unevaluated = new Map();

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
+import http from "node:http";
+import { networkInterfaces } from "node:os";
 import { NextRequest } from "next/server";
 
 import { proxy } from "./proxy";
@@ -12,6 +14,75 @@ afterEach(() => {
 function remote(authorization: string): NextRequest {
   return new NextRequest("http://viewer.example/api/agent/snapshot", { headers: { host: "viewer.example", "x-forwarded-for": "203.0.113.10", authorization } });
 }
+
+function nonLoopbackIpv4Address(): string {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === "IPv4" && !address.internal) return address.address;
+    }
+  }
+  throw new Error("the auth exposure regression needs a non-loopback IPv4 interface");
+}
+
+async function requestThroughProxy(hostname: string): Promise<{ peerAddress: string; status: number }> {
+  let peerAddress = "";
+  const server = http.createServer(async (incoming, outgoing) => {
+    peerAddress = incoming.socket.remoteAddress ?? "";
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(incoming.headers)) {
+      if (Array.isArray(value)) {
+        for (const entry of value) headers.append(name, entry);
+      } else if (value !== undefined) {
+        headers.set(name, value);
+      }
+    }
+    const response = proxy(new NextRequest(`http://localhost${incoming.url ?? "/"}`, { headers }));
+    outgoing.writeHead(response.status, Object.fromEntries(response.headers));
+    outgoing.end(Buffer.from(await response.arrayBuffer()));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "0.0.0.0", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("auth exposure regression server did not bind a TCP port");
+  }
+
+  try {
+    const status = await new Promise<number>((resolve, reject) => {
+      const request = http.get({
+        hostname,
+        port: address.port,
+        path: "/api/agent/snapshot",
+        headers: {
+          host: "localhost",
+          "x-forwarded-for": "127.0.0.1",
+        },
+      }, (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode ?? 0));
+      });
+      request.once("error", reject);
+    });
+    return { peerAddress, status };
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+test("a configured access token protects loopback and non-loopback peers despite loopback request headers", async () => {
+  process.env.LLV_TOKEN = "viewer-token";
+
+  const remoteRequest = await requestThroughProxy(nonLoopbackIpv4Address());
+  expect(remoteRequest.peerAddress).not.toMatch(/^(?:127\.|::1$|::ffff:127\.)/);
+  expect(remoteRequest.status).toBe(403);
+
+  const localRequest = await requestThroughProxy("127.0.0.1");
+  expect(localRequest.peerAddress).toMatch(/^(?:127\.|::1$|::ffff:127\.)/);
+  expect(localRequest.status).toBe(403);
+});
 
 test("remote agent access accepts the exact Bearer LLV_TOKEN", () => {
   process.env.LLV_TOKEN = "viewer-token";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,56 +3,8 @@ import type { NextRequest } from "next/server";
 
 import { tokensMatch } from "@/lib/authToken";
 
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 const AUTH_COOKIE = "llv_auth";
 const COOKIE_MAX_AGE_SECONDS = 2_592_000;
-
-function hostWithoutPort(host: string): string {
-  if (host.startsWith("[")) {
-    const end = host.indexOf("]");
-    return end === -1 ? host : host.slice(1, end);
-  }
-
-  const idx = host.lastIndexOf(":");
-  return idx === -1 ? host : host.slice(0, idx);
-}
-
-function isLoopbackAddress(address: string): boolean {
-  if (address === "::1" || address === "::ffff:127.0.0.1") {
-    return true;
-  }
-
-  const ipv4Match = /^127(?:\.(?:\d{1,3})){3}$/.exec(address);
-  if (ipv4Match === null) {
-    return false;
-  }
-
-  return address
-    .split(".")
-    .every((part) => {
-      const value = Number(part);
-      return Number.isInteger(value) && value >= 0 && value <= 255;
-    });
-}
-
-function hasRemoteForwardedAddress(header: string): boolean {
-  return header
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-    .some((entry) => !isLoopbackAddress(entry));
-}
-
-function isRemote(request: NextRequest): boolean {
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  // Next injects loopback X-Forwarded-For in production, so inspect values instead of treating header presence as remote.
-  if (forwardedFor !== null && hasRemoteForwardedAddress(forwardedFor)) {
-    return true;
-  }
-
-  const host = request.headers.get("host");
-  return host === null || !LOOPBACK_HOSTS.has(hostWithoutPort(host));
-}
 
 function tokenMatches(candidate: string | undefined, token: string): boolean {
   if (candidate === undefined) {
@@ -99,17 +51,16 @@ export function proxy(request: NextRequest): NextResponse {
     return NextResponse.next();
   }
 
-  if (!isRemote(request)) {
-    return NextResponse.next();
-  }
+  // LLV_TOKEN is the explicit access-control switch. Once configured, every
+  // connection authenticates because loopback is shared by every OS account.
 
   const cookieToken = request.cookies.get(AUTH_COOKIE)?.value;
   if (tokenMatches(cookieToken, token)) {
     return NextResponse.next();
   }
 
-  const authorization = request.headers.get("authorization");
-  const bearer = authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+  const authorizationHeader = request.headers.get("authorization");
+  const bearer = authorizationHeader?.match(/^Bearer\s+(.+)$/i)?.[1];
   if (tokenMatches(bearer, token)) {
     return NextResponse.next();
   }


### PR DESCRIPTION
Closes #1496 and #1495. Both were found this week while putting the Viewer on a shared server where four teammates now have accounts, so neither was hypothetical.

**#1496 — "local" was decided from a header the caller controls.** `isRemote` read the `Host` header and skipped the token gate whenever it looked like loopback. `Host` says which name the client dialled; it is never evidence of where a connection came from. Measured on the shared box before the fix: a second, unprivileged account ran `curl 127.0.0.1:8898` and got **200** — every transcript, plus a control surface able to spawn agents on the operator's own subscriptions. A configured `LLV_TOKEN` now authenticates every connection, loopback included, and neither `Host` nor `X-Forwarded-For` offers a bypass.

**#1495 — the bind address was silently dropped on one of the two launch paths.** The standalone path honoured `--hostname` through the environment; `next start` takes it as an argument and got nothing, so a plain checkout started with the default `127.0.0.1` bound every interface. The sharper half was second-order: the non-loopback guard read the *requested* address rather than the bound one, so the one code path meant to notice this was guaranteed not to. The CLI now forwards `--hostname` and verifies the kernel-visible bind.

Three review rounds, each finding something real and each fixed:

1. unscoped link-local IPv6 (`fe80::…`) passed to `listen()` returns `EINVAL` on Linux, killing a correctly bound Viewer — interface scope is now preserved;
2. the bind guard attributed any `EADDRINUSE` on the port to the Viewer child, so an unrelated service holding that port on another address killed a correctly loopback-bound Viewer — occupancy is now captured before launch and only newly occupied addresses are rejected;
3. the final round confirmed both directions still hold.

Every regression test was verified RED before GREEN by reverting the code it guards, and the reviewer re-ran those reverts independently rather than trusting the report — which mattered, because a test written against the header alone passes on the unfixed code, and that is exactly how #1496 survived this long.

Gates at `110bb337`: `bunx tsc --noEmit --incremental false` exit 0; `src/proxy.test.ts` 3 pass, `bin/cli.exposure.integration.test.ts` 3 pass; privacy gate PASS. Reviewed fresh-context on Sol: **APPROVE**.

This also unblocks #1497 — identity in front of a bypass would have been theatre.