### PR TITLE
fix(ci): bounded dependency audit retries and truthful failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,38 +137,45 @@ jobs:
           set -euo pipefail
 
           audit_ids="$(bun -e '
-          const fs = require("node:fs");
+          // Bun 1.3.3 can swallow an uncaught CommonJS eval exception.
+          // Explicitly exit so malformed or expired allowlist entries block the gate.
+          try {
+            const fs = require("node:fs");
 
-          const allowlist = JSON.parse(fs.readFileSync("security/audit-allowlist.json", "utf8"));
-          const today = new Date().toISOString().slice(0, 10);
-          const idPattern = /^(?:CVE-\d{4}-\d{4,}|GHSA-[a-z0-9]+(?:-[a-z0-9]+)+)$/i;
-          const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-          const seen = new Set();
+            const allowlist = JSON.parse(fs.readFileSync("security/audit-allowlist.json", "utf8"));
+            const today = new Date().toISOString().slice(0, 10);
+            const idPattern = /^(?:CVE-\d{4}-\d{4,}|GHSA-[a-z0-9]+(?:-[a-z0-9]+)+)$/i;
+            const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+            const seen = new Set();
 
-          if (!Array.isArray(allowlist)) {
-            throw new Error("security/audit-allowlist.json must contain an array");
-          }
-          for (const [index, entry] of allowlist.entries()) {
-            if (!entry || typeof entry !== "object") {
-              throw new Error(`Allowlist entry ${index} must be an object`);
+            if (!Array.isArray(allowlist)) {
+              throw new Error("security/audit-allowlist.json must contain an array");
             }
-            const id = typeof entry.id === "string" ? entry.id.trim() : "";
-            const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
-            const expires = entry.expires;
-            if (!idPattern.test(id)) throw new Error(`Allowlist entry ${index} has an invalid advisory id`);
-            if (!reason) throw new Error(`Allowlist entry ${index} must include a reason`);
-            if (typeof expires !== "string" || !datePattern.test(expires)) {
-              throw new Error(`Allowlist entry ${index} must include an ISO expiry date`);
+            for (const [index, entry] of allowlist.entries()) {
+              if (!entry || typeof entry !== "object") {
+                throw new Error(`Allowlist entry ${index} must be an object`);
+              }
+              const id = typeof entry.id === "string" ? entry.id.trim() : "";
+              const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
+              const expires = entry.expires;
+              if (!idPattern.test(id)) throw new Error(`Allowlist entry ${index} has an invalid advisory id`);
+              if (!reason) throw new Error(`Allowlist entry ${index} must include a reason`);
+              if (typeof expires !== "string" || !datePattern.test(expires)) {
+                throw new Error(`Allowlist entry ${index} must include an ISO expiry date`);
+              }
+              const parsedExpiry = new Date(`${expires}T00:00:00Z`);
+              if (parsedExpiry.toISOString().slice(0, 10) !== expires) {
+                throw new Error(`Allowlist entry ${index} has an invalid expiry date`);
+              }
+              if (expires < today) throw new Error(`Allowlist entry ${id} expired on ${expires}`);
+              if (seen.has(id.toUpperCase())) throw new Error(`Duplicate allowlist entry for ${id}`);
+              seen.add(id.toUpperCase());
+              console.error(`Allowlisting ${id} through ${expires}: ${reason}`);
+              process.stdout.write(`${id}\n`);
             }
-            const parsedExpiry = new Date(`${expires}T00:00:00Z`);
-            if (parsedExpiry.toISOString().slice(0, 10) !== expires) {
-              throw new Error(`Allowlist entry ${index} has an invalid expiry date`);
-            }
-            if (expires < today) throw new Error(`Allowlist entry ${id} expired on ${expires}`);
-            if (seen.has(id.toUpperCase())) throw new Error(`Duplicate allowlist entry for ${id}`);
-            seen.add(id.toUpperCase());
-            console.error(`Allowlisting ${id} through ${expires}: ${reason}`);
-            process.stdout.write(`${id}\n`);
+          } catch (error) {
+            console.error(error);
+            process.exit(1);
           }
           '
           )"
@@ -179,7 +186,7 @@ jobs:
               audit_args+=("--ignore=$advisory")
             done <<< "$audit_ids"
           fi
-          bun audit --audit-level=high "${audit_args[@]}"
+          bash scripts/audit-with-retry.sh --audit-level=high "${audit_args[@]}"
 
       - name: Verify npm signatures before publish
         if: steps.registry.outputs.exists == 'false'

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -88,44 +88,63 @@ jobs:
       - name: Install production and development dependencies
         run: bun install --frozen-lockfile
 
+      - name: Verify audit retry behavior
+        env:
+          HOME: ${{ runner.temp }}/audit-tests/home
+          XDG_CONFIG_HOME: ${{ runner.temp }}/audit-tests/config
+          LLV_STATE_DIR: ${{ runner.temp }}/audit-tests/state
+          LLV_CLAUDE_HOME: ${{ runner.temp }}/audit-tests/claude
+          LLV_CODEX_HOME: ${{ runner.temp }}/audit-tests/codex
+          TMPDIR: ${{ runner.temp }}/audit-tests/tmp
+        run: |
+          mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$LLV_STATE_DIR" "$LLV_CLAUDE_HOME" "$LLV_CODEX_HOME" "$TMPDIR"
+          bun test scripts/audit-with-retry.test.ts
+
       - name: Audit production and development dependencies
         shell: bash
         run: |
           set -euo pipefail
 
           audit_ids="$(bun -e '
-          const fs = require("node:fs");
+          // Bun 1.3.3 can swallow an uncaught CommonJS eval exception.
+          // Explicitly exit so malformed or expired allowlist entries block the gate.
+          try {
+            const fs = require("node:fs");
 
-          const allowlist = JSON.parse(fs.readFileSync("security/audit-allowlist.json", "utf8"));
-          const today = new Date().toISOString().slice(0, 10);
-          const idPattern = /^(?:CVE-\d{4}-\d{4,}|GHSA-[a-z0-9]+(?:-[a-z0-9]+)+)$/i;
-          const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-          const seen = new Set();
+            const allowlist = JSON.parse(fs.readFileSync("security/audit-allowlist.json", "utf8"));
+            const today = new Date().toISOString().slice(0, 10);
+            const idPattern = /^(?:CVE-\d{4}-\d{4,}|GHSA-[a-z0-9]+(?:-[a-z0-9]+)+)$/i;
+            const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+            const seen = new Set();
 
-          if (!Array.isArray(allowlist)) {
-            throw new Error("security/audit-allowlist.json must contain an array");
-          }
-          for (const [index, entry] of allowlist.entries()) {
-            if (!entry || typeof entry !== "object") {
-              throw new Error(`Allowlist entry ${index} must be an object`);
+            if (!Array.isArray(allowlist)) {
+              throw new Error("security/audit-allowlist.json must contain an array");
             }
-            const id = typeof entry.id === "string" ? entry.id.trim() : "";
-            const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
-            const expires = entry.expires;
-            if (!idPattern.test(id)) throw new Error(`Allowlist entry ${index} has an invalid advisory id`);
-            if (!reason) throw new Error(`Allowlist entry ${index} must include a reason`);
-            if (typeof expires !== "string" || !datePattern.test(expires)) {
-              throw new Error(`Allowlist entry ${index} must include an ISO expiry date`);
+            for (const [index, entry] of allowlist.entries()) {
+              if (!entry || typeof entry !== "object") {
+                throw new Error(`Allowlist entry ${index} must be an object`);
+              }
+              const id = typeof entry.id === "string" ? entry.id.trim() : "";
+              const reason = typeof entry.reason === "string" ? entry.reason.trim() : "";
+              const expires = entry.expires;
+              if (!idPattern.test(id)) throw new Error(`Allowlist entry ${index} has an invalid advisory id`);
+              if (!reason) throw new Error(`Allowlist entry ${index} must include a reason`);
+              if (typeof expires !== "string" || !datePattern.test(expires)) {
+                throw new Error(`Allowlist entry ${index} must include an ISO expiry date`);
+              }
+              const parsedExpiry = new Date(`${expires}T00:00:00Z`);
+              if (parsedExpiry.toISOString().slice(0, 10) !== expires) {
+                throw new Error(`Allowlist entry ${index} has an invalid expiry date`);
+              }
+              if (expires < today) throw new Error(`Allowlist entry ${id} expired on ${expires}`);
+              if (seen.has(id.toUpperCase())) throw new Error(`Duplicate allowlist entry for ${id}`);
+              seen.add(id.toUpperCase());
+              console.error(`Allowlisting ${id} through ${expires}: ${reason}`);
+              process.stdout.write(`${id}\n`);
             }
-            const parsedExpiry = new Date(`${expires}T00:00:00Z`);
-            if (parsedExpiry.toISOString().slice(0, 10) !== expires) {
-              throw new Error(`Allowlist entry ${index} has an invalid expiry date`);
-            }
-            if (expires < today) throw new Error(`Allowlist entry ${id} expired on ${expires}`);
-            if (seen.has(id.toUpperCase())) throw new Error(`Duplicate allowlist entry for ${id}`);
-            seen.add(id.toUpperCase());
-            console.error(`Allowlisting ${id} through ${expires}: ${reason}`);
-            process.stdout.write(`${id}\n`);
+          } catch (error) {
+            console.error(error);
+            process.exit(1);
           }
           '
           )"
@@ -136,4 +155,4 @@ jobs:
               audit_args+=("--ignore=$advisory")
             done <<< "$audit_ids"
           fi
-          bun audit --audit-level=high "${audit_args[@]}"
+          bash scripts/audit-with-retry.sh --audit-level=high "${audit_args[@]}"

--- a/scripts/audit-with-retry.sh
+++ b/scripts/audit-with-retry.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Both Ubuntu audit gates use this wrapper. Bun remains the authority for
+# --audit-level and --ignore; every argument is forwarded unchanged.
+set -euo pipefail
+
+output="$(mktemp)"
+child=""
+trap 'rm -f "$output"' EXIT
+cancel() {
+  trap '' INT TERM
+  if [[ -n "$child" ]]; then
+    kill -TERM "$child" 2>/dev/null || true
+    wait "$child" 2>/dev/null || true
+  fi
+  echo 'Audit execution interrupted; security gate remains blocked.' >&2
+  exit "$1"
+}
+trap 'cancel 130' INT
+trap 'cancel 143' TERM
+
+# Bun's observed request timeout is 300s. The outer deadline allows it to
+# report that error, then bounds even an unresponsive child (315s maximum).
+# Three attempts plus 5s/10s backoff take at most 960s.
+for attempt in 1 2 3; do
+  echo "Dependency audit attempt ${attempt}/3" >&2
+  NO_COLOR=1 FORCE_COLOR=0 timeout --foreground --kill-after=5s 310s bun audit "$@" >"$output" 2>&1 &
+  child=$!
+  status=0
+  wait "$child" || status=$?
+  child=""
+  cat "$output"
+  if (( status == 0 )); then
+    echo 'Dependency audit passed.' >&2
+    exit 0
+  fi
+
+  if (( status == 124 || status >= 128 )); then
+    echo "Audit execution timed out or was terminated (exit ${status}); security gate remains blocked." >&2
+    exit "$status"
+  fi
+
+  # Match the complete diagnostic, excluding only Bun's banner and blank
+  # lines. A title mentioning Timeout, extra diagnostics, or a changed output
+  # format cannot turn an advisory or unknown failure into a retry.
+  # Format: oven-sh/bun, bun-v1.3.3, src/cli/audit_command.zig sendAuditRequest.
+  diagnostic="$(sed -E '/^bun audit v[^[:space:]]+.*$/d; /^[[:space:]]*$/d' "$output")"
+  case "$diagnostic" in
+    'Timeout: audit request failed'|\
+    'ConnectionRefused: audit request failed'|\
+    'ConnectionReset: audit request failed'|\
+    'ConnectionClosed: audit request failed'|\
+    'FailedToOpenSocket: audit request failed'|\
+    'error: audit request failed (status 408)'|\
+    'error: audit request failed (status 429)'|\
+    'error: audit request failed (status 500)'|\
+    'error: audit request failed (status 502)'|\
+    'error: audit request failed (status 503)'|\
+    'error: audit request failed (status 504)')
+      if (( attempt == 3 )); then
+        availability=unreachable
+        if [[ "$diagnostic" == 'error: audit request failed (status '* ]]; then
+          availability=unavailable
+        fi
+        echo "Advisory service ${availability} after 3 attempts; dependency audit could not complete. Security gate remains blocked." >&2
+        exit "$status"
+      fi
+      delay=$((attempt * 5))
+      echo "Advisory service transport failure; retrying in ${delay}s." >&2
+      sleep "$delay" &
+      child=$!
+      wait "$child"
+      child=""
+      ;;
+    *)
+      if grep -Eq '^[1-9][0-9]* vulnerabilities \(.*[1-9][0-9]* (high|critical)(,|\))' "$output"; then
+        echo 'Dependency audit reported high/critical advisories; security gate remains blocked.' >&2
+      else
+        echo "Audit failed with an unrecognized error (exit ${status}); security gate remains blocked. No retry." >&2
+      fi
+      exit "$status"
+      ;;
+  esac
+done

--- a/scripts/audit-with-retry.sh
+++ b/scripts/audit-with-retry.sh
@@ -39,11 +39,13 @@ for attempt in 1 2 3; do
     exit "$status"
   fi
 
+  # Bun 1.3.3 colors its banner even with NO_COLOR. Remove SGR formatting
+  # before matching; retain all other diagnostics and control sequences.
   # Match the complete diagnostic, excluding only Bun's banner and blank
   # lines. A title mentioning Timeout, extra diagnostics, or a changed output
   # format cannot turn an advisory or unknown failure into a retry.
   # Format: oven-sh/bun, bun-v1.3.3, src/cli/audit_command.zig sendAuditRequest.
-  diagnostic="$(sed -E '/^bun audit v[^[:space:]]+.*$/d; /^[[:space:]]*$/d' "$output")"
+  diagnostic="$(sed -E -e $'s/\033\\[[0-9;]*m//g' -e '/^bun audit v[^[:space:]]+.*$/d; /^[[:space:]]*$/d' "$output")"
   case "$diagnostic" in
     'Timeout: audit request failed'|\
     'ConnectionRefused: audit request failed'|\
@@ -72,7 +74,7 @@ for attempt in 1 2 3; do
       child=""
       ;;
     *)
-      if grep -Eq '^[1-9][0-9]* vulnerabilities \(.*[1-9][0-9]* (high|critical)(,|\))' "$output"; then
+      if grep -Eq '^[1-9][0-9]* vulnerabilities \(.*[1-9][0-9]* (high|critical)(,|\))' <<< "$diagnostic"; then
         echo 'Dependency audit reported high/critical advisories; security gate remains blocked.' >&2
       else
         echo "Audit failed with an unrecognized error (exit ${status}); security gate remains blocked. No retry." >&2

--- a/scripts/audit-with-retry.test.ts
+++ b/scripts/audit-with-retry.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, expect, test } from "bun:test";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture(sequence: string[], deadline = "310s") {
+  const root = mkdtempSync(join(tmpdir(), "audit-retry-"));
+  roots.push(root);
+  for (const dir of ["bin", "home", "config", "state", "claude", "codex", "tmp", "scripts", "security"]) {
+    mkdirSync(join(root, dir));
+  }
+  copyFileSync(join(import.meta.dir, "audit-with-retry.sh"), join(root, "scripts/audit-with-retry.sh"));
+  writeFileSync(join(root, "security/audit-allowlist.json"), JSON.stringify([
+    { id: "GHSA-aaaa-bbbb-cccc", reason: "Synthetic test exception", expires: "2999-12-31" },
+    { id: "CVE-2099-12345", reason: "Second synthetic test exception", expires: "2999-12-31" },
+  ]));
+  const env = {
+    PATH: `${join(root, "bin")}:/usr/bin:/bin`,
+    HOME: join(root, "home"), XDG_CONFIG_HOME: join(root, "config"),
+    LLV_STATE_DIR: join(root, "state"), LLV_CLAUDE_HOME: join(root, "claude"),
+    LLV_CODEX_HOME: join(root, "codex"), TMPDIR: join(root, "tmp"),
+    AUDIT_TEST_ROOT: root, AUDIT_TEST_BUN: process.execPath,
+    AUDIT_TEST_SEQUENCE: JSON.stringify(sequence), AUDIT_TEST_DEADLINE: deadline,
+  };
+  const shim = (name: string, body: string) => {
+    writeFileSync(join(root, "bin", name), `#!/bin/bash\nset -eu\n${body}\n`);
+    chmodSync(join(root, "bin", name), 0o755);
+  };
+  shim("bun", 'if [[ "$1" == -e ]]; then exec "$AUDIT_TEST_BUN" "$@"; fi\nexec "$AUDIT_TEST_BUN" "$AUDIT_TEST_ROOT/fake.ts" "$@"');
+  shim("sleep", 'echo "$1" >> "$AUDIT_TEST_ROOT/sleeps"\nexec /bin/sleep 0.001');
+  // Exercise GNU timeout itself with a shorter deadline; record the production
+  // arguments before substitution so the bounds are also part of the proof.
+  shim("timeout", 'printf "%s\\n" "$*" >> "$AUDIT_TEST_ROOT/deadlines"\nshift 3\nexec /usr/bin/timeout --foreground --kill-after=0.1s "$AUDIT_TEST_DEADLINE" "$@"');
+  writeFileSync(join(root, "fake.ts"), `
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+const root = process.env.AUDIT_TEST_ROOT!;
+const calls = root + "/calls";
+const count = existsSync(calls) ? readFileSync(calls, "utf8").trim().split("\\n").length : 0;
+appendFileSync(calls, JSON.stringify(process.argv.slice(2)) + "\\n");
+const sequence = JSON.parse(process.env.AUDIT_TEST_SEQUENCE!);
+const scenario = sequence[Math.min(count, sequence.length - 1)];
+console.error("bun audit v1.3.3 (fixture)");
+if (scenario === "success") { console.log("No vulnerabilities found"); process.exit(0); }
+if (scenario === "timeout") { console.error("Timeout: audit request failed"); process.exit(1); }
+if (scenario === "503") { console.error("error: audit request failed (status 503)"); process.exit(1); }
+if (scenario === "unknown") { console.error("error: invalid lockfile"); process.exit(42); }
+if (scenario === "403") { console.error("error: audit request failed (status 403)"); process.exit(1); }
+if (scenario === "mixed") { console.error("Timeout: audit request failed"); console.error("error: invalid lockfile"); process.exit(1); }
+if (scenario === "signal") { process.kill(process.pid, "SIGTERM"); await Bun.sleep(1000); }
+if (scenario === "hang" || scenario === "resist") {
+  if (scenario === "resist") process.on("SIGTERM", () => {});
+  writeFileSync(root + "/pid", String(process.pid));
+  setInterval(() => {}, 1000);
+} else {
+  console.log("fixture-package  <2.0.0\\n  high: Timeout: audit request failed\\n  https://github.com/advisories/GHSA-aaaa-bbbb-cccc\\n\\n1 vulnerabilities (1 high)");
+  process.exit(1);
+}
+`);
+  const lines = (file: string) => existsSync(join(root, file)) ? readFileSync(join(root, file), "utf8").trim().split("\n") : [];
+  const start = (script = 'bash scripts/audit-with-retry.sh --audit-level=high "--ignore=GHSA-aaaa-bbbb-cccc"') => {
+    const child = Bun.spawn(["/bin/bash", "-c", script], { cwd: root, env, stdout: "pipe", stderr: "pipe" });
+    const output = Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text()]);
+    return { child, async result() {
+      const status = await child.exited;
+      const [stdout, stderr] = await output;
+      return { status, text: stdout + stderr, calls: lines("calls").map(line => JSON.parse(line) as string[]), sleeps: lines("sleeps"), deadlines: lines("deadlines") };
+    } };
+  };
+  return { root, start };
+}
+
+for (const sequence of [["success"], ["timeout", "success"], ["timeout", "503", "success"]]) {
+  test(`audit succeeds after ${sequence.length} attempt(s)`, async () => {
+    const result = await fixture(sequence).start().result();
+    expect(result.status).toBe(0);
+    expect(result.calls).toHaveLength(sequence.length);
+    expect(result.sleeps).toEqual(["5", "10"].slice(0, sequence.length - 1));
+    for (const args of result.calls) expect(args).toEqual(["audit", "--audit-level=high", "--ignore=GHSA-aaaa-bbbb-cccc"]);
+    for (const deadline of result.deadlines) expect(deadline).toStartWith("--foreground --kill-after=5s 310s bun audit ");
+  });
+}
+
+test("exhausted transport errors block with an unreachable classification", async () => {
+  const result = await fixture(["timeout"]).start().result();
+  expect(result.status).toBe(1);
+  expect(result.calls).toHaveLength(3);
+  expect(result.sleeps).toEqual(["5", "10"]);
+  expect(result.text).toContain("Advisory service unreachable after 3 attempts");
+  expect(result.text).not.toContain("reported high/critical");
+});
+
+for (const [scenario, status] of [["advisory", 1], ["unknown", 42], ["403", 1], ["mixed", 1], ["signal", 143]] as const) {
+  test(`${scenario} fails promptly and preserves the child status`, async () => {
+    const result = await fixture([scenario, "success"]).start().result();
+    expect(result.status).toBe(status);
+    expect(result.calls).toHaveLength(1);
+    expect(result.sleeps).toEqual([]);
+    expect(result.text).not.toContain("service unreachable");
+    expect(result.text).toContain(scenario === "advisory" ? "reported high/critical advisories" : scenario === "signal" ? "was terminated" : "unrecognized error");
+  });
+}
+
+test("a transport retry followed by advisories stops immediately", async () => {
+  const result = await fixture(["timeout", "advisory", "success"]).start().result();
+  expect(result.status).toBe(1);
+  expect(result.calls).toHaveLength(2);
+  expect(result.sleeps).toEqual(["5"]);
+  expect(result.text).toContain("reported high/critical advisories");
+});
+
+for (const scenario of ["hang", "resist"]) {
+  test(`outer deadline reaps a ${scenario} child and fails closed`, async () => {
+    const f = fixture([scenario], "0.2s");
+    const result = await f.start().result();
+    expect([124, 137]).toContain(result.status);
+    expect(result.calls).toHaveLength(1);
+    expect(result.sleeps).toEqual([]);
+    expect(result.text).toContain("execution timed out or was terminated");
+    const pid = Number(readFileSync(join(f.root, "pid"), "utf8"));
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+}
+
+for (const scenario of ["hang", "resist"]) {
+  test(`wrapper cancellation terminates and waits for its ${scenario} child`, async () => {
+    const f = fixture([scenario]);
+    const run = f.start("exec bash scripts/audit-with-retry.sh --audit-level=high");
+    try {
+      for (let i = 0; i < 200 && !existsSync(join(f.root, "pid")); i++) await Bun.sleep(10);
+      expect(existsSync(join(f.root, "pid"))).toBe(true);
+      run.child.kill("SIGTERM");
+      const result = await run.result();
+      expect(result.status).toBe(143);
+      expect(result.calls).toHaveLength(1);
+      expect(result.text).toContain("execution interrupted");
+      expect(() => process.kill(Number(readFileSync(join(f.root, "pid"), "utf8")), 0)).toThrow();
+    } finally {
+      if (run.child.exitCode === null) run.child.kill("SIGTERM");
+      await run.child.exited;
+    }
+  });
+
+}
+
+function auditStep(workflow: string): string {
+  const source = readFileSync(join(import.meta.dir, "../.github/workflows", workflow), "utf8");
+  const step = source.split(/\n      - /).find(part => part.startsWith("name: Audit "))!;
+  expect(step).toBeDefined();
+  return step.split("        run: |\n")[1].split("\n").map(line => line.slice(10)).join("\n");
+}
+
+for (const workflow of ["supply-chain.yml", "publish.yml"]) {
+  test(`${workflow} executes the wrapper with its validated allowlist`, async () => {
+    const result = await fixture(["timeout", "success"]).start(auditStep(workflow)).result();
+    expect(result.status).toBe(0);
+    expect(result.calls).toEqual(Array(2).fill(["audit", "--audit-level=high", "--ignore=GHSA-aaaa-bbbb-cccc", "--ignore=CVE-2099-12345"]));
+    expect(result.sleeps).toEqual(["5"]);
+  });
+  test(`${workflow} rejects an expired allowlist before any audit`, async () => {
+    const f = fixture(["success"]);
+    writeFileSync(join(f.root, "security/audit-allowlist.json"), JSON.stringify([
+      { id: "CVE-2000-12345", reason: "Expired fixture", expires: "2000-01-01" },
+    ]));
+    const result = await f.start(auditStep(workflow)).result();
+    expect(result.status).not.toBe(0);
+    expect(result.calls).toEqual([]);
+    expect(result.text).toContain("expired on");
+  });
+}
+
+for (const diagnostic of ["ConnectionRefused", "ConnectionReset", "ConnectionClosed", "FailedToOpenSocket"]) {
+  test(`${diagnostic} is retried only as a standalone request failure`, async () => {
+    const f = fixture(["success"]);
+    writeFileSync(join(f.root, "fake.ts"), `console.error("bun audit v1.3.3 (fixture)"); console.error("${diagnostic}: audit request failed"); process.exit(1);`);
+    const result = await f.start().result();
+    expect(result.status).toBe(1);
+    expect(result.deadlines).toHaveLength(3);
+    expect(result.sleeps).toEqual(["5", "10"]);
+    expect(result.text).toContain("unreachable after 3 attempts");
+  });
+}
+
+test("a missing audit executable fails once and preserves exit 127", async () => {
+  const f = fixture(["success"]);
+  rmSync(join(f.root, "bin/bun"));
+  const result = await f.start().result();
+  expect(result.status).toBe(127);
+  expect(result.deadlines).toHaveLength(1);
+  expect(result.sleeps).toEqual([]);
+  expect(result.text).toContain("unrecognized error");
+});
+
+test("exhausted HTTP service errors are classified as unavailable", async () => {
+  const result = await fixture(["503"]).start().result();
+  expect(result.status).toBe(1);
+  expect(result.calls).toHaveLength(3);
+  expect(result.text).toContain("Advisory service unavailable after 3 attempts");
+  expect(result.text).not.toContain("service unreachable");
+});

--- a/scripts/audit-with-retry.test.ts
+++ b/scripts/audit-with-retry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -44,7 +45,7 @@ const count = existsSync(calls) ? readFileSync(calls, "utf8").trim().split("\\n"
 appendFileSync(calls, JSON.stringify(process.argv.slice(2)) + "\\n");
 const sequence = JSON.parse(process.env.AUDIT_TEST_SEQUENCE!);
 const scenario = sequence[Math.min(count, sequence.length - 1)];
-console.error("bun audit v1.3.3 (fixture)");
+console.error("\\x1b[0m\\x1b[1mbun audit \\x1b[0m\\x1b[2mv1.3.3 (fixture)\\x1b[0m");
 if (scenario === "success") { console.log("No vulnerabilities found"); process.exit(0); }
 if (scenario === "timeout") { console.error("Timeout: audit request failed"); process.exit(1); }
 if (scenario === "503") { console.error("error: audit request failed (status 503)"); process.exit(1); }
@@ -57,7 +58,7 @@ if (scenario === "hang" || scenario === "resist") {
   writeFileSync(root + "/pid", String(process.pid));
   setInterval(() => {}, 1000);
 } else {
-  console.log("fixture-package  <2.0.0\\n  high: Timeout: audit request failed\\n  https://github.com/advisories/GHSA-aaaa-bbbb-cccc\\n\\n1 vulnerabilities (1 high)");
+  console.log("fixture-package  <2.0.0\\n  high: Timeout: audit request failed\\n  https://github.com/advisories/GHSA-aaaa-bbbb-cccc\\n\\n\\x1b[1m1 vulnerabilities (1 \\x1b[31mhigh\\x1b[0m)");
   process.exit(1);
 }
 `);
@@ -93,6 +94,42 @@ test("exhausted transport errors block with an unreachable classification", asyn
   expect(result.text).toContain("Advisory service unreachable after 3 attempts");
   expect(result.text).not.toContain("reported high/critical");
 });
+
+for (const statuses of [[503, 200], [503, 503, 503], [403]]) {
+  test(`real Bun advisory endpoint responds with ${statuses.join(" then ")}`, async () => {
+    const f = fixture([], "2s");
+    // Keep Bun's actual output and HTTP request path in the regression. Only
+    // backoff duration and the outer deadline are shortened by fixture shims.
+    writeFileSync(join(f.root, "bin/bun"), '#!/bin/bash\nexec "$AUDIT_TEST_BUN" "$@"\n');
+    for (const file of ["package.json", "bun.lock"]) {
+      copyFileSync(join(import.meta.dir, "..", file), join(f.root, file));
+    }
+    const requests: { method: string; path: string; body: string }[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1", port: 0,
+      async fetch(request) {
+        const bytes = Buffer.from(await request.arrayBuffer());
+        const body = request.headers.get("content-encoding") === "gzip" ? gunzipSync(bytes).toString() : bytes.toString();
+        requests.push({ method: request.method, path: new URL(request.url).pathname, body });
+        return Response.json({}, { status: statuses[Math.min(requests.length - 1, statuses.length - 1)] });
+      },
+    });
+    try {
+      const result = await f.start(`bash scripts/audit-with-retry.sh --audit-level=high --registry=http://127.0.0.1:${server.port}`).result();
+      expect(result.status).toBe(statuses.includes(200) ? 0 : 1);
+      expect(requests).toHaveLength(statuses.length);
+      for (const request of requests) {
+        expect(request.method).toBe("POST");
+        expect(request.path).toBe("/-/npm/v1/security/advisories/bulk");
+        expect(Object.keys(JSON.parse(request.body)).length).toBeGreaterThan(0);
+      }
+      expect(result.sleeps).toEqual(["5", "10"].slice(0, statuses.length - 1));
+      expect(result.text).toContain(statuses.includes(200) ? "Dependency audit passed" : statuses[0] === 403 ? "unrecognized error" : "Advisory service unavailable after 3 attempts");
+    } finally {
+      await server.stop(true);
+    }
+  });
+}
 
 for (const [scenario, status] of [["advisory", 1], ["unknown", 42], ["403", 1], ["mixed", 1], ["signal", 143]] as const) {
   test(`${scenario} fails promptly and preserves the child status`, async () => {


### PR DESCRIPTION
A single advisory-service timeout currently blocks the dependency audit without retry. Both audit workflows now share a wrapper that retries recognized transport failures up to three times with 5-second and 10-second backoff. Exhausted connection failures say the service is unreachable; exhausted retryable HTTP errors say it is unavailable. Both outcomes remain blocking.

High/critical advisories and unknown errors fail promptly. Arguments, severity, and ignore semantics remain under Bun's control. GNU timeout permits Bun's observed 300-second request timeout to report, then enforces a 310-second deadline with a 5-second termination grace period. Cancellation waits for the child.

Bun 1.3.3 emits a colored banner despite NO_COLOR. The wrapper removes ANSI SGR formatting before strict whole-diagnostic classification, preserving other diagnostics and control sequences. Real Bun tests against a loopback advisory endpoint prove 503-to-success recovery, three-attempt exhaustion, and immediate 403 failure. Colored fixtures retain advisory, mixed-error, and unknown-error blocking coverage.

Both workflows also explicitly exit when their existing allowlist validation throws: Bun 1.3.3 can otherwise swallow the exception in CommonJS eval. Allowlist rules are unchanged, with expired-entry regression coverage.

Main was normal-merged without conflicts from `e57008f3f2ed42cc7b47ada9de4f94033aea6f11` into original head `7096ee5192669d8224972b048301551664ce17d5`. This review repair advances refreshed head `fe9fcb2ccf7d679c1d9ebb0999a4c838852325db` to `7789f643cfaa8c5fb382fd947802c16553ea6745`. No manifest or lockfile changes.

Local validation after frozen dependency installation:

- Audit helper tests: 27 passed, including real Bun endpoint coverage. Retry regressions failed before the normalization fix.
- `bunx tsc --noEmit --incremental false`: passed.
- Helper and workflow audit-step Bash syntax, diff whitespace, and commit-aware publication privacy checks: passed.
- Publish-workflow tests: 14 passed, one failure at line 340 in publication integrity capture. Extracting the test and workflow from the exact main SHA reproduces the same failure in isolated state. This repair leaves that surface unchanged.

Tests use isolated home, config, Viewer, account, and temporary state. Hosted checks and two new independent exact-head reviews remain merge gates. Old-head approvals or green CI do not satisfy those gates. No release publication or deployment was performed.

Closes #1510
