### PR TITLE
fix(deploy): nothing could ship, because the deploy gate required the hole #1496 closed (#1511)

### DIFF
--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -33,6 +33,7 @@ import { flowStateCollectionSeed } from "../src/lib/flows/store";
 import { pipelineStateCollectionSeeds } from "../src/lib/pipelines/store";
 import { workflowStateCollectionSeed } from "../src/lib/workflows/store";
 import { initializeStateCollections } from "../src/lib/state/sqliteStateStore";
+import { VIEWER_CONTROL_TOKEN_ENV } from "../src/lib/mcp/controlEndpoint";
 import { mcpProbeEnvironment, runBootstrapRelease } from "./runtime-host-viewer-adapter";
 
 const root = path.resolve(import.meta.dir, "..");
@@ -51,6 +52,26 @@ test("candidate MCP probes read through the candidate Viewer endpoint", () => {
 
   expect(environment.LLV_VIEWER_CONTROL_URL).toBe("http://candidate.invalid");
   expect(environment.LLV_VIEWER_DEPLOY_TARGET).toBe("/state/candidate-target.json");
+});
+
+/** #1511: the candidate authenticates every connection when a token is
+    configured (#1496), so the probe carries the credential of the endpoint it
+    was pinned to. A candidate with no token configured carries none. */
+test("a candidate MCP probe carries the candidate's own credential, and none when there is none", () => {
+  const credentialed = mcpProbeEnvironment(
+    "http://candidate.invalid",
+    "/state/candidate-target.json",
+    { NODE_ENV: "test" },
+    "candidate-key",
+  );
+  const bare = mcpProbeEnvironment(
+    "http://candidate.invalid",
+    "/state/candidate-target.json",
+    { NODE_ENV: "test" },
+  );
+
+  expect(credentialed[VIEWER_CONTROL_TOKEN_ENV]).toBe("candidate-key");
+  expect(bare).not.toHaveProperty(VIEWER_CONTROL_TOKEN_ENV);
 });
 
 test("a candidate MCP probe without a candidate endpoint refuses instead of reading the deployed Viewer", () => {

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -36,7 +36,7 @@ import {
 import { ensureCanonicalMirror, resolveCanonicalRevision } from "../src/runtime-host/canonicalMirror";
 import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandidatePortAvailable } from "../src/runtime-host/candidatePort";
 import { withBootstrapMcpHealthProbeAdmission } from "../src/runtime-host/bootstrapMcpHealthProbeAdmission";
-import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
+import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotPath } from "../src/runtime-host/deploymentArtifacts";
 import { bootstrapViewerRelease } from "../src/runtime-host/deploymentBootstrap";
 import {
   parseRuntimeHostRehearsalReport,
@@ -44,6 +44,7 @@ import {
 } from "../src/runtime-host/hostRehearsal";
 import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
 import type { McpHealthProbeAdmissionConsumer } from "../src/runtime-host/mcpHealthProbeAdmissionChannel";
+import { VIEWER_CONTROL_TOKEN_ENV } from "../src/lib/mcp/controlEndpoint";
 import { probeControlUrl, probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
 import { McpRuntimeReleaseStore } from "../src/runtime-host/mcpRuntimeRelease";
 import {
@@ -173,7 +174,7 @@ async function resolveRevision(requested: string): Promise<string> {
 }
 
 function composeConfigFile(container: string): string {
-  return path.join(deploymentDir, "compose", viewerComposeSnapshotName(container));
+  return viewerComposeSnapshotPath(stateDir, container);
 }
 
 function writeComposeConfig(container: string, config: string): void {
@@ -376,6 +377,18 @@ function serviceToken(candidate: ViewerReleaseIdentity): string | null {
   return viewerAuthenticationTokenFromConfig(fs.readFileSync(composeConfigFile(candidate.container), "utf8"));
 }
 
+/** The same credential where the release may predate Compose snapshots: a
+    release published by an older adapter has none to read, and the probe then
+    resolves whatever the machine's own state offers, as any client does. */
+function optionalServiceToken(release: ViewerReleaseIdentity): string | null {
+  try {
+    return serviceToken(release);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 const PROBE_TIMEOUT_MS = 5_000;
 
 interface ProbeResponse {
@@ -561,6 +574,7 @@ export function mcpProbeEnvironment(
   endpoint: string,
   deployTarget: string,
   env: NodeJS.ProcessEnv = process.env,
+  token: string | null = null,
 ): Record<string, string> {
   /* An empty endpoint would leave the probe's control reads on the binding's
      fixed-port fallback, which addresses the deployed Viewer rather than the
@@ -577,6 +591,11 @@ export function mcpProbeEnvironment(
     // Candidate health must exercise the candidate's web/runtime client. The
     // stable listener still serves the previous generation before promotion.
     LLV_VIEWER_CONTROL_URL: controlUrl,
+    /* The probed Viewer authenticates every connection when a token is
+       configured (#1496), and the release state still names the incumbent, so
+       the probe carries the credential of the endpoint it was pinned to rather
+       than resolving one for a Viewer it is not grading (#1511). */
+    ...(token ? { [VIEWER_CONTROL_TOKEN_ENV]: token } : {}),
   };
 }
 
@@ -634,7 +653,7 @@ async function verify(
     ? targetFile
     : path.join(stateDir, `mcp-candidate-probe-${candidate.mcpRuntime.releaseId}.json`);
   if (!promoted) writeReleaseTarget(probeTarget, candidate);
-  const probeEnvironment = mcpProbeEnvironment(endpoint, probeTarget);
+  const probeEnvironment = mcpProbeEnvironment(endpoint, probeTarget, process.env, serviceToken(candidate));
   const mcpRuntime = await probeMcpRuntime({
     command: process.execPath,
     args: [path.join(mcpRuntimeRoot, "bin", "mcp-server.mjs")],
@@ -1091,7 +1110,7 @@ async function reconcileMcpRuntime(
   try {
     mcpRuntimeStore.installStableLauncher(deploymentPackageRoot);
     const publication = switchTarget({ ...previous, mcpRuntime: runtime }, "activate");
-    const probeEnvironment = mcpProbeEnvironment(stableEndpoint, targetFile);
+    const probeEnvironment = mcpProbeEnvironment(stableEndpoint, targetFile, process.env, optionalServiceToken(previous));
     const health = await probeMcpRuntime({
       command: process.execPath,
       args: [path.join(mcpRuntimeRoot, "bin", "mcp-server.mjs")],

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -132,7 +132,7 @@ import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
 import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolCallContext, type McpToolPayload } from "./server";
-import { viewerControlOrigin } from "./controlEndpoint";
+import { viewerControlOrigin, viewerControlToken } from "./controlEndpoint";
 import {
   productionSelectedContextDependencies,
   resolveSelectedContext,
@@ -208,6 +208,7 @@ async function requestViewerControl(
   pinConfiguredEndpoint = false,
 ): Promise<{ response: Response; parsed: unknown; unreadable: boolean }> {
   const baseUrl = viewerControlOrigin(process.env, pinConfiguredEndpoint);
+  const token = viewerControlToken(process.env, baseUrl);
   const now = Date.now();
   const deadlineAt = context.deadlineAt;
   const retryable = deadlineAt !== undefined;
@@ -227,6 +228,10 @@ async function requestViewerControl(
     });
     try {
       const headers = new Headers(init.headers);
+      /* The Viewer authenticates every connection once a token is configured
+         (#1496), so a control read that sends nothing is refused exactly like a
+         stranger's (#1511). A caller that set its own authorization keeps it. */
+      if (token && !headers.has("authorization")) headers.set("authorization", `Bearer ${token}`);
       if (init.method === "POST") {
         headers.set("origin", baseUrl);
         headers.set("sec-fetch-site", "same-origin");

--- a/src/lib/mcp/controlEndpoint.test.ts
+++ b/src/lib/mcp/controlEndpoint.test.ts
@@ -225,3 +225,58 @@ test("a client pinned by a partial release environment reads no ambient state at
     readFile.mockRestore();
   }
 });
+
+/* The Viewer parses its header with `/^Bearer\s+(.+)$/i`, so a key holding an
+   internal space authenticates against the running release. A client that
+   discarded such a key would send nothing and be refused 403 — #1511's own
+   failure moved one layer along. Only a value that cannot travel in a header
+   is absent. */
+
+const SPACED = "release key with spaces";
+
+test("a key the Viewer authenticates survives every resolver path when it holds a space", () => {
+  const directory = sandbox();
+  try {
+    const endpoint = "http://127.0.0.1:19020";
+    const stateDir = releaseState(directory, { endpoint, token: SPACED });
+    expect(viewerControlToken({
+      LLV_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_PORT: "19020",
+    }, endpoint)).toBe(SPACED);
+    expect(viewerControlToken({ [VIEWER_CONTROL_TOKEN_ENV]: SPACED }, endpoint)).toBe(SPACED);
+
+    const keyFile = path.join(directory, "agent-log-viewer", "token");
+    fs.mkdirSync(path.dirname(keyFile), { recursive: true });
+    fs.writeFileSync(keyFile, `  ${SPACED}  `, { mode: 0o600 });
+    expect(viewerControlToken({
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_PORT: "19021",
+    }, "http://127.0.0.1:19021")).toBe(SPACED);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a key that cannot travel in a header still counts as absent", () => {
+  const directory = sandbox();
+  try {
+    const endpoint = "http://127.0.0.1:19022";
+    /* Built from character codes on purpose: a real control byte written into
+       this file would be invisible to everyone reading it. CR, LF, NUL, VT and
+       DEL are all outside the field-vchar an HTTP header value is made of. */
+    for (const code of [0x0d, 0x0a, 0x00, 0x0b, 0x7f]) {
+      const unsendable = `release${String.fromCharCode(code)}key`;
+      const stateDir = releaseState(directory, { endpoint, token: unsendable });
+      expect(viewerControlToken({
+        LLV_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: directory,
+        LLV_TOKEN: unsendable,
+        LLV_VIEWER_PORT: "19022",
+      }, endpoint)).toBeNull();
+      expect(viewerControlToken({ [VIEWER_CONTROL_TOKEN_ENV]: unsendable }, endpoint)).toBeNull();
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/mcp/controlEndpoint.test.ts
+++ b/src/lib/mcp/controlEndpoint.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { viewerControlOrigin } from "./controlEndpoint";
+import { viewerComposeSnapshotPath } from "@/runtime-host/deploymentArtifacts";
+
+import { VIEWER_CONTROL_TOKEN_ENV, viewerControlOrigin, viewerControlToken } from "./controlEndpoint";
 
 function releaseTarget(directory: string, endpoint: string): string {
   const filename = path.join(directory, "viewer-release.json");
@@ -96,5 +98,130 @@ test("a malformed release target fails loudly instead of preserving a stale laun
     })).toThrow("Viewer release target is invalid");
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+/* #1511: #1496 made the Viewer authenticate every connection once a token is
+   configured, so a control client that sends nothing is refused like a
+   stranger. Agent processes are launched with LLV_TOKEN unset on purpose, and
+   the credential is resolved from the operator-only state that already names
+   the control origin. */
+
+function sandbox(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "llv-control-token-"));
+}
+
+function releaseState(
+  directory: string,
+  options: { endpoint: string; container?: string; token?: string },
+): string {
+  const stateDir = path.join(directory, "state");
+  const container = options.container ?? "viewer-fixture";
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "viewer-release.json"), JSON.stringify({
+    revision: "a".repeat(40),
+    image: "viewer:fixture",
+    container,
+    endpoint: options.endpoint,
+  }));
+  if (options.token !== undefined) {
+    const snapshot = viewerComposeSnapshotPath(stateDir, container);
+    fs.mkdirSync(path.dirname(snapshot), { recursive: true });
+    fs.writeFileSync(snapshot, JSON.stringify({
+      services: { viewer: { environment: { LLV_TOKEN: options.token } } },
+    }));
+  }
+  return stateDir;
+}
+
+test("an agent environment with no token of its own carries the running Viewer's key", () => {
+  const directory = sandbox();
+  try {
+    const stable = "http://127.0.0.1:19011";
+    const stateDir = releaseState(directory, { endpoint: "http://127.0.0.1:19012", token: "release-key" });
+    expect(viewerControlToken({
+      LLV_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_PORT: "19011",
+    }, stable)).toBe("release-key");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a probe pinned to a candidate carries the credential it was given, not the incumbent's", () => {
+  const directory = sandbox();
+  try {
+    const candidate = "http://127.0.0.1:19013";
+    const stateDir = releaseState(directory, { endpoint: "http://127.0.0.1:19014", token: "release-key" });
+    expect(viewerControlToken({
+      [VIEWER_CONTROL_TOKEN_ENV]: "pinned-key",
+      LLV_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_CONTROL_URL: candidate,
+      LLV_VIEWER_DEPLOY_TARGET: path.join(stateDir, "viewer-release.json"),
+    }, candidate)).toBe("pinned-key");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a Viewer started outside a deployment is reached with the machine's own key", () => {
+  const directory = sandbox();
+  try {
+    const keyFile = path.join(directory, "agent-log-viewer", "token");
+    fs.mkdirSync(path.dirname(keyFile), { recursive: true });
+    fs.writeFileSync(keyFile, "machine-key\n", { mode: 0o600 });
+    expect(viewerControlToken({
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_PORT: "19015",
+    }, "http://127.0.0.1:19015")).toBe("machine-key");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a Viewer with no token configured is still reached with a bare request", () => {
+  const directory = sandbox();
+  try {
+    const stateDir = releaseState(directory, { endpoint: "http://127.0.0.1:19016" });
+    expect(viewerControlToken({
+      LLV_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: directory,
+      LLV_VIEWER_PORT: "19016",
+    }, "http://127.0.0.1:19016")).toBeNull();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("no ambient key travels to an endpoint the release state does not name", () => {
+  const directory = sandbox();
+  try {
+    const stranger = "http://127.0.0.1:19017";
+    const stateDir = releaseState(directory, { endpoint: "http://127.0.0.1:19018", token: "release-key" });
+    expect(viewerControlToken({
+      LLV_STATE_DIR: stateDir,
+      XDG_CONFIG_HOME: directory,
+      LLV_TOKEN: "release-key",
+      LLV_VIEWER_CONTROL_URL: stranger,
+      LLV_VIEWER_DEPLOY_TARGET: path.join(stateDir, "viewer-release.json"),
+      LLV_VIEWER_PORT: "19018",
+    }, stranger)).toBeNull();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a client pinned by a partial release environment reads no ambient state at all", () => {
+  const endpoint = "http://127.0.0.1:19019";
+  const readFile = spyOn(fs, "readFileSync").mockImplementation(() => {
+    throw new Error("ambient state was read for a credential");
+  });
+  try {
+    expect(viewerControlToken({ LLV_VIEWER_CONTROL_URL: endpoint }, endpoint)).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+  } finally {
+    readFile.mockRestore();
   }
 });

--- a/src/lib/mcp/controlEndpoint.ts
+++ b/src/lib/mcp/controlEndpoint.ts
@@ -100,10 +100,16 @@ function readJsonRecord(filename: string): Record<string, unknown> | null {
 
 /* A credential travels in an HTTP header, so a value that cannot appear in one
    counts as absent. Sending nothing draws the Viewer's own legible refusal;
-   throwing at header construction would take the whole tool call down first. */
+   throwing at header construction would take the whole tool call down first.
+   The line sits where a header field value's does: printable ASCII, the space
+   included, because the Viewer matches `Bearer\s+(.+)` and authenticates a key
+   holding one — discarding it here would only move #1511's 403 from the gate
+   into this client. Everything outside that range stays absent: a control byte
+   is no part of a field value, and a non-ASCII one this runtime either refuses
+   to construct or re-encodes into a key the Viewer never configured. */
 function credential(value: unknown): string | null {
   const token = typeof value === "string" ? value.trim() : "";
-  return token.length > 0 && !/[^!-~]/.test(token) ? token : null;
+  return token.length > 0 && !/[^\x20-\x7e]/.test(token) ? token : null;
 }
 
 function configRoot(env: ControlEnvironment): string {

--- a/src/lib/mcp/controlEndpoint.ts
+++ b/src/lib/mcp/controlEndpoint.ts
@@ -1,4 +1,8 @@
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { viewerComposeSnapshotPath } from "@/runtime-host/deploymentArtifacts";
 
 const DEFAULT_VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
 
@@ -78,4 +82,105 @@ export function viewerControlOrigin(
   if (!currentRelease) return configured;
   if (loopbackOrigin(configured) === currentRelease) return currentRelease;
   return stableControlOrigin(env);
+}
+
+export const VIEWER_CONTROL_TOKEN_ENV = "LLV_VIEWER_CONTROL_TOKEN";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function readJsonRecord(filename: string): Record<string, unknown> | null {
+  try {
+    return record(JSON.parse(fs.readFileSync(filename, "utf8")) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+/* A credential travels in an HTTP header, so a value that cannot appear in one
+   counts as absent. Sending nothing draws the Viewer's own legible refusal;
+   throwing at header construction would take the whole tool call down first. */
+function credential(value: unknown): string | null {
+  const token = typeof value === "string" ? value.trim() : "";
+  return token.length > 0 && !/[^!-~]/.test(token) ? token : null;
+}
+
+function configRoot(env: ControlEnvironment): string {
+  /* `os.homedir()` rather than `$HOME`, matching the launcher: on Windows HOME
+     is not a Windows variable at all. */
+  return env.XDG_CONFIG_HOME?.trim() || path.join(os.homedir(), ".config");
+}
+
+function stateDirectory(env: ControlEnvironment): string {
+  return env.LLV_STATE_DIR?.trim() || path.join(configRoot(env), "agent-log-viewer", "state");
+}
+
+function releaseTargetFile(env: ControlEnvironment, stateDir: string): string {
+  return env.LLV_VIEWER_DEPLOY_TARGET?.trim() || path.join(stateDir, "viewer-release.json");
+}
+
+/** Whether `origin` is the Viewer this machine's own release state names — its
+    release endpoint, or the stable listener in front of it. An ambient
+    credential travels only there: an endpoint someone else pointed this client
+    at gets no key of the operator's. */
+function addressesOwnViewer(
+  env: ControlEnvironment,
+  origin: string,
+  target: Record<string, unknown> | null,
+): boolean {
+  if (origin === loopbackOrigin(target?.endpoint)) return true;
+  try {
+    return origin === stableControlOrigin(env);
+  } catch {
+    return false;
+  }
+}
+
+/** The exact environment the running Viewer enforces, from the release
+    container's Compose snapshot (0600, inside the operator's 0700 state). */
+function releaseCredential(stateDir: string, target: Record<string, unknown> | null): string | null {
+  const container = typeof target?.container === "string" && target.container.trim() ? target.container : null;
+  if (!container) return null;
+  const compose = readJsonRecord(viewerComposeSnapshotPath(stateDir, container));
+  return credential(record(record(record(compose?.services)?.viewer)?.environment)?.LLV_TOKEN);
+}
+
+/** The key the CLI writes for its own links, which is what a Viewer started
+    outside a deployment authenticates against. */
+function machineKey(env: ControlEnvironment): string | null {
+  try {
+    return credential(fs.readFileSync(path.join(configRoot(env), "agent-log-viewer", "token"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The credential a control request must carry. #1496 made the Viewer
+ * authenticate every connection whenever a token is configured, loopback
+ * included, because loopback is shared by every OS account. This client sent
+ * none, so a candidate's own deployment probe was refused by the release it was
+ * grading, and every agent's Viewer tools would have answered 403 the moment
+ * such a build was promoted (#1511).
+ *
+ * Agent processes are launched with `LLV_TOKEN` unset on purpose, so the key is
+ * resolved from the same operator-only state that already names the control
+ * origin, never from the agent's environment. A caller that pinned its own
+ * credential keeps it; nothing else travels to an endpoint the release state
+ * does not name; and a Viewer with no token configured still gets a bare
+ * request, which is what it expects.
+ */
+export function viewerControlToken(env: ControlEnvironment, origin: string): string | null {
+  const pinned = credential(env[VIEWER_CONTROL_TOKEN_ENV]);
+  if (pinned) return pinned;
+  /* The same rule the origin resolution follows: a client pinned to an explicit
+     endpoint by a partial release environment consults no ambient state, so it
+     can neither resolve a credential there nor send one to that endpoint. */
+  if (env.LLV_VIEWER_CONTROL_URL?.trim()
+    && (!env.LLV_VIEWER_DEPLOY_TARGET?.trim() || !env.LLV_VIEWER_PORT?.trim())) return null;
+  const stateDir = stateDirectory(env);
+  const target = readJsonRecord(releaseTargetFile(env, stateDir));
+  if (!addressesOwnViewer(env, origin, target)) return null;
+  return credential(env.LLV_TOKEN) ?? releaseCredential(stateDir, target) ?? machineKey(env);
 }

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, spyOn, test } from "bun:test";
+import { NextRequest } from "next/server";
 import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import net from "node:net";
@@ -6,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { RUNTIME_PLANE_ABSENT } from "@/lib/runtime/flags";
+import { proxy } from "@/proxy";
 
 import { viewerMcpBindings, type ViewerControlDependencies } from "./bindings";
 import { createMcpToolService, McpToolRefusal, MemoryMcpReceiptStore } from "./server";
@@ -14,6 +16,7 @@ const originalRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
 const originalRuntimeSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
 const originalRuntimeJournal = process.env.LLV_RUNTIME_JOURNAL;
 const originalViewerControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+const originalViewerToken = process.env.LLV_TOKEN;
 const originalViewerDeployTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
 const originalViewerPort = process.env.LLV_VIEWER_PORT;
 const originalStateDirectory = process.env.LLV_STATE_DIR;
@@ -39,6 +42,8 @@ afterEach(async () => {
   else process.env.LLV_RUNTIME_JOURNAL = originalRuntimeJournal;
   if (originalViewerControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
   else process.env.LLV_VIEWER_CONTROL_URL = originalViewerControlUrl;
+  if (originalViewerToken === undefined) delete process.env.LLV_TOKEN;
+  else process.env.LLV_TOKEN = originalViewerToken;
   if (originalViewerDeployTarget === undefined) delete process.env.LLV_VIEWER_DEPLOY_TARGET;
   else process.env.LLV_VIEWER_DEPLOY_TARGET = originalViewerDeployTarget;
   if (originalViewerPort === undefined) delete process.env.LLV_VIEWER_PORT;
@@ -763,3 +768,44 @@ test("a control surface that never answers falls back instead of hanging the pro
   expect(Date.now() - started).toBeLessThan(8_000);
   expect(runtimeMethods).toEqual([]);
 }, 9_000);
+
+/** #1511: #1496 made the Viewer authenticate every connection once a token is
+    configured, and the MCP control client sent none. The candidate's own
+    deployment probe was refused 403 by the release it was grading, and the
+    whole MCP surface — every agent's Viewer tools, the orchestrator's included
+    — would have answered 403 the moment such a build was promoted. The gate in
+    front of this fixture is the real `proxy()`, so the client is judged by the
+    Viewer's own rule rather than by a restatement of it. */
+test("an MCP control read carries the credential the Viewer's own gate requires", async () => {
+  delete process.env.LLV_RUNTIME_EVENTS;
+  delete process.env.LLV_RUNTIME_HOST_SOCKET;
+  process.env.LLV_TOKEN = "control-plane-gate-token";
+  const deployment = {
+    deploymentId: "deployment_gated_read",
+    phase: "succeeded",
+    revision: "e".repeat(40),
+  };
+  const refusals: number[] = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const gate = proxy(new NextRequest(request.url, { headers: request.headers, method: request.method }));
+      if (gate.headers.get("x-middleware-next") !== "1") {
+        refusals.push(gate.status);
+        return gate;
+      }
+      return Response.json({ count: 1, deployments: [deployment] });
+    },
+  });
+  installViewerControlFixture(server.url.origin);
+
+  try {
+    expect(await viewerMcpBindings().deployment_status({
+      clientRequestId: "deployment-gated-read",
+    })).toEqual({ count: 1, deployments: [deployment] });
+    expect(refusals).toEqual([]);
+  } finally {
+    server.stop(true);
+  }
+});

--- a/src/lib/mcp/deploymentReads.test.ts
+++ b/src/lib/mcp/deploymentReads.test.ts
@@ -769,22 +769,29 @@ test("a control surface that never answers falls back instead of hanging the pro
   expect(runtimeMethods).toEqual([]);
 }, 9_000);
 
-/** #1511: #1496 made the Viewer authenticate every connection once a token is
-    configured, and the MCP control client sent none. The candidate's own
-    deployment probe was refused 403 by the release it was grading, and the
-    whole MCP surface — every agent's Viewer tools, the orchestrator's included
-    — would have answered 403 the moment such a build was promoted. The gate in
-    front of this fixture is the real `proxy()`, so the client is judged by the
-    Viewer's own rule rather than by a restatement of it. */
-test("an MCP control read carries the credential the Viewer's own gate requires", async () => {
+/* #1511: #1496 made the Viewer authenticate every connection once a token is
+   configured, and the MCP control client sent none. The candidate's own
+   deployment probe was refused 403 by the release it was grading, and the
+   whole MCP surface — every agent's Viewer tools, the orchestrator's included
+   — would have answered 403 the moment such a build was promoted. The gate in
+   front of this fixture is the real `proxy()`, so the client is judged by the
+   Viewer's own rule rather than by a restatement of it. */
+const GATED_DEPLOYMENT = {
+  deploymentId: "deployment_gated_read",
+  phase: "succeeded",
+  revision: "e".repeat(40),
+};
+
+/** One control read with `key` configured on both ends, reporting every status
+    the gate refused with — so a read that reached the surface some other way
+    cannot pass for an authenticated one. */
+async function gatedControlRead(
+  key: string,
+  clientRequestId: string,
+): Promise<{ read: unknown; refusals: number[] }> {
   delete process.env.LLV_RUNTIME_EVENTS;
   delete process.env.LLV_RUNTIME_HOST_SOCKET;
-  process.env.LLV_TOKEN = "control-plane-gate-token";
-  const deployment = {
-    deploymentId: "deployment_gated_read",
-    phase: "succeeded",
-    revision: "e".repeat(40),
-  };
+  process.env.LLV_TOKEN = key;
   const refusals: number[] = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -795,17 +802,29 @@ test("an MCP control read carries the credential the Viewer's own gate requires"
         refusals.push(gate.status);
         return gate;
       }
-      return Response.json({ count: 1, deployments: [deployment] });
+      return Response.json({ count: 1, deployments: [GATED_DEPLOYMENT] });
     },
   });
   installViewerControlFixture(server.url.origin);
 
   try {
-    expect(await viewerMcpBindings().deployment_status({
-      clientRequestId: "deployment-gated-read",
-    })).toEqual({ count: 1, deployments: [deployment] });
-    expect(refusals).toEqual([]);
+    return { read: await viewerMcpBindings().deployment_status({ clientRequestId }), refusals };
   } finally {
     server.stop(true);
   }
+}
+
+test("an MCP control read carries the credential the Viewer's own gate requires", async () => {
+  expect(await gatedControlRead("control-plane-gate-token", "deployment-gated-read"))
+    .toEqual({ read: { count: 1, deployments: [GATED_DEPLOYMENT] }, refusals: [] });
+});
+
+/* One layer along from the same defect: the Viewer matches `Bearer\s+(.+)`,
+   so a configured key holding an internal space authenticates. A client that
+   judged such a key unsendable would send nothing and be refused 403 by the
+   release it is reading — #1511's failure, moved from the gate into the
+   client. */
+test("a configured key holding a space is carried, because the Viewer accepts it", async () => {
+  expect(await gatedControlRead("control plane gate key", "deployment-gated-spaced-read"))
+    .toEqual({ read: { count: 1, deployments: [GATED_DEPLOYMENT] }, refusals: [] });
 });

--- a/src/runtime-host/deploymentArtifacts.ts
+++ b/src/runtime-host/deploymentArtifacts.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 function artifactKey(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
@@ -14,4 +15,11 @@ export function viewerCandidateImageName(revision: string, container: string): s
 
 export function viewerComposeSnapshotName(container: string): string {
   return `${artifactKey(container)}.json`;
+}
+
+/** Where that snapshot lives under a state directory. One definition, because
+    the runtime host writes it and the MCP control client reads the Viewer
+    credential back out of it (#1511). */
+export function viewerComposeSnapshotPath(stateDir: string, container: string): string {
+  return path.join(stateDir, "deployments", "compose", viewerComposeSnapshotName(container));
 }

--- a/src/runtime-host/deploymentHealth.test.ts
+++ b/src/runtime-host/deploymentHealth.test.ts
@@ -28,6 +28,7 @@ import {
   viewerDeploymentReleaseReady,
   viewerDeploymentStructuredHostStartup,
   viewerHealthFailureDetail,
+  type ViewerHealthRequest,
   viewerHealthRequestPlan,
   waitForViewerReadiness,
 } from "./deploymentHealth";
@@ -109,7 +110,9 @@ test("health request plan exercises remote authorization and rejection", () => {
   const authorized = proxy(new NextRequest(plan.authenticated.url, { headers: plan.authenticated.headers }));
   const unauthorized = proxy(new NextRequest(plan.unauthorized.url, { headers: plan.unauthorized.headers }));
 
-  expect(plan.root.headers).toEqual({});
+  const bearer = plan.authenticated.headers.authorization;
+  expect(bearer?.startsWith("Bearer ")).toBe(true);
+  expect(plan.root).toEqual({ url: "http://127.0.0.1:18001/", headers: { authorization: bearer } });
   expect(plan.capability).toEqual({
     url: "http://127.0.0.1:18001/api/runtime/deployments/capabilities/v1",
     headers: plan.authenticated.headers,
@@ -420,4 +423,37 @@ test("probe bodies and candidate output stay bounded and printable", () => {
   expect(probeExcerpt("x".repeat(400))).toHaveLength(203);
   expect(candidateLogExcerpt("first\n\nsecond\nthird\n", { maxLines: 2 })).toEqual(["second", "third"]);
   expect(candidateLogExcerpt("y".repeat(300), { maxChars: 40 })).toEqual([`${"y".repeat(40)}...`]);
+});
+
+/** #1511: readiness required an unauthenticated 200 on `root`, and #1496 began
+    correctly refusing exactly that, so no token-configured candidate could ship.
+    Every probe the gate requires to answer 200 must carry credentials of its
+    own. `unauthorized` is excluded because the refusal *is* its expectation. */
+test("a token-configured readiness plan requires no unauthenticated success", () => {
+  process.env.LLV_TOKEN = "viewer-token";
+  const plan = viewerHealthRequestPlan("http://127.0.0.1:18001", "viewer-token");
+  if (!plan.authenticated || !plan.unauthorized) throw new Error("authenticated request plan is missing");
+  const mustSucceed: Array<[string, ViewerHealthRequest]> = [
+    ["root", plan.root],
+    ["authenticated", plan.authenticated],
+    ["capability", plan.capability],
+  ];
+
+  const refused = mustSucceed
+    .filter(([, request]) => proxy(new NextRequest(request.url, { headers: request.headers })).status === 403)
+    .map(([name]) => name);
+
+  expect(refused).toEqual([]);
+  expect(proxy(new NextRequest(plan.unauthorized.url, { headers: plan.unauthorized.headers })).status).toBe(403);
+});
+
+test("a tokenless readiness plan still requires a plain 200 on root", () => {
+  delete process.env.LLV_TOKEN;
+  const plan = viewerHealthRequestPlan("http://127.0.0.1:18001", null);
+
+  expect(plan.root).toEqual({ url: "http://127.0.0.1:18001/", headers: {} });
+  expect(plan.authenticated).toBeNull();
+  expect(plan.unauthorized).toBeNull();
+  expect(proxy(new NextRequest(plan.root.url, { headers: plan.root.headers }))
+    .headers.get("x-middleware-next")).toBe("1");
 });

--- a/src/runtime-host/deploymentHealth.ts
+++ b/src/runtime-host/deploymentHealth.ts
@@ -22,7 +22,15 @@ export function viewerHealthRequestPlan(endpoint: string, token: string | null):
   const remoteHeaders = { "x-forwarded-for": "203.0.113.10" };
   const authenticatedHeaders = token ? { ...remoteHeaders, authorization: `Bearer ${token}` } : {};
   return {
-    root: { url: `${endpoint}/`, headers: {} },
+    /* Every probe whose expectation is a 200 carries whatever credentials the
+       candidate requires of it. Once a token is configured, every request
+       authenticates, loopback included (#1496), so an unauthenticated success
+       is no longer a property a correct Viewer has, and requiring one held a
+       healthy candidate out of promotion (#1511). With no token there is
+       nothing to carry, and a plain 200 remains the proof that the Viewer
+       serves its own root. `unauthorized` below is the one probe left
+       uncredentialed, because the refusal is what it asserts. */
+    root: { url: `${endpoint}/`, headers: token ? { authorization: `Bearer ${token}` } : {} },
     authenticated: token
       ? { url: `${endpoint}/`, headers: authenticatedHeaders }
       : null,

--- a/src/runtime-host/mcpRuntimeProbe.test.ts
+++ b/src/runtime-host/mcpRuntimeProbe.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { VIEWER_CONTROL_TOKEN_ENV } from "@/lib/mcp/controlEndpoint";
 import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
 
 import { RuntimeHost } from "./host";
@@ -407,3 +408,81 @@ test("a refusal naming a home path is redacted and clamped before it is recorded
   expect(failure!.error.endsWith("...")).toBe(true);
   expect(failure!.error.length).toBeLessThan(refusal.length / 2);
 });
+
+/** #1511: once a token is configured the Viewer authenticates every connection,
+    loopback included (#1496), so a probe whose reads carry nothing is refused by
+    the very candidate it is grading and the deploy fails one gate after
+    readiness. This stub refuses exactly as the real gate does, so the credential
+    has to travel from the adapter's probe environment, through the spawned MCP
+    server, to the read. */
+function gatedCandidateControl(token: string) {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      if (request.headers.get("authorization") !== `Bearer ${token}`) {
+        return Response.json({ error: "access denied: key required" }, { status: 403 });
+      }
+      return new URL(request.url).pathname === "/api/runtime/deployments"
+        ? Response.json({ count: 0, deployments: [] })
+        : Response.json({ error: "not found" }, { status: 404 });
+    },
+  });
+}
+
+test("a candidate that authenticates every connection is probed with the credential it was handed", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-gated-"));
+  const socketPath = path.join(sandbox, "runtime.sock");
+  const journal = new RuntimeJournal(path.join(sandbox, "runtime.sqlite"));
+  const admissions = new McpHealthProbeAdmissions();
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(
+    journal,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    admissions,
+  ));
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  environment.LLV_STATE_DIR = sandbox;
+  environment.LLV_RUNTIME_EVENTS = "1";
+  environment.LLV_RUNTIME_HOST_SOCKET = socketPath;
+  environment.LLV_AGENT_REGISTRY_SQLITE = "off";
+  environment.LLV_CODEX_HOME = path.join(sandbox, "codex");
+  environment.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+  const control = gatedCandidateControl("candidate-key");
+  environment[VIEWER_CONTROL_URL_ENV] = control.url.origin;
+  environment[VIEWER_CONTROL_TOKEN_ENV] = "candidate-key";
+
+  try {
+    const evidence = await probeMcpRuntime({
+      command: process.execPath,
+      args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+      cwd: process.cwd(),
+      env: environment,
+      runtime: {
+        source: "managed",
+        revision: "8".repeat(40),
+        releaseId: "deploy-probe-gated",
+        artifactDigest: "b".repeat(64),
+        stagedAt: "2026-09-04T08:00:00.000Z",
+      },
+      healthProbeCapability: admissions.issue(),
+      healthProbeAdmissions: admissions,
+    });
+
+    expect(evidence).toMatchObject({
+      ok: true,
+      processReady: true,
+      calls: { deploymentStatus: true, boardSnapshot: true },
+    });
+    expect(evidence.callFailures).toBeUndefined();
+  } finally {
+    control.stop(true);
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    journal.close();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 20_000);


### PR DESCRIPTION
Closes #1511.

A production deployment failed with the candidate healthy on every probe but one:

```
candidate readiness timed out after 30 attempts over 32.1s:
root GET http://127.0.0.1:19891/ -> HTTP 403, expected 200
```

The readiness gate made a **plain unauthenticated** GET to the candidate root and required 200. Since #1496 an unauthenticated request is refused whenever a token is configured — loopback included, because loopback is shared by every OS account. So the gate was rejecting a correct candidate for behaving correctly, and **no commit on `main` could ship at all**, the security fix least of all.

## Three commits, and the second is the one that mattered

**`a36bf078` — readiness proves the root with credentials.** Every probe whose expectation is a 200 now carries whatever the candidate requires. With no token there is nothing to carry and a plain 200 remains the proof; `unauthorized` stays the one uncredentialed probe, because the refusal is what it asserts. Nothing was widened to accept 403 — that would be the vulnerability restated as a gate.

**`f196dcb8` — the MCP control client authenticates like every other caller.** Review round 1 found that fixing readiness only moved the wall: the very next gate, the candidate MCP probe, fetched `/api/runtime/deployments` with no credentials and got the same 403. And that client is not just the probe — it serves **every agent's Viewer tools** through the stable launcher, so promoting any post-#1496 build would have answered 403 to the entire MCP surface, orchestrator included. The failing gate was the only thing standing between us and that. Agents are launched without `LLV_TOKEN` on purpose, so the credential is resolved from the same operator-only release state that already names the control origin, never from the agent environment, and only for an endpoint that state actually names.

**`f2c70815` — the client accepts every key the Viewer accepts.** Round 2 found the resolver discarding any token containing a character outside `!-~`, which excludes the ASCII space — while `proxy.ts` parses `/^Bearer\s+(.+)$/i` and authenticates exactly such a token. A validly configured token would have been silently dropped and refused: the same failure class, one layer along. Values that genuinely cannot travel in a header (CR, LF, NUL) still count as absent, which draws the Viewer's own legible refusal instead of throwing at header construction.

## Review

Reviewed by a fresh reviewer on **GPT-6-Astra**, three rounds, final verdict NO FINDINGS. It re-derived both round-1 mechanisms itself, confirmed internal-space tokens now authenticate through the real `proxy()`, confirmed CR/LF/NUL are discarded without header errors, and checked that no token reaches a log line, an error message or a persisted record.

Known and not from this branch: two admission cases in `mcpRuntimeProbe.test.ts` fail here **and** on an exact `origin/main` scratch copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)