### PR TITLE
fix(mobile): show Re-bind from fresh live-host evidence

### DIFF
--- a/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.render.test.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { decodeHTML } from "entities";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { OrchestratorSeat } from "@/lib/orchestrator/seats";
@@ -109,3 +110,24 @@ test("the mobile sheet shows the quiet banner for a later stalled turn", () => {
 test("the mobile sheet preserves the quiet warning when assistant history is unknown", () => {
   expect(quietBannerCount(stalledFile({ lastAssistantMessageAt: undefined }))).toBe(1);
 });
+
+
+for (const reason of ["catalog", "surface", null] as const) {
+  test(`live sheet renders the bounded ${reason ?? "absent"} reason and a separate read footer`, () => {
+    const html = renderToStaticMarkup(
+      <MobileOrchestratorSheet project="atlas" projectName="Atlas" sheet="seat" now={1_800_000_000}
+        state={{ ...state, bindFailure: reason }} status={{ seat, pending: null, exists: true, viewerMcpRegistered: false }}
+        file={reason === "catalog" ? null : stalledFile()} incumbent={null} pendingMandate=""
+        viewerMcpRegistered={false} submitting={false}
+        rotate={{ open: false, seat: null, vacated: false, opening: false, submitting: false, failure: null, onOpen() {}, onCancel() {}, onConfirm() {} }}
+        onConfirm={() => {}} onRecheck={() => {}} onOpenConversation={() => {}} onClose={() => {}} />,
+    );
+    expect(html.includes("data-orchestrator-rebind")).toBe(reason !== null);
+    expect(html).toContain("data-orchestrator-rotate");
+    if (reason) {
+      expect(html).toContain(`role="status" data-orchestrator-bind-failure="${reason}"`);
+      expect(decodeHTML(html)).toContain(translate("en", reason === "catalog" ? "orchPanel.bindStalledCatalog" : "orchPanel.bindStalledSurface"));
+      expect(html).toContain('min-h-11 w-full');
+    }
+  });
+}

--- a/src/components/mobile/MobileOrchestratorSheet.tsx
+++ b/src/components/mobile/MobileOrchestratorSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Bot, ChevronRight, Command, CornerDownRight, LoaderCircle, Pencil, RefreshCw, RotateCcw, Sparkle, TriangleAlert } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { X } from "@/components/icons";
 import {
@@ -232,6 +232,7 @@ function SeatStatusSheet({
   onClose,
 }: SeatSheetProps) {
   const { t } = useLocale();
+  const kbInset = useKeyboardInset();
   const launch = useCreateDraft(project);
   const view = orchestratorRowView(state, { conversationReady: Boolean(file) });
   const mode = state.kind === "live" ? "live" : "create";
@@ -258,45 +259,65 @@ function SeatStatusSheet({
         ? { key: "mobile2.seat.open", run: onOpenConversation, busy: false }
         : null;
 
+  // The conversation can open this sheet while its overlay keyboard remains
+  // visible. Budget the fixed scrim against the same inset as the composer.
   return (
+    <div
+      className="[&>[data-mobile2-scrim]]:bottom-[var(--seat-keyboard-inset)]"
+      style={{ "--seat-keyboard-inset": `${kbInset}px` } as CSSProperties}
+    >
     <MobileSheet
       name="seat"
       title={t("mobile2.seat.sheetTitle", { project: projectName })}
       onClose={onClose}
       footer={
-        <>
-          {/* Rotate: a control, and only a control. The advisory in the body
-              states the recommendation; this performs it, and ONLY when
-              pressed and then confirmed in the draft it opens. */}
-          {state.kind === "live" ? (
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          {state.kind === "live" && state.bindFailure ? (
             <button
               type="button"
-              data-orchestrator-rotate
-              data-mobile2-open="rotate"
-              onClick={rotate.onOpen}
-              disabled={rotate.opening || rotate.submitting}
-              title={t("orchPanel.rotateTitle")}
-              className="inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-control border border-border bg-card px-3 text-body font-semibold text-primary active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+              data-orchestrator-rebind
+              onClick={onRecheck}
+              title={t("orchPanel.rebindTitle")}
+              className="inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-control border border-border bg-card px-3 text-body font-semibold text-primary active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
             >
-              {rotate.opening
-                ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden />
-                : <RefreshCw className="h-4 w-4" aria-hidden />}
-              {t(rotate.opening ? "orchMobile.rotateOpening" : "orchPanel.rotate")}
+              <RefreshCw className="h-4 w-4" aria-hidden />
+              {t("orchPanel.rebind")}
             </button>
           ) : null}
-          {primary ? (
-            <button
-              type="button"
-              data-orchestrator-confirm
-              disabled={primary.busy}
-              onClick={primary.run}
-              className="inline-flex min-h-11 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-control border border-accent bg-accent px-3 text-body font-semibold text-white shadow-1 active:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
-            >
-              {primary.busy ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden /> : <Bot className="h-4 w-4" aria-hidden />}
-              <span className="truncate">{t(primary.key)}</span>
-            </button>
-          ) : null}
-        </>
+          <div className="flex min-w-0 gap-2">
+            {/* Rotate: a control, and only a control. The advisory in the body
+                states the recommendation; this performs it, and ONLY when
+                pressed and then confirmed in the draft it opens. */}
+            {state.kind === "live" ? (
+              <button
+                type="button"
+                data-orchestrator-rotate
+                data-mobile2-open="rotate"
+                onClick={rotate.onOpen}
+                disabled={rotate.opening || rotate.submitting}
+                title={t("orchPanel.rotateTitle")}
+                className="inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-control border border-border bg-card px-3 text-body font-semibold text-primary active:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+              >
+                {rotate.opening
+                  ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden />
+                  : <RefreshCw className="h-4 w-4" aria-hidden />}
+                {t(rotate.opening ? "orchMobile.rotateOpening" : "orchPanel.rotate")}
+              </button>
+            ) : null}
+            {primary ? (
+              <button
+                type="button"
+                data-orchestrator-confirm
+                disabled={primary.busy}
+                onClick={primary.run}
+                className="inline-flex min-h-11 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-control border border-accent bg-accent px-3 text-body font-semibold text-white shadow-1 active:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+              >
+                {primary.busy ? <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden /> : <Bot className="h-4 w-4" aria-hidden />}
+                <span className="truncate">{t(primary.key)}</span>
+              </button>
+            ) : null}
+          </div>
+        </div>
       }
     >
       <div
@@ -356,6 +377,7 @@ function SeatStatusSheet({
         )}
       </div>
     </MobileSheet>
+    </div>
   );
 }
 
@@ -934,6 +956,12 @@ function LiveView({
         now={now}
         predecessorConversationId={state.seat.predecessorConversationId}
       />
+      {state.bindFailure ? (
+        <div role="status" data-orchestrator-bind-failure={state.bindFailure} className="rounded-control border border-warning/30 bg-warning/10 px-3 py-2 text-ui text-primary">
+          <p className="font-semibold">{t("orchPanel.bindStalled")}</p>
+          <p>{t(state.bindFailure === "catalog" ? "orchPanel.bindStalledCatalog" : "orchPanel.bindStalledSurface")}</p>
+        </div>
+      ) : null}
       {state.transition ? <TransitionCard transition={state.transition} /> : null}
       {orchestratorQuietBannerEligible(state, file) ? <Note tone="warning">{t("orchPanel.stalled")}</Note> : null}
       {state.liveness === "resumable" ? <Note tone="quiet">{t("orchPanel.resumable")}</Note> : null}

--- a/src/components/mobile/MobileSeatCard.tsx
+++ b/src/components/mobile/MobileSeatCard.tsx
@@ -4,6 +4,7 @@ import { Bot, ChevronRight, LoaderCircle, RotateCw, SlidersHorizontal, TriangleA
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { applySpawnedConversationSnapshot } from "@/hooks/useFiles";
+import { refreshRuntime } from "@/hooks/useRuntime";
 import { requestFilesRefresh } from "@/lib/filesEvents";
 import { useLocale } from "@/lib/i18n";
 import { ORCHESTRATOR_PROMPT_VERSION, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
@@ -21,12 +22,15 @@ import {
   classifySeatFailure,
   deriveOrchestratorPanelState,
   newSeatRequestId,
+  seatBindPending,
   seatRequestSettled,
   type SeatSubmitFailure,
 } from "../orchestrator/seatState";
 import { useOrchestratorIncumbent } from "../orchestrator/useOrchestratorIncumbent";
 import { useOrchestratorSeat, type OrchestratorSeatRead } from "../orchestrator/useOrchestratorSeat";
 import { useSeatConfirm } from "../orchestrator/useSeatConfirm";
+import { incumbentHostLive } from "../orchestrator/incumbent";
+import { useSeatBindingFeedback } from "../orchestrator/useSeatBindingFeedback";
 import { useSeatSurface } from "../orchestrator/useSeatSurface";
 import { MobileMeter } from "./MobileMeter";
 import { MobileOrchestratorSheet, SeatBadge, seatBadgeReading, type SeatConfirmPayload, type SeatRotateFlow } from "./MobileOrchestratorSheet";
@@ -182,7 +186,7 @@ export function MobileSeatCard({
      is showing them or a rotate draft is about to prefill from them: the card
      itself carries the board's own reading, so a phone that never opens the
      sheet never pays for the slower status poll. */
-  const { incumbent: read, refresh: refreshIncumbent } = useOrchestratorIncumbent(project, seated && sheetOpen);
+  const { incumbent: read, stale: readStale, refresh: refreshIncumbent } = useOrchestratorIncumbent(project, seated && sheetOpen);
   /* A reading is only about the conversation it names: right after a rotation
      the seat has already advanced to the successor while this slower poll still
      describes the predecessor. */
@@ -201,6 +205,15 @@ export function MobileSeatCard({
     [files, seatConversationId, currentPath, seatPath],
   );
   const surface = useSeatSurface(file);
+  const unboundForMs = useSeatBindingFeedback({
+    project,
+    conversationId: seatConversationId,
+    active: seated && openName === "seat",
+    pending: seatBindPending(file, surface),
+    hasReading: incumbent !== null,
+    stale: readStale,
+    refreshIncumbent,
+  });
 
   /* The rotate flow, on the dock's own Rotate keys: a rotation half-written on
      one surface continues — and replays the same durable intent — on the other. */
@@ -218,6 +231,8 @@ export function MobileSeatCard({
     file,
     surface,
     incumbent,
+    hostLive: !readStale && incumbentHostLive(incumbent),
+    unboundForMs,
   });
   const view = seatCardView(state, { conversationReady: Boolean(file) });
 
@@ -461,7 +476,12 @@ export function MobileSeatCard({
       now={clock}
       rotate={rotateFlow}
       onConfirm={(payload) => void confirm(payload)}
-      onRecheck={() => void refresh()}
+      onRecheck={() => {
+        void refresh();
+        void refreshIncumbent();
+        requestFilesRefresh();
+        void refreshRuntime();
+      }}
       onOpenConversation={() => {
         closeSheet();
         openConversation();

--- a/src/components/mobile/mobileSeatCard.dom.test.tsx
+++ b/src/components/mobile/mobileSeatCard.dom.test.tsx
@@ -50,6 +50,7 @@ mock.module("@/hooks/useRuntime", () => ({
   useRuntimeSessionByArtifact: () => null,
   useRuntimeReceiptsForArtifact: () => [],
   useRuntimeFlow: () => null,
+  refreshRuntime: async () => { runtimeRefreshes += 1; return true; },
 }));
 mock.module("@/hooks/useLogTail", () => ({
   useLogTail: () => ({
@@ -64,6 +65,9 @@ const { MobileSeatCard } = await import("./MobileSeatCard");
 const { createMobileNav, MobileNavContext } = await import("./mobileNav");
 const { resetOrchestratorSeatCacheForTests } = await import("../orchestrator/useOrchestratorSeat");
 
+const { resetOrchestratorIncumbentCacheForTests } = await import("../orchestrator/useOrchestratorIncumbent");
+const { FILES_CHANGED_EVENT } = await import("@/lib/filesEvents");
+
 interface SeatAnswer { seat: unknown; pending: unknown; exists: boolean }
 interface Recorded { url: string; method: string; body: Record<string, unknown> }
 
@@ -72,12 +76,15 @@ let postSeat: (body: Record<string, unknown>) => Promise<Response> = async () =>
   new Response(JSON.stringify({ ok: true, state: "starting" }), { status: 200, headers: { "content-type": "application/json" } });
 const requests: Recorded[] = [];
 const realFetch = globalThis.fetch;
+let incumbentAnswer: Record<string, unknown> | null = null;
+let runtimeRefreshes = 0;
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const url = String(input);
   const method = init?.method ?? "GET";
   const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
   requests.push({ url, method, body });
+  if (url.startsWith("/api/orchestrator/seat/status")) return Response.json(incumbentAnswer);
   if (url.startsWith("/api/orchestrator/seat") && method === "POST") return postSeat(body);
   if (url.startsWith("/api/orchestrator/seat")) {
     return new Response(JSON.stringify(seatAnswer), { status: 200, headers: { "content-type": "application/json" } });
@@ -100,6 +107,9 @@ beforeEach(() => {
   /* Each test is a tab that has never read this project's seat; the answer is
      cached per project for the session since #1149. */
   resetOrchestratorSeatCacheForTests();
+  resetOrchestratorIncumbentCacheForTests();
+  incumbentAnswer = null;
+  runtimeRefreshes = 0;
   nav = createMobileNav(navHost());
   requests.length = 0;
   seatAnswer = { seat: null, pending: null, exists: true };
@@ -794,3 +804,61 @@ test("an unreadable seat offers a re-read that recovers the row without a page r
     globalThis.fetch = previousFetch;
   }
 });
+
+
+test("missing-catalog board card offers Re-bind after 10s and clears only when the catalog read delivers its file", async () => {
+  seatAnswer = { seat: seat(), pending: null, exists: true };
+  incumbentAnswer = { project: "atlas", designated: true, conversationId: "conv_orchestrator", engine: "claude", model: "opus", liveness: { hostState: "alive", lifecycle: "running" } };
+  // The board-card host, without mounting a conversation screen behind it.
+  const cardView = (files: FileEntry[]) => <MobileNavContext.Provider value={nav}>
+    <MobileSeatCard project="atlas" projectName="Atlas" files={files} now={NOW} onOpenConversation={() => { throw new Error("unexpected navigation"); }} />
+  </MobileNavContext.Provider>;
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+  flushSync(() => root.render(cardView([])));
+  await settle(root, cardView([]));
+  const rerender = async (files: FileEntry[]) => {
+    flushSync(() => root.render(cardView(files)));
+    await settle(root, cardView(files));
+  };
+  flushSync(() => openButton(host).click());
+  await settle(root, cardView([]));
+  const rebind = () => host.querySelector<HTMLButtonElement>("[data-orchestrator-rebind]");
+  expect(sheet(host)).not.toBeNull();
+  expect(rebind()).toBeNull();
+  await new Promise((resolve) => setTimeout(resolve, 10_050));
+  await settle(root, cardView([]));
+  expect(host.querySelector('[data-orchestrator-bind-failure="catalog"]')).not.toBeNull();
+  expect(rebind()!.className).toContain("min-h-11");
+  const storageBefore = dom.localStorage.length;
+  const before = requests.length;
+  let catalogReads = 0;
+  let deliver = false;
+  const refreshCatalog = () => {
+    catalogReads += 1;
+    if (deliver) void rerender([orchestrator]);
+  };
+  dom.addEventListener(FILES_CHANGED_EVENT, refreshCatalog);
+  try {
+    flushSync(() => rebind()!.click());
+    await settle(root, cardView([]));
+    expect(rebind()).not.toBeNull(); // Callback completion cannot clear the fault.
+    deliver = true;
+    flushSync(() => rebind()!.click());
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(rebind()).toBeNull();
+    expect(sheet(host)).not.toBeNull();
+    expect(nav.getState().sheet).toBe("seat");
+    expect(catalogReads).toBe(2);
+    expect(runtimeRefreshes).toBe(2);
+    const reads = requests.slice(before);
+    expect(reads.filter((r) => r.url.startsWith("/api/orchestrator/seat/status")).length).toBeGreaterThanOrEqual(2);
+    expect(reads.filter((r) => r.url.startsWith("/api/orchestrator/seat?")).length).toBeGreaterThanOrEqual(2);
+    expect(reads.every((r) => r.method === "GET")).toBe(true);
+    expect(dom.localStorage.length).toBe(storageBefore);
+  } finally {
+    dom.removeEventListener(FILES_CHANGED_EVENT, refreshCatalog);
+  }
+}, 15_000);

--- a/src/components/orchestrator/useSeatBindingFeedback.ts
+++ b/src/components/orchestrator/useSeatBindingFeedback.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { SEAT_BIND_TIMEOUT_MS } from "./seatState";
+
+/** Mobile observes binding only while the seat sheet is open. Each project,
+ * seat and uninterrupted unresolved episode gets the full grace interval. */
+export function useSeatBindingFeedback({
+  project, conversationId, active, pending, hasReading, stale, refreshIncumbent,
+}: {
+  project: string;
+  conversationId: string | null;
+  active: boolean;
+  pending: boolean;
+  hasReading: boolean;
+  stale: boolean;
+  refreshIncumbent: () => Promise<void>;
+}): number | null {
+  const key = JSON.stringify([project, conversationId]);
+  const waiting = active && pending;
+  const [bounded, setBounded] = useState<string | null>(null);
+  useEffect(() => {
+    if (!waiting) return;
+    const timer = setTimeout(() => setBounded(key), SEAT_BIND_TIMEOUT_MS);
+    return () => {
+      clearTimeout(timer);
+      setBounded(null);
+    };
+  }, [waiting, key]);
+
+  useEffect(() => {
+    if (active) void refreshIncumbent();
+  }, [active, key, refreshIncumbent]);
+
+  // A retained reading that cannot bind asks once again on this edge, just as
+  // desktop does. Failed reads then retry until fresh evidence answers.
+  const unboundWithReading = waiting && hasReading;
+  useEffect(() => {
+    if (unboundWithReading) void refreshIncumbent();
+  }, [unboundWithReading, key, refreshIncumbent]);
+  const unboundWithoutFreshReading = waiting && stale;
+  useEffect(() => {
+    if (!unboundWithoutFreshReading) return;
+    const timer = setInterval(() => void refreshIncumbent(), 2_000);
+    return () => clearInterval(timer);
+  }, [unboundWithoutFreshReading, key, refreshIncumbent]);
+
+  return waiting && bounded === key ? SEAT_BIND_TIMEOUT_MS : null;
+}

--- a/src/components/orchestrator/useSeatPanel.dom.test.tsx
+++ b/src/components/orchestrator/useSeatPanel.dom.test.tsx
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { RuntimeSession, RuntimeSnapshot } from "@/components/runtime/runtimeModel";
+import { createRuntimeBus, setRuntimeBusForTests } from "@/hooks/runtimeBus";
+import { refreshRuntime } from "@/hooks/useRuntime";
+import { FILES_CHANGED_EVENT } from "@/lib/filesEvents";
+import type { FileEntry } from "@/lib/types";
+import { MobileOrchestratorSheet } from "../mobile/MobileOrchestratorSheet";
+import { resetOrchestratorIncumbentCacheForTests } from "./useOrchestratorIncumbent";
+import { resetOrchestratorSeatCacheForTests, useOrchestratorSeat } from "./useOrchestratorSeat";
+import { useSeatPanel } from "./useSeatPanel";
+
+const dom = new HappyWindow({ innerWidth: 390, innerHeight: 844 });
+Object.assign(globalThis, {
+  window: dom, document: dom.document, navigator: dom.navigator, Node: dom.Node,
+  HTMLElement: dom.HTMLElement, Event: dom.Event, CustomEvent: dom.CustomEvent,
+  sessionStorage: dom.sessionStorage, localStorage: dom.localStorage,
+});
+const realFetch = globalThis.fetch;
+const nativeTimeout = globalThis.setTimeout;
+const nativeClearTimeout = globalThis.clearTimeout;
+const nativeInterval = globalThis.setInterval;
+const nativeClearInterval = globalThis.clearInterval;
+// Only the feedback's bound and retry cadence use this clock. HTTP promises,
+// React, the seat poll and runtime bus retain their actual asynchronous paths.
+let clock = 0;
+let nextTimer = 10_000;
+const timers = new Map<number, { at: number; fn: () => void; repeat: number }>();
+let root: Root;
+let host: HTMLElement;
+let project: string;
+let conversationId: string;
+let open: boolean;
+let hostState: string;
+let statusDown: boolean;
+let runtimeReady: boolean;
+let seq: number;
+let refreshSeat: () => Promise<void>;
+let catalogReads: number;
+const requests: { url: string; method: string; body: unknown }[] = [];
+const file = (): FileEntry => ({
+  path: "/transcripts/seat.jsonl", name: "seat.jsonl", root: "claude-projects", project,
+  title: "Atlas orchestrator", engine: "claude", kind: "session", fmt: "claude",
+  parent: null, mtime: 100, size: 1, activity: "live", proc: "running", pid: 42,
+  conversationId, model: "opus", cwd: "/repo/atlas", projectRoot: "/repo/atlas",
+  pendingQuestion: null, waitingInput: null,
+} as FileEntry);
+const seat = () => ({
+  project, seatEpoch: 4, conversationId, path: file().path, mandate: "Run the board.",
+  promptVersion: 4, predecessorConversationId: null, state: "active",
+  intent: { clientRequestId: "seatreq-0001", mode: "spawn", launchId: "launch-0001", error: null },
+  designatedAt: "2026-09-01T10:00:00Z", activatedAt: "2026-09-01T10:00:02Z",
+});
+const session = (): RuntimeSession => ({
+  conversationId, sessionKey: { engine: "claude", sessionId: "seat-session" },
+  hostKind: "claude-broker", host: "hosted", turn: "idle", provenance: "structured",
+  revision: seq, attentionIds: [], recentReceipts: [], accountId: null,
+  parentConversationId: null, flowId: null, workflowId: null, cwd: "/repo/atlas",
+  artifactPath: file().path, capabilities: { steer: true, structuredAttention: true }, activeTurnId: null,
+});
+const snapshot = (): RuntimeSnapshot => ({
+  schemaVersion: 1, snapshotSeq: ++seq, retentionFloorSeq: 0,
+  structuredHostsEnabled: true, runtime: { hostEpoch: 1, health: "ok" }, filesRevision: 0,
+  sessions: runtimeReady ? [session()] : [], attentions: [], recentOperations: [], edges: [],
+  flows: [], workflows: [], tasks: [],
+});
+
+function Consumer() {
+  const read = useOrchestratorSeat(project);
+  refreshSeat = read.refresh;
+  const panel = useSeatPanel({ project, files: [file()], seat: read, holdsSeat: true, open });
+  if (!open || !panel) return null;
+  return <MobileOrchestratorSheet project={project} projectName="Atlas" sheet="seat" now={1_800_000_000}
+    state={panel.state} status={panel.status} file={panel.file} incumbent={panel.incumbent}
+    pendingMandate={panel.pendingMandate} viewerMcpRegistered={panel.viewerMcpRegistered}
+    rotate={panel.rotate} submitting={false} onRecheck={panel.onRecheck}
+    onConfirm={() => { throw new Error("unexpected mutation"); }} onOpenConversation={() => {}}
+    onClose={() => { open = false; render(); }} />;
+}
+function render() { flushSync(() => root.render(<Consumer />)); }
+async function settle() {
+  for (let i = 0; i < 5; i++) await new Promise((resolve) => nativeTimeout(resolve, 5));
+  flushSync(() => {});
+}
+async function advance(ms: number) {
+  const end = clock + ms;
+  while (true) {
+    const entry = [...timers].filter(([, t]) => t.at <= end).sort((a, b) => a[1].at - b[1].at)[0];
+    if (!entry) break;
+    const [id, timer] = entry;
+    clock = timer.at;
+    if (timer.repeat) timer.at += timer.repeat;
+    else timers.delete(id);
+    flushSync(timer.fn);
+    await settle();
+  }
+  clock = end;
+}
+const rebind = () => host.querySelector<HTMLButtonElement>("[data-orchestrator-rebind]");
+const reason = () => host.querySelector("[data-orchestrator-bind-failure]")?.getAttribute("data-orchestrator-bind-failure") ?? null;
+const incumbentReads = () => requests.filter((r) => r.url.includes("/seat/status")).length;
+const catalogListener = () => { catalogReads++; };
+
+beforeEach(() => {
+  resetOrchestratorIncumbentCacheForTests();
+  resetOrchestratorSeatCacheForTests();
+  clock = 0; timers.clear(); requests.length = 0; seq = 0; catalogReads = 0;
+  project = "atlas"; conversationId = "conv_seat"; open = true;
+  hostState = "alive"; statusDown = false; runtimeReady = false;
+  globalThis.setTimeout = ((fn: () => void, ms: number, ...args: unknown[]) => {
+    if (ms !== 10_000) return nativeTimeout(fn, ms, ...args);
+    const id = nextTimer++; timers.set(id, { at: clock + ms, fn, repeat: 0 }); return id;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((id: number) => { if (!timers.delete(id)) nativeClearTimeout(id); }) as typeof clearTimeout;
+  globalThis.setInterval = ((fn: () => void, ms: number, ...args: unknown[]) => {
+    if (ms !== 2_000) return nativeInterval(fn, ms, ...args);
+    const id = nextTimer++; timers.set(id, { at: clock + ms, fn, repeat: ms }); return id;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((id: number) => { if (!timers.delete(id)) nativeClearInterval(id); }) as typeof clearInterval;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    requests.push({ url, method: init?.method ?? "GET", body: init?.body });
+    if (init?.method && init.method !== "GET") throw new Error("unexpected mutation");
+    if (url.includes("/seat/status")) return Response.json({ project, designated: true, conversationId,
+      engine: "claude", model: "opus", liveness: { hostState, lifecycle: "running" } }, { status: statusDown ? 503 : 200 });
+    if (url.includes("/orchestrator/seat?")) return Response.json({ seat: seat(), pending: null, exists: true });
+    if (url.includes("/runtime/snapshot")) return Response.json(snapshot());
+    if (url.includes("/accounts")) return Response.json({ claude: { accounts: [] }, codex: { accounts: [] } });
+    return Response.json({});
+  }) as typeof fetch;
+  const bus = createRuntimeBus({
+    fetch: (url, init) => fetch(url, init), now: Date.now,
+    createEventSource: () => ({ onopen: null, onerror: null, onmessage: null, addEventListener() {}, close() {} }),
+    setTimeout: nativeTimeout, clearTimeout: nativeClearTimeout,
+    setInterval: nativeInterval, clearInterval: nativeClearInterval,
+  });
+  setRuntimeBusForTests(bus);
+  dom.addEventListener(FILES_CHANGED_EVENT, catalogListener);
+  host = dom.document.createElement("div") as unknown as HTMLElement;
+  document.body.append(host);
+  root = createRoot(host);
+});
+afterEach(() => {
+  flushSync(() => root.unmount());
+  setRuntimeBusForTests(null);
+  dom.removeEventListener(FILES_CHANGED_EVENT, catalogListener);
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = nativeTimeout; globalThis.clearTimeout = nativeClearTimeout;
+  globalThis.setInterval = nativeInterval; globalThis.clearInterval = nativeClearInterval;
+  dom.document.body.replaceChildren(); dom.localStorage.clear(); dom.sessionStorage.clear();
+});
+
+test("actual useSeatPanel and runtime bus clear the same seat only after Re-bind fetches a resolved snapshot", async () => {
+  render(); await settle();
+  await advance(9_999); expect(rebind()).toBeNull();
+  await advance(1); expect(reason()).toBe("surface");
+  const before = requests.length;
+  flushSync(() => rebind()!.click()); await settle();
+  expect(reason()).toBe("surface");
+  runtimeReady = true; // No unsolicited response: the next read must fetch it.
+  expect(reason()).toBe("surface");
+  flushSync(() => rebind()!.click()); await settle();
+  expect(reason()).toBeNull(); expect(rebind()).toBeNull();
+  expect(host.querySelector('[data-mobile2-sheet="seat"]')).not.toBeNull();
+  const reads = requests.slice(before);
+  for (const path of ["/seat?", "/seat/status", "/runtime/snapshot"]) {
+    expect(reads.filter((r) => r.url.includes(path))).toHaveLength(2);
+  }
+  expect(catalogReads).toBe(2);
+  expect(reads.every((r) => r.method === "GET" && r.body === undefined)).toBe(true);
+  expect(dom.localStorage.length).toBe(0); expect(dom.sessionStorage.length).toBe(0);
+});
+
+for (const evidence of ["gone", "unknown", "stale", "bound"] as const) {
+  test(`${evidence} evidence never offers Re-bind past the bound`, async () => {
+    if (evidence === "bound") runtimeReady = true;
+    else if (evidence !== "stale") hostState = evidence;
+    render(); await settle();
+    if (evidence === "stale") {
+      statusDown = true;
+      // Closing/reopening reacquires status; the retained live reading becomes stale.
+      open = false; render(); open = true; render(); await settle();
+    }
+    await advance(10_000);
+    expect(rebind()).toBeNull(); expect(reason()).toBeNull();
+  });
+}
+
+test("failed status retries every 2s only while open and unresolved, then stops on fresh evidence", async () => {
+  statusDown = true; render(); await settle();
+  await advance(10_000); expect(rebind()).toBeNull();
+  const before = incumbentReads(); statusDown = false;
+  await advance(2_000); expect(incumbentReads()).toBeGreaterThan(before);
+  expect(reason()).toBe("surface");
+  const fresh = incumbentReads(); await advance(4_000); expect(incumbentReads()).toBe(fresh);
+});
+
+for (const change of ["project", "seat", "close", "bound"] as const) {
+  test(`${change} resets the grace interval and cancels the old timer`, async () => {
+    render(); await settle(); await advance(8_000);
+    if (change === "project") project = "beacon";
+    if (change === "seat") conversationId = "conv_successor";
+    if (change === "close") open = false;
+    if (change === "bound") { runtimeReady = true; await refreshRuntime(); await settle(); }
+    render(); await settle();
+    // Update the caller's existing read without remounting useSeatPanel.
+    if (change === "seat") { await refreshSeat(); await settle(); }
+    await advance(2_000); expect(rebind()).toBeNull();
+    if (change === "close") { open = true; render(); await settle(); }
+    if (change === "bound") { runtimeReady = false; await refreshRuntime(); await settle(); }
+    await advance(7_999); expect(rebind()).toBeNull();
+    await advance(change === "project" || change === "seat" ? 1 : 2_001); expect(reason()).toBe("surface");
+  });
+}
+
+test("unmount removes retry and bound timers", async () => {
+  statusDown = true; render(); await settle();
+  expect(timers.size).toBeGreaterThan(0);
+  flushSync(() => root.render(null));
+  expect(timers.size).toBe(0);
+  const before = incumbentReads(); await advance(20_000); expect(incumbentReads()).toBe(before);
+});
+
+test("a bounded failure that binds gets a new full grace interval on becoming unresolved again", async () => {
+  render(); await settle(); await advance(10_000); expect(reason()).toBe("surface");
+  runtimeReady = true; await refreshRuntime(); await settle(); expect(reason()).toBeNull();
+  runtimeReady = false; await refreshRuntime(); await settle();
+  expect(rebind()).toBeNull(); await advance(9_999); expect(rebind()).toBeNull();
+  await advance(1); expect(reason()).toBe("surface");
+});
+
+test("closing a stale unresolved sheet cancels retries and reopening starts a fresh bound", async () => {
+  statusDown = true; render(); await settle(); await advance(10_000);
+  open = false; render(); await settle();
+  expect(timers.size).toBe(0);
+  const closed = incumbentReads(); await advance(20_000); expect(incumbentReads()).toBe(closed);
+  statusDown = false; open = true; render(); await settle();
+  expect(incumbentReads()).toBeGreaterThan(closed); expect(rebind()).toBeNull();
+  await advance(9_999); expect(rebind()).toBeNull(); await advance(1); expect(reason()).toBe("surface");
+});
+
+test("the live status sheet budgets its footer above an overlay keyboard", async () => {
+  render(); await settle(); await advance(10_000);
+  const viewport = new dom.EventTarget();
+  Object.assign(viewport, { height: 524, offsetTop: 0, scale: 1 });
+  Object.defineProperty(dom, "visualViewport", { configurable: true, value: viewport });
+  // Subscribe while the viewport exists, as it does in a browser.
+  open = false; render(); open = true; render(); await settle();
+  viewport.dispatchEvent(new dom.Event("resize")); await settle();
+  const wrapper = host.querySelector<HTMLElement>('[style*="--seat-keyboard-inset"]');
+  expect(wrapper?.style.getPropertyValue("--seat-keyboard-inset")).toBe("320px");
+  Object.assign(viewport, { height: 844 }); viewport.dispatchEvent(new dom.Event("resize")); await settle();
+  expect(wrapper?.style.getPropertyValue("--seat-keyboard-inset")).toBe("0px");
+  Object.defineProperty(dom, "visualViewport", { configurable: true, value: undefined });
+});

--- a/src/components/orchestrator/useSeatPanel.ts
+++ b/src/components/orchestrator/useSeatPanel.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { refreshRuntime } from "@/hooks/useRuntime";
+import { requestFilesRefresh } from "@/lib/filesEvents";
 import type { FileEntry } from "@/lib/types";
 
 import type { SeatRotateFlow } from "../mobile/MobileOrchestratorSheet";
@@ -9,13 +11,15 @@ import { seatFlowStorage } from "../mobile/orchestratorDraftStorage";
 import {
   deriveOrchestratorPanelState,
   resolveSeatFile,
+  seatBindPending,
   seatRequestSettled,
   type OrchestratorPanelState,
   type OrchestratorSeatStatus,
 } from "./seatState";
-import type { OrchestratorIncumbent } from "./incumbent";
+import { incumbentHostLive, type OrchestratorIncumbent } from "./incumbent";
 import { useOrchestratorIncumbent } from "./useOrchestratorIncumbent";
 import { useSeatConfirm } from "./useSeatConfirm";
+import { useSeatBindingFeedback } from "./useSeatBindingFeedback";
 import { useSeatSurface } from "./useSeatSurface";
 
 /**
@@ -67,7 +71,7 @@ export function useSeatPanel(input: {
   const { status, failed, refresh } = seat;
   const seatConversationId = status?.seat?.conversationId ?? null;
 
-  const { incumbent: read, refresh: refreshIncumbent } = useOrchestratorIncumbent(project, holdsSeat && open);
+  const { incumbent: read, stale: readStale, refresh: refreshIncumbent } = useOrchestratorIncumbent(project, holdsSeat && open);
   /* A reading is only about the conversation it names: right after a rotation
      the seat has already advanced to the successor while this slower poll still
      describes the predecessor. */
@@ -82,6 +86,15 @@ export function useSeatPanel(input: {
     [files, seatConversationId, status?.seat?.path, incumbent?.transcriptPath],
   );
   const surface = useSeatSurface(file);
+  const unboundForMs = useSeatBindingFeedback({
+    project,
+    conversationId: seatConversationId,
+    active: holdsSeat && open && Boolean(status?.exists && seatConversationId),
+    pending: seatBindPending(file, surface),
+    hasReading: incumbent !== null,
+    stale: readStale,
+    refreshIncumbent,
+  });
 
   /* The rotate flow, on the dock's own Rotate keys: one durable intent per
      submission wherever it was started (`useSeatConfirm`). */
@@ -101,6 +114,8 @@ export function useSeatPanel(input: {
     file,
     surface,
     incumbent,
+    hostLive: !readStale && incumbentHostLive(incumbent),
+    unboundForMs,
   });
 
   /* A rotation whose outcome is not yet settled KEEPS the draft; settled, the
@@ -148,6 +163,11 @@ export function useSeatPanel(input: {
     pendingMandate: status?.pending?.mandate ?? "",
     viewerMcpRegistered: status?.viewerMcpRegistered === true,
     rotate: rotateFlow,
-    onRecheck: () => void refresh(),
+    onRecheck: () => {
+      void refresh();
+      void refreshIncumbent();
+      requestFilesRefresh();
+      void refreshRuntime();
+    },
   };
 }


### PR DESCRIPTION
Mobile seat sheets could remain at “opening” indefinitely when a live host's conversation was missing from the file catalog or runtime view. Both mobile hosts now show the existing bounded reason and a 44px Re-bind control after ten unresolved seconds with fresh, matching live-host evidence.

This follows the desktop parity requirement recorded by [the original mobile-controls change](https://github.com/Latand/live-log-viewer-next/pull/1421). It corrects two phrases in #1427: the predicate requires a fresh **live** host, and Re-bind refreshes reads without a mutation submission or idempotency key. The action refreshes seat status, incumbent status, the file catalog, and the runtime snapshot. Feedback clears only when refreshed state resolves the binding, and the sheet stays open.

The change is limited to the two mobile hosts, their small shared timer/read hook, the mobile sheet, and three tests. Existing translations and desktop derivation are reused. Rotate, Open, and create retain their behavior. The seat sheet also uses the existing keyboard-inset signal so its footer remains reachable above an overlay keyboard.

Validation:
- Frozen dependency install; manifest and lockfile unchanged.
- Five named test files run individually in fresh isolated state: mobileSeatCard.dom (20), MobileOrchestratorSheet.render (7), useSeatPanel.dom (14), OrchestratorPanel.dom (50), and seatState (44): 135 passed.
- Actual board-card catalog recovery and actual useSeatPanel/runtime-bus recovery, four read seams, retained unresolved feedback, negative liveness/stale cases, retry, identity/close/unmount cleanup, and bound-to-unbound timer reset.
- TypeScript with `--noEmit --incremental false`, whitespace, and privacy gates passed.
- Local Chromium fixture uses the actual components and compiled application styles: catalog/surface × English/Ukrainian × light/dark at 390×844. Re-bind is 358×44px, with no horizontal overflow. A 524px visual viewport and 34px safe-area inset leave the footer above the keyboard. Causal request traces contain all four GET reads and no mutation requests or prompts; refreshed responses clear the failure on the same seat. Images visually inspected without OCR.
- Scoped ESLint is blocked by the existing ESLint 10 / React-plugin crash (`contextOrFilename.getFilename is not a function`), reproduced on unchanged main source. This is not a passed lint check.

Browser and test results above are local proof; hosted checks are reported separately by CI. Two independent exact-head reviews remain required before merge.

Closes #1427
