### PR TITLE
fix(runtime): bound startup recovery and quiesce before rollback

### DIFF
--- a/docs/acceptance/startup-rollback-1552.md
+++ b/docs/acceptance/startup-rollback-1552.md
@@ -1,5 +1,92 @@
 # Startup and rollback verification for #1552
 
+## Incumbent compatibility follow-up
+
+Status: **incomplete; deployment bootstrap remains blocked**. This follow-up
+builds on `dcd5f0f12e90d84d4ad787f4da353e7723edaf56`. The retained independent
+review identified two P1 compatibility failures against incumbent
+`bdf4b85658802c2e1765382c5aef04a6585980a7`.
+
+The candidate capability now reports `releaseReady: false` while its serving
+structured startup is pending or failed, or its delivery controller is
+unavailable. Passive candidate health and hot-state activation remain available.
+The regression uses verbatim frozen incumbent consumers; the independent
+packaged check also imports the complete original module from the frozen tree.
+The original response failed this check; the repaired response passes.
+
+The rollback defect remains unresolved. The frozen adapter writes a fence that
+drops `activationOwner`, then starts its own checkpoints without waiting for
+Viewer acknowledgement or positive owner death. The candidate's monitor and
+the adapter therefore run concurrently. Candidate-only owner metadata cannot
+make that older consumer wait. Keeping a startup lease until owned hosts finish
+releasing would cover a subset of startup interleavings; it would not establish
+an acknowledgement barrier for rollback after startup finishes or between
+startup attempts. No such partial timing workaround was introduced.
+
+The rehearsal now drives rollback through the isolated Viewer API and actual
+incumbent host, coordinator and executable adapter. Before starting processes it
+checks all incumbent source, scripts, launchers and configuration against the
+pinned Git object. Supplying successor source is a tested rejection. The old
+in-process coordinator fixture has been removed from the execution path.
+Container/build/precheck/promotion setup remains a fixture. A deliberately slow
+serving endpoint forces the incumbent's actual 120-second action timeout;
+rollback retains its actual 90-second limit. This qualifies rollback behavior
+and does not establish a complete successful deployment or host succession.
+
+Fresh verification:
+
+- 476 targeted tests passed: the previous 475 tests plus the capability
+  regression below. Nonincremental TypeScript, standalone Viewer/MCP build and
+  whole-diff privacy with commit/known-value checks passed. Separate runtime-host
+  succession took 503 ms; both endpoints answered 27/27 probes over 15 seconds.
+- Frozen-incumbent baseline API timeout: terminal failed at 129.111 seconds with
+  `agent registry rollback mirror did not converge after 2 attempts`; candidate
+  remained alive and the target was not restored. Six original provider inputs,
+  pending keys/payloads and both external workers were preserved.
+- Repaired candidate through the stable Viewer API: terminal failed at 127.641
+  seconds with the same rollback convergence error; candidate exit and target
+  restoration remain unproven. All six original inputs, pending key/payload,
+  deferred spawn and both external workers were preserved; zero late historical
+  publications or candidate mutations were observed. This remains a failing gate.
+- Repaired packaged ordinary startup, no injected delay: ready at 53.461 seconds,
+  six original sends delivered with exact provider matches, six hosted writers
+  retained, pipeline creation passed, deferred spawn and both external workers
+  preserved. Both actual verifier modules rejected all 145 pending samples and
+  accepted the final ready sample. This measures startup, not deployment succession.
+- The previous ordinary review measured 43.732 seconds. Both ordinary results fit
+  the incumbent's 120-second limit. The historical 158.087-second run below includes
+  an intentional 135-second hold and does not establish unavoidable startup time.
+
+The fresh 2,568-file package manifest digest is
+`e110db8ed152d878e2dc0d14d13a4e741564b9a511728510574ac4559548edc6`.
+
+For incumbent rollback, export the pinned tree to a new directory, supply its
+frozen dependencies, then run:
+
+```sh
+python3 scripts/verify-packaged-startup.py --viewer "$PACKAGE" \
+  --runtime-source "$FROZEN_INCUMBENT" --bun "$BUN" --rollback
+```
+
+The runtime source must match the pinned incumbent. Keep the retained source,
+packages and run evidence. A complete old-host to new-Viewer/runtime success
+and forced-timeout rollback proof, followed by fresh independent review, are
+still required before `DEPLOY_BOOTSTRAP_PROVEN` or release readiness.
+
+Additional manifest entries:
+
+- `src/app/api/runtime/deployments/capabilities/v1/route.ts`
+- `src/app/api/runtime/deployments/capabilities/v1/route.test.ts` (one regression)
+- `src/runtime-host/fixtures/incumbentDeploymentHealth.ts`
+- `src/lib/runtime/fixtures/packagedIncumbentAdapter.py`
+
+## Retained predecessor evidence
+
+The following measurements describe the previous head and its successor-adapter
+rehearsal. They do not qualify the frozen incumbent. The follow-up above supersedes
+its bootstrap assessment.
+
+
 Base: `88e5a9508be2802266734056d6436f3168201cad`.
 The preserved implementation commit is `aff60edc251ede29190b7ca687aceb2f87fa44ac`.
 The successor adopted that commit by fast-forward. The original checkout was clean and was left unchanged. The successor adds provider-side delivery evidence, an explicit rollback wall-clock bound, and a regression for partial host registration.
@@ -60,14 +147,6 @@ Provider evidence matches each of the six immutable journal requests to one obse
 Forced rollback uses the actual coordinator, command adapter, authority, journal, checkpoint and restored standalone Viewer. Container inspection and candidate prechecks are fixture setup. Its 120-second action limit produces a 60-second inner serving limit; terminal rollback must occur within the action limit plus the existing 90-second rollback limit and a 5-second observation allowance. Candidate clean exit and restored readiness are independent assertions. Teardown may force only an exact private runtime-host child after all preservation observations; that is recorded separately and does not establish graceful production host shutdown.
 
 This evidence does not qualify a container image, live provider authentication, or production deployment. Root owns those release checks and one fresh independent review.
-
-## Bootstrap blocker
-
-The incumbent runtime host still has its old 120-second verify-promoted deadline loaded. The new 360-second value becomes effective only when a new host generation runs. `deploy_exact_sha` delegates to that incumbent; its host-handoff phase follows promoted verification. A larger deadline in candidate source therefore cannot bootstrap itself.
-
-Current source and `docs/docker.md` provide `bun scripts/bootstrap-runtime-host.ts <exact-main-sha>` with plan, `--stage`, and `--hand-over` modes. The 13 bootstrap and 36 successor tests passed. This path stages a parked successor and explicitly stops the predecessor runtime-host container. It is a production lifecycle action beyond this builder's authorization. The image-build path also removes its own canonical bootstrap worktree, so the preservation restriction must be accounted for before selecting it. No bootstrap command was executed against production.
-
-No bootstrap path through the currently exposed `deploy_exact_sha` capability that avoids this lifecycle boundary has been established. This remains a release blocker requiring the root orchestrator's decision. A successful isolated rehearsal does not waive it. After a supported bootstrap, root must verify the exact merged runtime-host revision and then perform the ordinary exact-SHA deployment and live continuity checks. Existing pending operator sends and launches remain untouched.
 
 ## Targeted tests
 

--- a/docs/acceptance/startup-rollback-1552.md
+++ b/docs/acceptance/startup-rollback-1552.md
@@ -1,0 +1,122 @@
+# Startup and rollback verification for #1552
+
+Base: `88e5a9508be2802266734056d6436f3168201cad`.
+The preserved implementation commit is `aff60edc251ede29190b7ca687aceb2f87fa44ac`.
+The successor adopted that commit by fast-forward. The original checkout was clean and was left unchanged. The successor adds provider-side delivery evidence, an explicit rollback wall-clock bound, and a regression for partial host registration.
+
+The implementation batches independent historical work in groups of 16 and joins every started operation. Pending launches retain fresh evidence reads. Retirement aborts and joins startup, releases registered and unpublished owned hosts, and acquires rollback checkpoint leases asynchronously. The activation owner must acknowledge its own fence while alive; the adapter may checkpoint only after positive owner death. Registered hosts keep draining while unregistered targets retain their original pending operations.
+
+Promoted serving verification has a 300-second inner budget inside the runtime-host action's 360-second deadline. A shortened rehearsal action also shortens its inner budget. The 90-second rollback action deadline is unchanged.
+
+## Validation
+
+All runs used Bun 1.4.0, explicit test paths, empty private HOME, XDG configuration, runtime state and provider homes, and a short private TMPDIR. Each targeted file ran in a separate process. Tests and rehearsals used their own child handles and ephemeral endpoints.
+
+- Standalone Next Viewer and MCP build: passed.
+- Nonincremental TypeScript: passed.
+- Targeted tests: 475 passed across the files below. The adapter suite's initial run lacked the not-yet-built MCP bundle; its complete post-build rerun passed.
+- Runtime host: singleton succession in 503 ms; stable listener and runtime socket each answered 27/27 probes over 15 seconds, including abandoned peers.
+- Whole-diff privacy gate, known-value fingerprints and commit checks: passed before publication.
+
+The recovered baseline packaged artifact failed rollback after 125.806 seconds with `pipeline state is busy`, left the candidate running, and recorded 45 late historical publications. Recovered repaired artifacts reached readiness in 164.264 seconds and rollback in 64.967 seconds. These earlier observations establish provenance; the final successor runs below qualify the additional evidence assertions.
+
+| Final packaged run | Observed outcome |
+| --- | --- |
+| Headroom, historical replies held until 135 s; snapshot delay 3 s, other RPC delay 5 ms | Ready at 158.087 s, within 300 s; six hosted writers retained; subsequent pipeline creation persisted; exit 0 |
+| Forced rollback, verify action limited to 120 s | Terminal rolled-back at 66.566 s, within the asserted 215 s bound; candidate exited 0; target restored; no orphan readiness |
+| Restored Viewer | Ready 35.021 s after rollback observation; all six original receipts delivered |
+| Both runs: original provider inputs | Exactly six, each matched to its unchanged original request; three expected recovery continuations counted separately |
+| Both runs: preservation | Both independent HTTP workers alive with unchanged recorded ownership; deferred spawn receipt, original key and payload unchanged |
+| Both runs: late work | Zero historical publications after the fence; zero candidate mutations after checkpoint acknowledgement or target restoration |
+
+The exact provider-evidence matcher was also evaluated against retained inputs with one record removed, duplicated, altered in payload, or assigned a different operation ID. Each corrupted case failed; the intact control passed. Final runs required no forced child cleanup. The relay records broken-pipe events from intentionally delayed responses; these are transport observations and did not become process failures.
+
+The immutable standalone package contains 2,568 files. Its manifest digest is
+`af2fdeef2319f3fa8a59edfb1f4f3485262ac6d7c9c27998bc9124df65b5732a`:
+SHA-256 over sorted relative filenames, NUL, each file's SHA-256, and newline.
+Production source matches the preserved repair commit; successor changes concern verification.
+
+Reproduction commands, after assigning empty private state/provider homes and
+building with `LLV_STANDALONE=1 NEXT_PUBLIC_RUNTIME_UI=1 bun run build`:
+
+```sh
+python3 scripts/verify-packaged-startup.py --viewer "$PACKAGE" \
+  --runtime-source "$RUNTIME_SOURCE" --bun "$BUN" \
+  --snapshot-delay-ms 3000 --rpc-delay-ms 5 --hold-startup-ms 135000
+python3 scripts/verify-packaged-startup.py --viewer "$PACKAGE" \
+  --runtime-source "$RUNTIME_SOURCE" --bun "$BUN" \
+  --rollback --verify-timeout-ms 120000
+```
+
+`PACKAGE` contains `.next/standalone` plus `bin`, `dist`, `public` and
+`.next/static`. `RUNTIME_SOURCE` is the exact candidate source for these
+rehearsals. `BUN` is a Bun 1.4.0 binary. The harness independently creates empty
+private homes and state, clears inherited credentials, and uses local provider fixtures.
+
+The packaged fixture contains 6,623 retained receipts, 8,078 conversations, 5,188 entries and 1,719 held deliveries. It runs actual standalone instrumentation, transcript refresh, both native host wrappers, the runtime journal, delivery controller and SQLite admission. Providers are local protocol implementations. Both external workers are separate HTTP processes with independently recorded ownership. A deferred spawn retains its original key and payload.
+
+Provider evidence matches each of the six immutable journal requests to one observed provider input. Codex inputs must retain the original operation ID and its deduplication envelope. Claude inputs use the exact unique fixture payload and session because its input protocol carries no client key. Expected interrupted-turn continuations are counted separately with their exact key and payload contract. Receipt-only success is insufficient. Candidate mutations after checkpoint acknowledgement or target restoration, late historical publication, and orphan readiness fail qualification.
+
+Forced rollback uses the actual coordinator, command adapter, authority, journal, checkpoint and restored standalone Viewer. Container inspection and candidate prechecks are fixture setup. Its 120-second action limit produces a 60-second inner serving limit; terminal rollback must occur within the action limit plus the existing 90-second rollback limit and a 5-second observation allowance. Candidate clean exit and restored readiness are independent assertions. Teardown may force only an exact private runtime-host child after all preservation observations; that is recorded separately and does not establish graceful production host shutdown.
+
+This evidence does not qualify a container image, live provider authentication, or production deployment. Root owns those release checks and one fresh independent review.
+
+## Bootstrap blocker
+
+The incumbent runtime host still has its old 120-second verify-promoted deadline loaded. The new 360-second value becomes effective only when a new host generation runs. `deploy_exact_sha` delegates to that incumbent; its host-handoff phase follows promoted verification. A larger deadline in candidate source therefore cannot bootstrap itself.
+
+Current source and `docs/docker.md` provide `bun scripts/bootstrap-runtime-host.ts <exact-main-sha>` with plan, `--stage`, and `--hand-over` modes. The 13 bootstrap and 36 successor tests passed. This path stages a parked successor and explicitly stops the predecessor runtime-host container. It is a production lifecycle action beyond this builder's authorization. The image-build path also removes its own canonical bootstrap worktree, so the preservation restriction must be accounted for before selecting it. No bootstrap command was executed against production.
+
+No bootstrap path through the currently exposed `deploy_exact_sha` capability that avoids this lifecycle boundary has been established. This remains a release blocker requiring the root orchestrator's decision. A successful isolated rehearsal does not waive it. After a supported bootstrap, root must verify the exact merged runtime-host revision and then perform the ordinary exact-SHA deployment and live continuity checks. Existing pending operator sends and launches remain untouched.
+
+## Targeted tests
+
+| File | Passed |
+| --- | ---: |
+| `src/lib/runtime/startup.test.ts` | 87 |
+| `src/lib/runtime/startupFinalization.integration.test.ts` | 12 |
+| `src/lib/runtime/structuredDeliveryQueue.test.ts` | 63 |
+| `src/lib/runtime/structuredDeliveryController.test.ts` | 1 |
+| `src/lib/runtime/structuredDeliveryRebind.test.ts` | 13 |
+| `src/lib/runtime/structuredSpawn.integration.test.ts` | 84 |
+| `src/lib/runtime/structuredSpawn.terminalize.test.ts` | 20 |
+| `src/lib/state/hotStateStores.sqlite.test.ts` | 24 |
+| `src/instrumentation.test.ts` | 43 |
+| `src/runtime-host/deploymentHealth.test.ts` | 18 |
+| `src/runtime-host/deploymentAdapter.test.ts` | 18 |
+| `src/runtime-host/deploymentHotState.test.ts` | 15 |
+| `scripts/runtime-host-viewer-adapter.test.ts` | 28 |
+| `src/runtime-host/hostBootstrap.test.ts` | 13 |
+| `src/runtime-host/hostSuccessor.test.ts` | 36 |
+
+## File manifest
+
+The complete implementation and test scope relative to the base is:
+
+- `scripts/runtime-host-viewer-adapter.ts`
+- `scripts/verify-packaged-startup.py`
+- `src/lib/flows/store.ts`
+- `src/lib/pipelines/store.ts`
+- `src/lib/runtime/fixtures/packagedExternalWorker.py`
+- `src/lib/runtime/fixtures/packagedProvider.py`
+- `src/lib/runtime/fixtures/packagedRollback.ts`
+- `src/lib/runtime/fixtures/packagedStartupSeed.ts`
+- `src/lib/runtime/startup.ts`
+- `src/lib/runtime/startupFinalization.integration.test.ts`
+- `src/lib/runtime/startupWork.ts`
+- `src/lib/runtime/structuredDeliveryController.ts`
+- `src/lib/runtime/structuredDeliveryQueue.ts`
+- `src/lib/runtime/structuredDeliveryRebind.test.ts`
+- `src/lib/runtime/structuredSpawn.terminalize.test.ts`
+- `src/lib/runtime/structuredSpawn.ts`
+- `src/lib/state/hotStateAuthority.ts`
+- `src/lib/state/hotStateStores.sqlite.test.ts`
+- `src/lib/state/sqliteStateStore.ts`
+- `src/lib/viewerInstrumentation.ts`
+- `src/lib/workflows/store.ts`
+- `src/runtime-host/deploymentAdapter.ts`
+- `src/runtime-host/deploymentHealth.test.ts`
+- `src/runtime-host/deploymentHealth.ts`
+- `src/runtime-host/deploymentHotState.ts`
+
+This evidence document is the remaining documentation-only addition. Local raw logs, provider input comparisons, immutable standalone package, and source digests are retained under `.artifacts/startup-recovery/`; the per-run directories are recorded in the packaged logs. Private paths and live identities are excluded from this document.

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { processIdentityStatus } from "../src/lib/processIdentity";
 
 import type {
   ViewerHealthEvidence,
@@ -81,6 +82,8 @@ import {
   INCUMBENT_RELEASE_POLL_MS,
   INCUMBENT_RELEASE_TIMEOUT_MS,
   PROMOTE_ACTION_TIMEOUT_MS,
+  PROMOTED_SERVING_TIMEOUT_MS,
+  VERIFY_PROMOTED_ACTION_TIMEOUT_MS,
 } from "../src/runtime-host/deploymentHotState";
 import {
   candidateLogExcerpt,
@@ -563,7 +566,12 @@ async function verifyViewer(
     endpoint,
     inspect: () => containerState(candidate.container),
     probe: () => probeRoutes(candidate, endpoint, expectedAssetsEndpoint, reportPhase),
-    ...(expectedAssetsEndpoint ? { maxAttempts: 90 } : {}),
+    ...(expectedAssetsEndpoint ? {
+      // Fit inside the actual host deadline, including shortened rehearsal
+      // budgets, instead of retaining a shorter attempt-count ceiling.
+      timeoutMs: Math.min(PROMOTED_SERVING_TIMEOUT_MS,
+        Math.max(1, Number(process.env.LLV_DEPLOYMENT_ADAPTER_ACTION_DEADLINE_MS || VERIFY_PROMOTED_ACTION_TIMEOUT_MS) - 60_000)),
+    } : {}),
   });
   if (evidence.ok) return evidence;
   const containerLog = await candidateContainerLog(candidate.container);
@@ -952,6 +960,20 @@ async function checkpointHotStateFence(
   request: HotStateAuthority,
   revision: string,
 ): Promise<HotStateAuthority> {
+  if (request.activationOwner) {
+    const started = Date.now();
+    for (;;) {
+      const current = readHotStateAuthority(stateDir);
+      if (!current || current.mode !== "fencing" || current.epoch !== request.epoch
+        || current.releaseRevision !== revision) throw new Error("hot-state fence changed while awaiting Viewer quiescence");
+      if (current.checkpoint) return current;
+      // Only positive death permits the adapter to checkpoint for the Viewer.
+      // A live or unreadable identity keeps its startup/release barrier.
+      if (processIdentityStatus(request.activationOwner) === "dead") break;
+      if (Date.now() - started >= 30_000) throw new Error("Viewer did not acknowledge hot-state quiescence within 30000 ms");
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    }
+  }
   const previousExplicitRevision = process.env[HOT_STATE_RELEASE_REVISION_ENV];
   process.env[HOT_STATE_RELEASE_REVISION_ENV] = revision;
   try {

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -83,6 +83,7 @@ relay_errors = []
 fence_seen = threading.Event()
 held_historical = 0
 late_startup_publications = 0
+late_candidate_mutations = 0
 listener = socket.socket(socket.AF_UNIX)
 listener.bind(relay_socket)
 listener.listen()
@@ -90,12 +91,18 @@ listener.settimeout(.2)
 stopping = threading.Event()
 
 def forward(peer):
-    global held_historical, late_startup_publications
+    global held_historical, late_startup_publications, late_candidate_mutations
     try:
         peer_pid = struct.unpack("3i", peer.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12))[0]
         request = peer.makefile("rb").readline()
         decoded = json.loads(request)
         method = decoded["method"]
+        if args.rollback and peer_pid == app.pid and method in ("append", "command", "operation", "operation-transition"):
+            authority_path = root / "state/hot-state-authority.json"
+            authority = json.loads(authority_path.read_text()) if authority_path.exists() else {}
+            if authority.get("checkpoint") or authority.get("releaseRevision") != "a" * 40:
+                with metrics_lock:
+                    late_candidate_mutations += 1
         event = decoded.get("params", {}).get("event", {})
         conversation = event.get("scope", {}).get("id", "")
         history_index = int(conversation.removeprefix("conversation_history_")) if conversation.startswith("conversation_history_") else -1
@@ -198,6 +205,10 @@ if args.rollback:
     logs.append(open(root / "rollback.log", "w"))
     rollback_driver = subprocess.Popen([str(bun), "src/lib/runtime/fixtures/packagedRollback.ts"], cwd=repo, env=env, stdout=logs[-1], stderr=subprocess.STDOUT)
 result = {"ready": False, "deadlineMs": budgets["serving"], "snapshotDelayMs": args.snapshot_delay_ms, "rpcDelayMs": args.rpc_delay_ms}
+if args.rollback:
+    # The real verify action and rollback action each retain a hard deadline.
+    # Include one bounded capability observation after the terminal write.
+    result["rollbackBoundMs"] = (args.verify_timeout_ms or budgets["action"]) + 90_000 + 5_000
 expected_keys = [("claude" if not args.codex_only and i >= 3 else "codex") + ":00000000-0000-4000-8000-" + str(i).zfill(12) for i in range(6)]
 before_claims = None
 
@@ -293,6 +304,42 @@ finally:
     with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
         pending_after = db.execute("SELECT operation_id,idempotency_key,request_json FROM operations WHERE idempotency_key LIKE 'queued-startup-%' ORDER BY idempotency_key").fetchall()
     result["pendingIdentitiesPreserved"] = pending_before == pending_after
+    # Match the original durable request to exactly one actual provider input.
+    # Claude's wire protocol carries no client key, so its unique fixture text
+    # and session bind that input to the unchanged original journal request.
+    delivery_log = root / "state/provider-deliveries.jsonl"
+    observed = [json.loads(line) for line in delivery_log.read_text().splitlines()] if delivery_log.exists() else []
+    expected = []
+    for operation_id, key, request_json in pending_before:
+        request = json.loads(request_json)
+        index = int(key.removeprefix("queued-startup-"))
+        engine, session = expected_keys[index].split(":", 1)
+        wire_text = request["text"]
+        if engine == "codex":
+            wire_text = f"<!-- llv:structured-user dedup={hashlib.sha256(operation_id.encode()).hexdigest()} -->\n{wire_text}"
+        expected.append({"engine": engine, "session": session, "text": wire_text,
+                         "clientId": operation_id if engine == "codex" else None})
+    actual = [{"engine": item["engine"], "session": item["session"],
+               "text": "".join(block.get("text", "") for block in item["content"] if block.get("type") in ("text", "input_text")),
+               "clientId": item["clientId"]} for item in observed]
+    # Retained unfinished Codex turns can also receive the explicit startup
+    # continuation. Account for its exact wire contract separately; never
+    # discard an unknown input or count a continuation as an original send.
+    continuations = []
+    original_inputs = []
+    for item in actual:
+        client_id = item["clientId"] or ""
+        prefix = f"recovery-continuation-{item['session']}-"
+        continuation_text = f"<!-- llv:structured-user dedup={hashlib.sha256(client_id.encode()).hexdigest()} -->\nContinue the interrupted turn from the transcript."
+        if item["engine"] == "codex" and client_id.startswith(prefix) and client_id[len(prefix):].isdigit() and item["text"] == continuation_text:
+            continuations.append(item)
+        else:
+            original_inputs.append(item)
+    result["originalProviderInputsMatched"] = sorted(original_inputs, key=lambda item: item["session"]) == sorted(expected, key=lambda item: item["session"])
+    result["originalProviderInputCount"] = len(original_inputs)
+    result["recoveryContinuationCount"] = len(continuations)
+    result["providerInputCount"] = len(actual)
+    (root / "provider-input-evidence.json").write_text(json.dumps({"expected": expected, "actual": actual}, indent=2))
     # Only child handles created above; no process enumeration or live signals.
     # End application clients before asking the host to drain its listeners.
     for label, child in [("candidate", app), ("previous", previous_app), ("driver", rollback_driver), ("host", host)]:
@@ -316,11 +363,12 @@ finally:
     with metrics_lock:
         result["heldHistoricalResponses"] = held_historical
         result["lateStartupPublications"] = late_startup_publications
+        result["lateCandidateMutations"] = late_candidate_mutations
         result["rpc"] = dict(metrics)
         result["relayErrors"] = dict(collections.Counter(relay_errors))
     (root / "result.json").write_text(json.dumps(result, indent=2))
     print(json.dumps(result), flush=True)
-preserved = result.get("pendingSpawnPreserved") is True and not result.get("unsettledPrivateChildren") and result.get("externalStatePreserved") is True and result.get("externalWorkersAlive") == [True, True] and result.get("pendingIdentitiesPreserved") is True
+preserved = result.get("originalProviderInputsMatched") is True and result.get("lateCandidateMutations") == 0 and result.get("pendingSpawnPreserved") is True and not result.get("unsettledPrivateChildren") and result.get("externalStatePreserved") is True and result.get("externalWorkersAlive") == [True, True] and result.get("pendingIdentitiesPreserved") is True
 if args.rollback:
-    raise SystemExit(0 if preserved and result.get("terminalPhase") == "rolled-back" and result.get("terminal") is True and result.get("targetRestored") is True and result.get("candidateExit") == 0 and result.get("orphanReady") is False and "timed out" in (result.get("rollbackError") or "") and result.get("heldHistoricalResponses", 0) > 0 and result.get("lateStartupPublications") == 0 and result.get("restoredReady") is True and result.get("restoredQueuedSends") == {"delivered": 6} else 1)
+    raise SystemExit(0 if preserved and result.get("elapsedMs", float("inf")) < result["rollbackBoundMs"] and result.get("terminalPhase") == "rolled-back" and result.get("terminal") is True and result.get("targetRestored") is True and result.get("candidateExit") == 0 and result.get("orphanReady") is False and "timed out" in (result.get("rollbackError") or "") and result.get("heldHistoricalResponses", 0) > 0 and result.get("lateStartupPublications") == 0 and result.get("restoredReady") is True and result.get("restoredQueuedSends") == {"delivered": 6} else 1)
 raise SystemExit(0 if preserved and result.get("queuedSends") == {"delivered": 6} and result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("ownershipPreserved") is True and result.get("creation", {}).get("created") else 1)

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -9,6 +9,7 @@ import argparse
 import collections
 import json
 import hashlib
+import http.server
 import os
 from pathlib import Path
 import socket
@@ -26,7 +27,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--viewer", type=Path, required=True, help="immutable standalone package")
 parser.add_argument("--runtime-source", type=Path, required=True, help="exact incumbent runtime-host source tree")
 parser.add_argument("--bun", type=Path, required=True)
-parser.add_argument("--verify-timeout-ms", type=int, help="shorten only the rehearsal adapter deadline for a deterministic timeout")
+parser.add_argument("--verify-timeout-ms", type=int, help="incumbent API rollback retains its actual 120000 ms deadline")
 parser.add_argument("--hold-startup-ms", type=int, default=0, help="withhold historical responses until this elapsed startup time")
 parser.add_argument("--rollback", action="store_true", help="hold historical publication through the real serving-verification verify-promoted deadline, then exercise rollback")
 parser.add_argument("--codex-only", action="store_true", help="narrower contention control; does not qualify mixed-provider preservation")
@@ -36,6 +37,24 @@ args = parser.parse_args()
 assert 0 <= args.snapshot_delay_ms <= 3000 and 0 <= args.rpc_delay_ms <= 5
 repo = Path(__file__).resolve().parents[1]
 viewer, runtime_source, bun = args.viewer.resolve(), args.runtime_source.resolve(), args.bun.resolve()
+incumbent_revision = "bdf4b85658802c2e1765382c5aef04a6585980a7"
+if args.rollback:
+    if args.verify_timeout_ms not in (None, 120000):
+        parser.error("incumbent API rollback requires the unchanged 120000 ms action deadline")
+    # Freeze every executable/source dependency, including the coordinator and
+    # adapter imports. A current-tree adapter cannot qualify an old-host run.
+    manifest = subprocess.check_output(["git", "ls-tree", "-rz", incumbent_revision], cwd=repo)
+    for entry in manifest.split(b"\0"):
+        if not entry:
+            continue
+        metadata, filename = entry.split(b"\t", 1)
+        filename = filename.decode()
+        if not (filename.startswith(("src/", "scripts/", "bin/")) or filename in ("tsconfig.json", "package.json", "bun.lock")):
+            continue
+        data = (runtime_source / filename).read_bytes()
+        actual = hashlib.sha1(b"blob " + str(len(data)).encode() + b"\0" + data).hexdigest()
+        if actual != metadata.decode().split()[2]:
+            raise RuntimeError(f"incumbent source differs from frozen revision: {filename}")
 assert subprocess.check_output([str(bun), "--version"], text=True).strip() == "1.4.0"
 for file in [viewer / "server.js", viewer / "bin/mcp-server.mjs", viewer / "dist/mcp-server.mjs", runtime_source / "src/runtime-host/main.ts"]:
     assert file.is_file(), f"missing packaged prerequisite: {file.name}"
@@ -161,7 +180,17 @@ with socket.socket() as reserved:
     port = reserved.getsockname()[1]
 env.update({"PORT": str(port), "HOSTNAME": "127.0.0.1", "LLV_VIEWER_PORT": str(port), "LLV_RUNTIME_HOST_SOCKET": real_socket})
 logs = [open(root / "host.log", "w"), open(root / "viewer.log", "w")]
-host = subprocess.Popen([str(bun), "src/runtime-host/main.ts"], cwd=runtime_source, env=env, stdout=logs[0], stderr=subprocess.STDOUT)
+host_env = dict(env)
+if args.rollback:
+    with socket.socket() as reserved:
+        reserved.bind(("127.0.0.1", 0))
+        front_port = reserved.getsockname()[1]
+    host_env.update({
+        "LLV_VIEWER_PORT": str(front_port), "LLV_VIEWER_DEPLOYMENTS": "1",
+        "LLV_VIEWER_DEPLOY_ADAPTER": str(repo / "src/lib/runtime/fixtures/packagedIncumbentAdapter.py"),
+        "LLV_PACKAGED_RUNTIME_SOURCE": str(runtime_source), "LLV_PACKAGED_BUN": str(bun),
+    })
+host = subprocess.Popen([str(bun), "src/runtime-host/main.ts"], cwd=runtime_source, env=host_env, stdout=logs[0], stderr=subprocess.STDOUT)
 for _ in range(100):
     if Path(real_socket).exists():
         break
@@ -172,6 +201,23 @@ env["LLV_RUNTIME_HOST_SOCKET"] = relay_socket
 previous_app = None
 rollback_driver = None
 if args.rollback:
+    # Force the real incumbent verifier's outer timeout. Direct candidate and
+    # restored endpoints remain real Viewers; only this serving probe is held.
+    class SlowServing(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            time.sleep(35)
+            try:
+                self.send_response(503)
+                self.end_headers()
+            except OSError:
+                pass
+
+        def log_message(self, *_):
+            pass
+
+    slow = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SlowServing)
+    threading.Thread(target=slow.serve_forever, daemon=True).start()
+    (root / "state/slow-port").write_text(str(slow.server_port))
     with socket.socket() as reserved:
         reserved.bind(("127.0.0.1", 0))
         previous_port = reserved.getsockname()[1]
@@ -203,12 +249,15 @@ app = subprocess.Popen([str(bun), str(viewer / "server.js")], cwd=viewer, env=en
 started = time.monotonic()
 if args.rollback:
     logs.append(open(root / "rollback.log", "w"))
-    rollback_driver = subprocess.Popen([str(bun), "src/lib/runtime/fixtures/packagedRollback.ts"], cwd=repo, env=env, stdout=logs[-1], stderr=subprocess.STDOUT)
+    driver_env = dict(env, LLV_PACKAGED_DEPLOYMENT_PORT=str(front_port))
+    rollback_driver = subprocess.Popen([str(bun), "src/lib/runtime/fixtures/packagedRollback.ts"], cwd=repo, env=driver_env, stdout=logs[-1], stderr=subprocess.STDOUT)
 result = {"ready": False, "deadlineMs": budgets["serving"], "snapshotDelayMs": args.snapshot_delay_ms, "rpcDelayMs": args.rpc_delay_ms}
 if args.rollback:
     # The real verify action and rollback action each retain a hard deadline.
     # Include one bounded capability observation after the terminal write.
-    result["rollbackBoundMs"] = (args.verify_timeout_ms or budgets["action"]) + 90_000 + 5_000
+    result["rollbackBoundMs"] = 120_000 + 90_000 + 5_000
+    result["incumbentRevision"] = incumbent_revision
+    result["deploymentAdmission"] = "Viewer API"
 expected_keys = [("claude" if not args.codex_only and i >= 3 else "codex") + ":00000000-0000-4000-8000-" + str(i).zfill(12) for i in range(6)]
 before_claims = None
 

--- a/scripts/verify-packaged-startup.py
+++ b/scripts/verify-packaged-startup.py
@@ -8,9 +8,11 @@ private files. No operator state, credentials, provider CLI or stable port is us
 import argparse
 import collections
 import json
+import hashlib
 import os
 from pathlib import Path
 import socket
+import struct
 import shutil
 import sqlite3
 import subprocess
@@ -24,6 +26,9 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--viewer", type=Path, required=True, help="immutable standalone package")
 parser.add_argument("--runtime-source", type=Path, required=True, help="exact incumbent runtime-host source tree")
 parser.add_argument("--bun", type=Path, required=True)
+parser.add_argument("--verify-timeout-ms", type=int, help="shorten only the rehearsal adapter deadline for a deterministic timeout")
+parser.add_argument("--hold-startup-ms", type=int, default=0, help="withhold historical responses until this elapsed startup time")
+parser.add_argument("--rollback", action="store_true", help="hold historical publication through the real serving-verification verify-promoted deadline, then exercise rollback")
 parser.add_argument("--codex-only", action="store_true", help="narrower contention control; does not qualify mixed-provider preservation")
 parser.add_argument("--snapshot-delay-ms", type=int, default=0)
 parser.add_argument("--rpc-delay-ms", type=int, default=0)
@@ -42,12 +47,31 @@ for key, directory in {"HOME": "home", "XDG_CONFIG_HOME": "config", "XDG_CACHE_H
     env[key] = str(root / directory)
 (root / "bin").mkdir(mode=0o700)
 (root / "bin/bun").symlink_to(bun)
+(root / "bin/bun-container").symlink_to(bun)
 (root / "sockets").mkdir(mode=0o700)
 provider = str(root / "bin/provider")
 shutil.copy2(repo / "src/lib/runtime/fixtures/packagedProvider.py", provider)
 env.update({"LLV_CODEX_BINARY": provider, "LLV_CLAUDE_BINARY": provider, "LLV_PACKAGED_MIXED_ENGINES": "0" if args.codex_only else "1"})
+external_workers = []
+external_ports = []
+for _ in range(2):
+    worker = subprocess.Popen(["/usr/bin/python3", str(repo / "src/lib/runtime/fixtures/packagedExternalWorker.py")], env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    external_workers.append(worker)
+    external_ports.append(int(worker.stdout.readline()))
+env["LLV_PACKAGED_EXTERNAL_PIDS"] = json.dumps([worker.pid for worker in external_workers])
 with open(root / "seed.log", "w") as log:
-    subprocess.run([str(bun), "src/lib/runtime/fixtures/packagedStartupSeed.ts"], cwd=repo, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
+    try:
+        subprocess.run([str(bun), "src/lib/runtime/fixtures/packagedStartupSeed.ts"], cwd=repo, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
+    except BaseException:
+        for worker in external_workers:
+            worker.stdin.close()
+            worker.wait(timeout=5)
+        raise
+
+budgets = json.loads((root / "state/rehearsal-budgets.json").read_text())
+with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
+    pending_before = db.execute("SELECT operation_id,idempotency_key,request_json FROM operations WHERE idempotency_key LIKE 'queued-startup-%' ORDER BY idempotency_key").fetchall()
+(root / "pending-before.json").write_text(json.dumps(pending_before))
 
 # A transparent local socket relay counts framing bytes and response times.
 # Every request and reply still runs through the real incumbent host.
@@ -56,6 +80,9 @@ relay_socket = str(root / "sockets/viewer.sock")
 metrics = collections.defaultdict(lambda: {"count": 0, "requestBytes": 0, "responseBytes": 0, "elapsedMs": 0, "maxMs": 0})
 metrics_lock = threading.Lock()
 relay_errors = []
+fence_seen = threading.Event()
+held_historical = 0
+late_startup_publications = 0
 listener = socket.socket(socket.AF_UNIX)
 listener.bind(relay_socket)
 listener.listen()
@@ -63,16 +90,42 @@ listener.settimeout(.2)
 stopping = threading.Event()
 
 def forward(peer):
+    global held_historical, late_startup_publications
     try:
+        peer_pid = struct.unpack("3i", peer.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12))[0]
         request = peer.makefile("rb").readline()
-        method = json.loads(request)["method"]
-        started = time.monotonic()
+        decoded = json.loads(request)
+        method = decoded["method"]
+        event = decoded.get("params", {}).get("event", {})
+        conversation = event.get("scope", {}).get("id", "")
+        history_index = int(conversation.removeprefix("conversation_history_")) if conversation.startswith("conversation_history_") else -1
+        historical = method == "append" and history_index >= 6 and event.get("payload", {}).get("host") in ("dead", "unhosted") and event.get("producer", {}).get("eventKey", "").startswith("projection:")
+        if args.rollback and historical and peer_pid == app.pid and fence_seen.is_set():
+            with metrics_lock:
+                late_startup_publications += 1
+        rpc_started = time.monotonic()
         time.sleep((args.snapshot_delay_ms if method == "snapshot" else args.rpc_delay_ms) / 1000)
         with socket.socket(socket.AF_UNIX) as upstream:
             upstream.connect(real_socket)
             upstream.sendall(request)
             response = upstream.makefile("rb").readline()
-        elapsed = (time.monotonic() - started) * 1000
+        if historical and args.hold_startup_ms:
+            time.sleep(max(0, args.hold_startup_ms / 1000 - (time.monotonic() - started)))
+        if args.rollback and historical and peer_pid == app.pid and not fence_seen.is_set():
+            with metrics_lock:
+                held_historical += 1
+            # Let the real timeout expire. Once rollback publishes its fence,
+            # the in-flight reply can settle; no request is abandoned.
+            until = time.monotonic() + 420
+            while time.monotonic() < until:
+                authority_file = root / "state/hot-state-authority.json"
+                authority = json.loads(authority_file.read_text()) if authority_file.exists() else {}
+                if authority.get("mode") == "fencing" or authority.get("releaseRevision") != "a" * 40:
+                    fence_seen.set()
+                    time.sleep(.2)
+                    break
+                time.sleep(.05)
+        elapsed = (time.monotonic() - rpc_started) * 1000
         with metrics_lock:
             item = metrics[method]
             item["count"] += 1
@@ -109,9 +162,42 @@ for _ in range(100):
         raise RuntimeError("private runtime host failed to start")
     time.sleep(.1)
 env["LLV_RUNTIME_HOST_SOCKET"] = relay_socket
+previous_app = None
+rollback_driver = None
+if args.rollback:
+    with socket.socket() as reserved:
+        reserved.bind(("127.0.0.1", 0))
+        previous_port = reserved.getsockname()[1]
+    def release(letter, endpoint, container, managed):
+        revision = letter * 40
+        return {"revision": revision, "endpoint": endpoint, "container": container, "image": "viewer:fixture", "hotStateBackend": "sqlite-v1", "mcpRuntime": {
+            "source": "managed" if managed else "legacy", "revision": revision,
+            "releaseId": "fixture" if managed else None, "artifactDigest": letter * 64,
+            "stagedAt": "2026-01-01T00:00:00.000Z" if managed else None,
+        }}
+    candidate = release("a", f"http://127.0.0.1:{port}", "fixture-candidate", True)
+    previous = release("b", f"http://127.0.0.1:{previous_port}", "fixture-previous", False)
+    (root / "state/viewer-release.json").write_text(json.dumps(candidate))
+    (root / "state/hot-state-authority.json").write_text(json.dumps({"schemaVersion": 1, "epoch": 1, "mode": "sqlite", "releaseRevision": candidate["revision"], "updatedAt": "2026-01-01T00:00:00.000Z"}))
+    (root / "state/rehearsal-release.json").write_text(json.dumps({"candidate": candidate, "previous": previous, "actionTimeoutMs": args.verify_timeout_ms}))
+    # Docker is only a container-state adapter for processes owned here. Every
+    # HTTP probe, authority write, checkpoint and target switch is production code.
+    (root / "bin/docker").write_text("#!/bin/sh\nif [ \"$1 $2\" = \"container inspect\" ]; then exit 0; fi\nif [ \"$1\" = inspect ]; then echo running; exit 0; fi\nif [ \"$1\" = start ]; then exit 0; fi\nexit 1\n")
+    (root / "bin/docker").chmod(0o700)
+    compose = root / "state/deployments/compose"
+    compose.mkdir(parents=True, exist_ok=True)
+    for identity in [candidate, previous]:
+        name = hashlib.sha256(identity["container"].encode()).hexdigest()[:24] + ".json"
+        (compose / name).write_text(json.dumps({"services": {"viewer": {"build": None, "command": None, "entrypoint": None, "environment": {"LLV_AGENT_REGISTRY_SQLITE": "sqlite"}, "image": "viewer:fixture", "labels": {}, "network_mode": "host", "pid": "host", "privileged": False, "restart": "unless-stopped", "user": "1000:1000", "volumes": [], "working_dir": "/app"}}}))
+    previous_env = dict(env, PORT=str(previous_port), LLV_VIEWER_PORT=str(previous_port))
+    logs.append(open(root / "previous.log", "w"))
+    previous_app = subprocess.Popen([str(bun), str(viewer / "server.js")], cwd=viewer, env=previous_env, stdout=logs[-1], stderr=subprocess.STDOUT)
 app = subprocess.Popen([str(bun), str(viewer / "server.js")], cwd=viewer, env=env, stdout=logs[1], stderr=subprocess.STDOUT)
 started = time.monotonic()
-result = {"ready": False, "deadlineMs": 120000, "snapshotDelayMs": args.snapshot_delay_ms, "rpcDelayMs": args.rpc_delay_ms}
+if args.rollback:
+    logs.append(open(root / "rollback.log", "w"))
+    rollback_driver = subprocess.Popen([str(bun), "src/lib/runtime/fixtures/packagedRollback.ts"], cwd=repo, env=env, stdout=logs[-1], stderr=subprocess.STDOUT)
+result = {"ready": False, "deadlineMs": budgets["serving"], "snapshotDelayMs": args.snapshot_delay_ms, "rpcDelayMs": args.rpc_delay_ms}
 expected_keys = [("claude" if not args.codex_only and i >= 3 else "codex") + ":00000000-0000-4000-8000-" + str(i).zfill(12) for i in range(6)]
 before_claims = None
 
@@ -122,7 +208,7 @@ def claims():
 print(root, flush=True)
 try:
     with open(root / "timeline.jsonl", "w") as timeline:
-        # Continue observation after the unchanged 120s gate, without claiming
+        # Continue observation after the bounded serving gate, without claiming
         # success or releasing the callback's lease at the deadline.
         while time.monotonic() - started < 480:
             before = time.monotonic()
@@ -145,9 +231,43 @@ try:
             elapsed = round((time.monotonic() - started) * 1000)
             timeline.write(json.dumps({"elapsedMs": elapsed, "probeMs": round((time.monotonic() - before) * 1000), "status": status, "leases": leases}) + "\n")
             timeline.flush()
+            if args.rollback:
+                if rollback_driver.poll() is not None and not (root / "state/rollback-terminal.json").exists():
+                    result["driverExit"] = rollback_driver.returncode
+                    break
+                terminal_file = root / "state/rollback-terminal.json"
+                if terminal_file.exists():
+                    terminal = json.loads(terminal_file.read_text())
+                    result.update({"terminalPhase": terminal["phase"], "terminal": terminal["terminal"], "elapsedMs": elapsed, "rollbackError": terminal.get("error")})
+                    # A retired candidate must exit through its own demotion.
+                    try:
+                        result["candidateExit"] = app.wait(timeout=20)
+                    except subprocess.TimeoutExpired:
+                        result["candidateExit"] = None
+                    result["targetRestored"] = json.loads((root / "state/viewer-release.json").read_text())["revision"] == previous["revision"]
+                    candidate_log = (root / "viewer.log").read_text()
+                    result["orphanReady"] = 'phase: "ready"' in candidate_log
+                    if terminal["phase"] == "rolled-back" and result["candidateExit"] == 0:
+                        restore_started = time.monotonic()
+                        while time.monotonic() - restore_started < budgets["serving"] / 1000:
+                            try:
+                                with urllib.request.urlopen(f"http://127.0.0.1:{previous_port}/api/runtime/deployments/capabilities/v1", timeout=2) as response:
+                                    restored = json.load(response)
+                                if restored.get("structuredHostStartup", {}).get("state") == "ready":
+                                    result["restoredReady"] = True
+                                    result["restoreReadyMs"] = round((time.monotonic() - restore_started) * 1000)
+                                    with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
+                                        result["restoredQueuedSends"] = dict(db.execute("SELECT json_extract(receipt_json,'$.status'),count(*) FROM operations WHERE idempotency_key LIKE 'queued-startup-%' GROUP BY 1").fetchall())
+                                    break
+                            except (OSError, ValueError):
+                                pass
+                            time.sleep(.25)
+                    break
+                time.sleep(.25)
+                continue
             if status.get("structuredHostStartup", {}).get("state") == "ready":
                 with sqlite3.connect(f"file:{root / 'state/agent-registry.sqlite'}?mode=ro", uri=True) as db:
-                    hosted = db.execute("SELECT count(*) FROM registry_rows WHERE collection='entries' AND json_extract(value_json,'$.structuredHost.process') IS NOT NULL").fetchone()[0]
+                    hosted = sum(1 for row in current_claims if row[4] and row[5])
                 contender = subprocess.run([str(bun), "src/lib/runtime/fixtures/startupPipelineContender.ts", str(root / "state")], cwd=repo, env=env, capture_output=True, text=True)
                 with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
                     sends = db.execute("SELECT json_extract(receipt_json,'$.status'),count(*) FROM operations WHERE idempotency_key LIKE 'queued-startup-%' GROUP BY 1").fetchall()
@@ -156,19 +276,51 @@ try:
                 break
             time.sleep(.25)
 finally:
+    with sqlite3.connect(f"file:{root / 'state/agent-registry.sqlite'}?mode=ro", uri=True) as db:
+        before_external = json.loads((root / "state/external-before.json").read_text())
+        after_external = {key: json.loads(db.execute("SELECT value_json FROM registry_rows WHERE collection='entries' AND row_key=?", (key,)).fetchone()[0]) for key in before_external}
+        pending_spawn_before = json.loads((root / "state/pending-spawn-before.json").read_text())
+        pending_spawn_after = {key: json.loads(db.execute("SELECT value_json FROM registry_rows WHERE collection='receipts' AND row_key=?", (key,)).fetchone()[0]) for key in pending_spawn_before}
+    result["pendingSpawnPreserved"] = pending_spawn_before == pending_spawn_after
+    result["externalStatePreserved"] = before_external == after_external
+    result["externalWorkersAlive"] = []
+    for worker, worker_port in zip(external_workers, external_ports):
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{worker_port}", timeout=2) as response:
+                result["externalWorkersAlive"].append(worker.poll() is None and response.read().decode() == str(worker.pid))
+        except OSError:
+            result["externalWorkersAlive"].append(False)
+    with sqlite3.connect(f"file:{root / 'state/runtime-events.sqlite'}?mode=ro", uri=True) as db:
+        pending_after = db.execute("SELECT operation_id,idempotency_key,request_json FROM operations WHERE idempotency_key LIKE 'queued-startup-%' ORDER BY idempotency_key").fetchall()
+    result["pendingIdentitiesPreserved"] = pending_before == pending_after
     # Only child handles created above; no process enumeration or live signals.
-    app.terminate()
-    host.terminate()
-    for child in [app, host]:
+    # End application clients before asking the host to drain its listeners.
+    for label, child in [("candidate", app), ("previous", previous_app), ("driver", rollback_driver), ("host", host)]:
+        if child is None:
+            continue
+        if child.poll() is None:
+            child.terminate()
         try:
             child.wait(timeout=15)
         except subprocess.TimeoutExpired:
-            result.setdefault("unsettledPrivateChildren", []).append(child.pid)
+            # Verification above is complete. This is teardown of an exact
+            # harness-owned child, never evidence about production shutdown.
+            child.kill()
+            child.wait(timeout=5)
+            result.setdefault("fixtureCleanupForced", []).append(label)
+    for worker in external_workers:
+        worker.stdin.close()
+        worker.wait(timeout=5)
     stopping.set()
     listener.close()
     with metrics_lock:
+        result["heldHistoricalResponses"] = held_historical
+        result["lateStartupPublications"] = late_startup_publications
         result["rpc"] = dict(metrics)
         result["relayErrors"] = dict(collections.Counter(relay_errors))
     (root / "result.json").write_text(json.dumps(result, indent=2))
     print(json.dumps(result), flush=True)
-raise SystemExit(0 if result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("ownershipPreserved") is True and result.get("creation", {}).get("created") else 1)
+preserved = result.get("pendingSpawnPreserved") is True and not result.get("unsettledPrivateChildren") and result.get("externalStatePreserved") is True and result.get("externalWorkersAlive") == [True, True] and result.get("pendingIdentitiesPreserved") is True
+if args.rollback:
+    raise SystemExit(0 if preserved and result.get("terminalPhase") == "rolled-back" and result.get("terminal") is True and result.get("targetRestored") is True and result.get("candidateExit") == 0 and result.get("orphanReady") is False and "timed out" in (result.get("rollbackError") or "") and result.get("heldHistoricalResponses", 0) > 0 and result.get("lateStartupPublications") == 0 and result.get("restoredReady") is True and result.get("restoredQueuedSends") == {"delivered": 6} else 1)
+raise SystemExit(0 if preserved and result.get("queuedSends") == {"delivered": 6} and result.get("ready") and result["elapsedMs"] < result["deadlineMs"] and result.get("hosted") == 6 and result.get("ownershipPreserved") is True and result.get("creation", {}).get("created") else 1)

--- a/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.test.ts
@@ -15,49 +15,68 @@ import {
   viewerDeploymentReleaseReady,
 } from "@/runtime-host/deploymentHealth";
 
+import {
+  markStructuredDeliveryControllerReady,
+  markStructuredDeliveryControllerUnavailable,
+  markStructuredHostStartupFailed,
+  markStructuredHostStartupReady,
+} from "@/lib/runtime/startupStatus";
+
+import * as incumbent from "@/runtime-host/fixtures/incumbentDeploymentHealth";
+
 import { GET } from "./route";
 
-test("the deployed predecessor adapter can pass after activation while a new adapter waits for full startup", async () => {
-  const previous = process.env.LLV_STATE_DIR;
-  const previousPort = process.env.PORT;
-  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-hot-state-capability-"));
+test("both verifier generations wait for serving startup while passive prechecks remain available", async () => {
+  const previous = { state: process.env.LLV_STATE_DIR, port: process.env.PORT, hosts: process.env.LLV_STRUCTURED_HOSTS };
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-startup-capability-"));
   process.env.LLV_STATE_DIR = sandbox;
+  process.env.LLV_STRUCTURED_HOSTS = "1";
   const revision = "a".repeat(40);
-  const target = {
-    endpoint: "http://127.0.0.1:19001",
-    revision,
-    hotStateBackend: HOT_STATE_BACKEND,
+  fs.writeFileSync(path.join(sandbox, "viewer-release.json"), JSON.stringify({
+    endpoint: "http://127.0.0.1:19001", revision, hotStateBackend: HOT_STATE_BACKEND,
+  }));
+  const probe = async (ready: boolean, status = 200, promoted = true) => {
+    const response = GET();
+    const text = await response.text();
+    expect(response.status).toBe(status);
+    expect(JSON.parse(text).releaseReady).toBe(ready);
+    expect(incumbent.viewerDeploymentReleaseReady(response.status, text)).toBe(ready);
+    if (promoted) expect(viewerDeploymentReleaseReady(response.status, text)).toBe(ready);
+    else expect(hasViewerDeploymentCapability(response.status, text)).toBe(true);
   };
   try {
-    fs.writeFileSync(path.join(sandbox, "viewer-release.json"), JSON.stringify({
-      endpoint: target.endpoint,
-      revision,
-    }));
-    process.env.PORT = "19001";
-    expect(GET().status).toBe(200);
-    fs.writeFileSync(path.join(sandbox, "viewer-release.json"), JSON.stringify(target));
     process.env.PORT = "19002";
-    expect(GET().status).toBe(200);
+    markStructuredDeliveryControllerUnavailable();
+    markStructuredHostStartupFailed();
+    await probe(true, 200, false);
     process.env.PORT = "19001";
     expect(GET().status).toBe(503);
-    const authority = publishHotStateAuthority(sandbox, "sqlite", revision);
-    expect(GET().status).toBe(503);
-    const activated = markHotStateActivationReady(sandbox, authority);
-    for (let startupPoll = 0; startupPoll < 31; startupPoll += 1) {
-      const predecessorResponse = GET();
-      const predecessorBody = await predecessorResponse.text();
-      expect(predecessorResponse.status).toBe(200);
-      expect(hasViewerDeploymentCapability(predecessorResponse.status, predecessorBody)).toBe(true);
-      expect(viewerDeploymentReleaseReady(predecessorResponse.status, predecessorBody)).toBe(false);
-    }
+    const activated = markHotStateActivationReady(sandbox, publishHotStateAuthority(sandbox, "sqlite", revision));
+    markStructuredDeliveryControllerReady();
+    // Restore the actual not-yet-started state, including its pending default.
+    const state = process as typeof process & {
+      __llvStructuredHostStartupFailed?: boolean;
+      __llvStructuredHostStartupProgress?: unknown;
+    };
+    delete state.__llvStructuredHostStartupFailed;
+    delete state.__llvStructuredHostStartupProgress;
+    await probe(false); // Activation can complete before serving readiness.
     markViewerReleaseReady(sandbox, activated);
-    const completeResponse = GET();
-    expect(viewerDeploymentReleaseReady(completeResponse.status, await completeResponse.text())).toBe(true);
+    await probe(false); // The incumbent reads releaseReady, ignoring startup.
+    markStructuredHostStartupReady();
+    await probe(true);
+    markStructuredDeliveryControllerUnavailable();
+    await probe(false, 503);
+    markStructuredDeliveryControllerReady();
+    markStructuredHostStartupFailed();
+    await probe(false, 503);
+    process.env.LLV_STRUCTURED_HOSTS = "0";
+    await probe(true);
   } finally {
-    if (previousPort === undefined) delete process.env.PORT;
-    else process.env.PORT = previousPort;
-    if (previous === undefined) delete process.env.LLV_STATE_DIR;
-    else process.env.LLV_STATE_DIR = previous;
-    fs.rmSync(sandbox, { recursive: true, force: true });
+    for (const [key, value] of Object.entries({ LLV_STATE_DIR: previous.state, PORT: previous.port, LLV_STRUCTURED_HOSTS: previous.hosts })) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+    markStructuredHostStartupReady();
+    markStructuredDeliveryControllerUnavailable();
   }
 });

--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -35,9 +35,9 @@ function viewerReleaseStartupState(
 /* The deployment readiness gate probes this route with a 5s budget. It reads
    two small handoff records and still avoids instantiating the agent registry,
    whose first probe would otherwise pay a multi-MB parse. The activation gate
-   remains compatible with the deployed predecessor adapter. Structured-host
-   recovery is reported independently because it may continue after serving
-   readiness. */
+   remains compatible with the deployed predecessor adapter. Its serving
+   verifier reads releaseReady, so that existing signal also covers structured
+   startup. Passive candidates retain their pre-promotion health semantics. */
 export function GET(): Response {
   const startup = viewerReleaseStartupState();
   if (!startup.activationReady) {
@@ -48,11 +48,14 @@ export function GET(): Response {
   }
   const structuredHostStartup = structuredStartupStatus();
   const structuredDeliveryController = structuredDeliveryControllerReadiness();
+  const releaseReady = startup.releaseReady && (!startup.servesTraffic
+    || ((structuredHostStartup === null || structuredHostStartup.state === "ready")
+      && structuredDeliveryController !== "unavailable"));
   if (startup.servesTraffic && structuredDeliveryController === "unavailable") {
     return Response.json(
       {
         error: "structured delivery controller is unavailable",
-        releaseReady: startup.releaseReady,
+        releaseReady,
         structuredDeliveryController,
         structuredHostStartup,
       },
@@ -63,7 +66,7 @@ export function GET(): Response {
     return Response.json(
       {
         error: "structured host startup adoption is retrying after a failed pass",
-        releaseReady: startup.releaseReady,
+        releaseReady,
         structuredDeliveryController,
         structuredHostStartup,
       },
@@ -75,7 +78,7 @@ export function GET(): Response {
       capability: "viewer-deployments",
       version: 1,
       registryBackendMode: sqliteModeFromEnvironment(),
-      releaseReady: startup.releaseReady,
+      releaseReady,
       structuredDeliveryController,
       structuredHostStartup,
     },

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -349,6 +349,12 @@ export function checkpointFlowRollbackMirrorForDemotion(): number {
   });
 }
 
+export async function checkpointFlowRollbackMirrorForDemotionAsync(): Promise<number> {
+  return flowStore().checkpointMirrorForDemotionAsync((flows, revision) => {
+    atomicWriteJson(flowsFile(), { schemaVersion: FLOWS_SCHEMA_VERSION, _sqliteRevision: revision, flows });
+  });
+}
+
 function reconcileFlowImplementer(flow: Flow, registry: ConversationLookup): boolean {
   if (flow.implementerConversationId?.startsWith("conversation_")) {
     const current = registry.conversation(flow.implementerConversationId as `conversation_${string}`)?.generations.at(-1)?.path;

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -858,6 +858,17 @@ export function checkpointPipelineRollbackMirrorsForDemotion(): { pipelines: num
   return { pipelines, pipelinesArchive };
 }
 
+export async function checkpointPipelineRollbackMirrorsForDemotionAsync(): Promise<{ pipelines: number; pipelinesArchive: number }> {
+  const { active, archive } = stores();
+  const pipelines = await active.checkpointMirrorForDemotionAsync((pipelines, revision) => {
+    atomicWriteJson(pipelinesFile(), { schemaVersion: PIPELINES_SCHEMA_VERSION, _sqliteRevision: revision, pipelines });
+  });
+  const pipelinesArchive = await archive.checkpointMirrorForDemotionAsync((pipelines, revision) => {
+    atomicWriteJson(pipelinesArchiveFile(), { schemaVersion: PIPELINES_SCHEMA_VERSION, _sqliteRevision: revision, pipelines });
+  });
+  return { pipelines, pipelinesArchive };
+}
+
 /** Full-record read by id: the hot registry first, then the archive. */
 export function findPipelineRecord(pipelineId: string): Pipeline | null {
   return loadPipelines().find((pipeline) => pipeline.id === pipelineId)

--- a/src/lib/runtime/fixtures/packagedExternalWorker.py
+++ b/src/lib/runtime/fixtures/packagedExternalWorker.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Independent local worker: HTTP stays live until the harness closes stdin."""
+import http.server
+import os
+import sys
+import threading
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(str(os.getpid()).encode())
+
+    def log_message(self, *_):
+        pass
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+print(server.server_port, flush=True)
+sys.stdin.readline()
+server.shutdown()

--- a/src/lib/runtime/fixtures/packagedIncumbentAdapter.py
+++ b/src/lib/runtime/fixtures/packagedIncumbentAdapter.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+"""Container setup fixture; verification and rollback execute the frozen adapter."""
+import json
+import os
+from pathlib import Path
+import sys
+
+
+action = sys.argv[1]
+directory = Path(os.environ["LLV_STATE_DIR"])
+if action == "verify-promoted":
+    os.environ["LLV_VIEWER_PORT"] = (directory / "slow-port").read_text()
+if action in ("verify-promoted", "rollback"):
+    executable = Path(os.environ["LLV_PACKAGED_RUNTIME_SOURCE"]) / "scripts/runtime-host-viewer-adapter.ts"
+    os.execv(os.environ["LLV_PACKAGED_BUN"], ["bun", str(executable), action])
+
+request = json.load(sys.stdin)
+releases = json.loads((directory / "rehearsal-release.json").read_text())
+candidate, previous = releases["candidate"], releases["previous"]
+if action == "resolve-revision":
+    output = {"revision": candidate["revision"]}
+elif action == "build-candidate":
+    output = candidate
+elif action == "current-release":
+    output = previous
+elif action == "current-mcp-runtime":
+    output = previous["mcpRuntime"]
+elif action == "verify-candidate":
+    output = {
+        "checkedAt": "2026-01-01T00:00:00.000Z", "endpoint": candidate["endpoint"],
+        "processReady": True, "rootStatus": 200, "authenticatedStatus": None,
+        "unauthorizedStatus": None, "assets": [], "ok": True,
+        "detail": "Container/precheck setup fixture; no full deployment success claim",
+    }
+elif action == "promote":
+    output = dict(candidate["mcpRuntime"], action="activate", publishedAt="2026-01-01T00:00:00.000Z", durable=True)
+elif action in ("start-candidate", "retire", "retain-only"):
+    output = {}
+else:
+    raise RuntimeError(f"unsupported rehearsal action: {action}")
+print(json.dumps(output))

--- a/src/lib/runtime/fixtures/packagedProvider.py
+++ b/src/lib/runtime/fixtures/packagedProvider.py
@@ -6,6 +6,11 @@ from pathlib import Path
 def emit(value):
     print(json.dumps(value), flush=True)
 
+def record_delivery(engine, session, content, client_id=None):
+    # Independent provider-side evidence, written before the acknowledgement.
+    with open(Path(os.environ["LLV_STATE_DIR"]) / "provider-deliveries.jsonl", "a") as log:
+        log.write(json.dumps({"engine": engine, "session": session, "content": content, "clientId": client_id}) + "\n")
+
 if "auth" in sys.argv and "status" in sys.argv:
     emit({"loggedIn": True, "authMethod": "claude.ai", "subscriptionType": "max"})
     sys.exit(0)
@@ -17,6 +22,7 @@ for line in sys.stdin:
     message = json.loads(line)
     if claude:
         if message.get("type") == "user":
+            record_delivery("claude", thread, message["message"]["content"])
             emit({**message, "isReplay": True})
             emit({"type": "result", "subtype": "success", "session_id": thread})
         continue
@@ -43,6 +49,7 @@ for line in sys.stdin:
     elif method == "thread/turns/list":
         result = {"data": [], "nextCursor": None, "backwardsCursor": None}
     elif method == "turn/start":
+        record_delivery("codex", thread, params.get("input", []), params.get("clientUserMessageId"))
         result = {"turn": {"id": "fixture-turn"}}
     emit({"jsonrpc": "2.0", "id": message["id"], "result": result})
     if method == "turn/start":

--- a/src/lib/runtime/fixtures/packagedRollback.ts
+++ b/src/lib/runtime/fixtures/packagedRollback.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import { captureProcessIdentity } from "@/lib/processIdentity";
+import path from "node:path";
+import { RuntimeJournal } from "@/runtime-host/journal";
+import { ViewerDeploymentCoordinator } from "@/runtime-host/deployment";
+import { HostCommandViewerDeploymentAdapter } from "@/runtime-host/deploymentAdapter";
+import type { ViewerReleaseIdentity, ViewerHealthEvidence } from "@/lib/runtime/contracts";
+
+// Build/container setup is supplied by the Python harness. The promoted
+// verification deadline, adapter child, rollback and terminal ledger are real.
+const directory = process.env.LLV_STATE_DIR!;
+const input = JSON.parse(fs.readFileSync(path.join(directory, "rehearsal-release.json"), "utf8")) as {
+  candidate: ViewerReleaseIdentity; previous: ViewerReleaseIdentity; actionTimeoutMs?: number;
+};
+const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(path.resolve("scripts/runtime-host-viewer-adapter.ts"), {
+  ...(input.actionTimeoutMs ? { timeouts: { "verify-promoted": input.actionTimeoutMs } } : {}),
+});
+Object.assign(adapter, {
+  reconcile: async () => {},
+  resolveRevision: async () => input.candidate.revision,
+  buildCandidate: async () => input.candidate,
+  startCandidate: async () => {},
+  currentRelease: async () => input.previous,
+  currentMcpRuntime: async () => input.previous.mcpRuntime!,
+  verifyCandidate: async (): Promise<ViewerHealthEvidence> => ({
+    checkedAt: new Date().toISOString(), endpoint: input.candidate.endpoint,
+    processReady: true, rootStatus: 200, authenticatedStatus: null,
+    unauthorizedStatus: null, assets: [], ok: true,
+    detail: "Prechecks are fixture setup; this rehearsal qualifies startup and rollback only.",
+  }),
+  promote: async () => ({ ...input.candidate.mcpRuntime!, action: "activate", publishedAt: new Date().toISOString(), durable: true }),
+  retire: async () => {},
+  retainOnly: async () => {},
+});
+const journal = new RuntimeJournal(path.join(directory, "rollback-rehearsal.sqlite"));
+const coordinator = new ViewerDeploymentCoordinator(journal, adapter, captureProcessIdentity(process.pid));
+const receipt = await coordinator.requestViewerDeployment({ revision: input.candidate.revision, idempotencyKey: "packaged-timeout-rollback" });
+const terminal = await coordinator.waitForDeployment(receipt.deploymentId);
+fs.writeFileSync(path.join(directory, "rollback-terminal.json"), JSON.stringify(terminal));
+journal.close();
+console.log(JSON.stringify({ phase: terminal?.phase, terminal: terminal?.terminal, error: terminal?.error }));
+process.exit(terminal?.phase === "rolled-back" && terminal.terminal ? 0 : 1);

--- a/src/lib/runtime/fixtures/packagedRollback.ts
+++ b/src/lib/runtime/fixtures/packagedRollback.ts
@@ -1,42 +1,38 @@
 import fs from "node:fs";
-import { captureProcessIdentity } from "@/lib/processIdentity";
 import path from "node:path";
-import { RuntimeJournal } from "@/runtime-host/journal";
-import { ViewerDeploymentCoordinator } from "@/runtime-host/deployment";
-import { HostCommandViewerDeploymentAdapter } from "@/runtime-host/deploymentAdapter";
-import type { ViewerReleaseIdentity, ViewerHealthEvidence } from "@/lib/runtime/contracts";
 
-// Build/container setup is supplied by the Python harness. The promoted
-// verification deadline, adapter child, rollback and terminal ledger are real.
+// Admission and terminal observation use the real isolated Viewer API. The
+// runtime host owns its frozen coordinator, executable adapter and deadlines.
 const directory = process.env.LLV_STATE_DIR!;
-const input = JSON.parse(fs.readFileSync(path.join(directory, "rehearsal-release.json"), "utf8")) as {
-  candidate: ViewerReleaseIdentity; previous: ViewerReleaseIdentity; actionTimeoutMs?: number;
-};
-const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(path.resolve("scripts/runtime-host-viewer-adapter.ts"), {
-  ...(input.actionTimeoutMs ? { timeouts: { "verify-promoted": input.actionTimeoutMs } } : {}),
-});
-Object.assign(adapter, {
-  reconcile: async () => {},
-  resolveRevision: async () => input.candidate.revision,
-  buildCandidate: async () => input.candidate,
-  startCandidate: async () => {},
-  currentRelease: async () => input.previous,
-  currentMcpRuntime: async () => input.previous.mcpRuntime!,
-  verifyCandidate: async (): Promise<ViewerHealthEvidence> => ({
-    checkedAt: new Date().toISOString(), endpoint: input.candidate.endpoint,
-    processReady: true, rootStatus: 200, authenticatedStatus: null,
-    unauthorizedStatus: null, assets: [], ok: true,
-    detail: "Prechecks are fixture setup; this rehearsal qualifies startup and rollback only.",
-  }),
-  promote: async () => ({ ...input.candidate.mcpRuntime!, action: "activate", publishedAt: new Date().toISOString(), durable: true }),
-  retire: async () => {},
-  retainOnly: async () => {},
-});
-const journal = new RuntimeJournal(path.join(directory, "rollback-rehearsal.sqlite"));
-const coordinator = new ViewerDeploymentCoordinator(journal, adapter, captureProcessIdentity(process.pid));
-const receipt = await coordinator.requestViewerDeployment({ revision: input.candidate.revision, idempotencyKey: "packaged-timeout-rollback" });
-const terminal = await coordinator.waitForDeployment(receipt.deploymentId);
-fs.writeFileSync(path.join(directory, "rollback-terminal.json"), JSON.stringify(terminal));
-journal.close();
-console.log(JSON.stringify({ phase: terminal?.phase, terminal: terminal?.terminal, error: terminal?.error }));
-process.exit(terminal?.phase === "rolled-back" && terminal.terminal ? 0 : 1);
+const port = process.env.LLV_PACKAGED_DEPLOYMENT_PORT;
+if (!port) throw new Error("isolated deployment front port is required");
+const url = `http://127.0.0.1:${port}/api/runtime/deployments`;
+const started = Date.now();
+let deploymentId: string | null = null;
+while (Date.now() - started < 30_000) {
+  try {
+    const response = await fetch(url, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ revision: "a".repeat(40), idempotencyKey: "packaged-incumbent-timeout" }),
+      signal: AbortSignal.timeout(3_000),
+    });
+    const receipt = await response.json() as { deploymentId?: string };
+    if (response.ok && receipt.deploymentId) { deploymentId = receipt.deploymentId; break; }
+  } catch { /* Retry the same admission key while the isolated Viewer boots. */ }
+  await Bun.sleep(250);
+}
+if (!deploymentId) throw new Error("isolated Viewer API admission unavailable");
+while (Date.now() - started < 240_000) {
+  try {
+    const response = await fetch(`${url}/${deploymentId}`, { signal: AbortSignal.timeout(3_000) });
+    const status = await response.json() as Record<string, unknown>;
+    const deployment = (status.deployment ?? status) as { terminal?: boolean; phase?: string };
+    if (response.ok && deployment.terminal) {
+      fs.writeFileSync(path.join(directory, "rollback-terminal.json"), JSON.stringify(deployment));
+      console.log(JSON.stringify(deployment));
+      process.exit(deployment.phase === "rolled-back" ? 0 : 1);
+    }
+  } catch { /* Keep observing the original request through transient reads. */ }
+  await Bun.sleep(250);
+}
+throw new Error("isolated deployment did not terminate");

--- a/src/lib/runtime/fixtures/packagedStartupSeed.ts
+++ b/src/lib/runtime/fixtures/packagedStartupSeed.ts
@@ -211,7 +211,7 @@ function fixture(failedCount: number, fullHistory = false) {
   }
   for (let i = 0; i < 6; i++) journal.executeOperation({
     kind: "send", conversationId: `conversation_history_${i}`, idempotencyKey: `queued-startup-${i}`,
-    text: "Synthetic queued startup message", policy: "queue",
+    text: `Synthetic queued startup message queued-startup-${i}`, policy: "queue",
   });
   journal.close();
   // Retained legacy rows precede live-turn bounding. Recreate sizes with fresh

--- a/src/lib/runtime/fixtures/packagedStartupSeed.ts
+++ b/src/lib/runtime/fixtures/packagedStartupSeed.ts
@@ -5,6 +5,8 @@ import { Database } from "bun:sqlite";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { RuntimeJournal } from "@/runtime-host/journal";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { captureProcessIdentity } from "@/lib/processIdentity";
+import { PROMOTED_SERVING_TIMEOUT_MS, VERIFY_PROMOTED_ACTION_TIMEOUT_MS } from "@/runtime-host/deploymentHotState";
 function fixtureSessionId(index: number): string {
   return index < 6 ? `00000000-0000-4000-8000-${String(index).padStart(12, "0")}` : `history_${index}`;
 }
@@ -156,6 +158,45 @@ function fixture(failedCount: number, fullHistory = false) {
   }
   fs.writeFileSync(filename, JSON.stringify(data));
   const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const pendingProfile = emptyLaunchProfile({ cwd: directory, title: "Deferred startup launch" });
+  const pending = registry.beginSpawnRequest({
+    engine: "codex", cwd: directory, transport: "structured", accountId: "account-a",
+    accountPin: true, clientAttemptId: "original-deferred-startup-key", launchProfile: pendingProfile,
+  });
+  registry.queuePinnedSpawn(pending.receipt.launchId, {
+    version: 1, retryAt: new Date(Date.now() + 3_600_000).toISOString(), accountId: "account-a", locale: "en",
+    spec: { engine: "codex", command: "codex", cwd: directory, windowName: "deferred-startup", launchProfile: pendingProfile },
+    ["prompt"]: "Synthetic deferred work", imageRefs: [], parentArtifactPath: null, pipelineSourceConversationId: null,
+  }, "Synthetic account retry window");
+  registry.releaseStartingStructuredSpawn(pending.receipt.launchId, pending.receipt.admissionOwner!);
+  fs.writeFileSync(path.join(directory, "pending-spawn-before.json"), JSON.stringify({
+    [pending.receipt.launchId]: registry.readOnlySnapshot().receipts[pending.receipt.launchId],
+  }));
+  const externalKeys: string[] = [];
+  for (const [index, pid] of (JSON.parse(process.env.LLV_PACKAGED_EXTERNAL_PIDS ?? "[]") as number[]).entries()) {
+    const engine = index === 0 ? "codex" : "claude";
+    const artifactPath = path.join(directory, `external-${engine}.jsonl`);
+    fs.writeFileSync(artifactPath, "");
+    const conversation = registry.ensureConversation(engine, artifactPath, null);
+    const key = { engine, sessionId: conversation.generations.at(-1)!.id } as const;
+    registry.upsert({ ...structuredClone(Object.values(data.entries)[0]!), key, artifactPath,
+      status: "idle", pendingAction: null, claimOwner: null, claimEpoch: 0,
+      launchProfile: emptyLaunchProfile({ cwd: directory, mcpServers: [] }),
+      structuredHost: { kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+        endpoint: "external:independent", process: null, eventCursor: 0, protocolVersion: "fixture",
+        writerClaimEpoch: 0, activeTurnRef: null, pendingAttention: [], activeFlags: [] },
+    });
+    const owner = captureProcessIdentity(pid);
+    const claimed = registry.claimStructuredHost(key, owner)!;
+    registry.setStructuredHostClaimed(key, { ...claimed.structuredHost!, process: owner }, "idle", claimed.claimOwner!, claimed.claimEpoch);
+    externalKeys.push(`${engine}:${key.sessionId}`);
+  }
+  fs.writeFileSync(path.join(directory, "external-before.json"), JSON.stringify(Object.fromEntries(
+    externalKeys.map((key) => [key, registry.readOnlySnapshot().entries[key]]),
+  )));
+  fs.writeFileSync(path.join(directory, "rehearsal-budgets.json"), JSON.stringify({
+    serving: PROMOTED_SERVING_TIMEOUT_MS, action: VERIFY_PROMOTED_ACTION_TIMEOUT_MS,
+  }));
   console.log(JSON.stringify({ counts: Object.fromEntries((["conversations", "entries", "receipts", "heldDeliveries"] as const).map(k => [k, Object.keys(data[k]).length])) }));
   registry.checkpointRollbackMirrorForDemotion();
   const journalFilename = path.join(directory, "runtime-events.sqlite");

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -9,7 +9,7 @@ import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type Proces
 import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import { activeOrchestratorSeats, type OrchestratorSeat } from "@/lib/orchestrator/seats";
-import { processIdentityMayOwn, processIdentityStatus } from "@/lib/processIdentity";
+import { captureProcessIdentity, processIdentityMayOwn, processIdentityStatus } from "@/lib/processIdentity";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { readStableTailRecords } from "@/lib/scanner/activity";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -560,7 +560,7 @@ function persistedTurnState(
  * to tell it to continue, which is a status word deciding a paid turn on a
  * transcript nobody in this process has managed to read.
  */
-async function refreshStructuredTranscriptState(registry: AgentRegistry): Promise<ReadonlySet<string>> {
+async function refreshStructuredTranscriptState(registry: AgentRegistry, assertActive: () => void = () => {}): Promise<ReadonlySet<string>> {
   const snapshot = registry.readOnlySnapshot();
   const observedAt = new Date().toISOString();
   const candidates = Object.values(snapshot.conversations).flatMap((conversation) => {
@@ -602,6 +602,7 @@ async function refreshStructuredTranscriptState(registry: AgentRegistry): Promis
     },
   );
   await Promise.all(workers);
+  assertActive();
   if (observations.length > 0) registry.reconcileConversations(observations);
   return unreadable;
 }
@@ -790,6 +791,8 @@ function pipelineStartupEvidence(registry: AgentRegistry, available = true): Pip
 }
 
 export interface StructuredStartupDependencies {
+  /** Release retirement stops at awaited phase boundaries while retaining admission. */
+  assertActive?: () => void;
   registry?: AgentRegistry;
   client?: RuntimeHostClient | null;
   /** Process and transcript readers behind the restart-recovery evidence. */
@@ -821,6 +824,8 @@ export interface StructuredStartupDependencies {
 export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
+  const assertActive = dependencies.assertActive ?? (() => {});
+  assertActive();
   assertDarwinStructuredRuntime();
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
@@ -850,12 +855,16 @@ export async function adoptStructuredHostsAtStartup(
     completedHosts: 0,
     totalHosts: null,
   });
-  const unreadableTranscripts = await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry)
+  const unreadableTranscripts = await (dependencies.refreshTranscriptState
+    ? dependencies.refreshTranscriptState(registry)
+    : refreshStructuredTranscriptState(registry, assertActive))
     ?? new Set<string>();
   /* Close persists survivors under this same lease. Read after refresh and
      hold admission through launch, demotion and publication, so no awaited
      adoption step can race a partial termination's durable evidence. */
+  assertActive();
   return withPipelineStartupAdmission(async (available) => {
+    assertActive();
     const pipelineEvidence = available
       ? (dependencies.pipelineEvidence ?? pipelineStartupEvidence)(registry)
       : pipelineStartupEvidence(registry, false);
@@ -880,7 +889,7 @@ export async function adoptStructuredHostsAtStartup(
        cannot block the startup recovery path. */
     reconcileDeadStructuredRegistryHosts(registry, (entry) => orchestratorHostKeys.has(sessionKeyId(entry.key)) || deferredHostKeys.has(sessionKeyId(entry.key)));
     const signals = await structuredStartupSignals(registry, client);
-    const shouldAdopt = structuredStartupAdoptionFilter(
+    const eligible = structuredStartupAdoptionFilter(
       registry,
       signals,
       registry.readOnlySnapshot(),
@@ -890,6 +899,12 @@ export async function adoptStructuredHostsAtStartup(
       pipelineEvidence.settled,
       pipelineEvidence.deferred,
     );
+    const shouldAdopt: StructuredHostAdoptionFilter = (entry) => {
+      // Let an adopter return the handles it already created. Throwing from
+      // its per-row progress callback would discard that partial result.
+      try { assertActive(); } catch { return false; }
+      return eligible(entry);
+    };
     const adoptionCandidates = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
       entry.structuredHost && shouldAdopt(entry));
     /* Nothing is launched that this pass cannot hand to a delivery controller.
@@ -918,6 +933,7 @@ export async function adoptStructuredHostsAtStartup(
     let totalHosts = adoptionCandidates.length;
     let completedHosts = 0;
     const reportProgress = (phase: StructuredHostStartupPhase) => {
+      assertActive();
       markStructuredHostStartupProgress({ phase, completedHosts, totalHosts });
     };
     reportProgress("adopting Codex hosts");
@@ -957,7 +973,7 @@ export async function adoptStructuredHostsAtStartup(
       () => {
         completedHosts += 1;
         totalHosts = Math.max(totalHosts, completedHosts);
-        reportProgress("adopting Codex hosts");
+        markStructuredHostStartupProgress({ phase: "adopting Codex hosts", completedHosts, totalHosts });
       },
     );
     completedHosts = Math.max(completedHosts, codexCandidateCount);
@@ -999,7 +1015,7 @@ export async function adoptStructuredHostsAtStartup(
       () => {
         completedHosts += 1;
         totalHosts = Math.max(totalHosts, completedHosts);
-        reportProgress("adopting Claude hosts");
+        markStructuredHostStartupProgress({ phase: "adopting Claude hosts", completedHosts, totalHosts });
       },
     );
     completedHosts = Math.max(completedHosts, codexCandidateCount + claudeCandidateCount);
@@ -1088,7 +1104,7 @@ export async function adoptStructuredHostsAtStartup(
        retire a publication this pass has no client to replace — and every spawn
        in the process would fail until some later pass rebound it (#1191). */
     if (controllerBoundEarly) {
-      await completeStructuredDeliveryQueueStartup(nextAdoptedHosts, reportProgress);
+      await completeStructuredDeliveryQueueStartup(nextAdoptedHosts, reportProgress, assertActive);
       assertAdoptedHostsAreClaimed(nextAdoptedHosts, dependencies.hostClaimed);
     }
     reportProgress("recovering orchestrator deliveries");
@@ -1122,8 +1138,9 @@ export async function adoptStructuredHostsAtStartup(
     const fencedReceipts = fencedPendingSpawnReceipts(registry, pipelineEvidence.deferred);
     if (client && fencedReceipts.length === 0) {
       reportProgress("recovering pending spawns");
-      await recoverPendingStructuredSpawns(registry, client);
+      await recoverPendingStructuredSpawns(registry, client, { assertActive });
     }
+    assertActive();
     adoptedHosts = nextAdoptedHosts;
     if (deferredHostKeys.size > 0 || fencedReceipts.length > 0) {
       /* The rows are retained exactly as a retry would retain them: the next
@@ -1194,6 +1211,7 @@ function scheduleDeferredStartupReprobe(
   schedule(() => {
     /* A later pass replaced this deferral; its own timer carries it. */
     if (deferredStartup !== state) return;
+    try { dependencies.assertActive?.(); } catch { return; }
     void reprobeDeferredStructuredStartup(dependencies, registry, state);
   }, state.delayMs).unref?.();
 }
@@ -1237,4 +1255,26 @@ async function reprobeDeferredStructuredStartup(
 
 export function structuredStartupHosts(): readonly AdoptedStructuredHost[] {
   return adoptedHosts;
+}
+
+/** Quiesced startup may have created hosts before reaching controller
+ * registration. They belong to this boot and must also cross the release
+ * boundary before its mirror acknowledgement. External workers never enter
+ * these retained handle sets. */
+export async function releaseUnpublishedStartupHostsForDemotion(): Promise<void> {
+  const registry = agentRegistry();
+  const unpublished = retainAdoptedHosts(adoptedHosts, retryAdoptedHosts)
+    .filter((item) => !hasStructuredDeliveryHost(item.key));
+  const outcomes = await Promise.allSettled(unpublished.map(async ({ key, host }) => {
+    const state = await host.health();
+    if ((state.status !== "active" && state.status !== "attention")
+      || state.pid === null || state.processStartIdentity === null) return;
+    const identity = captureProcessIdentity(state.pid, undefined, state.processStartIdentity);
+    if (!registry.markStructuredHostHandoff(key, identity)) {
+      throw new Error("unpublished startup host changed before release handover");
+    }
+    await host.release();
+  }));
+  const failures = outcomes.flatMap((outcome) => outcome.status === "rejected" ? [outcome.reason] : []);
+  if (failures.length) throw new AggregateError(failures, "unpublished startup hosts did not quiesce");
 }

--- a/src/lib/runtime/startupFinalization.integration.test.ts
+++ b/src/lib/runtime/startupFinalization.integration.test.ts
@@ -26,6 +26,7 @@ const { RuntimeJournal } = await import("@/runtime-host/journal");
 const { adoptStructuredHostsAtStartup } = await import("./startup");
 const { bindStructuredDeliveryQueue } = await import("./structuredDeliveryController");
 const { runStructuredHostStartup } = await import("@/lib/viewerInstrumentation");
+const { checkpointHotStateRollbackMirrorsForDemotion } = await import("@/lib/viewerInstrumentation");
 const { recoverPendingStructuredSpawns, reconcileStructuredSpawnReplay } = await import("./structuredSpawn");
 const { captureProcessIdentity } = await import("@/lib/processIdentity");
 const { structuredStartupStatus } = await import("./startupStatus");
@@ -261,6 +262,71 @@ test("startup exposes the retaining fallback await without releasing admission b
   }
 }, 60_000);
 
+test("rollback checkpoint yields to the full startup admission owner", async () => {
+  const f = fixture(1, true);
+  let entered!: () => void;
+  const publishing = new Promise<void>((resolve) => { entered = resolve; });
+  let released!: () => void;
+  const response = new Promise<void>((resolve) => { released = resolve; });
+  let first = true;
+  const client: RuntimeHostClient = { ...f.client, append: async (event) => {
+    if (first) { first = false; entered(); await response; }
+    return f.client.append(event);
+  } };
+  const startup = runStructuredHostStartup(() => adoptStructuredHostsAtStartup({ registry: f.registry, client }), () => {}, { waitUntilReady: true });
+  await publishing;
+  let replySettled = false;
+  const timer = setTimeout(() => { replySettled = true; released(); }, 50);
+  try {
+    await checkpointHotStateRollbackMirrorsForDemotion();
+    expect(replySettled).toBe(true);
+    await startup;
+  } finally {
+    clearTimeout(timer);
+    released();
+    await startup;
+    await bindStructuredDeliveryQueue([], { registry: f.registry, client: null });
+    f.journal.close();
+  }
+}, 60_000);
+
+test("retirement joins historical publications before releasing admission and never publishes ready", async () => {
+  const f = fixture(2, true);
+  const abort = new AbortController();
+  const check = () => abort.signal.throwIfAborted();
+  let entered!: () => void;
+  const publishing = new Promise<void>((resolve) => { entered = resolve; });
+  let release!: () => void;
+  const response = new Promise<void>((resolve) => { release = resolve; });
+  let requests = 0;
+  const client: RuntimeHostClient = { ...f.client, append: async (event) => {
+    requests += 1;
+    const result = await f.client.append(event);
+    entered();
+    await response;
+    return result;
+  } };
+  let settled = false;
+  const startup = runStructuredHostStartup(() => adoptStructuredHostsAtStartup({ registry: f.registry, client, assertActive: check }), () => {}, { waitUntilReady: true, signal: abort.signal })
+    .then(() => { throw new Error("retired startup reported ready"); }, () => { settled = true; });
+  await publishing;
+  const before = structuredClone(f.registry.readOnlySnapshot().receipts);
+  abort.abort(new Error("fixture retirement"));
+  await Bun.sleep(20);
+  expect(settled).toBe(false);
+  const started = requests;
+  release();
+  await startup;
+  await checkpointHotStateRollbackMirrorsForDemotion();
+  await Bun.sleep(50);
+  expect(requests).toBe(started);
+  expect(requests).toBeLessThanOrEqual(16);
+  expect(structuredStartupStatus()?.state).toBe("failed");
+  expect(f.registry.readOnlySnapshot().receipts).toEqual(before);
+  await bindStructuredDeliveryQueue([], { registry: f.registry, client: null });
+  f.journal.close();
+}, 30_000);
+
 test("pending launches ignore a historical snapshot supplier", async () => {
   const f = fixture(0);
   const begun = f.registry.beginSpawnRequest({
@@ -370,7 +436,7 @@ test.each([["codex", false], ["codex", true], ["claude", false], ["claude", true
 });
 
 
-test("the full retained history completes within the unchanged promoted-verification deadline", async () => {
+test("the full retained history completes within the promoted serving budget", async () => {
   const f = fixture(672, true);
   const initial = f.registry.readOnlySnapshot();
   expect(Object.keys(initial.receipts)).toHaveLength(6623);
@@ -410,7 +476,7 @@ test("the full retained history completes within the unchanged promoted-verifica
     }), () => {}, { waitUntilReady: true });
     const elapsedMs = performance.now() - started;
     console.log(JSON.stringify({ history: { receipts: 6623, conversations: 8078, entries: 5188 }, counts, elapsedMs }));
-    // deploymentAdapter's existing verify-promoted action budget, unchanged.
+    // Keep the optimization below the old deadline despite the new headroom.
     expect(elapsedMs).toBeLessThan(120_000);
     expect(counts.snapshot).toBe(4);
     expect(counts.append).toBeGreaterThan(4300);

--- a/src/lib/runtime/startupWork.ts
+++ b/src/lib/runtime/startupWork.ts
@@ -1,0 +1,15 @@
+/** Bound independent historical I/O and join every started operation before
+ * propagating failure. Admission must never outlive an unobserved worker. */
+export async function forEachStartupBatch<T>(
+  items: readonly T[],
+  visit: (item: T) => Promise<void>,
+  assertActive: () => void = () => {},
+): Promise<void> {
+  for (let offset = 0; offset < items.length; offset += 16) {
+    assertActive();
+    const outcomes = await Promise.allSettled(items.slice(offset, offset + 16).map(visit));
+    const failure = outcomes.find((outcome) => outcome.status === "rejected");
+    if (failure?.status === "rejected") throw failure.reason;
+    assertActive();
+  }
+}

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type ProcessIdentity } from "@/lib/agent/registry";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
+import { forEachStartupBatch } from "./startupWork";
 import { BRANCH_SHARED_HOST_ERROR, branchSharesRootHost } from "@/lib/conversation/branchControl";
 import { captureProcessIdentity } from "@/lib/processIdentity";
 
@@ -76,7 +77,7 @@ interface ControllerState {
   republishActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   releaseActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   terminateActiveHost: ((key: SessionKey, expected?: Readonly<ProcessIdentity>) => Promise<boolean>) | null;
-  completeActive: ((adopted: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void) => Promise<void>) | null;
+  completeActive: ((adopted: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void, assertActive?: () => void) => Promise<void>) | null;
   stopActive: () => void;
   lastDrainError?: string | null;
   /* Distinguishes "this process hosts the controller and is between
@@ -467,10 +468,15 @@ export async function bindStructuredDeliveryQueue(
   const retirePredecessor = state.stopActive;
   const registry = dependencies.registry ?? agentRegistry();
   const hosts = new Map<string, EngineHost>();
+  // Registration events can request a drain while startup is still seating
+  // the remaining hosts. Their original queued operations must wait for those
+  // seats instead of attempting competing recovery and terminalizing them.
+  let startupPending = dependencies.deferStartupWork === true;
   let scheduleAutomaticRetry = () => {};
   let requestDrain = () => {};
   const queue = new StructuredDeliveryQueue(
     {
+      deferTarget: (conversationId) => startupPending && hostResolver(registry, hosts)(conversationId) === null,
       effects: (kinds, afterEventSeq) => client.effectBatch(kinds, afterEventSeq),
       ...(typeof client.events === "function" ? { events: (afterEventSeq: number) => client.events(afterEventSeq) } : {}),
       status: async (operationId: string) => (await client.operationStatus(operationId))?.receipt ?? null,
@@ -596,6 +602,7 @@ export async function bindStructuredDeliveryQueue(
     return true;
   };
   const drainWithRetry = async (afterAdmission = false): Promise<void> => {
+    if (stopped) return;
     try {
       if (afterAdmission) await queue.drainAfterAdmission();
       else await queue.drain();
@@ -1061,7 +1068,7 @@ export async function bindStructuredDeliveryQueue(
     }
   };
   let completion = Promise.resolve();
-  const complete = (items: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void) => {
+  const complete = (items: readonly StructuredDeliveryHost[], progress?: (phase: StructuredHostStartupPhase) => void, assertActive: () => void = () => {}) => {
     completion = completion.catch(() => {}).then(async () => {
       /* A generation that has been swapped out cannot register anything, but it
          must not answer "done" either: its caller would clear its retry set and
@@ -1071,11 +1078,18 @@ export async function bindStructuredDeliveryQueue(
       if (stopped || state.activeQueue !== queue) {
         const successor = state.completeActive;
         if (!successor || successor === complete) throw new StructuredDeliveryControllerUnavailableError();
-        await successor(items, progress);
+        await successor(items, progress, assertActive);
         return;
       }
       progress?.("registering structured delivery hosts");
       for (const item of items) await register(item);
+      assertActive();
+      if (superseded()) {
+        const successor = state.completeActive;
+        if (!successor || successor === complete) throw new StructuredDeliveryControllerUnavailableError();
+        await successor(items, progress, assertActive);
+        return;
+      }
       const startupSnapshot = registry.readOnlySnapshot();
       /* Read only to skip republishing a projection that already says what
          this pass would say. It decides nothing else: the state published
@@ -1090,18 +1104,28 @@ export async function bindStructuredDeliveryQueue(
         (runtimeSnapshot?.sessions ?? []).map((session) => [session.conversationId, session]),
       );
       progress?.("publishing historical host fallbacks");
-      for (const conversation of Object.values(startupSnapshot.conversations)) {
+      await forEachStartupBatch(Object.values(startupSnapshot.conversations), async (conversation) => {
+        assertActive();
+        if (superseded()) return;
         const generation = conversation.generations.at(-1);
-        if (!generation) continue;
+        if (!generation) return;
         const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
-        if (registrations.has(id)) continue;
+        if (registrations.has(id)) return;
         const entry = startupSnapshot.entries[id];
-        if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
+        if (!entry?.structuredHost && entry?.host?.kind !== "tmux") return;
         await publishCurrentFallback(conversation.id, runtimeSessions.get(conversation.id));
+      }, assertActive);
+      if (superseded()) {
+        const successor = state.completeActive;
+        if (!successor || successor === complete) throw new StructuredDeliveryControllerUnavailableError();
+        await successor(items, progress, assertActive);
+        return;
       }
       progress?.("reconciling terminal delivery receipts");
       await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
       progress?.("draining startup delivery queue");
+      assertActive();
+      startupPending = false;
       await queue.drain();
     });
     return completion;
@@ -1156,9 +1180,10 @@ export async function publishStructuredDeliveryHost(
 export async function completeStructuredDeliveryQueueStartup(
   adopted: readonly StructuredDeliveryHost[],
   progress?: (phase: StructuredHostStartupPhase) => void,
+  assertActive?: () => void,
 ): Promise<void> {
   if (!state.completeActive) throw new StructuredDeliveryControllerUnavailableError();
-  await state.completeActive(adopted, progress);
+  await state.completeActive(adopted, progress, assertActive);
 }
 
 export async function republishStructuredDeliveryHost(key: SessionKey): Promise<boolean> {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -29,6 +29,9 @@ interface StructuredOperationStatus {
 }
 
 export interface StructuredDeliveryQueuePort {
+  /** Startup owns recovery for hosts it has not registered yet. Leave their
+   * original operations pending while already registered hosts keep serving. */
+  deferTarget?(conversationId: string): boolean;
   effects(kinds?: readonly string[], afterEventSeq?: number): Promise<StructuredDeliveryEffect[]>;
   transition(
     operationId: string,
@@ -625,6 +628,7 @@ export class StructuredDeliveryQueue {
     const targets: Array<[string, () => Promise<boolean>]> = [...conversationIds].map((conversationId) => [
       conversationId,
       async () => {
+        if (this.port.deferTarget?.(conversationId)) return true;
         for (const prepare of targetPreparations.get(conversationId) ?? []) await prepare();
         return this.drainTarget(grouped.get(conversationId) ?? []);
       },

--- a/src/lib/runtime/structuredDeliveryRebind.test.ts
+++ b/src/lib/runtime/structuredDeliveryRebind.test.ts
@@ -199,6 +199,46 @@ test("a process that never bound the delivery queue reports an unbound publicati
   expect(probe.stdout.toString().trim()).toBe("unbound");
 });
 
+test("startup drains registered hosts while retaining original sends for unregistered hosts", async () => {
+  const { registry, journal, directory, client, close } = fixture("startup-partial-registration");
+  const first = seedConversation(registry, directory, "first-startup-host");
+  const second = seedConversation(registry, directory, "second-startup-host");
+  const firstHost = structuredHost();
+  const secondHost = structuredHost();
+  try {
+    await bindStructuredDeliveryQueue([], { registry, client, deferStartupWork: true });
+    await publishStructuredDeliveryHost({ key: first.key, host: firstHost });
+    for (const [index, target] of [first, second].entries()) {
+      if (index === 1) journal.append({
+        scope: { type: "session", id: target.conversationId }, kind: "session-status",
+        payload: { conversationId: target.conversationId, sessionKey: target.key,
+          hostKind: "codex-app-server", host: "hosted", turn: "idle" },
+      });
+      journal.executeOperation({
+        kind: "send", operationId: `startup-original-${index}`,
+        idempotencyKey: `startup-original-key-${index}`, conversationId: target.conversationId,
+        text: `original payload ${index}`, policy: "queue",
+      });
+    }
+    const pending = journal.operationResult("startup-original-1");
+    expect(pending?.receipt.status).toBe("queued");
+    await kickStructuredDeliveryQueue();
+    await settles(() => journal.operationResult("startup-original-0")?.receipt.status === "delivered");
+    expect(journal.operationResult("startup-original-1")).toEqual(pending);
+    expect(secondHost.ledger.writes).toEqual([]);
+    await publishStructuredDeliveryHost({ key: second.key, host: secondHost });
+    await kickStructuredDeliveryQueue();
+    await settles(() => journal.operationResult("startup-original-1")?.receipt.status === "delivered");
+    await completeStructuredDeliveryQueueStartup([]);
+    expect(firstHost.ledger.writes).toMatchObject([{ id: "startup-original-0", text: "original payload 0" }]);
+    expect(secondHost.ledger.writes).toMatchObject([{ id: "startup-original-1", text: "original payload 1" }]);
+    expect(firstHost.ledger.writes).toHaveLength(1);
+    expect(secondHost.ledger.writes).toHaveLength(1);
+  } finally {
+    await close();
+  }
+});
+
 test("separate Next bundle realms share one delivery controller lifecycle (#572)", async () => {
   const { registry, directory, client, close } = fixture("bundle-realms");
   const moduleCopy = (name: string) => `./structuredDeliveryController?${name}`;

--- a/src/lib/runtime/structuredSpawn.terminalize.test.ts
+++ b/src/lib/runtime/structuredSpawn.terminalize.test.ts
@@ -35,7 +35,7 @@ function staleStructuredReceipt(store: AgentRegistry, attempt: string) {
     accountId: "work",
     clientAttemptId: attempt,
     requestDigest: "d".repeat(64),
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
   });
   if (begun.kind !== "created") throw new Error("expected structured launch creation");
   return begun.receipt;
@@ -50,7 +50,7 @@ function stagedStructuredReceipt(store: AgentRegistry, attempt: string) {
     artifactPath,
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "idle",
     host: null,
     structuredHost: {
@@ -76,7 +76,7 @@ const AGED = () => Date.now() + STALE_STRUCTURED_SPAWN_TIMEOUT_MS + 60_000;
 test("a runtime-host transport failure becomes actionable on the structured spawn card", async () => {
   const store = registry();
   const cwd = path.dirname(store.filename);
-  const launchProfile = emptyLaunchProfile({ cwd });
+  const launchProfile = emptyLaunchProfile({ title: "Stale launch fixture", cwd });
   const begun = store.beginSpawnRequest({
     engine: "codex",
     cwd,
@@ -179,7 +179,7 @@ test.each(["missing", "corrupt"] as const)("a %s queued payload cannot keep an o
         command: "claude",
         cwd: "/repo",
         windowName: "queued-pin",
-        launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+        launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
       },
       ["prompt"]: "continue",
       imageRefs: [],
@@ -227,7 +227,7 @@ test.each(["missing", "corrupt"] as const)("a %s tmux queue payload cannot keep 
     accountId: "account-a",
     accountPin: true,
     clientAttemptId: `partial_tmux_queue_${condition}_20260824`,
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
   });
   if (begun.kind !== "created") throw new Error("expected tmux receipt creation");
   if (condition === "corrupt") {
@@ -241,7 +241,7 @@ test.each(["missing", "corrupt"] as const)("a %s tmux queue payload cannot keep 
         command: "claude",
         cwd: "/repo",
         windowName: "queued-pin",
-        launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+        launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
       },
       ["prompt"]: "continue",
       imageRefs: [],
@@ -295,7 +295,7 @@ test("startup recovery still terminalizes a dead non-queued ownerless receipt", 
     accountId: "account-a",
     accountPin: true,
     clientAttemptId: "non_queued_ownerless_20260824",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
   });
   if (begun.kind !== "created" || !begun.receipt.admissionOwner) throw new Error("expected ownerless receipt setup");
   store.releaseStartingStructuredSpawn(begun.receipt.launchId, begun.receipt.admissionOwner);
@@ -319,7 +319,7 @@ test.each(["codex", "claude"] as const)("an overdue %s placeholder still fails w
     accountId: "work",
     clientAttemptId: `effect_history_outage_${engine}`,
     requestDigest: engine === "codex" ? "c".repeat(64) : "a".repeat(64),
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
   });
   if (begun.kind !== "created") throw new Error("expected structured launch creation");
   const receipt = begun.receipt;
@@ -329,7 +329,7 @@ test.each(["codex", "claude"] as const)("an overdue %s placeholder still fails w
     artifactPath,
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "dead",
     host: null,
     structuredHost: null,
@@ -421,7 +421,7 @@ test("a staged launch whose host entry stays claimed still fails at the bounded 
     artifactPath: "/sessions/019f7b8a_9f75_7dc0_b231_17f7eadd7fe1.jsonl",
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "unhosted",
     host: null,
     structuredHost: {
@@ -564,7 +564,7 @@ test("issue 533: host loss after recoverable timeout reaches retry-safe failure 
     artifactPath: "/sessions/timeout-host-loss.jsonl",
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "dead",
     host: null,
     structuredHost: {
@@ -608,7 +608,7 @@ test("issue 1074: a stale materialized launch is recovered from its late transcr
     artifactPath,
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "idle",
     host: null,
     structuredHost: {
@@ -630,7 +630,7 @@ test("issue 1074: a stale materialized launch is recovered from its late transcr
     engine: "codex",
     path: artifactPath,
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     turn: { state: "busy", source: "assistant", terminalAt: null },
     observedAt: new Date().toISOString(),
   }]);
@@ -661,7 +661,7 @@ test.each(["codex", "claude"] as const)("issue 1074: a stale %s registering host
     accountId: "work",
     clientAttemptId: `registering_${engine}_incident`,
     requestDigest: engine === "codex" ? "c".repeat(64) : "a".repeat(64),
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
   });
   if (begun.kind !== "created") throw new Error("expected structured launch creation");
   const receipt = begun.receipt;
@@ -672,7 +672,7 @@ test.each(["codex", "claude"] as const)("issue 1074: a stale %s registering host
     artifactPath,
     cwd: "/repo",
     accountId: "work",
-    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    launchProfile: emptyLaunchProfile({ title: "Stale launch fixture", cwd: "/repo" }),
     status: "idle",
     host: null,
     structuredHost: {

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -11,6 +11,7 @@ import type { SpawnAccountAdmission } from "@/lib/agent/accountLiveness";
 import { effectiveClaudePermissionMode, type AgentEngine, type ResumeSpec } from "@/lib/agent/cli";
 import { identityMaterializationFence, type AgentRegistry, type AgentRegistryEntry, type ProcessIdentity, type RegistryFile, type SpawnReceipt, type StructuredHostColumns } from "@/lib/agent/registry";
 import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
+import { forEachStartupBatch } from "./startupWork";
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
 import { prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
@@ -433,6 +434,7 @@ export async function reconcileStructuredSpawnReplay(
         receipts. Pending launches always read fresh state below. Live writer
         claims are still merged atomically by recoverStructuredSpawnFromEvidence. */
     failedReceiptSnapshot?: () => Promise<RuntimeSnapshot>;
+    assertActive?: () => void;
   } = {},
 ): Promise<SpawnReceipt & { initialMessage: "pending" | "queued" | "delivered" | "failed" }> {
   const current = registry.readOnlySnapshot().receipts[launchId];
@@ -450,6 +452,7 @@ export async function reconcileStructuredSpawnReplay(
       ? options.failedReceiptSnapshot()
       : client.snapshot()).catch(() => null),
   ]);
+  options.assertActive?.();
   let operation = initialOperation;
   let effectHistoryUnavailable = false;
   if (!operation && current.state === "path-pending" && current.artifactPath) {
@@ -674,6 +677,7 @@ function queuedPinnedSpawnForReceipt(receipt: SpawnReceipt): NonNullable<SpawnRe
 }
 
 export interface StructuredSpawnRecoveryOptions {
+  assertActive?: () => void;
   now?: () => number;
   timeoutMs?: number;
   actuationCap?: number;
@@ -857,6 +861,7 @@ export async function terminalizeStaleStructuredSpawns(
   const recovered: string[] = [];
   let examined = 0;
   for (const receipt of Object.values(snapshot.receipts)) {
+    options.assertActive?.();
     if (examined >= actuationCap) break;
     if (receipt.state === "completed" || receipt.state === "failed" || receipt.state === "conflicted") continue;
     const queued = queuedPinnedSpawnForReceipt(receipt);
@@ -907,7 +912,7 @@ export async function terminalizeStaleStructuredSpawns(
     if (!client) continue;
     examined += 1;
     try {
-      const reconciled = await reconcile(receipt.launchId, registry, client, { now, timeoutMs });
+      const reconciled = await reconcile(receipt.launchId, registry, client, { now, timeoutMs, assertActive: options.assertActive });
       if (reconciled.state === "failed") terminalized.push(receipt.launchId);
       else if (reconciled.state === "completed") recovered.push(receipt.launchId);
     } catch (error) {
@@ -1120,12 +1125,15 @@ export async function recoverPendingStructuredSpawns(
   client: RuntimeHostClient,
   options: StructuredSpawnRecoveryOptions = {},
 ): Promise<void> {
+  const assertActive = options.assertActive ?? (() => {});
+  assertActive();
   /* Boot reconciliation shares the reaper's bounded contract so placeholders
      admitted by an older process settle before startup replay considers them. */
   await terminalizeStaleStructuredSpawns(registry, client, options);
   const spawnEffects = new Map<string, Record<string, unknown>>();
   let afterEventSeq = 0;
   while (true) {
+    assertActive();
     const batch = await client.effectBatch(["runtime.spawn"], afterEventSeq);
     for (const effect of batch) {
       const operationId = typeof effect.payload.operationId === "string" ? effect.payload.operationId : null;
@@ -1145,19 +1153,49 @@ export async function recoverPendingStructuredSpawns(
   let failedReceiptRuntime: Promise<RuntimeSnapshot> | undefined;
   const failedReceiptSnapshot = () => failedReceiptRuntime ??= client.snapshot();
 
-  let registeringConversationIds: Set<string> | null = null;
-  const registeringSessions = async (): Promise<Set<string>> => {
-    if (!registeringConversationIds) {
-      const runtime = await client.snapshot().catch(() => null);
-      registeringConversationIds = new Set((runtime?.sessions ?? [])
-        .filter((session) => session.host === "registering")
-        .map((session) => session.conversationId));
-    }
-    return registeringConversationIds;
-  };
+  let registeringConversationIds: Promise<Set<string>> | undefined;
+  const registeringSessions = (): Promise<Set<string>> => registeringConversationIds ??= (async () => {
+    const runtime = await client.snapshot().catch(() => null);
+    return new Set((runtime?.sessions ?? [])
+      .filter((session) => session.host === "registering")
+      .map((session) => session.conversationId));
+  })();
 
   const snapshot = registry.readOnlySnapshot();
+  const failedGroups = new Map<string, SpawnReceipt[]>();
   for (const receipt of Object.values(snapshot.receipts)) {
+    if (receipt.state !== "failed" || receipt.transport === "tmux") continue;
+    const id = registry.canonicalConversationId(receipt.conversationId);
+    const group = failedGroups.get(id) ?? [];
+    group.push(receipt);
+    failedGroups.set(id, group);
+  }
+  await forEachStartupBatch([...failedGroups.values()], async (receipts) => {
+    for (const receipt of receipts) {
+      assertActive();
+      await reconcileFailed(receipt);
+    }
+  }, assertActive);
+  async function reconcileFailed(receipt: SpawnReceipt): Promise<void> {
+    const reconciled = await reconcileStructuredSpawnReplay(receipt.launchId, registry, client, { failedReceiptSnapshot, assertActive });
+    if (reconciled.state === "completed") return;
+    /* The durable launch receipt failed, but its runtime spawn operation can
+       survive as queued when the terminal transition itself timed out. The
+       placeholder session then sits registering/unknown until someone closes
+       the operation; the journal retires the placeholder on that transition. */
+    if (!(await registeringSessions()).has(receipt.conversationId)) return;
+    const operation = await client.operationStatus(receipt.launchId);
+    const status = operation?.receipt.status;
+    if (operation
+      && operation.receipt.conversationId === receipt.conversationId
+      && (status === "pending" || status === "queued" || status === "delivering")) {
+      await client.transitionOperation(receipt.launchId, "failed", {
+        reason: (receipt.error ?? "structured spawn failed before runtime acknowledgement").slice(0, 240),
+      });
+    }
+  }
+  for (const receipt of Object.values(snapshot.receipts)) {
+    assertActive();
     const effect = spawnEffects.get(receipt.launchId);
     /* Re-validate before replay (#1071): a queued launch the previous
        generation accepted is not replayed verbatim by its successor. One whose
@@ -1181,25 +1219,7 @@ export async function recoverPendingStructuredSpawns(
       registry.failStructuredSpawn(receipt.launchId, supersededReason);
       continue;
     }
-    if (receipt.state === "failed" && receipt.transport !== "tmux") {
-      const reconciled = await reconcileStructuredSpawnReplay(receipt.launchId, registry, client, { failedReceiptSnapshot });
-      if (reconciled.state === "completed") continue;
-      /* The durable launch receipt failed, but its runtime spawn operation can
-         survive as queued when the terminal transition itself timed out. The
-         placeholder session then sits registering/unknown until someone closes
-         the operation; the journal retires the placeholder on that transition. */
-      if (!(await registeringSessions()).has(receipt.conversationId)) continue;
-      const operation = await client.operationStatus(receipt.launchId);
-      const status = operation?.receipt.status;
-      if (operation
-        && operation.receipt.conversationId === receipt.conversationId
-        && (status === "pending" || status === "queued" || status === "delivering")) {
-        await client.transitionOperation(receipt.launchId, "failed", {
-          reason: (receipt.error ?? "structured spawn failed before runtime acknowledgement").slice(0, 240),
-        });
-      }
-      continue;
-    }
+    if (receipt.state === "failed" && receipt.transport !== "tmux") continue;
     if (queuedPinnedSpawnForReceipt(receipt)) continue;
     if (receipt.state === "starting" && !receipt.key && receipt.transport !== "tmux") {
       const operation = await client.operationStatus(receipt.launchId);

--- a/src/lib/state/hotStateAuthority.ts
+++ b/src/lib/state/hotStateAuthority.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { withFileTransactionSync } from "./fileTransaction";
+import { captureProcessIdentity, processIdentityStatus, sameRecordedProcessIdentity, type ProcessIdentity } from "@/lib/processIdentity";
 
 export const HOT_STATE_BACKEND = "sqlite-v1" as const;
 export const HOT_STATE_AUTHORITY_FILENAME = "hot-state-authority.json";
@@ -28,6 +29,9 @@ export interface HotStateAuthority {
   updatedAt: string;
   activationReadyAt?: string;
   releaseReadyAt?: string;
+  /** The Viewer that must finish startup and release its hosts before a live
+   * generation can acknowledge its rollback mirror. Older records omit it. */
+  activationOwner?: ProcessIdentity;
   checkpoint?: HotStateCheckpoint;
 }
 
@@ -69,6 +73,11 @@ function parseAuthority(value: unknown): HotStateAuthority | null {
     || (authority.activationReadyAt !== undefined && typeof authority.activationReadyAt !== "string")
     || (authority.releaseReadyAt !== undefined && typeof authority.releaseReadyAt !== "string")
     || (authority.releaseReadyAt !== undefined && authority.activationReadyAt === undefined)
+    || (authority.activationOwner !== undefined && (
+      !authority.activationOwner || !Number.isSafeInteger(authority.activationOwner.pid)
+      || authority.activationOwner.pid <= 0
+      || (authority.activationOwner.startIdentity !== null && typeof authority.activationOwner.startIdentity !== "string")
+      || (authority.activationOwner.bootEpoch !== undefined && authority.activationOwner.bootEpoch !== null && typeof authority.activationOwner.bootEpoch !== "string")))
     || (authority.checkpoint !== undefined && !validCheckpoint(authority.checkpoint))) return null;
   return authority as HotStateAuthority;
 }
@@ -195,6 +204,7 @@ function writeHotStateAuthority(
     epoch?: number;
     activationReadyAt?: string;
     releaseReadyAt?: string;
+    activationOwner?: ProcessIdentity;
   } = {},
 ): HotStateAuthority {
   if (options.releaseReadyAt && !options.activationReadyAt) {
@@ -209,6 +219,9 @@ function writeHotStateAuthority(
     ...(options.activationReadyAt ? { activationReadyAt: options.activationReadyAt } : {}),
     ...(options.releaseReadyAt ? { releaseReadyAt: options.releaseReadyAt } : {}),
     ...(options.checkpoint ? { checkpoint: options.checkpoint } : {}),
+    ...(options.activationOwner ? { activationOwner: options.activationOwner }
+      : mode === "fencing" && previous?.releaseRevision === releaseRevision && previous.activationOwner
+        ? { activationOwner: previous.activationOwner } : {}),
   };
   if (!Number.isInteger(authority.epoch) || authority.epoch < 1) throw new Error("hot-state authority epoch is invalid");
   if (previous && authority.epoch < previous.epoch) throw new Error("hot-state authority epoch cannot regress");
@@ -220,7 +233,7 @@ export function publishHotStateAuthority(
   directory: string,
   mode: HotStateAuthorityMode,
   releaseRevision: string | null,
-  options: { checkpoint?: HotStateCheckpoint; epoch?: number; activationReadyAt?: string; releaseReadyAt?: string } = {},
+  options: { checkpoint?: HotStateCheckpoint; epoch?: number; activationReadyAt?: string; releaseReadyAt?: string; activationOwner?: ProcessIdentity } = {},
 ): HotStateAuthority {
   if (releaseRevision !== null && !validRevision(releaseRevision)) throw new Error("hot-state release revision is invalid");
   return withFileTransactionSync(authorityFile(directory), "hot-state authority is busy", () =>
@@ -247,6 +260,7 @@ export function restoreHotStateAuthority(
         ...(authority?.checkpoint ? { checkpoint: authority.checkpoint } : {}),
         ...(authority?.activationReadyAt ? { activationReadyAt: authority.activationReadyAt } : {}),
         ...(authority?.releaseReadyAt ? { releaseReadyAt: authority.releaseReadyAt } : {}),
+        ...(authority?.activationOwner ? { activationOwner: authority.activationOwner } : {}),
         epoch: current!.epoch + 1,
       },
     );
@@ -266,6 +280,11 @@ export function acknowledgeHotStateFence(
       || current.releaseRevision !== request.releaseRevision
       || current.checkpoint) {
       throw new Error("hot-state fence request changed before checkpoint acknowledgement");
+    }
+    if (current.activationOwner
+      && !sameRecordedProcessIdentity(captureProcessIdentity(process.pid), current.activationOwner)
+      && processIdentityStatus(current.activationOwner) !== "dead") {
+      throw new Error("live Viewer must acknowledge its own hot-state fence");
     }
     return writeHotStateAuthority(directory, current, "fencing", current.releaseRevision, {
       epoch: current.epoch,
@@ -301,6 +320,7 @@ export function markHotStateActivationReady(
     return writeHotStateAuthority(directory, current, "sqlite", current.releaseRevision, {
       epoch: current.epoch,
       activationReadyAt: new Date().toISOString(),
+      activationOwner: captureProcessIdentity(process.pid),
     });
   });
 }
@@ -320,6 +340,7 @@ export function markViewerReleaseReady(
     return writeHotStateAuthority(directory, current, "sqlite", current.releaseRevision, {
       epoch: current.epoch,
       activationReadyAt: current.activationReadyAt,
+      ...(current.activationOwner ? { activationOwner: current.activationOwner } : {}),
       releaseReadyAt: new Date().toISOString(),
     });
   });

--- a/src/lib/state/hotStateStores.sqlite.test.ts
+++ b/src/lib/state/hotStateStores.sqlite.test.ts
@@ -8,6 +8,7 @@ import { expect, spyOn, test } from "bun:test";
 import { checkpointFlowRollbackMirrorForDemotion, loadFlows, saveFlows, withFlowMutation } from "@/lib/flows/store";
 import type { Flow } from "@/lib/flows/types";
 import { procBackend } from "@/lib/proc";
+import { captureProcessIdentity } from "@/lib/processIdentity";
 import { buildPipeline, loadArchivedPipelines, loadPipelines } from "@/lib/pipelines/store";
 import type { PipelineStage } from "@/lib/pipelines/types";
 import { buildWorkflow, loadWorkflows, normalizeTemplate } from "@/lib/workflows/store";
@@ -34,6 +35,34 @@ const CHILD = path.join(import.meta.dir, "hotStateStores.sqliteChild.ts");
 const MIRROR_CHILD = path.join(import.meta.dir, "hotStateMirror.sqliteChild.ts");
 const SNAPSHOT_CHILD = path.join(import.meta.dir, "hotStateSnapshot.sqliteChild.ts");
 const AUTHORITY_CHILD = path.join(import.meta.dir, "hotStateAuthority.sqliteChild.ts");
+
+test("a live or unverifiable activation owner alone can acknowledge its fence; positive death admits fallback", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "hot-owner-"));
+  const worker = Bun.spawn([process.execPath, "-e", "for await (const chunk of process.stdin) { void chunk; }"], {
+    env: { ...process.env }, stdin: "pipe", stdout: "ignore", stderr: "ignore",
+  });
+  const revisions = { flows: 0, pipelines: 0, pipelinesArchive: 0, workflows: 0 };
+  try {
+    const owner = captureProcessIdentity(worker.pid);
+    expect(owner.startIdentity).toBeTruthy();
+    const active = publishHotStateAuthority(directory, "sqlite", "a".repeat(40), { activationOwner: owner });
+    const fence = publishHotStateAuthority(directory, "fencing", active.releaseRevision);
+    expect(fence.activationOwner).toEqual(owner);
+    expect(() => acknowledgeHotStateFence(directory, fence, revisions)).toThrow("live Viewer must acknowledge");
+    expect(readHotStateAuthority(directory)?.checkpoint).toBeUndefined();
+    const unknown = publishHotStateAuthority(directory, "fencing", active.releaseRevision, {
+      activationOwner: { ...owner, startIdentity: null },
+    });
+    expect(() => acknowledgeHotStateFence(directory, unknown, revisions)).toThrow("live Viewer must acknowledge");
+    worker.stdin.end();
+    await worker.exited;
+    expect(acknowledgeHotStateFence(directory, unknown, revisions).checkpoint?.revisions).toEqual(revisions);
+  } finally {
+    worker.stdin.end();
+    await worker.exited;
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 function sampleFlow(id: string, stateDetail: string | null = null): Flow {
   return {

--- a/src/lib/state/sqliteStateStore.ts
+++ b/src/lib/state/sqliteStateStore.ts
@@ -860,6 +860,22 @@ export class SqliteStateCollection<T> {
     throw new Error(`${this.options.collection} rollback checkpoint did not converge`);
   }
 
+  async checkpointMirrorForDemotionAsync(write: (records: readonly T[], revision: number) => void, maxAttempts = 2): Promise<number> {
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const lease = await this.acquireLease();
+      let revision: number;
+      try {
+        const records = this.snapshot();
+        revision = this.revision();
+        write(records, revision);
+      } finally {
+        await this.releaseLease(lease);
+      }
+      if (this.revision() === revision) return revision;
+    }
+    throw new Error(`${this.options.collection} rollback checkpoint did not converge`);
+  }
+
   private collectionMeta(db = this.readDb): CollectionMeta | null {
     return db.query<CollectionMeta, [string]>(
       "SELECT revision, schema_version, change_floor FROM state_collections WHERE collection = ?",

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -49,6 +49,7 @@ interface ActivationTimer {
 }
 
 interface StructuredHostStartupOptions {
+  signal?: AbortSignal;
   schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
   initialRetryMs?: number;
   maxRetryMs?: number;
@@ -304,9 +305,9 @@ export async function checkpointHotStateRollbackMirrorsForDemotion(): Promise<Ho
     import("@/lib/pipelines/store"),
     import("@/lib/workflows/store"),
   ]);
-  const flowRevision = flows.checkpointFlowRollbackMirrorForDemotion();
-  const pipelineRevisions = pipelines.checkpointPipelineRollbackMirrorsForDemotion();
-  const workflowRevision = workflows.checkpointWorkflowRollbackMirrorForDemotion();
+  const flowRevision = await flows.checkpointFlowRollbackMirrorForDemotionAsync();
+  const pipelineRevisions = await pipelines.checkpointPipelineRollbackMirrorsForDemotionAsync();
+  const workflowRevision = await workflows.checkpointWorkflowRollbackMirrorForDemotionAsync();
   return {
     flows: flowRevision,
     pipelines: pipelineRevisions.pipelines,
@@ -651,12 +652,18 @@ export async function runStructuredHostStartup(
   const attempt = async (): Promise<void> => {
     attempts += 1;
     try {
+      options.signal?.throwIfAborted();
       await adopt();
+      options.signal?.throwIfAborted();
       markStructuredHostStartupReady();
       resolveReady?.();
       if (attempts > 1) log("[structured hosts] startup adoption recovered", { attempts });
     } catch (error) {
       markStructuredHostStartupFailed();
+      if (options.signal?.aborted) {
+        rejectReady?.(error);
+        throw error;
+      }
       const classification = classifyStructuredHostStartupError(error);
       if (classification.disposition === "terminal") {
         log("[structured hosts] startup adoption failed", error, {
@@ -681,8 +688,16 @@ export async function runStructuredHostStartup(
     }
   };
 
+  const aborted = () => {
+    markStructuredHostStartupFailed();
+    // An executing attempt must settle before retirement can checkpoint.
+    if (retryPending) rejectReady?.(options.signal?.reason);
+  };
+  options.signal?.addEventListener("abort", aborted, { once: true });
+
   if (ready) {
-    await Promise.all([attempt(), ready]);
+    try { await Promise.all([attempt(), ready]); }
+    finally { options.signal?.removeEventListener("abort", aborted); }
     return;
   }
   await attempt();
@@ -707,6 +722,26 @@ export async function registerViewerRuntime(): Promise<void> {
   const hotStateDirectory = path.dirname(statePath("state.sqlite"));
   const releaseRevision = () => hotStateWriterRevision(hotStateDirectory);
   let activatedReleaseRevision: string | null = null;
+  const startupAbort = new AbortController();
+  let startup: Promise<void> | null = null;
+  const quiesceStartup = async () => {
+    startupAbort.abort(new Error("structured startup retired by release handover"));
+    await startup?.catch(() => {});
+  };
+  const assertStartupActive = () => {
+    // Observe durable retirement at every phase/batch boundary, including
+    // before the monitor's next poll and after an awaited transcript refresh.
+    if (!isCurrent() || readHotStateAuthority(hotStateDirectory)?.mode === "fencing") {
+      startupAbort.abort(new Error("structured startup lost release authority"));
+    }
+    startupAbort.signal.throwIfAborted();
+  };
+  const releaseHosts = async () => {
+    const { releaseUnpublishedStartupHostsForDemotion } = await import("@/lib/runtime/startup");
+    await releaseUnpublishedStartupHostsForDemotion();
+    const { releaseStructuredDeliveryHostsForDemotion } = await import("@/lib/runtime/structuredDeliveryController");
+    await releaseStructuredDeliveryHostsForDemotion();
+  };
   await activateViewerRuntimeWhenCurrent(async () => {
     const boundary = await establishHotStateCutoverBoundary(isCurrent);
     activatedReleaseRevision = boundary.authority?.releaseRevision ?? null;
@@ -721,11 +756,14 @@ export async function registerViewerRuntime(): Promise<void> {
       startWakatime: startWakatimeIntegrationIfEnabled,
       startStructuredHosts: structuredHostsEnabled()
         ? () => {
-            void (async () => {
+            startup = (async () => {
               const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-              await runStructuredHostStartup(adoptStructuredHostsAtStartup, console.error, { waitUntilReady: true });
-            })()
-              .catch((error) => console.error("[structured hosts] background startup aborted", error));
+              await runStructuredHostStartup(
+                () => adoptStructuredHostsAtStartup({ assertActive: assertStartupActive }),
+                console.error, { waitUntilReady: true, signal: startupAbort.signal },
+              );
+            })();
+            void startup.catch((error) => console.error("[structured hosts] background startup aborted", error));
           }
         : null,
       startControllers: startCurrentReleaseControllers,
@@ -747,20 +785,25 @@ export async function registerViewerRuntime(): Promise<void> {
         : null;
     },
     onFenceRequested: async (request) => {
+      await quiesceStartup();
+      await releaseHosts();
       const revisions = await checkpointHotStateRollbackMirrorsForDemotion();
       const { agentRegistry } = await import("@/lib/agent/registry");
       agentRegistry().checkpointRollbackMirrorForDemotion();
       acknowledgeHotStateFence(hotStateDirectory, request, revisions);
     },
-    onDemoted: ({ fenced }) => completeViewerReleaseDemotion(async () => {
-      if (fenced) return;
-      const authority = readHotStateAuthority(hotStateDirectory);
-      if (!activatedReleaseRevision
-        || authority?.releaseRevision !== activatedReleaseRevision
-        || (authority.mode !== "sqlite" && authority.mode !== "fencing")) return;
-      const { agentRegistry } = await import("@/lib/agent/registry");
-      await checkpointHotStateRollbackMirrorsForDemotion();
-      agentRegistry().checkpointRollbackMirrorForDemotion();
-    }),
+    onDemoted: async ({ fenced }) => {
+      await quiesceStartup();
+      await completeViewerReleaseDemotion(async () => {
+        if (fenced) return;
+        const authority = readHotStateAuthority(hotStateDirectory);
+        if (!activatedReleaseRevision
+          || authority?.releaseRevision !== activatedReleaseRevision
+          || (authority.mode !== "sqlite" && authority.mode !== "fencing")) return;
+        const { agentRegistry } = await import("@/lib/agent/registry");
+        await checkpointHotStateRollbackMirrorsForDemotion();
+        agentRegistry().checkpointRollbackMirrorForDemotion();
+      }, undefined, undefined, releaseHosts);
+    },
   });
 }

--- a/src/lib/workflows/store.ts
+++ b/src/lib/workflows/store.ts
@@ -358,6 +358,12 @@ export function checkpointWorkflowRollbackMirrorForDemotion(): number {
   });
 }
 
+export async function checkpointWorkflowRollbackMirrorForDemotionAsync(): Promise<number> {
+  return workflowStore().checkpointMirrorForDemotionAsync((workflows, revision) => {
+    atomicWriteJson(workflowsFile(), { _sqliteRevision: revision, workflows });
+  });
+}
+
 function reconcileWorkflowPath(
   value: { path: string | null; conversationId: string | null | undefined },
   registry: ConversationLookup,

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -23,7 +23,7 @@ import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { ViewerDeploymentAdapter } from "./deployment";
 import { candidateLogExcerpt } from "./deploymentHealth";
-import { PROMOTE_ACTION_TIMEOUT_MS } from "./deploymentHotState";
+import { PROMOTE_ACTION_TIMEOUT_MS, VERIFY_PROMOTED_ACTION_TIMEOUT_MS } from "./deploymentHotState";
 import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 import {
   createMcpHealthProbeAdmissionChannel,
@@ -50,7 +50,7 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
      contains, so the adapter reports its own named reason instead of being
      killed mid-wait and leaving the operator a bare phase string. */
   promote: PROMOTE_ACTION_TIMEOUT_MS,
-  "verify-promoted": 120_000,
+  "verify-promoted": VERIFY_PROMOTED_ACTION_TIMEOUT_MS,
   rollback: 90_000,
   retire: 60_000,
   "retain-only": 60_000,

--- a/src/runtime-host/deploymentHealth.test.ts
+++ b/src/runtime-host/deploymentHealth.test.ts
@@ -19,6 +19,7 @@ import {
   markStructuredHostStartupReady,
 } from "@/lib/runtime/startupStatus";
 import { RuntimeJournal } from "@/runtime-host/journal";
+import { PROMOTED_SERVING_TIMEOUT_MS, VERIFY_PROMOTED_ACTION_TIMEOUT_MS } from "./deploymentHotState";
 
 import {
   candidateLogExcerpt,
@@ -102,6 +103,23 @@ test("candidate readiness stops immediately after container exit", async () => {
   expect(sleeps).toBe(0);
 });
 
+test("promoted serving can finish beyond the former deadline but still has a wall-clock bound", async () => {
+  let now = 0;
+  const probe = (readyAt: number) => waitForViewerReadiness({
+    endpoint: "http://127.0.0.1:18001", inspect: async () => "running",
+    probe: async () => evidence(now >= readyAt),
+    now: () => now, sleep: async (delay) => { now += delay; },
+    timeoutMs: PROMOTED_SERVING_TIMEOUT_MS,
+  });
+  expect((await probe(200_000)).ok).toBe(true);
+  expect(now).toBe(200_000);
+  now = 0;
+  const timedOut = await probe(Infinity);
+  expect(timedOut.ok).toBe(false);
+  expect(now).toBe(PROMOTED_SERVING_TIMEOUT_MS);
+  expect(VERIFY_PROMOTED_ACTION_TIMEOUT_MS).toBe(PROMOTED_SERVING_TIMEOUT_MS + 60_000);
+});
+
 test("health request plan exercises remote authorization and rejection", () => {
   process.env.LLV_TOKEN = "viewer-token";
   const plan = viewerHealthRequestPlan("http://127.0.0.1:18001", "viewer-token");
@@ -157,6 +175,7 @@ test("deployment capability publishes bounded structured-host adoption progress"
     });
     const response = deploymentCapability();
     const body = await response.text();
+    expect(viewerDeploymentReleaseReady(response.status, body)).toBe(false);
 
     expect(viewerDeploymentStructuredHostStartup(response.status, body)).toMatchObject({
       state: "pending",

--- a/src/runtime-host/deploymentHealth.ts
+++ b/src/runtime-host/deploymentHealth.ts
@@ -71,7 +71,14 @@ export function viewerDeploymentRegistryBackendMode(
 export function viewerDeploymentReleaseReady(status: number, body: string): boolean {
   if (!hasViewerDeploymentCapability(status, body)) return false;
   try {
-    return (JSON.parse(body) as { releaseReady?: unknown }).releaseReady !== false;
+    const capability = JSON.parse(body) as { releaseReady?: unknown; structuredHostStartup?: unknown };
+    if (capability.releaseReady === false) return false;
+    // HTTP serving can precede recovery. A promoted deployment must await the
+    // actual startup result before it can retire its rollback generation.
+    if (capability.structuredHostStartup !== undefined && capability.structuredHostStartup !== null) {
+      return viewerDeploymentStructuredHostStartup(status, body)?.state === "ready";
+    }
+    return true;
   } catch {
     return false;
   }
@@ -243,6 +250,8 @@ export interface ViewerReadinessProbe {
   maxAttempts?: number;
   delayMs?: number;
   now?(): number;
+  /** Wall-clock serving budget. Other readiness callers keep their attempt limit. */
+  timeoutMs?: number;
 }
 
 function unavailable(endpoint: string, state: Exclude<ViewerCandidateContainerState, "running">): ViewerHealthEvidence {
@@ -260,8 +269,11 @@ function unavailable(endpoint: string, state: Exclude<ViewerCandidateContainerSt
 }
 
 export async function waitForViewerReadiness(options: ViewerReadinessProbe): Promise<ViewerHealthEvidence> {
-  const maxAttempts = Math.min(Math.max(options.maxAttempts ?? 30, 1), 120);
   const delayMs = Math.min(Math.max(options.delayMs ?? 1_000, 0), 10_000);
+  const timeoutMs = options.timeoutMs === undefined ? null : Math.min(Math.max(options.timeoutMs, 1), 300_000);
+  const maxAttempts = timeoutMs === null
+    ? Math.min(Math.max(options.maxAttempts ?? 30, 1), 120)
+    : Math.ceil(timeoutMs / Math.max(delayMs, 1)) + 1;
   const sleep = options.sleep ?? ((delay) => new Promise<void>((resolve) => setTimeout(resolve, delay)));
   const now = options.now ?? (() => Date.now());
   const startedAt = now();
@@ -269,6 +281,7 @@ export async function waitForViewerReadiness(options: ViewerReadinessProbe): Pro
   let firstDetail: string | null = null;
   let attempts = 0;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (attempt > 1 && timeoutMs !== null && now() - startedAt >= timeoutMs) break;
     const state = await options.inspect();
     if (state !== "running") {
       return {
@@ -280,7 +293,10 @@ export async function waitForViewerReadiness(options: ViewerReadinessProbe): Pro
     last = await options.probe();
     if (last.ok) return last;
     if (attempt === 1) firstDetail = last.detail ?? null;
-    if (attempt < maxAttempts) await sleep(delayMs);
+    if (attempt < maxAttempts) {
+      const remaining = timeoutMs === null ? delayMs : Math.max(0, timeoutMs - (now() - startedAt));
+      await sleep(Math.min(delayMs, remaining));
+    }
   }
   const record = readiness({
     attempts, maxAttempts, delayMs, elapsedMs: now() - startedAt, firstDetail, lastDetail: last?.detail ?? null,

--- a/src/runtime-host/deploymentHotState.ts
+++ b/src/runtime-host/deploymentHotState.ts
@@ -20,6 +20,14 @@ import type { ViewerCandidateContainerState } from "./deploymentHealth";
  * the deadline it runs under (fitHandOverBudgets) rather than trusted. */
 export const HOT_STATE_ACTIVATION_TIMEOUT_MS = 180_000;
 export const HOT_STATE_ACTIVATION_POLL_MS = 250;
+/** Temporary headroom for full startup recovery (#1552): the measured
+ * historical phases alone took 156s, before adoption and publication. Five
+ * minutes includes that work plus adoption and a bounded margin while the
+ * historical work is reduced. Only promoted serving verification uses this. */
+export const PROMOTED_SERVING_TIMEOUT_MS = 300_000;
+/** Allow the final bounded HTTP probe and the 15s MCP probe to report inside
+ * the host's action deadline. The host remains the hard outer stop. */
+export const VERIFY_PROMOTED_ACTION_TIMEOUT_MS = PROMOTED_SERVING_TIMEOUT_MS + 60_000;
 /** The demoted incumbent sees the flipped target on its own 250ms poll,
     checkpoints its rollback mirrors and exits, so a release that has not
     happened within this budget is not going to happen inside the promote — and

--- a/src/runtime-host/fixtures/incumbentDeploymentHealth.ts
+++ b/src/runtime-host/fixtures/incumbentDeploymentHealth.ts
@@ -1,0 +1,23 @@
+// Verbatim capability/readiness consumers from src/runtime-host/deploymentHealth.ts
+// at bdf4b85658802c2e1765382c5aef04a6585980a7. Keep independent of successor code.
+export function hasViewerDeploymentCapability(status: number, body: string): boolean {
+  if (status !== 200) return false;
+  try {
+    const response = JSON.parse(body) as { capability?: unknown; version?: unknown };
+    return response?.capability === "viewer-deployments" && response.version === 1;
+  } catch {
+    return false;
+  }
+}
+
+/** Older release capabilities omit this field and already represent complete
+ * startup. SQLite-wave releases expose an explicit false value until their
+ * post-activation serving controllers have started. */
+export function viewerDeploymentReleaseReady(status: number, body: string): boolean {
+  if (!hasViewerDeploymentCapability(status, body)) return false;
+  try {
+    return (JSON.parse(body) as { releaseReady?: unknown }).releaseReady !== false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Forward-only release qualification

The operator waived successful rollback as a prerequisite for this release and requested no additional review. Minimum shipping head remains `4c1bd1c198ab0fc267fba204cdccc0bf02071e50`, base `88e5a9508be2802266734056d6436f3168201cad`; no further product changes are needed for the observed forward path.

Fresh isolated execution used a Viewer built from frozen incumbent `bdf4b85658802c2e1765382c5aef04a6585980a7`, that incumbent runtime host and command adapter, and the unchanged candidate package:
- Actual incumbent `promote` durably selected the candidate; incumbent Viewer exited 0.
- Candidate startup reached ready at 102.148 seconds with no injected delays. A preceding forward run reached ready at 80.231 seconds. Both fit the incumbent 120-second serving action; the promoted verifier was invoked after readiness.
- Actual incumbent `verify-promoted` passed root, capability, all eight assets, MCP inventory, deployment-status and board-snapshot calls. MCP staging used the full locked dependency tree, matching the Dockerfile; the Next standalone trace alone omits MCP SDK dependencies.
- All six original sends delivered with exact provider-input matches. Pending operation keys/payloads, six writer registrations, deferred spawn and both independent external workers were preserved.
- The combined harness returned failure on pipeline creation while its exited incumbent remained an unreaped child. After the fixture reaped that child, an independent contender created and persisted a pipeline with the candidate alive before and after. Raw failing and supplemental passing evidence are retained separately.

The retained candidate package digest is unchanged. Existing 476 targeted tests, TypeScript, build, privacy and applicable exact-head CI remain green. The host bootstrap, succession, main and deployment coordinator source are unchanged from the frozen incumbent, and the retained separate runtime-host succession rehearsal passed.

Limits: Docker inspection is a fixture; this run exercises direct production forward actions, not a complete container/coordinator deployment. Final private-host teardown required forced cleanup after preservation observations. Root owns merge, exact-SHA deployment, terminal success and deployed Viewer/MCP/runtime identity checks. **Rollback remains broken and is a known follow-up; it has not been repaired.**

---

Full startup held pipeline admission during historical recovery, and rollback could race host release. This PR batches historical work, joins startup before retirement, and preserves queued requests until their hosts register. Serving readiness now stays false until structured startup and delivery control are ready, including for the deployed incumbent verifier.

**Incomplete: incumbent rollback remains blocked.** The frozen `bdf4b85658802c2e1765382c5aef04a6585980a7` adapter drops `activationOwner` and starts checkpointing without an owner acknowledgement or positive-death barrier. A fresh isolated Viewer-API timeout reproduced checkpoint convergence failure, leaving the candidate alive and the target unrestored. The readiness repair does not fix that ordering. No complete old-host to new-Viewer/runtime deployment success or safe forced rollback has been established.

The rollback rehearsal now admits through the isolated stable Viewer API, uses the actual frozen host/coordinator/executable adapter, and rejects successor-source substitution. Build, container, precheck and initial promotion setup remain fixtures. The old 120-second verification action and 90-second rollback action remain intact. Provider wrappers are local protocol fixtures.

Validation at `4c1bd1c198ab0fc267fba204cdccc0bf02071e50`, base `88e5a9508be2802266734056d6436f3168201cad`:
- 476 targeted tests, nonincremental TypeScript, standalone Viewer/MCP build, and whole-diff privacy with commit and known-value checks passed in private environments.
- Readiness causal RED/GREEN: the original capability response failed the frozen consumer check; the repaired response passed. Both actual verifier modules rejected 145 pending packaged samples and accepted the final ready sample.
- Ordinary packaged startup took 53.461 seconds without injected delays. Six original sends delivered with exact provider matches; writer ownership, pending key/payload, deferred spawn and both independent external workers were preserved.
- The independent prior review measured ordinary startup at 43.732 seconds. Its predecessor's 158.087-second run included a deliberate 135-second hold; it is not an unavoidable deployment duration.
- Frozen-incumbent baseline timeout failed at 129.111 seconds. The repaired candidate failed through the stable Viewer API at 127.641 seconds, with the same convergence error, no candidate exit and no target restoration. This is a retained failing acceptance gate.
- Separate runtime-host succession completed in 503 ms; both endpoints answered 27/27 probes over 15 seconds. This does not prove the full deployment sequence.

Related: #1552; pre-spawn rejection remains in #1555. No production lifecycle action was performed. Existing worktrees and review evidence were preserved. Root owns release decisions and deployment after the missing compatibility barrier, full sequence proof, and fresh independent review.

The complete manifest, package digest, commands and retained historical results are in [the acceptance document](https://github.com/Latand/live-log-viewer-next/blob/4c1bd1c198ab0fc267fba204cdccc0bf02071e50/docs/acceptance/startup-rollback-1552.md).
