### PR TITLE
feat(feed): show the images an agent reads, instead of "[image output]" (#1498)

### DIFF
--- a/src/components/feed/cards/ImageCard.tsx
+++ b/src/components/feed/cards/ImageCard.tsx
@@ -2,25 +2,52 @@
 
 import { useState } from "react";
 
+import { useIsMobile } from "@/hooks/useIsMobile";
+
 import { GlyphIcon } from "../../icons";
 import { Lightbox } from "../Lightbox";
 import { tr } from "../parse";
 
 type ImageView = "chip" | "thumb" | "full";
 
-export function ImageCard({ media, data, w, h, bytes }: { media: string; data: string; w?: number; h?: number; bytes?: number }) {
-  /* Screenshots carry the story of an agent run, so they open as thumbnails right away. */
-  const [view, setView] = useState<ImageView>("thumb");
+/**
+ * A raster in the feed: a pasted or attached picture, or one an agent read
+ * (#1498). `initialView` picks how it opens — a message's picture starts as a
+ * thumbnail, a tool result's as the collapsed chip, so a capture run's dozens
+ * of frames decode nothing until the operator opens one. `inset` drops the
+ * feed-gutter indent for a card that already sits inside a tool body.
+ */
+export function ImageCard({
+  media,
+  data,
+  w,
+  h,
+  bytes,
+  initialView = "thumb",
+  inset = false,
+}: {
+  media: string;
+  data: string;
+  w?: number;
+  h?: number;
+  bytes?: number;
+  initialView?: "chip" | "thumb";
+  inset?: boolean;
+}) {
+  /* Screenshots carry the story of an agent run, so a message's picture opens as a thumbnail right away. */
+  const [view, setView] = useState<ImageView>(initialView);
+  const isMobile = useIsMobile();
   const kb = Math.round((bytes ?? (data.length * 3) / 4) / 1024);
   const dims = w && h ? `${w}×${h}` : tr("render.image");
+  const gutter = inset ? "" : "ml-9 ";
   if (view === "chip") {
     return (
       <button
         type="button"
         onClick={() => setView("thumb")}
-        className="my-2 ml-9 flex items-center gap-2 rounded-[14px] border border-border bg-card px-3.5 py-2 text-[13px] shadow-1"
+        className={`my-2 ${gutter}flex max-w-full items-center gap-2 rounded-[14px] border border-border bg-card px-3.5 py-2 text-[13px] shadow-1 [@media(pointer:coarse)]:min-h-11 ${isMobile ? "min-h-11" : ""}`}
       >
-        <span className="flex h-6.5 w-6.5 items-center justify-center rounded-lg bg-sunken">
+        <span className="flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-lg bg-sunken">
           <GlyphIcon name="image" className="h-4 w-4" />
         </span>
         <span className="font-semibold">{dims}</span>
@@ -31,16 +58,16 @@ export function ImageCard({ media, data, w, h, bytes }: { media: string; data: s
   }
   const src = `data:${media};base64,${data}`;
   return (
-    <div className="my-2 ml-9">
+    <div className={`my-2 ${gutter}min-w-0`}>
       {/* Lazy insert: the data URI only enters the DOM once expanded. next/image cannot serve a base64 data URI here. */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={src}
         alt={`${tr("render.image")} ${dims}`}
         onClick={() => setView("full")}
-        className="max-h-[240px] cursor-zoom-in rounded-[14px] border border-border"
+        className="max-h-[240px] max-w-full cursor-zoom-in rounded-[14px] border border-border object-contain"
       />
-      <button type="button" onClick={() => setView("chip")} className="mt-1 block text-[12px] text-muted">
+      <button type="button" onClick={() => setView("chip")} className="mt-1 block text-[12px] text-muted [@media(pointer:coarse)]:min-h-11">
         {tr("common.collapse")}
       </button>
       {view === "full" ? (

--- a/src/components/feed/cards/ToolCard.imageOutput.dom.test.tsx
+++ b/src/components/feed/cards/ToolCard.imageOutput.dom.test.tsx
@@ -1,0 +1,185 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import type { ReactElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { MOBILE_LAYOUT_QUERY } from "@/lib/attention/eligibility";
+import { translate } from "@/lib/i18n";
+
+import { toolEvent } from "../__fixtures__/readableTools";
+import type { CmdGroupItem, ToolEvent, ToolOutputBlock } from "../parse";
+import { CmdGroupCard } from "./CmdGroupCard";
+import { ToolCard } from "./ToolCard";
+
+/*
+ * #1498: an image an agent reads is a block of its tool result, and the tool
+ * card draws it with the feed's ImageCard — among the result's text, in order.
+ * Nothing decodes until the operator asks: the block renders as the collapsed
+ * chip (dimensions · size · show), and the data URI enters the DOM only when
+ * the chip is opened. One frame is ~400 KB of base64 and a capture run makes
+ * dozens, so the phone (390 × 844) and the desktop both start collapsed.
+ */
+
+let narrowViewport = false;
+
+const normalize = (query: string) => String(query).replace(/\s+/g, "");
+/* The phone is whatever `useIsMobile` asks for — the shared layout query, so a
+   future pin change cannot leave this stub matching a query nobody consults. */
+const matchMediaStub = (query: string) => ({
+  matches: normalize(query) === normalize(MOBILE_LAYOUT_QUERY) ? narrowViewport : false,
+  media: String(query),
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent() { return false; },
+});
+
+const dom = new Window({ url: "http://localhost/" });
+(dom as unknown as { matchMedia: unknown }).matchMedia = matchMediaStub;
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDetailsElement: dom.HTMLDetailsElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  matchMedia: matchMediaStub,
+});
+
+const en = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+  narrowViewport = false;
+  dom.document.body.replaceChildren();
+});
+
+function mount(node: ReactElement): Element {
+  const el = dom.document.createElement("div");
+  dom.document.body.append(el);
+  root = createRoot(el as unknown as HTMLElement);
+  flushSync(() => root!.render(node));
+  return el as unknown as Element;
+}
+
+function toggle(details: Element, open: boolean): void {
+  (details as unknown as { open: boolean }).open = open;
+  flushSync(() => details.dispatchEvent(new dom.Event("toggle") as unknown as Event));
+}
+
+function click(el: Element): void {
+  flushSync(() => el.dispatchEvent(new dom.MouseEvent("click", { bubbles: true, cancelable: true }) as unknown as Event));
+}
+
+const FRAME_DATA = "c3ludGhldGljLWZyYW1l";
+const FRAME_URI = `data:image/jpeg;base64,${FRAME_DATA}`;
+const frame: ToolOutputBlock = { type: "image", media: "image/jpeg", data: FRAME_DATA, w: 1999, h: 1161, bytes: 304134 };
+
+/** A Read of a rendered frame whose result carried text around the picture. */
+function frameRead(over: Partial<ToolEvent> = {}): ToolEvent {
+  return toolEvent({
+    id: "read-frame",
+    family: "read",
+    tool: "Read",
+    icon: "file",
+    summary: "Read op-image-1.jpg",
+    outputPreview: `before the frame\n[${en("render.imageOutput")}]\nafter the frame`,
+    outputBlocks: [{ type: "text", text: "before the frame" }, frame, { type: "text", text: "after the frame" }],
+    open: true,
+    ...over,
+  });
+}
+
+const chipOf = (host: Element) => [...host.querySelectorAll("button")].find((button) => button.textContent?.includes(en("common.show"))) ?? null;
+const order = (text: string, ...needles: string[]) => needles.map((needle) => text.indexOf(needle));
+
+test("desktop: the picture renders as a collapsed chip among the result's text, in order, with nothing decoded", () => {
+  const host = mount(<ToolCard event={frameRead()} />);
+  const body = host.querySelector("details > div")!;
+  expect(body).toBeTruthy();
+  /* No data URI in the DOM until the operator opens the chip. */
+  expect(host.querySelector("img")).toBeNull();
+  expect(host.innerHTML).not.toContain(FRAME_DATA);
+  const chip = chipOf(host)!;
+  expect(chip).toBeTruthy();
+  expect(chip.textContent).toContain("1999×1161");
+  expect(chip.textContent).toContain(`297 ${en("common.kb")}`);
+  /* Text, picture, text — the transcript's order, and the placeholder text is gone. */
+  const [before, picture, after] = order(body.textContent ?? "", "before the frame", "1999×1161", "after the frame");
+  expect(before).toBeGreaterThanOrEqual(0);
+  expect(picture).toBeGreaterThan(before);
+  expect(after).toBeGreaterThan(picture);
+  expect(body.textContent).not.toContain(`[${en("render.imageOutput")}]`);
+  /* Inside the sunken body there is no feed-gutter indent to double up. */
+  expect(chip.getAttribute("class")).not.toContain("ml-9");
+  /* Opening the chip is what inserts the data URI. */
+  click(chip);
+  const img = host.querySelector("img")!;
+  expect(img).toBeTruthy();
+  expect(img.getAttribute("src")).toBe(FRAME_URI);
+  expect(img.getAttribute("class")).not.toContain("ml-9");
+});
+
+test("phone at 390 px: the line is closed until tapped, then the picture is a 44 px chip that expands in place", () => {
+  narrowViewport = true;
+  const host = mount(<ToolCard event={frameRead()} />);
+  const details = host.querySelector("details")!;
+  expect((details as unknown as { open: boolean }).open).toBe(false);
+  expect(host.querySelector("details > div")).toBeNull();
+  expect(host.innerHTML).not.toContain(FRAME_DATA);
+  toggle(details, true);
+  expect(host.querySelector("img")).toBeNull();
+  const chip = chipOf(host)!;
+  expect(chip).toBeTruthy();
+  expect(chip.getAttribute("class")).toContain("min-h-11");
+  expect(chip.getAttribute("class")).not.toContain("ml-9");
+  click(chip);
+  const img = host.querySelector("img")!;
+  expect(img.getAttribute("src")).toBe(FRAME_URI);
+  /* The thumbnail never forces the 390 px document sideways. */
+  expect(img.getAttribute("class")).toContain("max-w-full");
+});
+
+test("a live run block shows every picture as a chip and still decodes none of them", () => {
+  const calls = [1, 2, 3].map((n) =>
+    frameRead({ id: `read-frame-${n}`, summary: `Read op-image-${n}.jpg`, outputPreview: `[${en("render.imageOutput")}]`, outputBlocks: [frame] }),
+  );
+  const group: CmdGroupItem = {
+    kind: "cmd-group",
+    ids: calls.map((call) => call.id),
+    calls,
+    t0: calls[0]!.ts,
+    t1: calls[2]!.ts,
+    byTool: { Read: 3 },
+    okCount: 3,
+    errCount: 0,
+    hasErr: false,
+    active: true,
+  };
+  const host = mount(<CmdGroupCard item={group} />);
+  const chips = [...host.querySelectorAll("button")].filter((button) => button.textContent?.includes(en("common.show")));
+  expect(chips).toHaveLength(3);
+  expect(host.querySelectorAll("img")).toHaveLength(0);
+  expect(host.innerHTML).not.toContain(FRAME_DATA);
+});
+
+test("a picture block without data falls back to the text placeholder and never blanks the card", () => {
+  const event = frameRead({
+    outputPreview: `captured\n[${en("render.imageOutput")}]`,
+    outputBlocks: [{ type: "text", text: "captured" }, { type: "image", media: "image/png", data: "" }],
+  });
+  const host = mount(<ToolCard event={event} />);
+  const body = host.querySelector("details > div")!;
+  expect(body.textContent).toContain("captured");
+  expect(body.textContent).toContain(en("render.imageOutput"));
+  expect(chipOf(host)).toBeNull();
+  expect(host.querySelector("img")).toBeNull();
+});

--- a/src/components/feed/cards/ToolCard.imageOutput.dom.test.tsx
+++ b/src/components/feed/cards/ToolCard.imageOutput.dom.test.tsx
@@ -183,3 +183,43 @@ test("a picture block without data falls back to the text placeholder and never 
   expect(chipOf(host)).toBeNull();
   expect(host.querySelector("img")).toBeNull();
 });
+
+test("phone at 390 px: a folded run of image Reads opens into readable blocks whose pictures are chips, decoding none until one is opened", () => {
+  narrowViewport = true;
+  const calls = [1, 2, 3].map((n) =>
+    frameRead({ id: `read-frame-${n}`, summary: `Read op-image-${n}.jpg`, outputPreview: `[${en("render.imageOutput")}]`, outputBlocks: [frame], open: false }),
+  );
+  const group: CmdGroupItem = {
+    kind: "cmd-group",
+    ids: calls.map((call) => call.id),
+    calls,
+    t0: calls[0]!.ts,
+    t1: calls[2]!.ts,
+    byTool: { Read: 3 },
+    okCount: 3,
+    errCount: 0,
+    hasErr: false,
+    active: false,
+  };
+  const host = mount(<CmdGroupCard item={group} />);
+  /* The phone folds a settled run to one line; nothing of the pictures is in the DOM yet. */
+  const fold = host.querySelector("[data-mobile-run-fold]")!;
+  expect(fold).toBeTruthy();
+  expect(fold.getAttribute("aria-expanded")).toBe("false");
+  expect(fold.textContent).toContain("Read ×3");
+  expect(chipOf(host)).toBeNull();
+  expect(host.innerHTML).not.toContain(FRAME_DATA);
+  /* Opening the run shows every picture as a chip and still decodes none of them. */
+  click(fold);
+  const chips = [...host.querySelectorAll("button")].filter((button) => button.textContent?.includes(en("common.show")));
+  expect(chips).toHaveLength(3);
+  expect(chips.every((chip) => chip.getAttribute("class")?.includes("min-h-11"))).toBe(true);
+  expect(host.querySelectorAll("img")).toHaveLength(0);
+  expect(host.innerHTML).not.toContain(FRAME_DATA);
+  /* One tap decodes exactly that picture, width-bounded so the 390 px page never scrolls sideways. */
+  click(chips[1]!);
+  const imgs = host.querySelectorAll("img");
+  expect(imgs).toHaveLength(1);
+  expect(imgs[0]!.getAttribute("src")).toBe(FRAME_URI);
+  expect(imgs[0]!.getAttribute("class")).toContain("max-w-full");
+});

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -9,10 +9,11 @@ import { GlyphIcon, Loader2 } from "../../icons";
 import { hhmm } from "../../utils";
 import { ACTION_GUTTER, MESSAGE_ACTION } from "../actionStyles";
 import { CopyButton } from "../CopyButton";
-import { tr, type ToolEvent } from "../parse";
+import { tr, type ToolEvent, type ToolOutputBlock } from "../parse";
 import type { ArgChip } from "../tools";
 import { formatDuration, isFollowUpCall, toolDurationMs } from "../toolBlocks";
 import { DiffCard } from "./DiffCard";
+import { ImageCard } from "./ImageCard";
 import { OrchestrationCard } from "./OrchestrationCard";
 import { OutputPreview } from "./OutputPreview";
 import { StatusIcon } from "./shared";
@@ -135,12 +136,21 @@ export function ToolBody({ event }: { event: ToolEvent }) {
       {event.orchestration ? <OrchestrationCard orchestration={event.orchestration} source={event.command} /> : null}
       {hasDiff && event.body?.type === "diff" ? <DiffCard body={event.body} /> : null}
       {showOutput ? (
-        <OutputPreview
-          output={event.outputPreview}
-          truncated={event.outputTruncated}
-          lang={event.lang}
-          heading={event.stderr !== undefined ? tr("tools.stdout") : undefined}
-        />
+        event.outputBlocks?.length ? (
+          <ToolOutputBlocks
+            blocks={event.outputBlocks}
+            truncated={event.outputTruncated}
+            lang={event.lang}
+            heading={event.stderr !== undefined ? tr("tools.stdout") : undefined}
+          />
+        ) : (
+          <OutputPreview
+            output={event.outputPreview}
+            truncated={event.outputTruncated}
+            lang={event.lang}
+            heading={event.stderr !== undefined ? tr("tools.stdout") : undefined}
+          />
+        )
       ) : null}
       {event.stderr !== undefined ? (
         <OutputPreview
@@ -153,6 +163,40 @@ export function ToolBody({ event }: { event: ToolEvent }) {
         />
       ) : null}
     </div>
+  );
+}
+
+/* #1498: a result that carried pictures renders its blocks in transcript
+   order — text through the capped preview, a picture through the feed's own
+   ImageCard, collapsed to its chip so the data URI enters the DOM only when
+   the operator opens it. A picture whose data did not survive falls back to
+   the same text placeholder the flattened preview carries, so a broken frame
+   degrades to a line rather than to a blank card. */
+function ToolOutputBlocks({
+  blocks,
+  truncated,
+  lang,
+  heading,
+}: {
+  blocks: readonly ToolOutputBlock[];
+  truncated: boolean;
+  lang?: string | null;
+  heading?: string;
+}) {
+  const lastText = blocks.reduce((last, block, index) => (block.type === "text" ? index : last), -1);
+  let firstText = true;
+  return (
+    <>
+      {blocks.map((block, index) => {
+        if (block.type === "image" && block.data) {
+          return <ImageCard key={index} media={block.media} data={block.data} w={block.w} h={block.h} bytes={block.bytes} initialView="chip" inset />;
+        }
+        const text = block.type === "text" ? block.text : `[${tr("render.imageOutput")}]`;
+        const node = <OutputPreview key={index} output={text} truncated={truncated && index === lastText} lang={lang} heading={firstText ? heading : undefined} />;
+        firstText = false;
+        return node;
+      })}
+    </>
   );
 }
 

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -1525,15 +1525,21 @@ describe("Codex payload audit fixture", () => {
     }
   });
 
-  test("typed tool output keeps an image placeholder beside captured text", () => {
+  test("typed tool output carries its image on the card and keeps a text placeholder for copy/speech (#1498)", () => {
     const feed = buildFeed(codexFile, lines, false, "");
     const tools = feed.items.flatMap((item): Extract<Item, { kind: "tool" }>[] =>
       item.kind === "tool" ? [item] : item.kind === "cmd-group" ? item.calls : [],
     );
     const custom = tools.find((item) => item.id === "custom-call");
     expect(custom?.outputPreview).toContain("Synthetic poll output");
+    /* The flattened text keeps a placeholder where the picture sits, never the payload. */
     expect(custom?.outputPreview.toLowerCase()).toContain("image");
     expect(custom?.outputPreview).not.toContain("c3ludGhldGlj");
+    /* The picture itself rides the card as an ordered block after the text. */
+    expect(custom?.outputBlocks).toEqual([
+      { type: "text", text: "Synthetic poll output" },
+      { type: "image", media: "image/png", data: "c3ludGhldGlj" },
+    ]);
   });
 
   test("typed tool output keeps primitive values and unknown block labels", () => {
@@ -2384,5 +2390,119 @@ describe("issue 1398: one Codex user message reaches the rollout as several reco
       userItemCompleted("2026-09-01T09:01:00.002Z", "A second question."),
     ], false, "");
     expect(userRows(feed).map((item) => (item as { text: string }).text)).toEqual([PROMPT, "A second question."]);
+  });
+});
+
+describe("tool results carry their images (#1498)", () => {
+  const frameData = "c3ludGhldGljLWZyYW1l";
+  const claudeRead = (id: string, file: string) =>
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-09-03T23:52:20.000Z",
+      message: { content: [{ type: "tool_use", id, name: "Read", input: { file_path: file } }] },
+    });
+  /* The CLI's own shape for a Read of a raster: the base64 sits in the
+     tool_result block, and `toolUseResult.file` repeats it with the dimensions. */
+  const claudeImageResult = (id: string, data: string, more: Record<string, unknown>[] = []) =>
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-09-03T23:52:23.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: id, content: [{ type: "image", source: { type: "base64", media_type: "image/jpeg", data } }, ...more] }],
+      },
+      toolUseResult: {
+        type: "image",
+        file: { base64: data, type: "image/jpeg", originalSize: 304134, dimensions: { originalWidth: 1999, originalHeight: 1161, displayWidth: 1999, displayHeight: 1161 } },
+      },
+    });
+  const codexTyped = (id: string, output: unknown[]) => [
+    JSON.stringify({ type: "response_item", timestamp: "t1", payload: { type: "custom_tool_call", call_id: id, name: "exec", input: "capture();" } }),
+    JSON.stringify({ type: "response_item", timestamp: "t2", payload: { type: "custom_tool_call_output", call_id: id, output } }),
+  ];
+  const toolItems = (feed: ReturnType<typeof buildFeed>) =>
+    feed.items.flatMap((item): Extract<Item, { kind: "tool" }>[] => (item.kind === "tool" ? [item] : item.kind === "cmd-group" ? item.calls : []));
+
+  test("a Claude Read of an image file puts the picture on the Read card instead of beside it", () => {
+    const lines = [claudeRead("toolu-frame", "/workspace/frames/op-image-1.jpg"), claudeImageResult("toolu-frame", frameData)];
+    const feed = buildFeed(claudeFile, lines, false, "");
+    const read = toolItems(feed).find((item) => item.id === "toolu-frame");
+    expect(read?.status).toBe("ok");
+    expect(read?.outputBlocks).toEqual([{ type: "image", media: "image/jpeg", data: frameData, w: 1999, h: 1161, bytes: 304134 }]);
+    /* The card owns the picture: no standalone image row is pushed around it. */
+    expect(itemsOfKind(feed, "image")).toHaveLength(0);
+    expect(read?.outputPreview).not.toContain(frameData);
+    /* A result that carries a picture opens on the desktop the way an edit's diff does. */
+    expect(read?.open).toBe(true);
+    assertParity(claudeFile, lines, { chunks: [1] });
+  });
+
+  test("a pasted Claude image keeps its own standalone card (the path that already worked)", () => {
+    const pasted = JSON.stringify({
+      type: "user",
+      timestamp: "2026-09-03T23:50:00.000Z",
+      message: { role: "user", content: [{ type: "text", text: "compare with this" }, { type: "image", source: { type: "base64", media_type: "image/png", data: frameData } }] },
+    });
+    const feed = buildFeed(claudeFile, [pasted], false, "");
+    expect(itemsOfKind(feed, "image")).toEqual([{ kind: "image", media: "image/png", data: frameData, w: undefined, h: undefined, bytes: undefined }]);
+    expect(itemsOfKind(feed, "user")).toHaveLength(1);
+  });
+
+  test("a Codex typed output keeps text and images in order, neither replacing the other", () => {
+    const lines = codexTyped("mixed-image", [
+      { type: "input_text", text: "Script completed\nWall time 0.1 seconds\nOutput:\nbefore the frame" },
+      { type: "input_image", image_url: "data:image/png;base64,c3ludGhldGlj" },
+      { type: "input_text", text: "after the frame" },
+    ]);
+    const feed = buildFeed(codexFile, lines, false, "");
+    const call = toolItems(feed).find((item) => item.id === "mixed-image");
+    expect(call?.outputBlocks).toEqual([
+      { type: "text", text: "before the frame" },
+      { type: "image", media: "image/png", data: "c3ludGhldGlj" },
+      { type: "text", text: "after the frame" },
+    ]);
+    expect(call?.outputPreview).toContain("before the frame");
+    expect(call?.outputPreview).toContain("after the frame");
+    expect(call?.outputPreview).not.toContain("c3ludGhldGlj");
+    expect(itemsOfKind(feed, "image")).toHaveLength(0);
+    assertParity(codexFile, lines, { chunks: [1] });
+  });
+
+  test("a malformed, unsupported or oversized image block degrades to the text placeholder and keeps the card's text", () => {
+    const oversized = "A".repeat(Math.ceil((12 * 1024 * 1024 * 4) / 3));
+    const lines = codexTyped("broken-image", [
+      { type: "input_text", text: "captured" },
+      { type: "input_image" },
+      { type: "image", source: { type: "base64", media_type: "image/jpeg" } },
+      { type: "input_image", image_url: "data:image/svg+xml;base64,PHN2Zz4=" },
+      { type: "input_image", image_url: `data:image/png;base64,${oversized}` },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "not base64 at all!" } },
+    ]);
+    const feed = buildFeed(codexFile, lines, false, "");
+    const call = toolItems(feed).find((item) => item.id === "broken-image");
+    expect(call?.status).toBe("ok");
+    expect(call?.outputPreview).toContain("captured");
+    expect(call?.outputPreview.toLowerCase()).toContain("image");
+    /* Nothing survived as a picture, so the card keeps the plain text path. */
+    expect(call?.outputBlocks).toBeUndefined();
+    const serialized = JSON.stringify(feed.items);
+    expect(serialized).not.toContain("PHN2Zz4=");
+    expect(serialized).not.toContain(oversized.slice(0, 128));
+    expect(serialized).not.toContain("not base64 at all!");
+  });
+
+  test("a Claude result mixing text and images keeps both in order and the file's dimensions on the picture", () => {
+    const lines = [
+      claudeRead("toolu-mixed", "/workspace/frames/op-image-2.jpg"),
+      claudeImageResult("toolu-mixed", frameData, [{ type: "text", text: "1999x1161 frame, captured at 100%" }]),
+    ];
+    const feed = buildFeed(claudeFile, lines, false, "");
+    const read = toolItems(feed).find((item) => item.id === "toolu-mixed");
+    expect(read?.outputBlocks).toEqual([
+      { type: "image", media: "image/jpeg", data: frameData, w: 1999, h: 1161, bytes: 304134 },
+      { type: "text", text: "1999x1161 frame, captured at 100%" },
+    ]);
+    expect(read?.outputPreview).toContain("1999x1161 frame, captured at 100%");
+    assertParity(claudeFile, lines, { chunks: [1] });
   });
 });

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -35,6 +35,16 @@ export type ToolStatus = "run" | "ok" | "err";
     (e.g. a highlighted Read body) actually needs them. */
 export type ToolBody = { type: "diff"; files: FileDiff[]; filesTruncated: boolean };
 
+/** One ordered block of a tool result (#1498). A result is text until an
+    engine hands the agent a picture — a Read of a raster, a capture script's
+    frame — and a picture cannot survive the flattened string. A `text` block
+    is decoded, redacted and capped like the preview; an `image` block is the
+    raster the agent saw, bounded by the inbox image policy, with the file's
+    dimensions when the engine reported them. */
+export type ToolOutputBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; media: string; data: string; w?: number; h?: number; bytes?: number };
+
 /** One inner operation of a `functions.exec` orchestration record. Per-call
     status and output are not in the transcript — the combined output attaches
     to the outer event — so a nested call carries only what was parsed: its
@@ -92,6 +102,12 @@ export type ToolEvent = {
   statusLabel: string;
   outputPreview: string;
   outputTruncated: boolean;
+  /** The result's ordered text and image blocks (#1498). Present only when the
+      result carried at least one picture; a text-only result keeps
+      `outputPreview` alone and the card's plain text path. The flattened
+      preview keeps a text placeholder where each picture sits, so copy,
+      speech and the phone's failure detail still read in order. */
+  outputBlocks?: ToolOutputBlock[];
   /** Working directory recovered from the call args or a `cd … &&` prefix. */
   cwd?: string;
   /** Numeric exit code recovered from a `exited with code N` result line. */
@@ -511,26 +527,103 @@ function normalizeCodexUserContent(content: unknown): CodexUserContent {
   return { ...decodeCodexStructuredUserText(text.join(" ").trim()), attachments };
 }
 
-/** Responses custom tools return either plain text or typed text blocks. */
-function toolOutputText(value: unknown): string {
-  if (typeof value === "string") return redactTranscriptText(value);
-  if (Array.isArray(value)) {
-    return value
-      .map((part) => {
-        if (typeof part === "string") return redactTranscriptText(part);
-        if (typeof part === "number" || typeof part === "boolean") return String(part);
-        if (!part || typeof part !== "object" || Array.isArray(part)) return "";
-        const block = rec(part);
-        const text = textPart(block.text) || textPart(block.input_text) || textPart(block.output_text);
-        if (text) return redactTranscriptText(text);
-        if (block.type === "input_image" || block.type === "image") return `[${tr("render.imageOutput")}]`;
-        const type = redactTranscriptText(textPart(block.type)).slice(0, ATTACHMENT_TYPE_MAX);
-        return `[${type ? tr("render.toolOutputType", { type }) : tr("render.toolOutput")}]`;
-      })
-      .filter(Boolean)
-      .join("\n");
+type ToolImageBlock = Extract<ToolOutputBlock, { type: "image" }>;
+/** A tool result parsed for the card: the flattened text every consumer reads,
+    and — only when a picture survived — the ordered blocks the card draws. */
+type ToolOutput = { text: string; blocks?: ToolOutputBlock[] };
+
+const BASE64_BODY_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/* The raster a tool-result block carries, in either engine's shape: Claude's
+   `{ source: { type: "base64", media_type, data } }` and Codex's
+   `{ image_url: "data:…;base64,…" }` (or `{ image_url: { url } }` / `data`).
+   Null for anything the feed may not draw — no payload, an unsupported media
+   type, a body that is not base64, or one over the inbox limit — so the caller
+   keeps the text placeholder for it and the card degrades to text (#1498). */
+function toolImageBlock(block: Record<string, unknown>): ToolImageBlock | null {
+  const source = rec(block.source);
+  const inline = textPart(source.data);
+  if (inline) {
+    const media = textPart(source.media_type).trim().toLowerCase();
+    if (!inboxImageExt(media)) return null;
+    if (!BASE64_BODY_RE.test(inline) || base64DecodedLength(inline) > MAX_INBOX_IMAGE_BYTES) return null;
+    return { type: "image", media, data: inline };
   }
-  return value === undefined || value === null ? "" : redactTranscriptText(JSON.stringify(value));
+  const url = textPart(block.image_url) || textPart(rec(block.image_url).url) || textPart(block.data);
+  const image = url ? codexImageFromDataUrl(url) : null;
+  return image ? { type: "image", media: image.media, data: image.data } : null;
+}
+
+/* Typed result parts become one flattened text and, when a picture survived,
+   the ordered blocks. Text parts keep flowing into the string exactly as
+   before; a picture leaves a placeholder in the string and rides beside it as
+   a block, so the card can draw it where the transcript put it (#1498).
+   `decorate` lets the Claude arm attach the file's reported dimensions. */
+function toolOutputFromBlocks(parts: unknown[], decorate: (image: ToolImageBlock, ordinal: number) => ToolImageBlock = (image) => image): ToolOutput {
+  const texts: string[] = [];
+  const blocks: ToolOutputBlock[] = [];
+  let pictures = 0;
+  const pushText = (text: string) => {
+    if (!text) return;
+    texts.push(text);
+    const last = blocks[blocks.length - 1];
+    if (last?.type === "text") last.text = `${last.text}\n${text}`;
+    else blocks.push({ type: "text", text });
+  };
+  for (const part of parts) {
+    if (typeof part === "string") {
+      pushText(redactTranscriptText(part));
+      continue;
+    }
+    if (typeof part === "number" || typeof part === "boolean") {
+      pushText(String(part));
+      continue;
+    }
+    if (!part || typeof part !== "object" || Array.isArray(part)) continue;
+    const block = rec(part);
+    const text = textPart(block.text) || textPart(block.input_text) || textPart(block.output_text);
+    if (text) {
+      pushText(redactTranscriptText(text));
+      continue;
+    }
+    if (block.type === "input_image" || block.type === "image") {
+      const image = toolImageBlock(block);
+      if (image) {
+        pictures += 1;
+        blocks.push(decorate(image, pictures));
+        texts.push(`[${tr("render.imageOutput")}]`);
+      } else {
+        pushText(`[${tr("render.imageOutput")}]`);
+      }
+      continue;
+    }
+    const type = redactTranscriptText(textPart(block.type)).slice(0, ATTACHMENT_TYPE_MAX);
+    pushText(`[${type ? tr("render.toolOutputType", { type }) : tr("render.toolOutput")}]`);
+  }
+  return { text: texts.join("\n"), ...(pictures ? { blocks } : {}) };
+}
+
+/** Responses custom tools return either plain text or typed text blocks, and a
+    typed block may be a picture (#1498). */
+function toolOutput(value: unknown): ToolOutput {
+  if (typeof value === "string") return { text: redactTranscriptText(value) };
+  if (Array.isArray(value)) return toolOutputFromBlocks(value);
+  return { text: value === undefined || value === null ? "" : redactTranscriptText(JSON.stringify(value)) };
+}
+
+function toolOutputText(value: unknown): string {
+  return toolOutput(value).text;
+}
+
+/* A Read's `toolUseResult.file` describes the one raster the Read returned:
+   its dimensions and byte size label the picture's chip. It says nothing about
+   a result carrying several pictures, so those keep their bare blocks. */
+function withFileDimensions(image: ToolImageBlock, fileWrap: Record<string, unknown>): ToolImageBlock {
+  const dims = rec(fileWrap.dimensions);
+  const w = num(dims.originalWidth);
+  const h = num(dims.originalHeight);
+  const bytes = num(fileWrap.originalSize);
+  return { ...image, ...(w !== undefined ? { w } : {}), ...(h !== undefined ? { h } : {}), ...(bytes !== undefined ? { bytes } : {}) };
 }
 
 /* Read the interactive session identifier from the original output envelope
@@ -673,6 +766,29 @@ const WAKEUP_PROMPT_MAX = 4_000;
 /* A Codex result-preamble line (custom-tool + interactive-shell wrappers, all
    known variants). Used to strip the contiguous leading metadata block. */
 const PREAMBLE_LINE = /^(?:Chunk ID:|Wall time\b|Original token count:|Output:[ \t]*$|Script completed\b|Script running with (?:cell|session) ID\b|Process running with (?:cell|session) ID\b|Process exited with code\b)/;
+
+/* One result text made readable: real newlines, ANSI removed (issue #141), and
+   — for the leading block of a result — the Codex wrapper preamble stripped.
+   A bare `{}` (a script that returned nothing) is no output (issue #90). */
+function cleanOutputText(text: string, stripPreamble: boolean): string {
+  const lines = decodeTerminalText(text).split("\n");
+  let start = 0;
+  if (stripPreamble) while (start < lines.length && PREAMBLE_LINE.test(lines[start]!)) start += 1;
+  const stripped = lines.slice(start).join("\n").trim();
+  return stripped === "{}" ? "" : stripped;
+}
+
+/* Adjacent text blocks read as one block, so the seam between what earlier
+   polls carried and what a new result adds never splits a paragraph. */
+function mergeTextBlocks(blocks: readonly ToolOutputBlock[]): ToolOutputBlock[] {
+  const out: ToolOutputBlock[] = [];
+  for (const block of blocks) {
+    const last = out[out.length - 1];
+    if (block.type === "text" && last?.type === "text") out[out.length - 1] = { type: "text", text: `${last.text}\n${block.text}` };
+    else out.push(block);
+  }
+  return out;
+}
 const CODE_EXT_RE = /\.([A-Za-z0-9]{1,10})$/;
 const CWD_MAX = 400;
 
@@ -1635,7 +1751,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   };
   /* Attaches a result copy-on-write: the record gets a fresh ToolEvent and the
      owning entry a fresh item, so exactly one row changes identity. */
-  const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean, rawSession?: string, resultTs?: unknown) => {
+  const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean, rawSession?: string, resultTs?: unknown, blocks?: ToolOutputBlock[]) => {
     if (!callRec) return null;
     const code = output.match(/exited with code (\d+)/)?.[1];
     /* Codex interactive-shell wall time, read before the preamble is stripped, so
@@ -1651,11 +1767,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
        Strip the contiguous leading block of those lines, decode the payload (real
        newlines, ANSI removed — issue #141), and treat a bare `{}` (a script that
        returned nothing) as no output (issue #90). */
-    const lines = decodeTerminalText(output).split("\n");
-    let start = 0;
-    while (start < lines.length && PREAMBLE_LINE.test(lines[start]!)) start += 1;
-    const stripped = lines.slice(start).join("\n").trim();
-    const body = stripped === "{}" ? "" : stripped;
+    const body = cleanOutputText(output, true);
     const isErr = errFlag === true || (code !== undefined && code !== "0");
     const prev = callRec.event;
     /* An empty codex wait/stdin chunk collapses to "waiting Ns" rather than an
@@ -1679,6 +1791,25 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       const combined = (prev.outputPreview + "\n" + redactSecrets(stdoutBody)).trim();
       outputTruncated = prev.outputTruncated || combined.length > limit;
       outputPreview = combined.slice(-limit);
+    }
+    /* #1498: a result that carried pictures keeps them as ordered blocks
+       beside the flattened preview. Each text block gets the preview's own
+       decode, wrapper strip (leading block only), redaction and cap; what
+       earlier polls of the same call already showed stays ahead of them. */
+    let outputBlocks = prev.outputBlocks;
+    if (blocks?.some((block) => block.type === "image")) {
+      const limit = isErr ? OUTPUT_ERR_MAX : OUTPUT_OK_MAX;
+      const carried: ToolOutputBlock[] = prev.outputBlocks ?? (prev.outputPreview ? [{ type: "text", text: prev.outputPreview }] : []);
+      const fresh: ToolOutputBlock[] = [];
+      blocks.forEach((block, index) => {
+        if (block.type === "image") {
+          fresh.push(block);
+          return;
+        }
+        const text = redactSecrets(cleanOutputText(block.text, index === 0)).slice(-limit);
+        if (text) fresh.push({ type: "text", text });
+      });
+      outputBlocks = mergeTextBlocks([...carried, ...fresh]);
     }
     let stderr = prev.stderr;
     let stderrTruncated = prev.stderrTruncated;
@@ -1729,10 +1860,14 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         : idleWait
           ? tr("tools.waitingSeconds", { n: Math.round(Number(wallSeconds)) })
           : "ok",
-      open: prev.open || isErr,
+      /* A result that carried a picture opens the card by default the way an
+         edit's diff does (issue #90): the chip is visible without a click and
+         decodes nothing until the operator opens it (#1498). */
+      open: prev.open || isErr || outputBlocks !== prev.outputBlocks,
       srcResult: curSrc,
       outputPreview,
       outputTruncated,
+      ...(outputBlocks !== undefined ? { outputBlocks } : {}),
       ...(exitCode !== undefined ? { exitCode } : {}),
       ...(durationMs !== undefined ? { durationMs } : {}),
       ...(endTs !== undefined ? { endTs } : {}),
@@ -1756,7 +1891,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (wakeup && wakeup.failed) recomputeWakeupStates();
     return event;
   };
-  const addOutput = (callId: string | undefined, output: string, err?: boolean, rawSession?: string, resultTs?: unknown) => {
+  const addOutput = (callId: string | undefined, output: string, err?: boolean, rawSession?: string, resultTs?: unknown, blocks?: ToolOutputBlock[]) => {
     if (!callId) return;
     const tseq = tmsgSeqs.get(callId);
     if (tseq !== undefined) {
@@ -1773,7 +1908,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       }
       return;
     }
-    const event = attach(calls.get(callId), output, err, rawSession, resultTs);
+    const event = attach(calls.get(callId), output, err, rawSession, resultTs, blocks);
     if (!event && output && showSvc) push({ kind: "svc", text: "output: " + redactSecrets(output).slice(0, 200) });
   };
   const addSvc = (text: string) => {
@@ -2405,8 +2540,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       }
       if (p.type === "function_call_output") {
         const rawSession = toolOutputSession(p.output);
-        const output = toolOutputText(p.output);
-        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession, ts);
+        const { text: output, blocks } = toolOutput(p.output);
+        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession, ts, blocks);
       }
       /* Fresh rollouts wrap apply_patch as a "custom_tool_call": `input` is the
          raw patch text directly (unlike function_call, whose `arguments` is a
@@ -2422,8 +2557,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       }
       if (p.type === "custom_tool_call_output") {
         const rawSession = toolOutputSession(p.output);
-        const output = toolOutputText(p.output);
-        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession, ts);
+        const { text: output, blocks } = toolOutput(p.output);
+        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession, ts, blocks);
       }
       if (p.type === "reasoning" || p.type === "agent_message") return addSvc(textPart(p.type));
       return addRecord(ts, textPart(p.type) || "item", p);
@@ -2471,15 +2606,20 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
           if (part.type === "text") addUserText(ts, textPart(part.text), isHarness, deliveredMessage);
           else if (part.type === "image") pushImage(part, fileWrap);
           else if (part.type === "tool_result") {
-            const inner = arr(part.content);
-            for (const block of inner) {
-              if (block.type === "image") pushImage(block, fileWrap);
+            if (typeof part.content === "string") {
+              addOutput(textPart(part.tool_use_id), part.content, part.is_error === true, undefined, ts);
+              continue;
             }
-            const contentText =
-              typeof part.content === "string"
-                ? part.content
-                : inner.filter((x) => x.type !== "image").map((x) => textPart(x.text)).join(" ");
-            addOutput(textPart(part.tool_use_id), contentText, part.is_error === true, undefined, ts);
+            /* #1498: a picture in the result — a Read of a raster — belongs to
+               the tool's card, not to a standalone row pushed beside it. The
+               text keeps its shape; the file wrapper describes the one raster a
+               Read returned, so its dimensions label a lone picture only. */
+            const inner = arr(part.content);
+            const pictures = inner.filter((block) => block.type === "image").length;
+            const output = pictures
+              ? toolOutputFromBlocks(inner, (image) => (pictures === 1 ? withFileDimensions(image, fileWrap) : image))
+              : { text: inner.map((x) => textPart(x.text)).join(" ") };
+            addOutput(textPart(part.tool_use_id), output.text, part.is_error === true, undefined, ts, output.blocks);
           }
         }
       }

--- a/src/hooks/useLogTail.dom.test.tsx
+++ b/src/hooks/useLogTail.dom.test.tsx
@@ -131,3 +131,35 @@ test("A to B to A restores cached tail lines before the delayed transport respon
   expect(dom.document.querySelector("output")?.textContent).toContain("cached A");
   expect(dom.document.querySelector("output")?.textContent).toContain("live A");
 });
+
+/* #1498: a chunk that begins past where the window left off — the bounded
+   catch-up jumping a stale subscriber forward — starts inside a record whose
+   head was never delivered. The carried partial line and the half record it
+   begins with are both dropped, so no spliced garbage line ever reaches the
+   parser; a contiguous chunk still joins the partial it continues. */
+test("a resumed chunk drops the carried partial and the half record it begins with; a contiguous chunk still joins its partial", async () => {
+  const a = entry("/sessions/project-a/resumed.jsonl");
+  mount(a);
+  const subscriber = await waitForSubscriber(a.path);
+  const one = '{"message":"one"}\n';
+  const head = '{"mess';
+  deliver(subscriber, { data: one + head, offset: one.length + head.length, size: 400, start: 0 });
+  expect(dom.document.querySelector("output")?.textContent).toBe('{"message":"one"}');
+
+  /* The server jumped ahead: this chunk starts well past the offset the
+     window left off at, inside a record the client never saw the head of. */
+  const jumpStart = 200;
+  const half = 'age-of-a-different-record"}\n';
+  const live = '{"message":"live"}\n';
+  deliver(subscriber, { data: half + live, offset: jumpStart + half.length + live.length, size: 400, start: jumpStart });
+  const text = dom.document.querySelector("output")?.textContent ?? "";
+  expect(text).toBe('{"message":"one"}|{"message":"live"}');
+  expect(text).not.toContain("different-record");
+
+  /* A contiguous chunk (start === the offset the window left off at) keeps
+     joining the partial it continues, exactly as before. */
+  const from = subscriber.getOffset();
+  deliver(subscriber, { data: '{"mess', offset: from + 6, size: 400, start: from });
+  deliver(subscriber, { data: 'age":"two"}\n', offset: from + 6 + 12, size: 400, start: from + 6 });
+  expect(dom.document.querySelector("output")?.textContent).toBe('{"message":"one"}|{"message":"live"}|{"message":"two"}');
+});

--- a/src/hooks/useLogTail.ts
+++ b/src/hooks/useLogTail.ts
@@ -248,17 +248,23 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
           updateWin(target, { lines: [], start: 0 });
         }
         if (chunk.data) {
-          let data = tailRef.current + chunk.data;
+          /* A chunk that begins past where this window left off — the first
+             read of a large file, or the bounded catch-up jumping a stale
+             subscriber forward — starts inside a record whose head was never
+             delivered. Drop through its first newline, and drop whatever
+             partial the previous chunk left behind, so no half record ever
+             reaches the parser as a line (#1498). */
+          const resumed = firstRef.current || chunk.start > offsetRef.current;
+          let data = (resumed ? "" : tailRef.current) + chunk.data;
           tailRef.current = "";
-          if (firstRef.current) {
-            startRef.current = chunk.start;
-            if (chunk.start > 0) {
-              const nl = data.indexOf("\n");
-              startRef.current = chunk.start + (nl >= 0 ? utf8len(data.slice(0, nl + 1)) : utf8len(data));
-              data = nl >= 0 ? data.slice(nl + 1) : "";
-            }
-            updateHasMore(target, startRef.current > 0);
+          if (firstRef.current) startRef.current = chunk.start;
+          if (resumed && chunk.start > 0) {
+            const nl = data.indexOf("\n");
+            const skipped = nl >= 0 ? data.slice(0, nl + 1) : data;
+            if (firstRef.current) startRef.current = chunk.start + utf8len(skipped);
+            data = nl >= 0 ? data.slice(nl + 1) : "";
           }
+          if (firstRef.current) updateHasMore(target, startRef.current > 0);
           const parts = data.split("\n");
           tailRef.current = parts.pop() ?? "";
           const complete = parts.map((line) => line.trim()).filter(Boolean);

--- a/src/lib/logRead.ts
+++ b/src/lib/logRead.ts
@@ -3,6 +3,33 @@ import fs from "node:fs/promises";
 import { MAX_CHUNK, pathAllowed } from "@/lib/scanner/roots";
 import type { LogChunk } from "@/lib/types";
 
+const NEWLINE = 0x0a;
+const SCAN_PIECE = 64 * 1024;
+
+/* The absolute index of the first newline in [from, to), or null. Reads in
+   small pieces so a bounded scan never allocates the whole span. */
+async function firstNewline(fh: fs.FileHandle, from: number, to: number): Promise<number | null> {
+  const piece = Buffer.alloc(Math.min(SCAN_PIECE, Math.max(0, to - from)));
+  let at = from;
+  while (at < to) {
+    const { bytesRead } = await fh.read(piece, 0, Math.min(piece.length, to - at), at);
+    if (bytesRead === 0) return null;
+    const hit = piece.subarray(0, bytesRead).indexOf(NEWLINE);
+    if (hit >= 0) return at + hit;
+    at += bytesRead;
+  }
+  return null;
+}
+
+/* Whether `offset` begins a record: the file start, or the byte before it is
+   the newline that closed the previous record. */
+async function startsRecord(fh: fs.FileHandle, offset: number): Promise<boolean> {
+  if (offset === 0) return true;
+  const one = Buffer.alloc(1);
+  const { bytesRead } = await fh.read(one, 0, 1, offset - 1);
+  return bytesRead === 1 && one[0] === NEWLINE;
+}
+
 /**
  * Forward tail read shared by /api/log and the batched /api/logs: `offset`
  * continues a poll, the very first read of a large file jumps to the last
@@ -11,6 +38,15 @@ import type { LogChunk } from "@/lib/types";
  * ran out of budget gets an idle chunk at its current offset so the client
  * simply catches up on the next tick. Returns null for a path outside the
  * whitelisted roots (or one that is not a file).
+ *
+ * The bounded catch-up only ever skips whole records (#1498). An agent
+ * reading a rendered frame appends one record larger than the window — the
+ * base64 sits in the transcript twice — and jumping into its middle handed
+ * the client a partial line it could only drop, so the operator's feed lost
+ * the picture. A record is served from its first byte however long it is,
+ * and a subscriber already inside a record is handed the rest of it before
+ * any jump; only a subscriber on a record boundary with ordinary records
+ * behind it is jumped to the live window, as before.
  */
 export async function readTailChunk(pathname: string, offsetInput: number, budget = MAX_CHUNK): Promise<LogChunk | null> {
   let stat;
@@ -25,17 +61,31 @@ export async function readTailChunk(pathname: string, offsetInput: number, budge
   let offset = offsetInput;
   if (!Number.isFinite(offset) || offset < 0) offset = 0;
   if (offset > size) offset = 0;
-  /* A disconnected live subscriber can return with a very old offset. Bound
-     every forward catch-up to the live tail window so reconnect churn cannot
-     replay a multi-hundred-megabyte transcript through the Viewer event loop.
-     Older feed pages remain available through the backward history route. */
-  if (size - offset > MAX_CHUNK) offset = size - MAX_CHUNK;
 
-  const want = Math.min(MAX_CHUNK, Math.max(0, budget), Math.max(0, size - offset));
+  let want = Math.min(MAX_CHUNK, Math.max(0, budget), Math.max(0, size - offset));
   if (want === 0) return { offset, start: offset, size, data: "" };
 
   const fh = await fs.open(pathname, "r");
   try {
+    /* A disconnected live subscriber can return with a very old offset. Bound
+       every forward catch-up to the live tail window so reconnect churn cannot
+       replay a multi-hundred-megabyte transcript through the Viewer event loop.
+       Older feed pages remain available through the backward history route. */
+    if (size - offset > MAX_CHUNK) {
+      const target = size - MAX_CHUNK;
+      const boundary = await firstNewline(fh, offset, Math.min(target, offset + MAX_CHUNK));
+      if (boundary === null) {
+        /* The record at `offset` spans the live window: serve it in sequence. */
+      } else if (!(await startsRecord(fh, offset))) {
+        /* The subscriber holds the head of this record: hand it the tail and
+           stop at the boundary, so the partial line it carries stays whole.
+           The next read starts on a record and jumps from there. */
+        want = Math.min(want, boundary + 1 - offset);
+      } else {
+        offset = target;
+        want = Math.min(MAX_CHUNK, Math.max(0, budget), size - offset);
+      }
+    }
     const buf = Buffer.alloc(want);
     const { bytesRead } = await fh.read(buf, 0, buf.length, offset);
     return {

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -37,11 +37,14 @@ function asChunk(event: LogTailStreamEvent): LogChunk {
 
 describe("LogTailStreamSession", () => {
   test("a stale live offset skips an oversized backlog and resumes from the bounded tail", async () => {
-    const prefix = "x".repeat(MAX_CHUNK + 128);
+    /* A backlog of ordinary records: the stale subscriber sits on a record
+       boundary and the bounded catch-up jumps it to the live window. */
+    const line = "x".repeat(1023) + "\n";
+    const prefix = line.repeat(Math.ceil((MAX_CHUNK + 128) / line.length));
     const tail = "y".repeat(MAX_CHUNK);
     const file = writeLog("stale-offset.log", prefix + tail);
 
-    const chunk = await readTailChunk(file, 1);
+    const chunk = await readTailChunk(file, line.length);
 
     expect(chunk).not.toBeNull();
     expect(chunk).toMatchObject({
@@ -50,6 +53,48 @@ describe("LogTailStreamSession", () => {
       size: prefix.length + tail.length,
       data: tail,
     });
+  });
+
+  /* #1498: an agent reading a rendered frame appends one 800 KB record — larger
+     than the live window — and the operator's feed lost it: the bounded
+     catch-up jumped into the middle of the record and the partial line was
+     dropped. A record is served from its first byte however long it is; the
+     jump only ever skips whole records. */
+  test("a record longer than the live window is served from its first byte, in sequence", async () => {
+    const head = '{"seq":1}\n';
+    const record = '{"frame":"' + "z".repeat(MAX_CHUNK + 4096) + '"}\n';
+    const file = writeLog("oversized-record.log", head + record);
+
+    const first = await readTailChunk(file, head.length);
+    expect(first).toMatchObject({ start: head.length, offset: head.length + MAX_CHUNK, size: head.length + record.length });
+    const second = await readTailChunk(file, first!.offset);
+    expect(second).toMatchObject({ start: first!.offset, offset: head.length + record.length });
+    expect(first!.data + second!.data).toBe(record);
+  });
+
+  test("a subscriber inside a record finishes that record before the bounded jump skips ahead", async () => {
+    const one = '{"frame":1,"data":"' + "a".repeat(MAX_CHUNK + 2048) + '"}\n';
+    const two = '{"frame":2,"data":"' + "b".repeat(MAX_CHUNK + 2048) + '"}\n';
+    const file = writeLog("back-to-back-records.log", one + two);
+
+    /* Holding the head of record one, the subscriber is handed its tail — and
+       nothing past it, so the carried partial line stays whole. */
+    const finish = await readTailChunk(file, MAX_CHUNK);
+    expect(finish).toMatchObject({ start: MAX_CHUNK, offset: one.length, data: one.slice(MAX_CHUNK) });
+    /* On the boundary, the next record is itself longer than the window: it is
+       served from its first byte rather than jumped into. */
+    const next = await readTailChunk(file, one.length);
+    expect(next).toMatchObject({ start: one.length, offset: one.length + MAX_CHUNK, data: two.slice(0, MAX_CHUNK) });
+  });
+
+  test("a subscriber on a record boundary behind ordinary records still jumps to the live window", async () => {
+    const line = '{"seq":0,"pad":"' + "p".repeat(1000) + '"}\n';
+    const backlog = line.repeat(Math.ceil((2 * MAX_CHUNK) / line.length));
+    const tail = '{"seq":1}\n';
+    const file = writeLog("boundary-jump.log", backlog + tail);
+
+    const chunk = await readTailChunk(file, line.length);
+    expect(chunk).toMatchObject({ start: backlog.length + tail.length - MAX_CHUNK, offset: backlog.length + tail.length });
   });
 
   test("initial catch-up spends one connection byte budget and continues later", async () => {


### PR DESCRIPTION
Closes #1498.

The operator watched a design lane read rendered frames and saw the conversation print a filename and nothing else — while noting that earlier in the same conversation images *had* appeared, when the agent got at them another way.

## Two defects, one symptom

**The tool-output path could not express an image.** `parse.ts` met image blocks twice: message content built a real image item and rendered it through `ImageCard`, while the tool-result flattener returned a **string**, so an image could only ever become the text placeholder. That is a shape problem, not a styling one.

**And on Claude, the picture never reached the feed at all.** The parser already pushed tool-result images as standalone rows, yet the operator's lane still showed only the filename. The Read record is 812 KB (the CLI writes the base64 twice) against a 768 KB live tail window: the bounded catch-up jumped into the middle of the record and the client dropped the partial line. Every fresh open after that point lost it the same way.

## What changed

- **`parse.ts`** — a tool result now yields ordered text and image blocks beside the flattened preview. The preview keeps a text placeholder where each picture sits, so copy, speech and the phone's failure detail are unchanged. Missing, unsupported, non-base64 and over-limit payloads degrade to that placeholder.
- **`ToolCard.tsx`** — blocks render in transcript order through the existing `ImageCard`, as a collapsed chip on desktop and phone alike. Nothing decodes until the operator opens it, which matters: one frame is 405 KB of base64 and a capture run produces dozens.
- **`ImageCard.tsx`** — an initial-view and an inset prop. Message images keep their thumbnail default.
- **`logRead.ts` / `useLogTail.ts`** — the bounded catch-up skips only whole records, a record longer than the window is served from its first byte, and the client drops the half record a resumed chunk begins with.

Pasted and attached images are untouched — that path already worked and was the regression risk.

## Verification

RED before GREEN, each file run by path against `origin/main` first:

| File | RED | GREEN |
|---|---|---|
| `src/components/feed/cards/ToolCard.imageOutput.dom.test.tsx` (new) | 1 pass, 3 fail | 5 pass |
| `src/components/feed/parse.test.ts` | 120 pass, 4 fail | 124 pass |
| `src/lib/logTailStream.test.ts` | 8 pass, 2 fail | 10 pass |
| `src/hooks/useLogTail.dom.test.tsx` | 1 pass, 1 fail | 2 pass |

`bunx tsc --noEmit --incremental false` exits 0. Privacy gate from the merge base passes. A seeded production render at 1280×800 and 390×844 confirmed the chips, the ordering and that no data URI is in the DOM until one is opened.

Reviewed and passed by a fresh-context reviewer (Fable, extra-high), round 3.

## Known, out of scope

- Three phone suites are red here **and red with identical counts on `main`** — they stub the old mobile media query. Tracked in #1500.
- Capture harnesses spawn the bare PATH `bun`, which cannot serve this Next; tracked in #1502.
- A record longer than the live window cannot sit inside the initial window on reopen. It is served whole to a live subscriber and reachable through "older", like any earlier record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)