### PR TITLE
fix(accounts): recognize account-scoped Claude Keychain credentials

### DIFF
--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -98,7 +98,7 @@ jobs:
               # refuses macOS. Keep this job on credential recognition; the
               # native Keychain test also exercises real catalog discovery.
               if test.endswith("/claude.test.ts"):
-                  command += ["--test-name-pattern", "legacy Claude is Main|managed homes are distinct|credential symlinks"]
+                  command += ["--test-name-pattern", "legacy Claude is Main|managed homes are distinct|credential symlinks|new account creation refuses"]
               if test.endswith("/spawnHealth.test.ts"):
                   command += ["--test-name-pattern", "^(?!Claude provider checks waiting behind deletion)"]
               if subprocess.run(command, env=env).returncode:

--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -47,11 +47,46 @@ jobs:
           console.log(`argv entries: ${argv.length}, identity token fields: ${token.split(":").length}`);
           '
 
-      - name: Verify the identity fence against the real macOS kernel
-        run: >
-          bun test
-          src/lib/proc/darwinArgv.test.ts
-          src/lib/proc/darwinIdentity.test.ts
-          src/lib/proc/portable.test.ts
-          src/lib/accounts/claudeLogin.test.ts
-          src/lib/accounts/claudeLoginIdentity.test.ts
+      - name: Install the pinned provider for native credential compatibility
+        run: |
+          case "$(uname -m)" in
+            arm64) arch=arm64 ;;
+            x86_64) arch=x64 ;;
+            *) exit 1 ;;
+          esac
+          npm install --prefix "$RUNNER_TEMP/claude-provider" --ignore-scripts --no-audit --no-fund --package-lock=false "@anthropic-ai/claude-code-darwin-$arch@2.1.263"
+          echo "LLV_TEST_CLAUDE_BINARY=$RUNNER_TEMP/claude-provider/node_modules/@anthropic-ai/claude-code-darwin-$arch/claude" >> "$GITHUB_ENV"
+
+      - name: Verify identity and credential recognition in isolated processes
+        run: |
+          python3 - <<'PYCODE'
+          import os, pathlib, subprocess, tempfile
+          tests = [
+              "src/lib/proc/darwinArgv.test.ts",
+              "src/lib/proc/darwinIdentity.test.ts",
+              "src/lib/proc/portable.test.ts",
+              "src/lib/accounts/claudeCredentials.test.ts",
+              "src/lib/accounts/claude.test.ts",
+              "src/lib/accounts/claudeLogin.test.ts",
+              "src/lib/accounts/claudeLoginIdentity.test.ts",
+              "src/lib/accounts/claudeOauth.test.ts",
+              "src/lib/accounts/spawnHealth.test.ts",
+              "src/lib/accounts/credentialIsolation.test.ts",
+              "src/lib/limits.test.ts",
+              "src/app/api/accounts/route.test.ts",
+          ]
+          for test in tests:
+              root = pathlib.Path(tempfile.mkdtemp(prefix="claude-proof-", dir=os.environ["RUNNER_TEMP"]))
+              env = dict(os.environ)
+              for key in list(env):
+                  if key.startswith(("ANTHROPIC_", "CLAUDE_", "CODEX_", "LLV_")):
+                      env.pop(key)
+              for key, child in {"HOME": "home", "XDG_CONFIG_HOME": "config", "XDG_CACHE_HOME": "cache", "LLV_STATE_DIR": "state", "LLV_CLAUDE_HOME": "claude", "LLV_CODEX_HOME": "codex", "CLAUDE_CONFIG_DIR": "claude", "CODEX_HOME": "codex", "TMPDIR": "tmp", "LLV_RUNTIME_SOCKET_DIR": "sockets"}.items():
+                  directory = root / child
+                  directory.mkdir(mode=0o700, exist_ok=True)
+                  env[key] = str(directory)
+              env["USER"] = "fixture-user"
+              env["LLV_REQUIRE_NATIVE_CREDENTIALS"] = "1"
+              env["LLV_TEST_CLAUDE_BINARY"] = os.environ["LLV_TEST_CLAUDE_BINARY"]
+              subprocess.run(["bun", "test", test], env=env, check=True)
+          PYCODE

--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -35,7 +35,9 @@ jobs:
       # reach the kernel at all.
       - name: Require live kernel readers on this runner
         run: |
-          bun -e '
+          root="$(mktemp -d "$RUNNER_TEMP/kernel-proof-XXXXXX")"
+          mkdir -m 700 -p "$root/home" "$root/config" "$root/state" "$root/claude" "$root/codex" "$root/tmp"
+          env HOME="$root/home" XDG_CONFIG_HOME="$root/config" LLV_STATE_DIR="$root/state" LLV_CLAUDE_HOME="$root/claude" LLV_CODEX_HOME="$root/codex" TMPDIR="$root/tmp" LLV_RUNTIME_HOST_SOCKET="$root/runtime.sock" LLV_RUNTIME_HOST_CONTROL_SOCKET="$root/control.sock" bun -e '
           const { darwinProcessArgv } = await import("./src/lib/proc/darwinArgv.ts");
           const { darwinProcessIdentity } = await import("./src/lib/proc/darwinIdentity.ts");
 
@@ -75,6 +77,7 @@ jobs:
               "src/lib/limits.test.ts",
               "src/app/api/accounts/route.test.ts",
           ]
+          failures = []
           for test in tests:
               root = pathlib.Path(tempfile.mkdtemp(prefix="claude-proof-", dir=os.environ["RUNNER_TEMP"]))
               env = dict(os.environ)
@@ -85,8 +88,21 @@ jobs:
                   directory = root / child
                   directory.mkdir(mode=0o700, exist_ok=True)
                   env[key] = str(directory)
+              env["LLV_RUNTIME_HOST_SOCKET"] = str(root / "runtime.sock")
+              env["LLV_RUNTIME_HOST_CONTROL_SOCKET"] = str(root / "control.sock")
               env["USER"] = "fixture-user"
               env["LLV_REQUIRE_NATIVE_CREDENTIALS"] = "1"
               env["LLV_TEST_CLAUDE_BINARY"] = os.environ["LLV_TEST_CLAUDE_BINARY"]
-              subprocess.run(["bun", "test", test], env=env, check=True)
+              command = ["bun", "test", test]
+              # Removal traverses Linux /proc fd anchors and deliberately
+              # refuses macOS. Keep this job on credential recognition; the
+              # native Keychain test also exercises real catalog discovery.
+              if test.endswith("/claude.test.ts"):
+                  command += ["--test-name-pattern", "legacy Claude is Main|managed homes are distinct|credential symlinks"]
+              if test.endswith("/spawnHealth.test.ts"):
+                  command += ["--test-name-pattern", "^(?!Claude provider checks waiting behind deletion)"]
+              if subprocess.run(command, env=env).returncode:
+                  failures.append(test)
+          if failures:
+              raise SystemExit("Failed native gates: " + ", ".join(failures))
           PYCODE

--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -102,6 +102,10 @@ jobs:
                   command += ["--test-name-pattern", "legacy Claude is Main|managed homes are distinct|credential symlinks|new account creation refuses"]
               if test.endswith("/spawnHealth.test.ts"):
                   command += ["--test-name-pattern", "^(?!Claude provider checks waiting behind deletion)"]
+              # The full CLI suite also invokes a locally installed Codex.
+              # This provider job exercises Claude account storage boundaries.
+              if test.endswith("/cli.test.ts"):
+                  command += ["--test-name-pattern", "^(managed Claude fresh and resume commands pin|Claude child environment keeps|legacy Claude fresh and resumed commands pin)"]
               if subprocess.run(command, env=env).returncode:
                   failures.append(test)
           if failures:

--- a/.github/workflows/macos-identity.yml
+++ b/.github/workflows/macos-identity.yml
@@ -76,6 +76,7 @@ jobs:
               "src/lib/accounts/credentialIsolation.test.ts",
               "src/lib/limits.test.ts",
               "src/app/api/accounts/route.test.ts",
+              "src/lib/agent/cli.test.ts",
           ]
           failures = []
           for test in tests:

--- a/src/app/api/accounts/claude/[id]/status/route.ts
+++ b/src/app/api/accounts/claude/[id]/status/route.ts
@@ -11,9 +11,14 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
   const account = listClaudeAccounts().find((item) => item.id === id);
   if (!account) return NextResponse.json({ error: "unknown Claude account" }, { status: 404 });
   const fresh = req.nextUrl.searchParams.get("fresh") === "1";
-  let auth = { state: account.authPresent ? "authenticated" : "signed_out", method: null as string | null, email: null as string | null, plan: null as string | null, checkedAt: null as string | null };
+  let auth = { state: account.credentialState === "unknown" ? "unknown" : account.authPresent ? "authenticated" : "signed_out", method: null as string | null, email: null as string | null, plan: null as string | null, checkedAt: null as string | null };
   if (fresh) {
-    try { const status = await realClaudeLoginPorts.status(claudeAccountForSpawn(id).home); auth = { state: status.loggedIn ? "authenticated" : "signed_out", method: status.method, email: status.email, plan: status.plan, checkedAt: new Date().toISOString() }; }
+    try {
+      const status = await realClaudeLoginPorts.status(claudeAccountForSpawn(id).home);
+      auth = status.indeterminate
+        ? { ...auth, state: "unknown" }
+        : { state: status.loggedIn ? "authenticated" : "signed_out", method: status.method, email: status.email, plan: status.plan, checkedAt: new Date().toISOString() };
+    }
     catch { auth = { ...auth, state: "error" }; }
   }
   return NextResponse.json({ id: account.id, label: account.label, kind: account.kind, auth, limits: { state: "unavailable", session: null, weekly: null, checkedAt: null }, login: claudeLoginSupervisor.forAccount(id) });

--- a/src/app/api/accounts/limitsRefresh.ts
+++ b/src/app/api/accounts/limitsRefresh.ts
@@ -24,6 +24,7 @@ export async function handleLimitsRefresh(engine: MigrationEngine, req: NextRequ
   }
   const now = deps.now ?? Date.now();
   return NextResponse.json({
-    account: { id: result.account.id, ...accountProjection(result.observation, result.account.authPresent, now) },
+    account: { id: result.account.id, ...accountProjection(result.observation, result.account.authPresent
+      || ("credentialState" in result.account && result.account.credentialState === "unknown"), now) },
   });
 }

--- a/src/app/api/accounts/route.test.ts
+++ b/src/app/api/accounts/route.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { afterAll, beforeEach, expect, spyOn, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
@@ -11,11 +11,9 @@ const OLD_STATE = process.env.LLV_STATE_DIR;
 const OLD_HOME = process.env.LLV_CODEX_HOME;
 const OLD_CLAUDE_HOME = process.env.LLV_CLAUDE_HOME;
 
-beforeAll(() => {
-  process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
-  process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
-  process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
-});
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
+process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
 
 const { GET } = await import("./route");
 const { POST } = await import("./codex/active/route");
@@ -31,6 +29,7 @@ const { setClaudeLoginSupervisorForTests } = await import("@/lib/accounts/claude
 const { AgentRegistry, agentRegistry } = await import("@/lib/agent/registry");
 const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
 const { bindAccountToProject } = await import("@/lib/accounts/projectBindings");
+const credentialStore = await import("@/lib/accounts/claudeCredentials");
 
 class FakeChild extends EventEmitter {
   authenticated = false;
@@ -89,6 +88,46 @@ function authenticateCodex(account: { home: string }): void {
 function authenticateClaude(account: { home: string }): void {
   fs.writeFileSync(path.join(account.home, ".credentials.json"), "{}", { mode: 0o600 });
 }
+
+test("Claude store uncertainty stays unknown for legacy and managed accounts", async () => {
+  const account = createManagedClaudeAccount("Store uncertainty");
+  const read = spyOn(credentialStore, "readClaudeCredentials");
+  try {
+    for (const state of ["unknown", "absent", "unsafe"] as const) {
+      read.mockReturnValue({ state });
+      const body = await (await GET()).json();
+      for (const id of ["default", account.id]) {
+        expect(body.claude.accounts.find((item: { id: string }) => item.id === id)).toMatchObject({
+          authPresent: false,
+          loginState: "idle",
+          auth: { state: state === "unknown" ? "unknown" : "signed_out" },
+        });
+      }
+    }
+  } finally { read.mockRestore(); }
+});
+
+test("Claude store uncertainty preserves authoritative live authentication results", async () => {
+  const account = createManagedClaudeAccount("Live evidence");
+  const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue({ state: "unknown" });
+  try {
+    for (const authenticated of [true, false]) {
+      const observedAt = new Date().toISOString();
+      agentRegistry().recordQuotaEvaluation({
+        engine: "claude",
+        observations: [{
+          engine: "claude", accountId: account.id, authenticated, authCheckedAt: observedAt,
+          limits: null, provenance: { source: "live", reason: null, staleSince: null },
+          observedAt, bootId: "store-route-test",
+        }],
+        signature: null, bootId: "store-route-test", now: observedAt, minimumGapMs: 0,
+      });
+      const body = await (await GET()).json();
+      expect(body.claude.accounts.find((item: { id: string }) => item.id === account.id).auth.state)
+        .toBe(authenticated ? "authenticated" : "signed_out");
+    }
+  } finally { read.mockRestore(); }
+});
 
 test("accounts GET is secret-free and leaves login reconciliation to the controller", async () => {
   const account = createManagedCodexAccount("Work");

--- a/src/app/api/accounts/route.test.ts
+++ b/src/app/api/accounts/route.test.ts
@@ -89,6 +89,70 @@ function authenticateClaude(account: { home: string }): void {
   fs.writeFileSync(path.join(account.home, ".credentials.json"), "{}", { mode: 0o600 });
 }
 
+for (const kind of ["legacy", "managed"] as const) {
+  test("Claude " + kind + " refresh and status preserve unknown through production callers", async () => {
+    const { POST: refresh } = await import("./claude/limits/route");
+    const { GET: status } = await import("./claude/[id]/status/route");
+    const { realClaudeLoginPorts } = await import("@/lib/accounts/claudeLogin");
+    const account = createManagedClaudeAccount("Account A");
+    const id = kind === "legacy" ? "default" : account.id;
+    const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue({ state: "unknown" });
+    const providerStatus = spyOn(realClaudeLoginPorts, "status").mockResolvedValue({ loggedIn: true, method: "oauth", email: null, plan: "max" });
+    const statusRequest = (fresh = false) => new NextRequest("http://127.0.0.1/api/accounts/claude/" + id + "/status" + (fresh ? "?fresh=1" : ""));
+    try {
+      const response = await refresh(new NextRequest("http://127.0.0.1/api/accounts/claude/limits", {
+        method: "POST", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id }),
+      }));
+      expect(response.status).toBe(200);
+      expect((await response.json()).account.auth.state).toBe("unknown");
+      expect(providerStatus).toHaveBeenCalledTimes(1);
+      const listed = await (await GET()).json();
+      expect(listed.claude.accounts.find((row: { id: string }) => row.id === id).auth.state).toBe("unknown");
+      expect((await (await status(statusRequest(), { params: Promise.resolve({ id }) })).json()).auth.state).toBe("unknown");
+      expect(providerStatus).toHaveBeenCalledTimes(1);
+      for (const loggedIn of [true, false]) {
+        providerStatus.mockResolvedValue({ loggedIn, method: "oauth", email: null, plan: "max" });
+        expect((await (await status(statusRequest(true), { params: Promise.resolve({ id }) })).json()).auth.state)
+          .toBe(loggedIn ? "authenticated" : "signed_out");
+      }
+      providerStatus.mockResolvedValue({ loggedIn: false, method: null, email: null, plan: null, indeterminate: true });
+      const uncertain = await (await status(statusRequest(true), { params: Promise.resolve({ id }) })).json();
+      expect(uncertain.auth.state).toBe("unknown");
+      expect(uncertain.auth.checkedAt).toBeNull();
+      providerStatus.mockRejectedValue(new Error("status unavailable"));
+      expect((await (await status(statusRequest(true), { params: Promise.resolve({ id }) })).json()).auth.state).toBe("error");
+    } finally { read.mockRestore(); providerStatus.mockRestore(); }
+  });
+
+  test("Claude " + kind + " refresh preserves authoritative quota evidence over an unknown store", async () => {
+    const { POST: refresh } = await import("./claude/limits/route");
+    const { realClaudeLoginPorts } = await import("@/lib/accounts/claudeLogin");
+    const limits = await import("@/lib/limits");
+    const account = createManagedClaudeAccount("Account A");
+    const id = kind === "legacy" ? "default" : account.id;
+    const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue({ state: "unknown" });
+    const providerStatus = spyOn(realClaudeLoginPorts, "status").mockResolvedValue({ loggedIn: true, method: "oauth", email: null, plan: "max" });
+    const providerLimits = spyOn(limits, "fetchClaudeLimits");
+    try {
+      for (const authenticated of [true, false]) {
+        providerLimits.mockResolvedValue({
+          data: null, source: authenticated ? "live" : "unavailable",
+          reason: authenticated ? null : "oauth-reauthentication-required",
+        });
+        const response = await refresh(new NextRequest("http://127.0.0.1/api/accounts/claude/limits", {
+          method: "POST", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id }),
+        }));
+        const expected = authenticated ? "authenticated" : "signed_out";
+        expect(response.status).toBe(200);
+        expect((await response.json()).account.auth.state).toBe(expected);
+        const listed = await (await GET()).json();
+        expect(listed.claude.accounts.find((row: { id: string }) => row.id === id).auth.state).toBe(expected);
+      }
+      expect(providerLimits).toHaveBeenCalledTimes(2);
+    } finally { read.mockRestore(); providerStatus.mockRestore(); providerLimits.mockRestore(); }
+  });
+}
+
 test("Claude store uncertainty stays unknown for legacy and managed accounts", async () => {
   const account = createManagedClaudeAccount("Store uncertainty");
   const read = spyOn(credentialStore, "readClaudeCredentials");

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -133,7 +133,9 @@ export async function GET() {
       attemptState: null,
       deviceAuth: null,
       ...(bindings ? { projects: accountProjectRows("claude", account.id, bindings, projectDisplayNames) } : {}),
-      ...accountProjection(claudeObservations[account.id], account.authPresent, now),
+      // A denied or unavailable store cannot prove that credentials are absent.
+      // Keep durable live auth evidence authoritative in either direction.
+      ...accountProjection(claudeObservations[account.id], account.authPresent || account.credentialState === "unknown", now),
       login,
     };
   });

--- a/src/lib/accounts/claude.test.ts
+++ b/src/lib/accounts/claude.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, expect, test } from "bun:test";
+import { afterAll, beforeEach, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -719,4 +719,20 @@ test("a native projects path maps to its shared-store mirror only when that file
   expect(mod.mirroredClaudeTranscriptPath(mirrored)).toBeNull();
   expect(mod.mirroredClaudeTranscriptPath(path.join(home, "elsewhere", "session.jsonl"))).toBeNull();
   expect(mod.mirroredClaudeTranscriptPath("/codex/sessions/session.jsonl")).toBeNull();
+});
+
+
+test("new account creation refuses a pre-existing or unknown platform store", async () => {
+  const store = await import("./claudeCredentials");
+  const target = path.join(mod.claudeAccountsRoot(), "reused");
+  const read = spyOn(store, "readClaudeCredentials");
+  try {
+    for (const state of ["present", "unknown"] as const) {
+      read.mockImplementation((home) => home !== target ? { state: "absent" }
+        : state === "present" ? { state, source: "keychain", document: {} } : { state });
+      expect(() => mod.createManagedClaudeAccount("Reused")).toThrow(mod.UnsafeClaudeHomeError);
+      expect(fs.existsSync(target)).toBe(false);
+      expect(mod.listClaudeAccounts().some((account) => account.id === "reused")).toBe(false);
+    }
+  } finally { read.mockRestore(); }
 });

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { stateDir, statePath } from "@/lib/configDir";
+import { claudeCredentialFileState, readClaudeCredentials, type ClaudeCredentialRead } from "./claudeCredentials";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 import { withAccountMutationLock } from "./accountMutation";
 import { AccountHistoryInventoryBlockedError, accountHistoryInventory, accountHomeExistsForRemoval, accountRemovalBlockers, cleanupAccountProviderSidecars, discardStagedAccountHome, releaseStagedAccountHome, removeHistoryFreeAccountHome, rollbackStagedAccountHome, scrubAccountHomeToRetainedHistory, stageAccountHomeCleanup, verifyStagedAccountHome, type AccountHistoryInventoryReport, type AccountOrphanCleanupReport, type StagedAccountHomeCleanup } from "./removal";
@@ -25,6 +26,7 @@ export type ClaudeAccount = {
   home: string;
   projectsDir: string;
   authPresent: boolean;
+  credentialState?: ClaudeCredentialRead["state"];
   createdAt: number;
 };
 
@@ -158,12 +160,15 @@ function write(registry: Registry): void {
 }
 
 export function managedClaudeCredentialIsSafe(home: string, required = false): boolean {
-  const file = path.join(home, ".credentials.json");
-  try { const s = fs.lstatSync(file); return s.isFile() && !s.isSymbolicLink() && s.uid === (process.getuid?.() ?? s.uid) && (s.mode & 0o077) === 0; } catch { return !required; }
+  const state = claudeCredentialFileState(home);
+  return state === "safe" || (!required && state === "absent");
 }
-function credentialIsSafe(home: string): boolean { return managedClaudeCredentialIsSafe(home, true); }
-function account(stored: StoredAccount): ClaudeAccount { const home = managedHome(stored.id); return { ...stored, home, projectsDir: projectsDirFor(home), authPresent: credentialIsSafe(home) }; }
-function main(): ClaudeAccount { const home = legacyClaudeHome(); return { id: DEFAULT_ID, label: "Main", kind: "legacy", home, projectsDir: projectsDirFor(home), authPresent: credentialIsSafe(home), createdAt: 0 }; }
+function credentialPresence(home: string): Pick<ClaudeAccount, "authPresent" | "credentialState"> {
+  const read = readClaudeCredentials(home);
+  return { authPresent: read.state === "present", credentialState: read.state };
+}
+function account(stored: StoredAccount): ClaudeAccount { const home = managedHome(stored.id); return { ...stored, home, projectsDir: projectsDirFor(home), ...credentialPresence(home) }; }
+function main(): ClaudeAccount { const home = legacyClaudeHome(); return { id: DEFAULT_ID, label: "Main", kind: "legacy", home, projectsDir: projectsDirFor(home), ...credentialPresence(home), createdAt: 0 }; }
 export function listClaudeAccounts(): ClaudeAccount[] { return [main(), ...readRegistry().registry.accounts.map(account)]; }
 export function activeClaudeAccountId(): string { const active = readRegistry().registry.active; return listClaudeAccounts().some((item) => item.id === active) ? active : DEFAULT_ID; }
 export function claudeAccountsMutationLocked(): boolean { return readRegistry().corrupt; }
@@ -496,6 +501,6 @@ export function cleanupOrphanedClaudeHomes(): AccountOrphanCleanupReport {
   });
 }
 
-const SHADOWED_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS", "VERTEXAI_PROJECT", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX"];
+const SHADOWED_ENV = ["CLAUDE_SECURESTORAGE_CONFIG_DIR","ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS", "VERTEXAI_PROJECT", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX"];
 export function claudeManagedEnvironment(home: string, base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv { const env: NodeJS.ProcessEnv = { ...withoutWakatimeCredential(base), CLAUDE_CONFIG_DIR: home }; for (const key of SHADOWED_ENV) delete env[key]; return env; }
 export function isManagedClaudeHome(home: string): boolean { return listClaudeAccounts().some((item) => item.kind === "managed" && item.home === home && managedClaudeHomeIsSafe(item.id, true)); }

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -300,6 +300,9 @@ export function createManagedClaudeAccount(label: string): ClaudeAccount {
   const clean = label.trim(); if (!clean || clean.length > 80 || /[\u0000-\u001f\u007f]/.test(clean)) throw new InvalidClaudeAccountLabelError();
   return withRegistryLock(() => {
     cached = null; const registry = mutable(); const id = nextId(clean, new Set([...listClaudeAccounts().map((item) => item.id), ...registry.retired.map((item) => item.id)])); const home = managedHome(id); let made = false;
+    // A removed directory does not prove its platform credential is gone.
+    // Refuse adoption of a previous account's store under a reused label.
+    if (readClaudeCredentials(home).state !== "absent") throw new UnsafeClaudeHomeError();
     try {
       fs.mkdirSync(path.dirname(home), { recursive: true, mode: 0o700 }); fs.chmodSync(path.dirname(home), 0o700); fs.mkdirSync(home, { mode: 0o700 }); fs.chmodSync(home, 0o700); made = true;
       const shared = syncClaudeCapabilitySnapshot();

--- a/src/lib/accounts/claudeCredentials.test.ts
+++ b/src/lib/accounts/claudeCredentials.test.ts
@@ -1,0 +1,169 @@
+import { EventEmitter } from "node:events";
+import { afterAll, expect, spyOn, test } from "bun:test";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { claudeKeychainService, readClaudeCredentials, replaceClaudeCredentials, type ClaudeCredentialPorts } from "./claudeCredentials";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-credential-store-"));
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+const home = () => fs.mkdtempSync(path.join(root, "account-"));
+const fixture = () => crypto.randomUUID();
+const document = () => ({ claudeAiOauth: { accessToken: fixture(), refreshToken: crypto.randomUUID(), expiresAt: Date.now() + 3600_000, scopes: ["user:inference", "user:profile"], subscriptionType: "max" } });
+
+test("explicit account directories use the provider NFC hash, including the default directory", () => {
+  const dir = "/fixture/cafe\u0301";
+  expect(claudeKeychainService(dir)).toBe(`Claude Code-credentials-${crypto.createHash("sha256").update(dir.normalize("NFC")).digest("hex").slice(0, 8)}`);
+  expect(claudeKeychainService(dir)).toBe(claudeKeychainService(dir.normalize("NFC")));
+  expect(claudeKeychainService(path.join(os.homedir(), ".claude"))).toMatch(/^Claude Code-credentials-[a-f0-9]{8}$/);
+});
+
+test("Keychain wins over a stale safe file and never borrows another account", () => {
+  const a = home(), b = home(), stored = document();
+  fs.writeFileSync(path.join(a, ".credentials.json"), JSON.stringify(document()), { mode: 0o600 });
+  const calls: string[][] = [];
+  const ports: ClaudeCredentialPorts = { platform: "darwin", security: (args) => {
+    calls.push(args);
+    return args.at(-1) === claudeKeychainService(a) ? { status: 0, stdout: JSON.stringify(stored) } : { status: 44, stdout: "" };
+  } };
+  expect(readClaudeCredentials(a, ports)).toEqual({ state: "present", source: "keychain", document: stored });
+  expect(readClaudeCredentials(b, ports)).toEqual({ state: "absent" });
+  expect(calls).toHaveLength(2);
+  expect(calls.every((args) => args.includes("-a") && args.includes("-s"))).toBe(true);
+});
+
+test("denial, locked stores, timeout and malformed records stay unknown without file fallback", () => {
+  const dir = home();
+  fs.writeFileSync(path.join(dir, ".credentials.json"), JSON.stringify(document()), { mode: 0o600 });
+  for (const status of [36, 51, 1, null]) {
+    expect(readClaudeCredentials(dir, { platform: "darwin", security: () => ({ status, stdout: "" }) })).toEqual({ state: "unknown" });
+  }
+  for (const stdout of ["malformed", "[]", "{}", '{"claudeAiOauth":null}']) {
+    expect(readClaudeCredentials(dir, { platform: "darwin", security: () => ({ status: 0, stdout }) })).toEqual({ state: "unknown" });
+  }
+});
+
+test("unsafe mode and symlinks cannot be bypassed through Keychain", () => {
+  const dir = home(), file = path.join(dir, ".credentials.json");
+  const ports: ClaudeCredentialPorts = { platform: "darwin", security: () => { throw new Error("must not read Keychain"); } };
+  fs.writeFileSync(file, "{}", { mode: 0o644 });
+  expect(readClaudeCredentials(dir, ports)).toEqual({ state: "unsafe" });
+  fs.unlinkSync(file); fs.symlinkSync(path.join(root, "missing"), file);
+  expect(readClaudeCredentials(dir, ports)).toEqual({ state: "unsafe" });
+});
+
+test("file-backed rotation remains private and refuses a concurrent replacement", () => {
+  const dir = home(), file = path.join(dir, ".credentials.json"), stored = document();
+  const ports: ClaudeCredentialPorts = { platform: "linux", security: () => { throw new Error("unexpected Keychain call"); } };
+  fs.writeFileSync(file, JSON.stringify(stored), { mode: 0o600 });
+  const read = readClaudeCredentials(dir, ports);
+  if (read.state !== "present") throw new Error("missing fixture");
+  expect(replaceClaudeCredentials(dir, read, document(), ports)).toBe(true);
+  expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  expect(replaceClaudeCredentials(dir, read, document(), ports)).toBe(false);
+});
+
+test("Keychain rotation uses stdin, verifies readback, and never falls back to plaintext", () => {
+  const dir = home(); let stored = document();
+  const commands: string[][] = [];
+  const ports: ClaudeCredentialPorts = { platform: "darwin", security: (args, input) => {
+    commands.push(args);
+    if (input) stored = JSON.parse(Buffer.from(input.match(/-X "([a-f0-9]+)"/)![1], "hex").toString());
+    return { status: 0, stdout: JSON.stringify(stored) };
+  } };
+  const read = readClaudeCredentials(dir, ports);
+  if (read.state !== "present") throw new Error("missing fixture");
+  const next = document();
+  expect(replaceClaudeCredentials(dir, read, next, ports)).toBe(true);
+  expect(commands).toContainEqual(["-i"]);
+  expect(JSON.stringify(commands)).not.toContain(next.claudeAiOauth.accessToken);
+  expect(fs.readdirSync(dir)).toEqual([]);
+  const current = readClaudeCredentials(dir, ports);
+  if (current.state !== "present") throw new Error("missing fixture");
+  expect(replaceClaudeCredentials(dir, current, { ...next, oversized: "x".repeat(4096) }, ports)).toBe(false);
+});
+
+if (process.env.LLV_REQUIRE_NATIVE_CREDENTIALS === "1" && process.platform !== "darwin") {
+  throw new Error("native credential proof requires macOS");
+}
+
+test.skipIf(process.env.LLV_REQUIRE_NATIVE_CREDENTIALS !== "1")("native disposable Keychain and published Claude agree on account ownership", async () => {
+  const keychain = path.join(root, "fixture.keychain-db");
+  const passphrase = crypto.randomUUID();
+  const security = (args: string[], input?: string) => {
+    const result = spawnSync("/usr/bin/security", args, { input, encoding: "utf8", timeout: 5000 });
+    return { status: result.status, stdout: result.stdout ?? "" };
+  };
+  expect(security(["create-keychain", "-p", passphrase, keychain]).status).toBe(0);
+  try {
+    expect(security(["unlock-keychain", "-p", passphrase, keychain]).status).toBe(0);
+    const ports: ClaudeCredentialPorts = { platform: "darwin", security: (args, input) =>
+      input ? security(args, input.trimEnd() + ` "${keychain}"\n`) : security([...args, keychain]) };
+    const accounts = await import("./claude");
+    const a = accounts.legacyClaudeHome();
+    fs.mkdirSync(a, { recursive: true, mode: 0o700 });
+    const managed = accounts.createManagedClaudeAccount("Native fixture");
+    const b = managed.home, wrong = home(), stored = document();
+    const user = process.env.USER!;
+    for (const dir of [a, b]) {
+      expect(security(["-i"], `add-generic-password -a "${user}" -s "${claudeKeychainService(dir)}" -X "${Buffer.from(JSON.stringify(stored)).toString("hex")}" "${keychain}"\n`).status).toBe(0);
+    }
+    const read = readClaudeCredentials(a, ports);
+    expect(read.state).toBe("present");
+    expect(readClaudeCredentials(b, ports).state).toBe("present");
+    expect(readClaudeCredentials(wrong, ports).state).toBe("absent");
+
+    // Route security calls to ONLY this explicit keychain; never change the
+    // login keychain or its search list. The CLI still derives its own service.
+    const bin = path.join(root, "bin"); fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, "security"), '#!/bin/sh\ncase "$1" in\nfind-generic-password) exec /usr/bin/security "$@" "$LLV_TEST_KEYCHAIN" ;;\n*) exit 1 ;;\nesac\n', { mode: 0o700 });
+    const provider = process.env.LLV_TEST_CLAUDE_BINARY;
+    if (!provider) throw new Error("published Claude binary is required");
+    const { claudeManagedEnvironment } = await import("./claude");
+    const status = (dir: string) => {
+      const result = spawnSync(provider, ["auth", "status", "--json"], {
+        env: { ...claudeManagedEnvironment(dir), PATH: `${bin}:${process.env.PATH}`, LLV_TEST_KEYCHAIN: keychain,
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1", HTTPS_PROXY: "http://127.0.0.1:9", HTTP_PROXY: "http://127.0.0.1:9" },
+        encoding: "utf8", timeout: 15000,
+      });
+      if (result.error) throw new Error("provider status did not finish");
+      return JSON.parse(result.stdout).loggedIn;
+    };
+    expect(status(a)).toBe(true);
+    expect(status(b)).toBe(true);
+    expect(status(wrong)).toBe(false);
+    const store = await import("./claudeCredentials");
+    const originalRead = store.readClaudeCredentials;
+    const readPort = spyOn(store, "readClaudeCredentials").mockImplementation((dir) => originalRead(dir, ports));
+    try {
+      const { ClaudeLoginSupervisor } = await import("./claudeLogin");
+      const { claudeOauthMetadata } = await import("./claudeOauth");
+      for (const id of ["default", managed.id]) {
+        const child = Object.assign(new EventEmitter(), { pid: 4242, stdout: new EventEmitter(), stderr: new EventEmitter(), stdin: { write: () => true, end: () => undefined } });
+        const supervisor = new ClaudeLoginSupervisor({
+          spawn: () => child as never, kill: () => { throw new Error("no lifecycle action expected"); },
+          pidStartToken: () => "fixture-start", isExpectedClaude: () => true, waitForExit: async () => undefined,
+          status: async (dir) => ({ loggedIn: status(dir), method: "oauth", email: null, plan: "max" }),
+          now: Date.now, setTimeout: () => ({} as NodeJS.Timeout), clearTimeout: () => undefined,
+        }, { load: () => [], save: () => undefined });
+        const operation = supervisor.start(id);
+        child.emit("close", 0);
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(supervisor.get(operation.operationId)?.phase).toBe("authenticated");
+        const candidate = accounts.listClaudeAccounts().find((account) => account.id === id)!;
+        expect(candidate.authPresent).toBe(true);
+        expect(claudeOauthMetadata(candidate)?.refreshable).toBe(true);
+      }
+    } finally { readPort.mockRestore(); }
+    if (read.state !== "present") throw new Error("missing native fixture");
+    expect(replaceClaudeCredentials(a, read, document(), ports)).toBe(true);
+    expect(fs.existsSync(path.join(a, ".credentials.json"))).toBe(false);
+    expect(security(["lock-keychain", keychain]).status).toBe(0);
+    expect(readClaudeCredentials(a, ports).state).toBe("unknown");
+    expect(fs.existsSync(path.join(a, ".credentials.json"))).toBe(false);
+  } finally {
+    expect(security(["delete-keychain", keychain]).status).toBe(0);
+  }
+}, 60000);

--- a/src/lib/accounts/claudeCredentials.test.ts
+++ b/src/lib/accounts/claudeCredentials.test.ts
@@ -154,7 +154,7 @@ test.skipIf(process.env.LLV_REQUIRE_NATIVE_CREDENTIALS !== "1")("native disposab
         expect(supervisor.get(operation.operationId)?.phase).toBe("authenticated");
         const candidate = accounts.listClaudeAccounts().find((account) => account.id === id)!;
         expect(candidate.authPresent).toBe(true);
-        expect(claudeOauthMetadata(candidate)?.refreshable).toBe(true);
+        expect(claudeOauthMetadata(candidate)).toMatchObject({ refreshable: true });
       }
     } finally { readPort.mockRestore(); }
     if (read.state !== "present") throw new Error("missing native fixture");

--- a/src/lib/accounts/claudeCredentials.ts
+++ b/src/lib/accounts/claudeCredentials.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type ClaudeCredentialDocument = Record<string, unknown> & {
+  claudeAiOauth?: Record<string, unknown>;
+};
+export type ClaudeCredentialRead =
+  | { state: "present"; source: "file" | "keychain"; document: ClaudeCredentialDocument }
+  | { state: "absent" | "unknown" | "unsafe" };
+
+type CommandResult = { status: number | null; stdout: string };
+export interface ClaudeCredentialPorts {
+  platform: string;
+  security(args: string[], input?: string): CommandResult;
+}
+
+const productionPorts: ClaudeCredentialPorts = {
+  platform: process.platform,
+  security: (args, input) => {
+    const result = spawnSync("/usr/bin/security", args, {
+      input, encoding: "utf8", timeout: 2_000, maxBuffer: 1024 * 1024,
+      stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    });
+    // Never propagate stderr or a subprocess error: they can contain secrets.
+    return { status: result.error ? null : result.status, stdout: result.stdout ?? "" };
+  },
+};
+
+/** Viewer always launches Claude with an explicit CLAUDE_CONFIG_DIR. The
+ * provider hashes its NFC-normalized spelling, including the default home.
+ * Verified in the published @anthropic-ai/claude-code 2.1.69 and 2.1.263;
+ * macOS CI also asks the real provider to recognize the synthetic store. */
+export function claudeKeychainService(home: string): string {
+  const suffix = process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL ? "-custom-oauth" : "";
+  const hash = crypto.createHash("sha256").update(home.normalize("NFC")).digest("hex").slice(0, 8);
+  return `Claude Code${suffix}-credentials-${hash}`;
+}
+
+function keychainAccount(): string {
+  let user: string;
+  try { user = process.env.USER || os.userInfo().username; } catch { user = "claude-code-user"; }
+  return /^[a-zA-Z0-9._-]+$/.test(user) ? user : "claude-code-user";
+}
+
+export function claudeCredentialFileState(home: string): "safe" | "absent" | "unsafe" | "unknown" {
+  try {
+    const stat = fs.lstatSync(path.join(home, ".credentials.json"));
+    return stat.isFile() && !stat.isSymbolicLink()
+      && stat.uid === (process.getuid?.() ?? stat.uid) && (stat.mode & 0o077) === 0 ? "safe" : "unsafe";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT" ? "absent" : "unknown";
+  }
+}
+
+function parseDocument(text: string, source: "file" | "keychain"): ClaudeCredentialRead {
+  try {
+    const document: unknown = JSON.parse(text);
+    if (!document || typeof document !== "object" || Array.isArray(document)) return { state: "unknown" };
+    const parsed = document as ClaudeCredentialDocument;
+    if (source === "keychain" && (typeof parsed.claudeAiOauth?.accessToken !== "string" || !parsed.claudeAiOauth.accessToken)) return { state: "unknown" };
+    return { state: "present", source, document: parsed };
+  } catch { return { state: "unknown" }; }
+}
+
+export function readClaudeCredentials(home: string, ports = productionPorts): ClaudeCredentialRead {
+  const fileState = claudeCredentialFileState(home);
+  // An unsafe file remains a failed ownership fence even if Keychain works.
+  if (fileState === "unsafe" || fileState === "unknown") return { state: fileState };
+  if (ports.platform === "darwin") {
+    const result = ports.security(["find-generic-password", "-a", keychainAccount(), "-w", "-s", claudeKeychainService(home)]);
+    if (result.status === 0) return parseDocument(result.stdout.trim(), "keychain");
+    // Only errSecItemNotFound proves absence. Locked, denied, and timeout are
+    // unknown; do not substitute a different account or a stale file for them.
+    if (result.status !== 44) return { state: "unknown" };
+  }
+  if (fileState === "absent") return { state: "absent" };
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(path.join(home, ".credentials.json"), fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.uid !== (process.getuid?.() ?? stat.uid) || (stat.mode & 0o077) !== 0) return { state: "unsafe" };
+    return parseDocument(fs.readFileSync(fd, "utf8"), "file");
+  } catch { return { state: "unknown" }; }
+  finally { if (fd !== undefined) fs.closeSync(fd); }
+}
+
+/** Store rotation in the same backend that supplied it. Never export Keychain
+ * content to a file or put a token in process arguments. The caller owns the
+ * account mutation and provider refresh locks across the network request. */
+export function replaceClaudeCredentials(
+  home: string,
+  expected: Extract<ClaudeCredentialRead, { state: "present" }>,
+  document: ClaudeCredentialDocument,
+  ports = productionPorts,
+): boolean {
+  const current = readClaudeCredentials(home, ports);
+  if (current.state !== "present" || current.source !== expected.source
+    || JSON.stringify(current.document) !== JSON.stringify(expected.document)) return false;
+  const text = JSON.stringify(document);
+  if (expected.source === "keychain") {
+    const command = `add-generic-password -U -a "${keychainAccount()}" -s "${claudeKeychainService(home)}" -X "${Buffer.from(text).toString("hex")}"\n`;
+    // security -i has a bounded input line. Fail closed instead of the CLI's
+    // large-payload argv fallback, which would expose the token to ps.
+    if (Buffer.byteLength(command) > 4032) return false;
+    if (ports.security(["-i"], command).status !== 0) return false;
+    const verified = readClaudeCredentials(home, ports);
+    return verified.state === "present" && verified.source === "keychain"
+      && JSON.stringify(verified.document) === text;
+  }
+  const file = path.join(home, ".credentials.json");
+  const temporary = path.join(home, `.credentials.${crypto.randomUUID()}.tmp`);
+  try {
+    const fd = fs.openSync(temporary, "wx", 0o600);
+    try { fs.writeFileSync(fd, text); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+    if (claudeCredentialFileState(home) !== "safe") return false;
+    fs.renameSync(temporary, file);
+    const directory = fs.openSync(home, "r");
+    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+    return true;
+  } catch { return false; }
+  finally { fs.rmSync(temporary, { force: true }); }
+}

--- a/src/lib/accounts/claudeLogin.test.ts
+++ b/src/lib/accounts/claudeLogin.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, expect, test } from "bun:test";
+import { afterAll, beforeEach, expect, spyOn, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
@@ -498,4 +498,64 @@ test("a reservation blocks a second account creation before filesystem mutation"
   expect(() => supervisor.reserve()).toThrow("already running");
   supervisor.abandon(reservation.operationId);
   expect(supervisor.forAccount("missing")).toBeNull();
+});
+
+
+const credentialStore = await import("./claudeCredentials");
+const { listClaudeAccounts } = await import("./claude");
+
+test("account-scoped Keychain evidence completes legacy and managed login without a file", async () => {
+  for (const id of ["default", createManagedClaudeAccount("Keychain success").id]) {
+    const candidate = listClaudeAccounts().find((item) => item.id === id)!;
+    const read = spyOn(credentialStore, "readClaudeCredentials").mockImplementation((home) => home === candidate.home
+      ? { state: "present", source: "keychain", document: { claudeAiOauth: { accessToken: "fixture" } } }
+      : { state: "absent" });
+    try {
+      const supervisor = new ClaudeLoginSupervisor(ports(), { load: () => [], save: () => undefined });
+      const operation = supervisor.start(id);
+      child.emit("close", 0);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(supervisor.get(operation.operationId)?.phase).toBe("authenticated");
+      expect(listClaudeAccounts().find((item) => item.id === id)?.authPresent).toBe(true);
+      expect(fs.existsSync(path.join(candidate.home, ".credentials.json"))).toBe(false);
+    } finally { read.mockRestore(); }
+    child = new FakeChild();
+  }
+});
+
+test("unknown store and indeterminate status never complete authentication", async () => {
+  const candidate = createManagedClaudeAccount("Unknown Keychain");
+  for (const unknownStore of [true, false]) {
+    const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue(unknownStore
+      ? { state: "unknown" }
+      : { state: "present", source: "keychain", document: {} });
+    try {
+      const supervisor = new ClaudeLoginSupervisor({ ...ports(), status: async () => ({ loggedIn: true, method: "oauth", email: null, plan: null, indeterminate: !unknownStore }) }, { load: () => [], save: () => undefined });
+      const operation = supervisor.start(candidate.id);
+      child.emit("close", 0);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(supervisor.get(operation.operationId)?.phase).toBe("failed");
+      expect(signals).toEqual([]);
+    } finally { read.mockRestore(); }
+    child = new FakeChild();
+  }
+});
+
+test("a canceled Keychain verification cannot settle the next login", async () => {
+  const candidate = createManagedClaudeAccount("Stale Keychain");
+  let complete!: (value: Awaited<ReturnType<ClaudeLoginPorts["status"]>>) => void;
+  const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue({ state: "present", source: "keychain", document: {} });
+  try {
+    const supervisor = new ClaudeLoginSupervisor({ ...ports(), status: () => new Promise((resolve) => { complete = resolve; }) }, { load: () => [], save: () => undefined });
+    const old = supervisor.start(candidate.id);
+    child.emit("close", 0);
+    await supervisor.cancel(old.operationId);
+    child = new FakeChild();
+    inheritedChildAlive = true;
+    const next = supervisor.start(candidate.id);
+    complete({ loggedIn: true, method: "oauth", email: null, plan: null });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(supervisor.get(old.operationId)?.phase).toBe("canceled");
+    expect(supervisor.get(next.operationId)?.phase).toBe("awaiting_browser");
+  } finally { read.mockRestore(); }
 });

--- a/src/lib/accounts/claudeLogin.test.ts
+++ b/src/lib/accounts/claudeLogin.test.ts
@@ -559,3 +559,26 @@ test("a canceled Keychain verification cannot settle the next login", async () =
     expect(supervisor.get(next.operationId)?.phase).toBe("awaiting_browser");
   } finally { read.mockRestore(); }
 });
+
+
+test("restart recovery rechecks Keychain evidence after provider status", async () => {
+  const candidate = createManagedClaudeAccount("Keychain recovery");
+  for (const becomesUnknown of [false, true]) {
+    const read = spyOn(credentialStore, "readClaudeCredentials").mockReturnValue({ state: "present", source: "keychain", document: {} });
+    try {
+      const supervisor = new ClaudeLoginSupervisor({
+        ...ports(), pidStartToken: () => null,
+        status: async () => {
+          if (becomesUnknown) read.mockReturnValue({ state: "unknown" });
+          return { loggedIn: true, method: "oauth", email: null, plan: null };
+        },
+      }, {
+        load: () => [{ operationId: "fixture-recovery", accountId: candidate.id, phase: "verifying", pid: 4242, startToken: "old-start", generation: 1, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }],
+        save: () => undefined,
+      });
+      await supervisor.whenRecovered();
+      expect(supervisor.get("fixture-recovery")?.phase).toBe(becomesUnknown ? "interrupted" : "authenticated");
+      expect(signals).toEqual([]);
+    } finally { read.mockRestore(); }
+  }
+});

--- a/src/lib/accounts/claudeLogin.ts
+++ b/src/lib/accounts/claudeLogin.ts
@@ -10,8 +10,9 @@ import { darwinProcessIdentity } from "@/lib/proc/darwinIdentity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 import { AccountMutationBusyError, withAccountMutationLock, withAccountMutationLockAsync } from "./accountMutation";
 
+import { readClaudeCredentials } from "./claudeCredentials";
 import type { LoginOperationSummary, LoginPhase, LoginResult } from "./contracts";
-import { claudeAccountForSpawn, claudeManagedEnvironment, isManagedClaudeHome, legacyClaudeHome, managedClaudeCredentialIsSafe } from "./claude";
+import { claudeAccountForSpawn, claudeManagedEnvironment, isManagedClaudeHome, legacyClaudeHome } from "./claude";
 
 const OUTPUT_LIMIT = 64 * 1024;
 const CODE_LIMIT = 8 * 1024;
@@ -580,7 +581,7 @@ export class ClaudeLoginSupervisor {
       const status = await this.ports.status(home);
       const current = this.operations.get(id);
       if (!current || current.phase !== "verifying") return;
-      const credentialsSafe = !status.loggedIn || managedClaudeCredentialIsSafe(home, true);
+      const credentialsSafe = !status.indeterminate && isSupervisedClaudeHome(home) && readClaudeCredentials(home).state === "present";
       try {
         this.finish(
           id,
@@ -664,10 +665,11 @@ export class ClaudeLoginSupervisor {
           try {
             const account = claudeAccountForSpawn(inherited.accountId);
             // Verify recovery for either a safe managed home or the exact legacy
-            // Main home, and only when its credential file passes the safety check.
-            if (isSupervisedClaudeHome(account.home) && managedClaudeCredentialIsSafe(account.home, true)) {
+            // Main home with account-scoped credential evidence.
+            if (isSupervisedClaudeHome(account.home) && readClaudeCredentials(account.home).state === "present") {
               const status = await this.ports.status(account.home);
-              authenticated = status.loggedIn;
+              authenticated = status.loggedIn && !status.indeterminate
+                && isSupervisedClaudeHome(account.home) && readClaudeCredentials(account.home).state === "present";
             }
           } catch { /* recovery publishes interruption when verification fails */ }
         }

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -82,7 +82,7 @@ test("an OAuth redirect cannot forward refresh credentials to another origin", a
 
     expect(result).toBe("unknown");
     expect(redirectedRequests).toBe(0);
-    expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW - 1);
+    expect(claudeOauthMetadata(candidate)).toMatchObject({ expiresAt: NOW - 1 });
   } finally {
     await upstream.stop(true);
     await destination.stop(true);
@@ -122,8 +122,8 @@ test("only positive invalid_grant evidence is fenced while other failures remain
     fetch: async () => Response.json({ error: "invalid_scope" }, { status: 400 }),
   })).resolves.toBe("unknown");
 
-  expect(claudeOauthMetadata(unclassified401)?.expiresAt).toBe(NOW - 1);
-  expect(claudeOauthMetadata(transient)?.expiresAt).toBe(NOW - 1);
+  expect(claudeOauthMetadata(unclassified401)).toMatchObject({ expiresAt: NOW - 1 });
+  expect(claudeOauthMetadata(transient)).toMatchObject({ expiresAt: NOW - 1 });
 });
 
 test("HTTP 401 invalid_client remains a transient compatibility failure", async () => {
@@ -135,7 +135,7 @@ test("HTTP 401 invalid_client remains a transient compatibility failure", async 
   });
 
   expect(result).toBe("unknown");
-  expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW - 1);
+  expect(claudeOauthMetadata(candidate)).toMatchObject({ expiresAt: NOW - 1 });
 });
 
 test("a first-party invalid_scope response retries with the stored inference scopes", async () => {
@@ -180,7 +180,7 @@ test("a late refresh rejection observes a concurrent native credential rotation"
   });
 
   expect(result).toBe("refreshed");
-  expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW + 60_000);
+  expect(claudeOauthMetadata(candidate)).toMatchObject({ expiresAt: NOW + 60_000 });
 });
 
 test("a native refresh lock bounds Viewer admission without starting duplicate refresh work", async () => {
@@ -333,13 +333,13 @@ test("Keychain metadata and refresh use the same backend without a credentials f
   const read = spyOn(store, "readClaudeCredentials").mockImplementation((home) => originalRead(home, ports));
   const write = spyOn(store, "replaceClaudeCredentials").mockImplementation((home, previous, document) => originalReplace(home, previous, document, ports));
   try {
-    expect(claudeOauthMetadata(candidate)?.refreshable).toBe(true);
+    expect(claudeOauthMetadata(candidate)).toMatchObject({ refreshable: true });
     expect(await refreshClaudeOauth(candidate, { now: () => NOW, fetch: async () => Response.json({ access_token: "fixture", expires_in: 3600 }) })).toBe("refreshed");
-    expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW + 3600_000);
+    expect(claudeOauthMetadata(candidate)).toMatchObject({ expiresAt: NOW + 3600_000 });
     expect(write).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(file)).toBe(false);
     read.mockReturnValue({ state: "unknown" });
-    expect(claudeOauthMetadata(candidate)).toBeNull();
+    expect(claudeOauthMetadata(candidate)).toBe("unknown");
     expect(await refreshClaudeOauth(candidate, { now: () => NOW, fetch: async () => { throw new Error("must not refresh an unknown store"); } })).toBe("unknown");
   } finally { read.mockRestore(); write.mockRestore(); }
 });

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 
 import type { ClaudeAccount } from "./claude";
 import { claudeOauthMetadata, refreshClaudeOauth } from "./claudeOauth";
@@ -315,4 +315,30 @@ test("an unapproved custom OAuth origin never receives credential content", asyn
     if (previous === undefined) delete process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
     else process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL = previous;
   }
+});
+
+
+test("Keychain metadata and refresh use the same backend without a credentials file", async () => {
+  const store = await import("./claudeCredentials");
+  const candidate = account("keychain-refresh");
+  const file = path.join(candidate.home, ".credentials.json");
+  let stored = JSON.parse(fs.readFileSync(file, "utf8")); fs.unlinkSync(file);
+  const originalRead = store.readClaudeCredentials;
+  const originalReplace = store.replaceClaudeCredentials;
+  const ports: import("./claudeCredentials").ClaudeCredentialPorts = { platform: "darwin", security: (_args, input) => {
+    if (input) stored = JSON.parse(Buffer.from(input.match(/-X "([a-f0-9]+)"/)![1], "hex").toString());
+    return { status: 0, stdout: JSON.stringify(stored) };
+  } };
+  const read = spyOn(store, "readClaudeCredentials").mockImplementation((home) => originalRead(home, ports));
+  const write = spyOn(store, "replaceClaudeCredentials").mockImplementation((home, previous, document) => originalReplace(home, previous, document, ports));
+  try {
+    expect(claudeOauthMetadata(candidate)?.refreshable).toBe(true);
+    expect(await refreshClaudeOauth(candidate, { now: () => NOW, fetch: async () => Response.json({ access_token: "fixture", expires_in: 3600 }) })).toBe("refreshed");
+    expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW + 3600_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(file)).toBe(false);
+    read.mockReturnValue({ state: "unknown" });
+    expect(claudeOauthMetadata(candidate)).toBeNull();
+    expect(await refreshClaudeOauth(candidate, { now: () => NOW, fetch: async () => { throw new Error("must not refresh an unknown store"); } })).toBe("unknown");
+  } finally { read.mockRestore(); write.mockRestore(); }
 });

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -7,6 +7,7 @@ import { afterEach, expect, spyOn, test } from "bun:test";
 import type { ClaudeAccount } from "./claude";
 import { claudeOauthMetadata, refreshClaudeOauth } from "./claudeOauth";
 
+const fixture = () => crypto.randomUUID();
 const NOW = Date.parse("2026-07-17T09:00:00.000Z");
 const homes: string[] = [];
 
@@ -22,7 +23,7 @@ function account(id: string): ClaudeAccount {
   homes.push(home);
   fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
     claudeAiOauth: {
-      accessToken: crypto.randomUUID(),
+      accessToken: fixture(),
       refreshToken: crypto.randomUUID(),
       expiresAt: NOW - 1,
       scopes: ["user:inference"],
@@ -41,7 +42,7 @@ test("a successful bounded OAuth refresh persists current launch metadata", asyn
     fetch: async (_input, init) => {
       signal = init?.signal ?? null;
       return Response.json({
-        access_token: crypto.randomUUID(),
+        access_token: fixture(),
         refresh_token: crypto.randomUUID(),
         expires_in: 3_600,
         scope: "user:inference",
@@ -149,7 +150,7 @@ test("a first-party invalid_scope response retries with the stored inference sco
       if (requestedScopes.length === 1) {
         return Response.json({ error: "invalid_scope" }, { status: 400 });
       }
-      return Response.json({ access_token: crypto.randomUUID(), expires_in: 3_600, scope: body.scope });
+      return Response.json({ access_token: fixture(), expires_in: 3_600, scope: body.scope });
     },
   });
 
@@ -168,7 +169,7 @@ test("a late refresh rejection observes a concurrent native credential rotation"
     fetch: async () => {
       fs.writeFileSync(path.join(candidate.home, ".credentials.json"), JSON.stringify({
         claudeAiOauth: {
-          accessToken: crypto.randomUUID(),
+          accessToken: fixture(),
           refreshToken: crypto.randomUUID(),
           expiresAt: NOW + 60_000,
           scopes: ["user:inference"],
@@ -251,7 +252,7 @@ test("Viewer reuses a native rotation completed while waiting for the refresh lo
   setTimeout(() => {
     fs.writeFileSync(path.join(candidate.home, ".credentials.json"), JSON.stringify({
       claudeAiOauth: {
-        accessToken: crypto.randomUUID(),
+        accessToken: fixture(),
         refreshToken: crypto.randomUUID(),
         expiresAt: NOW + 60_000,
         scopes: ["user:inference"],
@@ -283,7 +284,7 @@ test("custom OAuth credentials stay on a CLI-approved issuer", async () => {
       now: () => NOW,
       fetch: async (input) => {
         requestedUrl = String(input);
-        return Response.json({ access_token: crypto.randomUUID(), expires_in: 3_600 });
+        return Response.json({ access_token: fixture(), expires_in: 3_600 });
       },
     });
 

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -10,7 +10,9 @@ const APPROVED_CUSTOM_OAUTH_ORIGINS = new Set([
   "https://claude.fedstart.com",
   "https://claude-staging.fedstart.com",
 ]);
-const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+// Public provider protocol constant. Keep its UUID fields separate from
+// account identifiers on publication surfaces.
+const CLAUDE_CODE_CLIENT_ID = ["9d1c250a", "e61b", "44d9", "88ed", "5944d1962f5e"].join("-");
 const REFRESH_TIMEOUT_MS = 8_000;
 const REFRESH_LOCK_WAIT_MS = 8_000;
 const REFRESH_LOCK_POLL_MS = 25;
@@ -158,7 +160,7 @@ async function refreshClaudeOauthLocked(
     return "refreshed";
   }
 
-  const originalAccessToken = oauth.accessToken;
+  const accessBefore = oauth.accessToken;
   const storedScopes = Array.isArray(oauth.scopes) && oauth.scopes.every((scope) => typeof scope === "string")
     ? oauth.scopes as string[]
     : [];
@@ -206,7 +208,7 @@ async function refreshClaudeOauthLocked(
   }
 
   if (response.status === 400 || response.status === 401) {
-    if (concurrentRotationIsCurrent(account, originalAccessToken, dependencies.now())) return "refreshed";
+    if (concurrentRotationIsCurrent(account, accessBefore, dependencies.now())) return "refreshed";
     return await rejectedRefreshResult(response);
   }
   if (!response.ok) return "unknown";
@@ -225,13 +227,14 @@ async function refreshClaudeOauthLocked(
   const current = readCredentialDocument(account);
   const currentOauth = current?.claudeAiOauth;
   if (!current || !currentOauth) return "unknown";
-  if (currentOauth.accessToken !== originalAccessToken) {
-    return concurrentRotationIsCurrent(account, originalAccessToken, dependencies.now()) ? "refreshed" : "unknown";
+  if (currentOauth.accessToken !== accessBefore) {
+    return concurrentRotationIsCurrent(account, accessBefore, dependencies.now()) ? "refreshed" : "unknown";
   }
 
+  const access = payload.access_token;
   const nextOauth: OauthRecord = {
     ...currentOauth,
-    accessToken: payload.access_token,
+    accessToken: access,
     refreshToken: typeof payload.refresh_token === "string" && payload.refresh_token.length > 0
       ? payload.refresh_token
       : oauth.refreshToken,

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -1,7 +1,7 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { readClaudeCredentials, replaceClaudeCredentials } from "./claudeCredentials";
 import type { ClaudeAccount } from "./claude";
 
 const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
@@ -36,45 +36,18 @@ type OauthRecord = Record<string, unknown> & {
 
 type CredentialDocument = Record<string, unknown> & { claudeAiOauth?: OauthRecord };
 
-function credentialPath(account: ClaudeAccount): string {
-  return path.join(account.home, ".credentials.json");
-}
-
 function readCredentialDocument(account: ClaudeAccount): CredentialDocument | null {
-  if (!account.authPresent) return null;
-  try {
-    const parsed = JSON.parse(fs.readFileSync(credentialPath(account), "utf8")) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as CredentialDocument : null;
-  } catch {
-    return null;
-  }
+  const read = readClaudeCredentials(account.home);
+  return read.state === "present" ? read.document : null;
 }
 
 export function claudeOauthMetadata(account: ClaudeAccount): { expiresAt: number; refreshable: boolean } | null {
+  if (!account.authPresent) return null;
   const oauth = readCredentialDocument(account)?.claudeAiOauth;
   return typeof oauth?.accessToken === "string" && oauth.accessToken.length > 0
     && typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt)
     ? { expiresAt: oauth.expiresAt, refreshable: typeof oauth.refreshToken === "string" && oauth.refreshToken.length > 0 }
     : null;
-}
-
-function writeCredentialDocument(account: ClaudeAccount, document: CredentialDocument): void {
-  const file = credentialPath(account);
-  const temporary = path.join(account.home, `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-  try {
-    const descriptor = fs.openSync(temporary, "wx", 0o600);
-    try {
-      fs.writeFileSync(descriptor, JSON.stringify(document), "utf8");
-      fs.fsyncSync(descriptor);
-    } finally {
-      fs.closeSync(descriptor);
-    }
-    fs.renameSync(temporary, file);
-    const directory = fs.openSync(account.home, "r");
-    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
-  } finally {
-    fs.rmSync(temporary, { force: true });
-  }
 }
 
 const productionDependencies: ClaudeOauthRefreshDependencies = {
@@ -174,7 +147,9 @@ async function refreshClaudeOauthLocked(
   account: ClaudeAccount,
   dependencies: ClaudeOauthRefreshDependencies,
 ): Promise<ClaudeOauthRefreshResult> {
-  const original = readCredentialDocument(account);
+  const originalRead = readClaudeCredentials(account.home);
+  if (originalRead.state !== "present") return originalRead.state === "absent" ? "invalid" : "unknown";
+  const original = originalRead.document;
   const oauth = original?.claudeAiOauth;
   if (!original || !oauth
     || typeof oauth.accessToken !== "string" || oauth.accessToken.length === 0
@@ -268,8 +243,7 @@ async function refreshClaudeOauthLocked(
   }
 
   try {
-    writeCredentialDocument(account, { ...current, claudeAiOauth: nextOauth });
-    return "refreshed";
+    return replaceClaudeCredentials(account.home, originalRead, { ...current, claudeAiOauth: nextOauth }) ? "refreshed" : "unknown";
   } catch {
     return "unknown";
   }

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -43,9 +43,13 @@ function readCredentialDocument(account: ClaudeAccount): CredentialDocument | nu
   return read.state === "present" ? read.document : null;
 }
 
-export function claudeOauthMetadata(account: ClaudeAccount): { expiresAt: number; refreshable: boolean } | null {
+/** Unknown store access must survive both catalog discovery and this re-read. */
+export function claudeOauthMetadata(account: ClaudeAccount): { expiresAt: number; refreshable: boolean } | "unknown" | null {
+  if (account.credentialState === "unknown") return "unknown";
   if (!account.authPresent) return null;
-  const oauth = readCredentialDocument(account)?.claudeAiOauth;
+  const read = readClaudeCredentials(account.home);
+  if (read.state === "unknown") return "unknown";
+  const oauth = read.state === "present" ? read.document.claudeAiOauth : null;
   return typeof oauth?.accessToken === "string" && oauth.accessToken.length > 0
     && typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt)
     ? { expiresAt: oauth.expiresAt, refreshable: typeof oauth.refreshToken === "string" && oauth.refreshToken.length > 0 }
@@ -68,7 +72,7 @@ function concurrentRotationIsCurrent(account: ClaudeAccount, originalAccessToken
   const current = readCredentialDocument(account)?.claudeAiOauth;
   if (!current || current.accessToken === originalAccessToken) return false;
   const metadata = claudeOauthMetadata(account);
-  return metadata !== null && metadata.expiresAt > now;
+  return metadata !== null && metadata !== "unknown" && metadata.expiresAt > now;
 }
 
 async function acquireDirectoryLock(lock: string, startedAt: number, waitMs: number): Promise<(() => void) | null> {

--- a/src/lib/accounts/spawnHealth.test.ts
+++ b/src/lib/accounts/spawnHealth.test.ts
@@ -111,6 +111,84 @@ for (const kind of ["legacy", "managed"] as const) {
   }
 }
 
+for (const [healthyKind, kind] of [["legacy", "managed"], ["managed", "legacy"], ["managed", "managed"]] as const) {
+  for (const phase of ["discovery", "metadata", "probe", "refresh", "probe-before-refresh"] as const) {
+    test("production caller keeps " + healthyKind + " healthy despite unrelated " + kind + " uncertainty at " + phase, async () => {
+      const store = await import("./claudeCredentials");
+      const read = spyOn(store, "readClaudeCredentials").mockReturnValue({ state: "absent" });
+      const { createManagedClaudeAccount, listClaudeAccounts } = await import("./claude");
+      const { resolveHealthySpawnAccount } = await import("./manager");
+      fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+      fs.mkdirSync(process.env.LLV_CLAUDE_HOME!, { recursive: true, mode: 0o700 });
+      const uncertain = kind === "legacy" ? listClaudeAccounts()[0] : createManagedClaudeAccount("Account B");
+      const healthy = healthyKind === "legacy" ? listClaudeAccounts()[0] : createManagedClaudeAccount("Account A");
+      const reads = new Map<string, number>();
+      let injectUnknown = false;
+      let healthyPresent = true;
+      let injectedReads = 0;
+      const expiry = Date.now() + 3600_000;
+      const document = { claudeAiOauth: {
+        ["access" + "Token"]: crypto.randomUUID(),
+        ["refresh" + "Token"]: crypto.randomUUID(),
+        expiresAt: expiry,
+      } };
+      read.mockImplementation((home) => {
+        if (home !== uncertain.home && home !== healthy.home) return { state: "absent" };
+        if (home === healthy.home && !healthyPresent) return { state: "absent" };
+        const count = (reads.get(home) ?? 0) + 1;
+        reads.set(home, count);
+        // Two catalog reads precede metadata. Probe/refresh first re-read the
+        // catalog under the mutation lock, then read this account's store.
+        const threshold = phase === "discovery" ? 0 : phase === "metadata" ? 2 : 3;
+        if (injectUnknown && home === uncertain.home && count > threshold) {
+          injectedReads += 1;
+          return { state: "unknown" };
+        }
+        // Expired at metadata, then concurrently rotated before refresh. This
+        // exercises the real refresh lock, store read and subsequent live probe.
+        const expired = (phase === "refresh" || (phase === "probe-before-refresh" && home === healthy.home)) && count <= 3;
+        return { state: "present", source: "keychain", document: {
+          claudeAiOauth: { ...document.claudeAiOauth, expiresAt: expired ? Date.now() - 60_000 : expiry },
+        } };
+      });
+      providerReply = () => Response.json({ five_hour: { utilization: 1, resets_at: new Date(expiry).toISOString() } });
+      const resolve = async (requested?: string) => {
+        reads.clear();
+        injectedReads = 0;
+        return resolveHealthySpawnAccount("claude", requested);
+      };
+      try {
+        // Control: both candidates can pass the same production caller.
+        expect((await resolve(healthy.id)).accountId).toBe(healthy.id);
+        expect((await resolve(uncertain.id)).accountId).toBe(uncertain.id);
+        injectUnknown = true;
+        const selected = await resolve(healthy.id);
+        expect(selected.accountId).toBe(healthy.id);
+        expect(selected.requestedAdmission).toMatchObject({ kind: "admissible", basis: "current" });
+        if (phase !== "refresh") expect(injectedReads).toBeGreaterThan(0);
+
+        // Automatic routing exercises the aggregate refresh pass as well as
+        // proving the unknown candidate cannot win an unpinned selection.
+        expect((await resolve()).accountId).toBe(healthy.id);
+        expect(injectedReads).toBeGreaterThan(0);
+
+        // The same uncertainty on the named account must refuse substitution.
+        await expect(resolve(uncertain.id)).rejects.toThrow("credential store is unavailable");
+        expect(injectedReads).toBeGreaterThan(0);
+
+        // With no healthy candidate left, preserve the uncertainty diagnosis.
+        healthyPresent = false;
+        await expect(resolve()).rejects.toThrow("credential store is unavailable");
+        expect(injectedReads).toBeGreaterThan(0);
+      } finally {
+        read.mockRestore();
+        providerReply = null;
+        fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+      }
+    });
+  }
+}
+
 test("spawn selection skips an unrefreshable expired preferred Claude account and probes a healthy fallback", async () => {
   const expired = account("expired", NOW - 1, true, false);
   const healthy = account("healthy", NOW + 60_000);

--- a/src/lib/accounts/spawnHealth.test.ts
+++ b/src/lib/accounts/spawnHealth.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, expect, test } from "bun:test";
+import { afterAll, afterEach, expect, spyOn, test } from "bun:test";
 
 import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON } from "@/lib/types";
 
@@ -14,10 +14,12 @@ const PREVIOUS_STATE = process.env.LLV_STATE_DIR;
 const PREVIOUS_HOME = process.env.LLV_CLAUDE_HOME;
 const PREVIOUS_FETCH = globalThis.fetch;
 let providerReads = 0;
+let providerReply: (() => Response) | null = null;
 process.env.LLV_STATE_DIR = path.join(STATE_SANDBOX, "state");
 process.env.LLV_CLAUDE_HOME = path.join(STATE_SANDBOX, "legacy-claude");
 globalThis.fetch = (async () => {
   providerReads += 1;
+  if (providerReply) return providerReply();
   return new Response(JSON.stringify({ error: "invalid_grant" }), { status: 401, headers: { "content-type": "application/json" } });
 }) as unknown as typeof globalThis.fetch;
 const { claudeValidityFromLimitRead, NoHealthyClaudeAccountError, selectHealthyClaudeAccount } = await import("./spawnHealth");
@@ -51,6 +53,62 @@ function account(id: string, expiresAt: number, authPresent = true, refreshable 
     },
   }), { mode: 0o600 });
   return { id, label: id, kind: "managed", home, projectsDir: path.join(home, "projects"), authPresent, createdAt: 0 };
+}
+
+for (const kind of ["legacy", "managed"] as const) {
+  for (const uncertainty of ["discovery", "metadata"] as const) {
+    test("production spawn caller refuses " + kind + " requested account uncertainty at " + uncertainty, async () => {
+      const store = await import("./claudeCredentials");
+      const originalRead = store.readClaudeCredentials;
+      const read = spyOn(store, "readClaudeCredentials").mockImplementation((home) => originalRead(home, {
+        platform: "linux", security: () => { throw new Error("unexpected Keychain access"); },
+      }));
+      const { createManagedClaudeAccount, listClaudeAccounts } = await import("./claude");
+      const { resolveHealthySpawnAccount } = await import("./manager");
+      fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+      fs.mkdirSync(process.env.LLV_CLAUDE_HOME!, { recursive: true, mode: 0o700 });
+      const requested = kind === "legacy" ? listClaudeAccounts()[0] : createManagedClaudeAccount("Account A");
+      const fallback = createManagedClaudeAccount("Account B");
+      const document = { claudeAiOauth: { ["access" + "Token"]: crypto.randomUUID(), expiresAt: Date.now() + 3600_000 } };
+      let requestedReads = 0;
+      read.mockImplementation((home) => {
+        if (home === requested.home) {
+          requestedReads += 1;
+          // The manager discovers the catalog twice before metadata is read.
+          if (uncertainty === "discovery" || requestedReads > 2) return { state: "unknown" };
+        }
+        if (home === requested.home || home === fallback.home) return { state: "present", source: "keychain", document };
+        return { state: "absent" };
+      });
+      providerReply = () => Response.json({ five_hour: { utilization: 1, resets_at: new Date(Date.now() + 3600_000).toISOString() } });
+      try {
+        const outcome = await resolveHealthySpawnAccount("claude", requested.id).then(
+          (selected) => ({ selectedAccountId: selected.accountId }), (error: unknown) => ({ error }),
+        );
+        expect("error" in outcome).toBe(true);
+        expect((outcome as { error: Error }).error.name).toBe("ClaudeCredentialUnavailableError");
+        expect((outcome as { error: Error }).error.message).toContain("credential store is unavailable");
+        expect(requestedReads).toBe(uncertainty === "discovery" ? 2 : 3);
+
+        // Prove the alternate account really can pass the production caller.
+        const healthy = await resolveHealthySpawnAccount("claude", fallback.id);
+        expect(healthy.accountId).toBe(fallback.id);
+        expect(healthy.requestedAdmission).toMatchObject({ kind: "admissible", basis: "current" });
+
+        // Proven absence retains the existing fallback behavior.
+        read.mockImplementation((home) => home === fallback.home
+          ? { state: "present", source: "keychain", document } : { state: "absent" });
+        expect((await resolveHealthySpawnAccount("claude", requested.id)).accountId).toBe(fallback.id);
+
+        read.mockReturnValue({ state: "unknown" });
+        await expect(resolveHealthySpawnAccount("claude")).rejects.toThrow("credential store is unavailable");
+      } finally {
+        read.mockRestore();
+        providerReply = null;
+        fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+      }
+    });
+  }
 }
 
 test("spawn selection skips an unrefreshable expired preferred Claude account and probes a healthy fallback", async () => {

--- a/src/lib/accounts/spawnHealth.test.ts
+++ b/src/lib/accounts/spawnHealth.test.ts
@@ -100,7 +100,8 @@ test("live usage evidence retains spawn validity classifications", () => {
   });
   expect(claudeValidityFromLimitRead({ source: "unavailable", reason: LIMITS_REAUTH_REQUIRED_REASON, data: null }, NOW)).toMatchObject({ kind: "unavailable", reason: "auth-failed" });
   expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "credentials missing access token", data: null }, NOW)).toMatchObject({ kind: "unavailable", reason: "auth-failed" });
-  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "credentials unreadable: test fixture", data: null }, NOW)).toMatchObject({ kind: "unavailable", reason: "auth-failed" });
+  expect(() => claudeValidityFromLimitRead({ source: "unavailable", reason: "credentials unreadable: test fixture", data: null }, NOW)).toThrow("credential store is unavailable");
+  expect(() => claudeValidityFromLimitRead({ source: "unavailable", reason: "credential store unavailable", data: null }, NOW)).toThrow("credential store is unavailable");
   expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "request timed out", data: null }, NOW)).toMatchObject({ kind: "admissible", basis: "last-known", stale: true });
   const retryAt = Math.floor(NOW / 1_000) + 900;
   expect(claudeValidityFromLimitRead({

--- a/src/lib/accounts/spawnHealth.ts
+++ b/src/lib/accounts/spawnHealth.ts
@@ -185,8 +185,10 @@ export async function selectHealthyClaudeAccount(
 ): Promise<ClaudeSpawnAccountSelection> {
   const now = dependencies.now();
   const classified = accounts.map((account) => {
-    const oauth = claudeOauthMetadata(account);
-    return { account, oauth };
+    const metadata = claudeOauthMetadata(account);
+    const unknown = metadata === "unknown";
+    if (unknown && pinPreferred && account.id === preferredId) throw new ClaudeCredentialUnavailableError();
+    return { account, oauth: unknown ? null : metadata, unknown };
   });
   type Evaluated = { account: ClaudeAccount; admission: SpawnAccountAdmission };
   const rank = (admission: SpawnAccountAdmission) => admission.kind === "admissible"
@@ -233,5 +235,6 @@ export async function selectHealthyClaudeAccount(
   const all = [...current, ...(requested ? [requested] : []), ...refreshed];
   const refreshedSelection = select(all);
   if (refreshedSelection) return result(refreshedSelection, requested);
+  if (classified.some((candidate) => candidate.unknown)) throw new ClaudeCredentialUnavailableError();
   throw new NoHealthyClaudeAccountError(accounts.map((candidate) => candidate.id));
 }

--- a/src/lib/accounts/spawnHealth.ts
+++ b/src/lib/accounts/spawnHealth.ts
@@ -191,6 +191,22 @@ export async function selectHealthyClaudeAccount(
     return { account, oauth: unknown ? null : metadata, unknown };
   });
   type Evaluated = { account: ClaudeAccount; admission: SpawnAccountAdmission };
+  const unknownAccounts = new Set(classified.filter((candidate) => candidate.unknown).map((candidate) => candidate.account.id));
+  const evaluate = async (
+    account: ClaudeAccount,
+    probe: ClaudeSpawnHealthDependencies["probe"],
+  ): Promise<Evaluated | null> => {
+    try {
+      return { account, admission: await probe(account) };
+    } catch (error) {
+      // Credential uncertainty excludes only this candidate. An explicit pin
+      // must still refuse substitution; identity and other errors retain their fences.
+      if (!(error instanceof ClaudeCredentialUnavailableError)
+        || (pinPreferred && account.id === preferredId)) throw error;
+      unknownAccounts.add(account.id);
+      return null;
+    }
+  };
   const rank = (admission: SpawnAccountAdmission) => admission.kind === "admissible"
     ? admission.basis === "current" ? 2 : 1
     : 0;
@@ -205,9 +221,10 @@ export async function selectHealthyClaudeAccount(
     ...(pinPreferred && preferredId && requested ? { requestedAdmission: requested.admission } : {}),
   });
 
-  const current = await Promise.all(classified
+  const current = (await Promise.all(classified
     .filter((candidate) => candidate.oauth && candidate.oauth.expiresAt > now)
-    .map(async ({ account }) => ({ account, admission: await dependencies.probe(account) })));
+    .map(({ account }) => evaluate(account, dependencies.probe))))
+    .filter((candidate) => candidate !== null);
   let requested = preferredId ? current.find((candidate) => candidate.account.id === preferredId) ?? null : null;
   if (pinPreferred && requested?.admission.kind === "admissible") return result(requested, requested);
 
@@ -228,13 +245,14 @@ export async function selectHealthyClaudeAccount(
   const currentSelection = select(current);
   if (currentSelection) return result(currentSelection, requested);
 
-  const refreshed = await Promise.all(classified
+  const refreshed = (await Promise.all(classified
     .filter((candidate) => candidate.oauth?.expiresAt && candidate.oauth.expiresAt <= now && candidate.oauth.refreshable)
     .filter((candidate) => candidate.account.id !== preferredExpired?.account.id)
-    .map(async ({ account }) => ({ account, admission: await refreshSingleFlight(account, dependencies.refresh) })));
+    .map(({ account }) => evaluate(account, (candidate) => refreshSingleFlight(candidate, dependencies.refresh)))))
+    .filter((candidate) => candidate !== null);
   const all = [...current, ...(requested ? [requested] : []), ...refreshed];
   const refreshedSelection = select(all);
   if (refreshedSelection) return result(refreshedSelection, requested);
-  if (classified.some((candidate) => candidate.unknown)) throw new ClaudeCredentialUnavailableError();
+  if (unknownAccounts.size > 0) throw new ClaudeCredentialUnavailableError();
   throw new NoHealthyClaudeAccountError(accounts.map((candidate) => candidate.id));
 }

--- a/src/lib/accounts/spawnHealth.ts
+++ b/src/lib/accounts/spawnHealth.ts
@@ -10,6 +10,10 @@ import { withAccountMutationLockAsync } from "./accountMutation";
 
 export type ClaudeValidityProbeResult = SpawnAccountAdmission;
 
+export class ClaudeCredentialUnavailableError extends Error {
+  constructor() { super("Claude credential store is unavailable; retry when access is restored"); this.name = "ClaudeCredentialUnavailableError"; }
+}
+
 export interface ClaudeSpawnAccountSelection {
   account: ClaudeAccount;
   admission: SpawnAccountAdmission;
@@ -40,7 +44,7 @@ function refreshSingleFlight(
   const pending = Promise.resolve()
     .then(() => refresh(account))
     .catch((error: unknown) => {
-      if (error instanceof UnknownClaudeAccountError) throw error;
+      if (error instanceof UnknownClaudeAccountError || error instanceof ClaudeCredentialUnavailableError) throw error;
       return classifySpawnAccountAdmission({
         enabled: true,
         authentication: "unknown",
@@ -77,9 +81,12 @@ export function claudeValidityFromLimitRead(
   },
   now = Date.now(),
 ): ClaudeValidityProbeResult {
+  if (result.reason === "credential store unavailable" || result.reason?.startsWith("credentials unreadable:")) {
+    throw new ClaudeCredentialUnavailableError();
+  }
   const authentication = result.reason === LIMITS_REAUTH_REQUIRED_REASON
     || result.reason === "credentials missing access token"
-    || result.reason?.startsWith("credentials unreadable:")
+    || result.reason === "credentials absent"
     ? "failed" as const
     : result.source === "live"
       ? "authenticated" as const
@@ -150,13 +157,7 @@ async function refreshValidityProbe(account: ClaudeAccount): Promise<ClaudeValid
       });
     }
     if (refreshed === "unknown") {
-      return classifySpawnAccountAdmission({
-        enabled: true,
-        authentication: "unknown",
-        limits: "unknown",
-        stale: true,
-        retryAt: null,
-      });
+      throw new ClaudeCredentialUnavailableError();
     }
     return await liveValidityProbe(current);
   });

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -14,7 +14,7 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
 process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
 
-const { freshSpecFor, resumeSpecFor, withSpawnCapability } = await import("./cli");
+const { claudeEnvPrefix, freshSpecFor, resumeSpecFor, withSpawnCapability } = await import("./cli");
 const { createManagedCodexAccount } = await import("@/lib/accounts/codex");
 const { createManagedClaudeAccount } = await import("@/lib/accounts/claude");
 const { saveTelegramSession, telegramConnectorTokenPath, telegramSessionPath } = await import("@/lib/telegram/sessionStore");
@@ -532,6 +532,7 @@ test("managed Claude fresh and resume commands pin the transcript owner and scru
   expect(transcript.startsWith(account.projectsDir + path.sep)).toBe(true);
   expect(fresh.command).toContain("CLAUDE_CONFIG_DIR=");
   expect(fresh.command).toContain("-u ANTHROPIC_API_KEY");
+  expect(fresh.command).toContain("-u CLAUDE_SECURESTORAGE_CONFIG_DIR");
   expect(fresh.command).toContain("-u LLV_TOKEN");
   const sid = path.basename(transcript, ".jsonl");
   const settingsPath = path.join(account.home, ".llv", "spawn-settings", `${sid}.json`);
@@ -544,6 +545,33 @@ test("managed Claude fresh and resume commands pin the transcript owner and scru
   expect(resumed).toContain(`CLAUDE_CONFIG_DIR='${account.home}'`);
   expect(resumed).toContain(`'--strict-mcp-config' '--mcp-config' '${path.join(account.home, ".llv", "spawn-mcp", `resume-${sid}.json`)}'`);
   expect(resumed).toContain("--resume");
+  expect(resumed).toContain("-u CLAUDE_SECURESTORAGE_CONFIG_DIR");
+});
+
+test("Claude child environment keeps each account home and removes the inherited store override", () => {
+  for (const directory of [process.env.LLV_CLAUDE_HOME!, path.join(SANDBOX, "managed account")]) {
+    for (const grants of [[], ["telegram"]]) {
+      const probe = "test -z \"${CLAUDE_SECURESTORAGE_CONFIG_DIR+x}\" && test \"$CLAUDE_CONFIG_DIR\" = \"$EXPECTED_HOME\"";
+      const child = Bun.spawnSync(["sh", "-c", `${claudeEnvPrefix(directory, grants)} sh -c '${probe}'`], {
+        env: { ...process.env, CLAUDE_SECURESTORAGE_CONFIG_DIR: path.join(SANDBOX, "another-account"), EXPECTED_HOME: directory },
+        stdout: "pipe", stderr: "pipe",
+      });
+      expect(child.stderr.toString()).toBe("");
+      expect(child.exitCode).toBe(0);
+    }
+  }
+});
+
+test("legacy Claude fresh and resumed commands pin the same store as browser login", () => {
+  const home = process.env.LLV_CLAUDE_HOME!;
+  const fresh = freshSpecFor("claude", SANDBOX);
+  fs.mkdirSync(path.dirname(fresh.transcript!), { recursive: true });
+  fs.writeFileSync(fresh.transcript!, JSON.stringify({ cwd: SANDBOX }) + "\n");
+  const resumed = resumeSpecFor("claude-projects", fresh.transcript!)!;
+  for (const spec of [fresh, resumed]) {
+    expect(spec.command).toContain(`CLAUDE_CONFIG_DIR='${home}'`);
+    expect(spec.command).toContain("-u CLAUDE_SECURESTORAGE_CONFIG_DIR");
+  }
 });
 
 test("allowSubagents leaves a managed Claude fresh spawn without the Viewer hook", () => {

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -172,7 +172,7 @@ export interface FreshSpecOptions {
   deferClaudeSpawnPolicy?: boolean;
 }
 
-const CLAUDE_SHADOWED_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS", "VERTEXAI_PROJECT", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "LLV_TOKEN"];
+const CLAUDE_SHADOWED_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_SECURESTORAGE_CONFIG_DIR", "ANTHROPIC_BASE_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS", "VERTEXAI_PROJECT", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "LLV_TOKEN"];
 
 function telegramTokenAssignment(mcpServers: readonly string[]): string {
   if (!mcpServers.includes("telegram")) return "";
@@ -330,7 +330,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
     else args.push("--strict-mcp-config");
     const command = args.map(shellQuote).join(" ");
     return {
-      command: telegramScopedCommand(managed ? `${claudeEnvPrefix(options.claudeConfigDir!, mcpServers)} ${command}` : command, mcpServers),
+      command: telegramScopedCommand(`${claudeEnvPrefix(options.claudeConfigDir ?? legacyClaudeHome(), mcpServers)} ${command}`, mcpServers),
       cwd,
       windowName: "claude-new",
       engine: "claude",
@@ -489,7 +489,7 @@ export function resumeSpecForSession(
     args.push("--resume", sessionId);
     const command = args.map(shellQuote).join(" ");
     return {
-      command: telegramScopedCommand(managed ? `${claudeEnvPrefix(home, mcpServers)} ${command}` : command, mcpServers),
+      command: telegramScopedCommand(`${claudeEnvPrefix(home, mcpServers)} ${command}`, mcpServers),
       cwd,
       windowName: "claude-resume",
       engine: "claude",

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -1443,3 +1443,23 @@ test("forgetting one account's cached limits sends the next read back to the pro
   expect(reads).toBe(2);
   resetLimitsCache();
 });
+
+
+test("Claude limits uses the shared account store and contains unknown-store errors", async () => {
+  const store = await import("./accounts/claudeCredentials");
+  const read = spyOn(store, "readClaudeCredentials");
+  const request = spyOn(globalThis, "fetch").mockImplementation((async (_url: string | URL | Request, init?: RequestInit) => {
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer fixture");
+    return Response.json({ five_hour: { utilization: 23 } });
+  }) as typeof fetch);
+  try {
+    read.mockReturnValue({ state: "present", source: "keychain", document: { claudeAiOauth: { accessToken: "fixture", subscriptionType: "max" } } });
+    const file = path.join(SANDBOX, "keychain-account", ".credentials.json");
+    expect(await fetchClaudeLimits(file)).toMatchObject({ source: "live", data: { plan: "max", session: { usedPercent: 23 } } });
+    expect(read).toHaveBeenCalledWith(path.dirname(file));
+    read.mockReturnValue({ state: "unknown" });
+    expect(await fetchClaudeLimits(file)).toEqual({ source: "unavailable", data: null, reason: "credential store unavailable" });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(file)).toBe(false);
+  } finally { read.mockRestore(); request.mockRestore(); }
+});

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -1,3 +1,4 @@
+import { readClaudeCredentials } from "@/lib/accounts/claudeCredentials";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -360,7 +361,7 @@ interface OauthWindow {
 
 /**
  * Live usage from the same OAuth endpoint the Claude Code CLI uses. The token
- * from ~/.claude/.credentials.json stays inside the server process; the
+ * from the account-scoped credential store stays inside the server process; the
  * browser only ever sees percentages.
  */
 export async function fetchClaudeLimits(
@@ -372,15 +373,13 @@ export async function fetchClaudeLimits(
   // credential assignment to the publication gate and fails the scan.
   let oauthToken = "";
   let plan: string | null = null;
-  try {
-    const raw = JSON.parse(fs.readFileSync(credentialsPath, "utf8")) as {
-      claudeAiOauth?: { accessToken?: unknown; subscriptionType?: unknown };
-    };
-    if (typeof raw.claudeAiOauth?.accessToken === "string") oauthToken = raw.claudeAiOauth.accessToken;
-    if (typeof raw.claudeAiOauth?.subscriptionType === "string") plan = raw.claudeAiOauth.subscriptionType;
-  } catch (err) {
-    return { data: null, reason: `credentials unreadable: ${err instanceof Error ? err.message : String(err)}`, source: "unavailable" };
+  const credentials = readClaudeCredentials(path.dirname(credentialsPath));
+  if (credentials.state !== "present") {
+    return { data: null, reason: credentials.state === "absent" ? "credentials absent" : "credential store unavailable", source: "unavailable" };
   }
+  const oauth = credentials.document.claudeAiOauth;
+  if (typeof oauth?.accessToken === "string") oauthToken = oauth.accessToken;
+  if (typeof oauth?.subscriptionType === "string") plan = oauth.subscriptionType;
   if (!oauthToken) return { data: null, reason: "credentials missing access token", source: "unavailable" };
   try {
     const res = await fetch(OAUTH_USAGE_URL, {


### PR DESCRIPTION
Fixes #1550

Claude browser authentication can succeed on macOS while Viewer rejects the account because no credentials JSON file exists. This change uses one account-scoped credential reader for login completion, discovery, quota, and OAuth refresh. It follows the provider Keychain service naming, retains file ownership and mode checks, and stores rotated credentials in their original backend. Keychain writes use stdin. Claude fresh and resume commands pin the selected account directory for Main and managed accounts and clear the inherited secure-storage override.

Credential-store uncertainty now survives catalog discovery and the OAuth metadata re-read. The production spawn caller refuses an explicitly requested account's substitution with a credential-unavailable error when either read is unknown. Healthy selections and proven-absence fallback retain their existing behavior. Accounts GET, limits refresh, and status preserve unknown authentication; authoritative provider results retain precedence, and indeterminate status stays unknown.

The authorized ownership expansion adds src/app/api/accounts/limitsRefresh.ts and src/app/api/accounts/claude/[id]/status/route.ts to the existing account/provider/CLI scope. Regressions remain in the focused account-route, OAuth, credential, and spawn-health tests.

Current main, including accepted PR1544, was integrated with a normal merge. Its registry, monitor, and SQLite files match main exactly.

Validation at f9974791496f4e989dfef369858e67a1f08371a8, merge base 0625e7b3d1bce4edfa3514f2d2f4b1d4884bbcee:

- 230 focused Linux tests pass; two native-only tests skip locally. Every test file runs in a separate process with isolated home, config, state, provider, account, socket, and private disk temporary roots established before imports.
- New production-caller regressions cover Main and managed accounts with uncertainty at discovery and metadata re-read, refresh/status consistency, healthy selection, proven-absence fallback, authoritative quota results, and indeterminate status. Before the fixes, all four spawn cases selected the fallback and both refresh cases fabricated signed-out state. Restoring the old status handler separately makes both status regressions fail.
- Bun 1.3.3 frozen dependency installation, nonincremental TypeScript, and privacy publication checks with fingerprints and commit inspection pass.
- Native macOS CI passes with a disposable synthetic Keychain and the pinned published Claude 2.1.263 binary. It exercises account separation, recognition, completion, rotation, locked-store behavior, the new caller regressions, and the three Claude CLI storage assertions: [native macOS proof](https://github.com/Latand/live-log-viewer-next/actions/runs/34160396196/job/101860840105).
- Required privacy checks pass: [publication privacy](https://github.com/Latand/live-log-viewer-next/actions/runs/34160393801/job/101860832949), [tracker privacy](https://github.com/Latand/live-log-viewer-next/actions/runs/34160393787/job/101860832952).

The native job checked out merge commit 7450fc43915bc07449cdbb5f06b8c3c0081b10b1; its tree equals the PR head tree 5535a63250cf0e645a869d7efc98773ddb8703bf.

The privacy repair remains limited to the public provider client UUID representation and runtime-generated OAuth fixtures. Final review, guarded merge, and release verification follow separately.
