### PR TITLE
fix(preview): surface lazy PDF failures and fence stale paints

### DIFF
--- a/src/components/preview/PdfPane.dom.test.tsx
+++ b/src/components/preview/PdfPane.dom.test.tsx
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test";
 import { Window } from "happy-dom";
+import type { PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -10,7 +11,7 @@ import type { ArtifactFailure } from "./artifactResource";
 
 installActEnv();
 
-const dom = new Window();
+const dom = new Window({ url: "http://localhost:3000/" });
 Object.assign(globalThis, {
   window: dom,
   document: dom.document,
@@ -18,6 +19,7 @@ Object.assign(globalThis, {
   Node: dom.Node,
   HTMLElement: dom.HTMLElement,
   Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
   requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
   cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
 });
@@ -28,18 +30,21 @@ Object.assign(globalThis, {
    the module mock cannot reach any other suite's dependencies. */
 const getDocumentCalls: Record<string, unknown>[] = [];
 let taskRejection: unknown = null;
+let loadedDocument: PDFDocumentProxy | null = null;
 mock.module("pdfjs-dist", () => ({
   GlobalWorkerOptions: { workerSrc: "" },
   getDocument: (params: Record<string, unknown>) => {
     getDocumentCalls.push(params);
     return {
-      promise: taskRejection ? Promise.reject(taskRejection) : new Promise(() => {}),
+      promise: taskRejection ? Promise.reject(taskRejection) : loadedDocument ? Promise.resolve(loadedDocument) : new Promise(() => {}),
       destroy: () => Promise.resolve(),
     };
   },
 }));
 
 const { default: PdfPane } = await import("./PdfPane");
+const { ArtifactPreviewHost } = await import("./ArtifactPreviewHost");
+const { openArtifactPreview } = await import("./previewBus");
 
 let root: Root | null = null;
 let failures: ArtifactFailure[] = [];
@@ -49,6 +54,8 @@ beforeEach(() => {
   setLocale("en");
   getDocumentCalls.length = 0;
   taskRejection = null;
+  loadedDocument = null;
+  spyOn(dom.HTMLCanvasElement.prototype, "getContext").mockReturnValue({} as never);
   failures = [];
   const host = dom.document.createElement("div");
   dom.document.body.appendChild(host);
@@ -58,6 +65,10 @@ beforeEach(() => {
 afterEach(async () => {
   await act(async () => root?.unmount());
   dom.document.body.replaceChildren();
+  mock.restore();
+  Reflect.deleteProperty(globalThis, "ResizeObserver");
+  dom.history.replaceState(null, "", "/");
+  await new Promise((resolve) => setTimeout(resolve, 0));
 });
 
 const flush = async () => {
@@ -96,3 +107,180 @@ test("mobile pdf controls carry the 44px touch-target sizing", async () => {
     expect(control!.className).toContain("h-11 w-11");
   }
 });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function pdfPage(width = 100, promise = Promise.resolve()) {
+  const cancel = mock(() => {});
+  const render = mock(() => ({ promise, cancel }));
+  return {
+    page: { getViewport: () => ({ width, height: width * 2 }), render } as unknown as PDFPageProxy,
+    render,
+    cancel,
+  };
+}
+
+function documentWith(getPage: (page: number) => Promise<PDFPageProxy>) {
+  loadedDocument = { numPages: 3, getPage } as PDFDocumentProxy;
+}
+
+async function click(label: string) {
+  await act(async () => {
+    const button = dom.document.querySelector(`[aria-label="${label}"]`);
+    expect(button).not.toBeNull();
+    (button as unknown as HTMLButtonElement).click();
+  });
+}
+
+async function openHost() {
+  spyOn(globalThis, "fetch").mockImplementation(Object.assign(async () => new Response(JSON.stringify({
+    name: "report.pdf", kind: "pdf", mime: "application/pdf", size: 200000, etag: '"p1"',
+  })), { preconnect: () => {} }));
+  await act(async () => root!.render(<ArtifactPreviewHost mobile={false} />));
+  await act(async () => openArtifactPreview("~/fixtures/report.pdf"));
+  await flush();
+}
+
+for (const phase of ["initial load", "lazy page"] as const) {
+  test(`${phase} 412 exposes the real host changed state and working Reload`, async () => {
+    const pending = deferred<PDFPageProxy>();
+    const first = pdfPage();
+    if (phase === "initial load") taskRejection = { status: 412 };
+    else documentWith((page) => page === 1 ? Promise.resolve(first.page) : pending.promise);
+    await openHost();
+    if (phase === "lazy page") {
+      expect(first.render).toHaveBeenCalledTimes(1);
+      await click("Next page");
+      await act(async () => pending.reject({ status: 412 }));
+    }
+    expect(dom.document.querySelector("[data-artifact-preview]")?.getAttribute("data-artifact-state")).toBe("changed");
+    const reload = Array.from(dom.document.querySelectorAll("button")).find((button) => button.textContent === "Reload");
+    expect(reload).toBeDefined();
+    taskRejection = null;
+    documentWith(() => Promise.resolve(first.page));
+    await act(async () => reload!.click());
+    await flush();
+    expect(getDocumentCalls).toHaveLength(2);
+    expect(dom.document.querySelector("[data-artifact-preview]")?.getAttribute("data-artifact-state")).toBe("ready");
+    expect(dom.document.querySelector("canvas")).not.toBeNull();
+  });
+}
+
+for (const teardown of ["navigation", "unmount"] as const) {
+  for (const settlement of ["reject", "resolve"] as const) {
+    test(`late getPage ${settlement} after ${teardown} cannot report or paint`, async () => {
+      const pending = deferred<PDFPageProxy>();
+      const stale = pdfPage(900);
+      const current = pdfPage(200);
+      documentWith((page) => page === 1 ? pending.promise : Promise.resolve(current.page));
+      await render();
+      const canvas = dom.document.querySelector("canvas")!;
+      if (teardown === "navigation") await click("Next page");
+      else await act(async () => { root!.unmount(); root = null; });
+      const width = canvas.width;
+      await act(async () => {
+        if (settlement === "reject") pending.reject({ status: 412 });
+        else pending.resolve(stale.page);
+      });
+      expect(failures).toEqual([]);
+      expect(stale.render).not.toHaveBeenCalled();
+      expect(canvas.width).toBe(width);
+      if (teardown === "navigation") {
+        expect(current.render).toHaveBeenCalledTimes(1);
+        expect(current.cancel).not.toHaveBeenCalled();
+      }
+    });
+  }
+}
+
+for (const error of [{ status: 403 }, new Error("page unavailable"), null]) {
+  test(`current lazy failure maps honestly: ${JSON.stringify(error)}`, async () => {
+    documentWith(() => Promise.reject(error));
+    await render();
+    expect(failures).toEqual([error && "status" in error ? "denied" : "error"]);
+  });
+}
+
+for (const teardown of ["navigation", "unmount"] as const) {
+  test(`an active render is cancelled on ${teardown} and its rejection is ignored`, async () => {
+    const pending = deferred<void>();
+    const stale = pdfPage(100, pending.promise);
+    const current = pdfPage(200);
+    documentWith((page) => Promise.resolve(page === 1 ? stale.page : current.page));
+    await render();
+    expect(stale.render).toHaveBeenCalledTimes(1);
+    if (teardown === "navigation") await click("Next page");
+    else await act(async () => { root!.unmount(); root = null; });
+    expect(stale.cancel).toHaveBeenCalledTimes(1);
+    await act(async () => pending.reject(new Error("render cancelled")));
+    expect(failures).toEqual([]);
+  });
+}
+
+test("a current render failure is surfaced", async () => {
+  const pending = deferred<void>();
+  documentWith(() => Promise.resolve(pdfPage(100, pending.promise).page));
+  await render();
+  await act(async () => pending.reject(new Error("render failed")));
+  expect(failures).toEqual(["error"]);
+});
+
+for (const settlement of ["reject", "resolve"] as const) {
+  test(`resize supersedes a pending fetch before its late ${settlement}`, async () => {
+    let resize!: () => void;
+    const disconnect = mock(() => {});
+    Object.assign(globalThis, { ResizeObserver: class {
+      constructor(callback: () => void) { resize = callback; }
+      observe() {}
+      disconnect = disconnect;
+    } });
+    const pending = deferred<PDFPageProxy>();
+    const stale = pdfPage(900);
+    const current = pdfPage(200);
+    let calls = 0;
+    documentWith(() => ++calls === 1 ? pending.promise : Promise.resolve(current.page));
+    await render();
+    await act(async () => resize());
+    const canvas = dom.document.querySelector("canvas")!;
+    const width = canvas.width;
+    await act(async () => {
+      if (settlement === "reject") pending.reject({ status: 412 });
+      else pending.resolve(stale.page);
+    });
+    expect(failures).toEqual([]);
+    expect(stale.render).not.toHaveBeenCalled();
+    expect(current.render).toHaveBeenCalledTimes(1);
+    expect(current.cancel).not.toHaveBeenCalled();
+    expect(canvas.width).toBe(width);
+    await act(async () => { root!.unmount(); root = null; });
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    await act(async () => resize());
+    expect(calls).toBe(2);
+  });
+
+  test(`switching artifacts ignores the old page's late ${settlement}`, async () => {
+    const pending = deferred<PDFPageProxy>();
+    const stale = pdfPage(900);
+    const current = pdfPage(200);
+    documentWith(() => pending.promise);
+    await openHost();
+    documentWith(() => Promise.resolve(current.page));
+    await act(async () => openArtifactPreview("~/fixtures/another.pdf"));
+    await flush();
+    const canvas = dom.document.querySelector("canvas")!;
+    const width = canvas.width;
+    await act(async () => {
+      if (settlement === "reject") pending.reject({ status: 412 });
+      else pending.resolve(stale.page);
+    });
+    expect(dom.document.querySelector("[data-artifact-preview]")?.getAttribute("data-artifact-state")).toBe("ready");
+    expect(stale.render).not.toHaveBeenCalled();
+    expect(current.render).toHaveBeenCalledTimes(1);
+    expect(canvas.width).toBe(width);
+  });
+}

--- a/src/components/preview/PdfPane.tsx
+++ b/src/components/preview/PdfPane.tsx
@@ -54,7 +54,6 @@ export default function PdfPane({
   const [fitWidth, setFitWidth] = useState(true);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const frameRef = useRef<HTMLDivElement | null>(null);
-  const renderTaskRef = useRef<{ cancel: () => void } | null>(null);
 
   useEffect(() => {
     let task: { promise: Promise<PDFDocumentProxy>; destroy: () => Promise<void> } | null = null;
@@ -83,47 +82,62 @@ export default function PdfPane({
     };
   }, [path, etag, onFailure]);
 
-  const paint = useCallback(async () => {
+  useEffect(() => {
     const canvas = canvasRef.current;
     const frame = frameRef.current;
     if (!doc || !canvas || !frame) return;
-    const pdfPage = await doc.getPage(page);
-    const base = pdfPage.getViewport({ scale: 1 });
-    const scale = (fitWidth ? Math.max((frame.clientWidth - 24) / base.width, 0.1) : 1) * zoom;
-    const viewport = pdfPage.getViewport({ scale });
-    const ratio = window.devicePixelRatio || 1;
-    canvas.width = Math.floor(viewport.width * ratio);
-    canvas.height = Math.floor(viewport.height * ratio);
-    canvas.style.width = `${Math.floor(viewport.width)}px`;
-    canvas.style.height = `${Math.floor(viewport.height)}px`;
-    const context = canvas.getContext("2d");
-    if (!context) return;
-    renderTaskRef.current?.cancel();
-    const renderTask = pdfPage.render({
-      canvas,
-      canvasContext: context,
-      viewport,
-      transform: ratio !== 1 ? [ratio, 0, 0, ratio, 0, 0] : undefined,
-    });
-    renderTaskRef.current = renderTask;
-    await renderTask.promise.catch(() => {
-      /* superseded by a newer paint */
-    });
-  }, [doc, page, zoom, fitWidth]);
+    let disposed = false;
+    let paintId = 0;
+    let renderTask: { cancel: () => void } | null = null;
 
-  useEffect(() => {
+    const paint = async () => {
+      const id = ++paintId;
+      const isCurrent = () => !disposed && id === paintId;
+      renderTask?.cancel();
+      renderTask = null;
+      try {
+        const pdfPage = await doc.getPage(page);
+        // A pending page fetch can outlive navigation, resize, or unmount.
+        if (!isCurrent()) return;
+        const base = pdfPage.getViewport({ scale: 1 });
+        const scale = (fitWidth ? Math.max((frame.clientWidth - 24) / base.width, 0.1) : 1) * zoom;
+        const viewport = pdfPage.getViewport({ scale });
+        const ratio = window.devicePixelRatio || 1;
+        canvas.width = Math.floor(viewport.width * ratio);
+        canvas.height = Math.floor(viewport.height * ratio);
+        canvas.style.width = `${Math.floor(viewport.width)}px`;
+        canvas.style.height = `${Math.floor(viewport.height)}px`;
+        const context = canvas.getContext("2d");
+        if (!context) return;
+        const task = pdfPage.render({
+          canvas,
+          canvasContext: context,
+          viewport,
+          transform: ratio !== 1 ? [ratio, 0, 0, ratio, 0, 0] : undefined,
+        });
+        renderTask = task;
+        await task.promise;
+      } catch (error: unknown) {
+        if (!isCurrent()) return;
+        const status = (error as { status?: number } | null)?.status;
+        onFailure(typeof status === "number" ? failureFromStatus(status) : "error");
+      } finally {
+        if (isCurrent()) renderTask = null;
+      }
+    };
+
     void paint();
-  }, [paint]);
-
-  /* Fit-width follows the sheet being resized. */
-  useEffect(() => {
-    if (!fitWidth || typeof ResizeObserver === "undefined") return;
-    const frame = frameRef.current;
-    if (!frame) return;
-    const observer = new ResizeObserver(() => void paint());
-    observer.observe(frame);
-    return () => observer.disconnect();
-  }, [fitWidth, paint]);
+    /* Fit-width follows the sheet being resized, sharing the paint fence. */
+    const observer = fitWidth && typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => { if (!disposed) void paint(); })
+      : null;
+    observer?.observe(frame);
+    return () => {
+      disposed = true;
+      observer?.disconnect();
+      renderTask?.cancel();
+    };
+  }, [doc, page, zoom, fitWidth, onFailure]);
 
   /* Same touch-target contract as the host header: 44 px controls on mobile. */
   const control = mobile ? "h-11 w-11" : "h-7 w-7";


### PR DESCRIPTION
When a PDF changes after loading, navigating to an unfetched page now surfaces the existing changed state with Reload. Current page-fetch and render errors use the existing failure mapping. Each paint has an identity, and cleanup cancels active rendering so late work after navigation, resize, artifact switching, or unmount cannot report stale errors or overwrite the canvas.

Closes #883.

Validation:
- Frozen dependency installation; manifest and lockfile unchanged.
- `bun test src/components/preview/PdfPane.dom.test.tsx`: 19 passed, 0 failed. The new regressions failed on the original implementation.
- `bunx tsc --noEmit --incremental false`: passed.
- Publication gate with commit checking: passed.
- Focused ESLint is blocked before analysis by the existing ESLint 10/react-plugin `contextOrFilename.getFilename` incompatibility; the untouched main version fails identically.

Tests use isolated state and mocked pdf.js with the real preview host for changed-state and Reload assertions. They establish DOM lifecycle behavior; native PDF parsing, HTTP range transport, and browser canvas pixels were not exercised. Only the PDF pane and its focused test file changed.
