### PR TITLE
fix(feed): preserve reader movement during asynchronous history prepend

### DIFF
--- a/src/components/LogFeed.prependAnchor.dom.test.tsx
+++ b/src/components/LogFeed.prependAnchor.dom.test.tsx
@@ -1,0 +1,287 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import type { FileEntry } from "@/lib/types";
+import type { LogTailState } from "@/hooks/useLogTail";
+
+const dom = new Window({ width: 390, height: 844 });
+Object.assign(globalThis, {
+  window: dom, document: dom.document, navigator: dom.navigator,
+  HTMLElement: dom.HTMLElement, Node: dom.Node, Event: dom.Event,
+  CustomEvent: dom.CustomEvent, localStorage: dom.localStorage, sessionStorage: dom.sessionStorage,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+  ResizeObserver: class { observe() {} disconnect() {} unobserve() {} },
+});
+const previousFetch = globalThis.fetch;
+globalThis.fetch = (async () => new Response("{}", { status: 404 })) as unknown as typeof fetch;
+const { LogFeed } = await import("./LogFeed");
+const { setLogFeedDependenciesForTests } = await import("./logFeedDependencies");
+
+// Native Codex envelopes, with synthetic content/identities. Actual parser and
+// FeedItem stay mounted. Geometry comes from committed DOM attributes, so the
+// before-mutation snapshot sees old layout and the layout phase sees insertion.
+const message = (id: string, role = "assistant") => JSON.stringify({ type: "response_item", payload: {
+  type: "message", id, role, content: [{ type: role === "user" ? "input_text" : "output_text", text: id }],
+}});
+const tool = (id: string) => JSON.stringify({ type: "response_item", payload: {
+  type: "custom_tool_call", call_id: id, name: "exec", input: "{}",
+}});
+const lines = [message("older-user", "user"), message("older-answer"), message("boundary", "user"),
+  tool("tool-a"), tool("tool-b"), message("answer"), message("next", "user"), message("last")];
+let root: Root | undefined;
+let host: HTMLDivElement;
+let tail: LogTailState;
+let file: FileEntry;
+let finish: (count: number) => void;
+let calls: number;
+const render = () => flushSync(() => root!.render(<LogFeed file={file} showSvc={false} lineFilter=""
+  onStatus={() => {}} paused={false} follow={false} setFollow={() => {}} />));
+const wait = () => new Promise((resolve) => setTimeout(resolve, 50));
+let serial = 0;
+async function mount(fixture = lines) {
+  calls = 0;
+  tail = { lines: fixture.slice(3), linesStart: 3, size: 1000, loading: false, error: null,
+    tickTime: null, paused: false, setPaused() {}, clear() {}, hasMore: true, loadingOlder: false,
+    loadOlder: () => { calls++; return new Promise<number>((resolve) => { finish = resolve; }); }, prependGen: 0 };
+  setLogFeedDependenciesForTests({ useLogTail: () => tail });
+  file = { path: `/fixture/prepend-${++serial}`, name: "fixture", root: "fixture", engine: "codex",
+    fmt: "codex", kind: "session", size: 1000, mtime: 0, activity: "idle" } as unknown as FileEntry;
+  host = document.createElement("div"); document.body.append(host); root = createRoot(host);
+  render(); await wait(); render();
+  const scroller = host.querySelector<HTMLElement>("[data-log-feed-scroller]")!;
+  const prepended = () => scroller.dataset.tailLinesStart === "0";
+  Object.defineProperty(scroller, "scrollHeight", { configurable: true, get: () => prepended() ? 2400 : 2000 });
+  Object.defineProperty(scroller, "clientHeight", { configurable: true, get: () => 500 });
+  const original = dom.HTMLElement.prototype.getBoundingClientRect;
+  dom.HTMLElement.prototype.getBoundingClientRect = function () {
+    const key = this.getAttribute("data-feed-key");
+    if (!key) return original.call(this);
+    const source = Number(key.split(":")[1]);
+    const top = (source < 3 ? source * 100 : 400 + (source - 3) * 100) + (prepended() && source >= 3 ? 400 : 0) - scroller.scrollTop;
+    return new dom.DOMRect(0, top, 390, 100);
+  };
+  restoreGeometry = () => { dom.HTMLElement.prototype.getBoundingClientRect = original; };
+  scroller.scrollTop = 80;
+  return scroller;
+}
+let restoreGeometry = () => {};
+afterEach(async () => {
+  if (root) flushSync(() => root!.unmount()); root = undefined;
+  host?.remove(); restoreGeometry(); setLogFeedDependenciesForTests(null);
+  await dom.happyDOM.abort();
+});
+afterAll(() => { globalThis.fetch = previousFetch; });
+function request() {
+  const button = [...host.querySelectorAll("button")].find((button) => /earlier/i.test(button.textContent ?? ""));
+  expect(button).toBeDefined(); flushSync(() => button!.click());
+}
+for (const movement of [0, 60, -60]) {
+  test(`pending prepend preserves current group offset with movement ${movement}`, async () => {
+    const scroller = await mount(); request();
+    scroller.scrollTop = 80 + movement;
+    const key = "group:3:0";
+    const offset = () => host.querySelector<HTMLElement>(`[data-feed-key="${key}"]`)!.getBoundingClientRect().top;
+    const before = offset();
+    tail = { ...tail, lines, linesStart: 0, prependGen: 1, hasMore: false };
+    render(); finish(3); await wait(); render();
+    expect(offset()).toBe(before);
+    expect(scroller.scrollTop).toBe(480 + movement);
+    expect([...host.querySelectorAll("[data-feed-key]")].map((row) => row.getAttribute("data-feed-key")))
+      .toEqual(["row:0:0", "row:1:0", "row:2:0", "group:3:0", "row:5:0", "row:6:0", "row:7:0"]);
+  });
+}
+
+test("interleaved tail growth and media below the reader do not enter prepend compensation", async () => {
+  const scroller = await mount(); request(); scroller.scrollTop = 140;
+  tail = { ...tail, lines: [...tail.lines, message("tail-arrival")] }; render();
+  Object.defineProperty(scroller, "scrollHeight", { configurable: true, get: () => tail.prependGen ? 3300 : 2900 });
+  const before = host.querySelector<HTMLElement>('[data-feed-key="group:3:0"]')!.getBoundingClientRect().top;
+  tail = { ...tail, lines: [...lines, message("tail-arrival")], linesStart: 0, prependGen: 1 }; render();
+  finish(3); await wait();
+  expect(scroller.scrollTop).toBe(540);
+  expect(host.querySelector<HTMLElement>('[data-feed-key="group:3:0"]')!.getBoundingClientRect().top).toBe(before);
+  // A late size change below the anchor has no continuing restoration authority.
+  scroller.scrollTop += 25; render(); expect(scroller.scrollTop).toBe(565);
+});
+
+test("repeated request triggers share a pending load and an empty result permits retry", async () => {
+  const scroller = await mount(); request(); request(); expect(calls).toBe(1);
+  scroller.scrollTop = 140; finish(0); await wait(); render(); expect(scroller.scrollTop).toBe(140);
+  request(); expect(calls).toBe(2);
+  tail = { ...tail, lines, linesStart: 0, prependGen: 1 }; render(); finish(3); await wait();
+  expect(scroller.scrollTop).toBe(540);
+});
+
+test("a previous conversation response cannot reveal more rows in the new project", async () => {
+  await mount(); request(); const oldFinish = finish;
+  file = { ...file, path: file.path + "-other", project: "other-project" };
+  tail = { ...tail, lines: Array.from({ length: 1700 }, (_, i) => message(`other-${i}`, i % 2 ? "assistant" : "user")),
+    linesStart: 0, hasMore: false, prependGen: 0 };
+  render(); await wait(); render();
+  expect(host.querySelectorAll("[data-feed-key]").length).toBe(1500);
+  oldFinish(3); await wait(); render();
+  expect(host.querySelectorAll("[data-feed-key]").length).toBe(1500);
+});
+
+test("an unmounted pending load cannot change the replacement pane", async () => {
+  await mount(); request(); const oldFinish = finish;
+  flushSync(() => root!.unmount()); root = undefined; host.remove(); restoreGeometry();
+  const scroller = await mount(); scroller.scrollTop = 140;
+  oldFinish(3); await wait(); render(); expect(scroller.scrollTop).toBe(140);
+});
+
+test("a tool group coalescing across the page boundary preserves the current group offset", async () => {
+  const scroller = await mount(); request(); scroller.scrollTop = 140;
+  const original = dom.HTMLElement.prototype.getBoundingClientRect;
+  dom.HTMLElement.prototype.getBoundingClientRect = function () {
+    if (this.getAttribute("data-feed-kind") === "cmd-group") {
+      return new dom.DOMRect(0, (scroller.dataset.tailLinesStart === "0" ? 800 : 400) - scroller.scrollTop, 390, 100);
+    }
+    return original.call(this);
+  };
+  tail = { ...tail, lines: [message("older", "user"), message("commentary"), tool("older-tool"), ...lines.slice(3)],
+    linesStart: 0, prependGen: 1 };
+  render(); finish(3); await wait();
+  expect(host.querySelector('[data-feed-key="group:3:0"]')).toBeNull();
+  expect(host.querySelector<HTMLElement>('[data-feed-key="group:2:0"]')!.getBoundingClientRect().top).toBe(260);
+});
+
+test("successive pages each preserve movement made after their own request", async () => {
+  const scroller = await mount();
+  const original = dom.HTMLElement.prototype.getBoundingClientRect;
+  dom.HTMLElement.prototype.getBoundingClientRect = function () {
+    if (this.getAttribute("data-feed-key") === "group:3:0") {
+      const start = Number(scroller.dataset.tailLinesStart);
+      return new dom.DOMRect(0, (start === 3 ? 400 : start === 0 ? 800 : 1100) - scroller.scrollTop, 390, 100);
+    }
+    return original.call(this);
+  };
+  request(); scroller.scrollTop = 140;
+  tail = { ...tail, lines, linesStart: 0, prependGen: 1 }; render(); finish(3); await wait();
+  expect(scroller.scrollTop).toBe(540);
+  request(); scroller.scrollTop += 20;
+  tail = { ...tail, lines: [message("oldest", "user"), message("oldest-answer"), message("oldest-boundary", "user"), ...lines],
+    linesStart: -3, prependGen: 2, hasMore: false }; render(); finish(3); await wait();
+  expect(scroller.scrollTop).toBe(860);
+});
+
+test("a scaled compact canvas converts viewport pixels to scroll coordinates", async () => {
+  const scroller = await mount(); request(); scroller.scrollTop = 140;
+  Object.defineProperty(scroller, "offsetHeight", { configurable: true, get: () => 500 });
+  const original = dom.HTMLElement.prototype.getBoundingClientRect;
+  dom.HTMLElement.prototype.getBoundingClientRect = function () {
+    if (this.hasAttribute("data-log-feed-scroller")) return new dom.DOMRect(0, 0, 312, 400);
+    const rect = original.call(this);
+    return new dom.DOMRect(rect.x * 0.8, rect.y * 0.8, rect.width * 0.8, rect.height * 0.8);
+  };
+  tail = { ...tail, lines, linesStart: 0, prependGen: 1 }; render(); finish(3); await wait();
+  expect(scroller.scrollTop).toBe(540);
+});
+
+// Optional private API-record replay: the path and captured records never enter
+// source or public CI logs. The same mounted geometry model checks the native
+// group identity retained by the diagnostic capture.
+for (const movement of [0, 60, -60]) {
+test.skipIf(!process.env.LLV_PREPEND_RECORDS)(`sanitized API page preserves current group with movement ${movement}`, async () => {
+  const records = (await Bun.file(process.env.LLV_PREPEND_RECORDS!).json() as unknown[]).map((record) => JSON.stringify(record));
+  const scroller = await mount(records); request(); scroller.scrollTop = 80 + movement;
+  expect(host.querySelector('[data-feed-key="group:3:0"]')).not.toBeNull();
+  tail = { ...tail, lines: records, linesStart: 0, prependGen: 1 }; render(); finish(3); await wait();
+  expect(scroller.scrollTop).toBe(480 + movement);
+  expect(host.querySelector<HTMLElement>('[data-feed-key="group:3:0"]')!.getBoundingClientRect().top).toBe(320 - movement);
+});
+}
+
+// Opt-in real layout check. A private ephemeral HTTP fixture serves the actual
+// LogFeed bundle, with an inert tail dependency and no Viewer API or live state.
+test.skipIf(!process.env.LLV_PREPEND_BROWSER)("mobile Chromium measures prepend with native anchoring enabled and disabled", async () => {
+  const { chromium } = await import("playwright-core");
+  const source = `
+    import React from 'react';
+    import {createRoot} from 'react-dom/client';
+    import {flushSync} from 'react-dom';
+    import {LogFeed} from './src/components/LogFeed';
+    import {setLogFeedDependenciesForTests} from './src/components/logFeedDependencies';
+    const records = ${JSON.stringify(lines)};
+    const message = ${message.toString()};
+    let finish;
+    let tail = {lines: records.slice(3).concat(Array.from({length:30},(_,i)=>message('later-'+i, i%2?'assistant':'user'))),
+      linesStart:3,size:1000,loading:false,error:null,tickTime:null,paused:false,setPaused(){},clear(){},
+      hasMore:true,loadingOlder:false,prependGen:0,loadOlder:()=>new Promise(r=>finish=r)};
+    setLogFeedDependenciesForTests({useLogTail:()=>tail});
+    const root = createRoot(document.getElementById('root'));
+    const file = {path:'/fixture/browser',name:'fixture',root:'codex',engine:'codex',fmt:'codex',activity:'idle'};
+    const render=()=>flushSync(()=>root.render(<LogFeed file={file} showSvc={false} lineFilter='' onStatus={()=>{}}
+      paused={false} follow={false} setFollow={()=>{}}/>));
+    render();
+    window.prepend=()=>{tail={...tail,lines:records.slice(0,3).concat(tail.lines),linesStart:0,prependGen:1,hasMore:false};render();finish(3);};
+    window.ready=true;
+  `;
+  const baseline = process.env.LLV_PREPEND_BASELINE
+    ? await new Response(Bun.spawn(["git", "show", "ddc788e9:src/components/LogFeed.tsx"], { stdout: "pipe" }).stdout).text()
+    : null;
+  const build = await Bun.build({ entrypoints: ["prepend-browser-fixture"], target: "browser",
+    define: { "process.env.NODE_ENV": JSON.stringify("development"), "process.env": "{}" },
+    plugins: [{ name: "fixture", setup(builder) {
+      if (baseline) builder.onLoad({ filter: /[/\\]LogFeed\.tsx$/ }, () => ({ contents: baseline, loader: "tsx", resolveDir: `${process.cwd()}/src/components` }));
+      builder.onResolve({ filter: /^prepend-browser-fixture$/ }, () => ({ path: "fixture", namespace: "fixture" }));
+      builder.onLoad({ filter: /.*/, namespace: "fixture" }, () => ({ contents: source, loader: "tsx", resolveDir: process.cwd() }));
+    } }],
+  });
+  expect(build.success).toBe(true);
+  const bundle = await build.outputs[0].text();
+  const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch(request) {
+    if (new URL(request.url).pathname === "/bundle.js") return new Response(bundle, { headers: { "Content-Type": "application/javascript" } });
+    if (new URL(request.url).pathname.startsWith("/api/")) return new Response("{}", { status: 404 });
+    return new Response(`<style>
+      body{margin:0} [data-log-feed-scroller]{height:500px;overflow-y:auto;width:390px}
+      [data-feed-key]{min-height:100px;box-sizing:border-box} svg{height:16px;width:16px}
+      button{min-height:44px} [data-feed-key] pre{white-space:pre-wrap}
+    </style><div id="root"></div><script src="/bundle.js"></script>`, { headers: { "Content-Type": "text/html" } });
+  } });
+  const browser = await chromium.launch({ executablePath: process.env.LLV_PREPEND_BROWSER, headless: true,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"] });
+  try {
+    for (const anchoring of ["auto", "none"]) {
+      for (const movement of [0, 60, -60]) {
+        const page = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+        page.on("pageerror", (error) => console.log("fixture error:", error.message));
+        await page.goto(`http://127.0.0.1:${server.port}`);
+        await page.waitForFunction(() => (window as unknown as {ready:boolean}).ready);
+        await page.waitForTimeout(100);
+        const before = await page.evaluate(({ anchoring, movement }) => {
+          const scroller = document.querySelector<HTMLElement>("[data-log-feed-scroller]")!;
+          scroller.style.overflowAnchor = anchoring;
+          scroller.scrollTop = 80;
+          [...document.querySelectorAll("button")].find(b => /earlier/i.test(b.textContent ?? ""))!.click();
+          scroller.scrollTop += movement;
+          const row = document.querySelector<HTMLElement>('[data-feed-key="group:3:0"]')!;
+          return row.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+        }, { anchoring, movement });
+        await page.evaluate(() => (window as unknown as {prepend():void}).prepend());
+        await page.waitForTimeout(100);
+        const after = await page.evaluate(() => document.querySelector('[data-feed-key="group:3:0"]')!.getBoundingClientRect().top
+          - document.querySelector('[data-log-feed-scroller]')!.getBoundingClientRect().top);
+        expect(Math.abs(after - before)).toBeLessThan(1);
+        console.log(`browser anchor=${anchoring} movement=${movement} offset=${before} -> ${after}`);
+        // A delayed image below the visible row must not start a second restore.
+        await page.evaluate(async () => {
+          const last = [...document.querySelectorAll("[data-feed-key]")].at(-1)!;
+          const img = document.createElement("img"); img.width = 200; img.height = 1;
+          last.append(img);
+          await new Promise(resolve => setTimeout(resolve, 20));
+          img.height = 200;
+          img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+          await img.decode();
+        });
+        await page.waitForTimeout(50);
+        const afterImage = await page.evaluate(() => document.querySelector('[data-feed-key="group:3:0"]')!.getBoundingClientRect().top
+          - document.querySelector('[data-log-feed-scroller]')!.getBoundingClientRect().top);
+        expect(Math.abs(afterImage - before)).toBeLessThan(1);
+        await page.close();
+      }
+    }
+  } finally { await browser.close(); server.stop(true); }
+}, 30000);

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowDownToLine, CornerDownRight, type LucideIcon, Wrench } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Component, type ReactNode, type RefObject, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { ArrowDown, ChevronUp, Sparkle } from "@/components/icons";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -124,6 +124,51 @@ function viewportAnchor(scroller: HTMLElement, path: string): ViewportAnchor | n
 
 function rowForAnchor(scroller: HTMLElement, key: string): HTMLElement | null {
   return feedRows(scroller).find((row) => row.dataset.feedKey === key) ?? null;
+}
+
+interface PrependViewportProps {
+  children: ReactNode;
+  scroller: RefObject<HTMLDivElement | null>;
+  identity: string;
+  prependGen: number;
+  visibleCount: number;
+  following: RefObject<boolean>;
+}
+
+/* The before-mutation lifecycle reads the current viewport, including gestures
+   made while history was in flight. Layout-effect cleanups can run after DOM
+   mutations and therefore cannot supply this snapshot. */
+class PrependViewport extends Component<PrependViewportProps> {
+  getSnapshotBeforeUpdate(previous: PrependViewportProps): (ViewportAnchor & { toolSource?: string }) | null {
+    const { scroller, identity, prependGen, visibleCount, following } = this.props;
+    if (identity !== previous.identity || following.current
+      || (prependGen === previous.prependGen && visibleCount <= previous.visibleCount)) return null;
+    const el = scroller.current;
+    const anchor = el ? viewportAnchor(el, identity) : null;
+    if (!el || !anchor) return null;
+    const toolSource = rowForAnchor(el, anchor.key)?.dataset.feedToolSources?.split(" ")[0];
+    return { ...anchor, toolSource };
+  }
+
+  componentDidUpdate(_previous: PrependViewportProps, _state: unknown, anchor: (ViewportAnchor & { toolSource?: string }) | null) {
+    const el = this.props.scroller.current;
+    if (!el || !anchor || this.props.following.current) return;
+    // A boundary tool run can absorb older calls and acquire a new group key.
+    // Source positions disambiguate repeated provider tool ids in that run.
+    const row = rowForAnchor(el, anchor.key) ?? (anchor.toolSource
+      ? feedRows(el).find((candidate) => candidate.dataset.feedToolSources?.split(" ").includes(anchor.toolSource!))
+      : null);
+    if (!row) return;
+    // Measure the residual after native anchoring, avoiding double compensation.
+    const bounds = el.getBoundingClientRect();
+    const delta = row.getBoundingClientRect().top - bounds.top - anchor.offset;
+    // Compact panes can sit inside the scaled project canvas. DOM rectangles
+    // use viewport pixels while scrollTop uses untransformed layout pixels.
+    const scale = el.offsetHeight ? bounds.height / el.offsetHeight : 1;
+    if (delta && scale > 0) el.scrollTop += delta / scale;
+  }
+
+  render() { return this.props.children; }
 }
 
 function canScrollVertically(element: HTMLElement, deltaY: number): boolean {
@@ -276,7 +321,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   );
   const scroller = useRef<HTMLDivElement | null>(null);
   const content = useRef<HTMLDivElement | null>(null);
-  const anchorRef = useRef<{ top: number; height: number } | null>(null);
+  const olderRequestRef = useRef<object | null>(null);
+  const historyOwnerRef = useRef<object>({});
   const initialCount = compact ? COMPACT_INITIAL : RENDER_STEP;
   const revealStep = compact ? COMPACT_STEP : RENDER_STEP;
   const firstPaintCount = Math.min(FIRST_PAINT_ROWS, initialCount);
@@ -390,8 +436,6 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     const cancel = (handle: number) => (raf ? cancelAnimationFrame(handle) : clearTimeout(handle));
     let handle = schedule(() => {
       handle = schedule(() => {
-        const el = scroller.current;
-        if (el) anchorRef.current = { top: el.scrollTop, height: el.scrollHeight };
         setVisibleCount((count) => Math.max(count, initialCount));
       });
     });
@@ -529,15 +573,14 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     pendingRestoreRef.current = null;
   }, [tailPath]);
 
-  /* Older history grows the content above the viewport; keep what the user
-     was reading in place by compensating the scroll offset. */
   useLayoutEffect(() => {
-    const el = scroller.current;
-    const anchor = anchorRef.current;
-    if (!el || !anchor) return;
-    anchorRef.current = null;
-    el.scrollTop = anchor.top + (el.scrollHeight - anchor.height);
-  }, [tail.prependGen, visibleCount]);
+    historyOwnerRef.current = {};
+    olderRequestRef.current = null;
+    return () => {
+      historyOwnerRef.current = {};
+      olderRequestRef.current = null;
+    };
+  }, [tailPath, memoryKey]);
 
   /* Glued: keep the bottom in view. Keyed by item-list identity, not length —
      at the tail cap every poll trims above and appends below with the count
@@ -589,10 +632,20 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   }, []);
 
   const revealOlder = () => {
-    const el = scroller.current;
-    if (el) anchorRef.current = { top: el.scrollTop, height: el.scrollHeight };
-    if (hiddenLocal) setVisibleCount((value) => value + revealStep);
-    else if (tail.hasMore) void tail.loadOlder().then(() => setVisibleCount((value) => value + revealStep));
+    if (hiddenLocal) {
+      setVisibleCount((value) => value + revealStep);
+    } else if (tail.hasMore && !olderRequestRef.current) {
+      const owner = historyOwnerRef.current;
+      const request = {};
+      olderRequestRef.current = request;
+      void tail.loadOlder().then((added) => {
+        if (historyOwnerRef.current === owner && added > 0) {
+          setVisibleCount((value) => value + revealStep);
+        }
+      }).finally(() => {
+        if (olderRequestRef.current === request) olderRequestRef.current = null;
+      });
+    }
   };
   const canRevealOlder = hiddenLocal > 0 || tail.hasMore;
 
@@ -953,6 +1006,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
           if (el.scrollTop < 120 && canRevealOlder && !tail.loadingOlder && !tail.loading) revealOlder();
         }}
       >
+      <PrependViewport scroller={scroller} identity={`${memoryKey}\0${tailPath}`}
+        prependGen={tail.prependGen} visibleCount={visibleCount} following={magnetRef}>
       <div ref={content} className={compact ? "px-3 pb-3 text-body" : "mx-auto w-full max-w-[1060px] px-6 pb-4"}>
         {!file ? (
           <div className="mt-[20vh] text-center text-muted">{t("feed.pickLog")}</div>
@@ -1002,6 +1057,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                     key={key}
                     data-feed-key={anchorKey ?? undefined}
                     data-feed-kind={item.kind}
+                    data-feed-tool-sources={item.kind === "cmd-group" ? item.calls.map((call) => call.srcCall).join(" ")
+                      : item.kind === "tool" ? String(item.srcCall) : undefined}
                     data-feed-source-id={"sourceId" in item ? item.sourceId : undefined}
                     className={compact ? "feed-cv" : undefined}
                   >
@@ -1100,6 +1157,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
           </>
         )}
         </div>
+      </PrependViewport>
       </div>
     </div>
     {/* Bottom working-status slot: live elapsed from the transcript receipt.


### PR DESCRIPTION
When a reader moves while older history loads, the feed now preserves the row and offset visible immediately before insertion. The original implementation restored request-start geometry and undid intervening movement.

The change captures the viewport in React's before-mutation lifecycle and applies only the remaining row displacement after insertion. It accounts for native anchoring and canvas scaling, follows source positions when a tool group coalesces across the page boundary, and fences pending reveal completions across conversation changes and unmounts. Source order and parsing are unchanged.

Validation:
- Mounted regression against baseline `ddc788e9`: no movement passed; +60px and -60px failed. The +60px case reproduced offset 260 → 320.
- Actual LogFeed in mobile-sized Chromium: baseline passed no movement and failed +60px by exactly 60px. Updated code preserves measured offsets for 0/+60/-60px with native anchoring enabled and disabled, including a delayed image below the reader.
- New isolated suite: 14 tests passed (including three private API-page controls and one browser test covering six geometry cases). Coverage: modeled geometry, sanitized API-page controls, repeated loads, empty response/retry, interleaved tail growth, group coalescing, canvas scaling, conversation/project change and unmount. All 33 existing LogFeed and focused tail/scroll-memory tests passed, with each file run separately under isolated state.
- Refresh: normally merged main `bd390ffbfb83a3f56da55e51d79a51642f2afff4`; refreshed HEAD `8c44fd434df783a993477acf8665ddd677044ccd`. Original reviewed tree preserved. The earlier approvals apply only to the old head; two new exact-head reviews are required.
- Repeated locally after refresh: all 14 prepend tests (including sanitized API-page controls and six Chromium geometry cases) and 71 existing focused regressions passed, each file invoked separately in isolated state. Original +60px loss reproduced 3/3 and no-movement control passed 3/3; matched mounted baseline failed both movement directions. Chromium baseline passed no movement and lost exactly 60px with movement.
- Historical hosted checks were green at `329ef0a54d6ba992edf91910577260420e21c868`; all seven applicable refreshed-head hosted checks passed at `8c44fd434df783a993477acf8665ddd677044ccd` (including Windows on its first run and the Viewer/runtime-host verification). The old Windows preflight required one unchanged-head retry.
- Frozen dependency install; TypeScript (`bunx tsc --noEmit --incremental false`); local privacy gate.
- ESLint cannot load `react/display-name` under the frozen dependency graph (`contextOrFilename.getFilename is not a function`); the unchanged baseline fails identically.

Limits: Happy DOM geometry is explicit modeling. The browser fixture uses the actual component/parser with an inert tail and constrained CSS at 390×844, rather than the complete application shell. Browser and sanitized API-record checks are opt-in local evidence; hosted checks do not certify them. Historical Safari gesture traces, delayed media above the reader after the prepend commit, and expanded tool-group interior continuity remain unverified. This correction owns the asynchronous prepend commit only; it establishes no continuing scroll lock.

The actual tool-wall, global delivery-cycle, and historical Claude-provenance reports remain unresolved investigations. Earlier bounded tool-order and provenance controls do not clear those reports. Two fresh reviews and green required hosted gates must precede merge. No deployment.

Closes #1531
