### PR TITLE
feat(mcp): safe task coordinates with atomic project and revision guards (#631)

### DIFF
--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -3129,3 +3129,42 @@ test("incomplete and contradictory mutation answers remain unknown when no durab
     store.close();
   }
 });
+
+
+test("task placement bindings require atomic guards and classify field refusals as non-retryable", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "task-binding-position-"));
+  sandboxes.push(sandbox);
+  const env: NodeJS.ProcessEnv = { ...process.env, LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:1", LLV_RUNTIME_HOST_SOCKET: path.join(sandbox, "runtime.sock") };
+  for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "LLV_STATE_DIR", "LLV_CODEX_HOME", "LLV_CLAUDE_HOME", "CODEX_HOME", "CLAUDE_CONFIG_DIR", "TMPDIR"]) {
+    const dir = path.join(sandbox, key); fs.mkdirSync(dir); env[key] = dir;
+  }
+  // Child imports happen only after every root has been isolated. The parent
+  // file already imports bindings for its existing dependency-injected tests.
+  const child = Bun.spawn([process.execPath, "-e", `
+    import fs from "node:fs";
+    import { viewerMcpBindings } from "./src/lib/mcp/bindings";
+    import { createMcpToolService, MemoryMcpReceiptStore } from "./src/lib/mcp/server";
+    import { TASKS_FILE } from "./src/lib/tasks/store";
+    if (!TASKS_FILE.startsWith(process.env.LLV_STATE_DIR + "/")) throw new Error("state escaped sandbox");
+    const service = createMcpToolService(viewerMcpBindings(), new MemoryMcpReceiptStore());
+    const created = await service.callTool("create_task", { clientRequestId: "binding-position-create", project: "fixture-project", text: "task" });
+    if (!created.ok) throw new Error(created.error);
+    const before = fs.readFileSync(TASKS_FILE, "utf8");
+    const missing = await service.callTool("update_task", { clientRequestId: "binding-missing-guard", taskId: created.taskId, pos: { x: 0, y: 0 } });
+    const invalid = [];
+    for (const [index, pos] of [null, {}, { x: 1 }, { x: Infinity, y: 1 }, { x: 0, y: NaN }].entries()) {
+      invalid.push(await service.callTool("create_task", { clientRequestId: "binding-invalid-pos-" + index, project: "fixture-project", text: "task", placement: "pinned", pos }));
+    }
+    console.log(JSON.stringify({ missing, invalid, unchanged: fs.readFileSync(TASKS_FILE, "utf8") === before }));
+  `], { cwd: process.cwd(), env, stdout: "pipe", stderr: "pipe" });
+  const output = await new Response(child.stdout).text();
+  const error = await new Response(child.stderr).text();
+  expect([await child.exited, error]).toEqual([0, ""]);
+  const result = JSON.parse(output);
+  expect(result.missing).toMatchObject({ ok: false, code: "TASK_INVALID_FIELD", retryable: false, details: { field: "expectedProject" } });
+  for (const invalid of result.invalid) {
+    expect(invalid).toMatchObject({ ok: false, code: "TASK_INVALID_FIELD", retryable: false });
+    expect(invalid.details.field.startsWith("pos")).toBe(true);
+  }
+  expect(result.unchanged).toBe(true);
+});

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1152,7 +1152,7 @@ async function createBoardTask(args: McpToolArgs): Promise<McpToolPayload> {
       result: outcome,
     };
   });
-  if (!result.ok) throw new Error(result.error);
+  if (!result.ok) throw new McpToolRefusal(result.error, { code: result.code ?? (result.status === 404 ? "TASK_NOT_FOUND" : "TASK_INVALID_FIELD"), field: result.field, status: result.status });
   return { taskId: result.task.id, task: result.task, replay: result.replay };
 }
 
@@ -1160,10 +1160,10 @@ async function updateBoardTask(args: McpToolArgs): Promise<McpToolPayload> {
   const taskId = required(args, "taskId");
   const patch = withoutKeys(args, ["taskId", "clientRequestId"]);
   const result = mutateTasks((tasks) => {
-    const outcome = patchTask(tasks, taskId, patch as PatchTaskInput);
+    const outcome = patchTask(tasks, taskId, patch as PatchTaskInput, undefined, { requirePlacementGuards: true });
     return { tasks: outcome.ok ? outcome.tasks : undefined, result: outcome };
   });
-  if (!result.ok) throw new Error(result.error);
+  if (!result.ok) throw new McpToolRefusal(result.error, { code: result.code ?? (result.status === 404 ? "TASK_NOT_FOUND" : "TASK_INVALID_FIELD"), field: result.field, status: result.status });
   return { taskId, task: result.task };
 }
 

--- a/src/lib/mcp/schemaParity.test.ts
+++ b/src/lib/mcp/schemaParity.test.ts
@@ -847,3 +847,30 @@ test("spawn_agent and send_message publish recoveryOnly and the recovery contrac
     await server.close();
   }
 });
+
+
+test("task coordinates publish finite axes and retain pinned-update position semantics", async () => {
+  await withProtocolClient(inertBindings(), async client => {
+    const listed = await client.listTools();
+    for (const name of ["create_task", "update_task"] as const) {
+      const tool = listed.tools.find(t => t.name === name)!;
+      const pos = tool.inputSchema.properties!.pos as { required: string[]; properties: Record<string, { type: string }> };
+      expect(pos.required.slice().sort()).toEqual(["x", "y"]);
+      expect(pos.properties.x.type).toBe("number");
+      expect(pos.properties.y.type).toBe("number");
+      expect(tool.inputSchema.required).not.toContain("pos");
+      expect(tool.inputSchema.required?.slice().sort()).toEqual(name === "create_task" ? ["clientRequestId", "project", "text"] : ["clientRequestId", "taskId"]);
+      for (const invalid of [null, {}, { x: 1 }, { y: 2 }, { x: "1", y: 2 }, { x: Infinity, y: 0 }, { x: NaN, y: 0 }]) {
+        const args = { clientRequestId: "invalid-coordinate", project: "fixture-project", text: "task", taskId: "task-fixture", pos: invalid };
+        const parsed = TOOL_INPUT_SCHEMAS[name].safeParse(args);
+        expect(parsed.success).toBe(false);
+        expect(parsed.error?.issues.some(issue => issue.path[0] === "pos")).toBe(true);
+        const result = await client.callTool({ name, arguments: args });
+        expect(result.isError).toBe(true);
+        expect(JSON.stringify(result.content)).toContain("pos");
+        expect(result.structuredContent).toMatchObject({ ok: false, code: "TASK_INVALID_FIELD", retryable: false });
+      }
+    }
+    expect(TOOL_INPUT_SCHEMAS.update_task.safeParse({ clientRequestId: "retain-position", taskId: "task-fixture", placement: "pinned", expectedProject: "fixture-project", expectedRevision: "opaque" }).success).toBe(true);
+  });
+});

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2518,12 +2518,15 @@ export function createMcpToolService(
             : context.signal?.aborted
               ? "cancelled"
               : "failure";
+          const taskCode = (typedTool === "create_task" || typedTool === "update_task")
+            && error instanceof McpToolRefusal && typeof error.details.code === "string"
+            && error.details.code.startsWith("TASK_") ? error.details.code : null;
           settled = failure(
             typedTool,
             requestId,
-            "tool_failed",
+            taskCode ?? "tool_failed",
             error instanceof Error ? error.message : String(error),
-            true,
+            taskCode === null,
             false,
             error instanceof McpToolRefusal ? error.details : undefined,
           );
@@ -2858,7 +2861,8 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     clientRequestId: clientRequestIdSchema,
     project: z.string().min(1),
     text: z.string().min(1),
-    placement: z.enum(["pinned", "unplaced"]).optional(),
+    placement: z.enum(["pinned", "unplaced"]).optional().describe("Omitted placement creates an unplaced task. Pinned requires pos; unplaced must omit pos."),
+    pos: z.object({ x: z.number().finite(), y: z.number().finite() }).optional(),
     dueAt: z.string().optional(),
     dueTz: z.string().optional(),
     attachments: z.array(z.unknown()).optional(),
@@ -2866,9 +2870,12 @@ export const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
   update_task: z.object({
     clientRequestId: clientRequestIdSchema,
     taskId: entityIdSchema,
+    expectedProject: z.string().min(1).optional().describe("Required for pos or placement updates: copy the current task project exactly."),
+    expectedRevision: z.string().min(1).optional().describe("Required for pos or placement updates: copy the opaque revision from get_task or list_tasks."),
     text: z.string().optional(),
     status: z.enum(["inbox", "assigned", "blocked", "done"]).optional(),
-    placement: z.enum(["pinned", "unplaced"]).optional(),
+    placement: z.enum(["pinned", "unplaced"]).optional().describe("Pinned retains existing pos when omitted; unplaced removes pos. Placement updates require expectedProject and expectedRevision."),
+    pos: z.object({ x: z.number().finite(), y: z.number().finite() }).optional(),
     dueAt: z.string().nullable().optional(),
     dueTz: z.string().nullable().optional(),
   }).passthrough(),
@@ -3174,10 +3181,29 @@ export function createViewerMcpServer(service: McpToolService): McpServer {
     instructions: "Use clientRequestId on every call. Reuse it only when replaying the same logical operation.",
   });
   for (const toolName of MCP_TOOL_NAMES) {
+    const taskMutation = toolName === "create_task" || toolName === "update_task";
+    const schema = TOOL_INPUT_SCHEMAS[toolName];
+    // The SDK's default validation error has no retryability or field envelope.
+    // Preserve the published input shape, but carry invalid optional task fields through
+    // to our strict validation below, before dispatch or receipt acquisition.
+    const inputSchema = taskMutation ? schema.extend(Object.fromEntries(
+      Object.entries(schema.shape).filter(([, fieldSchema]) => fieldSchema.isOptional())
+        .map(([field, fieldSchema]) => [field, fieldSchema.catch((context: { input: unknown } | undefined) => context?.input)]),
+    )) : schema;
     server.registerTool(toolName, {
       description: TOOL_DESCRIPTIONS[toolName],
-      inputSchema: TOOL_INPUT_SCHEMAS[toolName],
+      inputSchema,
     }, async (args, extra) => {
+      if (taskMutation) {
+        const parsed = schema.safeParse(args);
+        if (!parsed.success) {
+          const issues = parsed.error.issues.map(issue => ({ field: issue.path.join("."), message: issue.message }));
+          const result = failure(toolName, String((args as McpToolArgs).clientRequestId), "TASK_INVALID_FIELD",
+            issues.map(issue => `${issue.field}: ${issue.message}`).join("; "), false, false,
+            { field: issues[0]?.field, issues });
+          return { content: [{ type: "text" as const, text: JSON.stringify(result) }], structuredContent: result, isError: true };
+        }
+      }
       const timeoutMs = 30_000;
       const deadline = deadlineSignal(timeoutMs, {
         signal: extra.signal,

--- a/src/lib/mcp/taskPosition.integration.test.ts
+++ b/src/lib/mcp/taskPosition.integration.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { TaskWithRevision } from "@/lib/tasks/revision";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+// Establish every state root before importing production bindings.
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "task-position-"));
+for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "LLV_STATE_DIR", "LLV_CODEX_HOME", "LLV_CLAUDE_HOME", "CODEX_HOME", "CLAUDE_CONFIG_DIR", "TMPDIR"]) {
+  const dir = path.join(sandbox, key);
+  fs.mkdirSync(dir, { recursive: true });
+  process.env[key] = dir;
+}
+process.env.LLV_VIEWER_CONTROL_URL = "http://127.0.0.1:1";
+process.env.LLV_RUNTIME_HOST_SOCKET = path.join(sandbox, "runtime.sock");
+process.env.LLV_RUNTIME_HOST_CONTROL_SOCKET = path.join(sandbox, "absent.sock");
+const { viewerMcpBindings } = await import("./bindings");
+const { createMcpToolService, createViewerMcpServer, SqliteMcpReceiptStore } = await import("./server");
+const { TASKS_FILE, loadTasks } = await import("@/lib/tasks/store");
+expect(TASKS_FILE.startsWith(sandbox + path.sep)).toBe(true);
+
+async function protocol() {
+  const receipts = new SqliteMcpReceiptStore(path.join(sandbox, "receipts.sqlite"));
+  const server = createViewerMcpServer(createMcpToolService(viewerMcpBindings(), receipts));
+  const client = new Client({ name: "task-position-test", version: "1" });
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(a), server.connect(b)]);
+  return { client, close: async () => { await client.close(); await server.close(); receipts.close(); } };
+}
+
+test("published positioning contract carries coordinates and current-row guards", async () => {
+  const p = await protocol();
+  try {
+    const { tools } = await p.client.listTools();
+    for (const name of ["create_task", "update_task"]) {
+      expect(tools.find(t => t.name === name)!.inputSchema.properties).toHaveProperty("pos");
+    }
+    expect(tools.find(t => t.name === "update_task")!.inputSchema.properties).toHaveProperty("expectedRevision");
+  } finally { await p.close(); }
+});
+
+test.each([["foreign", "other-project"], ["stale", "fixture-project"]])("%s placement refuses atomically through real protocol and persistence", async (key, expectedProject) => {
+  const p = await protocol();
+  try {
+    const created = (await p.client.callTool({ name: "create_task", arguments: {
+      clientRequestId: `create-fence-${key}`, project: "fixture-project", text: "original", placement: "pinned", pos: { x: -0.5, y: 0 },
+    } })).structuredContent as { ok: boolean; task: { id: string; revision?: string } };
+    expect(created.ok).toBe(true);
+    expect(loadTasks().find(task => task.id === created.task.id)!.pos).toEqual({ x: -0.5, y: 0 });
+    const expectedRevision = key === "foreign" ? created.task.revision ?? "missing-baseline-token" : "task-v1:stale";
+      const before = fs.readFileSync(TASKS_FILE, "utf8");
+      const result = (await p.client.callTool({ name: "update_task", arguments: {
+        clientRequestId: key, taskId: created.task.id, expectedProject, expectedRevision,
+        pos: { x: 50, y: 60 }, text: "must not land", dueAt: "2026-10-01T00:00:00Z", dueTz: "UTC",
+      } })).structuredContent;
+      expect(result).toMatchObject({ ok: false, retryable: false });
+      expect(fs.readFileSync(TASKS_FILE, "utf8")).toBe(before);
+  } finally { await p.close(); }
+});
+
+
+test("completed SQLite receipts replay original coordinates and revisions after restart and deletion", async () => {
+  let p = await protocol();
+  const createArgs = { clientRequestId: "replay-create", project: "fixture-project", text: "receipt", placement: "pinned", pos: { x: -2.25, y: 0 } };
+  const created = (await p.client.callTool({ name: "create_task", arguments: createArgs })).structuredContent as { task: { id: string; revision: string; project: string } };
+  const updateArgs = { clientRequestId: "replay-update", taskId: created.task.id, expectedProject: created.task.project, expectedRevision: created.task.revision, pos: { x: 3.5, y: -4 } };
+  const updated = (await p.client.callTool({ name: "update_task", arguments: updateArgs })).structuredContent as { task: unknown };
+  expect(updated).toMatchObject({ ok: true });
+  const { mutateTasks } = await import("@/lib/tasks/store");
+  mutateTasks(tasks => ({ tasks: tasks.filter(t => t.id !== created.task.id), result: undefined }));
+  const before = fs.readFileSync(TASKS_FILE, "utf8");
+  await p.close(); p = await protocol();
+  try {
+    const replayCreate = (await p.client.callTool({ name: "create_task", arguments: createArgs })).structuredContent;
+    const replayUpdate = (await p.client.callTool({ name: "update_task", arguments: updateArgs })).structuredContent;
+    expect(replayCreate).toMatchObject({ ok: true, replayed: true, task: created.task });
+    expect(replayUpdate).toMatchObject({ ok: true, replayed: true, task: updated.task });
+    for (const [name, args] of [["create_task", { ...createArgs, text: "changed" }], ["update_task", { ...updateArgs, pos: { x: 9, y: 9 } }]] as const) {
+      expect((await p.client.callTool({ name, arguments: args })).structuredContent).toMatchObject({ ok: false, code: "idempotency_conflict", retryable: false });
+    }
+    expect(fs.readFileSync(TASKS_FILE, "utf8")).toBe(before);
+  } finally { await p.close(); }
+});
+
+test("MCP placement semantics and independent HTTP handlers share durable coordinates and optional guards", async () => {
+  const { NextRequest } = await import("next/server");
+  const { POST } = await import("@/app/api/tasks/route");
+  const { PATCH } = await import("@/app/api/tasks/[id]/route");
+  const p = await protocol();
+  let sequence = 0;
+  const call = async (name: string, args: Record<string, unknown>) => (await p.client.callTool({ name, arguments: { clientRequestId: `semantics-${++sequence}`, ...args } })).structuredContent as { task: TaskWithRevision; tasks: TaskWithRevision[] };
+  const request = (body: unknown) => new NextRequest("http://localhost/api/tasks", { method: "POST", headers: { "content-type": "application/json", host: "localhost" }, body: JSON.stringify(body) });
+  try {
+    const unplaced = await call("create_task", { project: "fixture-project", text: "unplaced" });
+    expect(unplaced.task.placement).toBe("unplaced");
+    for (const args of [{ placement: "pinned" }, { placement: "unplaced", pos: { x: 0, y: 0 } }, { pos: { x: 0, y: 0 } }]) {
+      const refused = await call("create_task", { project: "fixture-project", text: "invalid", ...args });
+      expect(refused).toMatchObject({ ok: false, retryable: false, details: { field: "pos" } });
+    }
+    let task = unplaced.task;
+    const guarded = (args: Record<string, unknown>) => call("update_task", { taskId: task.id, expectedProject: task.project, expectedRevision: task.revision, ...args });
+    expect(await guarded({ placement: "pinned" })).toMatchObject({ ok: false, retryable: false, details: { field: "pos" } });
+    task = (await guarded({ pos: { x: -1.25, y: 0 } })).task;
+    expect(task.placement).toBe("pinned");
+    task = (await guarded({ placement: "pinned" })).task;
+    expect(task.pos).toEqual({ x: -1.25, y: 0 });
+    const beforeContent = task;
+    task = (await call("update_task", { taskId: task.id, text: "content only" })).task;
+    expect(task.pos).toEqual(beforeContent.pos);
+    expect(task.revision).not.toBe(beforeContent.revision);
+    const read = await call("get_task", { taskId: task.id });
+    expect(read.task.revision).toBe(task.revision);
+    const listed = await call("list_tasks", { project: task.project });
+    expect(listed.tasks.find((t: { id: string }) => t.id === task.id)!.revision).toBe(task.revision);
+    expect(await call("update_task", { taskId: task.id, pos: { x: 1, y: 2 } })).toMatchObject({ ok: false, retryable: false, details: { field: "expectedProject" } });
+    const oldToken = task.revision;
+    const http = await PATCH(request({ pos: { x: 12.5, y: -7 } }), { params: Promise.resolve({ id: task.id }) });
+    expect(http.status).toBe(200);
+    const httpTask = (await http.json()).task;
+    expect(httpTask.revision).not.toBe(oldToken);
+    expect(await guarded({ pos: { x: 9, y: 9 } })).toMatchObject({ ok: false, code: "TASK_REVISION_MISMATCH", retryable: false });
+    const bytes = fs.readFileSync(TASKS_FILE, "utf8");
+    expect((await PATCH(request({ expectedProject: "foreign", expectedRevision: httpTask.revision, text: "wrong" }), { params: Promise.resolve({ id: task.id }) })).status).toBe(409);
+    expect(fs.readFileSync(TASKS_FILE, "utf8")).toBe(bytes);
+    task = httpTask;
+    task = (await guarded({ placement: "unplaced", pos: { x: 8, y: 9 } })).task;
+    expect(task.placement).toBe("unplaced"); expect(task.pos).toBeUndefined();
+    const httpCreated = await POST(request({ project: "fixture-project", text: "http", placement: "pinned", pos: { x: -0.5, y: 1.25 } }));
+    expect(httpCreated.status).toBe(200);
+    const durable = (await httpCreated.json()).task;
+    expect(loadTasks().find(t => t.id === durable.id)).toEqual(durable);
+  } finally { await p.close(); }
+});
+
+test("two independent processes racing identical coordinates under one revision have exactly one winner", async () => {
+  const p = await protocol();
+  const created = (await p.client.callTool({ name: "create_task", arguments: { clientRequestId: "race-create", project: "fixture-project", text: "race", placement: "pinned", pos: { x: 1, y: 1 } } })).structuredContent as { task: { id: string; revision: string } };
+  await p.close();
+  const gate = path.join(sandbox, "race-go");
+  const script = `
+    import fs from "node:fs";
+    import { viewerMcpBindings } from "./src/lib/mcp/bindings";
+    import { createMcpToolService, createViewerMcpServer, SqliteMcpReceiptStore } from "./src/lib/mcp/server";
+    import type { TaskWithRevision } from "@/lib/tasks/revision";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+    import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+    const args = JSON.parse(process.env.POSITION_RACE_ARGS!);
+    const store = new SqliteMcpReceiptStore(process.env.POSITION_RACE_RECEIPTS!);
+    const server = createViewerMcpServer(createMcpToolService(viewerMcpBindings(), store));
+    const client = new Client({ name: "race", version: "1" });
+    const [a,b] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(a), server.connect(b)]);
+    fs.writeFileSync(process.env.POSITION_RACE_READY!, "ready");
+    while (!fs.existsSync(process.env.POSITION_RACE_GATE!)) await Bun.sleep(5);
+    Date.now = () => 1788220800000;
+    Date.prototype.toISOString = () => "2026-09-01T00:00:00.000Z";
+    const result = await client.callTool({ name: "update_task", arguments: args });
+    console.log(JSON.stringify(result.structuredContent));
+    await client.close(); await server.close(); store.close();
+  `;
+  const children = [0, 1].map(index => {
+    const ready = path.join(sandbox, `race-ready-${index}`);
+    const child = Bun.spawn([process.execPath, "-e", script], { cwd: process.cwd(), env: { ...process.env,
+      POSITION_RACE_ARGS: JSON.stringify({ clientRequestId: `race-${index}`, taskId: created.task.id, expectedProject: "fixture-project", expectedRevision: created.task.revision, pos: { x: 1, y: 1 } }),
+      POSITION_RACE_RECEIPTS: path.join(sandbox, `race-${index}.sqlite`), POSITION_RACE_READY: ready, POSITION_RACE_GATE: gate,
+    }, stdout: "pipe", stderr: "pipe" });
+    return { child, ready };
+  });
+  const deadline = Date.now() + 15000;
+  while (!children.every(c => fs.existsSync(c.ready)) && Date.now() < deadline) await Bun.sleep(10);
+  fs.writeFileSync(gate, "go");
+  const results = await Promise.all(children.map(async ({ child }) => {
+    const output = await new Response(child.stdout).text();
+    const error = await new Response(child.stderr).text();
+    expect([await child.exited, error]).toEqual([0, ""]);
+    return JSON.parse(output);
+  }));
+  expect(results.filter(r => r.ok)).toHaveLength(1);
+  expect(results.find(r => !r.ok)).toMatchObject({ code: "TASK_REVISION_MISMATCH", retryable: false });
+}, 20000);
+
+
+test("canonical readback includes the persisted generation and placement preserves all unrelated fields", async () => {
+  const { saveTasks } = await import("@/lib/tasks/store");
+  const p = await protocol();
+  try {
+    const create = (await p.client.callTool({ name: "create_task", arguments: { clientRequestId: "preserve-create", project: "fixture-project", text: "preserve", placement: "pinned", pos: { x: 0, y: 0 } } })).structuredContent as { task: { id: string; revision: string } };
+    expect(typeof create.task.revision).toBe("string");
+    const tasks = loadTasks();
+    const task = tasks.find(t => t.id === create.task.id)!;
+    Object.assign(task, { dueAt: "2026-10-01T00:00:00.000Z", dueTz: "UTC", extension: { keep: true },
+      assignments: [{ path: "fixture.jsonl", panePid: null, state: "delivered", error: null, at: "2026-09-01T00:00:00Z" }],
+      source: { path: "fixture.jsonl", ts: null, text: "source", fingerprint: "fixture", engine: "codex" },
+      attachments: [{ id: crypto.randomUUID(), sha256: "a".repeat(64), ext: "png", mime: "image/png", bytes: 1, createdAt: "2026-09-01T00:00:00.000Z" }],
+    });
+    saveTasks(tasks);
+    const before = JSON.parse(fs.readFileSync(TASKS_FILE, "utf8")).tasks;
+    const current = before.find((t: { id: string }) => t.id === task.id);
+    const result = (await p.client.callTool({ name: "update_task", arguments: { clientRequestId: "preserve-move", taskId: task.id, expectedProject: task.project, expectedRevision: current.revision, pos: { x: -5.25, y: 0 } } })).structuredContent as { task: Record<string, unknown> };
+    expect(result).toMatchObject({ ok: true });
+    const after = JSON.parse(fs.readFileSync(TASKS_FILE, "utf8")).tasks;
+    expect(after.find((t: { id: string }) => t.id === task.id)).toEqual(result.task);
+    expect(after.filter((t: { id: string }) => t.id !== task.id)).toEqual(before.filter((t: { id: string }) => t.id !== task.id));
+    const { pos: _pos, revision: _revision, updatedAt: _updatedAt, ...preserved } = result.task;
+    const { pos: _oldPos, revision: _oldRevision, updatedAt: _oldUpdatedAt, ...expected } = current;
+    expect(preserved).toEqual(expected);
+  } finally { await p.close(); }
+});

--- a/src/lib/tasks/commands.ts
+++ b/src/lib/tasks/commands.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { isTaskAttachment } from "./attachments";
+import { taskRevision } from "./revision";
 import { isoNow } from "./helpers";
 import type { AssignmentRef, BoardTask, TaskAttachment, TaskAssignment, TaskSource, TaskStatus } from "./types";
 
@@ -11,9 +12,11 @@ export const TASKS_PER_PROJECT_LIMIT = 300;
     can mint a twin (documented, durability beyond the cap is deferred). */
 export const RECENT_CREATES_CAP = 100;
 
+export type TaskRefusal = { ok: false; error: string; status: number; code?: string; field?: string };
+
 export type TaskCommandResult =
   | { ok: true; tasks: BoardTask[]; task: BoardTask }
-  | { ok: false; error: string; status: number };
+  | TaskRefusal;
 
 /** A `clientRequestId → taskId` receipt, persisted in `tasks.json` so a replay
     survives a server restart. Oldest entries evict past {@link RECENT_CREATES_CAP}. */
@@ -24,7 +27,7 @@ export interface RecentCreate {
 
 export type CreateTaskResult =
   | { ok: true; tasks: BoardTask[]; task: BoardTask; recentCreates: RecentCreate[]; replay: boolean }
-  | { ok: false; error: string; status: number };
+  | TaskRefusal;
 
 export interface CreateTaskInput {
   project?: unknown;
@@ -39,6 +42,8 @@ export interface CreateTaskInput {
 }
 
 export interface PatchTaskInput {
+  expectedProject?: unknown;
+  expectedRevision?: unknown;
   text?: unknown;
   status?: unknown;
   placement?: unknown;
@@ -67,6 +72,12 @@ function normalizeProject(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const project = value.trim();
   return project ? project : null;
+}
+
+function positionError(value: unknown): TaskRefusal {
+  const pos = value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+  const field = !pos ? "pos" : typeof pos.x !== "number" || !Number.isFinite(pos.x) ? "pos.x" : "pos.y";
+  return { ok: false, error: `${field} must be ${field === "pos" ? "an object with finite x and y" : "a finite number"}`, status: 400, code: "TASK_INVALID_FIELD", field };
 }
 
 function normalizePos(value: unknown): { x: number; y: number } | null {
@@ -112,7 +123,7 @@ function normalizeDue(dueAt: unknown, dueTz: unknown): DueResult {
   return { ok: true, dueAt: new Date(parsed).toISOString(), dueTz };
 }
 
-type AttachmentsResult = { ok: true; attachments?: TaskAttachment[] } | { ok: false; error: string; status: number };
+type AttachmentsResult = { ok: true; attachments?: TaskAttachment[] } | TaskRefusal;
 
 function normalizeAttachments(value: unknown, exists: (att: TaskAttachment) => boolean): AttachmentsResult {
   if (value === undefined || value === null) return { ok: true };
@@ -175,17 +186,16 @@ export function createTask(
   }
 
   const pos = normalizePos(input.pos);
-  const posGiven = input.pos !== undefined && input.pos !== null;
-  if (posGiven && !pos) return { ok: false, error: "invalid task position", status: 400 };
+  if (Object.hasOwn(input, "pos") && !pos) return positionError(input.pos);
   /* Placement omitted stays back-compatible: a `pos` means `pinned`, none is an
      error (the legacy create path always sent a pos). */
   const placement = normalizePlacement(input.placement) ?? (pos ? "pinned" : null);
   if (input.placement !== undefined && placement === null) {
     return { ok: false, error: "invalid placement", status: 400 };
   }
-  if (placement === "pinned" && !pos) return { ok: false, error: "task position is required", status: 400 };
-  if (placement === "unplaced" && pos) return { ok: false, error: "unplaced task must not carry a position", status: 400 };
-  if (placement === null) return { ok: false, error: "task position is required", status: 400 };
+  if (placement === "pinned" && !pos) return { ok: false, error: "task position is required", status: 400, code: "TASK_INVALID_FIELD", field: "pos" };
+  if (placement === "unplaced" && pos) return { ok: false, error: "unplaced task must not carry a position", status: 400, code: "TASK_INVALID_FIELD", field: "pos" };
+  if (placement === null) return { ok: false, error: "task position is required", status: 400, code: "TASK_INVALID_FIELD", field: "pos" };
 
   const due = normalizeDue(input.dueAt, input.dueTz);
   if (!due.ok) return { ok: false, error: due.error, status: 400 };
@@ -221,10 +231,24 @@ export function createTask(
   return { ok: true, tasks: [...existing, task], task, recentCreates: nextRecent, replay: false };
 }
 
-export function patchTask(existing: BoardTask[], id: string, input: PatchTaskInput, now = isoNow()): TaskCommandResult {
+export function patchTask(existing: BoardTask[], id: string, input: PatchTaskInput, now = isoNow(), options: { requirePlacementGuards?: boolean } = {}): TaskCommandResult {
   const index = existing.findIndex((task) => task.id === id);
   if (index < 0) return { ok: false, error: "task not found", status: 404 };
   const task = existing[index]!;
+  const guardRequired = options.requirePlacementGuards && (Object.hasOwn(input, "pos") || Object.hasOwn(input, "placement"));
+  if (guardRequired || Object.hasOwn(input, "expectedProject") || Object.hasOwn(input, "expectedRevision")) {
+    for (const field of ["expectedProject", "expectedRevision"] as const) {
+      if (typeof input[field] !== "string" || !input[field].trim()) {
+        return { ok: false, status: 400, code: "TASK_INVALID_FIELD", field, error: `${field} must be a non-empty string copied from the current task` };
+      }
+    }
+    if (input.expectedProject !== task.project) {
+      return { ok: false, status: 409, code: "TASK_PROJECT_MISMATCH", field: "expectedProject", error: "expectedProject does not match the current task project; read the task and reconsider the request" };
+    }
+    if (input.expectedRevision !== taskRevision(task)) {
+      return { ok: false, status: 409, code: "TASK_REVISION_MISMATCH", field: "expectedRevision", error: "expectedRevision is stale; read the task and reconsider the request" };
+    }
+  }
   const patch: Partial<BoardTask> = {};
 
   if (Object.hasOwn(input, "text")) {
@@ -240,7 +264,7 @@ export function patchTask(existing: BoardTask[], id: string, input: PatchTaskInp
   }
   if (Object.hasOwn(input, "pos")) {
     const pos = normalizePos(input.pos);
-    if (!pos) return { ok: false, error: "invalid task position", status: 400 };
+    if (!pos) return positionError(input.pos);
     /* A pos always pins: place-on-map and free drags both land here, so an
        unplaced task that gets a position becomes pinned in the same PATCH, and
        the collision pass then leaves it exactly where the user dropped it. */
@@ -252,7 +276,7 @@ export function patchTask(existing: BoardTask[], id: string, input: PatchTaskInp
     if (!placement) return { ok: false, error: "invalid placement", status: 400 };
     /* Pinned needs a position: either supplied in this PATCH or already held. */
     if (placement === "pinned" && !patch.pos && !task.pos) {
-      return { ok: false, error: "task position is required", status: 400 };
+      return { ok: false, error: "task position is required", status: 400, code: "TASK_INVALID_FIELD", field: "pos" };
     }
     patch.placement = placement;
   }

--- a/src/lib/tasks/revision.test.ts
+++ b/src/lib/tasks/revision.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "task-revision-"));
+for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "LLV_STATE_DIR", "LLV_CODEX_HOME", "LLV_CLAUDE_HOME", "CODEX_HOME", "CLAUDE_CONFIG_DIR", "TMPDIR"]) {
+  process.env[key] = path.join(sandbox, key);
+  fs.mkdirSync(process.env[key]!, { recursive: true });
+}
+process.env.LLV_VIEWER_CONTROL_URL = "http://127.0.0.1:1";
+process.env.LLV_RUNTIME_HOST_SOCKET = path.join(sandbox, "runtime.sock");
+const { loadTasks, saveTasks, saveTasksFile, mutateTasks, mutateTasksFile, TASKS_FILE } = await import("./store");
+const { patchTask, applyAssignmentPatches, removeAssignment } = await import("./commands");
+const { taskRevision } = await import("./revision");
+const { createServerRuntimeConsumers } = await import("@/lib/runtime/serverConsumers");
+import type { BoardTask } from "./types";
+const now = "2026-09-01T00:00:00.000Z";
+function row(id = "task-a"): BoardTask {
+  return { id, project: "fixture-project", text: "A", placement: "pinned", pos: { x: 0, y: -1.5 },
+    status: "inbox", assignments: [], createdAt: now, updatedAt: now };
+}
+function file() { return path.join(sandbox, `${crypto.randomUUID()}.json`); }
+function patch(filePath: string, input: Parameters<typeof patchTask>[2]) {
+  return mutateTasks(tasks => {
+    const result = patchTask(tasks, "task-a", input, now);
+    return { tasks: result.ok ? result.tasks : undefined, result };
+  }, filePath);
+}
+
+test("all four writers advance generations; ABA, identical writes and recreation cannot reuse tokens", () => {
+  const f = file();
+  saveTasks([row(), row("untouched")], f);
+  const other = loadTasks(f)[1];
+  const seen = new Set<string>();
+  const remember = () => { const token = taskRevision(loadTasks(f)[0]!); expect(seen.has(token)).toBe(false); seen.add(token); };
+  remember();
+  for (const text of ["B", "A", "A"]) { expect(patch(f, { text }).ok).toBe(true); remember(); }
+  for (const pos of [{ x: 5, y: 8 }, { x: 0, y: -1.5 }]) { patch(f, { pos }); remember(); }
+  mutateTasks(tasks => {
+    const r = applyAssignmentPatches(tasks, "task-a", [{ path: "fixture.jsonl", panePid: null, state: "spawning", error: null, at: now }], now);
+    if (!r.ok) throw new Error(r.error);
+    return { tasks: r.tasks, result: r.task };
+  }, f); remember();
+  mutateTasks(tasks => { const r = removeAssignment(tasks, "task-a", "fixture.jsonl", now); if (!r.ok) throw new Error(r.error); return { tasks: r.tasks, result: r.task }; }, f); remember();
+  mutateTasksFile(state => { state.tasks[0]!.text = "in-place"; return { state, result: undefined }; }, f); remember();
+  const saved = loadTasks(f); saved[0]!.text = "whole-list"; saveTasks(saved, f); remember();
+  const savedFile = { tasks: loadTasks(f), recentCreates: [] }; savedFile.tasks[0]!.text = "whole-file"; saveTasksFile(savedFile, f); remember();
+  expect(loadTasks(f)[1]).toEqual(other);
+  for (const token of seen) {
+    const before = fs.readFileSync(f, "utf8");
+    if (token === taskRevision(loadTasks(f)[0]!)) continue;
+    expect(patch(f, { pos: { x: 1, y: 1 }, expectedProject: "fixture-project", expectedRevision: token }).ok).toBe(false);
+    expect(fs.readFileSync(f, "utf8")).toBe(before);
+  }
+  mutateTasks(tasks => ({ tasks: tasks.filter(t => t.id !== "task-a"), result: undefined }), f);
+  mutateTasks(tasks => ({ tasks: [row(), ...tasks], result: undefined }), f); remember();
+});
+
+test("legacy reads are stable and read-only; first update persists a generation and retains extension fields", () => {
+  const f = file();
+  const legacy = { ...row(), extension: { retained: [1, 2] } };
+  const untouched = { ...row("untouched"), extension: "keep" };
+  const raw = { tasks: [legacy, untouched], recentCreates: [{ clientRequestId: "old", taskId: "task-a" }] };
+  fs.writeFileSync(f, JSON.stringify(raw));
+  const bytes = fs.readFileSync(f, "utf8");
+  const token = taskRevision(loadTasks(f)[0]!);
+  expect(token.startsWith("task-legacy:")).toBe(true);
+  expect(taskRevision(loadTasks(f)[0]!)).toBe(token);
+  expect(fs.readFileSync(f, "utf8")).toBe(bytes);
+  expect(patch(f, { text: "B", expectedProject: "fixture-project", expectedRevision: token }).ok).toBe(true);
+  patch(f, { text: "A" });
+  expect(taskRevision(loadTasks(f)[0]!)).not.toBe(token);
+  const persisted = JSON.parse(fs.readFileSync(f, "utf8"));
+  expect(persisted.tasks[0].extension).toEqual(legacy.extension);
+  expect(persisted.tasks[1]).toEqual(untouched);
+  expect(persisted.recentCreates).toEqual(raw.recentCreates);
+});
+
+test("corrupt, null, malformed revisions, duplicate ids and unreadable state never authorize a write", () => {
+  for (const raw of ["{", "null", JSON.stringify({ tasks: [{ ...row(), revision: "bad" }] }), JSON.stringify({ tasks: [row(), row()] }), JSON.stringify({ tasks: [{ id: "invalid" }] })]) {
+    const f = file(); fs.writeFileSync(f, raw);
+    let called = false;
+    expect(() => mutateTasks(tasks => { called = true; return { tasks, result: null }; }, f)).toThrow();
+    expect(called).toBe(false);
+    expect(() => saveTasks([row()], f)).toThrow();
+    expect(() => saveTasksFile({ tasks: [row()], recentCreates: [] }, f)).toThrow();
+    expect(fs.readFileSync(f, "utf8")).toBe(raw);
+  }
+  const directory = file(); fs.mkdirSync(directory);
+  expect(() => saveTasks([row()], directory)).toThrow();
+});
+
+test("actual runtime acknowledgment invalidates the token after nested in-place assignment mutation", () => {
+  expect(TASKS_FILE.startsWith(sandbox + path.sep)).toBe(true);
+  const task = row(); task.assignments = [{ path: "fixture.jsonl", panePid: null, state: "spawning", error: null, at: now }];
+  saveTasks([task]);
+  const token = taskRevision(loadTasks()[0]!);
+  const result = createServerRuntimeConsumers().taskDeliveryAcknowledged("task-a", "fixture.jsonl");
+  expect(result).toBeDefined();
+  expect(loadTasks()[0]!.assignments[0]!.state).toBe("delivered");
+  expect(taskRevision(loadTasks()[0]!)).not.toBe(token);
+  expect(patch(TASKS_FILE, { pos: { x: 1, y: 1 }, expectedProject: "fixture-project", expectedRevision: token }).ok).toBe(false);
+});
+
+
+test("actual reconciliation invalidates a previous placement token", async () => {
+  const { reconcileTasks } = await import("./reconcile");
+  const f = file(); const initial = row();
+  initial.assignments = [{ path: null, panePid: 123, state: "spawning", error: null, at: now }];
+  saveTasks([initial], f); const token = taskRevision(loadTasks(f)[0]!);
+  mutateTasks(tasks => {
+    const outcome = reconcileTasks([], tasks, { panePidAlive: () => false, now: () => now });
+    return { tasks: outcome.dirty ? outcome.tasks : undefined, result: outcome };
+  }, f);
+  expect(loadTasks(f)[0]!.assignments[0]!.state).toBe("failed");
+  expect(patch(f, { pos: { x: 2, y: 3 }, expectedProject: "fixture-project", expectedRevision: token }).ok).toBe(false);
+});

--- a/src/lib/tasks/revision.ts
+++ b/src/lib/tasks/revision.ts
@@ -1,0 +1,41 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { BoardTask } from "./types";
+
+export type TaskWithRevision = BoardTask & { revision: string };
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") return Object.fromEntries(
+    Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, canonical(item)]),
+  );
+  return value;
+}
+
+/** Full persisted content, including extension fields; revision is store-owned. */
+export function taskFingerprint(task: BoardTask): string {
+  const { revision: _revision, ...content } = task as TaskWithRevision;
+  return createHash("sha256").update(JSON.stringify(canonical(content))).digest("hex");
+}
+
+export function taskRevision(task: BoardTask): string {
+  const revision = (task as Partial<TaskWithRevision>).revision;
+  if (revision === undefined) return `task-legacy:${taskFingerprint(task)}`;
+  if (typeof revision !== "string" || !/^(task-v1:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|task-legacy:[0-9a-f]{64})$/.test(revision)) {
+    throw new Error("invalid persisted task revision");
+  }
+  return revision;
+}
+
+export function snapshotTasks(tasks: BoardTask[]) {
+  return new Map(tasks.map(task => [task.id, { ref: task, fingerprint: taskFingerprint(task), revision: taskRevision(task) }]));
+}
+
+/** Snapshot before the callback: writers can mutate nested assignments in place. */
+export function stampTaskRevisions(tasks: BoardTask[], before: ReturnType<typeof snapshotTasks>, replacementsAreWrites: boolean): void {
+  for (const task of tasks) {
+    const prior = before.get(task.id);
+    const changed = !prior || prior.fingerprint !== taskFingerprint(task)
+      || (replacementsAreWrites && prior.ref !== task);
+    (task as TaskWithRevision).revision = changed ? `task-v1:${randomUUID()}` : prior.revision;
+  }
+}

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -6,11 +6,25 @@ import { statePath } from "@/lib/configDir";
 import { canonicalProject } from "@/lib/projects/aliases";
 import { withFileTransactionSync } from "@/lib/state/fileTransaction";
 
+import { snapshotTasks, stampTaskRevisions, taskRevision } from "./revision";
 import { isTaskAttachment } from "./attachments";
 import type { RecentCreate } from "./commands";
 import type { AssignmentState, BoardTask, TaskAssignment, TaskPlacement, TaskSource, TaskStatus } from "./types";
 
 export const TASKS_FILE = statePath("tasks.json");
+
+// Keep untouched legacy rows exactly as stored, including extension fields and
+// omitted placement/revision. Response coercion must not migrate other rows.
+const persistedRows = new WeakMap<BoardTask, unknown>();
+function committedRows(tasks: BoardTask[], before: ReturnType<typeof snapshotTasks>, replacements: boolean): unknown[] {
+  for (const task of tasks) task.project = canonicalProject(task.project);
+  stampTaskRevisions(tasks, before, replacements);
+  return tasks.map(task => {
+    const prior = before.get(task.id);
+    return prior && taskRevision(task) === prior.revision && persistedRows.has(prior.ref)
+      ? persistedRows.get(prior.ref) : task;
+  });
+}
 
 type TasksFile = { tasks?: unknown; recentCreates?: unknown };
 
@@ -30,8 +44,9 @@ function atomicWriteJson(filePath: string, value: unknown): void {
 function readJson(filePath: string): unknown {
   try {
     return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
-  } catch {
-    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
   }
 }
 
@@ -121,7 +136,8 @@ function coerceTask(value: unknown): BoardTask | null {
   const hasPos = isFinitePos(raw.pos);
   const placement: TaskPlacement = isPlacement(raw.placement) ? raw.placement : hasPos ? "pinned" : "unplaced";
   const pinned = placement === "pinned" && hasPos;
-  return {
+  const task: BoardTask = {
+    ...raw,
     id: raw.id!,
     project: canonicalProject(raw.project!),
     status: raw.status!,
@@ -135,6 +151,9 @@ function coerceTask(value: unknown): BoardTask | null {
     createdAt: raw.createdAt!,
     updatedAt: raw.updatedAt!,
   };
+  if (!pinned) delete task.pos;
+  try { Object.assign(task, { revision: taskRevision(task) }); } catch { return null; }
+  return task;
 }
 
 export function isTask(value: unknown): value is BoardTask {
@@ -151,13 +170,22 @@ export function loadTasks(filePath = TASKS_FILE): BoardTask[] {
   return loadTasksFile(filePath).tasks;
 }
 
-/** The whole persisted file, with legacy rows coerced and receipts filtered. */
+/** Read without writes; malformed existing state refuses instead of dropping rows. */
 export function loadTasksFile(filePath = TASKS_FILE): TasksFileState {
-  const raw = readJson(filePath) as TasksFile | null;
-  const tasks = Array.isArray(raw?.tasks)
-    ? raw.tasks.map(coerceTask).filter((task): task is BoardTask => task !== null)
-    : [];
-  const recentCreates = Array.isArray(raw?.recentCreates) ? raw.recentCreates.filter(isRecentCreate) : [];
+  const raw = readJson(filePath) as TasksFile | undefined;
+  if (raw === undefined) return { tasks: [], recentCreates: [] };
+  if (!raw || !Array.isArray(raw.tasks)) throw new Error("invalid persisted task state");
+  const tasks = raw.tasks.map(value => {
+    const task = coerceTask(value);
+    if (!task) throw new Error("invalid persisted task row");
+    persistedRows.set(task, value);
+    return task;
+  });
+  if (new Set(tasks.map(task => task.id)).size !== tasks.length) throw new Error("duplicate persisted task id");
+  if (raw.recentCreates !== undefined && (!Array.isArray(raw.recentCreates) || !raw.recentCreates.every(isRecentCreate))) {
+    throw new Error("invalid persisted task receipts");
+  }
+  const recentCreates = (raw.recentCreates ?? []) as RecentCreate[];
   return { tasks, recentCreates };
 }
 
@@ -165,14 +193,16 @@ export function saveTasks(tasks: BoardTask[], filePath = TASKS_FILE): void {
   withFileTransactionSync(filePath, "task state is busy", () => {
     /* Preserve the idempotency receipts a tasks-only save (patch/delete/send)
        doesn't touch, so a create replay still resolves after them. */
-    const { recentCreates } = loadTasksFile(filePath);
-    atomicWriteJson(filePath, recentCreates.length ? { tasks, recentCreates } : { tasks });
+    const { tasks: current, recentCreates } = loadTasksFile(filePath);
+    const rows = committedRows(tasks, snapshotTasks(current), false);
+    atomicWriteJson(filePath, recentCreates.length ? { tasks: rows, recentCreates } : { tasks: rows });
   });
 }
 
 export function saveTasksFile(state: TasksFileState, filePath = TASKS_FILE): void {
   withFileTransactionSync(filePath, "task state is busy", () => {
-    atomicWriteJson(filePath, state.recentCreates.length ? { tasks: state.tasks, recentCreates: state.recentCreates } : { tasks: state.tasks });
+    const rows = committedRows(state.tasks, snapshotTasks(loadTasksFile(filePath).tasks), false);
+    atomicWriteJson(filePath, state.recentCreates.length ? { tasks: rows, recentCreates: state.recentCreates } : { tasks: rows });
   });
 }
 
@@ -187,11 +217,13 @@ export function mutateTasks<R>(
 ): R {
   return withFileTransactionSync(filePath, "task state is busy", () => {
     const current = loadTasksFile(filePath);
+    const before = snapshotTasks(current.tasks);
     const outcome = mutate(current.tasks);
     if (outcome.tasks) {
+      const rows = committedRows(outcome.tasks, before, true);
       atomicWriteJson(filePath, current.recentCreates.length
-        ? { tasks: outcome.tasks, recentCreates: current.recentCreates }
-        : { tasks: outcome.tasks });
+        ? { tasks: rows, recentCreates: current.recentCreates }
+        : { tasks: rows });
     }
     return outcome.result;
   });
@@ -208,11 +240,14 @@ export function mutateTasksFile<R>(
   filePath = TASKS_FILE,
 ): R {
   return withFileTransactionSync(filePath, "task state is busy", () => {
-    const outcome = mutate(loadTasksFile(filePath));
+    const current = loadTasksFile(filePath);
+    const before = snapshotTasks(current.tasks);
+    const outcome = mutate(current);
     if (outcome.state) {
+      const rows = committedRows(outcome.state.tasks, before, true);
       atomicWriteJson(filePath, outcome.state.recentCreates.length
-        ? { tasks: outcome.state.tasks, recentCreates: outcome.state.recentCreates }
-        : { tasks: outcome.state.tasks });
+        ? { tasks: rows, recentCreates: outcome.state.recentCreates }
+        : { tasks: rows });
     }
     return outcome.result;
   });

--- a/src/lib/tasks/tasks.test.ts
+++ b/src/lib/tasks/tasks.test.ts
@@ -88,18 +88,18 @@ describe("task store", () => {
     expect(loadTasks(filePath)).toEqual(tasks);
   });
 
-  test("corrupt or missing files load as an empty list", () => {
+  test("only a missing file establishes an empty store", () => {
     const filePath = tmpFile();
     expect(loadTasks(filePath)).toEqual([]);
     fs.writeFileSync(filePath, "{", "utf8");
-    expect(loadTasks(filePath)).toEqual([]);
+    expect(() => loadTasks(filePath)).toThrow();
   });
 
-  test("runtime validation filters malformed tasks", () => {
+  test("runtime validation refuses malformed task state", () => {
     const filePath = tmpFile();
     const valid = task();
     fs.writeFileSync(filePath, JSON.stringify({ tasks: [valid, { ...valid, id: 3 }, { ...valid, pos: { x: Number.NaN, y: 0 } }] }));
-    expect(loadTasks(filePath)).toEqual([valid]);
+    expect(() => loadTasks(filePath)).toThrow("invalid persisted task row");
     expect(isTask(valid)).toBe(true);
   });
 
@@ -469,7 +469,7 @@ describe("task delivery assembly", () => {
   });
 
   test("task launch replay updates one assignment by durable launch identity", () => {
-    const launchId = "9173e9a2-2f14-4a70-818a-bd4052a1ad4a";
+    const launchId = crypto.randomUUID();
     const conversationId = "conversation_ac6029b9";
     const pending = mergeAssignments([], [{
       launchId,
@@ -512,4 +512,21 @@ describe("task delivery assembly", () => {
     expect(pinnedAccountId(assignments, "claude")).toBe("claude-work");
     expect(pinnedAccountId(assignments, "codex")).toBe("codex-work");
   });
+});
+
+
+test("placement guards leave unrelated content callers compatible and validate against the selected row", () => {
+  const original = task();
+  expect(patchTask([original], original.id, { text: "content" }).ok).toBe(true);
+  const missing = patchTask([original], original.id, { pos: { x: 1, y: 2 } }, undefined, { requirePlacementGuards: true });
+  expect(missing).toMatchObject({ ok: false, code: "TASK_INVALID_FIELD", field: "expectedProject" });
+  expect(patchTask([original], original.id, { text: "content", expectedProject: "proj" })).toMatchObject({ ok: false, field: "expectedRevision" });
+  expect(patchTask([original], original.id, { placement: "pinned" }).ok).toBe(true);
+  const unplaced = patchTask([original], original.id, { placement: "unplaced", pos: { x: -0.5, y: 0 } });
+  expect(unplaced.ok).toBe(true);
+  if (unplaced.ok) expect(unplaced.task.pos).toBeUndefined();
+  for (const pos of [null, {}, { x: 0 }, { x: 0, y: Infinity }, { x: NaN, y: 0 }]) {
+    expect(patchTask([original], original.id, { pos })).toMatchObject({ ok: false, code: "TASK_INVALID_FIELD" });
+  }
+  expect(original).toEqual(task());
 });


### PR DESCRIPTION
Viewer MCP advertised pinned task placement without coordinates and accepted placement updates without checking the current project or revision. This first increment exposes finite `pos: { x, y }` and requires `expectedProject` plus an opaque `expectedRevision` for MCP placement updates, checked inside the existing task-store transaction.

Task reads and successful mutations return the committed generation. All four central store writers maintain generations, including in-place assignment changes; legacy reads remain read-only, malformed existing state refuses writes, and untouched rows retain their stored fields. Existing HTTP and content-only callers remain compatible. Completed MCP receipts replay their original result after restart and later task deletion.

Refs #631 and its [September 5 scope decision](https://github.com/Latand/live-log-viewer-next/issues/631#issuecomment-5549484859). This delivers the approved first increment. Batch/cluster arrangement, Kanban column/rank semantics, collisions, board changes, and desktop/mobile production rendering remain deferred under the open umbrella issue. Deployment is outside this PR.

Validation:

- Causal baseline RED at `2dce06a8`: real SDK tools/list omits coordinates; real registered task calls accept foreign-project and stale placement updates; successful create has no revision. Those assertions are GREEN with this change.
- Isolated real SDK → production bindings → commands/store tests: persisted readback, byte-identical refusals, SQLite receipt restart/replay, same-key payload conflicts, actual HTTP POST/PATCH parity, unrelated-field preservation, and two independent processes racing identical coordinates under one revision with a frozen clock.
- Revision tests: all four store writers, content/assignment/position ABA, same-time replacement, deletion/recreation, legacy extension fields and receipts, malformed state, actual runtime acknowledgment, and actual reconciliation.
- Focused files: schema parity 21, bindings 58, task commands/store 34, revision 5, task-position integration 7, task create 22, assignment route 2, send route 1, spawn route 12, spawn binding 6, curator 4, inbox scanner 4 tests passed. Writer concurrency has 3 passing task/lock cases.
- Nonincremental TypeScript, production build including MCP bundle, diff checks, and privacy publication gate passed.
- Pre-existing limitations reproduced on the baseline: two pipeline cases in writer concurrency time out waiting for their barrier; the task GET fixture expects a JSON pipeline mirror absent under the current SQLite store; ESLint crashes in the React plugin before producing a lint verdict. These are not counted as passing checks.

Two fresh independent reviews must approve the same head and base before the guarded merge. Hosted check results are attached to this PR.
