### PR TITLE
feat(mcp): recover send/spawn outcomes under the original clientRequestId (#1490)

### DIFF
--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -2663,3 +2663,288 @@ test("an ambiguous send's operation id and resend guidance survive the control r
     globalThis.fetch = originalFetch;
   }
 });
+
+/* ── ORIGINAL-KEY RECOVERY (#1490) ─────────────────────────────────────── */
+
+import { McpDispatchUncertainError, McpToolRefusal, type McpRequestBinding } from "./server";
+import { productionViewerControlDependencies, sendDownstreamKey, viewerMcpRecoverableTools } from "./bindings";
+import { SEND_UNVERIFIED_REASON } from "@/lib/runtime/sendSettlement";
+
+const originalControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+const originalDeployTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
+afterEach(() => {
+  if (originalControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
+  else process.env.LLV_VIEWER_CONTROL_URL = originalControlUrl;
+  if (originalDeployTarget === undefined) delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  else process.env.LLV_VIEWER_DEPLOY_TARGET = originalDeployTarget;
+});
+
+async function classify(run: () => Promise<unknown>): Promise<{ kind: "answer" | "uncertain" | "refusal" | "error"; value: unknown }> {
+  try {
+    return { kind: "answer", value: await run() };
+  } catch (error) {
+    if (error instanceof McpDispatchUncertainError) return { kind: "uncertain", value: error.message };
+    if (error instanceof McpToolRefusal) return { kind: "refusal", value: { message: error.message, details: error.details } };
+    return { kind: "error", value: (error as Error).message };
+  }
+}
+
+test("the single dispatch classifies every transport outcome by what it can prove, and sends exactly once", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-dispatch-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  let requests = 0;
+  let answer: () => Response | Promise<Response> = () => Response.json({ ok: true });
+  const viewer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => {
+      requests += 1;
+      return answer();
+    },
+  });
+  process.env.LLV_VIEWER_CONTROL_URL = viewer.url.origin;
+  const dispatch = productionViewerControlDependencies().dispatch!;
+  const send = () => dispatch("/api/tmux", { text: "x" }, {}, { deadlineAt: Date.now() + 2_000 });
+  try {
+    expect(await classify(send)).toEqual({ kind: "answer", value: { ok: true } });
+    expect(requests).toBe(1);
+
+    answer = () => new Response(null, { status: 503 });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    answer = () => new Response("bad gateway", { status: 502 });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    answer = () => new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    answer = () => new Response("null", { status: 200, headers: { "content-type": "application/json" } });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    answer = () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"ok":'));
+        setTimeout(() => controller.error(new Error("cut")), 5);
+      },
+    }), { headers: { "content-type": "application/json" } });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    answer = () => new Promise<Response>(() => {});
+    expect(await classify(() => dispatch("/api/tmux", { text: "x" }, {}, { deadlineAt: Date.now() + 600 }))).toMatchObject({ kind: "uncertain", value: expect.stringContaining("deadline") });
+    expect(requests).toBe(7);
+
+    /* The server's own verdicts. */
+    answer = () => Response.json({ error: "empty message" }, { status: 400 });
+    expect(await classify(send)).toEqual({ kind: "refusal", value: { message: "empty message", details: { status: 400 } } });
+    answer = () => Response.json({ error: "delivery was started and never settled", operationId: "op_admitted", resend: "verify-first", actuation: "started" }, { status: 409 });
+    expect(await classify(send)).toEqual({
+      kind: "refusal",
+      value: { message: "delivery was started and never settled", details: { operationId: "op_admitted", resend: "verify-first", actuation: "started" } },
+    });
+    answer = () => Response.json({ error: "spawn was refused", code: "ROLE_DENIED", launchId: "launch_refused", conversationId: "conversation_refused" }, { status: 403 });
+    expect(await classify(send)).toMatchObject({ kind: "refusal", value: { details: { launchId: "launch_refused", conversationId: "conversation_refused", code: "ROLE_DENIED" } } });
+    answer = () => Response.json({ error: "host is starting", code: "HOST_STARTING" }, { status: 503 });
+    expect(await classify(send)).toMatchObject({ kind: "refusal", value: { details: { status: 503, code: "HOST_STARTING" } } });
+    answer = () => new Response("<html>not found</html>", { status: 404 });
+    expect(await classify(send)).toMatchObject({ kind: "error", value: expect.stringContaining("refused the request with status 404") });
+    /* A 409 whose body was lost may have named an admitted operation. */
+    answer = () => new Response("", { status: 409 });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    expect(requests).toBe(13);
+  } finally {
+    await viewer.stop(true);
+  }
+  /* A refused connection never carried the request: a plain (not-executed) error. */
+  expect(await classify(send)).toMatchObject({ kind: "error", value: expect.stringContaining("connection was refused") });
+});
+
+test("send and spawn bindings dispatch through the single-attempt seam with the persisted downstream key", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-dispatch-seam-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const dispatched: Array<{ pathname: string; body: Record<string, unknown> }> = [];
+  const posted: string[] = [];
+  const bindings = viewerMcpBindings(undefined, {
+    post: async (pathname) => { posted.push(pathname); return {}; },
+    dispatch: async (pathname, body) => {
+      dispatched.push({ pathname, body });
+      return pathname === "/api/spawn"
+        ? { conversationId: "conversation_new", path: null, launchId: "launch_new", state: "starting" }
+        : { operationId: "op_new", outcome: "queued" };
+    },
+  }, { registrySnapshot: () => ({ conversations: {}, conversationAliases: {} }) } as never);
+  const binding = (downstreamKey: string): McpRequestBinding => ({
+    version: 1,
+    toolName: "send_message",
+    clientRequestId: "seam-1",
+    caller: { kind: "worker", conversationId: "conversation_caller", project: null },
+    target: { project: null, identity: "conversation_target" },
+    downstreamKey,
+    owner: { pid: process.pid, startIdentity: null },
+    claimedAt: new Date().toISOString(),
+  });
+  await bindings.send_message({ clientRequestId: "seam-1", conversationId: "conversation_target", text: "hello", recoveryOnly: false }, { binding: binding("persisted-send-key") });
+  await bindings.spawn_agent({ clientRequestId: "seam-1", cwd: sandbox, "prompt": "go", title: "Seam launch", recoveryOnly: false }, { binding: { ...binding("persisted_spawn_key"), toolName: "spawn_agent" } });
+  const longKey = "k".repeat(300);
+  await bindings.send_message({ clientRequestId: longKey, conversationId: "conversation_target", text: "hello" });
+  expect(posted).toEqual([]);
+  expect(dispatched.map((request) => request.pathname)).toEqual(["/api/tmux", "/api/spawn", "/api/tmux"]);
+  expect(dispatched[0]?.body.clientMessageId).toBe("persisted-send-key");
+  expect(dispatched[1]?.body.clientAttemptId).toBe("persisted_spawn_key");
+  expect("recoveryOnly" in dispatched[1]!.body).toBe(false);
+  /* Without a binding the key is derived, bounded to what the route keeps. */
+  expect(dispatched[2]?.body.clientMessageId).toBe(sendDownstreamKey(longKey));
+  expect(sendDownstreamKey(longKey).length).toBeLessThanOrEqual(128);
+  expect(sendDownstreamKey(longKey)).toBe(sendDownstreamKey(longKey));
+  expect(sendDownstreamKey(longKey)).not.toBe(sendDownstreamKey(`${longKey}x`));
+  expect(sendDownstreamKey("short-key")).toBe("short-key");
+});
+
+test("bind resolves caller and target server-side, never from the arguments", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bind-"));
+  sandboxes.push(sandbox);
+  const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const transcriptPath = path.join(sandbox, "recipient.jsonl");
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: transcriptPath,
+    accountId: "bind-fixture-account",
+    launchProfile: emptyLaunchProfile({ cwd: sandbox }),
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-09-05T08:00:00.000Z",
+  }]);
+  const recipient = Object.values(registry.snapshot().conversations)[0]!;
+  const tools = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    attentionAuthority: () => ({ kind: "worker", conversationId: "conversation_real_caller", role: "builder" }),
+    callerProject: () => "proj-real",
+  } as never);
+  const forged = { callerConversationId: "conversation_forged", callerProject: "proj-forged", caller: { kind: "root" }, origin: { kind: "operator" } };
+  const send = await tools.send_message!.bind({ clientRequestId: "bind-request-1", transcriptPath, text: "hi", ...forged });
+  expect(send).toMatchObject({
+    caller: { kind: "worker", conversationId: "conversation_real_caller", project: "proj-real" },
+    target: { identity: recipient.id },
+    downstreamKey: "bind-request-1",
+  });
+  const spawn = await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", ...forged });
+  expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: "conversation_real_caller", project: "proj-real" }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
+  expect(typeof spawn.target.project).toBe("string");
+  expect(await tools.spawn_agent!.bind({ clientRequestId: "x".repeat(200), cwd: sandbox, "prompt": "go", title: "Bind launch" }))
+    .toMatchObject({ downstreamKey: expect.stringMatching(/^mcp_[0-9a-f]{24}$/) });
+
+  /* A faulting or absent resolver reads as unidentified, which fails closed. */
+  const faulting = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    attentionAuthority: () => { throw new Error("registry unreadable"); },
+  } as never);
+  expect(await faulting.send_message!.bind({ clientRequestId: "bind-2", conversationId: recipient.id, text: "hi" }))
+    .toMatchObject({ caller: { kind: "unidentified", conversationId: null, project: null } });
+  expect(() => tools.send_message!.bind({ clientRequestId: "bind-3", text: "hi" })).toThrow("conversationId or transcriptPath is required");
+  expect(() => tools.spawn_agent!.bind({ clientRequestId: "bind-3", "prompt": "go" })).toThrow("cwd is required");
+});
+
+test("send recovery maps the durable delivery record to the closed outcome set", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recover-send-"));
+  sandboxes.push(sandbox);
+  const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const transcriptPath = path.join(sandbox, "recipient.jsonl");
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: transcriptPath,
+    accountId: "recover-fixture-account",
+    launchProfile: emptyLaunchProfile({ cwd: sandbox }),
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-09-05T08:00:00.000Z",
+  }]);
+  const recipient = Object.values(registry.snapshot().conversations)[0]!;
+  const generationId = recipient.generations.at(-1)!.id;
+  const tools = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    attentionAuthority: () => ({ kind: "worker", conversationId: "conversation_caller", role: null }),
+    sendSettlementPorts: () => ({ registry, client: null }),
+  } as never);
+  const binding = (key: string, legacy = false): [McpRequestBinding, { legacy: boolean }] => [{
+    version: 1,
+    toolName: "send_message",
+    clientRequestId: key,
+    caller: { kind: "worker", conversationId: "conversation_caller", project: null },
+    target: { project: null, identity: recipient.id },
+    downstreamKey: key,
+    owner: { pid: process.pid, startIdentity: null },
+    claimedAt: new Date().toISOString(),
+  }, { legacy }];
+  const recover = tools.send_message!.recover;
+
+  expect(await recover(...binding("absent"))).toMatchObject({ outcome: "unknown", evidence: "none", ids: {} });
+  /* Legacy: a send has no durable sender identity, so ownership is never established. */
+  const reservation = registry.holdDelivery(recipient.id, "hold", "legacy-key", "text", [], null, { operationId: "op_legacy", kind: "send", policy: "queue" });
+  const legacy = await recover(...binding("legacy-key", true));
+  expect(legacy).toMatchObject({ outcome: "unknown", evidence: "legacy-receipt-unbound", ownership: "unknown", ids: {} });
+  expect(JSON.stringify(legacy)).not.toContain("op_legacy");
+
+  const held = registry.holdDelivery(recipient.id, "hold", "accepted-key", "text", [], null, { operationId: "op_accepted", kind: "send", policy: "queue" });
+  expect(await recover(...binding("accepted-key"))).toMatchObject({ outcome: "accepted", evidence: "delivery-record", ids: { operationId: "op_accepted", conversationId: recipient.id, deliveryId: held.id } });
+  registry.beginDeliveryAttempt(held.id, generationId);
+  expect(await recover(...binding("accepted-key"))).toMatchObject({ outcome: "in-flight", ids: { operationId: "op_accepted" }, facts: { state: "in-flight" } });
+  registry.recordDeliveryOutcome(held.id, "delivered", null, "delivered");
+  expect(await recover(...binding("accepted-key"))).toMatchObject({ outcome: "settled", ids: { operationId: "op_accepted" }, facts: { state: "delivered", resend: "not-needed", duplicateRisk: false } });
+  registry.recordDeliveryOutcome(reservation.id, "failed", SEND_UNVERIFIED_REASON, "unverified");
+  expect(await recover(...binding("legacy-key"))).toMatchObject({ outcome: "settled", reason: SEND_UNVERIFIED_REASON, facts: { state: "failed", resend: "verify-first", duplicateRisk: true } });
+
+  /* Unreadable state keeps uncertainty; a bound target with no identity is unknown. */
+  const broken = viewerMcpRecoverableTools({
+    registrySnapshot: () => { throw new Error("registry unreadable"); },
+    sendSettlementPorts: () => ({ registry: { readOnlySnapshot: () => { throw new Error("registry unreadable"); } } as never, client: null }),
+  } as never);
+  expect(await broken.send_message!.recover(...binding("accepted-key"))).toMatchObject({ outcome: "unknown", evidence: "delivery-record", reason: expect.stringContaining("registry unreadable"), ids: {} });
+  const [unbound, options] = binding("accepted-key");
+  expect(await recover({ ...unbound, target: { project: null, identity: null } }, options)).toMatchObject({ outcome: "unknown", ids: {} });
+});
+
+test("spawn recovery maps the launch receipt to the closed outcome set and establishes legacy ownership only from the parent edge", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recover-spawn-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const tools = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    attentionAuthority: () => ({ kind: "worker", conversationId: "conversation_caller", role: null }),
+  } as never);
+  const recover = tools.spawn_agent!.recover;
+  const binding = (key: string, legacy = false, caller = "conversation_caller"): [McpRequestBinding, { legacy: boolean }] => [{
+    version: 1,
+    toolName: "spawn_agent",
+    clientRequestId: key,
+    caller: { kind: "worker", conversationId: caller, project: null },
+    target: { project: null, identity: sandbox },
+    downstreamKey: key,
+    owner: { pid: process.pid, startIdentity: null },
+    claimedAt: new Date().toISOString(),
+  }, { legacy }];
+
+  expect(await recover(...binding("absent_attempt"))).toMatchObject({ outcome: "unknown", evidence: "none", ids: {} });
+  expect(await recover(...binding("absent_attempt", true))).toMatchObject({ outcome: "unknown", ownership: "unknown" });
+
+  const parent = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Parent conversation" });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: sandbox,
+    clientAttemptId: "child_attempt_1",
+    launchProfile: { cwd: sandbox, title: "Child launch" },
+    parentConversationId: parent.conversationId,
+    transport: "structured",
+  });
+  if (begun.kind !== "created") throw new Error("fixture receipt was not created");
+  const ids = { launchId: begun.receipt.launchId, conversationId: begun.receipt.conversationId };
+  expect(await recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "accepted", evidence: "spawn-receipt", ids, facts: { state: "starting" } });
+
+  /* Legacy ownership: only the durable parent edge establishes it. */
+  const owned = await recover(...binding("child_attempt_1", true, parent.conversationId));
+  expect(owned).toMatchObject({ outcome: "accepted", ownership: "established", ids });
+  const notOwned = await recover(...binding("child_attempt_1", true, "conversation_someone_else"));
+  expect(notOwned).toMatchObject({ outcome: "unknown", evidence: "legacy-receipt-unbound", ownership: "unknown", ids: {} });
+  expect(JSON.stringify(notOwned)).not.toContain(ids.launchId);
+
+  registry.failStructuredSpawn(ids.launchId, "structured spawn transport failed: fixture");
+  expect(await recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "settled", ids, facts: { state: "failed", launched: false }, reason: expect.stringContaining("fixture") });
+
+  const broken = viewerMcpRecoverableTools({ registrySnapshot: () => { throw new Error("registry unreadable"); } } as never);
+  expect(await broken.spawn_agent!.recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "unknown", evidence: "spawn-receipt", reason: expect.stringContaining("registry unreadable") });
+});

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -2798,7 +2798,16 @@ test("send and spawn bindings dispatch through the single-attempt seam with the 
     claimedAt: new Date().toISOString(),
   });
   await bindings.send_message({ clientRequestId: "seam-1", conversationId: "conversation_target", text: "hello", recoveryOnly: false }, { binding: binding("persisted-send-key") });
-  await bindings.spawn_agent({ clientRequestId: "seam-1", cwd: sandbox, "prompt": "go", title: "Seam launch", recoveryOnly: false }, { binding: { ...binding("persisted_spawn_key"), toolName: "spawn_agent" } });
+  await bindings.spawn_agent({ clientRequestId: "seam-1", cwd: sandbox, "prompt": "go", title: "Seam launch", recoveryOnly: false }, {
+    binding: { ...binding("persisted_spawn_key"), toolName: "spawn_agent", target: { project: projectForCwd(sandbox), identity: sandbox } },
+  });
+  /* A persisted binding that does not name the canonical target of these
+     arguments is not dispatched under: refused before the request is built. */
+  const drifted = { ...binding("persisted_spawn_key"), toolName: "spawn_agent" as const, target: { project: "proj-forged", identity: sandbox } };
+  expect(bindings.spawn_agent({ clientRequestId: "seam-2", cwd: sandbox, "prompt": "go", title: "Seam launch" }, { binding: drifted }))
+    .rejects.toMatchObject({ details: { code: "binding_mismatch", status: 400 } });
+  await expect(bindings.spawn_agent({ clientRequestId: "seam-2", cwd: sandbox, "prompt": "go", title: "Seam launch" }, { binding: drifted })).rejects.toThrow("canonical target");
+  expect(dispatched.filter((call) => call.pathname === "/api/spawn")).toHaveLength(1);
   const longKey = "k".repeat(300);
   await bindings.send_message({ clientRequestId: longKey, conversationId: "conversation_target", text: "hello" });
   expect(posted).toEqual([]);
@@ -2870,6 +2879,23 @@ test("bind resolves caller and target server-side, never from the arguments", as
   const spawn = await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", ...forged });
   expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: callerA.id, project: projectA }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
   expect(typeof spawn.target.project).toBe("string");
+  /* The target project is the launch directory's and nothing the arguments
+     say: a supplied `project` may only repeat it. A contradiction — another
+     project, a value that is not a project key — is refused before any
+     claim, because the route would record it as the conversation's owner. */
+  const canonical = spawn.target.project!;
+  expect(await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", project: canonical }))
+    .toMatchObject({ target: { project: canonical, identity: sandbox } });
+  for (const project of ["proj-forged", projectB, "not a project key!"]) {
+    expect(() => tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", project }))
+      .toThrow("contradicts the canonical project");
+  }
+  try {
+    tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", project: "proj-forged" });
+  } catch (error) {
+    expect(error).toBeInstanceOf(McpToolRefusal);
+    expect((error as McpToolRefusal).details).toMatchObject({ code: "invalid_request", status: 400, canonicalProject: canonical });
+  }
   expect(await tools.spawn_agent!.bind({ clientRequestId: "x".repeat(200), cwd: sandbox, "prompt": "go", title: "Bind launch" }))
     .toMatchObject({ downstreamKey: expect.stringMatching(/^mcp_[0-9a-f]{24}$/) });
   /* Another authenticated conversation binds to ITS project: a replay from a

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -550,7 +550,7 @@ test("runtime-bound MCP tools use the live Viewer control surface", async () => 
   ]);
   expect(requests[0]?.body.clientAttemptId).toBe("spawn-http-control");
   expect(requests[0]?.body.mcpServers).toEqual(["viewer", "agent-browser"]);
-  expect(requests[1]?.body.clientMessageId).toBe("send-http-control");
+  expect(requests[1]?.body.clientMessageId).toBe(sendDownstreamKey("send-http-control"));
   expect(requests[1]?.body.text).toBe(exactMessage);
   expect(requests[1]?.headers?.[VIEWER_SPAWN_CAPABILITY_HEADER]).toBe("c".repeat(43));
   expect(requests[2]?.body.idempotencyKey).toBe("deploy-http-control");
@@ -2838,7 +2838,8 @@ test("send and spawn bindings dispatch through the single-attempt seam with the 
   expect(sendDownstreamKey(longKey).length).toBeLessThanOrEqual(128);
   expect(sendDownstreamKey(longKey)).toBe(sendDownstreamKey(longKey));
   expect(sendDownstreamKey(longKey)).not.toBe(sendDownstreamKey(`${longKey}x`));
-  expect(sendDownstreamKey("short-key")).toBe("short-key");
+  expect(sendDownstreamKey("short-key")).not.toBe("short-key");
+  expect(sendDownstreamKey(sendDownstreamKey(longKey))).not.toBe(sendDownstreamKey(longKey));
 });
 
 test("bind resolves caller and target server-side, never from the arguments", async () => {
@@ -2892,12 +2893,12 @@ test("bind resolves caller and target server-side, never from the arguments", as
   expect(send).toMatchObject({
     caller: { kind: "worker", conversationId: callerA.id, project: projectA },
     target: { identity: recipient.id },
-    downstreamKey: "bind-request-1",
+    downstreamKey: sendDownstreamKey("bind-request-1"),
   });
   expect(await tools.send_message!.bind({ clientRequestId: "unindexed", transcriptPath: path.join(sandbox, "late.jsonl"), text: "hi" }))
     .toMatchObject({ target: { identity: path.join(sandbox, "late.jsonl") } });
   const spawn = await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", ...forged });
-  expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: callerA.id, project: projectA }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
+  expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: callerA.id, project: projectA }, target: { identity: sandbox }, downstreamKey: expect.stringMatching(/^mcp_spawn_[0-9a-f]{64}$/) });
   expect(typeof spawn.target.project).toBe("string");
   /* The target project is the launch directory's and nothing the arguments
      say: a supplied `project` may only repeat it. A contradiction — another
@@ -2917,7 +2918,7 @@ test("bind resolves caller and target server-side, never from the arguments", as
     expect((error as McpToolRefusal).details).toMatchObject({ code: "invalid_request", status: 400, canonicalProject: canonical });
   }
   expect(await tools.spawn_agent!.bind({ clientRequestId: "x".repeat(200), cwd: sandbox, "prompt": "go", title: "Bind launch" }))
-    .toMatchObject({ downstreamKey: expect.stringMatching(/^mcp_[0-9a-f]{24}$/) });
+    .toMatchObject({ downstreamKey: expect.stringMatching(/^mcp_spawn_[0-9a-f]{64}$/) });
   /* Another authenticated conversation binds to ITS project: a replay from a
      caller whose project differs is what the service then refuses. */
   authority = { kind: "worker", conversationId: callerB.id, role: "builder" };
@@ -2990,6 +2991,10 @@ test("send recovery maps the durable delivery record to the closed outcome set",
   registry.recordDeliveryOutcome(reservation.id, "failed", SEND_UNVERIFIED_REASON, "unverified");
   expect(await recover(...binding("legacy-key"))).toMatchObject({ outcome: "settled", reason: SEND_UNVERIFIED_REASON, facts: { state: "failed", resend: "verify-first", duplicateRisk: true } });
 
+  const [payloadBinding] = binding("accepted-key");
+  expect(await recover(payloadBinding, { legacy: false, args: { text: "another caller payload" } }))
+    .toMatchObject({ outcome: "unknown", ids: {}, ownership: "unknown" });
+
   /* A target bound to a path the registry never resolved matches no record:
      one or many operations under the key, none is disclosed. */
   const [byPath, pathOptions] = binding("accepted-key");
@@ -3047,7 +3052,12 @@ test("spawn recovery maps the launch receipt to the closed outcome set and estab
   });
   if (begun.kind !== "created") throw new Error("fixture receipt was not created");
   const ids = { launchId: begun.receipt.launchId, conversationId: begun.receipt.conversationId };
-  expect(await recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "accepted", evidence: "spawn-receipt", ids, facts: { state: "starting" } });
+  expect(await recover(...binding("child_attempt_1", false, parent.conversationId))).toMatchObject({ outcome: "accepted", evidence: "spawn-receipt", ids, facts: { state: "starting" } });
+
+  expect(await recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "unknown", ids: {}, ownership: "unknown" });
+  const [ownedBinding] = binding("child_attempt_1", false, parent.conversationId);
+  expect(await recover({ ...ownedBinding, target: { project: null, identity: path.join(sandbox, "elsewhere") } }, { legacy: false }))
+    .toMatchObject({ outcome: "unknown", ids: {}, ownership: "unknown" });
 
   /* Legacy ownership: only the durable parent edge establishes it. */
   const owned = await recover(...binding("child_attempt_1", true, parent.conversationId));
@@ -3057,7 +3067,7 @@ test("spawn recovery maps the launch receipt to the closed outcome set and estab
   expect(JSON.stringify(notOwned)).not.toContain(ids.launchId);
 
   registry.failStructuredSpawn(ids.launchId, "structured spawn transport failed: fixture");
-  expect(await recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "settled", ids, facts: { state: "failed", launched: false }, reason: expect.stringContaining("fixture") });
+  expect(await recover(...binding("child_attempt_1", false, parent.conversationId))).toMatchObject({ outcome: "settled", ids, facts: { state: "failed", launched: false }, reason: expect.stringContaining("fixture") });
 
   const broken = viewerMcpRecoverableTools({ registrySnapshot: () => { throw new Error("registry unreadable"); } } as never);
   expect(await broken.spawn_agent!.recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "unknown", evidence: "spawn-receipt", reason: expect.stringContaining("registry unreadable") });

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -172,7 +172,7 @@ test("MCP message delivery always presents authenticated service provenance with
   const send = viewerMcpBindings(undefined, {
     post: async (_pathname, _body, headers) => {
       requests.push({ headers });
-      return { outcome: "delivered" };
+      return { operationId: "op_service_provenance", outcome: "delivered" };
     },
   }).send_message;
   const previous = process.env[VIEWER_SPAWN_CAPABILITY_ENV];
@@ -314,7 +314,8 @@ test("spawn_agent derives required role params from the prompt and preserves sup
         conversationId: `conversation_${bodies.length}`,
         path: `/repo/session-${bodies.length}.jsonl`,
         launchId: `launch_${bodies.length}`,
-        state: "queued",
+        state: "starting",
+        initialMessage: "pending",
       };
     },
   }).spawn_agent;
@@ -398,7 +399,8 @@ test("spawn_agent coerces and clamps bounded role params before the control requ
         conversationId: `conversation_${bodies.length}`,
         path: `/repo/session-${bodies.length}.jsonl`,
         launchId: `launch_${bodies.length}`,
-        state: "queued",
+        state: "starting",
+        initialMessage: "pending",
       };
     },
   }), new MemoryMcpReceiptStore());
@@ -2799,7 +2801,7 @@ test("send and spawn bindings dispatch through the single-attempt seam with the 
     dispatch: async (pathname, body) => {
       dispatched.push({ pathname, body });
       return pathname === "/api/spawn"
-        ? { conversationId: "conversation_new", path: null, launchId: "launch_new", state: "starting" }
+        ? { conversationId: "conversation_new", path: null, launchId: "launch_new", state: "starting", initialMessage: "pending" }
         : { operationId: "op_new", outcome: "queued" };
     },
   }, { registrySnapshot: () => ({ conversations: {}, conversationAliases: {} }) } as never);
@@ -3059,4 +3061,61 @@ test("spawn recovery maps the launch receipt to the closed outcome set and estab
 
   const broken = viewerMcpRecoverableTools({ registrySnapshot: () => { throw new Error("registry unreadable"); } } as never);
   expect(await broken.spawn_agent!.recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "unknown", evidence: "spawn-receipt", reason: expect.stringContaining("registry unreadable") });
+});
+
+
+test("incomplete and contradictory mutation answers remain unknown when no durable evidence exists, including SQLite restart", async () => {
+  const { SqliteMcpReceiptStore } = await import("./server");
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-incomplete-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const databasePath = path.join(sandbox, "receipts.sqlite");
+  let response: Record<string, unknown> = {};
+  let dispatches = 0;
+  let reads = 0;
+  const bindings = viewerMcpBindings(undefined, {
+    post: async () => { throw new Error("automatic POST fallback is forbidden"); },
+    dispatch: async () => { dispatches += 1; return response; },
+  }, { registrySnapshot: () => ({ conversations: {}, conversationAliases: {} }) } as never);
+  const caller = { kind: "worker" as const, conversationId: "conversation_caller", project: null };
+  const recovery = {
+    bind: (args: Record<string, unknown>) => ({ caller, target: { identity: String(args.conversationId ?? args.cwd), project: projectForCwd(sandbox) }, downstreamKey: String(args.clientRequestId) }),
+    recover: async () => { reads += 1; return { outcome: "unknown" as const, evidence: "none", reason: null, ids: {} }; },
+  };
+  let store = new SqliteMcpReceiptStore(databasePath);
+  const service = () => createMcpToolService(bindings, store, undefined, { recovery: { send_message: recovery, spawn_agent: recovery } });
+  try {
+    for (const tool of ["send_message", "spawn_agent"] as const) {
+      const valid = tool === "send_message"
+        ? { operationId: "op_answer", outcome: "delivered" }
+        : { launchId: "launch_answer", conversationId: "conversation_answer", state: "settled", initialMessage: "delivered" };
+      const incomplete = Object.keys(valid).map((key) => Object.fromEntries(Object.entries(valid).filter(([field]) => field !== key)));
+      const contradictory = tool === "send_message"
+        ? [{ ...valid, receipt: { operationId: "op_other", status: "delivered" } },
+          { ...valid, receipt: { operationId: "op_answer", status: "queued" } },
+          { ...valid, outcome: "queued", receipt: { operationId: "op_answer", status: "delivered" } },
+          { ...valid, outcome: "unknown" }, { ...valid, operationId: 123 }]
+        : [{ ...valid, state: "starting" }, { ...valid, state: " starting " }, { ...valid, launched: false },
+          { ...valid, retrySafe: true }, { ...valid, path: {} }, { ...valid, conversationId: 123 }];
+      for (const [index, value] of [{}, { ok: true }, ...incomplete, ...contradictory, { ...valid, ok: false }].entries()) {
+        response = value;
+        const clientRequestId = `${tool}-incomplete-${index}`;
+        const args = tool === "send_message"
+          ? { clientRequestId, conversationId: "conversation_target", text: "hello" }
+          : { clientRequestId, cwd: sandbox, prompt: "go", title: "Incomplete response" };
+        const before = dispatches;
+        const beforeReads = reads;
+        const unknown = { ok: false, code: "outcome_unknown", retryable: false, details: { outcome: "unknown", nextAction: "original-key-lookup" } };
+        expect(await service().callTool(tool, args)).toMatchObject(unknown);
+        expect(reads).toBeGreaterThan(beforeReads);
+        store.close();
+        store = new SqliteMcpReceiptStore(databasePath);
+        expect(await service().callTool(tool, { ...args, recoveryOnly: true })).toMatchObject(unknown);
+        expect(await service().callTool(tool, args)).toMatchObject(unknown);
+        expect(dispatches).toBe(before + 1);
+      }
+    }
+  } finally {
+    store.close();
+  }
 });

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -2757,11 +2757,27 @@ test("the single dispatch classifies every transport outcome by what it can prov
     answer = () => Response.json({ error: "host is starting", code: "HOST_STARTING" }, { status: 503 });
     expect(await classify(send)).toMatchObject({ kind: "verdict", value: { details: { status: 503, code: "HOST_STARTING" } } });
     answer = () => new Response("<html>not found</html>", { status: 404 });
-    expect(await classify(send)).toMatchObject({ kind: "verdict", value: { message: expect.stringContaining("refused the request with status 404"), details: { status: 404 } } });
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
     /* A 409 whose body was lost may have named an admitted operation. */
     answer = () => new Response("", { status: 409 });
     expect(await classify(send)).toMatchObject({ kind: "uncertain" });
     expect(requests).toBe(13);
+    // Exercise every error status, including nonstandard proxy 4xx/5xx,
+    // for both mutation endpoints. An unreadable body proves no refusal.
+    for (const pathname of ["/api/tmux", "/api/spawn"]) {
+      for (let status = 300; status <= 599; status += 1) {
+        answer = () => new Response("<html>response lost</html>", { status });
+        const before = requests;
+        expect(await classify(() => dispatch(pathname, {}, {}, { deadlineAt: Date.now() + 2_000 }))).toMatchObject({ kind: "uncertain" });
+        expect(requests).toBe(before + 1);
+      }
+    }
+
+    // A 307 must not automatically repeat the POST at its Location.
+    answer = () => new Response(null, { status: 307, headers: { location: "/redirected" } });
+    const beforeRedirect = requests;
+    expect(await classify(send)).toMatchObject({ kind: "uncertain" });
+    expect(requests).toBe(beforeRedirect + 1);
     expect(tracker.attempted).toBe(true);
   } finally {
     unanswered.release?.(Response.json({ ok: true }));
@@ -2876,6 +2892,8 @@ test("bind resolves caller and target server-side, never from the arguments", as
     target: { identity: recipient.id },
     downstreamKey: "bind-request-1",
   });
+  expect(await tools.send_message!.bind({ clientRequestId: "unindexed", transcriptPath: path.join(sandbox, "late.jsonl"), text: "hi" }))
+    .toMatchObject({ target: { identity: path.join(sandbox, "late.jsonl") } });
   const spawn = await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", ...forged });
   expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: callerA.id, project: projectA }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
   expect(typeof spawn.target.project).toBe("string");

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -2655,6 +2655,7 @@ test("an ambiguous send's operation id and resend guidance survive the control r
     expect(refusal).toBeInstanceOf(Error);
     expect((refusal as Error).message).toContain("delivery was started and never settled");
     expect((refusal as { details?: Record<string, unknown> }).details).toEqual({
+      status: 409,
       operationId,
       resend: "verify-first",
       actuation: "started",
@@ -2666,9 +2667,10 @@ test("an ambiguous send's operation id and resend guidance survive the control r
 
 /* ── ORIGINAL-KEY RECOVERY (#1490) ─────────────────────────────────────── */
 
-import { McpDispatchUncertainError, McpToolRefusal, type McpRequestBinding } from "./server";
-import { productionViewerControlDependencies, sendDownstreamKey, viewerMcpRecoverableTools } from "./bindings";
+import { McpDispatchNotExecutedError, McpDispatchUncertainError, McpDispatchVerdictError, McpToolRefusal, type McpDispatchTracker, type McpRequestBinding } from "./server";
+import { productionDomainDependencies, productionViewerControlDependencies, sendDownstreamKey, viewerMcpRecoverableTools } from "./bindings";
 import { SEND_UNVERIFIED_REASON } from "@/lib/runtime/sendSettlement";
+import { projectForCwd } from "@/lib/scanner/describe";
 
 const originalControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
 const originalDeployTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
@@ -2679,11 +2681,13 @@ afterEach(() => {
   else process.env.LLV_VIEWER_DEPLOY_TARGET = originalDeployTarget;
 });
 
-async function classify(run: () => Promise<unknown>): Promise<{ kind: "answer" | "uncertain" | "refusal" | "error"; value: unknown }> {
+async function classify(run: () => Promise<unknown>): Promise<{ kind: "answer" | "uncertain" | "verdict" | "refusal" | "not-executed" | "error"; value: unknown }> {
   try {
     return { kind: "answer", value: await run() };
   } catch (error) {
     if (error instanceof McpDispatchUncertainError) return { kind: "uncertain", value: error.message };
+    if (error instanceof McpDispatchNotExecutedError) return { kind: "not-executed", value: error.message };
+    if (error instanceof McpDispatchVerdictError) return { kind: "verdict", value: { message: error.message, details: error.details } };
     if (error instanceof McpToolRefusal) return { kind: "refusal", value: { message: error.message, details: error.details } };
     return { kind: "error", value: (error as Error).message };
   }
@@ -2706,10 +2710,20 @@ test("the single dispatch classifies every transport outcome by what it can prov
   });
   process.env.LLV_VIEWER_CONTROL_URL = viewer.url.origin;
   const dispatch = productionViewerControlDependencies().dispatch!;
-  const send = () => dispatch("/api/tmux", { text: "x" }, {}, { deadlineAt: Date.now() + 2_000 });
+  /* The tracker the service hands down: the transport marks it the moment the
+     request may be on the wire, and never before. */
+  let tracker: McpDispatchTracker = { attempted: false };
+  const send = () => {
+    tracker = { attempted: false };
+    return dispatch("/api/tmux", { text: "x" }, {}, { deadlineAt: Date.now() + 2_000, dispatch: tracker });
+  };
+  /* The deliberately unanswered request, released before the server stops so
+     the teardown never waits on a handler that would otherwise hang forever. */
+  const unanswered: { release: ((response: Response) => void) | null } = { release: null };
   try {
     expect(await classify(send)).toEqual({ kind: "answer", value: { ok: true } });
     expect(requests).toBe(1);
+    expect(tracker.attempted).toBe(true);
 
     answer = () => new Response(null, { status: 503 });
     expect(await classify(send)).toMatchObject({ kind: "uncertain" });
@@ -2726,33 +2740,36 @@ test("the single dispatch classifies every transport outcome by what it can prov
       },
     }), { headers: { "content-type": "application/json" } });
     expect(await classify(send)).toMatchObject({ kind: "uncertain" });
-    answer = () => new Promise<Response>(() => {});
+    answer = () => new Promise<Response>((resolve) => { unanswered.release = resolve; });
     expect(await classify(() => dispatch("/api/tmux", { text: "x" }, {}, { deadlineAt: Date.now() + 600 }))).toMatchObject({ kind: "uncertain", value: expect.stringContaining("deadline") });
     expect(requests).toBe(7);
 
-    /* The server's own verdicts. */
+    /* The server's own verdicts, tagged as such and carrying their status. */
     answer = () => Response.json({ error: "empty message" }, { status: 400 });
-    expect(await classify(send)).toEqual({ kind: "refusal", value: { message: "empty message", details: { status: 400 } } });
+    expect(await classify(send)).toEqual({ kind: "verdict", value: { message: "empty message", details: { status: 400 } } });
     answer = () => Response.json({ error: "delivery was started and never settled", operationId: "op_admitted", resend: "verify-first", actuation: "started" }, { status: 409 });
     expect(await classify(send)).toEqual({
-      kind: "refusal",
-      value: { message: "delivery was started and never settled", details: { operationId: "op_admitted", resend: "verify-first", actuation: "started" } },
+      kind: "verdict",
+      value: { message: "delivery was started and never settled", details: { status: 409, operationId: "op_admitted", resend: "verify-first", actuation: "started" } },
     });
     answer = () => Response.json({ error: "spawn was refused", code: "ROLE_DENIED", launchId: "launch_refused", conversationId: "conversation_refused" }, { status: 403 });
-    expect(await classify(send)).toMatchObject({ kind: "refusal", value: { details: { launchId: "launch_refused", conversationId: "conversation_refused", code: "ROLE_DENIED" } } });
+    expect(await classify(send)).toMatchObject({ kind: "verdict", value: { details: { status: 403, launchId: "launch_refused", conversationId: "conversation_refused", code: "ROLE_DENIED" } } });
     answer = () => Response.json({ error: "host is starting", code: "HOST_STARTING" }, { status: 503 });
-    expect(await classify(send)).toMatchObject({ kind: "refusal", value: { details: { status: 503, code: "HOST_STARTING" } } });
+    expect(await classify(send)).toMatchObject({ kind: "verdict", value: { details: { status: 503, code: "HOST_STARTING" } } });
     answer = () => new Response("<html>not found</html>", { status: 404 });
-    expect(await classify(send)).toMatchObject({ kind: "error", value: expect.stringContaining("refused the request with status 404") });
+    expect(await classify(send)).toMatchObject({ kind: "verdict", value: { message: expect.stringContaining("refused the request with status 404"), details: { status: 404 } } });
     /* A 409 whose body was lost may have named an admitted operation. */
     answer = () => new Response("", { status: 409 });
     expect(await classify(send)).toMatchObject({ kind: "uncertain" });
     expect(requests).toBe(13);
+    expect(tracker.attempted).toBe(true);
   } finally {
+    unanswered.release?.(Response.json({ ok: true }));
     await viewer.stop(true);
   }
-  /* A refused connection never carried the request: a plain (not-executed) error. */
-  expect(await classify(send)).toMatchObject({ kind: "error", value: expect.stringContaining("connection was refused") });
+  /* A refused connection never carried the request: proven not executed. */
+  expect(await classify(send)).toMatchObject({ kind: "not-executed", value: expect.stringContaining("connection was refused") });
+  expect(tracker.attempted).toBe(true);
 });
 
 test("send and spawn bindings dispatch through the single-attempt seam with the persisted downstream key", async () => {
@@ -2811,30 +2828,69 @@ test("bind resolves caller and target server-side, never from the arguments", as
     observedAt: "2026-09-05T08:00:00.000Z",
   }]);
   const recipient = Object.values(registry.snapshot().conversations)[0]!;
+  /* Two calling conversations launched from two directories: the project a
+     caller is bound to is the canonical one of the conversation the server
+     authenticated, read from the registry, never a separately resolved guess. */
+  const callerCwdA = path.join(sandbox, "caller-a");
+  const callerCwdB = path.join(sandbox, "caller-b");
+  const callerFor = (cwd: string, name: string) => {
+    const callerPath = path.join(cwd, `${name}.jsonl`);
+    registry.reconcileConversations([{
+      engine: "codex",
+      path: callerPath,
+      accountId: "bind-fixture-account",
+      launchProfile: emptyLaunchProfile({ cwd }),
+      turn: { state: "idle", source: "assistant", terminalAt: null },
+      observedAt: "2026-09-05T08:00:00.000Z",
+    }]);
+    return registry.conversationForPath(callerPath)!;
+  };
+  const callerA = callerFor(callerCwdA, "caller-a");
+  const callerB = callerFor(callerCwdB, "caller-b");
+  const projectA = projectForCwd(callerCwdA);
+  const projectB = projectForCwd(callerCwdB);
+  expect(typeof projectA).toBe("string");
+  expect(projectA).not.toBe(projectB);
+  let authority: { kind: "worker"; conversationId: string; role: string | null } = { kind: "worker", conversationId: callerA.id, role: "builder" };
+  /* The REAL production dependency set, with only the registry projection and
+     the caller-authority seam replaced — so a resolver the production set does
+     not wire cannot pass here. */
   const tools = viewerMcpRecoverableTools({
+    ...productionDomainDependencies,
     registrySnapshot: () => registry.readOnlySnapshot(),
-    attentionAuthority: () => ({ kind: "worker", conversationId: "conversation_real_caller", role: "builder" }),
-    callerProject: () => "proj-real",
-  } as never);
+    attentionAuthority: () => authority,
+  });
   const forged = { callerConversationId: "conversation_forged", callerProject: "proj-forged", caller: { kind: "root" }, origin: { kind: "operator" } };
   const send = await tools.send_message!.bind({ clientRequestId: "bind-request-1", transcriptPath, text: "hi", ...forged });
   expect(send).toMatchObject({
-    caller: { kind: "worker", conversationId: "conversation_real_caller", project: "proj-real" },
+    caller: { kind: "worker", conversationId: callerA.id, project: projectA },
     target: { identity: recipient.id },
     downstreamKey: "bind-request-1",
   });
   const spawn = await tools.spawn_agent!.bind({ clientRequestId: "bind-request-1", cwd: sandbox, "prompt": "go", title: "Bind launch", ...forged });
-  expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: "conversation_real_caller", project: "proj-real" }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
+  expect(spawn).toMatchObject({ caller: { kind: "worker", conversationId: callerA.id, project: projectA }, target: { identity: sandbox }, downstreamKey: "bind-request-1" });
   expect(typeof spawn.target.project).toBe("string");
   expect(await tools.spawn_agent!.bind({ clientRequestId: "x".repeat(200), cwd: sandbox, "prompt": "go", title: "Bind launch" }))
     .toMatchObject({ downstreamKey: expect.stringMatching(/^mcp_[0-9a-f]{24}$/) });
+  /* Another authenticated conversation binds to ITS project: a replay from a
+     caller whose project differs is what the service then refuses. */
+  authority = { kind: "worker", conversationId: callerB.id, role: "builder" };
+  expect(await tools.send_message!.bind({ clientRequestId: "bind-request-1", transcriptPath, text: "hi" }))
+    .toMatchObject({ caller: { kind: "worker", conversationId: callerB.id, project: projectB } });
 
-  /* A faulting or absent resolver reads as unidentified, which fails closed. */
+  /* A faulting authority, or a registry that cannot answer for the caller's
+     project, reads as unidentified, which fails closed. */
   const faulting = viewerMcpRecoverableTools({
     registrySnapshot: () => registry.readOnlySnapshot(),
     attentionAuthority: () => { throw new Error("registry unreadable"); },
   } as never);
   expect(await faulting.send_message!.bind({ clientRequestId: "bind-2", conversationId: recipient.id, text: "hi" }))
+    .toMatchObject({ caller: { kind: "unidentified", conversationId: null, project: null } });
+  const projectless = viewerMcpRecoverableTools({
+    registrySnapshot: () => { throw new Error("registry unreadable"); },
+    attentionAuthority: () => authority,
+  } as never);
+  expect(await projectless.spawn_agent!.bind({ clientRequestId: "bind-2", cwd: sandbox, "prompt": "go", title: "Bind launch" }))
     .toMatchObject({ caller: { kind: "unidentified", conversationId: null, project: null } });
   expect(() => tools.send_message!.bind({ clientRequestId: "bind-3", text: "hi" })).toThrow("conversationId or transcriptPath is required");
   expect(() => tools.spawn_agent!.bind({ clientRequestId: "bind-3", "prompt": "go" })).toThrow("cwd is required");
@@ -2887,6 +2943,18 @@ test("send recovery maps the durable delivery record to the closed outcome set",
   expect(await recover(...binding("accepted-key"))).toMatchObject({ outcome: "settled", ids: { operationId: "op_accepted" }, facts: { state: "delivered", resend: "not-needed", duplicateRisk: false } });
   registry.recordDeliveryOutcome(reservation.id, "failed", SEND_UNVERIFIED_REASON, "unverified");
   expect(await recover(...binding("legacy-key"))).toMatchObject({ outcome: "settled", reason: SEND_UNVERIFIED_REASON, facts: { state: "failed", resend: "verify-first", duplicateRisk: true } });
+
+  /* A target bound to a path the registry never resolved matches no record:
+     one or many operations under the key, none is disclosed. */
+  const [byPath, pathOptions] = binding("accepted-key");
+  const unresolved = await recover({ ...byPath, target: { project: null, identity: "/nowhere/recipient.jsonl" } }, pathOptions);
+  expect(unresolved).toMatchObject({ outcome: "unknown", evidence: "none", ids: {} });
+  expect(JSON.stringify(unresolved)).not.toContain("op_accepted");
+  /* Recovery reads leave the delivery record exactly as it was. */
+  const before = JSON.stringify(registry.readOnlySnapshot());
+  await recover(...binding("accepted-key"));
+  await recover(...binding("legacy-key"));
+  expect(JSON.stringify(registry.readOnlySnapshot())).toBe(before);
 
   /* Unreadable state keeps uncertainty; a bound target with no identity is unknown. */
   const broken = viewerMcpRecoverableTools({

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -97,7 +97,7 @@ import type { RuntimeHostRequestHealth } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { messageOriginRole, type MessageOrigin } from "@/lib/runtime/messageOrigin";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
-import { resolveSendReceipt } from "@/lib/runtime/sendSettlement";
+import { resolveOriginalSend, resolveSendReceipt, type SendSettlementPorts } from "@/lib/runtime/sendSettlement";
 import {
   SELECTED_TAIL_MAX_BYTES,
   SELECTED_TAIL_MAX_LINES,
@@ -131,7 +131,20 @@ import { resolveSiblings } from "@/lib/view/siblings";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
-import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolCallContext, type McpToolPayload } from "./server";
+import {
+  McpDispatchUncertainError,
+  McpToolRefusal,
+  type McpRecoverableTool,
+  type McpRecoveryEvidence,
+  type McpRequestBinding,
+  type McpRequestBindingInput,
+  type McpRequestCaller,
+  type McpToolArgs,
+  type McpToolBindings,
+  type McpToolCallContext,
+  type McpToolName,
+  type McpToolPayload,
+} from "./server";
 import { viewerControlOrigin, viewerControlToken } from "./controlEndpoint";
 import {
   productionSelectedContextDependencies,
@@ -160,6 +173,16 @@ const productionLinkTaskDependencies: LinkTaskToPipelineDependencies = {
 export interface ViewerControlDependencies {
   get?(pathname: string, context?: McpToolCallContext): Promise<Record<string, unknown>>;
   post(
+    pathname: string,
+    body: Record<string, unknown>,
+    headers?: Record<string, string>,
+    context?: McpToolCallContext,
+  ): Promise<Record<string, unknown>>;
+  /** #1490: ONE attempt, never repeated once the request may have reached the
+      Viewer. Throws {@link McpDispatchUncertainError} for every failure that
+      cannot prove the server did nothing. Optional so a harness that supplies
+      only `post` keeps working; the production set always provides it. */
+  dispatch?(
     pathname: string,
     body: Record<string, unknown>,
     headers?: Record<string, string>,
@@ -373,12 +396,118 @@ async function postViewerControl(
   return result;
 }
 
+/**
+ * One dispatch of a recoverable mutation (#1490). No reconnect loop: the
+ * request is written once, and what comes back is classified by what it can
+ * PROVE. A connection the kernel refused never carried a byte, so the server
+ * did nothing; a reset, a timeout after the write, an unreadable or missing
+ * body, and a proxy status that says nothing about the upstream all leave the
+ * request possibly on the server and are reported as uncertain. A JSON answer
+ * from the handler is the server's own verdict and is returned or refused as
+ * such — a refusal carrying an admitted id keeps that id.
+ */
+async function dispatchViewerControl(
+  pathname: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+  context: McpToolCallContext = {},
+  pinConfiguredEndpoint = false,
+): Promise<Record<string, unknown>> {
+  const baseUrl = viewerControlOrigin(process.env, pinConfiguredEndpoint);
+  const token = viewerControlToken(process.env, baseUrl);
+  const now = Date.now();
+  const budgetMs = context.deadlineAt === undefined
+    ? CONTROL_UNSCOPED_RECOVERY_BUDGET_MS
+    : Math.max(1, context.deadlineAt - now - CONTROL_DEADLINE_RESERVE_MS);
+  const attempt = deadlineSignal(Math.min(CONTROL_ATTEMPT_TIMEOUT_MS, budgetMs), {
+    signal: context.signal,
+    reason: "Viewer control dispatch timed out",
+  });
+  const requestHeaders = new Headers({ "content-type": "application/json", ...headers });
+  if (token && !requestHeaders.has("authorization")) requestHeaders.set("authorization", `Bearer ${token}`);
+  requestHeaders.set("origin", baseUrl);
+  requestHeaders.set("sec-fetch-site", "same-origin");
+  let response: Response;
+  try {
+    response = await fetch(new URL(pathname, baseUrl), {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify(body),
+      signal: attempt.signal,
+    });
+  } catch (error) {
+    attempt.release();
+    const code = (error as { code?: unknown }).code;
+    if (code === "ConnectionRefused" || code === "ECONNREFUSED") {
+      throw new Error("Viewer control is unreachable: the connection was refused before the request was sent");
+    }
+    throw new McpDispatchUncertainError(
+      attempt.signal.aborted
+        ? "the Viewer did not answer before the dispatch deadline; the request may have been received"
+        : `the connection failed after the request may have been sent (${code ? String(code) : "connection failed"})`,
+    );
+  }
+  let parsed: unknown;
+  let unreadable = false;
+  try {
+    parsed = await response.json() as unknown;
+  } catch {
+    unreadable = true;
+  } finally {
+    attempt.release();
+  }
+  const result = objectRecord(parsed) ? parsed : {};
+  const answered = !unreadable && objectRecord(parsed) && Boolean(text(result.error) || text(result.code) || Object.keys(result).length);
+  if (TRANSIENT_CONTROL_STATUSES.has(response.status) || (response.status === 503 && !answered)) {
+    throw new McpDispatchUncertainError(`Viewer control answered status ${response.status} without a verdict; the request may have been received`);
+  }
+  if (unreadable) {
+    /* A 4xx whose body could not be read is still the handler's refusal —
+       except a 409, which in this codebase is how an ADMITTED but ambiguous
+       operation is answered, with its id in the body that was just lost. */
+    if (response.status >= 400 && response.status < 500 && response.status !== 409) {
+      throw new Error(`Viewer control refused the request with status ${response.status}`);
+    }
+    throw new McpDispatchUncertainError(`Viewer control returned an unreadable response with status ${response.status}; the request may have been received`);
+  }
+  if (!objectRecord(parsed)) {
+    throw new McpDispatchUncertainError(`Viewer control returned a malformed response with status ${response.status}; the request may have been received`);
+  }
+  if (result.error || (!response.ok && result.state !== "busy")) {
+    const message = text(result.error) || `Viewer control request failed with status ${response.status}`;
+    const operationId = text(result.operationId);
+    const launchId = text(result.launchId);
+    if (operationId || launchId) {
+      throw new McpToolRefusal(message, {
+        ...(operationId ? { operationId } : {}),
+        ...(launchId ? { launchId } : {}),
+        ...(text(result.conversationId) ? { conversationId: text(result.conversationId) } : {}),
+        ...(text(result.resend) ? { resend: text(result.resend) } : {}),
+        ...(result.actuation === "started" ? { actuation: "started" } : {}),
+        ...(text(result.code) ? { code: text(result.code) } : {}),
+      });
+    }
+    throw new McpToolRefusal(message, {
+      status: response.status,
+      ...(text(result.code) ? { code: text(result.code) } : {}),
+    });
+  }
+  return result;
+}
+
 export function productionViewerControlDependencies(
   pinConfiguredEndpoint = false,
 ): ViewerControlDependencies {
   return {
     get: (pathname, context) => getViewerControl(pathname, context, pinConfiguredEndpoint),
     post: (pathname, body, headers, context) => postViewerControl(
+      pathname,
+      body,
+      headers,
+      context,
+      pinConfiguredEndpoint,
+    ),
+    dispatch: (pathname, body, headers, context) => dispatchViewerControl(
       pathname,
       body,
       headers,
@@ -404,7 +533,14 @@ function viewerControlForCall(
   return {
     ...(control.get ? { get: (pathname: string) => control.get!(pathname, context) } : {}),
     post: (pathname, body, headers) => control.post(pathname, body, headers, context),
+    ...(control.dispatch ? { dispatch: (pathname, body, headers) => control.dispatch!(pathname, body, headers, context) } : {}),
   };
+}
+
+/** The single-attempt dispatch where the control set provides one, and the
+    plain post of a harness that provides only that. */
+function dispatchControl(control: ViewerControlDependencies): NonNullable<ViewerControlDependencies["dispatch"]> {
+  return control.dispatch ?? control.post;
 }
 
 type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySnapshot"]>;
@@ -503,6 +639,9 @@ export interface ViewerMcpDomainDependencies {
   /** Accounts the catalog holds, per engine, so a binding can be answered with
       labels and a caller can see what there is to bind. */
   listBindableAccounts?(engine: BindingEngine): { accountId: string; label: string }[];
+  /** #1490: the ports the original-key send lookup settles through. Absent
+      means production (the shared registry and the runtime host socket). */
+  sendSettlementPorts?(): SendSettlementPorts;
 }
 
 /**
@@ -842,12 +981,14 @@ export function requestAttentionOperationKey(clientRequestId: string): string {
   return mcpOperationId("request_attention", clientRequestId);
 }
 
-async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
+async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies, context?: McpToolCallContext): Promise<McpToolPayload> {
   validateExplicitMcpLaunchModel(args);
-  const clientAttemptId = spawnAttemptId(requestId(args));
-  const body = withoutKeys(args, ["clientRequestId"]);
+  /* #1490: the persisted downstream key wins over a recomputation — it is the
+     key the claim was bound to and the one recovery will look up. */
+  const clientAttemptId = context?.binding?.downstreamKey ?? spawnAttemptId(requestId(args));
+  const body = withoutKeys(args, ["clientRequestId", "recoveryOnly"]);
   const roleParams = defaultMcpSpawnRoleParams(args);
-  const result = await control.post("/api/spawn", {
+  const result = await dispatchControl(control)("/api/spawn", {
     ...body,
     ...(roleParams ? { roleParams } : {}),
     clientAttemptId,
@@ -865,21 +1006,34 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies)
   };
 }
 
+/**
+ * The exact client message key a send hands the conversation-host route
+ * (#1490). The route keeps the first 128 characters of what it is given, so a
+ * longer clientRequestId is bounded HERE, deterministically, rather than
+ * truncated there where two long keys with one prefix would collide.
+ */
+export function sendDownstreamKey(clientRequestId: string): string {
+  return clientRequestId.length <= 128
+    ? clientRequestId
+    : `mcp_send_${crypto.createHash("sha256").update(clientRequestId).digest("hex").slice(0, 32)}`;
+}
+
 async function sendMessage(
   args: McpToolArgs,
   control: ViewerControlDependencies,
   dependencies: Pick<ViewerMcpDomainDependencies, "registrySnapshot"> &
     Partial<Pick<ViewerMcpDomainDependencies, "callerAttribution" | "attentionAuthority">>,
+  context?: McpToolCallContext,
 ): Promise<McpToolPayload> {
   const conversationId = text(args.conversationId);
   const transcriptPath = text(args.transcriptPath) || text(args.path);
   if (!conversationId && !transcriptPath) throw new Error("conversationId or transcriptPath is required");
   const message = requiredMessageText(args);
-  const outcome = await control.post("/api/tmux", {
+  const outcome = await dispatchControl(control)("/api/tmux", {
     pid: null,
     path: transcriptPath,
     ...(conversationId ? { conversationId } : {}),
-    clientMessageId: requestId(args),
+    clientMessageId: context?.binding?.downstreamKey ?? sendDownstreamKey(requestId(args)),
     text: message,
     images: [],
     /* #1117: an MCP send is inter-agent traffic by definition; the sender role
@@ -3603,14 +3757,209 @@ export function viewerMcpToolPolicy(
   );
 }
 
+/* ── ORIGINAL-KEY RECOVERY (#1490) ──────────────────────────────────────── */
+
+/** The server-derived caller, and nothing the arguments say. A resolver that
+    faults reads as unidentified, which fails recovery closed. */
+function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, "attentionAuthority" | "callerProject">>): McpRequestCaller {
+  let authority: AttentionCallerAuthority;
+  try {
+    authority = dependencies.attentionAuthority?.() ?? { kind: "unidentified" };
+  } catch {
+    authority = { kind: "unidentified" };
+  }
+  if (authority.kind === "unidentified") return { kind: "unidentified", conversationId: null, project: null };
+  let project: string | null = null;
+  try {
+    project = dependencies.callerProject?.() ?? null;
+  } catch {
+    project = null;
+  }
+  return { kind: authority.kind, conversationId: authority.conversationId, project };
+}
+
+function spawnCwd(args: McpToolArgs): string {
+  const raw = text(args.cwd);
+  if (!raw) throw new Error("cwd is required");
+  return path.resolve(raw === "~" || raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(1)) : raw);
+}
+
+function conversationProject(conversation: { projectOwnership?: { project?: string } | null; generations: { launchProfile?: { cwd?: string | null } | null }[] } | null | undefined): string | null {
+  if (!conversation) return null;
+  if (conversation.projectOwnership?.project) return conversation.projectOwnership.project;
+  const cwd = conversation.generations.at(-1)?.launchProfile?.cwd?.trim();
+  return cwd ? projectForCwd(cwd) : null;
+}
+
+function bindSend(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): McpRequestBindingInput {
+  const conversationId = text(args.conversationId);
+  const transcriptPath = text(args.transcriptPath) || text(args.path);
+  if (!conversationId && !transcriptPath) throw new Error("conversationId or transcriptPath is required");
+  requiredMessageText(args);
+  const lookup = readOnlyConversationLookupFromSnapshot(dependencies.registrySnapshot());
+  const conversation = conversationId
+    ? lookup.conversation(conversationId as `conversation_${string}`)
+    : lookup.conversationForPath(transcriptPath);
+  return {
+    caller: recoveryCaller(dependencies),
+    target: {
+      project: conversationProject(conversation),
+      identity: conversation?.id ?? conversationId ?? transcriptPath,
+    },
+    downstreamKey: sendDownstreamKey(requestId(args)),
+  };
+}
+
+function bindSpawn(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): McpRequestBindingInput {
+  const cwd = spawnCwd(args);
+  return {
+    caller: recoveryCaller(dependencies),
+    target: { project: text(args.project) || projectForCwd(cwd), identity: cwd },
+    downstreamKey: spawnAttemptId(requestId(args)),
+  };
+}
+
+const RECOVERY_ABSENT_REASON = "no downstream record holds this request yet; execution remains possible, so look it up again under the same clientRequestId";
+
+async function recoverSend(
+  binding: McpRequestBinding,
+  legacy: boolean,
+  dependencies: ViewerMcpDomainDependencies,
+): Promise<McpRecoveryEvidence> {
+  /* A send carries no durable sender identity of its own, so a claim made
+     before bindings existed has no evidence that establishes its owner. */
+  if (legacy) {
+    return { outcome: "unknown", evidence: "legacy-receipt-unbound", reason: "no durable evidence establishes the owner of this send", ids: {}, ownership: "unknown" };
+  }
+  if (!binding.target.identity) {
+    return { outcome: "unknown", evidence: "none", reason: "the bound target names no conversation", ids: {} };
+  }
+  const ports: SendSettlementPorts = dependencies.sendSettlementPorts?.() ?? {};
+  const found = await resolveOriginalSend({ conversationId: binding.target.identity, clientMessageId: binding.downstreamKey }, ports);
+  if (found.kind === "unreadable") {
+    return { outcome: "unknown", evidence: "delivery-record", reason: `the delivery record could not be read: ${found.reason}`, ids: {} };
+  }
+  if (found.kind === "absent") return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {} };
+  if (found.kind === "ambiguous") {
+    return { outcome: "unknown", evidence: "delivery-record", reason: "more than one delivery operation claims this key; the match is ambiguous", ids: {} };
+  }
+  const receipt = found.current.readable && found.current.value ? found.current.value : found.receipt;
+  const ids: Record<string, string> = {
+    operationId: found.operationId,
+    ...(receipt.conversationId ? { conversationId: receipt.conversationId } : {}),
+    ...(found.deliveryId ? { deliveryId: found.deliveryId } : {}),
+  };
+  const unreadableNote = found.current.readable ? null : `; the current runtime answer could not be read (${found.current.reason})`;
+  if (receipt.state === "delivered" || receipt.state === "failed") {
+    return {
+      outcome: "settled",
+      evidence: receipt.evidence,
+      reason: receipt.reason ? `${receipt.reason}${unreadableNote ?? ""}` : unreadableNote?.slice(2) ?? null,
+      ids,
+      facts: {
+        state: receipt.state,
+        resend: receipt.resend,
+        duplicateRisk: receipt.duplicateRisk,
+        acceptedAt: receipt.acceptedAt,
+        settledAt: receipt.settledAt,
+      },
+    };
+  }
+  const executing = found.reservationState === "delivery-uncertain";
+  return {
+    outcome: executing ? "in-flight" : "accepted",
+    evidence: receipt.evidence,
+    reason: `${receipt.reason ?? "accepted for delivery"}${unreadableNote ?? ""}`,
+    ids,
+    facts: { state: receipt.state, acceptedAt: receipt.acceptedAt, resend: receipt.resend, duplicateRisk: receipt.duplicateRisk },
+  };
+}
+
+async function recoverSpawn(
+  binding: McpRequestBinding,
+  legacy: boolean,
+  dependencies: ViewerMcpDomainDependencies,
+): Promise<McpRecoveryEvidence> {
+  let snapshot: RegistrySnapshot;
+  try {
+    snapshot = dependencies.registrySnapshot();
+  } catch (error) {
+    return { outcome: "unknown", evidence: "spawn-receipt", reason: `the launch record could not be read: ${error instanceof Error ? error.message : String(error)}`, ids: {} };
+  }
+  const receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === binding.downstreamKey);
+  if (receipts.length === 0) {
+    return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {}, ...(legacy ? { ownership: "unknown" as const } : {}) };
+  }
+  if (receipts.length > 1) {
+    return { outcome: "unknown", evidence: "spawn-receipt", reason: "more than one launch receipt claims this key; the match is ambiguous", ids: {}, ...(legacy ? { ownership: "unknown" as const } : {}) };
+  }
+  const receipt = receipts[0]!;
+  const ownership = legacy
+    ? (binding.caller.conversationId !== null && receipt.parentConversationId === binding.caller.conversationId ? "established" : "unknown")
+    : undefined;
+  if (legacy && ownership !== "established") {
+    return { outcome: "unknown", evidence: "legacy-receipt-unbound", reason: "no durable evidence establishes the owner of this launch", ids: {}, ownership: "unknown" };
+  }
+  const ids: Record<string, string> = {
+    launchId: receipt.launchId,
+    conversationId: receipt.conversationId,
+    ...(receipt.artifactPath ? { transcriptPath: receipt.artifactPath } : {}),
+  };
+  const terminal = receipt.rejection !== null || receipt.state === "failed" || receipt.state === "conflicted" || receipt.state === "completed";
+  if (terminal) {
+    return {
+      outcome: "settled",
+      evidence: "spawn-receipt",
+      reason: receipt.rejection?.guidance ?? receipt.error ?? null,
+      ids,
+      facts: {
+        state: receipt.state,
+        launched: receipt.state === "completed",
+        ...(receipt.rejection ? { rejection: receipt.rejection.code } : {}),
+      },
+      ...(ownership ? { ownership } : {}),
+    };
+  }
+  const executing = receipt.verifiedHost !== null || receipt.pane !== null
+    || receipt.state === "host-verified" || receipt.state === "prompt-delivered" || receipt.state === "path-pending";
+  return {
+    outcome: executing ? "in-flight" : "accepted",
+    evidence: "spawn-receipt",
+    reason: `launch receipt is ${receipt.state}`,
+    ids,
+    facts: { state: receipt.state },
+    ...(ownership ? { ownership } : {}),
+  };
+}
+
+/**
+ * The recoverable mutations (#1490): both bind the caller before dispatch and
+ * answer an existing claim from durable evidence only. Neither `recover` can
+ * reach a mutation binding.
+ */
+export function viewerMcpRecoverableTools(
+  domainDependencies: ViewerMcpDomainDependencies = productionDomainDependencies,
+): Partial<Record<McpToolName, McpRecoverableTool>> {
+  return {
+    spawn_agent: {
+      bind: (args) => bindSpawn(args, domainDependencies),
+      recover: (binding, options) => recoverSpawn(binding, options.legacy, domainDependencies),
+    },
+    send_message: {
+      bind: (args) => bindSend(args, domainDependencies),
+      recover: (binding, options) => recoverSend(binding, options.legacy, domainDependencies),
+    },
+  };
+}
+
 export function viewerMcpBindings(
   linkTaskDependencies: LinkTaskToPipelineDependencies = productionLinkTaskDependencies,
   controlDependencies: ViewerControlDependencies = productionViewerControlDependencies(),
   domainDependencies: ViewerMcpDomainDependencies = productionDomainDependencies,
 ): McpToolBindings {
   return {
-    spawn_agent: (args, context) => spawnAgent(args, viewerControlForCall(controlDependencies, context)),
-    send_message: (args, context) => sendMessage(args, viewerControlForCall(controlDependencies, context), domainDependencies),
+    spawn_agent: (args, context) => spawnAgent(args, viewerControlForCall(controlDependencies, context), context),
+    send_message: (args, context) => sendMessage(args, viewerControlForCall(controlDependencies, context), domainDependencies, context),
     message_receipt: (args) => messageReceipt(args),
     create_task: createBoardTask,
     update_task: updateBoardTask,

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -406,8 +406,8 @@ async function postViewerControl(
  * did nothing; a reset, a timeout after the write, an unreadable or missing
  * body, and a proxy status that says nothing about the upstream all leave the
  * request possibly on the server and are reported as uncertain. A JSON answer
- * from the handler is the server's own verdict and is returned or refused as
- * such — a refusal carrying an admitted id keeps that id.
+ * carrying an admitted id keeps that id. A status or error body alone cannot
+ * prove that the handler rejected the request before dispatch.
  */
 async function dispatchViewerControl(
   pathname: string,
@@ -437,6 +437,8 @@ async function dispatchViewerControl(
   try {
     response = await fetch(new URL(pathname, baseUrl), {
       method: "POST",
+      // Redirects can repeat a POST after the first endpoint accepted it.
+      redirect: "error",
       headers: requestHeaders,
       body: JSON.stringify(body),
       signal: attempt.signal,
@@ -468,12 +470,6 @@ async function dispatchViewerControl(
     throw new McpDispatchUncertainError(`Viewer control answered status ${response.status} without a verdict; the request may have been received`);
   }
   if (unreadable) {
-    /* A 4xx whose body could not be read is still the handler's refusal —
-       except a 409, which in this codebase is how an ADMITTED but ambiguous
-       operation is answered, with its id in the body that was just lost. */
-    if (response.status >= 400 && response.status < 500 && response.status !== 409) {
-      throw new McpDispatchVerdictError(`Viewer control refused the request with status ${response.status}`, { status: response.status });
-    }
     throw new McpDispatchUncertainError(`Viewer control returned an unreadable response with status ${response.status}; the request may have been received`);
   }
   if (!objectRecord(parsed)) {
@@ -3840,7 +3836,7 @@ function bindSend(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies):
     caller: recoveryCaller(dependencies),
     target: {
       project: conversationProject(conversation),
-      identity: conversation?.id ?? conversationId ?? transcriptPath,
+      identity: conversation?.id ?? (conversationId || transcriptPath),
     },
     downstreamKey: sendDownstreamKey(requestId(args)),
   };

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1022,6 +1022,20 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies,
     ...internalServiceHeaders("mcp"),
     [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
   });
+  // A readable body alone establishes no acceptance. Validate the fields
+  // this binding publishes before the service can persist a successful replay.
+  if (!text(result.launchId) || !text(result.conversationId)
+    || !["starting", "path-pending", "settled"].includes(result.state as string)
+    || !["pending", "queued", "delivered"].includes(result.initialMessage as string)
+    || (result.ok !== undefined && result.ok !== true)
+    || (result.launched !== undefined && typeof result.launched !== "boolean")
+    || (result.retrySafe !== undefined && result.retrySafe !== false)
+    || (result.path !== undefined && result.path !== null && !text(result.path))
+    || (result.initialMessage === "delivered" && result.launched === false)
+    || (result.state === "starting" && result.initialMessage !== "pending")
+    || (result.state === "settled" && result.initialMessage !== "delivered")) {
+    throw new McpDispatchUncertainError("the spawn response lacks consistent acceptance evidence; recover the original request from its durable receipt");
+  }
   return {
     conversationId: result.conversationId,
     transcriptPath: result.path,
@@ -1066,6 +1080,19 @@ async function sendMessage(
        is the server's own caller attribution, so the feed can say WHO relayed. */
     origin: mcpSenderOrigin(dependencies),
   }, callerCapabilityHeaders());
+  const receipt = objectRecord(outcome.receipt) ? outcome.receipt : null;
+  const operationId = text(outcome.operationId) || text(receipt?.operationId);
+  const settledOutcome = text(outcome.outcome);
+  if (!operationId
+    || !["delivered-to-live", "resumed", "held", "pending", "reconfigured", "queued", "delivering", "delivered"].includes(settledOutcome)
+    || (outcome.ok !== undefined && outcome.ok !== true)
+    || (outcome.operationId !== undefined && outcome.operationId !== operationId)
+    || (outcome.receipt !== undefined && (!receipt
+      || receipt.operationId !== operationId
+      || !["queued", "delivered"].includes(receipt.status as string)
+      || (settledOutcome === "delivered") !== (receipt.status === "delivered")))) {
+    throw new McpDispatchUncertainError("the send response lacks consistent acceptance evidence; recover the original request from its durable receipt");
+  }
   /* The registry's OWN lookup over the projection this call already holds (#845),
      rather than a local reimplementation of it. The alias walk is multi-hop and
      cycle-guarded and the path index covers continuity paths, so a send addressed by
@@ -1075,11 +1102,10 @@ async function sendMessage(
   const conversation = conversationId
     ? lookup.conversation(conversationId as `conversation_${string}`)
     : lookup.conversationForPath(transcriptPath);
-  const settledOutcome = outcome.outcome ?? "delivered";
   return {
     conversationId: (conversation?.id ?? conversationId) || null,
     transcriptPath: (conversation?.generations.at(-1)?.path ?? transcriptPath) || null,
-    operationId: outcome.operationId ?? (outcome.receipt as { operationId?: unknown } | undefined)?.operationId ?? null,
+    operationId,
     outcome: settledOutcome,
     /* #1131: acceptance is not arrival. A `queued` send is admitted and not yet
        settled, and saying so on the answer itself is what stops a caller from

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1048,14 +1048,12 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies,
 
 /**
  * The exact client message key a send hands the conversation-host route
- * (#1490). The route keeps the first 128 characters of what it is given, so a
- * longer clientRequestId is bounded HERE, deterministically, rather than
- * truncated there where two long keys with one prefix would collide.
+ * (#1490). The route keeps the first 128 characters of what it is given, so
+ * every clientRequestId is hashed into a bounded key. No raw input shares
+ * the generated namespace. Recovery always uses the already persisted key.
  */
 export function sendDownstreamKey(clientRequestId: string): string {
-  return clientRequestId.length <= 128
-    ? clientRequestId
-    : `mcp_send_${crypto.createHash("sha256").update(clientRequestId).digest("hex").slice(0, 32)}`;
+  return `mcp_send_${crypto.createHash("sha256").update(clientRequestId).digest("hex")}`;
 }
 
 async function sendMessage(
@@ -3894,7 +3892,7 @@ function bindSpawn(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies)
   return {
     caller: recoveryCaller(dependencies),
     target: { project: spawnTargetProject(args, cwd), identity: cwd },
-    downstreamKey: spawnAttemptId(requestId(args)),
+    downstreamKey: `mcp_spawn_${crypto.createHash("sha256").update(requestId(args)).digest("hex")}`,
   };
 }
 
@@ -3904,6 +3902,7 @@ async function recoverSend(
   binding: McpRequestBinding,
   legacy: boolean,
   dependencies: ViewerMcpDomainDependencies,
+  args?: McpToolArgs,
 ): Promise<McpRecoveryEvidence> {
   /* A send carries no durable sender identity of its own, so a claim made
      before bindings existed has no evidence that establishes its owner. */
@@ -3914,13 +3913,16 @@ async function recoverSend(
     return { outcome: "unknown", evidence: "none", reason: "the bound target names no conversation", ids: {} };
   }
   const ports: SendSettlementPorts = dependencies.sendSettlementPorts?.() ?? {};
-  const found = await resolveOriginalSend({ conversationId: binding.target.identity, clientMessageId: binding.downstreamKey }, ports);
+  const found = await resolveOriginalSend({ conversationId: binding.target.identity, clientMessageId: binding.downstreamKey, ...(typeof args?.text === "string" ? { text: args.text } : {}) }, ports);
   if (found.kind === "unreadable") {
     return { outcome: "unknown", evidence: "delivery-record", reason: `the delivery record could not be read: ${found.reason}`, ids: {} };
   }
   if (found.kind === "absent") return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {} };
   if (found.kind === "unresolved") {
     return { outcome: "unknown", evidence: "none", reason: "the bound target names no conversation the registry knows, so no delivery record can be matched to it", ids: {} };
+  }
+  if (found.kind === "contradictory") {
+    return { outcome: "unknown", evidence: "delivery-record", reason: "the delivery payload contradicts the bound request", ids: {}, ownership: "unknown" };
   }
   if (found.kind === "ambiguous") {
     return { outcome: "unknown", evidence: "delivery-record", reason: "more than one delivery operation claims this key; the match is ambiguous", ids: {} };
@@ -3961,6 +3963,7 @@ async function recoverSpawn(
   binding: McpRequestBinding,
   legacy: boolean,
   dependencies: ViewerMcpDomainDependencies,
+  args?: McpToolArgs,
 ): Promise<McpRecoveryEvidence> {
   let snapshot: RegistrySnapshot;
   try {
@@ -3968,7 +3971,8 @@ async function recoverSpawn(
   } catch (error) {
     return { outcome: "unknown", evidence: "spawn-receipt", reason: `the launch record could not be read: ${error instanceof Error ? error.message : String(error)}`, ids: {} };
   }
-  const receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === binding.downstreamKey);
+  const key = legacy ? spawnAttemptId(binding.clientRequestId) : binding.downstreamKey;
+  const receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === key);
   if (receipts.length === 0) {
     return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {}, ...(legacy ? { ownership: "unknown" as const } : {}) };
   }
@@ -3981,6 +3985,11 @@ async function recoverSpawn(
     : undefined;
   if (legacy && ownership !== "established") {
     return { outcome: "unknown", evidence: "legacy-receipt-unbound", reason: "no durable evidence establishes the owner of this launch", ids: {}, ownership: "unknown" };
+  }
+  if ((receipt.parentConversationId !== null && receipt.parentConversationId !== binding.caller.conversationId)
+    || (binding.target.identity && path.resolve(receipt.cwd) !== binding.target.identity)
+    || (typeof args?.prompt === "string" && receipt.launchDisplay && receipt.launchDisplay.prompt !== args.prompt)) {
+    return { outcome: "unknown", evidence: "spawn-receipt", reason: "the durable launch owner or payload contradicts the bound request", ids: {}, ownership: "unknown" };
   }
   const ids: Record<string, string> = {
     launchId: receipt.launchId,
@@ -4025,11 +4034,11 @@ export function viewerMcpRecoverableTools(
   return {
     spawn_agent: {
       bind: (args) => bindSpawn(args, domainDependencies),
-      recover: (binding, options) => recoverSpawn(binding, options.legacy, domainDependencies),
+      recover: (binding, options) => recoverSpawn(binding, options.legacy, domainDependencies, options.args),
     },
     send_message: {
       bind: (args) => bindSend(args, domainDependencies),
-      recover: (binding, options) => recoverSend(binding, options.legacy, domainDependencies),
+      recover: (binding, options) => recoverSend(binding, options.legacy, domainDependencies, options.args),
     },
   };
 }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -86,6 +86,7 @@ import { loadPipelinesForList } from "@/lib/pipelines/store";
 import type { CreatePipelineRequest, PatchPipelineRequest, Pipeline, PipelineAction } from "@/lib/pipelines/types";
 import type { PauseResumeActor } from "@/lib/pauseResumeActor";
 import { listFiles } from "@/lib/scanner";
+import { validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { describe, projectForCwd, reprojectFileDescription } from "@/lib/scanner/describe";
 import { pathAllowed, scanRootEntries } from "@/lib/scanner/roots";
 import { completedFileScan } from "@/lib/scanner/scanCache";
@@ -1001,6 +1002,20 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies,
   /* #1490: the persisted downstream key wins over a recomputation — it is the
      key the claim was bound to and the one recovery will look up. */
   const clientAttemptId = context?.binding?.downstreamKey ?? spawnAttemptId(requestId(args));
+  if (context?.binding) {
+    /* The persisted binding must be the one this dispatch would make now: a
+       row whose target disagrees with the canonical resolution of these
+       arguments is not dispatched under it. Nothing has left this process,
+       so the attempt closes as not-executed. */
+    const cwd = spawnCwd(args);
+    const target = context.binding.target;
+    if (target.identity !== cwd || target.project !== spawnTargetProject(args, cwd)) {
+      throw new McpToolRefusal(
+        "the persisted binding does not name the canonical target of this spawn; nothing was dispatched",
+        { code: "binding_mismatch", status: 400 },
+      );
+    }
+  }
   const body = withoutKeys(args, ["clientRequestId", "recoveryOnly"]);
   const roleParams = defaultMcpSpawnRoleParams(args);
   const result = await dispatchControl(control)("/api/spawn", {
@@ -3831,11 +3846,32 @@ function bindSend(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies):
   };
 }
 
+/** The canonical project of a spawn's target: the launch directory's, and
+    nothing the arguments say. A supplied `project` is admitted only when it
+    names that same project. The route records an explicit project as the new
+    conversation's durable ownership, so a value that contradicts the launch
+    directory would make a forged project both the binding's metadata and the
+    conversation's owner; it is refused before any claim, so the key is not
+    burned. */
+function spawnTargetProject(args: McpToolArgs, cwd: string): string | null {
+  const canonical = projectForCwd(cwd);
+  const supplied = text(args.project).trim();
+  if (!supplied) return canonical;
+  const explicit = validExplicitProject(supplied);
+  if (!explicit || explicit !== canonical) {
+    throw new McpToolRefusal(
+      "project contradicts the canonical project of cwd; omit it or name the launch directory's own project",
+      { code: "invalid_request", status: 400, ...(canonical ? { canonicalProject: canonical } : {}) },
+    );
+  }
+  return canonical;
+}
+
 function bindSpawn(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): McpRequestBindingInput {
   const cwd = spawnCwd(args);
   return {
     caller: recoveryCaller(dependencies),
-    target: { project: text(args.project) || projectForCwd(cwd), identity: cwd },
+    target: { project: spawnTargetProject(args, cwd), identity: cwd },
     downstreamKey: spawnAttemptId(requestId(args)),
   };
 }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -132,7 +132,9 @@ import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
 import {
+  McpDispatchNotExecutedError,
   McpDispatchUncertainError,
+  McpDispatchVerdictError,
   McpToolRefusal,
   type McpRecoverableTool,
   type McpRecoveryEvidence,
@@ -428,6 +430,9 @@ async function dispatchViewerControl(
   requestHeaders.set("origin", baseUrl);
   requestHeaders.set("sec-fetch-site", "same-origin");
   let response: Response;
+  /* From here on the request may be on the wire: the service reads this to
+     tell a failure that happened BEFORE any dispatch from one after it. */
+  if (context.dispatch) context.dispatch.attempted = true;
   try {
     response = await fetch(new URL(pathname, baseUrl), {
       method: "POST",
@@ -439,7 +444,7 @@ async function dispatchViewerControl(
     attempt.release();
     const code = (error as { code?: unknown }).code;
     if (code === "ConnectionRefused" || code === "ECONNREFUSED") {
-      throw new Error("Viewer control is unreachable: the connection was refused before the request was sent");
+      throw new McpDispatchNotExecutedError("Viewer control is unreachable: the connection was refused before the request was sent");
     }
     throw new McpDispatchUncertainError(
       attempt.signal.aborted
@@ -466,7 +471,7 @@ async function dispatchViewerControl(
        except a 409, which in this codebase is how an ADMITTED but ambiguous
        operation is answered, with its id in the body that was just lost. */
     if (response.status >= 400 && response.status < 500 && response.status !== 409) {
-      throw new Error(`Viewer control refused the request with status ${response.status}`);
+      throw new McpDispatchVerdictError(`Viewer control refused the request with status ${response.status}`, { status: response.status });
     }
     throw new McpDispatchUncertainError(`Viewer control returned an unreadable response with status ${response.status}; the request may have been received`);
   }
@@ -478,7 +483,8 @@ async function dispatchViewerControl(
     const operationId = text(result.operationId);
     const launchId = text(result.launchId);
     if (operationId || launchId) {
-      throw new McpToolRefusal(message, {
+      throw new McpDispatchVerdictError(message, {
+        status: response.status,
         ...(operationId ? { operationId } : {}),
         ...(launchId ? { launchId } : {}),
         ...(text(result.conversationId) ? { conversationId: text(result.conversationId) } : {}),
@@ -487,7 +493,7 @@ async function dispatchViewerControl(
         ...(text(result.code) ? { code: text(result.code) } : {}),
       });
     }
-    throw new McpToolRefusal(message, {
+    throw new McpDispatchVerdictError(message, {
       status: response.status,
       ...(text(result.code) ? { code: text(result.code) } : {}),
     });
@@ -654,7 +660,16 @@ function productionCallerProject(): string | null {
   const authority = attentionCallerAuthority(attentionCallerSources());
   const conversationId = authority.kind === "root" || authority.kind === "worker" ? authority.conversationId : null;
   if (!conversationId) return null;
-  const conversation = agentRegistry().conversation(conversationId as `conversation_${string}`);
+  return callerProjectFromSnapshot(agentRegistry().readOnlySnapshot(), conversationId);
+}
+
+/**
+ * The canonical project of an authenticated caller: its conversation's
+ * recorded project ownership, else the project of its launch directory. One
+ * resolver for every consumer, read from the registry's own projection.
+ */
+function callerProjectFromSnapshot(snapshot: RegistrySnapshot, conversationId: string): string | null {
+  const conversation = readOnlyConversationLookupFromSnapshot(snapshot).conversation(conversationId as `conversation_${string}`);
   if (!conversation) return null;
   if (conversation.projectOwnership?.project) return conversation.projectOwnership.project;
   const cwd = conversation.generations.at(-1)?.launchProfile?.cwd?.trim();
@@ -3759,21 +3774,27 @@ export function viewerMcpToolPolicy(
 
 /* ── ORIGINAL-KEY RECOVERY (#1490) ──────────────────────────────────────── */
 
-/** The server-derived caller, and nothing the arguments say. A resolver that
-    faults reads as unidentified, which fails recovery closed. */
-function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, "attentionAuthority" | "callerProject">>): McpRequestCaller {
+/** The server-derived caller, and nothing the arguments say. The project is
+    the canonical one of the AUTHENTICATED conversation, read from the registry
+    projection the call already holds — never a separately resolved guess. An
+    authority or registry that faults reads as unidentified, which fails both
+    a fresh claim and a recovery closed. */
+function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, "attentionAuthority" | "registrySnapshot">>): McpRequestCaller {
+  const unidentified: McpRequestCaller = { kind: "unidentified", conversationId: null, project: null };
   let authority: AttentionCallerAuthority;
   try {
     authority = dependencies.attentionAuthority?.() ?? { kind: "unidentified" };
   } catch {
-    authority = { kind: "unidentified" };
+    return unidentified;
   }
-  if (authority.kind === "unidentified") return { kind: "unidentified", conversationId: null, project: null };
-  let project: string | null = null;
+  if (authority.kind === "unidentified") return unidentified;
+  if (authority.conversationId === null) return { kind: authority.kind, conversationId: null, project: null };
+  let project: string | null;
   try {
-    project = dependencies.callerProject?.() ?? null;
+    if (!dependencies.registrySnapshot) return unidentified;
+    project = callerProjectFromSnapshot(dependencies.registrySnapshot(), authority.conversationId);
   } catch {
-    project = null;
+    return unidentified;
   }
   return { kind: authority.kind, conversationId: authority.conversationId, project };
 }
@@ -3840,10 +3861,13 @@ async function recoverSend(
     return { outcome: "unknown", evidence: "delivery-record", reason: `the delivery record could not be read: ${found.reason}`, ids: {} };
   }
   if (found.kind === "absent") return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {} };
+  if (found.kind === "unresolved") {
+    return { outcome: "unknown", evidence: "none", reason: "the bound target names no conversation the registry knows, so no delivery record can be matched to it", ids: {} };
+  }
   if (found.kind === "ambiguous") {
     return { outcome: "unknown", evidence: "delivery-record", reason: "more than one delivery operation claims this key; the match is ambiguous", ids: {} };
   }
-  const receipt = found.current.readable && found.current.value ? found.current.value : found.receipt;
+  const receipt = found.current.readable ? found.current.value : found.receipt;
   const ids: Record<string, string> = {
     operationId: found.operationId,
     ...(receipt.conversationId ? { conversationId: receipt.conversationId } : {}),

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -1,4 +1,6 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 
 import {
   MCP_TOOL_NAMES,
@@ -13,40 +15,222 @@ function waitFor(filename: string): void {
   }
 }
 
-const filename = process.argv[2]!;
-const readyPath = process.argv[3]!;
-const startPath = process.argv[4]!;
-const ownerReadyPath = process.argv[5]!;
-const ownerReleasePath = process.argv[6]!;
-const ownerCountPath = process.argv[7]!;
-const resultPath = process.argv[8]!;
-const index = Number(process.argv[9]!);
+/** The same barrier without blocking the listener's event loop, so a held
+    response never stops the next request from being served. */
+async function awaitFile(filename: string): Promise<void> {
+  while (!fs.existsSync(filename)) await Bun.sleep(5);
+}
 
-const store = new SqliteMcpReceiptStore(filename);
-let peakRssBytes = process.memoryUsage().rss;
-fs.writeFileSync(readyPath, JSON.stringify({ index, steadyRssBytes: peakRssBytes }));
-waitFor(startPath);
+/**
+ * ── ROLE: controlled Viewer (#1490) ───────────────────────────────────────
+ *
+ * A real HTTP listener in front of the PRODUCTION handlers — `/api/tmux` is
+ * `conversationHostPOST` and `/api/spawn` is `POST.withDependencies` — with
+ * the runtime behind them replaced at the existing injection seams by
+ * fixtures that write into the isolated registry this process shares with the
+ * MCP process under test. Every effect the fixtures produce is appended to an
+ * effects log, one line per actual recipient delivery or writer launch, so the
+ * assertion "one delivery" counts what the recipient received rather than
+ * what the HTTP layer answered.
+ *
+ * A control file, re-read on every request, decides how the RESPONSE behaves
+ * after the handler has run: answered normally, held until a release file
+ * appears, or held forever so the test can kill this process once the
+ * acceptance marker is written. The handler itself always runs to completion
+ * first — the response is what gets lost, never the effect.
+ */
+interface HttpHostConfig {
+  portFile: string;
+  effectsPath: string;
+  /** Every answer the production handlers produced, whether or not it was
+      delivered — the fixture's own record of what the HTTP layer said. */
+  responsesPath: string;
+  controlPath: string;
+  markerDir: string;
+  recipientGenerationId: string;
+  transcriptRoot: string;
+}
 
-const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
-bindings.list_tasks = async () => {
+interface HttpHostControl {
+  /** `respond`: answer normally. `hold`: run the handler, write the accepted
+      marker, then wait for the release file before answering. `lose`: run the
+      handler, write the accepted marker, never answer. `hold-before`: write the
+      reached marker BEFORE the handler runs and wait for the release file. */
+  mode?: "respond" | "hold" | "lose" | "hold-before";
+  /** What the send fixture does once the reservation exists. */
+  sendEffect?: "deliver" | "queue";
+}
+
+async function runHttpHost(configPath: string): Promise<void> {
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as HttpHostConfig;
+  const { NextRequest } = await import("next/server");
+  const { conversationHostPOST } = await import("@/app/api/conversation-host/handlers");
+  const { setConversationHostDependenciesForTests } = await import("@/app/api/conversation-host/dependencies");
+  const { POST } = await import("@/app/api/spawn/route");
+  const { agentRegistry } = await import("@/lib/agent/registry");
+  const { runtimeReceiptForSend, sendReceiptFor } = await import("@/lib/runtime/sendSettlement");
+  const { spawnResponseForReceipt } = await import("@/lib/agent/spawnResponse");
+
+  const control = (): HttpHostControl => {
+    try {
+      return JSON.parse(fs.readFileSync(config.controlPath, "utf8")) as HttpHostControl;
+    } catch {
+      return {};
+    }
+  };
+  const effect = (record: Record<string, unknown>): void => {
+    fs.appendFileSync(config.effectsPath, `${JSON.stringify(record)}\n`);
+  };
+  const marker = (name: string): void => {
+    fs.writeFileSync(path.join(config.markerDir, name), String(Date.now()));
+  };
+
+  setConversationHostDependenciesForTests({
+    completedFileScan: async () => ({ snapshot: { files: [] } }) as never,
+    readTranscriptHosts: async () => ({}) as never,
+    recordDirectOperatorWakatimeActivity: () => null,
+    enqueueStructuredMessage: async (request) => {
+      const registry = agentRegistry();
+      const clientMessageId = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
+      const conversationId = (request.conversationId?.startsWith("conversation_")
+        ? request.conversationId
+        : registry.conversationForPath(request.path)?.id) as `conversation_${string}` | undefined;
+      if (!conversationId) {
+        return { ok: false, structured: true, outcome: "failed", error: "recipient conversation is unknown", status: 404 };
+      }
+      const operationId = `op_${crypto.createHash("sha256").update(clientMessageId).digest("hex").slice(0, 16)}`;
+      const reservation = registry.holdDelivery(
+        conversationId,
+        request.text,
+        clientMessageId,
+        "text",
+        [],
+        null,
+        { operationId, kind: "send", policy: "queue" },
+      );
+      if (reservation.state === "assigned") {
+        registry.beginDeliveryAttempt(reservation.id, config.recipientGenerationId);
+        /* THE recipient effect: the controlled recipient takes the message
+           exactly here, once per actuation, whatever the HTTP layer answers. */
+        effect({ kind: "recipient", clientMessageId, operationId, text: request.text });
+        if ((control().sendEffect ?? "deliver") === "deliver") {
+          registry.recordDeliveryOutcome(reservation.id, "delivered", null, "delivered");
+        }
+      }
+      const receipt = sendReceiptFor(registry.readOnlySnapshot(), operationId);
+      if (!receipt) return { ok: false, structured: true, outcome: "failed", error: "reservation vanished", status: 500 };
+      return {
+        ok: true,
+        structured: true,
+        target: null,
+        outcome: receipt.state === "delivered" ? "delivered" : "queued",
+        operationId,
+        receipt: runtimeReceiptForSend(receipt),
+      };
+    },
+  });
+
+  const account = {
+    engine: "codex" as const,
+    accountId: "fixture-spawn-account",
+    kind: "managed" as const,
+    home: path.join(config.transcriptRoot, "home"),
+    transcriptRoot: config.transcriptRoot,
+    env: {},
+  };
+  const spawnDependencies = {
+    registry: agentRegistry,
+    resolveHealthySpawnAccount: async () => account,
+    resolveSpawnAccount: () => account,
+    runtimeHostClient: () => ({ fixture: true }) as never,
+    assertStructuredRuntime: () => {},
+    defer: (work: () => Promise<void>) => { void work(); },
+    storeImages: () => [],
+    spawnStructuredConversation: async (input: { receipt: { launchId: string; conversationId: string; clientAttemptId: string | null }; prompt: string }) => {
+      /* THE writer effect: the controlled writer creates the conversation's
+         transcript exactly here, once per launch it is handed. */
+      const transcriptPath = path.join(config.transcriptRoot, `${input.receipt.launchId}.jsonl`);
+      fs.mkdirSync(config.transcriptRoot, { recursive: true });
+      fs.writeFileSync(transcriptPath, `${JSON.stringify({ prompt: input.prompt })}\n`);
+      effect({
+        kind: "writer",
+        launchId: input.receipt.launchId,
+        conversationId: input.receipt.conversationId,
+        clientAttemptId: input.receipt.clientAttemptId,
+      });
+      return spawnResponseForReceipt(input.receipt as never, transcriptPath, { structured: true });
+    },
+  };
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      const current = control();
+      if (current.mode === "hold-before") {
+        marker("reached");
+        await awaitFile(path.join(config.markerDir, "release"));
+      }
+      const body = await request.text();
+      const next = new NextRequest(request.url, { method: request.method, headers: request.headers, body });
+      let response: Response;
+      if (url.pathname === "/api/tmux") response = await conversationHostPOST(next);
+      else if (url.pathname === "/api/spawn") response = await POST.withDependencies(next, spawnDependencies as never);
+      else return new Response(JSON.stringify({ error: "unrouted" }), { status: 404, headers: { "content-type": "application/json" } });
+      const answerBody = await response.text();
+      fs.appendFileSync(config.responsesPath, `${JSON.stringify({ pathname: url.pathname, status: response.status, body: answerBody })}\n`);
+      const answer = new Response(answerBody, { status: response.status, headers: { "content-type": "application/json" } });
+      if (current.mode === "hold" || current.mode === "lose") {
+        marker("accepted");
+        if (current.mode === "lose") return new Promise<Response>(() => {});
+        await awaitFile(path.join(config.markerDir, "release"));
+      }
+      return answer;
+    },
+  });
+  fs.writeFileSync(config.portFile, String(server.port));
+  await new Promise<never>(() => {});
+}
+
+if (process.argv[2] === "http-host") {
+  await runHttpHost(process.argv[3]!);
+} else {
+  const filename = process.argv[2]!;
+  const readyPath = process.argv[3]!;
+  const startPath = process.argv[4]!;
+  const ownerReadyPath = process.argv[5]!;
+  const ownerReleasePath = process.argv[6]!;
+  const ownerCountPath = process.argv[7]!;
+  const resultPath = process.argv[8]!;
+  const index = Number(process.argv[9]!);
+
+  const store = new SqliteMcpReceiptStore(filename);
+  let peakRssBytes = process.memoryUsage().rss;
+  fs.writeFileSync(readyPath, JSON.stringify({ index, steadyRssBytes: peakRssBytes }));
+  waitFor(startPath);
+
+  const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+  bindings.list_tasks = async () => {
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
+    fs.appendFileSync(ownerCountPath, `${index}\n`);
+    fs.writeFileSync(ownerReadyPath, String(index), { flag: "wx" });
+    waitFor(ownerReleasePath);
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
+    return { ownerIndex: index, count: 1 };
+  };
+
+  const startedAt = performance.now();
+  const result = await createMcpToolService(bindings, store).callTool("list_tasks", {
+    clientRequestId: "twenty-process-owner",
+    limit: 1,
+  });
   peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
-  fs.appendFileSync(ownerCountPath, `${index}\n`);
-  fs.writeFileSync(ownerReadyPath, String(index), { flag: "wx" });
-  waitFor(ownerReleasePath);
-  peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
-  return { ownerIndex: index, count: 1 };
-};
-
-const startedAt = performance.now();
-const result = await createMcpToolService(bindings, store).callTool("list_tasks", {
-  clientRequestId: "twenty-process-owner",
-  limit: 1,
-});
-peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss);
-store.close();
-fs.writeFileSync(resultPath, JSON.stringify({
-  index,
-  durationMs: performance.now() - startedAt,
-  peakRssBytes,
-  result,
-}));
+  store.close();
+  fs.writeFileSync(resultPath, JSON.stringify({
+    index,
+    durationMs: performance.now() - startedAt,
+    peakRssBytes,
+    result,
+  }));
+}

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -35,12 +35,21 @@ async function awaitFile(filename: string): Promise<void> {
  *
  * A control file, re-read on every request, decides how the RESPONSE behaves
  * after the handler has run: answered normally, held until a release file
- * appears, or held forever so the test can kill this process once the
- * acceptance marker is written. The handler itself always runs to completion
- * first — the response is what gets lost, never the effect.
+ * appears, cut after its headers, or held forever so the test can kill this
+ * process once the acceptance marker is written.
+ *
+ * Admission and execution are two separate barriers. With `admission:
+ * "hold-effect"` the fixtures write the `admitted` marker the moment the
+ * durable record exists (the reservation for a send, the launch receipt for a
+ * spawn) and produce their effect only once the `execute` file appears — so a
+ * test can lose the response BETWEEN the server admitting the request and the
+ * recipient or writer doing anything, and then count exactly one effect.
  */
 interface HttpHostConfig {
   portFile: string;
+  /** The stable port every generation of this host listens on, as the
+      production Viewer does, so an MCP process outlives a host restart. */
+  port?: number;
   effectsPath: string;
   /** Every answer the production handlers produced, whether or not it was
       delivered — the fixture's own record of what the HTTP layer said. */
@@ -56,9 +65,12 @@ interface HttpHostControl {
       marker, then wait for the release file before answering. `lose`: run the
       handler, write the accepted marker, never answer. `hold-before`: write the
       reached marker BEFORE the handler runs and wait for the release file. */
-  mode?: "respond" | "hold" | "lose" | "hold-before";
+  mode?: "respond" | "hold" | "lose" | "hold-before" | "cut";
   /** What the send fixture does once the reservation exists. */
   sendEffect?: "deliver" | "queue";
+  /** `hold-effect`: write the `admitted` marker as soon as the durable record
+      exists and defer the effect until the `execute` file appears. */
+  admission?: "immediate" | "hold-effect";
 }
 
 async function runHttpHost(configPath: string): Promise<void> {
@@ -84,6 +96,13 @@ async function runHttpHost(configPath: string): Promise<void> {
   const marker = (name: string): void => {
     fs.writeFileSync(path.join(config.markerDir, name), String(Date.now()));
   };
+  /* The execution barrier: an admitted request's effect waits here until the
+     test releases execution. Runs off the request path so a held effect never
+     blocks the response or the next request. */
+  const executionBarrier = async (): Promise<void> => {
+    marker("admitted");
+    await awaitFile(path.join(config.markerDir, "execute"));
+  };
 
   setConversationHostDependenciesForTests({
     completedFileScan: async () => ({ snapshot: { files: [] } }) as never,
@@ -108,13 +127,22 @@ async function runHttpHost(configPath: string): Promise<void> {
         null,
         { operationId, kind: "send", policy: "queue" },
       );
-      if (reservation.state === "assigned") {
+      const actuate = (): void => {
         registry.beginDeliveryAttempt(reservation.id, config.recipientGenerationId);
         /* THE recipient effect: the controlled recipient takes the message
            exactly here, once per actuation, whatever the HTTP layer answers. */
         effect({ kind: "recipient", clientMessageId, operationId, text: request.text });
         if ((control().sendEffect ?? "deliver") === "deliver") {
           registry.recordDeliveryOutcome(reservation.id, "delivered", null, "delivered");
+        }
+      };
+      if (reservation.state === "assigned") {
+        if (control().admission === "hold-effect") {
+          /* Admitted and answered as queued; the recipient takes it only once
+             execution is released, like a drain the runtime runs later. */
+          void executionBarrier().then(actuate);
+        } else {
+          actuate();
         }
       }
       const receipt = sendReceiptFor(registry.readOnlySnapshot(), operationId);
@@ -147,6 +175,10 @@ async function runHttpHost(configPath: string): Promise<void> {
     defer: (work: () => Promise<void>) => { void work(); },
     storeImages: () => [],
     spawnStructuredConversation: async (input: { receipt: { launchId: string; conversationId: string; clientAttemptId: string | null }; prompt: string }) => {
+      /* The launch receipt already exists when the route hands the launch
+         here: that is the admission. The writer runs only once execution is
+         released. */
+      if (control().admission === "hold-effect") await executionBarrier();
       /* THE writer effect: the controlled writer creates the conversation's
          transcript exactly here, once per launch it is handed. */
       const transcriptPath = path.join(config.transcriptRoot, `${input.receipt.launchId}.jsonl`);
@@ -164,7 +196,7 @@ async function runHttpHost(configPath: string): Promise<void> {
 
   const server = Bun.serve({
     hostname: "127.0.0.1",
-    port: 0,
+    port: config.port ?? 0,
     fetch: async (request) => {
       const url = new URL(request.url);
       const current = control();
@@ -185,6 +217,14 @@ async function runHttpHost(configPath: string): Promise<void> {
         marker("accepted");
         if (current.mode === "lose") return new Promise<Response>(() => {});
         await awaitFile(path.join(config.markerDir, "release"));
+      }
+      if (current.mode === "cut") {
+        /* The response is lost after its status line: the body errors before
+           a byte of it is readable, so the caller learns nothing from it. */
+        marker("accepted");
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) { controller.error(new Error("response cut by the fixture")); },
+        }), { status: response.status, headers: { "content-type": "application/json" } });
       }
       return answer;
     },

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -79,6 +79,8 @@ interface HttpHostControl {
   /** Replace an actual handler answer after its effects with a proxy error. */
   lostStatus?: number;
   lostJson?: boolean;
+  /** Replace the admitted handler's response with incomplete or contradictory JSON. */
+  replacedAnswer?: Record<string, unknown>;
 }
 
 async function runHttpHost(configPath: string): Promise<void> {
@@ -220,6 +222,10 @@ async function runHttpHost(configPath: string): Promise<void> {
       else return new Response(JSON.stringify({ error: "unrouted" }), { status: 404, headers: { "content-type": "application/json" } });
       const answerBody = await response.text();
       fs.appendFileSync(config.responsesPath, `${JSON.stringify({ pathname: url.pathname, status: response.status, body: answerBody })}\n`);
+      if (current.replacedAnswer) {
+        marker("accepted");
+        return Response.json(current.replacedAnswer);
+      }
       if (current.lostStatus) {
         marker("accepted");
         return new Response(current.lostJson ? JSON.stringify({ error: "upstream response lost" }) : "<html>upstream response lost</html>", {

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -76,6 +76,9 @@ interface HttpHostControl {
       verify-first`, `actuation: started` — instead of the handler's own
       answer. The delayed error that would regress a recovered success. */
   lateVerdict?: { status: number };
+  /** Replace an actual handler answer after its effects with a proxy error. */
+  lostStatus?: number;
+  lostJson?: boolean;
 }
 
 async function runHttpHost(configPath: string): Promise<void> {
@@ -217,6 +220,13 @@ async function runHttpHost(configPath: string): Promise<void> {
       else return new Response(JSON.stringify({ error: "unrouted" }), { status: 404, headers: { "content-type": "application/json" } });
       const answerBody = await response.text();
       fs.appendFileSync(config.responsesPath, `${JSON.stringify({ pathname: url.pathname, status: response.status, body: answerBody })}\n`);
+      if (current.lostStatus) {
+        marker("accepted");
+        return new Response(current.lostJson ? JSON.stringify({ error: "upstream response lost" }) : "<html>upstream response lost</html>", {
+          status: current.lostStatus,
+          headers: { "content-type": current.lostJson ? "application/json" : "text/html" },
+        });
+      }
       const answer = new Response(answerBody, { status: response.status, headers: { "content-type": "application/json" } });
       if (current.mode === "hold" || current.mode === "lose") {
         marker("accepted");

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -280,8 +280,40 @@ async function runHttpHost(configPath: string): Promise<void> {
   await new Promise<never>(() => {});
 }
 
+/** Spin until a shared wall-clock instant so every cold process opens the
+    database in the same few microseconds, which is what a file barrier polled
+    every few milliseconds cannot line up. */
+function waitUntil(deadlineMs: number): void {
+  while (Date.now() < deadlineMs) { /* spin */ }
+}
+
 if (process.argv[2] === "http-host") {
   await runHttpHost(process.argv[3]!);
+} else if (process.argv[2] === "cold-start") {
+  /* ── ROLE: cold concurrent starter (#1490) ───────────────────────────────
+     One of N processes opening an EXISTING database whose schema predates the
+     repair columns, or a database that does not exist yet, at the same
+     instant. Nothing here pre-initializes the schema: the constructor under
+     test is what races. The process reports whether it initialized and what
+     it read back for the seeded receipt. */
+  const filename = process.argv[3]!;
+  const readyPath = process.argv[4]!;
+  const startPath = process.argv[5]!;
+  const resultPath = process.argv[6]!;
+  const index = Number(process.argv[7]!);
+  const key = process.argv[8]!;
+  fs.writeFileSync(readyPath, String(index));
+  waitFor(startPath);
+  waitUntil(Number(fs.readFileSync(startPath, "utf8")));
+  let outcome: Record<string, unknown>;
+  try {
+    const store = new SqliteMcpReceiptStore(filename);
+    outcome = { index, ok: true, record: await store.lookup(key) };
+    store.close();
+  } catch (error) {
+    outcome = { index, ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+  fs.writeFileSync(resultPath, JSON.stringify(outcome));
 } else {
   const filename = process.argv[2]!;
   const readyPath = process.argv[3]!;

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -187,7 +187,7 @@ async function runHttpHost(configPath: string): Promise<void> {
     assertStructuredRuntime: () => {},
     defer: (work: () => Promise<void>) => { void work(); },
     storeImages: () => [],
-    spawnStructuredConversation: async (input: { receipt: { launchId: string; conversationId: string; clientAttemptId: string | null }; prompt: string }) => {
+    spawnStructuredConversation: async (input: { receipt: { launchId: string; conversationId: string; clientAttemptId: string | null; cwd: string }; prompt: string }) => {
       /* The launch receipt already exists when the route hands the launch
          here: that is the admission. The writer runs only once execution is
          released. */
@@ -206,7 +206,7 @@ async function runHttpHost(configPath: string): Promise<void> {
       if (control().settleWriter) {
         agentRegistry().completeSpawn(input.receipt.launchId, {
           key: { engine: "codex", sessionId: input.receipt.launchId },
-          artifactPath: transcriptPath, cwd: config.transcriptRoot, accountId: null,
+          artifactPath: transcriptPath, cwd: input.receipt.cwd, accountId: null,
           status: "idle", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
         });
       }

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -79,6 +79,9 @@ interface HttpHostControl {
   /** Replace an actual handler answer after its effects with a proxy error. */
   lostStatus?: number;
   lostJson?: boolean;
+  /** Lose the held response after a concurrent recovery has completed. */
+  lateUnreadableStatus?: number;
+  settleWriter?: boolean;
   /** Replace the admitted handler's response with incomplete or contradictory JSON. */
   replacedAnswer?: Record<string, unknown>;
 }
@@ -200,6 +203,13 @@ async function runHttpHost(configPath: string): Promise<void> {
         conversationId: input.receipt.conversationId,
         clientAttemptId: input.receipt.clientAttemptId,
       });
+      if (control().settleWriter) {
+        agentRegistry().completeSpawn(input.receipt.launchId, {
+          key: { engine: "codex", sessionId: input.receipt.launchId },
+          artifactPath: transcriptPath, cwd: config.transcriptRoot, accountId: null,
+          status: "idle", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
+        });
+      }
       return spawnResponseForReceipt(input.receipt as never, transcriptPath, { structured: true });
     },
   };
@@ -238,6 +248,7 @@ async function runHttpHost(configPath: string): Promise<void> {
         marker("accepted");
         if (current.mode === "lose") return new Promise<Response>(() => {});
         await awaitFile(path.join(config.markerDir, "release"));
+        if (current.lateUnreadableStatus) return new Response("response lost", { status: current.lateUnreadableStatus });
         if (current.lateVerdict) {
           let admitted: Record<string, unknown> = {};
           try {

--- a/src/lib/mcp/receiptStoreProbeChild.ts
+++ b/src/lib/mcp/receiptStoreProbeChild.ts
@@ -71,6 +71,11 @@ interface HttpHostControl {
   /** `hold-effect`: write the `admitted` marker as soon as the durable record
       exists and defer the effect until the `execute` file appears. */
   admission?: "immediate" | "hold-effect";
+  /** With `hold`: once released, answer with this status and the server's
+      ambiguity verdict — the ids the handler actually admitted, `resend:
+      verify-first`, `actuation: started` — instead of the handler's own
+      answer. The delayed error that would regress a recovered success. */
+  lateVerdict?: { status: number };
 }
 
 async function runHttpHost(configPath: string): Promise<void> {
@@ -217,6 +222,21 @@ async function runHttpHost(configPath: string): Promise<void> {
         marker("accepted");
         if (current.mode === "lose") return new Promise<Response>(() => {});
         await awaitFile(path.join(config.markerDir, "release"));
+        if (current.lateVerdict) {
+          let admitted: Record<string, unknown> = {};
+          try {
+            admitted = JSON.parse(answerBody) as Record<string, unknown>;
+          } catch { /* the verdict then names no id, as a lost body would */ }
+          const verdict = {
+            error: "delivery was started and never settled",
+            ...(typeof admitted.operationId === "string" ? { operationId: admitted.operationId } : {}),
+            ...(typeof admitted.launchId === "string" ? { launchId: admitted.launchId } : {}),
+            ...(typeof admitted.conversationId === "string" ? { conversationId: admitted.conversationId } : {}),
+            resend: "verify-first",
+            actuation: "started",
+          };
+          return new Response(JSON.stringify(verdict), { status: current.lateVerdict.status, headers: { "content-type": "application/json" } });
+        }
       }
       if (current.mode === "cut") {
         /* The response is lost after its status line: the body errors before

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -791,7 +791,13 @@ test("spawn_agent and send_message publish recoveryOnly and the recovery contrac
     for (const toolName of ["spawn_agent", "send_message"] as const) {
       const tool = listed.tools.find((candidate) => candidate.name === toolName)!;
       const schema = tool.inputSchema as { properties: Record<string, { type?: string; description?: string }>; required?: string[] };
+      /* Captured before toMatchObject, which swaps the matched field for its matcher. */
+      const recoveryOnlyDescription = String(schema.properties.recoveryOnly?.description);
       expect(schema.properties.recoveryOnly).toMatchObject({ type: "boolean", description: expect.stringContaining("never claim an absent key") });
+      expect(recoveryOnlyDescription).toContain("nothing is disclosed");
+      if (toolName === "spawn_agent") {
+        expect(String(schema.properties.project.description)).toContain("resolved server-side from cwd");
+      }
       expect(schema.required ?? []).not.toContain("recoveryOnly");
       expect(tool.description).toContain(RECOVERY_CONTRACT_DESCRIPTION);
       for (const rule of [

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -780,3 +780,64 @@ test("request_attention admits every target shape the attention record accepts",
   expect(refused.success).toBe(false);
   expect(JSON.stringify(refused.error?.issues)).toContain("conversation");
 });
+
+/* ── ORIGINAL-KEY RECOVERY (#1490) ─────────────────────────────────────── */
+
+import { RECOVERY_CONTRACT_DESCRIPTION, type McpRecoverableTool } from "./server";
+
+test("spawn_agent and send_message publish recoveryOnly and the recovery contract, and the flag never enters the digest", async () => {
+  await withProtocolClient(inertBindings(), async (client) => {
+    const listed = await client.listTools();
+    for (const toolName of ["spawn_agent", "send_message"] as const) {
+      const tool = listed.tools.find((candidate) => candidate.name === toolName)!;
+      const schema = tool.inputSchema as { properties: Record<string, { type?: string; description?: string }>; required?: string[] };
+      expect(schema.properties.recoveryOnly).toMatchObject({ type: "boolean", description: expect.stringContaining("never claim an absent key") });
+      expect(schema.required ?? []).not.toContain("recoveryOnly");
+      expect(tool.description).toContain(RECOVERY_CONTRACT_DESCRIPTION);
+      for (const rule of [
+        "sent exactly once",
+        "`recoveryOnly: true` never claims an absent key",
+        "`idempotency_conflict`",
+        "refused without disclosure",
+        "`accepted`",
+        "`in-flight`",
+        "`settled`",
+        "`not-executed`",
+        "`unknown`",
+        "`retryable` never means a new key may be used",
+        "`message_receipt(operationId)` remains available",
+      ]) expect(tool.description).toContain(rule);
+    }
+    expect(listed.tools.find((candidate) => candidate.name === "message_receipt")).toBeDefined();
+  });
+
+  /* Over the protocol: the same logical call with and without the flag is one
+     call, answered once by dispatch and afterwards by recovery only. */
+  const bindingCalls: unknown[] = [];
+  const bindings = inertBindings({
+    send_message: async (args) => { bindingCalls.push(args); return { operationId: "op_parity" }; },
+  });
+  const tool: McpRecoverableTool = {
+    bind: () => ({ caller: { kind: "worker", conversationId: "conversation_parity", project: null }, target: { project: null, identity: "conversation_target" }, downstreamKey: "parity-1" }),
+    recover: async () => ({ outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_parity" }, facts: { state: "delivered" } }),
+  };
+  const server = createViewerMcpServer(createMcpToolService(bindings, new MemoryMcpReceiptStore(), undefined, { recovery: { send_message: tool } }));
+  const client = new Client({ name: "schema-parity-recovery", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    const args = { clientRequestId: "parity-1", conversationId: "conversation_target", text: "hold" };
+    const first = await client.callTool({ name: "send_message", arguments: { ...args, recoveryOnly: false } });
+    expect(first.structuredContent).toMatchObject({ ok: true, operationId: "op_parity", replayed: false });
+    const explicit = await client.callTool({ name: "send_message", arguments: { ...args, recoveryOnly: true } });
+    expect(explicit.structuredContent).toMatchObject({ ok: true, recovered: true, outcome: "settled", operationId: "op_parity", replayed: true });
+    const ordinary = await client.callTool({ name: "send_message", arguments: args });
+    expect(ordinary.structuredContent).toMatchObject({ ok: true, operationId: "op_parity", replayed: true });
+    expect(bindingCalls).toHaveLength(1);
+    const rejected = await client.callTool({ name: "send_message", arguments: { ...args, recoveryOnly: "yes" } });
+    expect(rejected.isError).toBe(true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -2510,3 +2510,61 @@ for (const tool of ["send_message", "spawn_agent"] as const) {
     expect(observer.bindingCalls).toHaveLength(0);
   });
 }
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  for (const backend of ["memory", "file", "sqlite"] as const) {
+    test(`${tool}: ${backend} preserves ordinary acceptance and stronger terminal recovery separately`, async () => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-accepted-terminal-"));
+      scratch.push(directory);
+      const filename = path.join(directory, backend === "sqlite" ? "receipts.sqlite" : "receipts.json");
+      const memory = new MemoryMcpReceiptStore();
+      const open = () => backend === "memory" ? memory : backend === "file"
+        ? new FileMcpReceiptStore(filename) : new SqliteMcpReceiptStore(filename);
+      let store = open();
+      const args = tool === "send_message" ? SEND : SPAWN;
+      const ids: Record<string, string> = tool === "send_message" ? { operationId: "op_accepted" }
+        : { launchId: "launch_accepted", conversationId: "conversation_accepted" };
+      const terminal: McpRecoveryEvidence = { outcome: "settled", evidence: "durable-fixture", reason: null, ids,
+        facts: { state: tool === "send_message" ? "failed" : "completed", resend: "verify-first", duplicateRisk: true } };
+      const original = recoveryHarness(OWNER, store, { bindingImpl: async () => ({ ...ids, state: "queued" }) });
+      const accepted = await original.service.callTool(tool, args);
+      original.evidence = terminal;
+      const recovered = await original.service.callTool(tool, { ...args, recoveryOnly: true });
+      expect(recovered).toMatchObject({ ok: true, outcome: "settled", ...ids, resend: "verify-first", duplicateRisk: true });
+      expect(await original.service.callTool(tool, args)).toEqual({ ...accepted, replayed: true });
+      expect(original.bindingCalls).toHaveLength(1);
+      const key = `${tool}:${args.clientRequestId}`;
+      const record = (await store.lookup(key))!;
+      expect(record.result).toEqual(accepted);
+      expect(record.recoveryResult).toEqual(recovered);
+      if (backend === "file") {
+        const imported = new SqliteMcpReceiptStore(path.join(directory, "imported.sqlite"), { legacyFilePath: filename });
+        try { expect(imported.lookup(key)).toMatchObject({ result: accepted, recoveryResult: recovered }); }
+        finally { imported.close(); }
+      }
+      // Conflicting terminal writes from a second owner cannot regress the first.
+      const contender = open();
+      expect(await contender.settle(key, record.digest, { ...recovered, state: "contradictory" } as McpToolResult, "settled", true)).toEqual(recovered);
+      await expect(Promise.resolve().then(() => contender.settle(key, "changed-digest", recovered, "settled", true))).rejects.toThrow("ownership changed");
+      if (contender instanceof SqliteMcpReceiptStore) contender.close();
+      if (store instanceof SqliteMcpReceiptStore) store.close();
+      store = open();
+      try {
+        const restarted = recoveryHarness(OWNER, store);
+        for (const evidence of [
+          { outcome: "unknown", evidence: "none", reason: "absent", ids: {} },
+          "unreadable",
+        ]) {
+          restarted.evidence = (evidence === "unreadable" ? Promise.reject(new Error("downstream unreadable")) : evidence) as McpRecoveryEvidence;
+          expect(await restarted.service.callTool(tool, { ...args, recoveryOnly: true })).toMatchObject({
+            ok: true, outcome: "settled", evidence: "mcp-receipt", ...ids, resend: "verify-first", duplicateRisk: true,
+          });
+          expect(await restarted.service.callTool(tool, args)).toEqual({ ...accepted, replayed: true });
+        }
+        const stranger = recoveryHarness(OTHER, store);
+        expect(await stranger.service.callTool(tool, { ...args, recoveryOnly: true })).toMatchObject({ code: "recovery_not_permitted" });
+        expect(restarted.bindingCalls).toHaveLength(0);
+      } finally { if (store instanceof SqliteMcpReceiptStore) store.close(); }
+    });
+  }
+}

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -2114,7 +2114,7 @@ describe("original-key recovery (#1490)", () => {
     const reopened = new SqliteMcpReceiptStore(filename);
     const restarted = recoveryHarness(OWNER, reopened, { evidence: { outcome: "unknown", evidence: "none", reason: "gone", ids: {} } });
     expect(await restarted.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", state: "delivered", resend: "not-needed", replayed: true });
-    expect(await restarted.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: false, code: "outcome_unknown", details: { original: { ok: true, state: "delivered" } } });
+    expect(await restarted.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId: "op_late_error" });
     expect(restarted.bindingCalls).toHaveLength(0);
     reopened.close();
   });
@@ -2430,3 +2430,83 @@ describe("original-key recovery (#1490)", () => {
     expect(service.callTool("send_message", SEND)).rejects.toThrow("cannot recover send_message");
   });
 });
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  for (const response of ["timeout", "reset", "error", "success", "recovery", "not-executed", "write-failure"] as const) {
+    test(`${tool}: delayed ${response} preserves concurrently stored terminal evidence and IDs`, async () => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-terminal-race-"));
+      scratch.push(directory);
+      const filename = path.join(directory, "receipts.sqlite");
+      const first = new SqliteMcpReceiptStore(filename);
+      const second = new SqliteMcpReceiptStore(filename);
+      let release!: () => void;
+      let reached!: () => void;
+      const held = new Promise<void>((resolve) => { release = resolve; });
+      const entered = new Promise<void>((resolve) => { reached = resolve; });
+      const args = tool === "send_message" ? SEND : SPAWN;
+      const ids: Record<string, string> = tool === "send_message" ? { operationId: "op_terminal" } : { launchId: "launch_terminal", conversationId: "conversation_terminal" };
+      const terminal: McpRecoveryEvidence = { outcome: "settled", evidence: "durable-fixture", reason: null, ids, facts: { state: tool === "send_message" ? "delivered" : "completed" } };
+      const original = recoveryHarness(OWNER, first, {
+        bindingImpl: async () => {
+          reached();
+          await held;
+          if (response === "success" || response === "write-failure") return { ...ids, outcome: "queued" };
+          if (response === "not-executed") throw new McpDispatchNotExecutedError("late refusal");
+          if (response === "error") throw new McpDispatchVerdictError("late error", { status: 503, ...ids });
+          throw new McpDispatchUncertainError(response);
+        },
+      });
+      const observer = recoveryHarness(OWNER, second, { evidence: terminal });
+      try {
+        const pending = original.service.callTool(tool, args);
+        await entered;
+        expect(await observer.service.callTool(tool, { ...args, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        // The original's evidence reader has only unknown. Terminal state must
+        // survive both an explicit lookup and every delayed response class.
+        if (response === "recovery") {
+          expect(await original.service.callTool(tool, { ...args, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        }
+        if (response === "write-failure") first.settle = () => { throw new Error("receipt write unavailable"); };
+        release();
+        expect(await pending).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        expect(original.bindingCalls).toHaveLength(1);
+        expect(observer.bindingCalls).toHaveLength(0);
+      } finally {
+        release();
+        first.close();
+        second.close();
+      }
+      const reopened = new SqliteMcpReceiptStore(filename);
+      try {
+        const restarted = recoveryHarness(OWNER, reopened);
+        for (const recoveryOnly of [true, false]) expect(await restarted.service.callTool(tool, { ...args, recoveryOnly })).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        expect(restarted.bindingCalls).toHaveLength(0);
+      } finally { reopened.close(); }
+    });
+  }
+}
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: a pending evidence read cannot hide terminal recovery committed before that read returns`, async () => {
+    let release!: () => void;
+    let reached!: () => void;
+    const waiting = new Promise<void>((resolve) => { reached = resolve; });
+    const heldEvidence = new Promise<McpRecoveryEvidence>((resolve) => {
+      release = () => resolve({ outcome: "unknown", evidence: "none", reason: null, ids: {} });
+    });
+    const store = new MemoryMcpReceiptStore();
+    const args = tool === "send_message" ? SEND : SPAWN;
+    const original = recoveryHarness(OWNER, store, {
+      bindingImpl: async () => { reached(); throw new McpDispatchUncertainError("reset"); },
+      evidence: heldEvidence as unknown as McpRecoveryEvidence,
+    });
+    const pending = original.service.callTool(tool, args);
+    await waiting;
+    const observer = recoveryHarness(OWNER, store, { evidence: { outcome: "settled", evidence: "durable-fixture", reason: null, ids: { operationId: "op_read_race" } } });
+    expect(await observer.service.callTool(tool, { ...args, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", operationId: "op_read_race" });
+    release();
+    expect(await pending).toMatchObject({ ok: true, outcome: "settled", operationId: "op_read_race" });
+    expect(original.bindingCalls).toHaveLength(1);
+    expect(observer.bindingCalls).toHaveLength(0);
+  });
+}

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1980,12 +1980,24 @@ describe("original-key recovery (#1490)", () => {
     });
     expect(await carried.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", conversationId: "conversation_named" } });
 
-    /* Proven: the transport never connected (even though it tried), a 4xx
-       verdict from the server, or a failure before the request was handed to
-       the transport at all. */
+    // All error status families without affirmative dispatch proof stay open.
+    for (let status = 300; status <= 599; status += 1) {
+      const harness = recoveryHarness(OWNER, undefined, {
+        bindingImpl: async (_args, context) => {
+          context!.dispatch!.attempted = true;
+          throw new McpDispatchVerdictError("response without dispatch proof", { status });
+        },
+      });
+      expect(await harness.service.callTool("send_message", SEND)).toMatchObject({
+        code: "outcome_unknown", details: { outcome: "unknown", nextAction: "original-key-lookup" },
+      });
+      expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+      expect(harness.recoverCalls).toHaveLength(1);
+    }
+    /* Proven: the transport never connected, or the failure happened before
+       the request was handed to the transport. */
     for (const thrown of [
       new McpDispatchNotExecutedError("Viewer control is unreachable: the connection was refused before the request was sent"),
-      new McpDispatchVerdictError("empty message", { status: 400 }),
     ]) {
       const harness = recoveryHarness(OWNER, undefined, {
         bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; throw thrown; },

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -315,7 +315,7 @@ describe("MCP tool service", () => {
       .toEqual({ ...completed, replayed: true });
     expect(restarted.claim("list_tasks:abandoned-0", digest, "bounded")).toEqual({ kind: "fresh" });
     expect(restarted.claim("send_message:durable-pending", digest, "durable")).toMatchObject({ kind: "pending" });
-    expect(restarted.claim("send_message:durable-pending", "b".repeat(64), "durable")).toEqual({ kind: "conflict" });
+    expect(restarted.claim("send_message:durable-pending", "b".repeat(64), "durable")).toMatchObject({ kind: "conflict" });
     restarted.close();
 
     const database = new Database(filename, { readonly: true, strict: true });
@@ -1672,4 +1672,438 @@ test("#774 tool schemas publish the closed sets their servers enforce", () => {
     clientRequestId: "snapshot-extra-key",
     unknown: true,
   }).success).toBe(false);
+});
+
+/* ── ORIGINAL-KEY RECOVERY (#1490) ─────────────────────────────────────── */
+
+import {
+  McpDispatchUncertainError,
+  McpToolRefusal,
+  type McpRecoverableTool,
+  type McpRecoveryEvidence,
+  type McpRecoveryReceiptStore,
+  type McpRequestBinding,
+  type McpRequestCaller,
+  type McpToolCallContext,
+} from "./server";
+
+const OWNER: McpRequestCaller = { kind: "worker", conversationId: "conversation_owner", project: "proj-a" };
+const OTHER: McpRequestCaller = { kind: "worker", conversationId: "conversation_other", project: "proj-a" };
+const OTHER_PROJECT: McpRequestCaller = { kind: "worker", conversationId: "conversation_owner", project: "proj-b" };
+const UNIDENTIFIED: McpRequestCaller = { kind: "unidentified", conversationId: null, project: null };
+
+interface RecoveryHarness {
+  service: ReturnType<typeof createMcpToolService>;
+  store: McpRecoveryReceiptStore;
+  bindingCalls: McpToolCallContext[];
+  recoverCalls: { binding: McpRequestBinding; legacy: boolean }[];
+  evidence: McpRecoveryEvidence;
+  bindingImpl: (args: Record<string, unknown>, context?: McpToolCallContext) => Promise<Record<string, unknown>>;
+}
+
+function recoveryHarness(
+  caller: McpRequestCaller,
+  store: McpRecoveryReceiptStore = new MemoryMcpReceiptStore(),
+  overrides: Partial<Pick<RecoveryHarness, "evidence" | "bindingImpl">> = {},
+): RecoveryHarness {
+  const harness: RecoveryHarness = {
+    service: undefined as never,
+    store,
+    bindingCalls: [],
+    recoverCalls: [],
+    evidence: overrides.evidence ?? { outcome: "unknown", evidence: "none", reason: "nothing recorded yet", ids: {} },
+    bindingImpl: overrides.bindingImpl ?? (async () => ({ operationId: "op_dispatched", outcome: "queued" })),
+  };
+  const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+  bindings.send_message = async (args, context) => {
+    harness.bindingCalls.push(context ?? {});
+    return harness.bindingImpl(args, context);
+  };
+  const tool: McpRecoverableTool = {
+    bind: (args) => {
+      if (typeof args.text !== "string") throw new McpToolRefusal("text is required", { code: "invalid_request" });
+      return { caller, target: { project: "proj-a", identity: String(args.conversationId) }, downstreamKey: `key:${String(args.clientRequestId)}` };
+    },
+    recover: async (binding, options) => {
+      harness.recoverCalls.push({ binding, legacy: options.legacy });
+      return harness.evidence;
+    },
+  };
+  harness.service = createMcpToolService(bindings, store, undefined, { recovery: { send_message: tool } });
+  return harness;
+}
+
+const SEND = { clientRequestId: "recover-1", conversationId: "conversation_target", text: "hold" };
+
+describe("original-key recovery (#1490)", () => {
+  test("a fresh ordinary call binds before dispatch, dispatches once with the persisted key, and settles", async () => {
+    const harness = recoveryHarness(OWNER);
+    const first = await harness.service.callTool("send_message", SEND);
+    expect(first).toMatchObject({ ok: true, operationId: "op_dispatched", replayed: false });
+    expect(harness.bindingCalls).toHaveLength(1);
+    expect(harness.bindingCalls[0]?.binding).toMatchObject({
+      version: 1,
+      toolName: "send_message",
+      clientRequestId: "recover-1",
+      caller: OWNER,
+      target: { project: "proj-a", identity: "conversation_target" },
+      downstreamKey: "key:recover-1",
+      owner: { pid: process.pid },
+    });
+    const record = await harness.store.lookup("send_message:recover-1");
+    expect(record).toMatchObject({ stage: "settled", binding: { downstreamKey: "key:recover-1", caller: OWNER } });
+    expect(record?.result).toMatchObject({ ok: true, operationId: "op_dispatched" });
+
+    /* Ordinary replay keeps the recorded result; the binding is never re-run. */
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_dispatched", replayed: true });
+    expect(harness.bindingCalls).toHaveLength(1);
+    expect(harness.recoverCalls).toHaveLength(0);
+
+    /* Explicit recovery of a completed call reads current evidence and
+       carries the original alongside — recoveryOnly is not in the digest. */
+    harness.evidence = { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_dispatched" }, facts: { state: "delivered" } };
+    const explicit = await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true });
+    expect(explicit).toMatchObject({ ok: true, recovered: true, outcome: "settled", state: "delivered", operationId: "op_dispatched", nextAction: "follow-disposition", replayed: true });
+    expect((explicit as { original?: unknown }).original).toMatchObject({ ok: true, operationId: "op_dispatched" });
+    expect(harness.recoverCalls).toEqual([{ binding: expect.objectContaining({ downstreamKey: "key:recover-1" }), legacy: false }]);
+    expect(harness.bindingCalls).toHaveLength(1);
+  });
+
+  test("recoveryOnly under an absent key starts no work and permanently closes the key", async () => {
+    const harness = recoveryHarness(OWNER);
+    const probe = await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true });
+    expect(probe).toMatchObject({ ok: false, code: "not_executed", retryable: true, details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
+    expect(harness.bindingCalls).toHaveLength(0);
+    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed", binding: { caller: OWNER } });
+    /* The original call arriving later finds the closed row and never dispatches. */
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+    expect(harness.bindingCalls).toHaveLength(0);
+  });
+
+  test("changed arguments conflict, and recoveryOnly alone never changes the digest", async () => {
+    const harness = recoveryHarness(OWNER);
+    await harness.service.callTool("send_message", { ...SEND, recoveryOnly: false });
+    expect(await harness.service.callTool("send_message", { ...SEND, text: "changed" })).toMatchObject({ ok: false, code: "idempotency_conflict" });
+    expect(await harness.service.callTool("send_message", { ...SEND, text: "changed", recoveryOnly: true })).toMatchObject({ ok: false, code: "idempotency_conflict" });
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, replayed: true });
+    expect(harness.bindingCalls).toHaveLength(1);
+  });
+
+  test("another caller, another project, or an unidentified caller is refused without disclosure", async () => {
+    const store = new MemoryMcpReceiptStore();
+    const owner = recoveryHarness(OWNER, store);
+    await owner.service.callTool("send_message", SEND);
+    for (const caller of [OTHER, OTHER_PROJECT, UNIDENTIFIED]) {
+      const stranger = recoveryHarness(caller, store);
+      for (const args of [SEND, { ...SEND, recoveryOnly: true }, { ...SEND, text: "changed" }]) {
+        const answer = await stranger.service.callTool("send_message", args);
+        expect(answer).toEqual({
+          ok: false,
+          toolName: "send_message",
+          clientRequestId: "recover-1",
+          replayed: true,
+          error: "this clientRequestId cannot be recovered by this caller",
+          code: "recovery_not_permitted",
+          retryable: false,
+        });
+        expect(JSON.stringify(answer)).not.toContain("op_dispatched");
+      }
+      expect(stranger.bindingCalls).toHaveLength(0);
+      expect(stranger.recoverCalls).toHaveLength(0);
+    }
+    /* An unidentified caller may still make a fresh ordinary call of its own
+       (as before), but cannot recover it afterwards. */
+    const anonymous = recoveryHarness(UNIDENTIFIED, store);
+    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-1" })).toMatchObject({ ok: true, replayed: false });
+    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-1", recoveryOnly: true })).toMatchObject({ ok: false, code: "recovery_not_permitted" });
+    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-2", recoveryOnly: true })).toMatchObject({ ok: false, code: "recovery_not_permitted" });
+    expect(await anonymous.store.lookup("send_message:anon-2")).toBeNull();
+  });
+
+  test("an uncertain dispatch leaves the claim open, answers from evidence, and is never redispatched", async () => {
+    const harness = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async () => { throw new McpDispatchUncertainError("the connection failed after the request may have been sent"); },
+    });
+    const lost = await harness.service.callTool("send_message", SEND);
+    expect(lost).toMatchObject({
+      ok: false,
+      code: "outcome_unknown",
+      retryable: false,
+      replayed: false,
+      details: { outcome: "unknown", nextAction: "original-key-lookup", evidence: "none" },
+    });
+    expect(String((lost as { error: string }).error)).toContain("may have been sent");
+    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+    expect(harness.recoverCalls).toHaveLength(1);
+
+    /* Later calls under the key read evidence only. */
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "outcome_unknown", replayed: true });
+    harness.evidence = { outcome: "accepted", evidence: "delivery-record", reason: "accepted for delivery", ids: { operationId: "op_found" }, facts: { state: "in-flight" } };
+    expect(await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true }))
+      .toMatchObject({ ok: true, recovered: true, outcome: "accepted", operationId: "op_found", nextAction: "original-key-lookup", replayed: true });
+    harness.evidence = { outcome: "settled", evidence: "delivery-journal", reason: null, ids: { operationId: "op_found" }, facts: { state: "delivered", resend: "not-needed" } };
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", resend: "not-needed", nextAction: "follow-disposition" });
+    expect(harness.bindingCalls).toHaveLength(1);
+    /* Evidence never becomes a stored result: the row stays open for the
+       original response, and nothing pretends to know more than it does. */
+    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+  });
+
+  test("a server refusal before dispatch settles as not-executed; one carrying an admitted id keeps it", async () => {
+    const refused = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async () => { throw new McpToolRefusal("directory does not exist", { status: 400 }); },
+    });
+    expect(await refused.service.callTool("send_message", SEND)).toMatchObject({
+      ok: false,
+      code: "tool_failed",
+      retryable: true,
+      details: { status: 400, outcome: "not-executed", nextAction: "new-request-permitted" },
+    });
+    expect(await refused.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed" });
+    expect(await refused.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "tool_failed", replayed: true, details: { outcome: "not-executed" } });
+    expect(refused.bindingCalls).toHaveLength(1);
+
+    const admitted = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async () => { throw new McpToolRefusal("delivery was started and never settled", { operationId: "op_ambiguous", resend: "verify-first", actuation: "started" }); },
+    });
+    expect(await admitted.service.callTool("send_message", SEND)).toMatchObject({
+      ok: false,
+      code: "tool_failed",
+      retryable: false,
+      details: { operationId: "op_ambiguous", resend: "verify-first", outcome: "settled", nextAction: "follow-disposition" },
+    });
+    expect(await admitted.store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled" });
+  });
+
+  test("a claim whose owner died before dispatch is closed as not-executed; a live owner's claim stays unknown", async () => {
+    const store = new MemoryMcpReceiptStore();
+    const harness = recoveryHarness(OWNER, store);
+    const digest = (await (async () => {
+      /* Produce the exact digest the service computes by claiming through it once. */
+      const probe = recoveryHarness(OWNER, new MemoryMcpReceiptStore());
+      await probe.service.callTool("send_message", SEND);
+      return (await probe.store.lookup("send_message:recover-1"))!.digest;
+    })());
+    const binding = (context: Partial<McpRequestBinding["owner"]>): McpRequestBinding => ({
+      version: 1,
+      toolName: "send_message",
+      clientRequestId: "recover-1",
+      caller: OWNER,
+      target: { project: "proj-a", identity: "conversation_target" },
+      downstreamKey: "key:recover-1",
+      owner: { pid: process.pid, startIdentity: null, ...context },
+      claimedAt: new Date().toISOString(),
+    });
+
+    /* Live owner: the dispatch may be a moment away — unknown, nothing closed. */
+    expect(store.claim("send_message:recover-1", digest, "durable", binding({}))).toEqual({ kind: "fresh" });
+    const live = await harness.service.callTool("send_message", SEND);
+    expect(live).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", evidence: "mcp-receipt" } });
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "claimed", result: null });
+    expect(harness.bindingCalls).toHaveLength(0);
+    expect(harness.recoverCalls).toHaveLength(0);
+
+    /* Dead owner: closed for good, and the closure is what proves zero effect. */
+    const dead = new MemoryMcpReceiptStore();
+    const deadHarness = recoveryHarness(OWNER, dead);
+    expect(dead.claim("send_message:recover-1", digest, "durable", binding({ pid: 2 ** 22 - 1 }))).toEqual({ kind: "fresh" });
+    const closed = await deadHarness.service.callTool("send_message", { ...SEND, recoveryOnly: true });
+    expect(closed).toMatchObject({ ok: false, code: "not_executed", details: { outcome: "not-executed", evidence: "mcp-receipt" }, replayed: true });
+    expect(await dead.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed" });
+    expect(dead.markDispatching("send_message:recover-1", digest)).toBe(false);
+    expect(await deadHarness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+    expect(deadHarness.bindingCalls).toHaveLength(0);
+  });
+
+  test("a legacy claim without a binding discloses its result only when downstream evidence establishes ownership", async () => {
+    const store = new MemoryMcpReceiptStore();
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({ operationId: "op_legacy" })])) as unknown as McpToolBindings;
+    /* The row as a pre-#1490 server wrote it: no binding, no stage. */
+    await createMcpToolService(bindings, store).callTool("send_message", SEND);
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ binding: null, stage: "settled" });
+
+    const unowned = recoveryHarness(OWNER, store, {
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_legacy" }, ownership: "unknown" },
+    });
+    for (const args of [SEND, { ...SEND, recoveryOnly: true }]) {
+      const answer = await unowned.service.callTool("send_message", args);
+      expect(answer).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", evidence: "legacy-receipt-unbound" } });
+      expect(JSON.stringify(answer)).not.toContain("op_legacy");
+    }
+    expect(unowned.recoverCalls.map((call) => call.legacy)).toEqual([true, true]);
+    expect(unowned.bindingCalls).toHaveLength(0);
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ binding: null, stage: "settled" });
+
+    const owned = recoveryHarness(OWNER, store, {
+      evidence: { outcome: "settled", evidence: "spawn-receipt", reason: null, ids: { launchId: "launch_legacy" }, ownership: "established" },
+    });
+    expect(await owned.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_legacy", replayed: true });
+    expect(await owned.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, recovered: true, outcome: "settled", launchId: "launch_legacy" });
+    expect(await owned.service.callTool("send_message", { ...SEND, text: "changed" })).toMatchObject({ ok: false, code: "idempotency_conflict" });
+  });
+
+  test("the original response completing after a recovery settles once, and a later error cannot overwrite it", async () => {
+    const store = new MemoryMcpReceiptStore();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const original = recoveryHarness(OWNER, store, {
+      bindingImpl: async () => { await held; return { operationId: "op_late" }; },
+    });
+    const pending = original.service.callTool("send_message", SEND);
+    await Bun.sleep(5);
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+
+    const observer = recoveryHarness(OWNER, store, {
+      evidence: { outcome: "accepted", evidence: "delivery-record", reason: "accepted", ids: { operationId: "op_late" } },
+    });
+    expect(await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "accepted", operationId: "op_late" });
+    expect(observer.bindingCalls).toHaveLength(0);
+
+    release();
+    expect(await pending).toMatchObject({ ok: true, operationId: "op_late", replayed: false });
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled" });
+    expect(await observer.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_late", replayed: true });
+
+    /* A terminal answer already recorded wins over any later write. */
+    const digest = (await store.lookup("send_message:recover-1"))!.digest;
+    const late = { ok: false as const, toolName: "send_message", clientRequestId: "recover-1", replayed: false, error: "late", code: "tool_failed", retryable: true };
+    expect(store.settle("send_message:recover-1", digest, late)).toMatchObject({ ok: true, operationId: "op_late" });
+    expect(store.fenceUndispatched("send_message:recover-1", digest, late)).toBe(false);
+    expect((await store.lookup("send_message:recover-1"))?.result).toMatchObject({ ok: true, operationId: "op_late" });
+  });
+
+  test("the file and SQLite stores persist the binding and stage, transition conditionally, and migrate in place", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recovery-stores-"));
+    scratch.push(directory);
+    const binding: McpRequestBinding = {
+      version: 1,
+      toolName: "send_message",
+      clientRequestId: "durable-1",
+      caller: OWNER,
+      target: { project: "proj-a", identity: "conversation_target" },
+      downstreamKey: "durable-1",
+      owner: { pid: process.pid, startIdentity: null },
+      claimedAt: "2026-09-05T08:00:00.000Z",
+    };
+    const digest = "c".repeat(64);
+    const result: McpToolResult = { ok: true, toolName: "send_message", clientRequestId: "durable-1", replayed: false, operationId: "op_durable" };
+    const closed: McpToolResult = { ok: false, toolName: "send_message", clientRequestId: "durable-1", replayed: false, error: "closed", code: "not_executed", retryable: true };
+
+    /* An existing SQLite database from before the columns existed. */
+    const sqlitePath = path.join(directory, "mcp-receipts.sqlite");
+    const raw = new Database(sqlitePath, { create: true, strict: true });
+    raw.exec(`
+      CREATE TABLE mcp_receipt_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE mcp_receipts (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        receipt_key TEXT NOT NULL UNIQUE,
+        digest TEXT NOT NULL,
+        retention TEXT NOT NULL CHECK(retention IN ('bounded', 'durable')),
+        result_json TEXT,
+        storage_bytes INTEGER NOT NULL,
+        claimed_at INTEGER NOT NULL
+      );
+    `);
+    raw.query("INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at) VALUES (?, ?, 'durable', ?, 1, 1)")
+      .run("send_message:legacy-1", digest, JSON.stringify({ ...result, clientRequestId: "legacy-1" }));
+    raw.query("INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at) VALUES (?, ?, 'durable', NULL, 1, 1)")
+      .run("send_message:legacy-pending", digest);
+    raw.close();
+
+    const stores: { name: string; store: McpRecoveryReceiptStore }[] = [
+      { name: "file", store: new FileMcpReceiptStore(path.join(directory, "receipts.json")) },
+      { name: "sqlite", store: new SqliteMcpReceiptStore(sqlitePath) },
+    ];
+    for (const { name, store } of stores) {
+      const key = `send_message:durable-1`;
+      expect(await store.claim(key, digest, "durable", binding)).toEqual({ kind: "fresh" });
+      expect(await store.lookup(key)).toEqual({ digest, result: null, binding, stage: "claimed" });
+      expect(await store.claim(key, digest, "durable", binding)).toMatchObject({ kind: "pending", record: { stage: "claimed", binding } });
+      expect(await store.claim(key, "d".repeat(64), "durable", binding)).toMatchObject({ kind: "conflict", record: { binding } });
+      expect(await store.markDispatching(key, "d".repeat(64))).toBe(false);
+      expect(await store.fenceAbsent(key, digest, binding, closed)).toBe(false);
+      expect(await store.markDispatching(key, digest)).toBe(true);
+      expect(await store.markDispatching(key, digest)).toBe(false);
+      expect(await store.fenceUndispatched(key, digest, closed)).toBe(false);
+      expect((await store.lookup(key))?.stage).toBe("dispatching");
+      expect(await store.settle(key, digest, result)).toEqual(result);
+      expect(await store.settle(key, digest, closed)).toEqual(result);
+      expect(await store.lookup(key)).toMatchObject({ result, stage: "settled", binding });
+      expect(await store.claim(key, digest, "durable", binding)).toMatchObject({ kind: "replay", result, record: { stage: "settled" } });
+
+      const fenced = `send_message:fenced-${name}`;
+      const fencedBinding = { ...binding, clientRequestId: `fenced-${name}` };
+      expect(await store.fenceAbsent(fenced, digest, fencedBinding, { ...closed, clientRequestId: `fenced-${name}` })).toBe(true);
+      expect(await store.lookup(fenced)).toMatchObject({ stage: "not-executed", binding: fencedBinding });
+      expect(await store.claim(fenced, digest, "durable", fencedBinding)).toMatchObject({ kind: "replay", record: { stage: "not-executed" } });
+
+      const undispatched = `send_message:undispatched-${name}`;
+      const undispatchedBinding = { ...binding, clientRequestId: `undispatched-${name}` };
+      expect(await store.claim(undispatched, digest, "durable", undispatchedBinding)).toEqual({ kind: "fresh" });
+      expect(await store.fenceUndispatched(undispatched, digest, { ...closed, clientRequestId: `undispatched-${name}` })).toBe(true);
+      expect(await store.markDispatching(undispatched, digest)).toBe(false);
+      expect(await store.lookup(undispatched)).toMatchObject({ stage: "not-executed" });
+    }
+    /* Rows from before the columns existed read as legacy: no binding, no
+       claim stage, and their results intact. */
+    const sqlite = stores[1]!.store;
+    expect(await sqlite.lookup("send_message:legacy-1")).toMatchObject({ binding: null, stage: "settled", result: { operationId: "op_durable" } });
+    expect(await sqlite.lookup("send_message:legacy-pending")).toEqual({ digest, result: null, binding: null, stage: null });
+    (sqlite as SqliteMcpReceiptStore).close();
+
+    /* The file store's bytes survive a reopen with the binding intact, and
+       the legacy JSON import carries binding and stage into SQLite. */
+    const reopened = new FileMcpReceiptStore(path.join(directory, "receipts.json"));
+    expect(await reopened.lookup("send_message:durable-1")).toMatchObject({ binding, stage: "settled" });
+    const imported = new SqliteMcpReceiptStore(path.join(directory, "imported.sqlite"), { legacyFilePath: path.join(directory, "receipts.json") });
+    expect(imported.lookup("send_message:durable-1")).toMatchObject({ binding, stage: "settled", result });
+    expect(imported.lookup("send_message:fenced-file")).toMatchObject({ stage: "not-executed" });
+    imported.close();
+
+    /* A malformed binding fails closed on read. */
+    const corrupt = path.join(directory, "corrupt.json");
+    fs.writeFileSync(corrupt, JSON.stringify({
+      version: 2,
+      readReceipts: {},
+      mutationReceipts: { "send_message:bad": { digest, binding: { version: 1, toolName: "send_message" }, stage: "claimed" } },
+    }));
+    await expect(new FileMcpReceiptStore(corrupt).lookup("send_message:bad")).rejects.toThrow("invalid MCP receipt file");
+  });
+
+  test("two SQLite store instances racing one key yield one dispatch owner", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recovery-race-"));
+    scratch.push(directory);
+    const filename = path.join(directory, "mcp-receipts.sqlite");
+    const first = new SqliteMcpReceiptStore(filename);
+    const second = new SqliteMcpReceiptStore(filename);
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const a = recoveryHarness(OWNER, first, { bindingImpl: async () => { await held; return { operationId: "op_race" }; } });
+    const b = recoveryHarness(OWNER, second, {
+      evidence: { outcome: "unknown", evidence: "none", reason: "nothing recorded yet", ids: {} },
+      bindingImpl: async () => { throw new Error("the second process must never dispatch"); },
+    });
+    const winner = a.service.callTool("send_message", SEND);
+    await Bun.sleep(5);
+    expect(await b.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "outcome_unknown", replayed: true });
+    expect(await b.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: false, code: "outcome_unknown" });
+    expect(b.bindingCalls).toHaveLength(0);
+    release();
+    expect(await winner).toMatchObject({ ok: true, operationId: "op_race", replayed: false });
+    expect(await b.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_race", replayed: true });
+    expect(a.bindingCalls).toHaveLength(1);
+    first.close();
+    second.close();
+  });
+
+  test("a recoverable tool requires a store that can recover", () => {
+    const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
+    const legacyStore: McpReceiptStore = { claim: () => ({ kind: "fresh" }), complete: () => {} };
+    const tool: McpRecoverableTool = {
+      bind: () => ({ caller: OWNER, target: { project: null, identity: null }, downstreamKey: "k" }),
+      recover: async () => ({ outcome: "unknown", evidence: "none", reason: null, ids: {} }),
+    };
+    const service = createMcpToolService(bindings, legacyStore, undefined, { recovery: { send_message: tool } });
+    expect(service.callTool("send_message", SEND)).rejects.toThrow("cannot recover send_message");
+  });
 });

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1677,7 +1677,9 @@ test("#774 tool schemas publish the closed sets their servers enforce", () => {
 /* ── ORIGINAL-KEY RECOVERY (#1490) ─────────────────────────────────────── */
 
 import {
+  McpDispatchNotExecutedError,
   McpDispatchUncertainError,
+  McpDispatchVerdictError,
   McpToolRefusal,
   type McpRecoverableTool,
   type McpRecoveryEvidence,
@@ -1695,6 +1697,9 @@ const UNIDENTIFIED: McpRequestCaller = { kind: "unidentified", conversationId: n
 interface RecoveryHarness {
   service: ReturnType<typeof createMcpToolService>;
   store: McpRecoveryReceiptStore;
+  /** Who the authority resolver says is calling — changeable mid-test, as a
+      real process's resolved identity can differ from one call to the next. */
+  caller: McpRequestCaller;
   bindingCalls: McpToolCallContext[];
   recoverCalls: { binding: McpRequestBinding; legacy: boolean }[];
   evidence: McpRecoveryEvidence;
@@ -1709,6 +1714,7 @@ function recoveryHarness(
   const harness: RecoveryHarness = {
     service: undefined as never,
     store,
+    caller,
     bindingCalls: [],
     recoverCalls: [],
     evidence: overrides.evidence ?? { outcome: "unknown", evidence: "none", reason: "nothing recorded yet", ids: {} },
@@ -1722,7 +1728,7 @@ function recoveryHarness(
   const tool: McpRecoverableTool = {
     bind: (args) => {
       if (typeof args.text !== "string") throw new McpToolRefusal("text is required", { code: "invalid_request" });
-      return { caller, target: { project: "proj-a", identity: String(args.conversationId) }, downstreamKey: `key:${String(args.clientRequestId)}` };
+      return { caller: harness.caller, target: { project: "proj-a", identity: String(args.conversationId) }, downstreamKey: `key:${String(args.clientRequestId)}` };
     },
     recover: async (binding, options) => {
       harness.recoverCalls.push({ binding, legacy: options.legacy });
@@ -1769,15 +1775,41 @@ describe("original-key recovery (#1490)", () => {
     expect(harness.bindingCalls).toHaveLength(1);
   });
 
-  test("recoveryOnly under an absent key starts no work and permanently closes the key", async () => {
-    const harness = recoveryHarness(OWNER);
-    const probe = await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true });
-    expect(probe).toMatchObject({ ok: false, code: "not_executed", retryable: true, details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
-    expect(harness.bindingCalls).toHaveLength(0);
-    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed", binding: { caller: OWNER } });
-    /* The original call arriving later finds the closed row and never dispatches. */
-    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "not_executed", replayed: true });
-    expect(harness.bindingCalls).toHaveLength(0);
+  test("recoveryOnly under an absent key starts no work, writes nothing, and leaves a legitimate original free to claim and dispatch", async () => {
+    const store = new MemoryMcpReceiptStore();
+    const observer = recoveryHarness(OWNER, store);
+    const probe = await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true });
+    expect(probe).toMatchObject({
+      ok: false,
+      code: "outcome_unknown",
+      retryable: false,
+      replayed: false,
+      details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup", reason: expect.stringContaining("no claim exists") },
+    });
+    expect(observer.bindingCalls).toHaveLength(0);
+    expect(observer.recoverCalls).toEqual([{ binding: expect.objectContaining({ clientRequestId: "recover-1" }), legacy: false }]);
+    /* Nothing under the key: the lookup is an observation, never a claim. */
+    expect(await store.lookup("send_message:recover-1")).toBeNull();
+
+    /* The original arriving AFTER the lookup — the concurrent
+       original-before-claim case — claims and dispatches exactly once. */
+    const original = recoveryHarness(OWNER, store);
+    expect(await original.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_dispatched", replayed: false });
+    expect(original.bindingCalls).toHaveLength(1);
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled" });
+    /* And the observer now reads it. */
+    observer.evidence = { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_dispatched" }, facts: { state: "delivered" } };
+    expect(await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", operationId: "op_dispatched" });
+    expect(original.bindingCalls).toHaveLength(1);
+
+    /* Work admitted downstream by a path that never claimed here is still
+       found through the bound key. */
+    const found = recoveryHarness(OWNER, new MemoryMcpReceiptStore(), {
+      evidence: { outcome: "accepted", evidence: "delivery-record", reason: "accepted", ids: { operationId: "op_elsewhere" } },
+    });
+    expect(await found.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "accepted", operationId: "op_elsewhere", nextAction: "original-key-lookup" });
+    expect(await found.store.lookup("send_message:recover-1")).toBeNull();
+    expect(found.bindingCalls).toHaveLength(0);
   });
 
   test("changed arguments conflict, and recoveryOnly alone never changes the digest", async () => {
@@ -1793,7 +1825,7 @@ describe("original-key recovery (#1490)", () => {
     const store = new MemoryMcpReceiptStore();
     const owner = recoveryHarness(OWNER, store);
     await owner.service.callTool("send_message", SEND);
-    for (const caller of [OTHER, OTHER_PROJECT, UNIDENTIFIED]) {
+    for (const caller of [OTHER, OTHER_PROJECT]) {
       const stranger = recoveryHarness(caller, store);
       for (const args of [SEND, { ...SEND, recoveryOnly: true }, { ...SEND, text: "changed" }]) {
         const answer = await stranger.service.callTool("send_message", args);
@@ -1811,13 +1843,153 @@ describe("original-key recovery (#1490)", () => {
       expect(stranger.bindingCalls).toHaveLength(0);
       expect(stranger.recoverCalls).toHaveLength(0);
     }
-    /* An unidentified caller may still make a fresh ordinary call of its own
-       (as before), but cannot recover it afterwards. */
+    /* An unidentified caller is refused before anything is claimed: the same
+       answer under an existing key, an absent key, ordinary or explicit — so
+       it neither dispatches a mutation nobody could recover nor learns whether
+       the key exists. */
     const anonymous = recoveryHarness(UNIDENTIFIED, store);
-    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-1" })).toMatchObject({ ok: true, replayed: false });
-    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-1", recoveryOnly: true })).toMatchObject({ ok: false, code: "recovery_not_permitted" });
-    expect(await anonymous.service.callTool("send_message", { ...SEND, clientRequestId: "anon-2", recoveryOnly: true })).toMatchObject({ ok: false, code: "recovery_not_permitted" });
-    expect(await anonymous.store.lookup("send_message:anon-2")).toBeNull();
+    for (const args of [SEND, { ...SEND, recoveryOnly: true }, { ...SEND, text: "changed" }, { ...SEND, clientRequestId: "anon-1" }, { ...SEND, clientRequestId: "anon-2", recoveryOnly: true }]) {
+      const answer = await anonymous.service.callTool("send_message", args);
+      expect(answer).toEqual({
+        ok: false,
+        toolName: "send_message",
+        clientRequestId: String(args.clientRequestId),
+        replayed: false,
+        error: expect.stringContaining("identity could not be established"),
+        code: "caller_unidentified",
+        retryable: false,
+      });
+      expect(JSON.stringify(answer)).not.toContain("op_dispatched");
+    }
+    expect(anonymous.bindingCalls).toHaveLength(0);
+    expect(anonymous.recoverCalls).toHaveLength(0);
+    expect(await store.lookup("send_message:anon-1")).toBeNull();
+    expect(await store.lookup("send_message:anon-2")).toBeNull();
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", binding: { caller: OWNER } });
+  });
+
+  test("a duplicate in the same process is authenticated and answered from the durable record, never joined to the original", async () => {
+    const store = new MemoryMcpReceiptStore();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const harness = recoveryHarness(OWNER, store, {
+      bindingImpl: async () => { await held; return { operationId: "op_joined" }; },
+    });
+    const original = harness.service.callTool("send_message", SEND);
+    await Bun.sleep(5);
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+
+    /* The resolved identity changes while the original is still out: the
+       same service instance now speaks for another caller, and learns nothing. */
+    harness.caller = OTHER;
+    for (const args of [SEND, { ...SEND, recoveryOnly: true }]) {
+      const stranger = await harness.service.callTool("send_message", args);
+      expect(stranger).toMatchObject({ ok: false, code: "recovery_not_permitted", replayed: true });
+      expect(JSON.stringify(stranger)).not.toContain("op_joined");
+    }
+    harness.caller = OTHER_PROJECT;
+    expect(await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: false, code: "recovery_not_permitted" });
+    harness.caller = UNIDENTIFIED;
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "caller_unidentified" });
+    expect(harness.recoverCalls).toHaveLength(0);
+
+    /* The owner's own duplicate reads the durable evidence rather than
+       waiting on the in-process promise: what another process would see. */
+    harness.caller = OWNER;
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "outcome_unknown", replayed: true, details: { outcome: "unknown", nextAction: "original-key-lookup" } });
+    harness.evidence = { outcome: "accepted", evidence: "delivery-record", reason: "accepted", ids: { operationId: "op_joined" } };
+    expect(await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "accepted", operationId: "op_joined", replayed: true });
+    expect(harness.recoverCalls).toHaveLength(2);
+    expect(harness.bindingCalls).toHaveLength(1);
+
+    release();
+    expect(await original).toMatchObject({ ok: true, operationId: "op_joined", replayed: false });
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, operationId: "op_joined", replayed: true });
+    expect(harness.bindingCalls).toHaveLength(1);
+  });
+
+  test("a failure after the request may be on the server stays unknown with the ids it carried; only proven pre-dispatch failures close the attempt", async () => {
+    /* The production send binding reads the registry AFTER the HTTP
+       acceptance; that read throwing is not proof of anything. */
+    const afterDispatch = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async (_args, context) => {
+        context!.dispatch!.attempted = true;
+        throw new Error("the delivery record could not be read after acceptance");
+      },
+    });
+    const lost = await afterDispatch.service.callTool("send_message", SEND);
+    expect(lost).toMatchObject({
+      ok: false,
+      code: "outcome_unknown",
+      retryable: false,
+      replayed: false,
+      error: expect.stringContaining("could not be read after acceptance"),
+      details: { outcome: "unknown", nextAction: "original-key-lookup" },
+    });
+    expect(JSON.stringify(lost)).not.toContain("not-executed");
+    expect(JSON.stringify(lost)).not.toContain("new-request-permitted");
+    expect(await afterDispatch.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+    expect(afterDispatch.recoverCalls).toHaveLength(1);
+    /* The evidence found later is the answer, under the same key. */
+    afterDispatch.evidence = { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_after" }, facts: { state: "delivered" } };
+    expect(await afterDispatch.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_after", replayed: true });
+    expect(afterDispatch.bindingCalls).toHaveLength(1);
+
+    /* A 5xx verdict, a 409 whose ids were lost, and a refusal after the
+       attempt carrying an id: never not-executed. */
+    for (const [thrown, expected] of [
+      [new McpDispatchVerdictError("upstream failed", { status: 500 }), { code: "outcome_unknown", details: { outcome: "unknown" } }],
+      [new McpDispatchVerdictError("conflict", { status: 409 }), { code: "outcome_unknown", details: { outcome: "unknown" } }],
+      [new McpToolRefusal("delivery was started", { operationId: "op_kept", resend: "verify-first" }), { code: "tool_failed", details: { outcome: "settled", operationId: "op_kept", nextAction: "follow-disposition" } }],
+    ] as const) {
+      const harness = recoveryHarness(OWNER, undefined, {
+        bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; throw thrown; },
+      });
+      expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, ...expected });
+    }
+    /* Ids a refusal carried are kept on an uncertain answer. */
+    const carried = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; throw new McpToolRefusal("host lost the answer", { conversationId: "conversation_named", status: 502 }); },
+    });
+    expect(await carried.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", conversationId: "conversation_named" } });
+
+    /* Proven: the transport never connected (even though it tried), a 4xx
+       verdict from the server, or a failure before the request was handed to
+       the transport at all. */
+    for (const thrown of [
+      new McpDispatchNotExecutedError("Viewer control is unreachable: the connection was refused before the request was sent"),
+      new McpDispatchVerdictError("empty message", { status: 400 }),
+    ]) {
+      const harness = recoveryHarness(OWNER, undefined, {
+        bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; throw thrown; },
+      });
+      expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "tool_failed", retryable: true, details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
+      expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed" });
+      expect(harness.recoverCalls).toHaveLength(0);
+    }
+    const beforeTransport = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async () => { throw new Error("cwd is required"); },
+    });
+    expect(await beforeTransport.service.callTool("send_message", SEND)).toMatchObject({ ok: false, code: "tool_failed", details: { outcome: "not-executed" } });
+    expect(await beforeTransport.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed" });
+
+    /* A late error from the original response after a recovery already saw
+       success: the terminal answer stands, and the row is never closed. */
+    const store = new MemoryMcpReceiptStore();
+    let fail!: () => void;
+    const failing = new Promise<void>((resolve) => { fail = resolve; });
+    const original = recoveryHarness(OWNER, store, {
+      bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; await failing; throw new Error("socket closed after the answer was written"); },
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_late_success" }, facts: { state: "delivered" } },
+    });
+    const pending = original.service.callTool("send_message", SEND);
+    await Bun.sleep(5);
+    const observer = recoveryHarness(OWNER, store, { evidence: original.evidence });
+    expect(await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success" });
+    fail();
+    expect(await pending).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success", replayed: false });
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+    expect(await observer.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success" });
   });
 
   test("an uncertain dispatch leaves the claim open, answers from evidence, and is never redispatched", async () => {
@@ -2021,7 +2193,6 @@ describe("original-key recovery (#1490)", () => {
       expect(await store.claim(key, digest, "durable", binding)).toMatchObject({ kind: "pending", record: { stage: "claimed", binding } });
       expect(await store.claim(key, "d".repeat(64), "durable", binding)).toMatchObject({ kind: "conflict", record: { binding } });
       expect(await store.markDispatching(key, "d".repeat(64))).toBe(false);
-      expect(await store.fenceAbsent(key, digest, binding, closed)).toBe(false);
       expect(await store.markDispatching(key, digest)).toBe(true);
       expect(await store.markDispatching(key, digest)).toBe(false);
       expect(await store.fenceUndispatched(key, digest, closed)).toBe(false);
@@ -2030,12 +2201,6 @@ describe("original-key recovery (#1490)", () => {
       expect(await store.settle(key, digest, closed)).toEqual(result);
       expect(await store.lookup(key)).toMatchObject({ result, stage: "settled", binding });
       expect(await store.claim(key, digest, "durable", binding)).toMatchObject({ kind: "replay", result, record: { stage: "settled" } });
-
-      const fenced = `send_message:fenced-${name}`;
-      const fencedBinding = { ...binding, clientRequestId: `fenced-${name}` };
-      expect(await store.fenceAbsent(fenced, digest, fencedBinding, { ...closed, clientRequestId: `fenced-${name}` })).toBe(true);
-      expect(await store.lookup(fenced)).toMatchObject({ stage: "not-executed", binding: fencedBinding });
-      expect(await store.claim(fenced, digest, "durable", fencedBinding)).toMatchObject({ kind: "replay", record: { stage: "not-executed" } });
 
       const undispatched = `send_message:undispatched-${name}`;
       const undispatchedBinding = { ...binding, clientRequestId: `undispatched-${name}` };
@@ -2057,7 +2222,7 @@ describe("original-key recovery (#1490)", () => {
     expect(await reopened.lookup("send_message:durable-1")).toMatchObject({ binding, stage: "settled" });
     const imported = new SqliteMcpReceiptStore(path.join(directory, "imported.sqlite"), { legacyFilePath: path.join(directory, "receipts.json") });
     expect(imported.lookup("send_message:durable-1")).toMatchObject({ binding, stage: "settled", result });
-    expect(imported.lookup("send_message:fenced-file")).toMatchObject({ stage: "not-executed" });
+    expect(imported.lookup("send_message:undispatched-file")).toMatchObject({ stage: "not-executed" });
     imported.close();
 
     /* A malformed binding fails closed on read. */

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1721,25 +1721,30 @@ function recoveryHarness(
     bindingImpl: overrides.bindingImpl ?? (async () => ({ operationId: "op_dispatched", outcome: "queued" })),
   };
   const bindings = Object.fromEntries(MCP_TOOL_NAMES.map((toolName) => [toolName, async () => ({})])) as unknown as McpToolBindings;
-  bindings.send_message = async (args, context) => {
+  const recording: McpToolBindings[keyof McpToolBindings] = async (args, context) => {
     harness.bindingCalls.push(context ?? {});
     return harness.bindingImpl(args, context);
   };
+  bindings.send_message = recording;
+  bindings.spawn_agent = recording;
+  /* One recoverable tool shape serves both mutations: a send binds its
+     conversation, a spawn its directory, and the service treats them alike. */
   const tool: McpRecoverableTool = {
     bind: (args) => {
-      if (typeof args.text !== "string") throw new McpToolRefusal("text is required", { code: "invalid_request" });
-      return { caller: harness.caller, target: { project: "proj-a", identity: String(args.conversationId) }, downstreamKey: `key:${String(args.clientRequestId)}` };
+      if (typeof args.text !== "string" && typeof args.cwd !== "string") throw new McpToolRefusal("text is required", { code: "invalid_request" });
+      return { caller: harness.caller, target: { project: "proj-a", identity: String(args.conversationId ?? args.cwd) }, downstreamKey: `key:${String(args.clientRequestId)}` };
     },
     recover: async (binding, options) => {
       harness.recoverCalls.push({ binding, legacy: options.legacy });
       return harness.evidence;
     },
   };
-  harness.service = createMcpToolService(bindings, store, undefined, { recovery: { send_message: tool } });
+  harness.service = createMcpToolService(bindings, store, undefined, { recovery: { send_message: tool, spawn_agent: tool } });
   return harness;
 }
 
 const SEND = { clientRequestId: "recover-1", conversationId: "conversation_target", text: "hold" };
+const SPAWN = { clientRequestId: "recover-1", cwd: "/fixture/launch-dir", "prompt": "go", title: "Recovery launch" };
 
 describe("original-key recovery (#1490)", () => {
   test("a fresh ordinary call binds before dispatch, dispatches once with the persisted key, and settles", async () => {
@@ -1787,7 +1792,9 @@ describe("original-key recovery (#1490)", () => {
       details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup", reason: expect.stringContaining("no claim exists") },
     });
     expect(observer.bindingCalls).toHaveLength(0);
-    expect(observer.recoverCalls).toEqual([{ binding: expect.objectContaining({ clientRequestId: "recover-1" }), legacy: false }]);
+    /* Without a claim there is no binding that could authorise a downstream
+       read, so none is made. */
+    expect(observer.recoverCalls).toHaveLength(0);
     /* Nothing under the key: the lookup is an observation, never a claim. */
     expect(await store.lookup("send_message:recover-1")).toBeNull();
 
@@ -1802,14 +1809,34 @@ describe("original-key recovery (#1490)", () => {
     expect(await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", operationId: "op_dispatched" });
     expect(original.bindingCalls).toHaveLength(1);
 
-    /* Work admitted downstream by a path that never claimed here is still
-       found through the bound key. */
-    const found = recoveryHarness(OWNER, new MemoryMcpReceiptStore(), {
-      evidence: { outcome: "accepted", evidence: "delivery-record", reason: "accepted", ids: { operationId: "op_elsewhere" } },
-    });
-    expect(await found.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "accepted", operationId: "op_elsewhere", nextAction: "original-key-lookup" });
-    expect(await found.store.lookup("send_message:recover-1")).toBeNull();
-    expect(found.bindingCalls).toHaveLength(0);
+  });
+
+  test("an absent claim discloses nothing, to anyone, for either tool: a downstream record under the key is never read without the binding that proves whose it is", async () => {
+    /* The reviewer's reproduction: work exists downstream under a key nobody
+       claimed HERE (the key's owner claimed it in another store, or the row
+       was lost), and a downstream read would hand its ids to whoever asks
+       with the key — another caller, another project, a changed payload,
+       even the owner. No claim, no binding, no read, no ids. */
+    for (const [toolName, args] of [["send_message", SEND], ["spawn_agent", SPAWN]] as const) {
+      for (const caller of [OWNER, OTHER, OTHER_PROJECT]) {
+        const harness = recoveryHarness(caller, new MemoryMcpReceiptStore(), {
+          evidence: { outcome: "accepted", evidence: "spawn-receipt", reason: "accepted", ids: { launchId: "launch_elsewhere", conversationId: "conversation_elsewhere", operationId: "op_elsewhere" } },
+        });
+        for (const variant of [{ ...args, recoveryOnly: true }, { ...args, recoveryOnly: true, [toolName === "send_message" ? "text" : "prompt"]: "changed" }]) {
+          const answer = await harness.service.callTool(toolName, variant);
+          expect(answer).toMatchObject({
+            ok: false,
+            code: "outcome_unknown",
+            replayed: false,
+            details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup", reason: expect.stringContaining("no claim exists") },
+          });
+          expect(JSON.stringify(answer)).not.toContain("elsewhere");
+        }
+        expect(harness.recoverCalls).toHaveLength(0);
+        expect(harness.bindingCalls).toHaveLength(0);
+        expect(await harness.store.lookup(`${toolName}:recover-1`)).toBeNull();
+      }
+    }
   });
 
   test("changed arguments conflict, and recoveryOnly alone never changes the digest", async () => {
@@ -1974,7 +2001,8 @@ describe("original-key recovery (#1490)", () => {
     expect(await beforeTransport.store.lookup("send_message:recover-1")).toMatchObject({ stage: "not-executed" });
 
     /* A late error from the original response after a recovery already saw
-       success: the terminal answer stands, and the row is never closed. */
+       success: the terminal answer was written when it was seen, so it is
+       what the original's own call gets, and the row is never closed. */
     const store = new MemoryMcpReceiptStore();
     let fail!: () => void;
     const failing = new Promise<void>((resolve) => { fail = resolve; });
@@ -1986,10 +2014,10 @@ describe("original-key recovery (#1490)", () => {
     await Bun.sleep(5);
     const observer = recoveryHarness(OWNER, store, { evidence: original.evidence });
     expect(await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success" });
+    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", result: { ok: true, outcome: "settled", operationId: "op_late_success" } });
     fail();
-    expect(await pending).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success", replayed: false });
-    expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
-    expect(await observer.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success" });
+    expect(await pending).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success", replayed: true });
+    expect(await observer.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_late_success", replayed: true });
   });
 
   test("an uncertain dispatch leaves the claim open, answers from evidence, and is never redispatched", async () => {
@@ -2013,12 +2041,130 @@ describe("original-key recovery (#1490)", () => {
     harness.evidence = { outcome: "accepted", evidence: "delivery-record", reason: "accepted for delivery", ids: { operationId: "op_found" }, facts: { state: "in-flight" } };
     expect(await harness.service.callTool("send_message", { ...SEND, recoveryOnly: true }))
       .toMatchObject({ ok: true, recovered: true, outcome: "accepted", operationId: "op_found", nextAction: "original-key-lookup", replayed: true });
+    /* Open evidence never becomes a stored result: the row stays open for the
+       original response, and nothing pretends to know more than it does. */
+    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
     harness.evidence = { outcome: "settled", evidence: "delivery-journal", reason: null, ids: { operationId: "op_found" }, facts: { state: "delivered", resend: "not-needed" } };
     expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", resend: "not-needed", nextAction: "follow-disposition" });
     expect(harness.bindingCalls).toHaveLength(1);
-    /* Evidence never becomes a stored result: the row stays open for the
-       original response, and nothing pretends to know more than it does. */
-    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+    /* TERMINAL evidence is the row's answer from now on, so nothing that
+       arrives later can replace it. */
+    expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", result: { ok: true, recovered: true, outcome: "settled", operationId: "op_found" } });
+    harness.evidence = { outcome: "unknown", evidence: "none", reason: "gone", ids: {} };
+    expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_found", replayed: true });
+  });
+
+  test("terminal evidence recovered while the original still dispatches is persisted, so a delayed admitted error cannot replace it — across store instances and a reopen", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recovery-late-error-"));
+    scratch.push(directory);
+    const filename = path.join(directory, "mcp-receipts.sqlite");
+    const first = new SqliteMcpReceiptStore(filename);
+    const second = new SqliteMcpReceiptStore(filename);
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    /* The original's dispatch answers late, and with a 409 that names the
+       admitted operation: the server's ambiguity verdict, which would settle
+       the row as `tool_failed` / verify-first if nothing better were known. */
+    const original = recoveryHarness(OWNER, first, {
+      bindingImpl: async () => {
+        await held;
+        throw new McpDispatchVerdictError("delivery was started and never settled", { status: 409, operationId: "op_late_error", resend: "verify-first", actuation: "started" });
+      },
+    });
+    const pending = original.service.callTool("send_message", SEND);
+    await Bun.sleep(5);
+    expect(await first.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
+
+    /* Another process recovers under the key while the dispatch is open and
+       the durable delivery record already proves delivery. */
+    const observer = recoveryHarness(OWNER, second, {
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_late_error" }, facts: { state: "delivered", resend: "not-needed", duplicateRisk: false } },
+    });
+    const recovered = await observer.service.callTool("send_message", { ...SEND, recoveryOnly: true });
+    expect(recovered).toMatchObject({ ok: true, recovered: true, outcome: "settled", state: "delivered", resend: "not-needed", operationId: "op_late_error", replayed: true });
+    expect(observer.bindingCalls).toHaveLength(0);
+    expect(await second.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", result: { ok: true, outcome: "settled", state: "delivered" } });
+
+    /* The delayed error arrives: the row already holds the terminal answer,
+       so the original's own call gets that answer, never the regression. */
+    release();
+    const late = await pending;
+    expect(late).toMatchObject({ ok: true, outcome: "settled", state: "delivered", resend: "not-needed", operationId: "op_late_error", replayed: true });
+    expect(JSON.stringify(late)).not.toContain("verify-first");
+    for (const harness of [original, observer]) {
+      expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", state: "delivered", resend: "not-needed", replayed: true });
+    }
+    expect(original.bindingCalls).toHaveLength(1);
+    first.close();
+    second.close();
+
+    /* After a restart against the same file the answer is the same. */
+    const reopened = new SqliteMcpReceiptStore(filename);
+    const restarted = recoveryHarness(OWNER, reopened, { evidence: { outcome: "unknown", evidence: "none", reason: "gone", ids: {} } });
+    expect(await restarted.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", state: "delivered", resend: "not-needed", replayed: true });
+    expect(await restarted.service.callTool("send_message", { ...SEND, recoveryOnly: true })).toMatchObject({ ok: false, code: "outcome_unknown", details: { original: { ok: true, state: "delivered" } } });
+    expect(restarted.bindingCalls).toHaveLength(0);
+    reopened.close();
+  });
+
+  test("a receipt record that cannot be read is answered unknown with original-key guidance: nothing claimed, dispatched or disclosed", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-recovery-unreadable-"));
+    scratch.push(directory);
+    const expectUnknown = async (harness: RecoveryHarness, args: Record<string, unknown>, replayed: boolean) => {
+      const answer = await harness.service.callTool("send_message", args);
+      expect(answer).toMatchObject({
+        ok: false,
+        code: "outcome_unknown",
+        retryable: false,
+        replayed,
+        details: { outcome: "unknown", evidence: "mcp-receipt-unreadable", nextAction: "original-key-lookup", reason: expect.stringContaining("could not be read") },
+      });
+      expect(JSON.stringify(answer)).not.toContain("op_");
+      expect(harness.bindingCalls).toHaveLength(0);
+      expect(harness.recoverCalls).toHaveLength(0);
+    };
+
+    /* A store that faults on every read. */
+    const faulting = new MemoryMcpReceiptStore();
+    faulting.lookup = () => { throw new Error("disk read failed"); };
+    faulting.claim = () => { throw new Error("disk read failed"); };
+    const faultingHarness = recoveryHarness(OWNER, faulting, {
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_hidden" } },
+    });
+    await expectUnknown(faultingHarness, { ...SEND, recoveryOnly: true }, false);
+    await expectUnknown(faultingHarness, SEND, false);
+
+    /* A corrupted file record. */
+    const filePath = path.join(directory, "receipts.json");
+    const fileHarness = recoveryHarness(OWNER, new FileMcpReceiptStore(filePath), {
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_hidden" } },
+    });
+    await fileHarness.service.callTool("send_message", SEND);
+    expect(fileHarness.bindingCalls).toHaveLength(1);
+    const state = JSON.parse(fs.readFileSync(filePath, "utf8")) as { mutationReceipts: Record<string, { binding: unknown }> };
+    state.mutationReceipts["send_message:recover-1"]!.binding = { version: 1, toolName: "send_message" };
+    fs.writeFileSync(filePath, JSON.stringify(state));
+    fileHarness.bindingCalls.length = 0;
+    await expectUnknown(fileHarness, { ...SEND, recoveryOnly: true }, false);
+    await expectUnknown(fileHarness, SEND, false);
+
+    /* A corrupted SQLite record, and the same answer after a reopen. */
+    const sqlitePath = path.join(directory, "mcp-receipts.sqlite");
+    const sqlite = new SqliteMcpReceiptStore(sqlitePath);
+    const sqliteHarness = recoveryHarness(OWNER, sqlite, {
+      evidence: { outcome: "settled", evidence: "delivery-record", reason: null, ids: { operationId: "op_hidden" } },
+    });
+    await sqliteHarness.service.callTool("send_message", SEND);
+    const raw = new Database(sqlitePath, { strict: true });
+    raw.query("UPDATE mcp_receipts SET binding_json = ? WHERE receipt_key = ?").run("{not json", "send_message:recover-1");
+    raw.close();
+    sqliteHarness.bindingCalls.length = 0;
+    await expectUnknown(sqliteHarness, { ...SEND, recoveryOnly: true }, false);
+    await expectUnknown(sqliteHarness, SEND, false);
+    sqlite.close();
+    const reopened = recoveryHarness(OWNER, new SqliteMcpReceiptStore(sqlitePath));
+    await expectUnknown(reopened, SEND, false);
+    (reopened.store as SqliteMcpReceiptStore).close();
   });
 
   test("a server refusal before dispatch settles as not-executed; one carrying an admitted id keeps it", async () => {

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -241,6 +241,85 @@ describe("MCP tool service", () => {
     }));
   }, 30_000);
 
+  test("cold concurrent starts migrate every prior SQLite schema once and keep the receipts", async () => {
+    /* #1490: two processes that both inspect the columns and then both ALTER
+       TABLE make the loser throw "duplicate column name". Every schema a
+       production database can carry is opened cold by twenty processes at the
+       same instant; each must initialize and read the seeded receipt back. */
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-cold-"));
+    scratch.push(directory);
+    const childPath = path.join(import.meta.dir, "receiptStoreProbeChild.ts");
+    const digest = "e".repeat(64);
+    const key = "send_message:cold-seeded";
+    const seededResult: McpToolResult = { ok: true, toolName: "send_message", clientRequestId: "cold-seeded", replayed: false, operationId: "op_cold" };
+    const baseColumns = `
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      receipt_key TEXT NOT NULL UNIQUE,
+      digest TEXT NOT NULL,
+      retention TEXT NOT NULL CHECK(retention IN ('bounded', 'durable')),
+      result_json TEXT,
+      storage_bytes INTEGER NOT NULL,
+      claimed_at INTEGER NOT NULL`;
+    const schemas: { name: string; extraColumns: string; seed: (raw: Database) => void; expected: unknown }[] = [
+      {
+        name: "legacy",
+        extraColumns: "",
+        seed: (raw) => raw.query("INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at) VALUES (?, ?, 'durable', ?, 1, 1)")
+          .run(key, digest, JSON.stringify(seededResult)),
+        expected: { digest, result: seededResult, binding: null, stage: "settled" },
+      },
+      {
+        name: "previous-repair",
+        extraColumns: ", binding_json TEXT, stage TEXT",
+        seed: (raw) => raw.query("INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage) VALUES (?, ?, 'durable', ?, 1, 1, NULL, 'settled')")
+          .run(key, digest, JSON.stringify(seededResult)),
+        expected: { digest, result: seededResult, binding: null, stage: "settled" },
+      },
+      { name: "absent", extraColumns: "", seed: () => {}, expected: null },
+    ];
+    for (const schema of schemas) {
+      const sqlitePath = path.join(directory, `${schema.name}.sqlite`);
+      if (schema.name !== "absent") {
+        const raw = new Database(sqlitePath, { create: true, strict: true });
+        raw.exec(`
+          CREATE TABLE mcp_receipt_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+          CREATE TABLE mcp_receipts (${baseColumns}${schema.extraColumns});
+        `);
+        schema.seed(raw);
+        raw.close();
+      }
+      const startPath = path.join(directory, `${schema.name}-start`);
+      const processes = 20;
+      const children = Array.from({ length: processes }, (_value, index) => Bun.spawn({
+        cmd: [
+          process.execPath, childPath, "cold-start", sqlitePath,
+          path.join(directory, `${schema.name}-ready-${index}`), startPath,
+          path.join(directory, `${schema.name}-result-${index}.json`), String(index), key,
+        ],
+        cwd: import.meta.dir,
+        env: { ...process.env, LLV_STATE_DIR: path.join(directory, "state", schema.name, String(index)) },
+        stdout: "pipe",
+        stderr: "pipe",
+      }));
+      expect(await waitForFileCount(directory, `${schema.name}-ready-`, processes)).toBeTrue();
+      fs.writeFileSync(startPath, String(Date.now() + 150));
+      const outcomes = await Promise.all(children.map(childResult));
+      expect(outcomes).toEqual(Array.from({ length: processes }, () => ({ exit: 0, error: "" })));
+      const results = Array.from({ length: processes }, (_value, index) => JSON.parse(
+        fs.readFileSync(path.join(directory, `${schema.name}-result-${index}.json`), "utf8"),
+      ) as { index: number; ok: boolean; error?: string; record?: unknown });
+      expect(results.map(({ ok, error }) => `${schema.name}:${ok ? "ok" : error}`))
+        .toEqual(Array.from({ length: processes }, () => `${schema.name}:ok`));
+      expect(results.map(({ record }) => record)).toEqual(Array.from({ length: processes }, () => schema.expected));
+
+      const migrated = new Database(sqlitePath, { readonly: true, strict: true });
+      const columns = migrated.query<{ name: string }, []>("PRAGMA table_info(mcp_receipts)").all().map((column) => column.name);
+      expect(columns).toEqual(["sequence", "receipt_key", "digest", "retention", "result_json", "storage_bytes", "claimed_at", "binding_json", "stage", "recovery_result_json"]);
+      expect(migrated.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM mcp_receipts").get()?.count).toBe(schema.name === "absent" ? 0 : 1);
+      migrated.close();
+    }
+  }, 60_000);
+
   test("SQLite read receipt count retention expires the oldest completed replay", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipts-count-"));
     scratch.push(directory);

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1967,7 +1967,7 @@ describe("original-key recovery (#1490)", () => {
     for (const [thrown, expected] of [
       [new McpDispatchVerdictError("upstream failed", { status: 500 }), { code: "outcome_unknown", details: { outcome: "unknown" } }],
       [new McpDispatchVerdictError("conflict", { status: 409 }), { code: "outcome_unknown", details: { outcome: "unknown" } }],
-      [new McpToolRefusal("delivery was started", { operationId: "op_kept", resend: "verify-first" }), { code: "tool_failed", details: { outcome: "settled", operationId: "op_kept", nextAction: "follow-disposition" } }],
+      [new McpToolRefusal("delivery was started", { operationId: "op_kept", resend: "verify-first" }), { code: "outcome_unknown", details: { outcome: "unknown", operationId: "op_kept", nextAction: "original-key-lookup" } }],
     ] as const) {
       const harness = recoveryHarness(OWNER, undefined, {
         bindingImpl: async (_args, context) => { context!.dispatch!.attempted = true; throw thrown; },
@@ -2075,8 +2075,8 @@ describe("original-key recovery (#1490)", () => {
     let release!: () => void;
     const held = new Promise<void>((resolve) => { release = resolve; });
     /* The original's dispatch answers late, and with a 409 that names the
-       admitted operation: the server's ambiguity verdict, which would settle
-       the row as `tool_failed` / verify-first if nothing better were known. */
+       admitted operation. Admission does not establish a terminal outcome;
+       the already recovered delivery must remain the answer. */
     const original = recoveryHarness(OWNER, first, {
       bindingImpl: async () => {
         await held;
@@ -2198,11 +2198,11 @@ describe("original-key recovery (#1490)", () => {
     });
     expect(await admitted.service.callTool("send_message", SEND)).toMatchObject({
       ok: false,
-      code: "tool_failed",
+      code: "outcome_unknown",
       retryable: false,
-      details: { operationId: "op_ambiguous", resend: "verify-first", outcome: "settled", nextAction: "follow-disposition" },
+      details: { operationId: "op_ambiguous", outcome: "unknown", nextAction: "original-key-lookup" },
     });
-    expect(await admitted.store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled" });
+    expect(await admitted.store.lookup("send_message:recover-1")).toMatchObject({ stage: "dispatching", result: null });
   });
 
   test("a claim whose owner died before dispatch is closed as not-executed; a live owner's claim stays unknown", async () => {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2315,15 +2315,9 @@ export function createMcpToolService(
               : evidence;
             return answerFromEvidence(uncertain, false);
           }
-          /* What the failure PROVES decides the answer. An error naming an
-             ADMITTED id (an operation or a launch) is a terminal verdict about
-             work the server holds and keeps that id and its guidance. Nothing
-             executed only when the request provably never left: the transport
-             says so or the request was never handed to it. HTTP status and
-             an error body alone provide no pre-dispatch proof. Everything
-             else after the request may be on the server
-             leaves the row `dispatching` and is answered from the evidence,
-             exactly as a lost response is; nothing here may invite a new key. */
+          /* Admission identifies work whose outcome still needs evidence.
+             Only affirmative pre-dispatch proof closes an attempt. HTTP
+             status, error text, and admitted IDs cannot establish termination. */
           outcome = error instanceof DeadlineExceededError ? "deadline" : "failure";
           const refusal = error instanceof McpToolRefusal ? error.details : {};
           const admitted = typeof refusal.operationId === "string" || typeof refusal.launchId === "string";
@@ -2331,8 +2325,17 @@ export function createMcpToolService(
             error instanceof McpDispatchNotExecutedError
             || !dispatch.attempted
           );
-          if (!admitted && !proven) {
+          if (!proven) {
             outcome = context.signal?.aborted ? "cancelled" : "failure";
+            // A concurrent recovery may already have established termination.
+            // Preserve that result even if the downstream read is now unavailable.
+            let current: McpReceiptRecord | null;
+            try {
+              current = await store.lookup(key);
+            } catch (cause) {
+              return unreadableReceipt(cause, false);
+            }
+            if (current?.result) return { ...current.result, replayed: true };
             const message = error instanceof Error ? error.message : String(error);
             const evidence = await readEvidence(binding, false);
             const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
@@ -2342,16 +2345,16 @@ export function createMcpToolService(
           }
           const details: McpToolPayload = {
             ...refusal,
-            outcome: admitted ? "settled" : "not-executed",
-            evidence: admitted ? "dispatch-answer" : "dispatch-refused",
-            nextAction: admitted ? "follow-disposition" : "new-request-permitted",
+            outcome: "not-executed",
+            evidence: "dispatch-refused",
+            nextAction: "new-request-permitted",
           };
           settled = failure(
             typedTool,
             requestId,
             "tool_failed",
             error instanceof Error ? error.message : String(error),
-            !admitted,
+            true,
             false,
             details,
           );

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -172,6 +172,10 @@ export type McpToolPayload = Record<string, unknown>;
 export interface McpToolCallContext {
   signal?: AbortSignal;
   deadlineAt?: number;
+  /** #1490: the durable binding this call's dispatch must use. Present only on
+      a recoverable mutation's single dispatch; the binding reads its downstream
+      idempotency key from here rather than deriving one of its own. */
+  binding?: McpRequestBinding;
 }
 export type McpToolBinding = (args: McpToolArgs, context?: McpToolCallContext) => Promise<McpToolPayload>;
 export type McpToolBindings = Record<McpToolName, McpToolBinding>;
@@ -344,39 +348,177 @@ export class McpToolRefusal extends Error {
 
 export type McpToolResult = McpToolSuccess | McpToolFailure;
 
+/**
+ * Where one recoverable mutation's dispatch stands (#1490).
+ *
+ * `claimed` — the receipt row exists and NOTHING has been sent: the process
+ * that owns it has not yet marked the dispatch. `dispatching` — the owner wrote
+ * this marker before its one and only POST, so the server may hold the request
+ * from this moment on and nothing can prove otherwise. `not-executed` — the
+ * attempt was permanently closed while still `claimed`, so it can never be
+ * dispatched: the one state that proves zero effect. `settled` — a result was
+ * written. Rows written before this field existed carry null and are treated
+ * as legacy: their fate is whatever downstream evidence says, never assumed.
+ */
+export type McpDispatchStage = "claimed" | "dispatching" | "not-executed" | "settled";
+
+/** The server-resolved identity of who made a recoverable call. Never read
+    from the arguments: the authority resolver decides it. */
+export interface McpRequestCaller {
+  kind: "root" | "worker" | "unidentified";
+  conversationId: string | null;
+  project: string | null;
+}
+
+export interface McpRequestTarget {
+  /** Canonical project of the target (the recipient's for a send, the
+      launch directory's for a spawn), or null when it has none. */
+  project: string | null;
+  /** Canonical target identity: the alias-resolved conversation id or
+      transcript path for a send, the resolved working directory for a spawn. */
+  identity: string | null;
+}
+
+/** What a recoverable tool's binding contributes to the durable claim. */
+export interface McpRequestBindingInput {
+  caller: McpRequestCaller;
+  target: McpRequestTarget;
+  /** The EXACT idempotency key handed downstream (clientAttemptId for a
+      spawn, clientMessageId for a send). Persisted so recovery reads the same
+      key the dispatch used, never a recomputed one. */
+  downstreamKey: string;
+}
+
+/** The identity persisted with a recoverable mutation's claim, before its
+    dispatch, so recovery under the original clientRequestId can be authorised
+    and can find the downstream record without any caller-supplied fact. */
+export interface McpRequestBinding extends McpRequestBindingInput {
+  version: 1;
+  toolName: McpToolName;
+  clientRequestId: string;
+  /** The process that holds the claim, so a `claimed` row whose owner is gone
+      can be closed as never dispatched instead of waiting forever. */
+  owner: { pid: number; startIdentity: string | null };
+  claimedAt: string;
+}
+
+export interface McpReceiptRecord {
+  digest: string;
+  result: McpToolResult | null;
+  binding: McpRequestBinding | null;
+  stage: McpDispatchStage | null;
+}
+
 type Receipt = {
   digest: string;
   result?: McpToolResult;
+  binding?: McpRequestBinding;
+  stage?: McpDispatchStage;
 };
 
 export type ReceiptClaim =
   | { kind: "fresh" }
-  | { kind: "pending"; unfinishedAgeMs?: number }
-  | { kind: "replay"; result: McpToolResult }
-  | { kind: "conflict" };
+  | { kind: "pending"; unfinishedAgeMs?: number; record?: McpReceiptRecord }
+  | { kind: "replay"; result: McpToolResult; record?: McpReceiptRecord }
+  | { kind: "conflict"; record?: McpReceiptRecord };
 
 export interface McpReceiptStore {
-  claim(key: string, digest: string, retention: ReceiptRetention): ReceiptClaim | Promise<ReceiptClaim>;
+  claim(key: string, digest: string, retention: ReceiptRetention, binding?: McpRequestBinding): ReceiptClaim | Promise<ReceiptClaim>;
   complete(key: string, digest: string, result: McpToolResult, retention: ReceiptRetention): void | Promise<void>;
 }
 
-export class MemoryMcpReceiptStore implements McpReceiptStore {
+/**
+ * The store surface original-key recovery needs (#1490). Every transition is
+ * conditional on the row's current stage, so two processes racing over one
+ * key can never both dispatch, and a late answer can never overwrite an
+ * earlier terminal one.
+ */
+export interface McpRecoveryReceiptStore extends McpReceiptStore {
+  /** Read one row without claiming it. */
+  lookup(key: string): McpReceiptRecord | null | Promise<McpReceiptRecord | null>;
+  /** `claimed` → `dispatching`. False means the attempt was closed by someone
+      else first, and the caller must not dispatch. */
+  markDispatching(key: string, digest: string): boolean | Promise<boolean>;
+  /** `claimed` → `not-executed`, writing the terminal result. False means the
+      row is no longer merely claimed (it was dispatched, or already closed). */
+  fenceUndispatched(key: string, digest: string, result: McpToolResult): boolean | Promise<boolean>;
+  /** Writes the result only if none is recorded yet, and returns whatever the
+      row holds afterwards — the first terminal answer always wins. */
+  settle(key: string, digest: string, result: McpToolResult, stage?: "settled" | "not-executed"): McpToolResult | Promise<McpToolResult>;
+  /** Inserts a permanently closed `not-executed` row under a key nothing has
+      claimed. False when the key was claimed in the meantime. */
+  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean | Promise<boolean>;
+}
+
+export function supportsMcpRecovery(store: McpReceiptStore): store is McpRecoveryReceiptStore {
+  const candidate = store as Partial<McpRecoveryReceiptStore>;
+  return typeof candidate.lookup === "function"
+    && typeof candidate.markDispatching === "function"
+    && typeof candidate.fenceUndispatched === "function"
+    && typeof candidate.settle === "function"
+    && typeof candidate.fenceAbsent === "function";
+}
+
+function recordOf(receipt: Receipt): McpReceiptRecord {
+  return {
+    digest: receipt.digest,
+    result: receipt.result ?? null,
+    binding: receipt.binding ?? null,
+    stage: receipt.stage ?? (receipt.result ? "settled" : null),
+  };
+}
+
+export class MemoryMcpReceiptStore implements McpRecoveryReceiptStore {
   private readonly receipts = new Map<string, Receipt>();
 
-  claim(key: string, digest: string): ReceiptClaim {
+  claim(key: string, digest: string, _retention?: ReceiptRetention, binding?: McpRequestBinding): ReceiptClaim {
     const receipt = this.receipts.get(key);
     if (!receipt) {
-      this.receipts.set(key, { digest });
+      this.receipts.set(key, { digest, ...(binding ? { binding, stage: "claimed" } : {}) });
       return { kind: "fresh" };
     }
-    if (receipt.digest !== digest) return { kind: "conflict" };
-    return receipt.result ? { kind: "replay", result: receipt.result } : { kind: "pending" };
+    const record = recordOf(receipt);
+    if (receipt.digest !== digest) return { kind: "conflict", record };
+    return receipt.result ? { kind: "replay", result: receipt.result, record } : { kind: "pending", record };
   }
 
   complete(key: string, digest: string, result: McpToolResult): void {
     const receipt = this.receipts.get(key);
     if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
-    this.receipts.set(key, { digest, result });
+    this.receipts.set(key, { ...receipt, digest, result, stage: "settled" });
+  }
+
+  lookup(key: string): McpReceiptRecord | null {
+    const receipt = this.receipts.get(key);
+    return receipt ? recordOf(receipt) : null;
+  }
+
+  markDispatching(key: string, digest: string): boolean {
+    const receipt = this.receipts.get(key);
+    if (!receipt || receipt.digest !== digest || receipt.stage !== "claimed" || receipt.result) return false;
+    this.receipts.set(key, { ...receipt, stage: "dispatching" });
+    return true;
+  }
+
+  fenceUndispatched(key: string, digest: string, result: McpToolResult): boolean {
+    const receipt = this.receipts.get(key);
+    if (!receipt || receipt.digest !== digest || receipt.stage !== "claimed" || receipt.result) return false;
+    this.receipts.set(key, { ...receipt, result, stage: "not-executed" });
+    return true;
+  }
+
+  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): McpToolResult {
+    const receipt = this.receipts.get(key);
+    if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
+    if (receipt.result) return receipt.result;
+    this.receipts.set(key, { ...receipt, result, stage });
+    return result;
+  }
+
+  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean {
+    if (this.receipts.has(key)) return false;
+    this.receipts.set(key, { digest, binding, result, stage: "not-executed" });
+    return true;
   }
 }
 
@@ -456,6 +598,32 @@ function validReceiptResult(value: unknown, toolName: McpToolName, requestId: st
     && typeof value.retryable === "boolean";
 }
 
+const RECEIPT_MEMBER_KEYS = ["binding", "digest", "result", "stage"] as const;
+const DISPATCH_STAGES: ReadonlySet<string> = new Set<McpDispatchStage>(["claimed", "dispatching", "not-executed", "settled"]);
+
+function isDispatchStage(value: unknown): value is McpDispatchStage {
+  return typeof value === "string" && DISPATCH_STAGES.has(value);
+}
+
+function nullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+export function validRequestBinding(value: unknown, toolName?: McpToolName, requestId?: string): value is McpRequestBinding {
+  if (!isRecord(value) || value.version !== 1) return false;
+  if (typeof value.toolName !== "string" || !(MCP_TOOL_NAMES as readonly string[]).includes(value.toolName)) return false;
+  if (toolName !== undefined && value.toolName !== toolName) return false;
+  if (typeof value.clientRequestId !== "string" || (requestId !== undefined && value.clientRequestId !== requestId)) return false;
+  if (typeof value.downstreamKey !== "string" || !value.downstreamKey) return false;
+  if (typeof value.claimedAt !== "string") return false;
+  const { caller, target, owner } = value;
+  if (!isRecord(caller) || !["root", "worker", "unidentified"].includes(String(caller.kind))
+    || !nullableString(caller.conversationId) || !nullableString(caller.project)) return false;
+  if (!isRecord(target) || !nullableString(target.project) || !nullableString(target.identity)) return false;
+  if (!isRecord(owner) || typeof owner.pid !== "number" || !nullableString(owner.startIdentity)) return false;
+  return true;
+}
+
 function validateReceiptRecord(
   value: unknown,
   retention?: ReceiptRetention,
@@ -466,10 +634,12 @@ function validateReceiptRecord(
     const parts = receiptKeyParts(key);
     if (!parts) throw new Error(`invalid MCP receipt file: invalid receipt key ${JSON.stringify(key)}`);
     if (!isRecord(candidate)
-      || !hasExactKeys(candidate, "result" in candidate ? ["digest", "result"] : ["digest"])
+      || !hasExactKeys(candidate, RECEIPT_MEMBER_KEYS.filter((member) => member in candidate))
       || typeof candidate.digest !== "string"
       || !/^[0-9a-f]{64}$/i.test(candidate.digest)
-      || ("result" in candidate && !validReceiptResult(candidate.result, parts.toolName, parts.requestId))) {
+      || ("result" in candidate && !validReceiptResult(candidate.result, parts.toolName, parts.requestId))
+      || ("binding" in candidate && !validRequestBinding(candidate.binding, parts.toolName, parts.requestId))
+      || ("stage" in candidate && !isDispatchStage(candidate.stage))) {
       throw new Error(`invalid MCP receipt file: invalid receipt ${JSON.stringify(key)}`);
     }
     const actualRetention: ReceiptRetention = MUTATING_MCP_TOOL_NAMES.has(parts.toolName) ? "durable" : "bounded";
@@ -1037,19 +1207,20 @@ function writeReceiptFile(filePath: string, state: ReceiptFile): void {
   fs.renameSync(temporary, filePath);
 }
 
-export class FileMcpReceiptStore implements McpReceiptStore {
+export class FileMcpReceiptStore implements McpRecoveryReceiptStore {
   constructor(private readonly filePath: string) {}
 
-  async claim(key: string, digest: string, retention: ReceiptRetention): Promise<ReceiptClaim> {
+  async claim(key: string, digest: string, retention: ReceiptRetention, binding?: McpRequestBinding): Promise<ReceiptClaim> {
     return withFileLock(this.filePath, () => {
       const state = readReceiptFile(this.filePath);
       const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
       if (receipt) {
-        if (receipt.digest !== digest) return { kind: "conflict" };
-        return receipt.result ? { kind: "replay", result: receipt.result } : { kind: "pending" };
+        const record = recordOf(receipt);
+        if (receipt.digest !== digest) return { kind: "conflict", record };
+        return receipt.result ? { kind: "replay", result: receipt.result, record } : { kind: "pending", record };
       }
       const target = retention === "durable" ? state.mutationReceipts : state.readReceipts;
-      target[key] = { digest };
+      target[key] = { digest, ...(binding ? { binding, stage: "claimed" as const } : {}) };
       const keys = Object.keys(state.readReceipts);
       for (const expired of keys.slice(0, Math.max(0, keys.length - FILE_RECEIPT_CAP))) delete state.readReceipts[expired];
       writeReceiptFile(this.filePath, state);
@@ -1062,16 +1233,70 @@ export class FileMcpReceiptStore implements McpReceiptStore {
       const state = readReceiptFile(this.filePath);
       const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
       if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
+      const settled: Receipt = { ...receipt, digest, result, stage: "settled" };
       if (retention === "durable") {
         delete state.readReceipts[key];
-        state.mutationReceipts[key] = { digest, result };
+        state.mutationReceipts[key] = settled;
       } else if (state.mutationReceipts[key]) {
-        state.mutationReceipts[key] = { digest, result };
+        state.mutationReceipts[key] = settled;
       } else {
-        state.readReceipts[key] = { digest, result };
+        state.readReceipts[key] = settled;
       }
       writeReceiptFile(this.filePath, state);
     });
+  }
+
+  async lookup(key: string): Promise<McpReceiptRecord | null> {
+    return withFileLock(this.filePath, () => {
+      const state = readReceiptFile(this.filePath);
+      const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
+      return receipt ? recordOf(receipt) : null;
+    });
+  }
+
+  private async transition(
+    key: string,
+    digest: string,
+    apply: (receipt: Receipt | undefined) => Receipt | null,
+  ): Promise<boolean> {
+    return withFileLock(this.filePath, () => {
+      const state = readReceiptFile(this.filePath);
+      const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
+      if (receipt && receipt.digest !== digest) return false;
+      const next = apply(receipt);
+      if (!next) return false;
+      delete state.readReceipts[key];
+      state.mutationReceipts[key] = next;
+      writeReceiptFile(this.filePath, state);
+      return true;
+    });
+  }
+
+  markDispatching(key: string, digest: string): Promise<boolean> {
+    return this.transition(key, digest, (receipt) =>
+      receipt && receipt.stage === "claimed" && !receipt.result ? { ...receipt, stage: "dispatching" } : null);
+  }
+
+  fenceUndispatched(key: string, digest: string, result: McpToolResult): Promise<boolean> {
+    return this.transition(key, digest, (receipt) =>
+      receipt && receipt.stage === "claimed" && !receipt.result ? { ...receipt, result, stage: "not-executed" } : null);
+  }
+
+  async settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): Promise<McpToolResult> {
+    return withFileLock(this.filePath, () => {
+      const state = readReceiptFile(this.filePath);
+      const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
+      if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
+      if (receipt.result) return receipt.result;
+      delete state.readReceipts[key];
+      state.mutationReceipts[key] = { ...receipt, result, stage };
+      writeReceiptFile(this.filePath, state);
+      return result;
+    });
+  }
+
+  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): Promise<boolean> {
+    return this.transition(key, digest, (receipt) => (receipt ? null : { digest, binding, result, stage: "not-executed" }));
   }
 }
 
@@ -1079,6 +1304,8 @@ type StoredSqliteReceipt = {
   digest: string;
   result_json: string | null;
   claimed_at: number;
+  binding_json: string | null;
+  stage: string | null;
 };
 
 export interface SqliteMcpReceiptStoreOptions {
@@ -1097,7 +1324,7 @@ export interface SqliteMcpReceiptStoreOptions {
  * large read responses. The legacy JSON import is validated by the same parser
  * as the legacy adapter and committed atomically with its import marker.
  */
-export class SqliteMcpReceiptStore implements McpReceiptStore {
+export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
   private readonly db: BunDatabase;
   private readonly readReceiptCountCap: number;
   private readonly readReceiptByteCap: number;
@@ -1131,6 +1358,12 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
       CREATE INDEX IF NOT EXISTS mcp_receipts_retention_sequence
       ON mcp_receipts(retention, sequence);
     `);
+    /* #1490: the bound identity and dispatch stage of a recoverable mutation.
+       Added in place so an existing database keeps every row it holds; rows
+       from before carry NULL in both and are read as legacy. */
+    const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(mcp_receipts)").all().map((column) => column.name));
+    if (!columns.has("binding_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN binding_json TEXT");
+    if (!columns.has("stage")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN stage TEXT");
     this.importLegacyFile(options.legacyFilePath);
     this.db.exec("BEGIN IMMEDIATE");
     try {
@@ -1143,29 +1376,27 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
     this.secureFiles();
   }
 
-  claim(key: string, digest: string, retention: ReceiptRetention): ReceiptClaim {
+  claim(key: string, digest: string, retention: ReceiptRetention, binding?: McpRequestBinding): ReceiptClaim {
     this.db.exec("BEGIN IMMEDIATE");
     try {
       const now = this.now();
       this.pruneBoundedReceipts(now);
-      const receipt = this.db.query<StoredSqliteReceipt, [string]>(`
-        SELECT digest, result_json, claimed_at
-        FROM mcp_receipts
-        WHERE receipt_key = ?
-      `).get(key);
+      const receipt = this.selectRow(key);
       if (receipt) {
         this.db.exec("COMMIT");
-        if (receipt.digest !== digest) return { kind: "conflict" };
+        const record = this.recordOfRow(key, receipt);
+        if (receipt.digest !== digest) return { kind: "conflict", record };
         if (receipt.result_json === null) {
-          return { kind: "pending", unfinishedAgeMs: Math.max(0, now - receipt.claimed_at) };
+          return { kind: "pending", unfinishedAgeMs: Math.max(0, now - receipt.claimed_at), record };
         }
-        return { kind: "replay", result: this.parseResult(key, receipt.result_json) };
+        return { kind: "replay", result: record.result!, record };
       }
-      const storageBytes = this.storageBytes(key, digest, null);
-      this.db.query<unknown, [string, string, ReceiptRetention, number, number]>(`
-        INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at)
-        VALUES (?, ?, ?, NULL, ?, ?)
-      `).run(key, digest, retention, storageBytes, now);
+      const bindingJson = binding ? JSON.stringify(binding) : null;
+      const storageBytes = this.storageBytes(key, digest, null, bindingJson);
+      this.db.query<unknown, [string, string, ReceiptRetention, number, number, string | null, string | null]>(`
+        INSERT INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage)
+        VALUES (?, ?, ?, NULL, ?, ?, ?, ?)
+      `).run(key, digest, retention, storageBytes, now, bindingJson, binding ? "claimed" : null);
       this.pruneBoundedReceipts(now);
       this.db.exec("COMMIT");
       return { kind: "fresh" };
@@ -1177,19 +1408,19 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
 
   complete(key: string, digest: string, result: McpToolResult, retention: ReceiptRetention): void {
     const resultJson = JSON.stringify(result);
-    const storageBytes = this.storageBytes(key, digest, resultJson);
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const receipt = this.db.query<Pick<StoredSqliteReceipt, "digest"> & { retention: ReceiptRetention }, [string]>(`
-        SELECT digest, retention
+      const receipt = this.db.query<Pick<StoredSqliteReceipt, "digest" | "binding_json"> & { retention: ReceiptRetention }, [string]>(`
+        SELECT digest, retention, binding_json
         FROM mcp_receipts
         WHERE receipt_key = ?
       `).get(key);
       if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
       const effectiveRetention = receipt.retention === "durable" ? "durable" : retention;
+      const storageBytes = this.storageBytes(key, digest, resultJson, receipt.binding_json);
       this.db.query<unknown, [ReceiptRetention, string, number, string]>(`
         UPDATE mcp_receipts
-        SET retention = ?, result_json = ?, storage_bytes = ?
+        SET retention = ?, result_json = ?, storage_bytes = ?, stage = 'settled'
         WHERE receipt_key = ?
       `).run(effectiveRetention, resultJson, storageBytes, key);
       this.pruneBoundedReceipts(this.now());
@@ -1198,6 +1429,102 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
     }
+  }
+
+  lookup(key: string): McpReceiptRecord | null {
+    const receipt = this.selectRow(key);
+    return receipt ? this.recordOfRow(key, receipt) : null;
+  }
+
+  markDispatching(key: string, digest: string): boolean {
+    return this.db.query<unknown, [string, string]>(`
+      UPDATE mcp_receipts
+      SET stage = 'dispatching'
+      WHERE receipt_key = ? AND digest = ? AND stage = 'claimed' AND result_json IS NULL
+    `).run(key, digest).changes === 1;
+  }
+
+  fenceUndispatched(key: string, digest: string, result: McpToolResult): boolean {
+    const resultJson = JSON.stringify(result);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const receipt = this.selectRow(key);
+      if (!receipt || receipt.digest !== digest || receipt.stage !== "claimed" || receipt.result_json !== null) {
+        this.db.exec("COMMIT");
+        return false;
+      }
+      this.db.query<unknown, [string, number, string]>(`
+        UPDATE mcp_receipts
+        SET result_json = ?, storage_bytes = ?, stage = 'not-executed', retention = 'durable'
+        WHERE receipt_key = ?
+      `).run(resultJson, this.storageBytes(key, digest, resultJson, receipt.binding_json), key);
+      this.db.exec("COMMIT");
+      return true;
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): McpToolResult {
+    const resultJson = JSON.stringify(result);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const receipt = this.selectRow(key);
+      if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
+      if (receipt.result_json !== null) {
+        this.db.exec("COMMIT");
+        return this.parseResult(key, receipt.result_json);
+      }
+      this.db.query<unknown, [string, number, string, string]>(`
+        UPDATE mcp_receipts
+        SET result_json = ?, storage_bytes = ?, stage = ?, retention = 'durable'
+        WHERE receipt_key = ?
+      `).run(resultJson, this.storageBytes(key, digest, resultJson, receipt.binding_json), stage, key);
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean {
+    const resultJson = JSON.stringify(result);
+    const bindingJson = JSON.stringify(binding);
+    return this.db.query<unknown, [string, string, string, number, number, string]>(`
+      INSERT OR IGNORE INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage)
+      VALUES (?, ?, 'durable', ?, ?, ?, ?, 'not-executed')
+    `).run(key, digest, resultJson, this.storageBytes(key, digest, resultJson, bindingJson), this.now(), bindingJson).changes === 1;
+  }
+
+  private selectRow(key: string): StoredSqliteReceipt | null {
+    return this.db.query<StoredSqliteReceipt, [string]>(`
+      SELECT digest, result_json, claimed_at, binding_json, stage
+      FROM mcp_receipts
+      WHERE receipt_key = ?
+    `).get(key);
+  }
+
+  private recordOfRow(key: string, receipt: StoredSqliteReceipt): McpReceiptRecord {
+    const parts = receiptKeyParts(key);
+    let binding: McpRequestBinding | null = null;
+    if (receipt.binding_json !== null) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(receipt.binding_json);
+      } catch (error) {
+        throw new Error("invalid MCP receipt database binding JSON", { cause: error });
+      }
+      if (!validRequestBinding(parsed, parts?.toolName, parts?.requestId)) throw new Error("invalid MCP receipt database binding");
+      binding = parsed;
+    }
+    return {
+      digest: receipt.digest,
+      result: receipt.result_json === null ? null : this.parseResult(key, receipt.result_json),
+      binding,
+      stage: isDispatchStage(receipt.stage) ? receipt.stage : receipt.result_json === null ? null : "settled",
+    };
   }
 
   close(): void {
@@ -1216,16 +1543,20 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
     if (!fs.existsSync(legacyFilePath)) return;
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const insert = this.db.query<unknown, [string, string, ReceiptRetention, string | null, number, number]>(`
+      const insert = this.db.query<unknown, [string, string, ReceiptRetention, string | null, number, number, string | null, string | null]>(`
         INSERT OR IGNORE INTO mcp_receipts(
-          receipt_key, digest, retention, result_json, storage_bytes, claimed_at
-        ) VALUES (?, ?, ?, ?, ?, ?)
+          receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
       let claimedAt = this.now() - Object.keys(state.readReceipts).length - Object.keys(state.mutationReceipts).length;
       const importCollection = (receipts: Record<string, Receipt>, retention: ReceiptRetention) => {
         for (const [key, receipt] of Object.entries(receipts)) {
           const resultJson = receipt.result === undefined ? null : JSON.stringify(receipt.result);
-          insert.run(key, receipt.digest, retention, resultJson, this.storageBytes(key, receipt.digest, resultJson), claimedAt);
+          const bindingJson = receipt.binding === undefined ? null : JSON.stringify(receipt.binding);
+          insert.run(
+            key, receipt.digest, retention, resultJson,
+            this.storageBytes(key, receipt.digest, resultJson, bindingJson), claimedAt, bindingJson, receipt.stage ?? null,
+          );
           claimedAt += 1;
         }
       };
@@ -1308,8 +1639,11 @@ export class SqliteMcpReceiptStore implements McpReceiptStore {
     return parsed;
   }
 
-  private storageBytes(key: string, digest: string, resultJson: string | null): number {
-    return Buffer.byteLength(key) + Buffer.byteLength(digest) + (resultJson === null ? 0 : Buffer.byteLength(resultJson));
+  private storageBytes(key: string, digest: string, resultJson: string | null, bindingJson: string | null = null): number {
+    return Buffer.byteLength(key)
+      + Buffer.byteLength(digest)
+      + (resultJson === null ? 0 : Buffer.byteLength(resultJson))
+      + (bindingJson === null ? 0 : Buffer.byteLength(bindingJson));
   }
 
   private meta(key: string): string | null {
@@ -1500,6 +1834,118 @@ export function mcpToolTimingSnapshot(): McpToolTimingSummary[] {
 
 export interface McpToolServiceOptions {
   timings?: McpToolTimingAggregate;
+  /** #1490: the tools whose claim is bound to the caller before dispatch and
+      recoverable under the original clientRequestId afterwards. Requires a
+      store that {@link supportsMcpRecovery}. */
+  recovery?: Partial<Record<McpToolName, McpRecoverableTool>>;
+}
+
+/** The closed outcome vocabulary of original-key recovery (#1490). */
+export type McpRecoveryOutcome = "accepted" | "in-flight" | "settled" | "not-executed" | "unknown";
+
+/** What a caller may do next, stated on the answer rather than implied by
+    `retryable`. `original-key-lookup` is the ONLY permitted action on an
+    unknown or open outcome: never a new key, never an automatic resend. */
+export type McpRecoveryNextAction = "original-key-lookup" | "follow-disposition" | "new-request-permitted";
+
+export interface McpRecoveryEvidence {
+  outcome: McpRecoveryOutcome;
+  /** Provenance of this answer: which durable record or journal supplied it,
+      or `none` when nothing was found. */
+  evidence: string;
+  reason: string | null;
+  /** Every actual identifier the evidence carries (operationId, launchId,
+      conversationId, transcriptPath, deliveryId). Empty when nothing was found. */
+  ids: Record<string, string>;
+  /** Terminal facts for a settled outcome: the actual state, resend guidance,
+      duplicate risk, or the recorded error. */
+  facts?: McpToolPayload;
+  /** For a legacy record (claimed before bindings existed): whether existing
+      durable evidence establishes that the CURRENT caller owns it. Anything
+      but `established` discloses nothing. */
+  ownership?: "established" | "unknown";
+}
+
+export interface McpRecoverableTool {
+  /** Resolve the server-derived caller and target for these arguments. Runs
+      before the receipt store is touched; may throw {@link McpToolRefusal}. */
+  bind(args: McpToolArgs): McpRequestBindingInput | Promise<McpRequestBindingInput>;
+  /** Read-only: what the downstream durable records say about this binding.
+      Must never dispatch, enqueue, retry, withdraw or spawn. */
+  recover(binding: McpRequestBinding, options: { legacy: boolean; context?: McpToolCallContext }): Promise<McpRecoveryEvidence>;
+}
+
+/**
+ * Thrown by a binding whose one dispatch may have reached the server without
+ * an answer coming back: a timeout after the request was written, a reset, an
+ * unreadable body, a proxy status that says nothing about the upstream. The
+ * service reports it as `unknown` and never redispatches.
+ */
+export class McpDispatchUncertainError extends Error {
+  constructor(message: string, readonly details: McpToolPayload = {}) {
+    super(message);
+    this.name = "McpDispatchUncertainError";
+  }
+}
+
+function sameCaller(recorded: McpRequestCaller, current: McpRequestCaller): boolean {
+  return recorded.kind === current.kind
+    && recorded.conversationId === current.conversationId
+    && recorded.project === current.project;
+}
+
+function identifiedCaller(caller: McpRequestCaller): boolean {
+  return caller.kind === "root" || (caller.kind === "worker" && caller.conversationId !== null);
+}
+
+function nextActionFor(outcome: McpRecoveryOutcome): McpRecoveryNextAction {
+  if (outcome === "settled") return "follow-disposition";
+  if (outcome === "not-executed") return "new-request-permitted";
+  return "original-key-lookup";
+}
+
+const RECOVERY_NOT_PERMITTED = "this clientRequestId cannot be recovered by this caller";
+
+function recoveryAnswer(
+  toolName: McpToolName,
+  requestId: string,
+  evidence: McpRecoveryEvidence,
+  replayed: boolean,
+  original?: McpToolResult | null,
+): McpToolResult {
+  const shared: McpToolPayload = {
+    recovered: true,
+    outcome: evidence.outcome,
+    evidence: evidence.evidence,
+    reason: evidence.reason,
+    nextAction: nextActionFor(evidence.outcome),
+    ...evidence.ids,
+    ...(evidence.facts ?? {}),
+    ...(original ? { original } : {}),
+  };
+  if (evidence.outcome === "unknown") {
+    return failure(
+      toolName,
+      requestId,
+      "outcome_unknown",
+      evidence.reason ?? "the outcome of this request is unknown; look it up again under the same clientRequestId",
+      false,
+      replayed,
+      shared,
+    );
+  }
+  if (evidence.outcome === "not-executed") {
+    return failure(
+      toolName,
+      requestId,
+      "not_executed",
+      evidence.reason ?? "this request was never dispatched and the attempt is permanently closed",
+      true,
+      replayed,
+      shared,
+    );
+  }
+  return { ...shared, ok: true, toolName, clientRequestId: requestId, replayed };
 }
 
 export function createMcpToolService(
@@ -1545,6 +1991,9 @@ export function createMcpToolService(
       const retention: ReceiptRetention = MUTATING_MCP_TOOL_NAMES.has(typedTool) ? "durable" : "bounded";
       const requestId = clientRequestId(effectiveArgs);
       if (!requestId) return finish(failure(toolName, null, "invalid_request", "clientRequestId is required", false), "failure");
+      const recoverable = options.recovery?.[typedTool] ?? null;
+      const recoveryStore = recoverable && supportsMcpRecovery(receipts) ? receipts : null;
+      if (recoverable && !recoveryStore) throw new Error(`MCP receipt store cannot recover ${typedTool}`);
 
       /* Refused before the receipt is claimed, on purpose. A refusal is a
          property of who is calling, not of the operation, so it must not burn the
@@ -1555,7 +2004,14 @@ export function createMcpToolService(
         return finish(failure(typedTool, requestId, verdict.code, verdict.error, false), "failure");
       }
 
-      const digest = requestDigest(typedTool, effectiveArgs);
+      /* #1490: `recoveryOnly` decides only whether an absent claim may start
+         work, so it is excluded from the digest — the same logical call with
+         and without it is one call. */
+      const recoveryOnly = recoverable !== null && effectiveArgs.recoveryOnly === true;
+      const digestArgs: McpToolArgs = recoverable
+        ? Object.fromEntries(Object.entries(effectiveArgs).filter(([name]) => name !== "recoveryOnly"))
+        : effectiveArgs;
+      const digest = requestDigest(typedTool, digestArgs);
       const key = `${typedTool}:${requestId}`;
       const active = inFlight.get(key);
       if (active) {
@@ -1569,7 +2025,220 @@ export function createMcpToolService(
       }
       let outcome: McpTimingOutcome = "failure";
       let unfinishedAgeMs: number | undefined;
+      const recoverableCall = async (tool: McpRecoverableTool, store: McpRecoveryReceiptStore): Promise<McpToolResult> => {
+        /* Authority first, before the store is read: who is calling decides
+           what may be disclosed, so it cannot be learned from the answer. A
+           refusal here burns nothing — no claim exists yet. */
+        let bound: McpRequestBindingInput;
+        try {
+          bound = await tool.bind(digestArgs);
+        } catch (error) {
+          outcome = "failure";
+          return failure(
+            typedTool,
+            requestId,
+            error instanceof McpToolRefusal && typeof error.details.code === "string" ? error.details.code : "tool_failed",
+            error instanceof Error ? error.message : String(error),
+            false,
+            false,
+            error instanceof McpToolRefusal ? error.details : undefined,
+          );
+        }
+        const binding: McpRequestBinding = {
+          version: 1,
+          toolName: typedTool,
+          clientRequestId: requestId,
+          ...bound,
+          owner: { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) },
+          claimedAt: new Date().toISOString(),
+        };
+        const notPermitted = () => {
+          outcome = "failure";
+          return failure(typedTool, requestId, "recovery_not_permitted", RECOVERY_NOT_PERMITTED, false, true);
+        };
+        const recoverRecord = async (record: McpReceiptRecord): Promise<McpToolResult> => {
+          const recorded = record.binding;
+          if (!recorded) {
+            /* A legacy row: claimed before bindings existed, so ownership has
+               to come from the downstream record itself or not at all. The
+               row stays intact either way; what it holds is disclosed only to
+               a caller the durable evidence names as its owner. */
+            if (!identifiedCaller(binding.caller)) return notPermitted();
+            const evidence = await tool.recover(binding, { legacy: true, context });
+            if (evidence.ownership !== "established") {
+              outcome = "failure";
+              return recoveryAnswer(typedTool, requestId, {
+                outcome: "unknown",
+                evidence: "legacy-receipt-unbound",
+                reason: "this clientRequestId was claimed before caller bindings existed and no durable evidence establishes its owner; its fate is unknown",
+                ids: {},
+              }, true);
+            }
+            if (record.digest !== digest) {
+              outcome = "conflict";
+              return failure(typedTool, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
+            }
+            if (record.result && !recoveryOnly) {
+              outcome = "replay";
+              return { ...record.result, replayed: true };
+            }
+            outcome = evidence.outcome === "unknown" ? "failure" : "replay";
+            return recoveryAnswer(typedTool, requestId, evidence, true, record.result);
+          }
+          if (!identifiedCaller(binding.caller) || !sameCaller(recorded.caller, binding.caller)) return notPermitted();
+          if (record.digest !== digest) {
+            outcome = "conflict";
+            return failure(typedTool, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
+          }
+          if (record.result && (!recoveryOnly || record.stage === "not-executed")) {
+            outcome = "replay";
+            return { ...record.result, replayed: true };
+          }
+          if (record.stage === "claimed") {
+            /* Claimed and never marked dispatching. While its owner lives the
+               dispatch may be a moment away; once the owner is gone the row
+               can be closed for good, and only THEN does absence prove zero
+               effect. Closing it is the permanent pre-dispatch fence: the
+               owner's own markDispatching fails against it. */
+            const alive = processOwnerAlive({ ...recorded.owner, token: "" });
+            if (!alive) {
+              const closed = recoveryAnswer(typedTool, requestId, {
+                outcome: "not-executed",
+                evidence: "mcp-receipt",
+                reason: "the MCP process that claimed this request ended before it dispatched anything; the attempt is permanently closed",
+                ids: {},
+              }, false);
+              if (await store.fenceUndispatched(key, digest, closed)) {
+                outcome = "failure";
+                return { ...closed, replayed: true };
+              }
+              const current = await store.lookup(key);
+              if (current) return recoverRecord(current);
+            }
+            outcome = "failure";
+            return recoveryAnswer(typedTool, requestId, {
+              outcome: "unknown",
+              evidence: "mcp-receipt",
+              reason: "the claim is held by a live MCP process that has not reported its dispatch; look it up again under the same clientRequestId",
+              ids: {},
+            }, true);
+          }
+          const evidence = await tool.recover(recorded, { legacy: false, context });
+          outcome = evidence.outcome === "unknown" ? "failure" : "replay";
+          return recoveryAnswer(typedTool, requestId, evidence, true, record.result);
+        };
+        const claimStartedAt = performance.now();
+        if (recoveryOnly) {
+          const record = await store.lookup(key);
+          phaseDurations.claim = performance.now() - claimStartedAt;
+          if (record) return recoverRecord(record);
+          if (!identifiedCaller(binding.caller)) return notPermitted();
+          /* Nothing ever claimed this key here, so nothing was dispatched
+             from here — and closing the key now makes that permanent: an
+             original call still on its way claims a closed row instead of
+             dispatching. Recovery starts no work; it only stops any. */
+          const closed = recoveryAnswer(typedTool, requestId, {
+            outcome: "not-executed",
+            evidence: "mcp-receipt",
+            reason: "no claim exists for this clientRequestId, so it was never dispatched; the key is now permanently closed and a new request may be made deliberately",
+            ids: {},
+          }, false);
+          if (await store.fenceAbsent(key, digest, binding, closed)) {
+            outcome = "failure";
+            return closed;
+          }
+          const raced = await store.lookup(key);
+          if (raced) return recoverRecord(raced);
+          outcome = "failure";
+          return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the receipt store could not be read consistently", ids: {} }, false);
+        }
+        const claim = await store.claim(key, digest, retention, binding);
+        phaseDurations.claim = performance.now() - claimStartedAt;
+        if (claim.kind !== "fresh") {
+          const record = claim.record ?? await store.lookup(key);
+          if (record) return recoverRecord(record);
+          outcome = "failure";
+          return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the receipt store could not be read consistently", ids: {} }, true);
+        }
+        /* The fence before the one dispatch. Failing here means another
+           process closed the attempt between the claim and now. */
+        if (!await store.markDispatching(key, digest)) {
+          const current = await store.lookup(key);
+          if (current) return recoverRecord(current);
+          outcome = "failure";
+          return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the claim disappeared before dispatch", ids: {} }, true);
+        }
+        const bindingStartedAt = performance.now();
+        let settled: McpToolResult;
+        try {
+          const payload = await bindings[typedTool](effectiveArgs, { ...context, binding });
+          settled = {
+            ...payload,
+            ...(normalized.clamped ? { clamped: normalized.clamped } : {}),
+            ok: true,
+            toolName: typedTool,
+            clientRequestId: requestId,
+            replayed: false,
+          };
+          outcome = "success";
+        } catch (error) {
+          phaseDurations.binding = performance.now() - bindingStartedAt;
+          if (error instanceof McpDispatchUncertainError) {
+            /* The request may be on the server. Nothing is written: the row
+               stays `dispatching`, which is exactly "unknown" — and every later
+               call under this key reads the downstream evidence rather than
+               replaying a guess. The evidence is read once now so an answer
+               the server already recorded is not withheld. */
+            outcome = context.signal?.aborted ? "cancelled" : "failure";
+            const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+              outcome: "unknown",
+              evidence: "none",
+              reason: cause instanceof Error ? cause.message : String(cause),
+              ids: {},
+            }));
+            const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
+              ? { ...evidence, reason: `${error.message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}` }
+              : evidence;
+            return recoveryAnswer(typedTool, requestId, uncertain, false);
+          }
+          /* Anything else is the server's own answer, or a refusal before any
+             dispatch. A refusal that names an ADMITTED id (an operation or a
+             launch) is a terminal verdict about work the server holds and keeps
+             that id and its guidance; one that names none proves nothing
+             executed, and the attempt is closed as such. */
+          outcome = error instanceof DeadlineExceededError ? "deadline" : "failure";
+          const refusal = error instanceof McpToolRefusal ? error.details : {};
+          const admitted = typeof refusal.operationId === "string" || typeof refusal.launchId === "string";
+          const details: McpToolPayload = {
+            ...refusal,
+            outcome: admitted ? "settled" : "not-executed",
+            evidence: admitted ? "dispatch-answer" : "dispatch-refused",
+            nextAction: admitted ? "follow-disposition" : "new-request-permitted",
+          };
+          settled = failure(
+            typedTool,
+            requestId,
+            "tool_failed",
+            error instanceof Error ? error.message : String(error),
+            !admitted,
+            false,
+            details,
+          );
+        }
+        phaseDurations.binding = performance.now() - bindingStartedAt;
+        const completionStartedAt = performance.now();
+        const stored = await store.settle(
+          key,
+          digest,
+          settled,
+          settled.ok || settled.details?.outcome === "settled" ? "settled" : "not-executed",
+        );
+        phaseDurations.completion = performance.now() - completionStartedAt;
+        if (stored !== settled) outcome = "replay";
+        return stored === settled ? settled : { ...stored, replayed: true };
+      };
       const result = (async (): Promise<McpToolResult> => {
+        if (recoverable && recoveryStore) return recoverableCall(recoverable, recoveryStore);
         const claimStartedAt = performance.now();
         const claim = await receipts.claim(key, digest, retention);
         phaseDurations.claim = performance.now() - claimStartedAt;
@@ -1655,12 +2324,26 @@ export function createMcpToolService(
   };
 }
 
+/**
+ * The original-key recovery contract (#1490), published on both mutations
+ * whose response can be lost after the server may already hold the request.
+ */
+export const RECOVERY_CONTRACT_DESCRIPTION = [
+  "Recovery under the ORIGINAL `clientRequestId` (#1490): the claim is bound server-side to the calling conversation, its project, the canonical target and the exact downstream key BEFORE the one dispatch, and the request is sent exactly once — never re-POSTed after it may have reached the Viewer.",
+  "Repeat the same call with the same arguments (with or without `recoveryOnly: true`) to learn what became of it. A fresh ordinary call claims and dispatches once; an existing claim is answered by READING the durable downstream record, never by dispatching again; `recoveryOnly: true` never claims an absent key or starts any work. Changed arguments under an existing key are an `idempotency_conflict`; another caller or project is refused without disclosure.",
+  "The answer's `outcome` is closed: `accepted` (durably admitted, with its actual ids), `in-flight` (executing), `settled` (terminal, with the actual state and resend guidance), `not-executed` (the server proves dispatch never began and the attempt is permanently closed), or `unknown` (timeout, interrupted claim, unreadable or ambiguous evidence, or absence while execution is still possible). `nextAction` says what is permitted: on `unknown`, `accepted` and `in-flight` ONLY another lookup under the same key — `retryable` never means a new key may be used, and nothing is ever redelivered automatically. `message_receipt(operationId)` remains available for an accepted send.",
+].join(" ");
+
 const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
-  spawn_agent: "Create a Viewer-managed agent conversation and return its durable conversation and launch ids.",
+  spawn_agent: [
+    "Create a Viewer-managed agent conversation and return its durable conversation and launch ids.",
+    RECOVERY_CONTRACT_DESCRIPTION,
+  ].join(" "),
   send_message: [
     "Deliver a message to a Viewer conversation through its registered runtime host.",
     "A reclaimed conversation host is resumed after the instruction is durably reserved, and the delivery queue keeps that single operation through publication.",
     "The answer reports acceptance. `outcome` is `held`, `queued` or `delivering` until the delivery record settles, and `settled` says whether arrival is established. Hold `operationId` and ask `message_receipt` what became of it — never treat an unsettled outcome as terminal, and never re-send an unsettled operation, because a send whose fate is unknown can be delivered twice.",
+    RECOVERY_CONTRACT_DESCRIPTION,
   ].join(" "),
   message_receipt: [
     "Answer what became of one accepted send, by the `operationId` `send_message` returned.",
@@ -1738,6 +2421,10 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
 };
 
 const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key for this logical call.");
+/* #1490: the one recovery switch. Excluded from the argument digest, so the
+   same logical call with and without it is one call. */
+const recoveryOnlySchema = z.boolean().optional()
+  .describe("Default false. true: read what became of the call already made under this clientRequestId with these same arguments, and never claim an absent key or start any work — an absent claim is closed as not-executed. false: claim and dispatch once if the key is new; otherwise recover exactly as with true. Excluded from the argument digest.");
 /* #844 §7: the selected-card reference an operator turn carried, in either of
    the two forms a caller actually holds — the `ctx=` token copied off the
    structured-user marker, or that token already decoded. The object stays open
@@ -1913,12 +2600,14 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
       .optional()
       .describe("Per-spawn MCP server allowlist, resolved server-side. Only servers the Viewer may grant are accepted; any other name is refused outright, never silently trimmed. Viewer is always included. The grant is then decided by the new session's origin — a delegated launch, which every role-preset spawn is, receives the Viewer baseline whatever it lists here — so this can narrow the surface, never widen it."),
     images: z.array(z.unknown()).optional(),
+    recoveryOnly: recoveryOnlySchema,
   }).passthrough(),
   send_message: z.object({
     clientRequestId: clientRequestIdSchema,
     conversationId: z.string().optional(),
     transcriptPath: z.string().optional(),
     text: z.string().min(1),
+    recoveryOnly: recoveryOnlySchema,
   }).passthrough(),
   message_receipt: z.object({
     clientRequestId: clientRequestIdSchema,
@@ -2276,18 +2965,20 @@ export async function startViewerMcpServer(): Promise<void> {
   const {
     productionViewerControlDependencies,
     viewerMcpBindings,
+    viewerMcpRecoverableTools,
     viewerMcpToolPolicy,
   } = await import("./bindings");
   const healthProbeCapability = process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
   delete process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
   const hostHealthProbe = await admittedMcpHealthProbe(healthProbeCapability);
+  const controlDependencies = productionViewerControlDependencies(hostHealthProbe);
   const service = createMcpToolService(
-    viewerMcpBindings(undefined, productionViewerControlDependencies(hostHealthProbe)),
+    viewerMcpBindings(undefined, controlDependencies),
     new SqliteMcpReceiptStore(statePath("mcp-receipts.sqlite"), {
       legacyFilePath: statePath("mcp-receipts.json"),
     }),
     viewerMcpToolPolicy(undefined, hostHealthProbe),
-    { timings: productionMcpToolTimings },
+    { timings: productionMcpToolTimings, recovery: viewerMcpRecoverableTools() },
   );
   const server = createViewerMcpServer(service);
   const transport = new StdioServerTransport();

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2319,19 +2319,17 @@ export function createMcpToolService(
              ADMITTED id (an operation or a launch) is a terminal verdict about
              work the server holds and keeps that id and its guidance. Nothing
              executed only when the request provably never left: the transport
-             says so, the request was never handed to it, or the server's own
-             4xx verdict refused it. Everything else — an exception after the
-             request may be on the server, a 5xx, a 409 whose id was lost —
+             says so or the request was never handed to it. HTTP status and
+             an error body alone provide no pre-dispatch proof. Everything
+             else after the request may be on the server
              leaves the row `dispatching` and is answered from the evidence,
              exactly as a lost response is; nothing here may invite a new key. */
           outcome = error instanceof DeadlineExceededError ? "deadline" : "failure";
           const refusal = error instanceof McpToolRefusal ? error.details : {};
           const admitted = typeof refusal.operationId === "string" || typeof refusal.launchId === "string";
-          const verdictStatus = error instanceof McpDispatchVerdictError ? Number(error.details.status) : null;
           const proven = !admitted && (
             error instanceof McpDispatchNotExecutedError
             || !dispatch.attempted
-            || (verdictStatus !== null && verdictStatus >= 400 && verdictStatus < 500 && verdictStatus !== 409)
           );
           if (!admitted && !proven) {
             outcome = context.signal?.aborted ? "cancelled" : "failure";

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -414,6 +414,8 @@ export interface McpRequestBinding extends McpRequestBindingInput {
 export interface McpReceiptRecord {
   digest: string;
   result: McpToolResult | null;
+  /** Stronger terminal recovery, kept separately from the ordinary replay. */
+  recoveryResult?: McpToolResult | null;
   binding: McpRequestBinding | null;
   stage: McpDispatchStage | null;
 }
@@ -421,6 +423,7 @@ export interface McpReceiptRecord {
 type Receipt = {
   digest: string;
   result?: McpToolResult;
+  recoveryResult?: McpToolResult;
   binding?: McpRequestBinding;
   stage?: McpDispatchStage;
 };
@@ -452,8 +455,9 @@ export interface McpRecoveryReceiptStore extends McpReceiptStore {
       row is no longer merely claimed (it was dispatched, or already closed). */
   fenceUndispatched(key: string, digest: string, result: McpToolResult): boolean | Promise<boolean>;
   /** Writes the result only if none is recorded yet, and returns whatever the
-      row holds afterwards — the first terminal answer always wins. */
-  settle(key: string, digest: string, result: McpToolResult, stage?: "settled" | "not-executed"): McpToolResult | Promise<McpToolResult>;
+      row holds afterwards — the first terminal answer always wins. Recovery
+      may save stronger terminal evidence alongside an ordinary acceptance. */
+  settle(key: string, digest: string, result: McpToolResult, stage?: "settled" | "not-executed", recovery?: boolean): McpToolResult | Promise<McpToolResult>;
 }
 
 export function supportsMcpRecovery(store: McpReceiptStore): store is McpRecoveryReceiptStore {
@@ -468,9 +472,34 @@ function recordOf(receipt: Receipt): McpReceiptRecord {
   return {
     digest: receipt.digest,
     result: receipt.result ?? null,
+    ...(receipt.recoveryResult ? { recoveryResult: receipt.recoveryResult } : {}),
     binding: receipt.binding ?? null,
     stage: receipt.stage ?? (receipt.result ? "settled" : null),
   };
+}
+
+function terminalReceiptResult(result: McpToolResult | null | undefined): result is McpToolResult {
+  return Boolean(result && (result.ok
+    ? result.outcome === "settled" || result.settled === true
+      || (result.toolName === "spawn_agent" && result.state === "settled")
+    : result.details?.outcome === "settled"));
+}
+
+function receiptSettlement(
+  receipt: Receipt,
+  result: McpToolResult,
+  stage: "settled" | "not-executed",
+  recovery: boolean,
+): { receipt: Receipt; result: McpToolResult } {
+  if (recovery && !terminalReceiptResult(result)) throw new Error("MCP recovery requires terminal evidence");
+  if (receipt.recoveryResult) return { receipt, result: receipt.recoveryResult };
+  if (receipt.result) {
+    if (recovery && !terminalReceiptResult(receipt.result) && receipt.stage !== "not-executed") {
+      return { receipt: { ...receipt, recoveryResult: result }, result };
+    }
+    return { receipt, result: receipt.result };
+  }
+  return { receipt: { ...receipt, result, stage }, result };
 }
 
 export class MemoryMcpReceiptStore implements McpRecoveryReceiptStore {
@@ -512,12 +541,12 @@ export class MemoryMcpReceiptStore implements McpRecoveryReceiptStore {
     return true;
   }
 
-  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): McpToolResult {
+  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled", recovery = false): McpToolResult {
     const receipt = this.receipts.get(key);
     if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
-    if (receipt.result) return receipt.result;
-    this.receipts.set(key, { ...receipt, result, stage });
-    return result;
+    const settled = receiptSettlement(receipt, result, stage, recovery);
+    this.receipts.set(key, settled.receipt);
+    return settled.result;
   }
 
 }
@@ -598,7 +627,7 @@ function validReceiptResult(value: unknown, toolName: McpToolName, requestId: st
     && typeof value.retryable === "boolean";
 }
 
-const RECEIPT_MEMBER_KEYS = ["binding", "digest", "result", "stage"] as const;
+const RECEIPT_MEMBER_KEYS = ["binding", "digest", "recoveryResult", "result", "stage"] as const;
 const DISPATCH_STAGES: ReadonlySet<string> = new Set<McpDispatchStage>(["claimed", "dispatching", "not-executed", "settled"]);
 
 function isDispatchStage(value: unknown): value is McpDispatchStage {
@@ -638,6 +667,7 @@ function validateReceiptRecord(
       || typeof candidate.digest !== "string"
       || !/^[0-9a-f]{64}$/i.test(candidate.digest)
       || ("result" in candidate && !validReceiptResult(candidate.result, parts.toolName, parts.requestId))
+      || ("recoveryResult" in candidate && (!validReceiptResult(candidate.recoveryResult, parts.toolName, parts.requestId) || !terminalReceiptResult(candidate.recoveryResult)))
       || ("binding" in candidate && !validRequestBinding(candidate.binding, parts.toolName, parts.requestId))
       || ("stage" in candidate && !isDispatchStage(candidate.stage))) {
       throw new Error(`invalid MCP receipt file: invalid receipt ${JSON.stringify(key)}`);
@@ -1282,16 +1312,18 @@ export class FileMcpReceiptStore implements McpRecoveryReceiptStore {
       receipt && receipt.stage === "claimed" && !receipt.result ? { ...receipt, result, stage: "not-executed" } : null);
   }
 
-  async settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): Promise<McpToolResult> {
+  async settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled", recovery = false): Promise<McpToolResult> {
     return withFileLock(this.filePath, () => {
       const state = readReceiptFile(this.filePath);
       const receipt = state.mutationReceipts[key] ?? state.readReceipts[key];
       if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
-      if (receipt.result) return receipt.result;
-      delete state.readReceipts[key];
-      state.mutationReceipts[key] = { ...receipt, result, stage };
-      writeReceiptFile(this.filePath, state);
-      return result;
+      const settled = receiptSettlement(receipt, result, stage, recovery);
+      if (settled.receipt !== receipt) {
+        delete state.readReceipts[key];
+        state.mutationReceipts[key] = settled.receipt;
+        writeReceiptFile(this.filePath, state);
+      }
+      return settled.result;
     });
   }
 
@@ -1300,6 +1332,7 @@ export class FileMcpReceiptStore implements McpRecoveryReceiptStore {
 type StoredSqliteReceipt = {
   digest: string;
   result_json: string | null;
+  recovery_result_json: string | null;
   claimed_at: number;
   binding_json: string | null;
   stage: string | null;
@@ -1361,6 +1394,7 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
     const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(mcp_receipts)").all().map((column) => column.name));
     if (!columns.has("binding_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN binding_json TEXT");
     if (!columns.has("stage")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN stage TEXT");
+    if (!columns.has("recovery_result_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN recovery_result_json TEXT");
     this.importLegacyFile(options.legacyFilePath);
     this.db.exec("BEGIN IMMEDIATE");
     try {
@@ -1463,23 +1497,30 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
     }
   }
 
-  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled"): McpToolResult {
-    const resultJson = JSON.stringify(result);
+  settle(key: string, digest: string, result: McpToolResult, stage: "settled" | "not-executed" = "settled", recovery = false): McpToolResult {
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const receipt = this.selectRow(key);
-      if (!receipt || receipt.digest !== digest) throw new Error("MCP receipt ownership changed");
-      if (receipt.result_json !== null) {
-        this.db.exec("COMMIT");
-        return this.parseResult(key, receipt.result_json);
+      const row = this.selectRow(key);
+      if (!row || row.digest !== digest) throw new Error("MCP receipt ownership changed");
+      const record = this.recordOfRow(key, row);
+      const receipt: Receipt = {
+        digest, ...(record.result ? { result: record.result } : {}),
+        ...(record.recoveryResult ? { recoveryResult: record.recoveryResult } : {}),
+        ...(record.stage ? { stage: record.stage } : {}),
+      };
+      const settled = receiptSettlement(receipt, result, stage, recovery);
+      if (settled.receipt !== receipt) {
+        const resultJson = settled.receipt.result ? JSON.stringify(settled.receipt.result) : null;
+        const recoveryJson = settled.receipt.recoveryResult ? JSON.stringify(settled.receipt.recoveryResult) : null;
+        this.db.query<unknown, [string | null, string | null, number, string | null, string]>(`
+          UPDATE mcp_receipts
+          SET result_json = ?, recovery_result_json = ?, storage_bytes = ?, stage = ?, retention = 'durable'
+          WHERE receipt_key = ?
+        `).run(resultJson, recoveryJson,
+          this.storageBytes(key, digest, resultJson, row.binding_json, recoveryJson), settled.receipt.stage ?? null, key);
       }
-      this.db.query<unknown, [string, number, string, string]>(`
-        UPDATE mcp_receipts
-        SET result_json = ?, storage_bytes = ?, stage = ?, retention = 'durable'
-        WHERE receipt_key = ?
-      `).run(resultJson, this.storageBytes(key, digest, resultJson, receipt.binding_json), stage, key);
       this.db.exec("COMMIT");
-      return result;
+      return settled.result;
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
@@ -1488,7 +1529,7 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
 
   private selectRow(key: string): StoredSqliteReceipt | null {
     return this.db.query<StoredSqliteReceipt, [string]>(`
-      SELECT digest, result_json, claimed_at, binding_json, stage
+      SELECT digest, result_json, recovery_result_json, claimed_at, binding_json, stage
       FROM mcp_receipts
       WHERE receipt_key = ?
     `).get(key);
@@ -1507,8 +1548,11 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
       if (!validRequestBinding(parsed, parts?.toolName, parts?.requestId)) throw new Error("invalid MCP receipt database binding");
       binding = parsed;
     }
+    const recoveryResult = receipt.recovery_result_json === null ? null : this.parseResult(key, receipt.recovery_result_json);
+    if (recoveryResult && !terminalReceiptResult(recoveryResult)) throw new Error("invalid MCP terminal recovery result");
     return {
       digest: receipt.digest,
+      ...(recoveryResult ? { recoveryResult } : {}),
       result: receipt.result_json === null ? null : this.parseResult(key, receipt.result_json),
       binding,
       stage: isDispatchStage(receipt.stage) ? receipt.stage : receipt.result_json === null ? null : "settled",
@@ -1531,19 +1575,20 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
     if (!fs.existsSync(legacyFilePath)) return;
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const insert = this.db.query<unknown, [string, string, ReceiptRetention, string | null, number, number, string | null, string | null]>(`
+      const insert = this.db.query<unknown, [string, string, ReceiptRetention, string | null, number, number, string | null, string | null, string | null]>(`
         INSERT OR IGNORE INTO mcp_receipts(
-          receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage, recovery_result_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       let claimedAt = this.now() - Object.keys(state.readReceipts).length - Object.keys(state.mutationReceipts).length;
       const importCollection = (receipts: Record<string, Receipt>, retention: ReceiptRetention) => {
         for (const [key, receipt] of Object.entries(receipts)) {
           const resultJson = receipt.result === undefined ? null : JSON.stringify(receipt.result);
           const bindingJson = receipt.binding === undefined ? null : JSON.stringify(receipt.binding);
+          const recoveryJson = receipt.recoveryResult === undefined ? null : JSON.stringify(receipt.recoveryResult);
           insert.run(
             key, receipt.digest, retention, resultJson,
-            this.storageBytes(key, receipt.digest, resultJson, bindingJson), claimedAt, bindingJson, receipt.stage ?? null,
+            this.storageBytes(key, receipt.digest, resultJson, bindingJson, recoveryJson), claimedAt, bindingJson, receipt.stage ?? null, recoveryJson,
           );
           claimedAt += 1;
         }
@@ -1627,11 +1672,12 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
     return parsed;
   }
 
-  private storageBytes(key: string, digest: string, resultJson: string | null, bindingJson: string | null = null): number {
+  private storageBytes(key: string, digest: string, resultJson: string | null, bindingJson: string | null = null, recoveryJson: string | null = null): number {
     return Buffer.byteLength(key)
       + Buffer.byteLength(digest)
       + (resultJson === null ? 0 : Buffer.byteLength(resultJson))
-      + (bindingJson === null ? 0 : Buffer.byteLength(bindingJson));
+      + (bindingJson === null ? 0 : Buffer.byteLength(bindingJson))
+      + (recoveryJson === null ? 0 : Buffer.byteLength(recoveryJson));
   }
 
   private meta(key: string): string | null {
@@ -2113,22 +2159,19 @@ export function createMcpToolService(
             reason: cause instanceof Error ? cause.message : String(cause),
             ids: {},
           }));
-        const terminalResult = (result: McpToolResult | null | undefined): result is McpToolResult => Boolean(result && (result.ok
-          ? result.outcome === "settled" || result.settled === true
-            || (typedTool === "spawn_agent" && result.state === "settled")
-          : result.details?.outcome === "settled"));
+        const terminalResult = terminalReceiptResult;
         const readableStoredResult = async (): Promise<McpToolResult | null> => {
           const current = await store.lookup(key);
           if (!current?.result || current.digest !== digest || !current.binding
             || !sameCaller(current.binding.caller, binding.caller)) return null;
-          return current.result;
+          return current.recoveryResult ?? current.result;
         };
         /* Terminal downstream evidence becomes the row's answer, written
            conditionally: the first terminal answer wins, so a dispatch error
            that arrives after the work was proven delivered — or a late
            original response — can never replace it. Open outcomes are never
-           written: the row stays open for the original response, and a row
-           that already holds a result keeps it. */
+           written: the row stays open for the original response. An ordinary
+           acceptance keeps its replay while terminal recovery is saved beside it. */
         const answerFromEvidence = async (
           evidence: McpRecoveryEvidence,
           replayed: boolean,
@@ -2146,7 +2189,7 @@ export function createMcpToolService(
           if (current && current.digest !== digest) return notPermitted();
           // Contradictory ownership never licenses disclosure of cached IDs.
           if (evidence.ownership === "unknown") return recoveryAnswer(typedTool, requestId, evidence, replayed);
-          const previous = current?.result ?? original;
+          const previous = current?.recoveryResult ?? current?.result ?? original;
           if (terminalResult(previous)) return {
             ...previous,
             ...(recoveryOnly && previous.ok ? {
@@ -2160,10 +2203,10 @@ export function createMcpToolService(
             replayed: true,
           };
           const answer = recoveryAnswer(typedTool, requestId, evidence, replayed, previous);
-          if (evidence.outcome !== "settled" || previous) return answer;
+          if (evidence.outcome !== "settled") return answer;
           let stored: McpToolResult;
           try {
-            stored = await store.settle(key, digest, answer, "settled");
+            stored = await store.settle(key, digest, answer, "settled", true);
           } catch {
             // A failed write can race a successful terminal recovery.
             try {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1370,31 +1370,10 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
     this.readReceiptByteCap = Math.max(1, Math.floor(options.readReceiptByteCap ?? SQLITE_READ_RECEIPT_BYTE_CAP));
     this.boundedPendingTtlMs = Math.max(1, Math.floor(options.boundedPendingTtlMs ?? SQLITE_BOUNDED_PENDING_TTL_MS));
     this.now = options.now ?? Date.now;
+    /* The journal mode cannot change inside a transaction, so these run
+       before the schema transaction below. */
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA auto_vacuum = INCREMENTAL;");
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS mcp_receipt_meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS mcp_receipts (
-        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-        receipt_key TEXT NOT NULL UNIQUE,
-        digest TEXT NOT NULL,
-        retention TEXT NOT NULL CHECK(retention IN ('bounded', 'durable')),
-        result_json TEXT,
-        storage_bytes INTEGER NOT NULL,
-        claimed_at INTEGER NOT NULL
-      );
-      CREATE INDEX IF NOT EXISTS mcp_receipts_retention_sequence
-      ON mcp_receipts(retention, sequence);
-    `);
-    /* #1490: the bound identity and dispatch stage of a recoverable mutation.
-       Added in place so an existing database keeps every row it holds; rows
-       from before carry NULL in both and are read as legacy. */
-    const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(mcp_receipts)").all().map((column) => column.name));
-    if (!columns.has("binding_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN binding_json TEXT");
-    if (!columns.has("stage")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN stage TEXT");
-    if (!columns.has("recovery_result_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN recovery_result_json TEXT");
+    this.initializeSchema();
     this.importLegacyFile(options.legacyFilePath);
     this.db.exec("BEGIN IMMEDIATE");
     try {
@@ -1561,6 +1540,48 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
 
   close(): void {
     this.db.close();
+  }
+
+  /**
+   * Creates the tables and adds every column a database from an earlier
+   * schema lacks, in ONE write transaction. Several MCP processes start cold
+   * against the same database at once; the write lock makes one of them
+   * inspect and migrate while the others wait on `busy_timeout` and then find
+   * the columns already there. Two processes that both inspected first would
+   * both ALTER, and the second would throw "duplicate column name".
+   */
+  private initializeSchema(): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS mcp_receipt_meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS mcp_receipts (
+          sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          receipt_key TEXT NOT NULL UNIQUE,
+          digest TEXT NOT NULL,
+          retention TEXT NOT NULL CHECK(retention IN ('bounded', 'durable')),
+          result_json TEXT,
+          storage_bytes INTEGER NOT NULL,
+          claimed_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS mcp_receipts_retention_sequence
+        ON mcp_receipts(retention, sequence);
+      `);
+      /* #1490: the bound identity and dispatch stage of a recoverable mutation.
+         Added in place so an existing database keeps every row it holds; rows
+         from before carry NULL in both and are read as legacy. */
+      const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(mcp_receipts)").all().map((column) => column.name));
+      if (!columns.has("binding_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN binding_json TEXT");
+      if (!columns.has("stage")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN stage TEXT");
+      if (!columns.has("recovery_result_json")) this.db.exec("ALTER TABLE mcp_receipts ADD COLUMN recovery_result_json TEXT");
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   private importLegacyFile(legacyFilePath: string | undefined): void {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1860,7 +1860,7 @@ export interface McpRecoverableTool {
   bind(args: McpToolArgs): McpRequestBindingInput | Promise<McpRequestBindingInput>;
   /** Read-only: what the downstream durable records say about this binding.
       Must never dispatch, enqueue, retry, withdraw or spawn. */
-  recover(binding: McpRequestBinding, options: { legacy: boolean; context?: McpToolCallContext }): Promise<McpRecoveryEvidence>;
+  recover(binding: McpRequestBinding, options: { legacy: boolean; context?: McpToolCallContext; args?: McpToolArgs }): Promise<McpRecoveryEvidence>;
 }
 
 /**
@@ -2107,12 +2107,22 @@ export function createMcpToolService(
         /* Downstream evidence that has failed to be read is unknown too, with
            the cause on the answer, and never a thrown error. */
         const readEvidence = (bound: McpRequestBinding, legacy: boolean): Promise<McpRecoveryEvidence> =>
-          tool.recover(bound, { legacy, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+          tool.recover(bound, { legacy, context, args: digestArgs }).catch((cause: unknown): McpRecoveryEvidence => ({
             outcome: "unknown",
             evidence: "none",
             reason: cause instanceof Error ? cause.message : String(cause),
             ids: {},
           }));
+        const terminalResult = (result: McpToolResult | null | undefined): result is McpToolResult => Boolean(result && (result.ok
+          ? result.outcome === "settled" || result.settled === true
+            || (typedTool === "spawn_agent" && result.state === "settled")
+          : result.details?.outcome === "settled"));
+        const readableStoredResult = async (): Promise<McpToolResult | null> => {
+          const current = await store.lookup(key);
+          if (!current?.result || current.digest !== digest || !current.binding
+            || !sameCaller(current.binding.caller, binding.caller)) return null;
+          return current.result;
+        };
         /* Terminal downstream evidence becomes the row's answer, written
            conditionally: the first terminal answer wins, so a dispatch error
            that arrives after the work was proven delivered — or a late
@@ -2124,14 +2134,42 @@ export function createMcpToolService(
           replayed: boolean,
           original?: McpToolResult | null,
         ): Promise<McpToolResult> => {
-          const answer = recoveryAnswer(typedTool, requestId, evidence, replayed, original);
-          if (evidence.outcome !== "settled" || original) return answer;
+          // Read again after the evidence lookup: another process may have
+          // settled the operation while this read was pending or unavailable.
+          let current: McpReceiptRecord | null;
+          try {
+            current = await store.lookup(key);
+          } catch (cause) {
+            return unreadableReceipt(cause, replayed);
+          }
+          if (current?.binding && !sameCaller(current.binding.caller, binding.caller)) return notPermitted();
+          if (current && current.digest !== digest) return notPermitted();
+          // Contradictory ownership never licenses disclosure of cached IDs.
+          if (evidence.ownership === "unknown") return recoveryAnswer(typedTool, requestId, evidence, replayed);
+          const previous = current?.result ?? original;
+          if (terminalResult(previous)) return {
+            ...previous,
+            ...(recoveryOnly && previous.ok ? {
+              recovered: true, outcome: "settled", evidence: "mcp-receipt", nextAction: "follow-disposition",
+              ...(!previous.recovered ? {
+                original: previous,
+                state: typedTool === "send_message" ? "delivered" : "completed",
+                ...(typedTool === "send_message" ? { resend: "not-needed", duplicateRisk: false } : {}),
+              } : {}),
+            } : {}),
+            replayed: true,
+          };
+          const answer = recoveryAnswer(typedTool, requestId, evidence, replayed, previous);
+          if (evidence.outcome !== "settled" || previous) return answer;
           let stored: McpToolResult;
           try {
             stored = await store.settle(key, digest, answer, "settled");
           } catch {
-            /* The row would not take it; the evidence still stands as the
-               answer, and the next lookup reads the same evidence again. */
+            // A failed write can race a successful terminal recovery.
+            try {
+              const current = await readableStoredResult();
+              if (terminalResult(current)) return { ...current, replayed: true };
+            } catch { /* The independently read evidence remains available. */ }
             return answer;
           }
           return stored === answer ? answer : { ...stored, replayed: true };
@@ -2143,7 +2181,7 @@ export function createMcpToolService(
                to come from the downstream record itself or not at all. The
                row stays intact either way; what it holds is disclosed only to
                a caller the durable evidence names as its owner. */
-            const evidence = await tool.recover(binding, { legacy: true, context });
+            const evidence = await tool.recover(binding, { legacy: true, context, args: digestArgs });
             if (evidence.ownership !== "established") {
               outcome = "failure";
               return recoveryAnswer(typedTool, requestId, {
@@ -2327,19 +2365,10 @@ export function createMcpToolService(
           );
           if (!proven) {
             outcome = context.signal?.aborted ? "cancelled" : "failure";
-            // A concurrent recovery may already have established termination.
-            // Preserve that result even if the downstream read is now unavailable.
-            let current: McpReceiptRecord | null;
-            try {
-              current = await store.lookup(key);
-            } catch (cause) {
-              return unreadableReceipt(cause, false);
-            }
-            if (current?.result) return { ...current.result, replayed: true };
             const message = error instanceof Error ? error.message : String(error);
             const evidence = await readEvidence(binding, false);
             const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
-              ? { ...evidence, reason: `${message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}`, ids: { ...stringIds(refusal), ...evidence.ids } }
+              ? { ...evidence, reason: `${message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}`, ids: evidence.ownership === "unknown" ? {} : { ...stringIds(refusal), ...evidence.ids } }
               : evidence;
             return answerFromEvidence(uncertain, false);
           }
@@ -2374,6 +2403,10 @@ export function createMcpToolService(
              `dispatching`, and every later call under the key reads the
              downstream evidence, which is what this answer was made from. */
           phaseDurations.completion = performance.now() - completionStartedAt;
+          try {
+            const current = await readableStoredResult();
+            if (terminalResult(current)) return { ...current, replayed: true };
+          } catch { /* The original response remains independently available. */ }
           return settled;
         }
         phaseDurations.completion = performance.now() - completionStartedAt;

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -176,6 +176,15 @@ export interface McpToolCallContext {
       a recoverable mutation's single dispatch; the binding reads its downstream
       idempotency key from here rather than deriving one of its own. */
   binding?: McpRequestBinding;
+  /** #1490: written by the transport the moment the request may be on the
+      wire. A failure raised while this still says `false` happened before any
+      dispatch, which is the only way an error without an id proves that the
+      server did nothing. */
+  dispatch?: McpDispatchTracker;
+}
+
+export interface McpDispatchTracker {
+  attempted: boolean;
 }
 export type McpToolBinding = (args: McpToolArgs, context?: McpToolCallContext) => Promise<McpToolPayload>;
 export type McpToolBindings = Record<McpToolName, McpToolBinding>;
@@ -445,9 +454,6 @@ export interface McpRecoveryReceiptStore extends McpReceiptStore {
   /** Writes the result only if none is recorded yet, and returns whatever the
       row holds afterwards — the first terminal answer always wins. */
   settle(key: string, digest: string, result: McpToolResult, stage?: "settled" | "not-executed"): McpToolResult | Promise<McpToolResult>;
-  /** Inserts a permanently closed `not-executed` row under a key nothing has
-      claimed. False when the key was claimed in the meantime. */
-  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean | Promise<boolean>;
 }
 
 export function supportsMcpRecovery(store: McpReceiptStore): store is McpRecoveryReceiptStore {
@@ -455,8 +461,7 @@ export function supportsMcpRecovery(store: McpReceiptStore): store is McpRecover
   return typeof candidate.lookup === "function"
     && typeof candidate.markDispatching === "function"
     && typeof candidate.fenceUndispatched === "function"
-    && typeof candidate.settle === "function"
-    && typeof candidate.fenceAbsent === "function";
+    && typeof candidate.settle === "function";
 }
 
 function recordOf(receipt: Receipt): McpReceiptRecord {
@@ -515,11 +520,6 @@ export class MemoryMcpReceiptStore implements McpRecoveryReceiptStore {
     return result;
   }
 
-  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean {
-    if (this.receipts.has(key)) return false;
-    this.receipts.set(key, { digest, binding, result, stage: "not-executed" });
-    return true;
-  }
 }
 
 type ReceiptFile = {
@@ -1295,9 +1295,6 @@ export class FileMcpReceiptStore implements McpRecoveryReceiptStore {
     });
   }
 
-  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): Promise<boolean> {
-    return this.transition(key, digest, (receipt) => (receipt ? null : { digest, binding, result, stage: "not-executed" }));
-  }
 }
 
 type StoredSqliteReceipt = {
@@ -1487,15 +1484,6 @@ export class SqliteMcpReceiptStore implements McpRecoveryReceiptStore {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
     }
-  }
-
-  fenceAbsent(key: string, digest: string, binding: McpRequestBinding, result: McpToolResult): boolean {
-    const resultJson = JSON.stringify(result);
-    const bindingJson = JSON.stringify(binding);
-    return this.db.query<unknown, [string, string, string, number, number, string]>(`
-      INSERT OR IGNORE INTO mcp_receipts(receipt_key, digest, retention, result_json, storage_bytes, claimed_at, binding_json, stage)
-      VALUES (?, ?, 'durable', ?, ?, ?, ?, 'not-executed')
-    `).run(key, digest, resultJson, this.storageBytes(key, digest, resultJson, bindingJson), this.now(), bindingJson).changes === 1;
   }
 
   private selectRow(key: string): StoredSqliteReceipt | null {
@@ -1888,6 +1876,31 @@ export class McpDispatchUncertainError extends Error {
   }
 }
 
+/**
+ * Thrown by the transport when it can PROVE the request never left this
+ * process: the kernel refused the connection, so no byte was written and the
+ * server did nothing. The one transport failure that closes an attempt as
+ * not-executed.
+ */
+export class McpDispatchNotExecutedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpDispatchNotExecutedError";
+  }
+}
+
+/**
+ * The server's own answer to the one dispatch: a JSON verdict with a status.
+ * Carries every id the verdict named. Distinct from a refusal a binding raises
+ * on its own, so the service knows this one came back from the server.
+ */
+export class McpDispatchVerdictError extends McpToolRefusal {
+  constructor(message: string, details: McpToolPayload & { status: number }) {
+    super(message, details);
+    this.name = "McpDispatchVerdictError";
+  }
+}
+
 function sameCaller(recorded: McpRequestCaller, current: McpRequestCaller): boolean {
   return recorded.kind === current.kind
     && recorded.conversationId === current.conversationId
@@ -1898,6 +1911,16 @@ function identifiedCaller(caller: McpRequestCaller): boolean {
   return caller.kind === "root" || (caller.kind === "worker" && caller.conversationId !== null);
 }
 
+/** The string-valued ids a refusal carried, kept on an uncertain answer. */
+function stringIds(details: McpToolPayload): Record<string, string> {
+  const ids: Record<string, string> = {};
+  for (const name of ["operationId", "launchId", "conversationId", "deliveryId", "transcriptPath"]) {
+    const value = details[name];
+    if (typeof value === "string" && value) ids[name] = value;
+  }
+  return ids;
+}
+
 function nextActionFor(outcome: McpRecoveryOutcome): McpRecoveryNextAction {
   if (outcome === "settled") return "follow-disposition";
   if (outcome === "not-executed") return "new-request-permitted";
@@ -1905,6 +1928,7 @@ function nextActionFor(outcome: McpRecoveryOutcome): McpRecoveryNextAction {
 }
 
 const RECOVERY_NOT_PERMITTED = "this clientRequestId cannot be recovered by this caller";
+const CALLER_UNIDENTIFIED = "the caller's identity could not be established, so this mutation is refused before anything is claimed or dispatched";
 
 function recoveryAnswer(
   toolName: McpToolName,
@@ -2013,7 +2037,10 @@ export function createMcpToolService(
         : effectiveArgs;
       const digest = requestDigest(typedTool, digestArgs);
       const key = `${typedTool}:${requestId}`;
-      const active = inFlight.get(key);
+      /* A recoverable mutation never joins an in-process duplicate: who is
+         calling is decided first, and every later call under the key — in
+         this process or another — is answered from the durable record. */
+      const active = recoverable ? undefined : inFlight.get(key);
       if (active) {
         if (active.digest !== digest) {
           return finish(failure(toolName, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true), "conflict");
@@ -2052,6 +2079,13 @@ export function createMcpToolService(
           owner: { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) },
           claimedAt: new Date().toISOString(),
         };
+        /* No identity, no claim: a mutation nobody could ever recover is not
+           dispatched, and the refusal is the same whether or not the key
+           exists, so it discloses nothing. */
+        if (!identifiedCaller(binding.caller)) {
+          outcome = "failure";
+          return failure(typedTool, requestId, "caller_unidentified", CALLER_UNIDENTIFIED, false, false);
+        }
         const notPermitted = () => {
           outcome = "failure";
           return failure(typedTool, requestId, "recovery_not_permitted", RECOVERY_NOT_PERMITTED, false, true);
@@ -2063,7 +2097,6 @@ export function createMcpToolService(
                to come from the downstream record itself or not at all. The
                row stays intact either way; what it holds is disclosed only to
                a caller the durable evidence names as its owner. */
-            if (!identifiedCaller(binding.caller)) return notPermitted();
             const evidence = await tool.recover(binding, { legacy: true, context });
             if (evidence.ownership !== "established") {
               outcome = "failure";
@@ -2085,7 +2118,7 @@ export function createMcpToolService(
             outcome = evidence.outcome === "unknown" ? "failure" : "replay";
             return recoveryAnswer(typedTool, requestId, evidence, true, record.result);
           }
-          if (!identifiedCaller(binding.caller) || !sameCaller(recorded.caller, binding.caller)) return notPermitted();
+          if (!sameCaller(recorded.caller, binding.caller)) return notPermitted();
           if (record.digest !== digest) {
             outcome = "conflict";
             return failure(typedTool, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
@@ -2132,25 +2165,27 @@ export function createMcpToolService(
           const record = await store.lookup(key);
           phaseDurations.claim = performance.now() - claimStartedAt;
           if (record) return recoverRecord(record);
-          if (!identifiedCaller(binding.caller)) return notPermitted();
-          /* Nothing ever claimed this key here, so nothing was dispatched
-             from here — and closing the key now makes that permanent: an
-             original call still on its way claims a closed row instead of
-             dispatching. Recovery starts no work; it only stops any. */
-          const closed = recoveryAnswer(typedTool, requestId, {
-            outcome: "not-executed",
-            evidence: "mcp-receipt",
-            reason: "no claim exists for this clientRequestId, so it was never dispatched; the key is now permanently closed and a new request may be made deliberately",
+          /* Nothing has claimed this key HERE — which is an observation, not a
+             verdict: the original may be a moment from claiming it, in this
+             process or another, and a lookup that wrote anything under the
+             key would be the claim it promised never to make, cancelling that
+             original. So nothing is written, the downstream record is read in
+             case the work was admitted by a path that never claimed here, and
+             the answer stays unknown while execution remains possible. */
+          const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+            outcome: "unknown",
+            evidence: "none",
+            reason: cause instanceof Error ? cause.message : String(cause),
             ids: {},
-          }, false);
-          if (await store.fenceAbsent(key, digest, binding, closed)) {
-            outcome = "failure";
-            return closed;
-          }
-          const raced = await store.lookup(key);
-          if (raced) return recoverRecord(raced);
+          }));
           outcome = "failure";
-          return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the receipt store could not be read consistently", ids: {} }, false);
+          if (evidence.outcome === "unknown") {
+            return recoveryAnswer(typedTool, requestId, {
+              ...evidence,
+              reason: `no claim exists for this clientRequestId yet and ${evidence.reason ?? "no downstream record holds it"}; the original call may still be on its way, so look it up again under the same key`,
+            }, false);
+          }
+          return recoveryAnswer(typedTool, requestId, evidence, false);
         }
         const claim = await store.claim(key, digest, retention, binding);
         phaseDurations.claim = performance.now() - claimStartedAt;
@@ -2170,8 +2205,9 @@ export function createMcpToolService(
         }
         const bindingStartedAt = performance.now();
         let settled: McpToolResult;
+        const dispatch: McpDispatchTracker = { attempted: false };
         try {
-          const payload = await bindings[typedTool](effectiveArgs, { ...context, binding });
+          const payload = await bindings[typedTool](effectiveArgs, { ...context, binding, dispatch });
           settled = {
             ...payload,
             ...(normalized.clamped ? { clamped: normalized.clamped } : {}),
@@ -2201,14 +2237,38 @@ export function createMcpToolService(
               : evidence;
             return recoveryAnswer(typedTool, requestId, uncertain, false);
           }
-          /* Anything else is the server's own answer, or a refusal before any
-             dispatch. A refusal that names an ADMITTED id (an operation or a
-             launch) is a terminal verdict about work the server holds and keeps
-             that id and its guidance; one that names none proves nothing
-             executed, and the attempt is closed as such. */
+          /* What the failure PROVES decides the answer. An error naming an
+             ADMITTED id (an operation or a launch) is a terminal verdict about
+             work the server holds and keeps that id and its guidance. Nothing
+             executed only when the request provably never left: the transport
+             says so, the request was never handed to it, or the server's own
+             4xx verdict refused it. Everything else — an exception after the
+             request may be on the server, a 5xx, a 409 whose id was lost —
+             leaves the row `dispatching` and is answered from the evidence,
+             exactly as a lost response is; nothing here may invite a new key. */
           outcome = error instanceof DeadlineExceededError ? "deadline" : "failure";
           const refusal = error instanceof McpToolRefusal ? error.details : {};
           const admitted = typeof refusal.operationId === "string" || typeof refusal.launchId === "string";
+          const verdictStatus = error instanceof McpDispatchVerdictError ? Number(error.details.status) : null;
+          const proven = !admitted && (
+            error instanceof McpDispatchNotExecutedError
+            || !dispatch.attempted
+            || (verdictStatus !== null && verdictStatus >= 400 && verdictStatus < 500 && verdictStatus !== 409)
+          );
+          if (!admitted && !proven) {
+            outcome = context.signal?.aborted ? "cancelled" : "failure";
+            const message = error instanceof Error ? error.message : String(error);
+            const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+              outcome: "unknown",
+              evidence: "none",
+              reason: cause instanceof Error ? cause.message : String(cause),
+              ids: {},
+            }));
+            const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
+              ? { ...evidence, reason: `${message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}`, ids: { ...stringIds(refusal), ...evidence.ids } }
+              : evidence;
+            return recoveryAnswer(typedTool, requestId, uncertain, false);
+          }
           const details: McpToolPayload = {
             ...refusal,
             outcome: admitted ? "settled" : "not-executed",
@@ -2330,7 +2390,7 @@ export function createMcpToolService(
  */
 export const RECOVERY_CONTRACT_DESCRIPTION = [
   "Recovery under the ORIGINAL `clientRequestId` (#1490): the claim is bound server-side to the calling conversation, its project, the canonical target and the exact downstream key BEFORE the one dispatch, and the request is sent exactly once — never re-POSTed after it may have reached the Viewer.",
-  "Repeat the same call with the same arguments (with or without `recoveryOnly: true`) to learn what became of it. A fresh ordinary call claims and dispatches once; an existing claim is answered by READING the durable downstream record, never by dispatching again; `recoveryOnly: true` never claims an absent key or starts any work. Changed arguments under an existing key are an `idempotency_conflict`; another caller or project is refused without disclosure.",
+  "Repeat the same call with the same arguments (with or without `recoveryOnly: true`) to learn what became of it. A fresh ordinary call claims and dispatches once; an existing claim is answered by READING the durable downstream record, never by dispatching again; `recoveryOnly: true` never claims an absent key or starts any work. Changed arguments under an existing key are an `idempotency_conflict`; another caller or project is refused without disclosure, and a caller whose identity the server cannot establish is refused (`caller_unidentified`) before anything is claimed or dispatched.",
   "The answer's `outcome` is closed: `accepted` (durably admitted, with its actual ids), `in-flight` (executing), `settled` (terminal, with the actual state and resend guidance), `not-executed` (the server proves dispatch never began and the attempt is permanently closed), or `unknown` (timeout, interrupted claim, unreadable or ambiguous evidence, or absence while execution is still possible). `nextAction` says what is permitted: on `unknown`, `accepted` and `in-flight` ONLY another lookup under the same key — `retryable` never means a new key may be used, and nothing is ever redelivered automatically. `message_receipt(operationId)` remains available for an accepted send.",
 ].join(" ");
 
@@ -2424,7 +2484,7 @@ const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key
 /* #1490: the one recovery switch. Excluded from the argument digest, so the
    same logical call with and without it is one call. */
 const recoveryOnlySchema = z.boolean().optional()
-  .describe("Default false. true: read what became of the call already made under this clientRequestId with these same arguments, and never claim an absent key or start any work — an absent claim is closed as not-executed. false: claim and dispatch once if the key is new; otherwise recover exactly as with true. Excluded from the argument digest.");
+  .describe("Default false. true: read what became of the call already made under this clientRequestId with these same arguments, and never claim an absent key or start any work — an absent claim is answered unknown (the original may still be on its way) and nothing is written under the key. false: claim and dispatch once if the key is new; otherwise recover exactly as with true. Excluded from the argument digest.");
 /* #844 §7: the selected-card reference an operator turn carried, in either of
    the two forms a caller actually holds — the `ctx=` token copied off the
    structured-user marker, or that token already decoded. The object stays open

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2090,6 +2090,52 @@ export function createMcpToolService(
           outcome = "failure";
           return failure(typedTool, requestId, "recovery_not_permitted", RECOVERY_NOT_PERMITTED, false, true);
         };
+        /* A receipt row that cannot be read is exactly "unknown": nothing is
+           claimed, dispatched or disclosed on its behalf, and the same key
+           answers again once the store can be read. Never a thrown error —
+           that would leave the caller with no outcome at all. */
+        const unreadableReceipt = (cause: unknown, replayed: boolean): McpToolResult => {
+          outcome = "failure";
+          const message = cause instanceof Error ? cause.message : String(cause);
+          return recoveryAnswer(typedTool, requestId, {
+            outcome: "unknown",
+            evidence: "mcp-receipt-unreadable",
+            reason: `the receipt record for this clientRequestId could not be read (${message}); nothing was claimed, dispatched or disclosed, and its fate stays unknown until the record can be read again under the same key`,
+            ids: {},
+          }, replayed);
+        };
+        /* Downstream evidence that has failed to be read is unknown too, with
+           the cause on the answer, and never a thrown error. */
+        const readEvidence = (bound: McpRequestBinding, legacy: boolean): Promise<McpRecoveryEvidence> =>
+          tool.recover(bound, { legacy, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+            outcome: "unknown",
+            evidence: "none",
+            reason: cause instanceof Error ? cause.message : String(cause),
+            ids: {},
+          }));
+        /* Terminal downstream evidence becomes the row's answer, written
+           conditionally: the first terminal answer wins, so a dispatch error
+           that arrives after the work was proven delivered — or a late
+           original response — can never replace it. Open outcomes are never
+           written: the row stays open for the original response, and a row
+           that already holds a result keeps it. */
+        const answerFromEvidence = async (
+          evidence: McpRecoveryEvidence,
+          replayed: boolean,
+          original?: McpToolResult | null,
+        ): Promise<McpToolResult> => {
+          const answer = recoveryAnswer(typedTool, requestId, evidence, replayed, original);
+          if (evidence.outcome !== "settled" || original) return answer;
+          let stored: McpToolResult;
+          try {
+            stored = await store.settle(key, digest, answer, "settled");
+          } catch {
+            /* The row would not take it; the evidence still stands as the
+               answer, and the next lookup reads the same evidence again. */
+            return answer;
+          }
+          return stored === answer ? answer : { ...stored, replayed: true };
+        };
         const recoverRecord = async (record: McpReceiptRecord): Promise<McpToolResult> => {
           const recorded = record.binding;
           if (!recorded) {
@@ -2141,11 +2187,22 @@ export function createMcpToolService(
                 reason: "the MCP process that claimed this request ended before it dispatched anything; the attempt is permanently closed",
                 ids: {},
               }, false);
-              if (await store.fenceUndispatched(key, digest, closed)) {
+              let fenced: boolean;
+              try {
+                fenced = await store.fenceUndispatched(key, digest, closed);
+              } catch (cause) {
+                return unreadableReceipt(cause, true);
+              }
+              if (fenced) {
                 outcome = "failure";
                 return { ...closed, replayed: true };
               }
-              const current = await store.lookup(key);
+              let current: McpReceiptRecord | null;
+              try {
+                current = await store.lookup(key);
+              } catch (cause) {
+                return unreadableReceipt(cause, true);
+              }
               if (current) return recoverRecord(current);
             }
             outcome = "failure";
@@ -2156,49 +2213,75 @@ export function createMcpToolService(
               ids: {},
             }, true);
           }
-          const evidence = await tool.recover(recorded, { legacy: false, context });
+          const evidence = await readEvidence(recorded, false);
           outcome = evidence.outcome === "unknown" ? "failure" : "replay";
-          return recoveryAnswer(typedTool, requestId, evidence, true, record.result);
+          return answerFromEvidence(evidence, true, record.result);
         };
         const claimStartedAt = performance.now();
         if (recoveryOnly) {
-          const record = await store.lookup(key);
+          let record: McpReceiptRecord | null;
+          try {
+            record = await store.lookup(key);
+          } catch (cause) {
+            return unreadableReceipt(cause, false);
+          }
           phaseDurations.claim = performance.now() - claimStartedAt;
           if (record) return recoverRecord(record);
-          /* Nothing has claimed this key HERE — which is an observation, not a
+          /* Nothing has claimed this key HERE — an observation, never a
              verdict: the original may be a moment from claiming it, in this
              process or another, and a lookup that wrote anything under the
              key would be the claim it promised never to make, cancelling that
-             original. So nothing is written, the downstream record is read in
-             case the work was admitted by a path that never claimed here, and
-             the answer stays unknown while execution remains possible. */
-          const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
+             original. Nothing is written, and nothing downstream is read
+             either: without a claim there is no durable binding that
+             establishes whose work a downstream record under this key would
+             be, so an answer built from it could hand one caller another's
+             ids. The answer stays unknown while execution remains possible. */
+          outcome = "failure";
+          return recoveryAnswer(typedTool, requestId, {
             outcome: "unknown",
             evidence: "none",
-            reason: cause instanceof Error ? cause.message : String(cause),
+            reason: "no claim exists for this clientRequestId yet; nothing was claimed, dispatched or read on its behalf, and the original call may still be on its way, so look it up again under the same key",
             ids: {},
-          }));
-          outcome = "failure";
-          if (evidence.outcome === "unknown") {
-            return recoveryAnswer(typedTool, requestId, {
-              ...evidence,
-              reason: `no claim exists for this clientRequestId yet and ${evidence.reason ?? "no downstream record holds it"}; the original call may still be on its way, so look it up again under the same key`,
-            }, false);
-          }
-          return recoveryAnswer(typedTool, requestId, evidence, false);
+          }, false);
         }
-        const claim = await store.claim(key, digest, retention, binding);
+        let claim: ReceiptClaim;
+        try {
+          claim = await store.claim(key, digest, retention, binding);
+        } catch (cause) {
+          return unreadableReceipt(cause, false);
+        }
         phaseDurations.claim = performance.now() - claimStartedAt;
         if (claim.kind !== "fresh") {
-          const record = claim.record ?? await store.lookup(key);
+          let record = claim.record ?? null;
+          if (!record) {
+            try {
+              record = await store.lookup(key);
+            } catch (cause) {
+              return unreadableReceipt(cause, true);
+            }
+          }
           if (record) return recoverRecord(record);
           outcome = "failure";
           return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the receipt store could not be read consistently", ids: {} }, true);
         }
         /* The fence before the one dispatch. Failing here means another
            process closed the attempt between the claim and now. */
-        if (!await store.markDispatching(key, digest)) {
-          const current = await store.lookup(key);
+        let dispatching: boolean;
+        try {
+          dispatching = await store.markDispatching(key, digest);
+        } catch (cause) {
+          /* The claim is this process's and stays `claimed`: nothing was
+             dispatched, and once this process is gone the row closes as
+             not-executed. */
+          return unreadableReceipt(cause, false);
+        }
+        if (!dispatching) {
+          let current: McpReceiptRecord | null;
+          try {
+            current = await store.lookup(key);
+          } catch (cause) {
+            return unreadableReceipt(cause, true);
+          }
           if (current) return recoverRecord(current);
           outcome = "failure";
           return recoveryAnswer(typedTool, requestId, { outcome: "unknown", evidence: "mcp-receipt", reason: "the claim disappeared before dispatch", ids: {} }, true);
@@ -2226,16 +2309,11 @@ export function createMcpToolService(
                replaying a guess. The evidence is read once now so an answer
                the server already recorded is not withheld. */
             outcome = context.signal?.aborted ? "cancelled" : "failure";
-            const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
-              outcome: "unknown",
-              evidence: "none",
-              reason: cause instanceof Error ? cause.message : String(cause),
-              ids: {},
-            }));
+            const evidence = await readEvidence(binding, false);
             const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
               ? { ...evidence, reason: `${error.message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}` }
               : evidence;
-            return recoveryAnswer(typedTool, requestId, uncertain, false);
+            return answerFromEvidence(uncertain, false);
           }
           /* What the failure PROVES decides the answer. An error naming an
              ADMITTED id (an operation or a launch) is a terminal verdict about
@@ -2258,16 +2336,11 @@ export function createMcpToolService(
           if (!admitted && !proven) {
             outcome = context.signal?.aborted ? "cancelled" : "failure";
             const message = error instanceof Error ? error.message : String(error);
-            const evidence = await tool.recover(binding, { legacy: false, context }).catch((cause: unknown): McpRecoveryEvidence => ({
-              outcome: "unknown",
-              evidence: "none",
-              reason: cause instanceof Error ? cause.message : String(cause),
-              ids: {},
-            }));
+            const evidence = await readEvidence(binding, false);
             const uncertain: McpRecoveryEvidence = evidence.outcome === "unknown"
               ? { ...evidence, reason: `${message}; ${evidence.reason ?? "no durable evidence of the request was found yet"}`, ids: { ...stringIds(refusal), ...evidence.ids } }
               : evidence;
-            return recoveryAnswer(typedTool, requestId, uncertain, false);
+            return answerFromEvidence(uncertain, false);
           }
           const details: McpToolPayload = {
             ...refusal,
@@ -2287,12 +2360,21 @@ export function createMcpToolService(
         }
         phaseDurations.binding = performance.now() - bindingStartedAt;
         const completionStartedAt = performance.now();
-        const stored = await store.settle(
-          key,
-          digest,
-          settled,
-          settled.ok || settled.details?.outcome === "settled" ? "settled" : "not-executed",
-        );
+        let stored: McpToolResult;
+        try {
+          stored = await store.settle(
+            key,
+            digest,
+            settled,
+            settled.ok || settled.details?.outcome === "settled" ? "settled" : "not-executed",
+          );
+        } catch {
+          /* The answer is real whether or not the row took it: the row stays
+             `dispatching`, and every later call under the key reads the
+             downstream evidence, which is what this answer was made from. */
+          phaseDurations.completion = performance.now() - completionStartedAt;
+          return settled;
+        }
         phaseDurations.completion = performance.now() - completionStartedAt;
         if (stored !== settled) outcome = "replay";
         return stored === settled ? settled : { ...stored, replayed: true };
@@ -2391,7 +2473,7 @@ export function createMcpToolService(
 export const RECOVERY_CONTRACT_DESCRIPTION = [
   "Recovery under the ORIGINAL `clientRequestId` (#1490): the claim is bound server-side to the calling conversation, its project, the canonical target and the exact downstream key BEFORE the one dispatch, and the request is sent exactly once — never re-POSTed after it may have reached the Viewer.",
   "Repeat the same call with the same arguments (with or without `recoveryOnly: true`) to learn what became of it. A fresh ordinary call claims and dispatches once; an existing claim is answered by READING the durable downstream record, never by dispatching again; `recoveryOnly: true` never claims an absent key or starts any work. Changed arguments under an existing key are an `idempotency_conflict`; another caller or project is refused without disclosure, and a caller whose identity the server cannot establish is refused (`caller_unidentified`) before anything is claimed or dispatched.",
-  "The answer's `outcome` is closed: `accepted` (durably admitted, with its actual ids), `in-flight` (executing), `settled` (terminal, with the actual state and resend guidance), `not-executed` (the server proves dispatch never began and the attempt is permanently closed), or `unknown` (timeout, interrupted claim, unreadable or ambiguous evidence, or absence while execution is still possible). `nextAction` says what is permitted: on `unknown`, `accepted` and `in-flight` ONLY another lookup under the same key — `retryable` never means a new key may be used, and nothing is ever redelivered automatically. `message_receipt(operationId)` remains available for an accepted send.",
+  "The answer's `outcome` is closed: `accepted` (durably admitted, with its actual ids), `in-flight` (executing), `settled` (terminal, with the actual state and resend guidance), `not-executed` (the server proves dispatch never began and the attempt is permanently closed), or `unknown` (timeout, interrupted claim, an unreadable receipt record, unreadable or ambiguous evidence, or absence while execution is still possible). `nextAction` says what is permitted: on `unknown`, `accepted` and `in-flight` ONLY another lookup under the same key — `retryable` never means a new key may be used, and nothing is ever redelivered automatically. `message_receipt(operationId)` remains available for an accepted send.",
 ].join(" ");
 
 const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
@@ -2484,7 +2566,7 @@ const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key
 /* #1490: the one recovery switch. Excluded from the argument digest, so the
    same logical call with and without it is one call. */
 const recoveryOnlySchema = z.boolean().optional()
-  .describe("Default false. true: read what became of the call already made under this clientRequestId with these same arguments, and never claim an absent key or start any work — an absent claim is answered unknown (the original may still be on its way) and nothing is written under the key. false: claim and dispatch once if the key is new; otherwise recover exactly as with true. Excluded from the argument digest.");
+  .describe("Default false. true: read what became of the call already made under this clientRequestId with these same arguments, and never claim an absent key or start any work — an absent claim is answered unknown (the original may still be on its way), nothing is written under the key, and nothing is disclosed — without a claim no durable binding establishes whose work a downstream record would be. false: claim and dispatch once if the key is new; otherwise recover exactly as with true. Excluded from the argument digest.");
 /* #844 §7: the selected-card reference an operator turn carried, in either of
    the two forms a caller actually holds — the `ctx=` token copied off the
    structured-user marker, or that token already decoded. The object stays open
@@ -2654,7 +2736,8 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
       .describe("Role-specific parameters. Bounded integers accept numeric strings, clamp to their declared role bounds, and report the applied value in clamped."),
     reviews: z.string().optional(),
     parentConversationId: z.string().optional(),
-    project: z.string().optional(),
+    project: z.string().optional()
+      .describe("Optional. The target project is resolved server-side from cwd; a value that contradicts it is refused before anything is claimed or dispatched."),
     allowSubagents: z.boolean().optional(),
     mcpServers: z.array(z.string().regex(/^[^\s\u0000-\u001f\u007f]{1,128}$/u))
       .optional()

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
+import { Database } from "bun:sqlite";
+
 import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
@@ -335,7 +337,9 @@ interface CausalFixture {
   execute(): void;
   resetMarkers(): void;
   startHost(): Promise<HostProcess>;
-  mcp(options?: { identified?: boolean; name?: string }): Promise<McpSession>;
+  /** `caller: "other"` speaks as a second authenticated conversation — a
+      launch receipt of its own with its own capability. */
+  mcp(options?: { identified?: boolean; name?: string; caller?: "owner" | "other" }): Promise<McpSession>;
   registryFile(): ReturnType<AgentRegistry["readOnlySnapshot"]>;
 }
 
@@ -374,6 +378,8 @@ async function causalFixture(prefix: string): Promise<CausalFixture> {
      binds to — server-derived, never something the arguments could say. */
   const callerReceipt = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Causal proof caller" });
   const capability = registry.rotateSpawnCapabilityForReceipt(callerReceipt.launchId);
+  const otherReceipt = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Causal proof other caller" });
+  const otherCapability = registry.rotateSpawnCapabilityForReceipt(otherReceipt.launchId);
 
   /* One stable port for every generation of the controlled host, as the
      production Viewer has: an MCP process keeps its endpoint across a host
@@ -465,7 +471,7 @@ async function causalFixture(prefix: string): Promise<CausalFixture> {
     mcp: (options = {}) => startMcp({
       ...environment,
       LLV_VIEWER_CONTROL_URL: `http://127.0.0.1:${Number(fs.readFileSync(config.portFile, "utf8"))}`,
-      ...(options.identified === false ? {} : { LLV_SPAWN_CAPABILITY: capability }),
+      ...(options.identified === false ? {} : { LLV_SPAWN_CAPABILITY: options.caller === "other" ? otherCapability : capability }),
     }, options.name ?? "viewer-causal-proof"),
     registryFile: () => registry.readOnlySnapshot(),
   };
@@ -592,8 +598,9 @@ test("lookup before acceptance stays unknown, late acceptance is then found, and
     expect(late).toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId: settled.operationId });
     expect(late.original).toMatchObject({ ok: true, operationId: settled.operationId });
 
-    /* A response that arrives AFTER a recovery already answered: the
-       original settles its own success and the recovery answer stands. */
+    /* A response that arrives AFTER a recovery already answered from
+       terminal evidence: that answer was written when it was seen, so the
+       original's own call receives it too, and nothing later replaces it. */
     fixture.resetMarkers();
     fixture.control({ mode: "hold", sendEffect: "deliver" });
     const held = call(original, "send_message", sendArguments(fixture, "send-late-2"));
@@ -602,7 +609,7 @@ test("lookup before acceptance stays unknown, late acceptance is then found, and
     expect(during).toMatchObject({ ok: true, outcome: "settled", state: "delivered" });
     fixture.release();
     const originalAnswer = await held;
-    expect(originalAnswer).toMatchObject({ ok: true, replayed: false, operationId: during.operationId });
+    expect(originalAnswer).toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId: during.operationId, replayed: true });
     const after = await call(observer, "send_message", sendArguments(fixture, "send-late-2"));
     expect(after).toMatchObject({ ok: true, replayed: true, operationId: during.operationId });
     expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(2);
@@ -872,6 +879,102 @@ test("a lookup from another process before the original ever claims stays unknow
   } finally {
     await owner.close();
     await observer.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("send: a delayed 409 after recovery already proved delivery never regresses the answer — across MCP restart, one recipient delivery", async () => {
+  const fixture = await causalFixture("llv-1490-late-verdict-");
+  const host = await fixture.startHost();
+  let original = await fixture.mcp({ name: "viewer-original" });
+  const observer = await fixture.mcp({ name: "viewer-observer" });
+  try {
+    /* The handler delivers, the response is held, and what the original
+       finally receives is the server's ambiguity verdict naming the admitted
+       operation — the answer that, taken alone, settles as verify-first. */
+    fixture.control({ mode: "hold", sendEffect: "deliver", lateVerdict: { status: 409 } });
+    const held = call(original, "send_message", sendArguments(fixture, "send-late-verdict-1"));
+    await fixture.marker("accepted");
+    const during = await call(observer, "send_message", sendArguments(fixture, "send-late-verdict-1", { recoveryOnly: true }));
+    expect(during).toMatchObject({ ok: true, recovered: true, outcome: "settled", state: "delivered", resend: "not-needed", nextAction: "follow-disposition" });
+    const operationId = during.operationId as string;
+    expect(typeof operationId).toBe("string");
+
+    fixture.release();
+    const late = await held;
+    expect(late).toMatchObject({ ok: true, outcome: "settled", state: "delivered", resend: "not-needed", operationId, replayed: true });
+    expect(JSON.stringify(late)).not.toContain("verify-first");
+    for (const session of [original, observer]) {
+      expect(await call(session, "send_message", sendArguments(fixture, "send-late-verdict-1")))
+        .toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId, replayed: true });
+    }
+
+    /* A fresh MCP process against the same store reads the same answer. */
+    await original.close();
+    original = await fixture.mcp({ name: "viewer-original-restarted" });
+    expect(await call(original, "send_message", sendArguments(fixture, "send-late-verdict-1")))
+      .toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId, replayed: true });
+    const receipt = await original.client.callTool({ name: "message_receipt", arguments: { clientRequestId: "send-late-verdict-1-receipt", operationId } });
+    expect(receipt.structuredContent).toMatchObject({ ok: true, operationId, state: "delivered" });
+
+    const deliveries = fixture.effects().filter((effect) => effect.kind === "recipient");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({ clientMessageId: "send-late-verdict-1", operationId });
+    expect(fixture.responses().filter((response) => response.pathname === "/api/tmux")).toHaveLength(1);
+  } finally {
+    await original.close();
+    await observer.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("through the protocol: a lost claim discloses nothing to another caller, and an unreadable receipt row answers unknown without dispatching", async () => {
+  const fixture = await causalFixture("llv-1490-store-damage-");
+  const host = await fixture.startHost();
+  const owner = await fixture.mcp({ name: "viewer-owner" });
+  const other = await fixture.mcp({ caller: "other", name: "viewer-other" });
+  try {
+    fixture.control({ mode: "respond", sendEffect: "deliver" });
+    const launched = await call(owner, "spawn_agent", spawnArguments(fixture, "spawn-lost-claim-1"));
+    expect(launched).toMatchObject({ ok: true, replayed: false });
+    const launchId = launched.launchId as string;
+    const conversationId = launched.conversationId as string;
+    const sent = await call(owner, "send_message", sendArguments(fixture, "send-corrupt-1"));
+    expect(sent).toMatchObject({ ok: true, replayed: false });
+    const operationId = sent.operationId as string;
+    expect(fixture.effects()).toHaveLength(2);
+
+    /* The receipt store is damaged underneath every process: the spawn's
+       claim row is gone, and the send's row carries a binding that cannot be
+       parsed. The downstream records — the launch receipt, the delivery —
+       are intact. */
+    const database = new Database(path.join(fixture.state, "mcp-receipts.sqlite"), { strict: true });
+    database.query("DELETE FROM mcp_receipts WHERE receipt_key = ?").run("spawn_agent:spawn-lost-claim-1");
+    database.query("UPDATE mcp_receipts SET binding_json = ? WHERE receipt_key = ?").run("{not json", "send_message:send-corrupt-1");
+    database.close();
+
+    for (const session of [other, owner]) {
+      /* No claim: nothing establishes whose launch the intact receipt is, so
+         nobody — another authenticated caller, or the owner — is handed it. */
+      const absent = await call(session, "spawn_agent", spawnArguments(fixture, "spawn-lost-claim-1", { recoveryOnly: true }));
+      expect(absent).toMatchObject({ ok: false, code: "outcome_unknown", retryable: false, replayed: false, details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup" } });
+      expect(JSON.stringify(absent)).not.toContain(launchId);
+      expect(JSON.stringify(absent)).not.toContain(conversationId);
+      /* An unreadable row: unknown, with the guidance, and nothing read or
+         dispatched on its behalf — explicit or ordinary. */
+      for (const args of [sendArguments(fixture, "send-corrupt-1", { recoveryOnly: true }), sendArguments(fixture, "send-corrupt-1")]) {
+        const unreadable = await call(session, "send_message", args);
+        expect(unreadable).toMatchObject({ ok: false, code: "outcome_unknown", retryable: false, details: { outcome: "unknown", evidence: "mcp-receipt-unreadable", nextAction: "original-key-lookup" } });
+        expect(String(unreadable.error)).toContain("could not be read");
+        expect(JSON.stringify(unreadable)).not.toContain(operationId);
+      }
+    }
+    expect(fixture.effects()).toHaveLength(2);
+    expect(fixture.responses().filter((response) => response.pathname === "/api/tmux")).toHaveLength(1);
+    expect(fixture.responses().filter((response) => response.pathname === "/api/spawn")).toHaveLength(1);
+  } finally {
+    await owner.close();
+    await other.close();
     await host.stop();
   }
 }, 40_000);

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -42,6 +42,20 @@ function isolatedEnvironment(sandbox: string, extra: Record<string, string> = {}
   return { ...environment, ...directories, ...extra };
 }
 
+/**
+ * A calling conversation the packaged MCP server can present: a launch
+ * receipt in the sandbox registry and the spawn capability minted for it.
+ * Since #1490 a recoverable mutation from a caller the server cannot identify
+ * is refused before anything is claimed, so every test that dispatches one
+ * speaks as this conversation.
+ */
+function identifiedEnvironment(sandbox: string, extra: Record<string, string> = {}): Record<string, string> {
+  const environment = isolatedEnvironment(sandbox, extra);
+  const registry = new AgentRegistry(path.join(environment.LLV_STATE_DIR!, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const caller = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Packaged MCP caller" });
+  return { ...environment, LLV_SPAWN_CAPABILITY: registry.rotateSpawnCapabilityForReceipt(caller.launchId) };
+}
+
 function spawnResult(label: string): Response {
   return Response.json({
     conversationId: `conversation_${label}`,
@@ -145,7 +159,7 @@ test("a packaged MCP spawn is dispatched once: a Viewer restart mid-request answ
     },
   });
   const viewerPort = firstViewer.port;
-  const environment = isolatedEnvironment(sandbox, {
+  const environment = identifiedEnvironment(sandbox, {
     LLV_VIEWER_DEPLOY_TARGET: path.join(sandbox, "viewer-release.json"),
     LLV_VIEWER_CONTROL_URL: firstViewer.url.origin,
   });
@@ -199,13 +213,12 @@ test("a packaged MCP spawn is dispatched once: a Viewer restart mid-request answ
     /* The restarted Viewer never received the lost request again. */
     expect(restartedKeys).not.toContain("restart-during");
 
-    /* This MCP process carries no caller identity, so an existing claim is
-       not its to recover: a repeat under the key, explicit or ordinary, is
-       refused without disclosure — and still dispatches nothing. */
+    /* A repeat under the key, explicit or ordinary, is a READ of the durable
+       record — which holds no launch receipt for it, so the fate stays
+       unknown — and still dispatches nothing. */
     for (const extra of [{ recoveryOnly: true }, {}]) {
       const lookup = await callSpawn(session.client, "restart-during", extra);
-      expect(lookup.structuredContent).toMatchObject({ ok: false, code: "recovery_not_permitted", retryable: false });
-      expect((lookup.structuredContent as { details?: unknown }).details).toBeUndefined();
+      expect(lookup.structuredContent).toMatchObject({ ok: false, code: "outcome_unknown", retryable: false, replayed: true, details: { outcome: "unknown", nextAction: "original-key-lookup" } });
     }
     expect(restartedKeys).not.toContain("restart-during");
 
@@ -276,7 +289,7 @@ test("a packaged MCP tool falls back from a retired launch port to the stable Vi
     container: "viewer-fixture",
     endpoint: stableViewer.url.origin,
   }));
-  const session = await startMcp(isolatedEnvironment(sandbox, {
+  const session = await startMcp(identifiedEnvironment(sandbox, {
     LLV_VIEWER_DEPLOY_TARGET: targetFile,
     LLV_VIEWER_CONTROL_URL: retiredOrigin,
     LLV_VIEWER_PORT: String(stableViewer.port),
@@ -318,6 +331,8 @@ interface CausalFixture {
   control(value: Record<string, unknown>): void;
   marker(name: string, timeoutMs?: number): Promise<void>;
   release(): void;
+  /** Releases the execution barrier: admitted effects run from here on. */
+  execute(): void;
   resetMarkers(): void;
   startHost(): Promise<HostProcess>;
   mcp(options?: { identified?: boolean; name?: string }): Promise<McpSession>;
@@ -360,8 +375,16 @@ async function causalFixture(prefix: string): Promise<CausalFixture> {
   const callerReceipt = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Causal proof caller" });
   const capability = registry.rotateSpawnCapabilityForReceipt(callerReceipt.launchId);
 
+  /* One stable port for every generation of the controlled host, as the
+     production Viewer has: an MCP process keeps its endpoint across a host
+     restart, so a call after the restart reaches the production route rather
+     than a dead port. */
+  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") });
+  const port = probe.port;
+  await probe.stop(true);
   const config = {
     portFile: path.join(sandbox, "host.port"),
+    port,
     effectsPath,
     responsesPath,
     controlPath,
@@ -400,6 +423,7 @@ async function causalFixture(prefix: string): Promise<CausalFixture> {
       }
     },
     release: () => fs.writeFileSync(path.join(markerDir, "release"), "1"),
+    execute: () => fs.writeFileSync(path.join(markerDir, "execute"), "1"),
     resetMarkers: () => {
       for (const entry of fs.readdirSync(markerDir)) fs.rmSync(path.join(markerDir, entry), { force: true });
     },
@@ -615,18 +639,31 @@ test("network failure without dispatch proof stays unknown and never redelivers;
 
     /* A pre-dispatch rejection by the production route: no receipt, no writer. */
     const rejected = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") }));
-    expect(rejected).toMatchObject({ ok: false, code: "tool_failed", details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
+    expect(rejected).toMatchObject({ ok: false, code: "tool_failed", details: { outcome: "not-executed", nextAction: "new-request-permitted", evidence: "dispatch-refused" } });
+    /* The proof is the production route's OWN 4xx verdict, not a dead port. */
+    expect(String(rejected.error)).not.toContain("connection was refused");
+    const verdicts = fixture.responses().filter((response) => response.pathname === "/api/spawn" && response.body.includes("missing"));
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0]!.status).toBeGreaterThanOrEqual(400);
+    expect(verdicts[0]!.status).toBeLessThan(500);
+    expect(rejected.details?.status).toBe(verdicts[0]!.status);
     expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") })))
       .toMatchObject({ ok: false, replayed: true, details: { outcome: "not-executed" } });
     expect(fixture.effects()).toHaveLength(0);
     expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-rejected-1")).toHaveLength(0);
 
-    /* recoveryOnly under a key nothing ever claimed starts no work and closes
-       the key: a later ordinary call under it cannot dispatch. */
+    /* recoveryOnly under a key nothing ever claimed starts no work and writes
+       nothing: unknown, because the original may still be on its way — and
+       when it arrives it claims and dispatches exactly once. */
     const probe = await call(mcp, "send_message", sendArguments(fixture, "send-never-1", { recoveryOnly: true }));
-    expect(probe).toMatchObject({ ok: false, code: "not_executed", details: { outcome: "not-executed" } });
-    expect(await call(mcp, "send_message", sendArguments(fixture, "send-never-1"))).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+    expect(probe).toMatchObject({ ok: false, code: "outcome_unknown", replayed: false, details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup" } });
     expect(fixture.effects()).toHaveLength(0);
+    const arrived = await call(mcp, "send_message", sendArguments(fixture, "send-never-1"));
+    expect(arrived).toMatchObject({ ok: true, replayed: false, outcome: "delivered" });
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-never-1")).toHaveLength(1);
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-never-1", { recoveryOnly: true })))
+      .toMatchObject({ ok: true, outcome: "settled", operationId: arrived.operationId, state: "delivered" });
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-never-1")).toHaveLength(1);
   } finally {
     await mcp.close();
     await host.stop();
@@ -645,15 +682,28 @@ test("spoofing and concurrency: another caller, a changed payload, and two proce
     expect(accepted).toMatchObject({ ok: true, outcome: "queued", settled: false });
 
     /* An unidentified caller — the same key, the same payload, even forged
-       caller fields — learns nothing. */
+       caller fields — learns nothing, and cannot dispatch a fresh mutation
+       either: the refusal is the same under an existing and an absent key. */
     const forged = await call(stranger, "send_message", sendArguments(fixture, "send-owned-1", {
       recoveryOnly: true,
       callerConversationId: fixture.caller.conversationId,
       callerProject: "spoofed",
     }));
-    expect(forged).toMatchObject({ ok: false, code: "recovery_not_permitted" });
+    expect(forged).toMatchObject({ ok: false, code: "caller_unidentified", retryable: false });
     expect(forged.details).toBeUndefined();
     expect(JSON.stringify(forged)).not.toContain(String(accepted.operationId));
+    for (const [name, args] of [
+      ["send_message", sendArguments(fixture, "send-owned-1")],
+      ["send_message", sendArguments(fixture, "send-anonymous-1")],
+      ["spawn_agent", spawnArguments(fixture, "spawn-anonymous-1")],
+    ] as const) {
+      const refused = await call(stranger, name, args);
+      expect(refused).toMatchObject({ ok: false, code: "caller_unidentified", replayed: false });
+      expect(refused.details).toBeUndefined();
+    }
+    expect(fixture.effects().filter((effect) => String(effect.clientMessageId ?? effect.clientAttemptId).includes("anonymous"))).toHaveLength(0);
+    expect(fixture.responses().filter((response) => response.body.includes("anonymous"))).toHaveLength(0);
+    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-anonymous-1")).toHaveLength(0);
 
     /* The owner with a changed payload is a conflict, not a second send. */
     expect(await call(owner, "send_message", sendArguments(fixture, "send-owned-1", { text: "changed" })))
@@ -678,6 +728,150 @@ test("spoofing and concurrency: another caller, a changed payload, and two proce
     await owner.close();
     await stranger.close();
     await peer.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("send: admitted, response lost BEFORE the recipient acts, original-key recovery across MCP and host restart — one recipient delivery", async () => {
+  const fixture = await causalFixture("llv-1490-send-barrier-");
+  let host = await fixture.startHost();
+  let mcp = await fixture.mcp();
+  try {
+    /* The production handler admits the send (the reservation exists), the
+       response is cut after its status line, and the recipient has NOT yet
+       taken anything: two barriers, admission and execution, and the loss
+       happens between them. */
+    fixture.control({ mode: "cut", sendEffect: "deliver", admission: "hold-effect" });
+    const original = call(mcp, "send_message", sendArguments(fixture, "send-barrier-1"));
+    await fixture.marker("admitted");
+    await fixture.marker("accepted");
+    expect(fixture.effects()).toHaveLength(0);
+    const lost = await original;
+    expect(lost).toMatchObject({ ok: true, recovered: true, outcome: "accepted", state: "in-flight", nextAction: "original-key-lookup" });
+    expect(typeof lost.operationId).toBe("string");
+    const operationId = lost.operationId as string;
+    expect(fixture.effects()).toHaveLength(0);
+
+    /* The MCP process that made the call is gone before anything executed.
+       A fresh one, under the original key, reads the admission and starts
+       nothing; the ordinary call under the key starts nothing either. */
+    await mcp.close();
+    mcp = await fixture.mcp({ name: "viewer-causal-proof-restarted" });
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-barrier-1", { recoveryOnly: true })))
+      .toMatchObject({ ok: true, outcome: "accepted", operationId, replayed: true });
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-barrier-1")))
+      .toMatchObject({ ok: true, outcome: "accepted", operationId, replayed: true });
+    expect(fixture.effects()).toHaveLength(0);
+
+    /* Execution is released: the recipient takes the admitted send once. */
+    fixture.execute();
+    const deadline = Date.now() + 10_000;
+    while (fixture.effects().length === 0) {
+      if (Date.now() > deadline) throw new Error("the admitted send never executed");
+      await Bun.sleep(5);
+    }
+    const recovered = await call(mcp, "send_message", sendArguments(fixture, "send-barrier-1", { recoveryOnly: true }));
+    expect(recovered).toMatchObject({ ok: true, outcome: "settled", operationId, state: "delivered", resend: "not-needed", nextAction: "follow-disposition" });
+
+    /* The host restarts against the same stores: same answer, nothing new. */
+    await host.kill();
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-barrier-1")))
+      .toMatchObject({ ok: true, outcome: "settled", operationId, state: "delivered" });
+    const receipt = await mcp.client.callTool({ name: "message_receipt", arguments: { clientRequestId: "send-barrier-1-receipt", operationId } });
+    expect(receipt.structuredContent).toMatchObject({ ok: true, operationId, state: "delivered" });
+
+    const deliveries = fixture.effects().filter((effect) => effect.kind === "recipient");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({ clientMessageId: "send-barrier-1", operationId });
+    expect(Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === "send-barrier-1")).toHaveLength(1);
+    expect(fixture.responses().filter((response) => response.pathname === "/api/tmux" && response.body.includes("send-barrier-1"))).toHaveLength(1);
+  } finally {
+    await mcp.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("spawn: admitted, response lost BEFORE the writer acts, original-key recovery across MCP and host restart — one launch, one conversation, one writer", async () => {
+  const fixture = await causalFixture("llv-1490-spawn-barrier-");
+  let host = await fixture.startHost();
+  let mcp = await fixture.mcp();
+  try {
+    fixture.control({ mode: "cut", admission: "hold-effect" });
+    const original = call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-barrier-1"));
+    await fixture.marker("admitted");
+    await fixture.marker("accepted");
+    expect(fixture.effects()).toHaveLength(0);
+    const lost = await original;
+    expect(lost).toMatchObject({ ok: true, recovered: true, nextAction: "original-key-lookup" });
+    expect(["accepted", "in-flight"]).toContain(String(lost.outcome));
+    const launchId = lost.launchId as string;
+    const conversationId = lost.conversationId as string;
+    expect(typeof launchId).toBe("string");
+    expect(typeof conversationId).toBe("string");
+    expect(fixture.effects()).toHaveLength(0);
+
+    await mcp.close();
+    mcp = await fixture.mcp({ name: "viewer-causal-proof-restarted" });
+    expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-barrier-1", { recoveryOnly: true })))
+      .toMatchObject({ ok: true, launchId, conversationId, replayed: true });
+    expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-barrier-1")))
+      .toMatchObject({ ok: true, launchId, conversationId, replayed: true });
+    expect(fixture.effects()).toHaveLength(0);
+
+    fixture.execute();
+    const deadline = Date.now() + 10_000;
+    while (fixture.effects().length === 0) {
+      if (Date.now() > deadline) throw new Error("the admitted launch never executed");
+      await Bun.sleep(5);
+    }
+    expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-barrier-1", { recoveryOnly: true })))
+      .toMatchObject({ ok: true, launchId, conversationId });
+
+    await host.kill();
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-barrier-1")))
+      .toMatchObject({ ok: true, launchId, conversationId });
+
+    const launches = fixture.effects().filter((effect) => effect.kind === "writer");
+    expect(launches).toHaveLength(1);
+    expect(launches[0]).toMatchObject({ launchId, conversationId, clientAttemptId: "spawn-barrier-1" });
+    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-barrier-1");
+    expect(receipts).toHaveLength(1);
+    expect(String(receipts[0]?.conversationId)).toBe(conversationId);
+    expect(fixture.responses().filter((response) => response.pathname === "/api/spawn" && response.body.includes(launchId))).toHaveLength(1);
+  } finally {
+    await mcp.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("a lookup from another process before the original ever claims stays unknown, writes nothing, and the original then dispatches once", async () => {
+  const fixture = await causalFixture("llv-1490-before-claim-");
+  const host = await fixture.startHost();
+  const owner = await fixture.mcp({ name: "viewer-owner" });
+  const observer = await fixture.mcp({ name: "viewer-observer" });
+  try {
+    fixture.control({ mode: "respond", sendEffect: "deliver" });
+    for (const name of ["send_message", "spawn_agent"] as const) {
+      const args = name === "send_message" ? sendArguments(fixture, "before-claim-1") : spawnArguments(fixture, "before-claim-1");
+      const early = await call(observer, name, { ...args, recoveryOnly: true });
+      expect(early).toMatchObject({ ok: false, code: "outcome_unknown", replayed: false, details: { outcome: "unknown", evidence: "none", nextAction: "original-key-lookup" } });
+      /* The original, arriving after the lookup, is not suppressed: it
+         claims, dispatches once, and the observer then reads its record. */
+      const original = await call(owner, name, args);
+      expect(original).toMatchObject({ ok: true, replayed: false });
+      const late = await call(observer, name, { ...args, recoveryOnly: true });
+      expect(late).toMatchObject({ ok: true, recovered: true, replayed: true });
+      expect(late.operationId ?? late.launchId).toBe(original.operationId ?? original.launchId);
+    }
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(1);
+    expect(fixture.effects().filter((effect) => effect.kind === "writer")).toHaveLength(1);
+  } finally {
+    await owner.close();
+    await observer.close();
     await host.stop();
   }
 }, 40_000);

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -1,10 +1,46 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+
+/* Every process these tests start — the packaged MCP server, the controlled
+   Viewer host — runs against a sandbox of its own: state, home, config, temp
+   and provider homes all point inside it, and nothing this session's own
+   environment carries (a spawn capability, a control URL, a deploy target)
+   reaches a child. */
+const sandboxes: string[] = [];
+afterEach(() => {
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function sandboxDir(prefix: string): string {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  sandboxes.push(sandbox);
+  return sandbox;
+}
+
+function isolatedEnvironment(sandbox: string, extra: Record<string, string> = {}): Record<string, string> {
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"
+      && !entry[0].startsWith("LLV_")
+      && !entry[0].startsWith("NEXT_PUBLIC_")));
+  const directories = {
+    HOME: path.join(sandbox, "home"),
+    XDG_CONFIG_HOME: path.join(sandbox, "config"),
+    TMPDIR: path.join(sandbox, "tmp"),
+    LLV_STATE_DIR: path.join(sandbox, "state"),
+    LLV_CLAUDE_HOME: path.join(sandbox, "claude-home"),
+    LLV_CODEX_HOME: path.join(sandbox, "codex-home"),
+  };
+  for (const directory of Object.values(directories)) fs.mkdirSync(directory, { recursive: true });
+  return { ...environment, ...directories, ...extra };
+}
 
 function spawnResult(label: string): Response {
   return Response.json({
@@ -16,23 +52,14 @@ function spawnResult(label: string): Response {
   });
 }
 
-async function callSpawn(client: Client, clientRequestId: string) {
-  return client.callTool({
-    name: "spawn_agent",
-    arguments: {
-      clientRequestId,
-      cwd: process.cwd(),
-      "prompt": "Run the restart fixture.",
-      title: "Restart fixture",
-    },
-  });
+interface McpSession {
+  client: Client;
+  transport: StdioClientTransport;
+  stderr(): string;
+  close(): Promise<void>;
 }
 
-test("the packaged stdio host publishes and invokes the expanded read surface", async () => {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-stdio-"));
-  const environment = Object.fromEntries(Object.entries(process.env)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
-  environment.LLV_STATE_DIR = sandbox;
+async function startMcp(environment: Record<string, string>, name: string): Promise<McpSession> {
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
@@ -40,22 +67,51 @@ test("the packaged stdio host publishes and invokes the expanded read surface", 
     env: environment,
     stderr: "pipe",
   });
-  const client = new Client({ name: "viewer-stdio-integration", version: "1.0.0" });
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+  const client = new Client({ name, version: "1.0.0" });
+  await client.connect(transport);
+  return {
+    client,
+    transport,
+    stderr: () => stderr,
+    close: async () => {
+      await Promise.race([client.close().catch(() => {}), Bun.sleep(1_000)]);
+      await Promise.race([transport.close().catch(() => {}), Bun.sleep(1_000)]);
+    },
+  };
+}
+
+async function callSpawn(client: Client, clientRequestId: string, extra: Record<string, unknown> = {}) {
+  return client.callTool({
+    name: "spawn_agent",
+    arguments: {
+      clientRequestId,
+      cwd: process.cwd(),
+      "prompt": "Run the restart fixture.",
+      title: "Restart fixture",
+      ...extra,
+    },
+  });
+}
+
+test("the packaged stdio host publishes and invokes the expanded read surface", async () => {
+  const sandbox = sandboxDir("llv-mcp-stdio-");
+  const session = await startMcp(isolatedEnvironment(sandbox), "viewer-stdio-integration");
   try {
-    await client.connect(transport);
-    const tools = await client.listTools();
+    const tools = await session.client.listTools();
     expect(tools.tools.map((tool) => tool.name)).toContain("board_snapshot");
     expect(tools.tools.map((tool) => tool.name)).toContain("conversation_migration");
 
-    const first = await client.callTool({
+    const first = await session.client.callTool({
       name: "list_flows",
       arguments: { clientRequestId: "stdio-list-flows", limit: 1 },
     });
-    const replay = await client.callTool({
+    const replay = await session.client.callTool({
       name: "list_flows",
       arguments: { clientRequestId: "stdio-list-flows", limit: 1 },
     });
-    const tasks = await client.callTool({
+    const tasks = await session.client.callTool({
       name: "list_tasks",
       arguments: { clientRequestId: "stdio-list-tasks", limit: 1 },
     });
@@ -64,13 +120,16 @@ test("the packaged stdio host publishes and invokes the expanded read surface", 
     expect(replay.structuredContent).toMatchObject({ ok: true, toolName: "list_flows", replayed: true });
     expect(tasks.structuredContent).toMatchObject({ ok: true, toolName: "list_tasks", replayed: false });
   } finally {
-    await client.close().catch(() => {});
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    await session.close();
   }
 });
 
-test("an already-running packaged MCP channel retries through a same-port Viewer restart and fails loudly when recovery exhausts", async () => {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-viewer-restart-"));
+test("a packaged MCP spawn is dispatched once: a Viewer restart mid-request answers unknown and nothing is re-POSTed", async () => {
+  /* #1490: this used to be the reconnect-and-repeat test. A spawn whose
+     response is lost after the Viewer may hold the request is now reported as
+     `unknown` with the original key as the only permitted next step, and the
+     restarted Viewer never sees the request a second time. */
+  const sandbox = sandboxDir("llv-mcp-viewer-restart-");
   const blockedRequest = { release: null as ((response: Response) => void) | null };
   let markBlockedRequestReached: (() => void) | null = null;
   const blockedRequestReached = new Promise<void>((resolve) => { markBlockedRequestReached = resolve; });
@@ -86,38 +145,28 @@ test("an already-running packaged MCP channel retries through a same-port Viewer
     },
   });
   const viewerPort = firstViewer.port;
-  const environment = Object.fromEntries(Object.entries(process.env)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
-  environment.LLV_STATE_DIR = sandbox;
-  environment.LLV_VIEWER_DEPLOY_TARGET = path.join(sandbox, "viewer-release.json");
-  environment.LLV_VIEWER_CONTROL_URL = firstViewer.url.origin;
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
-    cwd: process.cwd(),
-    env: environment,
-    stderr: "pipe",
+  const environment = isolatedEnvironment(sandbox, {
+    LLV_VIEWER_DEPLOY_TARGET: path.join(sandbox, "viewer-release.json"),
+    LLV_VIEWER_CONTROL_URL: firstViewer.url.origin,
   });
-  const client = new Client({ name: "viewer-restart-integration", version: "1.0.0" });
-  let mcpStderr = "";
-  transport.stderr?.on("data", (chunk) => { mcpStderr += String(chunk); });
+  const session = await startMcp(environment, "viewer-restart-integration");
   let restartedViewer: ReturnType<typeof Bun.serve> | null = null;
-  let restartedRequests = 0;
+  const restartedKeys: string[] = [];
   let transientProxyFailures = 0;
   let breakResponseBody = false;
   try {
-    await client.connect(transport);
-    expect((await callSpawn(client, "restart-before")).structuredContent)
+    expect((await callSpawn(session.client, "restart-before")).structuredContent)
       .toMatchObject({ ok: true, conversationId: "conversation_before_restart" });
 
-    const inFlight = callSpawn(client, "restart-during");
+    const inFlight = callSpawn(session.client, "restart-during");
     await blockedRequestReached;
     void firstViewer.stop(false);
     restartedViewer = Bun.serve({
       hostname: "127.0.0.1",
       port: viewerPort,
-      fetch: () => {
-        restartedRequests += 1;
+      fetch: async (request) => {
+        const body = await request.json() as { clientAttemptId?: string };
+        restartedKeys.push(body.clientAttemptId ?? "");
         if (transientProxyFailures > 0) {
           transientProxyFailures -= 1;
           return new Response(null, { status: 503 });
@@ -135,51 +184,75 @@ test("an already-running packaged MCP channel retries through a same-port Viewer
       },
     });
     expect(restartedViewer.port).toBe(viewerPort);
-    expect((await fetch(restartedViewer.url, { method: "POST" })).status).toBe(200);
 
-    const landed = await Promise.race([
+    const lost = await Promise.race([
       inFlight,
-      Bun.sleep(7_000).then(() => { throw new Error(`MCP call did not reconnect to the restarted Viewer (new requests: ${restartedRequests})\n${mcpStderr}`); }),
+      Bun.sleep(15_000).then(() => { throw new Error(`MCP call did not settle after the Viewer restart\n${session.stderr()}`); }),
     ]);
-    expect(landed.structuredContent)
-      .toMatchObject({ ok: true, conversationId: "conversation_after_restart" });
-    expect(restartedRequests).toBe(2);
+    expect(lost.isError).toBe(true);
+    expect(lost.structuredContent).toMatchObject({
+      ok: false,
+      code: "outcome_unknown",
+      retryable: false,
+      details: { outcome: "unknown", nextAction: "original-key-lookup" },
+    });
+    /* The restarted Viewer never received the lost request again. */
+    expect(restartedKeys).not.toContain("restart-during");
 
+    /* This MCP process carries no caller identity, so an existing claim is
+       not its to recover: a repeat under the key, explicit or ordinary, is
+       refused without disclosure — and still dispatches nothing. */
+    for (const extra of [{ recoveryOnly: true }, {}]) {
+      const lookup = await callSpawn(session.client, "restart-during", extra);
+      expect(lookup.structuredContent).toMatchObject({ ok: false, code: "recovery_not_permitted", retryable: false });
+      expect((lookup.structuredContent as { details?: unknown }).details).toBeUndefined();
+    }
+    expect(restartedKeys).not.toContain("restart-during");
+
+    /* A bodiless proxy status proves nothing about the upstream: unknown, one POST. */
     transientProxyFailures = 1;
-    expect((await callSpawn(client, "restart-proxy-gap")).structuredContent)
-      .toMatchObject({ ok: true, conversationId: "conversation_after_restart" });
-    expect(restartedRequests).toBe(4);
+    expect((await callSpawn(session.client, "restart-proxy-gap")).structuredContent)
+      .toMatchObject({ ok: false, code: "outcome_unknown" });
+    expect(restartedKeys.filter((key) => key === "restart-proxy-gap")).toHaveLength(1);
 
+    /* A response body cut after the request was accepted: unknown, one POST. */
     breakResponseBody = true;
-    expect((await callSpawn(client, "restart-cut-body")).structuredContent)
+    expect((await callSpawn(session.client, "restart-cut-body")).structuredContent)
+      .toMatchObject({ ok: false, code: "outcome_unknown" });
+    expect(restartedKeys.filter((key) => key === "restart-cut-body")).toHaveLength(1);
+
+    /* An ordinary call still dispatches once and answers normally. */
+    expect((await callSpawn(session.client, "restart-after")).structuredContent)
       .toMatchObject({ ok: true, conversationId: "conversation_after_restart" });
-    expect(restartedRequests).toBe(6);
+    expect(restartedKeys.filter((key) => key === "restart-after")).toHaveLength(1);
 
     await restartedViewer.stop(true);
     restartedViewer = null;
-    const unavailable = await callSpawn(client, "restart-unavailable");
+    /* A refused connection carried no byte: the server provably did nothing. */
+    const unavailable = await callSpawn(session.client, "restart-unavailable");
     expect(unavailable.isError).toBe(true);
     expect(unavailable.structuredContent).toMatchObject({
       ok: false,
-      error: expect.stringContaining("Viewer control did not reconnect after"),
+      code: "tool_failed",
+      error: expect.stringContaining("connection was refused"),
+      details: { outcome: "not-executed", nextAction: "new-request-permitted" },
     });
-    expect((await client.listTools()).tools.map((tool) => tool.name)).toContain("spawn_agent");
+    expect((await session.client.listTools()).tools.map((tool) => tool.name)).toContain("spawn_agent");
   } finally {
     blockedRequest.release?.(Response.json({ error: "retired Viewer generation" }, { status: 503 }));
     await Promise.race([
       Promise.all([
-        transport.close().catch(() => {}),
+        session.close(),
         Promise.resolve(firstViewer.stop(true)).catch(() => {}),
         Promise.resolve(restartedViewer?.stop(true)).catch(() => {}),
       ]),
-      Bun.sleep(1_000),
+      Bun.sleep(1_500),
     ]);
-    fs.rmSync(sandbox, { recursive: true, force: true });
   }
-}, 20_000);
+}, 25_000);
 
 test("a packaged MCP tool falls back from a retired launch port to the stable Viewer resolver", async () => {
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-dead-launch-port-"));
+  const sandbox = sandboxDir("llv-mcp-dead-launch-port-");
   const retiredViewer = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -203,28 +276,408 @@ test("a packaged MCP tool falls back from a retired launch port to the stable Vi
     container: "viewer-fixture",
     endpoint: stableViewer.url.origin,
   }));
-  const environment = Object.fromEntries(Object.entries(process.env)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
-  environment.LLV_STATE_DIR = sandbox;
-  environment.LLV_VIEWER_DEPLOY_TARGET = targetFile;
-  environment.LLV_VIEWER_CONTROL_URL = retiredOrigin;
-  environment.LLV_VIEWER_PORT = String(stableViewer.port);
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
-    cwd: process.cwd(),
-    env: environment,
-    stderr: "pipe",
-  });
-  const client = new Client({ name: "viewer-dead-launch-port", version: "1.0.0" });
+  const session = await startMcp(isolatedEnvironment(sandbox, {
+    LLV_VIEWER_DEPLOY_TARGET: targetFile,
+    LLV_VIEWER_CONTROL_URL: retiredOrigin,
+    LLV_VIEWER_PORT: String(stableViewer.port),
+  }), "viewer-dead-launch-port");
   try {
-    await client.connect(transport);
-    expect((await callSpawn(client, "dead-launch-port-fallback")).structuredContent)
+    expect((await callSpawn(session.client, "dead-launch-port-fallback")).structuredContent)
       .toMatchObject({ ok: true, conversationId: "conversation_stable_resolver" });
     expect(stableRequests).toBe(1);
   } finally {
-    await client.close().catch(() => {});
+    await session.close();
     await stableViewer.stop(true);
-    fs.rmSync(sandbox, { recursive: true, force: true });
   }
 }, 12_000);
+
+/* ── CAUSAL PROOF (#1490) ─────────────────────────────────────────────────
+   The packaged MCP server, over its production control transport, against
+   the PRODUCTION `/api/tmux` and `/api/spawn` handlers served by the
+   controlled Viewer role of `receiptStoreProbeChild.ts`. The three processes
+   share one isolated registry and one isolated receipt store; the recipient
+   and the writer are fixtures that log every actual effect. */
+
+interface HostProcess {
+  process: ReturnType<typeof Bun.spawn>;
+  origin: string;
+  stderr(): Promise<string>;
+  stop(): Promise<void>;
+  kill(): Promise<void>;
+}
+
+interface CausalFixture {
+  sandbox: string;
+  state: string;
+  environment: Record<string, string>;
+  registry: AgentRegistry;
+  recipient: { conversationId: string; generationId: string; transcriptPath: string };
+  caller: { conversationId: string; capability: string };
+  effects(): Record<string, unknown>[];
+  responses(): { pathname: string; status: number; body: string }[];
+  control(value: Record<string, unknown>): void;
+  marker(name: string, timeoutMs?: number): Promise<void>;
+  release(): void;
+  resetMarkers(): void;
+  startHost(): Promise<HostProcess>;
+  mcp(options?: { identified?: boolean; name?: string }): Promise<McpSession>;
+  registryFile(): ReturnType<AgentRegistry["readOnlySnapshot"]>;
+}
+
+async function causalFixture(prefix: string): Promise<CausalFixture> {
+  const sandbox = sandboxDir(prefix);
+  const environment = isolatedEnvironment(sandbox);
+  const state = environment.LLV_STATE_DIR!;
+  const markerDir = path.join(sandbox, "markers");
+  const transcriptRoot = path.join(sandbox, "transcripts");
+  fs.mkdirSync(markerDir, { recursive: true });
+  fs.mkdirSync(transcriptRoot, { recursive: true });
+  const effectsPath = path.join(sandbox, "effects.ndjson");
+  const responsesPath = path.join(sandbox, "responses.ndjson");
+  const controlPath = path.join(sandbox, "control.json");
+  fs.writeFileSync(controlPath, JSON.stringify({ mode: "respond" }));
+
+  const registry = new AgentRegistry(path.join(state, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const transcriptPath = path.join(transcriptRoot, "recipient.jsonl");
+  fs.writeFileSync(transcriptPath, "{}\n");
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: transcriptPath,
+    accountId: "fixture-recipient-account",
+    launchProfile: emptyLaunchProfile({ cwd: sandbox }),
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-09-05T08:00:00.000Z",
+  }]);
+  const recipientConversation = Object.values(registry.snapshot().conversations)[0]!;
+  const recipient = {
+    conversationId: recipientConversation.id,
+    generationId: recipientConversation.generations.at(-1)!.id,
+    transcriptPath,
+  };
+  /* The calling conversation: a launch receipt of its own, whose capability is
+     what the MCP process presents. That is the identity the recovery contract
+     binds to — server-derived, never something the arguments could say. */
+  const callerReceipt = registry.beginSpawn("codex", sandbox, { cwd: sandbox, title: "Causal proof caller" });
+  const capability = registry.rotateSpawnCapabilityForReceipt(callerReceipt.launchId);
+
+  const config = {
+    portFile: path.join(sandbox, "host.port"),
+    effectsPath,
+    responsesPath,
+    controlPath,
+    markerDir,
+    recipientGenerationId: recipient.generationId,
+    transcriptRoot,
+  };
+  const configPath = path.join(sandbox, "host.json");
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  /* The production spawn route enumerates the launch account's MCP servers by
+     running the engine binary; the controlled runtime answers with none. */
+  const codexBinary = path.join(sandbox, "codex");
+  fs.writeFileSync(codexBinary, "#!/bin/sh\necho '[]'\n", { mode: 0o755 });
+
+  let hosts = 0;
+  const fixture: CausalFixture = {
+    sandbox,
+    state,
+    environment,
+    registry,
+    recipient,
+    caller: { conversationId: callerReceipt.conversationId, capability },
+    effects: () => (fs.existsSync(effectsPath)
+      ? fs.readFileSync(effectsPath, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>)
+      : []),
+    responses: () => (fs.existsSync(responsesPath)
+      ? fs.readFileSync(responsesPath, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as { pathname: string; status: number; body: string })
+      : []),
+    control: (value) => fs.writeFileSync(controlPath, JSON.stringify(value)),
+    marker: async (name, timeoutMs = 10_000) => {
+      const deadline = Date.now() + timeoutMs;
+      const file = path.join(markerDir, name);
+      while (!fs.existsSync(file)) {
+        if (Date.now() > deadline) throw new Error(`marker ${name} never appeared`);
+        await Bun.sleep(5);
+      }
+    },
+    release: () => fs.writeFileSync(path.join(markerDir, "release"), "1"),
+    resetMarkers: () => {
+      for (const entry of fs.readdirSync(markerDir)) fs.rmSync(path.join(markerDir, entry), { force: true });
+    },
+    startHost: async () => {
+      hosts += 1;
+      fs.rmSync(config.portFile, { force: true });
+      const child = Bun.spawn([
+        process.execPath,
+        path.join(process.cwd(), "src", "lib", "mcp", "receiptStoreProbeChild.ts"),
+        "http-host",
+        configPath,
+      ], {
+        cwd: process.cwd(),
+        env: {
+          ...environment,
+          LLV_SPAWN_TRANSPORT: "structured",
+          LLV_RUNTIME_HOST_SOCKET: path.join(state, "runtime-host.sock"),
+          LLV_CODEX_BINARY: codexBinary,
+          NODE_ENV: "test",
+        },
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const deadline = Date.now() + 20_000;
+      while (!fs.existsSync(config.portFile)) {
+        if (child.exitCode !== null) throw new Error(`host ${hosts} exited: ${await new Response(child.stderr).text()}`);
+        if (Date.now() > deadline) { child.kill(9); throw new Error(`host ${hosts} never published its port`); }
+        await Bun.sleep(10);
+      }
+      const port = Number(fs.readFileSync(config.portFile, "utf8"));
+      return {
+        process: child,
+        origin: `http://127.0.0.1:${port}`,
+        stderr: () => new Response(child.stderr).text(),
+        stop: async () => { child.kill(); await Promise.race([child.exited, Bun.sleep(2_000)]); },
+        kill: async () => { child.kill(9); await Promise.race([child.exited, Bun.sleep(2_000)]); },
+      };
+    },
+    mcp: (options = {}) => startMcp({
+      ...environment,
+      LLV_VIEWER_CONTROL_URL: `http://127.0.0.1:${Number(fs.readFileSync(config.portFile, "utf8"))}`,
+      ...(options.identified === false ? {} : { LLV_SPAWN_CAPABILITY: capability }),
+    }, options.name ?? "viewer-causal-proof"),
+    registryFile: () => registry.readOnlySnapshot(),
+  };
+  return fixture;
+}
+
+function sendArguments(fixture: CausalFixture, clientRequestId: string, extra: Record<string, unknown> = {}) {
+  return { clientRequestId, conversationId: fixture.recipient.conversationId, text: "hold the cutover until I say go", ...extra };
+}
+
+function spawnArguments(fixture: CausalFixture, clientRequestId: string, extra: Record<string, unknown> = {}) {
+  return { clientRequestId, cwd: fixture.sandbox, "prompt": "Inspect the fixture checkout.", title: "Causal proof launch", engine: "codex", ...extra };
+}
+
+async function call(session: McpSession, name: "send_message" | "spawn_agent", args: Record<string, unknown>) {
+  const result = await session.client.callTool({ name, arguments: args });
+  return result.structuredContent as Record<string, unknown> & { details?: Record<string, unknown> };
+}
+
+test("send: acceptance, lost response, original-key recovery — one recipient delivery, across process restart", async () => {
+  const fixture = await causalFixture("llv-1490-send-");
+  let host = await fixture.startHost();
+  let mcp = await fixture.mcp();
+  try {
+    /* Lose the response AFTER the production handler accepted and the
+       controlled recipient took the message. */
+    fixture.control({ mode: "lose", sendEffect: "deliver" });
+    const original = call(mcp, "send_message", sendArguments(fixture, "send-lost-1"));
+    await fixture.marker("accepted");
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(1);
+    await host.kill();
+    const lost = await original;
+    /* The reset reaches the MCP process as uncertainty; the immediate
+       evidence read already finds the settled delivery under the ORIGINAL
+       key, with the operation id the recipient actually took. */
+    expect(lost).toMatchObject({ ok: true, recovered: true, outcome: "settled", state: "delivered", resend: "not-needed", nextAction: "follow-disposition" });
+    expect(typeof lost.operationId).toBe("string");
+    const operationId = lost.operationId as string;
+
+    /* Recovery under the original key and unchanged payload, host restarted. */
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    const recovered = await call(mcp, "send_message", sendArguments(fixture, "send-lost-1", { recoveryOnly: true }));
+    expect(recovered).toMatchObject({ ok: true, recovered: true, outcome: "settled", operationId, state: "delivered", replayed: true });
+    const ordinary = await call(mcp, "send_message", sendArguments(fixture, "send-lost-1"));
+    expect(ordinary).toMatchObject({ ok: true, recovered: true, outcome: "settled", operationId });
+
+    /* The MCP process restarts against the same stores: same answer, no dispatch. */
+    await mcp.close();
+    mcp = await fixture.mcp({ name: "viewer-causal-proof-restarted" });
+    const afterRestart = await call(mcp, "send_message", sendArguments(fixture, "send-lost-1", { recoveryOnly: true }));
+    expect(afterRestart).toMatchObject({ ok: true, outcome: "settled", operationId });
+    const receipt = await mcp.client.callTool({ name: "message_receipt", arguments: { clientRequestId: "send-lost-1-receipt", operationId } });
+    expect(receipt.structuredContent).toMatchObject({ ok: true, operationId, state: "delivered" });
+
+    /* Exactly one recipient delivery and one reservation for the key. */
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(1);
+    const reservations = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === "send-lost-1");
+    expect(reservations).toHaveLength(1);
+  } finally {
+    await mcp.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("spawn: acceptance, lost response, original-key recovery — one launch, one conversation, one writer, across process restart", async () => {
+  const fixture = await causalFixture("llv-1490-spawn-");
+  let host = await fixture.startHost();
+  let mcp = await fixture.mcp();
+  try {
+    fixture.control({ mode: "lose" });
+    const original = call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-lost-1"));
+    await fixture.marker("accepted");
+    const launched = fixture.effects().filter((effect) => effect.kind === "writer");
+    if (launched.length !== 1) throw new Error(`writer effects: ${JSON.stringify(fixture.effects())}; responses: ${JSON.stringify(fixture.responses())}`);
+    await host.kill();
+    const lost = await original;
+    expect(lost).toMatchObject({ ok: true, recovered: true, nextAction: "original-key-lookup", launchId: launched[0]!.launchId, conversationId: launched[0]!.conversationId });
+    expect(["accepted", "in-flight"]).toContain(String(lost.outcome));
+
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    const recovered = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-lost-1", { recoveryOnly: true }));
+    expect(recovered).toMatchObject({ ok: true, recovered: true, launchId: launched[0]!.launchId, conversationId: launched[0]!.conversationId, replayed: true });
+    const ordinary = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-lost-1"));
+    expect(ordinary).toMatchObject({ ok: true, recovered: true, launchId: launched[0]!.launchId });
+
+    await mcp.close();
+    mcp = await fixture.mcp({ name: "viewer-causal-proof-restarted" });
+    const afterRestart = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-lost-1", { recoveryOnly: true }));
+    expect(afterRestart).toMatchObject({ ok: true, launchId: launched[0]!.launchId });
+
+    expect(fixture.effects().filter((effect) => effect.kind === "writer")).toHaveLength(1);
+    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-lost-1");
+    expect(receipts).toHaveLength(1);
+    expect(new Set(receipts.map((receipt) => receipt.conversationId)).size).toBe(1);
+  } finally {
+    await mcp.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("lookup before acceptance stays unknown, late acceptance is then found, and a late original response never regresses the terminal answer", async () => {
+  const fixture = await causalFixture("llv-1490-late-");
+  const host = await fixture.startHost();
+  const original = await fixture.mcp({ name: "viewer-original" });
+  const observer = await fixture.mcp({ name: "viewer-observer" });
+  try {
+    /* The host reaches the request and holds it BEFORE the handler runs. */
+    fixture.control({ mode: "hold-before", sendEffect: "deliver" });
+    const inFlight = call(original, "send_message", sendArguments(fixture, "send-late-1"));
+    await fixture.marker("reached");
+    const early = await call(observer, "send_message", sendArguments(fixture, "send-late-1", { recoveryOnly: true }));
+    expect(early).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", nextAction: "original-key-lookup" } });
+    expect(fixture.effects()).toHaveLength(0);
+
+    /* Late acceptance: the handler runs, the recipient takes it, the original
+       response is answered. Nothing was dispatched twice. */
+    fixture.release();
+    const settled = await inFlight;
+    expect(settled).toMatchObject({ ok: true, replayed: false, outcome: "delivered", settled: true });
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(1);
+    const late = await call(observer, "send_message", sendArguments(fixture, "send-late-1", { recoveryOnly: true }));
+    expect(late).toMatchObject({ ok: true, outcome: "settled", state: "delivered", operationId: settled.operationId });
+    expect(late.original).toMatchObject({ ok: true, operationId: settled.operationId });
+
+    /* A response that arrives AFTER a recovery already answered: the
+       original settles its own success and the recovery answer stands. */
+    fixture.resetMarkers();
+    fixture.control({ mode: "hold", sendEffect: "deliver" });
+    const held = call(original, "send_message", sendArguments(fixture, "send-late-2"));
+    await fixture.marker("accepted");
+    const during = await call(observer, "send_message", sendArguments(fixture, "send-late-2", { recoveryOnly: true }));
+    expect(during).toMatchObject({ ok: true, outcome: "settled", state: "delivered" });
+    fixture.release();
+    const originalAnswer = await held;
+    expect(originalAnswer).toMatchObject({ ok: true, replayed: false, operationId: during.operationId });
+    const after = await call(observer, "send_message", sendArguments(fixture, "send-late-2"));
+    expect(after).toMatchObject({ ok: true, replayed: true, operationId: during.operationId });
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(2);
+  } finally {
+    await original.close();
+    await observer.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("network failure without dispatch proof stays unknown and never redelivers; proven pre-dispatch rejection has zero effects", async () => {
+  const fixture = await causalFixture("llv-1490-negative-");
+  let host = await fixture.startHost();
+  const mcp = await fixture.mcp();
+  try {
+    /* The connection dies while the host holds the request BEFORE the
+       handler runs: nothing executed, and nothing can prove it. */
+    fixture.control({ mode: "hold-before" });
+    const inFlight = call(mcp, "send_message", sendArguments(fixture, "send-cut-1"));
+    await fixture.marker("reached");
+    await host.kill();
+    const cut = await inFlight;
+    expect(cut).toMatchObject({ ok: false, code: "outcome_unknown", retryable: false, details: { outcome: "unknown", nextAction: "original-key-lookup" } });
+    expect(fixture.effects()).toHaveLength(0);
+
+    /* The host is back. The same key, ordinary or explicit, is a READ: the
+       unknown stays unknown and the recipient still has nothing. */
+    fixture.resetMarkers();
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-cut-1"))).toMatchObject({ ok: false, code: "outcome_unknown" });
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-cut-1", { recoveryOnly: true }))).toMatchObject({ ok: false, code: "outcome_unknown" });
+    expect(fixture.effects()).toHaveLength(0);
+
+    /* A pre-dispatch rejection by the production route: no receipt, no writer. */
+    const rejected = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") }));
+    expect(rejected).toMatchObject({ ok: false, code: "tool_failed", details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
+    expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") })))
+      .toMatchObject({ ok: false, replayed: true, details: { outcome: "not-executed" } });
+    expect(fixture.effects()).toHaveLength(0);
+    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-rejected-1")).toHaveLength(0);
+
+    /* recoveryOnly under a key nothing ever claimed starts no work and closes
+       the key: a later ordinary call under it cannot dispatch. */
+    const probe = await call(mcp, "send_message", sendArguments(fixture, "send-never-1", { recoveryOnly: true }));
+    expect(probe).toMatchObject({ ok: false, code: "not_executed", details: { outcome: "not-executed" } });
+    expect(await call(mcp, "send_message", sendArguments(fixture, "send-never-1"))).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+    expect(fixture.effects()).toHaveLength(0);
+  } finally {
+    await mcp.close();
+    await host.stop();
+  }
+}, 40_000);
+
+test("spoofing and concurrency: another caller, a changed payload, and two processes racing one key", async () => {
+  const fixture = await causalFixture("llv-1490-spoof-");
+  const host = await fixture.startHost();
+  const owner = await fixture.mcp({ name: "viewer-owner" });
+  const stranger = await fixture.mcp({ identified: false, name: "viewer-stranger" });
+  const peer = await fixture.mcp({ name: "viewer-peer" });
+  try {
+    fixture.control({ mode: "respond", sendEffect: "queue" });
+    const accepted = await call(owner, "send_message", sendArguments(fixture, "send-owned-1"));
+    expect(accepted).toMatchObject({ ok: true, outcome: "queued", settled: false });
+
+    /* An unidentified caller — the same key, the same payload, even forged
+       caller fields — learns nothing. */
+    const forged = await call(stranger, "send_message", sendArguments(fixture, "send-owned-1", {
+      recoveryOnly: true,
+      callerConversationId: fixture.caller.conversationId,
+      callerProject: "spoofed",
+    }));
+    expect(forged).toMatchObject({ ok: false, code: "recovery_not_permitted" });
+    expect(forged.details).toBeUndefined();
+    expect(JSON.stringify(forged)).not.toContain(String(accepted.operationId));
+
+    /* The owner with a changed payload is a conflict, not a second send. */
+    expect(await call(owner, "send_message", sendArguments(fixture, "send-owned-1", { text: "changed" })))
+      .toMatchObject({ ok: false, code: "idempotency_conflict" });
+    /* The owner's forged fields change the digest, never the authority. */
+    expect(await call(owner, "send_message", sendArguments(fixture, "send-owned-1", { recoveryOnly: true })))
+      .toMatchObject({ ok: true, outcome: "in-flight", operationId: accepted.operationId, state: "in-flight", nextAction: "original-key-lookup" });
+
+    /* Two processes race one fresh key: exactly one dispatch owner, and the
+       other answers from evidence. */
+    fixture.control({ mode: "respond", sendEffect: "deliver" });
+    const race = await Promise.all([
+      call(owner, "send_message", sendArguments(fixture, "send-race-1")),
+      call(peer, "send_message", sendArguments(fixture, "send-race-1")),
+    ]);
+    expect(race.every((answer) => answer.ok === true)).toBe(true);
+    const operationIds = new Set(race.map((answer) => answer.operationId));
+    expect(operationIds.size).toBe(1);
+    expect(race.filter((answer) => answer.replayed === false)).toHaveLength(1);
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-race-1")).toHaveLength(1);
+  } finally {
+    await owner.close();
+    await stranger.close();
+    await peer.close();
+    await host.stop();
+  }
+}, 40_000);

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -63,8 +63,8 @@ function spawnResult(label: string): Response {
     conversationId: `conversation_${label}`,
     path: `/fixture/${label}.jsonl`,
     launchId: `launch_${label}`,
-    state: "running",
-    initialMessage: null,
+    state: "starting",
+    initialMessage: "pending",
   });
 }
 
@@ -1060,3 +1060,77 @@ test("path-only send: late registration after binding, lost response, and restar
     await host.stop();
   }
 }, 40_000);
+
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: incomplete successful JSON recovers admission before execution and across restart`, async () => {
+    const fixture = await causalFixture("llv-1490-incomplete-");
+    let host = await fixture.startHost();
+    let mcp = await fixture.mcp();
+    try {
+      const answers = tool === "send_message"
+        ? [{}, { ok: true }, { outcome: "delivered" }, { operationId: "op_incomplete" },
+          { operationId: "op_incomplete", outcome: "delivered", receipt: { operationId: "op_other", status: "queued" } }]
+        : [{}, { ok: true }, { state: "settled" }, { launchId: "launch_incomplete" },
+          { launchId: "launch_incomplete", conversationId: "conversation_incomplete", state: "starting", initialMessage: "delivered" }];
+      for (const [index, replacedAnswer] of answers.entries()) {
+        fixture.resetMarkers();
+        fixture.control({ admission: "hold-effect", replacedAnswer });
+        const key = `incomplete-${index}`;
+        const args = tool === "send_message" ? sendArguments(fixture, key) : spawnArguments(fixture, key);
+        const before = fixture.effects().length;
+        const original = call(mcp, tool, args);
+        await fixture.marker("admitted");
+        await fixture.marker("accepted");
+        const result = await original;
+        expect(fixture.effects()).toHaveLength(before);
+        expect(result).toMatchObject({ ok: true, recovered: true, nextAction: "original-key-lookup" });
+        expect(["accepted", "in-flight"]).toContain(String(result.outcome));
+        const actual = JSON.parse(fixture.responses().at(-1)!.body);
+        const ids = tool === "send_message"
+          ? { operationId: actual.operationId }
+          : { launchId: actual.launchId, conversationId: actual.conversationId };
+        expect(result).toMatchObject(ids);
+        expect(Object.values(ids).every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+        await mcp.close();
+        mcp = await fixture.mcp();
+        for (const recoveryOnly of [true, false]) {
+          const replay = await call(mcp, tool, { ...args, recoveryOnly });
+          expect(replay).toMatchObject({ ok: true, recovered: true, ...ids });
+          expect(["accepted", "in-flight"]).toContain(String(replay.outcome));
+        }
+        expect(fixture.effects()).toHaveLength(before);
+        fixture.execute();
+        const deadline = Date.now() + 10_000;
+        while (fixture.effects().length === before) {
+          if (Date.now() > deadline) throw new Error("the admitted operation never executed");
+          await Bun.sleep(5);
+        }
+        expect(fixture.effects()).toHaveLength(before + 1);
+        expect(fixture.effects().at(-1)).toMatchObject(ids);
+        await mcp.close();
+        await host.kill();
+        fixture.control({ mode: "respond" });
+        host = await fixture.startHost();
+        mcp = await fixture.mcp();
+        for (const recoveryOnly of [true, false]) {
+          const replay = await call(mcp, tool, { ...args, recoveryOnly });
+          expect(replay).toMatchObject({ ok: true, ...ids });
+          if (tool === "send_message") expect(replay).toMatchObject({ outcome: "settled", state: "delivered" });
+        }
+        expect(fixture.effects()).toHaveLength(before + 1);
+        if (tool === "spawn_agent") {
+          const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === key);
+          expect(receipts).toHaveLength(1);
+          expect(receipts[0]).toMatchObject(ids);
+        } else {
+          const deliveries = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === key);
+          expect(deliveries).toHaveLength(1);
+        }
+      }
+    } finally {
+      await mcp.close();
+      await host.stop();
+    }
+  }, 120_000);
+}

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -1293,3 +1293,62 @@ for (const tool of ["send_message", "spawn_agent"] as const) {
     }
   }, 40_000);
 }
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: queued ordinary replay and terminal recovery both survive downstream loss and process restart`, async () => {
+    const fixture = await causalFixture("llv-1490-accepted-terminal-");
+    let host = await fixture.startHost();
+    let mcp = await fixture.mcp();
+    try {
+      fixture.control({ mode: "respond", admission: "hold-effect", settleWriter: true });
+      const args = tool === "send_message" ? sendArguments(fixture, "accepted-terminal") : spawnArguments(fixture, "accepted-terminal");
+      const accepted = await call(mcp, tool, args);
+      expect(accepted.ok).toBe(true);
+      expect(accepted.settled).not.toBe(true);
+      expect(fixture.effects()).toHaveLength(0);
+      fixture.execute();
+      // Poll the durable settlement barrier, not a widened delay: the effect
+      // and its terminal record are both required before the recovery read.
+      const deadline = Date.now() + 10_000;
+      while (true) {
+        const file = fixture.registryFile();
+        const terminal = tool === "send_message"
+          ? Object.values(file.heldDeliveries).some((delivery) => delivery.state === "delivered")
+          : Object.values(file.receipts).some((receipt) => receipt.launchId === accepted.launchId && receipt.state === "completed");
+        if (terminal) break;
+        if (Date.now() > deadline) throw new Error(`terminal effect barrier never reached: ${JSON.stringify({ accepted, effects: fixture.effects(), receipts: Object.values(file.receipts).map(({ launchId, state }) => ({ launchId, state })) })}`);
+        await Bun.sleep(5);
+      }
+      expect(fixture.effects()).toHaveLength(1);
+      const terminal = await call(mcp, tool, { ...args, recoveryOnly: true });
+      const effect = fixture.effects()[0]!;
+      const ids = tool === "send_message" ? { operationId: effect.operationId }
+        : { launchId: effect.launchId, conversationId: effect.conversationId };
+      expect(terminal).toMatchObject({ ok: true, outcome: "settled", ...ids });
+      const disposition = tool === "send_message" ? { state: terminal.state, resend: terminal.resend, duplicateRisk: terminal.duplicateRisk }
+        : { state: terminal.state, launched: terminal.launched };
+      expect(await call(mcp, tool, args)).toEqual({ ...accepted, replayed: true });
+      await mcp.close();
+      await host.kill();
+      const registryPath = path.join(fixture.state, "agent-registry.json");
+      const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+      if (tool === "send_message") {
+        registry.heldDeliveries = {};
+        registry.deliveryOperationOwners = {};
+      } else delete registry.receipts[String(effect.launchId)];
+      fs.writeFileSync(registryPath, JSON.stringify(registry));
+      fixture.control({ mode: "respond" });
+      host = await fixture.startHost();
+      mcp = await fixture.mcp();
+      expect(await call(mcp, tool, { ...args, recoveryOnly: true })).toMatchObject({
+        ok: true, outcome: "settled", evidence: "mcp-receipt", ...ids, ...disposition,
+      });
+      expect(await call(mcp, tool, args)).toEqual({ ...accepted, replayed: true });
+      expect(fixture.effects()).toHaveLength(1);
+      expect(fixture.responses()).toHaveLength(1);
+    } finally {
+      await mcp.close();
+      await host.stop();
+    }
+  }, 40_000);
+}

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -1062,8 +1062,9 @@ test("path-only send: late registration after binding, lost response, and restar
 }, 40_000);
 
 
-for (const tool of ["send_message", "spawn_agent"] as const) {
-  test(`${tool}: incomplete successful JSON recovers admission before execution and across restart`, async () => {
+for (const { tool, idBearingError } of (["send_message", "spawn_agent"] as const)
+  .flatMap((tool) => [false, true].map((idBearingError) => ({ tool, idBearingError })))) {
+  test(`${tool}: ${idBearingError ? "ID-bearing error" : "incomplete successful JSON"} recovers admission before execution and across restart`, async () => {
     const fixture = await causalFixture("llv-1490-incomplete-");
     let host = await fixture.startHost();
     let mcp = await fixture.mcp();
@@ -1073,15 +1074,18 @@ for (const tool of ["send_message", "spawn_agent"] as const) {
           { operationId: "op_incomplete", outcome: "delivered", receipt: { operationId: "op_other", status: "queued" } }]
         : [{}, { ok: true }, { state: "settled" }, { launchId: "launch_incomplete" },
           { launchId: "launch_incomplete", conversationId: "conversation_incomplete", state: "starting", initialMessage: "delivered" }];
-      for (const [index, replacedAnswer] of answers.entries()) {
+      for (const [index, replacedAnswer] of (idBearingError ? [{}] : answers).entries()) {
         fixture.resetMarkers();
-        fixture.control({ admission: "hold-effect", replacedAnswer });
+        fixture.control(idBearingError
+          ? { admission: "hold-effect", mode: "hold", lateVerdict: { status: 503 } }
+          : { admission: "hold-effect", replacedAnswer });
         const key = `incomplete-${index}`;
         const args = tool === "send_message" ? sendArguments(fixture, key) : spawnArguments(fixture, key);
         const before = fixture.effects().length;
         const original = call(mcp, tool, args);
         await fixture.marker("admitted");
         await fixture.marker("accepted");
+        if (idBearingError) fixture.release();
         const result = await original;
         expect(fixture.effects()).toHaveLength(before);
         expect(result).toMatchObject({ ok: true, recovered: true, nextAction: "original-key-lookup" });

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -644,20 +644,26 @@ test("network failure without dispatch proof stays unknown and never redelivers;
     expect(await call(mcp, "send_message", sendArguments(fixture, "send-cut-1", { recoveryOnly: true }))).toMatchObject({ ok: false, code: "outcome_unknown" });
     expect(fixture.effects()).toHaveLength(0);
 
-    /* A pre-dispatch rejection by the production route: no receipt, no writer. */
+    /* A route rejection without affirmative dispatch proof stays unknown. */
     const rejected = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") }));
-    expect(rejected).toMatchObject({ ok: false, code: "tool_failed", details: { outcome: "not-executed", nextAction: "new-request-permitted", evidence: "dispatch-refused" } });
-    /* The proof is the production route's OWN 4xx verdict, not a dead port. */
+    expect(rejected).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown", nextAction: "original-key-lookup" } });
+    /* The observed 4xx alone does not prove that no work was admitted. */
     expect(String(rejected.error)).not.toContain("connection was refused");
     const verdicts = fixture.responses().filter((response) => response.pathname === "/api/spawn" && response.body.includes("missing"));
     expect(verdicts).toHaveLength(1);
     expect(verdicts[0]!.status).toBeGreaterThanOrEqual(400);
     expect(verdicts[0]!.status).toBeLessThan(500);
-    expect(rejected.details?.status).toBe(verdicts[0]!.status);
+
     expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") })))
-      .toMatchObject({ ok: false, replayed: true, details: { outcome: "not-executed" } });
+      .toMatchObject({ ok: false, replayed: true, details: { outcome: "unknown" } });
     expect(fixture.effects()).toHaveLength(0);
     expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-rejected-1")).toHaveLength(0);
+
+    await host.kill();
+    const disconnected = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-unconnected"));
+    expect(disconnected).toMatchObject({ ok: false, details: { outcome: "not-executed", nextAction: "new-request-permitted" } });
+    expect(fixture.effects()).toHaveLength(0);
+    host = await fixture.startHost();
 
     /* recoveryOnly under a key nothing ever claimed starts no work and writes
        nothing: unknown, because the original may still be on its way — and
@@ -975,6 +981,82 @@ test("through the protocol: a lost claim discloses nothing to another caller, an
   } finally {
     await owner.close();
     await other.close();
+    await host.stop();
+  }
+}, 40_000);
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: proxy errors after actual effect recover the original identity across process restart`, async () => {
+    const fixture = await causalFixture("llv-1490-proxy-");
+    let host = await fixture.startHost();
+    let mcp = await fixture.mcp();
+    try {
+      // Cover timeout, throttling, nonstandard client/proxy and server errors,
+      // with both unreadable and valid JSON bodies after actual acceptance.
+      for (const status of [400, 408, 425, 429, 499, 500, 502, 503, 504]) {
+        for (const lostJson of [false, true]) {
+          const key = `proxy-${status}-${lostJson}`;
+          const args = tool === "send_message" ? sendArguments(fixture, key) : spawnArguments(fixture, key);
+          fixture.control({ lostStatus: status, lostJson });
+          const before = fixture.effects().length;
+          const result = await call(mcp, tool, args);
+          expect(fixture.effects()).toHaveLength(before + 1);
+          const effect = fixture.effects().at(-1)!;
+          const ids = tool === "send_message"
+            ? { operationId: effect.operationId }
+            : { launchId: effect.launchId, conversationId: effect.conversationId };
+          expect(result).toMatchObject({ ok: true, recovered: true, ...ids });
+          expect(result.nextAction).not.toBe("new-request-permitted");
+          await mcp.close();
+          await host.kill();
+          fixture.control({ mode: "respond" });
+          host = await fixture.startHost();
+          mcp = await fixture.mcp();
+          for (const recoveryOnly of [true, false]) {
+            expect(await call(mcp, tool, { ...args, recoveryOnly })).toMatchObject({ ok: true, ...ids });
+          }
+          expect(fixture.effects()).toHaveLength(before + 1);
+          if (tool === "spawn_agent") {
+            const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === key);
+            expect(receipts).toHaveLength(1);
+            expect(receipts[0]).toMatchObject({ conversationId: effect.conversationId });
+          }
+        }
+      }
+    } finally {
+      await mcp.close();
+      await host.stop();
+    }
+  }, 120_000);
+}
+
+test("path-only send: late registration after binding, lost response, and restart retain one delivery", async () => {
+  const fixture = await causalFixture("llv-1490-path-");
+  let host = await fixture.startHost();
+  let mcp = await fixture.mcp();
+  const transcriptPath = path.join(fixture.sandbox, "late-recipient.jsonl");
+  const args = { clientRequestId: "late-path", transcriptPath, text: "late registered recipient" };
+  try {
+    expect(fixture.registry.conversationForPath(transcriptPath)).toBeNull();
+    fixture.control({ mode: "hold-before", lostStatus: 408 });
+    const original = call(mcp, "send_message", args);
+    await fixture.marker("reached");
+    // HTTP has received the already-bound request but has not handled it yet.
+    fixture.registry.recordConversationContinuityPath(fixture.recipient.conversationId as `conversation_${string}`, transcriptPath);
+    fixture.release();
+    // The fixture replaces the accepted response with an unreadable 408.
+    const result = await original;
+    expect(result).toMatchObject({ ok: true, recovered: true, outcome: "settled" });
+    await mcp.close();
+    await host.kill();
+    fixture.control({ mode: "respond" });
+    host = await fixture.startHost();
+    mcp = await fixture.mcp();
+    const recovered = await call(mcp, "send_message", { ...args, recoveryOnly: true });
+    expect(recovered).toMatchObject({ ok: true, outcome: "settled", operationId: fixture.effects()[0]!.operationId });
+    expect(fixture.effects()).toHaveLength(1);
+  } finally {
+    await mcp.close();
     await host.stop();
   }
 }, 40_000);

--- a/src/lib/mcp/stdio.integration.test.ts
+++ b/src/lib/mcp/stdio.integration.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, expect, test } from "bun:test";
 import fs from "node:fs";
+import crypto from "node:crypto";
+
+const downstream = (tool: string, key: string) => `mcp_${tool === "send_message" ? "send" : "spawn"}_${crypto.createHash("sha256").update(key).digest("hex")}`;
 import os from "node:os";
 import path from "node:path";
 
@@ -213,7 +216,7 @@ test("a packaged MCP spawn is dispatched once: a Viewer restart mid-request answ
       details: { outcome: "unknown", nextAction: "original-key-lookup" },
     });
     /* The restarted Viewer never received the lost request again. */
-    expect(restartedKeys).not.toContain("restart-during");
+    expect(restartedKeys).not.toContain(downstream("spawn_agent", "restart-during"));
 
     /* A repeat under the key, explicit or ordinary, is a READ of the durable
        record — which holds no launch receipt for it, so the fate stays
@@ -222,24 +225,24 @@ test("a packaged MCP spawn is dispatched once: a Viewer restart mid-request answ
       const lookup = await callSpawn(session.client, "restart-during", extra);
       expect(lookup.structuredContent).toMatchObject({ ok: false, code: "outcome_unknown", retryable: false, replayed: true, details: { outcome: "unknown", nextAction: "original-key-lookup" } });
     }
-    expect(restartedKeys).not.toContain("restart-during");
+    expect(restartedKeys).not.toContain(downstream("spawn_agent", "restart-during"));
 
     /* A bodiless proxy status proves nothing about the upstream: unknown, one POST. */
     transientProxyFailures = 1;
     expect((await callSpawn(session.client, "restart-proxy-gap")).structuredContent)
       .toMatchObject({ ok: false, code: "outcome_unknown" });
-    expect(restartedKeys.filter((key) => key === "restart-proxy-gap")).toHaveLength(1);
+    expect(restartedKeys.filter((key) => key === downstream("spawn_agent", "restart-proxy-gap"))).toHaveLength(1);
 
     /* A response body cut after the request was accepted: unknown, one POST. */
     breakResponseBody = true;
     expect((await callSpawn(session.client, "restart-cut-body")).structuredContent)
       .toMatchObject({ ok: false, code: "outcome_unknown" });
-    expect(restartedKeys.filter((key) => key === "restart-cut-body")).toHaveLength(1);
+    expect(restartedKeys.filter((key) => key === downstream("spawn_agent", "restart-cut-body"))).toHaveLength(1);
 
     /* An ordinary call still dispatches once and answers normally. */
     expect((await callSpawn(session.client, "restart-after")).structuredContent)
       .toMatchObject({ ok: true, conversationId: "conversation_after_restart" });
-    expect(restartedKeys.filter((key) => key === "restart-after")).toHaveLength(1);
+    expect(restartedKeys.filter((key) => key === downstream("spawn_agent", "restart-after"))).toHaveLength(1);
 
     await restartedViewer.stop(true);
     restartedViewer = null;
@@ -529,7 +532,7 @@ test("send: acceptance, lost response, original-key recovery — one recipient d
 
     /* Exactly one recipient delivery and one reservation for the key. */
     expect(fixture.effects().filter((effect) => effect.kind === "recipient")).toHaveLength(1);
-    const reservations = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === "send-lost-1");
+    const reservations = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === downstream("send_message", "send-lost-1"));
     expect(reservations).toHaveLength(1);
   } finally {
     await mcp.close();
@@ -565,7 +568,7 @@ test("spawn: acceptance, lost response, original-key recovery — one launch, on
     expect(afterRestart).toMatchObject({ ok: true, launchId: launched[0]!.launchId });
 
     expect(fixture.effects().filter((effect) => effect.kind === "writer")).toHaveLength(1);
-    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-lost-1");
+    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", "spawn-lost-1"));
     expect(receipts).toHaveLength(1);
     expect(new Set(receipts.map((receipt) => receipt.conversationId)).size).toBe(1);
   } finally {
@@ -657,7 +660,7 @@ test("network failure without dispatch proof stays unknown and never redelivers;
     expect(await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-rejected-1", { cwd: path.join(fixture.sandbox, "missing") })))
       .toMatchObject({ ok: false, replayed: true, details: { outcome: "unknown" } });
     expect(fixture.effects()).toHaveLength(0);
-    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-rejected-1")).toHaveLength(0);
+    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", "spawn-rejected-1"))).toHaveLength(0);
 
     await host.kill();
     const disconnected = await call(mcp, "spawn_agent", spawnArguments(fixture, "spawn-unconnected"));
@@ -673,10 +676,10 @@ test("network failure without dispatch proof stays unknown and never redelivers;
     expect(fixture.effects()).toHaveLength(0);
     const arrived = await call(mcp, "send_message", sendArguments(fixture, "send-never-1"));
     expect(arrived).toMatchObject({ ok: true, replayed: false, outcome: "delivered" });
-    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-never-1")).toHaveLength(1);
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === downstream("send_message", "send-never-1"))).toHaveLength(1);
     expect(await call(mcp, "send_message", sendArguments(fixture, "send-never-1", { recoveryOnly: true })))
       .toMatchObject({ ok: true, outcome: "settled", operationId: arrived.operationId, state: "delivered" });
-    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-never-1")).toHaveLength(1);
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === downstream("send_message", "send-never-1"))).toHaveLength(1);
   } finally {
     await mcp.close();
     await host.stop();
@@ -714,9 +717,9 @@ test("spoofing and concurrency: another caller, a changed payload, and two proce
       expect(refused).toMatchObject({ ok: false, code: "caller_unidentified", replayed: false });
       expect(refused.details).toBeUndefined();
     }
-    expect(fixture.effects().filter((effect) => String(effect.clientMessageId ?? effect.clientAttemptId).includes("anonymous"))).toHaveLength(0);
+    expect(fixture.effects().filter((effect) => [downstream("send_message", "send-anonymous-1"), downstream("spawn_agent", "spawn-anonymous-1")].includes(String(effect.clientMessageId ?? effect.clientAttemptId)))).toHaveLength(0);
     expect(fixture.responses().filter((response) => response.body.includes("anonymous"))).toHaveLength(0);
-    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-anonymous-1")).toHaveLength(0);
+    expect(Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", "spawn-anonymous-1"))).toHaveLength(0);
 
     /* The owner with a changed payload is a conflict, not a second send. */
     expect(await call(owner, "send_message", sendArguments(fixture, "send-owned-1", { text: "changed" })))
@@ -736,7 +739,7 @@ test("spoofing and concurrency: another caller, a changed payload, and two proce
     const operationIds = new Set(race.map((answer) => answer.operationId));
     expect(operationIds.size).toBe(1);
     expect(race.filter((answer) => answer.replayed === false)).toHaveLength(1);
-    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === "send-race-1")).toHaveLength(1);
+    expect(fixture.effects().filter((effect) => effect.kind === "recipient" && effect.clientMessageId === downstream("send_message", "send-race-1"))).toHaveLength(1);
   } finally {
     await owner.close();
     await stranger.close();
@@ -797,9 +800,9 @@ test("send: admitted, response lost BEFORE the recipient acts, original-key reco
 
     const deliveries = fixture.effects().filter((effect) => effect.kind === "recipient");
     expect(deliveries).toHaveLength(1);
-    expect(deliveries[0]).toMatchObject({ clientMessageId: "send-barrier-1", operationId });
-    expect(Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === "send-barrier-1")).toHaveLength(1);
-    expect(fixture.responses().filter((response) => response.pathname === "/api/tmux" && response.body.includes("send-barrier-1"))).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({ clientMessageId: downstream("send_message", "send-barrier-1"), operationId });
+    expect(Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === downstream("send_message", "send-barrier-1"))).toHaveLength(1);
+    expect(fixture.responses().filter((response) => response.pathname === "/api/tmux" && response.body.includes(operationId))).toHaveLength(1);
   } finally {
     await mcp.close();
     await host.stop();
@@ -850,8 +853,8 @@ test("spawn: admitted, response lost BEFORE the writer acts, original-key recove
 
     const launches = fixture.effects().filter((effect) => effect.kind === "writer");
     expect(launches).toHaveLength(1);
-    expect(launches[0]).toMatchObject({ launchId, conversationId, clientAttemptId: "spawn-barrier-1" });
-    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === "spawn-barrier-1");
+    expect(launches[0]).toMatchObject({ launchId, conversationId, clientAttemptId: downstream("spawn_agent", "spawn-barrier-1") });
+    const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", "spawn-barrier-1"));
     expect(receipts).toHaveLength(1);
     expect(String(receipts[0]?.conversationId)).toBe(conversationId);
     expect(fixture.responses().filter((response) => response.pathname === "/api/spawn" && response.body.includes(launchId))).toHaveLength(1);
@@ -925,7 +928,7 @@ test("send: a delayed 409 after recovery already proved delivery never regresses
 
     const deliveries = fixture.effects().filter((effect) => effect.kind === "recipient");
     expect(deliveries).toHaveLength(1);
-    expect(deliveries[0]).toMatchObject({ clientMessageId: "send-late-verdict-1", operationId });
+    expect(deliveries[0]).toMatchObject({ clientMessageId: downstream("send_message", "send-late-verdict-1"), operationId });
     expect(fixture.responses().filter((response) => response.pathname === "/api/tmux")).toHaveLength(1);
   } finally {
     await original.close();
@@ -1017,7 +1020,7 @@ for (const tool of ["send_message", "spawn_agent"] as const) {
           }
           expect(fixture.effects()).toHaveLength(before + 1);
           if (tool === "spawn_agent") {
-            const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === key);
+            const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", key));
             expect(receipts).toHaveLength(1);
             expect(receipts[0]).toMatchObject({ conversationId: effect.conversationId });
           }
@@ -1124,11 +1127,11 @@ for (const { tool, idBearingError } of (["send_message", "spawn_agent"] as const
         }
         expect(fixture.effects()).toHaveLength(before + 1);
         if (tool === "spawn_agent") {
-          const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === key);
+          const receipts = Object.values(fixture.registryFile().receipts).filter((receipt) => receipt.clientAttemptId === downstream("spawn_agent", key));
           expect(receipts).toHaveLength(1);
           expect(receipts[0]).toMatchObject(ids);
         } else {
-          const deliveries = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === key);
+          const deliveries = Object.values(fixture.registryFile().heldDeliveries).filter((delivery) => delivery.clientMessageId === downstream("send_message", key));
           expect(deliveries).toHaveLength(1);
         }
       }
@@ -1137,4 +1140,156 @@ for (const { tool, idBearingError } of (["send_message", "spawn_agent"] as const
       await host.stop();
     }
   }, 120_000);
+}
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: constructed downstream keys cannot alias another caller and payload across restart`, async () => {
+    const fixture = await causalFixture("llv-1490-key-collision-");
+    let host = await fixture.startHost();
+    let owner = await fixture.mcp();
+    let other = await fixture.mcp({ caller: "other" });
+    try {
+      fixture.control({ mode: "respond" });
+      const longKey = "collision-original-key-".repeat(20);
+      const oldGenerated = tool === "send_message"
+        ? `mcp_send_${crypto.createHash("sha256").update(longKey).digest("hex").slice(0, 32)}`
+        : `mcp_${crypto.createHash("sha256").update(longKey).digest("hex").slice(0, 24)}`;
+      const argumentsFor = (key: string, payload: string) => tool === "send_message"
+        ? sendArguments(fixture, key, { text: payload })
+        : spawnArguments(fixture, key, { prompt: payload });
+      const originalArgs = argumentsFor(longKey, "original payload");
+      const first = await call(owner, tool, originalArgs);
+      const id = tool === "send_message" ? "operationId" : "launchId";
+      expect(first.ok).toBe(true);
+      const attempts: { args: Record<string, unknown>; result: Record<string, unknown> }[] = [];
+      for (const key of [oldGenerated, downstream(tool, longKey)]) {
+        const args = argumentsFor(key, `different payload ${key}`);
+        const result = await call(other, tool, args);
+        expect(result.ok).toBe(true);
+        expect(result[id]).not.toBe(first[id]);
+        expect(JSON.stringify(result)).not.toContain(String(first[id]));
+        attempts.push({ args, result });
+      }
+      expect(fixture.effects()).toHaveLength(3);
+      await owner.close();
+      await other.close();
+      await host.kill();
+      host = await fixture.startHost();
+      owner = await fixture.mcp();
+      other = await fixture.mcp({ caller: "other" });
+      for (const { args, result } of attempts) {
+        for (const recoveryOnly of [true, false]) {
+          const recovered = await call(other, tool, { ...args, recoveryOnly });
+          expect(recovered).toMatchObject({ ok: true, [id]: result[id] });
+          expect(JSON.stringify(recovered)).not.toContain(String(first[id]));
+        }
+      }
+      expect(await call(owner, tool, { ...originalArgs, recoveryOnly: true })).toMatchObject({ ok: true, [id]: first[id] });
+      expect(fixture.effects()).toHaveLength(3);
+      expect(fixture.responses()).toHaveLength(3);
+    } finally {
+      await owner.close();
+      await other.close();
+      await host.stop();
+    }
+  }, 40_000);
+}
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  for (const loss of ["timeout", "reset"] as const) {
+    test(`${tool}: terminal recovery survives a delayed ${loss}, missing downstream evidence and restart`, async () => {
+      const fixture = await causalFixture("llv-1490-terminal-loss-");
+      let host = await fixture.startHost();
+      let original = await fixture.mcp();
+      const observer = await fixture.mcp();
+      try {
+        fixture.control({ mode: "hold", lateUnreadableStatus: 408, settleWriter: true });
+        const args = tool === "send_message" ? sendArguments(fixture, "terminal-loss") : spawnArguments(fixture, "terminal-loss");
+        const held = call(original, tool, args);
+        await fixture.marker("accepted");
+        const recovered = await call(observer, tool, { ...args, recoveryOnly: true });
+        const effect = fixture.effects()[0]!;
+        const ids = tool === "send_message"
+          ? { operationId: effect.operationId }
+          : { launchId: effect.launchId, conversationId: effect.conversationId };
+        expect(recovered).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        // Remove only the fixture operation evidence. Caller authority and the
+        // readable MCP receipt remain intact, as in the independent probe.
+        const registryPath = path.join(fixture.state, "agent-registry.json");
+        const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+        if (tool === "send_message") {
+          registry.heldDeliveries = {};
+          registry.deliveryOperationOwners = {};
+        } else delete registry.receipts[String(effect.launchId)];
+        fs.writeFileSync(registryPath, JSON.stringify(registry));
+        if (loss === "reset") await host.kill();
+        else fixture.release();
+        expect(await held).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        expect(fixture.effects()).toHaveLength(1);
+        await original.close();
+        if (loss !== "reset") await host.kill();
+        fixture.control({ mode: "respond" });
+        host = await fixture.startHost();
+        original = await fixture.mcp();
+        for (const recoveryOnly of [true, false]) expect(await call(original, tool, { ...args, recoveryOnly })).toMatchObject({ ok: true, outcome: "settled", ...ids });
+        expect(fixture.effects()).toHaveLength(1);
+        expect(fixture.responses()).toHaveLength(1);
+      } finally {
+        await original.close();
+        await observer.close();
+        await host.stop();
+      }
+    }, 40_000);
+  }
+}
+
+for (const tool of ["send_message", "spawn_agent"] as const) {
+  test(`${tool}: a persisted colliding key never discloses contradictory downstream evidence`, async () => {
+    const fixture = await causalFixture("llv-1490-persisted-collision-");
+    let host = await fixture.startHost();
+    const owner = await fixture.mcp();
+    let other = await fixture.mcp({ caller: "other" });
+    try {
+      const makeArgs = (key: string, payload: string) => tool === "send_message"
+        ? sendArguments(fixture, key, { text: payload }) : spawnArguments(fixture, key, { prompt: payload });
+      const first = await call(owner, tool, makeArgs("persisted-original", "first payload"));
+      expect(first.ok).toBe(true);
+      fixture.control({ mode: "hold-before" });
+      const args = makeArgs("persisted-other", "another payload");
+      const pending = call(other, tool, args);
+      await fixture.marker("reached");
+      await host.kill();
+      expect(await pending).toMatchObject({ ok: false, code: "outcome_unknown" });
+      await other.close();
+      // Model an open claim written by the old passthrough/hash mapping.
+      // Its authenticated caller and argument digest remain those of B.
+      const database = new Database(path.join(fixture.state, "mcp-receipts.sqlite"), { strict: true });
+      const readBinding = (key: string) => JSON.parse((database.query("SELECT binding_json FROM mcp_receipts WHERE receipt_key = ?").get(`${tool}:${key}`) as { binding_json: string }).binding_json);
+      const oldKey = readBinding("persisted-original").downstreamKey;
+      const binding = readBinding("persisted-other");
+      binding.downstreamKey = oldKey;
+      database.query("UPDATE mcp_receipts SET binding_json = ? WHERE receipt_key = ?").run(JSON.stringify(binding), `${tool}:persisted-other`);
+      database.close();
+      fixture.control({ mode: "respond" });
+      host = await fixture.startHost();
+      other = await fixture.mcp({ caller: "other" });
+      for (const recoveryOnly of [true, false]) {
+        const result = await call(other, tool, { ...args, recoveryOnly });
+        expect(result).toMatchObject({ ok: false, code: "outcome_unknown", details: { nextAction: "original-key-lookup" } });
+        const id = tool === "send_message" ? first.operationId : first.launchId;
+        expect(JSON.stringify(result)).not.toContain(String(id));
+      }
+      expect(fixture.effects()).toHaveLength(1);
+      expect(fixture.responses()).toHaveLength(1);
+      const reopened = new Database(path.join(fixture.state, "mcp-receipts.sqlite"), { strict: true });
+      const row = reopened.query("SELECT binding_json, result_json FROM mcp_receipts WHERE receipt_key = ?").get(`${tool}:persisted-other`) as { binding_json: string; result_json: string | null };
+      expect(JSON.parse(row.binding_json).downstreamKey).toBe(oldKey);
+      expect(row.result_json).toBeNull();
+      reopened.close();
+    } finally {
+      await owner.close();
+      await other.close();
+      await host.stop();
+    }
+  }, 40_000);
 }

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -1315,24 +1315,82 @@ test("the original-key lookup answers ambiguity and unreadable state as such, ne
     acceptSend(active, { clientMessageId: "shared-key", operationId: "op_shared_a" });
     active.registry.holdDelivery(other.id, "hello", "shared-key", "text", [], null, { operationId: "op_shared_b", kind: "send", policy: "queue" });
 
-    /* Bound to a recipient, the key is unambiguous; bound only to a path the
-       registry cannot resolve, two operations claim it and none is disclosed. */
+    /* Bound to a recipient, the key is unambiguous. Bound to a path the
+       registry cannot resolve, NOTHING matches — whether one or two operations
+       carry the key — and none is disclosed; a path the registry does resolve
+       is the recipient it names. */
     expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: active.conversationId, clientMessageId: "shared-key" }))
       .toMatchObject({ kind: "found", operationId: "op_shared_a" });
     expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: "/nowhere/recipient.jsonl", clientMessageId: "shared-key" }))
-      .toEqual({ kind: "ambiguous", operationIds: ["op_shared_a", "op_shared_b"] });
+      .toEqual({ kind: "unresolved" });
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: "/nowhere/recipient.jsonl", clientMessageId: "original-key-1" }))
+      .toEqual({ kind: "unresolved" });
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: otherPath, clientMessageId: "shared-key" }))
+      .toMatchObject({ kind: "found", operationId: "op_shared_b" });
+    expect(await resolveOriginalSend({ conversationId: "/nowhere/recipient.jsonl", clientMessageId: "shared-key" }, { registry: active.registry, client: null }))
+      .toEqual({ kind: "unresolved" });
+    /* Two operations under one key for ONE recipient is ambiguity, and
+       discloses neither. */
+    const file = active.registry.readOnlySnapshot();
+    const ownerA = file.deliveryOperationOwners.op_shared_a!;
+    const twice = { ...file, deliveryOperationOwners: { ...file.deliveryOperationOwners, op_shared_twin: { ...ownerA, deliveryId: "delivery_twin" } } };
+    expect(lookupOriginalSend(twice, { conversationId: active.conversationId, clientMessageId: "shared-key" }))
+      .toEqual({ kind: "ambiguous", operationIds: ["op_shared_a", "op_shared_twin"] });
 
     const broken = { readOnlySnapshot: () => { throw new Error("registry file is unreadable"); } } as unknown as AgentRegistry;
     expect(await resolveOriginalSend({ conversationId: active.conversationId, clientMessageId: "shared-key" }, { registry: broken, client: null }))
       .toEqual({ kind: "unreadable", reason: "registry file is unreadable" });
 
-    /* A found send whose current answer cannot be read keeps its identity. */
+    /* A found send whose current answer cannot be read keeps its identity
+       and the durable projection, and says the current read failed. */
     const failingClient = {
       ...active.client,
       operationStatus: async () => { throw new Error("journal socket is gone"); },
     } as RuntimeHostClient;
     const kept = await resolveOriginalSend({ conversationId: active.conversationId, clientMessageId: "shared-key" }, { registry: active.registry, client: failingClient });
-    expect(kept).toMatchObject({ kind: "found", operationId: "op_shared_a", current: { readable: true, value: { state: "in-flight", evidence: "delivery-record" } } });
+    expect(kept).toMatchObject({ kind: "found", operationId: "op_shared_a", receipt: { state: "in-flight", evidence: "delivery-record" }, current: { readable: false, reason: expect.stringContaining("journal socket is gone") } });
+    /* Without a journal at all the durable record is the whole answer. */
+    expect(await resolveOriginalSend({ conversationId: active.conversationId, clientMessageId: "shared-key" }, { registry: active.registry, client: null }))
+      .toMatchObject({ kind: "found", operationId: "op_shared_a", current: { readable: true, value: { state: "in-flight", evidence: "delivery-record" } } });
+  } finally {
+    active.close();
+  }
+});
+
+test("the original-key lookup is read-only: past the deadline, without a journal, and with a terminal journal row, the durable record is left exactly as it was", async () => {
+  const active = fixture("original-key-read-only");
+  try {
+    const binding = { conversationId: active.conversationId, clientMessageId: "read-only-key" };
+    const accepted = acceptSend(active, { clientMessageId: binding.clientMessageId, operationId: "op_read_only" });
+    const before = JSON.stringify(active.registry.readOnlySnapshot());
+    const journalBefore = JSON.stringify(await active.client.operationStatus(accepted.operationId, { currentRetryLeaf: true }));
+
+    /* Past the settlement window, with and without a journal, and with a
+       journal that cannot be read: the reservation is still assigned and the
+       operation still queued afterwards. Where `message_receipt` would END
+       the send here, the lookup only reports it. */
+    for (const ports of [
+      { registry: active.registry, client: active.client, now: AFTER_THE_WINDOW },
+      { registry: active.registry, client: null, now: AFTER_THE_WINDOW },
+      { registry: active.registry, client: { ...active.client, operationStatus: async () => { throw new Error("journal socket is gone"); } } as RuntimeHostClient, now: AFTER_THE_WINDOW },
+    ]) {
+      const observed = await resolveOriginalSend(binding, ports);
+      expect(observed).toMatchObject({ kind: "found", operationId: accepted.operationId, reservationState: "delivery-uncertain" });
+      if (observed.kind !== "found") throw new Error("lookup lost the send");
+      if (observed.current.readable) expect(observed.current.value.state).toBe("in-flight");
+      expect(JSON.stringify(active.registry.readOnlySnapshot())).toBe(before);
+      expect(JSON.stringify(await active.client.operationStatus(accepted.operationId, { currentRetryLeaf: true }))).toBe(journalBefore);
+    }
+    expect(await resolveSendReceipt(accepted.operationId, { registry: active.registry, client: active.client })).toMatchObject({ state: "in-flight" });
+
+    /* A terminal journal row is REPORTED as the current answer and not
+       written onto the reservation: the durable record still says in flight
+       until the settlement read `message_receipt` performs ends it. */
+    active.journal.transitionOperation(accepted.operationId, "delivered", { turnId: "turn-read-only" });
+    const delivered = await resolveOriginalSend(binding, { registry: active.registry, client: active.client });
+    expect(delivered).toMatchObject({ kind: "found", current: { readable: true, value: { state: "delivered", resend: "not-needed", evidence: "delivery-journal" } } });
+    expect(sendReceiptFor(active.registry.readOnlySnapshot(), accepted.operationId)).toMatchObject({ state: "in-flight" });
+    expect(active.registry.readOnlySnapshot().heldDeliveries[accepted.deliveryId]?.state).toBe("delivery-uncertain");
   } finally {
     active.close();
   }

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -1395,3 +1395,25 @@ test("the original-key lookup is read-only: past the deadline, without a journal
     active.close();
   }
 });
+
+test("original-key payload checks survive delivery text removal and reservation compaction", async () => {
+  const active = fixture("original-key-payload");
+  try {
+    const accepted = acceptSend(active, { clientMessageId: "payload-key", operationId: "op_payload" });
+    const file = active.registry.readOnlySnapshot();
+    const text = file.heldDeliveries[accepted.deliveryId]!.text;
+    const binding = { conversationId: active.conversationId, clientMessageId: "payload-key", text };
+    expect(lookupOriginalSend(file, binding)).toMatchObject({ kind: "found" });
+    const contradictory = structuredClone(file);
+    contradictory.deliveryOperationOwners[accepted.operationId]!.conversationId = "conversation_elsewhere";
+    expect(lookupOriginalSend(contradictory, binding)).toEqual({ kind: "contradictory" });
+    expect(lookupOriginalSend(file, { ...binding, text: "another payload" })).toEqual({ kind: "contradictory" });
+    active.registry.recordDeliveryOutcome(accepted.deliveryId, "delivered", null, "delivered");
+    const delivered = active.registry.readOnlySnapshot();
+    expect(delivered.heldDeliveries[accepted.deliveryId]!.text).toBe("");
+    expect(lookupOriginalSend(delivered, binding)).toMatchObject({ kind: "found" });
+    delete delivered.heldDeliveries[accepted.deliveryId];
+    expect(lookupOriginalSend(delivered, binding)).toMatchObject({ kind: "found" });
+    expect(lookupOriginalSend(delivered, { ...binding, text: "another payload" })).toEqual({ kind: "contradictory" });
+  } finally { active.close(); }
+});

--- a/src/lib/runtime/sendSettlement.test.ts
+++ b/src/lib/runtime/sendSettlement.test.ts
@@ -1250,3 +1250,90 @@ test("compaction retires the reservation and keeps what it proved about the send
     active.close();
   }
 });
+
+/* ── ORIGINAL-KEY LOOKUP (#1490) ─────────────────────────────────────────── */
+
+const { lookupOriginalSend, resolveOriginalSend } = await import("./sendSettlement");
+
+test("the original-key lookup finds one send by bound recipient and key, and reads its current answer", async () => {
+  const active = fixture("original-key");
+  try {
+    const binding = { conversationId: active.conversationId, clientMessageId: "original-key-1" };
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), binding)).toEqual({ kind: "absent" });
+
+    const accepted = acceptSend(active, { clientMessageId: "original-key-1", operationId: "op_original_1" });
+    const found = lookupOriginalSend(active.registry.readOnlySnapshot(), binding);
+    expect(found).toMatchObject({ kind: "found", operationId: accepted.operationId, deliveryId: accepted.deliveryId, reservationState: "delivery-uncertain" });
+    expect(found.kind === "found" && found.receipt.state).toBe("in-flight");
+
+    /* The same key under a DIFFERENT recipient is a different send. */
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { ...binding, conversationId: "conversation_elsewhere" })).toEqual({ kind: "absent" });
+
+    /* The current answer is the settlement read `message_receipt` performs. */
+    active.journal.transitionOperation(accepted.operationId, "delivered", { turnId: "turn-original" });
+    const resolved = await resolveOriginalSend(binding, { registry: active.registry, client: active.client });
+    expect(resolved).toMatchObject({ kind: "found", operationId: accepted.operationId, current: { readable: true, value: { state: "delivered", resend: "not-needed" } } });
+  } finally {
+    active.close();
+  }
+});
+
+test("the original-key lookup survives reservation compaction through the owner row", async () => {
+  let clock = Date.now();
+  const active = fixture("original-key-compacted", { now: () => clock });
+  try {
+    const binding = { conversationId: active.conversationId, clientMessageId: "compacted-original-key" };
+    const accepted = acceptSend(active, { clientMessageId: binding.clientMessageId, operationId: "op_compacted_original" });
+    await resolveSendReceipt(accepted.operationId, { registry: active.registry, client: active.client, now: AFTER_THE_WINDOW });
+    clock += 8 * 24 * 60 * 60 * 1000;
+    const later = acceptSend(active, { clientMessageId: "compacting-original-key", operationId: "op_compacting_original" });
+    active.registry.recordDeliveryOutcome(later.deliveryId, "delivered", null, "delivered");
+    expect(active.registry.readOnlySnapshot().heldDeliveries[accepted.deliveryId]).toBeUndefined();
+
+    const found = lookupOriginalSend(active.registry.readOnlySnapshot(), binding);
+    expect(found).toMatchObject({ kind: "found", operationId: accepted.operationId, deliveryId: null, reservationState: null });
+    expect(found.kind === "found" && found.receipt).toMatchObject({ state: "failed", reason: SEND_LOST_REASON, resend: "safe" });
+  } finally {
+    active.close();
+  }
+});
+
+test("the original-key lookup answers ambiguity and unreadable state as such, never as absence or a match", async () => {
+  const active = fixture("original-key-ambiguous");
+  try {
+    /* A second recipient in the same registry holding the same key. */
+    const otherPath = path.join(path.dirname(active.transcriptPath), "other-recipient.jsonl");
+    active.registry.reconcileConversations([{
+      engine: "codex",
+      path: otherPath,
+      accountId: "settlement-fixture-account",
+      launchProfile: emptyLaunchProfile({ cwd: path.dirname(otherPath) }),
+      turn: { state: "idle", source: "assistant", terminalAt: null },
+      observedAt: "2026-08-30T10:00:00.000Z",
+    }]);
+    const other = Object.values(active.registry.snapshot().conversations).find((conversation) => conversation.id !== active.conversationId)!;
+    acceptSend(active, { clientMessageId: "shared-key", operationId: "op_shared_a" });
+    active.registry.holdDelivery(other.id, "hello", "shared-key", "text", [], null, { operationId: "op_shared_b", kind: "send", policy: "queue" });
+
+    /* Bound to a recipient, the key is unambiguous; bound only to a path the
+       registry cannot resolve, two operations claim it and none is disclosed. */
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: active.conversationId, clientMessageId: "shared-key" }))
+      .toMatchObject({ kind: "found", operationId: "op_shared_a" });
+    expect(lookupOriginalSend(active.registry.readOnlySnapshot(), { conversationId: "/nowhere/recipient.jsonl", clientMessageId: "shared-key" }))
+      .toEqual({ kind: "ambiguous", operationIds: ["op_shared_a", "op_shared_b"] });
+
+    const broken = { readOnlySnapshot: () => { throw new Error("registry file is unreadable"); } } as unknown as AgentRegistry;
+    expect(await resolveOriginalSend({ conversationId: active.conversationId, clientMessageId: "shared-key" }, { registry: broken, client: null }))
+      .toEqual({ kind: "unreadable", reason: "registry file is unreadable" });
+
+    /* A found send whose current answer cannot be read keeps its identity. */
+    const failingClient = {
+      ...active.client,
+      operationStatus: async () => { throw new Error("journal socket is gone"); },
+    } as RuntimeHostClient;
+    const kept = await resolveOriginalSend({ conversationId: active.conversationId, clientMessageId: "shared-key" }, { registry: active.registry, client: failingClient });
+    expect(kept).toMatchObject({ kind: "found", operationId: "op_shared_a", current: { readable: true, value: { state: "in-flight", evidence: "delivery-record" } } });
+  } finally {
+    active.close();
+  }
+});

--- a/src/lib/runtime/sendSettlement.ts
+++ b/src/lib/runtime/sendSettlement.ts
@@ -9,6 +9,7 @@ import {
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import type { HeldDelivery, ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
+import { structuredContentDigest } from "./structuredContent";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import {
   RUNTIME_DELIVERY_DISCARDED_REASON,
@@ -668,13 +669,16 @@ export interface OriginalSendBinding {
   conversationId: string;
   /** The exact `clientMessageId` the send route was handed. */
   clientMessageId: string;
+  /** Original text, when the caller has already verified its argument digest. */
+  text?: string;
 }
 
 export type OriginalSendLookup =
   | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null }
   | { kind: "absent" }
   | { kind: "ambiguous"; operationIds: string[] }
-  | { kind: "unresolved" };
+  | { kind: "unresolved" }
+  | { kind: "contradictory" };
 
 export function lookupOriginalSend(file: RegistryFile, binding: OriginalSendBinding): OriginalSendLookup {
   const lookup = readOnlyConversationLookupFromSnapshot(file);
@@ -702,9 +706,20 @@ export function lookupOriginalSend(file: RegistryFile, binding: OriginalSendBind
   if (operations.size === 0) return { kind: "absent" };
   if (operations.size > 1) return { kind: "ambiguous", operationIds: [...operations.keys()].sort() };
   const [[operationId, deliveryId]] = [...operations.entries()];
+  const reservation = deliveryId ? file.heldDeliveries[deliveryId] : undefined;
+  const owner = file.deliveryOperationOwners[operationId];
+  if ((owner && (!matches(owner.conversationId) || owner.clientMessageId !== binding.clientMessageId
+      || owner.deliveryId !== deliveryId || owner.retryOfOperationId))
+    || (reservation && (!matches(reservation.conversationId) || reservation.clientMessageId !== binding.clientMessageId
+      || reservation.command.operationId !== operationId))) return { kind: "contradictory" };
   const receipt = sendReceiptFor(file, operationId);
   if (!receipt) return { kind: "absent" };
-  const reservation = deliveryId ? file.heldDeliveries[deliveryId] : undefined;
+  if (binding.text !== undefined) {
+    const expected = structuredContentDigest({ text: binding.text, images: [] });
+    if ((reservation?.text && reservation.text !== binding.text)
+      || (reservation?.contentDigest && reservation.contentDigest !== expected)
+      || (owner?.contentDigest && owner.contentDigest !== expected)) return { kind: "contradictory" };
+  }
   return { kind: "found", operationId, deliveryId: reservation ? deliveryId : null, receipt, reservationState: reservation?.state ?? null };
 }
 
@@ -713,7 +728,8 @@ export type OriginalSendEvidence =
   | { kind: "absent" }
   | { kind: "ambiguous"; operationIds: string[] }
   | { kind: "unresolved" }
-  | { kind: "unreadable"; reason: string };
+  | { kind: "unreadable"; reason: string }
+  | { kind: "contradictory" };
 
 /**
  * The CURRENT answer for one found operation, projected without writing.

--- a/src/lib/runtime/sendSettlement.ts
+++ b/src/lib/runtime/sendSettlement.ts
@@ -650,12 +650,17 @@ function settleProjection(
  * exact client message key handed to the send route. This is the read-only
  * primitive the MCP recovery path and the seat monitor's harvest (#1465) share:
  * it accepts a binding somebody else established, answers from the registry's
- * own records, and can neither enqueue, retry, withdraw nor spawn.
+ * own records and the journal's CURRENT row, and can neither enqueue, retry,
+ * withdraw, settle, fence nor spawn. Nothing here writes: a reservation that is
+ * past its settlement deadline is reported exactly as it rests, because a
+ * lookup is an observation and `message_receipt` is where a send is ENDED.
  *
  * The answer is closed. `found` names exactly one operation; `absent` means
  * the records hold nothing under that key — an observation, never proof that
- * nothing executed; `ambiguous` means more than one operation claims the key,
- * which discloses none of them.
+ * nothing executed; `ambiguous` means more than one operation claims the key
+ * under the bound recipient, which discloses none of them; `unresolved` means
+ * the bound target names no conversation the registry knows, so no record can
+ * be matched to it and none is disclosed.
  */
 export interface OriginalSendBinding {
   /** Canonical conversation id (alias-resolved), or a transcript path when the
@@ -668,14 +673,23 @@ export interface OriginalSendBinding {
 export type OriginalSendLookup =
   | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null }
   | { kind: "absent" }
-  | { kind: "ambiguous"; operationIds: string[] };
+  | { kind: "ambiguous"; operationIds: string[] }
+  | { kind: "unresolved" };
 
 export function lookupOriginalSend(file: RegistryFile, binding: OriginalSendBinding): OriginalSendLookup {
   const lookup = readOnlyConversationLookupFromSnapshot(file);
   const canonical = (id: string): string => lookup.conversation(id as ViewerConversationId)?.id ?? id;
+  /* The target is resolved through the registry's own lookup — a conversation
+     id through its alias walk, a path through the path index — and a target
+     nothing resolves matches nothing. An exact id the registry does not know
+     still matches only records carrying that exact id; a path it does not know
+     matches no record at all, because a path is not an identity. */
   const byConversation = binding.conversationId.startsWith("conversation_");
-  const target = byConversation ? canonical(binding.conversationId) : null;
-  const matches = (conversationId: string): boolean => !byConversation || canonical(conversationId) === target;
+  const target = byConversation
+    ? canonical(binding.conversationId)
+    : lookup.conversationForPath(binding.conversationId)?.id ?? null;
+  if (!target) return { kind: "unresolved" };
+  const matches = (conversationId: string): boolean => canonical(conversationId) === target;
   const operations = new Map<string, string | null>();
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.clientMessageId !== binding.clientMessageId || !matches(delivery.conversationId)) continue;
@@ -695,15 +709,51 @@ export function lookupOriginalSend(file: RegistryFile, binding: OriginalSendBind
 }
 
 export type OriginalSendEvidence =
-  | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null; current: Evidence<SendReceipt | null> }
+  | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null; current: Evidence<SendReceipt> }
   | { kind: "absent" }
   | { kind: "ambiguous"; operationIds: string[] }
+  | { kind: "unresolved" }
   | { kind: "unreadable"; reason: string };
 
 /**
- * The lookup above, then the CURRENT answer for the one operation it found —
- * the same settlement read `message_receipt` performs, which may reconnect to
- * the runtime journal. A journal or registry that cannot be read keeps the
+ * The CURRENT answer for one found operation, projected without writing.
+ *
+ * A durable record that is already terminal is the answer. One still in flight
+ * is checked against the journal's current retry leaf, and a terminal verdict
+ * there is REPORTED — never written back onto the reservation, never fenced,
+ * never aged past a deadline. A journal that cannot be read leaves the durable
+ * projection standing and says so. Where {@link resolveSendReceipt} may end a
+ * send, this only looks at it.
+ */
+async function projectCurrentSend(
+  projected: SendReceipt,
+  operationId: string,
+  ports: SendSettlementPorts,
+): Promise<Evidence<SendReceipt>> {
+  if (projected.state !== "in-flight") return { readable: true, value: projected };
+  const client = ports.client === undefined ? runtimeHostClient() : ports.client;
+  if (!client) return { readable: true, value: { ...projected, evidence: "delivery-record" } };
+  const journal = await readEvidence(
+    () => client.operationStatus(operationId, { currentRetryLeaf: true }),
+    "runtime host is unavailable",
+  );
+  if (!journal.readable) return journal;
+  const receipt = journal.value?.receipt ?? null;
+  const verdict = journalVerdict(receipt?.status ?? null, receipt?.reason);
+  if (!verdict) return { readable: true, value: { ...projected, evidence: "delivery-journal" } };
+  if (verdict.state === "delivered") {
+    return { readable: true, value: { ...projected, state: "delivered", reason: null, duplicateRisk: false, resend: "not-needed", evidence: "delivery-journal" } };
+  }
+  return {
+    readable: true,
+    value: { ...projected, state: "failed", reason: verdict.reason, ...resendGuidance(verdict.disposition, verdict.reason), evidence: "delivery-journal" },
+  };
+}
+
+/**
+ * The lookup above, then the current answer for the one operation it found.
+ * Read-only end to end: the registry snapshot and the journal row are read,
+ * and neither is changed. A journal or registry that cannot be read keeps the
  * identity the durable record established and marks the current answer
  * unreadable; it never turns into an absence.
  */
@@ -716,6 +766,6 @@ export async function resolveOriginalSend(
   if (!snapshot.readable) return { kind: "unreadable", reason: snapshot.reason };
   const found = lookupOriginalSend(snapshot.value, binding);
   if (found.kind !== "found") return found;
-  const current = await readEvidence(() => resolveSendReceipt(found.operationId, ports), "the current delivery answer could not be read");
+  const current = await projectCurrentSend(found.receipt, found.operationId, ports);
   return { ...found, current };
 }

--- a/src/lib/runtime/sendSettlement.ts
+++ b/src/lib/runtime/sendSettlement.ts
@@ -1,5 +1,6 @@
 import {
   agentRegistry,
+  readOnlyConversationLookupFromSnapshot,
   type AgentRegistry,
   type DeliveryOperationOwner,
   type DeliveryTerminalDisposition,
@@ -14,7 +15,7 @@ import {
   type RuntimeOperationReceipt,
   type RuntimeReceiptStatus,
 } from "./contracts";
-import { readEvidence, unreadableEvidence } from "./evidence";
+import { readEvidence, readEvidenceSync, unreadableEvidence, type Evidence } from "./evidence";
 
 /**
  * Settlement of accepted sends (#1131).
@@ -639,4 +640,82 @@ function settleProjection(
     ...resendGuidance(verdict.disposition, verdict.reason),
     evidence,
   };
+}
+
+/**
+ * ── ORIGINAL-KEY LOOKUP (#1490) ───────────────────────────────────────────
+ *
+ * What the durable delivery records say about a send known only by the
+ * identity its caller bound BEFORE dispatch: the canonical recipient and the
+ * exact client message key handed to the send route. This is the read-only
+ * primitive the MCP recovery path and the seat monitor's harvest (#1465) share:
+ * it accepts a binding somebody else established, answers from the registry's
+ * own records, and can neither enqueue, retry, withdraw nor spawn.
+ *
+ * The answer is closed. `found` names exactly one operation; `absent` means
+ * the records hold nothing under that key — an observation, never proof that
+ * nothing executed; `ambiguous` means more than one operation claims the key,
+ * which discloses none of them.
+ */
+export interface OriginalSendBinding {
+  /** Canonical conversation id (alias-resolved), or a transcript path when the
+      send was addressed by path and no conversation was registered for it. */
+  conversationId: string;
+  /** The exact `clientMessageId` the send route was handed. */
+  clientMessageId: string;
+}
+
+export type OriginalSendLookup =
+  | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null }
+  | { kind: "absent" }
+  | { kind: "ambiguous"; operationIds: string[] };
+
+export function lookupOriginalSend(file: RegistryFile, binding: OriginalSendBinding): OriginalSendLookup {
+  const lookup = readOnlyConversationLookupFromSnapshot(file);
+  const canonical = (id: string): string => lookup.conversation(id as ViewerConversationId)?.id ?? id;
+  const byConversation = binding.conversationId.startsWith("conversation_");
+  const target = byConversation ? canonical(binding.conversationId) : null;
+  const matches = (conversationId: string): boolean => !byConversation || canonical(conversationId) === target;
+  const operations = new Map<string, string | null>();
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.clientMessageId !== binding.clientMessageId || !matches(delivery.conversationId)) continue;
+    operations.set(delivery.command.operationId, delivery.id);
+  }
+  for (const [operationId, owner] of Object.entries(file.deliveryOperationOwners)) {
+    if (owner.clientMessageId !== binding.clientMessageId || owner.retryOfOperationId || !matches(owner.conversationId)) continue;
+    if (!operations.has(operationId)) operations.set(operationId, owner.deliveryId);
+  }
+  if (operations.size === 0) return { kind: "absent" };
+  if (operations.size > 1) return { kind: "ambiguous", operationIds: [...operations.keys()].sort() };
+  const [[operationId, deliveryId]] = [...operations.entries()];
+  const receipt = sendReceiptFor(file, operationId);
+  if (!receipt) return { kind: "absent" };
+  const reservation = deliveryId ? file.heldDeliveries[deliveryId] : undefined;
+  return { kind: "found", operationId, deliveryId: reservation ? deliveryId : null, receipt, reservationState: reservation?.state ?? null };
+}
+
+export type OriginalSendEvidence =
+  | { kind: "found"; operationId: string; deliveryId: string | null; receipt: SendReceipt; reservationState: HeldDelivery["state"] | null; current: Evidence<SendReceipt | null> }
+  | { kind: "absent" }
+  | { kind: "ambiguous"; operationIds: string[] }
+  | { kind: "unreadable"; reason: string };
+
+/**
+ * The lookup above, then the CURRENT answer for the one operation it found —
+ * the same settlement read `message_receipt` performs, which may reconnect to
+ * the runtime journal. A journal or registry that cannot be read keeps the
+ * identity the durable record established and marks the current answer
+ * unreadable; it never turns into an absence.
+ */
+export async function resolveOriginalSend(
+  binding: OriginalSendBinding,
+  ports: SendSettlementPorts = {},
+): Promise<OriginalSendEvidence> {
+  const registry = ports.registry ?? agentRegistry();
+  const snapshot = readEvidenceSync(() => registry.readOnlySnapshot(), "the delivery record could not be read");
+  if (!snapshot.readable) return { kind: "unreadable", reason: snapshot.reason };
+  const found = lookupOriginalSend(snapshot.value, binding);
+  if (found.kind !== "found") return found;
+  const current = await readEvidence(() => resolveSendReceipt(found.operationId, ports), "the current delivery answer could not be read");
+  return { ...found, current };
 }


### PR DESCRIPTION
Closes #1490. Implements the [approved original-key recovery contract](https://github.com/Latand/live-log-viewer-next/issues/1490#issuecomment-5549484166).

When a send or spawn response is lost after acceptance, callers can recover with the original `clientRequestId` and unchanged arguments. Both tools publish `recoveryOnly: true`, excluded from the argument digest. Each durable claim binds the authenticated caller and project, canonical target, arguments, and exact downstream key before one dispatch. Matching claims recover through existing durable evidence; ordinary successful replays retain their result.

An absent recovery-only claim returns non-disclosing `unknown` and writes no claim, fence, or tombstone. Changed arguments conflict, and different or unidentified callers cannot recover private results. Legacy receipts require durable ownership evidence. Outcomes distinguish `accepted`, `in-flight`, `settled`, `not-executed`, and `unknown`, with known IDs, provenance, and next-action guidance. Missing or unreadable evidence never authorizes redispatch.

Both mutations disable automatic POST retries and redirects. HTTP statuses, error bodies, and admitted IDs cannot establish non-execution or terminal failure. Empty, incomplete, contradictory, unreadable, and ID-bearing error responses enter durable evidence recovery. Path-only sends retain the supplied transcript path when registration occurs after binding.

Every new claim hashes its downstream key; caller-supplied passthrough keys cannot collide with generated keys. Existing claims retain their persisted keys. Recovery rejects contradictory delivery ownership or payload evidence and contradictory launch parents, directories, or stored prompts. The read-only delivery lookup retains payload checks after delivery text removal and reservation compaction.

Terminal receipt results take precedence over delayed success, refusal, timeout, reset, write failure, and weaker recovery reads. Recovery rechecks the store after a downstream read so another process's terminal result cannot disappear behind a stale or unavailable answer. Explicit recovery retains established terminal IDs and identifies the MCP receipt as its evidence. When an ordinary acceptance response already exists, terminal recovery is saved separately under the existing receipt lock or transaction. Ordinary replay retains its original response; explicit recovery retains terminal IDs and disposition after downstream evidence disappears or becomes unreadable. Memory, File, and SQLite use the same conditional rule, and File-to-SQLite import preserves both results.

Changes remain within the nine approved files. The shared `resolveOriginalSend` primitive stays read-only for #1465; monitor integration and deployment remain separate.

Validation used isolated home, configuration, runtime, account, and temporary directories, one test file per invocation:

| Check | Result |
| --- | --- |
| MCP service | 72 passed |
| MCP bindings | 57 passed |
| Send settlement | 25 passed |
| Schema parity | 20 passed |
| Packaged stdio integration | 30 passed |
| Nonincremental TypeScript | passed |
| Local privacy publication gate | passed |

Causal tests use packaged MCP, production control transport, actual HTTP handlers, durable stores, and controlled recipient/writer effects. Separate barriers prove admission before execution and response loss; original-key recovery across MCP/HTTP restart retains one effect. Cases cover every 3xx–5xx transport family, incomplete success bodies, ID-bearing errors, late path registration, caller/payload conflicts, absent claims, concurrent claim owners, damaged records, compaction, and delayed completion.

Constructed-key and terminal timeout/reset regressions fail against the prior published implementation and pass with this repair. Both tools also exercise persisted colliding keys without disclosing another request's IDs, changing the stored key, or adding an effect. Two fresh independent reviews must approve the same published head before merge.

Both-tool regressions for acceptance followed by terminal recovery fail against `25479e85` and pass with this repair. Packaged MCP-to-HTTP tests return acceptance before releasing the recipient/writer effect, establish terminal recovery, then restart MCP and HTTP with downstream operation evidence removed. They retain one effect, the original ordinary replay, and terminal recovery IDs and disposition. Service tests cover missing and unreadable evidence across all three stores.
