### PR TITLE
fix(tasks): show settled stopped hosts as unhosted

### DIFF
--- a/src/components/scheme/assignmentState.test.ts
+++ b/src/components/scheme/assignmentState.test.ts
@@ -55,10 +55,30 @@ describe("assignmentAgentState", () => {
   test("migration, killed, and unhosted classifications stay truthful", () => {
     const migration = { intentId: "i", trigger: "manual", phase: "preparing", targetAccountId: "account", failure: null } as FileEntry["migration"];
     expect(assignmentAgentState(assignment(), file({ migration }))).toBe("migrating");
-    expect(assignmentAgentState(assignment(), file({ proc: "killed", activity: "idle" }))).toBe("killed");
+    expect(assignmentAgentState(assignment(), file({ proc: "killed", activity: "idle", lastTurn: { startedAt: 0, endedAt: null } }))).toBe("killed");
     expect(assignmentAgentState(assignment(), file({ proc: null, activity: "idle" }))).toBe("unhosted");
     expect(assignmentAgentState(assignment(), file({ proc: null, activity: "stalled" }))).toBe("unhosted");
     expect(assignmentAgentState(assignment(), file({ proc: "done", activity: "idle" }))).toBe("unhosted");
+  });
+
+  test.each([
+    ["settled turn with recent activity", { lastTurn: { startedAt: 0, endedAt: 1 }, activity: "recent" }, "unhosted"],
+    ["settled turn with live activity", { lastTurn: { startedAt: 0, endedAt: 1 }, activity: "live" }, "unhosted"],
+    ["authoritative terminal overrides open transcript", { authoritativeTurn: { state: "terminal", source: "lifecycle", terminalAt: null }, lastTurn: { startedAt: 0, endedAt: null }, activity: "stalled" }, "unhosted"],
+    ["authoritative idle overrides stalled evidence", { authoritativeTurn: { state: "idle", source: "lifecycle", terminalAt: null }, activityReason: "jsonl_turn_stalled", activity: "stalled" }, "unhosted"],
+    ["authoritative busy overrides settled transcript", { authoritativeTurn: { state: "busy", source: "lifecycle", terminalAt: null }, lastTurn: { startedAt: 0, endedAt: 1 } }, "killed"],
+    ["open transcript", { lastTurn: { startedAt: 0, endedAt: null } }, "killed"],
+    ["unknown authority falls back to open transcript", { authoritativeTurn: { state: "unknown", source: "empty", terminalAt: null }, lastTurn: { startedAt: 0, endedAt: null } }, "killed"],
+    ["unknown authority falls back to settled transcript", { authoritativeTurn: { state: "unknown", source: "empty", terminalAt: null }, lastTurn: { startedAt: 0, endedAt: 1 }, activityReason: "jsonl_turn_open", activity: "stalled" }, "unhosted"],
+    ["open activity reason", { activityReason: "jsonl_turn_open" }, "killed"],
+    ["stalled activity reason", { activityReason: "jsonl_turn_stalled" }, "killed"],
+    ["stalled activity alone", { activity: "stalled" }, "killed"],
+    ["unknown authority without open evidence", { authoritativeTurn: { state: "unknown", source: "empty", terminalAt: null } }, "unhosted"],
+    ["missing turn evidence", {}, "unhosted"],
+  ] satisfies [string, Partial<FileEntry>, "killed" | "unhosted"][])("stopped host: %s stays navigable", (_name, evidence, expected) => {
+    const state = assignmentAgentState(assignment(), file({ proc: "killed", ...evidence }));
+    expect(state).toBe(expected);
+    expect(assignmentOpenable(state)).toBe(true);
   });
 
   test("every present transcript state is openable — including stalled and idle hosts (fresh-review Finding 1)", () => {

--- a/src/components/scheme/assignmentState.ts
+++ b/src/components/scheme/assignmentState.ts
@@ -1,5 +1,6 @@
 import type { TaskAssignment } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { turnLeftOpen } from "../turnDuration";
 
 export type AssignmentAgentState = "spawning" | "failed" | "gone" | "migrating" | "killed" | "unhosted" | "live";
 
@@ -12,7 +13,7 @@ export function assignmentAgentState(
   if (assignment.state === "spawning" && !assignment.path) return "spawning";
   if (!file) return "gone";
   if (file.migration) return "migrating";
-  if (file.proc === "killed") return "killed";
+  if (file.proc === "killed") return turnLeftOpen(file) ? "killed" : "unhosted";
   if (file.proc === "running" || file.activity === "live" || file.activity === "recent") return "live";
   return "unhosted";
 }


### PR DESCRIPTION
A desktop assignment whose host stopped after its turn settled now shows the existing unhosted state, including when activity still reads recent or live. Hosts that died with an open turn retain the killed state. Both states remain navigable.

The classifier reuses `turnLeftOpen`, preserving provider-authoritative evidence precedence and the existing fallback for unknown or missing evidence. Only `assignmentState.ts` and its test change.

Local validation (Bun 1.3.3, isolated HOME/XDG/LLV/account/TMP directories; each test file run separately):
- Regression before the fix: 7 failures reproduced the killed-label defect.
- `bun test src/components/scheme/assignmentState.test.ts`: 20 passed.
- `bun test src/components/turnDuration.test.ts`: 13 passed.
- `bunx tsc --noEmit --incremental false`: passed.
- `git diff --check` and the local privacy publication gate: passed.

Hosted CI and two independent reviews are separate merge gates.

Closes #1506
