### PR TITLE
fix(composer): give phone recovery a real 44px hit target

### DIFF
--- a/src/components/ComposerBar.dom.test.tsx
+++ b/src/components/ComposerBar.dom.test.tsx
@@ -55,7 +55,7 @@ afterEach(() => {
   setLocale("en");
 });
 
-function Harness() {
+function Harness({ onRecover }: { onRecover?: () => void } = {}) {
   const composer = useComposer({ initialText: () => "", persistText: () => {}, submit: () => {} });
   return <ComposerBar
     composer={composer}
@@ -68,6 +68,8 @@ function Harness() {
     sendIdleClassName="bg-accent"
     imageDisabled
     imageDisabledReason="Capability unavailable"
+    sendDisabledReason={onRecover ? "Resolving conversation host…" : undefined}
+    onSendBlockedRecover={onRecover}
   />;
 }
 
@@ -481,4 +483,25 @@ test("attachment preview copy remains accurate for structured and tmux delivery 
     flushSync(() => root.unmount());
     host.remove();
   }
+});
+
+test("desktop blocked-send recovery keeps its compact control and invokes recovery once", () => {
+  let recovered = 0;
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<Harness onRecover={() => { recovered += 1; }} />));
+  const reason = host.querySelector('[data-testid="composer-send-blocked"]')!;
+  const recover = reason.querySelector("button") as HTMLButtonElement;
+  expect(reason.textContent).toContain("Resolving conversation host…");
+  expect(recover.textContent).toBe("Re-check");
+  expect(recover.type).toBe("button");
+  expect(recover.className).toContain("min-h-8");
+  expect(recover.className).not.toContain("min-h-11");
+  expect(recover.className).not.toContain("min-w-11");
+  expect(recover.className).toContain("bg-card");
+  expect(recover.children).toHaveLength(0);
+  flushSync(() => recover.click());
+  expect(recovered).toBe(1);
+  flushSync(() => root.unmount());
 });

--- a/src/components/ComposerBar.mobileUnit.dom.test.tsx
+++ b/src/components/ComposerBar.mobileUnit.dom.test.tsx
@@ -242,6 +242,13 @@ test("a blocked Send explains itself inline and offers the recovery action", () 
   const recover = reason.querySelector("button") as HTMLButtonElement;
   expect(recover).toBeTruthy();
   expect(recover.textContent).toContain("Re-check");
+  expect(recover.type).toBe("button");
+  expect(recover.disabled).toBe(false);
+  expect(recover.className).toContain("min-h-11");
+  expect(recover.className).toContain("min-w-11");
+  const visual = recover.firstElementChild as HTMLElement;
+  expect(visual.className).toContain("h-8");
+  expect(visual.className).toContain("border");
   flushSync(() => recover.click());
   expect(recovered).toBe(1);
   flushSync(() => root.unmount());

--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -586,9 +586,15 @@ export function ComposerBar({
             <button
               type="button"
               onClick={onSendBlockedRecover}
-              className="inline-flex min-h-8 shrink-0 items-center gap-1 rounded-control border border-border bg-card px-2 text-caption font-semibold text-primary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              className={isMobile
+                ? "group inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-control text-caption font-semibold text-primary hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                : "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-control border border-border bg-card px-2 text-caption font-semibold text-primary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"}
             >
-              {t("deadHost.recheck")}
+              {isMobile ? (
+                <span className="inline-flex h-8 items-center rounded-control border border-border bg-card px-2 group-hover:border-accent/45">
+                  {t("deadHost.recheck")}
+                </span>
+              ) : t("deadHost.recheck")}
             </button>
           ) : null}
         </span>


### PR DESCRIPTION
The phone composer’s blocked-send Re-check control had a 32 px tap target. It now provides a real minimum 44×44 px button around the existing 32 px visual. Desktop retains its original compact button.

Closes #1488.

Validation:
- Both ComposerBar DOM test files pass individually (12 + 11 tests), including recovery activation and desktop compactness.
- TypeScript and production build pass.
- Unchanged mobile capture driver: baseline 59×32 px and four red hit gates; patched strict capture passes all four frames at 390×844 and 430×932, dark and light, with no overlap or overflow.
- Supplemental browser measurements confirm a 59.09×44 px target around a 59.09×32 px visual in all four frames. Clicking the top padding triggers one runtime-snapshot request; desktop markup and geometry match baseline.
- Browser capture uses the repository-pinned Bun 1.4.0 and isolated synthetic state.
- Privacy publication gate passes. Optional ESLint remains unverified because the existing React plugin crashes under ESLint 10; the same crash was reproduced on main source.
