### PR TITLE
fix(rename): keep Cancel from saving on iOS button press

### DIFF
--- a/src/components/session/SessionTitle.dom.test.tsx
+++ b/src/components/session/SessionTitle.dom.test.tsx
@@ -23,11 +23,11 @@ Object.assign(globalThis, {
   PointerEvent: dom.MouseEvent,
 });
 
-const UUID = "11111111-2222-4333-8444-555555555555";
+const UUID = "session-title-test";
 
 function entry(over: Partial<FileEntry> = {}): FileEntry {
   return {
-    path: `/home/u/.claude/projects/proj/${UUID}.jsonl`,
+    path: `/fixtures/sessions/${UUID}.jsonl`,
     root: "claude-projects",
     name: "x",
     project: "proj",
@@ -142,6 +142,64 @@ test("Escape cancels without saving", async () => {
   await settle();
   expect(calls).toHaveLength(0);
   expect(view.host.querySelector('input[aria-label="Session title"]')).toBeNull();
+  expect(view.host.textContent).toContain("Fix the login bug");
+});
+
+for (const action of ["Cancel", "Save name", "Reset to auto title"] as const) {
+  test(`mouse press keeps focus until ${action} chooses persistence`, async () => {
+    const view = mount(entry({ title: "Custom name", autoTitle: "Auto title", titleRevision: 3 }));
+    flushSync(() => (view.host.querySelector('button[aria-label^="Rename"]') as HTMLButtonElement).click());
+    const input = view.host.querySelector("input")!;
+    flushSync(() => typeInto(input, "Edited name"));
+    const button = view.host.querySelector(`button[aria-label="${action}"]`) as HTMLButtonElement;
+    const press = new dom.PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerType: "mouse" });
+    flushSync(() => dispatch(button, press));
+    if (!press.defaultPrevented) flushSync(() => button.focus());
+    expect(press.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+    expect(calls).toHaveLength(0);
+    flushSync(() => button.click());
+    await settle();
+    expect(calls).toHaveLength(action === "Cancel" ? 0 : 1);
+    if (action !== "Cancel") expect(calls[0]!.body.title).toBe(action === "Save name" ? "Edited name" : null);
+    expect(view.host.querySelector("input")).toBeNull();
+  });
+}
+
+test("an abandoned button press preserves later outside blur-save and input selection", async () => {
+  const view = mount(entry());
+  flushSync(() => (view.host.querySelector('button[aria-label^="Rename"]') as HTMLButtonElement).click());
+  const input = view.host.querySelector("input")!;
+  flushSync(() => typeInto(input, "Save on leaving"));
+  const selectionPress = new dom.PointerEvent("pointerdown", { bubbles: true, cancelable: true });
+  flushSync(() => dispatch(input, selectionPress));
+  expect(selectionPress.defaultPrevented).toBe(false);
+  const cancel = view.host.querySelector('button[aria-label="Cancel"]')!;
+  const press = new dom.PointerEvent("pointerdown", { bubbles: true, cancelable: true });
+  flushSync(() => dispatch(cancel, press));
+  expect(press.defaultPrevented).toBe(true);
+  flushSync(() => dispatch(cancel, new dom.PointerEvent("pointercancel", { bubbles: true })));
+  flushSync(() => dispatch(input, new dom.FocusEvent("focusout", { bubbles: true, relatedTarget: null })));
+  await settle();
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.body.title).toBe("Save on leaving");
+});
+
+test("keyboard focus can reach Cancel and discard the draft", async () => {
+  const view = mount(entry());
+  flushSync(() => (view.host.querySelector('button[aria-label^="Rename"]') as HTMLButtonElement).click());
+  const input = view.host.querySelector("input")!;
+  flushSync(() => typeInto(input, "Discard by keyboard"));
+  const cancel = view.host.querySelector('button[aria-label="Cancel"]') as HTMLButtonElement;
+  flushSync(() => cancel.focus());
+  expect(view.host.querySelector("input")).toBe(input);
+  expect(document.activeElement).toBe(cancel);
+  expect(calls).toHaveLength(0);
+  // Keyboard activation emits click without a pointer press.
+  flushSync(() => cancel.click());
+  await settle();
+  expect(calls).toHaveLength(0);
+  expect(view.host.querySelector("input")).toBeNull();
   expect(view.host.textContent).toContain("Fix the login bug");
 });
 
@@ -341,8 +399,8 @@ test("an instance with no autoEditToken never auto-opens (the node's board pane 
   expect(view.host.querySelector('input[aria-label="Session title"]')).toBeNull();
 });
 
-const sessionA = () => entry({ path: "/home/u/.claude/projects/proj/aaaaaaaa-2222-4333-8444-555555555555.jsonl", conversationId: "conversation_A", title: "Session A" });
-const sessionB = () => entry({ path: "/home/u/.claude/projects/proj/bbbbbbbb-2222-4333-8444-555555555555.jsonl", conversationId: "conversation_B", title: "Session B" });
+const sessionA = () => entry({ path: "/fixtures/sessions/session-a.jsonl", conversationId: "conversation_A", title: "Session A" });
+const sessionB = () => entry({ path: "/fixtures/sessions/session-b.jsonl", conversationId: "conversation_B", title: "Session B" });
 
 test("switching sessions before a save settles resets the editor and shows the new session", () => {
   const view = mount(sessionA());
@@ -363,7 +421,7 @@ test("switching sessions before a save settles resets the editor and shows the n
 
 test("conversation-id enrichment on the same path keeps the editor open (no reset)", () => {
   // Initially no conversationId; identity is the path.
-  const bare = entry({ path: "/home/u/.claude/projects/proj/enrich.jsonl", title: "Session" });
+  const bare = entry({ path: "/fixtures/sessions/enrich.jsonl", title: "Session" });
   const view = mount(bare);
   flushSync(() => (view.host.querySelector('button[aria-label^="Rename"]') as HTMLButtonElement).click());
   expect(view.host.querySelector('input[aria-label="Session title"]')).toBeTruthy();
@@ -371,14 +429,14 @@ test("conversation-id enrichment on the same path keeps the editor open (no rese
   // A later poll fills in conversationId for the same path — enrichment, not a
   // switch: the open editor (an in-progress draft) must survive, and nothing is
   // saved.
-  view.rerender(entry({ path: "/home/u/.claude/projects/proj/enrich.jsonl", conversationId: "conversation_E", title: "Session" }));
+  view.rerender(entry({ path: "/fixtures/sessions/enrich.jsonl", conversationId: "conversation_E", title: "Session" }));
   expect(view.host.querySelector('input[aria-label="Session title"]')).toBeTruthy();
   expect(calls).toHaveLength(0);
 });
 
 test("succession (new path, same conversation id) keeps the editor open (no reset)", () => {
-  const gen1 = entry({ path: "/home/u/.claude/projects/proj/gen1.jsonl", conversationId: "conversation_X", title: "S" });
-  const gen2 = entry({ path: "/home/u/.claude/projects/proj/gen2.jsonl", conversationId: "conversation_X", title: "S" });
+  const gen1 = entry({ path: "/fixtures/sessions/gen1.jsonl", conversationId: "conversation_X", title: "S" });
+  const gen2 = entry({ path: "/fixtures/sessions/gen2.jsonl", conversationId: "conversation_X", title: "S" });
   const view = mount(gen1);
   flushSync(() => (view.host.querySelector('button[aria-label^="Rename"]') as HTMLButtonElement).click());
   expect(view.host.querySelector('input[aria-label="Session title"]')).toBeTruthy();

--- a/src/components/session/SessionTitle.mobile.dom.test.tsx
+++ b/src/components/session/SessionTitle.mobile.dom.test.tsx
@@ -274,3 +274,42 @@ test("Enter saves what was typed and the bar's title cell shows the new name", a
      sees the name they typed without waiting for the next scan. */
   expect(barTitle(host)).toBe("Phone rename");
 });
+
+for (const action of ["Cancel", "Save name"] as const) {
+  test(`a phone ${action} press prevents null-target blur before click`, async () => {
+    const files = [neighbour, focused];
+    const { host, root } = await mount(files);
+    const originalBarTitle = barTitle(host);
+    openRename(host);
+    await settle(root, view(files), 1);
+    const field = input(host)!;
+    flushSync(() => typeInto(field, "Phone draft"));
+    const button = editor(host)!.querySelector(`button[aria-label="${action}"]`)!;
+    // Press the icon too: the event must reach the button through its child.
+    const target = button.querySelector("svg")!;
+    const press = new dom.PointerEvent("pointerdown", { bubbles: true, cancelable: true, pointerType: "touch" });
+    flushSync(() => target.dispatchEvent(press as unknown as Event));
+    // happy-dom has no native Safari focus default. Model its reported
+    // blur-before-click ordering only when the press permits that default.
+    if (!press.defaultPrevented) {
+      flushSync(() => field.dispatchEvent(new dom.FocusEvent("focusout", { bubbles: true, relatedTarget: null }) as unknown as Event));
+    }
+    expect(requests.filter((request) => request.url === "/api/session/title")).toHaveLength(0);
+    expect(press.defaultPrevented).toBe(true);
+    expect(input(host)).toBe(field);
+    expect(dom.document.activeElement).toBe(field as unknown as typeof dom.document.activeElement);
+    flushSync(() => target.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event));
+    await settle(root, view(files));
+
+    const saves = requests.filter((request) => request.url === "/api/session/title");
+    expect(saves).toHaveLength(action === "Cancel" ? 0 : 1);
+    if (action === "Save name") expect(saves[0]!.body.title).toBe("Phone draft");
+    expect(input(host)).toBeNull();
+    expect(barTitle(host)).toBe(action === "Cancel" ? originalBarTitle : "Phone draft");
+    if (action === "Cancel") {
+      openRename(host);
+      await settle(root, view(files), 1);
+      expect(input(host)!.value).toBe(LONG_TITLE);
+    }
+  });
+}

--- a/src/components/session/SessionTitle.tsx
+++ b/src/components/session/SessionTitle.tsx
@@ -283,6 +283,9 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
   };
 
   const stop = (event: React.PointerEvent) => event.stopPropagation();
+  // Keep focus in the editor until the click chooses Save/Reset/Cancel.
+  // Safari can otherwise blur with relatedTarget=null before that click.
+  const keepEditorFocus = (event: React.PointerEvent<HTMLButtonElement>) => event.preventDefault();
   /* The phone's pane header is also its swipe handle (`MobileFocusView` steps
      to the next conversation on a horizontal drag across it). A drag INSIDE
      the editor is the operator moving through a long title, so it stays here
@@ -342,6 +345,7 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
           }`}
           aria-label={t("rename.save")}
           title={t("rename.save")}
+          onPointerDown={keepEditorFocus}
           onClick={() => commit(inputRef.current?.value ?? value)}
         >
           <Check className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />
@@ -354,6 +358,7 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
             }`}
             aria-label={t("rename.reset")}
             title={t("rename.resetHint", { title: cleanTitle(autoTitle, 60) })}
+            onPointerDown={keepEditorFocus}
             onClick={() => commit(null)}
           >
             <RotateCw className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />
@@ -366,6 +371,7 @@ export function SessionTitle({ file, displayMax = 90, titleClassName = "", class
           }`}
           aria-label={t("rename.cancel")}
           title={t("rename.cancel")}
+          onPointerDown={keepEditorFocus}
           onClick={cancel}
         >
           <X className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />


### PR DESCRIPTION
Tapping Cancel in the rename editor could save the draft first because Safari blurs the input with a null related target before click. Prevent the default pointer press on Save, Reset, and Cancel so each click performs its intended action. Input selection, keyboard navigation, Enter, Escape, and outside blur-save retain their behavior.

Closes #1425

Validation:
- `bun test src/components/session/SessionTitle.dom.test.tsx`: 25 passed.
- `bun test src/components/session/SessionTitle.mobile.dom.test.tsx`: 5 passed.
- `bunx tsc --noEmit --incremental false`: passed.
- Each test file ran separately with isolated HOME, XDG, LLV, provider account, and temporary state.
- New mobile ordering regressions failed on the original source with one premature save before click, then passed with the fix. They explicitly assert default prevention, Cancel discard/reopen, and a single Save request. Desktop coverage includes Reset, keyboard Cancel, input pointer selection, and outside blur after an abandoned press.
- Local privacy publication gate passed after replacing legacy fixture paths and UUID-shaped identifiers in the touched component test with synthetic fixture names.

The mobile tests model the reported Safari blur ordering in happy-dom. They do not prove native iOS Safari default actions; no native Safari run was performed. Hosted CI and two independent exact-head reviews are separate gates before merge.
