### PR TITLE
fix(monitor): admit seat ticks only at an idle turn boundary

### DIFF
--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -313,7 +313,7 @@ export interface DurableQuotaObservation {
 export interface HeldDeliveryCommand {
   operationId: string;
   kind: "send" | "steer";
-  policy: "queue" | "steer-if-active" | "interrupt-active";
+  policy: "queue" | "idle-only" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
   /** Message authorship stamped at admission (#1117), persisted on the held
       record so a migration-held delivery replays with the same attribution.

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1646,7 +1646,7 @@ function canonicalHeldDeliveryCommand(
   const command: HeldDeliveryCommand = {
     operationId: value?.operationId || deliveryId,
     kind: value?.kind === "steer" ? "steer" : "send",
-    policy: value?.policy === "queue" || value?.policy === "steer-if-active"
+    policy: value?.policy === "queue" || value?.policy === "idle-only" || value?.policy === "steer-if-active"
       ? value.policy
       : "interrupt-active",
   };

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -1472,3 +1472,26 @@ test("idle-only delivery preserves policy and uncertain original operation ident
   });
   expect(result).toMatchObject({ ok: false, operationId: "tick-operation", resend: "verify-first", actuation: "started" });
 });
+
+
+test("idle-only delivery reconciles a stale busy registry through the existing owner path", async () => {
+  const registry = new AgentRegistry(path.join(SANDBOX, "recovery-tick-registry.json"));
+  const pathname = path.join(SANDBOX, `${crypto.randomUUID()}.jsonl`);
+  const conversation = registry.ensureConversation("codex", pathname, null);
+  registry.reconcileConversations([{ engine: "codex", path: pathname, accountId: null,
+    launchProfile: emptyLaunchProfile(), turn: { state: "busy", source: "assistant", terminalAt: null }, observedAt: new Date().toISOString() }]);
+  setAgentRegistryForTests(registry);
+  let recovered = false;
+  const result = await deliverConversationMessage({ pid: null, path: pathname, conversationId: conversation.id,
+    clientMessageId: "recover-tick-key", text: "owed work", images: [], policy: "idle-only" }, {
+    recover: async () => { recovered = true; return { target: null, path: pathname, conversationId: conversation.id, spawned: true }; },
+    enqueueStructured: async (request) => {
+      expect(recovered).toBe(true);
+      expect(request.policy).toBe("idle-only");
+      return { ok: true, structured: true, outcome: "delivered", target: null, operationId: "recover-tick-operation",
+        receipt: { operationId: "recover-tick-operation", idempotencyKey: "recover-tick-key", conversationId: conversation.id,
+          kind: "send", status: "delivered", at: new Date().toISOString(), revision: 1 } };
+    },
+  });
+  expect(result).toMatchObject({ ok: true, outcome: "delivered", spawned: true });
+});

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -1452,3 +1452,23 @@ test("message-triggered relaunches carry the stored MCP grant on both the direct
     { path: rootPath, mcpServers: ["viewer"] },
   ]);
 });
+
+
+test("idle-only delivery preserves policy and uncertain original operation identity", async () => {
+  const registry = new AgentRegistry(path.join(SANDBOX, "idle-only-registry.json"));
+  const pathname = path.join(SANDBOX, `${crypto.randomUUID()}.jsonl`);
+  const conversation = registry.ensureConversation("codex", pathname, null);
+  registry.reconcileConversations([{ engine: "codex", path: pathname, accountId: null,
+    launchProfile: emptyLaunchProfile(), turn: { state: "idle", source: "assistant", terminalAt: new Date().toISOString() }, observedAt: new Date().toISOString() }]);
+  setAgentRegistryForTests(registry);
+  const result = await deliverConversationMessage({ pid: null, path: pathname, conversationId: conversation.id,
+    clientMessageId: "tick-key", text: "check", images: [], policy: "idle-only", origin: { kind: "agent", role: "seat-tick" } }, {
+    recover: async () => ({ target: null, path: pathname, conversationId: conversation.id, spawned: false }),
+    enqueueStructured: async (request) => {
+      expect(request.policy).toBe("idle-only");
+      expect(request.clientMessageId).toBe("tick-key");
+      return { ok: false, structured: true, outcome: "failed", error: "reply lost", status: 503, operationId: "tick-operation", transportUncertain: true };
+    },
+  });
+  expect(result).toMatchObject({ ok: false, operationId: "tick-operation", resend: "verify-first", actuation: "started" });
+});

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -633,6 +633,7 @@ export async function killConversation(filePath: string, overrides: KillConversa
 }
 
 export interface ConversationMessage {
+  policy?: "idle-only";
   pid: number | null;
   path: string;
   conversationId?: string | null;
@@ -686,6 +687,9 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     : registry.conversationForPath(message.path);
   const rejected = supersededRejection(registry, conversation);
   if (rejected) return rejected;
+  if (message.policy === "idle-only" && conversation?.turn.state !== "idle" && conversation?.turn.state !== "terminal") {
+    return failure("idle-only delivery requires a completed idle turn", 409);
+  }
   if (conversation) {
     try {
       const recovered = await (overrides.recover ?? recoverDeadStructuredConversation)(
@@ -702,11 +706,16 @@ export async function deliverConversationMessage(message: ConversationMessage, o
           text,
           hasImages: images.length > 0,
           ...(message.origin ? { origin: message.origin } : {}),
+          ...(message.policy ? { policy: message.policy } : {}),
         }, {
           registry: () => registry,
         });
         if (!structured) return failure("structured delivery ownership is unavailable", 503);
-        if (!structured.ok) return failure(structured.error, structured.status);
+        if (!structured.ok) return {
+          ...failure(structured.error, structured.status),
+          ...(structured.operationId ? { operationId: structured.operationId } : {}),
+          ...(structured.transportUncertain ? { resend: "verify-first" as const, actuation: "started" as const } : {}),
+        };
         if (structured.outcome === "held") {
           return {
             ok: true,
@@ -732,6 +741,9 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     }
   }
   let filePath = conversation?.generations.at(-1)?.path ?? message.path;
+  // Automatic input requires the structured host's final idle fence.
+  if (message.policy === "idle-only") return failure("idle-only delivery requires a structured host", 409);
+
   let deliveryId: string | null = null;
   let acceptedOperationId: string | null = null;
   if (conversation && !message.reservedDeliveryId) {

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -687,9 +687,8 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     : registry.conversationForPath(message.path);
   const rejected = supersededRejection(registry, conversation);
   if (rejected) return rejected;
-  if (message.policy === "idle-only" && conversation?.turn.state !== "idle" && conversation?.turn.state !== "terminal") {
-    return failure("idle-only delivery requires a completed idle turn", 409);
-  }
+  // Registry turns can outlive their owner. Existing recovery reconciles the
+  // owner; idle-only journal admission and the host fence decide whether input is safe.
   if (conversation) {
     try {
       const recovered = await (overrides.recover ?? recoverDeadStructuredConversation)(

--- a/src/lib/lifecycle/journal.ts
+++ b/src/lib/lifecycle/journal.ts
@@ -1,3 +1,4 @@
+import { requestSeatTick } from "@/lib/monitor/seatTickSignal";
 import crypto from "node:crypto";
 import fs from "node:fs";
 
@@ -249,6 +250,9 @@ export function appendLifecycleEvents(inputs: LifecycleEventInput[]): { appended
       file.retired = [...file.retired, ...trimmed.map((event) => event.id)].slice(-RETIRED_ID_CAPACITY);
     }
     writeJournalFile(file);
+    for (const project of new Set(appended.map((event) => event.project).filter((value): value is string => Boolean(value)))) {
+      requestSeatTick({ project });
+    }
     return { appended, skipped };
   });
 }

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -102,7 +102,7 @@ function input(over: Partial<SeatTickCheckInput> = {}): SeatTickCheckInput {
     children: [],
     childrenUnavailable: null,
     changeFingerprint: "fp-1",
-    state: emptySeatTickState(),
+    state: { ...emptySeatTickState(), turnIdleSince: new Date(NOW - 61 * MINUTE).toISOString() },
     policy: DEFAULT_SEAT_TICK_POLICY,
     /* The default a project nobody configured reads (#1275): every case below
        that does not say otherwise is the tick exactly as it shipped. */
@@ -125,7 +125,7 @@ function child(over: Partial<SeatTickChildInput> = {}): SeatTickChildInput {
 }
 
 function stateWith(over: Partial<SeatTickProjectState>): SeatTickProjectState {
-  return { ...emptySeatTickState(), ...over };
+  return { ...emptySeatTickState(), turnIdleSince: over.lastWakeAt ?? new Date(NOW - 61 * MINUTE).toISOString(), ...over };
 }
 
 /** The reasons a verdict carries, or none for every verdict that is not a wake. */
@@ -242,13 +242,11 @@ test("a lane with no activity verdict at all is never called stalled", () => {
   expect(decision.state.stalledSeen).toEqual([]);
 });
 
-/* A terminal lane event leads the next wake; it never raises an early one. The
-   hourly bound has no exempt reason kind, because a reason allowed to jump it
-   would make the ADR's cost argument describe a different system. */
-test("a terminal lane event leads the next wake rather than raising one early", () => {
+// Actionable events bypass the countdown while preserving the final idle fence.
+test("a terminal lane event bypasses the idle countdown", () => {
   const args = { events: [event()], pipelines: [lane()] };
   const early = seatTickDecision(input({ ...args, state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }) }));
-  expect(early.verdict.kind).toBe("quiet");
+  expect(reasonsOf(early.verdict)).toContain("lane-event");
 
   const due = seatTickDecision(input({ ...args, state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }) }));
   expect(reasonsOf(due.verdict)).toEqual(["lane-event"]);
@@ -341,7 +339,7 @@ test("the seal stops at the first event that is still owed", () => {
   expect(decision.state.eventsThrough).toBe(61);
   expect(reasonsOf(decision.verdict)).toEqual(["lane-event"]);
   /* And only a landing takes the cursor past the live one. */
-  expect(seatTickWakeCommit(decision.state, plan(decision.verdict, "fp-1", 63), NOW).eventsThrough).toBe(63);
+  expect(seatTickWakeCommit(decision.state, plan(decision.verdict, "fp-1", 63), NOW).eventsThrough).toBe(62);
 });
 
 /* A skipped check remembers nothing — including this. The turn it landed behind
@@ -403,12 +401,12 @@ test("a merged batch goes quiet on its own", () => {
 
 /* It is a reason, never a route around the bound: the hourly interval applies
    to it exactly as it applies to a terminal lane event. */
-test("an unmerged pull request waits out the wake interval like every other reason", () => {
+test("a newly observed unmerged pull request bypasses the idle countdown", () => {
   const decision = seatTickDecision(input({
     pullRequests: [pullRequest()],
     state: stateWith({ lastWakeAt: new Date(NOW - MINUTE).toISOString() }),
   }));
-  expect(decision.verdict.kind).toBe("quiet");
+  expect(reasonsOf(decision.verdict)).toContain("unmerged-pr");
 });
 
 /* And the retry guard applies to it too, so a pull request nobody merges stops
@@ -418,6 +416,7 @@ test("an unmerged pull request that has stopped producing change is held by the 
     pullRequests: [pullRequest()],
     state: stateWith({
       lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString(),
+      lastActionableKeys: (seatTickDecision(input({ pullRequests: [pullRequest()] })).verdict as Extract<SeatTickVerdict, { kind: "wake" }>).actionableKeys,
       lastWakeFingerprint: "fp-1",
       wakesWithoutChange: { "unmerged-pr": 2 },
     }),
@@ -823,13 +822,13 @@ test("a signal alone is agenda enough for the interval to wake", () => {
   expect(reasonsOf(decision.verdict)).toEqual(["interval"]);
 });
 
-test("standing reasons wait out the wake interval instead of firing every five minutes", () => {
+test("new actionable obligations bypass the idle interval", () => {
   const decision = seatTickDecision(input({
     pipelines: [lane({ state: "inert" })],
     tasks: [card()],
     state: stateWith({ lastWakeAt: new Date(NOW - 10 * MINUTE).toISOString(), stalledSeen: ["pipeline_a1"] }),
   }));
-  expect(decision.verdict.kind).toBe("quiet");
+  expect(decision.verdict.kind).toBe("wake");
 });
 
 test("a wake carries at most five items and reports the rest as deferred", () => {
@@ -1165,10 +1164,10 @@ test("a failed launch is a terminal child too, and the reason says so (#1465)", 
   expect(decision.verdict).toMatchObject({ reasons: [{ kind: "child-terminal", detail: "a spawned child failed and its outcome is unharvested" }] });
 });
 
-test("a terminal child waits out the wake interval like every other reason (#1465)", () => {
+test("a newly completed child bypasses the idle countdown (#1465)", () => {
   const finished = child({ status: "terminal", outcome: "finished", terminalAt: new Date(NOW - 20 * MINUTE).toISOString() });
   const decision = seatTickDecision(input({ children: [finished], state: stateWith({ lastWakeAt: new Date(NOW - 5 * MINUTE).toISOString() }) }));
-  expect(decision.verdict).toEqual({ kind: "quiet", detail: "nothing owed" });
+  expect(reasonsOf(decision.verdict)).toContain("child-terminal");
 });
 
 test("terminal children are named oldest outcome first, and the plan records only the ones the wake carries (#1465)", () => {
@@ -1316,8 +1315,79 @@ test("a child-terminal reason that stops producing change is held by the retry g
   const finished = child({ status: "terminal", outcome: "finished", terminalAt: new Date(NOW - 20 * MINUTE).toISOString() });
   const decision = seatTickDecision(input({
     children: [finished],
-    state: stateWith({ ...OVERDUE_STATE, lastWakeFingerprint: "fp-1", wakesWithoutChange: { "child-terminal": 2 } }),
+    state: stateWith({ ...OVERDUE_STATE, lastActionableKeys: (seatTickDecision(input({ children: [finished] })).verdict as Extract<SeatTickVerdict, { kind: "wake" }>).actionableKeys, lastWakeFingerprint: "fp-1", wakesWithoutChange: { "child-terminal": 2 } }),
   }));
   expect(decision.verdict).toEqual({ kind: "quiet", detail: "every wake reason is held by the retry guard" });
   expect(decision.cards.map((entry) => entry.ref)).toEqual(["seat-tick-stuck-child-terminal"]);
+});
+
+
+test("empty pending work starts a full interval at settlement", () => {
+  const first = seatTickDecision(input({ pipelines: [lane()], state: stateWith({ lastWakeAt: new Date(NOW - 10 * 60 * MINUTE).toISOString(), turnIdleSince: null }) }));
+  expect(first.verdict.kind).toBe("quiet");
+  expect(first.state).toMatchObject({ turnIdleSince: new Date(NOW).toISOString() });
+  const before = seatTickDecision(input({ now: NOW + 59 * MINUTE, pipelines: [lane()], state: first.state }));
+  expect(before.verdict.kind).toBe("quiet");
+  const due = seatTickDecision(input({ now: NOW + 60 * MINUTE, pipelines: [lane()], state: before.state }));
+  expect(reasonsOf(due.verdict)).toContain("interval");
+});
+
+test("busy work prepares actionable messages and settlement drains them without an interval", () => {
+  const busy = seatTickDecision(input({ seat: seat({ turn: "busy", activity: { lifecycle: "waiting", reason: "provider_throttled", turnState: "busy" } }),
+    tasks: [card()], state: stateWith({ lastWakeAt: new Date(NOW).toISOString() }) }));
+  expect(busy.verdict.kind).toBe("skipped");
+  expect(busy.state).toMatchObject({ turnIdleSince: null, pendingWork: { items: expect.arrayContaining([expect.objectContaining({ kind: "task" })]) } });
+  const settled = seatTickDecision(input({ tasks: [card()], state: busy.state }));
+  expect(reasonsOf(settled.verdict)).toContain("unstarted-task");
+});
+
+test("a genuine event during the idle countdown bypasses its remaining interval", () => {
+  const first = seatTickDecision(input({ pipelines: [lane()], state: stateWith({ lastWakeAt: new Date(NOW).toISOString() }) }));
+  const next = seatTickDecision(input({ now: NOW + MINUTE, pipelines: [lane()], events: [event()], state: first.state }));
+  expect(reasonsOf(next.verdict)).toContain("lane-event");
+});
+
+
+test("restart retains a continuous idle deadline and a changed generation starts a full interval", () => {
+  const state = stateWith({ turnIdleSince: new Date(NOW - 30 * MINUTE).toISOString(), idleRuntime: { generation: "native-one", cursor: 12 } });
+  const current = seat({ runtimeState: "idle", runtimeGeneration: "native-one", runtimeCursor: 12 });
+  const first = seatTickDecision(input({ seat: current, pipelines: [lane()], state }));
+  expect(first.state.turnIdleSince).toBe(state.turnIdleSince);
+  const changed = seatTickDecision(input({ seat: { ...current, runtimeGeneration: "native-two" }, pipelines: [lane()], state: first.state }));
+  expect(changed.verdict.kind).toBe("quiet");
+  expect(changed.state.turnIdleSince).toBe(new Date(NOW).toISOString());
+  const missedTurn = seatTickDecision(input({ seat: { ...current, runtimeCursor: 20 }, pipelines: [lane()], state: first.state }));
+  expect(missedTurn.state.turnIdleSince).toBe(new Date(NOW).toISOString());
+});
+
+test("a bounded wake acknowledges only the actionable events it actually carries", () => {
+  const events = Array.from({ length: 7 }, (_, index) => event({ seq: index + 1, summary: `outcome ${index + 1}` }));
+  const first = seatTickDecision(input({ events, pipelines: [lane()], state: stateWith({ eventsThrough: 0, turnIdleSince: null }) }));
+  const commit = seatTickWakeCommitPlan(first.verdict, { fingerprint: "events", eventsThrough: 7, unreadEvents: events })!;
+  expect(commit.eventsThrough).toBe(5);
+  const landed = seatTickWakeCommit(first.state, commit, NOW);
+  const second = seatTickDecision(input({ events: events.filter((event) => event.seq > landed.eventsThrough!), pipelines: [lane()], state: landed }));
+  expect(second.verdict).toMatchObject({ kind: "wake", items: [{ eventSeq: 6 }, { eventSeq: 7 }] });
+});
+
+
+test("a newer busy runtime boundary defeats an older idle observation", () => {
+  const decision = seatTickDecision(input({ seat: seat({ runtimeState: "idle", runtimeGeneration: "native", runtimeCursor: 1 }),
+    tasks: [card()], state: stateWith({ turnBoundary: { generation: "native", turnId: "new-turn", seq: 2, state: "busy", at: new Date(NOW).toISOString() } }) }));
+  expect(decision.verdict.kind).toBe("skipped");
+  expect(decision.state.turnIdleSince).toBeNull();
+  expect(decision.state.pendingWork?.items).toHaveLength(1);
+});
+
+
+test("a reclaimed owner preserves the settled idle countdown while unobservable ownership does not", () => {
+  const state = stateWith({ turnIdleSince: new Date(NOW - 30 * MINUTE).toISOString() });
+  const reclaimed = seat({ runtimeState: "unknown", activity: { lifecycle: "gone", reason: "host_gone_turn_settled", turnState: "idle" } });
+  const waiting = seatTickDecision(input({ seat: reclaimed, pipelines: [lane()], state }));
+  expect(waiting.state.turnIdleSince).toBe(state.turnIdleSince);
+  const due = seatTickDecision(input({ seat: reclaimed, pipelines: [lane()], state: waiting.state, now: NOW + 30 * MINUTE }));
+  expect(reasonsOf(due.verdict)).toContain("interval");
+  const unknown = seatTickDecision(input({ seat: { ...reclaimed, activity: { lifecycle: "gone", reason: "launch_unproven_expired", turnState: "unknown" } }, pipelines: [lane()], state }));
+  expect(unknown.verdict.kind).toBe("skipped");
+  expect(unknown.state.turnIdleSince).toBeNull();
 });

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -38,7 +38,7 @@ const CONVERSATION = ["conversation", "0f4c21b7729fbc9e"].join("_");
 const MINUTE = 60_000;
 
 function seat(over: Partial<SeatTickSeatInput> = {}): SeatTickSeatInput {
-  return { conversationId: CONVERSATION, seatEpoch: 7, path: null, turn: "idle", activity: null, ...over };
+  return { conversationId: CONVERSATION, seatEpoch: 7, path: null, turn: "idle", activity: { lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle" }, ...over };
 }
 
 function lane(over: Partial<SeatTickPipelineInput> = {}): SeatTickPipelineInput {
@@ -164,50 +164,17 @@ test("a seat whose turn is genuinely moving is skipped, not queued", () => {
   expect(decision.state.lastCheckAt).toBe(new Date(NOW).toISOString());
 });
 
-/* The permanent skip this replaces: a seat whose host died mid-turn keeps a
-   `busy` turn on the registry for as long as the record stands, so a plain busy
-   check dropped every tick forever — silenced by exactly the condition the wake
-   exists to clear. */
-test("a busy seat the registry reports stalled is no longer skipped, so the skip terminates", () => {
-  const stalledSeat = seat({ turn: "busy", activity: { lifecycle: "stalled", reason: "host_gone_turn_open" } });
-  const decision = seatTickDecision(input({
-    seat: stalledSeat,
-    pipelines: [lane()],
-    signals: [{ id: "seat-host", label: "the seat's own turn is stalled" }],
-    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
-  }));
-  expect(seatTurnProgressing(stalledSeat)).toBe(false);
-  expect(decision.verdict.kind).toBe("wake");
-  expect(reasonsOf(decision.verdict)).toEqual(["interval"]);
-});
-
-test("a busy seat the liveness plane cannot answer for is not skipped either — absence is not progress", () => {
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: null }))).toBe(false);
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: "gone", reason: "host_gone_turn_settled" } }))).toBe(false);
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: "waiting", reason: "provider_throttled", turnState: "busy" } }))).toBe(true);
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: "starting", reason: "launch_unproven" } }))).toBe(true);
-  expect(seatTurnProgressing(seat({ turn: "idle", activity: { lifecycle: "running", reason: "host_alive_turn_active" } }))).toBe(false);
-});
-
-/* #1262: the registry's turn record and the transcript's own turn are two
-   different facts, and the tick read them as one. A seat that finished its turn
-   leaves the registry record open for a while; the liveness verdict for it is
-   `waiting` (`host_alive_turn_idle`), which the tick counted as progress — so
-   an available seat was skipped at every check for as long as the stale record
-   stood, and could not be woken at all. Only the turn a retry deadline is
-   holding open is progress. */
-test("a seat whose turn the transcript says settled is available, not progressing", () => {
-  const settled = seat({ turn: "busy", activity: { lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle" } });
-  expect(seatTurnProgressing(settled)).toBe(false);
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: "waiting", reason: "provider_throttled", turnState: "busy" } }))).toBe(true);
-  /* An unstated turn is not a turn anybody proved open. */
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: "waiting", reason: "host_alive_turn_idle" } }))).toBe(false);
-  const decision = seatTickDecision(input({
-    seat: settled,
-    pipelines: [lane()],
-    state: stateWith({ lastWakeAt: new Date(NOW - 61 * MINUTE).toISOString() }),
-  }));
-  expect(decision.verdict.kind).toBe("wake");
+test("open, unknown, and contradictory seat turns stay protected", () => {
+  for (const turn of ["busy", "unknown"] as const) {
+    for (const activity of [null, { lifecycle: "stalled" as const, reason: "host_gone_turn_open" },
+      { lifecycle: "waiting" as const, reason: "host_alive_turn_idle", turnState: "idle" as const }]) {
+      const target = seat({ turn, activity });
+      expect(seatTurnProgressing(target)).toBe(true);
+      expect(seatTickDecision(input({ seat: target, pipelines: [lane()], state: stateWith(OVERDUE_STATE) })).verdict.kind).toBe("skipped");
+    }
+  }
+  expect(seatTurnProgressing(seat({ activity: { lifecycle: "running", reason: "host_alive_turn_active", turnState: "busy" } }))).toBe(true);
+  expect(seatTurnProgressing(seat())).toBe(false);
 });
 
 test("a healthy moving board is quiet and produces nothing operator-visible", () => {
@@ -1140,40 +1107,13 @@ test("the wake interval is a constant no environment can set", () => {
 
 const ALIVE = { host: { state: "alive" as const }, stallAfterMs: DEFAULT_SEAT_TICK_POLICY.stallAfterMs };
 
-test("the stall threshold catches a silent open turn, and never a long busy one", () => {
-  /* CAUGHT: six hours open, nothing written for 41 minutes past a 40-minute
-     threshold. The registry calls it stalled, so the tick stops treating the
-     turn as progress and the seat becomes reachable again. */
-  const silent = evaluateLiveness({ ...ALIVE, turnState: "busy", silentForMs: 41 * MINUTE });
-  expect(silent).toEqual({ lifecycle: "stalled", reason: "host_alive_transcript_silent" });
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: silent.lifecycle, reason: silent.reason } }))).toBe(false);
-
-  /* NOT CAUGHT, and this is the blind spot: the same six-hour turn, writing a
-     tool call thirty seconds ago. Silence is zero, so it reads `running`, the
-     tick calls it progress and drops its check — at every check, for as long
-     as the seat keeps writing. Duration is not an input anywhere on this path,
-     so no threshold on this surface can fire on it. */
-  const busy = evaluateLiveness({ ...ALIVE, turnState: "busy", silentForMs: 30_000 });
-  expect(busy).toEqual({ lifecycle: "running", reason: "host_alive_turn_active" });
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: busy.lifecycle, reason: busy.reason } }))).toBe(true);
-  expect(seatTickDecision(input({ seat: seat({ turn: "busy", activity: { lifecycle: busy.lifecycle, reason: busy.reason } }), pipelines: [lane()] })).verdict)
-    .toEqual({ kind: "skipped", reason: "seat-busy" });
-
-  /* That is the property "never interrupt a working seat" being kept, and it
-     is worth keeping — a seat writing every thirty seconds IS working, and the
-     Viewer cannot tell an eight-hour merge queue from a self-inflicted loop by
-     looking at the transcript clock. What it costs is that a seat which keeps
-     itself busy on purpose is unreachable, which is exactly the deadlock the
-     session cron produced. The answer is upstream of this surface: mandate v11
-     tells the seat to stop doing it, and the revoked-seat retirement ends a
-     predecessor that will not. */
-
-  /* The one case that is NOT a blind spot: a dead host holding an open turn
-     forever. Caught whatever the transcript clock says, which is why the skip
-     terminates rather than waiting behind a turn nothing can finish. */
-  const zombie = evaluateLiveness({ host: { state: "gone" }, turnState: "busy", silentForMs: 0, stallAfterMs: ALIVE.stallAfterMs });
-  expect(zombie).toEqual({ lifecycle: "stalled", reason: "host_gone_turn_open" });
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: { lifecycle: zombie.lifecycle, reason: zombie.reason } }))).toBe(false);
+test("both stalled and working open turns stay protected regardless of silence", () => {
+  for (const silentForMs of [30_000, 41 * MINUTE]) {
+    const activity = evaluateLiveness({ ...ALIVE, turnState: "busy", silentForMs });
+    expect(seatTurnProgressing(seat({ turn: "busy", activity }))).toBe(true);
+  }
+  const gone = evaluateLiveness({ host: { state: "gone" }, turnState: "busy", silentForMs: 0, stallAfterMs: ALIVE.stallAfterMs });
+  expect(seatTurnProgressing(seat({ turn: "busy", activity: gone }))).toBe(true);
 });
 
 test("the stall threshold the tick configures is the one the liveness read applies", () => {

--- a/src/lib/monitor/seatTick.test.ts
+++ b/src/lib/monitor/seatTick.test.ts
@@ -166,8 +166,7 @@ test("a seat whose turn is genuinely moving is skipped, not queued", () => {
 
 test("open, unknown, and contradictory seat turns stay protected", () => {
   for (const turn of ["busy", "unknown"] as const) {
-    for (const activity of [null, { lifecycle: "stalled" as const, reason: "host_gone_turn_open" },
-      { lifecycle: "waiting" as const, reason: "host_alive_turn_idle", turnState: "idle" as const }]) {
+    for (const activity of [null, { lifecycle: "stalled" as const, reason: "host_gone_turn_open" }]) {
       const target = seat({ turn, activity });
       expect(seatTurnProgressing(target)).toBe(true);
       expect(seatTickDecision(input({ seat: target, pipelines: [lane()], state: stateWith(OVERDUE_STATE) })).verdict.kind).toBe("skipped");
@@ -1113,7 +1112,7 @@ test("both stalled and working open turns stay protected regardless of silence",
     expect(seatTurnProgressing(seat({ turn: "busy", activity }))).toBe(true);
   }
   const gone = evaluateLiveness({ host: { state: "gone" }, turnState: "busy", silentForMs: 0, stallAfterMs: ALIVE.stallAfterMs });
-  expect(seatTurnProgressing(seat({ turn: "busy", activity: gone }))).toBe(true);
+  expect(seatTurnProgressing(seat({ turn: "busy", activity: { ...gone, turnState: "busy" } }))).toBe(false);
 });
 
 test("the stall threshold the tick configures is the one the liveness read applies", () => {

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { isTerminalHighSignalEvent } from "@/lib/lifecycle/vocabulary";
 
 import { seatTickRetryGuardRef, seatTickSourceGapRef, ORCHESTRATOR_ALERT_REF, SEAT_TICK_SETTINGS_REF } from "./cards";
@@ -252,6 +253,8 @@ function dischargedThrough(events: readonly SeatTickEventInput[], cursor: number
 
 /** Admission to the existing recovery path; the owned host still fences input. */
 export function seatTurnProgressing(seat: SeatTickSeatInput): boolean {
+  if (seat.runtimeState === "busy") return true;
+  if (seat.runtimeState === "idle") return false;
   const activity = seat.activity;
   if (!activity || activity.turnState === undefined || activity.turnState === "unknown") return true;
   if (activity.lifecycle === "starting" || activity.lifecycle === "running") return true;
@@ -631,12 +634,27 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
     };
   }
 
-  /* A tick that landed after the current turn would be acting on evidence the
-     turn has already superseded. Drop it: no delivery, no cursor advance, no
-     stall memory, and the next check re-reads everything. */
-  if (seatTurnProgressing(input.seat)) {
-    return { verdict: { kind: "skipped", reason: "seat-busy" }, state: unchanged, cards: [] };
+  const newerBusyBoundary = input.state.turnBoundary?.state === "busy"
+    && input.state.turnBoundary.generation === input.seat.runtimeGeneration
+    && input.state.turnBoundary.seq >= (input.seat.runtimeCursor ?? Infinity);
+  const busy = seatTurnProgressing(input.seat) || newerBusyBoundary;
+  const reclaimedIdle = input.seat.activity?.turnState === "idle"
+    && input.seat.activity.lifecycle === "gone" && input.seat.activity.reason === "host_gone_turn_settled";
+  const idle = !busy && (input.seat.runtimeState === "idle" || reclaimedIdle
+    || (input.seat.runtimeState === undefined && input.seat.activity?.turnState === "idle"));
+  if (busy && input.seat.runtimeGeneration && input.seat.runtimeTurnId && input.seat.runtimeCursor !== undefined) {
+    unchanged.turnBoundary = { generation: input.seat.runtimeGeneration, turnId: input.seat.runtimeTurnId,
+      seq: input.seat.runtimeCursor, state: "busy", at };
   }
+  const boundary = unchanged.turnBoundary;
+  const priorRuntime = input.state.idleRuntime;
+  const runtimeChanged = input.seat.runtimeGeneration !== undefined && priorRuntime != null
+    && (priorRuntime.generation !== input.seat.runtimeGeneration || priorRuntime.cursor !== input.seat.runtimeCursor);
+  const boundaryAt = boundary?.state === "settled" && boundary.generation === input.seat.runtimeGeneration
+    && boundary.seq >= (priorRuntime?.cursor ?? 0) ? boundary.at : null;
+  unchanged.turnIdleSince = idle ? (boundaryAt ?? (runtimeChanged ? at : input.state.turnIdleSince ?? at)) : null;
+  unchanged.idleRuntime = idle && input.seat.runtimeGeneration !== undefined && input.seat.runtimeCursor !== undefined
+    ? { generation: input.seat.runtimeGeneration, cursor: input.seat.runtimeCursor } : null;
 
   /* The seal (#1285) rides on every verdict from here down, a skipped check
      excepted — that one returns above and remembers nothing, deliberately. It
@@ -646,7 +664,7 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
   const base: SeatTickProjectState = {
     ...unchanged,
     seatEpoch: input.seat.seatEpoch,
-    eventsThrough: dischargedThrough(input.events, unchanged.eventsThrough),
+    eventsThrough: busy ? unchanged.eventsThrough : dischargedThrough(input.events, unchanged.eventsThrough),
   };
   const stalled = stalledLanes(input);
   const stalledKids = stalledChildren(input);
@@ -660,7 +678,7 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
   const unstarted = input.tasks.filter((task) => isUnstarted(task, input.now, input.policy.backlogAfterMs));
   const backlog = input.tasks.filter((task) => task.status === "assigned" && !task.owned).length - unstarted.length;
   const openWork = hasOpenWork(input);
-  const wakeDue = seatTickWakeDue(input.state.lastWakeAt, input.now, input.settings.wakeIntervalMs);
+  const wakeDue = unchanged.turnIdleSince !== null && elapsed(unchanged.turnIdleSince ?? null, input.now, input.settings.wakeIntervalMs);
 
   const observed: SeatTickProjectState = { ...base, stalledSeen: stalledNow };
 
@@ -686,7 +704,9 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
 
   const laneEvents = input.events.filter(isOwedEvent);
   const candidates: SeatTickWakeReason[] = [];
-  if (wakeDue) {
+  const seatRecovery = !busy && openWork && input.seat.activity?.reason === "host_gone_turn_open";
+  if (seatRecovery) candidates.push({ kind: "stalled", detail: "the seat owner is gone over an open turn; reconcile its owner before input" });
+  {
     /* A verdict the seat cannot decide without leads the wake — and waits for
        the wake like everything else. Routine progress never wakes on its own,
        and neither does an event whose lane has finished.
@@ -751,16 +771,40 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
        and an hourly wake with an empty agenda is the burnt-quota tick this
        replaces. */
     const intervalAgenda = input.pipelines.some(isOpenLane) || input.children.some(isRunningChild) || input.signals.length > 0;
-    if (openWork && intervalAgenda && candidates.length === 0) {
+    if (wakeDue && openWork && intervalAgenda && candidates.length === 0) {
       candidates.push({ kind: "interval", detail: "the wake interval elapsed while work is open" });
     }
   }
 
+  const agenda = wakeItems({ input, stalled: persistedStalls, stalledChildren: persistedChildStalls, harvest, laneEvents, unstarted, includeInterval: false });
+  if (seatRecovery) agenda.push({ kind: "signal", id: "seat-host", label: "the seat owner is gone over an open turn" });
+  const acknowledged = new Set(input.state.lastActionableKeys ?? []);
+  const freshAgenda = agenda.filter((item) => item.kind === "event" || !acknowledged.has(actionableKey(item, input)));
+  observed.lastActionableKeys = [...acknowledged].filter((key) => agenda.some((item) => actionableKey(item, input) === key));
+  const pending = wakeDue ? agenda : freshAgenda;
+  observed.pendingWork = pending.length ? {
+    at, items: pending.slice(0, input.policy.itemsPerWake), reasons: candidates.filter((reason) => reason.kind !== "interval"),
+    deferred: Math.max(0, pending.length - input.policy.itemsPerWake),
+  } : null;
+  if (busy) return { verdict: { kind: "skipped", reason: "seat-busy" }, state: observed, cards: [] };
+  // An unchanged, already delivered obligation waits for the next idle interval.
+  if (!wakeDue && freshAgenda.length === 0) candidates.length = 0;
+
+  const wanted = new Set(pending.map((item) => item.kind));
+  if (pending.length > 0) {
+    for (let index = candidates.length - 1; index >= 0; index--) {
+      const kind = candidates[index]!.kind;
+      if ((kind === "unmerged-pr" && !wanted.has("pull-request"))
+        || (kind === "unstarted-task" && !wanted.has("task"))
+        || (kind === "lane-event" && !wanted.has("event"))
+        || (kind === "child-terminal" && !wanted.has("child"))) candidates.splice(index, 1);
+    }
+  }
   const cards: SeatTickCard[] = [];
   const reasons: SeatTickWakeReason[] = [];
   let guardHeld = 0;
   for (const reason of candidates) {
-    if (guardCount(input.state, reason.kind, input.changeFingerprint) >= input.policy.retryGuard) {
+    if (freshAgenda.length === 0 && guardCount(input.state, reason.kind, input.changeFingerprint) >= input.policy.retryGuard) {
       guardHeld += 1;
       cards.push({
         ref: seatTickRetryGuardRef(reason.kind),
@@ -804,10 +848,11 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
      The guard and the interval are untouched by any of it: the reasons here
      passed both, and a gap adds none. */
   if (reasons.length > 0) {
-    const all = wakeItems({ input, stalled: persistedStalls, stalledChildren: persistedChildStalls, harvest, laneEvents, unstarted });
+    const all = pending.length ? pending : wakeItems({ input, stalled: persistedStalls, stalledChildren: persistedChildStalls, harvest, laneEvents, unstarted });
     return {
       verdict: {
         kind: "wake",
+        actionableKeys: all.slice(0, input.policy.itemsPerWake).map((item) => actionableKey(item, input)),
         reasons,
         items: all.slice(0, input.policy.itemsPerWake),
         deferred: Math.max(0, all.length - input.policy.itemsPerWake),
@@ -848,6 +893,7 @@ function decide(input: SeatTickCheckInput): SeatTickDecision {
      that nothing is owed — each of them resting on evidence the check above
      has already shown it could read. */
   if (guardHeld > 0) {
+    state.pendingWork = null;
     return { verdict: { kind: "quiet", detail: "every wake reason is held by the retry guard" }, state: quiet(state, at), cards };
   }
 
@@ -884,11 +930,12 @@ function wakeItems(context: {
   harvest: readonly SeatTickChildInput[];
   laneEvents: readonly SeatTickEventInput[];
   unstarted: SeatTickTaskInput[];
+  includeInterval?: boolean;
 }): SeatTickItem[] {
   const { input } = context;
   const items: SeatTickItem[] = [];
   for (const event of context.laneEvents) {
-    items.push({ kind: "event", id: event.pipelineId ?? event.type, label: `${event.type}: ${event.summary}` });
+    items.push({ kind: "event", eventSeq: event.seq, id: event.pipelineId ?? event.type, label: `${event.type}: ${event.summary}` });
   }
   /* Oldest outcome first (#1465), so the per-wake bound holds back the newest
      and the child that has waited longest is harvested first. Only the items
@@ -921,6 +968,7 @@ function wakeItems(context: {
   for (const task of context.unstarted) {
     items.push({ kind: "task", id: task.id, label: `${task.title} — assigned, nothing started it` });
   }
+  if (context.includeInterval === false) return items;
   /* On an interval wake the open lanes are the agenda; they carry no reason of
      their own, so they come last and only when nothing sharper displaced them. */
   for (const pipeline of input.pipelines) {
@@ -949,11 +997,19 @@ function wakeItems(context: {
  * message raised minutes earlier would credit the seat with the wrong wake, so
  * the raising check writes the plan down and the landing applies it verbatim.
  */
+function actionableKey(item: SeatTickItem, input: SeatTickCheckInput): string {
+  const revision = item.kind === "task" ? input.tasks.find((task) => task.id === item.id)?.updatedAt
+    : item.kind === "pull-request" ? input.pullRequests.find((pr) => `#${pr.number}` === item.id)?.updatedAt
+    : null;
+  return createHash("sha256").update(JSON.stringify([item.kind, item.id, item.eventSeq, item.outcomeId, item.label, revision])).digest("hex");
+}
+
 export function seatTickWakeCommitPlan(
   verdict: SeatTickVerdict,
   context: {
     fingerprint: string;
     eventsThrough: number;
+    unreadEvents?: readonly SeatTickEventInput[];
     /** The terminal children the check saw (#1465). Only those the wake
         actually names — inside the per-wake bound — are recorded as harvested
         by its landing; a child the bound held back stays owed. */
@@ -965,7 +1021,12 @@ export function seatTickWakeCommitPlan(
   if (verdict.kind !== "wake") return null;
   const terminal = new Set(context.terminalChildren ?? []);
   const children = verdict.items.filter((item) => item.kind === "child" && terminal.has(item.outcomeId ?? item.id)).map((item) => item.outcomeId ?? item.id);
-  return { proposal: false, reasons: verdict.reasons.map((reason) => reason.kind), fingerprint, eventsThrough, children };
+  const carriedEvents = verdict.items.flatMap((item) => item.kind === "event" && item.eventSeq !== undefined ? [item.eventSeq] : []);
+  const uncarried = context.unreadEvents?.find((event) => isOwedEvent(event) && !carriedEvents.includes(event.seq));
+  const committedEventsThrough = uncarried
+    ? context.unreadEvents!.filter((event) => event.seq < uncarried.seq).at(-1)?.seq ?? 0
+    : context.unreadEvents ? eventsThrough : carriedEvents.length ? Math.min(eventsThrough, Math.max(...carriedEvents)) : eventsThrough;
+  return { proposal: false, reasons: verdict.reasons.map((reason) => reason.kind), fingerprint, eventsThrough: committedEventsThrough, children, ...(verdict.actionableKeys ? { actionableKeys: verdict.actionableKeys } : {}) };
 }
 
 /**
@@ -995,6 +1056,9 @@ export function seatTickWakeCommit(
     return {
       ...state,
       lastWakeAt: at,
+      turnIdleSince: null,
+      turnBoundary: null,
+      pendingWork: null,
       lastProposalAt: at,
       lastWakeReasons: [],
       lastWakeFingerprint: commit.fingerprint,
@@ -1018,6 +1082,10 @@ export function seatTickWakeCommit(
   return {
     ...state,
     lastWakeAt: at,
+    turnIdleSince: null,
+    turnBoundary: null,
+    pendingWork: null,
+    lastActionableKeys: [...new Set([...(state.lastActionableKeys ?? []), ...(commit.actionableKeys ?? [])])],
     lastWakeReasons: carried,
     lastWakeFingerprint: commit.fingerprint,
     wakesWithoutChange,

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -250,12 +250,14 @@ function dischargedThrough(events: readonly SeatTickEventInput[], cursor: number
   return sealed;
 }
 
-/** Protect an open or unobservable turn. Silence never establishes completion. */
+/** Admission to the existing recovery path; the owned host still fences input. */
 export function seatTurnProgressing(seat: SeatTickSeatInput): boolean {
-  if (seat.turn !== "idle" && seat.turn !== "terminal") return true;
   const activity = seat.activity;
-  return !activity || activity.turnState !== "idle"
-    || activity.lifecycle === "running" || activity.lifecycle === "starting" || activity.lifecycle === "stalled";
+  if (!activity || activity.turnState === undefined || activity.turnState === "unknown") return true;
+  if (activity.lifecycle === "starting" || activity.lifecycle === "running") return true;
+  if (activity.turnState === "idle") return false;
+  // Silence under a live or unobservable turn does not authorize intervention.
+  return !(activity.lifecycle === "stalled" && activity.reason === "host_gone_turn_open");
 }
 
 /**

--- a/src/lib/monitor/seatTick.ts
+++ b/src/lib/monitor/seatTick.ts
@@ -250,32 +250,12 @@ function dischargedThrough(events: readonly SeatTickEventInput[], cursor: number
   return sealed;
 }
 
-/**
- * Whether the seat's turn is genuinely progressing, which is the only thing
- * that earns a dropped tick.
- *
- * The dead-host-over-an-open-turn case is why this is a positive test rather
- * than `turn === "busy"`. A seat whose host died mid-turn keeps a `busy` turn
- * on the registry forever, so a plain busy check skipped that seat at every
- * five-minute check for as long as the record stood — a permanent silence
- * produced by exactly the condition the wake exists to clear. Here the registry
- * decides: `running`, `waiting` under a turn the transcript still shows open (a
- * provider retry deadline) and `starting` (inside the launch grace, which
- * expires into `stalled` or `gone` on its own) are progress; everything else,
- * absent verdicts included, is not.
- */
+/** Protect an open or unobservable turn. Silence never establishes completion. */
 export function seatTurnProgressing(seat: SeatTickSeatInput): boolean {
-  if (seat.turn !== "busy") return false;
+  if (seat.turn !== "idle" && seat.turn !== "terminal") return true;
   const activity = seat.activity;
-  if (!activity) return false;
-  /* `waiting` covers two different seats. One is a turn held open by a provider
-     retry deadline, which is progress. The other is `host_alive_turn_idle`: the
-     transcript says the turn SETTLED and only the registry's record still calls
-     it open — a seat sitting available, which the tick then skipped at every
-     check for as long as the stale record stood (#1262). The evidence the
-     verdict came from decides between them. */
-  if (activity.lifecycle === "waiting") return activity.turnState === "busy";
-  return activity.lifecycle === "running" || activity.lifecycle === "starting";
+  return !activity || activity.turnState !== "idle"
+    || activity.lifecycle === "running" || activity.lifecycle === "starting" || activity.lifecycle === "stalled";
 }
 
 /**

--- a/src/lib/monitor/seatTickAccounting.ts
+++ b/src/lib/monitor/seatTickAccounting.ts
@@ -22,7 +22,7 @@ export type AccountingOwner = Base & { kind: "owner"; conversationId: string; ep
     row's own pointer, so a ticket moves in one keyed transaction. */
 export type AccountingChild = Base & { kind: "child"; identity: string; rowKey: string; owner: string; launchId: string; input: SeatTickChildInput; generationIndex: number; runningKey: string | null; pollKey: string | null };
 export type AccountingSource = Base & { kind: "source"; identity: string; child: string; engine: string; generation: string; legacyBoundary?: { identity: string; bytes: number }; cursor: LedgerCursor };
-export type AccountingOutcome = Base & { kind: "outcome"; identity: string; child: string; tuple: string[]; input: SeatTickChildInput; status: "owed" | "acknowledged"; landingKey: string | null; readyKey: string; gap: string | null };
+export type AccountingOutcome = Base & { observedAtSequence?: number; kind: "outcome"; identity: string; child: string; tuple: string[]; input: SeatTickChildInput; status: "owed" | "acknowledged"; landingKey: string | null; readyKey: string; gap: string | null };
 type Ticket = Base & { kind: "poll" | "ready" | "owner-poll" | "running"; target: string };
 /** Where a ticket enters its queue (#1465). The queues are FIFO by sequence;
     a `head` ticket sorts before every `tail` one, in sequence among heads, so
@@ -30,7 +30,7 @@ type Ticket = Base & { kind: "poll" | "ready" | "owner-poll" | "running"; target
     just found, a ledger the budget cut — is read by the next visit rather
     than after every cold child ahead of it. */
 export type TicketPosition = "head" | "tail";
-type Legacy = Base & { kind: "legacy"; conversationId: string; reconciled: boolean };
+type Legacy = Base & { landedThrough?: number; kind: "legacy"; conversationId: string; reconciled: boolean };
 export type AccountingRow = AccountingProject | AccountingOwner | AccountingChild | AccountingSource | AccountingOutcome | Ticket | Legacy;
 type Transaction = Parameters<Parameters<SqliteStateCollection<AccountingRow>["boundedPatch"]>[1]>[0];
 /** How a prepared attempt ends (#1465). `landed` acknowledges what it named
@@ -84,6 +84,15 @@ function decodeAccountingRow(raw: unknown): AccountingRow | null {
         const value = state[name];
         if (value !== null && (typeof value !== "string" || !Number.isFinite(Date.parse(value)))) return null;
       }
+      if (state.wakeAttempt !== undefined && !integer(state.wakeAttempt)) return null;
+      if (state.turnIdleSince !== undefined && state.turnIdleSince !== null
+        && (typeof state.turnIdleSince !== "string" || !Number.isFinite(Date.parse(state.turnIdleSince)))) return null;
+      if (state.lastActionableKeys !== undefined && (!Array.isArray(state.lastActionableKeys) || !state.lastActionableKeys.every(string))) return null;
+      if (state.idleRuntime !== undefined && state.idleRuntime !== null
+        && (!string(state.idleRuntime.generation) || !integer(state.idleRuntime.cursor))) return null;
+      if (state.turnBoundary !== undefined && state.turnBoundary !== null
+        && (!string(state.turnBoundary.generation) || !string(state.turnBoundary.turnId) || !integer(state.turnBoundary.seq)
+          || !["busy", "settled"].includes(state.turnBoundary.state) || !Number.isFinite(Date.parse(state.turnBoundary.at)))) return null;
       if (state.eventsThrough !== null && !integer(state.eventsThrough)) return null;
       if (!Array.isArray(state.harvestedChildren) || state.harvestedChildren.length !== 0
         || !Array.isArray(state.lastWakeReasons) || !Array.isArray(state.stalledSeen)
@@ -466,7 +475,7 @@ export class SeatTickAccounting {
         const input: SeatTickChildInput = { ...child.input, status: "terminal", outcome: result, outcomeId: identity };
         const readyKey = key("ready", this.project, String(row.sequence + 1).padStart(16, "0"));
         this.ticket(tx, row, "ready", id);
-        tx.put({ ...this.base("outcome", identity), kind: "outcome", identity, child: child.key, tuple, input, status: "owed", landingKey: null, readyKey,
+        tx.put({ ...this.base("outcome", identity), kind: "outcome", observedAtSequence: row.sequence, identity, child: child.key, tuple, input, status: "owed", landingKey: null, readyKey,
           gap: legacy && (failure || !source?.legacyBoundary || outcomes[index]!.endOffset <= source.legacyBoundary.bytes) ? "legacy-delivery-ambiguous" : null });
       });
       if (source) tx.put(source);
@@ -527,6 +536,11 @@ export class SeatTickAccounting {
       if (ticket.kind !== "ready") throw new Error("invalid ready ticket");
       const outcome = this.get(ticket.target);
       if (!outcome || outcome.kind !== "outcome") throw new Error("missing outcome");
+      const legacy = this.get(key("legacy", this.project, outcome.input.conversationId));
+      if (legacy?.kind === "legacy" && legacy.landedThrough !== undefined
+        && (outcome.observedAtSequence === undefined || outcome.observedAtSequence <= legacy.landedThrough)) {
+        outcome.gap = "legacy-delivery-ambiguous";
+      }
       if (outcome.status === "owed" && outcome.gap) this.defer(outcome);
       return outcome.status === "owed" && !outcome.gap ? [outcome] : [];
     });
@@ -536,6 +550,7 @@ export class SeatTickAccounting {
       const held = tx.get(outcome.key);
       if (!held || held.kind !== "outcome" || held.status !== "owed" || held.readyKey !== outcome.readyKey) return;
       tx.delete(held.readyKey);
+      held.gap = held.gap ?? outcome.gap;
       held.readyKey = key("ready", this.project, String(row.sequence + 1).padStart(16, "0"));
       this.ticket(tx, row, "ready", held.key);
       tx.put(held);
@@ -613,7 +628,7 @@ export class SeatTickAccounting {
           // A legacy prepared wake names conversations. Landing preserves that
           // positive evidence without attributing it to a guessed turn.
           if (!id.startsWith("conversation_")) throw new Error("missing frozen outcome");
-          tx.put({ ...this.base("legacy", id), kind: "legacy", conversationId: id, reconciled: true });
+          tx.put({ ...this.base("legacy", id), kind: "legacy", conversationId: id, reconciled: true, landedThrough: row.sequence });
           continue;
         }
         if (outcome.kind !== "outcome") throw new Error("invalid frozen outcome");
@@ -621,7 +636,7 @@ export class SeatTickAccounting {
         tx.delete(outcome.readyKey);
       }
       const current = disposition === "landed" ? seatTickWakeCommit(row.state, wake.commit, Date.parse(state.lastWakeAt!)) : row.state;
-      row.state = { ...current, accounting: undefined, harvestedChildren: [], outstandingWake: null };
+      row.state = { ...current, ...(disposition === "unsent" ? { wakeAttempt: (row.state.wakeAttempt ?? 0) + 1 } : {}), accounting: undefined, harvestedChildren: [], outstandingWake: null };
       return true;
     });
   }

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -19,7 +19,7 @@ const { openPullRequestsForRepo } = await import("./githubEvidence");
 const { defaultSeatTickSources, wakeStateFromRecord } = await import("./seatTickSources");
 const { resolveOriginalSend } = await import("@/lib/runtime/sendSettlement");
 const { deliverConversationMessage } = await import("@/lib/delivery");
-const { readSeatTickState, writeSeatTickState } = await import("./seatTickState");
+const { readSeatTickState, writeSeatTickState, seatTickStateForEpoch: seatTickStateForEpochForTest } = await import("./seatTickState");
 const { appendSeatTickRecord, readSeatTickRecords } = await import("./journalStore");
 const { SeatTickAccounting, outcomeIdentity } = await import("./seatTickAccounting");
 const { FileRuntimeEventStore } = await import("@/lib/runtime/eventStore");
@@ -166,7 +166,7 @@ function harness(options: {
   const result: Harness = { deps: {}, sent, journal, cards, written, withdrawn, liveness: livenessReads, snapshots: 0, seat: options.seat === undefined ? { conversationId: CONVERSATION, seatEpoch: 7, path: null } : options.seat };
   let reads = 0;
   const localStateFile = options.stateFile ?? path.join(fs.mkdtempSync(path.join(SANDBOX, "controller-state-")), "seat-tick.json");
-  if (!options.stateFile) writeSeatTickState(PROJECT, { ...emptySeatTickState(), seatEpoch: result.seat?.seatEpoch ?? null, ...options.state, accounting: undefined }, localStateFile);
+  if (!options.stateFile) writeSeatTickState(PROJECT, { ...emptySeatTickState(), seatEpoch: result.seat?.seatEpoch ?? null, turnIdleSince: options.state?.lastWakeAt ?? new Date((options.now ?? NOW) - 61 * MINUTE).toISOString(), ...options.state, accounting: undefined }, localStateFile);
 
   const pipelines = (options.pipelines ?? []).map(pipelineRecord);
   /* Lanes the hot store has already let go of: a settled record leaves after
@@ -188,7 +188,7 @@ function harness(options: {
     policy: DEFAULT_SEAT_TICK_POLICY,
     readState: (project) => {
       if (!options.stateFile && project !== PROJECT && !readSeatTickState(project, localStateFile).lastCheckAt) {
-        writeSeatTickState(project, { ...emptySeatTickState(), seatEpoch: result.seat?.seatEpoch ?? null, ...options.state, accounting: undefined }, localStateFile);
+        writeSeatTickState(project, { ...emptySeatTickState(), seatEpoch: result.seat?.seatEpoch ?? null, turnIdleSince: options.state?.lastWakeAt ?? new Date((options.now ?? NOW) - 61 * MINUTE).toISOString(), ...options.state, accounting: undefined }, localStateFile);
       }
       return readSeatTickState(project, localStateFile);
     },
@@ -478,7 +478,7 @@ test("the wake's identity comes from what it says, so an unlanded wake re-sends 
   await runSeatTickCheck(PROJECT, first.deps);
   const second = harness({ pipelines: OPEN_LANE, state: OVERDUE, delivery: held });
   await runSeatTickCheck(PROJECT, second.deps);
-  expect(second.sent[0]!.clientMessageId).toBe(first.sent[0]!.clientMessageId);
+  expect(second.sent[0]!.clientMessageId).toBe(first.sent[0]!.clientMessageId!);
 });
 
 /* The other half of the same key. An hourly wake on a board that has not moved
@@ -1568,11 +1568,12 @@ test("a check that outran its interval drops the next tick rather than queueing 
   });
   fire();
   fire();
+  await Promise.resolve();
   expect(sweeps).toBe(1);
   release();
-  await Promise.resolve();
-  await Promise.resolve();
+  await Bun.sleep(0);
   fire();
+  await Promise.resolve();
   expect(sweeps).toBe(2);
 });
 
@@ -1833,6 +1834,7 @@ function childFixture(name: string, gitRepository = false, sqliteMode: "sqlite" 
         ...emptySeatTickState(),
         seatEpoch: 7,
         lastWakeAt: new Date(now - 61 * MINUTE).toISOString(),
+        turnIdleSince: new Date(now - 61 * MINUTE).toISOString(),
         /* The proposal slot is not due, so an empty board is quiet rather than
            a proposal: what these cases test is the harvest, not the slot. */
         lastProposalAt: new Date(now - MINUTE).toISOString(),
@@ -2074,7 +2076,7 @@ test("a harvested child the seat re-instructs is owed again when it next finishe
     pendingAction: null,
   });
   const running = childRig(fixture, { now: fixture.now + 61 * MINUTE, childActivity: { [child.id]: { lifecycle: "running", reason: "host_alive_turn_active" } } });
-  expect(await runSeatTickCheck(fixture.project, running.deps)).toMatchObject({ verdict: "wake", reasons: ["interval"] });
+  expect(await runSeatTickCheck(fixture.project, running.deps)).toMatchObject({ verdict: "quiet" });
   expect(fixture.acknowledged()).toEqual([child.id]);
 
   fixture.registry.reconcileConversations([{
@@ -2443,14 +2445,15 @@ test("a child finishing while a wake is unresolved dispatches nothing, and is ha
 
   /* The holder delivers the first wake: it lands, and it credited no harvest. */
   const third = childRig(fixture, { wakeState: "landed" });
-  expect(await runSeatTickCheck(fixture.project, third.deps)).toMatchObject({ verdict: "quiet" });
+  expect(await runSeatTickCheck(fixture.project, third.deps)).toMatchObject({ verdict: "wake", reasons: ["child-terminal"] });
+  expect(third.sent[0]!.text).toContain(`[child] ${child.id}`);
   expect(third.journal[0]).toMatchObject({ verdict: "landed" });
   expect(fixture.row()).toMatchObject({ outstandingWake: null, harvestedChildren: [] });
 
-  /* The next interval carries the child. */
+  /* The refreshed pending outcome drains immediately; later checks do not repeat it. */
   const fourth = childRig(fixture, { now: fixture.now + 61 * MINUTE });
-  expect(await runSeatTickCheck(fixture.project, fourth.deps)).toMatchObject({ verdict: "wake", reasons: ["child-terminal"] });
-  expect(fourth.sent[0]!.text).toContain(`[child] ${child.id}`);
+  expect(await runSeatTickCheck(fixture.project, fourth.deps)).toMatchObject({ verdict: "quiet" });
+  expect(fourth.sent).toEqual([]);
   expect(fixture.acknowledged()).toEqual([child.id]);
 });
 
@@ -2565,7 +2568,7 @@ test("the projection uses bounded keyed registry reads and targeted liveness wit
   fixture.seed();
   const rig = childRig(fixture, { childActivity: { [busy.id]: { lifecycle: "running", reason: "host_alive_turn_active" } } });
   const record = await runSeatTickCheck(fixture.project, rig.deps);
-  expect(record).toMatchObject({ verdict: "wake", reasons: ["child-terminal"], items: 3 });
+  expect(record).toMatchObject({ verdict: "wake", reasons: ["child-terminal"], items: 2 });
   /* The child source uses keyed projections without a registry snapshot. */
   expect(rig.snapshots).toBe(0);
   /* Liveness is asked by id, for the one child whose turn is open, and never
@@ -2626,9 +2629,9 @@ test("a new turn discovered during an unknown send remains owed under the origin
     expect(fixture.acknowledged()).toEqual([]);
   }
   await runSeatTickCheck(fixture.project, childRig(fixture, { now: fixture.now + 61 * MINUTE, wakeState: "landed" }).deps);
-  expect(fixture.acknowledged()).toEqual([child.id]);
+  expect(fixture.acknowledged()).toEqual([child.id, child.id]);
   const final = childRig(fixture, { now: fixture.now + 122 * MINUTE });
-  expect(await runSeatTickCheck(fixture.project, final.deps)).toMatchObject({ verdict: "wake", items: 1 });
+  expect(await runSeatTickCheck(fixture.project, final.deps)).toMatchObject({ verdict: "quiet" });
   expect(fixture.acknowledged()).toEqual([child.id, child.id]);
 });
 
@@ -2915,7 +2918,7 @@ test("a stall on the twelfth of twelve running children is reported within two s
   expect(fixture.row().stalledSeen).toEqual([]);
 
   const second = childRig(fixture, { childActivity: activity, now: fixture.now + 61 * MINUTE });
-  expect(await runSeatTickCheck(fixture.project, second.deps)).toMatchObject({ verdict: "wake", reasons: ["interval"] });
+  expect(await runSeatTickCheck(fixture.project, second.deps)).toMatchObject({ verdict: "quiet" });
   expect(second.liveness.filter((read) => read.conversationId !== fixture.seat.conversationId).map((read) => read.conversationId)).toEqual(ids.slice(4, 12));
   expect(fixture.row().stalledSeen).toEqual([`child:${twelfth.id}`]);
 
@@ -3308,4 +3311,138 @@ for (const activity of [
   expect(record?.verdict).toBe("wake");
   expect(h.sent).toHaveLength(1);
   expect(h.sent[0]!.policy).toBe("idle-only");
+});
+
+
+async function flushSeatTickNotifications(): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    await Bun.sleep(1);
+    if (!(globalThis as { __llvSeatTickRunning?: boolean }).__llvSeatTickRunning) return;
+  }
+  throw new Error("fixture tick did not settle");
+}
+
+test("the existing controller starts a full idle countdown and cancels it during tool wait", async () => {
+  const { requestSeatTick } = await import("./seatTickSignal");
+  let now = NOW;
+  const options: Parameters<typeof harness>[0] = { pipelines: OPEN_LANE, state: { ...OVERDUE, turnIdleSince: null } };
+  const h = harness(options);
+  h.deps.sources!.now = () => now;
+  const deadlines: Array<{ run: () => void; delay: number }> = [];
+  startSeatTick({ now: () => now, boundary: () => {}, sweep: () => runSeatTickCheck(PROJECT, h.deps),
+    scheduleDeadline: (run, delay) => { deadlines.push({ run, delay }); const timer = setTimeout(() => {}, 1_000_000); timer.unref(); return timer; } });
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toEqual([]);
+  expect(deadlines.at(-1)!.delay).toBe(60 * MINUTE);
+  const oldDeadline = deadlines.at(-1)!.run;
+  now += 59 * MINUTE;
+  options.turn = "busy";
+  options.seatActivity = { lifecycle: "waiting", reason: "provider_throttled", turnState: "busy" };
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.written.at(-1)!.turnIdleSince).toBeNull();
+  now += MINUTE;
+  oldDeadline();
+  await flushSeatTickNotifications();
+  expect(h.sent).toEqual([]);
+  options.turn = "idle";
+  options.seatActivity = { lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle" };
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(deadlines.at(-1)!.delay).toBe(60 * MINUTE);
+  now += 60 * MINUTE;
+  deadlines.at(-1)!.run();
+  await flushSeatTickNotifications();
+  expect(h.sent).toHaveLength(1);
+  expect(h.journal.at(-1)!.reasons).toContain("interval");
+});
+
+test("busy actionable work is prepared durably and an idle notification drains it immediately", async () => {
+  const { requestSeatTick } = await import("./seatTickSignal");
+  const options: Parameters<typeof harness>[0] = { turn: "busy", seatActivity: { lifecycle: "running", reason: "host_alive_turn_active", turnState: "busy" },
+    tasks: [{ id: "queued-task", status: "assigned" }], state: { ...RECENT, turnIdleSince: null } };
+  const h = harness(options);
+  startSeatTick({ boundary: () => {}, sweep: () => runSeatTickCheck(PROJECT, h.deps) });
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toEqual([]);
+  expect(h.deps.readState!(PROJECT).pendingWork?.text).toContain("queued-task");
+  options.turn = "idle";
+  options.seatActivity = { lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle" };
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toHaveLength(1);
+  expect(h.sent[0]!.policy).toBe("idle-only");
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toHaveLength(1);
+});
+
+test("an actionable board event bypasses the idle timer and cancelled work is refreshed away", async () => {
+  const { requestSeatTick } = await import("./seatTickSignal");
+  const h = harness({ pipelines: OPEN_LANE, tasks: [{ id: "assigned-later", status: "inbox" }], state: { ...RECENT, turnIdleSince: null } });
+  const tasks = h.deps.sources!.tasks();
+  startSeatTick({ boundary: () => {}, sweep: () => runSeatTickCheck(PROJECT, h.deps) });
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toEqual([]);
+  tasks[0]!.status = "assigned";
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.sent).toHaveLength(1);
+  tasks[0]!.status = "done";
+  requestSeatTick({ project: PROJECT });
+  await flushSeatTickNotifications();
+  expect(h.deps.readState!(PROJECT).pendingWork).toBeNull();
+  expect(h.sent).toHaveLength(1);
+});
+
+
+test("only a matching owned runtime boundary arms the durable idle timer across restart", async () => {
+  const { recordSeatTickBoundary } = await import("./seatTickController");
+  const fixture = childFixture("owned-turn-boundary");
+  fixture.seed({ outstandingWake: outstandingWake() });
+  const h = childRig(fixture);
+  const generation = fixture.registry.conversation(fixture.seat.conversationId as never)!.generations.at(-1)!.id;
+    const signal = { project: fixture.project, conversationId: fixture.seat.conversationId,
+      boundary: { generation, turnId: "active-turn", seq: 1, state: "busy" as const, at: new Date(fixture.now).toISOString() } };
+    recordSeatTickBoundary(fixture.project, signal, h.deps.sources, h.deps);
+    expect(fixture.row().turnIdleSince).toBeNull();
+    recordSeatTickBoundary(fixture.project, { ...signal, boundary: { ...signal.boundary, turnId: "old-turn", seq: 2, state: "settled" } }, h.deps.sources, h.deps);
+    expect(fixture.row().turnIdleSince).toBeNull();
+    recordSeatTickBoundary(fixture.project, { ...signal, boundary: { ...signal.boundary, generation: "old-generation", seq: 2, state: "settled" } }, h.deps.sources, h.deps);
+    expect(fixture.row().turnIdleSince).toBeNull();
+    const at = new Date(fixture.now + MINUTE).toISOString();
+    recordSeatTickBoundary(fixture.project, { ...signal, boundary: { ...signal.boundary, seq: 2, state: "settled", at } }, h.deps.sources, h.deps);
+    const restarted = new SeatTickAccounting(`${fixture.stateFile}.sqlite`, fixture.project).readState();
+    expect(restarted.turnIdleSince).toBe(at);
+    expect(restarted.outstandingWake).toEqual(outstandingWake());
+    expect(seatTickStateForEpochForTest(restarted, 8).turnIdleSince).toBeNull();
+    expect(seatTickStateForEpochForTest(restarted, 8).outstandingWake).toEqual(outstandingWake());
+});
+
+
+test("a proven-unsent tick gets a fresh admission key while unknown attempts keep their original key", async () => {
+  const first = harness({ tasks: [{ id: "owed-task", status: "assigned" }], state: { ...RECENT, turnIdleSince: null },
+    delivery: { ok: true, structured: true, target: null, outcome: "queued", operationId: "old-operation" } });
+  await runSeatTickCheck(PROJECT, first.deps);
+  const original = first.written.at(-1)!;
+  const unknown = harness({ tasks: [{ id: "owed-task", status: "assigned" }], state: original, wakeState: "unknown" });
+  await runSeatTickCheck(PROJECT, unknown.deps);
+  expect(unknown.sent).toEqual([]);
+  expect(unknown.written.at(-1)!.outstandingWake?.clientMessageId).toBe(first.sent[0]!.clientMessageId!);
+  const refused = harness({ tasks: [{ id: "owed-task", status: "assigned" }], state: original, wakeState: "dropped" });
+  await runSeatTickCheck(PROJECT, refused.deps);
+  expect(refused.sent).toHaveLength(1);
+  expect(refused.sent[0]!.clientMessageId).not.toBe(first.sent[0]!.clientMessageId!);
+});
+
+
+test("a prose-derived idle projection cannot release work while the owned host is active", async () => {
+  const h = harness({ turn: "idle", tasks: [{ id: "owed-work", status: "assigned" }], state: RECENT });
+  h.deps.sources!.seatRuntime = async () => ({ state: "busy", generation: "native", cursor: 20, turnId: "working-turn" });
+  expect(await runSeatTickCheck(PROJECT, h.deps)).toMatchObject({ verdict: "skipped" });
+  expect(h.sent).toEqual([]);
+  expect(h.deps.readState!(PROJECT).pendingWork?.items).toHaveLength(1);
 });

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -1442,16 +1442,16 @@ test("a seat mid-turn is skipped without a send and without consuming the event 
 });
 
 // Recovery of an open turn belongs to its owner; a tick cannot force completion.
-test("a busy seat stays protected when its host is reported stalled", async () => {
+test("a dead open seat reaches recovery without an interrupt policy", async () => {
   const rig = harness({
     turn: "busy",
-    seatActivity: { lifecycle: "stalled", reason: "host_gone_turn_open" },
+    seatActivity: { lifecycle: "stalled", reason: "host_gone_turn_open", turnState: "busy" },
     pipelines: OPEN_LANE,
     state: OVERDUE,
   });
   const record = await runSeatTickCheck(PROJECT, rig.deps);
-  expect(record!.verdict).toBe("skipped");
-  expect(rig.sent).toHaveLength(0);
+  expect(record!.verdict).toBe("wake");
+  expect(rig.sent).toHaveLength(1);
 });
 
 test("open work with nobody seated raises the orchestrator card and wakes nothing", async () => {
@@ -3296,4 +3296,16 @@ test("rotation during recovery liveness prevents predecessor redispatch", async 
   await runSeatTickCheck(fixture.project, next.deps);
   expect(next.sent).toEqual([]);
   expect(fixture.acknowledged()).toEqual([]);
+});
+
+
+for (const activity of [
+  { lifecycle: "stalled" as const, reason: "host_gone_turn_open" as const, turnState: "busy" as const },
+  { lifecycle: "waiting" as const, reason: "host_alive_turn_idle" as const, turnState: "idle" as const },
+]) test(`owed work reaches fenced recovery for ${activity.reason}`, async () => {
+  const h = harness({ turn: "busy", seatActivity: activity, tasks: [{ id: "owed-task", status: "assigned" }], state: OVERDUE });
+  const record = await runSeatTickCheck(PROJECT, h.deps);
+  expect(record?.verdict).toBe("wake");
+  expect(h.sent).toHaveLength(1);
+  expect(h.sent[0]!.policy).toBe("idle-only");
 });

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -245,9 +245,9 @@ function harness(options: {
         livenessReads.push({ ...(request.project ? { project: request.project } : {}), ...(request.conversationId ? { conversationId: request.conversationId } : {}) });
         const child = request.conversationId ? options.childActivity?.[request.conversationId] : undefined;
         if (child) return [{ conversationId: request.conversationId, lifecycle: "running", reason: "host_alive_turn_active", turnState: "busy", ...child } as AgentLivenessRecord];
-        return request.conversationId && options.seatActivity
-          ? [{ lifecycle: "running", reason: "host_alive_turn_active", ...options.seatActivity } as AgentLivenessRecord]
-          : [];
+        if (!request.conversationId) return [];
+        if (options.seatActivity === null) return [];
+        return [{ conversationId: request.conversationId, lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle", ...options.seatActivity } as AgentLivenessRecord];
       },
       lifecycleJournal: () => ({ version: 1, lastSeq: options.events?.at(-1)?.seq ?? 0, events: options.events ?? [], retired: [] }),
       latestDeployment: () => ({ state: "unreadable", error: "no ledger" }) as never,
@@ -1441,9 +1441,8 @@ test("a seat mid-turn is skipped without a send and without consuming the event 
   expect(rig.sent).toEqual([]);
 });
 
-/* And the seat whose own host died under an open turn: the registry still says
-   `busy`, so the rule this replaces would have dropped every tick forever. */
-test("a busy seat the registry reports stalled is woken, which is what resumes its host", async () => {
+// Recovery of an open turn belongs to its owner; a tick cannot force completion.
+test("a busy seat stays protected when its host is reported stalled", async () => {
   const rig = harness({
     turn: "busy",
     seatActivity: { lifecycle: "stalled", reason: "host_gone_turn_open" },
@@ -1451,8 +1450,8 @@ test("a busy seat the registry reports stalled is woken, which is what resumes i
     state: OVERDUE,
   });
   const record = await runSeatTickCheck(PROJECT, rig.deps);
-  expect(record!.verdict).toBe("wake");
-  expect(rig.sent).toHaveLength(1);
+  expect(record!.verdict).toBe("skipped");
+  expect(rig.sent).toHaveLength(0);
 });
 
 test("open work with nobody seated raises the orchestrator card and wakes nothing", async () => {
@@ -1815,6 +1814,8 @@ function childFixture(name: string, gitRepository = false, sqliteMode: "sqlite" 
   const registry = new AgentRegistry(path.join(dir, "agent-registry.json"), () => false, undefined, { sqliteMode, onSqliteRowPayloadRead: onRead });
   const seatPath = path.join(dir, `${crypto.randomUUID()}.jsonl`);
   const seatConversation = registry.ensureConversation("claude", seatPath, null);
+  registry.reconcileConversations([{ engine: "claude", path: seatPath, accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd }), turn: { state: "idle", source: "assistant", terminalAt: new Date().toISOString() }, observedAt: new Date().toISOString() }]);
   const project = projectForCwd(cwd);
   if (!project) throw new Error("fixture cwd resolves to no project");
   const now = Date.now() + 3 * MINUTE;
@@ -1917,7 +1918,7 @@ test("a running spawned child with no lane is open work, and the interval wake n
   /* A live turn the liveness plane calls running is not a stall, however long
      it has been open. */
   expect(rig.cards).toEqual([]);
-  expect(rig.liveness).toEqual([{ conversationId: child.id }]);
+  expect(rig.liveness).toEqual([{ conversationId: fixture.seat.conversationId }, { conversationId: child.id }]);
 });
 
 test("a finished child is harvested by exactly one wake, across ticks, a fresh controller and a rotation (#1465)", async () => {
@@ -1964,7 +1965,7 @@ test("a child whose host was released after a settled turn is finished, and harv
   expect(rig.sent[0]!.text).toContain(`[child] ${child.id}`);
   expect(fixture.acknowledged()).toEqual([child.id]);
   /* No liveness read for a turn the registry says has settled. */
-  expect(rig.liveness).toEqual([]);
+  expect(rig.liveness).toEqual([{ conversationId: fixture.seat.conversationId }]);
 });
 
 test("a launch that failed before it ran is a terminal child with a failed outcome, harvested once (#1465)", async () => {
@@ -2502,7 +2503,7 @@ test("cross-project, pipeline-owned, engine-native and unrelated conversations a
   const record = await runSeatTickCheck(fixture.project, rig.deps);
   expect(record).toMatchObject({ verdict: "quiet", detail: "the board is done and the proposal slot is not due" });
   expect(rig.sent).toEqual([]);
-  expect(rig.liveness).toEqual([]);
+  expect(rig.liveness).toEqual([{ conversationId: fixture.seat.conversationId }]);
 });
 
 test("a child the registry cannot place is unknown: not open work, not harvested, and said so (#1465)", async () => {
@@ -2547,7 +2548,7 @@ test("a busy child whose host is gone is a stall the registry can see, reported 
   const record = await runSeatTickCheck(fixture.project, first.deps);
   /* Open work, so the interval wakes; the stall waits for its second check. */
   expect(record).toMatchObject({ verdict: "wake", reasons: ["interval"] });
-  expect(first.liveness).toEqual([]);
+  expect(first.liveness).toEqual([{ conversationId: fixture.seat.conversationId }]);
   expect(fixture.row().stalledSeen).toEqual([`child:${child.id}`]);
   const second = childRig(fixture, { now: fixture.now + 61 * MINUTE });
   const stalled = await runSeatTickCheck(fixture.project, second.deps);
@@ -2569,7 +2570,7 @@ test("the projection uses bounded keyed registry reads and targeted liveness wit
   expect(rig.snapshots).toBe(0);
   /* Liveness is asked by id, for the one child whose turn is open, and never
      project-wide: there is no lane to sweep for. */
-  expect(rig.liveness).toEqual([{ conversationId: busy.id }]);
+  expect(rig.liveness).toEqual([{ conversationId: fixture.seat.conversationId }, { conversationId: busy.id }]);
   expect(rig.liveness.some((read) => read.project)).toBe(false);
   /* The fixture wrote no transcript; nothing here could have read one. */
   expect(fs.existsSync(busy.path)).toBe(false);
@@ -2715,6 +2716,8 @@ test("first tick after rotation discovers predecessor children from committed re
   const abandoned = fixture.registry.ensureConversation("claude", path.join(fixture.dir, `${crypto.randomUUID()}.jsonl`), null);
   fixture.spawn({ title: "abandoned pending seat worker", turn: "terminal", parent: abandoned.id });
   const successor = fixture.registry.ensureConversation("claude", path.join(fixture.dir, `${crypto.randomUUID()}.jsonl`), null);
+  fixture.registry.reconcileConversations([{ engine: "claude", path: successor.generations[0]!.path!, accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: fixture.cwd }), turn: { state: "idle", source: "assistant", terminalAt: new Date().toISOString() }, observedAt: new Date().toISOString() }]);
   fixture.seed();
   const file = statePath("orchestrator-seats.json");
   const before = fs.existsSync(file) ? fs.readFileSync(file) : null;
@@ -2908,22 +2911,22 @@ test("a stall on the twelfth of twelve running children is reported within two s
 
   const first = childRig(fixture, { childActivity: activity });
   expect(await runSeatTickCheck(fixture.project, first.deps)).toMatchObject({ verdict: "wake", reasons: ["interval"] });
-  expect(first.liveness.map((read) => read.conversationId)).toEqual(ids.slice(0, 8));
+  expect(first.liveness.filter((read) => read.conversationId !== fixture.seat.conversationId).map((read) => read.conversationId)).toEqual(ids.slice(0, 8));
   expect(fixture.row().stalledSeen).toEqual([]);
 
   const second = childRig(fixture, { childActivity: activity, now: fixture.now + 61 * MINUTE });
   expect(await runSeatTickCheck(fixture.project, second.deps)).toMatchObject({ verdict: "wake", reasons: ["interval"] });
-  expect(second.liveness.map((read) => read.conversationId)).toEqual(ids.slice(4, 12));
+  expect(second.liveness.filter((read) => read.conversationId !== fixture.seat.conversationId).map((read) => read.conversationId)).toEqual(ids.slice(4, 12));
   expect(fixture.row().stalledSeen).toEqual([`child:${twelfth.id}`]);
 
   const third = childRig(fixture, { childActivity: activity, now: fixture.now + 122 * MINUTE });
   const stalled = await runSeatTickCheck(fixture.project, third.deps);
-  expect(third.liveness.map((read) => read.conversationId)).toEqual([...ids.slice(8, 12), ...ids.slice(0, 4)]);
+  expect(third.liveness.filter((read) => read.conversationId !== fixture.seat.conversationId).map((read) => read.conversationId)).toEqual([...ids.slice(8, 12), ...ids.slice(0, 4)]);
   expect(stalled).toMatchObject({ verdict: "wake", reasons: ["stalled"] });
   expect(stalled!.detail).toContain(`child ${twelfth.id} runs a turn the registry reports stalled (host_alive_transcript_silent)`);
   expect(third.sent[0]!.text).toContain(`[child] ${twelfth.id}`);
-  /* Every check observed a bounded window and asked liveness for it alone. */
-  for (const rig of [first, second, third]) expect(rig.liveness).toHaveLength(8);
+  /* Every check reads the seat and a bounded window of eight children. */
+  for (const rig of [first, second, third]) expect(rig.liveness).toHaveLength(9);
 });
 
 /* A registry without an indexed lineage projection reads the seat and names
@@ -2994,6 +2997,8 @@ test("a returned 409 or 503 refusal is fenced across rotation and the successor 
     expect(original.operationId).toBeNull();
     expect(await resolveOriginalSend({ conversationId: original.conversationId, clientMessageId: original.clientMessageId }, { registry: fixture.registry, client: null })).toEqual({ kind: "absent" });
     const successor = fixture.registry.ensureConversation("claude", path.join(fixture.dir, `${crypto.randomUUID()}.jsonl`), null);
+    fixture.registry.reconcileConversations([{ engine: "claude", path: successor.generations[0]!.path!, accountId: null,
+      launchProfile: emptyLaunchProfile({ cwd: fixture.cwd }), turn: { state: "idle", source: "assistant", terminalAt: new Date().toISOString() }, observedAt: new Date().toISOString() }]);
     const seat = { conversationId: successor.id, seatEpoch: 8, path: successor.generations[0]!.path };
     const next = childRig(fixture, { realWakeState: true, seat, now: fixture.now + 5 * MINUTE, deliverWith: async (message) => {
       expect(fixture.acknowledged()).toEqual([]);
@@ -3037,6 +3042,8 @@ test("a paused old lookup cannot dispatch after a successor replaces the refused
   } } });
   await waiting;
   const successor = fixture.registry.ensureConversation("claude", path.join(fixture.dir, `${crypto.randomUUID()}.jsonl`), null);
+  fixture.registry.reconcileConversations([{ engine: "claude", path: successor.generations[0]!.path!, accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: fixture.cwd }), turn: { state: "idle", source: "assistant", terminalAt: new Date().toISOString() }, observedAt: new Date().toISOString() }]);
   const next = childRig(fixture, { realWakeState: true, seat: { conversationId: successor.id, seatEpoch: 8, path: null }, now: fixture.now + 6 * MINUTE });
   await runSeatTickCheck(fixture.project, next.deps);
   expect(next.sent).toHaveLength(1);
@@ -3227,3 +3234,47 @@ test("new-child discovery runs during historical bootstrap and keeps every older
   const completedOwner = accounting.page("owner", 1)[0]!;
   expect(completedOwner.kind === "owner" && completedOwner.bootstrap).toBeUndefined();
 }, 30_000);
+
+// September idle-only directive: silence and absent lifecycle evidence do not end a turn.
+for (const activity of [null, { lifecycle: "stalled" as const, turnState: "busy" as const }, { lifecycle: "gone" as const, turnState: "busy" as const }]) {
+  test(`idle-only tick preserves an open turn with ${activity?.lifecycle ?? "missing"} evidence`, async () => {
+    const h = harness({ turn: "busy", seatActivity: activity, tasks: [{ id: "actionable-task", status: "assigned" }], state: OVERDUE });
+    const record = await runSeatTickCheck(PROJECT, h.deps);
+    expect(h.sent).toHaveLength(0);
+    expect(record?.verdict).toBe("skipped");
+    expect(h.written.at(-1)?.lastWakeAt).toBe(OVERDUE.lastWakeAt);
+  });
+}
+
+
+test("resumed work under a completed pipeline defers an actionable event until settlement", async () => {
+  const first = harness({ turn: "idle", seatActivity: { lifecycle: "running", turnState: "busy", reason: "host_alive_turn_active" },
+    pipelines: [{ id: "old-pipeline", state: "completed", createdAt: new Date(NOW - 60 * MINUTE).toISOString(), movedAt: null }],
+    tasks: [{ id: "new-obligation", status: "assigned" }], events: [terminalEvent(44)], state: { ...OVERDUE, eventsThrough: 12 } });
+  expect(await runSeatTickCheck(PROJECT, first.deps)).toMatchObject({ verdict: "skipped", eventsThrough: 12 });
+  expect(first.sent).toEqual([]);
+  const settled = harness({ tasks: [{ id: "new-obligation", status: "assigned" }], events: [terminalEvent(44)], state: first.written.at(-1) });
+  expect(await runSeatTickCheck(PROJECT, settled.deps)).toMatchObject({ verdict: "wake" });
+  expect(settled.sent).toHaveLength(1);
+  expect(settled.sent[0]!.policy).toBe("idle-only");
+});
+
+test("an unreadable idle-seat activity check generates no routine input", async () => {
+  const h = harness({ turn: "idle", seatActivity: null, tasks: [{ id: "new-obligation", status: "assigned" }], state: OVERDUE });
+  expect(await runSeatTickCheck(PROJECT, h.deps)).toMatchObject({ verdict: "skipped" });
+  expect(h.sent).toEqual([]);
+});
+
+
+test("original-key reconciliation does not redispatch a refused tick while the seat works", async () => {
+  const fixture = childFixture("busy-original-key");
+  setAgentRegistryForTests(fixture.registry);
+  fixture.spawn({ title: "owed worker", turn: "terminal" });
+  fixture.seed();
+  await runSeatTickCheck(fixture.project, childRig(fixture, { realWakeState: true, deliverWith: refuseBeforeReservation(503) }).deps);
+  expect(fixture.row().outstandingWake).not.toBeNull();
+  const busy = childRig(fixture, { realWakeState: true, seatActivity: { lifecycle: "running", turnState: "busy", reason: "host_alive_turn_active" }, now: fixture.now + 5 * MINUTE });
+  await runSeatTickCheck(fixture.project, busy.deps);
+  expect(busy.sent).toEqual([]);
+  expect(fixture.acknowledged()).toEqual([]);
+});

--- a/src/lib/monitor/seatTickController.test.ts
+++ b/src/lib/monitor/seatTickController.test.ts
@@ -3278,3 +3278,22 @@ test("original-key reconciliation does not redispatch a refused tick while the s
   expect(busy.sent).toEqual([]);
   expect(fixture.acknowledged()).toEqual([]);
 });
+
+
+test("rotation during recovery liveness prevents predecessor redispatch", async () => {
+  const fixture = childFixture("recovery-liveness-rotation");
+  setAgentRegistryForTests(fixture.registry);
+  fixture.spawn({ title: "owed worker", turn: "terminal" });
+  fixture.seed();
+  await runSeatTickCheck(fixture.project, childRig(fixture, { realWakeState: true, deliverWith: refuseBeforeReservation(503) }).deps);
+  const next = childRig(fixture, { realWakeState: true, now: fixture.now + 5 * MINUTE });
+  const liveness = next.deps.sources!.liveness;
+  next.deps.sources!.liveness = async (request) => {
+    const rows = await liveness(request);
+    next.seat = null;
+    return rows;
+  };
+  await runSeatTickCheck(fixture.project, next.deps);
+  expect(next.sent).toEqual([]);
+  expect(fixture.acknowledged()).toEqual([]);
+});

--- a/src/lib/monitor/seatTickController.ts
+++ b/src/lib/monitor/seatTickController.ts
@@ -21,7 +21,7 @@ import { openIssuesForProposal, type ProposalIssue } from "./githubEvidence";
 import { appendSeatTickRecord } from "./journalStore";
 import { redactBounded, redactMonitorText } from "./redact";
 import { seatTickProposalMessage, seatTickWakeMessage } from "./report";
-import { SEAT_TICK_WAKE_INTERVAL_MS, seatTickDecision, seatTickPolicy, seatTickWakeCommit, seatTickWakeCommitPlan } from "./seatTick";
+import { DEFAULT_SEAT_TICK_POLICY, SEAT_TICK_WAKE_INTERVAL_MS, seatTurnProgressing, seatTickDecision, seatTickPolicy, seatTickWakeCommit, seatTickWakeCommitPlan } from "./seatTick";
 import { effectiveSeatTickSettings, seatTickSettingsAfterLapse, writeSeatTickSettings } from "./seatTickSettings";
 import { readSeatTickState, seatTickStateForEpoch, writeSeatTickState } from "./seatTickState";
 import {
@@ -29,6 +29,7 @@ import {
   gatherSeatTickInput,
   repoDirForProject,
   seatTickProjects,
+  seatInput,
   type SeatTickSources,
   type SeatTickWakeState,
 } from "./seatTickSources";
@@ -289,7 +290,7 @@ function deliveryOutcomeLabel(outcome: DeliveryOutcome): string {
 }
 
 function verdictDetail(verdict: SeatTickVerdict): string | null {
-  if (verdict.kind === "skipped") return "the seat's turn is progressing; the tick is dropped, never queued";
+  if (verdict.kind === "skipped") return "the seat is busy or idle is unproven; this tick is skipped and obligations remain owed";
   if (verdict.kind === "wake") {
     /* The gap is journaled beside the reasons, not in place of them (#1298):
        a wake that went out over an unreadable source has to be readable back
@@ -486,6 +487,13 @@ async function reconcileOutstandingWake(context: {
     if (!authority || authority.conversationId !== wake.conversationId || authority.seatEpoch !== wake.seatEpoch) return state;
     const accounting = state.accounting ? new SeatTickAccounting(state.accounting.filename, context.project) : null;
     if (!accounting) return state;
+    // Reconciliation runs before the ordinary pre-check. It must not send into
+    // active work either; only a proven pre-reservation refusal can be cleared.
+    const currentTurn = await seatInput(context.project, DEFAULT_SEAT_TICK_POLICY, context.sources);
+    if (!currentTurn || seatTurnProgressing(currentTurn)) {
+      if (wake.dispatch?.state === "refused") accounting.settleAbsent(wake);
+      return accounting.readState();
+    }
     const token = accounting.beginDispatch(wake);
     state = accounting.readState();
     if (!token) return state;
@@ -493,7 +501,7 @@ async function reconcileOutstandingWake(context: {
     let outcome: DeliveryOutcome | null = null;
     try {
       outcome = await context.deliver({ pid: null, path: authority.path ?? context.seat?.path ?? "", conversationId: wake.conversationId,
-        clientMessageId: wake.clientMessageId, text: wake.text!, images: [], origin: { kind: "agent", role: "seat-tick" } });
+        clientMessageId: wake.clientMessageId, text: wake.text!, images: [], policy: "idle-only", origin: { kind: "agent", role: "seat-tick" } });
       redispatched = deliveryOutcomeLabel(outcome);
     } catch {
       redispatched = "unreturned";
@@ -794,7 +802,7 @@ async function check(
           try {
             if (accounting && !token) throw new Error("wake dispatch already claimed");
             outcome = await deliver({ pid: null, path: authority.path ?? input.seat.path ?? "", conversationId: authority.conversationId,
-              clientMessageId, text, images: [], origin: { kind: "agent", role: "seat-tick" } });
+              clientMessageId, text, images: [], policy: "idle-only", origin: { kind: "agent", role: "seat-tick" } });
             delivery = { clientMessageId, outcome: deliveryOutcomeLabel(outcome) };
           } catch {
             delivery = { clientMessageId, outcome: "unreturned" };

--- a/src/lib/monitor/seatTickController.ts
+++ b/src/lib/monitor/seatTickController.ts
@@ -1,3 +1,4 @@
+import { registerSeatTickKick, type SeatTickSignal } from "./seatTickSignal";
 import crypto from "node:crypto";
 import { SeatTickAccounting } from "./seatTickAccounting";
 
@@ -74,9 +75,8 @@ import type {
  *   waiting, delivered after all, or settled unsent. That one question answers
  *   both halves of the tick's accounting — when a stamp may move, and what a
  *   revocation has to reach — so the two cannot drift apart.
- * - It queued its fires and then double-fired into a finished turn. Here a seat
- *   whose turn is genuinely progressing is skipped and the tick is dropped;
- *   nothing is ever held.
+ * - Busy seats retain refreshable actionable work without input. A matching
+ *   idle boundary drains that work or starts the configured idle countdown.
  * - Its empty log was equally consistent with perfect operation and with total
  *   failure. Here every check leaves a line, including a check that threw.
  */
@@ -324,13 +324,14 @@ function wakeClientMessageId(
   project: string,
   seatEpoch: number,
   verdict: SeatTickVerdict,
-  context: { fingerprint: string; lastWakeAt: string | null; monitorPrompt: string | null },
+  context: { fingerprint: string; lastWakeAt: string | null; monitorPrompt: string | null; attempt?: number },
 ): string {
   const shape = verdict.kind === "wake"
     ? verdict.reasons.map((reason) => reason.kind).sort().join(",")
     : "proposal";
   return `seat-tick:${project}:${seatEpoch}:${context.lastWakeAt ?? "first"}:${shape}:${context.fingerprint}`
-    + wakePromptIdentity(context.monitorPrompt);
+    + wakePromptIdentity(context.monitorPrompt)
+    + (context.attempt ? `:attempt-${context.attempt}` : "");
 }
 
 /**
@@ -555,7 +556,7 @@ async function reconcileOutstandingWake(context: {
   const next: SeatTickProjectState = settlement.row === "commit"
     ? seatTickWakeCommit(state, wake.commit, context.now)
     : settlement.row === "clear"
-      ? { ...state, outstandingWake: null }
+      ? { ...state, outstandingWake: null, wakeAttempt: (state.wakeAttempt ?? 0) + 1 }
       : state;
 
   context.appendRecord({
@@ -681,6 +682,10 @@ async function check(
   }
 
   let state = decision.state;
+  if (state.pendingWork) state.pendingWork = { ...state.pendingWork, text: seatTickWakeMessage({
+    project: input.project, reasons: state.pendingWork.reasons, items: state.pendingWork.items,
+    deferred: state.pendingWork.deferred, signals: input.signals, monitorPrompt: input.settings.monitorPrompt,
+  }) };
   for (const card of decision.cards) {
     let carded = false;
     try {
@@ -707,6 +712,7 @@ async function check(
   if ((verdict.kind === "wake" || verdict.kind === "proactive") && input.seat) {
     const clientMessageId = wakeClientMessageId(input.project, input.seat.seatEpoch, verdict, {
       fingerprint: input.changeFingerprint,
+      attempt: input.state.wakeAttempt,
       lastWakeAt: input.state.lastWakeAt,
       /* The same row the message below reads its prompt from, read once: the
          identity and the text have to move together or they are exactly the
@@ -761,6 +767,7 @@ async function check(
     const commit = seatTickWakeCommitPlan(verdict, {
       fingerprint: input.changeFingerprint,
       eventsThrough: input.events.at(-1)?.seq ?? state.eventsThrough ?? 0,
+      unreadEvents: input.events,
       terminalChildren,
     });
     if (rotated) {
@@ -841,6 +848,11 @@ async function check(
   }
 
   writeState(input.project, state);
+  const persisted = readState(input.project);
+  const since = persisted.turnIdleSince ? Date.parse(persisted.turnIdleSince) : NaN;
+  tickHost.__llvSeatTickDeadline?.(input.project,
+    input.settings.enabled && !persisted.pendingWork && !persisted.outstandingWake && Number.isFinite(since)
+      ? since + input.settings.wakeIntervalMs : null);
   const record: SeatTickRunRecord = {
     schemaVersion: 1,
     at,
@@ -951,9 +963,27 @@ export async function reconcileSeatTick(dependencies: SeatTickControllerDependen
   return records;
 }
 
+/** Runtime notifications can change timing only for the current seat generation. */
+export function recordSeatTickBoundary(project: string, signal: SeatTickSignal, sources = defaultSeatTickSources(),
+  ports: Pick<SeatTickControllerDependencies, "readState" | "writeState"> = {}): void {
+  if (!signal.boundary || !signal.conversationId) return;
+  const seat = sources.seatFor(project).active;
+  if (!seat || seat.conversationId !== signal.conversationId) return;
+  const conversation = sources.registry().conversation(seat.conversationId as never);
+  if (conversation?.generations.at(-1)?.id !== signal.boundary.generation) return;
+  const state = seatTickStateForEpoch((ports.readState ?? readSeatTickState)(project), seat.seatEpoch);
+  const previous = state.turnBoundary;
+  const next = signal.boundary;
+  if (previous?.generation === next.generation && previous.seq >= next.seq) return;
+  if (next.state === "settled" && (previous?.generation !== next.generation || previous.turnId !== next.turnId)) return;
+  (ports.writeState ?? writeSeatTickState)(project, { ...state, turnBoundary: next, turnIdleSince: next.state === "settled" ? next.at : null });
+}
+
 const tickHost = globalThis as typeof globalThis & {
   __llvSeatTickTimer?: ReturnType<typeof setInterval>;
   __llvSeatTickRunning?: boolean;
+  __llvSeatTickDeadline?: (project: string, deadline: number | null) => void;
+  __llvSeatTickCleanup?: () => void;
 };
 
 /**
@@ -976,7 +1006,10 @@ const tickHost = globalThis as typeof globalThis & {
  */
 export function startSeatTick(ports: {
   scheduleInterval?: (callback: () => void, delayMs: number) => ReturnType<typeof setInterval>;
-  sweep?: () => Promise<unknown>;
+  sweep?: (project?: string) => Promise<unknown>;
+  scheduleDeadline?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  now?: () => number;
+  boundary?: (project: string, signal: SeatTickSignal) => void;
   policy?: SeatTickPolicy | null;
   log?: (line: string) => void;
   appendRecord?: typeof appendSeatTickRecord;
@@ -1011,17 +1044,75 @@ export function startSeatTick(ports: {
     return false;
   }
   const schedule = ports.scheduleInterval ?? ((callback, delayMs) => setInterval(callback, delayMs));
-  const sweep = ports.sweep ?? (() => reconcileSeatTick());
+  const sweep = ports.sweep ?? (async (project?: string) => {
+    if (!project) return reconcileSeatTick();
+    if (await releaseOwnsTraffic()) return runSeatTickCheck(project);
+  });
+  const now = ports.now ?? Date.now;
+  const scheduleDeadline = ports.scheduleDeadline ?? ((callback, delay) => setTimeout(callback, delay));
+  const pending = new Set<string>();
+  const deadlines = new Map<string, number>();
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  let scheduled = false;
+  let stopped = false;
+  const request = (project?: string) => {
+    if (stopped) return;
+    pending.add(project ?? "");
+    if (scheduled || tickHost.__llvSeatTickRunning) return;
+    scheduled = true;
+    queueMicrotask(() => {
+      scheduled = false;
+      if (stopped || tickHost.__llvSeatTickRunning) return;
+      const project = pending.has("") ? "" : pending.values().next().value;
+      if (project === undefined) return;
+      if (project === "") pending.clear(); else pending.delete(project);
+      tickHost.__llvSeatTickRunning = true;
+      void Promise.resolve(sweep(project || undefined))
+        .catch((error) => console.error("[seat tick] requested check failed", error instanceof Error ? error.name : "unknown"))
+        .finally(() => {
+          if (stopped) return;
+          tickHost.__llvSeatTickRunning = false;
+          if (pending.size) request(pending.values().next().value || undefined);
+        });
+    });
+  };
+  const arm = () => {
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+    deadlineTimer = null;
+    if (stopped || deadlines.size === 0) return;
+    const deadline = Math.min(...deadlines.values());
+    deadlineTimer = scheduleDeadline(() => {
+      deadlineTimer = null;
+      for (const [project, due] of deadlines) if (due <= now()) { deadlines.delete(project); request(project); }
+      arm();
+    }, Math.max(1, deadline - now()));
+    deadlineTimer.unref?.();
+  };
+  tickHost.__llvSeatTickDeadline = (project, deadline) => {
+    if (deadline !== null && deadline > now()) deadlines.set(project, deadline);
+    else deadlines.delete(project);
+    arm();
+  };
+  registerSeatTickKick((signal) => {
+    if (signal.project) {
+      (ports.boundary ?? recordSeatTickBoundary)(signal.project, signal);
+      if (signal.boundary?.state === "busy") tickHost.__llvSeatTickDeadline?.(signal.project, null);
+      request(signal.project);
+    } else request();
+  });
+  tickHost.__llvSeatTickCleanup = () => {
+    stopped = true;
+    registerSeatTickKick(null);
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+    deadlines.clear();
+    pending.clear();
+    tickHost.__llvSeatTickDeadline = undefined;
+  };
   const timer = schedule(() => {
-    /* A check that outran its interval drops the next one rather than stacking
-       it. A tick that would land behind the one before it is stale by
-       construction, and staleness is the whole reason nothing is queued. */
-    if (tickHost.__llvSeatTickRunning) return;
-    tickHost.__llvSeatTickRunning = true;
-    void Promise.resolve(sweep())
-      .catch((error) => console.error("[seat tick] sweep failed", error instanceof Error ? error.name : "unknown"))
-      .finally(() => { tickHost.__llvSeatTickRunning = false; });
+    if (!tickHost.__llvSeatTickRunning) request();
   }, policy.checkIntervalMs);
+  // Recover durable pending work and countdowns on boot through this same controller.
+  if (!ports.sweep) request();
   timer.unref?.();
   tickHost.__llvSeatTickTimer = timer;
   return true;
@@ -1030,6 +1121,8 @@ export function startSeatTick(ports: {
 /** Test seam: the timer is process-global, so a suite must be able to start
     from an unstarted one without reaching into module internals. */
 export function stopSeatTick(): void {
+  tickHost.__llvSeatTickCleanup?.();
+  tickHost.__llvSeatTickCleanup = undefined;
   const timer = tickHost.__llvSeatTickTimer;
   if (timer) clearInterval(timer);
   tickHost.__llvSeatTickTimer = undefined;

--- a/src/lib/monitor/seatTickController.ts
+++ b/src/lib/monitor/seatTickController.ts
@@ -494,6 +494,8 @@ async function reconcileOutstandingWake(context: {
       if (wake.dispatch?.state === "refused") accounting.settleAbsent(wake);
       return accounting.readState();
     }
+    const freshAuthority = context.sources.seatFor(context.project).active;
+    if (!freshAuthority || freshAuthority.conversationId !== wake.conversationId || freshAuthority.seatEpoch !== wake.seatEpoch) return state;
     const token = accounting.beginDispatch(wake);
     state = accounting.readState();
     if (!token) return state;

--- a/src/lib/monitor/seatTickSignal.test.ts
+++ b/src/lib/monitor/seatTickSignal.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { registerSeatTickKick, type SeatTickSignal } from "./seatTickSignal";
+import { appendLifecycleEvents } from "@/lib/lifecycle/journal";
+import { loadTasks, saveTasks } from "@/lib/tasks/store";
+import type { BoardTask } from "@/lib/tasks/types";
+
+afterEach(() => registerSeatTickKick(null));
+
+test("committed board changes kick the existing controller; unchanged saves do not", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "tick-board-notify-"));
+  const file = path.join(directory, "tasks.json");
+  const signals: SeatTickSignal[] = [];
+  registerSeatTickKick((signal) => {
+    expect(loadTasks(file)).toHaveLength(1);
+    signals.push(signal);
+  });
+  const task: BoardTask = { id: "pending-task", project: "fixture-project", status: "assigned", text: "work",
+    placement: "unplaced", assignments: [], createdAt: "2026-09-08T09:21:00.000Z", updatedAt: "2026-09-08T09:21:00.000Z" };
+  try {
+    saveTasks([task], file);
+    saveTasks(loadTasks(file), file);
+    expect(signals).toEqual([{ project: "fixture-project" }]);
+    saveTasks([{ ...task, status: "done" }], file);
+    expect(signals).toHaveLength(2);
+  } finally { fs.rmSync(directory, { recursive: true, force: true }); }
+});
+
+test("a committed lifecycle event kicks once and an idempotent replay does not", () => {
+  const signals: SeatTickSignal[] = [];
+  registerSeatTickKick((signal) => signals.push(signal));
+  const event = { key: `fixture-${crypto.randomUUID()}`, type: "review_verdict" as const,
+    at: "2026-09-08T09:21:00.000Z", project: "fixture-project", summary: "review finished" };
+  appendLifecycleEvents([event]);
+  appendLifecycleEvents([event]);
+  expect(signals).toEqual([{ project: "fixture-project" }]);
+});

--- a/src/lib/monitor/seatTickSignal.ts
+++ b/src/lib/monitor/seatTickSignal.ts
@@ -1,0 +1,14 @@
+/** A notification only: the existing seat tick controller owns all scheduling. */
+export interface SeatTickSignal {
+  project?: string | null;
+  conversationId?: string;
+  boundary?: { generation: string; turnId: string; seq: number; state: "busy" | "settled"; at: string };
+}
+const signals = process as typeof process & { __llvSeatTickKick?: ((signal: SeatTickSignal) => void) | null };
+export function registerSeatTickKick(callback: ((signal: SeatTickSignal) => void) | null): void {
+  signals.__llvSeatTickKick = callback;
+}
+export function requestSeatTick(signal: SeatTickSignal): void {
+  try { signals.__llvSeatTickKick?.(signal); }
+  catch (error) { console.error("[seat tick] notification failed", error instanceof Error ? error.name : "unknown"); }
+}

--- a/src/lib/monitor/seatTickSources.test.ts
+++ b/src/lib/monitor/seatTickSources.test.ts
@@ -194,7 +194,7 @@ function sources(over: {
       if (over.livenessThrows) throw new Error("the liveness plane is unavailable");
       const childRow = request.conversationId ? over.childRows?.[request.conversationId] : undefined;
       if (childRow) return [childRow];
-      return request.conversationId ? over.seatRows ?? [] : over.laneRows ?? [];
+      return request.conversationId ? over.seatRows ?? [livenessRow({ conversationId: request.conversationId, lifecycle: "waiting", reason: "host_alive_turn_idle", turnState: "idle" })] : over.laneRows ?? [];
     },
     lifecycleJournal: () => journal(over.events ?? []),
     latestDeployment: () => over.latestDeployment ?? ({ state: "unreadable", error: "no ledger" }) as never,
@@ -246,14 +246,12 @@ test("the tick's stall threshold is what the liveness read is asked for", async 
   ]);
 });
 
-/* A settled turn is never skipped and never signalled, so nothing reads its
-   verdict — and a transcript tail per project per five minutes is not a read
-   worth taking for an answer nobody consults. */
-test("a seat whose turn has settled is not asked for a verdict at all", async () => {
+// Registry idle can lag a newly resumed turn; always cross-check current activity.
+test("a registry-idle seat is checked for a newer active turn", async () => {
   const calls: { project?: string; conversationId?: string; stallAfterMs: number }[] = [];
   const input = await gather({ laneRows: [livenessRow()], livenessCalls: calls });
-  expect(calls.some((call) => call.conversationId)).toBe(false);
-  expect(input.seat!.activity).toBeNull();
+  expect(calls.some((call) => call.conversationId)).toBe(true);
+  expect(input.seat!.activity).toMatchObject({ turnState: "idle" });
 });
 
 test("a lane the liveness plane says nothing about carries no verdict, and is therefore never stalled", async () => {

--- a/src/lib/monitor/seatTickSources.test.ts
+++ b/src/lib/monitor/seatTickSources.test.ts
@@ -536,7 +536,8 @@ test("moving a stale card moves the fingerprint, so the retry guard cannot outli
 
   /* And it is the movement that released it, not the guard having lapsed: the
      same guard against the state this check actually read still holds. */
-  const held = seatTickDecision({ ...moved, state: { ...moved.state, ...spent, lastWakeFingerprint: moved.changeFingerprint } });
+  const held = seatTickDecision({ ...moved, state: { ...moved.state, ...spent, turnIdleSince: new Date(NOW - 61 * 60_000).toISOString(),
+    lastActionableKeys: released.verdict.kind === "wake" ? released.verdict.actionableKeys : [], lastWakeFingerprint: moved.changeFingerprint } });
   expect(reasonsOf(held)).toEqual([]);
   expect(held.cards.map((card) => card.kind)).toEqual(["retry-guard"]);
 });
@@ -679,27 +680,27 @@ test("a hidden lane leaves no pull request behind it", async () => {
 });
 
 /* The read is a subprocess, so it happens only where a wake could come of it. */
-test("the pull request read is skipped entirely until the wake interval has elapsed", async () => {
+test("pull request obligations are collected during the idle countdown", async () => {
   const calls: { cwd: string; limit: number }[] = [];
   const early = await gather(
     { pipelines: [finishedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls },
     withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
   );
-  expect(calls).toEqual([]);
-  expect(early.pullRequests).toEqual([]);
+  expect(calls).toEqual([{ cwd: "/srv/repo", limit: 60 }]);
+  expect(early.pullRequests).toHaveLength(1);
 
   await gather(
     { pipelines: [finishedLane()], openPullRequests: [openPullRequest()], pullRequestCalls: calls },
     withCursor(0, OVERDUE),
   );
-  expect(calls).toEqual([{ cwd: "/srv/repo", limit: 60 }]);
+  expect(calls).toHaveLength(2);
 });
 
 /* The same rule as the clause above, applied to the other two ways a check
    ends before any wake reason is composed. A seat mid-turn is the expensive
    one: a turn that runs for hours would otherwise pay a subprocess at every
    five-minute check for its whole length. */
-test("a check whose seat is already mid-turn asks GitHub nothing", async () => {
+test("a busy seat collects pull request obligations without dispatch", async () => {
   const calls: { cwd: string; limit: number }[] = [];
   const input = await gather(
     {
@@ -711,8 +712,9 @@ test("a check whose seat is already mid-turn asks GitHub nothing", async () => {
     },
     withCursor(0, OVERDUE),
   );
-  expect(calls).toEqual([]);
-  expect(input.pullRequests).toEqual([]);
+  expect(calls).toHaveLength(1);
+  expect(input.pullRequests).toHaveLength(1);
+  expect(seatTickDecision(input).verdict.kind).toBe("skipped");
 });
 
 test("a project with no seat to wake asks GitHub nothing", async () => {
@@ -800,13 +802,13 @@ test("once that pull request merges the same project is quiet again", async () =
 
 /* Cold storage is read only where the check has already committed to a
    subprocess, so the gates that skip `gh` skip the archive with it. */
-test("the archive is not read by a check that could raise no wake from it", async () => {
+test("archive collection during a countdown preserves the no-seat and disabled gates", async () => {
   const early: number[] = [];
   await gather(
     { pipelines: [finishedLane()], archiveCalls: early },
     withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
   );
-  expect(early).toEqual([]);
+  expect(early).toEqual([1]);
 
   const seated: number[] = [];
   await gather({ pipelines: [finishedLane()], archiveCalls: seated, noSeat: true }, withCursor(0, OVERDUE));
@@ -888,7 +890,7 @@ test("a successful empty answer leaves no gap behind it", async () => {
    because nothing was owed from this reason, not because something failed. */
 test("a check that asks GitHub nothing reports no gap", async () => {
   const input = await gather(
-    { pipelines: [finishedLane()], pullRequestsThrow: true },
+    { noSeat: true, pipelines: [finishedLane()], pullRequestsThrow: true },
     withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString() }),
   );
   expect(input.pullRequestsUnavailable).toBeNull();
@@ -1028,7 +1030,7 @@ test("a check that asks GitHub nothing leaves the run untouched", async () => {
     reported: true,
   };
   const input = await gather(
-    { pipelines: [finishedLane()], pullRequestsThrow: true },
+    { noSeat: true, pipelines: [finishedLane()], pullRequestsThrow: true },
     withCursor(0, { lastWakeAt: new Date(NOW - 60_000).toISOString(), pullRequestGap: standing }),
   );
   expect(input.pullRequestsUnavailable).toBeNull();

--- a/src/lib/monitor/seatTickSources.ts
+++ b/src/lib/monitor/seatTickSources.ts
@@ -44,8 +44,6 @@ import {
   SEAT_TICK_WAKE_INTERVAL_MS,
   seatTickSourceGapAfterFailure,
   seatTickSourceRetryDue,
-  seatTickWakeDue,
-  seatTurnProgressing,
 } from "./seatTick";
 import { effectiveSeatTickSettings, readSeatTickSettings, type SeatTickSettings } from "./seatTickSettings";
 import type { PipelineSummary, TaskSummary } from "./viewerApi";
@@ -268,6 +266,7 @@ export interface SeatTickSources {
   registry: () => ReturnType<typeof agentRegistry>;
   /** The registry's own activity verdict — `agent_activity`'s answer, which is
       the only thing this module is allowed to call a stall. */
+  seatRuntime?: (conversationId: string) => Promise<{ state: "idle" | "busy" | "unknown"; generation?: string; cursor?: number; turnId?: string | null }>;
   liveness: (request: { project?: string; conversationId?: string; stallAfterMs: number; limit: number }) => Promise<AgentLivenessRecord[]>;
   /** The lifecycle journal, read whole and paged in-process, so the tick's own
       cursor decides what is unread rather than a cursor that advanced at poll
@@ -310,6 +309,14 @@ export function defaultSeatTickSources(): SeatTickSources {
     archivedPipelines: () => loadArchivedPipelines(),
     tasks: () => loadTasks(),
     registry: () => agentRegistry(),
+    seatRuntime: async (conversationId) => {
+      const { structuredDeliveryHostForConversation } = await import("@/lib/runtime/structuredDeliveryController");
+      const host = structuredDeliveryHostForConversation(conversationId);
+      if (!host) return { state: "unknown" };
+      const health = await host.health();
+      return { state: health.status === "idle" && health.activeTurnRef === null && health.pendingAttention.length === 0
+        ? "idle" : health.status === "active" || health.status === "attention" ? "busy" : "unknown", generation: health.sessionKey, cursor: health.eventCursor, turnId: health.activeTurnRef };
+    },
     liveness: async (request) => {
       const snapshot = await agentLivenessSnapshot({
         ...(request.conversationId ? { conversationId: request.conversationId } : {}),
@@ -475,7 +482,14 @@ export async function seatInput(project: string, policy: Pick<SeatTickPolicy, "s
       activity = null;
     }
   }
-  return { conversationId: seat.conversationId, seatEpoch: seat.seatEpoch, path: seat.path, turn, activity };
+  let runtime: Awaited<ReturnType<NonNullable<SeatTickSources["seatRuntime"]>>> | undefined;
+  if (sources.seatRuntime) {
+    try { runtime = await sources.seatRuntime(seat.conversationId); }
+    catch { runtime = { state: "unknown" }; }
+  }
+  return { conversationId: seat.conversationId, seatEpoch: seat.seatEpoch, path: seat.path, turn, activity,
+    ...(runtime ? { runtimeState: runtime.state, runtimeGeneration: runtime.generation, runtimeCursor: runtime.cursor, runtimeTurnId: runtime.turnId } : {}) };
+
 }
 
 function signals(project: string, seat: SeatTickSeatInput | null, sources: SeatTickSources): SeatTickSignalInput[] {
@@ -708,7 +722,6 @@ interface PullRequestEvidence {
 async function unmergedPullRequests(context: {
   project: string;
   seat: SeatTickSeatInput | null;
-  wakeDue: boolean;
   enabled: boolean;
   now: number;
   wakeIntervalMs: number;
@@ -720,14 +733,9 @@ async function unmergedPullRequests(context: {
      left exactly as it stands. A gate is a statement about this check, never
      about whether the source can be read. */
   const unasked: PullRequestEvidence = { pullRequests: [], unavailable: null, gap: context.gap };
-  if (!context.wakeDue || !context.enabled) return unasked;
-  /* The other two ways a check can be unable to raise any reason at all: a
-     project with nobody to wake ends in `no-seat`, and a seat whose turn is
-     genuinely moving ends in `skipped`, both before a wake reason is composed.
-     Without this clause a seat that stays busy for hours pays a `gh` subprocess
-     every five minutes for the whole turn, to answer a question that check was
-     never going to ask. */
-  if (!context.seat || seatTurnProgressing(context.seat)) return unasked;
+  if (!context.enabled) return unasked;
+  // Busy seats still collect current obligations. The controller owns admission.
+  if (!context.seat) return unasked;
 
   const at = new Date(context.now).toISOString();
   const failed = (kind: SeatTickPullRequestGap): PullRequestEvidence => ({
@@ -1234,11 +1242,6 @@ export async function gatherSeatTickInput(
   const { pullRequests, unavailable: pullRequestsUnavailable, gap: pullRequestGap } = await unmergedPullRequests({
     project: canonical,
     seat,
-    /* The same clause the decision applies, asked here because the read behind
-       it is a subprocess: a reason that cannot be raised this check is a reason
-       whose evidence is not worth fetching. The decision applies the bound
-       again on its own terms — this is a cost gate, never the bound itself. */
-    wakeDue: seatTickWakeDue(state.lastWakeAt, now, settings.wakeIntervalMs),
     enabled: settings.enabled,
     now,
     wakeIntervalMs: settings.wakeIntervalMs,
@@ -1246,6 +1249,7 @@ export async function gatherSeatTickInput(
     sources,
   });
 
+  const current = state.accounting ? new SeatTickAccounting(state.accounting.filename, canonical).readState() : null;
   return {
     project: canonical,
     now,
@@ -1266,7 +1270,8 @@ export async function gatherSeatTickInput(
        is what attempted the read, so the gather is what records what became of
        it, and the decision reads that row to know whether this is the outage
        worth putting on the board. */
-    state: { ...state, eventsThrough: cursor, pullRequestGap, childrenGap, harvestedChildren, accounting: state.accounting ? new SeatTickAccounting(state.accounting.filename, canonical).readState().accounting : undefined },
+    state: { ...state, ...(current ? { turnBoundary: current.turnBoundary, turnIdleSince: current.turnIdleSince, idleRuntime: current.idleRuntime } : {}),
+      eventsThrough: cursor, pullRequestGap, childrenGap, harvestedChildren, accounting: current?.accounting },
     policy,
     settings,
   };

--- a/src/lib/monitor/seatTickSources.ts
+++ b/src/lib/monitor/seatTickSources.ts
@@ -460,20 +460,18 @@ async function laneActivity(project: string, policy: SeatTickPolicy, sources: Se
  * signalled. Targeted by conversation id, the way `get_orchestrator` asks it —
  * the targeted branch resolves one transcript and never sweeps the catalog.
  */
-async function seatInput(project: string, policy: SeatTickPolicy, sources: SeatTickSources): Promise<SeatTickSeatInput | null> {
+export async function seatInput(project: string, policy: Pick<SeatTickPolicy, "stallAfterMs">, sources: SeatTickSources): Promise<SeatTickSeatInput | null> {
   const seat = sources.seatFor(project).active;
   if (!seat?.conversationId) return null;
   const conversation = sources.registry().seatTickConversation(seat.conversationId);
   const turn = conversation?.turn.state ?? "unknown";
   let activity: SeatTickActivity | null = null;
-  if (turn === "busy") {
+  if (turn !== "unknown") {
     try {
       const rows = await sources.liveness({ conversationId: seat.conversationId, stallAfterMs: policy.stallAfterMs, limit: 1 });
-      activity = activityOf(rows[0]);
+      activity = activityOf(rows.find((row) => row.conversationId === seat.conversationId));
     } catch {
-      /* An unanswerable liveness read says nothing. The decision treats an
-         absent verdict as "not provably progressing", so the tick keeps working
-         rather than waiting behind a turn it cannot see. */
+      // Missing liveness cannot override the registry turn fence.
       activity = null;
     }
   }

--- a/src/lib/monitor/seatTickState.ts
+++ b/src/lib/monitor/seatTickState.ts
@@ -54,6 +54,7 @@ function normalizeWakeCommit(value: unknown): SeatTickWakeCommit | null {
     reasons: (Array.isArray(raw.reasons) ? raw.reasons : [])
       .filter((entry): entry is SeatTickWakeReasonKind => SEAT_TICK_WAKE_REASON_KINDS.includes(entry as SeatTickWakeReasonKind)),
     fingerprint: raw.fingerprint.slice(0, 200),
+    ...(Array.isArray(raw.actionableKeys) ? { actionableKeys: raw.actionableKeys.filter((key): key is string => typeof key === "string") } : {}),
     eventsThrough: raw.eventsThrough,
     /* A plan written before the harvest existed names no child, and a landing
        credited from it harvests nothing — the safe direction. */
@@ -144,6 +145,11 @@ function normalizeRow(value: unknown, legacy: boolean): SeatTickProjectState {
     seatEpoch: typeof raw.seatEpoch === "number" && Number.isSafeInteger(raw.seatEpoch) ? raw.seatEpoch : null,
     lastCheckAt: isoOrNull(raw.lastCheckAt),
     lastWakeAt: isoOrNull(raw.lastWakeAt),
+    turnIdleSince: isoOrNull(raw.turnIdleSince),
+    wakeAttempt: typeof raw.wakeAttempt === "number" && Number.isSafeInteger(raw.wakeAttempt) && raw.wakeAttempt >= 0 ? raw.wakeAttempt : 0,
+    lastActionableKeys: Array.isArray(raw.lastActionableKeys) ? raw.lastActionableKeys.filter((key): key is string => typeof key === "string") : [],
+    pendingWork: null,
+    turnBoundary: null,
     lastWakeReasons: (Array.isArray(raw.lastWakeReasons) ? raw.lastWakeReasons : [])
       .filter((entry): entry is SeatTickWakeReasonKind => SEAT_TICK_WAKE_REASON_KINDS.includes(entry as SeatTickWakeReasonKind)),
     wakesWithoutChange,
@@ -222,6 +228,7 @@ export function seatTickStateForEpoch(row: SeatTickProjectState, seatEpoch: numb
     seatEpoch,
     eventsThrough: row.eventsThrough,
     lastWakeAt: row.lastWakeAt,
+    lastActionableKeys: row.lastActionableKeys,
     lastProposalAt: row.lastProposalAt,
     outstandingWake: row.outstandingWake,
     pullRequestGap: row.pullRequestGap,

--- a/src/lib/monitor/types.ts
+++ b/src/lib/monitor/types.ts
@@ -212,6 +212,7 @@ export interface SeatTickWakeReason {
 
 /** One line of the wake's body. Bounded and structural — never transcript text. */
 export interface SeatTickItem {
+  eventSeq?: number;
   outcomeId?: string;
   kind: "pipeline" | "task" | "event" | "signal" | "pull-request" | "child";
   id: string;
@@ -229,6 +230,7 @@ export type SeatTickVerdict =
   | { kind: "quiet"; detail: string }
   | {
     kind: "wake";
+    actionableKeys?: string[];
     reasons: SeatTickWakeReason[];
     items: SeatTickItem[];
     deferred: number;
@@ -336,6 +338,10 @@ export interface SeatTickActivity {
 /** The active seat as the check sees it: durable identity, the registry's turn
     state for its conversation, and that turn's activity verdict. */
 export interface SeatTickSeatInput {
+  runtimeState?: "idle" | "busy" | "unknown";
+  runtimeGeneration?: string;
+  runtimeCursor?: number;
+  runtimeTurnId?: string | null;
   conversationId: string;
   seatEpoch: number;
   path: string | null;
@@ -563,6 +569,7 @@ export interface SeatTickPolicy {
  * from anything else would credit the seat with a different message.
  */
 export interface SeatTickWakeCommit {
+  actionableKeys?: string[];
   /** A proposal wake, which advances the 24-hour slot as well as the stamp. */
   proposal: boolean;
   reasons: SeatTickWakeReasonKind[];
@@ -615,6 +622,15 @@ export interface SeatTickOutstandingWake {
 
 /** Project tick state; SQLite accounting owns persistence and legacy migration. */
 export interface SeatTickProjectState {
+  /** Continuous observed idle interval; never derived from the previous wake. */
+  turnIdleSince?: string | null;
+  wakeAttempt?: number;
+
+  idleRuntime?: { generation: string; cursor: number } | null;
+  /** Prepared work remains refreshable until existing dispatch accounting freezes it. */
+  pendingWork?: { at: string; items: SeatTickItem[]; reasons: SeatTickWakeReason[]; deferred: number; text?: string } | null;
+  lastActionableKeys?: string[];
+  turnBoundary?: { generation: string; turnId: string; seq: number; state: "busy" | "settled"; at: string } | null;
   accounting?: { filename: string; revision: number; gap: string | null };
   seatEpoch: number | null;
   lastCheckAt: string | null;
@@ -853,6 +869,12 @@ export function emptySeatTickState(): SeatTickProjectState {
   return {
     seatEpoch: null,
     lastCheckAt: null,
+    turnIdleSince: null,
+    wakeAttempt: 0,
+    idleRuntime: null,
+    pendingWork: null,
+    lastActionableKeys: [],
+    turnBoundary: null,
     lastWakeAt: null,
     lastWakeReasons: [],
     wakesWithoutChange: {},

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -2280,3 +2280,22 @@ test("idle-only Claude tick preserves a working turn through tool wait and start
     expect(child.inputs.filter((input) => input.type === "user")).toHaveLength(2);
   } finally { await host.release(); }
 });
+
+
+test("a recovered Claude seat accepts a fenced wake after its dead predecessor", async () => {
+  const sessionId = "recovered-claude-seat";
+  const store = new MemoryEventStore();
+  store.append(sessionId, { kind: "turn-started", turnId: "old-turn", seq: 1 });
+  store.append(sessionId, { kind: "session-status", status: "dead", seq: 2 });
+  const ledger = new RecordingDeliveryLedger();
+  const child = new FakeClaude(ledger);
+  const host = await ClaudeStreamBrokerHost.adopt(sessionId, { cwd: "/repo", eventStore: store, deliveryLedger: ledger,
+    readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }), readTranscript: () => [], spawnProcess: fakeSpawn(child, {}) });
+  try {
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    const sent = host.send({ id: "recovery-wake", text: "owed work", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } });
+    child.emitJson({ type: "user", isReplay: true, session_id: sessionId, message: { role: "user", content: [{ type: "text", text: "owed work" }] } });
+    expect(await sent).toMatchObject({ outcome: "turn-started" });
+    expect(child.inputs.filter((input) => input.type === "user")).toHaveLength(1);
+  } finally { await host.release(); }
+});

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -2252,3 +2252,31 @@ describe("issue 367 concurrent launch admission", () => {
     }
   });
 });
+
+
+test("idle-only Claude tick preserves a working turn through tool wait and starts after completion", async () => {
+  const ledger = new RecordingDeliveryLedger();
+  const child = new FakeClaude(ledger);
+  const host = await ClaudeStreamBrokerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), deliveryLedger: ledger,
+    readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }), spawnProcess: fakeSpawn(child, {}) });
+  try {
+    const working = host.send({ id: "operator-turn", text: "work" });
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, message: { role: "user", content: [{ type: "text", text: "work" }] } });
+    await working;
+    child.emitJson({ type: "assistant", session_id: host.identity.sessionId,
+      message: { role: "assistant", content: [{ type: "tool_use", id: "awaited-tool", name: "Bash", input: { command: "fixture-only" } }] } });
+    const tick = { id: "automatic-tick", text: "check", expectedTurnId: null, origin: { kind: "agent" as const, role: "seat-tick" } };
+    expect(await host.send(tick)).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    expect(child.inputs.filter((input) => input.type === "user")).toHaveLength(1);
+    expect(child.signals).toEqual([]);
+    child.emitJson({ type: "user", session_id: host.identity.sessionId,
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "awaited-tool", content: "done" }] } });
+    expect(await host.send(tick)).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    child.emitJson({ type: "result", subtype: "success", session_id: host.identity.sessionId, result: "done" });
+    await waitUntilIdle(host);
+    const wake = host.send(tick);
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, message: { role: "user", content: [{ type: "text", text: "check" }] } });
+    expect(await wake).toEqual({ outcome: "turn-started", turnId: "automatic-tick" });
+    expect(child.inputs.filter((input) => input.type === "user")).toHaveLength(2);
+  } finally { await host.release(); }
+});

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -828,7 +828,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         : null;
       const recovered = started?.kind === "turn-started" && started.turnId === this.recoveredIdleTurnId;
       if ((!started && !this.idleTickHistoryKnown)
-        || (started && !recovered && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        || (started && !recovered && completed?.kind !== "turn-ended")) {
         return { outcome: "rejected", reason: "stale-turn" };
       }
     }

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -746,6 +746,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         ? options.readTranscript(options.cwd, sessionId)
         : defaultTranscriptUsers(options.cwd, sessionId, options.claudeProjectsDir));
       host.emit({ kind: "session-status", status: "idle" });
+      host.idleTickHistoryKnown = !resume;
       return host;
     } catch (error) {
       try {
@@ -790,6 +791,8 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     };
   }
 
+  private idleTickHistoryKnown = false;
+
   async send(entry: QueueEntry): Promise<DeliveryReceipt> {
     if (this.unavailable()) return { outcome: "rejected", reason: "dead-host" };
     if (!entry.id) throw new Error("queue entry id is required");
@@ -806,6 +809,23 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     }
     const existingPending = this.pendingDeliveries.get(entry.id);
     if (existingPending) return existingPending.promise;
+    if (duplicate && normalized.origin?.kind === "agent" && normalized.origin.role === "seat-tick") {
+      throw new Error("original tick delivery is unresolved");
+    }
+    if (!duplicate && normalized.expectedTurnId === null
+      && (this.currentState().status !== "idle" || [...this.compactions.values()].some((compaction) => !compaction.settled))) {
+      return { outcome: "rejected", reason: "stale-turn" };
+    }
+    if (!duplicate && normalized.origin?.kind === "agent" && normalized.origin.role === "seat-tick") {
+      const started = this.events.findLast((event) => event.kind === "turn-started");
+      const completed = started?.kind === "turn-started"
+        ? this.events.findLast((event) => event.kind === "turn-ended" && event.turnId === started.turnId)
+        : null;
+      if ((!started && !this.idleTickHistoryKnown)
+        || (started && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        return { outcome: "rejected", reason: "stale-turn" };
+      }
+    }
     const blocks: JsonObject[] = normalized.content.images.map((image) => ({
       type: "image",
       source: {

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -747,6 +747,10 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         : defaultTranscriptUsers(options.cwd, sessionId, options.claudeProjectsDir));
       host.emit({ kind: "session-status", status: "idle" });
       host.idleTickHistoryKnown = !resume;
+      if (resume) {
+        const previous = host.events.findLast((event) => event.kind === "turn-started");
+        host.recoveredIdleTurnId = previous?.kind === "turn-started" ? previous.turnId : null;
+      }
       return host;
     } catch (error) {
       try {
@@ -792,6 +796,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   }
 
   private idleTickHistoryKnown = false;
+  private recoveredIdleTurnId: string | null = null;
 
   async send(entry: QueueEntry): Promise<DeliveryReceipt> {
     if (this.unavailable()) return { outcome: "rejected", reason: "dead-host" };
@@ -821,8 +826,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       const completed = started?.kind === "turn-started"
         ? this.events.findLast((event) => event.kind === "turn-ended" && event.turnId === started.turnId)
         : null;
+      const recovered = started?.kind === "turn-started" && started.turnId === this.recoveredIdleTurnId;
       if ((!started && !this.idleTickHistoryKnown)
-        || (started && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        || (started && !recovered && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
         return { outcome: "rejected", reason: "stale-turn" };
       }
     }
@@ -1115,7 +1121,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         this.attentions.clear();
       }
     }
-    if (restoredTurn) this.emit({ kind: "turn-ended", turnId: restoredTurn, status: "error" });
+    if (restoredTurn) {
+      this.emit({ kind: "turn-ended", turnId: restoredTurn, status: "error" });
+    }
     for (const attentionId of this.attentions.keys()) {
       this.emit({ kind: "attention-resolved", id: attentionId, resolution: "host-restarted" });
     }

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -147,6 +147,12 @@ class FakeAppServer extends EventEmitter {
   realtimeAppendErrorAt: number | null = null;
   responseChunkBytes: number | null = null;
   oversizedTurnStartResult = false;
+  holdTurnStart = false;
+  readonly heldTurnStarts: Record<string, unknown>[] = [];
+  releaseTurnStarts(): void {
+    this.holdTurnStart = false;
+    for (const message of this.heldTurnStarts.splice(0)) this.accept(message);
+  }
   readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
   injectItemsDelayMs: number | null = null;
@@ -269,6 +275,7 @@ class FakeAppServer extends EventEmitter {
       });
     }
     if (method === "turn/start") {
+      if (this.holdTurnStart) { this.heldTurnStarts.push(message); return; }
       const turnId = `turn-${++this.turn}`;
       if (this.oversizedTurnStartResult) {
         return this.respond(message.id, { turn: { id: turnId }, padding: "p".repeat(26 * 1024 * 1024) });
@@ -5157,4 +5164,53 @@ test("a host with no live call releases without a stray hangup", async () => {
   });
   await host.release();
   expect(server.requests.some((request) => request.method === "thread/realtime/stop")).toBe(false);
+});
+
+
+test("idle-only tick loses a dispatch race without interrupt, steer, or user input", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    expect((await host.health()).status).toBe("idle");
+    await host.send({ id: "operator-turn", text: "continue working" });
+    const before = server.requests.filter((request) => ["turn/start", "turn/steer", "turn/interrupt"].includes(String(request.method))).length;
+    const receipt = await host.send({ id: "automatic-tick", text: "check work", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } });
+    expect(receipt).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    expect(server.requests.filter((request) => ["turn/start", "turn/steer", "turn/interrupt"].includes(String(request.method)))).toHaveLength(before);
+    expect((await host.health()).activeTurnRef).toBe("turn-1");
+  } finally { await host.release(); }
+});
+
+test("concurrent idle sends reserve only one pending start and duplicate keys join", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    const entry = { id: "first-start", text: "first", expectedTurnId: null };
+    server.holdTurnStart = true;
+    const sends = [host.send(entry), host.send(entry), host.send({ id: "second-start", text: "second", expectedTurnId: null })];
+    await Bun.sleep(0);
+    const held = server.heldTurnStarts.length;
+    server.releaseTurnStarts();
+    const receipts = await Promise.all(sends);
+    expect(held).toBe(1);
+    expect(receipts[0]).toEqual(receipts[1]);
+    expect(receipts[2]).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    expect(new Set(server.requests.filter((request) => request.method === "turn/start").map((request) => request.id)).size).toBe(1);
+    expect(server.requests.filter((request) => request.method === "turn/steer")).toHaveLength(0);
+  } finally { await host.release(); }
+});
+
+
+test("an old completion cannot make an interrupted current turn eligible for a tick", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    await host.send({ id: "operator-turn", text: "work" });
+    server.notify("turn/completed", { threadId: host.identity.threadId, turn: { id: "turn-1", status: "interrupted" } });
+    server.notify("turn/completed", { threadId: host.identity.threadId, turn: { id: "old-turn", status: "completed" } });
+    await Bun.sleep(0);
+    expect(await host.send({ id: "tick", text: "check", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } }))
+      .toEqual({ outcome: "rejected", reason: "stale-turn" });
+    expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+  } finally { await host.release(); }
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -147,6 +147,7 @@ class FakeAppServer extends EventEmitter {
   realtimeAppendErrorAt: number | null = null;
   responseChunkBytes: number | null = null;
   oversizedTurnStartResult = false;
+  rejectTurnStart = false;
   holdTurnStart = false;
   readonly heldTurnStarts: Record<string, unknown>[] = [];
   releaseTurnStarts(): void {
@@ -275,6 +276,7 @@ class FakeAppServer extends EventEmitter {
       });
     }
     if (method === "turn/start") {
+      if (this.rejectTurnStart) return this.respondError(message.id, "invalid turn input");
       if (this.holdTurnStart) { this.heldTurnStarts.push(message); return; }
       const turnId = `turn-${++this.turn}`;
       if (this.oversizedTurnStartResult) {
@@ -5212,5 +5214,57 @@ test("an old completion cannot make an interrupted current turn eligible for a t
     expect(await host.send({ id: "tick", text: "check", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } }))
       .toEqual({ outcome: "rejected", reason: "stale-turn" });
     expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+  } finally { await host.release(); }
+});
+
+
+test("a rejected start releases the reservation for corrected operator input", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    server.rejectTurnStart = true;
+    await expect(host.send({ id: "rejected-start", text: "invalid" })).rejects.toThrow("invalid turn input");
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    server.rejectTurnStart = false;
+    expect(await host.send({ id: "corrected-start", text: "valid" })).toMatchObject({ outcome: "turn-started" });
+  } finally { await host.release(); }
+});
+
+test("a recovered Codex seat can wake after its old open turn is authoritatively reconciled idle", async () => {
+  const threadId = "recovered-seat";
+  const store = new MemoryEventStore();
+  store.append(threadId, { kind: "turn-started", turnId: "old-open-turn", seq: 1 });
+  store.append(threadId, { kind: "session-status", status: "dead", seq: 2 });
+  const server = new FakeAppServer(threadId, threadId, false, [], { type: "idle", activeFlags: [] });
+  const host = await CodexAppServerHost.adopt(threadId, { cwd: "/repo", eventStore: store, spawnProcess: fakeSpawn(server) });
+  try {
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    expect(await host.send({ id: "recovered-tick", text: "owed work", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } }))
+      .toMatchObject({ outcome: "turn-started" });
+  } finally { await host.release(); }
+});
+
+
+test("matching canonical completion releases a lost start acknowledgment without a duplicate write", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    server.holdTurnStart = true;
+    const original = host.send({ id: "lost-ack", text: "work", expectedTurnId: null });
+    await waitForCondition(() => server.heldTurnStarts.length === 1, "start must reach fixture");
+    expect(await host.send({ id: "blocked-followup", text: "later", expectedTurnId: null })).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    const request = server.heldTurnStarts.shift()!;
+    const input = (request.params as { input: unknown[] }).input;
+    server.notify("turn/started", { threadId: host.identity.threadId, turn: { id: "settled-turn" } });
+    server.notify("item/completed", { threadId: host.identity.threadId, turnId: "settled-turn",
+      item: { type: "userMessage", id: "echo", clientId: "lost-ack", content: input } });
+    server.notify("turn/completed", { threadId: host.identity.threadId, turn: { id: "settled-turn", status: "completed" } });
+    expect(await original).toEqual({ outcome: "turn-started", turnId: "settled-turn" });
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    server.holdTurnStart = false;
+    expect(await host.send({ id: "after-settlement", text: "next", expectedTurnId: null })).toMatchObject({ outcome: "turn-started" });
+    server.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { turn: { id: "settled-turn" } } })}\n`);
+    expect((await host.health()).status).toBe("active");
+    expect(server.requests.filter((message) => message.method === "turn/start")).toHaveLength(2);
   } finally { await host.release(); }
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -5203,12 +5203,11 @@ test("concurrent idle sends reserve only one pending start and duplicate keys jo
 });
 
 
-test("an old completion cannot make an interrupted current turn eligible for a tick", async () => {
+test("an old completion cannot make an open current turn eligible for a tick", async () => {
   const server = new FakeAppServer();
   const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
   try {
     await host.send({ id: "operator-turn", text: "work" });
-    server.notify("turn/completed", { threadId: host.identity.threadId, turn: { id: "turn-1", status: "interrupted" } });
     server.notify("turn/completed", { threadId: host.identity.threadId, turn: { id: "old-turn", status: "completed" } });
     await Bun.sleep(0);
     expect(await host.send({ id: "tick", text: "check", expectedTurnId: null, origin: { kind: "agent", role: "seat-tick" } }))

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,3 +1,4 @@
+import { EngineRequestRefusedError } from "./engineHost";
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 import { createHash, type Hash } from "node:crypto";
@@ -1088,7 +1089,7 @@ function threadStatus(value: unknown): ThreadStatus | null {
 
 /** One stdio app-server owner with replayable, multi-subscriber event fan-out. */
 /** A correlated JSON-RPC error response proves that this request was refused. */
-class CodexRpcRefusal extends Error {}
+class CodexRpcRefusal extends EngineRequestRefusedError {}
 
 export class CodexAppServerHost implements EngineHost {
   readonly identity: CodexThreadIdentity;
@@ -1487,7 +1488,7 @@ export class CodexAppServerHost implements EngineHost {
         : null;
       const recovered = started?.kind === "turn-started" && started.turnId === this.recoveredIdleTurnId;
       if ((!started && !this.idleTickHistoryKnown)
-        || (started && !recovered && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        || (started && !recovered && completed?.kind !== "turn-ended")) {
         return { outcome: "rejected", reason: "stale-turn" };
       }
     }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1087,6 +1087,9 @@ function threadStatus(value: unknown): ThreadStatus | null {
 }
 
 /** One stdio app-server owner with replayable, multi-subscriber event fan-out. */
+/** A correlated JSON-RPC error response proves that this request was refused. */
+class CodexRpcRefusal extends Error {}
+
 export class CodexAppServerHost implements EngineHost {
   readonly identity: CodexThreadIdentity;
 
@@ -1329,7 +1332,11 @@ export class CodexAppServerHost implements EngineHost {
       provisional.flushPreRestoreEvents();
       provisional.flushPreRestoreMessages(threadId ? result : null);
       if (threadId) provisional.reconcileThreadHistory(result);
+      const oldStartedTurn = provisional.events.findLast((event) => event.kind === "turn-started");
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
+      if (threadId && threadStatus(result)?.type === "idle" && !provisional.activeTurnId) {
+        provisional.recoveredIdleTurnId = oldStartedTurn?.kind === "turn-started" ? oldStartedTurn.turnId : null;
+      }
       provisional.endBufferedNotificationReconciliation();
       provisional.idleTickHistoryKnown = !threadId || Array.isArray(record(record(result)?.thread)?.turns);
       return provisional;
@@ -1419,7 +1426,9 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private idleTickHistoryKnown = false;
-  private pendingTurnStart: string | null = null;
+  private pendingTurnStart: { operationId: string; rpcId: number; entry: QueueEntry } | null = null;
+  private readonly settledTurnStartResponses = new Set<number>();
+  private recoveredIdleTurnId: string | null = null;
   private readonly sending = new Map<string, { fingerprint: string; promise: Promise<DeliveryReceipt> }>();
 
   send(entry: QueueEntry): Promise<DeliveryReceipt> {
@@ -1466,7 +1475,7 @@ export class CodexAppServerHost implements EngineHost {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       return { outcome: "rejected", reason: "dead-host" };
     }
-    if (this.pendingTurnStart === entry.id) throw new Error("original turn start is unresolved");
+    if (this.pendingTurnStart?.operationId === entry.id) throw new Error("original turn start is unresolved");
     if (this.pendingTurnStart || (entry.expectedTurnId === null
       && (this.currentState().status !== "idle" || this.pendingCompactions.size > 0))) {
       return { outcome: "rejected", reason: "stale-turn" };
@@ -1476,8 +1485,9 @@ export class CodexAppServerHost implements EngineHost {
       const completed = started?.kind === "turn-started"
         ? this.events.findLast((event) => event.kind === "turn-ended" && event.turnId === started.turnId)
         : null;
+      const recovered = started?.kind === "turn-started" && started.turnId === this.recoveredIdleTurnId;
       if ((!started && !this.idleTickHistoryKnown)
-        || (started && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        || (started && !recovered && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
         return { outcome: "rejected", reason: "stale-turn" };
       }
     }
@@ -1535,16 +1545,25 @@ export class CodexAppServerHost implements EngineHost {
       : undefined;
     const effort = perTurnEffort ?? this.effort;
     // Reserve synchronously before the RPC write; a lost answer keeps this fence.
-    this.pendingTurnStart = entry.id;
-    const result = await this.rpc("turn/start", {
-      threadId: this.identity.threadId,
-      ...(effort ? { effort } : {}),
-      input,
-      clientUserMessageId: entry.id,
-    });
+    this.pendingTurnStart = { operationId: entry.id, rpcId: this.nextRpcId, entry };
+    let result: unknown;
+    try {
+      result = await this.rpc("turn/start", {
+        threadId: this.identity.threadId,
+        ...(effort ? { effort } : {}),
+        input,
+        clientUserMessageId: entry.id,
+      });
+    } catch (error) {
+      if (error instanceof CodexRpcRefusal && this.pendingTurnStart?.operationId === entry.id) {
+        this.pendingTurnStart = null;
+        this.notifyStateListeners();
+      }
+      throw error;
+    }
     const turnId = turnIdFromResult(result, "turn/start");
     if (!this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId)) this.activeTurnId = turnId;
-    this.pendingTurnStart = null;
+    if (this.pendingTurnStart?.operationId === entry.id) this.pendingTurnStart = null;
     this.notifyStateListeners();
     return this.awaitDeliveryConfirmation(entry, { outcome: "turn-started", turnId });
   }
@@ -2852,6 +2871,27 @@ export class CodexAppServerHost implements EngineHost {
     return confirmed.receipt;
   }
 
+  private settleConfirmedTurnStart(): void {
+    const start = this.pendingTurnStart;
+    if (!start) return;
+    const confirmation = this.confirmedDeliveries.get(start.operationId);
+    if (!confirmation) return;
+    let receipt: DeliveryReceipt;
+    try { receipt = this.confirmedReceipt(start.entry, confirmation); }
+    catch { return; }
+    if (receipt.outcome === "rejected"
+      || !this.events.some((event) => event.kind === "turn-ended" && event.turnId === receipt.turnId)) return;
+    const request = this.pending.get(start.rpcId);
+    this.pendingTurnStart = null;
+    if (request) {
+      this.pending.delete(start.rpcId);
+      clearTimeout(request.timer);
+      this.settledTurnStartResponses.add(start.rpcId);
+      request.resolve({ turn: { id: receipt.turnId } });
+    }
+    this.notifyStateListeners();
+  }
+
   private rememberConfirmedDelivery(turnId: string, value: unknown): void {
     const item = record(value);
     if (!item || stringField(item, "type") !== "userMessage") return;
@@ -2869,6 +2909,7 @@ export class CodexAppServerHost implements EngineHost {
       contentDigest: previous && (previous.text !== text || previous.contentDigest !== contentDigest) ? null : contentDigest,
     };
     this.confirmedDeliveries.set(clientId, confirmed);
+    this.settleConfirmedTurnStart();
     if (!pending) return;
     this.pendingDeliveries.delete(clientId);
     clearTimeout(pending.timer);
@@ -3224,12 +3265,13 @@ export class CodexAppServerHost implements EngineHost {
       if (typeof id !== "number") return this.fail(new Error("Codex app-server response id is invalid"));
       this.replayEnvelopeRequestIds.delete(id);
       const pending = this.pending.get(id);
+      if (!pending && this.settledTurnStartResponses.delete(id)) return;
       if (!pending && this.consumeLateThreadReadResponse(id)) return;
       if (!pending) return this.fail(new Error("Codex app-server response has no matching request"));
       this.pending.delete(id);
       clearTimeout(pending.timer);
       const error = record(message.error);
-      if (error) pending.reject(new Error(`Codex app-server request failed: ${safeError(error.message ?? "unknown error")}`));
+      if (error) pending.reject(new CodexRpcRefusal(`Codex app-server request failed: ${safeError(error.message ?? "unknown error")}`));
       else pending.resolve(message.result);
       return;
     }
@@ -3415,6 +3457,7 @@ export class CodexAppServerHost implements EngineHost {
         this.voiceStreams.delete(turnId);
       }
       this.emit({ kind: "turn-ended", turnId, status });
+      this.settleConfirmedTurnStart();
       this.settlePendingCompactionsFromTerminalTurn(turn, status);
       return;
     }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1331,6 +1331,7 @@ export class CodexAppServerHost implements EngineHost {
       if (threadId) provisional.reconcileThreadHistory(result);
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
       provisional.endBufferedNotificationReconciliation();
+      provisional.idleTickHistoryKnown = !threadId || Array.isArray(record(record(result)?.thread)?.turns);
       return provisional;
     } catch (error) {
       try {
@@ -1417,7 +1418,24 @@ export class CodexAppServerHost implements EngineHost {
     if (this.imageInputSupport === "supported") this.setSessionStatus(this.engineStatus, this.activeFlags);
   }
 
-  async send(entry: QueueEntry): Promise<DeliveryReceipt> {
+  private idleTickHistoryKnown = false;
+  private pendingTurnStart: string | null = null;
+  private readonly sending = new Map<string, { fingerprint: string; promise: Promise<DeliveryReceipt> }>();
+
+  send(entry: QueueEntry): Promise<DeliveryReceipt> {
+    const fingerprint = JSON.stringify(normalizeQueueEntry(entry));
+    const pending = this.sending.get(entry.id);
+    if (pending) {
+      if (pending.fingerprint !== fingerprint) return Promise.reject(new Error("queue entry id belongs to a different payload"));
+      return pending.promise;
+    }
+    const promise = this.sendEntry(entry);
+    this.sending.set(entry.id, { fingerprint, promise });
+    void promise.finally(() => { this.sending.delete(entry.id); }).catch(() => {});
+    return promise;
+  }
+
+  private async sendEntry(entry: QueueEntry): Promise<DeliveryReceipt> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       return { outcome: "rejected", reason: "dead-host" };
     }
@@ -1444,6 +1462,25 @@ export class CodexAppServerHost implements EngineHost {
     if (!entry.id) throw new Error("queue entry id is required");
     const confirmed = await this.confirmedDelivery(entry);
     if (confirmed) return confirmed;
+    // History/capability reads above may have yielded to a new turn or control.
+    if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
+      return { outcome: "rejected", reason: "dead-host" };
+    }
+    if (this.pendingTurnStart === entry.id) throw new Error("original turn start is unresolved");
+    if (this.pendingTurnStart || (entry.expectedTurnId === null
+      && (this.currentState().status !== "idle" || this.pendingCompactions.size > 0))) {
+      return { outcome: "rejected", reason: "stale-turn" };
+    }
+    if (entry.origin?.kind === "agent" && entry.origin.role === "seat-tick") {
+      const started = this.events.findLast((event) => event.kind === "turn-started");
+      const completed = started?.kind === "turn-started"
+        ? this.events.findLast((event) => event.kind === "turn-ended" && event.turnId === started.turnId)
+        : null;
+      if ((!started && !this.idleTickHistoryKnown)
+        || (started && (completed?.kind !== "turn-ended" || completed.status !== "completed"))) {
+        return { outcome: "rejected", reason: "stale-turn" };
+      }
+    }
     const currentTurn = this.activeTurnId;
     if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== currentTurn) {
       return { outcome: "rejected", reason: "stale-turn" };
@@ -1497,6 +1534,8 @@ export class CodexAppServerHost implements EngineHost {
       ? entry.runtime.effort
       : undefined;
     const effort = perTurnEffort ?? this.effort;
+    // Reserve synchronously before the RPC write; a lost answer keeps this fence.
+    this.pendingTurnStart = entry.id;
     const result = await this.rpc("turn/start", {
       threadId: this.identity.threadId,
       ...(effort ? { effort } : {}),
@@ -1504,7 +1543,8 @@ export class CodexAppServerHost implements EngineHost {
       clientUserMessageId: entry.id,
     });
     const turnId = turnIdFromResult(result, "turn/start");
-    this.activeTurnId = turnId;
+    if (!this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId)) this.activeTurnId = turnId;
+    this.pendingTurnStart = null;
     this.notifyStateListeners();
     return this.awaitDeliveryConfirmation(entry, { outcome: "turn-started", turnId });
   }
@@ -1658,7 +1698,7 @@ export class CodexAppServerHost implements EngineHost {
     /* The boundary refuses a live turn even though admission already fenced it:
        the turn may have started between admission and execution, and compacting
        underneath a running turn is exactly the race this control must not run. */
-    if (this.activeTurnId) {
+    if (this.activeTurnId || this.pendingTurnStart) {
       throw new StructuredCompactError("a turn is active; compaction would race it", "refused");
     }
     const existing = this.pendingCompactions.get(request.operationId);
@@ -2328,7 +2368,7 @@ export class CodexAppServerHost implements EngineHost {
     const status: HostState["status"] = this.dead ? "dead"
       : this.released ? "unhosted"
       : this.attentions.size > 0 ? "attention"
-      : this.activeTurnId ? "active"
+      : this.activeTurnId || this.pendingTurnStart ? "active"
       : this.engineStatus;
     return {
       status,

--- a/src/lib/runtime/commands.test.ts
+++ b/src/lib/runtime/commands.test.ts
@@ -156,3 +156,10 @@ test("runtime command parsing admits image-only content with a canonical digest"
     idempotencyKey: "send-images-invalid",
   })).toThrow("images are invalid");
 });
+
+
+test("idle-only send policy is explicit and unsupported policies refuse admission", () => {
+  const body = { conversationId: "seat", text: "check", idempotencyKey: "tick-key", policy: "idle-only" };
+  expect(parseRuntimeCommand("send", body)).toMatchObject({ policy: "idle-only" });
+  expect(() => parseRuntimeCommand("send", { ...body, policy: "unknown-policy" })).toThrow("policy is invalid");
+});

--- a/src/lib/runtime/commands.ts
+++ b/src/lib/runtime/commands.ts
@@ -77,7 +77,7 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
     if (!imageRefs) throw new Error("images are invalid");
     const content = structuredContent(text, imageRefs);
     const policy = body.policy === undefined ? undefined : body.policy;
-    if (policy !== undefined && policy !== "queue" && policy !== "steer-if-active" && policy !== "interrupt-active") {
+    if (policy !== undefined && policy !== "queue" && policy !== "idle-only" && policy !== "steer-if-active" && policy !== "interrupt-active") {
       throw new Error("policy is invalid");
     }
     const runtime = parseRuntimeSendSettings(body.runtime);

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -238,7 +238,7 @@ export interface RuntimeSendCommand extends RuntimeCommandBase {
   text: string;
   images?: StructuredImageRef[];
   contentDigest?: string;
-  policy?: "queue" | "steer-if-active" | "interrupt-active";
+  policy?: "queue" | "idle-only" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
   runtime?: RuntimeSendSettings;
   /** The Viewer card selected when this turn was submitted (#844). Admitted

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -169,3 +169,6 @@ export class StructuredHostAdoptionCleanupError<Host extends EngineHost = Engine
     this.name = "StructuredHostAdoptionCleanupError";
   }
 }
+
+/** A correlated engine response proved this input request was refused. */
+export class EngineRequestRefusedError extends Error {}

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -4211,3 +4211,40 @@ test("a real executor killed after the engine write leaves one actuation and an 
     reopened.close();
   }
 });
+
+
+test("owned host turn boundaries notify the seat controller and active item updates do not settle it", async () => {
+  const { registerSeatTickKick } = await import("@/lib/monitor/seatTickSignal");
+  const directory = path.join(sandbox, "seat-boundary-notifications");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const artifactPath = path.join(directory, "notification-session.jsonl");
+  const profile = emptyLaunchProfile({ cwd: directory, project: "fixture-project" });
+  registry.reconcileConversations([{ engine: "codex", path: artifactPath, accountId: null, launchProfile: profile,
+    turn: { state: "idle", source: "assistant", terminalAt: null }, observedAt: new Date().toISOString() }]);
+  registry.upsert({ key: { engine: "codex", sessionId: "notification-session" }, artifactPath, cwd: directory, accountId: null,
+    launchProfile: profile, status: "live", host: null, structuredHost: { kind: "codex-app-server", endpoint: "fake:seat",
+      process: null, eventCursor: 0, protocolVersion: "test", writerClaimEpoch: 0, activeTurnRef: null, pendingAttention: [], activeFlags: [] },
+    claimEpoch: 0, claimOwner: null, pendingAction: null });
+  const state: HostState = { status: "idle", sessionKey: "notification-session", endpoint: "fake:seat", pid: null,
+    processStartIdentity: null, eventCursor: 0, protocolVersion: "test", activeTurnRef: null, pendingAttention: [], activeFlags: [], account: null };
+  const fixture = statefulObservableFakeHost(state);
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const signals: Array<import("@/lib/monitor/seatTickSignal").SeatTickSignal> = [];
+  registerSeatTickKick((signal) => signals.push(signal));
+  try {
+    await bindStructuredDeliveryQueue([{ key: { engine: "codex", sessionId: "notification-session" }, host: fixture.host }], { registry, client: runtimeJournalClient(journal) });
+    fixture.setState({ ...state, status: "active", activeTurnRef: "work-turn", eventCursor: 1 });
+    fixture.setState({ ...state, status: "active", activeTurnRef: "work-turn", eventCursor: 2 });
+    expect(signals.flatMap((signal) => signal.boundary ? [signal.boundary.state] : [])).toEqual(["busy"]);
+    fixture.setState({ ...state, status: "idle", eventCursor: 3 });
+    expect(signals.flatMap((signal) => signal.boundary ? [signal.boundary.state] : [])).toEqual(["busy", "settled"]);
+    expect(signals.find((signal) => signal.boundary?.state === "settled")).toMatchObject({ project: "fixture-project",
+      boundary: { generation: "notification-session", turnId: "work-turn", seq: 3 } });
+    await waitForCondition(() => signals.filter((signal) => !signal.boundary).length >= 2);
+    expect(journal.snapshot().sessions[0]).toMatchObject({ turn: "idle", activeTurnId: null });
+  } finally {
+    registerSeatTickKick(null);
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+  }
+});

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -1,3 +1,5 @@
+import { requestSeatTick } from "@/lib/monitor/seatTickSignal";
+import { conversationProjectKey } from "@/lib/accounts/conversationProject";
 import crypto from "node:crypto";
 
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
@@ -875,9 +877,25 @@ export async function bindStructuredDeliveryQueue(
     if (abandoned()) return async () => {};
     if (superseded()) return await registerThroughSuccessor(item, ownsOperation);
     const observable = item.host as ObservableEngineHost;
+    const entry = entryForHost(registry, item);
+    const conversationId = entry ? conversationIdForEntry(registry, entry) : null;
+    const project = conversationProjectKey(null, entry?.launchProfile, { cwd: entry?.cwd });
+    let observedTurn: string | null = null;
     let deliveryState = deliveryStateKey(initialState);
     let projectedState = hostProjectionKey(initialState);
     const unsubscribe = observable.onStateChange((state) => {
+      if (conversationId) {
+        if (state.activeTurnRef && state.activeTurnRef !== observedTurn) {
+          observedTurn = state.activeTurnRef;
+          requestSeatTick({ project, conversationId, boundary: { generation: item.key.sessionId, turnId: observedTurn,
+            seq: state.eventCursor, state: "busy", at: new Date().toISOString() } });
+        } else if (state.status === "idle" && observedTurn) {
+          const ended = observedTurn;
+          observedTurn = null;
+          requestSeatTick({ project, conversationId, boundary: { generation: item.key.sessionId, turnId: ended,
+            seq: state.eventCursor, state: "settled", at: new Date().toISOString() } });
+        }
+      }
       const nextDeliveryState = deliveryStateKey(state);
       const nextProjectedState = hostProjectionKey(state);
       const previous = publishChains.get(key) ?? Promise.resolve();
@@ -890,12 +908,11 @@ export async function bindStructuredDeliveryQueue(
           if (nextDeliveryState === deliveryState) return;
           deliveryState = nextDeliveryState;
           requestDrain();
+          requestSeatTick({ project, ...(conversationId ? { conversationId } : {}) });
         })
         .catch(() => { console.error("[structured delivery] host state sync failed"); });
       publishChains.set(key, next);
     });
-    const entry = entryForHost(registry, item);
-    const conversationId = entry ? conversationIdForEntry(registry, entry) : null;
     const events = item.host.attach(acknowledgedEventCursor)[Symbol.asyncIterator]();
     let eventsStopped = false;
     void (async () => {
@@ -908,6 +925,9 @@ export async function bindStructuredDeliveryQueue(
         while (!eventsStopped) {
           try {
             await client.append(projected);
+            if (next.value.kind === "turn-started" || next.value.kind === "turn-ended") {
+              requestSeatTick({ project, conversationId });
+            }
             break;
           } catch {
             await new Promise<void>((resolve) => setTimeout(resolve, 100));

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -2502,3 +2502,64 @@ test("an unreadable host state issues no control at all", async () => {
   expect(answers).toEqual([]);
   expect(transitions).toEqual([]);
 });
+
+
+test("idle-only effects refuse busy admission and never interrupt or wait in the queue", async () => {
+  const transitions: Array<[string, string]> = [];
+  let writes = 0;
+  let interrupts = 0;
+  const target = host(async () => { writes++; return { outcome: "turn-started", turnId: "unexpected" }; });
+  target.health = async () => ({ ...idleState(), status: "active", activeTurnRef: "operator-turn" });
+  target.interrupt = async () => { interrupts++; };
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{ id: "effect:tick", kind: "runtime.send", eventSeq: 1,
+      payload: { kind: "send", operationId: "tick", conversationId: "seat", text: "check", policy: "idle-only" } }],
+    transition: async (id, status) => { transitions.push([id, status]); },
+  }, () => target);
+  await queue.drain();
+  expect(writes).toBe(0);
+  expect(interrupts).toBe(0);
+  expect(transitions).toEqual([["tick", "failed"]]);
+});
+
+test("idle-only effects carry a null fence and close proven-unsent races", async () => {
+  const transitions: Array<[string, string]> = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{ id: "effect:tick", kind: "runtime.send", eventSeq: 1,
+      payload: { kind: "send", operationId: "tick", conversationId: "seat", text: "check", policy: "idle-only", turnId: "old-turn" } }],
+    transition: async (id, status) => { transitions.push([id, status]); },
+  }, () => host(async (entry) => {
+    expect(entry.expectedTurnId).toBeNull();
+    return { outcome: "rejected", reason: "stale-turn" };
+  }));
+  await queue.drain();
+  expect(transitions).toEqual([["tick", "delivering"], ["tick", "failed"]]);
+});
+
+
+test("a retained legacy tick cannot use its old interrupt policy after restart", async () => {
+  let interrupts = 0;
+  const target = host(async () => { throw new Error("no input expected"); });
+  target.health = async () => ({ ...idleState(), status: "active", activeTurnRef: "operator-turn" });
+  target.interrupt = async () => { interrupts++; };
+  const transitions: string[] = [];
+  const queue = new StructuredDeliveryQueue({ effects: async () => [{ id: "effect:legacy-tick", kind: "runtime.send", eventSeq: 1,
+    payload: { kind: "send", operationId: "legacy-tick", conversationId: "seat", text: "check", policy: "interrupt-active", origin: { kind: "agent", role: "seat-tick" } } }],
+    transition: async (_id, status) => { transitions.push(status); },
+  }, () => target);
+  await queue.drain();
+  expect(interrupts).toBe(0);
+  expect(transitions).toEqual(["failed"]);
+});
+
+test("a tick with a lost reply becomes uncertain without an automatic second write", async () => {
+  let writes = 0;
+  const transitions: string[] = [];
+  const queue = new StructuredDeliveryQueue({ effects: async () => [{ id: "effect:unknown-tick", kind: "runtime.send", eventSeq: 1,
+    payload: { kind: "send", operationId: "unknown-tick", conversationId: "seat", text: "check", policy: "idle-only" } }],
+    transition: async (_id, status) => { transitions.push(status); },
+  }, () => host(async () => { writes++; throw new Error("request timed out: thread/read"); }));
+  await queue.drain();
+  expect(writes).toBe(1);
+  expect(transitions).toEqual(["delivering", "uncertain"]);
+});

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -1,3 +1,4 @@
+import { EngineRequestRefusedError } from "./engineHost";
 import { parseSelectedContextRef, type SelectedContextRef } from "@/lib/selection/selectedContext";
 
 import { parseMessageOrigin, type MessageOrigin } from "./messageOrigin";
@@ -905,6 +906,10 @@ export class StructuredDeliveryQueue {
         receipt = effect.policy === "idle-only" ? await host.send(entry) : await sendWithReadRetry(host, entry);
       } catch (error) {
         const reason = failureReason(error);
+        if (error instanceof EngineRequestRefusedError) {
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason });
+          continue;
+        }
         /* The one resend below is allowed only where the host is READ to be
            alive, so an unreadable state is grouped with the host being gone:
            the grouping that resends nothing. It costs a drain pass on a

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -89,7 +89,7 @@ interface SendEffect {
   content: StructuredMessageContent;
   contentDigest: string;
   turnId?: string | null;
-  policy?: "queue" | "steer-if-active" | "interrupt-active";
+  policy?: "queue" | "idle-only" | "steer-if-active" | "interrupt-active";
   kind: "send" | "steer";
   runtime?: RuntimeSendSettings;
   /** #844: the selected-card reference the operator submitted with. Replayed
@@ -227,7 +227,8 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
   const turnId = typeof effect.payload.turnId === "string" || effect.payload.turnId === null
     ? effect.payload.turnId
     : undefined;
-  const policy = effect.payload.policy === "queue"
+  const storedPolicy = effect.payload.policy === "idle-only"
+    || effect.payload.policy === "queue"
     || effect.payload.policy === "steer-if-active"
     || effect.payload.policy === "interrupt-active"
     ? effect.payload.policy
@@ -237,6 +238,9 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
      message must never be stranded by its own provenance. */
   const selectedContext = parseSelectedContextRef(effect.payload.selectedContext);
   const origin = parseMessageOrigin(effect.payload.origin);
+  // Retained ticks admitted by older releases receive the same protection.
+  const policy = origin?.kind === "agent" && origin.role === "seat-tick" ? "idle-only" : storedPolicy;
+  if (effect.payload.policy !== undefined && !policy) return null;
   return {
     operationId,
     conversationId,
@@ -786,6 +790,10 @@ export class StructuredDeliveryQueue {
       }
       const host = this.resolveHost(effect.conversationId);
       if (!host) {
+        if (effect.policy === "idle-only") {
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "idle-only-not-admitted" });
+          continue;
+        }
         if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) continue;
         await this.recoverUnavailableHost(effect);
         return true;
@@ -798,6 +806,10 @@ export class StructuredDeliveryQueue {
       if (!state.readable) return this.fenceUnavailable();
       const health = state.value;
       if (health.status === "dead" || health.status === "unhosted") {
+        if (effect.policy === "idle-only") {
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "idle-only-not-admitted" });
+          continue;
+        }
         if (!await this.transitionUnlessSettled(effect.operationId, "queued", { reason: "dead-host" })) continue;
         await this.recoverUnavailableHost(effect);
         return true;
@@ -810,6 +822,10 @@ export class StructuredDeliveryQueue {
       const shouldInterrupt = replacementIsActive
         && (effect.turnId === undefined || effect.turnId === health.activeTurnRef)
         && !this.interruptAcknowledged.has(effect.operationId);
+      if (effect.policy === "idle-only" && (health.status !== "idle" || health.activeTurnRef !== null || health.pendingAttention.length > 0)) {
+        await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "idle-only-not-admitted" });
+        continue;
+      }
       if (health.status !== "idle" && !maySteer && !shouldInterrupt) return true;
       if (health.status === "idle") this.interruptAcknowledged.delete(effect.operationId);
       const deliveryFence = shouldInterrupt
@@ -825,7 +841,7 @@ export class StructuredDeliveryQueue {
         contentDigest: effect.contentDigest,
         text: effect.content.text,
         images: effect.content.images,
-        expectedTurnId: effect.policy === "interrupt-active" ? null : deliveryFence,
+        expectedTurnId: effect.policy === "interrupt-active" || effect.policy === "idle-only" ? null : deliveryFence,
         ...(effect.runtime ? { runtime: effect.runtime } : {}),
         ...(effect.selectedContext ? { selectedContext: effect.selectedContext } : {}),
         ...(effect.origin ? { origin: effect.origin } : {}),
@@ -886,7 +902,7 @@ export class StructuredDeliveryQueue {
       }
       let receipt;
       try {
-        receipt = await sendWithReadRetry(host, entry);
+        receipt = effect.policy === "idle-only" ? await host.send(entry) : await sendWithReadRetry(host, entry);
       } catch (error) {
         const reason = failureReason(error);
         /* The one resend below is allowed only where the host is READ to be
@@ -898,7 +914,7 @@ export class StructuredDeliveryQueue {
         const hostIsGone = !afterFailure.readable
           || afterFailure.value.status === "dead"
           || afterFailure.value.status === "unhosted";
-        if (!hostIsGone && isThreadReadTimeout(error)) {
+        if (effect.policy !== "idle-only" && !hostIsGone && isThreadReadTimeout(error)) {
           /* The one resend this path issues, and the host dedupes it by
              queue-entry id: it reads the thread back and returns the confirmed
              receipt rather than writing a second message. Its own operation is
@@ -932,6 +948,10 @@ export class StructuredDeliveryQueue {
         continue;
       }
       if (receipt.outcome === "rejected") {
+        if (effect.policy === "idle-only") {
+          await this.transitionUnlessSettled(effect.operationId, "failed", { reason: "idle-only-not-admitted" });
+          continue;
+        }
         if (receipt.reason === "stale-turn") {
           if (effect.kind === "send" && effect.policy !== "steer-if-active") {
             await this.transitionUnlessSettled(effect.operationId, "queued", { reason: receipt.reason });

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -41,7 +41,7 @@ export interface StructuredMessageRequest {
   clientMessageId?: string | null;
   operationId?: string;
   kind?: "send" | "steer";
-  policy?: "queue" | "steer-if-active" | "interrupt-active";
+  policy?: "queue" | "idle-only" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
   text: string;
   images?: RuntimeImageUpload[];

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -1,3 +1,4 @@
+import { requestSeatTick } from "@/lib/monitor/seatTickSignal";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -35,10 +36,24 @@ export interface TasksFileState {
 }
 
 function atomicWriteJson(filePath: string, value: unknown): void {
+  const prior = readJson(filePath) as { tasks?: BoardTask[] } | undefined;
+  const previous = new Map((prior?.tasks ?? []).map((task) => [task.id, { project: task.project, revision: taskRevision(task) }]));
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tmp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
   fs.writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", "utf8");
   fs.renameSync(tmp, filePath);
+  const next = value as { tasks?: BoardTask[] };
+  const changed = new Set<string>();
+  for (const task of next.tasks ?? []) {
+    const before = previous.get(task.id);
+    if (!before || before.revision !== taskRevision(task)) {
+      if (before?.project) changed.add(before.project);
+      if (task.project) changed.add(task.project);
+    }
+    previous.delete(task.id);
+  }
+  for (const removed of previous.values()) if (removed.project) changed.add(removed.project);
+  for (const project of changed) requestSeatTick({ project });
 }
 
 function readJson(filePath: string): unknown {

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -3318,3 +3318,25 @@ test("issue 1100: tool items project into the session's live turn on both lifecy
   expect(reopened.snapshot().sessions.find((session) => session.conversationId === "conversation_tools")?.liveTurn?.items).toHaveLength(3);
   reopened.close();
 });
+
+
+test("idle-only policy and original key survive restart and busy admission is refused", () => {
+  const dir = sandbox("idle-only-restart");
+  const filename = path.join(dir, "events.sqlite");
+  let journal = new RuntimeJournal(filename, { structuredHosts: true, now: () => 100 });
+  const session = { conversationId: "seat", sessionKey: { engine: "codex" as const, sessionId: "seat-thread" },
+    hostKind: "codex-app-server", host: "hosted", turn: "idle", provenance: "structured", activeTurnId: null,
+    capabilities: { steer: true, structuredAttention: true } };
+  journal.append({ scope: runtimeScope("session", "seat"), kind: "session-status", payload: session });
+  const command = { kind: "send" as const, operationId: "tick-operation", idempotencyKey: "tick-key", conversationId: "seat", text: "check", policy: "idle-only" as const };
+  const first = journal.executeOperation(command);
+  expect(first.receipt.status).toBe("queued");
+  journal.close();
+  journal = new RuntimeJournal(filename, { structuredHosts: true, now: () => 200 });
+  expect(journal.executeOperation(command).receipt.operationId).toBe("tick-operation");
+  expect(journal.effectBatch()[0]!.payload).toMatchObject({ policy: "idle-only", operationId: "tick-operation" });
+  journal.append({ scope: runtimeScope("session", "seat"), kind: "session-status", payload: { ...session, turn: "running", activeTurnId: "operator-turn" } });
+  expect(journal.executeOperation({ ...command, operationId: "tick-late", idempotencyKey: "tick-late-key" }).receipt.status).toBe("rejected");
+  expect(journal.effectBatch()).toHaveLength(1);
+  journal.close();
+});

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1591,12 +1591,19 @@ export class RuntimeJournal {
     let reason: string | null = null;
     let turnId = "turnId" in command && typeof command.turnId === "string" ? command.turnId : session?.activeTurnId ?? null;
     let queuePosition: number | null = null;
-    if (this.structuredHosts
+    if (command.kind === "send" && command.policy === "idle-only"
+      && (!this.structuredHosts || (session?.hostKind !== "codex-app-server" && session?.hostKind !== "claude-broker"))) {
+      status = "rejected";
+      reason = "idle-only-unsupported-host";
+    } else if (this.structuredHosts
       && command.kind === "send"
       && (session?.hostKind === "codex-app-server" || session?.hostKind === "claude-broker")) {
       if (!session || session.host !== "hosted") {
         status = "rejected";
         reason = session?.host === "dead" || session?.host === "unhosted" ? "dead-host" : "no-claim";
+      } else if (command.policy === "idle-only" && (session.turn !== "idle" || session.activeTurnId !== null)) {
+        status = "rejected";
+        reason = "idle-only-not-admitted";
       } else if (command.turnId && command.turnId !== session.activeTurnId) {
         status = "rejected";
         reason = "stale-turn";
@@ -1609,6 +1616,9 @@ export class RuntimeJournal {
       if (!session || session.host !== "hosted") {
         status = "rejected";
         reason = session?.host === "dead" || session?.host === "unhosted" ? "dead-host" : "no-claim";
+      } else if (command.policy === "idle-only" && (session.turn !== "idle" || session.activeTurnId !== null)) {
+        status = "rejected";
+        reason = "idle-only-not-admitted";
       } else if (command.turnId && command.turnId !== session.activeTurnId) {
         status = "rejected";
         reason = "stale-turn";


### PR DESCRIPTION
Refs #1569 and #1245. Implements the automatic-tick slice of the approved idle-turn-delivery design at `2d3a6f4b110a9109846e0cc0852a9fc82e80a465`, including the operator's subsequent settlement/countdown directive.

While a seat works, the existing controller collects and prepares actionable obligations in its durable accounting state. It delivers no routine tick during model work, tool calls or waits. On authoritative turn settlement, retained work is refreshed and drained immediately. With an empty queue, the full configured default interval starts at that idle boundary. A genuine event during idle bypasses the remaining interval; busy activity cancels eligibility. Prose saying done cannot release the fence. Existing empty-board/proposal suppression remains after expiry.

The existing controller owns observation, notifications and its nearest deadline. Generation/cursor-bound timing survives restart conservatively. Superseded work is refreshed before admission; accepted unknown attempts retain their immutable original payload/key. Only a landed wake acknowledges its carried obligations. Final adapter admission fences an active/idle race, including previously queued ticks.

Earlier review findings:
- FIXED: authoritative Codex start refusal releases the pending reservation; uncertain handover keeps it. Corrected input can start after refusal, and a matching authoritative settlement releases a lost-ack fence without duplicating input.
- FIXED: settled and authoritatively dead/stalled seats can use existing owner recovery. Input still requires positive idle evidence. Active, retrying and unobservable turns remain protected.

Validation uses isolated homes, state and provider roots under Bun 1.4.0. Baseline causal fixtures sent ticks to busy seats and duplicated delayed turn starts. The corrected lane passed 797 tests across 16 specific files; a subsequent reclaimed-idle regression and fresh monitor/controller/source/signal run passed 299 tests. TypeScript, whitespace and privacy checks passed. Tests include full-interval settlement, immediate queue drain, tool waits, event-during-timer, dispatch races, restart/rotation, cancellation, original-key uncertainty, explicit refusal and authoritative recovery.

The four existing incident cards remain open for root-owned production verification. Stalled-seat and unmerged-PR retry cards require authoritative recovery and a successful admissible owed wake; the child-source card requires complete child-discovery evidence; the unresolved-wake card requires authoritative settlement under its original key and correct accounting. None closes from local tests alone.

Required root production probe after independent exact-head review and an approved release: observe a designated seat through model/tool/wait activity with zero automatic input; queue a genuine event while busy and verify exactly one refreshed drain after authoritative settlement; verify an empty queue waits the full interval; introduce an event during that timer; race a user turn against dispatch; exercise stalled-owner recovery and original-key uncertainty across restart/rotation in a scoped fixture. Observe actual production generation and receipts without interrupting an existing working host. No deployment or live lifecycle mutation is included here.
