### PR TITLE
fix(composer): preserve authoritative receipt settlement time

### DIFF
--- a/src/components/LogFeed.outboxTailOrder.dom.test.tsx
+++ b/src/components/LogFeed.outboxTailOrder.dom.test.tsx
@@ -8,6 +8,10 @@ import { createRoot, type Root } from "react-dom/client";
 import type { FileEntry } from "@/lib/types";
 import { setLocale } from "@/lib/i18n";
 import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { RuntimeReceipt } from "./runtime/runtimeModel";
+import { setTmuxComposerRuntimeDependenciesForTests } from "./tmuxComposerRuntime";
+import { attachModeFor, capabilitiesFor } from "./agentCapabilities";
+import type { RuntimeSessionView } from "@/hooks/useRuntime";
 
 /**
  * The delivered-bubble ordering invariant (successor of the #922/#933 class):
@@ -100,6 +104,7 @@ mock.module("@/hooks/useToolActivityCues", () => ({
 }));
 
 const { LogFeed } = await import("./LogFeed");
+const { TmuxComposer } = await import("./TmuxComposer");
 const { enqueueOutbox, readOutbox, resetOutboxForTests, seedLaunchOutbox, updateOutbox } = await import("./conversation/outbox");
 
 /* The newest fixture record: the agent's reply after the tool call. */
@@ -120,6 +125,7 @@ afterEach(() => {
   roots.clear();
   dom.document.body.replaceChildren();
   Date.now = originalDateNow;
+  setTmuxComposerRuntimeDependenciesForTests(null);
 });
 afterAll(() => {
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
@@ -148,22 +154,25 @@ const file: FileEntry = {
   conversationId: "conversation-tail-order",
 } as FileEntry;
 
-function render(renderedFile: FileEntry = file): HTMLElement {
+function render(renderedFile: FileEntry = file, withComposer = false): HTMLElement {
   const host = dom.document.createElement("div");
   dom.document.body.append(host);
   const root = createRoot(host as unknown as HTMLElement);
   roots.add(root);
   flushSync(() => {
     root.render(
-      <LogFeed
-        file={renderedFile}
-        showSvc={false}
-        lineFilter=""
-        onStatus={() => undefined}
-        paused
-        follow={false}
-        setFollow={() => undefined}
-      />,
+      <>
+        {withComposer ? <TmuxComposer file={renderedFile} /> : null}
+        <LogFeed
+          file={renderedFile}
+          showSvc={false}
+          lineFilter=""
+          onStatus={() => undefined}
+          paused
+          follow={false}
+          setFollow={() => undefined}
+        />
+      </>,
     );
   });
   return host as unknown as HTMLElement;
@@ -266,3 +275,58 @@ test.each([
   expect(host.querySelector("[data-outbox-entry]") === null).toBe(true);
   expect(readOutbox(conversationId)[0]).toMatchObject({ text: raw, echoText: scaffolded });
 });
+
+// Exercise receipt ingestion and feed projection together, with a capped tail.
+test.each([
+  ["delivered", "valid"], ["delivered", "missing"], ["delivered", "scaffolded-echo"],
+  ["queued", "valid"], ["delivering", "valid"], ["uncertain", "valid"],
+] as const)(
+  "mounted composer and feed preserve chronology for a late %s receipt (%s)",
+  (status, evidence) => {
+    const key = "late-tail-receipt";
+    const serverAt = NEWEST_RECORD_AT - 20_000;
+    const receipt: RuntimeReceipt = {
+      operationId: "op-late-tail", idempotencyKey: key, conversationId: file.conversationId!,
+      kind: "send", status, at: evidence === "missing" ? "" : new Date(serverAt).toISOString(), revision: 3,
+    };
+    const view = {
+      session: { conversationId: file.conversationId, hostKind: "codex-app-server", host: "hosted", recentReceipts: [] },
+      uiState: {}, attentions: [], receipts: [receipt], legacy: false, structuredControlsEnabled: true,
+    } as unknown as RuntimeSessionView;
+    setTmuxComposerRuntimeDependenciesForTests({
+      useAgentCapabilities: (candidate) => ({
+        caps: capabilitiesFor(candidate, view, { runtimeEnabled: true }),
+        runtime: view, structuredSession: view, runtimeEnabled: true,
+        attachMode: attachModeFor(candidate, view, { runtimeEnabled: true }),
+      }),
+      useRuntimeReceiptsForArtifact: () => [receipt],
+    });
+    enqueueOutbox(file.conversationId!, { id: key, text: "Inspect queued work.", images: 0, at: serverAt - 40_000 });
+    updateOutbox(file.conversationId!, key, { state: "delivering" });
+    if (evidence === "scaffolded-echo") {
+      const scaffold = "Context for this request.\n\nInspect queued work.";
+      updateOutbox(file.conversationId!, key, { echoText: scaffold });
+      // One echo belongs to the old request; an identical later submission remains.
+      enqueueOutbox(file.conversationId!, { id: "next-tail-receipt", text: "Inspect queued work.", images: 0, at: NOW, echoBaseline: 1 });
+      updateOutbox(file.conversationId!, "next-tail-receipt", { state: "delivering", echoText: scaffold });
+      tailLines = [JSON.stringify({ timestamp: new Date(serverAt).toISOString(), type: "response_item", payload: {
+        type: "message", id: "exact-scaffold-echo", role: "user", content: [{ type: "input_text", text: scaffold }],
+      } }), ...fixtureLines];
+    }
+    const host = render(file, true);
+    expect(host.querySelectorAll("[data-feed-kind]").length).toBeGreaterThan(0);
+    if (evidence === "missing") {
+      expect(readOutbox(file.conversationId!)[0]?.settledAt).toBeUndefined();
+      expect(host.querySelector<HTMLElement>("[data-outbox-entry]")?.dataset.outboxState).toBe("delivered");
+    } else if (evidence === "scaffolded-echo") {
+      const bubbles = host.querySelectorAll<HTMLElement>("[data-outbox-entry]");
+      expect(bubbles).toHaveLength(1);
+      expect(bubbles[0]?.dataset.outboxEntry).toBe("next-tail-receipt");
+    } else if (status === "delivered") {
+      expect(readOutbox(file.conversationId!)[0]?.settledAt).toBe(serverAt);
+      expect(host.querySelector("[data-outbox-entry]")).toBeNull();
+    } else {
+      expect(host.querySelector<HTMLElement>("[data-outbox-entry]")?.dataset.outboxState).toBe("delivering");
+    }
+  },
+);

--- a/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
+++ b/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
@@ -22,6 +22,7 @@ import { setLocale, translate } from "@/lib/i18n";
 import { attachModeFor, capabilitiesFor } from "./agentCapabilities";
 import { setTmuxComposerRuntimeDependenciesForTests } from "./tmuxComposerRuntime";
 import { useAgentCapabilities } from "./useAgentCapabilities";
+import type { RuntimeReceipt } from "./runtime/runtimeModel";
 
 const dom = new Window();
 installActEnv();
@@ -81,11 +82,14 @@ const structuredView: RuntimeSessionView = {
 
 import { TmuxComposer } from "./TmuxComposer";
 import { writeProfile } from "./runtimeProfile";
-import { readOutbox, resetOutboxForTests, retryOutbox } from "./conversation/outbox";
+import { enqueueOutbox, updateOutbox, visibleOutbox, readOutbox, resetOutboxForTests, retryOutbox } from "./conversation/outbox";
+
+let snapshotReceipts: RuntimeReceipt[] = [];
 
 const realFetch = globalThis.fetch;
 
 beforeEach(() => {
+  snapshotReceipts = [];
   setRuntimeUiEnabledForTests(false);
   setTmuxComposerRuntimeDependenciesForTests({
     useAgentCapabilities: (candidate) => {
@@ -102,7 +106,7 @@ beforeEach(() => {
     },
     useRuntimeReceiptsForArtifact: (path, conversationId) => {
       const real = useRuntimeReceiptsForArtifact(path, conversationId);
-      return path === "/codex-snapshot.jsonl" || conversationId === "conv-snapshot" ? [] : real;
+      return path === "/codex-snapshot.jsonl" || conversationId === "conv-snapshot" ? snapshotReceipts : real;
     },
   });
 });
@@ -235,7 +239,7 @@ test("text-only unhosted structured composer sends through durable recovery admi
   const sends: SendBody[] = [];
   mockWire(sends, [delivered]);
 
-  const { host, root } = await renderInto(<TmuxComposer file={file} deadHost />);
+  const { host, root } = await renderInto(<TmuxComposer file={{ ...file, proc: null }} deadHost />);
   const { type, submit } = composerControls(host);
   await settle(() => type("continue while the host recovers"));
   await settle(() => submit());
@@ -258,7 +262,7 @@ test("dead structured image-only input stays removable and avoids failing recove
 
   structuredView.session.host = "unhosted";
   await act(async () => {
-    root.render(<TmuxComposer file={file} deadHost />);
+    root.render(<TmuxComposer file={{ ...file, proc: null }} deadHost />);
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
@@ -296,7 +300,7 @@ test("dead structured text plus images stays local and retries after hosting ret
 
   structuredView.session.host = "unhosted";
   await act(async () => {
-    root.render(<TmuxComposer file={file} deadHost />);
+    root.render(<TmuxComposer file={{ ...file, proc: null }} deadHost />);
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
   await settle(() => composerControls(host).submit());
@@ -338,7 +342,7 @@ test("structured recovery state is bounded and exposes retry details", async () 
     return new Promise<Response>((resolve) => { finishRecovery = resolve; });
   }) as typeof fetch;
 
-  const { host, root } = await renderInto(<TmuxComposer file={file} deadHost />);
+  const { host, root } = await renderInto(<TmuxComposer file={{ ...file, proc: null }} deadHost />);
   const { type, submit } = composerControls(host);
   await settle(() => type("preserve this recovery draft"));
   await settle(() => submit());
@@ -488,4 +492,131 @@ test("a send with no explicit selection rides no runtime override, on first atte
   expect(sends[1]!.runtime).toBeUndefined();
 
   await act(async () => root.unmount());
+});
+
+// Synthetic delayed reconnect: the recipient settled before the retained reply.
+test("late receipt snapshot preserves delivery time across replay and remount", async () => {
+  const origin = Date.now() - 120_000;
+  const serverAt = origin + 40_000;
+  const key = "late-snapshot";
+  enqueueOutbox("conv-snapshot", { id: key, text: "Inspect queued work.", images: 0, at: origin });
+  updateOutbox("conv-snapshot", key, { state: "delivering" });
+  const sends: SendBody[] = [];
+  mockWire(sends, [delivered]);
+  let mounted = await renderInto(<TmuxComposer file={file} />);
+  try {
+    snapshotReceipts = [{
+      operationId: "op-late-snapshot", idempotencyKey: key, conversationId: "conv-snapshot",
+      kind: "send", status: "delivered", admittedAt: new Date(origin).toISOString(),
+      at: new Date(serverAt).toISOString(), revision: 3,
+    }];
+    await settle(() => mounted.root.render(<TmuxComposer file={file} />));
+    expect(readOutbox("conv-snapshot")[0]?.settledAt).toBe(serverAt);
+    expect(visibleOutbox(readOutbox("conv-snapshot"), new Map(), Date.now(), null, origin + 60_000)).toHaveLength(0);
+    await settle(() => mounted.root.render(<TmuxComposer file={file} />));
+    expect(readOutbox("conv-snapshot")[0]?.settledAt).toBe(serverAt);
+    await act(async () => mounted.root.unmount());
+    mounted = await renderInto(<TmuxComposer file={file} />);
+    expect(readOutbox("conv-snapshot")[0]?.settledAt).toBe(serverAt);
+    expect(sends).toHaveLength(0);
+  } finally {
+    await act(async () => mounted.root.unmount());
+  }
+});
+
+
+test.each(["missing", "invalid", "future", "before-submission", "before-admission"])(
+  "delivered snapshot with %s time waits for valid settlement evidence",
+  async (variant) => {
+    const origin = Date.now() - 1_200_000;
+    const key = "unknown-settlement";
+    const serverAt = origin + 40_000;
+    const at = variant === "missing" ? undefined : variant === "invalid" ? "not-a-date"
+      : variant === "future" ? new Date(Date.now() + 60_000).toISOString()
+      : variant === "before-submission" ? new Date(origin - 1_000).toISOString()
+      : new Date(origin + 1_000).toISOString();
+    snapshotReceipts = [{
+      operationId: "op-unknown-settlement", idempotencyKey: key, conversationId: "conv-snapshot",
+      kind: "send", status: "delivered", admittedAt: new Date(origin + 2_000).toISOString(),
+      at, revision: 3,
+    } as RuntimeReceipt];
+    enqueueOutbox("conv-snapshot", { id: key, text: "Inspect queued work.", images: 0, at: origin });
+    updateOutbox("conv-snapshot", key, { state: "delivering" });
+    mockWire([], [delivered]);
+    const mounted = await renderInto(<TmuxComposer file={file} />);
+    try {
+      expect(readOutbox("conv-snapshot")[0]?.state).toBe("delivered");
+      expect(readOutbox("conv-snapshot")[0]?.settledAt).toBeUndefined();
+      expect(visibleOutbox(readOutbox("conv-snapshot"), new Map(), Date.now(), null, origin + 60_000)).toHaveLength(1);
+      // Exact echo remains sufficient even while the settlement time is unknown.
+      expect(visibleOutbox(readOutbox("conv-snapshot"), new Map([["Inspect queued work.", 1]]), Date.now())).toHaveLength(0);
+      snapshotReceipts = [{ ...snapshotReceipts[0]!, at: new Date(serverAt).toISOString(), revision: 4 }];
+      await settle(() => mounted.root.render(<TmuxComposer file={file} />));
+      expect(readOutbox("conv-snapshot")[0]?.settledAt).toBe(serverAt);
+      expect(visibleOutbox(readOutbox("conv-snapshot"), new Map(), Date.now(), null, origin + 60_000)).toHaveLength(0);
+    } finally {
+      await act(async () => mounted.root.unmount());
+    }
+  },
+);
+
+test("immediate delivered response uses its terminal transition time", async () => {
+  const sends: SendBody[] = [];
+  let serverAt = 0;
+  const realNow = Date.now;
+  const origin = realNow();
+  let clock = origin;
+  Date.now = () => clock;
+  mockWire(sends, [(body) => {
+    serverAt = origin + 40_000;
+    clock = origin + 120_000;
+    const response = delivered(body);
+    response.json.receipt.at = new Date(serverAt).toISOString();
+    return response;
+  }]);
+  const { host, root } = await renderInto(<TmuxComposer file={file} />);
+  try {
+    const controls = composerControls(host);
+    await settle(() => controls.type("Inspect queued work."));
+    await settle(controls.submit);
+    expect(sends).toHaveLength(1);
+    expect(readOutbox("conv-snapshot")[0]).toMatchObject({ state: "delivered", settledAt: serverAt });
+  } finally {
+    Date.now = realNow;
+    await act(async () => root.unmount());
+  }
+});
+
+
+test("queued send settles from a later snapshot without resending or re-aging", async () => {
+  const sends: SendBody[] = [];
+  const originalNow = Date.now;
+  const origin = originalNow();
+  let clock = origin;
+  Date.now = () => clock;
+  mockWire(sends, [(body) => ({ status: 200, json: { ok: true, receipt: {
+    ...delivered(body).json.receipt, status: "queued", at: new Date(origin).toISOString(),
+  } } })]);
+  const { host, root } = await renderInto(<TmuxComposer file={file} />);
+  try {
+    const controls = composerControls(host);
+    await settle(() => controls.type("Inspect queued work."));
+    await settle(controls.submit);
+    expect(readOutbox("conv-snapshot")[0]).toMatchObject({ state: "delivering", awaitingTurn: true });
+    expect(readOutbox("conv-snapshot")[0]?.settledAt).toBeUndefined();
+    clock = origin + 120_000;
+    snapshotReceipts = [{ ...delivered(sends[0]!).json.receipt,
+      kind: "send", status: "delivered", at: new Date(origin + 40_000).toISOString(), revision: 3,
+    }];
+    await settle(() => root.render(<TmuxComposer file={file} />));
+    expect(readOutbox("conv-snapshot")[0]).toMatchObject({ state: "delivered", settledAt: origin + 40_000 });
+    snapshotReceipts = [{ ...snapshotReceipts[0]!, at: "", revision: 4 }];
+    clock += 60_000;
+    await settle(() => root.render(<TmuxComposer file={file} />));
+    expect(readOutbox("conv-snapshot")[0]?.settledAt).toBe(origin + 40_000);
+    expect(sends).toHaveLength(1);
+  } finally {
+    Date.now = originalNow;
+    await act(async () => root.unmount());
+  }
 });

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -34,9 +34,8 @@ import {
   enqueueOutbox,
   markOutboxResponded,
   outboxHistory,
-  outboxAwaitsTurnBoundary,
   outboxReceiptPatch,
-  outboxStateForReceiptStatus,
+  readOutbox,
   rebindOutboxEchoText,
   releaseHeldOutbox,
   transcriptEchoCount,
@@ -1856,14 +1855,11 @@ export function TmuxComposerCore({
          truly delivered receipt marks it `delivered`. */
       if (outboxKeys.current.has(settlement.entry.key)) {
         const receipt = displayedRuntimeReceipts.find((candidate) =>
-          candidate.idempotencyKey === settlement.entry.key && receiptIsAdmitted(candidate.status));
-        const state = receipt ? outboxStateForReceiptStatus(receipt.status) : "delivered";
-        updateOutbox(cardId, settlement.entry.key, {
-          state,
-          settledAt: nowMs(),
-          /* #1213: parked at a turn boundary is not "on the wire". */
-          awaitingTurn: receipt ? outboxAwaitsTurnBoundary(receipt.status) : undefined,
-        });
+          (candidate.idempotencyKey === settlement.entry.key
+            || candidate.operationId === settlement.entry.operationId) && receiptIsAdmitted(candidate.status));
+        const entry = readOutbox(cardId).find((candidate) => candidate.id === settlement.entry.key);
+        const patch = entry && receipt ? outboxReceiptPatch(entry, receipt.status, receipt, nowMs()) : null;
+        if (patch) updateOutbox(cardId, settlement.entry.key, patch);
       } else {
         const next = draftAfterDelivery(textRef.current, settlement.text);
         if (next !== textRef.current) setText(next);
@@ -1887,14 +1883,14 @@ export function TmuxComposerCore({
      bubble. Launch-owned bubbles retire on their echo, not on a receipt. */
   useEffect(() => {
     for (const entry of outbox) {
-      if (entry.launchOwned || entry.state === "delivered") continue;
+      if (entry.launchOwned) continue;
       const receipt = displayedRuntimeReceipts.find((candidate) =>
         candidate.idempotencyKey === entry.id
         && (receiptIsAdmitted(candidate.status) || receiptIsTerminal(candidate.status)));
       if (!receipt) continue;
-      const patch = outboxReceiptPatch(entry, receipt.status);
+      const patch = outboxReceiptPatch(entry, receipt.status, receipt, nowMs());
       if (!patch) continue;
-      updateOutbox(cardId, entry.id, { ...patch, settledAt: nowMs() });
+      updateOutbox(cardId, entry.id, patch);
     }
   }, [displayedRuntimeReceipts, outbox, cardId]);
 
@@ -2083,6 +2079,7 @@ export function TmuxComposerCore({
         `delivering`, only a delivered receipt reads `delivered` (round-1 P1#4). */
     const settleOutbox = (state: OutboxState, error?: string, held?: boolean, awaitingTurn?: true) => {
       if (!outboxId) return;
+      if (readOutbox(cardId).find((entry) => entry.id === outboxId)?.state === "delivered") return;
       /* A held settlement stamps the entry so `releaseHeldOutbox` can requeue
          it level-wise once the switch is over — a parked hold looks exactly
          like an in-flight delivery otherwise. */
@@ -2105,12 +2102,19 @@ export function TmuxComposerCore({
       /* `queued` is durable admission at a turn boundary. It is a switch hold
          only while the card's migration evidence says this delivery belongs to
          a successor; an ordinary queued receipt must never requeue itself. */
-      return settleOutbox(
-        outboxStateForReceiptStatus(receipt.status),
-        undefined,
-        holdsDelivery && receipt.status === "queued",
-        outboxAwaitsTurnBoundary(receipt.status),
-      );
+      if (!outboxId) return;
+      const entry = readOutbox(cardId).find((candidate) => candidate.id === outboxId);
+      if (!entry) return;
+      const patch = outboxReceiptPatch(entry, receipt.status, receipt, nowMs());
+      const held = holdsDelivery && receipt.status === "queued" && entry.state !== "delivered";
+      if (patch || (held && !entry.heldForSwitch)) updateOutbox(cardId, outboxId, {
+        ...patch,
+        ...(held ? { heldForSwitch: true as const } : {}),
+      });
+      if (receipt.status === "delivered") {
+        outboxImages.current.delete(outboxId);
+        outboxFiles.current.delete(outboxId);
+      }
     };
     /* Resolve the key before selecting the payload. A generation retained after
        uncertain admission owns an immutable text/image snapshot; later edits

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -13,6 +13,7 @@ import {
   OUTBOX_LIMIT,
   OUTBOX_MTIME_GRACE_MS,
   outboxStateForReceiptStatus,
+  outboxReceiptPatch,
   publishTranscriptEchoes,
   readOutbox,
   resetOutboxForTests,
@@ -1824,4 +1825,64 @@ test("a text-only delivering entry returns to the queue for replay after a refre
   const restored = readOutbox("conv");
   expect(restored[0]!.state).toBe("queued");
   expect(nextDispatch(restored)?.id).toBe("k1");
+});
+
+
+describe("authoritative receipt settlement", () => {
+  const origin = Date.parse("2026-01-01T00:00:00.000Z");
+  const terminalAt = origin + 40_000;
+  const now = origin + 120_000;
+  const receipt = { at: new Date(terminalAt).toISOString(), admittedAt: new Date(origin).toISOString() };
+  const entry: OutboxEntry = { id: "receipt-key", text: "Inspect queued work.", images: 0, at: origin, state: "delivering" };
+
+  test("terminal receipt time is stable across repeated, incomplete and stale projections", () => {
+    const patch = outboxReceiptPatch(entry, "delivered", receipt, now)!;
+    expect(patch).toMatchObject({ state: "delivered", settledAt: terminalAt, receiptSettlement: "known" });
+    const settled = { ...entry, ...patch };
+    for (const at of [receipt.at, "", new Date(now).toISOString()]) {
+      expect(outboxReceiptPatch(settled, "delivered", { at }, now + 60_000)).toBeNull();
+    }
+    for (const status of ["queued", "delivering", "uncertain", "pending", "failed"] as const) {
+      expect(outboxReceiptPatch(settled, status, receipt, now)).toBeNull();
+    }
+  });
+
+  test("unknown settlement survives persistence without using admission for retirement", () => {
+    enqueueOutbox("conv", entry);
+    updateOutbox("conv", entry.id, outboxReceiptPatch(entry, "delivered", { at: "" }, now)!);
+    resetOutboxForTests();
+    const restored = readOutbox("conv");
+    expect(restored[0]).toMatchObject({ state: "delivered", receiptSettlement: "unknown" });
+    expect(restored[0]?.settledAt).toBeUndefined();
+    expect(visibleOutbox(restored, echoes(), now + OUTBOX_DELIVERED_TTL_MS, null, now)).toHaveLength(1);
+    expect(visibleOutbox(restored, echoes(entry.text), now)).toHaveLength(0);
+    updateOutbox("conv", entry.id, outboxReceiptPatch(restored[0]!, "delivered", receipt, now)!);
+    resetOutboxForTests();
+    expect(readOutbox("conv")[0]?.settledAt).toBe(terminalAt);
+    expect(visibleOutbox(readOutbox("conv"), echoes(), now, null, origin + 60_000)).toHaveLength(0);
+  });
+
+  test("legacy persisted deliveries retain their old retirement contract", () => {
+    enqueueOutbox("conv", entry);
+    updateOutbox("conv", entry.id, { state: "delivered" });
+    resetOutboxForTests();
+    expect(visibleOutbox(readOutbox("conv"), echoes(), now, null, now)).toHaveLength(0);
+    // A fresh authoritative receipt also repairs a legacy browser-time stamp.
+    const old = { ...entry, state: "delivered" as const, settledAt: now };
+    expect(outboxReceiptPatch(old, "delivered", receipt, now)?.settledAt).toBe(terminalAt);
+  });
+
+  test("an exact scaffolded echo consumes only its own identical submission", () => {
+    const scaffold = "Context for this request.\n\nInspect queued work.";
+    const first = { ...entry, echoText: scaffold, ...outboxReceiptPatch(entry, "delivered", { at: "" }, now) };
+    const second = { ...entry, id: "next-key", echoText: scaffold, echoBaseline: 1 };
+    expect(visibleOutbox([first, second], echoes([scaffold, 1]), now)).toEqual([second]);
+  });
+
+  test.each(["queued", "delivering", "uncertain", "pending"] as const)("%s never establishes a delivery clock", (status) => {
+    const patch = outboxReceiptPatch(entry, status, receipt, now);
+    expect(patch?.settledAt).toBeUndefined();
+    expect(patch?.receiptSettlement).toBeUndefined();
+    expect(visibleOutbox([{ ...entry, ...patch }], echoes(), now + OUTBOX_DELIVERED_TTL_MS, null, now)).toHaveLength(1);
+  });
 });

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -48,6 +48,9 @@ export interface OutboxEntry {
   state: OutboxState;
   /** Moment the entry left `queued`/`delivering` (ms), for the hard-cap TTL. */
   settledAt?: number;
+  /** Receipt-driven delivery has its own clock authority. Unknown receipt
+      time must never fall back to submission time, including after reload. */
+  receiptSettlement?: "known" | "unknown";
   /** Assistant output began for the turn created by this submission. This is
       causal delivery proof and permanently retires the optimistic bubble. */
   responseStartedAt?: number;
@@ -195,9 +198,11 @@ export function outboxStateForReceiptStatus(status: ReceiptStatus): OutboxState 
  * failure, and never to `delivering` off an unproven receipt.
  */
 export function outboxReceiptPatch(
-  entry: Pick<OutboxEntry, "state" | "awaitingTurn">,
+  entry: Pick<OutboxEntry, "state" | "awaitingTurn"> & Partial<Pick<OutboxEntry, "at" | "settledAt" | "receiptSettlement">>,
   status: ReceiptStatus,
-): { state: OutboxState; awaitingTurn?: true } | null {
+  receipt?: { at: string; admittedAt?: string },
+  nowMs?: number,
+): ({ state: OutboxState; awaitingTurn?: true } & Partial<Pick<OutboxEntry, "settledAt" | "receiptSettlement">>) | null {
   /* Only a receipt that PROVES admission or settlement says anything about a
      bubble. `pending`, `applying` and `uncertain` are the request path still
      working, or an admission nobody confirmed: the bubble already reads
@@ -206,11 +211,51 @@ export function outboxReceiptPatch(
   if (!receiptIsAdmitted(status) && !receiptIsTerminal(status)) return null;
   const state = outboxStateForReceiptStatus(status);
   const awaitingTurn = outboxAwaitsTurnBoundary(status);
+  if (entry.state === "delivered" && (state !== "delivered" || !receipt)) return null;
+  if (receipt && state === "delivered") {
+    // A terminal journal transition stamps `at` once. An incomplete or repeated
+    // projection cannot replace a known authoritative settlement or extend TTL.
+    if (entry.state === "delivered" && entry.receiptSettlement === "known"
+      && Number.isFinite(entry.settledAt)) return null;
+    const settledAt = authoritativeReceiptTime(receipt, entry.at, nowMs);
+    const receiptSettlement = settledAt === undefined ? "unknown" : "known";
+    if (entry.state === state && entry.receiptSettlement === receiptSettlement
+      && entry.settledAt === settledAt) return null;
+    return { state, awaitingTurn, settledAt, receiptSettlement };
+  }
   if (state === entry.state && awaitingTurn === entry.awaitingTurn) return null;
   /* A failed bubble is never re-churned by another failure; it only advances on
      the proven admission or delivery above. */
   if (entry.state === "failed" && state === "failed") return null;
-  return { state, awaitingTurn };
+  return {
+    state, awaitingTurn,
+    ...(receipt ? {
+      settledAt: receiptIsTerminal(status) ? authoritativeReceiptTime(receipt, entry.at, nowMs) : undefined,
+      receiptSettlement: undefined,
+    } : {}),
+  };
+}
+
+/** The journal emits UTC ISO transition stamps. Reject malformed, future, or
+    causally stale times; admission is only a lower bound, never delivery proof.
+    Old but valid terminal evidence is retained verbatim, even beyond the TTL. */
+function authoritativeReceiptTime(
+  receipt: { at: string; admittedAt?: string },
+  submittedAt: number | undefined,
+  nowMs: number | undefined,
+): number | undefined {
+  const parse = (value: unknown): number | undefined => {
+    if (typeof value !== "string") return undefined;
+    const time = Date.parse(value);
+    return Number.isFinite(time) && new Date(time).toISOString() === value ? time : undefined;
+  };
+  const time = parse(receipt.at);
+  const admittedAt = parse(receipt.admittedAt);
+  if (time === undefined || nowMs === undefined || submittedAt === undefined
+    || !Number.isFinite(nowMs) || !Number.isFinite(submittedAt)
+    || time > nowMs || time < submittedAt
+    || (receipt.admittedAt !== undefined && (admittedAt === undefined || time < admittedAt))) return undefined;
+  return time;
 }
 
 /** Bounded per conversation: the queue is working state plus recent history for
@@ -1363,13 +1408,15 @@ export function visibleOutbox(
     }
     if (entry.adoptedAt !== undefined) continue;
     if (entry.responseStartedAt !== undefined) continue;
-    if (entry.state === "delivered") {
-      const settledAt = entry.settledAt ?? entry.at;
-      if (nowMs - settledAt >= OUTBOX_DELIVERED_TTL_MS) continue;
-      if (
-        newestTranscriptAtMs !== undefined
-        && newestTranscriptAtMs >= settledAt + OUTBOX_MTIME_GRACE_MS
-      ) continue;
+    if (entry.state === "delivered" && entry.receiptSettlement !== "unknown") {
+      const settledAt = entry.receiptSettlement === "known" ? entry.settledAt : entry.settledAt ?? entry.at;
+      if (settledAt !== undefined && Number.isFinite(settledAt)) {
+        if (nowMs - settledAt >= OUTBOX_DELIVERED_TTL_MS) continue;
+        if (
+          newestTranscriptAtMs !== undefined
+          && newestTranscriptAtMs >= settledAt + OUTBOX_MTIME_GRACE_MS
+        ) continue;
+      }
     }
     visible.push(entry);
   }


### PR DESCRIPTION
A browser that observes delivery late can leave an old Delivered bubble below a newer assistant reply when the native echo has left the retained tail. Receipt-driven settlement now uses the terminal journal transition's validated `at` timestamp in all three composer callers.

Missing, malformed, future, or causally stale timestamps preserve Delivered with explicit unknown settlement. Such entries retire through exact echo or response evidence until a valid timestamp arrives. A known authoritative timestamp survives incomplete and repeated snapshots unchanged. Admission timestamps only constrain validation. Legacy persisted entries retain their existing fallback behavior; a terminal receipt upgrades them to the authoritative clock.

Validation:
- Mounted composer regression and mounted composer + LogFeed regression demonstrated RED before the fix and pass afterward.
- Composer snapshot: 16 tests; LogFeed tail order: 10; outbox persistence/occurrence behavior: 67.
- Queue-first, hold release, reconciliation, delivery state, composer logic, echo shapes, delivery bubbles and discard notice suites pass in isolated state, one file per invocation.
- Original sanitized replay: baseline RED 3/3; identical scenario and controls with the candidate's exact receipt effect and production outbox functions PASS 3/3.
- `bunx tsc --noEmit --incremental false` and the local privacy publication gate pass. Frozen dependencies installed without manifest or lock changes.

The recovery fixtures in the snapshot suite now pair a dead host with an absent process, matching the current authority fence. Their prior contradictory state failed on the unchanged baseline.

The reproduced timestamp defect is established. Attribution of the original browser frame remains conditional because its receipt-arrival, outbox and echo state were not captured. The separate pre-dispatch wait remains unexplained. Two independent exact-head reviews and hosted gates remain required before merge.

Closes #1524
