### PR TITLE
fix(runtime): preserve startup progress and adopted writers

### DIFF
--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -151,6 +151,7 @@ try:
                 contender = subprocess.run([str(bun), "src/lib/runtime/fixtures/startupPipelineContender.ts", str(root / "state")], cwd=repo, env=env, capture_output=True, text=True)
                 with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
                     sends = db.execute("SELECT json_extract(receipt_json,'$.status'),count(*) FROM operations WHERE idempotency_key LIKE 'queued-startup-%' GROUP BY 1").fetchall()
+                (root / "ownership.json").write_text(json.dumps({"before": before_claims, "after": current_claims}, indent=2))
                 result.update({"ready": True, "elapsedMs": elapsed, "hosted": hosted, "queuedSends": dict(sends), "ownershipPreserved": before_claims is not None and current_claims == before_claims, "creation": json.loads(contender.stdout), "creationExit": contender.returncode})
                 break
             time.sleep(.25)

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python3
+"""Rehearse packaged Viewer startup with an explicitly pinned runtime-host tree.
+
+Build with LLV_STANDALONE=1 first. The package must contain bin/, dist/, public/
+and .next/static as the shipped distribution does. All state and logs are new,
+private files. No operator state, credentials, provider CLI or stable port is used.
+"""
+import argparse
+import collections
+import json
+import os
+from pathlib import Path
+import socket
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--viewer", type=Path, required=True, help="immutable standalone package")
+parser.add_argument("--runtime-source", type=Path, required=True, help="exact incumbent runtime-host source tree")
+parser.add_argument("--bun", type=Path, required=True)
+args = parser.parse_args()
+repo = Path(__file__).resolve().parents[1]
+viewer, runtime_source, bun = args.viewer.resolve(), args.runtime_source.resolve(), args.bun.resolve()
+assert subprocess.check_output([str(bun), "--version"], text=True).strip() == "1.4.0"
+for file in [viewer / "server.js", viewer / "bin/mcp-server.mjs", viewer / "dist/mcp-server.mjs", runtime_source / "src/runtime-host/main.ts"]:
+    assert file.is_file(), f"missing packaged prerequisite: {file.name}"
+root = Path(tempfile.mkdtemp(prefix="llv-packaged-startup-", dir="/var/tmp"))
+os.chmod(root, 0o700)
+env = {"PATH": str(root / "bin") + ":/usr/bin:/bin", "NODE_ENV": "production", "NEXT_TELEMETRY_DISABLED": "1", "NEXT_PUBLIC_RUNTIME_UI": "1", "LLV_AGENT_REGISTRY_SQLITE": "sqlite"}
+for key, directory in {"HOME": "home", "XDG_CONFIG_HOME": "config", "XDG_CACHE_HOME": "cache", "LLV_STATE_DIR": "state", "TMPDIR": "tmp", "CODEX_HOME": "codex", "LLV_CODEX_HOME": "codex", "CLAUDE_CONFIG_DIR": "claude", "LLV_CLAUDE_HOME": "claude"}.items():
+    (root / directory).mkdir(mode=0o700, exist_ok=True)
+    env[key] = str(root / directory)
+(root / "bin").mkdir(mode=0o700)
+(root / "bin/bun").symlink_to(bun)
+(root / "sockets").mkdir(mode=0o700)
+provider = str(root / "bin/provider")
+shutil.copy2(repo / "src/lib/runtime/fixtures/packagedProvider.py", provider)
+env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider})
+with open(root / "seed.log", "w") as log:
+    subprocess.run([str(bun), "src/lib/runtime/fixtures/packagedStartupSeed.ts"], cwd=repo, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
+
+# A transparent local socket relay counts framing bytes and response times.
+# Every request and reply still runs through the real incumbent host.
+real_socket = str(root / "sockets/host.sock")
+relay_socket = str(root / "sockets/viewer.sock")
+metrics = collections.defaultdict(lambda: {"count": 0, "requestBytes": 0, "responseBytes": 0, "elapsedMs": 0, "maxMs": 0})
+metrics_lock = threading.Lock()
+relay_errors = []
+listener = socket.socket(socket.AF_UNIX)
+listener.bind(relay_socket)
+listener.listen()
+listener.settimeout(.2)
+stopping = threading.Event()
+
+def forward(peer):
+    try:
+        request = peer.makefile("rb").readline()
+        method = json.loads(request)["method"]
+        started = time.monotonic()
+        with socket.socket(socket.AF_UNIX) as upstream:
+            upstream.connect(real_socket)
+            upstream.sendall(request)
+            response = upstream.makefile("rb").readline()
+        elapsed = (time.monotonic() - started) * 1000
+        with metrics_lock:
+            item = metrics[method]
+            item["count"] += 1
+            item["requestBytes"] += len(request)
+            item["responseBytes"] += len(response)
+            item["elapsedMs"] += round(elapsed)
+            item["maxMs"] = max(item["maxMs"], round(elapsed))
+        peer.sendall(response)
+    except (OSError, ValueError, KeyError) as error:
+        with metrics_lock:
+            relay_errors.append(type(error).__name__)
+    finally:
+        peer.close()
+
+def relay():
+    while not stopping.is_set():
+        try:
+            peer, _ = listener.accept()
+            threading.Thread(target=forward, args=(peer,), daemon=True).start()
+        except socket.timeout:
+            pass
+
+threading.Thread(target=relay, daemon=True).start()
+with socket.socket() as reserved:
+    reserved.bind(("127.0.0.1", 0))
+    port = reserved.getsockname()[1]
+env.update({"PORT": str(port), "HOSTNAME": "127.0.0.1", "LLV_VIEWER_PORT": str(port), "LLV_RUNTIME_HOST_SOCKET": real_socket})
+logs = [open(root / "host.log", "w"), open(root / "viewer.log", "w")]
+host = subprocess.Popen([str(bun), "src/runtime-host/main.ts"], cwd=runtime_source, env=env, stdout=logs[0], stderr=subprocess.STDOUT)
+for _ in range(100):
+    if Path(real_socket).exists():
+        break
+    if host.poll() is not None:
+        raise RuntimeError("private runtime host failed to start")
+    time.sleep(.1)
+env["LLV_RUNTIME_HOST_SOCKET"] = relay_socket
+app = subprocess.Popen([str(bun), str(viewer / "server.js")], cwd=viewer, env=env, stdout=logs[1], stderr=subprocess.STDOUT)
+started = time.monotonic()
+result = {"ready": False, "deadlineMs": 120000}
+print(root, flush=True)
+try:
+    with open(root / "timeline.jsonl", "w") as timeline:
+        # Continue observation after the unchanged 120s gate, without claiming
+        # success or releasing the callback's lease at the deadline.
+        while time.monotonic() - started < 480:
+            before = time.monotonic()
+            status = {}
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/runtime/deployments/capabilities/v1", timeout=2) as response:
+                    status = json.load(response)
+            except urllib.error.HTTPError as error:
+                status = json.load(error)
+            except (OSError, ValueError):
+                pass
+            leases = []
+            database = root / "state/state.sqlite"
+            if database.exists():
+                with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as db:
+                    leases = db.execute("SELECT collection,owner_pid,owner_start_identity,acquired_at FROM state_leases").fetchall()
+            elapsed = round((time.monotonic() - started) * 1000)
+            timeline.write(json.dumps({"elapsedMs": elapsed, "probeMs": round((time.monotonic() - before) * 1000), "status": status, "leases": leases}) + "\n")
+            timeline.flush()
+            if status.get("structuredHostStartup", {}).get("state") == "ready":
+                with sqlite3.connect(f"file:{root / 'state/agent-registry.sqlite'}?mode=ro", uri=True) as db:
+                    hosted = db.execute("SELECT count(*) FROM registry_rows WHERE collection='entries' AND json_extract(value_json,'$.structuredHost.process') IS NOT NULL").fetchone()[0]
+                contender = subprocess.run([str(bun), "src/lib/runtime/fixtures/startupPipelineContender.ts", str(root / "state")], cwd=repo, env=env, capture_output=True, text=True)
+                result.update({"ready": True, "elapsedMs": elapsed, "hosted": hosted, "creation": json.loads(contender.stdout), "creationExit": contender.returncode})
+                break
+            time.sleep(.25)
+finally:
+    # Only child handles created above; no process enumeration or live signals.
+    app.terminate()
+    host.terminate()
+    for child in [app, host]:
+        try:
+            child.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            result.setdefault("unsettledPrivateChildren", []).append(child.pid)
+    stopping.set()
+    listener.close()
+    with metrics_lock:
+        result["rpc"] = dict(metrics)
+        result["relayErrors"] = dict(collections.Counter(relay_errors))
+    (root / "result.json").write_text(json.dumps(result, indent=2))
+    print(json.dumps(result), flush=True)
+raise SystemExit(0 if result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("creation", {}).get("created") else 1)

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -24,8 +24,11 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--viewer", type=Path, required=True, help="immutable standalone package")
 parser.add_argument("--runtime-source", type=Path, required=True, help="exact incumbent runtime-host source tree")
 parser.add_argument("--bun", type=Path, required=True)
-parser.add_argument("--mixed-engines", action="store_true", help="include three Claude protocol fixtures; requires all six hosts to remain owned")
+parser.add_argument("--codex-only", action="store_true", help="narrower contention control; does not qualify mixed-provider preservation")
+parser.add_argument("--snapshot-delay-ms", type=int, default=0)
+parser.add_argument("--rpc-delay-ms", type=int, default=0)
 args = parser.parse_args()
+assert 0 <= args.snapshot_delay_ms <= 3000 and 0 <= args.rpc_delay_ms <= 5
 repo = Path(__file__).resolve().parents[1]
 viewer, runtime_source, bun = args.viewer.resolve(), args.runtime_source.resolve(), args.bun.resolve()
 assert subprocess.check_output([str(bun), "--version"], text=True).strip() == "1.4.0"
@@ -42,7 +45,7 @@ for key, directory in {"HOME": "home", "XDG_CONFIG_HOME": "config", "XDG_CACHE_H
 (root / "sockets").mkdir(mode=0o700)
 provider = str(root / "bin/provider")
 shutil.copy2(repo / "src/lib/runtime/fixtures/packagedProvider.py", provider)
-env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider, "LLV_PACKAGED_MIXED_ENGINES": "1" if args.mixed_engines else "0"})
+env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider, "LLV_PACKAGED_MIXED_ENGINES": "0" if args.codex_only else "1"})
 with open(root / "seed.log", "w") as log:
     subprocess.run([str(bun), "src/lib/runtime/fixtures/packagedStartupSeed.ts"], cwd=repo, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
 
@@ -64,6 +67,7 @@ def forward(peer):
         request = peer.makefile("rb").readline()
         method = json.loads(request)["method"]
         started = time.monotonic()
+        time.sleep((args.snapshot_delay_ms if method == "snapshot" else args.rpc_delay_ms) / 1000)
         with socket.socket(socket.AF_UNIX) as upstream:
             upstream.connect(real_socket)
             upstream.sendall(request)
@@ -107,7 +111,14 @@ for _ in range(100):
 env["LLV_RUNTIME_HOST_SOCKET"] = relay_socket
 app = subprocess.Popen([str(bun), str(viewer / "server.js")], cwd=viewer, env=env, stdout=logs[1], stderr=subprocess.STDOUT)
 started = time.monotonic()
-result = {"ready": False, "deadlineMs": 120000}
+result = {"ready": False, "deadlineMs": 120000, "snapshotDelayMs": args.snapshot_delay_ms, "rpcDelayMs": args.rpc_delay_ms}
+expected_keys = [("claude" if not args.codex_only and i >= 3 else "codex") + ":00000000-0000-4000-8000-" + str(i).zfill(12) for i in range(6)]
+before_claims = None
+
+def claims():
+    filename = root / "state/agent-registry.sqlite"
+    with sqlite3.connect(f"file:{filename}?mode=ro", uri=True) as db:
+        return db.execute("SELECT row_key,json_extract(value_json,'$.accountId'),json_extract(value_json,'$.claimOwner'),json_extract(value_json,'$.claimEpoch'),json_extract(value_json,'$.structuredHost.process.pid'),json_extract(value_json,'$.structuredHost.process.startIdentity'),json_extract(value_json,'$.artifactPath') FROM registry_rows WHERE collection='entries' AND row_key IN (?,?,?,?,?,?) ORDER BY row_key", expected_keys).fetchall()
 print(root, flush=True)
 try:
     with open(root / "timeline.jsonl", "w") as timeline:
@@ -128,6 +139,9 @@ try:
             if database.exists():
                 with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as db:
                     leases = db.execute("SELECT collection,owner_pid,owner_start_identity,acquired_at FROM state_leases").fetchall()
+            current_claims = claims()
+            if before_claims is None and len(current_claims) == 6 and all(row[2] and row[4] and row[5] for row in current_claims):
+                before_claims = current_claims
             elapsed = round((time.monotonic() - started) * 1000)
             timeline.write(json.dumps({"elapsedMs": elapsed, "probeMs": round((time.monotonic() - before) * 1000), "status": status, "leases": leases}) + "\n")
             timeline.flush()
@@ -135,7 +149,9 @@ try:
                 with sqlite3.connect(f"file:{root / 'state/agent-registry.sqlite'}?mode=ro", uri=True) as db:
                     hosted = db.execute("SELECT count(*) FROM registry_rows WHERE collection='entries' AND json_extract(value_json,'$.structuredHost.process') IS NOT NULL").fetchone()[0]
                 contender = subprocess.run([str(bun), "src/lib/runtime/fixtures/startupPipelineContender.ts", str(root / "state")], cwd=repo, env=env, capture_output=True, text=True)
-                result.update({"ready": True, "elapsedMs": elapsed, "hosted": hosted, "creation": json.loads(contender.stdout), "creationExit": contender.returncode})
+                with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
+                    sends = db.execute("SELECT json_extract(receipt_json,'$.status'),count(*) FROM operations WHERE idempotency_key LIKE 'queued-startup-%' GROUP BY 1").fetchall()
+                result.update({"ready": True, "elapsedMs": elapsed, "hosted": hosted, "queuedSends": dict(sends), "ownershipPreserved": before_claims is not None and current_claims == before_claims, "creation": json.loads(contender.stdout), "creationExit": contender.returncode})
                 break
             time.sleep(.25)
 finally:
@@ -154,4 +170,4 @@ finally:
         result["relayErrors"] = dict(collections.Counter(relay_errors))
     (root / "result.json").write_text(json.dumps(result, indent=2))
     print(json.dumps(result), flush=True)
-raise SystemExit(0 if result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("creation", {}).get("created") else 1)
+raise SystemExit(0 if result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("ownershipPreserved") is True and result.get("creation", {}).get("created") else 1)

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -24,6 +24,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--viewer", type=Path, required=True, help="immutable standalone package")
 parser.add_argument("--runtime-source", type=Path, required=True, help="exact incumbent runtime-host source tree")
 parser.add_argument("--bun", type=Path, required=True)
+parser.add_argument("--mixed-engines", action="store_true", help="include three Claude protocol fixtures; requires all six hosts to remain owned")
 args = parser.parse_args()
 repo = Path(__file__).resolve().parents[1]
 viewer, runtime_source, bun = args.viewer.resolve(), args.runtime_source.resolve(), args.bun.resolve()
@@ -41,7 +42,7 @@ for key, directory in {"HOME": "home", "XDG_CONFIG_HOME": "config", "XDG_CACHE_H
 (root / "sockets").mkdir(mode=0o700)
 provider = str(root / "bin/provider")
 shutil.copy2(repo / "src/lib/runtime/fixtures/packagedProvider.py", provider)
-env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider})
+env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider, "LLV_PACKAGED_MIXED_ENGINES": "1" if args.mixed_engines else "0"})
 with open(root / "seed.log", "w") as log:
     subprocess.run([str(bun), "src/lib/runtime/fixtures/packagedStartupSeed.ts"], cwd=repo, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5073,6 +5073,12 @@ export class AgentRegistry {
         void updatedAt;
         storedEvidence = entry;
       }
+      if (storedEvidence && (storedEvidence.structuredHost?.process || storedEvidence.claimOwner)
+        && receipt.accountId !== storedEvidence.accountId) {
+        // Settlement attributes an entry to the receipt's birth account. A
+        // stale or unknown account cannot rebind an already-owned writer.
+        return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
+      }
       /* Runtime snapshots prove delivery and session identity, while the
          registry remains authoritative for an active writer claim. Merge the
          live claim inside this mutation so synthesized evidence cannot clear

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5062,7 +5062,11 @@ export class AgentRegistry {
       if (receipt.state === "conflicted" || receipt.retryClaim) {
         return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
       }
-      const stored = receipt.key ? file.entries[sessionKeyId(receipt.key)] : null;
+      // An unstaged resume can lose admission to startup adoption before it
+      // records a key. Its recovery evidence identifies the existing entry;
+      // that entry's writer fence still governs late receipt settlement.
+      const storedKey = receipt.key ?? evidence?.key;
+      const stored = storedKey ? file.entries[sessionKeyId(storedKey)] : null;
       let storedEvidence: Omit<AgentRegistryEntry, "updatedAt"> | null = null;
       if (stored) {
         const { updatedAt, ...entry } = stored;

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -9,6 +9,55 @@ import type { Pipeline, PipelineStage } from "./types";
 
 const ARCHIVE_CHILD = path.join(import.meta.dir, "archive.sqliteChild.ts");
 
+test.each([false, true])("archive enabled=%s lets the same event loop settle startup admission before moving rows", async (enabled) => {
+  const previous = process.env.LLV_STATE_DIR;
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-startup-archive-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  const timeline: string[] = [];
+  let entered!: () => void;
+  const admissionEntered = new Promise<void>((resolve) => { entered = resolve; });
+  const pipeline = buildPipeline({ id: "aaaa0001", task: "Archive settled history", project: "viewer", repoDir: sandbox,
+    stages: [{ id: "build", kind: "run", prompt: "build", next: null,
+      effectiveRole: { roleId: null, engine: "codex", model: "gpt-6-astra", effort: "high", access: "read-write", promptScaffold: null } }],
+    srcPath: null, srcConversationId: null, now: "2026-07-01T00:00:00.000Z" });
+  pipeline.state = "closed";
+  pipeline.closedAt = "2026-07-02T00:00:00.000Z";
+  pipeline.cursor = null;
+  try {
+    savePipelines([pipeline]);
+    const start = performance.now();
+    const startup = withPipelineStartupAdmission(async (available) => {
+      expect(available).toBe(true);
+      timeline.push("admission-entered");
+      entered();
+      await Bun.sleep(100);
+      timeline.push("callback-settled");
+      expect(loadPipelines().map((row) => row.id)).toEqual([pipeline.id]);
+      expect(loadArchivedPipelines()).toEqual([]);
+    });
+    await admissionEntered;
+    // This is the real hourly sweep invoked by FlowPipelineController, on
+    // the same event loop as the timer/RPC continuation startup is awaiting.
+    const archive = enabled ? archiveSettledPipelines(Date.parse("2026-08-05T12:00:00.000Z"), {
+      beforeCommit: () => { timeline.push("archive-commit"); },
+    }).then((moved) => ({ moved, error: null }), (error) => ({ moved: null, error: String(error) })) : Promise.resolve({ moved: 0, error: null });
+    await startup;
+    const result = await archive;
+    const elapsedMs = performance.now() - start;
+    console.log(JSON.stringify({ archiveContention: { enabled, elapsedMs, timerDelayMs: Math.max(0, elapsedMs - 100), timeline, result } }));
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(result).toEqual({ moved: enabled ? 1 : 0, error: null });
+    expect(timeline).toEqual(enabled ? ["admission-entered", "callback-settled", "archive-commit"] : ["admission-entered", "callback-settled"]);
+    const db = new Database(path.join(sandbox, "state.sqlite"), { readonly: true });
+    try { expect(db.query("SELECT count(*) AS n FROM state_leases").get()).toEqual({ n: 0 }); }
+    finally { db.close(); }
+  } finally {
+    if (previous === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previous;
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 45_000);
+
 async function waitForFile(filename: string): Promise<void> {
   const deadline = Date.now() + 10_000;
   while (!fs.existsSync(filename)) {

--- a/src/lib/runtime/fixtures/packagedProvider.py
+++ b/src/lib/runtime/fixtures/packagedProvider.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+"""Local protocol-only providers for the packaged startup rehearsal. No network."""
+import json, os, sys
+from pathlib import Path
+
+def emit(value):
+    print(json.dumps(value), flush=True)
+
+if "auth" in sys.argv and "status" in sys.argv:
+    emit({"loggedIn": True, "authMethod": "claude.ai", "subscriptionType": "max"})
+    sys.exit(0)
+claude = "--resume" in sys.argv
+thread = sys.argv[sys.argv.index("--resume") + 1] if claude else "fixture-probe"
+if claude:
+    emit({"type": "system", "subtype": "init", "session_id": thread, "tools": [], "apiKeySource": "none"})
+for line in sys.stdin:
+    message = json.loads(line)
+    if claude:
+        if message.get("type") == "user":
+            emit({**message, "isReplay": True})
+            emit({"type": "result", "subtype": "success", "session_id": thread})
+        continue
+    if "id" not in message:
+        continue
+    method = message.get("method")
+    with open(Path(os.environ["LLV_STATE_DIR"]) / "provider-methods.jsonl", "a") as log:
+        log.write(json.dumps({"pid": os.getpid(), "method": method}) + "\n")
+    params = message.get("params") or {}
+    result = {}
+    if method == "initialize":
+        result = {"userAgent": "packaged-startup-fixture/1"}
+    elif method == "account/read":
+        result = {"account": {"type": "chatgpt", "planType": "fixture"}, "requiresOpenaiAuth": False}
+    elif method == "account/rateLimits/read":
+        result = {"rateLimits": {"primary": {"usedPercent": 0, "windowDurationMins": 300, "resetsAt": 1800000000}, "secondary": None, "planType": "pro"}}
+    elif method == "model/list":
+        result = {"data": [{"id": "fixture", "isDefault": True, "inputModalities": ["text"]}]}
+    elif method == "config/read":
+        result = {"config": {"mcp_servers": {}}}
+    elif method in ("thread/resume", "thread/start", "thread/read"):
+        thread = params.get("threadId", thread)
+        result = {"thread": {"id": thread, "path": str(Path(os.environ["LLV_STATE_DIR"]) / (thread + ".jsonl")), "turns": [], "status": {"type": "idle", "activeFlags": []}}}
+    elif method == "thread/turns/list":
+        result = {"data": [], "nextCursor": None, "backwardsCursor": None}
+    elif method == "turn/start":
+        result = {"turn": {"id": "fixture-turn"}}
+    emit({"jsonrpc": "2.0", "id": message["id"], "result": result})
+    if method == "turn/start":
+        emit({"method": "turn/started", "params": {"threadId": thread, "turn": {"id": "fixture-turn"}}})
+        emit({"method": "item/completed", "params": {"threadId": thread, "turnId": "fixture-turn", "item": {"type": "userMessage", "clientId": params.get("clientUserMessageId"), "content": params.get("input", [])}}})
+        emit({"method": "turn/completed", "params": {"threadId": thread, "turn": {"id": "fixture-turn", "status": "completed"}}})

--- a/src/lib/runtime/fixtures/packagedStartupSeed.ts
+++ b/src/lib/runtime/fixtures/packagedStartupSeed.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import path from "node:path";
+import { AgentRegistry, type RegistryFile } from "@/lib/agent/registry";
+import { Database } from "bun:sqlite";
+import { claudeTranscriptPath } from "@/lib/agent/transcript";
+import { RuntimeJournal } from "@/runtime-host/journal";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+function fixtureSessionId(index: number): string {
+  return index < 6 ? `00000000-0000-4000-8000-${String(index).padStart(12, "0")}` : `history_${index}`;
+}
+
+function fixture(failedCount: number, fullHistory = false) {
+  const directory = process.env.LLV_STATE_DIR!;
+  const filename = path.join(directory, "agent-registry.json");
+  if (!directory || fs.existsSync(filename)) throw new Error("packaged fixture requires an empty explicit state directory");
+  const seed = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+  const begun = seed.beginSpawnRequest({
+    engine: "codex", cwd: directory, transport: "structured", accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: directory, title: "Historical failed launch" }),
+  });
+  seed.failSpawn(begun.receipt.launchId, "historical failure");
+  if (fullHistory) {
+    const artifactPath = path.join(directory, "history-seed.jsonl");
+    const conversation = seed.ensureConversation("codex", artifactPath, null);
+    const sessionId = conversation.generations.at(-1)!.id;
+    const delivery = seed.holdDelivery(conversation.id, "Historical delivery", "history-seed", "text");
+    seed.recordDeliveryOutcome(delivery.id, "failed", "historical failure");
+    seed.upsert({
+      key: { engine: "codex", sessionId }, artifactPath, cwd: directory, accountId: null,
+      launchProfile: emptyLaunchProfile({ cwd: directory }), status: "dead", host: null,
+      structuredHost: { kind: "codex-app-server", endpoint: "stdio:released", process: null,
+        eventCursor: 0, protocolVersion: null, writerClaimEpoch: 0, activeTurnRef: null,
+        pendingAttention: [], activeFlags: [] },
+      claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+  }
+  const data = JSON.parse(fs.readFileSync(filename, "utf8")) as RegistryFile;
+  const receipt = data.receipts[begun.receipt.launchId]!;
+  data.receipts = {};
+  for (let i = 0; i < failedCount; i++) {
+    const launchId = `historical_launch_${i}`;
+    data.receipts[launchId] = { ...receipt, launchId, conversationId: `conversation_history_${i}` };
+  }
+  if (fullHistory) {
+    const entry = Object.values(data.entries)[0]!;
+    const conversation = Object.values(data.conversations)[0]!;
+    data.entries = {};
+    data.conversations = {};
+    for (let i = 0; i < 8078; i++) {
+      const id = `conversation_history_${i}` as const;
+      const sessionId = fixtureSessionId(i);
+      const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+      if (i < 5188) data.entries[`codex:${sessionId}`] = {
+        ...structuredClone(entry), key: { engine: "codex", sessionId }, artifactPath,
+      };
+      data.conversations[id] = {
+        ...structuredClone(conversation), id,
+        turn: { state: "terminal", source: "assistant", terminalAt: receipt.createdAt, observedAt: receipt.createdAt },
+        generations: conversation.generations.map((generation) => ({ ...structuredClone(generation), id: sessionId, path: artifactPath })),
+      };
+    }
+    const held = Object.values(data.heldDeliveries)[0]!;
+    data.heldDeliveries = {};
+    for (let i = 0; i < 1719; i++) {
+      const id = `historical_delivery_${i}`;
+      data.heldDeliveries[id] = {
+        ...held, id, conversationId: `conversation_history_${i}`, clientMessageId: id,
+        command: { ...held.command, operationId: `historical_operation_${i}` },
+        state: i < 153 ? "failed" : "delivered",
+      };
+    }
+    for (let i = failedCount; i < 6623; i++) {
+      const launchId = `historical_launch_${i}`;
+      data.receipts[launchId] = {
+        ...receipt, launchId, conversationId: `conversation_history_${i}`,
+        state: i < 6458 ? "completed" : i < 6590 ? "conflicted" : i < 6611 ? "starting"
+          : i < 6618 ? "host-verified" : i < 6622 ? "pane-bound" : "path-pending",
+      };
+    }
+  }
+  for (const entry of Object.values(data.entries)) {
+    // Real transcript refresh reads retained live rows; terminal tails prevent provider launches.
+    entry.status = entry.key.sessionId === "history_0" ? "live" : "dead";
+    fs.writeFileSync(entry.artifactPath, JSON.stringify({ type: "event_msg", timestamp: new Date().toISOString(), payload: { type: "task_complete", last_agent_message: "Synthetic terminal history" } }) + "\n");
+  }
+  for (const receipt of Object.values(data.receipts)) {
+    if (!["failed", "completed", "conflicted"].includes(receipt.state)) receipt.transport = null;
+  }
+  // Six real engine wrappers adopt local protocol-only provider children.
+  for (let i = 0; i < 6; i++) {
+    const id = fixtureSessionId(i);
+    const row = data.entries[`codex:${id}`]!;
+    row.pendingAction = "handoff";
+    row.status = "live";
+    data.conversations[`conversation_history_${i}`]!.turn = {
+      state: "busy", source: "lifecycle", terminalAt: null, observedAt: receipt.createdAt,
+    };
+    fs.writeFileSync(row.artifactPath, JSON.stringify(i < 3
+      ? { type: "event_msg", timestamp: receipt.createdAt, payload: { type: "task_started", turn_id: `retained-${i}` } }
+      : { type: "user", timestamp: receipt.createdAt, message: { role: "user", content: "Synthetic unfinished turn" } }) + "\n");
+    if (i >= 3) {
+      delete data.entries[`codex:${id}`];
+      const nativePath = claudeTranscriptPath(directory, id, path.join(process.env.LLV_CLAUDE_HOME!, "projects"));
+      fs.mkdirSync(path.dirname(nativePath), { recursive: true });
+      fs.renameSync(row.artifactPath, nativePath);
+      row.artifactPath = nativePath;
+      data.conversations[`conversation_history_${i}`]!.generations[0]!.path = nativePath;
+      row.key.engine = "claude";
+      row.structuredHost!.kind = "claude-broker";
+      data.entries[`claude:${id}`] = row;
+      data.conversations[`conversation_history_${i}`]!.engine = "claude";
+    }
+    const launched = data.receipts[`historical_launch_${i}`]!;
+    launched.state = "completed";
+    launched.engine = row.key.engine;
+    launched.key = { ...row.key };
+    launched.artifactPath = row.artifactPath;
+    data.receipts[`historical_launch_${failedCount + i}`]!.state = "failed";
+  }
+  data.identityMigrations["identity-wave-a-d-913"] = {
+    completedAt: receipt.createdAt, retitled: 0, rekeyed: 0, quarantinedRekeys: 0, edgesStamped: 0,
+  };
+  // Synthetic text only, approximating the live retained display-payload tail.
+  for (const [i, row] of Object.values(data.receipts).entries()) {
+    const size = i % 100 < 50 ? 0 : i % 100 < 95 ? 1800 : i % 100 < 99 ? 9200 : 62000;
+    row.launchDisplay = size ? { prompt: "s".repeat(size), images: 0, echo: "Synthetic history" } : null;
+    row.admissionOwner = null;
+  }
+  for (const [i, row] of Object.values(data.conversations).entries()) {
+    row.generations[0]!.launchProfile.goal = {
+      objective: "s".repeat(i % 100 < 50 ? 180 : i % 100 < 95 ? 900 : 2800),
+      status: "complete", tokensUsed: null, timeUsedSeconds: null,
+    };
+  }
+  const owner = Object.values(data.deliveryOperationOwners)[0]!;
+  data.deliveryOperationOwners = {};
+  for (let i = 0; i < 5649; i++) {
+    const id = i < 1719 ? `historical_operation_${i}` : `historical_owner_${i}`;
+    data.deliveryOperationOwners[id] = { ...owner, conversationId: `conversation_history_${i}`,
+      runtimeConversationId: `conversation_history_${i}`,
+      deliveryId: i < 1719 ? `historical_delivery_${i}` : id,
+      clientMessageId: i < 1719 ? `historical_delivery_${i}` : id,
+      terminalState: i < 153 ? "failed" : "delivered",
+      command: { ...owner.command, operationId: id } };
+  }
+  for (let i = 1; i <= 5347; i++) {
+    const id = `conversation_history_${i}` as const;
+    data.lineageEdges[id] = {
+      childConversationId: id, parentConversationId: "conversation_history_0",
+      childSessionKey: { engine: i >= 3 && i < 6 ? "claude" : "codex", sessionId: fixtureSessionId(i) }, parentSessionKey: null,
+      childArtifactPath: data.conversations[id]!.generations[0]!.path, parentArtifactPath: null,
+      kind: "spawn", role: "worker", reviewsConversationId: null, source: "viewer-spawn",
+      evidence: { launchId: `historical_launch_${i}`, clientAttemptId: null }, createdAt: receipt.createdAt,
+    };
+  }
+  fs.writeFileSync(filename, JSON.stringify(data));
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  console.log(JSON.stringify({ counts: Object.fromEntries((["conversations", "entries", "receipts", "heldDeliveries"] as const).map(k => [k, Object.keys(data[k]).length])) }));
+  registry.checkpointRollbackMirrorForDemotion();
+  const journalFilename = path.join(directory, "runtime-events.sqlite");
+  const journal = new RuntimeJournal(journalFilename, { structuredHosts: true });
+  for (let i = 0; i < 4336; i++) {
+    const entry = data.entries[`${i >= 3 && i < 6 ? "claude" : "codex"}:${fixtureSessionId(i)}`]!;
+    journal.append({ scope: { type: "session", id: `conversation_history_${i}` }, kind: "session-status",
+      payload: { conversationId: `conversation_history_${i}`, sessionKey: entry.key,
+        hostKind: entry.structuredHost!.kind, host: i < 734 ? "hosted" : "dead", turn: "idle", cwd: directory,
+        artifactPath: entry.artifactPath, accountId: null, activeTurnId: null },
+    });
+  }
+  for (let i = 0; i < 6; i++) journal.executeOperation({
+    kind: "send", conversationId: `conversation_history_${i}`, idempotencyKey: `queued-startup-${i}`,
+    text: "Synthetic queued startup message", policy: "queue",
+  });
+  journal.close();
+  // Retained legacy rows precede live-turn bounding. Recreate sizes with fresh
+  // synthetic text, using the same fixture seam as journal.test.ts.
+  const raw = new Database(journalFilename);
+  raw.transaction(() => {
+    const update = raw.query("UPDATE entities SET state_json = json_set(state_json, '$.liveTurn', json(?)) WHERE kind = 'session' AND id = ?");
+    for (let i = 0; i < 4336; i++) {
+      const size = i % 100 < 50 ? 23000 : i % 100 < 95 ? 30000 : i % 100 < 99 ? 99000 : 517000;
+      update.run(JSON.stringify({ turnId: "historical-turn", text: "s".repeat(size) }), `conversation_history_${i}`);
+    }
+  })();
+  raw.close();
+}
+fixture(672, true);

--- a/src/lib/runtime/fixtures/packagedStartupSeed.ts
+++ b/src/lib/runtime/fixtures/packagedStartupSeed.ts
@@ -10,6 +10,7 @@ function fixtureSessionId(index: number): string {
 }
 
 function fixture(failedCount: number, fullHistory = false) {
+  const mixed = process.env.LLV_PACKAGED_MIXED_ENGINES === "1";
   const directory = process.env.LLV_STATE_DIR!;
   const filename = path.join(directory, "agent-registry.json");
   if (!directory || fs.existsSync(filename)) throw new Error("packaged fixture requires an empty explicit state directory");
@@ -95,10 +96,10 @@ function fixture(failedCount: number, fullHistory = false) {
     data.conversations[`conversation_history_${i}`]!.turn = {
       state: "busy", source: "lifecycle", terminalAt: null, observedAt: receipt.createdAt,
     };
-    fs.writeFileSync(row.artifactPath, JSON.stringify(i < 3
+    fs.writeFileSync(row.artifactPath, JSON.stringify(!mixed || i < 3
       ? { type: "event_msg", timestamp: receipt.createdAt, payload: { type: "task_started", turn_id: `retained-${i}` } }
       : { type: "user", timestamp: receipt.createdAt, message: { role: "user", content: "Synthetic unfinished turn" } }) + "\n");
-    if (i >= 3) {
+    if (mixed && i >= 3) {
       delete data.entries[`codex:${id}`];
       const nativePath = claudeTranscriptPath(directory, id, path.join(process.env.LLV_CLAUDE_HOME!, "projects"));
       fs.mkdirSync(path.dirname(nativePath), { recursive: true });
@@ -147,7 +148,7 @@ function fixture(failedCount: number, fullHistory = false) {
     const id = `conversation_history_${i}` as const;
     data.lineageEdges[id] = {
       childConversationId: id, parentConversationId: "conversation_history_0",
-      childSessionKey: { engine: i >= 3 && i < 6 ? "claude" : "codex", sessionId: fixtureSessionId(i) }, parentSessionKey: null,
+      childSessionKey: { engine: mixed && i >= 3 && i < 6 ? "claude" : "codex", sessionId: fixtureSessionId(i) }, parentSessionKey: null,
       childArtifactPath: data.conversations[id]!.generations[0]!.path, parentArtifactPath: null,
       kind: "spawn", role: "worker", reviewsConversationId: null, source: "viewer-spawn",
       evidence: { launchId: `historical_launch_${i}`, clientAttemptId: null }, createdAt: receipt.createdAt,
@@ -160,7 +161,7 @@ function fixture(failedCount: number, fullHistory = false) {
   const journalFilename = path.join(directory, "runtime-events.sqlite");
   const journal = new RuntimeJournal(journalFilename, { structuredHosts: true });
   for (let i = 0; i < 4336; i++) {
-    const entry = data.entries[`${i >= 3 && i < 6 ? "claude" : "codex"}:${fixtureSessionId(i)}`]!;
+    const entry = data.entries[`${mixed && i >= 3 && i < 6 ? "claude" : "codex"}:${fixtureSessionId(i)}`]!;
     journal.append({ scope: { type: "session", id: `conversation_history_${i}` }, kind: "session-status",
       payload: { conversationId: `conversation_history_${i}`, sessionKey: entry.key,
         hostKind: entry.structuredHost!.kind, host: i < 734 ? "hosted" : "dead", turn: "idle", cwd: directory,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1459,7 +1459,7 @@ test("startup publishes per-host progress across the serial provider adoption lo
       }),
     ]);
     expect(structuredStartupStatus({ LLV_STRUCTURED_HOSTS: "1" })).toMatchObject({
-      phase: "finalizing structured delivery",
+      phase: "recovering pending spawns",
       completedHosts: 2,
       totalHosts: 2,
     });

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1088,9 +1088,10 @@ export async function adoptStructuredHostsAtStartup(
        retire a publication this pass has no client to replace — and every spawn
        in the process would fail until some later pass rebound it (#1191). */
     if (controllerBoundEarly) {
-      await completeStructuredDeliveryQueueStartup(nextAdoptedHosts);
+      await completeStructuredDeliveryQueueStartup(nextAdoptedHosts, reportProgress);
       assertAdoptedHostsAreClaimed(nextAdoptedHosts, dependencies.hostClaimed);
     }
+    reportProgress("recovering orchestrator deliveries");
     await enqueueOrchestratorRestartRecoveries(
       registry,
       client,
@@ -1099,6 +1100,7 @@ export async function adoptStructuredHostsAtStartup(
       orchestratorSeats,
     );
     if (client) {
+      reportProgress("recovering interrupted deliveries");
       await enqueueInterruptedCodexContinuations(
         registry,
         client,
@@ -1107,6 +1109,7 @@ export async function adoptStructuredHostsAtStartup(
         existingCodexContinuations,
         signals.pendingCodexContinuationConversationIds,
       );
+      reportProgress("kicking recovered deliveries");
       await kickStructuredDeliveryQueue();
     }
     /* A pending launch receipt reserved for a fenced pipeline conversation is
@@ -1117,7 +1120,10 @@ export async function adoptStructuredHostsAtStartup(
        unrelated lane's queued or superseded launch is reconciled by this boot
        whatever another pipeline's survivor is doing. */
     const fencedReceipts = fencedPendingSpawnReceipts(registry, pipelineEvidence.deferred);
-    if (client && fencedReceipts.length === 0) await recoverPendingStructuredSpawns(registry, client);
+    if (client && fencedReceipts.length === 0) {
+      reportProgress("recovering pending spawns");
+      await recoverPendingStructuredSpawns(registry, client);
+    }
     adoptedHosts = nextAdoptedHosts;
     if (deferredHostKeys.size > 0 || fencedReceipts.length > 0) {
       /* The rows are retained exactly as a retry would retain them: the next

--- a/src/lib/runtime/startupFinalization.integration.test.ts
+++ b/src/lib/runtime/startupFinalization.integration.test.ts
@@ -318,7 +318,7 @@ test("historical reconciliation recovers late transcript evidence and preserves 
   } finally { f.journal.close(); }
 });
 
-test.each(["codex", "claude"] as const)("late unkeyed %s resume recovery preserves the adopted writer", async (engine) => {
+test.each([["codex", false], ["codex", true], ["claude", false], ["claude", true]] as const)("late unkeyed %s resume preserves its writer (account mismatch=%s)", async (engine, accountMismatch) => {
   const f = fixture(0);
   const sessionId = crypto.randomUUID();
   const artifactPath = path.join(f.directory, `${sessionId}.jsonl`);
@@ -336,6 +336,8 @@ test.each(["codex", "claude"] as const)("late unkeyed %s resume recovery preserv
   });
   expect(begun.receipt.key).toBeNull();
   f.registry.failStructuredSpawn(begun.receipt.launchId, "resume lost admission to startup adoption");
+  const currentEntry = f.registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+  if (accountMismatch) f.registry.upsert({ ...currentEntry, accountId: "current-writer-account" });
   const externalWriter = Bun.spawn([process.execPath, "-e", "for await (const chunk of process.stdin) { void chunk; }"], {
     env: { ...process.env }, stdin: "pipe", stdout: "ignore", stderr: "ignore",
   });
@@ -355,10 +357,11 @@ test.each(["codex", "claude"] as const)("late unkeyed %s resume recovery preserv
   try {
     await recoverPendingStructuredSpawns(f.registry, f.client);
     const after = f.registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+    expect(after.accountId).toBe(before.accountId);
     expect(after.claimOwner).toBe(before.claimOwner);
     expect(after.claimEpoch).toBe(before.claimEpoch);
     expect(after.structuredHost).toEqual(before.structuredHost);
-    expect(f.registry.readOnlySnapshot().receipts[begun.receipt.launchId]!.state).toBe("completed");
+    expect(f.registry.readOnlySnapshot().receipts[begun.receipt.launchId]!.state).toBe(accountMismatch ? "failed" : "completed");
   } finally {
     externalWriter.stdin.end();
     await externalWriter.exited;

--- a/src/lib/runtime/startupFinalization.integration.test.ts
+++ b/src/lib/runtime/startupFinalization.integration.test.ts
@@ -318,6 +318,54 @@ test("historical reconciliation recovers late transcript evidence and preserves 
   } finally { f.journal.close(); }
 });
 
+test.each(["codex", "claude"] as const)("late unkeyed %s resume recovery preserves the adopted writer", async (engine) => {
+  const f = fixture(0);
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(f.directory, `${sessionId}.jsonl`);
+  const key = { engine, sessionId };
+  const profile = emptyLaunchProfile({ cwd: f.directory, title: "Unkeyed resume recovery" });
+  const conversation = f.registry.ensureConversation(engine, artifactPath, null);
+  f.registry.upsert({ key, artifactPath, cwd: f.directory, accountId: null, launchProfile: profile,
+    status: "unhosted", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
+    structuredHost: { kind: engine === "codex" ? "codex-app-server" : "claude-broker", endpoint: "stdio:released",
+      process: null, eventCursor: 0, protocolVersion: null, writerClaimEpoch: 0,
+      activeTurnRef: null, pendingAttention: [], activeFlags: [] },
+  });
+  const begun = f.registry.beginSpawnRequest({ engine, cwd: f.directory, transport: "structured", accountId: null,
+    conversationId: conversation.id, purpose: "resume-successor", expectedArtifactPath: artifactPath, launchProfile: profile,
+  });
+  expect(begun.receipt.key).toBeNull();
+  f.registry.failStructuredSpawn(begun.receipt.launchId, "resume lost admission to startup adoption");
+  const externalWriter = Bun.spawn([process.execPath, "-e", "for await (const chunk of process.stdin) { void chunk; }"], {
+    env: { ...process.env }, stdin: "pipe", stdout: "ignore", stderr: "ignore",
+  });
+  const owner = captureProcessIdentity(externalWriter.pid);
+  const claimed = f.registry.claimStructuredHost(key, owner, { allowUnhosted: true })!;
+  f.registry.setStructuredHostClaimed(key, { ...claimed.structuredHost!, endpoint: "fixture:current-writer",
+    process: owner,
+  }, "idle", claimed.claimOwner!, claimed.claimEpoch);
+  const before = f.registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+  fs.writeFileSync(artifactPath, JSON.stringify(engine === "codex"
+    ? { type: "event_msg", payload: { type: "user_message", message: "Synthetic prior turn" } }
+    : { type: "user", message: { role: "user", content: "Synthetic prior turn" } }) + "\n");
+  f.journal.append({ scope: { type: "session", id: conversation.id }, kind: "session-status",
+    payload: { conversationId: conversation.id, sessionKey: key, hostKind: before.structuredHost!.kind,
+      host: "hosted", turn: "idle", cwd: f.directory, artifactPath },
+  });
+  try {
+    await recoverPendingStructuredSpawns(f.registry, f.client);
+    const after = f.registry.readOnlySnapshot().entries[`${engine}:${sessionId}`]!;
+    expect(after.claimOwner).toBe(before.claimOwner);
+    expect(after.claimEpoch).toBe(before.claimEpoch);
+    expect(after.structuredHost).toEqual(before.structuredHost);
+    expect(f.registry.readOnlySnapshot().receipts[begun.receipt.launchId]!.state).toBe("completed");
+  } finally {
+    externalWriter.stdin.end();
+    await externalWriter.exited;
+    f.journal.close();
+  }
+});
+
 
 test("the full retained history completes within the unchanged promoted-verification deadline", async () => {
   const f = fixture(672, true);

--- a/src/lib/runtime/startupFinalization.integration.test.ts
+++ b/src/lib/runtime/startupFinalization.integration.test.ts
@@ -211,6 +211,56 @@ test("a failed historical snapshot remains unknown and a later pass retries it",
   } finally { f.journal.close(); }
 });
 
+test("startup exposes the retaining fallback await without releasing admission before it settles", async () => {
+  const f = fixture(1, true);
+  let entered!: () => void;
+  const publicationEntered = new Promise<void>((resolve) => { entered = resolve; });
+  let settle!: () => void;
+  const publicationSettlement = new Promise<void>((resolve) => { settle = resolve; });
+  const host = new RuntimeHost(f.journal);
+  const server = serveRuntimeHost(path.join(isolated, "sockets", "progress.sock"), {
+    handle: async (request, options) => {
+      if (request.method === "append") {
+        entered();
+        await publicationSettlement;
+      }
+      return host.handle(request, options);
+    },
+  });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const client = new UnixRuntimeHostClient(path.join(isolated, "sockets", "progress.sock"));
+  // No transcript/adopter/controller substitution: historical rows are dead;
+  // only the private socket peer withholds a publication response.
+  const startup = runStructuredHostStartup(() => adoptStructuredHostsAtStartup({
+    registry: f.registry, client,
+  }), () => {}, { waitUntilReady: true });
+  const leases = () => {
+    const db = new Database(path.join(process.env.LLV_STATE_DIR!, "state.sqlite"), { readonly: true });
+    try { return db.query("SELECT owner_pid FROM state_leases WHERE collection = 'pipelines'").all(); }
+    finally { db.close(); }
+  };
+  try {
+    await publicationEntered;
+    expect(structuredStartupStatus()).toMatchObject({
+      state: "pending", phase: "publishing historical host fallbacks",
+      pid: process.pid, phaseStartedAt: expect.any(String),
+    });
+    expect(leases()).toEqual([{ owner_pid: process.pid }]);
+    await Bun.sleep(25);
+    expect(leases()).toEqual([{ owner_pid: process.pid }]);
+    settle();
+    await startup;
+    expect(structuredStartupStatus()?.state).toBe("ready");
+    expect(leases()).toEqual([]);
+  } finally {
+    settle();
+    await startup;
+    await bindStructuredDeliveryQueue([], { registry: f.registry, client: null });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    f.journal.close();
+  }
+}, 60_000);
+
 test("pending launches ignore a historical snapshot supplier", async () => {
   const f = fixture(0);
   const begun = f.registry.beginSpawnRequest({

--- a/src/lib/runtime/startupStatus.test.ts
+++ b/src/lib/runtime/startupStatus.test.ts
@@ -97,3 +97,23 @@ test("structured startup status retains host adoption progress through failure a
     else store.__llvStructuredHostStartupProgress = previousProgress;
   }
 });
+
+test("substep timing survives host progress and failure without logging payloads", async () => {
+  const status = await import("./startupStatus");
+  const original = console.error;
+  const lines: unknown[][] = [];
+  console.error = (...args) => { lines.push(args); };
+  try {
+    status.markStructuredHostStartupProgress({ phase: "registering structured delivery hosts", completedHosts: 0, totalHosts: 2 });
+    const started = status.structuredStartupStatus()!.phaseStartedAt;
+    status.markStructuredHostStartupProgress({ phase: "registering structured delivery hosts", completedHosts: 1, totalHosts: 2 });
+    expect(status.structuredStartupStatus()!.phaseStartedAt).toBe(started);
+    expect(lines).toHaveLength(1);
+    status.markStructuredHostStartupFailed();
+    expect(status.structuredStartupStatus()).toMatchObject({ state: "failed", phase: "registering structured delivery hosts", pid: process.pid });
+    const detail = lines.at(-1)![1] as Record<string, unknown>;
+    expect(Object.keys(detail).sort()).toEqual(["phase", "pid", "previousPhase", "previousPhaseMs", "state"]);
+    expect(detail.previousPhaseMs).toBeNumber();
+    status.markStructuredHostStartupReady();
+  } finally { console.error = original; }
+});

--- a/src/lib/runtime/startupStatus.ts
+++ b/src/lib/runtime/startupStatus.ts
@@ -13,6 +13,15 @@ export type StructuredHostStartupPhase =
   | "adopting Claude hosts"
   | "reconciling structured hosts"
   | "finalizing structured delivery"
+  | "registering structured delivery hosts"
+  | "reading fallback runtime snapshot"
+  | "publishing historical host fallbacks"
+  | "reconciling terminal delivery receipts"
+  | "draining startup delivery queue"
+  | "recovering orchestrator deliveries"
+  | "recovering interrupted deliveries"
+  | "kicking recovered deliveries"
+  | "recovering pending spawns"
   | "ready";
 
 export interface StructuredHostStartupProgress {
@@ -24,6 +33,8 @@ export interface StructuredHostStartupProgress {
 export interface StructuredHostStartupStatus extends StructuredHostStartupProgress {
   state: "pending" | "failed" | "ready";
   updatedAt: string;
+  phaseStartedAt?: string;
+  pid?: number;
 }
 
 function pendingStatus(): StructuredHostStartupStatus {
@@ -48,10 +59,25 @@ function setStatus(
       || progress.totalHosts < progress.completedHosts)) {
     throw new Error("structured host startup total count is invalid");
   }
+  const previous = startupStore.__llvStructuredHostStartupProgress;
+  const now = new Date().toISOString();
+  const changed = previous?.phase !== progress.phase || previous.state !== state;
+  if (changed) {
+    // Fixed phase names and numeric timing only. No exception, host identity,
+    // transcript, operation payload or account data enters this diagnostic.
+    console.error("[structured hosts] startup progress", {
+      pid: process.pid, phase: progress.phase, state,
+      previousPhase: previous?.phase ?? null,
+      previousPhaseMs: previous?.phaseStartedAt
+        ? Math.max(0, Date.now() - Date.parse(previous.phaseStartedAt)) : null,
+    });
+  }
   startupStore.__llvStructuredHostStartupProgress = {
     ...progress,
     state,
-    updatedAt: new Date().toISOString(),
+    updatedAt: now,
+    phaseStartedAt: changed ? now : previous?.phaseStartedAt ?? now,
+    pid: process.pid,
   };
 }
 

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -23,6 +23,7 @@ import { STRUCTURED_IMAGE_CAPABILITY } from "./structuredContent";
 import {
   markStructuredDeliveryControllerReady,
   markStructuredDeliveryControllerUnavailable,
+  type StructuredHostStartupPhase,
 } from "./startupStatus";
 
 type ObservableEngineHost = EngineHost & { onStateChange(listener: (state: HostState) => void): () => void };
@@ -75,7 +76,7 @@ interface ControllerState {
   republishActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   releaseActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   terminateActiveHost: ((key: SessionKey, expected?: Readonly<ProcessIdentity>) => Promise<boolean>) | null;
-  completeActive: ((adopted: readonly StructuredDeliveryHost[]) => Promise<void>) | null;
+  completeActive: ((adopted: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void) => Promise<void>) | null;
   stopActive: () => void;
   lastDrainError?: string | null;
   /* Distinguishes "this process hosts the controller and is between
@@ -1060,7 +1061,7 @@ export async function bindStructuredDeliveryQueue(
     }
   };
   let completion = Promise.resolve();
-  const complete = (items: readonly StructuredDeliveryHost[]) => {
+  const complete = (items: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void) => {
     completion = completion.catch(() => {}).then(async () => {
       /* A generation that has been swapped out cannot register anything, but it
          must not answer "done" either: its caller would clear its retry set and
@@ -1070,9 +1071,10 @@ export async function bindStructuredDeliveryQueue(
       if (stopped || state.activeQueue !== queue) {
         const successor = state.completeActive;
         if (!successor || successor === complete) throw new StructuredDeliveryControllerUnavailableError();
-        await successor(items);
+        await successor(items, progress);
         return;
       }
+      progress?.("registering structured delivery hosts");
       for (const item of items) await register(item);
       const startupSnapshot = registry.readOnlySnapshot();
       /* Read only to skip republishing a projection that already says what
@@ -1080,12 +1082,14 @@ export async function bindStructuredDeliveryQueue(
          below is read off the registry, never off this snapshot, so a read
          that failed costs one redundant publish and authorises nothing
          (#1131). */
+      progress?.("reading fallback runtime snapshot");
       const runtimeSnapshot = typeof client.snapshot === "function"
         ? await client.snapshot().catch(() => null)
         : null;
       const runtimeSessions = new Map(
         (runtimeSnapshot?.sessions ?? []).map((session) => [session.conversationId, session]),
       );
+      progress?.("publishing historical host fallbacks");
       for (const conversation of Object.values(startupSnapshot.conversations)) {
         const generation = conversation.generations.at(-1);
         if (!generation) continue;
@@ -1095,7 +1099,9 @@ export async function bindStructuredDeliveryQueue(
         if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
         await publishCurrentFallback(conversation.id, runtimeSessions.get(conversation.id));
       }
+      progress?.("reconciling terminal delivery receipts");
       await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
+      progress?.("draining startup delivery queue");
       await queue.drain();
     });
     return completion;
@@ -1149,9 +1155,10 @@ export async function publishStructuredDeliveryHost(
 
 export async function completeStructuredDeliveryQueueStartup(
   adopted: readonly StructuredDeliveryHost[],
+  progress?: (phase: StructuredHostStartupPhase) => void,
 ): Promise<void> {
   if (!state.completeActive) throw new StructuredDeliveryControllerUnavailableError();
-  await state.completeActive(adopted);
+  await state.completeActive(adopted, progress);
 }
 
 export async function republishStructuredDeliveryHost(key: SessionKey): Promise<boolean> {

--- a/src/lib/state/sqliteStateStore.ts
+++ b/src/lib/state/sqliteStateStore.ts
@@ -684,12 +684,14 @@ export class SqliteStateCollection<T> {
     }
   }
 
-  /** Move selected rows to another collection in one SQLite commit. */
-  moveMatchingTo(
+  /** Move selected rows to another collection in one SQLite commit. Lease
+      contention must yield: startup can hold the source lease while awaiting
+      an RPC on this same event loop. A synchronous wait starves its release. */
+  async moveMatchingTo(
     target: SqliteStateCollection<T>,
     predicate: (record: T) => boolean,
     options: { beforeCommit?: () => void } = {},
-  ): number {
+  ): Promise<number> {
     if (target === this || target.filename !== this.filename) {
       throw new Error("atomic state moves require two collections in one database");
     }
@@ -697,7 +699,7 @@ export class SqliteStateCollection<T> {
     const ordered = [this, target].sort((left, right) => left.options.collection.localeCompare(right.options.collection));
     const leases = new Map<SqliteStateCollection<T>, string>();
     try {
-      for (const collection of ordered) leases.set(collection, collection.acquireLeaseSync());
+      for (const collection of ordered) leases.set(collection, await collection.acquireLease());
       const db = connectDatabase(this.filename);
       try {
         const moved = withImmediateTransaction(db, this.options.busyMessage, () => {
@@ -778,7 +780,7 @@ export class SqliteStateCollection<T> {
     } finally {
       for (const collection of [...ordered].reverse()) {
         const lease = leases.get(collection);
-        if (lease) collection.releaseLeaseSync(lease);
+        if (lease) await collection.releaseLease(lease);
       }
     }
   }


### PR DESCRIPTION
Packaged Viewer startup can starve its own runtime callbacks while holding pipeline admission. The background archive sweep synchronously waits for that lease on the same event loop. In the instrumented base, delivery-host registration awaits `publishFilesRevision` and its runtime snapshot; the 30-second block delayed that snapshot to a 32.7-second timeout and forced startup to retry. The earlier substituted-adopter test supplied zero hosts to this registration path. Separately, a failed resume with no staged session key can clear the writer already adopted by startup when late transcript evidence settles the receipt.

- Archive moves now await the existing asynchronous lease methods. Collection ordering, owner checks, atomic commit and release-after-settlement stay intact.
- Late recovery finds the existing writer through the evidence key when the receipt has no key, then applies the existing writer-preservation merge inside the registry transaction. A receipt with a different or unknown account binding remains unresolved instead of rebinding the owned writer to its birth account.
- Existing startup status/logs now distinguish registration, fallback snapshot/publication, terminal receipts, drain, continuation and pending-spawn recovery. Diagnostics contain fixed phase names, PID and timing only.

Refs #1552. Preserves #1553, #1544 and #1551. No readiness bypass, deadline increase, live-owner takeover, background callback abandonment, new telemetry framework or deployment action.

Validation:
- Same-event-loop causal control: without archive, a 100 ms startup continuation took 105 ms. With archive on the base, it took 30.57 seconds and archival failed busy. Candidate archival waits cooperatively and commits only after callback settlement.
- Both-engine late-unkeyed recovery regressions fail on the inherited code by clearing the owner. Candidate preserves a real external process identity, claim epoch and complete structured-host columns. A private packaged SQL-write trace identified this exact mutation during pending-spawn recovery; it was not a candidate regression.
- Complete packaged mixed-provider rehearsal: built standalone Next/instrumentation/bundles, real transcript refresh, both native host wrappers, background controllers, SQLite admission, runtime socket, delivery drain and recovery. Only subscription provider protocol processes are synthetic. The incumbent runtime-host source is `bdf4b85658802c2e1765382c5aef04a6585980a7`, matching the failed deployment's version pair.
- Synthetic retained history: 8,078 conversations, 6,623 receipts, 5,188 entries and 1,719 deliveries, plus retained ownership/lineage records and roughly 145 MB of runtime-session rows. No private payloads or identities were copied. Fixed transport additions are 3 seconds per snapshot and 5 ms per other RPC; live read-only snapshot HTTP samples were 3.6–4.0 seconds. This is conservative isolated qualification, not a measurement of the deployment's exact socket latency.
- At the unchanged 120-second deadline the base was still retrying finalization with admission held. It settled after 144.97 seconds with only three host projections retained. The final candidate settled after 109.45 seconds, retained all six hosts with unchanged PID/start identity, claim epoch, transcript path and account binding, released admission and persisted a subsequent pipeline creation. An earlier repaired run also passed at 110.60 seconds.
- Focused startup/admission, atomic archival, external-owner, late-success, unknown-evidence and ownership-race tests pass, with nonincremental TypeScript and privacy checks. One legacy handover fixture had an incomplete readiness-file read in a combined run; its focused both-engine rerun passed. ESLint remains unverified because both frozen baseline and candidate crash loading `react/display-name`.

Limits and root bootstrap:
The reproduced defects explain concrete startup failure mechanisms; this lane has not observed the original live retaining stack. The queued-send race fixture records one delivered and five explicitly failed initial sends on both base and candidate; it is not evidence that every queued send completes successfully. Request payloads and terminal outcomes remain durable. Mixed-provider retention is now exercised directly; the earlier failing probes are excluded from qualification.

After independent review and guarded merge, root should qualify the exact merged revision and use one supported deployment request. Capture capability substeps and phase/PID timestamps during the existing 120-second promoted verification, together with the lease owner/start identity. Keep failed receipts and leases intact. Require terminal deployment success, matching application/runtime/MCP identities, actual continuity delivery and post-ready pipeline creation. A failed or unknown deployment requires diagnosis before another request.

The documented runtime-host-only bootstrap was inspected. These repairs execute in the Viewer, and the rehearsal uses the old host, so a host-only update is not a prerequisite established by this evidence. No live state/lease edits, deployment, rollback, merge or operator process actions were performed.
