### PR TITLE
fix(feed): hide Codex usage records when services are disabled

### DIFF
--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -1082,6 +1082,65 @@ describe("Codex assistant prose coalescing", () => {
   });
 });
 
+describe("Codex token usage service visibility (#1523)", () => {
+  const usage = JSON.stringify({
+    timestamp: "2026-09-01T05:00:06.002Z",
+    type: "token_usage_record",
+    payload: { input_tokens: 12, output_tokens: 5 },
+  });
+  const tokenCount = JSON.stringify({ type: "event_msg", payload: { type: "token_count", info: { total_tokens: 17 } } });
+  const unknown = JSON.stringify({ type: "future_record", payload: { detail: "inspectable" } });
+
+  test("hides known usage and counts it alongside token_count while retaining unknown records", () => {
+    const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+    const hidden = session.feed([usage], 0, false);
+    expect(hidden.items).toEqual([]);
+    expect(hidden.hiddenServiceCount).toBe(1);
+
+    const mixed = session.feed([usage, tokenCount, unknown], 0, false);
+    expect(mixed.items.map((entry) => entry.item)).toEqual([
+      expect.objectContaining({ kind: "record", recordType: "future_record" }),
+    ]);
+    expect(mixed.hiddenServiceCount).toBe(2);
+    expect(session.feed([usage, tokenCount, unknown], 0, false)).toBe(mixed);
+    const trimmed = session.feed([unknown], 2, false);
+    expect(trimmed.hiddenServiceCount).toBe(0);
+    expect(trimmed.items).toHaveLength(1);
+  });
+
+  test("keeps the inspectable redacted usage payload when services are enabled", () => {
+    const feed = buildFeed(codexFile, [usage, tokenCount, unknown], true, "");
+    expect(feed.hiddenServiceCount).toBe(0);
+    expect(feed.items).toEqual([
+      expect.objectContaining({ kind: "record", recordType: "token_usage_record", body: expect.stringContaining('"input_tokens": "[redacted]"') }),
+      expect.objectContaining({ kind: "svc", text: "token_count" }),
+      expect.objectContaining({ kind: "record", recordType: "future_record" }),
+    ]);
+    expect(feed.items[0]).toMatchObject({ body: expect.stringContaining('"output_tokens": "[redacted]"') });
+  });
+
+  test("preserves mirrored tools and final prose across incremental live and completed feeds", () => {
+    const fixture = fixtureLines("codex-turn-chronology-0.151.jsonl");
+    const lines = [...fixture.slice(0, -1), usage, unknown, fixture[fixture.length - 1]];
+    for (const showSvc of [false, true]) {
+      const session = assertParity(codexFile, lines, { chunks: [1], live: true, showSvc });
+      const completed = session.feed(lines, 0, false);
+      const items = completed.items.map((entry) => entry.item);
+      expect(items).toEqual(buildFeed(codexFile, lines, showSvc, "").items);
+      expect(items.flatMap((item) => {
+        if (item.kind === "prose") return [item.text];
+        if (item.kind === "tool") return [item.id];
+        if (item.kind === "cmd-group") return item.calls.map((call) => call.id);
+        return [];
+      })).toEqual(["Inspecting the parser first.", "command-first", "command-second", "The task is complete."]);
+      expect(items.filter((item) => item.kind === "record").map((item) => item.recordType))
+        .toEqual(showSvc ? ["token_usage_record", "future_record"] : ["future_record"]);
+      expect(completed.hiddenServiceCount).toBe(buildFeed(codexFile, fixture, showSvc, "").hiddenServiceCount + (showSvc ? 0 : 1));
+      assertParity(codexFile, lines, { chunks: [1, 3], cap: 4, live: true, showSvc });
+    }
+  });
+});
+
 describe("Codex functions.exec orchestration", () => {
   const orch = (input: string, callId: string, ts = "t") =>
     JSON.stringify({ type: "response_item", timestamp: ts, payload: { type: "custom_tool_call", id: "ctc-" + callId, call_id: callId, name: "exec", status: "completed", input } });

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -2571,6 +2571,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       codexCompacted = { src: curSrc };
       return addCompact(ts);
     }
+    // Retain the diagnostic payload when shown; count hidden usage as service bookkeeping.
+    if (obj.type === "token_usage_record" && !showSvc) return addSvc(textPart(obj.type));
     if (obj.type === "turn_context" || obj.type === "world_state" || obj.type === "inter_agent_communication_metadata") {
       return addSvc(textPart(obj.type));
     }


### PR DESCRIPTION
Closes #1523

Codex `token_usage_record` rows now follow the service visibility setting. Hidden rows contribute to the existing hidden-service count; enabling services retains the current redacted diagnostic record. Unknown envelopes and tool/final ordering keep their existing behavior.

Added real parser regressions for both visibility settings, hidden-count trimming and repeat feeds, unknown-record fallback, and incremental live-to-completed parsing with mirrored Codex items. Before the fix, both visibility regressions failed while the enabled-service control passed. After the fix, all 183 tests across eight explicit parser test files passed; the main parser suite also passed after refreshing main. Local publication checks passed. The post-refresh `bunx tsc --noEmit --incremental false` check passed. Hosted checks are being monitored.

An additional scanner accounting check passed its Codex case (5/6 overall). Its Claude registry-date assertion expects `2026-07-10` while the registry is `2026-09-01`; the test and scanner sources are identical to main. This pre-existing expectation is outside this change.

Evidence uses synthetic usage records and the existing chronology fixture. It proves the classification defect; the original screenshot's service-toggle setting remains unknown. No deployment is included.
