### PR TITLE
fix(composer): keep delivery reasons and actions readable at 390px

### DIFF
--- a/src/components/TmuxComposer.deliveryNotice.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryNotice.dom.test.tsx
@@ -181,7 +181,7 @@ test("#1362 expanding the notice reveals the full cause and its remediation, onc
   expect(summary.getAttribute("aria-label")).toContain(t("runtime.receipt.hideDetails"));
 
   const details = stack.querySelector("[data-runtime-receipt-details]") as HTMLElement;
-  const detail = details.querySelector("[data-delivery-notice-detail]") as HTMLElement;
+  const detail = stack.querySelector("[data-delivery-notice-detail]") as HTMLElement;
   expect(detail).not.toBeNull();
   expect(detail.querySelector("[data-delivery-notice-sentence]")?.textContent).toBe(HOST_DOWN_SENTENCE);
   expect(detail.querySelector("[data-delivery-notice-remediation]")?.textContent).toBe(HOST_DOWN_REMEDIATION);
@@ -375,3 +375,44 @@ test("#1362 the notice holds its anatomy at desktop and 390px in both locales", 
     }
   }
 });
+
+for (const reason of [HOST_DOWN, "The connection to the structured recovery process was severed before the delivery acknowledgement could be recorded and the pending message remains unverified until the conversation can be opened again and its latest response checked"]) {
+  test(`#1426 expanded reason is outside capped history with three retries at 390px: ${reason}`, () => {
+    const retries: string[] = [];
+    const edits: string[] = [];
+    const dismissals: string[][] = [];
+    const mounted = mount({
+      receipts: threeRetries().map((entry) => ({ ...entry, reason })),
+      onRetry: (entry) => retries.push(entry.operationId),
+      onEdit: (entry) => edits.push(entry.operationId),
+      onDismiss: (ids) => dismissals.push(ids),
+    }, 390);
+    click(mounted.summary());
+    expect(mounted.stack().open).toBe(true);
+    const detail = mounted.stack().querySelector("[data-delivery-notice-detail]")!;
+    const history = mounted.stack().querySelector("[data-runtime-receipt-details]")!;
+    // DOM pins the boundary; real browser geometry is required to prove the fold.
+    expect(detail).not.toBeNull();
+    expect(history.contains(detail)).toBe(false);
+    expect(detail.nextElementSibling).toBe(history);
+    expect(classes(history)).toContain("max-h-36");
+    expect(classes(history)).toContain("overflow-y-auto");
+    const sentence = detail.querySelector("[data-delivery-notice-sentence]")!;
+    expect(sentence.textContent).toBe(reason.split(";")[0]);
+    expect(classes(sentence)).toContain("whitespace-pre-wrap");
+    expect(classes(sentence)).toContain("break-words");
+    expect(history.querySelectorAll("[data-receipt-message]")).toHaveLength(1);
+    const messageRow = history.querySelector("[data-receipt-message]")!.parentElement!;
+    expect(classes(messageRow)).toContain("max-sm:[&>[data-operation]]:contents");
+    const buttons = [...history.querySelectorAll("button")];
+    for (const key of ["runtime.receipt.retry", "runtime.receipt.edit", "runtime.receipt.dismiss"] as const) {
+      const button = buttons.find((entry) => (entry.textContent || entry.getAttribute("aria-label")) === translate("en", key));
+      expect(button).toBeDefined();
+      click(button!);
+    }
+    expect(retries).toEqual(["op-retry-2"]);
+    expect(edits).toEqual(["op-retry-2"]);
+    expect(dismissals).toEqual([["op-retry-2", "op-retry-1", "op-retry-0"]]);
+    mounted.cleanup();
+  });
+}

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -550,26 +550,26 @@ export function RuntimeComposerReceipts({
                 </span>
               ) : null}
             </summary>
+            {/* What expanding reveals (issue #1362): the full sentence and the
+                remediation after it, once for the run — never once per
+                attempt. Wraps rather than truncates: this is where the
+                operator reads what to do. */}
+            {notice && noticeFailure?.detail ? (
+              <div className="border-t border-border/70 px-3.5 py-2 text-secondary" data-delivery-notice-detail>
+                <p className="whitespace-pre-wrap break-words" data-delivery-notice-sentence>
+                  {noticeFailure.detail.sentence}
+                </p>
+                {noticeFailure.detail.remediation ? (
+                  <p className="whitespace-pre-wrap break-words text-muted" data-delivery-notice-remediation>
+                    {noticeFailure.detail.remediation}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
             <div
               className="max-h-36 space-y-1 overflow-y-auto border-t border-border/70 p-1.5"
               data-runtime-receipt-details
             >
-              {/* What expanding reveals (issue #1362): the full sentence and the
-                  remediation after it, once for the run — never once per
-                  attempt. Wraps rather than truncates: this is where the
-                  operator reads what to do. */}
-              {notice && noticeFailure?.detail ? (
-                <div className="rounded-control bg-card/70 px-2 py-1 text-secondary" data-delivery-notice-detail>
-                  <p className="whitespace-pre-wrap break-words" data-delivery-notice-sentence>
-                    {noticeFailure.detail.sentence}
-                  </p>
-                  {noticeFailure.detail.remediation ? (
-                    <p className="whitespace-pre-wrap break-words text-muted" data-delivery-notice-remediation>
-                      {noticeFailure.detail.remediation}
-                    </p>
-                  ) : null}
-                </div>
-              ) : null}
               {attemptGroups.map((group) => {
                 const receipt = group.current;
                 const history = supersededStatusLabels(group.attempts);
@@ -592,11 +592,10 @@ export function RuntimeComposerReceipts({
                     className="flex min-w-0 flex-col items-end gap-0.5 rounded-control bg-card/70 px-2 py-1"
                     {...(pending ? { "data-optimistic-message": "true" } : {})}
                   >
-                    {/* The action chip (state badge + Retry/Edit) wraps under
-                        the message on narrow screens instead of squeezing the
-                        text into a sliver — the payload must stay readable at
-                        390px in exactly the failed state that needs it. */}
-                    <div className="flex w-full min-w-0 flex-wrap items-start justify-end gap-1.5">
+                    {/* On phones the chip's children share the row's wrapping
+                        context, so Dismiss can sit beside Retry/Edit instead
+                        of consuming another 44px line below the whole chip. */}
+                    <div className="flex w-full min-w-0 flex-wrap items-start justify-end gap-1.5 max-sm:[&>[data-operation]]:contents">
                       <span
                         className="min-w-[8rem] flex-1 whitespace-pre-wrap break-words text-right text-secondary"
                         data-receipt-message

--- a/src/components/runtime/deliveryNotice.test.ts
+++ b/src/components/runtime/deliveryNotice.test.ts
@@ -48,7 +48,7 @@ test("#1362 a known reason code reads as its human sentence and has nothing furt
 });
 
 test("#1362 an unknown short reason is the cause itself; an absent reason has no cause", () => {
-  expect(describeReceiptFailure(t, "quota-exceeded")).toEqual({ cause: "quota-exceeded", full: "quota-exceeded", detail: null });
+  expect(describeReceiptFailure(t, "quota-exceeded")).toEqual({ cause: "quota-exceeded", full: "quota-exceeded", detail: { sentence: "quota-exceeded", remediation: null } });
   expect(describeReceiptFailure(t, null)).toEqual({ cause: null, full: null, detail: null });
   expect(describeReceiptFailure(t, "   ")).toEqual({ cause: null, full: null, detail: null });
 });
@@ -72,14 +72,12 @@ test("#1362 the run is the newest consecutive same-cause failures; older other c
   expect(run!.causeKey).toBe(failureCauseKey(HOST_DOWN));
   expect(run!.attempts.map((attempt) => attempt.operationId)).toEqual(["op-a2", "op-a1"]);
   expect(run!.dismissIds).toEqual(["op-a2", "op-a1"]);
-  expect(run!.groupCount).toBe(2);
 });
 
 test("#1362 three retries of one message count as three attempts of one group", () => {
   const groups = deliveryAttemptGroups([2, 1, 0].map((second) =>
     receipt({ operationId: `op-retry-${second}`, at: `2026-08-31T10:00:0${second}.000Z` })));
   const run = deliveryNoticeRun(groups, [])!;
-  expect(run.groupCount).toBe(1);
   expect(run.attempts).toHaveLength(3);
   expect(run.dismissIds).toEqual(["op-retry-2", "op-retry-1", "op-retry-0"]);
 });
@@ -104,5 +102,12 @@ test("#1362 textless failed sends join the run by time and cause", () => {
   const run = deliveryNoticeRun(groups, textless)!;
   expect(run.current.operationId).toBe("op-textless-new");
   expect(run.attempts.map((attempt) => attempt.operationId)).toEqual(["op-textless-new", "op-with-text", "op-textless-old"]);
-  expect(run.groupCount).toBe(3);
+});
+
+test("#1426 every single-clause verbatim reason remains available on expand", () => {
+  for (const reason of ["recovery failed", "The connection to the structured recovery process was severed before the delivery acknowledgement could be recorded and the pending message remains unverified until the conversation can be opened again and its latest response checked"]) {
+    expect(describeReceiptFailure(t, reason)).toEqual({
+      cause: reason, full: reason, detail: { sentence: reason, remediation: null },
+    });
+  }
 });

--- a/src/components/runtime/deliveryNotice.ts
+++ b/src/components/runtime/deliveryNotice.ts
@@ -63,8 +63,8 @@ export interface ReceiptFailureDescription {
   cause: string | null;
   /** The whole reason, for hover. */
   full: string | null;
-  /** What expanding reveals beyond the terse cause: the full first sentence
-      and the remediation after it. Null when the cause already says it all. */
+  /** Every verbatim reason stays readable on expand, even if the row clips it.
+      Known reason codes use their short human label and need no detail. */
   detail: { sentence: string; remediation: string | null } | null;
 }
 
@@ -86,11 +86,10 @@ export function describeReceiptFailure(t: TFunction, reason: string | null | und
   const { head, rest } = splitClauses(trimmed);
   const key = patternKey(head);
   const cause = key ? t(key) : head;
-  const revealsMore = rest !== null || cause.toLowerCase() !== head.toLowerCase();
   return {
     cause,
     full: trimmed,
-    detail: revealsMore ? { sentence: head, remediation: rest } : null,
+    detail: { sentence: head, remediation: rest },
   };
 }
 
@@ -102,8 +101,6 @@ export interface DeliveryNoticeRun {
   attempts: RuntimeReceipt[];
   /** Every settled attempt dismissing the notice hides (issue #264 rule 3). */
   dismissIds: string[];
-  /** Logical messages behind the notice; one for a single message's retries. */
-  groupCount: number;
 }
 
 /**
@@ -140,6 +137,5 @@ export function deliveryNoticeRun(
     dismissIds: run.flatMap((group) => group.attempts
       .filter((attempt) => receiptIsTerminal(attempt.status))
       .map((attempt) => attempt.operationId)),
-    groupCount: run.length,
   };
 }


### PR DESCRIPTION
At 390px, expanding a failed-delivery notice pushed Edit & resend and Dismiss below the capped history viewport. Unrecognized single-clause reasons also had no expanded text.

Move the full reason above the capped history and let the chip actions and Dismiss share the mobile wrapping context. Every verbatim reason is available on expand; remove the unused `groupCount` field. Retry, edit, and dismissal handlers retain their existing targets.

Validation:
- Frozen dependency installation; manifest and lockfile unchanged.
- Delivery notice model: 9 tests pass.
- Composer delivery notice DOM: 11 tests pass, including three-retry boundary and action-target checks.
- TypeScript and privacy publication gate pass.
- Local Chrome, real component and source-compiled production CSS, 390×844: English and Ukrainian host-error and long-reason fixtures pass. Before: 264px history content in a 143px viewport, Edit and Dismiss clipped. After: all action bounds remain inside the viewport without scrolling; the full long reason is rendered outside it. HTML, screenshots, capture script, and geometry JSON retained as local review artifacts.

Closes #1426
