### PR TITLE
fix(runtime): bound historical startup snapshot work

### DIFF
--- a/src/lib/runtime/fixtures/startupPipelineContender.ts
+++ b/src/lib/runtime/fixtures/startupPipelineContender.ts
@@ -1,0 +1,20 @@
+import { createPipelineFromRequest, defaultPipelinePorts } from "@/lib/pipelines/engine";
+import { loadPipelinesForProjection } from "@/lib/pipelines/store";
+import path from "node:path";
+
+// The parent supplies an empty private environment before this module loads.
+const directory = process.argv[2]!;
+try {
+  const result = await createPipelineFromRequest({
+    task: "Create during historical startup reconciliation",
+    repoDir: directory,
+    autoStart: false,
+    stages: [],
+  }, {
+    ...defaultPipelinePorts(),
+    preflightRepo: () => ({ ok: true, repoDir: directory, gitCommonDir: path.join(directory, ".git"), worktreeParent: directory }),
+  }, { allowOperatorDraftWithoutLineage: true });
+  console.log(JSON.stringify({ created: Boolean(result.pipeline), error: result.error ?? null, persisted: loadPipelinesForProjection().length }));
+} catch (error) {
+  console.log(JSON.stringify({ created: false, error: error instanceof Error ? error.message : String(error), persisted: loadPipelinesForProjection().length }));
+}

--- a/src/lib/runtime/startupFinalization.integration.test.ts
+++ b/src/lib/runtime/startupFinalization.integration.test.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+// Clear inherited credentials, runtime endpoints and provider roots BEFORE imports.
+// TMPDIR is supplied on private disk by the invoking test environment.
+const ambient = { ...process.env };
+const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-startup-finalization-"));
+for (const name of Object.keys(process.env)) delete process.env[name];
+Object.assign(process.env, { PATH: ambient.PATH, NODE_ENV: "test" });
+for (const [name, suffix] of Object.entries({ HOME: "home", XDG_CONFIG_HOME: "config", LLV_STATE_DIR: "state", TMPDIR: "tmp", CODEX_HOME: "codex", LLV_CODEX_HOME: "codex", CLAUDE_CONFIG_DIR: "claude", LLV_CLAUDE_HOME: "claude" })) {
+  const directory = path.join(isolated, suffix);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  process.env[name] = directory;
+}
+fs.mkdirSync(path.join(isolated, "sockets"), { mode: 0o700 });
+
+const { AgentRegistry } = await import("@/lib/agent/registry");
+const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+const { RuntimeHost } = await import("@/runtime-host/host");
+const { serveRuntimeHost } = await import("@/runtime-host/socket");
+const { UnixRuntimeHostClient } = await import("./client");
+const { RuntimeJournal } = await import("@/runtime-host/journal");
+const { adoptStructuredHostsAtStartup } = await import("./startup");
+const { bindStructuredDeliveryQueue } = await import("./structuredDeliveryController");
+const { runStructuredHostStartup } = await import("@/lib/viewerInstrumentation");
+const { recoverPendingStructuredSpawns, reconcileStructuredSpawnReplay } = await import("./structuredSpawn");
+const { captureProcessIdentity } = await import("@/lib/processIdentity");
+const { structuredStartupStatus } = await import("./startupStatus");
+type RuntimeHostClient = import("./client").RuntimeHostClient;
+type RegistryFile = import("@/lib/agent/registry").RegistryFile;
+
+afterAll(() => {
+  for (const name of Object.keys(process.env)) delete process.env[name];
+  Object.assign(process.env, ambient);
+  fs.rmSync(isolated, { recursive: true, force: true });
+});
+
+function fixture(failedCount: number, fullHistory = false) {
+  const directory = fs.mkdtempSync(path.join(isolated, "fixture-"));
+  const filename = path.join(directory, "registry.json");
+  const seed = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+  const begun = seed.beginSpawnRequest({
+    engine: "codex", cwd: directory, transport: "structured", accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: directory, title: "Historical failed launch" }),
+  });
+  seed.failSpawn(begun.receipt.launchId, "historical failure");
+  if (fullHistory) {
+    const artifactPath = path.join(directory, "history-seed.jsonl");
+    const conversation = seed.ensureConversation("codex", artifactPath, null);
+    const sessionId = conversation.generations.at(-1)!.id;
+    const delivery = seed.holdDelivery(conversation.id, "Historical delivery", "history-seed", "text");
+    seed.recordDeliveryOutcome(delivery.id, "failed", "historical failure");
+    seed.upsert({
+      key: { engine: "codex", sessionId }, artifactPath, cwd: directory, accountId: null,
+      launchProfile: emptyLaunchProfile({ cwd: directory }), status: "dead", host: null,
+      structuredHost: { kind: "codex-app-server", endpoint: "stdio:released", process: null,
+        eventCursor: 0, protocolVersion: null, writerClaimEpoch: 0, activeTurnRef: null,
+        pendingAttention: [], activeFlags: [] },
+      claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+  }
+  const data = JSON.parse(fs.readFileSync(filename, "utf8")) as RegistryFile;
+  const receipt = data.receipts[begun.receipt.launchId]!;
+  data.receipts = {};
+  for (let i = 0; i < failedCount; i++) {
+    const launchId = `historical_launch_${i}`;
+    data.receipts[launchId] = { ...receipt, launchId, conversationId: `conversation_history_${i}` };
+  }
+  if (fullHistory) {
+    const entry = Object.values(data.entries)[0]!;
+    const conversation = Object.values(data.conversations)[0]!;
+    data.entries = {};
+    data.conversations = {};
+    for (let i = 0; i < 8078; i++) {
+      const id = `conversation_history_${i}` as const;
+      const sessionId = `history_${i}`;
+      const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+      if (i < 5188) data.entries[`codex:${sessionId}`] = {
+        ...entry, key: { engine: "codex", sessionId }, artifactPath,
+      };
+      data.conversations[id] = {
+        ...conversation, id,
+        turn: { state: "terminal", source: "assistant", terminalAt: receipt.createdAt, observedAt: receipt.createdAt },
+        generations: conversation.generations.map((generation) => ({ ...generation, id: sessionId, path: artifactPath })),
+      };
+    }
+    const held = Object.values(data.heldDeliveries)[0]!;
+    data.heldDeliveries = {};
+    for (let i = 0; i < 1719; i++) {
+      const id = `historical_delivery_${i}`;
+      data.heldDeliveries[id] = {
+        ...held, id, conversationId: `conversation_history_${i}`, clientMessageId: id,
+        command: { ...held.command, operationId: `historical_operation_${i}` },
+        state: i < 153 ? "failed" : "delivered",
+      };
+    }
+    for (let i = failedCount; i < 6623; i++) {
+      const launchId = `historical_launch_${i}`;
+      data.receipts[launchId] = {
+        ...receipt, launchId, conversationId: `conversation_history_${i}`,
+        state: i < 6458 ? "completed" : i < 6590 ? "conflicted" : i < 6611 ? "starting"
+          : i < 6618 ? "host-verified" : i < 6622 ? "pane-bound" : "path-pending",
+      };
+    }
+  }
+  fs.writeFileSync(filename, JSON.stringify(data));
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = {
+    snapshot: async () => journal.snapshot(),
+    events: async (after) => journal.replay(after),
+    append: async (event) => journal.append(event),
+    command: async (command) => journal.executeOperation(command),
+    operationStatus: async (id, options) => options?.currentRetryLeaf ? journal.currentRetryResult(id) : journal.operationResult(id),
+    producerCursor: async (kind, prefix) => journal.producerCursor(kind, prefix),
+    effectBatch: async (kinds, after) => journal.effectBatch(100, kinds, after),
+    transitionOperation: async (id, status, details) => journal.transitionOperation(id, status, details),
+  } satisfies Partial<RuntimeHostClient> as RuntimeHostClient;
+  return { directory, registry, journal, client };
+}
+
+test("historical failed launches do not retain startup admission across one full runtime snapshot per receipt", async () => {
+  const f = fixture(672);
+  // Runtime history and failed receipt cardinalities match the incident's scale.
+  // Transport latency is bounded and lower than the measured live snapshot read.
+  for (let i = 0; i < 862; i++) f.journal.append({
+    scope: { type: "session", id: `conversation_runtime_history_${i}` },
+    kind: "session-status",
+    producer: { kind: "structured-delivery-controller", eventKey: `history:${i}` },
+    payload: { conversationId: `conversation_runtime_history_${i}`, host: "dead", turn: "idle", cwd: f.directory },
+  });
+  const before = structuredClone(f.registry.readOnlySnapshot().receipts);
+  let snapshots = 0;
+  let spawnRecovery = false;
+  let signalRecovery!: () => void;
+  const recoveryEntered = new Promise<void>((resolve) => { signalRecovery = resolve; });
+  const timeline: string[] = [];
+  const client: RuntimeHostClient = {
+    ...f.client,
+    snapshot: async () => {
+      snapshots += 1;
+      if (spawnRecovery) signalRecovery();
+      await Bun.sleep(60);
+      return f.journal.snapshot();
+    },
+    effectBatch: async (kinds, after) => {
+      if (kinds?.length === 1 && kinds[0] === "runtime.spawn") {
+        spawnRecovery = true;
+        timeline.push("spawn-recovery");
+      } else timeline.push("delivery-signals-or-drain");
+      return f.client.effectBatch(kinds, after);
+    },
+  };
+  const startup = runStructuredHostStartup(() => adoptStructuredHostsAtStartup({
+    registry: f.registry, client, refreshTranscriptState: async () => {},
+    adopt: async () => [], adoptClaude: async () => [], orchestratorSeats: () => [],
+  }), () => {}, { waitUntilReady: true });
+  try {
+    await recoveryEntered;
+    expect(structuredStartupStatus()?.state).toBe("pending");
+    const db = new Database(path.join(process.env.LLV_STATE_DIR!, "state.sqlite"), { readonly: true });
+    const held = db.query("SELECT owner_pid, owner_start_identity FROM state_leases WHERE collection = 'pipelines'").get() as { owner_pid: number; owner_start_identity: string };
+    db.close();
+    expect(held.owner_pid).toBe(process.pid);
+    expect(held.owner_start_identity).toBeTruthy();
+    timeline.push("lease-owned-during-recovery");
+    const contender = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures/startupPipelineContender.ts"), f.directory], {
+      env: { ...process.env }, stdout: "pipe", stderr: "pipe",
+    });
+    const stdout = new Response(contender.stdout).text();
+    const stderr = new Response(contender.stderr).text();
+    await startup;
+    timeline.push("startup-settled");
+    expect(await contender.exited).toBe(0);
+    expect(await stderr).toBe("");
+    const result = JSON.parse(await stdout);
+    console.log(JSON.stringify({ timeline, snapshots, creation: result }));
+    expect(result).toEqual({ created: true, error: null, persisted: 1 });
+    expect(snapshots).toBeLessThanOrEqual(4);
+    expect(structuredStartupStatus()?.state).toBe("ready");
+    expect(f.registry.readOnlySnapshot().receipts).toEqual(before);
+    const after = new Database(path.join(process.env.LLV_STATE_DIR!, "state.sqlite"), { readonly: true });
+    expect(after.query("SELECT count(*) AS n FROM state_leases WHERE collection = 'pipelines'").get()).toEqual({ n: 0 });
+    after.close();
+  } finally {
+    await startup;
+    await bindStructuredDeliveryQueue([], { registry: f.registry, client: null });
+    f.journal.close();
+  }
+}, 90_000);
+
+
+test("a failed historical snapshot remains unknown and a later pass retries it", async () => {
+  const f = fixture(3);
+  const before = structuredClone(f.registry.readOnlySnapshot().receipts);
+  let reads = 0;
+  const unavailable: RuntimeHostClient = {
+    ...f.client,
+    snapshot: async () => { reads += 1; throw new Error("fixture snapshot unavailable"); },
+  };
+  try {
+    await recoverPendingStructuredSpawns(f.registry, unavailable);
+    expect(reads).toBe(2); // Shared historical read plus the registering-session hint.
+    expect(f.registry.readOnlySnapshot().receipts).toEqual(before);
+    await recoverPendingStructuredSpawns(f.registry, unavailable);
+    expect(reads).toBe(4); // No rejected snapshot survives its pass.
+    expect(f.registry.readOnlySnapshot().receipts).toEqual(before);
+  } finally { f.journal.close(); }
+});
+
+test("pending launches ignore a historical snapshot supplier", async () => {
+  const f = fixture(0);
+  const begun = f.registry.beginSpawnRequest({
+    engine: "codex", cwd: f.directory, transport: "structured", accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: f.directory, title: "Pending launch" }),
+  });
+  let freshReads = 0;
+  try {
+    const result = await reconcileStructuredSpawnReplay(begun.receipt.launchId, f.registry, {
+      ...f.client, snapshot: async () => { freshReads += 1; return f.journal.snapshot(); },
+    }, { failedReceiptSnapshot: async () => { throw new Error("historical evidence must not be consulted"); } });
+    expect(freshReads).toBe(1);
+    expect(result.state).toBe("starting");
+  } finally { f.journal.close(); }
+});
+
+test("historical reconciliation recovers late transcript evidence and preserves a current writer claim", async () => {
+  const f = fixture(0);
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(f.directory, `${sessionId}.jsonl`);
+  const key = { engine: "codex" as const, sessionId };
+  const begun = f.registry.beginSpawnRequest({
+    engine: "codex", cwd: f.directory, transport: "structured", accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: f.directory, title: "Late delivery" }),
+  });
+  f.registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key, artifactPath, cwd: f.directory, accountId: null, status: "unhosted", host: null,
+    structuredHost: null, claimEpoch: 0, claimOwner: null, pendingAction: "spawn",
+  });
+  f.registry.failStructuredSpawn(begun.receipt.launchId, "unknown delivery before restart");
+  fs.writeFileSync(artifactPath, JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "Synthetic late delivery" } }) + "\n");
+  const stored = f.registry.readOnlySnapshot().entries[`codex:${sessionId}`]!;
+  f.registry.upsert({ ...stored, structuredHost: {
+    kind: "codex-app-server", endpoint: "fixture:late", process: null,
+    eventCursor: 0, protocolVersion: "fixture", writerClaimEpoch: 0,
+    activeTurnRef: null, pendingAttention: [], activeFlags: [],
+  } });
+  // The shared runtime evidence describes the old unhosted projection while
+  // the durable registry below has a newer writer; recovery must merge that claim.
+  f.journal.append({
+    scope: { type: "session", id: begun.receipt.conversationId }, kind: "session-status",
+    payload: { conversationId: begun.receipt.conversationId, sessionKey: key,
+      hostKind: "codex-app-server", host: "unhosted", cwd: f.directory, artifactPath },
+  });
+  const claimed = f.registry.claimStructuredHost(key, captureProcessIdentity(process.pid), { allowUnhosted: true });
+  expect(claimed?.claimOwner).toBeTruthy();
+  try {
+    await recoverPendingStructuredSpawns(f.registry, f.client);
+    const receipt = f.registry.readOnlySnapshot().receipts[begun.receipt.launchId]!;
+    expect(receipt.state).toBe("completed");
+    expect(receipt.conversationId).toBe(begun.receipt.conversationId);
+    expect(f.registry.readOnlySnapshot().entries[`codex:${sessionId}`]?.claimOwner).toBe(claimed!.claimOwner);
+    await recoverPendingStructuredSpawns(f.registry, f.client);
+    expect(f.registry.readOnlySnapshot().receipts[begun.receipt.launchId]).toEqual(receipt);
+  } finally { f.journal.close(); }
+});
+
+
+test("the full retained history completes within the unchanged promoted-verification deadline", async () => {
+  const f = fixture(672, true);
+  const initial = f.registry.readOnlySnapshot();
+  expect(Object.keys(initial.receipts)).toHaveLength(6623);
+  expect(Object.keys(initial.conversations)).toHaveLength(8078);
+  expect(Object.keys(initial.entries)).toHaveLength(5188);
+  const failed = Object.values(initial.receipts).filter((receipt) => receipt.state === "failed");
+  // Seed only the runtime's retained session window. Startup must publish the
+  // remaining historical registry rows through the real socket and journal.
+  for (let i = 0; i < 862; i++) f.journal.append({
+    scope: { type: "session", id: `conversation_history_${i}` }, kind: "session-status",
+    producer: { kind: "structured-delivery-controller", eventKey: `history:${i}` },
+    payload: {
+      conversationId: `conversation_history_${i}`, sessionKey: { engine: "codex", sessionId: `history_${i}` },
+      hostKind: "codex-app-server", host: "dead", turn: "unknown", provenance: "structured",
+      accountId: null, parentConversationId: null, cwd: f.directory,
+      artifactPath: path.join(f.directory, `history_${i}.jsonl`), activeTurnId: null,
+    },
+  });
+  const counts: Record<string, number> = {};
+  const host = new RuntimeHost(f.journal);
+  // A short private endpoint also fits Unix sockaddr limits on CI.
+  const socketPath = path.join(isolated, "sockets", "history.sock");
+  const server = serveRuntimeHost(socketPath, { handle: async (request, options) => {
+    counts[request.method] = (counts[request.method] ?? 0) + 1;
+    // Three seconds exceeds the measured 2.6s full snapshot HTTP read. Other
+    // calls pay 5ms before actual socket/journal work; live status reads were <1ms.
+    await Bun.sleep(request.method === "snapshot" ? 3000 : 5);
+    return host.handle(request, options);
+  } });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const client = new UnixRuntimeHostClient(socketPath);
+  const started = performance.now();
+  try {
+    await runStructuredHostStartup(() => adoptStructuredHostsAtStartup({
+      registry: f.registry, client, refreshTranscriptState: async () => {},
+      adopt: async () => [], adoptClaude: async () => [], orchestratorSeats: () => [],
+    }), () => {}, { waitUntilReady: true });
+    const elapsedMs = performance.now() - started;
+    console.log(JSON.stringify({ history: { receipts: 6623, conversations: 8078, entries: 5188 }, counts, elapsedMs }));
+    // deploymentAdapter's existing verify-promoted action budget, unchanged.
+    expect(elapsedMs).toBeLessThan(120_000);
+    expect(counts.snapshot).toBe(4);
+    expect(counts.append).toBeGreaterThan(4300);
+    expect(counts["operation-status"]).toBe(1518);
+    expect(structuredStartupStatus()?.state).toBe("ready");
+    expect(Object.values(f.registry.readOnlySnapshot().receipts).filter((receipt) => receipt.state === "failed").slice(0, 672)).toEqual(failed);
+    const contender = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures/startupPipelineContender.ts"), f.directory], {
+      env: { ...process.env }, stdout: "pipe", stderr: "pipe",
+    });
+    const output = new Response(contender.stdout).text();
+    const errors = new Response(contender.stderr).text();
+    expect(await contender.exited).toBe(0);
+    expect(await errors).toBe("");
+    expect(JSON.parse(await output)).toMatchObject({ created: true, error: null });
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry: f.registry, client: null });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    f.journal.close();
+  }
+}, 130_000);

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -32,7 +32,7 @@ import { isRuntimeHostTransportFailure, type RuntimeHostClient } from "./client"
 import { supervisedRuntimeHostUnavailableReason } from "./flags";
 import { StructuredHostAdoptionCleanupError, StructuredSessionMaterializationError, type EngineHost, type HostState, type SessionMaterializationEvidence } from "./engineHost";
 import { messageOriginRole, type MessageOrigin } from "./messageOrigin";
-import { runtimeSettingsCapability, type RuntimeOperationResult, type RuntimeSession } from "./contracts";
+import { runtimeSettingsCapability, type RuntimeOperationResult, type RuntimeSession, type RuntimeSnapshot } from "./contracts";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
 import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost, structuredDeliveryLastError } from "./structuredDeliveryController";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
@@ -429,6 +429,10 @@ export async function reconcileStructuredSpawnReplay(
     releaseHost?: (key: SessionKey) => Promise<boolean>;
     terminateHostProcess?: (expected: ProcessIdentity) => Promise<boolean>;
     drainError?: (conversationId: string) => string | null;
+    /** One startup pass may share historical identity evidence across failed
+        receipts. Pending launches always read fresh state below. Live writer
+        claims are still merged atomically by recoverStructuredSpawnFromEvidence. */
+    failedReceiptSnapshot?: () => Promise<RuntimeSnapshot>;
   } = {},
 ): Promise<SpawnReceipt & { initialMessage: "pending" | "queued" | "delivered" | "failed" }> {
   const current = registry.readOnlySnapshot().receipts[launchId];
@@ -442,7 +446,9 @@ export async function reconcileStructuredSpawnReplay(
   const [initialOperation, spawnOperation, runtime] = await Promise.all([
     client.operationStatus(`spawn_message_${launchId}`, { currentRetryLeaf: true }).catch(() => null),
     client.operationStatus(launchId, { currentRetryLeaf: true }).catch(() => null),
-    client.snapshot().catch(() => null),
+    (current.state === "failed" && options.failedReceiptSnapshot
+      ? options.failedReceiptSnapshot()
+      : client.snapshot()).catch(() => null),
   ]);
   let operation = initialOperation;
   let effectHistoryUnavailable = false;
@@ -1131,6 +1137,14 @@ export async function recoverPendingStructuredSpawns(
     afterEventSeq = next;
   }
 
+  // Historical failures need one identity snapshot for this pass. Fetching the
+  // entire runtime once per failed receipt multiplies startup admission work
+  // by both retained histories (#1552). Each receipt still
+  // reads its current operations and crosses the registry's atomic settlement.
+  // A failed snapshot stays unknown for this pass; it is never an empty snapshot.
+  let failedReceiptRuntime: Promise<RuntimeSnapshot> | undefined;
+  const failedReceiptSnapshot = () => failedReceiptRuntime ??= client.snapshot();
+
   let registeringConversationIds: Set<string> | null = null;
   const registeringSessions = async (): Promise<Set<string>> => {
     if (!registeringConversationIds) {
@@ -1168,7 +1182,7 @@ export async function recoverPendingStructuredSpawns(
       continue;
     }
     if (receipt.state === "failed" && receipt.transport !== "tmux") {
-      const reconciled = await reconcileStructuredSpawnReplay(receipt.launchId, registry, client);
+      const reconciled = await reconcileStructuredSpawnReplay(receipt.launchId, registry, client, { failedReceiptSnapshot });
       if (reconciled.state === "completed") continue;
       /* The durable launch receipt failed, but its runtime spawn operation can
          survive as queued when the terminal transition itself timed out. The


### PR DESCRIPTION
Startup replay reads the full runtime snapshot once for every historical failed launch while holding the pipeline admission lease. The regression on `8c2242e6f36fc1adea396863cb28cd9d83ec0cd6` made 675 snapshot reads, ran for 47.1 seconds, and an independent Bun process calling `createPipelineFromRequest` failed with `pipeline state is busy`.

Share one runtime snapshot across failed receipts within a recovery pass. Pending launches keep fresh snapshots, every receipt keeps fresh operation-status reads, and registry settlement preserves current writer claims. Snapshot failure remains unknown; the next pass retries it. Lease lifetime, survivor fences, readiness rules, and deployment deadlines are unchanged.

Closes #1552.

Verification:
- Causal regression: baseline 675 snapshots / pipeline creation refused; candidate four snapshots / creation persisted, about one second.
- Full synthetic history through the real Unix runtime socket, controller, journal and SQLite stores: 6,623 receipts, 8,078 conversations, 5,188 entries, and 1,719 held deliveries. With 3 seconds added to each snapshot and 5 ms to every other runtime request, finalization completed in 51.1 seconds against the existing 120-second promoted-verification deadline: four snapshots, 5,060 fallback publications, 1,518 fresh status reads. Creation after readiness succeeded. These bounds cover finalization; transcript refresh and engine launch are supplied by fixtures, with both-engine handover covered separately. This is isolated evidence, not a production deployment result.
- 53 focused tests passed, including late-success, unknown snapshot, current writer, survivor deferral, readiness and two-engine handover checks. Bun 1.4.0, frozen install, empty private provider homes/state on disk; inherited credentials cleared before imports. Nonincremental TypeScript passed.
- Scoped ESLint is unverified: the frozen toolchain crashes loading `react/display-name` with `contextOrFilename.getFilename is not a function`, reproduced on fresh baseline source.

Bootstrap after independent review and guarded merge:
1. Run root release gates against the exact merged revision.
2. The designated Deployer uses the existing `POST /api/runtime/deployments` with the new full revision and one idempotency key. That route delegates directly to the runtime host, so pipeline creation is not a prerequisite. The deployment API, coordinator, adapter and activation source are unchanged from deployed host revision `bdf4b85658802c2e1765382c5aef04a6585980a7`.
3. Let the supported target/authority handover demote the incumbent and activate the candidate. Keep polling the same deployment; do not clean leases or terminate owners. Confirm startup readiness and pipeline write availability before new lane creation. A creation during unfinished startup can still return busy under conservative transport latency.
4. Require terminal deployment success and matching Viewer/MCP/runtime identities; run the root account and runtime checks. An unknown or failed outcome requires diagnosis before another deployment.

No production state mutation, deployment, merge, lock cleanup, or process termination was performed by this lane. The isolated reproduction identifies excessive historical snapshot work; live evidence does not establish a dependency cycle or an exact live stack.
