### PR TITLE
fix(runtime-host): token-free localhost beside an authenticated tailnet entry (#1547)

### DIFF
--- a/.github/workflows/bun-runtime.yml
+++ b/.github/workflows/bun-runtime.yml
@@ -90,6 +90,24 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # The stable listener is the runtime host's front (#1547): the raw pipe
+      # and, on a host that opted in, the node:http local entry beside the
+      # authenticated remote entry. Both are driven here over real loopback
+      # listeners against the Viewer's real gate, under the pinned interpreter,
+      # because whether a reader that walked away is reported and whether an
+      # Upgrade socket is writable are decided by the interpreter's node:http
+      # (1.3.3 has neither), and this is the job that runs the pin.
+      - name: Exercise the stable listener under the pinned Bun
+        shell: bash
+        run: |
+          set -euo pipefail
+          front=src/runtime-host/deploymentProxy.test.ts
+          if [[ ! -f "$front" ]]; then
+            echo "$front is named here but is not in the tree" >&2
+            exit 1
+          fi
+          bun test "$front"
+
       # A check is evidence only if it can go red, and "it goes red, I ran it"
       # is the claim three rounds of #1248 could not attribute to anything.
       # These are the tests that hold the two verdicts: an empty target list is

--- a/.github/workflows/bun-runtime.yml
+++ b/.github/workflows/bun-runtime.yml
@@ -90,24 +90,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # The stable listener is the runtime host's front (#1547): the raw pipe
-      # and, on a host that opted in, the node:http local entry beside the
-      # authenticated remote entry. Both are driven here over real loopback
-      # listeners against the Viewer's real gate, under the pinned interpreter,
-      # because whether a reader that walked away is reported and whether an
-      # Upgrade socket is writable are decided by the interpreter's node:http
-      # (1.3.3 has neither), and this is the job that runs the pin.
-      - name: Exercise the stable listener under the pinned Bun
-        shell: bash
-        run: |
-          set -euo pipefail
-          front=src/runtime-host/deploymentProxy.test.ts
-          if [[ ! -f "$front" ]]; then
-            echo "$front is named here but is not in the tree" >&2
-            exit 1
-          fi
-          bun test "$front"
-
       # A check is evidence only if it can go red, and "it goes red, I ran it"
       # is the claim three rounds of #1248 could not attribute to anything.
       # These are the tests that hold the two verdicts: an empty target list is
@@ -124,6 +106,7 @@ jobs:
             scripts/verify-viewer-runtime.test.ts
             src/runtime-host/hostRehearsal.test.ts
             src/runtime-host/hostRehearsalRun.test.ts
+            src/runtime-host/deploymentProxy.test.ts
           )
           # `bun test` exits 0 for a path that is not there, so a file deleted
           # out from under this step would shrink what it holds and leave the

--- a/README.md
+++ b/README.md
@@ -467,6 +467,11 @@ inside the tailnet via `tailscale serve` and guarded by the token gate in
 `src/proxy.ts`. Non-loopback binds also force token mode. Treat any URL
 containing `?k=` as a credential.
 
+A Docker-deployed runtime host on a personal workstation can keep `LLV_TOKEN`
+for the tailnet while serving plain `http://127.0.0.1:8898/` token-free, by
+splitting its stable listener into a local entry and an authenticated remote
+entry; see [docs/docker.md](docs/docker.md#personal-workstation-token-free-localhost-authenticated-tailnet).
+
 ## Environment variables
 
 All optional. Transcription variables are documented in full in

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -135,6 +135,96 @@ The Compose `viewer` service exists only for the one-time listener migration. It
 `legacy-viewer-migration` profile and `LLV_ALLOW_LEGACY_VIEWER=1` launch grant
 must both be present.
 
+### Personal workstation: token-free localhost, authenticated tailnet
+
+Once `LLV_TOKEN` is configured, the Viewer authenticates every connection,
+loopback included (#1496). On a shared host that is the whole point. On a
+personal workstation it means the operator's own browser at
+`http://127.0.0.1:8898/` gets a 403, while the same port is also where
+Tailscale Serve delivers the tailnet, so the Viewer cannot tell the two apart
+from the connection: both arrive from 127.0.0.1, and `Host` or `X-Forwarded-*`
+say only what the caller wrote (#1547).
+
+Runtime-host can split the stable listener into two entries, decided by which
+listener the kernel accepted the connection on:
+
+- the **remote entry**, a second loopback port for Tailscale Serve to target.
+  It is the same raw pipe port 8898 has always been, so the Viewer's own gate
+  (cookie, bearer, `?k=` link) keeps authenticating it;
+- the **local entry**, port 8898 itself, which once marked trusted forwards
+  each request whose `Host` names loopback with the release's own credential.
+  A DNS-rebound page in the browser reaches the same port with the attacker's
+  `Host` and is not vouched for; the Viewer's gate refuses it as before.
+
+Nothing changes without the gateway file, and the Viewer image, `src/proxy.ts`
+and the CLI's `--tailscale` path are untouched. The file lives in the state
+directory beside `viewer-release.json`:
+
+```json
+{ "remoteEntryPort": 8897, "localEntry": "trusted" }
+```
+
+Whether port 8898 is the raw pipe or the local entry is read once, when a
+runtime-host generation boots. `localEntry` is read again on every request, so
+trust is granted and withdrawn by editing the file, with no restart. A file
+that cannot be read as this configuration — unknown key, unknown value, a
+remote port equal to the local one, malformed JSON — counts as absent at boot
+and as `"authenticated"` per request, and the boot log names the reason.
+
+**Setup**, on a host whose runtime-host image carries this change. Order
+matters: the tailnet moves to the authenticated entry before the local entry
+is trusted, so no remote traffic ever reaches a token-free listener.
+
+```bash
+state="${XDG_CONFIG_HOME:-$HOME/.config}/agent-log-viewer/state"
+
+# 1. Name the remote entry only. The local entry stays authenticated.
+printf '%s\n' '{ "remoteEntryPort": 8897 }' > "$state/viewer-gateway.json.next" \
+  && mv "$state/viewer-gateway.json.next" "$state/viewer-gateway.json"
+
+# 2. Boot a runtime-host generation on this image (see the host-only bootstrap
+#    above). Its log reports: viewer gateway: local entry 127.0.0.1:8898 is
+#    authenticated at boot (re-read per request); remote entry 127.0.0.1:8897
+docker compose --profile runtime-host logs --tail 20 runtime-host
+
+# 3. Point the tailnet at the remote entry and confirm it still authenticates.
+#    Only the https=443 handler changes; other serve/funnel handlers stay.
+tailscale serve --bg --https=443 http://127.0.0.1:8897
+tailscale serve status
+curl --silent --output /dev/null --write-out '%{http_code}\n' http://127.0.0.1:8897/   # 403
+
+# 4. Trust the local entry. Effective on the next request.
+printf '%s\n' '{ "remoteEntryPort": 8897, "localEntry": "trusted" }' > "$state/viewer-gateway.json.next" \
+  && mv "$state/viewer-gateway.json.next" "$state/viewer-gateway.json"
+curl --silent --output /dev/null --write-out '%{http_code}\n' http://127.0.0.1:8898/   # 200
+curl --silent --output /dev/null --write-out '%{http_code}\n' -H 'Host: attacker.example' http://127.0.0.1:8898/   # 403
+```
+
+The credential the local entry vouches with is the promoted release
+container's, read from its Compose snapshot under
+`state/deployments/compose/`; a release published before snapshots existed
+falls back to the runtime-host container's own `LLV_TOKEN`. If neither names
+a token the entry stays authenticated and logs it once.
+
+**Rollback.** Withdrawing trust is one file edit and takes effect on the next
+request; removing the gateway entirely takes a host restart because the
+listener kind is chosen at boot.
+
+```bash
+# Withdraw trust only: 8898 authenticates again, the tailnet keeps working.
+printf '%s\n' '{ "remoteEntryPort": 8897 }' > "$state/viewer-gateway.json.next" \
+  && mv "$state/viewer-gateway.json.next" "$state/viewer-gateway.json"
+
+# Full rollback: tailnet back on 8898, gateway file gone, host generation restarted.
+tailscale serve --bg --https=443 http://127.0.0.1:8898
+rm "$state/viewer-gateway.json"
+```
+
+Under the Bun the image pins (1.4.0) the local entry relays Upgrade requests
+and tears down a Viewer stream whose reader went away; Bun 1.3.3's node:http
+does neither, which is one more reason the runtime host runs only under the
+pin. On a shared host, leave the file absent.
+
 ## Legacy tmux supervisor migration
 
 The Viewer listens on `127.0.0.1:8898`. Legacy tmux panes acquire a separate user-service owner only after the explicitly approved migration. The service runs a foreground tmux server at `/run/user/1000/agent-log-viewer`, then bootstraps the canonical `agents` session.

--- a/src/runtime-host/deploymentProxy.test.ts
+++ b/src/runtime-host/deploymentProxy.test.ts
@@ -1,13 +1,26 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs/promises";
+import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { NextRequest } from "next/server";
 
-import { serveViewerDeploymentProxy } from "./deploymentProxy";
+import { proxy as viewerGate } from "@/proxy";
+
+import { viewerComposeSnapshotPath } from "./deploymentArtifacts";
+import {
+  isLoopbackHost,
+  parseViewerGatewayConfig,
+  readViewerGatewayConfig,
+  serveViewerDeploymentProxy,
+  serveViewerLocalEntry,
+  viewerReleaseCredentialResolver,
+} from "./deploymentProxy";
 
 async function listen(server: net.Server): Promise<number> {
   server.listen(0, "127.0.0.1");
@@ -20,6 +33,19 @@ async function listen(server: net.Server): Promise<number> {
 async function close(server: net.Server): Promise<void> {
   if (!server.listening) return;
   await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/** Every socket a server accepts, so a test can dispose of them itself. Bun
+    1.4.0 never reports `end` or `close` on a raw socket the proxy already
+    ended when its peer then closes, and `server.close()` waits for that
+    report forever; the fixture owns the teardown instead of the runtime. */
+function ownAccepted(server: net.Server): { destroyAll: () => void } {
+  const accepted = new Set<net.Socket>();
+  server.on("connection", (socket) => {
+    accepted.add(socket);
+    socket.once("close", () => accepted.delete(socket));
+  });
+  return { destroyAll: () => { for (const socket of accepted) socket.destroy(); } };
 }
 
 async function request(port: number): Promise<string> {
@@ -46,6 +72,7 @@ test("deployment proxy forwards an immediate request through a real TCP connecti
       socket.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 7\r\n\r\nproxied");
     });
   });
+  const upstreamSockets = ownAccepted(upstream);
   const upstreamPort = await listen(upstream);
   await fs.writeFile(targetFile, JSON.stringify({
     revision: "abc123",
@@ -55,6 +82,7 @@ test("deployment proxy forwards an immediate request through a real TCP connecti
   }));
 
   const proxy = serveViewerDeploymentProxy(targetFile, 0);
+  const proxySockets = ownAccepted(proxy);
   await once(proxy, "listening");
   const proxyAddress = proxy.address();
   if (!proxyAddress || typeof proxyAddress === "string") throw new Error("proxy did not bind a TCP port");
@@ -64,6 +92,8 @@ test("deployment proxy forwards an immediate request through a real TCP connecti
     expect(response).toContain("HTTP/1.1 200 OK");
     expect(response).toEndWith("proxied");
   } finally {
+    proxySockets.destroyAll();
+    upstreamSockets.destroyAll();
     await close(proxy);
     await close(upstream);
     await fs.rm(directory, { recursive: true, force: true });
@@ -95,5 +125,476 @@ test("a failed write on the stable listener ends the connection, not the runtime
   } finally {
     await close(proxy);
     await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+/* ------------------------------------------------------------------------ */
+/* The Viewer gateway (#1547): two real loopback listeners in front of the   */
+/* Viewer's real gate.                                                       */
+/* ------------------------------------------------------------------------ */
+
+const originalToken = process.env.LLV_TOKEN;
+afterEach(() => {
+  if (originalToken === undefined) delete process.env.LLV_TOKEN;
+  else process.env.LLV_TOKEN = originalToken;
+});
+
+/** Whether this interpreter's node:http reports a downstream that went away
+    and hands Upgrade sockets over writable. The image pins 1.4.0, which does
+    both; 1.3.3 does neither, and the runtime host never runs there. */
+const pinnedInterpreterBehaviour = Bun.semver.satisfies(Bun.version, ">=1.4.0");
+
+interface Seen {
+  method: string;
+  path: string;
+  host: string | undefined;
+  /** The gate admitted the request on the release credential this Viewer enforces. */
+  vouched: boolean;
+  body: string;
+}
+
+interface GatedViewer {
+  port: number;
+  seen: Seen[];
+  /** Resolves once a streaming response saw its downstream go away. */
+  streamClosed: Promise<void>;
+  close: () => Promise<void>;
+}
+
+/** A Viewer that is the real gate (`src/proxy.ts`) over node:http, answering
+    JSON about what it saw, or a two-chunk stream on `/stream`. */
+async function gatedViewer(token: string): Promise<GatedViewer> {
+  process.env.LLV_TOKEN = token;
+  const seen: Seen[] = [];
+  let markStreamClosed = () => undefined as void;
+  const streamClosed = new Promise<void>((resolve) => { markStreamClosed = resolve; });
+  const server = http.createServer(async (incoming, outgoing) => {
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(incoming.headers)) {
+      if (Array.isArray(value)) for (const entry of value) headers.append(name, entry);
+      else if (value !== undefined) headers.set(name, value);
+    }
+    let body = "";
+    for await (const chunk of incoming) body += chunk;
+    const decision = viewerGate(new NextRequest(`http://${incoming.headers.host ?? "viewer"}${incoming.url ?? "/"}`, { headers }));
+    const admitted = decision.headers.get("x-middleware-next") === "1";
+    seen.push({
+      method: incoming.method ?? "",
+      path: incoming.url ?? "",
+      host: incoming.headers.host,
+      vouched: admitted && incoming.headers.authorization === `Bearer ${token}`,
+      body,
+    });
+    if (!admitted) {
+      outgoing.writeHead(decision.status, Object.fromEntries(decision.headers));
+      outgoing.end(Buffer.from(await decision.arrayBuffer()));
+      return;
+    }
+    if (incoming.url?.startsWith("/stream")) {
+      outgoing.writeHead(200, { "content-type": "text/event-stream" });
+      outgoing.write("data: first\n\n");
+      const ticker = setInterval(() => outgoing.write("data: tick\n\n"), 40);
+      outgoing.on("close", () => { clearInterval(ticker); markStreamClosed(); });
+      if (incoming.url === "/stream") setTimeout(() => { clearInterval(ticker); outgoing.end("data: last\n\n"); }, 250);
+      return;
+    }
+    outgoing.writeHead(200, { "content-type": "application/json" });
+    outgoing.end(JSON.stringify({ path: incoming.url, method: incoming.method }));
+  });
+  const port = await listen(server);
+  return { port, seen, streamClosed, close: () => close(server) };
+}
+
+interface Gateway {
+  stateDir: string;
+  gatewayFile: string;
+  token: string;
+  viewer: GatedViewer;
+  reported: string[];
+  local: http.Server;
+  localPort: number;
+  remote: net.Server;
+  remotePort: number;
+  configure: (config: unknown) => Promise<void>;
+  close: () => Promise<void>;
+}
+
+/** Both entries on ephemeral ports, a release target naming the gated Viewer,
+    its Compose snapshot carrying the credential, and the gateway file. */
+async function gateway(options: { localEntry?: "trusted" | "authenticated"; credential?: "snapshot" | "none" } = {}): Promise<Gateway> {
+  const token = randomBytes(16).toString("hex");
+  const viewer = await gatedViewer(token);
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "llv-viewer-gateway-"));
+  const container = "llv-deploy-gateway-test";
+  await fs.writeFile(path.join(stateDir, "viewer-release.json"), JSON.stringify({
+    revision: "abc123",
+    image: "viewer:test",
+    container,
+    endpoint: `http://127.0.0.1:${viewer.port}`,
+  }));
+  if (options.credential !== "none") {
+    const snapshot = viewerComposeSnapshotPath(stateDir, container);
+    await fs.mkdir(path.dirname(snapshot), { recursive: true });
+    await fs.writeFile(snapshot, JSON.stringify({ services: { viewer: { environment: { LLV_TOKEN: token } } } }));
+  }
+  const gatewayFile = path.join(stateDir, "viewer-gateway.json");
+  const configure = async (config: unknown) => {
+    const staged = `${gatewayFile}.next`;
+    await fs.writeFile(staged, typeof config === "string" ? config : JSON.stringify(config));
+    await fs.rename(staged, gatewayFile);
+  };
+  const remote = serveViewerDeploymentProxy(path.join(stateDir, "viewer-release.json"), 0);
+  const remoteSockets = ownAccepted(remote);
+  await once(remote, "listening");
+  const remoteAddress = remote.address();
+  if (!remoteAddress || typeof remoteAddress === "string") throw new Error("remote entry did not bind a TCP port");
+  const remotePort = remoteAddress.port;
+  await configure({ remoteEntryPort: remotePort, localEntry: options.localEntry ?? "trusted" });
+  const reported: string[] = [];
+  /* The local entry's own port is only known after listen, and the parser
+     refuses a remote port equal to it; port 0 here never equals a bound one. */
+  const local = serveViewerLocalEntry(path.join(stateDir, "viewer-release.json"), 0, "127.0.0.1", {
+    gatewayFile,
+    releaseCredential: viewerReleaseCredentialResolver(stateDir, {}),
+    report: (line) => reported.push(line),
+  });
+  await once(local, "listening");
+  const localAddress = local.address();
+  if (!localAddress || typeof localAddress === "string") throw new Error("local entry did not bind a TCP port");
+  return {
+    stateDir, gatewayFile, token, viewer, reported, local, localPort: localAddress.port, remote, remotePort, configure,
+    close: async () => {
+      await close(local);
+      remoteSockets.destroyAll();
+      await close(remote);
+      await viewer.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    },
+  };
+}
+
+interface Answer { status: number; head: string; body: string; connects: number }
+
+async function curl(port: string | number, pathname: string, ...args: string[]): Promise<Answer> {
+  const { stdout } = await promisify(execFile)("curl", [
+    "--http1.1", "--include", "--silent", "--show-error", "--max-time", "5",
+    "--write-out", "\n%{num_connects}",
+    ...args,
+    `http://127.0.0.1:${port}${pathname}`,
+  ]);
+  const connects = Number(stdout.slice(stdout.lastIndexOf("\n") + 1));
+  const raw = stdout.slice(0, stdout.lastIndexOf("\n"));
+  const split = raw.indexOf("\r\n\r\n");
+  const head = raw.slice(0, split);
+  const status = Number(/^HTTP\/1\.1 (\d{3})/.exec(head)?.[1]);
+  return { status, head, body: raw.slice(split + 4), connects };
+}
+
+test("gateway configuration: no file is the default, and anything not a configuration is refused as a whole", () => {
+  expect(parseViewerGatewayConfig(null, 8898)).toEqual({ present: false, config: { remoteEntryPort: null, localEntry: "authenticated" }, problem: null });
+  expect(parseViewerGatewayConfig(JSON.stringify({ remoteEntryPort: 8897, localEntry: "trusted" }), 8898)).toEqual({
+    present: true, config: { remoteEntryPort: 8897, localEntry: "trusted" }, problem: null,
+  });
+  expect(parseViewerGatewayConfig(JSON.stringify({ remoteEntryPort: 8897 }), 8898).config.localEntry).toBe("authenticated");
+  for (const [raw, problem] of [
+    ["{", "not valid JSON"],
+    ["[]", "not a JSON object"],
+    [JSON.stringify({ remoteEntryPort: 8897, localEntry: "trusted", open: true }), "unknown key"],
+    [JSON.stringify({ remoteEntryPort: 8897, localEntry: "open" }), "localEntry must be"],
+    [JSON.stringify({ remoteEntryPort: "8897" }), "remoteEntryPort must be"],
+    [JSON.stringify({ remoteEntryPort: 8898, localEntry: "trusted" }), "is the local entry port"],
+  ] as const) {
+    const reading = parseViewerGatewayConfig(raw, 8898);
+    expect(reading.problem).toContain(problem);
+    // A partially valid file must not keep the half that parsed.
+    expect(reading.config).toEqual({ remoteEntryPort: null, localEntry: "authenticated" });
+  }
+  expect(readViewerGatewayConfig(path.join(os.tmpdir(), `llv-no-such-gateway-${process.pid}.json`), 8898).present).toBe(false);
+
+  for (const host of ["127.0.0.1", "127.0.0.1:8898", "localhost", "LOCALHOST:8898", "[::1]", "[::1]:8898"]) expect(isLoopbackHost(host)).toBe(true);
+  for (const host of [undefined, "", "attacker.example", "attacker.example:8898", "127.0.0.1.attacker.example", "localhost.attacker.example", "203.0.113.7:8898", "::1"]) {
+    expect(isLoopbackHost(host)).toBe(false);
+  }
+});
+
+test("the release credential comes from the release container's Compose snapshot, then the host's own environment", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "llv-viewer-credential-"));
+  try {
+    const target = { revision: "r", image: "i", container: "llv-deploy-credential-test", endpoint: "http://127.0.0.1:1" };
+    expect(viewerReleaseCredentialResolver(stateDir, {})(target)).toBeNull();
+    expect(viewerReleaseCredentialResolver(stateDir, { LLV_TOKEN: "from-environment" })(target)).toBe("from-environment");
+    const snapshot = viewerComposeSnapshotPath(stateDir, target.container);
+    await fs.mkdir(path.dirname(snapshot), { recursive: true });
+    await fs.writeFile(snapshot, JSON.stringify({ services: { viewer: { environment: { LLV_TOKEN: "from-snapshot" } } } }));
+    expect(viewerReleaseCredentialResolver(stateDir, { LLV_TOKEN: "from-environment" })(target)).toBe("from-snapshot");
+    // A release that names no token is a Viewer without a gate: nothing to vouch with.
+    await fs.writeFile(snapshot, JSON.stringify({ services: { viewer: { environment: {} } } }));
+    expect(viewerReleaseCredentialResolver(stateDir, { LLV_TOKEN: "from-environment" })(target)).toBeNull();
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("the trusted local entry admits a plain loopback request, replaces a stale key, and decides every request on a kept-alive connection", async () => {
+  const entry = await gateway();
+  try {
+    const plain = await curl(entry.localPort, "/api/files");
+    expect(plain.status).toBe(200);
+    expect(entry.viewer.seen.at(-1)).toMatchObject({ path: "/api/files", host: `127.0.0.1:${entry.localPort}`, vouched: true });
+
+    const stale = await curl(entry.localPort, "/api/files", "-H", "Authorization: Bearer stale");
+    expect(stale.status).toBe(200);
+    expect(entry.viewer.seen.at(-1)?.vouched).toBe(true);
+
+    // One curl, two URLs: the second request rides the first connection.
+    const { stdout } = await promisify(execFile)("curl", [
+      "--http1.1", "--silent", "--show-error", "--max-time", "5",
+      "--output", "/dev/null", "--output", "/dev/null",
+      "--write-out", "%{http_code} %{num_connects}\n",
+      `http://127.0.0.1:${entry.localPort}/first`, `http://127.0.0.1:${entry.localPort}/second`,
+    ]);
+    expect(stdout).toBe("200 1\n200 0\n");
+    expect(entry.viewer.seen.slice(-2).map((seen) => [seen.path, seen.vouched])).toEqual([["/first", true], ["/second", true]]);
+    expect(entry.reported).toEqual([]);
+  } finally {
+    await entry.close();
+  }
+});
+
+test("the trusted local entry vouches only for a Host that names loopback: a DNS-rebound page is refused by the Viewer's gate", async () => {
+  const entry = await gateway();
+  try {
+    for (const host of ["attacker.example", "attacker.example:8898", "127.0.0.1.attacker.example"]) {
+      const rebound = await curl(entry.localPort, "/api/files", "-H", `Host: ${host}`);
+      expect(rebound.status).toBe(403);
+      expect(entry.viewer.seen.at(-1)).toMatchObject({ host, vouched: false });
+    }
+    // The port in Host is whatever the browser dialled; the name is what matters.
+    const otherPort = await curl(entry.localPort, "/api/files", "-H", "Host: localhost:8898");
+    expect(otherPort.status).toBe(200);
+    expect(entry.viewer.seen.at(-1)).toMatchObject({ host: "localhost:8898", vouched: true });
+  } finally {
+    await entry.close();
+  }
+});
+
+test("the remote entry rejects an unauthenticated request whatever local identity its headers forge", async () => {
+  const entry = await gateway();
+  try {
+    const forged = await curl(
+      entry.remotePort, "/api/files",
+      "-H", "Host: 127.0.0.1:8898",
+      "-H", "X-Forwarded-For: 127.0.0.1",
+      "-H", "X-Real-IP: 127.0.0.1",
+      "-H", "Forwarded: for=127.0.0.1;host=127.0.0.1:8898",
+      "-H", "X-Forwarded-Host: localhost",
+      "-H", "Cookie: llv_auth=not-the-key",
+    );
+    expect(forged.status).toBe(403);
+    expect(entry.viewer.seen.at(-1)).toMatchObject({ path: "/api/files", vouched: false });
+
+    const page = await curl(entry.remotePort, "/", "-H", "Host: 127.0.0.1:8898");
+    expect(page.status).toBe(403);
+    expect(page.body).toContain("Access denied");
+    expect(page.body).not.toContain(entry.token);
+  } finally {
+    await entry.close();
+  }
+});
+
+test("the remote entry admits the Viewer's own credentials: bearer, cookie, and the ?k= link that mints the cookie", async () => {
+  const entry = await gateway();
+  try {
+    const bearer = await curl(entry.remotePort, "/api/files", "-H", `Authorization: Bearer ${entry.token}`);
+    expect(bearer.status).toBe(200);
+
+    const cookie = await curl(entry.remotePort, "/api/files", "-H", `Cookie: llv_auth=${entry.token}`);
+    expect(cookie.status).toBe(200);
+
+    const link = await curl(entry.remotePort, `/?k=${entry.token}`);
+    expect(link.status).toBe(307);
+    expect(link.head).toMatch(/set-cookie: llv_auth=/i);
+    expect(link.head).toMatch(/location: [^\r\n]*\/\r?$|location: [^\r\n]*\/$/im);
+    expect(/location: [^\r\n]*k=/i.test(link.head)).toBe(false);
+  } finally {
+    await entry.close();
+  }
+});
+
+test("the local entry fails closed and flips live: authenticated, unreadable, unknown, or credential-less gateways all leave the gate in charge", async () => {
+  const entry = await gateway({ localEntry: "authenticated" });
+  try {
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+    expect(entry.viewer.seen.at(-1)?.vouched).toBe(false);
+    // The caller's own credential still travels through an authenticated entry.
+    expect((await curl(entry.localPort, "/api/files", "-H", `Authorization: Bearer ${entry.token}`)).status).toBe(200);
+
+    await entry.configure("{ not json");
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+    expect(entry.reported.filter((line) => line.includes("not valid JSON"))).toHaveLength(1);
+    // Dozens of requests, one line.
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+    expect(entry.reported.filter((line) => line.includes("not valid JSON"))).toHaveLength(1);
+
+    await entry.configure({ remoteEntryPort: entry.remotePort, localEntry: "open" });
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+
+    await entry.configure({ remoteEntryPort: entry.remotePort, localEntry: "trusted", extra: 1 });
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+
+    // Trusted, no restart, the next request is admitted.
+    await entry.configure({ remoteEntryPort: entry.remotePort, localEntry: "trusted" });
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(200);
+    expect(entry.viewer.seen.at(-1)?.vouched).toBe(true);
+
+    // And withdrawn the same way.
+    await entry.configure({ remoteEntryPort: entry.remotePort, localEntry: "authenticated" });
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+
+    for (const line of entry.reported) expect(line).not.toContain(entry.token);
+  } finally {
+    await entry.close();
+  }
+});
+
+test("a trusted local entry with no known release credential stays authenticated and says so once", async () => {
+  const entry = await gateway({ credential: "none" });
+  try {
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(403);
+    expect(entry.reported).toHaveLength(1);
+    expect(entry.reported[0]).toContain("no credential is known");
+  } finally {
+    await entry.close();
+  }
+});
+
+test("methods, bodies and streamed responses cross the vouched entry unchanged", async () => {
+  const entry = await gateway();
+  try {
+    const body = "x".repeat(3000);
+    const posted = await curl(entry.localPort, "/api/spawn", "-X", "POST", "-H", "Content-Type: text/plain", "--data-binary", body);
+    expect(posted.status).toBe(200);
+    expect(entry.viewer.seen.at(-1)).toMatchObject({ method: "POST", path: "/api/spawn", vouched: true, body });
+
+    const head = await curl(entry.localPort, "/api/files", "--head");
+    expect(head.status).toBe(200);
+    expect(entry.viewer.seen.at(-1)?.method).toBe("HEAD");
+
+    // Each chunk arrives as the Viewer writes it, well before the stream ends.
+    const arrivals = await new Promise<number[]>((resolve, reject) => {
+      const started = Date.now();
+      const stamps: number[] = [];
+      let text = "";
+      http.get({ host: "127.0.0.1", port: entry.localPort, path: "/stream" }, (response) => {
+        expect(response.statusCode).toBe(200);
+        response.on("data", (chunk: Buffer) => { stamps.push(Date.now() - started); text += chunk; });
+        response.on("end", () => {
+          expect(text.startsWith("data: first\n\n")).toBe(true);
+          expect(text.endsWith("data: last\n\n")).toBe(true);
+          resolve(stamps);
+        });
+      }).on("error", reject);
+    });
+    expect(arrivals.length).toBeGreaterThanOrEqual(2);
+    expect(arrivals[0]).toBeLessThan(150);
+    expect(arrivals.at(-1)! - arrivals[0]).toBeGreaterThanOrEqual(150);
+  } finally {
+    await entry.close();
+  }
+});
+
+test.skipIf(!pinnedInterpreterBehaviour)("a downstream that walks away mid-stream takes its Viewer request with it, and the entry keeps serving", async () => {
+  const entry = await gateway();
+  try {
+    await new Promise<void>((resolve) => {
+      const client = net.createConnection({ host: "127.0.0.1", port: entry.localPort }, () => {
+        client.write(`GET /stream/forever HTTP/1.1\r\nHost: 127.0.0.1:${entry.localPort}\r\n\r\n`);
+      });
+      let received = "";
+      client.on("data", (chunk) => {
+        received += chunk;
+        if (received.includes("data: first")) client.destroy();
+      });
+      client.on("error", () => undefined);
+      client.once("close", resolve);
+    });
+    await Promise.race([
+      entry.viewer.streamClosed,
+      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("the Viewer's stream never learned its reader was gone")), 2_000)),
+    ]);
+    expect((await curl(entry.localPort, "/api/files")).status).toBe(200);
+  } finally {
+    await entry.close();
+  }
+});
+
+test.skipIf(!pinnedInterpreterBehaviour)("an Upgrade is relayed through the vouched entry carrying the release credential", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "llv-viewer-gateway-upgrade-"));
+  const token = randomBytes(16).toString("hex");
+  let upstreamHead = "";
+  const upstream = net.createServer((socket) => {
+    socket.once("data", (chunk) => {
+      upstreamHead = chunk.toString("latin1");
+      socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: echo\r\nConnection: Upgrade\r\n\r\n");
+      socket.on("data", (data) => socket.write(Buffer.concat([Buffer.from("echo:"), Buffer.from(data)])));
+    });
+    socket.on("error", () => undefined);
+  });
+  const upstreamPort = await listen(upstream);
+  await fs.writeFile(path.join(stateDir, "viewer-release.json"), JSON.stringify({
+    revision: "abc123", image: "viewer:test", container: "llv-deploy-upgrade-test", endpoint: `http://127.0.0.1:${upstreamPort}`,
+  }));
+  await fs.writeFile(path.join(stateDir, "viewer-gateway.json"), JSON.stringify({ localEntry: "trusted" }));
+  const local = serveViewerLocalEntry(path.join(stateDir, "viewer-release.json"), 0, "127.0.0.1", {
+    gatewayFile: path.join(stateDir, "viewer-gateway.json"),
+    releaseCredential: () => token,
+  });
+  await once(local, "listening");
+  const address = local.address();
+  if (!address || typeof address === "string") throw new Error("local entry did not bind a TCP port");
+  try {
+    const echoed = await new Promise<string>((resolve, reject) => {
+      const client = net.createConnection({ host: "127.0.0.1", port: address.port }, () => {
+        client.write(`GET /live HTTP/1.1\r\nHost: 127.0.0.1:${address.port}\r\nConnection: Upgrade\r\nUpgrade: echo\r\nAuthorization: Bearer stale\r\n\r\n`);
+      });
+      let received = "";
+      client.on("data", (chunk) => {
+        received += chunk;
+        if (received.includes("\r\n\r\n") && !received.includes("echo:")) client.write("ping");
+        if (received.includes("echo:ping")) { client.destroy(); resolve(received); }
+      });
+      client.on("error", reject);
+      setTimeout(() => reject(new Error(`no echo through the upgraded connection; received ${JSON.stringify(received)}`)), 3_000);
+    });
+    expect(echoed).toStartWith("HTTP/1.1 101 Switching Protocols");
+    expect(upstreamHead).toMatch(/^GET \/live HTTP\/1\.1\r\n/);
+    expect(upstreamHead).toMatch(/\r\nUpgrade: echo\r\n/i);
+    expect(upstreamHead).toMatch(/\r\nConnection: Upgrade\r\n/i);
+    expect(upstreamHead).toContain(`Authorization: Bearer ${token}`);
+    expect(upstreamHead).not.toContain("Bearer stale");
+  } finally {
+    await close(local);
+    await close(upstream);
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("without a release target the local entry answers 503 and stays up", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "llv-viewer-gateway-notarget-"));
+  await fs.writeFile(path.join(stateDir, "viewer-gateway.json"), JSON.stringify({ localEntry: "trusted" }));
+  const local = serveViewerLocalEntry(path.join(stateDir, "viewer-release.json"), 0, "127.0.0.1", {
+    gatewayFile: path.join(stateDir, "viewer-gateway.json"),
+    releaseCredential: () => "unused",
+  });
+  await once(local, "listening");
+  const address = local.address();
+  if (!address || typeof address === "string") throw new Error("local entry did not bind a TCP port");
+  try {
+    expect((await curl(address.port, "/")).status).toBe(503);
+    expect((await curl(address.port, "/api/files")).status).toBe(503);
+  } finally {
+    await close(local);
+    await fs.rm(stateDir, { recursive: true, force: true });
   }
 });

--- a/src/runtime-host/deploymentProxy.ts
+++ b/src/runtime-host/deploymentProxy.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
+import http from "node:http";
 import net from "node:net";
 
 import type { ViewerReleaseIdentity } from "@/lib/runtime/contracts";
+
+import { viewerComposeSnapshotPath } from "./deploymentArtifacts";
 
 function readTarget(filename: string): ViewerReleaseIdentity | null {
   try {
@@ -15,6 +18,8 @@ function readTarget(filename: string): ViewerReleaseIdentity | null {
     return null;
   }
 }
+
+const UNAVAILABLE = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
 
 /** Each accepted connection reads one atomically replaced release target. */
 export function serveViewerDeploymentProxy(targetFile: string, port = 8898, host = "127.0.0.1"): net.Server {
@@ -33,12 +38,12 @@ export function serveViewerDeploymentProxy(targetFile: string, port = 8898, host
     });
     const target = readTarget(targetFile);
     if (!target) {
-      downstream.end("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+      downstream.end(UNAVAILABLE);
       return;
     }
     const endpoint = new URL(target.endpoint);
     if (Number(endpoint.port) === port) {
-      downstream.end("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+      downstream.end(UNAVAILABLE);
       return;
     }
     upstream = net.createConnection({ host: endpoint.hostname, port: Number(endpoint.port) });
@@ -50,6 +55,304 @@ export function serveViewerDeploymentProxy(targetFile: string, port = 8898, host
     upstream.pipe(downstream);
     downstream.resume();
     downstream.once("close", () => upstream?.destroy());
+  });
+  server.listen(port, host);
+  return server;
+}
+
+/*
+ * The Viewer gateway (#1547).
+ *
+ * The Viewer authenticates every connection once LLV_TOKEN is configured,
+ * because loopback is shared by every OS account on a shared host (#1496).
+ * On a personal workstation that loopback is one human — but the stable
+ * listener is also where Tailscale Serve delivers the tailnet, so the Viewer
+ * cannot tell the operator's browser from a tailnet peer: both arrive from
+ * 127.0.0.1 on the same port, and `Host` or `X-Forwarded-*` say only what the
+ * caller wrote.
+ *
+ * The split therefore happens where the kernel already knows the answer —
+ * which listener accepted the connection — and only in this front, which owns
+ * the stable ports across Viewer generations. A gateway file in the state
+ * directory opts a host in:
+ *
+ *   - the *remote entry* is a second loopback port for Tailscale Serve to
+ *     target. It is the raw pipe above, exactly what the stable port has always
+ *     been, so the Viewer's own gate (cookie, bearer, `?k=` link) keeps deciding;
+ *   - the *local entry* is the stable port, served through node:http so that
+ *     every request on a connection is seen. When the file marks it trusted, a
+ *     request whose Host names loopback is forwarded with the release's own
+ *     credential in `Authorization`. Trust comes from the listener; the Host
+ *     restriction additionally keeps a DNS-rebound page in the operator's
+ *     browser, which reaches this same loopback port carrying the attacker's
+ *     Host, from being vouched for.
+ *
+ * Without a gateway file nothing here runs: the stable port stays the raw pipe.
+ * A file that cannot be read as a configuration counts as no file at boot, and
+ * as "authenticated" per request, so every unknown state is the strict one.
+ */
+
+export const VIEWER_GATEWAY_FILE = "viewer-gateway.json";
+
+export interface ViewerGatewayConfig {
+  /** Loopback port of the authenticated remote entry, bound at host start;
+      null means no remote entry. */
+  remoteEntryPort: number | null;
+  /** "authenticated": the local entry forwards requests as they are and the
+      Viewer's gate applies. "trusted": it vouches for loopback-addressed
+      requests. Re-read per request, so this flips without a restart. */
+  localEntry: "authenticated" | "trusted";
+}
+
+export const DEFAULT_VIEWER_GATEWAY: ViewerGatewayConfig = { remoteEntryPort: null, localEntry: "authenticated" };
+
+export interface ViewerGatewayReading {
+  /** Whether a file was there at all. */
+  present: boolean;
+  config: ViewerGatewayConfig;
+  /** Why the file's contents were ignored. Any problem yields the default
+      configuration as a whole: a half-read gateway is not a configuration. */
+  problem: string | null;
+}
+
+const GATEWAY_KEYS = new Set(["remoteEntryPort", "localEntry"]);
+
+function closed(problem: string): ViewerGatewayReading {
+  return { present: true, config: { ...DEFAULT_VIEWER_GATEWAY }, problem };
+}
+
+/** Pure. `localEntryPort` is the stable port, which the remote entry may not share. */
+export function parseViewerGatewayConfig(raw: string | null, localEntryPort: number): ViewerGatewayReading {
+  if (raw === null) return { present: false, config: { ...DEFAULT_VIEWER_GATEWAY }, problem: null };
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return closed("not valid JSON");
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return closed("not a JSON object");
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (!GATEWAY_KEYS.has(key)) return closed(`unknown key ${JSON.stringify(key)}`);
+  }
+  let remoteEntryPort: number | null = null;
+  if (record.remoteEntryPort !== undefined && record.remoteEntryPort !== null) {
+    const port = record.remoteEntryPort;
+    if (typeof port !== "number" || !Number.isInteger(port) || port < 1 || port > 65535) return closed("remoteEntryPort must be an integer port");
+    if (port === localEntryPort) return closed(`remoteEntryPort ${port} is the local entry port`);
+    remoteEntryPort = port;
+  }
+  let localEntry: ViewerGatewayConfig["localEntry"] = "authenticated";
+  if (record.localEntry !== undefined) {
+    if (record.localEntry !== "authenticated" && record.localEntry !== "trusted") {
+      return closed(`localEntry must be "authenticated" or "trusted"`);
+    }
+    localEntry = record.localEntry;
+  }
+  return { present: true, config: { remoteEntryPort, localEntry }, problem: null };
+}
+
+/** A missing file is the default; an unreadable one is the default with a reason. */
+export function readViewerGatewayConfig(filename: string, localEntryPort: number): ViewerGatewayReading {
+  let raw: string | null;
+  try {
+    raw = fs.readFileSync(filename, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") raw = null;
+    else return closed(`unreadable: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return parseViewerGatewayConfig(raw, localEntryPort);
+}
+
+/**
+ * The credential the promoted Viewer enforces, from its release container's
+ * Compose snapshot — the same file the MCP control client reads (#1511). A
+ * release published before snapshots existed has none, and then the host's
+ * own `LLV_TOKEN` is the machine's one remaining statement of that credential.
+ * A snapshot that names no token is a Viewer with no gate: nothing to vouch.
+ */
+export function viewerReleaseCredentialResolver(
+  stateDir: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): (target: ViewerReleaseIdentity) => string | null {
+  return (target) => {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(viewerComposeSnapshotPath(stateDir, target.container), "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return null;
+      return env.LLV_TOKEN?.trim() || null;
+    }
+    try {
+      const compose = JSON.parse(raw) as { services?: { viewer?: { environment?: { LLV_TOKEN?: unknown } } } };
+      const token = compose?.services?.viewer?.environment?.LLV_TOKEN;
+      return typeof token === "string" && token.trim() ? token : null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+/** The names a browser on this machine reaches the stable port by. Mirrors
+    the allowlist in `src/lib/sameOrigin.ts`, minus the tailnet name: the
+    tailnet never arrives on the local entry once the remote entry exists. */
+const LOOPBACK_HOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/** Pure. Whether a Host header names loopback, on any port. */
+export function isLoopbackHost(host: string | undefined): boolean {
+  if (!host) return false;
+  let name: string;
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    name = end === -1 ? host : host.slice(1, end);
+  } else {
+    const colon = host.lastIndexOf(":");
+    name = colon === -1 ? host : host.slice(0, colon);
+  }
+  return LOOPBACK_HOST_NAMES.has(name.toLowerCase());
+}
+
+/** Connection-scoped headers never cross the hop; node:http frames each hop
+    itself. Forwarding `transfer-encoding` verbatim made Bun 1.3.3 answer
+    `chunked, chunked`. */
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "proxy-connection",
+  "te", "trailer", "transfer-encoding", "upgrade",
+]);
+
+function forwardedHeaders(headers: http.IncomingHttpHeaders): http.OutgoingHttpHeaders {
+  const forwarded: http.OutgoingHttpHeaders = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (HOP_BY_HOP_HEADERS.has(name) || value === undefined) continue;
+    forwarded[name] = value;
+  }
+  return forwarded;
+}
+
+function endpointAddress(target: ViewerReleaseIdentity): { host: string; port: number } {
+  const endpoint = new URL(target.endpoint);
+  return { host: endpoint.hostname.replace(/^\[|\]$/g, ""), port: Number(endpoint.port) };
+}
+
+export interface ViewerLocalEntryOptions {
+  /** Read per request, so trust is granted and withdrawn without a restart. */
+  gatewayFile: string;
+  releaseCredential: (target: ViewerReleaseIdentity) => string | null;
+  report?: (line: string) => void;
+}
+
+/**
+ * The stable port as the gateway's local entry: the same release target per
+ * request, forwarded through node:http. Streaming responses pass through as
+ * they arrive, keep-alive connections carry many requests and each one is
+ * decided on its own, a downstream that walks away takes its upstream request
+ * with it, and an Upgrade is relayed on the raw sockets node:http hands over.
+ */
+export function serveViewerLocalEntry(
+  targetFile: string,
+  port: number,
+  host: string,
+  options: ViewerLocalEntryOptions,
+): http.Server {
+  const report = options.report ?? (() => undefined);
+  /* One line per distinct reason: a page load is dozens of requests and the
+     reason does not change between them. */
+  const reported = new Set<string>();
+  const reportOnce = (line: string) => {
+    if (reported.has(line)) return;
+    if (reported.size >= 64) reported.clear();
+    reported.add(line);
+    report(line);
+  };
+  const vouchedCredential = (target: ViewerReleaseIdentity, hostHeader: string | undefined): string | null => {
+    const gateway = readViewerGatewayConfig(options.gatewayFile, port);
+    if (gateway.problem) {
+      reportOnce(`[runtime host] viewer gateway ${options.gatewayFile} ignored, local entry stays authenticated: ${gateway.problem}`);
+      return null;
+    }
+    if (gateway.config.localEntry !== "trusted") return null;
+    if (!isLoopbackHost(hostHeader)) return null;
+    const credential = options.releaseCredential(target);
+    if (credential === null) {
+      reportOnce(`[runtime host] viewer gateway: local entry is trusted but no credential is known for release container ${target.container}; requests stay authenticated`);
+    }
+    return credential;
+  };
+  const currentTarget = (): ViewerReleaseIdentity | null => {
+    const target = readTarget(targetFile);
+    return target && endpointAddress(target).port !== port ? target : null;
+  };
+
+  const server = http.createServer((request, response) => {
+    const target = currentTarget();
+    if (!target) {
+      response.writeHead(503, { connection: "close", "content-length": "0" });
+      response.end();
+      return;
+    }
+    const headers = forwardedHeaders(request.headers);
+    const credential = vouchedCredential(target, request.headers.host);
+    if (credential !== null) headers.authorization = `Bearer ${credential}`;
+    const upstream = http.request({
+      ...endpointAddress(target),
+      method: request.method,
+      path: request.url,
+      headers,
+    }, (upstreamResponse) => {
+      upstreamResponse.on("error", () => response.destroy());
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.statusMessage, forwardedHeaders(upstreamResponse.headers));
+      upstreamResponse.pipe(response);
+    });
+    upstream.on("error", () => {
+      if (response.headersSent) {
+        response.destroy();
+        return;
+      }
+      response.writeHead(502, { connection: "close", "content-length": "0" });
+      response.end();
+    });
+    const abandon = () => { if (!response.writableFinished) upstream.destroy(); };
+    request.on("error", abandon);
+    response.on("error", abandon);
+    response.on("close", abandon);
+    request.pipe(upstream);
+  });
+
+  server.on("upgrade", (request, downstream, head) => {
+    downstream.on("error", () => downstream.destroy());
+    const target = currentTarget();
+    if (!target) {
+      downstream.end(UNAVAILABLE);
+      return;
+    }
+    const credential = vouchedCredential(target, request.headers.host);
+    const upstream = net.createConnection(endpointAddress(target));
+    upstream.on("error", () => {
+      upstream.destroy();
+      downstream.destroy();
+    });
+    upstream.on("connect", () => {
+      /* The request line and headers as node:http parsed them, re-serialised
+         in their original order and spelling; only Authorization changes when
+         the entry vouches. Connection and Upgrade must cross the hop here. */
+      const lines = [`${request.method} ${request.url} HTTP/${request.httpVersion}`];
+      for (let index = 0; index < request.rawHeaders.length; index += 2) {
+        const name = request.rawHeaders[index];
+        if (credential !== null && name.toLowerCase() === "authorization") continue;
+        lines.push(`${name}: ${request.rawHeaders[index + 1]}`);
+      }
+      if (credential !== null) lines.push(`Authorization: Bearer ${credential}`);
+      upstream.write(`${lines.join("\r\n")}\r\n\r\n`);
+      if (head.length > 0) upstream.write(head);
+      downstream.pipe(upstream);
+      upstream.pipe(downstream);
+    });
+    downstream.once("close", () => upstream.destroy());
+  });
+
+  server.on("clientError", (_error, socket) => {
+    socket.on("error", () => undefined);
+    socket.destroy();
   });
   server.listen(port, host);
   return server;

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -15,7 +15,13 @@ const { createLegacyRuntimeScheduler } = await import("./legacyScheduler");
 const { serveRuntimeHost } = await import("./socket");
 const { ViewerDeploymentCoordinator } = await import("./deployment");
 const { HostCommandViewerDeploymentAdapter } = await import("./deploymentAdapter");
-const { serveViewerDeploymentProxy } = await import("./deploymentProxy");
+const {
+  readViewerGatewayConfig,
+  serveViewerDeploymentProxy,
+  serveViewerLocalEntry,
+  VIEWER_GATEWAY_FILE,
+  viewerReleaseCredentialResolver,
+} = await import("./deploymentProxy");
 const { ReceiptSweepReporter, receiptSweepDebugEnabled } = await import("./receiptSweep");
 const { registryConversationRetentionStates } = await import("./journalRetention");
 const {
@@ -204,12 +210,39 @@ const host = new RuntimeHost(
   mcpHealthProbeAdmissions,
   () => startup.readyEvidence(),
 );
-const deploymentProxy = deployments
-  ? serveViewerDeploymentProxy(
-    process.env.LLV_VIEWER_DEPLOY_TARGET || statePath("viewer-release.json"),
-    Number(process.env.LLV_VIEWER_PORT || 8898),
-  )
+const viewerReleaseTarget = process.env.LLV_VIEWER_DEPLOY_TARGET || statePath("viewer-release.json");
+const viewerFrontPort = Number(process.env.LLV_VIEWER_PORT || 8898);
+/* #1547: a gateway file in the state directory makes the stable port the
+   local entry and binds the authenticated remote entry beside it. Which kind
+   of listener the stable port is gets decided here, once; whether the local
+   entry vouches is the file's `localEntry`, read per request. No file, or a
+   file that is not a configuration, is the raw pipe as before. */
+const viewerGatewayFile = statePath(VIEWER_GATEWAY_FILE);
+const viewerGateway = deployments ? readViewerGatewayConfig(viewerGatewayFile, viewerFrontPort) : null;
+if (viewerGateway?.problem) {
+  console.error(`[runtime host] viewer gateway ${viewerGatewayFile} ignored, stable listener stays the plain pipe: ${viewerGateway.problem}`);
+}
+const viewerGatewayConfig = viewerGateway?.present && viewerGateway.problem === null ? viewerGateway.config : null;
+const deploymentProxy = !deployments
+  ? null
+  : viewerGatewayConfig
+    ? serveViewerLocalEntry(viewerReleaseTarget, viewerFrontPort, "127.0.0.1", {
+      gatewayFile: viewerGatewayFile,
+      releaseCredential: viewerReleaseCredentialResolver(stateDir(), process.env),
+      report: (line) => console.error(line),
+    })
+    : serveViewerDeploymentProxy(viewerReleaseTarget, viewerFrontPort);
+const remoteEntryProxy = viewerGatewayConfig?.remoteEntryPort
+  ? serveViewerDeploymentProxy(viewerReleaseTarget, viewerGatewayConfig.remoteEntryPort)
   : null;
+/* The remote entry failing to bind must not take down the host that owns the
+   stable port and every agent behind it: the tailnet fails closed instead. */
+remoteEntryProxy?.on("error", (error) => {
+  console.error(`[runtime host] viewer gateway remote entry 127.0.0.1:${viewerGatewayConfig?.remoteEntryPort} is unavailable, tailnet access fails closed: ${error.message}`);
+});
+if (viewerGatewayConfig) {
+  console.error(`[runtime host] viewer gateway: local entry 127.0.0.1:${viewerFrontPort} is ${viewerGatewayConfig.localEntry} at boot (re-read per request); remote entry ${viewerGatewayConfig.remoteEntryPort ? `127.0.0.1:${viewerGatewayConfig.remoteEntryPort}` : "none"}`);
+}
 if (journal.isWritable()) await host.recoverConsumers();
 startup.record("consumers-recovered");
 const server = serveRuntimeHost(socketPath, host);
@@ -280,6 +313,7 @@ function stop(): void {
   if (receiptSweepTimer) clearInterval(receiptSweepTimer);
   if (journalMaintenanceTimer) clearInterval(journalMaintenanceTimer);
   deploymentProxy?.close();
+  remoteEntryProxy?.close();
   server.close(() => {
     journal.close();
     fence.release();
@@ -323,6 +357,7 @@ function handOffToStagedSuccessor(context: { deploymentId: string; revision: str
   if (receiptSweepTimer) clearInterval(receiptSweepTimer);
   if (journalMaintenanceTimer) clearInterval(journalMaintenanceTimer);
   deploymentProxy?.close();
+  remoteEntryProxy?.close();
   server.close(() => {
     journal.close();
     fence.release();


### PR DESCRIPTION
Closes #1547.

The operator's own browser at `http://127.0.0.1:8898/` gets a 403 since #1503, because a configured `LLV_TOKEN` now authenticates every connection, loopback included. That default is right on a shared host and stays. On this workstation the same port is also where Tailscale Serve delivers the tailnet, so the Viewer cannot tell the operator from a tailnet peer: both arrive from 127.0.0.1 on one port, and `Host` or `X-Forwarded-*` say only what the caller wrote.

## The proposed split entry, and what survived of it

The issue proposes a genuinely separate local entry and authenticated remote entry. That holds up, with two corrections found while placing it:

1. **It has to live in the runtime host's front, and only there.** The stable port is owned by the runtime host's deployment proxy across Viewer generations; the Viewer itself is `next start` with one listener, and `src/proxy.ts` sees headers, never a socket. So the Viewer cannot learn which port a connection arrived on, and any split at the Viewer would need a second Viewer listener or trust in a header. The front is the process that already knows, and it is the process whose files are byte-identical between the deployed revision and `main`.
2. **The local entry needs one more refusal than "it is loopback".** A DNS-rebound page in the operator's browser reaches the very same loopback port, and `rejectCrossOrigin` guards mutations only. So the trusted entry vouches only for a request whose `Host` names loopback. Trust still comes from the listener; the Host check is a restriction on top, never a source.

## What ships

A gateway file in the state directory opts a host in; nothing changes without it:

```json
{ "remoteEntryPort": 8897, "localEntry": "trusted" }
```

- **Remote entry**: a second loopback port for Tailscale Serve, the raw pipe exactly as 8898 has always been. The Viewer's own gate keeps authenticating it: cookie, bearer, and the `?k=` link that mints the cookie.
- **Local entry**: 8898 served through native `node:http`, so every request on a kept-alive connection is seen. When trusted, a loopback-`Host` request is forwarded with the promoted release's own credential, read from its Compose snapshot (the same file the MCP control client reads since #1511), falling back to the host container's `LLV_TOKEN` for a release that predates snapshots. A caller's stale key is replaced, so a rotation cannot lock a local agent out.
- Which kind of listener 8898 is gets read once at boot. `localEntry` is re-read per request, so trust is granted and withdrawn by editing the file, with no restart. Malformed JSON, an unknown key or value, a remote port equal to the local one, or no known credential: all fail closed to today's behaviour, and the boot log names the reason. A remote port that cannot bind logs and fails closed instead of taking the host down.
- Untouched: the Viewer image, `src/proxy.ts`, the CLI's `--tailscale` path, streaming, methods and bodies, `rejectCrossOrigin`, deployment target switching.

Files: `src/runtime-host/deploymentProxy.ts`, `src/runtime-host/main.ts`, `src/runtime-host/deploymentProxy.test.ts`, `docs/docker.md` (setup, migration order, rollback), `README.md` (pointer), `.github/workflows/bun-runtime.yml` (runs the test file under the pinned Bun).

## Evidence

Tests drive both entries over real loopback listeners against the Viewer's **real gate** (`src/proxy.ts` inside a `node:http` Viewer), with a random per-test credential that never appears in fixtures:

- plain loopback request admitted, stale bearer replaced, two requests on one kept-alive connection each vouched;
- `Host: attacker.example` (and `127.0.0.1.attacker.example`) refused by the gate on the trusted entry; `localhost:8898` admitted;
- remote entry refuses a request forging `Host`, `X-Forwarded-For`, `X-Real-IP`, `Forwarded`, `X-Forwarded-Host` and a wrong cookie; admits bearer, cookie, and `?k=` (307, cookie set, key absent from `Location`);
- authenticated, malformed, unknown-value, unknown-key and credential-less gateways all answer 403; trusted flips to 200 and back on the running listener; one log line per reason, none containing the credential;
- POST body, HEAD, and a two-chunk stream cross unchanged with the second chunk arriving when written;
- a reader that walks away mid-stream ends the Viewer's response, and the entry keeps serving; an Upgrade is relayed carrying the credential.

| check | result |
| --- | --- |
| `bunx tsc --noEmit --incremental false` | exit 0 |
| `bun test src/runtime-host/deploymentProxy.test.ts` under Bun 1.3.3 | 12 pass, 2 skip (the two that need the pinned interpreter) |
| same file under Bun 1.4.0 (the Dockerfile pin) | 14 pass |
| `bun test src/proxy.test.ts` | 3 pass |
| `bun scripts/verify-runtime-host.ts --runtime <bun 1.4.0>` | ok, succession completed in 502 ms, stable listener 31/31 with 15 abandoned callers |
| `src/runtime-host/main.ts` booted in a private state dir with a gateway file, under 1.3.3 and 1.4.0 | boot log names local entry trusted and the remote entry; 8898 answers the node:http 503, the remote port the raw 503; SIGTERM exits 0 |
| privacy gate (`--base <merge-base>`) | PASS |

Bun 1.4.0's `node:http` reports a reader that walked away and hands over writable Upgrade sockets; 1.3.3 does neither, so those two tests are gated to the pin and the new CI step runs the file there.

Separately: the pre-existing raw-pipe test timed out under Bun 1.4.0 identically at the merge base, because a socket the proxy already ended never reports its peer's close there. The fixture now owns and disposes the sockets it accepts; the raw pipe is unchanged and the runtime behaviour is #1548.

## Rollout order (operator-run, documented in `docs/docker.md`)

1. Write `{ "remoteEntryPort": 8897 }` (local entry stays authenticated).
2. Boot a runtime-host generation on this revision (host-only bootstrap; the Viewer release stays).
3. `tailscale serve --bg --https=443 http://127.0.0.1:8897`, confirm `tailscale serve status` and that the remote port answers 403 without a key.
4. Only then write `{ "remoteEntryPort": 8897, "localEntry": "trusted" }`.

Rollback: withdraw trust by editing the file (next request); full rollback is the tailnet back on 8898, the file removed, and a host restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
